### PR TITLE
fix(subprocess): use process_group=0 to avoid macOS MallocStackLogging warnings

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Dict, Optional, Any
 
 from hermes_constants import get_hermes_dir
+from tools.environments.local import _new_process_group_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -456,8 +457,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 ],
                 stdout=bridge_log_fh,
                 stderr=bridge_log_fh,
-                preexec_fn=None if _IS_WINDOWS else os.setsid,
                 env=bridge_env,
+                **_new_process_group_kwargs(),
             )
             
             # Wait for the bridge to connect to WhatsApp.

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1091,6 +1091,8 @@ def execute_code(
         _child_cwd = _resolve_child_cwd(_mode, tmpdir)
         _script_path = os.path.join(tmpdir, "script.py")
 
+        from tools.environments.local import _new_process_group_kwargs
+
         proc = subprocess.Popen(
             [_child_python, _script_path],
             cwd=_child_cwd,
@@ -1098,7 +1100,7 @@ def execute_code(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            **_new_process_group_kwargs(),
         )
 
         # --- Poll loop: watch for exit, timeout, and interrupt ---

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -6,12 +6,41 @@ import platform
 import shutil
 import signal
 import subprocess
+import sys
 import tempfile
 import time
 
 from tools.environments.base import BaseEnvironment, _pipe_stdin
 
 _IS_WINDOWS = platform.system() == "Windows"
+
+# Python 3.11+ supports process_group= in subprocess.Popen, which allows
+# the use of vfork (instead of fork) when preexec_fn is absent.  The fork
+# path triggers a spurious "MallocStackLogging: can't turn off malloc stack
+# logging because it was not enabled" warning that leaks onto the user's
+# terminal on macOS — vfork avoids this by not duplicating parent memory.
+# Using process_group=0 places the child in its own process group (needed
+# for killpg() cleanup) without requiring preexec_fn.
+_HAS_PROCESS_GROUP = sys.version_info >= (3, 11) and not _IS_WINDOWS
+
+
+def _new_process_group_kwargs() -> dict:
+    """Return Popen kwargs to place the child in its own process group.
+
+    On Python 3.11+ (non-Windows), uses ``process_group=0`` which avoids
+    the need for ``preexec_fn``, enabling CPython's vfork fast-path.  This
+    prevents macOS MallocStackLogging warnings caused by fork duplicating
+    parent memory (where malloc cleanup runs before exec).
+
+    On older Python or Windows, falls back to ``preexec_fn=os.setsid``
+    (POSIX) or nothing (Windows).
+    """
+    if _IS_WINDOWS:
+        return {}
+    if _HAS_PROCESS_GROUP:
+        return {"process_group": 0}
+    return {"preexec_fn": os.setsid}
+
 
 logger = logging.getLogger(__name__)
 
@@ -412,8 +441,8 @@ class LocalEnvironment(BaseEnvironment):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
             cwd=self.cwd,
+            **_new_process_group_kwargs(),
         )
         if not _IS_WINDOWS:
             try:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -41,7 +41,7 @@ import time
 import uuid
 
 _IS_WINDOWS = platform.system() == "Windows"
-from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
+from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env, _new_process_group_kwargs
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -545,7 +545,7 @@ class ProcessRegistry:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            **_new_process_group_kwargs(),
         )
 
         session.process = proc


### PR DESCRIPTION
## Problem

On macOS, CLI sessions show spurious warnings that corrupt the display:

```
Python(70404) MallocStackLogging: can't turn off malloc stack logging because it was not enabled.
Python(70443) MallocStackLogging: can't turn off malloc stack logging because it was not enabled.
```

## Root Cause

All subprocess spawning uses `preexec_fn=os.setsid`, which forces CPython to use `fork()` instead of `vfork()`. During `fork()`, the child process duplicates the parent's full memory — including malloc state. The child's malloc initialization then tries to disable stack logging (that was never enabled in the copy) and writes the warning to the inherited fd 2 (the user's terminal) before stderr gets redirected to a pipe.

The issue is intermittent: it depends on timing between `fork()` and the child's pipe setup, and becomes more likely with heavy subprocess spawning (parallel `delegate_task` + many terminal calls = 100+ fork() calls per session) and after macOS system updates that modify `libsystem_malloc` internals.

## Fix

Introduce `_new_process_group_kwargs()` helper that returns:
- `process_group=0` on Python 3.11+ → removes the need for `preexec_fn`, enabling CPython's `vfork()` fast-path. `vfork()` does NOT duplicate parent memory, so the child's malloc cleanup never runs the problematic code.
- `preexec_fn=os.setsid` on older Python → preserves existing behavior

`process_group=0` still creates a separate process group for `killpg()` cleanup — the only semantic change from `setsid` is that the child stays in the parent's session rather than creating a new one, which is irrelevant for our use case.

## Changed Files

| File | Role |
|------|------|
| `tools/environments/local.py` | Helper function + foreground terminal commands |
| `tools/process_registry.py` | Background processes |
| `tools/code_execution_tool.py` | execute_code subprocess |
| `gateway/platforms/whatsapp.py` | WhatsApp bridge process |

## Testing

- 282 relevant tests pass (terminal_tool, process_registry, code_execution, code_execution_modes, terminal_compound_background, terminal_exit_semantics, env_passthrough, windows_compat, subprocess_home_isolation)
- 711 gateway tests pass
- Verified `process_group=0` creates correct process group for `killpg()` child cleanup
- Pre-existing flakes confirmed unrelated (test_local_interrupt_cleanup, test_discord_free_response, test_dingtalk)
