### PR TITLE
fix: correct operator precedence in personality preview truncation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5987,7 +5987,7 @@ class HermesCLI:
             print(f"  {'none':<12} - (no personality overlay)")
             for name, prompt in self.personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = str(prompt)[:50]
                 print(f"  {name:<12} - {preview}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8229,7 +8229,7 @@ class GatewayRunner:
             lines.append("• `none` — (no personality overlay)")
             for name, prompt in personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                 else:
                     preview = prompt[:50] + "..." if len(prompt) > 50 else prompt
                 lines.append(f"• `{name}` — {preview}")

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1491,7 +1491,7 @@ class SlashCommandCompleter(Completer):
             for name, prompt in personalities.items():
                 if name.startswith(sub_lower) and name != sub_lower:
                     if isinstance(prompt, dict):
-                        meta = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                        meta = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
                     else:
                         meta = str(prompt)[:50]
                     yield Completion(

--- a/tests/cli/test_personality_none.py
+++ b/tests/cli/test_personality_none.py
@@ -69,6 +69,40 @@ class TestCLIPersonalityNone:
         output = " ".join(str(c) for c in mock_print.call_args_list)
         assert "none" in output.lower()
 
+    def test_long_description_is_truncated_in_list(self):
+        """Description longer than 50 chars should be truncated, not shown in full."""
+        long_desc = "A" * 200
+        cli = self._make_cli(personalities={
+            "test": {"description": long_desc, "system_prompt": "short"}
+        })
+        with patch("builtins.print") as mock_print:
+            cli._handle_personality_command("/personality")
+        output = " ".join(str(c) for c in mock_print.call_args_list)
+        assert long_desc not in output  # full 200-char description must NOT appear
+        assert "A" * 50 in output       # but a 50-char truncated version should
+
+    def test_short_description_is_not_padded(self):
+        """Short descriptions should be shown as-is, not padded to 50."""
+        cli = self._make_cli(personalities={
+            "test": {"description": "short desc", "system_prompt": "long prompt"}
+        })
+        with patch("builtins.print") as mock_print:
+            cli._handle_personality_command("/personality")
+        output = " ".join(str(c) for c in mock_print.call_args_list)
+        assert "short desc" in output
+
+    def test_no_description_falls_back_to_system_prompt_preview(self):
+        """When description is missing, system_prompt should be truncated to 50 chars."""
+        long_prompt = "B" * 200
+        cli = self._make_cli(personalities={
+            "test": {"system_prompt": long_prompt}
+        })
+        with patch("builtins.print") as mock_print:
+            cli._handle_personality_command("/personality")
+        output = " ".join(str(c) for c in mock_print.call_args_list)
+        assert long_prompt not in output
+        assert "B" * 50 in output
+
 
 # ── Gateway tests ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Fix operator precedence bug in personality list preview that causes long descriptions to overflow the display.

## The Bug

The personality list preview code uses:

```python
preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
```

Due to Python operator precedence, `[:50]` binds tighter than `or`. This means:
- When `description` is set → used **as-is** (no truncation, can be hundreds of chars)
- When `description` is missing → `system_prompt[:50]` is correctly truncated

The `[:50]` truncation was intended to apply to whichever value is selected, not just the fallback.

## Why It Matters

Users with custom personalities that have long descriptions will see the personality list (`/personality`) break its layout. The autocomplete `display_meta` in prompt_toolkit and the gateway `/personality` response are also affected.

## Fix

Add parentheses so `[:50]` applies to the result of `or`:

```python
preview = (prompt.get("description") or prompt.get("system_prompt", ""))[:50]
```

Fixed in 3 locations:
- `cli.py:5990` — CLI `/personality` list display
- `hermes_cli/commands.py:1494` — autocomplete `display_meta`
- `gateway/run.py:8232` — gateway `/personality` list response

## Before vs After

| Input | Before | After |
|-------|--------|-------|
| description="A"*200 | Shows all 200 chars | Truncated to 50 chars |
| description="short" | Shows "short" | Shows "short" (unchanged) |
| No description, system_prompt="B"*200 | "B"*50 | "B"*50 (unchanged) |

## Tests

Added 3 new tests to `tests/cli/test_personality_none.py`:
- `test_long_description_is_truncated_in_list` — verifies 200-char description is cut to 50
- `test_short_description_is_not_padded` — verifies short descriptions shown as-is
- `test_no_description_falls_back_to_system_prompt_preview` — verifies fallback truncation still works

All 22 tests in the file pass.