### PR TITLE
fix: normalize non-string tool results to prevent KeyError on slicing

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -827,6 +827,8 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
                 return True, " [full]"
 
     # Generic heuristic for non-terminal tools
+    if not isinstance(result, str):
+        result = str(result)
     lower = result[:500].lower()
     if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
         return True, " [error]"

--- a/model_tools.py
+++ b/model_tools.py
@@ -810,6 +810,8 @@ def handle_function_call(
         except Exception:
             pass
 
+        if not isinstance(result, str):
+            result = json.dumps(result, ensure_ascii=False)
         return result
 
     except Exception as e:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1599,6 +1599,8 @@ def _run_single_child(
                             trace_by_id[tc_id] = entry_t
                 elif msg.get("role") == "tool":
                     content = msg.get("content", "")
+                    if not isinstance(content, str):
+                        content = str(content)
                     is_error = bool(content and "error" in content[:80].lower())
                     result_meta = {
                         "result_bytes": len(content),


### PR DESCRIPTION
## Summary

Custom-tools plugins can return `dict` results, but `handle_function_call()` and downstream consumers (`_detect_tool_failure`, delegate tracing) assume `str`. When a dict reaches `result[:500]`, Python evaluates `dict.__getitem__(slice(...))` and raises `KeyError`.

## Changes

- **model_tools.py** — Normalize non-string results to JSON at the return point of `handle_function_call()`, matching the function's `-> str` type annotation.
- **agent/display.py** — Add defensive `isinstance(result, str)` guard in `_detect_tool_failure()` before string slicing.
- **tools/delegate_tool.py** — Add defensive `isinstance(content, str)` guard in the sub-agent trace builder before slicing.

## Verification

- All three files pass `py_compile`
- No new ruff lint issues introduced
- 166 relevant tests pass (`tests/agent/`, `tests/run_agent/` filtered by tool keywords)
- Pre-existing test failures in `test_delegate.py` (credential resolution) confirmed identical on `main`

Closes #19814
