### PR TITLE
fix: properly pass model.max_tokens config to AIAgent in gateway

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1976,6 +1976,7 @@ class HermesCLI:
         api_key: str = None,
         base_url: str = None,
         max_turns: int = None,
+        max_tokens: int = None,
         verbose: bool = False,
         compact: bool = False,
         resume: str = None,
@@ -1993,6 +1994,7 @@ class HermesCLI:
             api_key: API key (default: from environment)
             base_url: API base URL (default: OpenRouter)
             max_turns: Maximum tool-calling iterations shared with subagents (default: 90)
+            max_tokens: Maximum output token limit for model responses (default: from config or model default)
             verbose: Enable verbose logging
             compact: Use compact display mode
             resume: Session ID to resume (restores conversation history from SQLite)
@@ -2114,6 +2116,13 @@ class HermesCLI:
             self.api_key = api_key or os.getenv("OPENROUTER_API_KEY") or os.getenv("OPENAI_API_KEY")
         else:
             self.api_key = api_key or os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY")
+        # Max tokens priority: CLI arg > config file > model default
+        if max_tokens is not None:
+            self.max_tokens = max_tokens
+        elif isinstance(_model_config, dict) and _model_config.get("max_tokens"):
+            self.max_tokens = _model_config["max_tokens"]
+        else:
+            self.max_tokens = None
         # Max turns priority: CLI arg > config file > env var > default
         if max_turns is not None:  # CLI arg was explicitly set
             self.max_turns = max_turns

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -618,9 +618,11 @@ def _resolve_runtime_agent_kwargs() -> dict:
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
-    # Get max_tokens from model config
-    model_cfg = _get_model_config()
-    max_tokens = model_cfg.get("max_tokens") if isinstance(model_cfg, dict) else None
+    # Get max_tokens from runtime provider config first, fallback to model config
+    max_tokens = runtime.get("max_tokens")
+    if not max_tokens:
+        model_cfg = _get_model_config()
+        max_tokens = model_cfg.get("max_tokens") if isinstance(model_cfg, dict) else None
 
     return {
         "api_key": runtime.get("api_key"),
@@ -649,9 +651,6 @@ def _try_resolve_fallback_provider() -> dict | None:
             return None
         # Normalize to list
         fb_list = fb if isinstance(fb, list) else [fb]
-        # Get max_tokens from model config
-        model_cfg = _get_model_config()
-        max_tokens = model_cfg.get("max_tokens") if isinstance(model_cfg, dict) else None
         for entry in fb_list:
             if not isinstance(entry, dict):
                 continue
@@ -662,6 +661,11 @@ def _try_resolve_fallback_provider() -> dict | None:
                     explicit_api_key=entry.get("api_key"),
                 )
                 logger.info("Fallback provider resolved: %s", runtime.get("provider"))
+                # Get max_tokens from runtime provider config first, fallback to model config
+                max_tokens = runtime.get("max_tokens")
+                if not max_tokens:
+                    model_cfg = _get_model_config()
+                    max_tokens = model_cfg.get("max_tokens") if isinstance(model_cfg, dict) else None
                 return {
                     "api_key": runtime.get("api_key"),
                     "base_url": runtime.get("base_url"),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -599,6 +599,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
     from hermes_cli.runtime_provider import (
         resolve_runtime_provider,
         format_runtime_provider_error,
+        _get_model_config,
     )
     from hermes_cli.auth import AuthError
 
@@ -617,6 +618,10 @@ def _resolve_runtime_agent_kwargs() -> dict:
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
+    # Get max_tokens from model config
+    model_cfg = _get_model_config()
+    max_tokens = model_cfg.get("max_tokens") if isinstance(model_cfg, dict) else None
+
     return {
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
@@ -625,12 +630,13 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        "max_tokens": max_tokens,
     }
 
 
 def _try_resolve_fallback_provider() -> dict | None:
     """Attempt to resolve credentials from the fallback_model/fallback_providers config."""
-    from hermes_cli.runtime_provider import resolve_runtime_provider
+    from hermes_cli.runtime_provider import resolve_runtime_provider, _get_model_config
     try:
         import yaml as _y
         cfg_path = _hermes_home / "config.yaml"
@@ -643,6 +649,9 @@ def _try_resolve_fallback_provider() -> dict | None:
             return None
         # Normalize to list
         fb_list = fb if isinstance(fb, list) else [fb]
+        # Get max_tokens from model config
+        model_cfg = _get_model_config()
+        max_tokens = model_cfg.get("max_tokens") if isinstance(model_cfg, dict) else None
         for entry in fb_list:
             if not isinstance(entry, dict):
                 continue
@@ -661,6 +670,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "command": runtime.get("command"),
                     "args": list(runtime.get("args") or []),
                     "credential_pool": runtime.get("credential_pool"),
+                    "max_tokens": max_tokens,
                 }
             except Exception as fb_exc:
                 logger.debug("Fallback entry %s failed: %s", entry.get("provider"), fb_exc)
