### PR TITLE
docs(web_tools): correct web_extract summarizer timeout comment

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -698,8 +698,10 @@ Create a markdown summary that captures all key information in a well-organized,
                 "temperature": 0.1,
                 "max_tokens": max_tokens,
                 # No explicit timeout — async_call_llm reads auxiliary.web_extract.timeout
-                # from config (default 360s / 6min).  Users with slow local models can
-                # increase it in config.yaml.
+                # from config.yaml. Fresh configs ship with 360s; if the key is absent
+                # the runtime default is 30s (_DEFAULT_AUX_TIMEOUT in
+                # agent/auxiliary_client.py). Users with slow local models should set
+                # or increase auxiliary.web_extract.timeout in config.yaml.
             }
             if extra_body:
                 call_kwargs["extra_body"] = extra_body


### PR DESCRIPTION
## What does this PR do?

Corrects an inaccurate comment at `tools/web_tools.py:700-702` describing the timeout behavior for the web_extract LLM summarization call.

The current comment states the default is "360s / 6min". This is wrong:

- **Runtime default when `auxiliary.web_extract.timeout` is absent from config.yaml: 30s** (`_DEFAULT_AUX_TIMEOUT` in `agent/auxiliary_client.py:3140`, applied by `_get_task_timeout` at line 3157).
- **Config template default for fresh configs: 360s** (`hermes_cli/config.py:697`).

Two different defaults in two different files. The comment confuses them. Users with slow local models who read this comment believe they have 6 minutes when they actually have 30s, leading to mystery timeouts.

## Related Issue

No issue filed; surfaced while investigating `web_extract` timeout behavior on a slow local-model deployment.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `tools/web_tools.py:700-702` — replaced the comment with one that describes both code paths accurately and points users to the correct config key.

## How to Test

This is a comment-only change with no behavior modification. Verification that the comment is now accurate:

1. `grep -n '_DEFAULT_AUX_TIMEOUT' agent/auxiliary_client.py` → `_DEFAULT_AUX_TIMEOUT = 30.0` at line 3140.
2. `grep -A1 'web_extract' hermes_cli/config.py | grep timeout` → template default `360`.
3. With no `auxiliary.web_extract.timeout` key in `config.yaml`, `_get_task_timeout("web_extract")` returns 30.0 (falls through to `_DEFAULT_AUX_TIMEOUT`).

## Background

The comment was introduced in commit `20b4060d` ("fix: web_extract fast-fail on scrape timeout + summarizer resilience", Apr 5 2026). That commit bumped the config template default from 30 to 360 in `hermes_cli/config.py` but did not touch `_DEFAULT_AUX_TIMEOUT` in `agent/auxiliary_client.py`, which had been set to 30.0 since `839d9d74` (Mar 28 2026). The comment was written against the new template default rather than the runtime fallback.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`docs(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q -k 'web_extract or web_tools'` — 73 passed, 3 skipped, 0 failures (scoped run; full suite not feasible on this dev machine)
- [x] N/A on test-add — comment-only change, no behavior modified


