### PR TITLE
fix(wecom): split long markdown sends

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1207,15 +1207,18 @@ class WeComAdapter(BasePlatformAdapter):
         return response
 
     async def _send_reply_markdown(self, reply_req_id: str, content: str) -> Dict[str, Any]:
-        response = await self._send_reply_request(
-            reply_req_id,
-            {
-                "msgtype": "markdown",
-                "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
-            },
-        )
-        self._raise_for_wecom_error(response, "send reply markdown")
-        return response
+        responses = []
+        for chunk in self.truncate_message(content, self.MAX_MESSAGE_LENGTH):
+            response = await self._send_reply_request(
+                reply_req_id,
+                {
+                    "msgtype": "markdown",
+                    "markdown": {"content": chunk},
+                },
+            )
+            self._raise_for_wecom_error(response, "send reply markdown")
+            responses.append(response)
+        return self._collapse_chunk_responses(responses)
 
     async def _send_reply_media_message(
         self,
@@ -1351,14 +1354,7 @@ class WeComAdapter(BasePlatformAdapter):
             if reply_req_id:
                 response = await self._send_reply_markdown(reply_req_id, content)
             else:
-                response = await self._send_request(
-                    APP_CMD_SEND,
-                    {
-                        "chatid": chat_id,
-                        "msgtype": "markdown",
-                        "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
-                    },
-                )
+                response = await self._send_proactive_markdown(chat_id, content)
         except asyncio.TimeoutError:
             return SendResult(success=False, error="Timeout sending message to WeCom")
         except Exception as exc:
@@ -1374,6 +1370,34 @@ class WeComAdapter(BasePlatformAdapter):
             message_id=self._payload_req_id(response) or uuid.uuid4().hex[:12],
             raw_response=response,
         )
+
+    async def _send_proactive_markdown(self, chat_id: str, content: str) -> Dict[str, Any]:
+        responses = []
+        for chunk in self.truncate_message(content, self.MAX_MESSAGE_LENGTH):
+            response = await self._send_request(
+                APP_CMD_SEND,
+                {
+                    "chatid": chat_id,
+                    "msgtype": "markdown",
+                    "markdown": {"content": chunk},
+                },
+            )
+            self._raise_for_wecom_error(response, "send markdown")
+            responses.append(response)
+        return self._collapse_chunk_responses(responses)
+
+    @staticmethod
+    def _collapse_chunk_responses(responses: List[Dict[str, Any]]) -> Dict[str, Any]:
+        if not responses:
+            return {"errcode": 0}
+        if len(responses) == 1:
+            return responses[0]
+        last = responses[-1]
+        return {
+            "errcode": 0,
+            "headers": last.get("headers", {}),
+            "chunks": responses,
+        }
 
     async def send_image(
         self,

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -145,6 +145,30 @@ class TestWeComReplyMode:
         assert args[1]["markdown"]["content"] == "hello from reply"
 
     @pytest.mark.asyncio
+    async def test_send_splits_long_passive_reply_markdown(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter.MAX_MESSAGE_LENGTH = 40
+        adapter._reply_req_ids["msg-1"] = "req-1"
+        adapter._send_reply_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-1"}, "errcode": 0}
+        )
+        content = ("alpha " * 12) + "omega"
+
+        result = await adapter.send("chat-123", content, reply_to="msg-1")
+
+        assert result.success is True
+        assert adapter._send_reply_request.await_count > 1
+        chunks = [
+            call.args[1]["markdown"]["content"]
+            for call in adapter._send_reply_request.await_args_list
+        ]
+        assert all(len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in chunks)
+        assert any("omega" in chunk for chunk in chunks)
+        assert result.raw_response["chunks"]
+
+    @pytest.mark.asyncio
     async def test_send_image_file_uses_passive_reply_media_when_reply_context_exists(self):
         from gateway.platforms.wecom import WeComAdapter
 
@@ -447,6 +471,30 @@ class TestSend:
                 "markdown": {"content": "Hello WeCom"},
             },
         )
+
+    @pytest.mark.asyncio
+    async def test_send_splits_long_proactive_markdown(self):
+        from gateway.platforms.wecom import APP_CMD_SEND, WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter.MAX_MESSAGE_LENGTH = 40
+        adapter._send_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-1"}, "errcode": 0}
+        )
+        content = ("alpha " * 12) + "omega"
+
+        result = await adapter.send("chat-123", content)
+
+        assert result.success is True
+        assert adapter._send_request.await_count > 1
+        chunks = [
+            call.args[1]["markdown"]["content"]
+            for call in adapter._send_request.await_args_list
+        ]
+        assert {call.args[0] for call in adapter._send_request.await_args_list} == {APP_CMD_SEND}
+        assert all(len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in chunks)
+        assert any("omega" in chunk for chunk in chunks)
+        assert result.raw_response["chunks"]
 
     @pytest.mark.asyncio
     async def test_send_reports_wecom_errors(self):
@@ -788,4 +836,3 @@ class TestWeComZombieSessionFix:
         adapter._send_request.assert_awaited_once()
         cmd = adapter._send_request.await_args.args[0]
         assert cmd == APP_CMD_SEND
-


### PR DESCRIPTION
## Summary
- split long WeCom markdown replies instead of slicing to 4000 characters
- split proactive WeCom markdown sends with the same shared chunking behavior
- keep single-chunk responses backward-compatible while exposing chunk raw responses for split sends

Fixes #19689

## Tests
- `scripts/run_tests.sh tests/gateway/test_wecom.py`
- `git diff --check`