### PR TITLE
fix(snapshot): write hermes-snap-*.sh with mode 600 + clean up orphans on exit

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -15,6 +15,8 @@ import shlex
 import subprocess
 import threading
 import time
+import atexit
+import glob
 import uuid
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -24,6 +26,30 @@ from hermes_constants import get_hermes_home
 from tools.interrupt import is_interrupted
 
 logger = logging.getLogger(__name__)
+
+
+def _cleanup_orphan_snapshot_files():
+    """Remove any /tmp/hermes-{snap,cwd}-* files left behind on Python exit.
+
+    init_session() writes a per-session env snapshot to /tmp. The snapshot
+    is large (env vars + functions + aliases) and may contain secrets that
+    were exported into the parent shell. If the process is killed before
+    cleanup() runs (SIGKILL, OOM, abrupt restart), the file persists.
+
+    This sweeps the LOCAL host /tmp on Python exit. Remote-sandbox backends
+    (Docker/Daytona/Modal) clean up via container teardown — their snapshot
+    files live inside the container and disappear with it.
+    """
+    for pattern in ("/tmp/hermes-snap-*.sh", "/tmp/hermes-cwd-*.txt"):
+        for path in glob.glob(pattern):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+
+atexit.register(_cleanup_orphan_snapshot_files)
+
 
 # Opt-in debug tracing for the interrupt/activity/poll machinery.  Set
 # HERMES_DEBUG_INTERRUPT=1 to log loop entry/exit, periodic heartbeats, and
@@ -340,6 +366,10 @@ class BaseEnvironment(ABC):
         # pwd -P captures the profile's directory, not terminal.cwd.
         _quoted_cwd = shlex.quote(self.cwd)
         bootstrap = (
+            # umask 077 so snapshot/cwd files are mode 600 (owner-only).
+            # Prevents leakage of secrets carried in env vars (API keys,
+            # OAuth tokens, etc.) via world-readable /tmp on multi-user hosts.
+            f"umask 077\n"
             f"export -p > {self._snapshot_path}\n"
             f"declare -f | grep -vE '^_[^_]' >> {self._snapshot_path}\n"
             f"alias -p >> {self._snapshot_path}\n"


### PR DESCRIPTION
## Problem

`BaseEnvironment.init_session()` (`tools/environments/base.py`) writes the parent shell's full environment to `/tmp/hermes-snap-<session_id>.sh` via `export -p`:

https://github.com/NousResearch/hermes-agent/blob/main/tools/environments/base.py#L283-L292

With the default umask, the redirected file is created at mode `644` — world-readable. On hosts where Hermes inherits secrets via env vars (API keys, OAuth tokens, bot tokens, keyring passwords), the session snapshot exposes those secrets to any other local user or process for the lifetime of the file.

I encountered this when a host-level security watchdog flagged a 12-day-old `hermes-snap-*.sh` file containing live Discord and keyring tokens. The file was orphaned because the originating process was killed before `cleanup()` ran. Mode 644 + 12 days in /tmp = real local-disclosure window.

## Fix

Two small changes to `tools/environments/base.py`:

1. **Mode the snapshot 600 by prepending `umask 077\n` to the bootstrap.** The redirect's umask is applied at file creation, yielding owner-only.

2. **Add a module-level `atexit` hook** that sweeps `/tmp/hermes-snap-*.sh` and `/tmp/hermes-cwd-*.txt` on Python exit. `cleanup()` already removes the current session's files, but if the process is hard-killed (SIGKILL, OOM, abrupt systemd restart), those files orphan in /tmp. The atexit hook catches normal exits; orphans from hard kills are swept on the next process start (since the glob covers any matching file regardless of which process created it).

## Scope

- **Local environments**: directly affected, fixed.
- **Remote sandbox backends** (Docker / Daytona / Modal): unaffected. Their snapshot files live inside the container's `/tmp` and disappear with the container.
- **Multi-process Hermes deployments**: the atexit glob will match any `hermes-snap-*.sh` in host /tmp, including files belonging to a *concurrent* Hermes process. For a single-process deployment this is what we want. For multi-process, the upstream-correct fix would be a per-instance `weakref.finalize` keyed on `_session_id`. I went with the simpler global sweep because (a) the orphan-cleanup case is the common pain point, and (b) the umask fix is the security-critical bit and shouldn't be held up. Happy to refactor to per-instance if you'd prefer.

## Verification

```bash
$ bash -c 'umask 077; export -p > /tmp/test-snap.sh' && stat -c '%a %n' /tmp/test-snap.sh
600 /tmp/test-snap.sh
```

Patched on a production Hermes install; subsequent sessions write mode 600.

## Backwards compatibility

- File mode 600 doesn't break any read pattern — `_wrap_command` sources the snapshot from the same Python process that wrote it, owned by the same user. No external readers are intended.
- atexit hook is purely additive; if the registry runs in a context where `/tmp` is read-only or other glob targets exist, the OSError is swallowed.

## Disclosure

This is a local-disclosure issue, not remote. Sensitivity depends entirely on what env vars Hermes inherits at startup and who shares the local host. For single-tenant root-only servers the practical exposure is bounded; for shared hosts or where any non-root process has local code execution, it's real. Filing publicly because the fix is small, the underlying risk is widely understood, and a private channel wasn't obvious.