### PR TITLE
fix(agent): tolerate broken provider model dumps

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -89,6 +89,18 @@ class _OpenAIProxy:
 
 OpenAI = _OpenAIProxy()
 
+
+def _safe_model_dump(value: Any) -> Any:
+    """Best-effort Pydantic dump for provider metadata; keep original on failure."""
+    model_dump = getattr(value, "model_dump", None)
+    if not callable(model_dump):
+        return value
+    try:
+        return model_dump()
+    except Exception:
+        return value
+
+
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.env_loader import load_hermes_dotenv
@@ -6958,8 +6970,7 @@ class AIAgent:
                         if extra is None and hasattr(tc_delta, "model_extra"):
                             extra = (tc_delta.model_extra or {}).get("extra_content")
                         if extra is not None:
-                            if hasattr(extra, "model_dump"):
-                                extra = extra.model_dump()
+                            extra = _safe_model_dump(extra)
                             entry["extra_content"] = extra
                         # Fire once per tool when the full name is available
                         name = entry["function"]["name"]
@@ -8747,7 +8758,7 @@ class AIAgent:
                 elif hasattr(d, "__dict__"):
                     preserved.append(d.__dict__)
                 elif hasattr(d, "model_dump"):
-                    preserved.append(d.model_dump())
+                    preserved.append(_safe_model_dump(d))
             if preserved:
                 msg["reasoning_details"] = preserved
 
@@ -8807,8 +8818,7 @@ class AIAgent:
                 # thinking models reject the request with a 400 error.
                 extra = getattr(tool_call, "extra_content", None)
                 if extra is not None:
-                    if hasattr(extra, "model_dump"):
-                        extra = extra.model_dump()
+                    extra = _safe_model_dump(extra)
                     tc_dict["extra_content"] = extra
                 tool_calls.append(tc_dict)
             msg["tool_calls"] = tool_calls

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1412,6 +1412,22 @@ class TestBuildAssistantMessage:
         assert "reasoning_details" in result
         assert result["reasoning_details"][0]["text"] == "step1"
 
+    def test_reasoning_details_model_dump_failure_preserved(self, agent):
+        """Reasoning metadata with a broken model_dump should not abort storage."""
+
+        class BrokenDump:
+            __slots__ = ()
+
+            def model_dump(self):
+                raise AttributeError("'dict' object has no attribute 'model_dump'")
+
+        detail = BrokenDump()
+        msg = _mock_assistant_msg(content="ans", reasoning_details=[detail])
+
+        result = agent._build_assistant_message(msg, "stop")
+
+        assert result["reasoning_details"][0] is detail
+
     def test_empty_content(self, agent):
         msg = _mock_assistant_msg(content=None)
         result = agent._build_assistant_message(msg, "stop")
@@ -1485,6 +1501,24 @@ class TestBuildAssistantMessage:
         assert result["tool_calls"][0]["extra_content"] == {
             "google": {"thought_signature": "abc123"}
         }
+
+    def test_tool_call_extra_content_model_dump_failure_preserved(self, agent):
+        """MiniMax-like provider metadata should survive a broken model_dump."""
+
+        class BrokenDump:
+            def model_dump(self):
+                raise AttributeError("'dict' object has no attribute 'model_dump'")
+
+        extra_content = BrokenDump()
+        tc = _mock_tool_call(
+            name="get_weather", arguments='{"city":"NYC"}', call_id="c2"
+        )
+        tc.extra_content = extra_content
+        msg = _mock_assistant_msg(content="", tool_calls=[tc])
+
+        result = agent._build_assistant_message(msg, "tool_calls")
+
+        assert result["tool_calls"][0]["extra_content"] is extra_content
 
     def test_tool_call_without_extra_content(self, agent):
         """Standard tool calls (no thinking model) should not have extra_content."""

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -237,6 +237,53 @@ class TestStreamingAccumulator:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_tool_call_extra_content_model_dump_failure_preserved(self, mock_close, mock_create):
+        """Provider metadata that cannot model_dump should not crash streaming."""
+        from run_agent import AIAgent
+
+        class BrokenDump:
+            def model_dump(self):
+                raise AttributeError("'dict' object has no attribute 'model_dump'")
+
+        extra_content = BrokenDump()
+        chunks = [
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    tc_id="call_minimax",
+                    name="cronjob",
+                    extra_content=extra_content,
+                )
+            ]),
+            _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(index=0, arguments='{"task": "morning"}')
+            ]),
+            _make_stream_chunk(finish_reason="tool_calls"),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        tc = response.choices[0].message.tool_calls
+        assert tc is not None
+        assert tc[0].extra_content is extra_content
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_mixed_content_and_tool_calls(self, mock_close, mock_create):
         """Stream with both text and tool calls accumulates both."""
         from run_agent import AIAgent
@@ -1504,4 +1551,3 @@ class TestCopilotACPStreamingDecision:
             _use_streaming = False
 
         assert _use_streaming is True
-


### PR DESCRIPTION
## Summary
- add a small safe model-dump helper for opaque provider metadata in `run_agent.py`
- keep provider metadata unmodified when `model_dump()` raises, matching the existing fail-open pattern in `agent/transports/chat_completions.py`
- cover streaming tool-call `extra_content`, stored assistant tool-call `extra_content`, and `reasoning_details` preservation regressions

Closes #19968.

## Verification
- `scripts/run_tests.sh tests/run_agent/test_streaming.py tests/run_agent/test_run_agent.py` -> 351 passed, 4 warnings
- `git diff --check` -> passed

## Scope
This intentionally does not change MiniMax transport selection or provider SDK parsing. It only prevents opaque provider metadata dump failures from aborting the agent turn.