### PR TITLE
fix(cli): handle json.loads() errors in _cron_api

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6001,7 +6001,10 @@ class HermesCLI:
         from tools.cronjob_tools import cronjob as cronjob_tool
 
         def _cron_api(**kwargs):
-            return json.loads(cronjob_tool(**kwargs))
+            try:
+                return json.loads(cronjob_tool(**kwargs))
+            except (json.JSONDecodeError, TypeError) as e:
+                return {"success": False, "error": f"Failed to parse cron tool response: {e}"}
 
         def _normalize_skills(values):
             normalized = []

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -35,7 +35,10 @@ def _normalize_skills(single_skill=None, skills: Optional[Iterable[str]] = None)
 def _cron_api(**kwargs):
     from tools.cronjob_tools import cronjob as cronjob_tool
 
-    return json.loads(cronjob_tool(**kwargs))
+    try:
+        return json.loads(cronjob_tool(**kwargs))
+    except (json.JSONDecodeError, TypeError) as e:
+        return {"success": False, "error": f"Failed to parse cron tool response: {e}"}
 
 
 def cron_list(show_all: bool = False):


### PR DESCRIPTION
## Problem

`_cron_api()` in both `cli.py:6004` and `hermes_cli/cron.py:38` calls `json.loads(cronjob_tool(**kwargs))` without error handling. If the underlying cronjob tool returns a non-JSON string (error message, traceback, truncated response), this raises an unhandled `JSONDecodeError` that crashes the `/cron` slash command entirely.

All callers (lines 6090, 6115, 6149, 6194, 6223 in cli.py; lines 166, 222, 257 in cron.py) use `.get()` on the result assuming it's a dict, so an unhandled exception here kills every cron subcommand.

## Fix

Wrap `json.loads()` in try/except for `JSONDecodeError` and `TypeError`, returning a structured error dict `{"success": False, "error": "..."}` that callers can handle gracefully via their existing `.get()` calls.

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| cronjob tool returns error string | CLI crash with JSONDecodeError | Graceful error message |
| cronjob tool returns None/truncated | CLI crash | Graceful error message |

## Files Changed

- `cli.py` — inner `_cron_api()` function (1 of 2 identical copies)
- `hermes_cli/cron.py` — module-level `_cron_api()` function (2 of 2)