### PR TITLE
fix(kanban): wire dependency selects

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1922,11 +1922,10 @@
         ),
       ),
       h("div", { className: "hermes-kanban-deps-row" },
-        h(Select, {
+        h(Select, Object.assign({
           value: newParent,
-          onChange: function (e) { setNewParent(e.target.value); },
           className: "h-7 text-xs flex-1",
-        },
+        }, selectChangeHandler(setNewParent)),
           h(SelectOption, { value: "" }, "— add parent —"),
           candidatesFor(parentExclude).map(function (t) {
             return h(SelectOption, { key: t.id, value: t.id },
@@ -1961,11 +1960,10 @@
         ),
       ),
       h("div", { className: "hermes-kanban-deps-row" },
-        h(Select, {
+        h(Select, Object.assign({
           value: newChild,
-          onChange: function (e) { setNewChild(e.target.value); },
           className: "h-7 text-xs flex-1",
-        },
+        }, selectChangeHandler(setNewChild)),
           h(SelectOption, { value: "" }, "— add child —"),
           candidatesFor(childExclude).map(function (t) {
             return h(SelectOption, { key: t.id, value: t.id },

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -559,6 +559,27 @@ def test_bulk_status_ready(client):
     assert {a["id"], b["id"], c2["id"]}.issubset(ids)
 
 
+def test_dashboard_dependency_selects_use_value_change_handler():
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = (
+        repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    ).read_text()
+
+    parent_select = (
+        'value: newParent,\n'
+        '          className: "h-7 text-xs flex-1",\n'
+        '        }, selectChangeHandler(setNewParent))'
+    )
+    child_select = (
+        'value: newChild,\n'
+        '          className: "h-7 text-xs flex-1",\n'
+        '        }, selectChangeHandler(setNewChild))'
+    )
+
+    assert parent_select in bundle
+    assert child_select in bundle
+
+
 def test_bulk_archive(client):
     a = client.post("/api/plugins/kanban/tasks", json={"title": "a"}).json()["task"]
     b = client.post("/api/plugins/kanban/tasks", json={"title": "b"}).json()["task"]


### PR DESCRIPTION
Fixes #19998

## Summary
- use the dashboard bundle's existing `selectChangeHandler` for both dependency dropdowns
- restores value binding for add-parent and add-child selections so the action buttons can enable
- adds a static regression guard for the dependency editor wiring

## Scope
This is limited to the Kanban dashboard dependency editor. It does not change link API behavior or CLI dependency commands.

## Verification
- `env -u WEIXIN_TOKEN -u WEIXIN_ACCOUNT_ID -u WEIXIN_HOME_CHANNEL -u WEIXIN_HOME_CHANNEL_NAME -u WEIXIN_HOME_CHANNEL_THREAD_ID scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py::test_dashboard_dependency_selects_use_value_change_handler tests/plugins/test_kanban_dashboard_plugin.py::test_bulk_status_ready` -> 2 passed
- `env -u WEIXIN_TOKEN -u WEIXIN_ACCOUNT_ID -u WEIXIN_HOME_CHANNEL -u WEIXIN_HOME_CHANNEL_NAME -u WEIXIN_HOME_CHANNEL_THREAD_ID scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py` -> 54 passed
- `git diff --check`