### PR TITLE
fix(feishu): split long outbound messages

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -171,6 +171,7 @@ _FEISHU_IMAGE_UPLOAD_TYPE = "message"
 _FEISHU_FILE_UPLOAD_TYPE = "stream"
 _FEISHU_OPUS_UPLOAD_EXTENSIONS = {".ogg", ".opus"}
 _FEISHU_MEDIA_UPLOAD_EXTENSIONS = {".mp4", ".mov", ".avi", ".m4v"}
+_FEISHU_CHAT_CHUNK_TARGET_LENGTH = 2000
 _FEISHU_DOC_UPLOAD_TYPES = {
     ".pdf": "pdf",
     ".doc": "doc",
@@ -602,6 +603,84 @@ def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
 
     _flush_current()
     return rows or [[{"tag": "md", "text": content}]]
+
+
+def _split_markdown_blocks_for_feishu(content: str) -> List[str]:
+    if not content:
+        return []
+
+    blocks: List[str] = []
+    current: List[str] = []
+    in_code_block = False
+
+    def _flush_current() -> None:
+        nonlocal current
+        if current:
+            block = "\n".join(current).strip()
+            if block:
+                blocks.append(block)
+            current = []
+
+    for raw_line in content.splitlines():
+        stripped_line = raw_line.strip()
+        is_fence = bool(
+            _MARKDOWN_FENCE_CLOSE_RE.match(stripped_line)
+            if in_code_block
+            else _MARKDOWN_FENCE_OPEN_RE.match(stripped_line)
+        )
+
+        if is_fence:
+            if not in_code_block:
+                _flush_current()
+            current.append(raw_line.rstrip())
+            in_code_block = not in_code_block
+            if not in_code_block:
+                _flush_current()
+            continue
+
+        if in_code_block:
+            current.append(raw_line.rstrip())
+            continue
+
+        if not raw_line.strip():
+            _flush_current()
+            continue
+        current.append(raw_line.rstrip())
+
+    _flush_current()
+    return blocks
+
+
+def _split_delivery_chunks_for_feishu(content: str, max_length: int) -> List[str]:
+    max_length = max(1, int(max_length or 1))
+    target_length = min(max_length, max(1, _FEISHU_CHAT_CHUNK_TARGET_LENGTH))
+    if len(content) <= target_length:
+        return [content]
+
+    chunks: List[str] = []
+    current = ""
+    for block in _split_markdown_blocks_for_feishu(content):
+        block_lines = block.splitlines()
+        is_code_block = bool(block_lines and _MARKDOWN_FENCE_OPEN_RE.match(block_lines[0].strip()))
+        if len(block) > max_length:
+            units = BasePlatformAdapter.truncate_message(block, max_length)
+        elif len(block) > target_length and not is_code_block:
+            units = BasePlatformAdapter.truncate_message(block, target_length)
+        else:
+            units = [block]
+
+        for unit in units:
+            candidate = unit if not current else f"{current}\n\n{unit}"
+            if len(candidate) <= target_length:
+                current = candidate
+                continue
+            if current:
+                chunks.append(current)
+            current = unit
+
+    if current:
+        chunks.append(current)
+    return chunks or [content]
 
 
 def parse_feishu_post_payload(
@@ -1703,7 +1782,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         formatted = self.format_message(content)
-        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        chunks = _split_delivery_chunks_for_feishu(formatted, self.MAX_MESSAGE_LENGTH)
         last_response = None
 
         try:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -415,6 +415,49 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_splits_long_markdown_into_multiple_feishu_messages(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = []
+
+        class _MessageAPI:
+            def create(self, request):
+                captured.append(request)
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id=f"om_chunk_{len(captured)}"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = "**first paragraph**\n\n**second paragraph**\n\n**third paragraph**"
+        with (
+            patch("gateway.platforms.feishu._FEISHU_CHAT_CHUNK_TARGET_LENGTH", 24),
+            patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+        ):
+            result = asyncio.run(adapter.send("oc_chat", content))
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_chunk_3")
+        self.assertEqual(len(captured), 3)
+        for request, expected in zip(captured, ("first", "second", "third")):
+            self.assertEqual(request.request_body.msg_type, "post")
+            payload = json.loads(request.request_body.content)
+            rows = payload["zh_cn"]["content"]
+            self.assertIn(expected, rows[0][0]["text"])
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_get_chat_info_uses_real_feishu_chat_api(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
Fixes #19676\n\n## Summary\n- add Feishu block-aware outbound chunking with a chat-sized target while preserving the existing max message limit\n- keep fenced code blocks intact when possible and continue using the existing text/post payload and fallback path per chunk\n- add a Feishu send-pipeline regression test for multiple markdown post messages\n\n## Verification\n- scripts/run_tests.sh tests/gateway/test_feishu.py -k 'splits_long_markdown'\n- scripts/run_tests.sh tests/gateway/test_feishu.py\n- git diff --check\n\nNote: .venv/bin/python -m ruff check gateway/platforms/feishu.py tests/gateway/test_feishu.py still reports pre-existing lint issues in these files, including module-level import ordering and existing unused/import annotation warnings unrelated to this patch.