### PR TITLE
fix(packaging): include TUI runtime assets

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,7 @@
 graft skills
 graft optional-skills
+graft ui-tui
+prune ui-tui/node_modules
+include scripts/lib/node-bootstrap.sh
 global-exclude __pycache__
 global-exclude *.py[cod]

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -20,3 +20,11 @@ def test_manifest_includes_bundled_skills():
 
     assert "graft skills" in manifest
     assert "graft optional-skills" in manifest
+
+
+def test_manifest_includes_tui_runtime_assets():
+    manifest = (REPO_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+
+    assert "graft ui-tui" in manifest
+    assert "prune ui-tui/node_modules" in manifest
+    assert "include scripts/lib/node-bootstrap.sh" in manifest


### PR DESCRIPTION
## Summary
- include `ui-tui/` in the source distribution so pip installs have the TUI project that `hermes --tui` expects
- prune `ui-tui/node_modules` so local installs are not vendored into the package
- include `scripts/lib/node-bootstrap.sh`, the bootstrap helper used when Node/npm are missing
- add a packaging metadata regression test for these manifest entries

Closes #19514.

## Verification
- `scripts/run_tests.sh tests/test_packaging_metadata.py` -> 3 passed, 3 warnings
- `git diff --check` -> passed

## Scope
This is packaging-only. It does not change TUI launch logic, npm install behavior, or built web assets.