### PR TITLE
fix(cli): catch OSError in _resolve_attachment_path so long /goal pastes don't silently drop

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1450,7 +1450,21 @@ def _resolve_attachment_path(raw_path: str) -> Path | None:
     except Exception:
         resolved = path
 
-    if not resolved.exists() or not resolved.is_file():
+    # Path.exists() / is_file() invoke os.stat(), which raises OSError when
+    # the candidate string is structurally invalid as a path — most commonly
+    # ENAMETOOLONG (errno 63 on macOS, errno 36 on Linux) when the input
+    # exceeds NAME_MAX (typically 255 bytes). This bites pasted slash
+    # commands like `/goal <long prose>` because `_detect_file_drop()`'s
+    # `starts_like_path` prefilter accepts any input starting with `/`,
+    # then this resolver tries to stat it before short-circuiting on the
+    # slash-command path. Without this guard the OSError propagates up to
+    # the process_loop catch-all in _interactive_loop and the user input
+    # is silently lost (the warning ends up in agent.log but the user sees
+    # nothing — the prompt just hangs).
+    try:
+        if not resolved.exists() or not resolved.is_file():
+            return None
+    except OSError:
         return None
     return resolved
 

--- a/tests/cli/test_cli_file_drop.py
+++ b/tests/cli/test_cli_file_drop.py
@@ -68,6 +68,37 @@ class TestNonFileInputs:
         """A directory path should not be treated as a file drop."""
         assert _detect_file_drop(str(tmp_path)) is None
 
+    def test_long_slash_command_does_not_raise(self):
+        """Regression: long pasted slash commands like `/goal <long prose>`
+        used to raise OSError(ENAMETOOLONG, errno 63 macOS / 36 Linux)
+        from `Path.exists()` inside `_resolve_attachment_path`, which
+        propagated up to `process_loop`'s catch-all and silently lost
+        the user's input. The fix wraps the stat call in a try/except
+        OSError and returns None, letting the slash-command dispatch
+        path handle the input downstream.
+
+        Reproducer: paste a `/goal` followed by ~430 chars of prose.
+        Without the fix this triggers ENAMETOOLONG; with the fix it
+        cleanly returns None (file-drop = no), so `_looks_like_slash_command`
+        gets a chance to dispatch it.
+        """
+        # 430-char `/goal` payload — well above NAME_MAX (255 bytes) on
+        # all common filesystems.
+        long_goal = (
+            "/goal " + ("Drive the board: triage triage-status items, "
+                        "unblock spillover tasks where work is shipped, "
+                        "advance P1 items by decomposing where needed. ") * 4
+        )
+        assert len(long_goal) > 255  # confirms it would have triggered ENAMETOOLONG
+        assert _detect_file_drop(long_goal) is None
+
+    def test_path_longer_than_namemax_does_not_raise(self):
+        """Defensive: a single token longer than NAME_MAX should return
+        None, not raise. Could happen with absurdly long synthetic inputs
+        from prompt-injection attempts or fuzzers."""
+        very_long_path = "/" + ("a" * 300)
+        assert _detect_file_drop(very_long_path) is None
+
 
 # ---------------------------------------------------------------------------
 # Tests: image file detection


### PR DESCRIPTION
## Summary

`_detect_file_drop()` accepts any input starting with `/` as a candidate path, then forwards it to `_resolve_attachment_path()` which calls `Path.exists()` → `os.stat()`. When the candidate exceeds `NAME_MAX` (typically 255 bytes on most filesystems), `os.stat()` raises `OSError(errno=ENAMETOOLONG)` — errno 63 on macOS, errno 36 on Linux. The exception propagates up to the broad `except Exception` in `process_loop` (`cli.py:11798`), gets logged at WARNING level, and the user's input is silently dropped.

From the user's point of view the chat prompt hangs. The only signal is in `agent.log`:

```
WARNING cli: process_loop unhandled error (msg may be lost):
  [Errno 63] File name too long: "/goal Drive the space board: triage triage-status items, unblock spillover tasks where work is already shipped..."
```

## Affected commands

Any slash command with prose-length arguments. In practice:

- `/goal <long objective>` — Persistent Goals feature, very common to paste 300+ char goals
- `/skill <name> <long preamble>`
- `/cron <long prompt>`
- Custom user-defined slash commands invoked with long arguments

## Reproduction

From the repo root with the venv active:

```bash
source venv/bin/activate
python - <<'PY'
from cli import _detect_file_drop
long_goal = "/goal " + ("Drive the board: triage items, unblock spillover, advance P1 work. " * 8)
print(f"len = {len(long_goal)}")
_detect_file_drop(long_goal)
PY
```

Without the fix:

```
len = 518
Traceback (most recent call last):
  ...
  File "cli.py", line 1453, in _resolve_attachment_path
    if not resolved.exists() or not resolved.is_file():
OSError: [Errno 63] File name too long: '/goal Drive the board: ...'
```

With the fix:

```
len = 518
None
```

…and the slash-command dispatch path downstream handles it correctly.

## Fix

Wrap `exists()`/`is_file()` in `try/except OSError` so structurally-invalid path candidates cleanly return `None` instead of propagating. This is the minimum-surface-area fix; the prefilter and resolver logic are otherwise untouched.

```diff
-    if not resolved.exists() or not resolved.is_file():
+    try:
+        if not resolved.exists() or not resolved.is_file():
+            return None
+    except OSError:
         return None
-    return resolved
+    return resolved
```

## Tests

Two new regression cases in `tests/cli/test_cli_file_drop.py::TestNonFileInputs`:

- `test_long_slash_command_does_not_raise` — the original `/goal` reproducer (~430 chars)
- `test_path_longer_than_namemax_does_not_raise` — defensive 300-`a` path

```
$ pytest tests/cli/test_cli_file_drop.py -v
============================== 35 passed in 2.39s ==============================
```

All existing 33 tests still pass; both new tests fail before the fix (verified by reverting `cli.py` and re-running) and pass after.

## Discovery context

Hit while pasting a `/goal Drive the space board: triage triage-status items, unblock spillover tasks where work is already shipped (commit references in body), advance P1 items by decomposing where needed, route to the right specialist. Don't write code yourself; you have no terminal/file/browser. Stop when the board has zero P1 backlog and all blocked items are either P3-triage or awaiting Daniel visual.` (430 chars) into a fresh `harness chat` session on macOS. Prompt hung silently. Found the smoking gun in `agent.log` and traced through `cli.py:_detect_file_drop` → `_resolve_attachment_path` → `Path.exists()`.

## Related

The closely-related issue #15197 ("CLI file-drop misses quoted relative image paths") fixed the prefilter side of `_detect_file_drop`. This PR fixes the resolver side — they're complementary defensive layers in the same module.

## Checklist

- [x] Bug reproduces on the latest upstream `main` (commit `a1bed18`)
- [x] Fix is minimal — single function, 5 lines added
- [x] Tests added that fail before the fix and pass after
- [x] All 35 tests in `test_cli_file_drop.py` pass
- [x] No other test files reference `_resolve_attachment_path` directly
