### PR TITLE
fix(gateway): make stuck loop threshold configurable

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2708,6 +2708,29 @@ class GatewayRunner:
     _STUCK_LOOP_THRESHOLD = 3  # restarts while active before auto-suspend
     _STUCK_LOOP_FILE = ".restart_failure_counts"
 
+    def _stuck_loop_threshold(self) -> Optional[int]:
+        raw = os.getenv("HERMES_STUCK_LOOP_THRESHOLD")
+        if raw is None or raw.strip() == "":
+            return self._STUCK_LOOP_THRESHOLD
+
+        value = raw.strip().lower()
+        if value in {"0", "false", "off", "disabled", "none", "never"}:
+            return None
+
+        try:
+            threshold = int(value)
+        except ValueError:
+            logger.warning(
+                "Invalid HERMES_STUCK_LOOP_THRESHOLD=%r; using default %d",
+                raw,
+                self._STUCK_LOOP_THRESHOLD,
+            )
+            return self._STUCK_LOOP_THRESHOLD
+
+        if threshold <= 0:
+            return None
+        return threshold
+
     def _increment_restart_failure_counts(self, active_session_keys: set) -> None:
         """Increment restart-failure counters for sessions active at shutdown.
 
@@ -2753,8 +2776,12 @@ class GatewayRunner:
         except Exception:
             return 0
 
+        threshold = self._stuck_loop_threshold()
+        if threshold is None:
+            return 0
+
         suspended = 0
-        stuck_keys = [k for k, v in counts.items() if v >= self._STUCK_LOOP_THRESHOLD]
+        stuck_keys = [k for k, v in counts.items() if v >= threshold]
 
         for session_key in stuck_keys:
             try:
@@ -2776,11 +2803,14 @@ class GatewayRunner:
             except Exception:
                 pass
 
-        # Clear the file — counters start fresh after suspension
-        try:
-            path.unlink(missing_ok=True)
-        except Exception:
-            pass
+        # Clear the file only after threshold-reaching sessions were handled.
+        # Below-threshold counts must survive startup so consecutive restarts
+        # can accumulate toward the configured limit.
+        if stuck_keys:
+            try:
+                path.unlink(missing_ok=True)
+            except Exception:
+                pass
 
         return suspended
 

--- a/tests/gateway/test_stuck_loop.py
+++ b/tests/gateway/test_stuck_loop.py
@@ -79,6 +79,45 @@ class TestStuckLoopDetection:
         assert suspended == 0
         assert mock_entry.suspended is False
 
+    def test_env_override_raises_suspend_threshold(self, runner_with_home, monkeypatch):
+        runner, home = runner_with_home
+        monkeypatch.setenv("HERMES_STUCK_LOOP_THRESHOLD", "5")
+        for _ in range(4):
+            runner._increment_restart_failure_counts({"session:a"})
+
+        mock_entry = MagicMock()
+        mock_entry.suspended = False
+        runner.session_store._entries = {"session:a": mock_entry}
+        runner.session_store._save = MagicMock()
+
+        suspended = runner._suspend_stuck_loop_sessions()
+        assert suspended == 0
+        assert mock_entry.suspended is False
+
+        runner._increment_restart_failure_counts({"session:a"})
+        suspended = runner._suspend_stuck_loop_sessions()
+        assert suspended == 1
+        assert mock_entry.suspended is True
+
+    @pytest.mark.parametrize("value", ["0", "off", "disabled"])
+    def test_env_override_can_disable_auto_suspend(
+        self, runner_with_home, monkeypatch, value
+    ):
+        runner, home = runner_with_home
+        monkeypatch.setenv("HERMES_STUCK_LOOP_THRESHOLD", value)
+        for _ in range(5):
+            runner._increment_restart_failure_counts({"session:a"})
+
+        mock_entry = MagicMock()
+        mock_entry.suspended = False
+        runner.session_store._entries = {"session:a": mock_entry}
+        runner.session_store._save = MagicMock()
+
+        suspended = runner._suspend_stuck_loop_sessions()
+        assert suspended == 0
+        assert mock_entry.suspended is False
+        assert (home / runner._STUCK_LOOP_FILE).exists()
+
     def test_clear_on_success(self, runner_with_home):
         runner, home = runner_with_home
         runner._increment_restart_failure_counts({"session:a", "session:b"})


### PR DESCRIPTION
## Summary
- add `HERMES_STUCK_LOOP_THRESHOLD` for gateway stuck-loop auto-suspend tuning
- preserve the default threshold of 3 while allowing `0`, `off`, or `disabled` to opt out of auto-suspend
- keep below-threshold restart counters on disk so the counter can actually accumulate across consecutive restarts

Fixes #19578

## Tests
- `scripts/run_tests.sh tests/gateway/test_stuck_loop.py`
- `scripts/run_tests.sh tests/gateway/test_restart_resume_pending.py tests/gateway/test_stuck_loop.py`
- `git diff --check`
