### PR TITLE
fix(gateway): correct compression guidance command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -72,6 +72,14 @@ def _telegramize_command_mentions(text: str, platform: Any) -> str:
     return _TELEGRAM_COMMAND_MENTION_RE.sub(_replace, text)
 
 
+def _context_overflow_recovery_message() -> str:
+    return (
+        "⚠️ Session too large for the model's context window.\n"
+        "Use /compress to compress the conversation, or "
+        "/reset to start fresh."
+    )
+
+
 # Only auto-continue interrupted gateway turns while the interruption is fresh.
 # Stale tool-tail/resume markers can otherwise revive an unrelated old task
 # after a gateway restart when the user's next message starts new work.
@@ -6740,11 +6748,7 @@ class GatewayRunner:
                 )
 
                 if _is_ctx_fail:
-                    response = (
-                        "⚠️ Session too large for the model's context window.\n"
-                        "Use /compact to compress the conversation, or "
-                        "/reset to start fresh."
-                    )
+                    response = _context_overflow_recovery_message()
                 else:
                     response = (
                         f"The request failed: {str(error_detail)[:300]}\n"
@@ -7068,11 +7072,7 @@ class GatewayRunner:
                 # 500 with a large session often means the payload is too large
                 # for the API to process — treat it the same way.
                 if _hist_len > 50:
-                    return (
-                        "⚠️ Session too large for the model's context window.\n"
-                        "Use /compact to compress the conversation, or "
-                        "/reset to start fresh."
-                    )
+                    return _context_overflow_recovery_message()
                 elif status_code == 400:
                     status_hint = " The request was rejected by the API."
             return (

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -10,6 +10,15 @@ from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
+def test_context_overflow_guidance_uses_registered_compress_command():
+    from gateway.run import _context_overflow_recovery_message
+
+    message = _context_overflow_recovery_message()
+
+    assert "/compress" in message
+    assert "/compact" not in message
+
+
 def _make_source() -> SessionSource:
     return SessionSource(
         platform=Platform.TELEGRAM,


### PR DESCRIPTION
## Summary
- replace stale gateway context-overflow guidance that told users to run `/compact`
- centralize the guidance text so the failed-turn and exception paths stay aligned
- add a regression test that requires `/compress` and rejects `/compact`

Fixes #20020

## Tests
- `scripts/run_tests.sh tests/gateway/test_compress_command.py`
- `git diff --check`
- `rg -n "Use /compact|/compact to compress" gateway/run.py gateway tests/gateway/test_compress_command.py` (no matches)
