### PR TITLE
fix(nix): refresh tui npm deps hash

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -163,7 +163,7 @@
       for entry in "''${ENTRIES[@]}"; do
         IFS=":" read -r ATTR FOLDER NIX_FILE <<< "$entry"
         echo "==> .#$ATTR ($FOLDER -> $NIX_FILE)"
-        OUTPUT=$(nix build ".#$ATTR.npmDeps" --no-link --print-build-logs 2>&1)
+        OUTPUT=$(nix build ".#$ATTR.npmDeps" --rebuild --no-link --print-build-logs 2>&1)
         STATUS=$?
         if [ "$STATUS" -eq 0 ]; then
           echo "    ok"
@@ -205,7 +205,7 @@
 
         if [ "$MODE" = "--apply" ]; then
           sed -i "s|hash = \"sha256-[^\"]*\";|hash = \"$NEW_HASH\";|" "$NIX_FILE"
-          if ! nix build ".#$ATTR.npmDeps" --no-link --print-build-logs; then
+          if ! nix build ".#$ATTR.npmDeps" --rebuild --no-link --print-build-logs; then
             echo "    verification build failed after hash update" >&2
             exit 1
           fi

--- a/nix/tui.nix
+++ b/nix/tui.nix
@@ -4,7 +4,7 @@ let
   src = ../ui-tui;
   npmDeps = pkgs.fetchNpmDeps {
     inherit src;
-    hash = "sha256-a/HGI9OgVcTnZrMXA7xFMGnFoVxyHe95fulVz+WNYB0=";
+    hash = "sha256-MLcLhjTF6dgdvNBtJWzo8Nh19eNh/ZitD2b07nm61Tc=";
   };
 
   npm = hermesNpmLib.mkNpmPassthru { folder = "ui-tui"; attr = "tui"; pname = "hermes-tui"; };


### PR DESCRIPTION
## What does this PR do?

Refreshes the `ui-tui` Nix npm deps hash for the current `ui-tui/package-lock.json` on latest main.

Latest affected main:
- SHA: `601e5f1d57cfd4ceefee50a6df05a860a1a602e8`
- Nix run: `25357077973`, Ubuntu job `74348475250`
- Failure: `hermes-tui> ERROR: npmDepsHash is out of date`

This also forces `fix-lockfiles` to rebuild npmDeps while checking and while verifying a freshly applied hash. The latest failing run showed the package build detecting lockfile drift while `nix run .#fix-lockfiles -- --check` reported `ok`, because the checker could hit cached fixed-output derivations. Rebuilding makes the diagnostic match the real package build.

Related: #19766 targets an older hash and does not include the checker cache fix.

## Related Issue

Related to #19766.

Unblocks latest main Nix failure from run `25357077973`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `nix/tui.nix`: update the `fetchNpmDeps.hash` for `ui-tui` to `sha256-MLcLhjTF6dgdvNBtJWzo8Nh19eNh/ZitD2b07nm61Tc=`.
- `nix/lib.nix`: add `--rebuild` to `fix-lockfiles` npmDeps builds so stale cached fixed-output derivations cannot hide lockfile drift.

## How to Test

1. On affected main, run `nix build .#tui --no-link --print-build-logs` and observe the `hermes-tui> ERROR: npmDepsHash is out of date` failure.
2. Check out this branch.
3. Run `nix build .#tui --no-link --print-build-logs` and observe the TUI Nix package build complete.
4. Run `nix run .#fix-lockfiles -- --check` and observe the hash check exit successfully.

## Validation Status

- [x] `git diff --check`
- [x] `nix build .#tui --no-link --print-build-logs`, via nix-portable with `NP_RUNTIME=bwrap`, passed locally on Arch Linux x86_64.
- [x] `nix run .#fix-lockfiles -- --check`, via nix-portable with `NP_RUNTIME=bwrap`, exited 0 locally. It rebuilt `tui.npmDeps`; local `web.npmDeps` hit a transient invalid-output cache result and was skipped by the existing script handling.
- [ ] `pytest tests/ -q`, not run. This is a Nix-only lockfile/hash fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate. Found #19766, but it targets an older hash and does not include the checker cache fix.
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass. Not run for this Nix-only lockfile/hash fix.
- [ ] I've added tests for my changes. Covered by Nix package build and `fix-lockfiles --check` validation.
- [x] I've tested on my platform: Arch Linux x86_64 with nix-portable

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility). This only touches Nix derivations and the Nix lockfile helper.
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A

## Screenshots / Logs

Failure on latest main:

```text
hermes-tui> Validating consistency between /build/ui-tui/package-lock.json and /nix/store/...-npm-deps/package-lock.json
hermes-tui> ERROR: npmDepsHash is out of date
error: Cannot build '/nix/store/...-hermes-tui-0.0.1.drv'.
error: Nix build/flake check failed. See logs above.
```

Focused local validation:

```text
$ nix build .#tui --no-link --print-build-logs
hermes-tui> Successfully compiled 116 files with Babel (3198ms).
hermes-tui> patching script interpreter paths in /nix/store/...-hermes-tui-0.0.1

$ nix run .#fix-lockfiles -- --check
==> .#tui (ui-tui -> nix/tui.nix)
    ok
```
