### PR TITLE
fix(gateway): honor WhatsApp config disable

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -778,7 +778,7 @@ def load_gateway_config() -> GatewayConfig:
                 if not isinstance(extra, dict):
                     extra = {}
                     plat_data["extra"] = extra
-                if plat == Platform.SLACK and enabled_was_explicit:
+                if plat in (Platform.SLACK, Platform.WHATSAPP) and enabled_was_explicit:
                     extra["_enabled_explicit"] = True
                 extra.update(bridged)
 
@@ -1124,7 +1124,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     if whatsapp_enabled:
         if Platform.WHATSAPP not in config.platforms:
             config.platforms[Platform.WHATSAPP] = PlatformConfig()
-        config.platforms[Platform.WHATSAPP].enabled = True
+            config.platforms[Platform.WHATSAPP].enabled = True
+        else:
+            whatsapp_config = config.platforms[Platform.WHATSAPP]
+            enabled_was_explicit = bool(whatsapp_config.extra.pop("_enabled_explicit", False))
+            if whatsapp_config.enabled or not enabled_was_explicit:
+                whatsapp_config.enabled = True
     whatsapp_home = os.getenv("WHATSAPP_HOME_CHANNEL")
     if whatsapp_home and Platform.WHATSAPP in config.platforms:
         config.platforms[Platform.WHATSAPP].home_channel = HomeChannel(

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -307,6 +307,44 @@ class TestLoadGatewayConfig:
         assert config.platforms[Platform.API_SERVER].enabled is False
         assert Platform.API_SERVER not in config.get_connected_platforms()
 
+    def test_whatsapp_enabled_false_overrides_stale_env_enable(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "whatsapp:\n"
+            "  enabled: false\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("WHATSAPP_ENABLED", "true")
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.WHATSAPP].enabled is False
+        assert Platform.WHATSAPP not in config.get_connected_platforms()
+
+    def test_whatsapp_env_still_enables_when_config_has_no_enabled_decision(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "whatsapp:\n"
+            "  reply_prefix: Bot\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("WHATSAPP_ENABLED", "true")
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.WHATSAPP].enabled is True
+        assert config.platforms[Platform.WHATSAPP].extra["reply_prefix"] == "Bot"
+
     def test_bridges_quoted_false_session_notify_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()


### PR DESCRIPTION
## Summary
- keep explicit `whatsapp.enabled: false` authoritative when stale `WHATSAPP_ENABLED=true` remains in `.env`
- preserve the existing env-enable behavior when the WhatsApp config section only contains auxiliary settings
- add gateway config regressions for both precedence paths

Fixes #19124

## Tests
- `scripts/run_tests.sh tests/gateway/test_config.py`
- `git diff --check`