### PR TITLE
fix(acp): pass session_db to AIAgent in _make_agent()

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -9,6 +9,7 @@ history.
 from __future__ import annotations
 
 from hermes_constants import get_hermes_home
+from hermes_state import SessionDB
 
 import copy
 import json
@@ -609,6 +610,7 @@ class SessionManager:
             "quiet_mode": True,
             "session_id": session_id,
             "model": model or default_model,
+            "session_db": self._get_db(),
         }
 
         try:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -323,7 +323,7 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
 
 
 def session_search(
-    query: str,
+    query: str = "",
     role_filter: str = None,
     limit: int = 3,
     db=None,
@@ -336,8 +336,14 @@ def session_search(
     configured auxiliary session_search model.
     The current session is excluded from results since the agent already has that context.
     """
+    # Lazy-init DB if not provided (common when called via handle_function_call)
     if db is None:
-        return tool_error("Session database not available.", success=False)
+        try:
+            from hermes_state import SessionDB
+            from hermes_constants import get_hermes_home
+            db = SessionDB(db_path=get_hermes_home() / "state.db")
+        except Exception as e:
+            return tool_error(f"Session database unavailable: {e}", success=False)
 
     # Defensive: models (especially open-source) may send non-int limit values
     # (None when JSON null, string "int", or even a type object).  Coerce to a


### PR DESCRIPTION
ACP sessions created via acp_adapter/session.py:_make_agent() did not pass session_db to AIAgent.__init__, causing self._session_db to remain None. When session_search was invoked by an ACP-connected client, run_agent.py checked if not self._session_db and returned an error immediately.

CLI and gateway agents were unaffected.

Changes:
1. session.py: import SessionDB and pass self._get_db() to AIAgent
2. session_search_tool.py: add fallback lazy-init for db=None, give query param a default value

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

