### PR TITLE
fix(gateway): feishu websocket monkey-patch breaks dingtalk and other platforms

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1297,12 +1297,29 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         except Exception:
             logger.debug("[Feishu] Failed to apply websocket runtime overrides", exc_info=True)
 
-    async def _connect_with_overrides(*args: Any, **kwargs: Any) -> Any:
+    def _connect_with_overrides(*args: Any, **kwargs: Any) -> Any:
+        """Wrapper that preserves the original connect() interface (context manager).
+
+        The original ``websockets.connect()`` returns a context manager object
+        (not a coroutine).  Replacing it with an ``async def`` breaks other
+        consumers (e.g. ``dingtalk_stream``) that also ``import websockets``
+        and use ``async with websockets.connect(...)`` — because Python
+        modules are singletons, our monkey-patch would replace the class-based
+        connect with a plain coroutine function, causing:
+
+            TypeError: 'coroutine' object does not support the asynchronous
+            context manager protocol
+
+        By returning ``original_connect(*args, **kwargs)`` (which is itself a
+        context manager), we inject our overrides while keeping the return type
+        identical to the original.  This is compatible with all websockets
+        versions (13.x through 16.x).
+        """
         if adapter._ws_ping_interval is not None and "ping_interval" not in kwargs:
             kwargs["ping_interval"] = adapter._ws_ping_interval
         if adapter._ws_ping_timeout is not None and "ping_timeout" not in kwargs:
             kwargs["ping_timeout"] = adapter._ws_ping_timeout
-        return await original_connect(*args, **kwargs)
+        return original_connect(*args, **kwargs)
 
     def _configure_with_overrides(conf: Any) -> Any:
         if original_configure is None:


### PR DESCRIPTION
## Bug

The feishu adapter monkey-patches `websockets.connect` globally:

```python
websockets.connect = _connect_with_overrides
```

However, `_connect_with_overrides` was declared as `async def`, which returns a **coroutine object** instead of a **context manager**. Since Python modules are singletons, this replaces the global `websockets.connect` (a normal function returning a context manager) with a coroutine function.

## Impact

Any other platform that imports `websockets` and uses `async with websockets.connect(uri)` will crash with:

```
TypeError: "coroutine" object does not support the asynchronous context manager protocol
```

Confirmed broken: **dingtalk** (dingtalk_stream uses `async with websockets.connect(uri)`).

Potentially affected: any future gateway platform or third-party library that shares the same `websockets` module instance.

## Root Cause

```python
# Before (broken) — returns coroutine, not context manager
async def _connect_with_overrides(*args, **kwargs):
    ...
    return await original_connect(*args, **kwargs)
```

The `await` unwraps the context manager into a coroutine, breaking the `async with` protocol for all consumers.

## Fix

```python
# After (fixed) — returns context manager, same as original connect()
def _connect_with_overrides(*args, **kwargs):
    ...
    return original_connect(*args, **kwargs)
```

- `async def` → `def`: no longer a coroutine function
- `return await original_connect(...)` → `return original_connect(...)`: returns the context manager object directly, preserving the original `websockets.connect()` interface
- Override logic (ping_interval / ping_timeout injection) is unchanged

## Testing

Verified compatible with websockets 13.x, 15.x, and 16.x. All three gateway platforms (feishu, dingtalk, weixin) connect normally after the fix.