### PR TITLE
fix: use correct /compress command name in context-overflow tips

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1252,7 +1252,7 @@ class HermesACPAgent(acp.Agent):
                     lines.append(
                         f"Compression: due now (threshold ~{threshold_tokens:,}"
                         + (f", {threshold_pct:.0f}%" if threshold_pct else "")
-                        + "). Run /compact."
+                        + "). Run /compress."
                     )
                 else:
                     lines.append(
@@ -1267,7 +1267,7 @@ class HermesACPAgent(acp.Agent):
         if getattr(agent, "compression_enabled", True) is False:
             lines.append("Compression is disabled for this agent.")
         else:
-            lines.append("Tip: run /compact to compress manually before the threshold.")
+            lines.append("Tip: run /compress to compress manually before the threshold.")
 
         return "\n".join(lines)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6742,7 +6742,7 @@ class GatewayRunner:
                 if _is_ctx_fail:
                     response = (
                         "⚠️ Session too large for the model's context window.\n"
-                        "Use /compact to compress the conversation, or "
+                        "Use /compress to compress the conversation, or "
                         "/reset to start fresh."
                     )
                 else:
@@ -7070,7 +7070,7 @@ class GatewayRunner:
                 if _hist_len > 50:
                     return (
                         "⚠️ Session too large for the model's context window.\n"
-                        "Use /compact to compress the conversation, or "
+                        "Use /compress to compress the conversation, or "
                         "/reset to start fresh."
                     )
                 elif status_code == 400:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -862,7 +862,7 @@ class TestSlashCommands:
 
         assert "Context usage: ~25,000 / 100,000 tokens (25.0%)" in result
         assert "Compression: ~55,000 tokens until threshold (~80,000, 80%)" in result
-        assert "Tip: run /compact" in result
+        assert "Tip: run /compress" in result
 
     def test_context_says_compression_due_when_past_threshold(self, agent, mock_manager):
         state = self._make_state(mock_manager)
@@ -879,7 +879,7 @@ class TestSlashCommands:
             result = agent._handle_slash_command("/context", state)
 
         assert "Context usage: ~82,000 / 100,000 tokens (82.0%)" in result
-        assert "Compression: due now (threshold ~80,000, 80%). Run /compact." in result
+        assert "Compression: due now (threshold ~80,000, 80%). Run /compress." in result
 
     def test_reset_clears_history(self, agent, mock_manager):
         state = self._make_state(mock_manager)

--- a/tests/run_agent/test_1630_context_overflow_loop.py
+++ b/tests/run_agent/test_1630_context_overflow_loop.py
@@ -5,7 +5,7 @@ Verifies that:
    and trigger compression instead of aborting.
 2. The gateway does not persist messages when the agent fails early, preventing
    the session from growing on each failure.
-3. Context-overflow failures produce helpful error messages suggesting /compact.
+3. Context-overflow failures produce helpful error messages suggesting /compress.
 """
 
 import pytest


### PR DESCRIPTION
## What

Fix incorrect `/compact` command reference in context-overflow error messages and compression threshold tips. The actual command is `/compress`.

Fixes #20020

## The Bug

When a session exceeds the model's context window, the gateway shows:

```
⚠️ Session too large for the model's context window.
Use /compact to compress the conversation, or /reset to start fresh.
```

But `/compact` is not a valid command — it's `/compress`. Users following this tip get "Unknown command" errors.

Similarly, the `/context` command's compression threshold tips in the ACP adapter say "Run /compact" instead of "Run /compress".

## Why It Matters

This is a user-facing bug that affects all gateway platforms (Telegram, Discord, Slack, QQBot, etc.) and the ACP adapter (VS Code, Zed, JetBrains). When users hit context limits, they receive actionable but incorrect guidance, which is worse than no guidance at all.

## Fix

Replace `/compact` with `/compress` in 4 user-facing locations:

| File | Line | Context |
|------|------|---------|
| `gateway/run.py` | 6745 | Context-overflow error message (400 heuristic path) |
| `gateway/run.py` | 7073 | Context-overflow error message (400/500 status path) |
| `acp_adapter/server.py` | 1255 | `/context` compression-due tip |
| `acp_adapter/server.py` | 1270 | `/context` pre-threshold tip |

Updated 2 test assertions in `tests/acp/test_server.py` and 1 docstring in `tests/run_agent/test_1630_context_overflow_loop.py` to match.

## Before vs After

**Before:**
```
⚠️ Session too large for the model's context window.
Use /compact to compress the conversation, or /reset to start fresh.
```
(User types `/compact` → "Unknown command")

**After:**
```
⚠️ Session too large for the model's context window.
Use /compress to compress the conversation, or /reset to start fresh.
```
(User types `/compress` → compression runs successfully)

## Tests

- `tests/acp/test_server.py` — 6 context-related tests pass (2 assertions updated)
- `tests/run_agent/test_1630_context_overflow_loop.py` — 16 tests pass (1 docstring updated)