### PR TITLE
feat(cli): add initial chat prompt flag

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9935,7 +9935,7 @@ class HermesCLI:
             ] if item is not None
         ]
 
-    def run(self):
+    def run(self, initial_prompt: str = None):
         """Run the interactive CLI loop with persistent input at bottom."""
         # Push the entire TUI to the bottom of the terminal so the banner,
         # responses, and prompt all appear pinned to the bottom — empty
@@ -10032,6 +10032,8 @@ class HermesCLI:
         self._interrupt_queue = queue.Queue()   # For messages typed while agent is running
         self._should_exit = False
         self._last_ctrl_c_time = 0  # Track double Ctrl+C for force exit
+        if initial_prompt:
+            self._pending_input.put(initial_prompt)
 
         # Give plugin manager a CLI reference so plugins can inject messages
         from hermes_cli.plugins import get_plugin_manager
@@ -11987,6 +11989,7 @@ class HermesCLI:
 def main(
     query: str = None,
     q: str = None,
+    initial: str = None,
     image: str = None,
     toolsets: str = None,
     skills: str | list[str] | tuple[str, ...] = None,
@@ -12015,6 +12018,7 @@ def main(
     Args:
         query: Single query to execute (then exit). Alias: -q
         q: Shorthand for --query
+        initial: Initial prompt to submit before staying in interactive mode
         image: Optional local image path to attach to a single query
         toolsets: Comma-separated list of toolsets to enable (e.g., "web,terminal")
         skills: Comma-separated or repeated list of skills to preload for the session
@@ -12082,6 +12086,8 @@ def main(
     
     # Handle query shorthand
     query = query or q
+    if initial and (query or image):
+        raise ValueError("--initial cannot be combined with --query or --image")
     
     # Parse toolsets - handle both string and tuple/list inputs
     # Default to hermes-cli toolset which includes cronjob management tools
@@ -12261,7 +12267,7 @@ def main(
         return
     
     # Run interactive mode
-    cli.run()
+    cli.run(initial_prompt=initial)
 
 
 if __name__ == "__main__":

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -237,6 +237,11 @@ def build_top_level_parser():
         "-q", "--query", help="Single query (non-interactive mode)"
     )
     chat_parser.add_argument(
+        "-i",
+        "--initial",
+        help="Submit an initial prompt, then remain in interactive chat",
+    )
+    chat_parser.add_argument(
         "--image", help="Optional local image path to attach to a single query"
     )
     _inherited_flag(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1345,6 +1345,7 @@ def cmd_chat(args):
         "verbose": args.verbose,
         "quiet": getattr(args, "quiet", False),
         "query": args.query,
+        "initial": getattr(args, "initial", None),
         "image": getattr(args, "image", None),
         "resume": getattr(args, "resume", None),
         "worktree": getattr(args, "worktree", False),

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -5,6 +5,8 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
@@ -165,6 +167,38 @@ class TestSingleQueryState:
         assert cli._voice_tts_done.is_set()
         assert hasattr(cli, "_interrupt_queue")
         assert hasattr(cli, "_pending_input")
+
+
+class TestInitialPromptMode:
+    def test_main_passes_initial_prompt_to_interactive_run(self, monkeypatch):
+        import cli as cli_mod
+
+        captured = {}
+
+        class FakeCLI:
+            session_id = "sid"
+            system_prompt = ""
+            preloaded_skills = []
+            enabled_toolsets = []
+
+            def __init__(self, **kwargs):
+                captured["init_kwargs"] = kwargs
+
+            def run(self, initial_prompt=None):
+                captured["initial_prompt"] = initial_prompt
+
+        monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+        monkeypatch.setattr(cli_mod, "_run_cleanup", lambda: None)
+
+        cli_mod.main(initial="seed this session", toolsets="web")
+
+        assert captured["initial_prompt"] == "seed this session"
+
+    def test_main_rejects_initial_with_single_query(self):
+        import cli as cli_mod
+
+        with pytest.raises(ValueError, match="--initial"):
+            cli_mod.main(initial="seed", query="one shot", toolsets="web")
 
 
 class TestHistoryDisplay:

--- a/tests/hermes_cli/test_chat_skills_flag.py
+++ b/tests/hermes_cli/test_chat_skills_flag.py
@@ -73,6 +73,30 @@ def test_chat_subcommand_accepts_image_flag(monkeypatch):
     }
 
 
+def test_chat_subcommand_accepts_initial_flag(monkeypatch):
+    import hermes_cli.main as main_mod
+
+    captured = {}
+
+    def fake_cmd_chat(args):
+        captured["initial"] = args.initial
+        captured["query"] = args.query
+
+    monkeypatch.setattr(main_mod, "cmd_chat", fake_cmd_chat)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "chat", "--initial", "seed this session"],
+    )
+
+    main_mod.main()
+
+    assert captured == {
+        "initial": "seed this session",
+        "query": None,
+    }
+
+
 def test_continue_worktree_and_skills_flags_work_together(monkeypatch):
     import hermes_cli.main as main_mod
 


### PR DESCRIPTION
## Summary
- add `hermes chat -i/--initial` for a seeded first prompt that keeps the classic chat REPL open
- forward the new flag through `cmd_chat` into `cli.main()`
- queue the initial prompt at interactive startup so existing `cli.chat()` handling, tools, skills, memory, and session setup are reused

Fixes #19675

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_chat_skills_flag.py tests/cli/test_cli_init.py`
- `git diff --check`
