### PR TITLE
chore(security): add OSV-Scanner CI + Dependabot for github-actions only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+# Dependabot configuration for hermes-agent.
+#
+# Deliberately scoped to github-actions only.
+#
+# We do NOT enable Dependabot for pip / npm / any source-dependency ecosystem
+# because we pin source dependencies exactly (uv.lock, package-lock.json) as
+# part of our supply-chain posture. Automatic version-bump PRs against those
+# pins would undermine the strategy — pins are moved deliberately, after
+# review, not on a schedule.
+#
+# github-actions is the exception: action pins (we use full commit SHAs per
+# supply-chain policy) must be updated when upstream actions publish
+# patches — usually themselves security fixes. Dependabot opens a PR with
+# the new SHA and release notes; we review and merge like any other PR.
+#
+# Security-update PRs for source dependencies (opened ONLY when a CVE is
+# published affecting a currently-pinned version) are enabled separately
+# via the repo's Dependabot security updates setting
+# (Settings → Code security → Dependabot → Dependabot security updates).
+# Those are CVE-only, not schedule-driven, and do not conflict with our
+# pinning strategy — they fire when a pinned version becomes known-bad,
+# which is exactly when we want to move the pin.
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(actions)"
+      include: "scope"
+    groups:
+      # Batch routine action bumps into one PR per week to reduce noise.
+      # Security updates still open individually and bypass grouping.
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,67 @@
+name: OSV-Scanner
+
+# Scans lockfiles (uv.lock, package-lock.json) against the OSV vulnerability
+# database. Runs on every PR that touches a lockfile and on a weekly schedule
+# against main.
+#
+# This is detection-only — OSV-Scanner does NOT open PRs or modify pins.
+# It reports known CVEs in currently-pinned dependency versions so we can
+# decide when and how to patch on our own schedule. Our pinning strategy
+# (full SHA / exact version) is preserved; only the notification signal
+# is added.
+#
+# Complements the existing supply-chain-audit.yml workflow (which scans
+# for malicious code patterns in PR diffs) by covering the orthogonal
+# "currently-pinned dep became known-vulnerable" case.
+#
+# Uses Google's officially-recommended reusable workflow, pinned by SHA.
+# Findings land in the repo's Security tab (Code Scanning > OSV-Scanner).
+# fail-on-vuln is disabled so the job does not block merges on pre-existing
+# vulnerabilities in pinned deps that we may need to patch deliberately.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'uv.lock'
+      - 'pyproject.toml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'ui-tui/package.json'
+      - 'ui-tui/package-lock.json'
+      - 'website/package.json'
+      - 'website/package-lock.json'
+      - '.github/workflows/osv-scanner.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'uv.lock'
+      - 'pyproject.toml'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'ui-tui/package-lock.json'
+      - 'website/package-lock.json'
+  schedule:
+    # Weekly scan against main — catches CVEs published after merge for
+    # deps that haven't changed since.
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  # Required by the reusable workflow to upload SARIF to the Security tab.
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan lockfiles
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c51854704019a247608d928f370c98740469d4b5  # v2.3.5
+    with:
+      # Scan explicit lockfiles rather than recursing, so we only look at
+      # the three sources of truth and skip vendored / test / worktree dirs.
+      scan-args: |-
+        --lockfile=uv.lock
+        --lockfile=ui-tui/package-lock.json
+        --lockfile=website/package-lock.json
+      fail-on-vuln: false


### PR DESCRIPTION
## Summary
Adds two supply-chain controls that complement the existing pinning strategy (full-SHA action pins, exact-version source deps via uv.lock / package-lock.json) without undermining it.

## Changes
- `.github/workflows/osv-scanner.yml` — detection-only scan of `uv.lock`, `ui-tui/package-lock.json`, `website/package-lock.json` against the OSV database. Uses Google's recommended reusable workflow (`google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml`) pinned to `c518547` (v2.3.5). Runs on PRs touching lockfiles, on push to `main`, and weekly. Findings upload to the Security tab. `fail-on-vuln: false` — pre-existing vulns in pinned deps do not block merges.
- `.github/dependabot.yml` — scoped to `github-actions` only. Opens PRs when upstream actions publish new tags so the SHA pin can be reviewed and moved. Source-dep ecosystems (pip / npm) deliberately NOT enabled; those pins move on our schedule.

## What this is NOT
- Dependabot version updates for pip / npm — deliberately omitted to preserve pinning.
- A blocking control — OSV findings surface, don't gate merges.

## What still needs to be flipped in the GitHub UI (admin-only)
Settings → Code security → Dependabot:
1. Enable **Dependabot alerts** (passive notifications when a CVE hits a currently-pinned dep)
2. Enable **Dependabot security updates** (PRs only when a CVE exists — not schedule-driven, doesn't fight pinning)

These two settings can't be set via repo files. ~10 seconds of clicks once merged.

## Validation
- Both YAMLs parse with `yaml.safe_load`.
- OSV-Scanner reusable workflow confirmed to exist at `google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c518547` (v2.3.5 release, published 2026-03-26).
- `upload-sarif` action SHA `14c9a0c` = `github/codeql-action` v3.35.3 (latest v3).
- `actions/checkout` SHA `34e1148` matches the pin already in use across the repo's other workflows.
- Lockfile paths verified present in repo: `uv.lock`, `ui-tui/package-lock.json`, `website/package-lock.json`.