@@ -1546,6 +1556,7 @@ class GatewayRunner:
             "command": runtime_kwargs.get("command"),
             "args": list(runtime_kwargs.get("args") or []),
             "credential_pool": runtime_kwargs.get("credential_pool"),
+            "max_tokens": runtime_kwargs.get("max_tokens"),
         }
         route = {
             "model": model,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2551,6 +2551,7 @@ def _normalize_custom_provider_entry(
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
+        "max_tokens",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -2636,6 +2637,10 @@ def _normalize_custom_provider_entry(
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:
         normalized["context_length"] = context_length
+
+    max_tokens = entry.get("max_tokens")
+    if isinstance(max_tokens, int) and max_tokens > 0:
+        normalized["max_tokens"] = max_tokens
 
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -410,6 +410,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                     if api_mode:
                         result["api_mode"] = api_mode
+                    max_tokens = entry.get("max_tokens")
+                    if isinstance(max_tokens, int) and max_tokens > 0:
+                        result["max_tokens"] = max_tokens
                     return result
             # Also check the 'name' field if present
             display_name = entry.get("name", "")
@@ -428,6 +431,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                         if api_mode:
                             result["api_mode"] = api_mode
+                        max_tokens = entry.get("max_tokens")
+                        if isinstance(max_tokens, int) and max_tokens > 0:
+                            result["max_tokens"] = max_tokens
                         return result
 
     # Fall back to custom_providers: list (legacy format)
@@ -474,6 +480,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         model_name = str(entry.get("model", "") or "").strip()
         if model_name:
             result["model"] = model_name
+        max_tokens = entry.get("max_tokens")
+        if isinstance(max_tokens, int) and max_tokens > 0:
+            result["max_tokens"] = max_tokens
         return result
 
     return None
@@ -528,6 +537,10 @@ def _resolve_named_custom_runtime(
         model_name = custom_provider.get("model")
         if model_name:
             pool_result["model"] = model_name
+        # Also propagate max_tokens
+        max_tokens = custom_provider.get("max_tokens")
+        if isinstance(max_tokens, int) and max_tokens > 0:
+            pool_result["max_tokens"] = max_tokens
         return pool_result
 
     api_key_candidates = [
@@ -552,6 +565,8 @@ def _resolve_named_custom_runtime(
     # provider name differs from the actual model string the API expects.
     if custom_provider.get("model"):
         result["model"] = custom_provider["model"]
+    if custom_provider.get("max_tokens"):
+        result["max_tokens"] = custom_provider["max_tokens"]
     return result
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes the issue where  from config.yaml was not being passed to AIAgent when running via the gateway (Feishu, QQBot, etc.), causing model responses to be truncated due to conservative default output limits.

### Changes:
1. ****: Import and use  to read  from config
2. ****: Include  in the runtime dict passed to AIAgent
3. ****: Include  in fallback provider resolution
4. ****: Add  parameter with config priority: CLI args > config file > model default

### Why is this needed?
For custom providers like ByteDance Ark, the model default output token limit is quite conservative. When  is configured but not passed through, users see  warnings in platforms like Feishu.

### Testing
- Verified that the config path correctly reads 
- All changes are backward compatible (None is passed when config is not set)
- Gateway routes correctly unpack the runtime dict including max_tokens