### PR TITLE
docs(agents): list yuanbao platform in gateway/platforms tree (#19101)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,9 @@ hermes-agent/
 ├── gateway/              # Messaging gateway — run.py + session.py + platforms/
 │   ├── platforms/        # Adapter per platform (telegram, discord, slack, whatsapp,
 │   │                     #   homeassistant, signal, matrix, mattermost, email, sms,
-│   │                     #   dingtalk, wecom, weixin, feishu, qqbot, bluebubbles,
-│   │                     #   webhook, api_server, ...). See ADDING_A_PLATFORM.md.
+│   │                     #   dingtalk, wecom, weixin, feishu, qqbot, yuanbao,
+│   │                     #   bluebubbles, webhook, api_server, ...).
+│   │                     #   See ADDING_A_PLATFORM.md.
 │   └── builtin_hooks/    # Extension point for always-registered gateway hooks (none shipped)
 ├── plugins/              # Plugin system (see "Plugins" section below)
 │   ├── memory/           # Memory-provider plugins (honcho, mem0, supermemory, ...)


### PR DESCRIPTION
```
### Summary

Reported by @pty819 in #19101 as Issue 7 ("yuanbao Platform Not Documented"): `gateway/platforms/yuanbao.py`, `gateway/platforms/yuanbao_media.py`, and `gateway/platforms/yuanbao_proto.py` exist on `main` but the AGENTS.md platform-list comment in the project tree (around line 39) does not include `yuanbao` — every other adapter in that directory is named.

### Verification

```bash
$ ls gateway/platforms/yuanbao*
gateway/platforms/yuanbao.py
gateway/platforms/yuanbao_media.py
gateway/platforms/yuanbao_proto.py

$ grep -n "yuanbao" AGENTS.md  # before this PR
# (no matches)
```

### Fix

Adds `yuanbao` to the existing comma-separated platform list in the AGENTS.md file-tree comment, alphabetically slotted next to the other Tencent-owned / China-region adapters (`wecom, weixin, feishu, qqbot, yuanbao`). Reflowed the trailing `bluebubbles, webhook, api_server, ...).` portion to keep the comment box width consistent.

This PR is intentionally scoped to a single line — Issue 7 of #19101. The other 7 enumerated gaps in that report and the 8 follow-up gaps in #19107 are left for separate PRs so each can be reviewed and merged independently.

Refs #19101 (partial — Issue 7 only).
```