### PR TITLE
fix(gateway): acquire lock in list_pending() to prevent TOCTOU race

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -219,21 +219,22 @@ class PairingStore:
 
     def list_pending(self, platform: str = None) -> list:
         """List pending pairing requests, optionally filtered by platform."""
-        results = []
-        platforms = [platform] if platform else self._all_platforms("pending")
-        for p in platforms:
-            self._cleanup_expired(p)
-            pending = self._load_json(self._pending_path(p))
-            for code, info in pending.items():
-                age_min = int((time.time() - info["created_at"]) / 60)
-                results.append({
-                    "platform": p,
-                    "code": code,
-                    "user_id": info["user_id"],
-                    "user_name": info.get("user_name", ""),
-                    "age_minutes": age_min,
-                })
-        return results
+        with self._lock:
+            results = []
+            platforms = [platform] if platform else self._all_platforms("pending")
+            for p in platforms:
+                self._cleanup_expired(p)
+                pending = self._load_json(self._pending_path(p))
+                for code, info in pending.items():
+                    age_min = int((time.time() - info["created_at"]) / 60)
+                    results.append({
+                        "platform": p,
+                        "code": code,
+                        "user_id": info["user_id"],
+                        "user_name": info.get("user_name", ""),
+                        "age_minutes": age_min,
+                    })
+            return results
 
     def clear_pending(self, platform: str = None) -> int:
         """Clear all pending requests. Returns count removed."""


### PR DESCRIPTION
## Problem

`PairingStore.list_pending()` calls `_cleanup_expired()` without acquiring `self._lock`. Other methods that call the same cleanup (`generate_code()`, `approve_code()`) all hold the lock. When `list_pending()` runs concurrently with code generation:

1. Both read the same stale pending dict
2. Both add/remove entries independently
3. Second save clobbers the first's changes → newly-generated pairing code silently lost

## Fix

Wrap the entire `list_pending()` body with `with self._lock:`, matching the pattern used by all other `PairingStore` methods (`clear_pending`, `generate_code`, `approve_code`).

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| `/pairing list` during code generation | Race condition, possible lost codes | Serialized, safe |
| Concurrent `list_pending` + `generate_code` | TOCTOU on pending JSON | Lock prevents interleaving |

## Tests

This is a concurrency fix — the race window is timing-dependent and difficult to reproduce in unit tests. The fix is minimal (adding `with self._lock:`) and follows the exact pattern already used by every other method in the class.