### PR TITLE
fix(gateway): make rewrite_transcript() JSONL write atomic

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1293,11 +1293,25 @@ class SessionStore:
             except Exception as e:
                 logger.debug("Failed to rewrite transcript in DB: %s", e)
         
-        # JSONL: overwrite the file
+        # JSONL: overwrite atomically to prevent corruption on crash
         transcript_path = self.get_transcript_path(session_id)
-        with open(transcript_path, "w", encoding="utf-8") as f:
-            for msg in messages:
-                f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+        import tempfile
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(transcript_path.parent), suffix=".tmp", prefix=".transcript_"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                for msg in messages:
+                    f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+                f.flush()
+                os.fsync(f.fileno())
+            atomic_replace(tmp_path, transcript_path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript."""


### PR DESCRIPTION
## Problem

`SessionStore.rewrite_transcript()` overwrites the JSONL transcript file with a plain `open(..., 'w')` + loop. If the process is killed mid-write (SIGKILL, OOM, power loss), the file is left truncated. `load_transcript()` then loads incomplete conversation history, which can cause the agent to lose context.

This function is called by `/retry`, `/undo`, and `/compress` — operations where losing history is particularly harmful.

## Fix

Replace the direct `write_text` with the same `tempfile` + `fsync` + `atomic_replace` pattern already used by `_sessions_save()` in the same file. The old file is preserved until the new one is fully written and synced to disk.

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Crash during `/retry` | Truncated JSONL, lost history | Old file preserved, no data loss |
| Crash during `/compress` | Partial transcript | Atomic swap, consistent state |

## Tests

This is a crash-safety fix. The atomic write pattern (`tempfile.mkstemp` + `os.fdopen` + `fsync` + `atomic_replace`) is already battle-tested in `_sessions_save()` at line 722 of the same file.