### PR TITLE
fix(gateway): abort replace if old PID survives SIGKILL

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14911,12 +14911,14 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 except Exception:
                     pass
                 return False
+            old_gateway_exited = False
             # Wait up to 10 seconds for the old process to exit
             for _ in range(20):
                 try:
                     os.kill(existing_pid, 0)
                     time.sleep(0.5)
                 except (ProcessLookupError, PermissionError):
+                    old_gateway_exited = True
                     break  # Process is gone
             else:
                 # Still alive after 10s — force kill
@@ -14926,9 +14928,30 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 )
                 try:
                     terminate_pid(existing_pid, force=True)
-                    time.sleep(0.5)
-                except (ProcessLookupError, PermissionError, OSError):
+                except ProcessLookupError:
+                    old_gateway_exited = True
+                except (PermissionError, OSError):
                     pass
+                if not old_gateway_exited:
+                    for _ in range(20):
+                        try:
+                            os.kill(existing_pid, 0)
+                            time.sleep(0.25)
+                        except (ProcessLookupError, PermissionError):
+                            old_gateway_exited = True
+                            break
+                if not old_gateway_exited:
+                    logger.error(
+                        "Old gateway (PID %d) still appears alive after SIGKILL; "
+                        "aborting replacement to avoid a duplicate gateway.",
+                        existing_pid,
+                    )
+                    try:
+                        from gateway.status import clear_takeover_marker
+                        clear_takeover_marker()
+                    except Exception:
+                        pass
+                    return False
             remove_pid_file()
             # remove_pid_file() is a no-op when the PID doesn't match.
             # Force-unlink to cover the old-process-crashed case.

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -197,9 +197,18 @@ async def test_start_gateway_replace_force_uses_terminate_pid(monkeypatch, tmp_p
         "gateway.status.release_all_scoped_locks",
         lambda **kwargs: 0,
     )
-    monkeypatch.setattr("gateway.status.terminate_pid", lambda pid, force=False: calls.append((pid, force)))
+    def _mock_terminate_pid(pid, force=False):
+        calls.append((pid, force))
+        if force:
+            _pid_state["alive"] = False
+
+    monkeypatch.setattr("gateway.status.terminate_pid", _mock_terminate_pid)
     monkeypatch.setattr("gateway.run.os.getpid", lambda: 100)
-    monkeypatch.setattr("gateway.run.os.kill", lambda pid, sig: None)
+    def _mock_os_kill(pid, sig):
+        if not _pid_state["alive"]:
+            raise ProcessLookupError()
+
+    monkeypatch.setattr("gateway.run.os.kill", _mock_os_kill)
     monkeypatch.setattr("time.sleep", lambda _: None)
     monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
     monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path)
@@ -212,6 +221,57 @@ async def test_start_gateway_replace_force_uses_terminate_pid(monkeypatch, tmp_p
 
     assert ok is True
     assert calls == [(42, False), (42, True)]
+
+
+@pytest.mark.asyncio
+async def test_start_gateway_replace_aborts_when_force_killed_pid_still_alive(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    calls = []
+    removed_pid = False
+    released_locks = False
+
+    class _RunnerShouldNotStart:
+        def __init__(self, config):
+            raise AssertionError("replacement must not start while old PID is alive")
+
+    def _mock_remove_pid_file():
+        nonlocal removed_pid
+        removed_pid = True
+
+    def _mock_release_all_scoped_locks(**kwargs):
+        nonlocal released_locks
+        released_locks = True
+        return 0
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 42)
+    monkeypatch.setattr("gateway.status.remove_pid_file", _mock_remove_pid_file)
+    monkeypatch.setattr(
+        "gateway.status.release_all_scoped_locks",
+        _mock_release_all_scoped_locks,
+    )
+    monkeypatch.setattr(
+        "gateway.status.terminate_pid",
+        lambda pid, force=False: calls.append((pid, force)),
+    )
+    monkeypatch.setattr("gateway.run.os.getpid", lambda: 100)
+    monkeypatch.setattr("gateway.run.os.kill", lambda pid, sig: None)
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    monkeypatch.setattr("tools.skills_sync.sync_skills", lambda quiet=True: None)
+    monkeypatch.setattr("hermes_logging.setup_logging", lambda hermes_home, mode: tmp_path)
+    monkeypatch.setattr("hermes_logging._add_rotating_handler", lambda *args, **kwargs: None)
+    monkeypatch.setattr("gateway.run.GatewayRunner", _RunnerShouldNotStart)
+
+    from gateway.run import start_gateway
+
+    ok = await start_gateway(config=GatewayConfig(), replace=True, verbosity=None)
+
+    assert ok is False
+    assert calls == [(42, False), (42, True)]
+    assert removed_pid is False
+    assert released_locks is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- make gateway `--replace` verify the old gateway PID actually disappears after the forced-kill path
- abort replacement before clearing PID/scoped-lock metadata when the old PID still appears alive
- add a regression that prevents starting a duplicate gateway while the old process is still present

Fixes #19471

## Tests
- `scripts/run_tests.sh tests/gateway/test_runner_startup_failures.py`
- `scripts/run_tests.sh tests/gateway/test_status.py tests/gateway/test_runner_startup_failures.py`
- `git diff --check`