### PR TITLE
fix(gateway): gate lifecycle status messages

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -35,6 +35,7 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "show_reasoning": False,
     "tool_preview_length": 0,
     "streaming": None,  # None = follow top-level streaming config
+    "lifecycle_messages": True,
 }
 
 # ---------------------------------------------------------------------------
@@ -184,7 +185,7 @@ def _normalise(setting: str, value: Any) -> Any:
         if value is True:
             return "all"
         return str(value).lower()
-    if setting in ("show_reasoning", "streaming"):
+    if setting in ("show_reasoning", "streaming", "lifecycle_messages"):
         if isinstance(value, str):
             return value.lower() in ("true", "1", "yes", "on")
         return bool(value)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13046,6 +13046,10 @@ class GatewayRunner:
                 default=True,
             )
         )
+        lifecycle_messages_enabled = (
+            source.platform != Platform.WEBHOOK
+            and bool(resolve_display_setting(user_config, platform_key, "lifecycle_messages", True))
+        )
         
         # Queue for progress messages (thread-safe)
         progress_queue = queue.Queue() if tool_progress_enabled else None
@@ -13658,7 +13662,7 @@ class GatewayRunner:
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
-            agent.status_callback = _status_callback_sync
+            agent.status_callback = _status_callback_sync if lifecycle_messages_enabled else None
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -792,6 +792,7 @@ DEFAULT_CONFIG = {
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         "tool_progress_overrides": {},  # DEPRECATED — use display.platforms instead
         "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)
+        "lifecycle_messages": True,  # Gateway: send model fallback / lifecycle status messages to chat platforms
         # Auto-delete system-notice replies (e.g. "✨ New session started!",
         # "♻ Restarting gateway…", "⚡ Stopped…") after N seconds on platforms
         # that support message deletion (currently Telegram; other platforms

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -1,5 +1,4 @@
 """Tests for gateway.display_config — per-platform display/verbosity resolver."""
-import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -53,6 +52,12 @@ class TestResolveDisplaySetting:
         config = {}
         # Unknown platform, no config → global default "all"
         assert resolve_display_setting(config, "unknown_platform", "tool_progress") == "all"
+
+    def test_lifecycle_messages_default_on(self):
+        """Lifecycle status messages are shown unless explicitly disabled."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "telegram", "lifecycle_messages") is True
 
     def test_fallback_parameter_used_last(self):
         """Explicit fallback is used when nothing else matches."""
@@ -156,6 +161,13 @@ class TestYAMLNormalisation:
         config = {"display": {"platforms": {"telegram": {"show_reasoning": "true"}}}}
         assert resolve_display_setting(config, "telegram", "show_reasoning") is True
 
+    def test_lifecycle_messages_string_false(self):
+        """String 'false' is normalised to bool False."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"platforms": {"telegram": {"lifecycle_messages": "false"}}}}
+        assert resolve_display_setting(config, "telegram", "lifecycle_messages") is False
+
     def test_tool_preview_length_string(self):
         """String numbers are normalised to int."""
         from gateway.display_config import resolve_display_setting
@@ -255,7 +267,7 @@ class TestConfigMigration:
         import hermes_cli.config as cfg_mod
         importlib.reload(cfg_mod)
 
-        result = cfg_mod.migrate_config(interactive=False, quiet=True)
+        cfg_mod.migrate_config(interactive=False, quiet=True)
         # Re-read config
         updated = yaml.safe_load(config_path.read_text(encoding="utf-8"))
         platforms = updated.get("display", {}).get("platforms", {})

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -422,6 +422,21 @@ class CommentaryAgent:
         }
 
 
+class LifecycleStatusAgent:
+    def __init__(self, **kwargs):
+        self.status_callback = kwargs.get("status_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.status_callback:
+            self.status_callback("lifecycle", "Primary model failed — switching to fallback.")
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class PreviewedResponseAgent:
     def __init__(self, **kwargs):
         self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
@@ -626,6 +641,37 @@ async def test_run_agent_tool_progress_does_not_control_interim_commentary(monke
 
     assert result.get("already_sent") is not True
     assert not any(call["content"] == "I'll inspect the repo first." for call in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_surfaces_lifecycle_messages_by_default(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        LifecycleStatusAgent,
+        session_id="sess-lifecycle-default-on",
+    )
+
+    await asyncio.sleep(0)
+
+    assert result.get("final_response") == "done"
+    assert any("switching to fallback" in call["content"] for call in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_suppresses_lifecycle_messages_when_disabled(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        LifecycleStatusAgent,
+        session_id="sess-lifecycle-disabled",
+        config_data={"display": {"lifecycle_messages": False}},
+    )
+
+    await asyncio.sleep(0)
+
+    assert result.get("final_response") == "done"
+    assert not any("switching to fallback" in call["content"] for call in adapter.sent)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #19572\n\n## Summary\n- add display.lifecycle_messages to the gateway display resolver with per-platform overrides\n- gate gateway agent status_callback assignment so fallback/lifecycle notices can be suppressed in chat platforms\n- keep the default enabled for backward compatibility\n\n## Verification\n- scripts/run_tests.sh tests/gateway/test_display_config.py tests/gateway/test_run_progress_topics.py -k 'lifecycle_messages or lifecycle'\n- scripts/run_tests.sh tests/gateway/test_display_config.py tests/gateway/test_run_progress_topics.py\n- scripts/run_tests.sh tests/hermes_cli/test_config.py -k 'interim_assistant_messages or default_config'\n- scripts/run_tests.sh tests/gateway/test_display_config.py tests/gateway/test_run_progress_topics.py tests/hermes_cli/test_config.py -k 'lifecycle_messages or lifecycle or interim_assistant_messages or default_config'\n- .venv/bin/python -m ruff check gateway/display_config.py tests/gateway/test_display_config.py tests/gateway/test_run_progress_topics.py\n- git diff --check\n\nNote: a broader ruff run including gateway/run.py and hermes_cli/config.py still reports pre-existing style issues unrelated to this patch (module-level import ordering and existing f-string/import warnings).