### PR TITLE
Add Feishu multitenancy bundled plugin

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -726,8 +726,11 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                     f"{prompt}"
                 )
             else:
-                # Script produced no output — nothing to report, skip AI call.
-                return None
+                prompt = (
+                    "## Script Output\n"
+                    "The pre-run script completed successfully but produced no output.\n\n"
+                    f"{prompt}"
+                )
         else:
             prompt = (
                 "## Script Error\n"

--- a/plugins/platforms/feishu-multitenancy/README.md
+++ b/plugins/platforms/feishu-multitenancy/README.md
@@ -18,7 +18,10 @@ sender `open_id`, and run the message against a per-user Hermes profile.
    `feishu_<open_id>` when enabled.
 4. Normal turns run through the AIAgent subprocess with the routed profile's
    `HERMES_HOME` and sender open_id scope.
-5. Slash commands are handled by Hermes gateway/plugin/skill control paths and
+5. Cron/reminder jobs created inside that subprocess are bound back to the
+   shared gateway Hermes home (`~/.hermes/cron/jobs.json`) because the single
+   gateway cron ticker does not scan profile-local cron stores.
+6. Slash commands are handled by Hermes gateway/plugin/skill control paths and
    unknown slash commands return an unknown-command reply instead of entering the
    LLM prompt.
 
@@ -110,6 +113,8 @@ HERMES_MULTITENANCY_AUTO_PROVISION=0
 - Gateway and plugin slash handlers run under the routed profile's
   `HERMES_HOME`, serialized so concurrent slash commands cannot observe another
   profile's environment.
+- Cron/reminder jobs use the shared Hermes cron store watched by the gateway
+  ticker; profile-local `cron/jobs.json` files are intentionally avoided.
 - Outbound `MEDIA:<path>` file replies are delivered only when the target path
   resolves inside the routed profile home.
 - `quick_commands` entries with `type: exec` are disabled by default for Feishu

--- a/plugins/platforms/feishu-multitenancy/README.md
+++ b/plugins/platforms/feishu-multitenancy/README.md
@@ -87,6 +87,31 @@ Disable auto-provisioning with:
 HERMES_MULTITENANCY_AUTO_PROVISION=0
 ```
 
+## Tenant-boundary controls
+
+- Session history and gateway slash session keys are scoped by `(profile,
+  canonical sender)`; alternate IDs are route lookup helpers only.
+- Gateway and plugin slash handlers run under the routed profile's
+  `HERMES_HOME`, serialized so concurrent slash commands cannot observe another
+  profile's environment.
+- Outbound `MEDIA:<path>` file replies are delivered only when the target path
+  resolves inside the routed profile home.
+- `quick_commands` entries with `type: exec` are disabled by default for Feishu
+  multitenancy. Enable them only after profile sandboxing is enforced:
+
+```yaml
+multitenancy:
+  allow_quick_exec: true
+```
+
+or:
+
+```bash
+HERMES_MULTITENANCY_ALLOW_QUICK_EXEC=1
+```
+
+Allowed exec commands inherit the routed profile's `HERMES_HOME`.
+
 ## Toolsets
 
 When a profile sets `platform_toolsets.feishu`, the plugin defaults to merging

--- a/plugins/platforms/feishu-multitenancy/README.md
+++ b/plugins/platforms/feishu-multitenancy/README.md
@@ -21,7 +21,16 @@ sender `open_id`, and run the message against a per-user Hermes profile.
 5. Cron/reminder jobs created inside that subprocess are bound back to the
    shared gateway Hermes home (`~/.hermes/cron/jobs.json`) because the single
    gateway cron ticker does not scan profile-local cron stores.
-6. Slash commands are handled by Hermes gateway/plugin/skill control paths and
+6. Dangerous-command approvals are bridged back to the router with a
+   multitenant gateway session key plus child-local `HERMES_SESSION_KEY` /
+   `HERMES_GATEWAY_SESSION` / `HERMES_EXEC_ASK`, so terminal/process guard
+   worker threads resolve the same approval callback. The AIAgent child emits
+   `approval_required` / `approval_resolved` NDJSON events; the parent stream
+   parser forwards them to the router, and `/approve` / `/deny` resolves the
+   child through a decision file. The core terminal guard runs before
+   sandbox/environment creation so an approval prompt is not blocked by
+   environment startup.
+7. Slash commands are handled by Hermes gateway/plugin/skill control paths and
    unknown slash commands return an unknown-command reply instead of entering the
    LLM prompt.
 
@@ -115,6 +124,11 @@ HERMES_MULTITENANCY_AUTO_PROVISION=0
   profile's environment.
 - Cron/reminder jobs use the shared Hermes cron store watched by the gateway
   ticker; profile-local `cron/jobs.json` files are intentionally avoided.
+- Dangerous-command approval prompts are delivered by the parent router and
+  resolved by `/approve` / `/deny` through a decision file; child-local session
+  env covers tool worker threads that do not inherit contextvars, and the
+  parent stream parser must forward child `approval_required` /
+  `approval_resolved` events instead of dropping them.
 - Outbound `MEDIA:<path>` file replies are delivered only when the target path
   resolves inside the routed profile home.
 - `quick_commands` entries with `type: exec` are disabled by default for Feishu

--- a/plugins/platforms/feishu-multitenancy/README.md
+++ b/plugins/platforms/feishu-multitenancy/README.md
@@ -1,0 +1,127 @@
+# Feishu Multitenancy Plugin
+
+Route one Feishu bot to multiple isolated Hermes profiles.
+
+This bundled plugin is opt-in. It uses the `pre_gateway_dispatch` hook to
+intercept Feishu messages before the default gateway dispatch, resolve the real
+sender `open_id`, and run the message against a per-user Hermes profile.
+
+## Enable
+
+```bash
+hermes plugins enable platforms/feishu-multitenancy
+hermes gateway restart
+```
+
+## Configure Routes
+
+Create one Hermes profile per tenant persona:
+
+```bash
+mkdir -p ~/.hermes/profiles/alice ~/.hermes/profiles/bob
+$EDITOR ~/.hermes/profiles/alice/SOUL.md
+$EDITOR ~/.hermes/profiles/bob/SOUL.md
+```
+
+Apply a route file:
+
+```bash
+python plugins/platforms/feishu-multitenancy/sync.py apply users.json
+```
+
+Example `users.json`:
+
+```json
+[
+  {
+    "user_id": "alice",
+    "profile_name": "alice",
+    "open_id": "ou_xxx",
+    "union_id": "on_xxx"
+  },
+  {
+    "user_id": "bob",
+    "profile_name": "bob",
+    "open_id": "ou_yyy",
+    "union_id": "on_yyy"
+  }
+]
+```
+
+New routes should use Feishu `open_id` (`ou_*`). `union_id` remains available
+for legacy migration rows.
+
+## Shared Feishu App
+
+The plugin expects the gateway/default Hermes home to own the Feishu app
+credentials and per-user Feishu user access token files. Do not duplicate app
+credentials into every profile.
+
+```text
+~/.hermes/config.yaml                 # shared Feishu app config
+~/.hermes/feishu_uat/<open_id>.json   # per-user token files
+~/.hermes/profiles/<profile>/         # isolated SOUL, .env, config, memory
+```
+
+## Auto-Provisioning
+
+Auto-provisioning is enabled by default:
+
+```bash
+HERMES_MULTITENANCY_AUTO_PROVISION=1
+```
+
+An unseen sender `ou_new_user` gets a deterministic profile path such as:
+
+```text
+~/.hermes/profiles/feishu_ou_new_user/
+```
+
+The profile is seeded from the shared Hermes config where possible. If the
+shared config does not define a model, configure the generated profile before
+expecting AIAgent replies.
+
+Disable auto-provisioning with:
+
+```bash
+HERMES_MULTITENANCY_AUTO_PROVISION=0
+```
+
+## Toolsets
+
+When a profile sets `platform_toolsets.feishu`, the plugin defaults to merging
+those explicit entries with Hermes' default Feishu toolsets. This preserves
+general capabilities such as `web_search` / `web_extract` while still allowing
+per-profile Feishu tool additions.
+
+For a strictly narrowed schema, set:
+
+```yaml
+multitenancy:
+  toolsets_mode: explicit
+```
+
+or export:
+
+```bash
+HERMES_MULTITENANCY_TOOLSETS_MODE=explicit
+```
+
+## Verify
+
+```bash
+hermes plugins list
+sqlite3 ~/.hermes/multitenancy.db \
+  'select open_id, profile_name, active from multitenancy_routing;'
+```
+
+Then send the same prompt from two Feishu users to the same bot. The gateway
+log should show distinct sender `ou_*` values and distinct profile homes.
+
+## Notes
+
+- No Hermes core files are patched.
+- The plugin uses Feishu `open_id` first and only falls back to alternate IDs
+  for legacy rows.
+- AIAgent runs in an isolated subprocess so tool calls can execute without
+  blocking the gateway event loop.

--- a/plugins/platforms/feishu-multitenancy/README.md
+++ b/plugins/platforms/feishu-multitenancy/README.md
@@ -6,6 +6,22 @@ This bundled plugin is opt-in. It uses the `pre_gateway_dispatch` hook to
 intercept Feishu messages before the default gateway dispatch, resolve the real
 sender `open_id`, and run the message against a per-user Hermes profile.
 
+## How it works
+
+1. `register(ctx)` installs a `pre_gateway_dispatch` hook. Feishu messages are
+   skipped from normal dispatch and handled by the plugin router.
+2. The router resolves a canonical Feishu sender `open_id` (`ou_*`) from
+   context, event fields, or raw Feishu payloads. Alternate IDs are legacy route
+   lookup helpers only.
+3. `multitenancy_routing.open_id -> profile_name` selects a Hermes profile under
+   `~/.hermes/profiles/<profile>/`; route misses may auto-provision
+   `feishu_<open_id>` when enabled.
+4. Normal turns run through the AIAgent subprocess with the routed profile's
+   `HERMES_HOME` and sender open_id scope.
+5. Slash commands are handled by Hermes gateway/plugin/skill control paths and
+   unknown slash commands return an unknown-command reply instead of entering the
+   LLM prompt.
+
 ## Enable
 
 ```bash

--- a/plugins/platforms/feishu-multitenancy/__init__.py
+++ b/plugins/platforms/feishu-multitenancy/__init__.py
@@ -1,0 +1,8 @@
+"""Feishu multitenancy bundled plugin entry point."""
+
+try:
+    from .hermes_multitenancy import on_pre_gateway_dispatch, register
+except ImportError:  # Allows direct pytest/importlib loading outside the plugin namespace.
+    from hermes_multitenancy import on_pre_gateway_dispatch, register
+
+__all__ = ["register", "on_pre_gateway_dispatch"]

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/__init__.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/__init__.py
@@ -1,0 +1,35 @@
+"""Feishu multitenancy plugin.
+
+The plugin registers one ``pre_gateway_dispatch`` hook. The hook resolves the
+real Feishu sender ``open_id`` and dispatches the inbound message to a
+sender-specific Hermes profile while the gateway remains a single shared bot.
+"""
+from __future__ import annotations
+
+from .router import on_pre_gateway_dispatch
+
+
+def register(ctx) -> None:
+    """Hermes plugin entry point — wires the multitenancy router to pre_gateway_dispatch.
+
+    Called by Hermes plugin loader once at startup. ``ctx`` is a PluginContext
+    instance (hermes_cli.plugins.PluginContext). It exposes ``register_hook``.
+
+    Side effect: installs a RuntimePool whose factory uses ``real_run_agent``
+    (live LLM thin client) instead of the unit-test echo stub. Without this,
+    Bot replies would be the echo string, not real model output.
+    """
+    from .agent_real import real_run_agent
+    from .pool import RuntimePool
+    from .router import override_pool
+    from .runtime import ProfileRuntime
+
+    def _real_factory(profile_name, profile_home):
+        return ProfileRuntime(profile_home=profile_home, run_agent_fn=real_run_agent)
+
+    override_pool(RuntimePool(runtime_factory=_real_factory))
+
+    ctx.register_hook("pre_gateway_dispatch", on_pre_gateway_dispatch)
+
+
+__all__ = ["register", "on_pre_gateway_dispatch"]

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/agent_real.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/agent_real.py
@@ -28,6 +28,8 @@ import os
 import sys
 import time
 import hashlib
+import tempfile
+import uuid
 from pathlib import Path
 from typing import Any, Optional
 
@@ -662,26 +664,38 @@ async def _run_aiagent_subprocess(
     env = os.environ.copy()
     env["HERMES_SHARED_HOME"] = str(_resolve_shared_hermes_home(profile_home))
     env["HERMES_HOME"] = str(profile_home)
+    approval_dir = Path(tempfile.mkdtemp(prefix="hermes-mt-approval-"))
+    env["HERMES_MULTITENANCY_APPROVAL_DIR"] = str(approval_dir)
     child_script = Path(__file__).with_name("aiagent_subprocess.py")
 
-    proc = await asyncio.create_subprocess_exec(
-        sys.executable,
-        str(child_script),
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=env,
-    )
+    proc = None
     try:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            str(child_script),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
         stdout, stderr = await asyncio.wait_for(proc.communicate(payload), timeout_s)
     except asyncio.TimeoutError as exc:
-        proc.kill()
-        await proc.wait()
+        if proc is not None:
+            proc.kill()
+            await proc.wait()
         raise RuntimeError(f"AIAgent subprocess timed out after {timeout_s:g}s") from exc
     except asyncio.CancelledError:
-        proc.kill()
-        await proc.wait()
+        if proc is not None:
+            proc.kill()
+            await proc.wait()
         raise
+    finally:
+        try:
+            import shutil
+
+            shutil.rmtree(approval_dir, ignore_errors=True)
+        except Exception:
+            pass
 
     stderr_text = stderr.decode("utf-8", errors="replace").strip()
     stdout_text = stdout.decode("utf-8", errors="replace").strip()
@@ -724,6 +738,8 @@ async def _stream_aiagent_subprocess(
     env["HERMES_SHARED_HOME"] = str(_resolve_shared_hermes_home(profile_home))
     env["HERMES_HOME"] = str(profile_home)
     env["HERMES_AIAGENT_EVENT_STREAM"] = "1"
+    approval_dir = Path(tempfile.mkdtemp(prefix="hermes-mt-approval-"))
+    env["HERMES_MULTITENANCY_APPROVAL_DIR"] = str(approval_dir)
     child_script = Path(__file__).with_name("aiagent_subprocess.py")
 
     started_at = time.monotonic()
@@ -828,6 +844,12 @@ async def _stream_aiagent_subprocess(
             await proc.wait()
         if not stderr_task.done():
             stderr_task.cancel()
+        try:
+            import shutil
+
+            shutil.rmtree(approval_dir, ignore_errors=True)
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -935,6 +957,31 @@ def _resolve_aiagent_session_id(
     return f"{session_id[:200]}:{digest}"
 
 
+def _resolve_multitenant_gateway_session_key(
+    event: Any,
+    profile_home: Path,
+    sender_open_id: str = "",
+) -> str:
+    """Return the parent gateway session key used by multitenancy slash commands."""
+    source = getattr(event, "source", None)
+    platform = _resolve_platform_value(source)
+    chat_id = ""
+    if source is not None:
+        chat_id = str(
+            getattr(source, "chat_id", None)
+            or getattr(source, "parent_chat_id", None)
+            or getattr(source, "chat_id_alt", None)
+            or ""
+        )
+    user_key = str(
+        sender_open_id
+        or (getattr(source, "user_id", None) if source is not None else "")
+        or (getattr(source, "user_id_alt", None) if source is not None else "")
+        or "unknown"
+    )
+    return f"multitenancy:{platform}:{profile_home.name}:{chat_id or 'unknown'}:{user_key}"
+
+
 def _conversation_history_for_aiagent(
     messages: Optional[list[dict]],
     user_text: str,
@@ -949,6 +996,124 @@ def _conversation_history_for_aiagent(
     ):
         history = history[:-1]
     return history or None
+
+
+def _approval_bridge_timeout() -> float:
+    raw = os.getenv("HERMES_MULTITENANCY_APPROVAL_TIMEOUT")
+    if raw is None:
+        raw = os.getenv("HERMES_APPROVAL_GATEWAY_TIMEOUT", "300")
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        return 300.0
+
+
+def _approval_bridge_dir() -> Path:
+    raw = os.getenv("HERMES_MULTITENANCY_APPROVAL_DIR")
+    if raw:
+        root = Path(raw).expanduser()
+    else:
+        root = Path(tempfile.gettempdir()) / "hermes-multitenancy-approvals"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _read_approval_choice(path: Path) -> Optional[str]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except Exception as exc:
+        logger.debug("[multitenancy] approval decision read failed: %s", exc)
+        return "deny"
+    choice = str(data.get("choice") or "").strip().lower()
+    return choice if choice in {"once", "session", "always", "deny"} else "deny"
+
+
+def _configure_gateway_approval_bridge(event_sink, session_key: str):
+    """Register child-process approval notify and return a cleanup callback."""
+    try:
+        from tools.approval import (
+            register_gateway_notify,
+            reset_current_session_key,
+            resolve_gateway_approval,
+            set_current_session_key,
+            unregister_gateway_notify,
+        )
+    except Exception as exc:
+        logger.debug("[multitenancy] approval bridge unavailable: %s", exc)
+        return lambda: None
+
+    token = set_current_session_key(session_key)
+    registered = False
+
+    def _emit_bridge_event(event_name: str, **payload: Any) -> None:
+        if event_sink is None:
+            return
+        try:
+            event_sink(event_name, **payload)
+        except Exception:
+            logger.debug("[multitenancy] approval bridge event emit failed", exc_info=True)
+
+    if event_sink is not None:
+        approval_dir = _approval_bridge_dir()
+
+        def _approval_notify_sync(approval_data: dict) -> None:
+            approval_id = f"approval_{uuid.uuid4().hex}"
+            decision_path = approval_dir / f"{approval_id}.json"
+            command = str(approval_data.get("command") or "")
+            description = str(approval_data.get("description") or "dangerous command")
+            _emit_bridge_event(
+                "approval_required",
+                approval_id=approval_id,
+                session_key=session_key,
+                command=command,
+                description=description,
+                pattern_keys=approval_data.get("pattern_keys") or [],
+                decision_path=str(decision_path),
+            )
+
+            timeout_s = _approval_bridge_timeout()
+            deadline = time.monotonic() + timeout_s
+            choice: Optional[str] = None
+            timed_out = False
+            while True:
+                choice = _read_approval_choice(decision_path)
+                if choice is not None:
+                    break
+                if time.monotonic() >= deadline:
+                    choice = "deny"
+                    timed_out = True
+                    break
+                time.sleep(0.1)
+
+            try:
+                resolve_gateway_approval(session_key, choice)
+            except Exception as exc:
+                logger.debug("[multitenancy] child approval resolve failed: %s", exc)
+            _emit_bridge_event(
+                "approval_resolved",
+                approval_id=approval_id,
+                session_key=session_key,
+                choice=choice,
+                timed_out=timed_out,
+            )
+
+        register_gateway_notify(session_key, _approval_notify_sync)
+        registered = True
+
+    def _cleanup() -> None:
+        if registered:
+            try:
+                unregister_gateway_notify(session_key)
+            except Exception:
+                pass
+        try:
+            reset_current_session_key(token)
+        except Exception:
+            pass
+
+    return _cleanup
 
 
 def _run_with_aiagent(
@@ -1029,6 +1194,11 @@ def _run_with_aiagent(
     source = getattr(event, "source", None)
     user_text = getattr(event, "text", "") or ""
     session_id = _resolve_aiagent_session_id(event, profile_home, sender_open_id)
+    gateway_session_key = _resolve_multitenant_gateway_session_key(
+        event,
+        profile_home,
+        sender_open_id,
+    )
     conversation_history = _conversation_history_for_aiagent(messages, user_text)
 
     runtime_kwargs: dict[str, Any] = {"api_key": api_key}
@@ -1070,7 +1240,7 @@ def _run_with_aiagent(
                 thread_id=str(getattr(source, "thread_id", "") or "") if source else "",
                 user_id=str(getattr(source, "user_id", "") or "") if source else "",
                 user_name=str(getattr(source, "user_name", "") or "") if source else "",
-                session_key=str(session_id),
+                session_key=str(gateway_session_key),
             )
         def _emit(event_name: str, **payload: Any) -> None:
             if event_sink is None:
@@ -1142,6 +1312,7 @@ def _run_with_aiagent(
             "chat_id": str(getattr(source, "chat_id", "") or "") if source else "",
             "chat_name": str(getattr(source, "chat_name", "") or "") if source else "",
             "chat_type": str(getattr(source, "chat_type", "") or "") if source else "",
+            "gateway_session_key": str(gateway_session_key),
             "tool_progress_callback": _tool_progress_event_callback,
             "stream_delta_callback": _stream_delta_event_callback if event_sink is not None else None,
             "reasoning_callback": _reasoning_event_callback if event_sink is not None else None,
@@ -1152,6 +1323,10 @@ def _run_with_aiagent(
         if fallback_model:
             agent_kwargs["fallback_model"] = fallback_model
 
+        approval_cleanup = _configure_gateway_approval_bridge(
+            event_sink,
+            str(gateway_session_key),
+        )
         agent = AIAgent(**agent_kwargs)
         try:
             run_kwargs: dict[str, Any] = {
@@ -1162,11 +1337,16 @@ def _run_with_aiagent(
                 run_kwargs["conversation_history"] = conversation_history
             result = agent.run_conversation(**run_kwargs)
         finally:
+            approval_cleanup()
             if clear_session_vars is not None and session_tokens is not None:
                 clear_session_vars(session_tokens)
             try:
-                if hasattr(agent, "cleanup"):
-                    agent.cleanup()
+                close_agent = getattr(agent, "close", None)
+                cleanup_agent = getattr(agent, "cleanup", None)
+                if callable(close_agent):
+                    close_agent()
+                elif callable(cleanup_agent):
+                    cleanup_agent()
             except Exception:
                 pass
 

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/agent_real.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/agent_real.py
@@ -415,6 +415,59 @@ def _configure_feishu_uat_home(feishu_oapi_module: Any, profile_home: Path) -> P
     return shared_home
 
 
+def _configure_cron_home(shared_home: Path) -> None:
+    """Make cronjob tool writes visible to the shared gateway scheduler.
+
+    The gateway cron ticker imports ``cron.jobs`` under the shared Hermes home
+    and only scans ``<shared>/cron/jobs.json``. Multitenant AIAgent subprocesses
+    run with ``HERMES_HOME=<profile>``, so importing ``cron.jobs`` there would
+    otherwise bind cron storage to ``<profile>/cron/jobs.json``. That creates
+    jobs that remain forever ``scheduled`` because no gateway ticker watches
+    that profile-local file.
+    """
+    import importlib
+
+    shared_home = Path(shared_home).expanduser()
+    old_home = os.environ.get("HERMES_HOME")
+    try:
+        os.environ["HERMES_HOME"] = str(shared_home)
+        cron_jobs = importlib.import_module("cron.jobs")
+        cron_jobs.HERMES_DIR = shared_home.resolve()
+        cron_jobs.CRON_DIR = cron_jobs.HERMES_DIR / "cron"
+        cron_jobs.JOBS_FILE = cron_jobs.CRON_DIR / "jobs.json"
+        cron_jobs.OUTPUT_DIR = cron_jobs.CRON_DIR / "output"
+
+        cronjob_tools = importlib.import_module("tools.cronjob_tools")
+
+        def _validate_shared_cron_script_path(script: Optional[str]) -> Optional[str]:
+            if not script or not str(script).strip():
+                return None
+            raw = str(script).strip()
+            if raw.startswith(("/", "~")) or (len(raw) >= 2 and raw[1] == ":"):
+                return (
+                    "Script path must be relative to shared ~/.hermes/scripts/. "
+                    f"Got absolute or home-relative path: {raw!r}."
+                )
+            from tools.path_security import validate_within_dir
+
+            scripts_dir = shared_home / "scripts"
+            scripts_dir.mkdir(parents=True, exist_ok=True)
+            containment_error = validate_within_dir(scripts_dir / raw, scripts_dir)
+            if containment_error:
+                return f"Script path escapes the shared scripts directory via traversal: {raw!r}"
+            return None
+
+        cronjob_tools._validate_cron_script_path = _validate_shared_cron_script_path
+        logger.info("[multitenancy] cron jobs bound to shared Hermes home: %s", cron_jobs.JOBS_FILE)
+    except Exception as exc:
+        logger.warning("[multitenancy] failed to bind cron jobs to shared Hermes home: %s", exc)
+    finally:
+        if old_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = old_home
+
+
 def _log_aiagent_tool_progress(
     event_type: str,
     tool_name: str,
@@ -945,6 +998,7 @@ def _run_with_aiagent(
     sender_open_id_scope = feishu_oapi.sender_open_id_scope
     current_sender_open_id = feishu_oapi.current_sender_open_id
     shared_hermes_home = _configure_feishu_uat_home(feishu_oapi, profile_home)
+    _configure_cron_home(shared_hermes_home)
     if shared_hermes_home != profile_home:
         logger.info(
             "[multitenancy] using shared Feishu UAT dir: %s",

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/agent_real.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/agent_real.py
@@ -664,6 +664,8 @@ async def _run_aiagent_subprocess(
     env = os.environ.copy()
     env["HERMES_SHARED_HOME"] = str(_resolve_shared_hermes_home(profile_home))
     env["HERMES_HOME"] = str(profile_home)
+    env["HERMES_GATEWAY_SESSION"] = "1"
+    env["HERMES_EXEC_ASK"] = "1"
     approval_dir = Path(tempfile.mkdtemp(prefix="hermes-mt-approval-"))
     env["HERMES_MULTITENANCY_APPROVAL_DIR"] = str(approval_dir)
     child_script = Path(__file__).with_name("aiagent_subprocess.py")
@@ -738,6 +740,8 @@ async def _stream_aiagent_subprocess(
     env["HERMES_SHARED_HOME"] = str(_resolve_shared_hermes_home(profile_home))
     env["HERMES_HOME"] = str(profile_home)
     env["HERMES_AIAGENT_EVENT_STREAM"] = "1"
+    env["HERMES_GATEWAY_SESSION"] = "1"
+    env["HERMES_EXEC_ASK"] = "1"
     approval_dir = Path(tempfile.mkdtemp(prefix="hermes-mt-approval-"))
     env["HERMES_MULTITENANCY_APPROVAL_DIR"] = str(approval_dir)
     child_script = Path(__file__).with_name("aiagent_subprocess.py")
@@ -810,7 +814,12 @@ async def _stream_aiagent_subprocess(
                 yield "content", str(data.get("text") or "")
             elif event_name == "thinking":
                 yield "thinking", str(data.get("text") or "")
-            elif event_name in {"tool_started", "tool_completed"}:
+            elif event_name in {
+                "tool_started",
+                "tool_completed",
+                "approval_required",
+                "approval_resolved",
+            }:
                 payload_data = {k: v for k, v in data.items() if k != "event"}
                 yield str(event_name), payload_data
             else:
@@ -1045,6 +1054,17 @@ def _configure_gateway_approval_bridge(event_sink, session_key: str):
         return lambda: None
 
     token = set_current_session_key(session_key)
+    old_env = {
+        "HERMES_SESSION_KEY": os.environ.get("HERMES_SESSION_KEY"),
+        "HERMES_GATEWAY_SESSION": os.environ.get("HERMES_GATEWAY_SESSION"),
+        "HERMES_EXEC_ASK": os.environ.get("HERMES_EXEC_ASK"),
+    }
+    # Terminal/process guards may execute in worker threads that do not inherit
+    # contextvars. The child subprocess is single-turn, so process-local env is
+    # the safest compatibility bridge for those thread-local tool paths.
+    os.environ["HERMES_SESSION_KEY"] = session_key
+    os.environ["HERMES_GATEWAY_SESSION"] = "1"
+    os.environ["HERMES_EXEC_ASK"] = "1"
     registered = False
 
     def _emit_bridge_event(event_name: str, **payload: Any) -> None:
@@ -1112,6 +1132,14 @@ def _configure_gateway_approval_bridge(event_sink, session_key: str):
             reset_current_session_key(token)
         except Exception:
             pass
+        for key, old_value in old_env.items():
+            try:
+                if old_value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = old_value
+            except Exception:
+                pass
 
     return _cleanup
 

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/agent_real.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/agent_real.py
@@ -1,0 +1,1212 @@
+"""Phase 3 — real (non-stub) agent runner.
+
+Replaces ``runtime._default_run_agent`` (Phase-1 echo stub) with a thin
+OpenAI-compatible LLM call that reads its config + credentials from the
+profile_home directory. Designed to plug into ``ProfileRuntime`` via:
+
+    ProfileRuntime(profile_home, run_agent_fn=real_run_agent)
+
+Resolution order for an API key, given a model spec like ``"zai/glm-5.1"``:
+  1. Environment variable ``<PROVIDER>_API_KEY`` (e.g. ``GLM_API_KEY``,
+     ``ZAI_API_KEY``, ``OPENROUTER_API_KEY``) — sourced from the profile's
+     ``.env`` file via ``python-dotenv``.
+  2. ``auth.json`` ``credential_pool[provider]`` — first entry whose
+     ``last_status`` is not ``"exhausted"``.
+
+Fallback strategy: try the primary ``model.default``; on any error, walk the
+``fallback`` list. Returns the first non-empty content string.
+
+Spike scope: deliberate one-shot LLM call, no SessionStore, no tool-loop, no
+streaming. Phase 4 will graduate to a real AIAgent loop (~1700 LOC per the
+architect estimate). For end-to-end demo today, this thin runner is enough.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import time
+import hashlib
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# Map a model provider prefix to the env-var name that holds its API key.
+# Keep this list short and explicit — adding a provider is one line.
+_PROVIDER_ENV_KEYS: dict[str, tuple[str, ...]] = {
+    "zai": ("GLM_API_KEY", "ZAI_API_KEY"),
+    "openrouter": ("OPENROUTER_API_KEY",),
+    "anthropic": ("ANTHROPIC_API_KEY",),
+    "openai": ("OPENAI_API_KEY",),
+    "moonshot": ("MOONSHOT_API_KEY",),
+    "deepseek": ("DEEPSEEK_API_KEY",),
+}
+
+
+# Each provider's API base URL when the model spec has no explicit override.
+# Values mirror what ``hermes_cli/config.py`` infers for the same providers.
+_PROVIDER_BASE_URLS: dict[str, str] = {
+    "zai": "https://api.z.ai/api/coding/paas/v4",
+    "openrouter": "https://openrouter.ai/api/v1",
+    "anthropic": "https://api.anthropic.com/v1",
+    "openai": "https://api.openai.com/v1",
+    "moonshot": "https://api.moonshot.cn/v1",
+    "deepseek": "https://api.deepseek.com",
+}
+
+
+async def stream_run_agent(  # type: ignore[override]
+    event: Any,
+    profile_home: Path,
+    *,
+    messages: Optional[list[dict]] = None,
+):
+    """Yields ``(kind, text)`` tuples — Phase 4 routes through the real AIAgent.
+
+    With the AIAgent path enabled, the LLM gets the full toolset and can
+    actually call PR-added UAT tools. The subprocess bridge emits NDJSON
+    events so the parent can forward tool/reasoning/text deltas into the
+    Feishu streaming card while the synchronous AIAgent loop is still running.
+
+    Falls back to the legacy streaming path on AIAgent failure (preserves
+    the visible-typing UX even when tools cannot fire). ``messages`` is the
+    router-provided conversation history; the subprocess receives prior turns
+    as ``conversation_history`` and the current event text as the active user
+    message.
+    """
+    try:
+        content_parts: list[str] = []
+        final_text = ""
+        stream = (
+            _stream_aiagent_subprocess(event, profile_home, messages=messages)
+            if messages is not None
+            else _stream_aiagent_subprocess(event, profile_home)
+        )
+        async for kind, payload in stream:
+            if kind == "done":
+                final_text = str(payload or "")
+                continue
+            if kind == "content":
+                text = str(payload or "")
+                if text:
+                    content_parts.append(text)
+                    yield "content", text
+                continue
+            yield kind, payload
+        if final_text and not "".join(content_parts).strip():
+            yield "content", final_text
+        if final_text or content_parts:
+            return
+    except Exception as exc:
+        logger.warning(
+            "[multitenancy] streaming AIAgent path failed (%s); falling back to legacy stream",
+            exc, exc_info=True,
+        )
+
+    async for kind, text in _stream_loop(event, profile_home, messages=messages):
+        yield kind, text
+
+
+async def _stream_loop(
+    event: Any,
+    profile_home: Path,
+    *,
+    messages: Optional[list[dict]] = None,
+):
+    """Streaming counterpart to ``real_run_agent`` — yields content chunks.
+
+    Used by the multitenancy router to stream LLM tokens into a Feishu
+    ``edit_message`` loop, restoring the typewriter UX that hermes' main
+    flow provides natively. Falls through provider candidates the same way
+    as ``real_run_agent`` — first one whose first chunk is non-empty wins.
+
+    Yields
+    ------
+    str
+        Each non-empty content chunk from the live model.
+
+    Raises
+    ------
+    RuntimeError
+        If every candidate model+credential combination fails or yields
+        nothing. Caller should fall back to ``real_run_agent`` for a final
+        non-streamed attempt before giving up.
+    """
+    import yaml
+    from openai import AsyncOpenAI
+    from dotenv import dotenv_values
+
+    config = _load_yaml(profile_home / "config.yaml")
+    auth = _load_json(profile_home / "auth.json")
+    env_overrides = (
+        dotenv_values(profile_home / ".env") if (profile_home / ".env").exists() else {}
+    )
+
+    primary = config.get("model", {}).get("default")
+    fallback_models = config.get("fallback") or []
+    candidates: list[str] = [primary] if primary else []
+    candidates.extend(fallback_models)
+
+    soul_text = _load_soul(profile_home)
+    user_text = getattr(event, "text", "") or ""
+
+    # Caller can override the message list (used for multi-turn history).
+    # Default: system prompt + single user message.
+    if messages is None:
+        effective_messages: list[dict] = [
+            {"role": "system", "content": soul_text},
+            {"role": "user", "content": user_text},
+        ]
+    else:
+        # Caller supplies the conversation. We still inject SOUL as system
+        # to guarantee the profile's persona stays in force.
+        effective_messages = [
+            {"role": "system", "content": soul_text},
+            *messages,
+        ]
+
+    last_error: Optional[BaseException] = None
+
+    for model_spec in candidates:
+        if not model_spec:
+            continue
+        try:
+            provider, model_name = _split_model_spec(model_spec)
+        except ValueError:
+            continue
+        api_key = _resolve_api_key(provider, env_overrides, auth)
+        if not api_key:
+            continue
+        base_url = _resolve_base_url(provider, model_spec == primary, config)
+
+        client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        try:
+            stream = await client.chat.completions.create(
+                model=model_name,
+                messages=effective_messages,
+                max_tokens=512,
+                stream=True,
+            )
+            got_content = False
+            async for chunk in stream:
+                if not chunk.choices:
+                    continue
+                delta = chunk.choices[0].delta
+                if not delta:
+                    continue
+                # Reasoning models (e.g. GLM 5.1) stream reasoning_content
+                # BEFORE content; surfacing it gives the user real-time feedback
+                # instead of a 5-15s placeholder freeze.
+                reasoning = getattr(delta, "reasoning_content", None)
+                if reasoning:
+                    yield "thinking", reasoning
+                if delta.content:
+                    got_content = True
+                    yield "content", delta.content
+            if got_content:
+                return
+            logger.info("stream_run_agent: %s yielded no content, falling back", model_spec)
+        except Exception as exc:
+            last_error = exc
+            logger.info("stream_run_agent: %s failed (%s), falling back", model_spec, exc)
+
+    if last_error is not None:
+        raise RuntimeError(f"streaming failed; last error: {last_error}") from last_error
+    raise RuntimeError("streaming exhausted (no usable provider returned content)")
+
+
+async def real_run_agent(
+    event: Any,
+    profile_home: Path,
+    *,
+    messages: Optional[list[dict]] = None,
+) -> str:
+    """Run the inbound event through hermes' real AIAgent (with tool-loop).
+
+    Phase 4 — replaces the spike one-shot ``chat.completions.create`` call
+    with a full ``AIAgent.run_conversation()`` loop, so PR-added UAT tools
+    (e.g. feishu_calendar_list_events) actually fire. Sets
+    ``sender_open_id_scope`` so per-user UAT files are loaded correctly.
+
+    Falls back to the legacy thin LLM call (kept below as
+    ``_legacy_real_run_agent``) on any AIAgent failure so the spike-style
+    fallback path still answers the user — without tools, but at least with
+    a coherent reply.
+    """
+    try:
+        if messages is not None:
+            return await _run_aiagent_subprocess(event, profile_home, messages=messages)
+        return await _run_aiagent_subprocess(event, profile_home)
+    except Exception as exc:
+        logger.warning(
+            "[multitenancy] AIAgent path failed (%s); falling back to legacy spike",
+            exc, exc_info=True,
+        )
+    # Legacy / fallback path — no tool-loop, but still answers.
+    return await _legacy_real_run_agent(event, profile_home, messages=messages)
+
+
+async def _legacy_real_run_agent(
+    event: Any,
+    profile_home: Path,
+    *,
+    messages: Optional[list[dict]] = None,
+) -> str:
+    """Original spike implementation — kept as a fallback for the AIAgent path."""
+    from openai import AsyncOpenAI
+    from dotenv import dotenv_values
+
+    config = _load_yaml(profile_home / "config.yaml")
+    auth = _load_json(profile_home / "auth.json")
+    env_overrides = dotenv_values(profile_home / ".env") if (profile_home / ".env").exists() else {}
+
+    primary = config.get("model", {}).get("default")
+    fallback_models = config.get("fallback") or []
+    candidates: list[str] = [primary] if primary else []
+    candidates.extend(fallback_models)
+
+    soul_text = _load_soul(profile_home)
+    user_text = getattr(event, "text", "") or ""
+
+    if messages is None:
+        effective_messages: list[dict] = [
+            {"role": "system", "content": soul_text},
+            {"role": "user", "content": user_text},
+        ]
+    else:
+        effective_messages = [
+            {"role": "system", "content": soul_text},
+            *messages,
+        ]
+
+    last_error: Optional[BaseException] = None
+
+    for model_spec in candidates:
+        if not model_spec:
+            continue
+        try:
+            provider, model_name = _split_model_spec(model_spec)
+        except ValueError as exc:
+            logger.debug("real_run_agent: bad model spec %r: %s", model_spec, exc)
+            continue
+
+        api_key = _resolve_api_key(provider, env_overrides, auth)
+        if not api_key:
+            logger.debug("real_run_agent: no API key for provider %s", provider)
+            continue
+
+        base_url = _resolve_base_url(provider, model_spec == primary, config)
+
+        client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+        try:
+            rsp = await client.chat.completions.create(
+                model=model_name,
+                messages=effective_messages,
+                max_tokens=512,
+            )
+            text = (rsp.choices[0].message.content or "").strip()
+            if text:
+                logger.debug(
+                    "real_run_agent: %s ok (prompt=%d completion=%d)",
+                    model_spec,
+                    rsp.usage.prompt_tokens if rsp.usage else -1,
+                    rsp.usage.completion_tokens if rsp.usage else -1,
+                )
+                return text
+            # Empty content (often signals quota exhausted) — try next.
+            logger.info("real_run_agent: %s returned empty, falling back", model_spec)
+        except Exception as exc:
+            last_error = exc
+            logger.info("real_run_agent: %s failed (%s), falling back", model_spec, exc)
+
+    if last_error is not None:
+        raise RuntimeError(f"all providers failed; last error: {last_error}") from last_error
+    raise RuntimeError("all providers exhausted (no usable key or non-empty response)")
+
+
+# -- helpers ---------------------------------------------------------------
+
+
+def _split_model_spec(spec: str) -> tuple[str, str]:
+    """Split ``provider/model_name`` into its parts."""
+    if "/" not in spec:
+        raise ValueError(f"model spec missing provider prefix: {spec!r}")
+    provider, name = spec.split("/", 1)
+    return provider.strip().lower(), name.strip()
+
+
+def _resolve_api_key(
+    provider: str,
+    env_overrides: dict[str, Any],
+    auth: dict[str, Any],
+) -> Optional[str]:
+    """Find an API key for *provider* — env vars first, auth.json second."""
+    for env_name in _PROVIDER_ENV_KEYS.get(provider, ()):
+        key = env_overrides.get(env_name) or os.environ.get(env_name)
+        if key:
+            return key
+    pool = auth.get("credential_pool", {}).get(provider)
+    if isinstance(pool, list):
+        for cred in pool:
+            if not isinstance(cred, dict):
+                continue
+            if cred.get("last_status") == "exhausted":
+                continue
+            token = cred.get("access_token")
+            if token:
+                return token
+    return None
+
+
+def _resolve_base_url(provider: str, is_primary: bool, config: dict[str, Any]) -> Optional[str]:
+    """Resolve the API base URL for *provider*. Primary model honors config.model.base_url."""
+    if is_primary:
+        explicit = config.get("model", {}).get("base_url")
+        if explicit:
+            return explicit
+    return _PROVIDER_BASE_URLS.get(provider)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    import yaml
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {}
+
+
+def _load_soul(profile_home: Path) -> str:
+    """Read SOUL.md as the system prompt; fall back to a generic prompt."""
+    soul = profile_home / "SOUL.md"
+    if soul.exists():
+        text = soul.read_text().strip()
+        if text:
+            return text
+    return "You are a helpful assistant."
+
+
+def _resolve_shared_hermes_home(profile_home: Path) -> Path:
+    """Return the default Hermes root that stores cross-profile shared auth."""
+    explicit = os.getenv("HERMES_SHARED_HOME")
+    if explicit:
+        return Path(explicit).expanduser()
+    profile_home = Path(profile_home).expanduser()
+    if profile_home.parent.name == "profiles":
+        return profile_home.parent.parent
+    return profile_home
+
+
+def _configure_feishu_uat_home(feishu_oapi_module: Any, profile_home: Path) -> Path:
+    """Point Feishu UAT lookups at the shared Hermes root, not the profile dir."""
+    shared_home = _resolve_shared_hermes_home(profile_home)
+    feishu_oapi_module.FEISHU_UAT_PATH = shared_home / "feishu_uat.json"
+    feishu_oapi_module.FEISHU_UAT_DIR = shared_home / "feishu_uat"
+    return shared_home
+
+
+def _log_aiagent_tool_progress(
+    event_type: str,
+    tool_name: str,
+    preview: Any = None,
+    args: Any = None,
+    **kwargs: Any,
+) -> None:
+    """Persist AIAgent tool progress for gateway stress-test observability."""
+    if event_type == "tool.started":
+        logger.info("[multitenancy] tool.started %s preview=%s", tool_name, preview or "")
+    elif event_type == "tool.completed":
+        logger.info(
+            "[multitenancy] tool.completed %s duration=%.2fs error=%s",
+            tool_name,
+            float(kwargs.get("duration") or 0.0),
+            bool(kwargs.get("is_error")),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Isolated AIAgent subprocess bridge
+# ---------------------------------------------------------------------------
+
+
+def _jsonable(value: Any) -> Any:
+    """Return a JSON-safe representation for dataclass/enum-ish event fields."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    enum_value = getattr(value, "value", None)
+    if isinstance(enum_value, (str, int, float, bool)):
+        return enum_value
+    return str(value)
+
+
+def _jsonable_deep(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _jsonable_deep(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable_deep(v) for v in value]
+    return _jsonable(value)
+
+
+def _get_nested_value(obj: Any, path: tuple[str, ...]) -> Any:
+    cur = obj
+    for key in path:
+        if isinstance(cur, dict):
+            cur = cur.get(key)
+        else:
+            cur = getattr(cur, key, None)
+        if cur is None:
+            return None
+    return cur
+
+
+def _find_ou_value(obj: Any) -> str:
+    """Best-effort recursive search for a Feishu open_id in raw event data."""
+    if isinstance(obj, str):
+        return obj if obj.startswith("ou_") else ""
+    if isinstance(obj, dict):
+        for key in ("open_id", "openId"):
+            value = obj.get(key)
+            if isinstance(value, str) and value.startswith("ou_"):
+                return value
+        for value in obj.values():
+            found = _find_ou_value(value)
+            if found:
+                return found
+    elif isinstance(obj, (list, tuple)):
+        for value in obj:
+            found = _find_ou_value(value)
+            if found:
+                return found
+    return ""
+
+
+def _resolve_subprocess_sender_open_id(event: Any) -> str:
+    """Resolve sender ou_* for the child process after Feishu batching."""
+    try:
+        from tools.feishu_oapi_client import current_sender_open_id
+        current = current_sender_open_id.get()
+        if current and str(current).startswith("ou_"):
+            return str(current)
+    except Exception:
+        pass
+
+    source = getattr(event, "source", None)
+    for candidate in (
+        getattr(event, "sender_open_id", None),
+        getattr(source, "open_id", None) if source is not None else None,
+        getattr(source, "user_id", None) if source is not None else None,
+        getattr(source, "user_id_alt", None) if source is not None else None,
+    ):
+        if candidate and str(candidate).startswith("ou_"):
+            return str(candidate)
+
+    raw = getattr(event, "raw_message", None)
+    for path in (
+        ("event", "sender", "sender_id", "open_id"),
+        ("event", "message", "sender", "sender_id", "open_id"),
+        ("sender", "sender_id", "open_id"),
+        ("message", "sender", "sender_id", "open_id"),
+        ("sender_id", "open_id"),
+    ):
+        value = _get_nested_value(raw, path)
+        if value and str(value).startswith("ou_"):
+            return str(value)
+    return _find_ou_value(raw)
+
+
+def _jsonable_messages(messages: Optional[list[dict]]) -> list[dict] | None:
+    if not messages:
+        return None
+    payload_messages: list[dict] = []
+    for message in messages:
+        if isinstance(message, dict):
+            jsonable = _jsonable_deep(message)
+            if isinstance(jsonable, dict):
+                payload_messages.append(jsonable)
+    return payload_messages
+
+
+def _event_to_subprocess_payload(
+    event: Any,
+    profile_home: Path,
+    *,
+    messages: Optional[list[dict]] = None,
+) -> dict[str, Any]:
+    """Serialize the small MessageEvent surface needed by the child runner."""
+    source = getattr(event, "source", None)
+    source_payload: dict[str, Any] = {}
+    if source is not None:
+        for key in (
+            "platform",
+            "chat_id",
+            "chat_name",
+            "chat_type",
+            "user_id",
+            "user_name",
+            "thread_id",
+            "chat_topic",
+            "user_id_alt",
+            "chat_id_alt",
+            "is_bot",
+            "guild_id",
+            "parent_chat_id",
+            "message_id",
+        ):
+            if hasattr(source, key):
+                source_payload[key] = _jsonable(getattr(source, key))
+
+    message_id = (
+        getattr(event, "message_id", None)
+        or source_payload.get("message_id")
+        or ""
+    )
+    payload = {
+        "event": {
+            "text": getattr(event, "text", "") or "",
+            "message_id": _jsonable(message_id),
+            "sender_open_id": _resolve_subprocess_sender_open_id(event),
+            "source": source_payload,
+        },
+        "profile_home": str(profile_home),
+    }
+    payload_messages = _jsonable_messages(messages)
+    if payload_messages is not None:
+        payload["messages"] = payload_messages
+    return payload
+
+
+async def _run_aiagent_subprocess(
+    event: Any,
+    profile_home: Path,
+    *,
+    messages: Optional[list[dict]] = None,
+) -> str:
+    """Run the sync AIAgent body in a fresh Python process.
+
+    The gateway stays fully async while the child process owns the synchronous
+    AIAgent/tool loop. This avoids the gateway event-loop deadlock observed
+    when ``_run_with_aiagent`` runs through ``asyncio.to_thread``.
+    """
+    import asyncio
+
+    payload = json.dumps(
+        _event_to_subprocess_payload(event, profile_home, messages=messages),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    timeout_s = float(os.getenv("HERMES_AIAGENT_SUBPROCESS_TIMEOUT", "300"))
+    env = os.environ.copy()
+    env["HERMES_SHARED_HOME"] = str(_resolve_shared_hermes_home(profile_home))
+    env["HERMES_HOME"] = str(profile_home)
+    child_script = Path(__file__).with_name("aiagent_subprocess.py")
+
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        str(child_script),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(payload), timeout_s)
+    except asyncio.TimeoutError as exc:
+        proc.kill()
+        await proc.wait()
+        raise RuntimeError(f"AIAgent subprocess timed out after {timeout_s:g}s") from exc
+    except asyncio.CancelledError:
+        proc.kill()
+        await proc.wait()
+        raise
+
+    stderr_text = stderr.decode("utf-8", errors="replace").strip()
+    stdout_text = stdout.decode("utf-8", errors="replace").strip()
+    if stderr_text:
+        logger.debug("[multitenancy] AIAgent subprocess stderr: %s", stderr_text[-4000:])
+
+    try:
+        data = json.loads(stdout_text)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "AIAgent subprocess returned invalid JSON "
+            f"(exit={proc.returncode}, stdout={stdout_text[-1000:]!r}, stderr={stderr_text[-1000:]!r})"
+        ) from exc
+
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"AIAgent subprocess exited {proc.returncode}: "
+            f"{data.get('error') or stderr_text or stdout_text}"
+        )
+    if data.get("error"):
+        raise RuntimeError(f"AIAgent subprocess failed: {data['error']}")
+    return str(data.get("result") or "")
+
+
+async def _stream_aiagent_subprocess(
+    event: Any,
+    profile_home: Path,
+    *,
+    messages: Optional[list[dict]] = None,
+):
+    """Run AIAgent in a child process and yield its NDJSON progress events."""
+    import asyncio
+
+    payload = json.dumps(
+        _event_to_subprocess_payload(event, profile_home, messages=messages),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    timeout_s = float(os.getenv("HERMES_AIAGENT_SUBPROCESS_TIMEOUT", "300"))
+    env = os.environ.copy()
+    env["HERMES_SHARED_HOME"] = str(_resolve_shared_hermes_home(profile_home))
+    env["HERMES_HOME"] = str(profile_home)
+    env["HERMES_AIAGENT_EVENT_STREAM"] = "1"
+    child_script = Path(__file__).with_name("aiagent_subprocess.py")
+
+    started_at = time.monotonic()
+    logger.info(
+        "[multitenancy] AIAgent subprocess spawning profile_home=%s timeout=%.1fs",
+        profile_home,
+        timeout_s,
+    )
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        str(child_script),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    logger.info(
+        "[multitenancy] AIAgent subprocess spawned pid=%s elapsed=%.3fs",
+        proc.pid,
+        time.monotonic() - started_at,
+    )
+    stderr_task = asyncio.create_task(proc.stderr.read())
+    saw_done = False
+    first_event_logged = False
+    try:
+        assert proc.stdin is not None
+        proc.stdin.write(payload)
+        await proc.stdin.drain()
+        proc.stdin.close()
+        try:
+            await proc.stdin.wait_closed()
+        except Exception:
+            pass
+
+        assert proc.stdout is not None
+        while True:
+            line = await asyncio.wait_for(proc.stdout.readline(), timeout=timeout_s)
+            if not line:
+                break
+            text = line.decode("utf-8", errors="replace").strip()
+            if not text:
+                continue
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError:
+                logger.debug("[multitenancy] ignoring non-json child stream line: %r", text[-500:])
+                continue
+            event_name = data.get("event")
+            if not first_event_logged:
+                first_event_logged = True
+                logger.info(
+                    "[multitenancy] AIAgent subprocess first event kind=%s elapsed=%.3fs",
+                    event_name,
+                    time.monotonic() - started_at,
+                )
+            if event_name == "done":
+                saw_done = True
+                if data.get("error"):
+                    raise RuntimeError(f"AIAgent subprocess failed: {data['error']}")
+                logger.info(
+                    "[multitenancy] AIAgent subprocess done elapsed=%.3fs result_len=%s",
+                    time.monotonic() - started_at,
+                    len(str(data.get("result") or "")),
+                )
+                yield "done", str(data.get("result") or "")
+                continue
+            if event_name == "content":
+                yield "content", str(data.get("text") or "")
+            elif event_name == "thinking":
+                yield "thinking", str(data.get("text") or "")
+            elif event_name in {"tool_started", "tool_completed"}:
+                payload_data = {k: v for k, v in data.items() if k != "event"}
+                yield str(event_name), payload_data
+            else:
+                logger.debug("[multitenancy] ignoring unknown child stream event: %s", event_name)
+
+        returncode = await asyncio.wait_for(proc.wait(), timeout=5)
+        stderr_text = (await stderr_task).decode("utf-8", errors="replace").strip()
+        if stderr_text:
+            logger.debug("[multitenancy] AIAgent subprocess stderr: %s", stderr_text[-4000:])
+        logger.info(
+            "[multitenancy] AIAgent subprocess exited returncode=%s elapsed=%.3fs",
+            returncode,
+            time.monotonic() - started_at,
+        )
+        if returncode != 0:
+            raise RuntimeError(f"AIAgent subprocess exited {returncode}: {stderr_text[-1000:]}")
+        if not saw_done:
+            raise RuntimeError("AIAgent subprocess stream ended without done event")
+    except asyncio.CancelledError:
+        proc.kill()
+        await proc.wait()
+        raise
+    except Exception:
+        if proc.returncode is None:
+            proc.kill()
+            await proc.wait()
+        raise
+    finally:
+        if proc.returncode is None:
+            proc.kill()
+            await proc.wait()
+        if not stderr_task.done():
+            stderr_task.cancel()
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — real AIAgent runner with tool-loop (replaces the spike one-shot)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_sender_open_id(event: Any) -> str:
+    """Pick the real Feishu open_id (ou_*) from the event source for UAT lookup.
+
+    Prefer source.user_id (typical Feishu open_id); fall back to user_id_alt
+    when the former is a union_id (on_*). Returns "" if nothing usable is found.
+    """
+    source = getattr(event, "source", None)
+    event_sender = getattr(event, "sender_open_id", None)
+    if event_sender and str(event_sender).startswith("ou_"):
+        return str(event_sender)
+    if source is None:
+        return ""
+    for candidate in (
+        getattr(source, "open_id", None),
+        getattr(source, "user_id", None),
+        getattr(source, "user_id_alt", None),
+    ):
+        if candidate and str(candidate).startswith("ou_"):
+            return str(candidate)
+    # Fallback: any non-empty user_id, even if not ou_-prefixed
+    return str(getattr(source, "user_id", "") or "")
+
+
+def _session_part(value: Any, default: str = "unknown") -> str:
+    text = str(value or "").strip() or default
+    safe = "".join(ch if (ch.isalnum() or ch in "._:-") else "_" for ch in text)
+    return safe[:160] or default
+
+
+def _resolve_platform_value(source: Any, default: str = "feishu") -> str:
+    if source is None:
+        return default
+    platform = getattr(source, "platform", None)
+    return str(getattr(platform, "value", None) or platform or default)
+
+
+def _resolve_aiagent_session_id(
+    event: Any,
+    profile_home: Path,
+    sender_open_id: str = "",
+) -> str:
+    """Build a stable, per-profile/per-user AIAgent session id.
+
+    Feishu ``message_id`` changes every turn, so it must only be a last-ditch
+    fallback. Keeping profile and sender in the key prevents cross-tenant or
+    cross-user history bleed when multiple Feishu users hit the same bot.
+    """
+    source = getattr(event, "source", None)
+    platform = _resolve_platform_value(source)
+    chat_type = getattr(source, "chat_type", "") if source else ""
+    chat_id = (
+        getattr(source, "chat_id", None)
+        or getattr(source, "parent_chat_id", None)
+        or getattr(source, "chat_id_alt", None)
+        if source
+        else ""
+    )
+    thread_id = (
+        getattr(source, "thread_id", None)
+        or getattr(source, "chat_topic", None)
+        if source
+        else ""
+    )
+    user_id = (
+        sender_open_id
+        or (getattr(source, "user_id", None) if source else "")
+        or (getattr(source, "user_id_alt", None) if source else "")
+    )
+    message_id = (
+        getattr(event, "message_id", None)
+        or (getattr(source, "message_id", None) if source else "")
+    )
+
+    parts = [
+        "agent",
+        "profile",
+        profile_home.name,
+        "platform",
+        platform,
+        "chat_type",
+        chat_type or "unknown",
+    ]
+    if chat_id:
+        parts.extend(["chat", chat_id])
+    if thread_id:
+        parts.extend(["thread", thread_id])
+    if user_id:
+        parts.extend(["user", user_id])
+    elif message_id:
+        parts.extend(["message", message_id])
+    else:
+        parts.append("fallback")
+
+    session_id = ":".join(_session_part(part) for part in parts)
+    if len(session_id) <= 220:
+        return session_id
+    digest = hashlib.sha1(session_id.encode("utf-8")).hexdigest()[:12]
+    return f"{session_id[:200]}:{digest}"
+
+
+def _conversation_history_for_aiagent(
+    messages: Optional[list[dict]],
+    user_text: str,
+) -> Optional[list[dict]]:
+    if not messages:
+        return None
+    history = [dict(message) for message in messages if isinstance(message, dict)]
+    if (
+        history
+        and history[-1].get("role") == "user"
+        and str(history[-1].get("content") or "") == user_text
+    ):
+        history = history[:-1]
+    return history or None
+
+
+def _run_with_aiagent(
+    event: Any,
+    profile_home: Path,
+    *,
+    messages: Optional[list[dict]] = None,
+    event_sink=None,
+) -> str:
+    """Synchronous body — runs hermes' real AIAgent against the profile config.
+
+    Constructs an AIAgent with the profile's enabled toolsets + LLM
+    credentials, sets the per-user open_id contextvar so UAT tools load the
+    right token file, and runs a full tool-loop conversation.
+
+    Designed to run inside ``aiagent_subprocess.py`` so the parent gateway
+    keeps its async event loop isolated from the synchronous AIAgent/tool loop.
+    """
+    # 1) Anchor HERMES_HOME so any module that reads it sees the profile.
+    os.environ["HERMES_HOME"] = str(profile_home)
+
+    # 2) Read profile LLM config + credentials (mirrors the spike loader).
+    config = _load_yaml(profile_home / "config.yaml")
+    auth = _load_json(profile_home / "auth.json")
+    from dotenv import dotenv_values
+    env_overrides = dict(
+        dotenv_values(profile_home / ".env")
+        if (profile_home / ".env").exists()
+        else {}
+    )
+
+    primary = (config.get("model") or {}).get("default")
+    if not primary:
+        raise RuntimeError("profile config missing model.default")
+    fallback_models = config.get("fallback") or []
+
+    provider, model_only = _split_model_spec(primary)
+    api_key = _resolve_api_key(provider, env_overrides, auth)
+    if not api_key:
+        raise RuntimeError(f"no API key for primary provider {provider!r}")
+
+    base_url = _resolve_base_url(provider, True, config)
+
+    # 3) Lazy-import hermes core (only when this code path is hit).
+    from run_agent import AIAgent
+    from tools import feishu_oapi_client as feishu_oapi
+    sender_open_id_scope = feishu_oapi.sender_open_id_scope
+    current_sender_open_id = feishu_oapi.current_sender_open_id
+    shared_hermes_home = _configure_feishu_uat_home(feishu_oapi, profile_home)
+    if shared_hermes_home != profile_home:
+        logger.info(
+            "[multitenancy] using shared Feishu UAT dir: %s",
+            shared_hermes_home / "feishu_uat",
+        )
+    try:
+        from hermes_cli.tools_config import _get_platform_tools
+    except Exception:
+        _get_platform_tools = None  # graceful: fall back to None toolsets
+
+    # 4) Resolve toolsets enabled for this platform on this profile.
+    platform_key = "feishu"
+    enabled_toolsets = _resolve_enabled_toolsets(
+        config,
+        platform_key,
+        platform_tools_resolver=_get_platform_tools,
+    )
+
+    # 5) Sender's real Feishu open_id (ou_*) for per-user UAT routing.
+    # The feishu adapter already set this contextvar in
+    # _process_inbound_message before dispatching us — prefer that value
+    # because it comes straight from sender_id.open_id (the SDK gives the
+    # ou_* form). Only fall back to event.source on weird code paths
+    # (e.g., synthetic events constructed without going through the adapter).
+    sender_open_id = (current_sender_open_id.get() or "") or _resolve_sender_open_id(event)
+
+    # 6) Pull source / session metadata for AIAgent kwargs.
+    source = getattr(event, "source", None)
+    user_text = getattr(event, "text", "") or ""
+    session_id = _resolve_aiagent_session_id(event, profile_home, sender_open_id)
+    conversation_history = _conversation_history_for_aiagent(messages, user_text)
+
+    runtime_kwargs: dict[str, Any] = {"api_key": api_key}
+    if base_url:
+        runtime_kwargs["base_url"] = base_url
+
+    fallback_model = fallback_models[0] if fallback_models else None
+
+    # 7) Wrap the agent run in sender_open_id_scope so per-user UAT tools
+    #    pick up the right token from ~/.hermes/feishu_uat/<open_id>.json.
+    logger.info(
+        "[multitenancy] running AIAgent for sender=%s profile=%s toolsets=%s",
+        sender_open_id, profile_home.name,
+        enabled_toolsets if enabled_toolsets is not None else "<default>",
+    )
+    logger.info(
+        "[multitenancy] Feishu UAT lookup sender=%s dir=%s",
+        sender_open_id,
+        shared_hermes_home / "feishu_uat",
+    )
+    with sender_open_id_scope(sender_open_id or None):
+        try:
+            from gateway.session_context import clear_session_vars, set_session_vars
+        except Exception:
+            clear_session_vars = None
+            set_session_vars = None
+
+        platform_value = str(
+            getattr(getattr(source, "platform", ""), "value", None)
+            or getattr(source, "platform", "")
+            or platform_key
+        )
+        session_tokens = None
+        if set_session_vars is not None:
+            session_tokens = set_session_vars(
+                platform=platform_value,
+                chat_id=str(getattr(source, "chat_id", "") or "") if source else "",
+                chat_name=str(getattr(source, "chat_name", "") or "") if source else "",
+                thread_id=str(getattr(source, "thread_id", "") or "") if source else "",
+                user_id=str(getattr(source, "user_id", "") or "") if source else "",
+                user_name=str(getattr(source, "user_name", "") or "") if source else "",
+                session_key=str(session_id),
+            )
+        def _emit(event_name: str, **payload: Any) -> None:
+            if event_sink is None:
+                return
+            try:
+                event_sink(event_name, **payload)
+            except Exception:
+                logger.debug("[multitenancy] event_sink failed", exc_info=True)
+
+        def _tool_progress_event_callback(
+            event_type: str,
+            tool_name: str,
+            preview: Any = None,
+            args: Any = None,
+            **kwargs: Any,
+        ) -> None:
+            _log_aiagent_tool_progress(event_type, tool_name, preview, args, **kwargs)
+            if event_type == "tool.started":
+                _emit(
+                    "tool_started",
+                    name=str(tool_name or ""),
+                    preview=str(preview or "") if preview is not None else None,
+                )
+            elif event_type == "tool.completed":
+                _emit(
+                    "tool_completed",
+                    name=str(tool_name or ""),
+                    duration=float(kwargs.get("duration") or 0.0),
+                    is_error=bool(kwargs.get("is_error")),
+                )
+            elif event_type in {"reasoning.available", "_thinking"}:
+                text = str(preview or tool_name or "")
+                if text:
+                    _emit("thinking", text=text)
+
+        def _stream_delta_event_callback(text: Any) -> None:
+            if text is None:
+                return
+            text = str(text)
+            if text:
+                _emit("content", text=text)
+
+        def _reasoning_event_callback(text: Any) -> None:
+            if text is None:
+                return
+            text = str(text)
+            if text:
+                _emit("thinking", text=text)
+
+        def _tool_gen_event_callback(tool_name: str) -> None:
+            if tool_name:
+                _emit("tool_started", name=str(tool_name), preview="generating arguments")
+
+        agent_kwargs: dict[str, Any] = {
+            # AIAgent expects the bare model name (e.g. "glm-5.1"), not the
+            # provider-prefixed form. Provider was already used above to
+            # resolve api_key + base_url; the prefix would otherwise be
+            # forwarded verbatim to the OpenAI client and rejected with
+            # `1211 Unknown Model`.
+            "model": model_only,
+            **runtime_kwargs,
+            "max_iterations": int(os.getenv("HERMES_MAX_ITERATIONS", "30")),
+            "quiet_mode": True,
+            "verbose_logging": False,
+            "session_id": str(session_id),
+            "platform": platform_key,
+            "user_id": str(getattr(source, "user_id", "") or "") if source else "",
+            "user_name": str(getattr(source, "user_name", "") or "") if source else "",
+            "chat_id": str(getattr(source, "chat_id", "") or "") if source else "",
+            "chat_name": str(getattr(source, "chat_name", "") or "") if source else "",
+            "chat_type": str(getattr(source, "chat_type", "") or "") if source else "",
+            "tool_progress_callback": _tool_progress_event_callback,
+            "stream_delta_callback": _stream_delta_event_callback if event_sink is not None else None,
+            "reasoning_callback": _reasoning_event_callback if event_sink is not None else None,
+            "tool_gen_callback": _tool_gen_event_callback if event_sink is not None else None,
+        }
+        if enabled_toolsets is not None:
+            agent_kwargs["enabled_toolsets"] = enabled_toolsets
+        if fallback_model:
+            agent_kwargs["fallback_model"] = fallback_model
+
+        agent = AIAgent(**agent_kwargs)
+        try:
+            run_kwargs: dict[str, Any] = {
+                "user_message": user_text,
+                "task_id": str(session_id),
+            }
+            if conversation_history is not None:
+                run_kwargs["conversation_history"] = conversation_history
+            result = agent.run_conversation(**run_kwargs)
+        finally:
+            if clear_session_vars is not None and session_tokens is not None:
+                clear_session_vars(session_tokens)
+            try:
+                if hasattr(agent, "cleanup"):
+                    agent.cleanup()
+            except Exception:
+                pass
+
+    return (result or {}).get("final_response", "") or ""
+
+
+def _resolve_enabled_toolsets(
+    config: dict[str, Any],
+    platform_key: str,
+    *,
+    platform_tools_resolver: Any,
+) -> Optional[list[str]]:
+    """Resolve profile toolsets without dropping core non-Feishu abilities.
+
+    A plain Hermes Feishu gateway defaults to the composite ``hermes-feishu``
+    toolset, which includes web/search/browser/file/etc. During multitenant
+    UAT it is common to add ``platform_toolsets.feishu`` only for Feishu user
+    token helpers; treating that list as a hard replacement makes the agent
+    look competent inside Feishu but unable to search the web.
+
+    Default mode therefore merges explicit profile entries with the platform
+    default. Set ``multitenancy.toolsets_mode: explicit`` or
+    ``HERMES_MULTITENANCY_TOOLSETS_MODE=explicit`` to preserve the old strict
+    replacement behavior for providers that need a smaller schema.
+    """
+    explicit = (config.get("platform_toolsets") or {}).get(platform_key)
+    explicit_toolsets = _normalize_toolset_list(explicit)
+    mode = _toolsets_mode(config)
+
+    if explicit_toolsets and mode in {"explicit", "strict", "replace"}:
+        logger.info(
+            "[multitenancy] platform_toolsets explicit mode for %s: %s",
+            platform_key, explicit_toolsets,
+        )
+        return explicit_toolsets
+
+    default_toolsets: list[str] = []
+    if platform_tools_resolver is not None:
+        resolver_config = config
+        if explicit_toolsets:
+            import copy
+
+            resolver_config = copy.deepcopy(config)
+            platform_toolsets = resolver_config.get("platform_toolsets")
+            if isinstance(platform_toolsets, dict):
+                platform_toolsets.pop(platform_key, None)
+        try:
+            try:
+                resolved = platform_tools_resolver(
+                    resolver_config,
+                    platform_key,
+                    include_default_mcp_servers=("no_mcp" not in explicit_toolsets),
+                )
+            except TypeError:
+                resolved = platform_tools_resolver(resolver_config, platform_key)
+            default_toolsets = _normalize_toolset_list(resolved)
+        except Exception as exc:
+            logger.warning(
+                "[multitenancy] _get_platform_tools failed for %s: %s",
+                platform_key, exc,
+            )
+
+    if explicit_toolsets:
+        merged = sorted(set(default_toolsets) | set(explicit_toolsets))
+        logger.info(
+            "[multitenancy] platform_toolsets merged for %s: explicit=%s default=%s merged=%s",
+            platform_key, explicit_toolsets, default_toolsets, merged,
+        )
+        return merged
+
+    return default_toolsets or None
+
+
+def _normalize_toolset_list(value: Any) -> list[str]:
+    """Return a sorted list of non-empty string toolset names."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        items = value
+    elif isinstance(value, (set, tuple)):
+        items = list(value)
+    else:
+        return []
+    return sorted({str(item).strip() for item in items if str(item).strip()})
+
+
+def _toolsets_mode(config: dict[str, Any]) -> str:
+    """Return multitenancy toolset resolution mode."""
+    env_mode = os.getenv("HERMES_MULTITENANCY_TOOLSETS_MODE")
+    if env_mode:
+        return env_mode.strip().lower()
+    plugin_cfg = config.get("multitenancy") or {}
+    if isinstance(plugin_cfg, dict):
+        mode = plugin_cfg.get("toolsets_mode")
+        if mode:
+            return str(mode).strip().lower()
+    return "merge_default"

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/aiagent_subprocess.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/aiagent_subprocess.py
@@ -1,0 +1,129 @@
+"""Subprocess entry point for running AIAgent in isolation.
+
+Avoids the gateway-async-loop ↔ AIAgent-sync deadlock that occurs when
+``_run_with_aiagent`` is called via ``asyncio.to_thread`` from the gateway's
+event loop. Hermes' ``agent.run_conversation`` internally uses sync HTTP /
+nested loops that conflict with the parent async context.
+
+The fix: shell out to a fresh Python process with no parent event loop.
+Cost: ~0.5-1s extra startup per message.
+
+I/O contract:
+  stdin:  JSON {"event": {...}, "profile_home": "/path/to/profile", "messages": [...]}
+  stdout: JSON {"result": "...", "error": null}  on success
+          JSON {"result": "", "error": "..."}    on failure
+  exit:   0 always (errors are reported via JSON)
+
+The event dict must contain at minimum: text, message_id, source.* fields
+(open_id, user_id, user_name, chat_id, chat_name, chat_type, platform).
+"""
+
+import json
+import os
+import sys
+import traceback
+import importlib.util
+from pathlib import Path
+
+
+class _ReplayedSource:
+    """Reconstruct event.source from a flat dict."""
+    def __init__(self, d: dict):
+        for k, v in (d or {}).items():
+            setattr(self, k, v)
+
+
+class _ReplayedEvent:
+    """Reconstruct a MessageEvent-shaped object from a flat dict."""
+    def __init__(self, d: dict):
+        self.text = d.get("text", "")
+        self.message_id = d.get("message_id", "")
+        self.sender_open_id = d.get("sender_open_id", "")
+        self.source = _ReplayedSource(d.get("source") or {})
+
+
+def _load_run_with_aiagent():
+    """Load sibling agent_real regardless of package name used by Hermes."""
+    try:
+        from hermes_multitenancy.agent_real import _run_with_aiagent
+        return _run_with_aiagent
+    except ModuleNotFoundError as exc:
+        if exc.name != "hermes_multitenancy":
+            raise
+
+    agent_real_path = Path(__file__).with_name("agent_real.py")
+    spec = importlib.util.spec_from_file_location(
+        "_hermes_multitenancy_agent_real",
+        agent_real_path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load agent_real from {agent_real_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module._run_with_aiagent
+
+
+def main() -> None:
+    payload = json.loads(sys.stdin.read())
+    event = _ReplayedEvent(payload["event"])
+    profile_home = Path(payload["profile_home"])
+    messages = payload.get("messages")
+    if not isinstance(messages, list):
+        messages = None
+
+    # Lazy import so import errors are reported as JSON, not crash
+    _run_with_aiagent = _load_run_with_aiagent()
+
+    protocol_stdout = sys.stdout
+    event_stream = os.getenv("HERMES_AIAGENT_EVENT_STREAM") == "1"
+
+    def emit(event: str, **payload) -> None:
+        protocol_stdout.write(json.dumps({"event": event, **payload}, ensure_ascii=False) + "\n")
+        protocol_stdout.flush()
+
+    try:
+        # stdout is the parent/child JSON protocol. Send any incidental prints
+        # from Hermes core, providers, or tools to stderr so the parent can
+        # parse stdout deterministically.
+        sys.stdout = sys.stderr
+        if event_stream:
+            if messages is None:
+                result = _run_with_aiagent(event, profile_home, event_sink=emit)
+            else:
+                result = _run_with_aiagent(
+                    event,
+                    profile_home,
+                    messages=messages,
+                    event_sink=emit,
+                )
+            out = {"event": "done", "result": result or "", "error": None}
+        else:
+            if messages is None:
+                result = _run_with_aiagent(event, profile_home)
+            else:
+                result = _run_with_aiagent(event, profile_home, messages=messages)
+            out = {"result": result or "", "error": None}
+    except Exception as exc:
+        if event_stream:
+            out = {
+                "event": "done",
+                "result": "",
+                "error": f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}",
+            }
+        else:
+            out = {
+                "result": "",
+                "error": f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}",
+            }
+    finally:
+        sys.stdout = protocol_stdout
+
+    protocol_stdout.write(json.dumps(out, ensure_ascii=False))
+    if event_stream:
+        protocol_stdout.write("\n")
+    protocol_stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/commands.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/commands.py
@@ -1,24 +1,73 @@
-"""Slash command dispatch for the multitenancy plugin.
+"""Slash command helpers for the multitenancy plugin.
 
-Hermes' built-in command handlers (in ``GatewayRunner._handle_message``) only
-fire when the gateway main flow handles a message. Since the multitenancy
-plugin returns ``{"action": "skip"}`` from ``pre_gateway_dispatch``, the main
-flow never runs — so we own these commands ourselves.
-
-The plugin owns a small fixed set of operational commands:
-``/stop``, ``/status``, ``/new``, ``/reset``, and ``/help``.
+The router consumes Feishu messages before Hermes' normal gateway dispatcher,
+so slash commands must be recognized here. Recognition is intentionally
+derived from Hermes' central command registry when available; the small
+fallback only keeps the plugin testable outside a Hermes checkout.
 """
 from __future__ import annotations
 
 from typing import Optional
 
-# Commands the plugin owns. Anything else falls through to dispatch (where the
-# router treats it as a normal user message).
-_KNOWN_COMMANDS = frozenset({"stop", "status", "new", "reset", "help"})
+
+_FALLBACK_ALIASES = {
+    "provider": "model",
+    "reset": "new",
+    "bg": "background",
+    "btw": "background",
+    "tasks": "agents",
+    "q": "queue",
+    "fork": "branch",
+    "set-home": "sethome",
+    "reload_mcp": "reload-mcp",
+}
+
+_FALLBACK_GATEWAY_COMMANDS = frozenset(
+    {
+        "agents",
+        "approve",
+        "background",
+        "branch",
+        "commands",
+        "compress",
+        "debug",
+        "deny",
+        "fast",
+        "help",
+        "insights",
+        "model",
+        "new",
+        "personality",
+        "profile",
+        "queue",
+        "reasoning",
+        "reload-mcp",
+        "restart",
+        "resume",
+        "retry",
+        "rollback",
+        "sethome",
+        "status",
+        "steer",
+        "stop",
+        "title",
+        "undo",
+        "update",
+        "usage",
+        "verbose",
+        "voice",
+        "yolo",
+    }
+)
 
 
 def parse_command(text: str) -> Optional[tuple[str, str]]:
-    """Parse a slash command. Returns (cmd, args) or None."""
+    """Parse a slash command. Returns ``(canonical_command, args)`` or ``None``.
+
+    Unknown slash commands are still returned so the router can send Hermes'
+    native unknown-command guidance instead of leaking ``/unknown`` into the
+    LLM as a normal prompt.
+    """
     if not text or not text.startswith("/"):
         return None
     parts = text.split(maxsplit=1)
@@ -27,6 +76,48 @@ def parse_command(text: str) -> Optional[tuple[str, str]]:
     # Reject paths and known-bad shapes
     if "/" in raw or not raw:
         return None
-    if raw in _KNOWN_COMMANDS:
-        return (raw, args)
+    canonical = resolve_command_name(raw) or raw
+    return (canonical, args)
+
+
+def resolve_command_name(name: str) -> Optional[str]:
+    """Return Hermes' canonical command name when ``name`` is gateway-known."""
+    raw = name.lower().lstrip("/")
+    hyphenated = raw.replace("_", "-")
+    try:
+        from hermes_cli.commands import (  # type: ignore
+            is_gateway_known_command,
+            resolve_command,
+        )
+
+        cmd_def = resolve_command(raw) or resolve_command(hyphenated)
+        if cmd_def is not None:
+            canonical = getattr(cmd_def, "name", raw)
+            if is_gateway_known_command(raw) or is_gateway_known_command(hyphenated) or is_gateway_known_command(canonical):
+                return str(canonical)
+        if is_gateway_known_command(raw):
+            return raw
+        if is_gateway_known_command(hyphenated):
+            return hyphenated
+    except Exception:
+        pass
+
+    canonical = _FALLBACK_ALIASES.get(raw) or _FALLBACK_ALIASES.get(hyphenated) or hyphenated
+    if canonical in _FALLBACK_GATEWAY_COMMANDS:
+        return canonical
     return None
+
+
+def is_known_command(name: str) -> bool:
+    """Return True when ``name`` is recognized by Hermes' gateway command set."""
+    return resolve_command_name(name) is not None
+
+
+def unknown_command_message(command: str) -> str:
+    """Match Hermes' gateway wording for unknown slash commands."""
+    raw = command.lower().lstrip("/")
+    return (
+        f"Unknown command `/{raw}`. "
+        "Type /commands to see what's available, "
+        "or resend without the leading slash to send as a regular message."
+    )

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/commands.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/commands.py
@@ -1,0 +1,32 @@
+"""Slash command dispatch for the multitenancy plugin.
+
+Hermes' built-in command handlers (in ``GatewayRunner._handle_message``) only
+fire when the gateway main flow handles a message. Since the multitenancy
+plugin returns ``{"action": "skip"}`` from ``pre_gateway_dispatch``, the main
+flow never runs — so we own these commands ourselves.
+
+The plugin owns a small fixed set of operational commands:
+``/stop``, ``/status``, ``/new``, ``/reset``, and ``/help``.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+# Commands the plugin owns. Anything else falls through to dispatch (where the
+# router treats it as a normal user message).
+_KNOWN_COMMANDS = frozenset({"stop", "status", "new", "reset", "help"})
+
+
+def parse_command(text: str) -> Optional[tuple[str, str]]:
+    """Parse a slash command. Returns (cmd, args) or None."""
+    if not text or not text.startswith("/"):
+        return None
+    parts = text.split(maxsplit=1)
+    raw = parts[0][1:].lower()
+    args = parts[1] if len(parts) > 1 else ""
+    # Reject paths and known-bad shapes
+    if "/" in raw or not raw:
+        return None
+    if raw in _KNOWN_COMMANDS:
+        return (raw, args)
+    return None

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/pool.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/pool.py
@@ -1,0 +1,178 @@
+"""LRU RuntimePool: bounded in-memory cache of ProfileRuntime instances.
+
+Configurable parameters:
+  - max_loaded_runtimes: cache cap (default 50)
+  - idle_evict_seconds: drop entries idle longer than this (default 300)
+  - cold_start_concurrency: limit concurrent cold-starts (default 8)
+  - inflight_timeout_seconds: cancel a dispatch hung > this (default 600)
+  - inflight_no_evict: never evict a runtime currently dispatching
+
+Eviction strategy: lazy. Every ``acquire()`` call sweeps idle entries first.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Optional
+
+from .runtime import ProfileRuntime
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_LOADED = 50
+DEFAULT_IDLE_EVICT = 300.0
+DEFAULT_COLD_START_CONCURRENCY = 8
+DEFAULT_INFLIGHT_TIMEOUT = 600.0
+
+
+@dataclass
+class _PoolEntry:
+    profile_name: str
+    runtime: ProfileRuntime
+    last_used: float = field(default_factory=time.time)
+    in_flight: int = 0
+
+
+# A factory takes (profile_name, profile_home) and returns a fresh runtime.
+RuntimeFactory = Callable[[str, Path], ProfileRuntime]
+
+
+def _default_factory(profile_name: str, profile_home: Path) -> ProfileRuntime:
+    return ProfileRuntime(profile_home=profile_home)
+
+
+class RuntimePool:
+    """Bounded LRU cache of profile runtimes with cold-start throttling.
+
+    Use as::
+
+        pool = RuntimePool()
+        async with pool.dispatch("alice", profile_home, event) as response:
+            ...
+    """
+
+    def __init__(
+        self,
+        *,
+        max_loaded_runtimes: int = DEFAULT_MAX_LOADED,
+        idle_evict_seconds: float = DEFAULT_IDLE_EVICT,
+        cold_start_concurrency: int = DEFAULT_COLD_START_CONCURRENCY,
+        inflight_timeout_seconds: float = DEFAULT_INFLIGHT_TIMEOUT,
+        runtime_factory: RuntimeFactory = _default_factory,
+        time_fn: Callable[[], float] = time.time,
+    ) -> None:
+        self.max_loaded_runtimes = max_loaded_runtimes
+        self.idle_evict_seconds = idle_evict_seconds
+        self.inflight_timeout_seconds = inflight_timeout_seconds
+        self._factory = runtime_factory
+        self._now = time_fn
+        self._entries: "OrderedDict[str, _PoolEntry]" = OrderedDict()
+        self._cold_start_sem = asyncio.Semaphore(cold_start_concurrency)
+        # Lock-free LRU manipulation under asyncio cooperative scheduling.
+
+    # -- queries -----------------------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def loaded_profiles(self) -> list[str]:
+        return list(self._entries.keys())
+
+    def in_flight_count(self, profile_name: str) -> int:
+        entry = self._entries.get(profile_name)
+        return entry.in_flight if entry else 0
+
+    # -- core API ----------------------------------------------------------
+
+    async def dispatch(
+        self,
+        profile_name: str,
+        profile_home: Path,
+        event: Any,
+    ) -> str:
+        """Acquire (or cold-start) the runtime, run dispatch, release.
+
+        Honors ``inflight_timeout_seconds`` via ``asyncio.wait_for``.
+        """
+        entry = await self._acquire(profile_name, profile_home)
+        try:
+            return await asyncio.wait_for(
+                entry.runtime.dispatch(event),
+                timeout=self.inflight_timeout_seconds,
+            )
+        finally:
+            entry.in_flight -= 1
+            entry.last_used = self._now()
+
+    # -- helpers -----------------------------------------------------------
+
+    async def _acquire(self, profile_name: str, profile_home: Path) -> _PoolEntry:
+        # Lazy idle sweep on every acquire.
+        self._evict_idle_inplace()
+
+        existing = self._entries.get(profile_name)
+        if existing is not None:
+            self._entries.move_to_end(profile_name)
+            existing.in_flight += 1
+            existing.last_used = self._now()
+            return existing
+
+        # Cold-start path — throttled by semaphore.
+        async with self._cold_start_sem:
+            # Re-check after acquiring sem: another task may have created it.
+            existing = self._entries.get(profile_name)
+            if existing is not None:
+                self._entries.move_to_end(profile_name)
+                existing.in_flight += 1
+                existing.last_used = self._now()
+                return existing
+
+            self._evict_to_capacity()
+            runtime = self._factory(profile_name, profile_home)
+            entry = _PoolEntry(profile_name=profile_name, runtime=runtime, last_used=self._now())
+            entry.in_flight = 1
+            self._entries[profile_name] = entry
+            return entry
+
+    def _evict_idle_inplace(self) -> None:
+        """Drop entries idle > idle_evict_seconds and not in flight."""
+        cutoff = self._now() - self.idle_evict_seconds
+        for name in list(self._entries.keys()):
+            entry = self._entries[name]
+            if entry.in_flight > 0:
+                continue
+            if entry.last_used < cutoff:
+                del self._entries[name]
+                logger.debug("multitenancy: pool evicted idle %s", name)
+
+    def _evict_to_capacity(self) -> None:
+        """Drop oldest non-in-flight entries until len < max_loaded_runtimes.
+
+        If every loaded entry is in-flight, we exceed capacity rather than
+        blocking the gateway dispatch path.
+        """
+        while len(self._entries) >= self.max_loaded_runtimes:
+            for name in list(self._entries.keys()):
+                entry = self._entries[name]
+                if entry.in_flight == 0:
+                    del self._entries[name]
+                    logger.debug("multitenancy: pool LRU-evicted %s", name)
+                    break
+            else:
+                # All entries in-flight — log + bail
+                logger.warning(
+                    "multitenancy: pool over capacity (loaded=%d, max=%d), all in-flight",
+                    len(self._entries),
+                    self.max_loaded_runtimes,
+                )
+                return
+
+    def evict_idle(self) -> int:
+        """Public wrapper — returns number of entries evicted."""
+        before = len(self._entries)
+        self._evict_idle_inplace()
+        return before - len(self._entries)

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/router.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/router.py
@@ -835,6 +835,12 @@ async def _handle_child_approval_required(adapter: Any, chat_id: str, payload: A
     _record_pending_approval(data)
     command = str(data.get("command") or "")
     description = str(data.get("description") or "dangerous command")
+    logger.info(
+        "multitenancy child approval_required session=%s approval_id=%s command=%s",
+        str(data.get("session_key") or ""),
+        str(data.get("approval_id") or ""),
+        command[:120],
+    )
     preview = command[:200] + "..." if len(command) > 200 else command
     message = (
         "⚠️ Dangerous command requires approval:\n"

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/router.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/router.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import shutil
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Optional
 
@@ -28,9 +29,9 @@ except Exception:  # pragma: no cover - allows plugin unit tests without gateway
 _user_inflight_tasks: dict[str, asyncio.Task] = {}
 
 # Multi-turn session memory: maps (profile_name, user_key) → list of messages.
-# user_key prefers the real Feishu open_id (ou_*) used for routing, falling
-# back to union_id / alternate identifiers for legacy rows. SessionStore
-# persists the same key so memory survives gateway restarts.
+# user_key is the canonical sender chosen by routing. Alternate IDs are lookup
+# helpers only; using them as the memory key can merge distinct users that share
+# a stale or tenant-global alias.
 _SESSION_HISTORY_MAX = 20  # keep last N messages (user + assistant alternating)
 _session_history: dict[tuple[str, str], list[dict]] = {}
 # Tracks which (profile, user_key) pairs we've lazy-loaded from SessionStore
@@ -40,7 +41,16 @@ _session_loaded: set[tuple[str, str]] = set()
 
 def _history_key(profile_name: str, sender: str, sender_alt: Optional[str]) -> tuple[str, str]:
     """Return the per-(profile, user) key used to look up conversation history."""
-    return (profile_name, sender_alt or sender)
+    return (profile_name, _tenant_user_key(sender, sender_alt))
+
+
+def _tenant_user_key(sender: str, sender_alt: Optional[str]) -> str:
+    """Return the canonical per-user key for memory/session scoping."""
+    sender_key = str(sender or "").strip()
+    if sender_key and sender_key != "unknown":
+        return sender_key
+    alt_key = str(sender_alt or "").strip()
+    return alt_key or sender_key or "unknown"
 
 
 def _trim_history(history: list[dict]) -> list[dict]:
@@ -207,12 +217,46 @@ def _clean_stream_display_text(text: str) -> str:
         return cleaned.rstrip()
 
 
-async def _deliver_media_from_stream_response(gateway: Any, response: str, event: Any, adapter: Any) -> None:
+_MEDIA_DIRECTIVE_RE = re.compile(r'''(?P<prefix>[`"']?MEDIA:\s*)(?P<path>\S+)(?P<suffix>[`"']?)''')
+
+
+async def _deliver_media_from_stream_response(
+    gateway: Any,
+    response: str,
+    event: Any,
+    adapter: Any,
+    profile_home: Path,
+) -> None:
     """Delegate post-stream media attachment delivery to Hermes' native gateway path."""
     deliver = getattr(gateway, "_deliver_media_from_response", None)
     if not callable(deliver):
         return
-    await deliver(response, event, adapter)
+    scoped_response = _profile_scoped_media_response(response, profile_home)
+    if "MEDIA:" not in scoped_response:
+        return
+    await deliver(scoped_response, event, adapter)
+
+
+def _profile_scoped_media_response(response: str, profile_home: Path) -> str:
+    """Drop MEDIA directives that point outside the routed profile home."""
+    root = profile_home.expanduser().resolve(strict=False)
+
+    def repl(match: re.Match[str]) -> str:
+        raw_path = match.group("path").strip()
+        candidate = Path(raw_path).expanduser()
+        if not candidate.is_absolute():
+            candidate = root / candidate
+        resolved = candidate.resolve(strict=False)
+        if resolved == root or root in resolved.parents:
+            return f"{match.group('prefix')}{resolved}{match.group('suffix')}"
+        logger.warning(
+            "multitenancy: blocked outbound MEDIA outside profile home path=%s profile_home=%s",
+            raw_path,
+            root,
+        )
+        return ""
+
+    return _MEDIA_DIRECTIVE_RE.sub(repl, str(response or ""))
 
 
 async def _enrich_via_hermes_pipeline(event: Any, gateway: Any) -> Optional[str]:
@@ -330,7 +374,14 @@ def _should_defer_gateway_processing_complete(event: Any) -> bool:
     if parse_command(text) is not None:
         return False
     _profile_name, profile_home = _resolve_route(sender, alt_id=sender_alt)
-    return profile_home is not None or _auto_provision_enabled()
+    if profile_home is not None:
+        return True
+    return (
+        _auto_provision_enabled()
+        and _get_routing_table() is not None
+        and bool(sender)
+        and sender != "unknown"
+    )
 
 
 def _defer_gateway_processing_complete(event: Any, gateway: Any) -> None:
@@ -356,6 +407,8 @@ async def handle_async(*, event: Any, gateway: Any) -> None:
         chat_id = getattr(source, "chat_id", "unknown") if source else "unknown"
         fallback_sender = getattr(source, "user_id", "unknown") if source else "unknown"
         sender = _resolve_sender_for_routing(event, fallback=fallback_sender)
+        if _is_feishu_open_id(sender):
+            setattr(event, "sender_open_id", sender)
         text = getattr(event, "text", "") or ""
 
         sender_alt = getattr(source, "user_id_alt", None) if source else None
@@ -453,7 +506,7 @@ async def handle_async(*, event: Any, gateway: Any) -> None:
                 )
                 if response_text:
                     await _deliver_media_from_stream_response(
-                        gateway, response_text, agent_event, adapter
+                        gateway, response_text, agent_event, adapter, profile_home
                     )
             else:
                 # Mock / minimal adapter — old non-stream path (send_typing + pool.dispatch + send)
@@ -673,7 +726,7 @@ async def _dispatch_gateway_command(
 
     dispatcher = getattr(gateway, "_dispatch_slash_command", None)
     if callable(dispatcher):
-        with _profile_gateway_context(
+        async with _profile_gateway_context(
             gateway,
             event,
             sender=sender,
@@ -716,8 +769,17 @@ async def _dispatch_gateway_command(
         )
         if quick_result is not None:
             return quick_result
-        return await _dispatch_plugin_command(cmd, event)
-    with _profile_gateway_context(
+        return await _dispatch_plugin_command(
+            cmd,
+            event,
+            gateway,
+            sender=sender,
+            sender_alt=sender_alt,
+            profile_name=profile_name,
+            profile_home=profile_home,
+            chat_id=chat_id,
+        )
+    async with _profile_gateway_context(
         gateway,
         event,
         sender=sender,
@@ -754,12 +816,21 @@ async def _dispatch_quick_command(
         exec_cmd = qcmd.get("command", "")
         if not exec_cmd:
             return f"Quick command '/{cmd}' has no command defined."
+        if not _quick_exec_allowed(gateway, qcmd):
+            return (
+                f"Quick command '/{cmd}' exec is disabled for Feishu multitenancy. "
+                "Enable only after profile sandboxing is in place."
+            )
         logger.info("Hermes quick command exec: %s", cmd)
         try:
+            env = os.environ.copy()
+            if profile_home is not None:
+                env["HERMES_HOME"] = str(profile_home)
             proc = await asyncio.create_subprocess_shell(
                 exec_cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                env=env,
             )
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
             output = (stdout or stderr).decode().strip()
@@ -807,7 +878,44 @@ def _get_quick_command(gateway: Any, cmd: str) -> Any:
     return quick_commands.get(cmd)
 
 
-async def _dispatch_plugin_command(cmd: str, event: Any) -> Optional[str]:
+def _quick_exec_allowed(gateway: Any, qcmd: dict[str, Any]) -> bool:
+    """Return True only when multitenant Feishu quick exec is explicitly enabled."""
+    qcmd_flag = qcmd.get("multitenancy_allow_exec")
+    if qcmd_flag is None:
+        qcmd_cfg = qcmd.get("multitenancy")
+        if isinstance(qcmd_cfg, dict):
+            qcmd_flag = qcmd_cfg.get("allow_exec")
+    if qcmd_flag is not None:
+        return _truthy(qcmd_flag)
+
+    config = getattr(gateway, "config", None)
+    plugin_cfg = None
+    if isinstance(config, dict):
+        plugin_cfg = config.get("multitenancy")
+    else:
+        plugin_cfg = getattr(config, "multitenancy", None)
+    if isinstance(plugin_cfg, dict) and "allow_quick_exec" in plugin_cfg:
+        return _truthy(plugin_cfg.get("allow_quick_exec"))
+
+    env_value = os.getenv("HERMES_MULTITENANCY_ALLOW_QUICK_EXEC")
+    return _truthy(env_value) if env_value is not None else False
+
+
+def _truthy(value: Any) -> bool:
+    return str(value).strip().lower() in {"1", "true", "yes", "on", "allow", "enabled"}
+
+
+async def _dispatch_plugin_command(
+    cmd: str,
+    event: Any,
+    gateway: Any,
+    *,
+    sender: str,
+    sender_alt: Optional[str],
+    profile_name: Optional[str],
+    profile_home: Optional[Path],
+    chat_id: str,
+) -> Optional[str]:
     """Delegate plugin-registered slash commands to Hermes' plugin manager."""
     handler = _get_plugin_command_handler(cmd)
     if handler is None:
@@ -817,9 +925,18 @@ async def _dispatch_plugin_command(cmd: str, event: Any) -> Optional[str]:
     get_args = getattr(event, "get_command_args", None)
     if callable(get_args):
         user_args = (get_args() or "").strip()
-    result = handler(user_args)
-    if asyncio.iscoroutine(result):
-        result = await result
+    async with _profile_gateway_context(
+        gateway,
+        event,
+        sender=sender,
+        sender_alt=sender_alt,
+        profile_name=profile_name,
+        profile_home=profile_home,
+        chat_id=chat_id,
+    ):
+        result = handler(user_args)
+        if asyncio.iscoroutine(result):
+            result = await result
     return str(result) if result else None
 
 
@@ -881,7 +998,8 @@ def _event_platform_value(event: Any) -> Optional[str]:
     return str(value) if value else None
 
 
-def _profile_gateway_context(
+@asynccontextmanager
+async def _profile_gateway_context(
     gateway: Any,
     event: Any,
     *,
@@ -892,42 +1010,40 @@ def _profile_gateway_context(
     chat_id: str,
 ):
     """Temporarily scope Hermes gateway helpers to the routed profile."""
-    class _Context:
-        def __enter__(self):
-            self._old_home = os.environ.get("HERMES_HOME")
-            self._had_home = "HERMES_HOME" in os.environ
-            self._old_session_key_for_source = getattr(gateway, "_session_key_for_source", None)
-            if profile_home is not None:
-                os.environ["HERMES_HOME"] = str(profile_home)
-            session_key = _multitenant_gateway_session_key(
-                event,
-                profile_name=profile_name,
-                sender=sender,
-                sender_alt=sender_alt,
-                chat_id=chat_id,
-            )
-            if session_key:
-                def _scoped_session_key_for_source(source):
-                    return session_key
+    from .runtime import _get_env_lock
 
-                setattr(gateway, "_session_key_for_source", _scoped_session_key_for_source)
-            return self
+    async with _get_env_lock():
+        old_home = os.environ.get("HERMES_HOME")
+        had_home = "HERMES_HOME" in os.environ
+        old_session_key_for_source = getattr(gateway, "_session_key_for_source", None)
+        if profile_home is not None:
+            os.environ["HERMES_HOME"] = str(profile_home)
+        session_key = _multitenant_gateway_session_key(
+            event,
+            profile_name=profile_name,
+            sender=sender,
+            sender_alt=sender_alt,
+            chat_id=chat_id,
+        )
+        if session_key:
+            def _scoped_session_key_for_source(source):
+                return session_key
 
-        def __exit__(self, exc_type, exc, tb):
-            if self._old_session_key_for_source is not None:
-                setattr(gateway, "_session_key_for_source", self._old_session_key_for_source)
+            setattr(gateway, "_session_key_for_source", _scoped_session_key_for_source)
+        try:
+            yield
+        finally:
+            if old_session_key_for_source is not None:
+                setattr(gateway, "_session_key_for_source", old_session_key_for_source)
             elif hasattr(gateway, "_session_key_for_source"):
                 try:
                     delattr(gateway, "_session_key_for_source")
                 except Exception:
                     pass
-            if self._had_home:
-                os.environ["HERMES_HOME"] = self._old_home or ""
+            if had_home:
+                os.environ["HERMES_HOME"] = old_home or ""
             else:
                 os.environ.pop("HERMES_HOME", None)
-            return False
-
-    return _Context()
 
 
 def _multitenant_gateway_session_key(
@@ -942,7 +1058,7 @@ def _multitenant_gateway_session_key(
         return None
     source = getattr(event, "source", None)
     platform = getattr(getattr(source, "platform", None), "value", None) or "feishu"
-    user_key = sender_alt or sender
+    user_key = _tenant_user_key(sender, sender_alt)
     return f"multitenancy:{platform}:{profile_name}:{chat_id}:{user_key}"
 
 
@@ -1017,7 +1133,8 @@ def _resolve_or_auto_provision_route(
     alt_id: Optional[str] = None,
 ) -> tuple[str, Optional[Path]]:
     """Resolve an existing route, or create a dedicated profile for a new sender."""
-    profile_name, profile_home = _resolve_route(sender, alt_id=None)
+    alt_lookup = None if _is_feishu_open_id(sender) else alt_id
+    profile_name, profile_home = _resolve_route(sender, alt_id=alt_lookup)
     if profile_home is not None:
         _repair_auto_profile(profile_name, profile_home, route_key=sender, sender=sender)
         return profile_name, profile_home

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/router.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/router.py
@@ -37,6 +37,7 @@ _session_history: dict[tuple[str, str], list[dict]] = {}
 # Tracks which (profile, user_key) pairs we've lazy-loaded from SessionStore
 # so we only hit SQLite once per pair per process lifetime.
 _session_loaded: set[tuple[str, str]] = set()
+_pending_approval_requests: dict[str, list[dict]] = {}
 
 
 def _history_key(profile_name: str, sender: str, sender_alt: Optional[str]) -> tuple[str, str]:
@@ -650,7 +651,18 @@ async def _handle_command(
     cmd, _args = pair
     adapter = _get_feishu_adapter(gateway)
 
-    if cmd == "stop":
+    approval_reply = _handle_pending_approval_command(
+        cmd,
+        _args,
+        event,
+        profile_name=profile_name,
+        sender=sender,
+        sender_alt=sender_alt,
+        chat_id=chat_id,
+    )
+    if approval_reply is not None:
+        reply = approval_reply
+    elif cmd == "stop":
         task = _user_inflight_tasks.pop(sender, None)
         if task is not None and not task.done():
             task.cancel()
@@ -708,6 +720,131 @@ async def _handle_command(
 
     if adapter is not None:
         await _safe_call(adapter.send, chat_id, reply)
+
+
+def _handle_pending_approval_command(
+    cmd: str,
+    args: str,
+    event: Any,
+    *,
+    profile_name: Optional[str],
+    sender: str,
+    sender_alt: Optional[str],
+    chat_id: str,
+) -> Optional[str]:
+    """Resolve a child AIAgent approval bridge before falling back to gateway commands."""
+    if cmd not in {"approve", "deny"}:
+        return None
+    session_key = _multitenant_gateway_session_key(
+        event,
+        profile_name=profile_name,
+        sender=sender,
+        sender_alt=sender_alt,
+        chat_id=chat_id,
+    )
+    if not session_key or not _pending_approval_requests.get(session_key):
+        return None
+
+    if cmd == "deny":
+        resolve_all = "all" in str(args or "").lower().split()
+        count = _resolve_pending_approval_requests(session_key, "deny", resolve_all=resolve_all)
+        count_msg = f" ({count} commands)" if count > 1 else ""
+        return f"❌ Command{'s' if count > 1 else ''} denied{count_msg}."
+
+    parts = str(args or "").strip().lower().split()
+    resolve_all = "all" in parts
+    remaining = [part for part in parts if part != "all"]
+    if any(part in {"always", "permanent", "permanently"} for part in remaining):
+        choice = "always"
+        scope_msg = " (pattern approved permanently)"
+    elif any(part in {"session", "ses"} for part in remaining):
+        choice = "session"
+        scope_msg = " (pattern approved for this session)"
+    else:
+        choice = "once"
+        scope_msg = ""
+    count = _resolve_pending_approval_requests(session_key, choice, resolve_all=resolve_all)
+    count_msg = f" ({count} commands)" if count > 1 else ""
+    return f"✅ Command{'s' if count > 1 else ''} approved{scope_msg}{count_msg}. The agent is resuming..."
+
+
+def _resolve_pending_approval_requests(
+    session_key: str,
+    choice: str,
+    *,
+    resolve_all: bool = False,
+) -> int:
+    queue = _pending_approval_requests.get(session_key) or []
+    if not queue:
+        return 0
+    if resolve_all:
+        targets = list(queue)
+        queue.clear()
+    else:
+        targets = [queue.pop(0)]
+    if queue:
+        _pending_approval_requests[session_key] = queue
+    else:
+        _pending_approval_requests.pop(session_key, None)
+    for entry in targets:
+        raw_decision_path = str(entry.get("decision_path") or "").strip()
+        if not raw_decision_path:
+            continue
+        decision_path = Path(raw_decision_path)
+        try:
+            decision_path.parent.mkdir(parents=True, exist_ok=True)
+            decision_path.write_text(json.dumps({"choice": choice}), encoding="utf-8")
+        except Exception as exc:
+            logger.warning(
+                "multitenancy: failed to write approval decision for %s: %s",
+                entry.get("approval_id") or "?",
+                exc,
+            )
+    return len(targets)
+
+
+def _record_pending_approval(payload: dict) -> None:
+    session_key = str(payload.get("session_key") or "").strip()
+    decision_path = str(payload.get("decision_path") or "").strip()
+    if not session_key or not decision_path:
+        return
+    approval_id = str(payload.get("approval_id") or decision_path)
+    queue = _pending_approval_requests.setdefault(session_key, [])
+    queue[:] = [
+        item for item in queue
+        if str(item.get("approval_id") or item.get("decision_path")) != approval_id
+    ]
+    queue.append(dict(payload))
+
+
+def _clear_pending_approval(payload: dict) -> None:
+    session_key = str(payload.get("session_key") or "").strip()
+    approval_id = str(payload.get("approval_id") or "").strip()
+    if not session_key or not approval_id:
+        return
+    queue = _pending_approval_requests.get(session_key) or []
+    queue[:] = [item for item in queue if str(item.get("approval_id") or "") != approval_id]
+    if queue:
+        _pending_approval_requests[session_key] = queue
+    else:
+        _pending_approval_requests.pop(session_key, None)
+
+
+async def _handle_child_approval_required(adapter: Any, chat_id: str, payload: Any) -> None:
+    data = payload if isinstance(payload, dict) else {}
+    _record_pending_approval(data)
+    command = str(data.get("command") or "")
+    description = str(data.get("description") or "dangerous command")
+    preview = command[:200] + "..." if len(command) > 200 else command
+    message = (
+        "⚠️ Dangerous command requires approval:\n"
+        f"```\n{preview}\n```\n"
+        f"Reason: {description}\n\n"
+        "Reply `/approve` to execute, `/approve session` to approve this pattern "
+        "for the session, `/approve always` to approve permanently, or `/deny` to cancel."
+    )
+    if adapter is not None:
+        await _safe_call(adapter.send, chat_id, message)
 
 
 async def _dispatch_gateway_command(
@@ -1904,6 +2041,19 @@ async def _stream_into_feishu_shared_consumer(
                         )
                         continue
 
+                    if kind == "approval_required":
+                        await _handle_child_approval_required(adapter, chat_id, delta)
+                        try:
+                            await consumer.update_streaming_card_status("等待用户审批: /approve 或 /deny")
+                        except Exception as exc:
+                            logger.debug("multitenancy: approval status update failed: %s", exc)
+                        continue
+
+                    if kind == "approval_resolved":
+                        if isinstance(delta, dict):
+                            _clear_pending_approval(delta)
+                        continue
+
                     if kind == "done":
                         continue
 
@@ -2193,6 +2343,25 @@ async def _stream_into_feishu(
                             logger.debug("multitenancy: card tool-complete update failed: %s", exc)
                         last_edit_time = time.monotonic()
                         last_render_len = len(render())
+                        continue
+                    elif kind == "approval_required":
+                        await _handle_child_approval_required(adapter, chat_id, delta)
+                        try:
+                            await _update_feishu_stream_status(
+                                adapter,
+                                chat_id,
+                                placeholder_id,
+                                "等待用户审批: /approve 或 /deny",
+                                mode=stream_mode,
+                            )
+                        except Exception as exc:
+                            logger.debug("multitenancy: approval status update failed: %s", exc)
+                        last_edit_time = time.monotonic()
+                        last_render_len = len(render())
+                        continue
+                    elif kind == "approval_resolved":
+                        if isinstance(delta, dict):
+                            _clear_pending_approval(delta)
                         continue
                     elif kind == "done":
                         continue

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/router.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/router.py
@@ -575,6 +575,7 @@ def _maybe_rewrite_skill_slash_command(
         )
         if not msg:
             return False, None
+        logger.info("Hermes skill slash invocation: %s profile=%s", cmd_key, profile_name or "")
         setattr(event, "text", msg)
         return True, None
     except Exception as exc:
@@ -643,12 +644,14 @@ async def _handle_command(
         else:
             from .commands import is_known_command, unknown_command_message
 
-            reply = (
-                f"Command `/{cmd}` is recognized by Hermes, but this gateway does not "
-                "expose a reusable command dispatcher yet."
-                if is_known_command(cmd)
-                else unknown_command_message(cmd)
-            )
+            if is_known_command(cmd):
+                reply = (
+                    f"Command `/{cmd}` is recognized by Hermes, but this gateway does not "
+                    "expose a reusable command dispatcher yet."
+                )
+            else:
+                reply = unknown_command_message(cmd)
+                logger.info("%s", reply)
 
     if adapter is not None:
         await _safe_call(adapter.send, chat_id, reply)
@@ -696,6 +699,7 @@ async def _dispatch_gateway_command(
                 result = dispatcher(event)
             if asyncio.iscoroutine(result):
                 result = await result
+            logger.info("Hermes gateway command handled: %s", cmd)
             return str(result) if result is not None else None
 
     handler = _gateway_handler_for_command(gateway, cmd)
@@ -725,6 +729,7 @@ async def _dispatch_gateway_command(
         result = handler(event)
         if asyncio.iscoroutine(result):
             result = await result
+    logger.info("Hermes gateway command handled: %s", cmd)
     return str(result) if result is not None else None
 
 
@@ -749,6 +754,7 @@ async def _dispatch_quick_command(
         exec_cmd = qcmd.get("command", "")
         if not exec_cmd:
             return f"Quick command '/{cmd}' has no command defined."
+        logger.info("Hermes quick command exec: %s", cmd)
         try:
             proc = await asyncio.create_subprocess_shell(
                 exec_cmd,
@@ -775,6 +781,7 @@ async def _dispatch_quick_command(
         user_args = _command_args_from_event(event).strip()
         setattr(event, "text", f"{target} {user_args}".strip())
         _set_command_event_methods(event, new_cmd)
+        logger.info("Hermes quick command alias: %s -> %s", cmd, target)
         return await _dispatch_gateway_command(
             new_cmd,
             event,
@@ -805,6 +812,7 @@ async def _dispatch_plugin_command(cmd: str, event: Any) -> Optional[str]:
     handler = _get_plugin_command_handler(cmd)
     if handler is None:
         return None
+    logger.info("Hermes plugin slash handler: %s", cmd.replace("_", "-"))
     user_args = ""
     get_args = getattr(event, "get_command_args", None)
     if callable(get_args):

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/router.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/router.py
@@ -1,0 +1,1781 @@
+"""Pre-gateway-dispatch hook callback and async dispatch entry point.
+
+Wires together the SQLite routing table, optional in-memory route fallback,
+LRU runtime pool, slash commands, and Feishu streaming replies.
+"""
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import logging
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+try:  # Shared Hermes Feishu card/typewriter transport.
+    from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig  # type: ignore
+except Exception:  # pragma: no cover - allows plugin unit tests without gateway on path
+    GatewayStreamConsumer = None  # type: ignore
+    StreamConsumerConfig = None  # type: ignore
+
+# Per-user in-flight dispatch tasks — used by /stop to cancel the right task.
+_user_inflight_tasks: dict[str, asyncio.Task] = {}
+
+# Multi-turn session memory: maps (profile_name, user_key) → list of messages.
+# user_key prefers the real Feishu open_id (ou_*) used for routing, falling
+# back to union_id / alternate identifiers for legacy rows. SessionStore
+# persists the same key so memory survives gateway restarts.
+_SESSION_HISTORY_MAX = 20  # keep last N messages (user + assistant alternating)
+_session_history: dict[tuple[str, str], list[dict]] = {}
+# Tracks which (profile, user_key) pairs we've lazy-loaded from SessionStore
+# so we only hit SQLite once per pair per process lifetime.
+_session_loaded: set[tuple[str, str]] = set()
+
+
+def _history_key(profile_name: str, sender: str, sender_alt: Optional[str]) -> tuple[str, str]:
+    """Return the per-(profile, user) key used to look up conversation history."""
+    return (profile_name, sender_alt or sender)
+
+
+def _trim_history(history: list[dict]) -> list[dict]:
+    """Keep at most ``_SESSION_HISTORY_MAX`` most recent messages."""
+    if len(history) <= _SESSION_HISTORY_MAX:
+        return history
+    return history[-_SESSION_HISTORY_MAX:]
+
+
+def _load_history(key: tuple[str, str]) -> list[dict]:
+    """Get history for ``key`` — first call hydrates from SessionStore, subsequent calls hit cache."""
+    if key in _session_loaded:
+        return list(_session_history.get(key, []))
+    store = _get_session_store()
+    if store is not None:
+        try:
+            persisted = store.load_recent(key[0], key[1], _SESSION_HISTORY_MAX)
+        except Exception as exc:
+            logger.debug("multitenancy: SessionStore.load_recent failed (%s)", exc)
+            persisted = []
+        if persisted:
+            _session_history[key] = persisted
+    _session_loaded.add(key)
+    return list(_session_history.get(key, []))
+
+
+def _persist_turn(key: tuple[str, str], user_msg: dict, assistant_text: str) -> None:
+    """Append a (user, assistant) turn to both in-memory cache and SessionStore."""
+    new_history = _session_history.get(key, []) + [
+        user_msg,
+        {"role": "assistant", "content": assistant_text},
+    ]
+    _session_history[key] = _trim_history(new_history)
+    store = _get_session_store()
+    if store is None:
+        return
+    try:
+        # _build_user_message always sets content as a str — no cast needed.
+        store.append(key[0], key[1], user_msg["role"], user_msg["content"])
+        store.append(key[0], key[1], "assistant", assistant_text)
+    except Exception as exc:
+        logger.debug("multitenancy: SessionStore.append failed (%s)", exc)
+
+
+def _clear_history(key: tuple[str, str]) -> bool:
+    """Drop a user's history from cache + store. Returns True if anything was cleared."""
+    had_cache = _session_history.pop(key, None) is not None
+    _session_loaded.discard(key)
+    store = _get_session_store()
+    if store is None:
+        return had_cache
+    try:
+        rows = store.clear(key[0], key[1])
+    except Exception as exc:
+        logger.debug("multitenancy: SessionStore.clear failed (%s)", exc)
+        rows = 0
+    return had_cache or rows > 0
+
+
+def _build_user_message(event: Any, *, text_override: Optional[str] = None) -> dict:
+    """Construct the OpenAI-format user message, splicing in reply context if any.
+
+    Reply context: hermes mainstream sets ``event.reply_to_text`` when the
+    user is quoting an earlier message. We surface it inline so the model
+    knows what's being replied to.
+
+    ``text_override`` lets ``_enrich_with_vision`` rewrite the text before
+    the message is built (so reply context still wraps the enriched text).
+    """
+    text = text_override if text_override is not None else (getattr(event, "text", "") or "")
+    reply_to_text = getattr(event, "reply_to_text", None)
+    if reply_to_text:
+        text = f"(replying to: {reply_to_text})\n{text}"
+    return {"role": "user", "content": text}
+
+
+def _is_feishu_open_id(value: Any) -> bool:
+    return bool(value) and str(value).startswith("ou_")
+
+
+def _nested_get(value: Any, path: tuple[str, ...]) -> Any:
+    current = value
+    for key in path:
+        if current is None:
+            return None
+        if isinstance(current, dict):
+            current = current.get(key)
+        else:
+            current = getattr(current, key, None)
+    return current
+
+
+def _current_sender_open_id() -> Optional[str]:
+    """Return the adapter-provided Feishu open_id context, if available."""
+    try:
+        from tools import feishu_oapi_client as feishu_oapi  # type: ignore
+
+        candidate = feishu_oapi.current_sender_open_id.get()
+    except Exception:
+        return None
+    return str(candidate) if _is_feishu_open_id(candidate) else None
+
+
+def _resolve_sender_for_routing(event: Any, *, fallback: str = "unknown") -> str:
+    """Pick the stable Feishu user key used by the multitenancy router.
+
+    Feishu SDK events can expose ``source.user_id`` as a short tenant-local ID
+    such as ``g41a5b5g``. The UAT files and explicit routes are keyed by the
+    real app-scoped open_id (``ou_*``), so prefer that when the adapter or raw
+    event makes it available.
+    """
+    source = getattr(event, "source", None)
+    direct_candidates = (
+        _current_sender_open_id(),
+        getattr(event, "sender_open_id", None),
+        getattr(source, "open_id", None) if source is not None else None,
+        getattr(source, "user_id", None) if source is not None else None,
+        getattr(source, "user_id_alt", None) if source is not None else None,
+    )
+    for candidate in direct_candidates:
+        if _is_feishu_open_id(candidate):
+            return str(candidate)
+
+    raw_candidates = (
+        getattr(event, "raw", None),
+        getattr(event, "raw_event", None),
+        getattr(event, "event", None),
+    )
+    paths = (
+        ("sender", "sender_id", "open_id"),
+        ("event", "sender", "sender_id", "open_id"),
+        ("event", "message", "sender", "sender_id", "open_id"),
+        ("message", "sender", "sender_id", "open_id"),
+        ("sender_id", "open_id"),
+    )
+    for raw in raw_candidates:
+        for path in paths:
+            candidate = _nested_get(raw, path)
+            if _is_feishu_open_id(candidate):
+                return str(candidate)
+
+    return fallback
+
+
+def _event_with_text(event: Any, text: str) -> Any:
+    """Return an event-shaped object whose ``text`` matches the agent prompt."""
+    if text == (getattr(event, "text", "") or ""):
+        return event
+    cloned = copy.copy(event)
+    setattr(cloned, "text", text)
+    return cloned
+
+
+def _clean_stream_display_text(text: str) -> str:
+    """Hide native media-delivery directives from visible streaming text."""
+    try:
+        from gateway.stream_consumer import GatewayStreamConsumer  # type: ignore
+
+        return GatewayStreamConsumer._clean_for_display(text)
+    except Exception:
+        cleaned = str(text or "").replace("[[audio_as_voice]]", "")
+        cleaned = re.sub(r'''[`"']?MEDIA:\s*\S+[`"']?''', "", cleaned)
+        cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+        return cleaned.rstrip()
+
+
+async def _deliver_media_from_stream_response(gateway: Any, response: str, event: Any, adapter: Any) -> None:
+    """Delegate post-stream media attachment delivery to Hermes' native gateway path."""
+    deliver = getattr(gateway, "_deliver_media_from_response", None)
+    if not callable(deliver):
+        return
+    await deliver(response, event, adapter)
+
+
+async def _enrich_via_hermes_pipeline(event: Any, gateway: Any) -> Optional[str]:
+    """Delegate inbound preprocessing to hermes' ``_prepare_inbound_message_text``.
+
+    This is the single call that mainstream uses to:
+      - run vision_analyze_tool on attached images
+      - run transcribe_audio on voice messages
+      - inject text-file content (.txt / .md / .csv / etc.)
+      - prepend reply-quoted context
+      - attribute multi-user shared sessions
+
+    By calling the same gateway method, the plugin behaves *identically* to
+    mainstream for every multimodal input — no re-implementation, no drift.
+
+    Caveat: this depends on a private GatewayRunner method. If hermes-agent
+    refactors ``_prepare_inbound_message_text``, swap to local fallbacks
+    (``_local_enrich_with_vision_only`` below as a minimal safety net).
+
+    Returns:
+        Enriched text string, or None on failure (caller falls back to event.text).
+    """
+    if gateway is None:
+        return None
+    prep = getattr(gateway, "_prepare_inbound_message_text", None)
+    if prep is None or not callable(prep):
+        logger.debug("multitenancy: gateway._prepare_inbound_message_text unavailable")
+        return await _local_enrich_with_vision_only(event)
+    source = getattr(event, "source", None)
+    if source is None:
+        return None
+    try:
+        return await prep(event=event, source=source, history=[])
+    except Exception as exc:
+        logger.debug("multitenancy: gateway._prepare_inbound_message_text failed (%s)", exc)
+        return await _local_enrich_with_vision_only(event)
+
+
+async def _local_enrich_with_vision_only(event: Any) -> Optional[str]:
+    """Local fallback if hermes' ``_prepare_inbound_message_text`` is unavailable.
+
+    Only handles images (the most common multimodal input). Audio / files /
+    reply context degrade gracefully — the model will see ``event.text`` only.
+    """
+    media_urls = getattr(event, "media_urls", None) or []
+    media_types = getattr(event, "media_types", None) or []
+    if not media_urls:
+        return None
+    try:
+        from tools.vision_tools import vision_analyze_tool  # type: ignore
+    except ImportError:
+        return None
+    import json as _json
+    descriptions: list[str] = []
+    for path, mtype in zip(media_urls, media_types or [""] * len(media_urls)):
+        if mtype and not mtype.startswith("image"):
+            continue
+        try:
+            result_json = await vision_analyze_tool(
+                image_url=path,
+                user_prompt="Describe this image in thorough detail.",
+            )
+            result = _json.loads(result_json) if isinstance(result_json, str) else result_json
+            if result.get("success"):
+                descriptions.append(f"[Image: {result.get('analysis', '')}]")
+        except Exception as exc:
+            logger.debug("multitenancy: local vision fallback error on %s: %s", path, exc)
+    if not descriptions:
+        return None
+    base = getattr(event, "text", "") or ""
+    return "\n".join(descriptions) + ("\n" + base if base else "")
+
+
+# -- Hook entry point --------------------------------------------------------
+
+
+def on_pre_gateway_dispatch(*, event: Any, gateway: Any, session_store: Any = None, **_kwargs) -> dict:
+    """Sync hook callback (registered to ``pre_gateway_dispatch``).
+
+    Schedules the async work as a background task and returns immediately
+    with ``action: skip`` so the gateway main flow halts for this event.
+    """
+    try:
+        if _should_defer_gateway_processing_complete(event):
+            _defer_gateway_processing_complete(event, gateway)
+        loop = asyncio.get_running_loop()
+        task = loop.create_task(handle_async(event=event, gateway=gateway))
+        task.add_done_callback(_log_task_failure)
+    except RuntimeError:
+        # Test-only fallback: hook called from sync context (no running loop).
+        if os.environ.get("PYTEST_CURRENT_TEST"):
+            try:
+                asyncio.run(handle_async(event=event, gateway=gateway))
+            except Exception as exc:
+                logger.warning("multitenancy: sync fallback dispatch failed: %s", exc)
+        else:
+            logger.error(
+                "multitenancy: pre_gateway_dispatch invoked without a running loop "
+                "and not in pytest — dropping event"
+            )
+    except Exception as exc:
+        logger.warning("multitenancy: failed to schedule handle_async: %s", exc)
+    return {"action": "skip", "reason": "multitenancy router took over"}
+
+
+def _should_defer_gateway_processing_complete(event: Any) -> bool:
+    """Return True when the async router owns visible processing lifecycle."""
+    from .commands import parse_command
+
+    source = getattr(event, "source", None)
+    fallback_sender = getattr(source, "user_id", "unknown") if source else "unknown"
+    sender = _resolve_sender_for_routing(event, fallback=fallback_sender)
+    sender_alt = getattr(source, "user_id_alt", None) if source else None
+    text = getattr(event, "text", "") or ""
+    if parse_command(text) is not None:
+        return False
+    _profile_name, profile_home = _resolve_route(sender, alt_id=sender_alt)
+    return profile_home is not None or _auto_provision_enabled()
+
+
+def _defer_gateway_processing_complete(event: Any, gateway: Any) -> None:
+    adapter = _get_feishu_adapter(gateway)
+    defer = getattr(adapter, "defer_processing_complete", None)
+    if not callable(defer):
+        return
+    try:
+        defer(event)
+    except Exception as exc:
+        logger.debug("multitenancy: defer_processing_complete failed: %s", exc)
+
+
+# -- Async dispatch ----------------------------------------------------------
+
+
+async def handle_async(*, event: Any, gateway: Any) -> None:
+    """Async dispatch — orchestrates routing + pool + adapter calls + commands."""
+    from .commands import parse_command
+
+    try:
+        source = getattr(event, "source", None)
+        chat_id = getattr(source, "chat_id", "unknown") if source else "unknown"
+        fallback_sender = getattr(source, "user_id", "unknown") if source else "unknown"
+        sender = _resolve_sender_for_routing(event, fallback=fallback_sender)
+        text = getattr(event, "text", "") or ""
+
+        sender_alt = getattr(source, "user_id_alt", None) if source else None
+
+        # Slash command short-circuit (resolve route first so /status / /new
+        # know which profile's history to inspect). When _resolve_route signals
+        # a miss with profile_home=None, surface profile_name=None so command
+        # handlers reply "未路由" instead of leaking the sender id.
+        cmd_pair = parse_command(text)
+        if cmd_pair is not None:
+            cmd_profile_name, cmd_profile_home = _resolve_route(sender, alt_id=sender_alt)
+            cmd_profile = cmd_profile_name if cmd_profile_home is not None else None
+            await _handle_command(cmd_pair, sender, sender_alt, cmd_profile, chat_id, gateway)
+            return
+
+        # Routing: SQLite table first, then in-memory fallback.
+        profile_name, profile_home = _resolve_or_auto_provision_route(sender, alt_id=sender_alt)
+        if profile_home is None:
+            logger.info("multitenancy: no route for sender=%s, ignoring", sender)
+            return
+
+        # Register self in the user's in-flight slot (replace previous)
+        current = asyncio.current_task()
+        prev = _user_inflight_tasks.get(sender)
+        if prev is not None and not prev.done() and prev is not current:
+            prev.cancel()
+        if current is not None:
+            _user_inflight_tasks[sender] = current
+
+        adapter = _get_feishu_adapter(gateway)
+        # Detect whether adapter supports the streaming/reaction APIs we use.
+        # Real FeishuAdapter does; unit-test mocks typically don't.
+        feishu_full = (
+            adapter is not None
+            and hasattr(adapter, "edit_message")
+            and hasattr(adapter, "on_processing_start")
+            and hasattr(adapter, "on_processing_complete")
+        )
+
+        outcome_failed = False
+        if feishu_full:
+            try:
+                await adapter.on_processing_start(event)
+            except Exception as exc:
+                logger.debug("multitenancy: on_processing_start failed: %s", exc)
+
+        # Multi-modal enrichment — delegate to hermes' canonical pipeline so
+        # vision (images), STT (audio), text-file inject (.txt/.md/.csv etc.),
+        # reply-context wrapping, and multi-user attribution all behave EXACTLY
+        # like mainstream. Falls back to local vision-only on missing API.
+        enriched_text = await _enrich_via_hermes_pipeline(event, gateway)
+
+        # Build the conversation: prior history + current user message (with
+        # reply context spliced in). The runner prepends the profile's SOUL.
+        # First lookup for a (profile, user) pair hydrates from SessionStore.
+        hist_key = _history_key(profile_name, sender, sender_alt)
+        prior = _load_history(hist_key)
+        user_msg = _build_user_message(event, text_override=enriched_text)
+        conversation = prior + [user_msg]
+        agent_event = _event_with_text(event, user_msg["content"])
+
+        try:
+            if feishu_full:
+                # Streaming path — card stream when available; text edit fallback.
+                response_text = await _stream_into_feishu(
+                    adapter, chat_id, profile_name, profile_home, agent_event,
+                    messages=conversation,
+                )
+                if response_text:
+                    await _deliver_media_from_stream_response(
+                        gateway, response_text, agent_event, adapter
+                    )
+            else:
+                # Mock / minimal adapter — old non-stream path (send_typing + pool.dispatch + send)
+                if adapter is not None:
+                    await _safe_call(adapter.send_typing, chat_id)
+                response_text = await _get_pool().dispatch(profile_name, profile_home, agent_event)
+                if adapter is not None:
+                    await _safe_call(adapter.send, chat_id, response_text)
+
+            # Record turn into history + persist to SessionStore.
+            if response_text and isinstance(response_text, str):
+                _persist_turn(hist_key, user_msg, response_text)
+
+            _touch_route(sender, sender_alt)
+        except Exception:
+            outcome_failed = True
+            raise
+        finally:
+            if feishu_full:
+                try:
+                    out = _processing_outcome(failed=outcome_failed)
+                    complete_deferred = getattr(adapter, "complete_deferred_processing", None)
+                    if callable(complete_deferred):
+                        await complete_deferred(event, out)
+                    else:
+                        await adapter.on_processing_complete(event, out)
+                except Exception as exc:
+                    logger.debug("multitenancy: on_processing_complete failed: %s", exc)
+            if _user_inflight_tasks.get(sender) is current:
+                _user_inflight_tasks.pop(sender, None)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.exception("multitenancy: handle_async failed: %s", exc)
+
+
+def _processing_outcome(*, failed: bool) -> Any:
+    """Return Hermes' ProcessingOutcome enum, or a string-compatible fallback."""
+    try:
+        from gateway.platforms.base import ProcessingOutcome  # type: ignore
+
+        return ProcessingOutcome.FAILURE if failed else ProcessingOutcome.SUCCESS
+    except Exception:
+        class _FallbackOutcome:
+            def __str__(self) -> str:
+                status = "FAILURE" if failed else "SUCCESS"
+                return f"ProcessingOutcome.{status}"
+
+        return _FallbackOutcome()
+
+
+# -- Command dispatch --------------------------------------------------------
+
+
+async def _handle_command(
+    pair: tuple[str, str],
+    sender: str,
+    sender_alt: Optional[str],
+    profile_name: Optional[str],
+    chat_id: str,
+    gateway: Any,
+) -> None:
+    """Execute a parsed slash command and reply via the shared adapter."""
+    cmd, _args = pair
+    adapter = _get_feishu_adapter(gateway)
+
+    if cmd == "stop":
+        task = _user_inflight_tasks.pop(sender, None)
+        if task is not None and not task.done():
+            task.cancel()
+            reply = "已停止当前任务"
+        else:
+            reply = "没有进行中的任务"
+    elif cmd == "status":
+        task = _user_inflight_tasks.get(sender)
+        running = task is not None and not task.done()
+        # Surface session memory size + profile so the user knows their context.
+        if profile_name:
+            hist = _session_history.get(_history_key(profile_name, sender, sender_alt), [])
+            hist_len = len(hist)
+        else:
+            hist_len = 0
+        reply = (
+            f"状态: {'运行中' if running else '空闲'}\n"
+            f"profile: {profile_name or '(未路由)'}\n"
+            f"会话历史: {hist_len} 条消息"
+        )
+    elif cmd in ("new", "reset"):
+        # Clear this user's per-profile history (cache + persistent SessionStore).
+        if profile_name:
+            key = _history_key(profile_name, sender, sender_alt)
+            had = _clear_history(key)
+            reply = "会话已重置 ✅" if had else "会话已重置 (本来也是空的)"
+        else:
+            reply = "(未路由的用户) 没有历史可重置"
+    elif cmd == "help":
+        reply = (
+            "📖 可用命令\n"
+            "/help    — 显示这条帮助\n"
+            "/status  — 查看当前 profile + 历史长度\n"
+            "/new     — 重置会话历史 (开始新对话)\n"
+            "/reset   — /new 的别名\n"
+            "/stop    — 取消正在运行的任务\n"
+        )
+    else:
+        return
+
+    if adapter is not None:
+        await _safe_call(adapter.send, chat_id, reply)
+
+
+# -- Routing resolution ------------------------------------------------------
+
+
+def _resolve_route(sender: str, *, alt_id: Optional[str] = None) -> tuple[str, Optional[Path]]:
+    """Resolve sender → (profile_name, profile_home).
+
+    The routing table's ``open_id`` column is overloaded as "any stable user
+    identifier" — it can hold a real Feishu open_id (``ou_xxx``), a union_id
+    (``on_xxx``), or any other tenant-stable token chosen by feishu-sync.
+
+    Lookup order:
+      1. SQLite RoutingTable WHERE open_id = sender (typical: real Feishu ou_* open_id)
+      2. SQLite RoutingTable WHERE open_id = alt_id (legacy: source.user_id_alt = union_id)
+      3. In-memory route fallback for tests and local demos
+
+    Returns (sender, None) when no route hits.
+    """
+    from .runtime import resolve_profile_home as _resolve_in_memory_route
+
+    table = _get_routing_table()
+    candidates: list[str] = [sender]
+    if alt_id and alt_id != sender:
+        candidates.append(alt_id)
+
+    if table is not None:
+        for candidate in candidates:
+            try:
+                row = table.lookup_by_open_id(candidate)
+            except Exception as exc:
+                logger.debug("multitenancy: routing lookup failed (%s)", exc)
+                continue
+            if row is not None:
+                return (row.profile_name, _profile_name_to_home(row.profile_name))
+
+    # Fallback: in-memory route map.
+    for candidate in candidates:
+        in_memory_home = _resolve_in_memory_route(candidate)
+        if in_memory_home is not None:
+            return (in_memory_home.name, in_memory_home)
+    return (sender, None)
+
+
+def _resolve_or_auto_provision_route(
+    sender: str,
+    *,
+    alt_id: Optional[str] = None,
+) -> tuple[str, Optional[Path]]:
+    """Resolve an existing route, or create a dedicated profile for a new sender."""
+    profile_name, profile_home = _resolve_route(sender, alt_id=None)
+    if profile_home is not None:
+        _repair_auto_profile(profile_name, profile_home, route_key=sender, sender=sender)
+        return profile_name, profile_home
+    if _auto_provision_enabled():
+        provisioned = _auto_provision_route(sender, alt_id=alt_id)
+        if provisioned is not None:
+            return provisioned
+        return profile_name, None
+    return _resolve_route(sender, alt_id=alt_id)
+
+
+def _repair_auto_profile(
+    profile_name: str,
+    profile_home: Path,
+    *,
+    route_key: str,
+    sender: str,
+) -> None:
+    if not profile_name.startswith("feishu_"):
+        return
+    try:
+        _ensure_auto_profile(profile_name, profile_home, route_key=route_key, sender=sender)
+    except Exception as exc:
+        logger.debug("multitenancy: auto profile repair failed for %s: %s", profile_name, exc)
+
+
+def _auto_provision_enabled() -> bool:
+    value = os.environ.get("HERMES_MULTITENANCY_AUTO_PROVISION", "1").strip().lower()
+    return value not in {"0", "false", "no", "off"}
+
+
+def _auto_provision_route(
+    sender: str,
+    *,
+    alt_id: Optional[str] = None,
+) -> Optional[tuple[str, Path]]:
+    """Create a route/profile for an unseen Feishu user, then return it."""
+    if not _auto_provision_enabled():
+        return None
+    table = _get_routing_table()
+    if table is None:
+        return None
+
+    route_key = sender
+    if not route_key or route_key == "unknown":
+        return None
+
+    profile_name = _auto_profile_name(route_key)
+    profile_home = _profile_name_to_home(profile_name)
+    try:
+        _ensure_auto_profile(profile_name, profile_home, route_key=route_key, sender=sender)
+        table.upsert(
+            user_id=route_key,
+            profile_name=profile_name,
+            open_id=route_key,
+            union_id=alt_id if alt_id and alt_id != sender else None,
+        )
+    except Exception as exc:
+        logger.warning(
+            "multitenancy: auto-provision failed sender=%s alt=%s: %s",
+            sender,
+            alt_id,
+            exc,
+        )
+        return None
+
+    logger.info(
+        "multitenancy: auto-provisioned sender=%s alt=%s profile=%s",
+        sender,
+        alt_id,
+        profile_name,
+    )
+    return profile_name, profile_home
+
+
+def _auto_profile_name(route_key: str) -> str:
+    """Return a deterministic, filesystem-safe profile name for a tenant key."""
+    clean = re.sub(r"[^A-Za-z0-9_-]+", "_", route_key).strip("_")
+    if not clean:
+        clean = "unknown"
+    return f"feishu_{clean}"
+
+
+def _ensure_auto_profile(
+    profile_name: str,
+    profile_home: Path,
+    *,
+    route_key: str,
+    sender: str,
+) -> None:
+    """Create the on-disk profile skeleton required by AIAgent."""
+    profile_home.mkdir(parents=True, exist_ok=True)
+    shared_home = _shared_home_for_profile(profile_home)
+
+    config_path = profile_home / "config.yaml"
+    if config_path.exists():
+        _normalize_profile_config_file(config_path, shared_home=shared_home)
+    else:
+        config_path.write_text(
+            _dump_profile_config(_profile_config_from_shared_home(shared_home)),
+            encoding="utf-8",
+        )
+
+    soul_path = profile_home / "SOUL.md"
+    if not soul_path.exists():
+        soul_path.write_text(
+            "\n".join(
+                [
+                    f"# Hermes Profile {profile_name}",
+                    "",
+                    f"You are the dedicated Hermes tenant profile for Feishu route `{route_key}`.",
+                    f"The current Feishu sender open_id is `{sender}`.",
+                    "Keep tools, files, memory, and responses isolated to this profile.",
+                    "Do not claim to be another Hermes profile.",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+    for name in ("auth.json", ".env"):
+        _ensure_shared_profile_file(profile_home, shared_home, name)
+
+
+def _shared_home_for_profile(profile_home: Path) -> Path:
+    """Infer the shared Hermes root from a profile path."""
+    if profile_home.parent.name == "profiles":
+        return profile_home.parent.parent
+    return Path.home() / ".hermes"
+
+
+def _profile_config_from_shared_home(shared_home: Path) -> dict[str, Any]:
+    """Build a minimal profile config from the shared Hermes config."""
+    config: dict[str, Any] = {}
+    shared_config = shared_home / "config.yaml"
+    if shared_config.exists():
+        try:
+            import yaml
+
+            loaded = yaml.safe_load(shared_config.read_text(encoding="utf-8")) or {}
+            if isinstance(loaded, dict):
+                for key in ("model", "fallback", "platform_toolsets"):
+                    value = loaded.get(key)
+                    if value:
+                        config[key] = value
+                feishu_platform = ((loaded.get("platforms") or {}).get("feishu") or None)
+                if feishu_platform:
+                    config["platforms"] = {"feishu": feishu_platform}
+        except Exception as exc:
+            logger.debug("multitenancy: failed to read shared config %s: %s", shared_config, exc)
+
+    return _normalize_profile_config(config)
+
+
+def _normalize_profile_config(config: dict[str, Any]) -> dict[str, Any]:
+    model = config.get("model")
+    if not isinstance(model, dict) or not model.get("default"):
+        return config
+    else:
+        default_model = str(model.get("default") or "").strip()
+        provider = str(model.get("provider") or "").strip()
+        if default_model and provider and "/" not in default_model:
+            model["default"] = f"{provider}/{default_model}"
+    return config
+
+
+def _normalize_profile_config_file(config_path: Path, *, shared_home: Path) -> None:
+    try:
+        import yaml
+
+        loaded = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:
+        logger.debug("multitenancy: failed to normalize profile config %s: %s", config_path, exc)
+        return
+    if not isinstance(loaded, dict):
+        return
+    before = json.dumps(loaded, sort_keys=True, ensure_ascii=True)
+    _merge_shared_feishu_platform(loaded, shared_home)
+    normalized = _normalize_profile_config(loaded)
+    after = json.dumps(normalized, sort_keys=True, ensure_ascii=True)
+    if after != before:
+        config_path.write_text(_dump_profile_config(normalized), encoding="utf-8")
+
+
+def _merge_shared_feishu_platform(config: dict[str, Any], shared_home: Path) -> None:
+    shared_config = shared_home / "config.yaml"
+    if not shared_config.exists():
+        return
+    try:
+        import yaml
+
+        loaded = yaml.safe_load(shared_config.read_text(encoding="utf-8")) or {}
+    except Exception as exc:
+        logger.debug("multitenancy: failed to read shared Feishu platform config %s: %s", shared_config, exc)
+        return
+    if not isinstance(loaded, dict):
+        return
+    feishu_platform = ((loaded.get("platforms") or {}).get("feishu") or None)
+    if not feishu_platform:
+        return
+    platforms = config.setdefault("platforms", {})
+    if isinstance(platforms, dict):
+        platforms["feishu"] = feishu_platform
+
+
+def _dump_profile_config(config: dict[str, Any]) -> str:
+    try:
+        import yaml
+
+        return yaml.safe_dump(config, sort_keys=False, allow_unicode=False)
+    except Exception:
+        return json.dumps(config, indent=2, ensure_ascii=True) + "\n"
+
+
+def _ensure_shared_profile_file(profile_home: Path, shared_home: Path, name: str) -> None:
+    source = shared_home / name
+    target = profile_home / name
+    if target.exists() or target.is_symlink() or not source.exists():
+        return
+    try:
+        target.symlink_to(source)
+    except OSError:
+        shutil.copy2(source, target)
+
+
+def _profile_name_to_home(profile_name: str) -> Path:
+    """Map profile_name to its on-disk profile home directory.
+
+    Mirrors ``hermes_cli/profiles.py`` convention: ``~/.hermes/profiles/<name>``.
+    """
+    return Path.home() / ".hermes" / "profiles" / profile_name
+
+
+def _touch_route(sender: str, sender_alt: Optional[str] = None) -> None:
+    """Best-effort last_active_at update; no-op if no SQLite table or row.
+
+    Touch both identifiers because auto-provisioned rows are keyed by
+    app-scoped ``sender`` while older synced rows may still be keyed by
+    ``sender_alt`` / union_id.
+    """
+    table = _get_routing_table()
+    if table is None:
+        return
+    keys = [sender]
+    if sender_alt and sender_alt != sender:
+        keys.append(sender_alt)
+    for key in keys:
+        try:
+            table.touch_active(key)
+        except Exception as exc:
+            logger.debug("multitenancy: touch_active failed: %s", exc)
+
+
+# -- Lazy singletons (RoutingTable + RuntimePool) ----------------------------
+
+
+_routing_table: Any = None
+_routing_db_path: Optional[str] = None
+_pool: Any = None
+_session_store: Any = None
+_session_db_path: Optional[str] = None  # None → DEFAULT_DB_PATH inside SessionStore
+
+
+def _get_session_store():
+    """Lazy-init module-level SessionStore. Returns None if init fails (in-memory only)."""
+    global _session_store
+    if _session_store is None:
+        try:
+            from .sessions import SessionStore
+            _session_store = SessionStore(_session_db_path)
+        except Exception as exc:
+            logger.debug("multitenancy: SessionStore init failed (%s)", exc)
+            return None
+    return _session_store
+
+
+def override_session_store(store_or_path) -> None:
+    """Test helper — inject a SessionStore (or db path string, or None to disable)."""
+    global _session_store, _session_db_path, _session_loaded
+    if _session_store is not None and _session_store is not store_or_path:
+        try:
+            _session_store.close()
+        except Exception:
+            pass
+    _session_loaded.clear()
+    if store_or_path is None or isinstance(store_or_path, (str, Path)):
+        _session_store = None
+        _session_db_path = str(store_or_path) if store_or_path is not None else None
+    else:
+        _session_store = store_or_path
+        _session_db_path = None
+
+
+def _get_routing_table():
+    """Lazy-init module-level RoutingTable. Returns None if init fails."""
+    global _routing_table
+    if _routing_table is None:
+        try:
+            from .routing import RoutingTable
+            _routing_table = RoutingTable(_routing_db_path)
+        except Exception as exc:
+            logger.debug("multitenancy: RoutingTable init failed (%s)", exc)
+            return None
+    return _routing_table
+
+
+def _get_pool():
+    """Lazy-init module-level RuntimePool."""
+    global _pool
+    if _pool is None:
+        from .pool import RuntimePool
+        _pool = RuntimePool()
+    return _pool
+
+
+def override_routing_table(db_path: Optional[str | Path]) -> None:
+    """Test helper — reset the routing-table singleton, optionally pointing it at a different db."""
+    global _routing_table, _routing_db_path
+    if _routing_table is not None:
+        try:
+            _routing_table.close()
+        except Exception:
+            pass
+    _routing_table = None
+    _routing_db_path = str(db_path) if db_path is not None else None
+
+
+def override_pool(pool) -> None:
+    """Test helper — inject a custom RuntimePool (or None to reset)."""
+    global _pool
+    _pool = pool
+
+
+# -- Adapter resolution ------------------------------------------------------
+
+
+def _get_feishu_adapter(gateway: Any) -> Any:
+    """Pull the FeishuAdapter from the gateway, returning None if unavailable."""
+    if gateway is None:
+        return None
+    adapters = getattr(gateway, "adapters", None)
+    if adapters is None:
+        return None
+    try:
+        from gateway.platforms.base import Platform  # type: ignore
+        result = adapters.get(Platform.FEISHU)
+        if result is not None:
+            return result
+    except Exception as exc:  # pragma: no cover — only triggers when import fails
+        logger.debug("multitenancy: Platform import unavailable (%s)", exc)
+    if isinstance(adapters, dict):
+        return adapters.get("feishu")
+    return None
+
+
+async def _safe_call(fn, *args, **kwargs):
+    """Await fn(*args, **kwargs) whether it is sync or async."""
+    result = fn(*args, **kwargs)
+    if asyncio.iscoroutine(result):
+        return await result
+    return result
+
+
+# Detect Feishu rate-limit errors. Strings vary across SDK versions, so we
+# match on broad hints rather than exact codes.
+_RATE_LIMIT_HINTS = ("429", "rate limit", "too many requests", "ratelimit")
+
+
+def _is_rate_limit_error(exc: BaseException) -> bool:
+    msg = (str(exc) or "").lower()
+    return any(h in msg for h in _RATE_LIMIT_HINTS)
+
+
+async def _edit_with_retry(adapter, chat_id, message_id, content, *, finalize=False):
+    """Wrap adapter.edit_message with exponential backoff on 429.
+
+    On 429: backoff 0.5 → 1.0 → 2.0s, max 3 retries (4 total attempts), then
+    log a warning and return None so the caller can continue streaming.
+    On non-429: 1 retry after 0.2s, then propagate.
+    """
+    backoffs = (0.5, 1.0, 2.0)
+    for attempt in range(4):
+        try:
+            if finalize:
+                try:
+                    return await adapter.edit_message(chat_id, message_id, content, finalize=True)
+                except TypeError:
+                    return await adapter.edit_message(chat_id, message_id, content)
+            return await adapter.edit_message(chat_id, message_id, content)
+        except Exception as exc:
+            if _is_rate_limit_error(exc):
+                if attempt < len(backoffs):
+                    logger.debug(
+                        "multitenancy: edit_message 429, backoff %ss (attempt %d)",
+                        backoffs[attempt], attempt + 1,
+                    )
+                    await asyncio.sleep(backoffs[attempt])
+                    continue
+                logger.warning("multitenancy: edit_message rate-limited 4x, giving up")
+                return None
+            if attempt == 0:
+                logger.debug("multitenancy: edit_message non-429 retry: %s", exc)
+                await asyncio.sleep(0.2)
+                continue
+            raise
+    return None
+
+
+def _adapter_supports_streaming_card(adapter) -> bool:
+    """Return True when the shared Feishu adapter can drive card streaming."""
+    if adapter is None:
+        return False
+    supports = getattr(adapter, "supports_streaming_card", None)
+    if callable(supports):
+        try:
+            return bool(supports())
+        except Exception as exc:
+            logger.debug("multitenancy: supports_streaming_card failed: %s", exc)
+            return False
+    return bool(getattr(adapter, "SUPPORTS_STREAMING_CARD", False))
+
+
+async def _start_feishu_stream_target(adapter, chat_id) -> tuple[str, Optional[str]]:
+    """Start a card stream when possible, otherwise create the text placeholder."""
+    if _adapter_supports_streaming_card(adapter):
+        starter = getattr(adapter, "start_streaming_card", None)
+        updater = getattr(adapter, "update_streaming_card", None)
+        if callable(starter) and callable(updater):
+            try:
+                result = await starter(chat_id=chat_id, reply_to=None, metadata=None)
+            except Exception as exc:
+                logger.debug("multitenancy: start_streaming_card failed: %s", exc)
+            else:
+                message_id = getattr(result, "message_id", None)
+                if getattr(result, "success", False) and message_id:
+                    logger.info("multitenancy: streaming_card started message_id=%s", message_id)
+                    return ("card", str(message_id))
+                logger.debug(
+                    "multitenancy: start_streaming_card unsuccessful: %s",
+                    getattr(result, "error", None),
+                )
+
+    placeholder_send = await adapter.send(chat_id, "...")
+    message_id = (
+        placeholder_send.message_id
+        if getattr(placeholder_send, "success", False)
+        else None
+    )
+    return ("edit", str(message_id) if message_id else None)
+
+
+async def _update_feishu_stream_target(
+    adapter, chat_id, message_id, content, *, mode: str, finalize: bool = False
+):
+    """Update the current Feishu streaming surface."""
+    if mode == "card":
+        result = await adapter.update_streaming_card(
+            chat_id=chat_id,
+            message_id=message_id,
+            content=content,
+            finalize=finalize,
+        )
+        if not getattr(result, "success", False):
+            logger.debug(
+                "multitenancy: update_streaming_card unsuccessful: %s",
+                getattr(result, "error", None),
+            )
+        return result
+    return await _edit_with_retry(
+        adapter, chat_id, message_id, content, finalize=finalize
+    )
+
+
+async def _abort_feishu_stream_target(
+    adapter, chat_id, message_id, content, *, mode: str
+):
+    """Force the current streaming surface into an aborted terminal state."""
+    if mode == "card":
+        aborter = getattr(adapter, "abort_streaming_card", None)
+        if callable(aborter):
+            result = await aborter(
+                chat_id=chat_id,
+                message_id=message_id,
+                content=content,
+            )
+            if not getattr(result, "success", False):
+                logger.debug(
+                    "multitenancy: abort_streaming_card unsuccessful: %s",
+                    getattr(result, "error", None),
+                )
+            return result
+    return await _update_feishu_stream_target(
+        adapter,
+        chat_id,
+        message_id,
+        content or "Aborted.",
+        mode=mode,
+        finalize=True,
+    )
+
+
+async def _run_terminal_stream_update(update_coro, *, label: str):
+    """Run terminal card/edit update even if the caller is being cancelled."""
+    task = asyncio.create_task(update_coro)
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        try:
+            result = await task
+            logger.info("multitenancy: %s completed while task was cancelling", label)
+            return result
+        except Exception as exc:
+            logger.debug("multitenancy: %s failed while task was cancelling: %s", label, exc)
+        raise
+
+
+async def _update_feishu_stream_reasoning(
+    adapter, chat_id, message_id, content, *, mode: str
+):
+    """Update reasoning/status text without polluting the final answer block."""
+    if mode == "card":
+        updater = getattr(adapter, "update_streaming_card_reasoning", None)
+        if callable(updater):
+            return await updater(
+                chat_id=chat_id,
+                message_id=message_id,
+                content=content,
+            )
+    return await _update_feishu_stream_target(
+        adapter, chat_id, message_id, content, mode=mode
+    )
+
+
+async def _update_feishu_stream_status(
+    adapter, chat_id, message_id, content, *, mode: str
+):
+    """Update an ephemeral in-progress status without retaining it as reasoning."""
+    if mode == "card":
+        updater = getattr(adapter, "update_streaming_card_status", None)
+        if callable(updater):
+            return await updater(
+                chat_id=chat_id,
+                message_id=message_id,
+                content=content,
+            )
+    return await _update_feishu_stream_reasoning(
+        adapter, chat_id, message_id, content, mode=mode
+    )
+
+
+async def _update_feishu_stream_tool_event(
+    adapter, chat_id, message_id, payload, *, mode: str, completed: bool
+):
+    """Update active/completed tool state on the streaming surface."""
+    payload = payload if isinstance(payload, dict) else {"name": str(payload or "tool")}
+    tool_name = str(payload.get("name") or payload.get("tool_name") or "tool")
+    if mode == "card":
+        method_name = (
+            "update_streaming_card_tool_completed"
+            if completed
+            else "update_streaming_card_tool_started"
+        )
+        updater = getattr(adapter, method_name, None)
+        if callable(updater):
+            if completed:
+                return await updater(
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    tool_name=tool_name,
+                    duration=payload.get("duration"),
+                    is_error=bool(payload.get("is_error")),
+                )
+            return await updater(
+                chat_id=chat_id,
+                message_id=message_id,
+                tool_name=tool_name,
+                preview=payload.get("preview"),
+                args=payload.get("args"),
+            )
+
+    status = (
+        f"✅ 工具完成: {tool_name}"
+        if completed and not payload.get("is_error")
+        else f"⚠️ 工具失败: {tool_name}"
+        if completed
+        else f"🔧 正在调用工具: {tool_name}"
+    )
+    return await _update_feishu_stream_target(
+        adapter, chat_id, message_id, status, mode=mode
+    )
+
+
+# Throttle edit_message calls. Hermes mainstream uses 1.5s between edits
+# (run.py:9502 _PROGRESS_EDIT_INTERVAL); we mirror that as the floor for the
+# content phase. CardKit reasoning can update more often because it streams
+# into a stable card element; legacy edit_message keeps the wider heartbeat.
+_STREAM_CONTENT_MIN_CHARS = 60
+_STREAM_CONTENT_MIN_SECONDS = 1.0
+_STREAM_THINKING_MIN_SECONDS = 2.0
+_STREAM_CARD_REASONING_MIN_CHARS = 40
+_STREAM_CARD_REASONING_MIN_SECONDS = 0.8
+_STREAM_CARD_PRIME_STATUS = "Hermes 正在准备响应..."
+_STREAM_CARD_IDLE_HEARTBEAT_SECONDS = 2.5
+_STREAM_ABORT_FALLBACK = "Aborted."
+_STREAM_MAX_VISIBLE_CHARS = 3_000
+_STREAM_TRUNCATION_SUFFIX = "\n\n...[已截断: 回复过长，已保留前半部分以保证卡片及时完成]"
+
+
+def _stream_card_idle_status(tick: int) -> str:
+    """Return a visibly changing pre-token status for CardKit typewriter keepalive."""
+    dots = "." * (3 + (tick % 3))
+    return f"Hermes 正在准备响应{dots}"
+
+
+async def _stream_into_feishu_shared_consumer(
+    adapter, chat_id, profile_name, profile_home, event, *, messages: Optional[list[dict]] = None
+) -> Optional[str]:
+    """Stream Feishu card output through Hermes' shared GatewayStreamConsumer.
+
+    Returns None when the shared card surface cannot be started, allowing the
+    caller to fall back to the legacy text-edit transport.
+    """
+    if GatewayStreamConsumer is None or StreamConsumerConfig is None:
+        return None
+
+    import time
+    from .agent_real import stream_run_agent, real_run_agent
+    from .runtime import _PROFILE_HOME_VAR
+
+    stream_started_at = time.monotonic()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        chat_id,
+        StreamConsumerConfig(
+            edit_interval=_STREAM_CONTENT_MIN_SECONDS,
+            buffer_threshold=_STREAM_CONTENT_MIN_CHARS,
+            cursor=" ▉",
+        ),
+        metadata=None,
+    )
+    consumer_task: Optional[asyncio.Task] = None
+    idle_heartbeat_task: Optional[asyncio.Task] = None
+    terminal_update_sent = False
+    first_agent_event_seen = False
+    content_delta_seen = False
+    content = ""
+    thinking = ""
+    last_reasoning_edit = 0.0
+    last_reasoning_len = 0
+
+    async def _idle_card_heartbeat() -> None:
+        tick = 1
+        while True:
+            await asyncio.sleep(_STREAM_CARD_IDLE_HEARTBEAT_SECONDS)
+            if first_agent_event_seen or content_delta_seen:
+                return
+            try:
+                await consumer.update_streaming_card_status(_stream_card_idle_status(tick))
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.debug("multitenancy: shared card idle heartbeat failed: %s", exc)
+            tick += 1
+
+    async def _stop_idle_card_heartbeat() -> None:
+        if idle_heartbeat_task is None or idle_heartbeat_task.done():
+            return
+        idle_heartbeat_task.cancel()
+        try:
+            await idle_heartbeat_task
+        except asyncio.CancelledError:
+            pass
+
+    def _abort_content() -> str:
+        raw = content if content else (thinking if thinking else _STREAM_ABORT_FALLBACK)
+        return _clean_stream_display_text(raw)
+
+    async def _finish_consumer() -> None:
+        if consumer_task is None:
+            return
+        consumer.finish()
+        await consumer_task
+
+    try:
+        start_task = asyncio.create_task(consumer.ensure_streaming_card_started())
+        try:
+            started = await asyncio.shield(start_task)
+        except asyncio.CancelledError:
+            try:
+                started = await start_task
+            except Exception as exc:
+                logger.debug("multitenancy: shared card start failed while cancelling: %s", exc)
+                started = False
+            if started:
+                try:
+                    await consumer.abort_streaming_card(_STREAM_ABORT_FALLBACK)
+                except Exception as exc:
+                    logger.debug("multitenancy: shared card abort-after-start failed: %s", exc)
+            raise
+
+        if not started:
+            logger.debug("multitenancy: shared card start unavailable; falling back")
+            return None
+
+        logger.info(
+            "multitenancy: shared stream card ready elapsed=%.3fs",
+            time.monotonic() - stream_started_at,
+        )
+        consumer_task = asyncio.create_task(consumer.run())
+
+        prime_task = asyncio.create_task(
+            consumer.update_streaming_card_status(_STREAM_CARD_PRIME_STATUS)
+        )
+        try:
+            await asyncio.shield(prime_task)
+        except asyncio.CancelledError:
+            try:
+                await prime_task
+            except Exception as exc:
+                logger.debug("multitenancy: shared card prime failed while cancelling: %s", exc)
+            try:
+                await consumer.abort_streaming_card(_STREAM_ABORT_FALLBACK)
+            except Exception as exc:
+                logger.debug("multitenancy: shared card abort-after-prime failed: %s", exc)
+            raise
+
+        idle_heartbeat_task = asyncio.create_task(_idle_card_heartbeat())
+
+        token = _PROFILE_HOME_VAR.set(profile_home)
+        try:
+            try:
+                async for kind, delta in stream_run_agent(event, profile_home, messages=messages):
+                    if not first_agent_event_seen:
+                        first_agent_event_seen = True
+                        logger.info(
+                            "multitenancy: shared stream first agent event kind=%s total=%.3fs",
+                            kind,
+                            time.monotonic() - stream_started_at,
+                        )
+
+                    if kind == "thinking":
+                        thinking += str(delta or "")
+                        now = time.monotonic()
+                        if (
+                            not last_reasoning_len
+                            or len(thinking) - last_reasoning_len >= _STREAM_CARD_REASONING_MIN_CHARS
+                            or now - last_reasoning_edit >= _STREAM_CARD_REASONING_MIN_SECONDS
+                        ):
+                            await consumer.update_streaming_card_reasoning(thinking)
+                            last_reasoning_len = len(thinking)
+                            last_reasoning_edit = now
+                        continue
+
+                    if kind == "tool_started":
+                        payload = delta if isinstance(delta, dict) else {"name": str(delta or "tool")}
+                        await consumer.update_streaming_card_tool_started(
+                            str(payload.get("name") or payload.get("tool_name") or "tool"),
+                            preview=payload.get("preview"),
+                            args=payload.get("args"),
+                        )
+                        continue
+
+                    if kind == "tool_completed":
+                        payload = delta if isinstance(delta, dict) else {"name": str(delta or "tool")}
+                        await consumer.update_streaming_card_tool_completed(
+                            str(payload.get("name") or payload.get("tool_name") or "tool"),
+                            duration=payload.get("duration"),
+                            is_error=bool(payload.get("is_error")),
+                        )
+                        continue
+
+                    if kind == "done":
+                        continue
+
+                    piece = str(delta or "")
+                    if not piece:
+                        continue
+                    remaining = _STREAM_MAX_VISIBLE_CHARS - len(content)
+                    if remaining <= 0:
+                        continue
+                    if len(piece) > remaining:
+                        piece = piece[:remaining] + _STREAM_TRUNCATION_SUFFIX
+                        content = content[:_STREAM_MAX_VISIBLE_CHARS] + _STREAM_TRUNCATION_SUFFIX
+                        consumer.on_delta(piece)
+                        content_delta_seen = True
+                        logger.info(
+                            "multitenancy: shared stream content truncated max_chars=%s",
+                            _STREAM_MAX_VISIBLE_CHARS,
+                        )
+                        break
+                    content += piece
+                    consumer.on_delta(piece)
+                    content_delta_seen = True
+            except Exception as exc:
+                logger.info("multitenancy: shared streaming failed (%s) — falling back to non-stream", exc)
+                try:
+                    content = await real_run_agent(event, profile_home, messages=messages)
+                except Exception as fallback_exc:
+                    logger.warning("multitenancy: LLM fully unavailable: %s", fallback_exc)
+                    content = (
+                        "⚠️ 模型暂时不可用 (LLM provider rejected the request).\n"
+                        "请检查 profile 的 config.yaml 模型/凭据, 或稍后再试。"
+                    )
+                if not content_delta_seen:
+                    consumer.on_delta(_clean_stream_display_text(content))
+                    content_delta_seen = True
+        finally:
+            _PROFILE_HOME_VAR.reset(token)
+            await _stop_idle_card_heartbeat()
+
+        full = content if content else (thinking if thinking else "(empty response)")
+        if not content_delta_seen:
+            consumer.on_delta(_clean_stream_display_text(full))
+
+        await _finish_consumer()
+        terminal_update_sent = True
+        return full
+    except asyncio.CancelledError:
+        await _stop_idle_card_heartbeat()
+        if not terminal_update_sent:
+            try:
+                await _run_terminal_stream_update(
+                    consumer.abort_streaming_card(_abort_content()),
+                    label="shared stream abort update",
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as abort_exc:
+                logger.debug("multitenancy: shared stream abort update failed: %s", abort_exc)
+        if consumer_task is not None:
+            consumer.finish()
+            try:
+                await consumer_task
+            except Exception:
+                pass
+        raise
+
+
+async def _stream_into_feishu(
+    adapter, chat_id, profile_name, profile_home, event, *, messages: Optional[list[dict]] = None
+) -> str:
+    """Stream LLM tokens into Feishu.
+
+    Uses OpenClaw-style interactive card streaming when the shared Feishu
+    adapter supports it. Falls back to the legacy text placeholder +
+    ``edit_message`` loop for older adapters.
+
+    Falls back to a single non-streamed send() if streaming returns empty or
+    the initial stream target fails. Returns the final concatenated text.
+
+    ``messages`` (optional): full conversation including prior history. When
+    omitted the runner builds a single-turn system+user prompt from the event.
+    """
+    import time
+    from .agent_real import stream_run_agent, real_run_agent
+    from .runtime import _PROFILE_HOME_VAR
+
+    stream_started_at = time.monotonic()
+
+    # Without an adapter we can still produce text (used in unit tests).
+    if adapter is None:
+        token = _PROFILE_HOME_VAR.set(profile_home)
+        try:
+            content_parts: list[str] = []
+            async for kind, c in stream_run_agent(event, profile_home, messages=messages):
+                if kind == "content":
+                    content_parts.append(c)
+            return (
+                "".join(content_parts)
+                or await real_run_agent(event, profile_home, messages=messages)
+            )
+        finally:
+            _PROFILE_HOME_VAR.reset(token)
+
+    if _adapter_supports_streaming_card(adapter):
+        shared_response = await _stream_into_feishu_shared_consumer(
+            adapter,
+            chat_id,
+            profile_name,
+            profile_home,
+            event,
+            messages=messages,
+        )
+        if shared_response is not None:
+            return shared_response
+
+    stream_mode = "edit"
+    placeholder_id: Optional[str] = None
+    target_ready_at = stream_started_at
+    thinking = ""
+    content = ""
+    last_edit_time = 0.0
+    last_render_len = 0
+    last_reasoning_render_len = 0
+    content_started = False
+    first_agent_event_seen = False
+    terminal_update_sent = False
+    card_reasoning_sent = False
+    idle_heartbeat_task: Optional[asyncio.Task] = None
+
+    async def _idle_card_heartbeat() -> None:
+        tick = 1
+        while True:
+            await asyncio.sleep(_STREAM_CARD_IDLE_HEARTBEAT_SECONDS)
+            if first_agent_event_seen or content_started or placeholder_id is None:
+                return
+            try:
+                await _update_feishu_stream_status(
+                    adapter,
+                    chat_id,
+                    placeholder_id,
+                    _stream_card_idle_status(tick),
+                    mode=stream_mode,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.debug("multitenancy: card idle heartbeat failed: %s", exc)
+            tick += 1
+
+    async def _stop_idle_card_heartbeat() -> None:
+        if idle_heartbeat_task is None or idle_heartbeat_task.done():
+            return
+        idle_heartbeat_task.cancel()
+        try:
+            await idle_heartbeat_task
+        except asyncio.CancelledError:
+            pass
+
+    def render() -> str:
+        if content:
+            return _clean_stream_display_text(content)
+        preview = thinking[-160:].strip() if thinking else ""
+        return f"💭 思考中…\n{preview}" if preview else "💭 思考中…"
+
+    def abort_content() -> str:
+        raw = content if content else (thinking if thinking else _STREAM_ABORT_FALLBACK)
+        return _clean_stream_display_text(raw)
+
+    try:
+        # Create/send can complete remotely after this task is cancelled. Shield
+        # it so we can still obtain the message_id and close the card instead of
+        # leaving a Generating card behind.
+        start_task = asyncio.create_task(_start_feishu_stream_target(adapter, chat_id))
+        try:
+            stream_mode, placeholder_id = await asyncio.shield(start_task)
+        except asyncio.CancelledError:
+            try:
+                stream_mode, placeholder_id = await start_task
+                logger.info(
+                    "multitenancy: stream target start completed while task was cancelling "
+                    "mode=%s message_id=%s",
+                    stream_mode,
+                    placeholder_id,
+                )
+            except Exception as exc:
+                logger.debug("multitenancy: stream target start failed while cancelling: %s", exc)
+            raise
+
+        target_ready_at = time.monotonic()
+        logger.info(
+            "multitenancy: stream target ready mode=%s message_id=%s elapsed=%.3fs",
+            stream_mode,
+            placeholder_id,
+            target_ready_at - stream_started_at,
+        )
+
+        if placeholder_id is None:
+            # Couldn't get a message to edit — degrade to one-shot non-stream.
+            text = await real_run_agent(event, profile_home, messages=messages)
+            await adapter.send(chat_id, text)
+            return text
+
+        if stream_mode == "card":
+            try:
+                await _update_feishu_stream_status(
+                    adapter,
+                    chat_id,
+                    placeholder_id,
+                    _STREAM_CARD_PRIME_STATUS,
+                    mode=stream_mode,
+                )
+                logger.info(
+                    "multitenancy: stream card primed message_id=%s elapsed=%.3fs",
+                    placeholder_id,
+                    time.monotonic() - target_ready_at,
+                )
+                idle_heartbeat_task = asyncio.create_task(_idle_card_heartbeat())
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.debug("multitenancy: card prime update failed: %s", exc)
+
+        token = _PROFILE_HOME_VAR.set(profile_home)
+        try:
+            try:
+                async for kind, delta in stream_run_agent(event, profile_home, messages=messages):
+                    if not first_agent_event_seen:
+                        first_agent_event_seen = True
+                        logger.info(
+                            "multitenancy: stream first agent event kind=%s "
+                            "since_target=%.3fs total=%.3fs",
+                            kind,
+                            time.monotonic() - target_ready_at,
+                            time.monotonic() - stream_started_at,
+                        )
+                    if kind == "thinking":
+                        thinking += str(delta or "")
+                        if stream_mode == "card" and thinking:
+                            now = time.monotonic()
+                            should_update_card_reasoning = (
+                                not card_reasoning_sent
+                                or len(thinking) - last_reasoning_render_len >= _STREAM_CARD_REASONING_MIN_CHARS
+                                or now - last_edit_time >= _STREAM_CARD_REASONING_MIN_SECONDS
+                            )
+                            if should_update_card_reasoning:
+                                try:
+                                    await _update_feishu_stream_reasoning(
+                                        adapter,
+                                        chat_id,
+                                        placeholder_id,
+                                        thinking,
+                                        mode=stream_mode,
+                                    )
+                                    card_reasoning_sent = True
+                                    last_reasoning_render_len = len(thinking)
+                                except Exception as exc:
+                                    logger.debug("multitenancy: card reasoning update failed: %s", exc)
+                                last_edit_time = now
+                                last_render_len = len(render())
+                            continue
+                    elif kind == "tool_started":
+                        try:
+                            await _update_feishu_stream_tool_event(
+                                adapter,
+                                chat_id,
+                                placeholder_id,
+                                delta,
+                                mode=stream_mode,
+                                completed=False,
+                            )
+                        except Exception as exc:
+                            logger.debug("multitenancy: card tool-start update failed: %s", exc)
+                        last_edit_time = time.monotonic()
+                        last_render_len = len(render())
+                        continue
+                    elif kind == "tool_completed":
+                        try:
+                            await _update_feishu_stream_tool_event(
+                                adapter,
+                                chat_id,
+                                placeholder_id,
+                                delta,
+                                mode=stream_mode,
+                                completed=True,
+                            )
+                        except Exception as exc:
+                            logger.debug("multitenancy: card tool-complete update failed: %s", exc)
+                        last_edit_time = time.monotonic()
+                        last_render_len = len(render())
+                        continue
+                    elif kind == "done":
+                        continue
+                    else:
+                        content += str(delta or "")
+                        if len(content) > _STREAM_MAX_VISIBLE_CHARS:
+                            content = (
+                                content[:_STREAM_MAX_VISIBLE_CHARS]
+                                + _STREAM_TRUNCATION_SUFFIX
+                            )
+                            logger.info(
+                                "multitenancy: stream content truncated and finalized "
+                                "message_id=%s max_chars=%s",
+                                placeholder_id,
+                                _STREAM_MAX_VISIBLE_CHARS,
+                            )
+                            break
+                        if not content_started:
+                            # Force an immediate edit on phase transition so the user
+                            # sees the answer start the moment reasoning ends.
+                            content_started = True
+                            try:
+                                await _update_feishu_stream_target(
+                                    adapter,
+                                    chat_id,
+                                    placeholder_id,
+                                    render(),
+                                    mode=stream_mode,
+                                )
+                            except Exception as exc:
+                                logger.debug(
+                                    "multitenancy: phase-transition stream update failed: %s",
+                                    exc,
+                                )
+                            last_edit_time = time.monotonic()
+                            last_render_len = len(render())
+                            continue
+
+                    now = time.monotonic()
+                    rendered = render()
+                    if content_started:
+                        should_edit = (
+                            len(rendered) - last_render_len >= _STREAM_CONTENT_MIN_CHARS
+                            or now - last_edit_time >= _STREAM_CONTENT_MIN_SECONDS
+                        )
+                    else:
+                        # Reasoning phase — heartbeat-only edits, no char threshold.
+                        should_edit = now - last_edit_time >= _STREAM_THINKING_MIN_SECONDS
+                    if should_edit:
+                        try:
+                            await _update_feishu_stream_target(
+                                adapter,
+                                chat_id,
+                                placeholder_id,
+                                rendered,
+                                mode=stream_mode,
+                            )
+                        except Exception as exc:
+                            logger.debug("multitenancy: stream update mid-stream failed: %s", exc)
+                        last_edit_time = now
+                        last_render_len = len(rendered)
+            except Exception as exc:
+                logger.info("multitenancy: streaming failed (%s) — falling back to non-stream", exc)
+                try:
+                    content = await real_run_agent(event, profile_home, messages=messages)
+                except Exception as fallback_exc:
+                    # Both stream + non-stream LLM paths failed (e.g. region block,
+                    # exhausted credentials). Surface a user-visible error instead
+                    # of leaving the "..." placeholder hanging.
+                    logger.warning("multitenancy: LLM fully unavailable: %s", fallback_exc)
+                    content = (
+                        "⚠️ 模型暂时不可用 (LLM provider rejected the request).\n"
+                        "请检查 profile 的 config.yaml 模型/凭据, 或稍后再试。"
+                    )
+        finally:
+            _PROFILE_HOME_VAR.reset(token)
+            await _stop_idle_card_heartbeat()
+
+        full = content if content else (thinking if thinking else "(empty response)")
+        display_full = _clean_stream_display_text(full)
+
+        # 3. Final commit. finalize=True signals end of stream to Feishu.
+        try:
+            await _run_terminal_stream_update(
+                _update_feishu_stream_target(
+                    adapter,
+                    chat_id,
+                    placeholder_id,
+                    display_full,
+                    mode=stream_mode,
+                    finalize=True,
+                ),
+                label="stream final update",
+            )
+            terminal_update_sent = True
+        except Exception as exc:
+            logger.debug("multitenancy: final stream update failed: %s", exc)
+
+        return full
+    except asyncio.CancelledError:
+        if placeholder_id is not None and not terminal_update_sent:
+            full = abort_content()
+            logger.info(
+                "multitenancy: stream cancelled; aborting target mode=%s message_id=%s content_len=%s",
+                stream_mode,
+                placeholder_id,
+                len(full),
+            )
+            try:
+                await _run_terminal_stream_update(
+                    _abort_feishu_stream_target(
+                        adapter,
+                        chat_id,
+                        placeholder_id,
+                        full,
+                        mode=stream_mode,
+                    ),
+                    label="stream abort update",
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as abort_exc:
+                logger.debug("multitenancy: stream abort update failed: %s", abort_exc)
+        raise
+
+
+def _log_task_failure(task: asyncio.Task) -> None:
+    """Done-callback for fire-and-forget tasks — surfaces silent exceptions."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("multitenancy: background task crashed: %r", exc)

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/router.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/router.py
@@ -368,17 +368,35 @@ async def handle_async(*, event: Any, gateway: Any) -> None:
         if cmd_pair is not None:
             cmd_profile_name, cmd_profile_home = _resolve_route(sender, alt_id=sender_alt)
             cmd_profile = cmd_profile_name if cmd_profile_home is not None else None
-            await _handle_command(
+            skill_handled, skill_reply = _maybe_rewrite_skill_slash_command(
                 cmd_pair,
-                sender,
-                sender_alt,
-                cmd_profile,
-                cmd_profile_home,
-                chat_id,
-                gateway,
                 event,
+                gateway,
+                sender=sender,
+                sender_alt=sender_alt,
+                profile_name=cmd_profile,
+                profile_home=cmd_profile_home,
+                chat_id=chat_id,
             )
-            return
+            if skill_handled:
+                if skill_reply:
+                    adapter = _get_feishu_adapter(gateway)
+                    if adapter is not None:
+                        await _safe_call(adapter.send, chat_id, skill_reply)
+                    return
+                text = getattr(event, "text", "") or ""
+            else:
+                await _handle_command(
+                    cmd_pair,
+                    sender,
+                    sender_alt,
+                    cmd_profile,
+                    cmd_profile_home,
+                    chat_id,
+                    gateway,
+                    event,
+                )
+                return
 
         # Routing: SQLite table first, then in-memory spike fallback.
         profile_name, profile_home = _resolve_or_auto_provision_route(sender, alt_id=sender_alt)
@@ -488,6 +506,80 @@ def _processing_outcome(*, failed: bool) -> Any:
 
 
 # -- Command dispatch --------------------------------------------------------
+
+
+def _maybe_rewrite_skill_slash_command(
+    pair: tuple[str, str],
+    event: Any,
+    gateway: Any,
+    *,
+    sender: str,
+    sender_alt: Optional[str],
+    profile_name: Optional[str],
+    profile_home: Optional[Path],
+    chat_id: str,
+) -> tuple[bool, Optional[str]]:
+    """Rewrite Hermes skill slash commands into the native skill invocation text.
+
+    Native gateway treats ``/skill-name args`` as an agent turn after loading
+    the skill instructions. The multitenancy router sees the slash first, so it
+    must preserve that behavior instead of replying "unknown command".
+    """
+    cmd, args = pair
+    try:
+        from .commands import is_known_command
+
+        if is_known_command(cmd) or _gateway_handler_for_command(gateway, cmd) is not None:
+            return False, None
+        if _get_quick_command(gateway, cmd) is not None:
+            return False, None
+        if _get_plugin_command_handler(cmd) is not None:
+            return False, None
+
+        from agent.skill_commands import (  # type: ignore
+            build_skill_invocation_message,
+            get_skill_commands,
+            resolve_skill_command_key,
+        )
+
+        skill_cmds = get_skill_commands()
+        cmd_key = resolve_skill_command_key(cmd)
+        if cmd_key is None:
+            return False, None
+
+        skill_name = (skill_cmds.get(cmd_key) or {}).get("name", "")
+        platform = _event_platform_value(event)
+        if platform and skill_name:
+            try:
+                from agent.skill_utils import get_disabled_skill_names  # type: ignore
+
+                if skill_name in get_disabled_skill_names(platform=platform):
+                    return (
+                        True,
+                        f"The **{skill_name}** skill is disabled for {platform}.\n"
+                        "Enable it with: `hermes skills config`",
+                    )
+            except Exception as exc:
+                logger.debug("multitenancy: skill disabled check failed (%s)", exc)
+
+        msg = build_skill_invocation_message(
+            cmd_key,
+            args.strip(),
+            task_id=_multitenant_gateway_session_key(
+                event,
+                profile_name=profile_name,
+                sender=sender,
+                sender_alt=sender_alt,
+                chat_id=chat_id,
+            ),
+        )
+        if not msg:
+            return False, None
+        setattr(event, "text", msg)
+        return True, None
+    except Exception as exc:
+        logger.debug("multitenancy: skill command passthrough failed (%s)", exc)
+        return False, None
 
 
 async def _handle_command(
@@ -608,7 +700,19 @@ async def _dispatch_gateway_command(
 
     handler = _gateway_handler_for_command(gateway, cmd)
     if handler is None:
-        return None
+        quick_result = await _dispatch_quick_command(
+            cmd,
+            event,
+            gateway,
+            sender=sender,
+            sender_alt=sender_alt,
+            profile_name=profile_name,
+            profile_home=profile_home,
+            chat_id=chat_id,
+        )
+        if quick_result is not None:
+            return quick_result
+        return await _dispatch_plugin_command(cmd, event)
     with _profile_gateway_context(
         gateway,
         event,
@@ -622,6 +726,104 @@ async def _dispatch_gateway_command(
         if asyncio.iscoroutine(result):
             result = await result
     return str(result) if result is not None else None
+
+
+async def _dispatch_quick_command(
+    cmd: str,
+    event: Any,
+    gateway: Any,
+    *,
+    sender: str,
+    sender_alt: Optional[str],
+    profile_name: Optional[str],
+    profile_home: Optional[Path],
+    chat_id: str,
+) -> Optional[str]:
+    """Handle Hermes config.quick_commands without copying the command list."""
+    qcmd = _get_quick_command(gateway, cmd)
+    if not isinstance(qcmd, dict):
+        return None
+
+    kind = qcmd.get("type")
+    if kind == "exec":
+        exec_cmd = qcmd.get("command", "")
+        if not exec_cmd:
+            return f"Quick command '/{cmd}' has no command defined."
+        try:
+            proc = await asyncio.create_subprocess_shell(
+                exec_cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+            output = (stdout or stderr).decode().strip()
+            return output if output else "Command returned no output."
+        except asyncio.TimeoutError:
+            return "Quick command timed out (30s)."
+        except Exception as exc:
+            return f"Quick command error: {exc}"
+
+    if kind == "alias":
+        target = str(qcmd.get("target", "") or "").strip()
+        if not target:
+            return f"Quick command '/{cmd}' has no target defined."
+        target = target if target.startswith("/") else f"/{target}"
+        target_command = target.lstrip("/")
+        new_cmd = target_command.split()[0] if target_command else ""
+        if not new_cmd or new_cmd == cmd:
+            return f"Quick command '/{cmd}' has invalid target."
+        user_args = _command_args_from_event(event).strip()
+        setattr(event, "text", f"{target} {user_args}".strip())
+        _set_command_event_methods(event, new_cmd)
+        return await _dispatch_gateway_command(
+            new_cmd,
+            event,
+            gateway,
+            sender=sender,
+            sender_alt=sender_alt,
+            profile_name=profile_name,
+            profile_home=profile_home,
+            chat_id=chat_id,
+        )
+
+    return f"Quick command '/{cmd}' has unsupported type (supported: 'exec', 'alias')."
+
+
+def _get_quick_command(gateway: Any, cmd: str) -> Any:
+    config = getattr(gateway, "config", None)
+    if isinstance(config, dict):
+        quick_commands = config.get("quick_commands", {}) or {}
+    else:
+        quick_commands = getattr(config, "quick_commands", {}) or {}
+    if not isinstance(quick_commands, dict):
+        return None
+    return quick_commands.get(cmd)
+
+
+async def _dispatch_plugin_command(cmd: str, event: Any) -> Optional[str]:
+    """Delegate plugin-registered slash commands to Hermes' plugin manager."""
+    handler = _get_plugin_command_handler(cmd)
+    if handler is None:
+        return None
+    user_args = ""
+    get_args = getattr(event, "get_command_args", None)
+    if callable(get_args):
+        user_args = (get_args() or "").strip()
+    result = handler(user_args)
+    if asyncio.iscoroutine(result):
+        result = await result
+    return str(result) if result else None
+
+
+def _get_plugin_command_handler(cmd: str) -> Any:
+    """Return Hermes' plugin command handler for ``cmd`` when available."""
+    try:
+        from hermes_cli.plugins import get_plugin_command_handler  # type: ignore
+
+        return get_plugin_command_handler(cmd.replace("_", "-"))
+    except Exception as exc:
+        logger.debug("multitenancy: plugin command lookup failed (%s)", exc)
+        return None
 
 
 def _gateway_handler_for_command(gateway: Any, cmd: str) -> Any:
@@ -639,12 +841,36 @@ def _gateway_handler_for_command(gateway: Any, cmd: str) -> Any:
 
 def _ensure_command_event_methods(event: Any, cmd: str) -> None:
     """Add minimal MessageEvent command helpers for tests/fallback objects."""
-    text = getattr(event, "text", "") or ""
-    args = text.split(maxsplit=1)[1] if len(text.split(maxsplit=1)) > 1 else ""
+    args = _command_args_from_event(event)
     if not callable(getattr(event, "get_command", None)):
         setattr(event, "get_command", lambda: cmd)
     if not callable(getattr(event, "get_command_args", None)):
         setattr(event, "get_command_args", lambda: args)
+
+
+def _set_command_event_methods(event: Any, cmd: str) -> None:
+    args = _command_args_from_text(getattr(event, "text", "") or "")
+    setattr(event, "get_command", lambda: cmd)
+    setattr(event, "get_command_args", lambda: args)
+
+
+def _command_args_from_event(event: Any) -> str:
+    get_args = getattr(event, "get_command_args", None)
+    if callable(get_args):
+        return str(get_args() or "")
+    return _command_args_from_text(getattr(event, "text", "") or "")
+
+
+def _command_args_from_text(text: str) -> str:
+    parts = text.split(maxsplit=1)
+    return parts[1] if len(parts) > 1 else ""
+
+
+def _event_platform_value(event: Any) -> Optional[str]:
+    source = getattr(event, "source", None)
+    platform = getattr(source, "platform", None) if source is not None else None
+    value = getattr(platform, "value", platform)
+    return str(value) if value else None
 
 
 def _profile_gateway_context(

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/router.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/router.py
@@ -1,7 +1,8 @@
-"""Pre-gateway-dispatch hook callback and async dispatch entry point.
+"""Pre-gateway-dispatch hook callback (sync) + async dispatch entry point.
 
-Wires together the SQLite routing table, optional in-memory route fallback,
-LRU runtime pool, slash commands, and Feishu streaming replies.
+Wires together: SQLite RoutingTable (production) + in-memory _SPIKE_ROUTING
+(fallback) + LRU RuntimePool (cached profile runtimes) + Hermes-derived slash
+command dispatch.
 """
 from __future__ import annotations
 
@@ -367,10 +368,19 @@ async def handle_async(*, event: Any, gateway: Any) -> None:
         if cmd_pair is not None:
             cmd_profile_name, cmd_profile_home = _resolve_route(sender, alt_id=sender_alt)
             cmd_profile = cmd_profile_name if cmd_profile_home is not None else None
-            await _handle_command(cmd_pair, sender, sender_alt, cmd_profile, chat_id, gateway)
+            await _handle_command(
+                cmd_pair,
+                sender,
+                sender_alt,
+                cmd_profile,
+                cmd_profile_home,
+                chat_id,
+                gateway,
+                event,
+            )
             return
 
-        # Routing: SQLite table first, then in-memory fallback.
+        # Routing: SQLite table first, then in-memory spike fallback.
         profile_name, profile_home = _resolve_or_auto_provision_route(sender, alt_id=sender_alt)
         if profile_home is None:
             logger.info("multitenancy: no route for sender=%s, ignoring", sender)
@@ -485,8 +495,10 @@ async def _handle_command(
     sender: str,
     sender_alt: Optional[str],
     profile_name: Optional[str],
+    profile_home: Optional[Path],
     chat_id: str,
     gateway: Any,
+    event: Any,
 ) -> None:
     """Execute a parsed slash command and reply via the shared adapter."""
     cmd, _args = pair
@@ -522,19 +534,205 @@ async def _handle_command(
         else:
             reply = "(未路由的用户) 没有历史可重置"
     elif cmd == "help":
-        reply = (
-            "📖 可用命令\n"
-            "/help    — 显示这条帮助\n"
-            "/status  — 查看当前 profile + 历史长度\n"
-            "/new     — 重置会话历史 (开始新对话)\n"
-            "/reset   — /new 的别名\n"
-            "/stop    — 取消正在运行的任务\n"
-        )
+        reply = _gateway_help_text()
     else:
-        return
+        dispatched = await _dispatch_gateway_command(
+            cmd,
+            event,
+            gateway,
+            sender=sender,
+            sender_alt=sender_alt,
+            profile_name=profile_name,
+            profile_home=profile_home,
+            chat_id=chat_id,
+        )
+        if dispatched is not None:
+            reply = dispatched
+        else:
+            from .commands import is_known_command, unknown_command_message
+
+            reply = (
+                f"Command `/{cmd}` is recognized by Hermes, but this gateway does not "
+                "expose a reusable command dispatcher yet."
+                if is_known_command(cmd)
+                else unknown_command_message(cmd)
+            )
 
     if adapter is not None:
         await _safe_call(adapter.send, chat_id, reply)
+
+
+async def _dispatch_gateway_command(
+    cmd: str,
+    event: Any,
+    gateway: Any,
+    *,
+    sender: str,
+    sender_alt: Optional[str],
+    profile_name: Optional[str],
+    profile_home: Optional[Path],
+    chat_id: str,
+) -> Optional[str]:
+    """Delegate a Hermes-known slash command to the gateway when possible."""
+    _ensure_command_event_methods(event, cmd)
+
+    dispatcher = getattr(gateway, "_dispatch_slash_command", None)
+    if callable(dispatcher):
+        with _profile_gateway_context(
+            gateway,
+            event,
+            sender=sender,
+            sender_alt=sender_alt,
+            profile_name=profile_name,
+            profile_home=profile_home,
+            chat_id=chat_id,
+        ):
+            try:
+                result = dispatcher(event, multitenancy_context={
+                    "profile_name": profile_name,
+                    "profile_home": str(profile_home) if profile_home else "",
+                    "sender_open_id": sender,
+                    "session_key_override": _multitenant_gateway_session_key(
+                        event,
+                        profile_name=profile_name,
+                        sender=sender,
+                        sender_alt=sender_alt,
+                        chat_id=chat_id,
+                    ),
+                })
+            except TypeError:
+                result = dispatcher(event)
+            if asyncio.iscoroutine(result):
+                result = await result
+            return str(result) if result is not None else None
+
+    handler = _gateway_handler_for_command(gateway, cmd)
+    if handler is None:
+        return None
+    with _profile_gateway_context(
+        gateway,
+        event,
+        sender=sender,
+        sender_alt=sender_alt,
+        profile_name=profile_name,
+        profile_home=profile_home,
+        chat_id=chat_id,
+    ):
+        result = handler(event)
+        if asyncio.iscoroutine(result):
+            result = await result
+    return str(result) if result is not None else None
+
+
+def _gateway_handler_for_command(gateway: Any, cmd: str) -> Any:
+    """Return Hermes' handler method using naming conventions, not a command table."""
+    normalized = cmd.replace("-", "_")
+    candidates = [f"_handle_{normalized}_command"]
+    if normalized == "sethome":
+        candidates.append("_handle_set_home_command")
+    for name in candidates:
+        handler = getattr(gateway, name, None)
+        if callable(handler):
+            return handler
+    return None
+
+
+def _ensure_command_event_methods(event: Any, cmd: str) -> None:
+    """Add minimal MessageEvent command helpers for tests/fallback objects."""
+    text = getattr(event, "text", "") or ""
+    args = text.split(maxsplit=1)[1] if len(text.split(maxsplit=1)) > 1 else ""
+    if not callable(getattr(event, "get_command", None)):
+        setattr(event, "get_command", lambda: cmd)
+    if not callable(getattr(event, "get_command_args", None)):
+        setattr(event, "get_command_args", lambda: args)
+
+
+def _profile_gateway_context(
+    gateway: Any,
+    event: Any,
+    *,
+    sender: str,
+    sender_alt: Optional[str],
+    profile_name: Optional[str],
+    profile_home: Optional[Path],
+    chat_id: str,
+):
+    """Temporarily scope Hermes gateway helpers to the routed profile."""
+    class _Context:
+        def __enter__(self):
+            self._old_home = os.environ.get("HERMES_HOME")
+            self._had_home = "HERMES_HOME" in os.environ
+            self._old_session_key_for_source = getattr(gateway, "_session_key_for_source", None)
+            if profile_home is not None:
+                os.environ["HERMES_HOME"] = str(profile_home)
+            session_key = _multitenant_gateway_session_key(
+                event,
+                profile_name=profile_name,
+                sender=sender,
+                sender_alt=sender_alt,
+                chat_id=chat_id,
+            )
+            if session_key:
+                def _scoped_session_key_for_source(source):
+                    return session_key
+
+                setattr(gateway, "_session_key_for_source", _scoped_session_key_for_source)
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            if self._old_session_key_for_source is not None:
+                setattr(gateway, "_session_key_for_source", self._old_session_key_for_source)
+            elif hasattr(gateway, "_session_key_for_source"):
+                try:
+                    delattr(gateway, "_session_key_for_source")
+                except Exception:
+                    pass
+            if self._had_home:
+                os.environ["HERMES_HOME"] = self._old_home or ""
+            else:
+                os.environ.pop("HERMES_HOME", None)
+            return False
+
+    return _Context()
+
+
+def _multitenant_gateway_session_key(
+    event: Any,
+    *,
+    profile_name: Optional[str],
+    sender: str,
+    sender_alt: Optional[str],
+    chat_id: str,
+) -> Optional[str]:
+    if not profile_name:
+        return None
+    source = getattr(event, "source", None)
+    platform = getattr(getattr(source, "platform", None), "value", None) or "feishu"
+    user_key = sender_alt or sender
+    return f"multitenancy:{platform}:{profile_name}:{chat_id}:{user_key}"
+
+
+def _gateway_help_text() -> str:
+    """Render help from Hermes' central command registry when available."""
+    try:
+        from hermes_cli.commands import gateway_help_lines  # type: ignore
+
+        lines = gateway_help_lines()
+        if lines:
+            return "📖 可用命令\n" + "\n".join(lines[:30])
+    except Exception:
+        pass
+    return (
+        "📖 可用命令\n"
+        "/help    — 显示这条帮助\n"
+        "/status  — 查看当前 profile + 历史长度\n"
+        "/new     — 重置会话历史 (开始新对话)\n"
+        "/reset   — /new 的别名\n"
+        "/stop    — 取消正在运行的任务\n"
+        "/model   — 切换当前会话模型\n"
+        "/reasoning — 管理推理强度\n"
+        "/voice   — 切换语音回复模式\n"
+    )
 
 
 # -- Routing resolution ------------------------------------------------------
@@ -550,11 +748,11 @@ def _resolve_route(sender: str, *, alt_id: Optional[str] = None) -> tuple[str, O
     Lookup order:
       1. SQLite RoutingTable WHERE open_id = sender (typical: real Feishu ou_* open_id)
       2. SQLite RoutingTable WHERE open_id = alt_id (legacy: source.user_id_alt = union_id)
-      3. In-memory route fallback for tests and local demos
+      3. In-memory ``_SPIKE_ROUTING`` dict (Phase 1 compat / unit tests)
 
     Returns (sender, None) when no route hits.
     """
-    from .runtime import resolve_profile_home as _resolve_in_memory_route
+    from .runtime import resolve_profile_home as _spike_resolve
 
     table = _get_routing_table()
     candidates: list[str] = [sender]
@@ -571,11 +769,11 @@ def _resolve_route(sender: str, *, alt_id: Optional[str] = None) -> tuple[str, O
             if row is not None:
                 return (row.profile_name, _profile_name_to_home(row.profile_name))
 
-    # Fallback: in-memory route map.
+    # Fallback: in-memory spike routing dict
     for candidate in candidates:
-        in_memory_home = _resolve_in_memory_route(candidate)
-        if in_memory_home is not None:
-            return (in_memory_home.name, in_memory_home)
+        spike_home = _spike_resolve(candidate)
+        if spike_home is not None:
+            return (spike_home.name, spike_home)
     return (sender, None)
 
 
@@ -742,9 +940,7 @@ def _profile_config_from_shared_home(shared_home: Path) -> dict[str, Any]:
 
 def _normalize_profile_config(config: dict[str, Any]) -> dict[str, Any]:
     model = config.get("model")
-    if not isinstance(model, dict) or not model.get("default"):
-        return config
-    else:
+    if isinstance(model, dict) and model.get("default"):
         default_model = str(model.get("default") or "").strip()
         provider = str(model.get("provider") or "").strip()
         if default_model and provider and "/" not in default_model:

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/routing.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/routing.py
@@ -1,0 +1,171 @@
+"""SQLite-backed routing table for Feishu sender-to-profile routes.
+
+Schema:
+  - user_id PRIMARY KEY (business key for ops/feishu-sync)
+  - profile_name (NOT UNIQUE — guest profile can serve multiple users)
+  - open_id (queryable hot path, UNIQUE among active rows only)
+  - union_id (cross-app stable id, optional)
+  - active flag + deleted_at + synced_at + version (soft-delete + sync-staleness)
+
+Read/write contract:
+  - feishu-sync writes user_id / profile_name / open_id / union_id (and version++)
+  - router only updates last_active_at via touch_active(open_id)
+"""
+from __future__ import annotations
+
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+# Default db path — independent from ~/.hermes/state.db so router writes don't
+# contend with gateway sessions/pairing/cron writes for the WAL.
+DEFAULT_DB_PATH = Path.home() / ".hermes" / "multitenancy.db"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS multitenancy_routing (
+    user_id        TEXT PRIMARY KEY NOT NULL,
+    profile_name   TEXT NOT NULL,
+    open_id        TEXT NOT NULL,
+    union_id       TEXT,
+    active         INTEGER NOT NULL DEFAULT 1,
+    deleted_at     INTEGER,
+    synced_at      INTEGER NOT NULL,
+    version        INTEGER NOT NULL DEFAULT 1,
+    last_active_at INTEGER,
+    created_at     INTEGER NOT NULL,
+    updated_at     INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_routing_open_id_active
+    ON multitenancy_routing(open_id) WHERE active = 1;
+CREATE INDEX IF NOT EXISTS idx_routing_active_user
+    ON multitenancy_routing(active, user_id);
+"""
+
+
+@dataclass(frozen=True)
+class RoutingRow:
+    user_id: str
+    profile_name: str
+    open_id: str
+    union_id: Optional[str]
+    active: bool
+    last_active_at: Optional[int]
+    synced_at: int
+    version: int
+
+
+class RoutingTable:
+    """SQLite-backed routing table.
+
+    Use ``RoutingTable(":memory:")`` in tests for isolation.
+    Use ``RoutingTable()`` (default) in production — points to
+    ``~/.hermes/multitenancy.db``.
+    """
+
+    def __init__(self, db_path: Path | str | None = None) -> None:
+        self.db_path = str(db_path) if db_path is not None else str(DEFAULT_DB_PATH)
+        if self.db_path != ":memory:":
+            Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+        # check_same_thread=False so the same connection survives across the
+        # asyncio task switches that the plugin does. SQLite operations are
+        # short and serial within a single dispatch.
+        self._conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript("PRAGMA journal_mode=WAL;")
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+    # -- read path (router) -----------------------------------------------
+
+    def lookup_by_open_id(self, open_id: str) -> Optional[RoutingRow]:
+        """Return the active row for open_id, or None if missing/soft-deleted."""
+        cur = self._conn.execute(
+            "SELECT * FROM multitenancy_routing WHERE open_id = ? AND active = 1",
+            (open_id,),
+        )
+        row = cur.fetchone()
+        return _row_to_dataclass(row) if row else None
+
+    def touch_active(self, open_id: str) -> None:
+        """Update last_active_at — router-only, does NOT bump version."""
+        self._conn.execute(
+            "UPDATE multitenancy_routing SET last_active_at = ? WHERE open_id = ? AND active = 1",
+            (_now(), open_id),
+        )
+        self._conn.commit()
+
+    # -- write path (feishu-sync) ----------------------------------------
+
+    def upsert(
+        self,
+        *,
+        user_id: str,
+        profile_name: str,
+        open_id: str,
+        union_id: Optional[str] = None,
+    ) -> None:
+        """Insert or refresh a route. Bumps version, sets synced_at to now."""
+        now = _now()
+        self._conn.execute(
+            """
+            INSERT INTO multitenancy_routing
+                (user_id, profile_name, open_id, union_id, active,
+                 synced_at, version, created_at, updated_at)
+            VALUES (?, ?, ?, ?, 1, ?, 1, ?, ?)
+            ON CONFLICT(user_id) DO UPDATE SET
+                profile_name = excluded.profile_name,
+                open_id      = excluded.open_id,
+                union_id     = excluded.union_id,
+                active       = 1,
+                deleted_at   = NULL,
+                synced_at    = excluded.synced_at,
+                version      = version + 1,
+                updated_at   = excluded.updated_at
+            """,
+            (user_id, profile_name, open_id, union_id, now, now, now),
+        )
+        self._conn.commit()
+
+    def soft_delete(self, user_id: str) -> bool:
+        """Mark a route as inactive. Returns True if a row was updated."""
+        now = _now()
+        cur = self._conn.execute(
+            """
+            UPDATE multitenancy_routing
+            SET active = 0, deleted_at = ?, updated_at = ?, version = version + 1
+            WHERE user_id = ? AND active = 1
+            """,
+            (now, now, user_id),
+        )
+        self._conn.commit()
+        return cur.rowcount > 0
+
+    # -- diagnostics -------------------------------------------------------
+
+    def count_active(self) -> int:
+        cur = self._conn.execute(
+            "SELECT COUNT(*) FROM multitenancy_routing WHERE active = 1"
+        )
+        return int(cur.fetchone()[0])
+
+    def close(self) -> None:
+        self._conn.close()
+
+
+def _row_to_dataclass(row: sqlite3.Row) -> RoutingRow:
+    return RoutingRow(
+        user_id=row["user_id"],
+        profile_name=row["profile_name"],
+        open_id=row["open_id"],
+        union_id=row["union_id"],
+        active=bool(row["active"]),
+        last_active_at=row["last_active_at"],
+        synced_at=row["synced_at"],
+        version=row["version"],
+    )
+
+
+def _now() -> int:
+    return int(time.time())

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/runtime.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/runtime.py
@@ -1,0 +1,146 @@
+"""ProfileRuntime runs an agent inside a profile-specific HERMES_HOME context.
+
+The active profile is carried in a ``ContextVar`` so concurrent asyncio tasks
+cannot observe each other's profile home. ``HERMES_HOME`` is also switched
+under a per-event-loop lock for compatibility with Hermes modules that still
+read the environment directly.
+
+The actual AIAgent invocation stays abstract (via ``run_agent_fn``) so tests
+can inject mocks without spinning up real LLMs.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import logging
+import os
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+HERMES_HOME_ENV = "HERMES_HOME"
+
+# Authoritative per-task profile context.
+_PROFILE_HOME_VAR: contextvars.ContextVar[Optional[Path]] = contextvars.ContextVar(
+    "hermes_multitenancy_profile_home", default=None
+)
+
+
+def get_current_profile_home() -> Optional[Path]:
+    """Return the active profile_home for the current asyncio task, or None."""
+    return _PROFILE_HOME_VAR.get()
+
+
+# Serializes os.environ HERMES_HOME mutations across concurrent dispatches.
+# We key locks by event loop because asyncio.Lock binds to the loop on first
+# acquire — pytest spawns a fresh loop per test so a module-level lock would
+# raise "bound to a different event loop" on the second test. Production
+# runs a single loop so this dict stays at 1 entry.
+_ENV_LOCKS: dict[asyncio.AbstractEventLoop, asyncio.Lock] = {}
+
+
+def _get_env_lock() -> asyncio.Lock:
+    loop = asyncio.get_running_loop()
+    lock = _ENV_LOCKS.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _ENV_LOCKS[loop] = lock
+    return lock
+
+
+# Type for an agent-runner: takes the event + profile_home, returns a response string
+AgentRunner = Callable[[Any, Path], Awaitable[str]]
+
+
+# In-memory routing table for tests and non-persistent local demos.
+_IN_MEMORY_ROUTING: dict[str, Path] = {}
+
+
+def add_in_memory_route(open_id: str, profile_home: Path) -> None:
+    """Register a hard-coded route for tests or local demos."""
+    _IN_MEMORY_ROUTING[open_id] = profile_home
+
+
+def clear_in_memory_routes() -> None:
+    """Clear all in-memory routes."""
+    _IN_MEMORY_ROUTING.clear()
+
+
+def resolve_profile_home(open_id: str) -> Optional[Path]:
+    """Resolve open_id to a profile home directory using in-memory routes."""
+    return _IN_MEMORY_ROUTING.get(open_id)
+
+
+class ProfileRuntime:
+    """Runs an agent against a specific profile home directory.
+
+    Use as ``await ProfileRuntime(profile_home).dispatch(event)``.
+
+    Concurrency model:
+      * The ContextVar is set BEFORE acquiring the env lock so the runner sees
+        its profile_home immediately, even if env mutation is queued behind
+        another dispatch.
+      * The env lock is held for the entire body of the runner so any code
+        inside the runner that reads ``os.environ['HERMES_HOME']`` (e.g. a
+        legacy hermes module) sees the right value.
+
+    Trade-off: code that depends on ``HERMES_HOME`` is serialized while the
+    profile environment is active. The AIAgent subprocess path avoids sharing
+    this state across concurrent tenant runs.
+    """
+
+    def __init__(
+        self,
+        profile_home: Path,
+        run_agent_fn: Optional[AgentRunner] = None,
+    ) -> None:
+        self.profile_home = Path(profile_home)
+        self._run_agent_fn = run_agent_fn or _default_run_agent
+
+    async def dispatch(self, event: Any) -> str:
+        """Set per-task profile context, run the agent under env lock."""
+        token = _PROFILE_HOME_VAR.set(self.profile_home)
+        try:
+            async with _get_env_lock():
+                original = os.environ.get(HERMES_HOME_ENV)
+                os.environ[HERMES_HOME_ENV] = str(self.profile_home)
+                try:
+                    self._verify_switch()
+                    return await self._run_agent_fn(event, self.profile_home)
+                finally:
+                    if original is None:
+                        os.environ.pop(HERMES_HOME_ENV, None)
+                    else:
+                        os.environ[HERMES_HOME_ENV] = original
+        finally:
+            _PROFILE_HOME_VAR.reset(token)
+
+    def _verify_switch(self) -> None:
+        """Sanity-check that the switch reached both ContextVar and hermes_constants."""
+        ctx = get_current_profile_home()
+        if ctx != self.profile_home:
+            logger.warning(
+                "multitenancy: ContextVar mismatch (want=%s got=%s)",
+                self.profile_home,
+                ctx,
+            )
+
+        try:
+            from hermes_constants import get_hermes_home  # type: ignore
+        except ImportError:
+            logger.debug("hermes_constants not importable (ok in unit tests)")
+            return
+        actual = get_hermes_home()
+        if actual != self.profile_home:
+            logger.warning(
+                "multitenancy: HERMES_HOME env mismatch (want=%s got=%s)",
+                self.profile_home,
+                actual,
+            )
+
+
+async def _default_run_agent(event: Any, profile_home: Path) -> str:
+    """Fallback echo runner used when no concrete runner is injected."""
+    text = getattr(event, "text", "") or ""
+    return f"[profile={profile_home.name}] echo: {text}"

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/sessions.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/sessions.py
@@ -1,0 +1,94 @@
+"""SQLite-backed session memory — survives gateway restarts.
+
+Replaces the in-memory ``router._session_history`` dict with a persistent
+store. Schema is keyed by ``(profile_name, user_key, ts)`` so each user's
+history is isolated per profile.
+
+Persistence semantics:
+  - ``append`` adds a single (role, content) row with current timestamp.
+  - ``load_recent`` returns the last N messages for a (profile, user)
+    ordered by timestamp ascending — same shape the LLM expects.
+  - ``clear`` removes every row for a (profile, user). The table is small
+    enough that hard delete is fine.
+
+Default DB path is ``~/.hermes/multitenancy.db`` so it co-resides with
+``RoutingTable`` — they're conceptually one "multitenancy state" store.
+"""
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_DB_PATH = Path.home() / ".hermes" / "multitenancy.db"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS multitenancy_sessions (
+    profile_name TEXT NOT NULL,
+    user_key     TEXT NOT NULL,
+    ts           INTEGER NOT NULL,
+    role         TEXT NOT NULL,
+    content      TEXT NOT NULL,
+    PRIMARY KEY (profile_name, user_key, ts, role)
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_profile_user
+    ON multitenancy_sessions(profile_name, user_key, ts);
+"""
+
+
+class SessionStore:
+    """Persistent (profile, user) → conversation history store."""
+
+    def __init__(self, db_path: Path | str | None = None) -> None:
+        self.db_path = str(db_path) if db_path is not None else str(DEFAULT_DB_PATH)
+        if self.db_path != ":memory:":
+            Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript("PRAGMA journal_mode=WAL;")
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+    def append(self, profile_name: str, user_key: str, role: str, content: str) -> None:
+        """Append one message to a user's history. Microsecond ts dedups bursts."""
+        ts = time.monotonic_ns()
+        self._conn.execute(
+            "INSERT OR IGNORE INTO multitenancy_sessions"
+            " (profile_name, user_key, ts, role, content) VALUES (?, ?, ?, ?, ?)",
+            (profile_name, user_key, ts, role, content),
+        )
+        self._conn.commit()
+
+    def load_recent(self, profile_name: str, user_key: str, limit: int) -> list[dict]:
+        """Return the last ``limit`` messages oldest-first (LLM order)."""
+        cur = self._conn.execute(
+            "SELECT role, content FROM multitenancy_sessions"
+            " WHERE profile_name = ? AND user_key = ?"
+            " ORDER BY ts DESC LIMIT ?",
+            (profile_name, user_key, limit),
+        )
+        rows = list(cur.fetchall())
+        rows.reverse()  # back to oldest-first
+        return [{"role": r["role"], "content": r["content"]} for r in rows]
+
+    def clear(self, profile_name: str, user_key: str) -> int:
+        """Hard-delete a user's history. Returns rows removed."""
+        cur = self._conn.execute(
+            "DELETE FROM multitenancy_sessions WHERE profile_name = ? AND user_key = ?",
+            (profile_name, user_key),
+        )
+        self._conn.commit()
+        return cur.rowcount
+
+    def count(self, profile_name: str, user_key: str) -> int:
+        """Number of messages stored for a (profile, user). Diagnostic only."""
+        cur = self._conn.execute(
+            "SELECT COUNT(*) FROM multitenancy_sessions"
+            " WHERE profile_name = ? AND user_key = ?",
+            (profile_name, user_key),
+        )
+        return int(cur.fetchone()[0])
+
+    def close(self) -> None:
+        self._conn.close()

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/sync/__init__.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/sync/__init__.py
@@ -1,0 +1,17 @@
+"""feishu-sync keeps multitenancy_routing in sync with an external user list.
+
+Reference implementation. Real deployments wire this into a Feishu HR webhook
+(``feishu_hr.subscribe_events``); this package exposes the ``apply_users`` core
+so a CLI, cron job, or webhook can all share it.
+
+Contract:
+  - ``apply_users(table, users)`` is idempotent. Re-running with the same
+    list is a no-op (modulo synced_at + version bumps in the row).
+  - Users present in the table but absent from ``users`` get **soft-deleted**.
+    The plugin treats soft-deleted rows as routing-miss (per US-007 schema).
+"""
+from __future__ import annotations
+
+from .feishu_hr import UserSpec, apply_users
+
+__all__ = ["UserSpec", "apply_users"]

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/sync/cli.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/sync/cli.py
@@ -1,0 +1,52 @@
+"""``python -m hermes_multitenancy.sync apply <users.json>`` entry point.
+
+Minimal CLI for ops-style sync runs. Real deployments will likely call
+``apply_users`` from a webhook receiver instead — this exists to provide
+a one-command tier (cron + curl pipeline).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .feishu_hr import UserSpec, apply_users
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="hermes_multitenancy.sync", description="multitenancy routing sync")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_apply = sub.add_parser("apply", help="Reconcile routing table with a JSON user list")
+    p_apply.add_argument("users_json", type=Path, help="Path to JSON array of {user_id, profile_name, open_id, union_id?}")
+    p_apply.add_argument("--db", type=Path, default=None, help="Override DB path (default: ~/.hermes/multitenancy.db)")
+
+    args = parser.parse_args(argv)
+
+    if args.cmd == "apply":
+        from hermes_multitenancy.routing import RoutingTable
+
+        if not args.users_json.exists():
+            print(f"error: {args.users_json} not found", file=sys.stderr)
+            return 1
+        raw = json.loads(args.users_json.read_text())
+        if not isinstance(raw, list):
+            print("error: users.json must be a JSON array", file=sys.stderr)
+            return 1
+        users = [UserSpec(**entry) for entry in raw]
+
+        table = RoutingTable(args.db)
+        try:
+            stats = apply_users(table, users)
+        finally:
+            table.close()
+
+        print(json.dumps(stats, indent=2))
+        return 0
+
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/platforms/feishu-multitenancy/hermes_multitenancy/sync/feishu_hr.py
+++ b/plugins/platforms/feishu-multitenancy/hermes_multitenancy/sync/feishu_hr.py
@@ -1,0 +1,75 @@
+"""Idempotent user-list → routing-table sync.
+
+This is the *core* of feishu-sync — the integration with Feishu's HR APIs is
+left to the deployment (cron / webhook / manual export). All this module
+asserts is:
+
+  Given a desired ``users`` list, mutate ``RoutingTable`` so the active set
+  matches. Specifically:
+    * Insert / refresh routes present in the list.
+    * Soft-delete routes present in the table but missing from the list.
+    * Do nothing for matching rows (no version bumps, no last_active_at
+      churn — those are router-only fields).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+
+@dataclass(frozen=True)
+class UserSpec:
+    """One user → one profile route. Mirrors the columns feishu-sync writes."""
+    user_id: str
+    profile_name: str
+    open_id: str
+    union_id: Optional[str] = None
+
+
+def apply_users(table, users: Iterable[UserSpec]) -> dict[str, int]:
+    """Reconcile ``table`` to match ``users``.
+
+    Returns a counters dict::
+
+        {"upserted": int, "soft_deleted": int, "kept": int}
+
+    The numbers are per-row-action, useful for ops dashboards and tests.
+    """
+    desired = {u.user_id: u for u in users}
+
+    # Snapshot current active rows so we can detect deletes.
+    cur = table._conn.execute(
+        "SELECT user_id, profile_name, open_id, union_id"
+        " FROM multitenancy_routing WHERE active = 1"
+    )
+    current = {r["user_id"]: dict(r) for r in cur.fetchall()}
+
+    upserted = 0
+    soft_deleted = 0
+    kept = 0
+
+    # 1. Upsert / refresh
+    for u in desired.values():
+        existing = current.get(u.user_id)
+        if existing and (
+            existing["profile_name"] == u.profile_name
+            and existing["open_id"] == u.open_id
+            and (existing["union_id"] or None) == u.union_id
+        ):
+            kept += 1
+            continue
+        table.upsert(
+            user_id=u.user_id,
+            profile_name=u.profile_name,
+            open_id=u.open_id,
+            union_id=u.union_id,
+        )
+        upserted += 1
+
+    # 2. Soft-delete rows in table but missing from desired
+    for user_id in current:
+        if user_id not in desired:
+            if table.soft_delete(user_id):
+                soft_deleted += 1
+
+    return {"upserted": upserted, "soft_deleted": soft_deleted, "kept": kept}

--- a/plugins/platforms/feishu-multitenancy/plugin.yaml
+++ b/plugins/platforms/feishu-multitenancy/plugin.yaml
@@ -1,0 +1,8 @@
+manifest_version: 1
+name: platforms/feishu-multitenancy
+version: 0.1.0
+description: "Route one Feishu bot to many isolated Hermes profiles by sender open_id."
+author: NousResearch / Hermes contributors
+kind: standalone
+provides_hooks:
+  - pre_gateway_dispatch

--- a/plugins/platforms/feishu-multitenancy/sync.py
+++ b/plugins/platforms/feishu-multitenancy/sync.py
@@ -1,0 +1,21 @@
+"""Route-sync helper for Hermes directory-plugin installs.
+
+When using the bundled plugin from a source checkout, the plugin directory is
+not installed as a Python package. This wrapper makes route sync runnable
+without modifying PYTHONPATH:
+
+    python plugins/platforms/feishu-multitenancy/sync.py apply users.json
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from hermes_multitenancy.sync.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/plugins/test_feishu_multitenancy_plugin.py
+++ b/tests/plugins/test_feishu_multitenancy_plugin.py
@@ -460,6 +460,106 @@ def test_aiagent_subprocess_payload_carries_router_messages(tmp_path):
         assert payload["messages"] == messages
 
 
+def test_bundled_stream_aiagent_subprocess_forwards_child_approval_events(monkeypatch, tmp_path):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import agent_real
+
+        class FakeStdin:
+            def write(self, _payload):
+                pass
+
+            async def drain(self):
+                pass
+
+            def close(self):
+                pass
+
+            async def wait_closed(self):
+                pass
+
+        class FakeStdout:
+            def __init__(self):
+                self.lines = [
+                    json.dumps({
+                        "event": "approval_required",
+                        "session_key": "multitenancy:feishu:coder:oc_test:ou_test",
+                        "approval_id": "approval_1",
+                        "command": "python -c \"print(1)\"",
+                        "description": "script execution via -e/-c flag",
+                        "decision_path": "/tmp/approval_1.json",
+                    }).encode() + b"\n",
+                    json.dumps({
+                        "event": "approval_resolved",
+                        "session_key": "multitenancy:feishu:coder:oc_test:ou_test",
+                        "approval_id": "approval_1",
+                        "choice": "once",
+                    }).encode() + b"\n",
+                    b'{"event": "done", "result": "ok", "error": null}\n',
+                ]
+
+            async def readline(self):
+                if self.lines:
+                    return self.lines.pop(0)
+                return b""
+
+        class FakeStderr:
+            async def read(self):
+                return b""
+
+        class FakeProc:
+            def __init__(self):
+                self.stdin = FakeStdin()
+                self.stdout = FakeStdout()
+                self.stderr = FakeStderr()
+                self.pid = 123
+                self.returncode = None
+                self.killed = False
+
+            async def wait(self):
+                self.returncode = 0
+                return 0
+
+            def kill(self):
+                self.killed = True
+                self.returncode = -9
+
+        async def fake_create_subprocess_exec(*_args, **_kwargs):
+            return FakeProc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+        async def collect_events():
+            event = SimpleNamespace(
+                text="hello",
+                message_id="om_test",
+                source=SimpleNamespace(
+                    platform=SimpleNamespace(value="feishu"),
+                    chat_id="oc_test",
+                    user_id="ou_test",
+                ),
+            )
+            return [
+                item
+                async for item in agent_real._stream_aiagent_subprocess(event, tmp_path)
+            ]
+
+        assert asyncio.run(collect_events()) == [
+            ("approval_required", {
+                "session_key": "multitenancy:feishu:coder:oc_test:ou_test",
+                "approval_id": "approval_1",
+                "command": "python -c \"print(1)\"",
+                "description": "script execution via -e/-c flag",
+                "decision_path": "/tmp/approval_1.json",
+            }),
+            ("approval_resolved", {
+                "session_key": "multitenancy:feishu:coder:oc_test:ou_test",
+                "approval_id": "approval_1",
+                "choice": "once",
+            }),
+            ("done", "ok"),
+        ]
+
+
 def test_aiagent_session_id_is_stable_and_user_isolated(tmp_path):
     with _bundled_plugin_path():
         from hermes_multitenancy.agent_real import _resolve_aiagent_session_id
@@ -585,6 +685,60 @@ def test_bundled_aiagent_bridges_gateway_approval(monkeypatch, tmp_path):
         assert events[1]["event"] == "approval_resolved"
         assert events[1]["choice"] == "once"
         assert resolved == [("multitenancy:feishu:coder:oc_test:ou_test", "once")]
+
+
+def test_bundled_approval_bridge_exposes_session_key_to_tool_worker_threads(monkeypatch, tmp_path):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import agent_real
+
+        approval_dir = tmp_path / "approval"
+        monkeypatch.setenv("HERMES_MULTITENANCY_APPROVAL_DIR", str(approval_dir))
+        monkeypatch.setenv("HERMES_MULTITENANCY_APPROVAL_TIMEOUT", "1")
+        monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        registered, resolved = _install_fake_approval(monkeypatch)
+        events: list[dict] = []
+
+        def sink(event, **payload):
+            events.append({"event": event, **payload})
+            if event == "approval_required":
+                Path(payload["decision_path"]).write_text(
+                    json.dumps({"choice": "once"}),
+                    encoding="utf-8",
+                )
+
+        cleanup = agent_real._configure_gateway_approval_bridge(
+            sink,
+            "multitenancy:feishu:coder:oc_test:ou_test",
+        )
+        try:
+            worker_result: dict[str, str] = {}
+
+            def worker_thread_tool_guard():
+                session_key = os.getenv("HERMES_SESSION_KEY", "default")
+                notify = registered.get(session_key)
+                if notify is None:
+                    worker_result["status"] = "missing"
+                    return
+                notify({
+                    "command": "python -c 'print(1)'",
+                    "description": "script execution via -c flag",
+                    "pattern_keys": ["script execution via -c flag"],
+                })
+                worker_result["status"] = "notified"
+
+            worker_thread_tool_guard()
+
+            assert worker_result == {"status": "notified"}
+            assert events[0]["event"] == "approval_required"
+            assert resolved == [("multitenancy:feishu:coder:oc_test:ou_test", "once")]
+        finally:
+            cleanup()
+
+        assert os.getenv("HERMES_SESSION_KEY") is None
+        assert os.getenv("HERMES_GATEWAY_SESSION") is None
+        assert os.getenv("HERMES_EXEC_ASK") is None
 
 
 def test_bundled_aiagent_closes_real_agent_resources(monkeypatch, tmp_path):

--- a/tests/plugins/test_feishu_multitenancy_plugin.py
+++ b/tests/plugins/test_feishu_multitenancy_plugin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import asyncio
+import os
 import subprocess
 import sys
 from contextlib import contextmanager
@@ -140,6 +141,149 @@ def test_router_prefers_feishu_open_id_from_raw_event():
         )
 
         assert _resolve_sender_for_routing(event) == "ou_real_sender"
+
+
+def test_bundled_history_key_uses_sender_not_shared_alt(tmp_path):
+    with _bundled_plugin_path():
+        from hermes_multitenancy.router import _history_key
+
+        assert _history_key("coder", "ou_a", "shared_alt") == ("coder", "ou_a")
+        assert _history_key("coder", "ou_a", "shared_alt") != _history_key(
+            "coder",
+            "ou_b",
+            "shared_alt",
+        )
+
+
+def test_bundled_media_directives_stay_inside_profile(tmp_path):
+    with _bundled_plugin_path():
+        from hermes_multitenancy.router import _profile_scoped_media_response
+
+        profile_home = tmp_path / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        inside = profile_home / "cache" / "out.md"
+        outside = tmp_path / "profiles" / "other" / "secret.md"
+        inside.parent.mkdir()
+        outside.parent.mkdir(parents=True)
+
+        scoped = _profile_scoped_media_response(
+            f"ok\nMEDIA:{inside}\nMEDIA:{outside}",
+            profile_home,
+        )
+
+        assert f"MEDIA:{inside}" in scoped
+        assert str(outside) not in scoped
+
+
+def test_bundled_router_uses_legacy_alt_route_when_open_id_missing(tmp_path, monkeypatch):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import router as router_mod
+
+        db_path = tmp_path / "routing.db"
+        router_mod.override_routing_table(db_path)
+        table = router_mod._get_routing_table()
+        table.upsert(
+            user_id="legacy",
+            profile_name="legacy_profile",
+            open_id="on_legacy",
+            union_id="on_legacy",
+        )
+        monkeypatch.setattr(
+            router_mod,
+            "_profile_name_to_home",
+            lambda profile_name: tmp_path / "profiles" / profile_name,
+        )
+
+        captured: dict[str, object] = {}
+
+        class Pool:
+            async def dispatch(self, profile_name, profile_home, event):
+                captured["profile_name"] = profile_name
+                captured["profile_home"] = profile_home
+                return "ok"
+
+        monkeypatch.setattr(router_mod, "_get_pool", lambda: Pool())
+        event = SimpleNamespace(
+            text="hi",
+            source=SimpleNamespace(
+                platform=SimpleNamespace(value="feishu"),
+                chat_id="oc_test",
+                user_id="tenant-local-id",
+                user_id_alt="on_legacy",
+                user_name="legacy-user",
+                chat_type="dm",
+            ),
+        )
+
+        asyncio.run(
+            router_mod.handle_async(
+                event=event,
+                gateway=SimpleNamespace(adapters={}),
+            )
+        )
+
+        assert captured == {
+            "profile_name": "legacy_profile",
+            "profile_home": tmp_path / "profiles" / "legacy_profile",
+        }
+        assert table.lookup_by_open_id("tenant-local-id") is None
+        router_mod.override_routing_table(None)
+
+
+def test_bundled_router_sets_resolved_raw_event_open_id_on_agent_event(tmp_path, monkeypatch):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import router as router_mod
+        from hermes_multitenancy.runtime import add_in_memory_route, clear_in_memory_routes
+
+        clear_in_memory_routes()
+        profile_home = tmp_path / "raw-sender"
+        profile_home.mkdir()
+        add_in_memory_route("ou_raw_sender", profile_home)
+
+        captured: dict[str, object] = {}
+
+        class Pool:
+            async def dispatch(self, profile_name, profile_home, event):
+                captured["profile_name"] = profile_name
+                captured["sender_open_id"] = getattr(event, "sender_open_id", None)
+                return "ok"
+
+        monkeypatch.setattr(router_mod, "_get_pool", lambda: Pool())
+        event = SimpleNamespace(
+            text="hi",
+            raw_event={
+                "event": {
+                    "message": {
+                        "sender": {
+                            "sender_id": {
+                                "open_id": "ou_raw_sender",
+                                "union_id": "on_raw_sender",
+                            }
+                        }
+                    }
+                }
+            },
+            source=SimpleNamespace(
+                platform=SimpleNamespace(value="feishu"),
+                chat_id="oc_test",
+                user_id="tenant-local-id",
+                user_name="raw-user",
+                chat_type="dm",
+            ),
+        )
+
+        asyncio.run(
+            router_mod.handle_async(
+                event=event,
+                gateway=SimpleNamespace(adapters={}),
+            )
+        )
+
+        assert captured == {
+            "profile_name": "raw-sender",
+            "sender_open_id": "ou_raw_sender",
+        }
+        clear_in_memory_routes()
 
 
 def test_auto_profile_config_does_not_invent_a_default_model():
@@ -300,6 +444,7 @@ def test_bundled_router_delegates_known_gateway_command(tmp_path, caplog):
                 platform=SimpleNamespace(value="feishu"),
                 chat_id="oc_test",
                 user_id="ou_model",
+                user_id_alt="shared_alt",
                 user_name="model-user",
                 chat_type="dm",
             ),
@@ -309,6 +454,96 @@ def test_bundled_router_delegates_known_gateway_command(tmp_path, caplog):
 
         assert sends == ["multitenancy:feishu:coder:oc_test:ou_model"]
         assert "Hermes gateway command handled: model" in caplog.text
+        clear_in_memory_routes()
+
+
+def test_bundled_concurrent_gateway_commands_keep_profile_context(tmp_path):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import router as router_mod
+        from hermes_multitenancy.runtime import add_in_memory_route, clear_in_memory_routes
+
+        clear_in_memory_routes()
+        profile_a = tmp_path / "alice"
+        profile_b = tmp_path / "bob"
+        profile_a.mkdir()
+        profile_b.mkdir()
+        add_in_memory_route("ou_cmd_a", profile_a)
+        add_in_memory_route("ou_cmd_b", profile_b)
+
+        sends: list[tuple[str, str]] = []
+        observations: list[tuple[str, str | None, str]] = []
+
+        class Adapter:
+            async def send(self, chat_id, message, *, reply_to=None, metadata=None):
+                sends.append((chat_id, message))
+
+        class Gateway:
+            adapters = {"feishu": Adapter()}
+
+            def _session_key_for_source(self, _source):
+                return "native-session"
+
+            async def _handle_model_command(self, event):
+                source = event.source
+                observations.append(
+                    (
+                        source.user_id,
+                        os.environ.get("HERMES_HOME"),
+                        self._session_key_for_source(source),
+                    )
+                )
+                await asyncio.sleep(0.01)
+                observations.append(
+                    (
+                        source.user_id,
+                        os.environ.get("HERMES_HOME"),
+                        self._session_key_for_source(source),
+                    )
+                )
+                return os.environ.get("HERMES_HOME")
+
+        async def run_both():
+            gateway = Gateway()
+            await asyncio.gather(
+                router_mod.handle_async(
+                    event=SimpleNamespace(
+                        text="/model gpt-5",
+                        source=SimpleNamespace(
+                            platform=SimpleNamespace(value="feishu"),
+                            chat_id="oc_a",
+                            user_id="ou_cmd_a",
+                            user_name="a",
+                            chat_type="dm",
+                        ),
+                    ),
+                    gateway=gateway,
+                ),
+                router_mod.handle_async(
+                    event=SimpleNamespace(
+                        text="/model gpt-5",
+                        source=SimpleNamespace(
+                            platform=SimpleNamespace(value="feishu"),
+                            chat_id="oc_b",
+                            user_id="ou_cmd_b",
+                            user_name="b",
+                            chat_type="dm",
+                        ),
+                    ),
+                    gateway=gateway,
+                ),
+            )
+
+        asyncio.run(run_both())
+
+        expected_home = {"ou_cmd_a": str(profile_a), "ou_cmd_b": str(profile_b)}
+        expected_key = {
+            "ou_cmd_a": "multitenancy:feishu:alice:oc_a:ou_cmd_a",
+            "ou_cmd_b": "multitenancy:feishu:bob:oc_b:ou_cmd_b",
+        }
+        assert sorted(message for _chat, message in sends) == sorted(expected_home.values())
+        for user_id, home, session_key in observations:
+            assert home == expected_home[user_id]
+            assert session_key == expected_key[user_id]
         clear_in_memory_routes()
 
 
@@ -436,6 +671,7 @@ def test_bundled_router_delegates_plugin_slash_command(tmp_path, monkeypatch, ca
 
         async def plugin_handler(args):
             called["args"] = args
+            called["hermes_home"] = os.environ.get("HERMES_HOME")
             return f"plugin handled {args}"
 
         fake_plugins = SimpleNamespace(
@@ -475,7 +711,8 @@ def test_bundled_router_delegates_plugin_slash_command(tmp_path, monkeypatch, ca
             )
         )
 
-        assert called == {"args": "hi there"}
+        assert called["args"] == "hi there"
+        assert called["hermes_home"] == str(tmp_path)
         assert sends == ["plugin handled hi there"]
         assert "Hermes plugin slash handler: demo-plugin" in caplog.text
         clear_in_memory_routes()
@@ -527,14 +764,60 @@ def test_bundled_router_handles_quick_command_alias(tmp_path, monkeypatch, caplo
         clear_in_memory_routes()
 
 
-def test_bundled_router_handles_quick_command_exec(tmp_path, monkeypatch, caplog):
+def test_bundled_router_disables_quick_command_exec_by_default(tmp_path, monkeypatch):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import router as router_mod
+        from hermes_multitenancy.runtime import add_in_memory_route, clear_in_memory_routes
+
+        clear_in_memory_routes()
+        add_in_memory_route("ou_quick_exec_denied", tmp_path)
+
+        class PoolShouldNotRun:
+            async def dispatch(self, *args, **kwargs):
+                raise AssertionError("quick-command exec leaked into AIAgent dispatch")
+
+        monkeypatch.setattr(router_mod, "_get_pool", lambda: PoolShouldNotRun())
+
+        sends: list[str] = []
+
+        class Adapter:
+            async def send(self, _chat_id, message, *, reply_to=None, metadata=None):
+                sends.append(message)
+
+        event = SimpleNamespace(
+            text="/ping",
+            source=SimpleNamespace(
+                platform=SimpleNamespace(value="feishu"),
+                chat_id="oc_test",
+                user_id="ou_quick_exec_denied",
+                user_name="quick-user",
+                chat_type="dm",
+            ),
+        )
+        gateway = SimpleNamespace(
+            adapters={"feishu": Adapter()},
+            config={"quick_commands": {"ping": {"type": "exec", "command": "printf quick-ok"}}},
+        )
+
+        asyncio.run(router_mod.handle_async(event=event, gateway=gateway))
+
+        assert sends == [
+            "Quick command '/ping' exec is disabled for Feishu multitenancy. "
+            "Enable only after profile sandboxing is in place."
+        ]
+        clear_in_memory_routes()
+
+
+def test_bundled_router_handles_enabled_quick_command_exec_in_profile_env(tmp_path, monkeypatch, caplog):
     caplog.set_level("INFO")
     with _bundled_plugin_path():
         from hermes_multitenancy import router as router_mod
         from hermes_multitenancy.runtime import add_in_memory_route, clear_in_memory_routes
 
         clear_in_memory_routes()
-        add_in_memory_route("ou_quick_exec", tmp_path)
+        profile_home = tmp_path / "quick-profile"
+        profile_home.mkdir()
+        add_in_memory_route("ou_quick_exec", profile_home)
 
         class PoolShouldNotRun:
             async def dispatch(self, *args, **kwargs):
@@ -560,12 +843,15 @@ def test_bundled_router_handles_quick_command_exec(tmp_path, monkeypatch, caplog
         )
         gateway = SimpleNamespace(
             adapters={"feishu": Adapter()},
-            config={"quick_commands": {"ping": {"type": "exec", "command": "printf quick-ok"}}},
+            config={
+                "multitenancy": {"allow_quick_exec": True},
+                "quick_commands": {"ping": {"type": "exec", "command": "printf \"$HERMES_HOME\""}},
+            },
         )
 
         asyncio.run(router_mod.handle_async(event=event, gateway=gateway))
 
-        assert sends == ["quick-ok"]
+        assert sends == [str(profile_home)]
         assert "Hermes quick command exec" in caplog.text
         clear_in_memory_routes()
 

--- a/tests/plugins/test_feishu_multitenancy_plugin.py
+++ b/tests/plugins/test_feishu_multitenancy_plugin.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import asyncio
+import contextvars
 import os
 import subprocess
 import sys
@@ -25,6 +26,70 @@ def _forget_multitenancy_modules() -> None:
             or name.startswith("hermes_plugins.platforms__feishu_multitenancy")
         ):
             sys.modules.pop(name, None)
+
+
+def _install_fake_feishu_oapi(monkeypatch) -> None:
+    current_sender_open_id = contextvars.ContextVar("current_sender_open_id", default=None)
+
+    @contextmanager
+    def sender_open_id_scope(value):
+        token = current_sender_open_id.set(value)
+        try:
+            yield
+        finally:
+            current_sender_open_id.reset(token)
+
+    fake_feishu_oapi = SimpleNamespace(
+        current_sender_open_id=current_sender_open_id,
+        sender_open_id_scope=sender_open_id_scope,
+        FEISHU_UAT_PATH=None,
+        FEISHU_UAT_DIR=None,
+    )
+    try:
+        import tools as tools_mod
+    except Exception:
+        tools_mod = ModuleType("tools")
+    tools_mod.feishu_oapi_client = fake_feishu_oapi
+    monkeypatch.setitem(sys.modules, "tools", tools_mod)
+    monkeypatch.setitem(sys.modules, "tools.feishu_oapi_client", fake_feishu_oapi)
+
+
+def _install_fake_approval(monkeypatch):
+    registered: dict[str, object] = {}
+    resolved: list[tuple[str, str]] = []
+    current_session = contextvars.ContextVar("approval_session", default="")
+
+    def set_current_session_key(session_key: str):
+        return current_session.set(session_key)
+
+    def reset_current_session_key(token):
+        current_session.reset(token)
+
+    def register_gateway_notify(session_key: str, cb):
+        registered[session_key] = cb
+
+    def unregister_gateway_notify(session_key: str):
+        registered.pop(session_key, None)
+
+    def resolve_gateway_approval(session_key: str, choice: str, resolve_all=False):
+        resolved.append((session_key, choice))
+        return 1
+
+    fake_approval = SimpleNamespace(
+        set_current_session_key=set_current_session_key,
+        reset_current_session_key=reset_current_session_key,
+        register_gateway_notify=register_gateway_notify,
+        unregister_gateway_notify=unregister_gateway_notify,
+        resolve_gateway_approval=resolve_gateway_approval,
+    )
+    try:
+        import tools as tools_mod
+    except Exception:
+        tools_mod = ModuleType("tools")
+    tools_mod.approval = fake_approval
+    monkeypatch.setitem(sys.modules, "tools", tools_mod)
+    monkeypatch.setitem(sys.modules, "tools.approval", fake_approval)
+    return registered, resolved
 
 
 @contextmanager
@@ -437,6 +502,130 @@ def test_aiagent_session_id_is_stable_and_user_isolated(tmp_path):
         )
 
 
+def test_bundled_multitenant_gateway_session_key_matches_router_shape(tmp_path):
+    with _bundled_plugin_path():
+        from hermes_multitenancy.agent_real import _resolve_multitenant_gateway_session_key
+
+        profile_home = tmp_path / "profiles" / "coder"
+        event = SimpleNamespace(
+            text="hello",
+            source=SimpleNamespace(
+                platform=SimpleNamespace(value="feishu"),
+                chat_id="oc_test",
+                chat_type="dm",
+                user_id="ou_test",
+            ),
+        )
+
+        assert _resolve_multitenant_gateway_session_key(
+            event,
+            profile_home,
+            "ou_test",
+        ) == "multitenancy:feishu:coder:oc_test:ou_test"
+
+
+def test_bundled_aiagent_bridges_gateway_approval(monkeypatch, tmp_path):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import agent_real
+
+        profile_home = tmp_path / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        (profile_home / "config.yaml").write_text(
+            "model:\n  default: openai/test-model\n",
+            encoding="utf-8",
+        )
+        (profile_home / ".env").write_text("OPENAI_API_KEY=test-key\n", encoding="utf-8")
+        approval_dir = tmp_path / "approval"
+        monkeypatch.setenv("HERMES_MULTITENANCY_APPROVAL_DIR", str(approval_dir))
+        monkeypatch.setenv("HERMES_MULTITENANCY_APPROVAL_TIMEOUT", "1")
+        registered, resolved = _install_fake_approval(monkeypatch)
+        _install_fake_feishu_oapi(monkeypatch)
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+            def run_conversation(self, user_message, task_id):
+                session_key = self.kwargs["gateway_session_key"]
+                assert session_key == "multitenancy:feishu:coder:oc_test:ou_test"
+                registered[session_key]({
+                    "command": "python -c 'print(1)'",
+                    "description": "script execution via -c flag",
+                    "pattern_keys": ["script execution via -c flag"],
+                })
+                return {"final_response": "approved"}
+
+            def close(self):
+                pass
+
+        events: list[dict] = []
+
+        def sink(event, **payload):
+            events.append({"event": event, **payload})
+            if event == "approval_required":
+                Path(payload["decision_path"]).write_text(
+                    json.dumps({"choice": "once"}),
+                    encoding="utf-8",
+                )
+
+        monkeypatch.setitem(sys.modules, "run_agent", SimpleNamespace(AIAgent=FakeAgent))
+
+        source = SimpleNamespace(
+            platform=SimpleNamespace(value="feishu"),
+            chat_id="oc_test",
+            chat_type="dm",
+            user_id="ou_test",
+            user_name="tester",
+        )
+        event = SimpleNamespace(text="hello", message_id="om_test", source=source)
+
+        assert agent_real._run_with_aiagent(event, profile_home, event_sink=sink) == "approved"
+        assert events[0]["event"] == "approval_required"
+        assert events[0]["session_key"] == "multitenancy:feishu:coder:oc_test:ou_test"
+        assert events[1]["event"] == "approval_resolved"
+        assert events[1]["choice"] == "once"
+        assert resolved == [("multitenancy:feishu:coder:oc_test:ou_test", "once")]
+
+
+def test_bundled_aiagent_closes_real_agent_resources(monkeypatch, tmp_path):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import agent_real
+
+        profile_home = tmp_path / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+        (profile_home / "config.yaml").write_text(
+            "model:\n  default: openai/test-model\n",
+            encoding="utf-8",
+        )
+        (profile_home / ".env").write_text("OPENAI_API_KEY=test-key\n", encoding="utf-8")
+        _install_fake_feishu_oapi(monkeypatch)
+        seen = {"closed": False}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                pass
+
+            def run_conversation(self, user_message, task_id):
+                return {"final_response": "ok"}
+
+            def close(self):
+                seen["closed"] = True
+
+        monkeypatch.setitem(sys.modules, "run_agent", SimpleNamespace(AIAgent=FakeAgent))
+
+        source = SimpleNamespace(
+            platform=SimpleNamespace(value="feishu"),
+            chat_id="oc_test",
+            chat_type="dm",
+            user_id="ou_test",
+            user_name="tester",
+        )
+        event = SimpleNamespace(text="hello", message_id="om_test", source=source)
+
+        assert agent_real._run_with_aiagent(event, profile_home) == "ok"
+        assert seen["closed"] is True
+
+
 def test_bundled_command_parser_uses_hermes_registry():
     with _bundled_plugin_path():
         from hermes_multitenancy.commands import parse_command
@@ -490,6 +679,62 @@ def test_bundled_router_delegates_known_gateway_command(tmp_path, caplog):
         assert sends == ["multitenancy:feishu:coder:oc_test:ou_model"]
         assert "Hermes gateway command handled: model" in caplog.text
         clear_in_memory_routes()
+
+
+def test_bundled_router_approval_prompt_and_approve_resolves(tmp_path):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import router as router_mod
+
+        sent: list[tuple[str, str]] = []
+        decision_path = tmp_path / "approval-decision.json"
+
+        class Adapter:
+            async def send(self, chat_id, message, *, reply_to=None, metadata=None):
+                sent.append((chat_id, message))
+
+        adapter = Adapter()
+        payload = {
+            "approval_id": "approval-1",
+            "session_key": "multitenancy:feishu:coder:oc_test:ou_test",
+            "command": "python -c 'print(1)'",
+            "description": "script execution via -c flag",
+            "decision_path": str(decision_path),
+        }
+
+        asyncio.run(router_mod._handle_child_approval_required(adapter, "oc_test", payload))
+
+        assert sent
+        assert "requires approval" in sent[0][1]
+        assert "/approve" in sent[0][1]
+
+        event = SimpleNamespace(
+            text="/approve",
+            source=SimpleNamespace(
+                platform=SimpleNamespace(value="feishu"),
+                chat_id="oc_test",
+                user_id="ou_test",
+                user_name="tester",
+                chat_type="dm",
+            ),
+            get_command_args=lambda: "",
+        )
+        gateway = SimpleNamespace(adapters={"feishu": adapter}, config={})
+
+        asyncio.run(
+            router_mod._handle_command(
+                ("approve", ""),
+                "ou_test",
+                None,
+                "coder",
+                tmp_path,
+                "oc_test",
+                gateway,
+                event,
+            )
+        )
+
+        assert json.loads(decision_path.read_text(encoding="utf-8")) == {"choice": "once"}
+        assert "approved" in sent[-1][1].lower()
 
 
 def test_bundled_concurrent_gateway_commands_keep_profile_context(tmp_path):

--- a/tests/plugins/test_feishu_multitenancy_plugin.py
+++ b/tests/plugins/test_feishu_multitenancy_plugin.py
@@ -336,6 +336,41 @@ def test_aiagent_toolsets_allow_explicit_mode(monkeypatch):
         ) == ["feishu_drive", "web"]
 
 
+def test_bundled_cron_jobs_bind_to_shared_gateway_home(tmp_path, monkeypatch):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import agent_real
+
+        profile_home = tmp_path / ".hermes" / "profiles" / "coder"
+        shared_home = tmp_path / ".hermes"
+        profile_home.mkdir(parents=True)
+        shared_home.mkdir(exist_ok=True)
+
+        cron_pkg = ModuleType("cron")
+        cron_jobs = ModuleType("cron.jobs")
+        tools_pkg = ModuleType("tools")
+        cronjob_tools = ModuleType("tools.cronjob_tools")
+        path_security = ModuleType("tools.path_security")
+        path_security.validate_within_dir = lambda path, root: None
+        cron_pkg.jobs = cron_jobs
+        tools_pkg.cronjob_tools = cronjob_tools
+        tools_pkg.path_security = path_security
+
+        monkeypatch.setitem(sys.modules, "cron", cron_pkg)
+        monkeypatch.setitem(sys.modules, "cron.jobs", cron_jobs)
+        monkeypatch.setitem(sys.modules, "tools", tools_pkg)
+        monkeypatch.setitem(sys.modules, "tools.cronjob_tools", cronjob_tools)
+        monkeypatch.setitem(sys.modules, "tools.path_security", path_security)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        agent_real._configure_cron_home(shared_home)
+
+        assert cron_jobs.JOBS_FILE == shared_home.resolve() / "cron" / "jobs.json"
+        assert cron_jobs.OUTPUT_DIR == shared_home.resolve() / "cron" / "output"
+        assert os.environ["HERMES_HOME"] == str(profile_home)
+        assert cronjob_tools._validate_cron_script_path("reminder.py") is None
+        assert "relative to shared" in cronjob_tools._validate_cron_script_path("/tmp/reminder.py")
+
+
 def test_aiagent_subprocess_payload_carries_router_messages(tmp_path):
     with _bundled_plugin_path():
         from hermes_multitenancy.agent_real import _event_to_subprocess_payload

--- a/tests/plugins/test_feishu_multitenancy_plugin.py
+++ b/tests/plugins/test_feishu_multitenancy_plugin.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 from contextlib import contextmanager
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -344,6 +344,218 @@ def test_bundled_router_rejects_unknown_slash_without_agent(tmp_path):
             "Unknown command `/unknown_control`. Type /commands to see what's available, "
             "or resend without the leading slash to send as a regular message."
         ]
+
+
+def test_bundled_router_rewrites_skill_slash_into_agent_prompt(tmp_path, monkeypatch):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import router as router_mod
+        from hermes_multitenancy.runtime import add_in_memory_route, clear_in_memory_routes
+
+        clear_in_memory_routes()
+        profile_home = tmp_path / "coder"
+        profile_home.mkdir()
+        add_in_memory_route("ou_skill", profile_home)
+
+        fake_skill_commands = SimpleNamespace(
+            get_skill_commands=lambda: {"/demo-skill": {"name": "demo-skill"}},
+            resolve_skill_command_key=lambda command: "/demo-skill"
+            if command.replace("_", "-") == "demo-skill"
+            else None,
+            build_skill_invocation_message=lambda cmd_key, user_instruction, task_id=None: (
+                f"[skill:{cmd_key} task:{task_id}] {user_instruction}"
+            ),
+        )
+        fake_skill_utils = SimpleNamespace(get_disabled_skill_names=lambda platform=None: set())
+        monkeypatch.setitem(sys.modules, "agent", ModuleType("agent"))
+        monkeypatch.setitem(sys.modules, "agent.skill_commands", fake_skill_commands)
+        monkeypatch.setitem(sys.modules, "agent.skill_utils", fake_skill_utils)
+
+        seen: dict[str, object] = {}
+
+        class Pool:
+            async def dispatch(self, profile_name, home, event):
+                seen["profile_name"] = profile_name
+                seen["home"] = home
+                seen["text"] = event.text
+                return "agent ok"
+
+        monkeypatch.setattr(router_mod, "_get_pool", lambda: Pool())
+
+        sends: list[str] = []
+
+        class Adapter:
+            async def send_typing(self, _chat_id):
+                pass
+
+            async def send(self, _chat_id, message, *, reply_to=None, metadata=None):
+                sends.append(message)
+
+        event = SimpleNamespace(
+            text="/demo-skill write docs",
+            source=SimpleNamespace(
+                platform=SimpleNamespace(value="feishu"),
+                chat_id="oc_test",
+                user_id="ou_skill",
+                user_name="skill-user",
+                chat_type="dm",
+            ),
+        )
+
+        asyncio.run(
+            router_mod.handle_async(
+                event=event,
+                gateway=SimpleNamespace(adapters={"feishu": Adapter()}),
+            )
+        )
+
+        assert seen == {
+            "profile_name": "coder",
+            "home": profile_home,
+            "text": "[skill:/demo-skill task:multitenancy:feishu:coder:oc_test:ou_skill] write docs",
+        }
+        assert sends == ["agent ok"]
+        clear_in_memory_routes()
+
+
+def test_bundled_router_delegates_plugin_slash_command(tmp_path, monkeypatch):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import router as router_mod
+        from hermes_multitenancy.runtime import add_in_memory_route, clear_in_memory_routes
+
+        clear_in_memory_routes()
+        add_in_memory_route("ou_plugin", tmp_path)
+
+        called: dict[str, str] = {}
+
+        async def plugin_handler(args):
+            called["args"] = args
+            return f"plugin handled {args}"
+
+        fake_plugins = SimpleNamespace(
+            get_plugin_command_handler=lambda name: plugin_handler
+            if name == "demo-plugin"
+            else None
+        )
+        monkeypatch.setitem(sys.modules, "hermes_cli.plugins", fake_plugins)
+
+        class PoolShouldNotRun:
+            async def dispatch(self, *args, **kwargs):
+                raise AssertionError("plugin slash command leaked into AIAgent dispatch")
+
+        monkeypatch.setattr(router_mod, "_get_pool", lambda: PoolShouldNotRun())
+
+        sends: list[str] = []
+
+        class Adapter:
+            async def send(self, _chat_id, message, *, reply_to=None, metadata=None):
+                sends.append(message)
+
+        event = SimpleNamespace(
+            text="/demo_plugin hi there",
+            source=SimpleNamespace(
+                platform=SimpleNamespace(value="feishu"),
+                chat_id="oc_test",
+                user_id="ou_plugin",
+                user_name="plugin-user",
+                chat_type="dm",
+            ),
+        )
+
+        asyncio.run(
+            router_mod.handle_async(
+                event=event,
+                gateway=SimpleNamespace(adapters={"feishu": Adapter()}),
+            )
+        )
+
+        assert called == {"args": "hi there"}
+        assert sends == ["plugin handled hi there"]
+        clear_in_memory_routes()
+
+
+def test_bundled_router_handles_quick_command_alias(tmp_path, monkeypatch):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import router as router_mod
+        from hermes_multitenancy.runtime import add_in_memory_route, clear_in_memory_routes
+
+        clear_in_memory_routes()
+        add_in_memory_route("ou_quick_alias", tmp_path)
+
+        class PoolShouldNotRun:
+            async def dispatch(self, *args, **kwargs):
+                raise AssertionError("quick-command alias leaked into AIAgent dispatch")
+
+        monkeypatch.setattr(router_mod, "_get_pool", lambda: PoolShouldNotRun())
+
+        sends: list[str] = []
+
+        class Adapter:
+            async def send(self, _chat_id, message, *, reply_to=None, metadata=None):
+                sends.append(message)
+
+        class Gateway:
+            adapters = {"feishu": Adapter()}
+            config = {"quick_commands": {"mini": {"type": "alias", "target": "/model glm-5.1"}}}
+
+            async def _handle_model_command(self, event):
+                return f"model handler saw: {event.text}"
+
+        event = SimpleNamespace(
+            text="/mini high",
+            source=SimpleNamespace(
+                platform=SimpleNamespace(value="feishu"),
+                chat_id="oc_test",
+                user_id="ou_quick_alias",
+                user_name="quick-user",
+                chat_type="dm",
+            ),
+        )
+
+        asyncio.run(router_mod.handle_async(event=event, gateway=Gateway()))
+
+        assert sends == ["model handler saw: /model glm-5.1 high"]
+        clear_in_memory_routes()
+
+
+def test_bundled_router_handles_quick_command_exec(tmp_path, monkeypatch):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import router as router_mod
+        from hermes_multitenancy.runtime import add_in_memory_route, clear_in_memory_routes
+
+        clear_in_memory_routes()
+        add_in_memory_route("ou_quick_exec", tmp_path)
+
+        class PoolShouldNotRun:
+            async def dispatch(self, *args, **kwargs):
+                raise AssertionError("quick-command exec leaked into AIAgent dispatch")
+
+        monkeypatch.setattr(router_mod, "_get_pool", lambda: PoolShouldNotRun())
+
+        sends: list[str] = []
+
+        class Adapter:
+            async def send(self, _chat_id, message, *, reply_to=None, metadata=None):
+                sends.append(message)
+
+        event = SimpleNamespace(
+            text="/ping",
+            source=SimpleNamespace(
+                platform=SimpleNamespace(value="feishu"),
+                chat_id="oc_test",
+                user_id="ou_quick_exec",
+                user_name="quick-user",
+                chat_type="dm",
+            ),
+        )
+        gateway = SimpleNamespace(
+            adapters={"feishu": Adapter()},
+            config={"quick_commands": {"ping": {"type": "exec", "command": "printf quick-ok"}}},
+        )
+
+        asyncio.run(router_mod.handle_async(event=event, gateway=gateway))
+
+        assert sends == ["quick-ok"]
+        clear_in_memory_routes()
 
 
 def test_processing_outcome_fallback_without_gateway_package(monkeypatch):

--- a/tests/plugins/test_feishu_multitenancy_plugin.py
+++ b/tests/plugins/test_feishu_multitenancy_plugin.py
@@ -269,7 +269,8 @@ def test_bundled_command_parser_uses_hermes_registry():
         assert parse_command("/some/path") is None
 
 
-def test_bundled_router_delegates_known_gateway_command(tmp_path):
+def test_bundled_router_delegates_known_gateway_command(tmp_path, caplog):
+    caplog.set_level("INFO")
     with _bundled_plugin_path():
         from hermes_multitenancy import router as router_mod
         from hermes_multitenancy.runtime import add_in_memory_route, clear_in_memory_routes
@@ -307,10 +308,12 @@ def test_bundled_router_delegates_known_gateway_command(tmp_path):
         asyncio.run(router_mod.handle_async(event=event, gateway=Gateway()))
 
         assert sends == ["multitenancy:feishu:coder:oc_test:ou_model"]
+        assert "Hermes gateway command handled: model" in caplog.text
         clear_in_memory_routes()
 
 
-def test_bundled_router_rejects_unknown_slash_without_agent(tmp_path):
+def test_bundled_router_rejects_unknown_slash_without_agent(tmp_path, caplog):
+    caplog.set_level("INFO")
     with _bundled_plugin_path():
         from hermes_multitenancy import router as router_mod
         from hermes_multitenancy.runtime import clear_in_memory_routes
@@ -344,9 +347,11 @@ def test_bundled_router_rejects_unknown_slash_without_agent(tmp_path):
             "Unknown command `/unknown_control`. Type /commands to see what's available, "
             "or resend without the leading slash to send as a regular message."
         ]
+        assert "Unknown command `/unknown_control`" in caplog.text
 
 
-def test_bundled_router_rewrites_skill_slash_into_agent_prompt(tmp_path, monkeypatch):
+def test_bundled_router_rewrites_skill_slash_into_agent_prompt(tmp_path, monkeypatch, caplog):
+    caplog.set_level("INFO")
     with _bundled_plugin_path():
         from hermes_multitenancy import router as router_mod
         from hermes_multitenancy.runtime import add_in_memory_route, clear_in_memory_routes
@@ -414,10 +419,12 @@ def test_bundled_router_rewrites_skill_slash_into_agent_prompt(tmp_path, monkeyp
             "text": "[skill:/demo-skill task:multitenancy:feishu:coder:oc_test:ou_skill] write docs",
         }
         assert sends == ["agent ok"]
+        assert "Hermes skill slash invocation" in caplog.text
         clear_in_memory_routes()
 
 
-def test_bundled_router_delegates_plugin_slash_command(tmp_path, monkeypatch):
+def test_bundled_router_delegates_plugin_slash_command(tmp_path, monkeypatch, caplog):
+    caplog.set_level("INFO")
     with _bundled_plugin_path():
         from hermes_multitenancy import router as router_mod
         from hermes_multitenancy.runtime import add_in_memory_route, clear_in_memory_routes
@@ -470,10 +477,12 @@ def test_bundled_router_delegates_plugin_slash_command(tmp_path, monkeypatch):
 
         assert called == {"args": "hi there"}
         assert sends == ["plugin handled hi there"]
+        assert "Hermes plugin slash handler: demo-plugin" in caplog.text
         clear_in_memory_routes()
 
 
-def test_bundled_router_handles_quick_command_alias(tmp_path, monkeypatch):
+def test_bundled_router_handles_quick_command_alias(tmp_path, monkeypatch, caplog):
+    caplog.set_level("INFO")
     with _bundled_plugin_path():
         from hermes_multitenancy import router as router_mod
         from hermes_multitenancy.runtime import add_in_memory_route, clear_in_memory_routes
@@ -514,10 +523,12 @@ def test_bundled_router_handles_quick_command_alias(tmp_path, monkeypatch):
         asyncio.run(router_mod.handle_async(event=event, gateway=Gateway()))
 
         assert sends == ["model handler saw: /model glm-5.1 high"]
+        assert "Hermes quick command alias" in caplog.text
         clear_in_memory_routes()
 
 
-def test_bundled_router_handles_quick_command_exec(tmp_path, monkeypatch):
+def test_bundled_router_handles_quick_command_exec(tmp_path, monkeypatch, caplog):
+    caplog.set_level("INFO")
     with _bundled_plugin_path():
         from hermes_multitenancy import router as router_mod
         from hermes_multitenancy.runtime import add_in_memory_route, clear_in_memory_routes
@@ -555,6 +566,7 @@ def test_bundled_router_handles_quick_command_exec(tmp_path, monkeypatch):
         asyncio.run(router_mod.handle_async(event=event, gateway=gateway))
 
         assert sends == ["quick-ok"]
+        assert "Hermes quick command exec" in caplog.text
         clear_in_memory_routes()
 
 

--- a/tests/plugins/test_feishu_multitenancy_plugin.py
+++ b/tests/plugins/test_feishu_multitenancy_plugin.py
@@ -1,0 +1,267 @@
+"""Tests for the bundled Feishu multitenancy plugin."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_KEY = "platforms/feishu-multitenancy"
+PLUGIN_DIR = REPO_ROOT / "plugins" / "platforms" / "feishu-multitenancy"
+
+
+def _forget_multitenancy_modules() -> None:
+    for name in list(sys.modules):
+        if (
+            name == "hermes_multitenancy"
+            or name.startswith("hermes_multitenancy.")
+            or name.startswith("hermes_plugins.platforms__feishu_multitenancy")
+        ):
+            sys.modules.pop(name, None)
+
+
+@contextmanager
+def _bundled_plugin_path():
+    _forget_multitenancy_modules()
+    sys.path.insert(0, str(PLUGIN_DIR))
+    try:
+        yield
+    finally:
+        try:
+            sys.path.remove(str(PLUGIN_DIR))
+        except ValueError:
+            pass
+        _forget_multitenancy_modules()
+
+
+def test_bundled_plugin_loads_when_enabled(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "plugins:\n"
+        "  enabled:\n"
+        f"    - {PLUGIN_KEY}\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli.plugins import PluginManager
+
+    _forget_multitenancy_modules()
+    manager = PluginManager()
+    manager.discover_and_load(force=True)
+
+    loaded = manager._plugins[PLUGIN_KEY]
+    assert loaded.enabled
+    assert loaded.error is None
+    assert "pre_gateway_dispatch" in loaded.hooks_registered
+    assert any(
+        getattr(callback, "__name__", "") == "on_pre_gateway_dispatch"
+        for callback in manager._hooks["pre_gateway_dispatch"]
+    )
+
+
+def test_route_sync_wrapper_applies_users(tmp_path):
+    users_json = tmp_path / "users.json"
+    db_path = tmp_path / "multitenancy.db"
+    users_json.write_text(
+        json.dumps(
+            [
+                {
+                    "user_id": "tenant-a",
+                    "profile_name": "alice",
+                    "open_id": "ou_test_alice",
+                    "union_id": "on_test_alice",
+                },
+                {
+                    "user_id": "tenant-b",
+                    "profile_name": "bob",
+                    "open_id": "ou_test_bob",
+                },
+            ]
+        )
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(PLUGIN_DIR / "sync.py"),
+            "apply",
+            str(users_json),
+            "--db",
+            str(db_path),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert json.loads(result.stdout) == {
+        "upserted": 2,
+        "soft_deleted": 0,
+        "kept": 0,
+    }
+
+    with _bundled_plugin_path():
+        from hermes_multitenancy.routing import RoutingTable
+
+        table = RoutingTable(db_path)
+        try:
+            row = table.lookup_by_open_id("ou_test_alice")
+            assert row is not None
+            assert row.profile_name == "alice"
+            assert row.union_id == "on_test_alice"
+        finally:
+            table.close()
+
+
+def test_router_prefers_feishu_open_id_from_raw_event():
+    with _bundled_plugin_path():
+        from hermes_multitenancy.router import _resolve_sender_for_routing
+
+        event = SimpleNamespace(
+            source=SimpleNamespace(user_id="tenant-local-id", user_id_alt="on_union"),
+            raw={
+                "event": {
+                    "sender": {
+                        "sender_id": {
+                            "open_id": "ou_real_sender",
+                            "union_id": "on_union",
+                        }
+                    }
+                }
+            },
+        )
+
+        assert _resolve_sender_for_routing(event) == "ou_real_sender"
+
+
+def test_auto_profile_config_does_not_invent_a_default_model():
+    with _bundled_plugin_path():
+        from hermes_multitenancy.router import _normalize_profile_config
+
+        assert _normalize_profile_config({}) == {}
+        assert _normalize_profile_config({"tools": ["web"]}) == {"tools": ["web"]}
+
+
+def test_aiagent_toolsets_merge_explicit_feishu_entries_with_defaults():
+    with _bundled_plugin_path():
+        from hermes_multitenancy.agent_real import _resolve_enabled_toolsets
+
+        seen: dict[str, object] = {}
+
+        def fake_get_platform_tools(config, platform, *, include_default_mcp_servers=True):
+            seen["platform_toolsets"] = config.get("platform_toolsets")
+            seen["platform"] = platform
+            seen["include_default_mcp_servers"] = include_default_mcp_servers
+            return {"web", "browser", "feishu_doc"}
+
+        config = {"platform_toolsets": {"feishu": ["feishu_drive"]}}
+
+        assert _resolve_enabled_toolsets(
+            config,
+            "feishu",
+            platform_tools_resolver=fake_get_platform_tools,
+        ) == ["browser", "feishu_doc", "feishu_drive", "web"]
+        assert seen == {
+            "platform_toolsets": {},
+            "platform": "feishu",
+            "include_default_mcp_servers": True,
+        }
+
+
+def test_aiagent_toolsets_allow_explicit_mode(monkeypatch):
+    with _bundled_plugin_path():
+        from hermes_multitenancy.agent_real import _resolve_enabled_toolsets
+
+        def fake_get_platform_tools(*_args, **_kwargs):
+            raise AssertionError("explicit mode must not resolve platform defaults")
+
+        monkeypatch.setenv("HERMES_MULTITENANCY_TOOLSETS_MODE", "explicit")
+
+        assert _resolve_enabled_toolsets(
+            {"platform_toolsets": {"feishu": ["feishu_drive", "web"]}},
+            "feishu",
+            platform_tools_resolver=fake_get_platform_tools,
+        ) == ["feishu_drive", "web"]
+
+
+def test_aiagent_subprocess_payload_carries_router_messages(tmp_path):
+    with _bundled_plugin_path():
+        from hermes_multitenancy.agent_real import _event_to_subprocess_payload
+
+        event = SimpleNamespace(
+            text="send me the link",
+            message_id="om_current",
+            source=SimpleNamespace(
+                platform=SimpleNamespace(value="feishu"),
+                chat_id="oc_test",
+                user_id="ou_test",
+            ),
+        )
+        messages = [
+            {"role": "user", "content": "create a doc"},
+            {"role": "assistant", "content": "created doc doxcn123"},
+            {"role": "user", "content": "send me the link"},
+        ]
+
+        payload = _event_to_subprocess_payload(event, tmp_path, messages=messages)
+
+        assert payload["messages"] == messages
+
+
+def test_aiagent_session_id_is_stable_and_user_isolated(tmp_path):
+    with _bundled_plugin_path():
+        from hermes_multitenancy.agent_real import _resolve_aiagent_session_id
+
+        profile_home = tmp_path / "profiles" / "coder"
+        event = SimpleNamespace(
+            text="hello",
+            message_id="om_first",
+            source=SimpleNamespace(
+                platform=SimpleNamespace(value="feishu"),
+                chat_id="oc_test",
+                chat_type="dm",
+                user_id="ou_fallback",
+                message_id="om_source_first",
+            ),
+        )
+        next_event = SimpleNamespace(
+            text="next",
+            message_id="om_second",
+            source=SimpleNamespace(
+                platform=SimpleNamespace(value="feishu"),
+                chat_id="oc_test",
+                chat_type="dm",
+                user_id="ou_fallback",
+                message_id="om_source_second",
+            ),
+        )
+
+        first_session = _resolve_aiagent_session_id(event, profile_home, "ou_sender")
+        next_session = _resolve_aiagent_session_id(next_event, profile_home, "ou_sender")
+
+        assert first_session == next_session
+        assert "profile:coder" in first_session
+        assert "chat:oc_test" in first_session
+        assert "user:ou_sender" in first_session
+        assert first_session != _resolve_aiagent_session_id(
+            event,
+            profile_home,
+            "ou_other",
+        )
+
+
+def test_processing_outcome_fallback_without_gateway_package(monkeypatch):
+    with _bundled_plugin_path():
+        from hermes_multitenancy.router import _processing_outcome
+
+        monkeypatch.delitem(sys.modules, "gateway.platforms.base", raising=False)
+
+        assert str(_processing_outcome(failed=False)) == "ProcessingOutcome.SUCCESS"
+        assert str(_processing_outcome(failed=True)) == "ProcessingOutcome.FAILURE"

--- a/tests/plugins/test_feishu_multitenancy_plugin.py
+++ b/tests/plugins/test_feishu_multitenancy_plugin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import asyncio
 import subprocess
 import sys
 from contextlib import contextmanager
@@ -255,6 +256,94 @@ def test_aiagent_session_id_is_stable_and_user_isolated(tmp_path):
             profile_home,
             "ou_other",
         )
+
+
+def test_bundled_command_parser_uses_hermes_registry():
+    with _bundled_plugin_path():
+        from hermes_multitenancy.commands import parse_command
+
+        assert parse_command("/model gpt-5") == ("model", "gpt-5")
+        assert parse_command("/provider gpt-5") == ("model", "gpt-5")
+        assert parse_command("/reload_mcp") == ("reload-mcp", "")
+        assert parse_command("/definitely_unknown") == ("definitely_unknown", "")
+        assert parse_command("/some/path") is None
+
+
+def test_bundled_router_delegates_known_gateway_command(tmp_path):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import router as router_mod
+        from hermes_multitenancy.runtime import add_in_memory_route, clear_in_memory_routes
+
+        clear_in_memory_routes()
+        profile_home = tmp_path / "coder"
+        profile_home.mkdir()
+        add_in_memory_route("ou_model", profile_home)
+        sends: list[str] = []
+
+        class Adapter:
+            async def send(self, _chat_id, message, *, reply_to=None, metadata=None):
+                sends.append(message)
+
+        class Gateway:
+            adapters = {"feishu": Adapter()}
+
+            def _session_key_for_source(self, _source):
+                return "native-session"
+
+            async def _handle_model_command(self, event):
+                return self._session_key_for_source(event.source)
+
+        event = SimpleNamespace(
+            text="/model gpt-5",
+            source=SimpleNamespace(
+                platform=SimpleNamespace(value="feishu"),
+                chat_id="oc_test",
+                user_id="ou_model",
+                user_name="model-user",
+                chat_type="dm",
+            ),
+        )
+
+        asyncio.run(router_mod.handle_async(event=event, gateway=Gateway()))
+
+        assert sends == ["multitenancy:feishu:coder:oc_test:ou_model"]
+        clear_in_memory_routes()
+
+
+def test_bundled_router_rejects_unknown_slash_without_agent(tmp_path):
+    with _bundled_plugin_path():
+        from hermes_multitenancy import router as router_mod
+        from hermes_multitenancy.runtime import clear_in_memory_routes
+
+        clear_in_memory_routes()
+        sends: list[str] = []
+
+        class Adapter:
+            async def send(self, _chat_id, message, *, reply_to=None, metadata=None):
+                sends.append(message)
+
+        event = SimpleNamespace(
+            text="/unknown_control",
+            source=SimpleNamespace(
+                platform=SimpleNamespace(value="feishu"),
+                chat_id="oc_test",
+                user_id="ou_unknown",
+                user_name="unknown-user",
+                chat_type="dm",
+            ),
+        )
+
+        asyncio.run(
+            router_mod.handle_async(
+                event=event,
+                gateway=SimpleNamespace(adapters={"feishu": Adapter()}),
+            )
+        )
+
+        assert sends == [
+            "Unknown command `/unknown_control`. Type /commands to see what's available, "
+            "or resend without the leading slash to send as a regular message."
+        ]
 
 
 def test_processing_outcome_fallback_without_gateway_package(monkeypatch):

--- a/tests/tools/test_terminal_foreground_timeout_cap.py
+++ b/tests/tools/test_terminal_foreground_timeout_cap.py
@@ -76,6 +76,33 @@ class TestForegroundTimeoutCap:
         assert "long-lived" in result["error"].lower()
         assert "background=true" in result["error"]
 
+    def test_gateway_approval_required_returns_before_environment_creation(self):
+        """Dangerous commands in gateway ask mode should not wait on sandbox setup."""
+        from tools.terminal_tool import terminal_tool
+
+        def fail_if_environment_created(*_args, **_kwargs):
+            raise AssertionError("environment should not be created before approval")
+
+        with patch("tools.terminal_tool._get_env_config", return_value=_make_env_config()), \
+             patch("tools.terminal_tool._start_cleanup_thread"), \
+             patch("tools.terminal_tool._create_environment", side_effect=fail_if_environment_created), \
+             patch("tools.terminal_tool._check_all_guards", return_value={
+                 "approved": False,
+                 "status": "approval_required",
+                 "command": "python -c \"print('approval bridge ok')\"",
+                 "description": "script execution via -e/-c flag",
+                 "pattern_key": "script_flag",
+                 "message": "Waiting for user approval",
+             }):
+
+            result = json.loads(terminal_tool(
+                command="python -c \"print('approval bridge ok')\"",
+            ))
+
+        assert result["status"] == "approval_required"
+        assert result["description"] == "script execution via -e/-c flag"
+        assert result["command"] == "python -c \"print('approval bridge ok')\""
+
     def test_foreground_allows_help_variant_for_server_command(self):
         """Informational variants like '--help' should not be blocked."""
         from tools.terminal_tool import terminal_tool

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1732,6 +1732,45 @@ def terminal_tool(
                     "status": "error",
                 }, ensure_ascii=False)
 
+        # Pre-exec security checks (tirith + dangerous command detection)
+        # must run before sandbox/environment creation. In gateway ask mode,
+        # environment startup can be slow or blocked; approval_required should
+        # be emitted immediately so the gateway can show the approval prompt.
+        approval_note = None
+        if not force:
+            approval = _check_all_guards(command, env_type)
+            if not approval["approved"]:
+                # Check if this is an approval_required (gateway ask mode)
+                if approval.get("status") == "approval_required":
+                    return json.dumps({
+                        "output": "",
+                        "exit_code": -1,
+                        "error": approval.get("message", "Waiting for user approval"),
+                        "status": "approval_required",
+                        "command": approval.get("command", command),
+                        "description": approval.get("description", "command flagged"),
+                        "pattern_key": approval.get("pattern_key", ""),
+                    }, ensure_ascii=False)
+                # Command was blocked
+                desc = approval.get("description", "command flagged")
+                fallback_msg = (
+                    f"Command denied: {desc}. "
+                    "Use the approval prompt to allow it, or rephrase the command."
+                )
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": approval.get("message", fallback_msg),
+                    "status": "blocked"
+                }, ensure_ascii=False)
+            # Track whether approval was explicitly granted by the user
+            if approval.get("user_approved"):
+                desc = approval.get("description", "flagged as dangerous")
+                approval_note = f"Command required approval ({desc}) and was approved by the user."
+            elif approval.get("smart_approved"):
+                desc = approval.get("description", "flagged as dangerous")
+                approval_note = f"Command was flagged ({desc}) and auto-approved by smart approval."
+
         # Start cleanup thread
         _start_cleanup_thread()
 
@@ -1823,43 +1862,6 @@ def terminal_tool(
                         _last_activity[effective_task_id] = time.time()
                         env = new_env
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
-
-        # Pre-exec security checks (tirith + dangerous command detection)
-        # Skip check if force=True (user has confirmed they want to run it)
-        approval_note = None
-        if not force:
-            approval = _check_all_guards(command, env_type)
-            if not approval["approved"]:
-                # Check if this is an approval_required (gateway ask mode)
-                if approval.get("status") == "approval_required":
-                    return json.dumps({
-                        "output": "",
-                        "exit_code": -1,
-                        "error": approval.get("message", "Waiting for user approval"),
-                        "status": "approval_required",
-                        "command": approval.get("command", command),
-                        "description": approval.get("description", "command flagged"),
-                        "pattern_key": approval.get("pattern_key", ""),
-                    }, ensure_ascii=False)
-                # Command was blocked
-                desc = approval.get("description", "command flagged")
-                fallback_msg = (
-                    f"Command denied: {desc}. "
-                    "Use the approval prompt to allow it, or rephrase the command."
-                )
-                return json.dumps({
-                    "output": "",
-                    "exit_code": -1,
-                    "error": approval.get("message", fallback_msg),
-                    "status": "blocked"
-                }, ensure_ascii=False)
-            # Track whether approval was explicitly granted by the user
-            if approval.get("user_approved"):
-                desc = approval.get("description", "flagged as dangerous")
-                approval_note = f"Command required approval ({desc}) and was approved by the user."
-            elif approval.get("smart_approved"):
-                desc = approval.get("description", "flagged as dangerous")
-                approval_note = f"Command was flagged ({desc}) and auto-approved by smart approval."
 
         # Validate workdir against shell injection
         if workdir:

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -59,6 +59,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `observability/langfuse` | hooks | Trace turns / LLM calls / tools to [Langfuse](https://langfuse.com) |
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
+| `platforms/feishu-multitenancy` | gateway hook | Route one Feishu bot to many isolated Hermes profiles by sender `open_id` |
 | `image_gen/openai` | image backend | OpenAI `gpt-image-2` image generation backend (alternative to FAL) |
 | `image_gen/openai-codex` | image backend | OpenAI image generation via Codex OAuth |
 | `image_gen/xai` | image backend | xAI `grok-2-image` backend |
@@ -208,6 +209,31 @@ The agent kicks off the meeting join, streams the transcription back into its co
 **When to use it:** recurring standups where you want a bot to transcribe + summarize for async attendees; deposition-style interviews where you want structured notes; any case where you'd otherwise need Fireflies / Otter / Grain. When you'd rather not have an AI listening in — don't enable it.
 
 **Disabling:** `hermes plugins disable google_meet`. Any cached transcripts and recordings stay in `~/.hermes/cache/google_meet/` until you remove them.
+
+### platforms/feishu-multitenancy
+
+Routes a single Feishu bot to multiple Hermes profiles. It is useful for
+company or team deployments where one Feishu app should serve many users, but
+each user needs an isolated `SOUL.md`, session history, model configuration,
+and tool policy.
+
+**Enable:**
+
+```bash
+hermes plugins enable platforms/feishu-multitenancy
+hermes gateway restart
+```
+
+Routes are stored in `~/.hermes/multitenancy.db`. Apply route rows with the
+plugin's sync helper:
+
+```bash
+python plugins/platforms/feishu-multitenancy/sync.py apply users.json
+```
+
+Each route should key new users by Feishu `open_id` (`ou_*`). See
+`plugins/platforms/feishu-multitenancy/README.md` for route file format,
+auto-provisioning, and shared Feishu app guidance.
 
 ### hermes-achievements
 


### PR DESCRIPTION
## Summary

Adds and hardens the opt-in bundled `platforms/feishu-multitenancy` plugin for deployments that want one Feishu bot to route different Feishu senders into isolated Hermes profiles.

This PR now covers the routed profile runtime plus the active-return paths that must cross back from a profile AIAgent subprocess to the parent gateway:

- resolves canonical Feishu sender `open_id` before normal gateway dispatch
- routes each sender to a profile-specific `HERMES_HOME`
- stores routes and session history in `~/.hermes/multitenancy.db`
- forwards router conversation history into the AIAgent subprocess and uses stable profile/chat/user session IDs instead of per-message Feishu IDs
- keeps cron/reminder jobs in the shared gateway cron store so the parent cron ticker can deliver them back to Feishu
- bridges dangerous-command approvals from the child AIAgent back to the parent router and Feishu `/approve` / `/deny` flow
- forwards child `approval_required` / `approval_resolved` stream events instead of dropping them
- exposes child-local `HERMES_SESSION_KEY` / `HERMES_GATEWAY_SESSION` / `HERMES_EXEC_ASK` so terminal/process worker threads resolve the same approval callback
- runs terminal guard checks before sandbox/environment creation so gateway ask mode can surface approval promptly
- keeps Hermes registry slash commands, skill slash invocations, plugin slash handlers, quick aliases/exec, and unknown slash commands out of the LLM prompt path

## Root Cause Covered

The AR2 approval-bridge regression was not a Feishu bot or UAT-token issue. The real path is:

`profile AIAgent subprocess -> multitenancy approval bridge -> parent router -> Feishu bot -> Feishu user`.

Three gaps had to be fixed together:

1. terminal/process guards can run in worker threads that do not inherit Python `contextvars`, so the child needs process-local session env while the approval bridge is active;
2. `terminal_tool()` previously created/reused its execution environment before checking guards, which could block the approval prompt behind environment startup;
3. the parent subprocess stream parser forwarded tool events but dropped child approval events, so the router never saw `approval_required` in the live path.

## Docs

- Updates `plugins/platforms/feishu-multitenancy/README.md` with the profile-routing contract, shared cron store, approval bridge, slash command handling, and tenant-boundary controls.
- Documents the terminal approval bridge requirements so an agent reading the README can understand the implementation and required configuration.

## Tests

Fresh verification for the latest commit:

```bash
python3 -m pytest tests/tools/test_terminal_foreground_timeout_cap.py tests/plugins/test_feishu_multitenancy_plugin.py -q
```

Result: `41 passed, 20 warnings`.

```bash
python3 -m py_compile tools/terminal_tool.py plugins/platforms/feishu-multitenancy/hermes_multitenancy/agent_real.py plugins/platforms/feishu-multitenancy/hermes_multitenancy/router.py
```

Result: passed.

External standalone plugin repo verification:

```bash
./venv/bin/python -m pytest -q
```

Result: `141 passed, 3 deselected`.

Runtime UAT runner/terminal guard verification on the Feishu UAT checkout:

```bash
/Users/kite/code/hermes-feishu-uat/venv/bin/python -m pytest tests/tools/test_terminal_foreground_timeout_cap.py tests/scripts/test_stress_test_feishu_pipeline.py -q
```

Result: `84 passed`.

Live Feishu AR2 after gateway restart:

```bash
scripts/stress_test_feishu_pipeline.py --suite async-return --case-id AR2 --wait 75 --gap 0
```

Result: `Summary: 1/1 PASSED`; after `/approve`, profile logs showed `tool.completed terminal ... error=False` and the final streaming card was finalized.

## Notes for Maintainers

The plugin remains opt-in and Feishu-specific. The bundled plugin changes are isolated under `plugins/platforms/feishu-multitenancy`, while the `tools/terminal_tool.py` change fixes the generic gateway approval timing issue exposed by this integration.
