### PR TITLE
fix(kanban): ignore stale current board pointers

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -190,12 +190,12 @@ def get_current_board() -> str:
     1. ``HERMES_KANBAN_BOARD`` env var (set by the dispatcher on worker
        spawn, or manually for ad-hoc overrides).
     2. ``<root>/kanban/current`` on disk (set by ``hermes kanban boards
-       switch``).
+       switch``), but only when that board still exists.
     3. ``DEFAULT_BOARD`` (``"default"``).
 
-    A malformed slug at any step falls through to the next layer with a
-    best-effort warning — the dispatcher must never crash because a user
-    hand-edited a file.
+    A malformed or stale slug at any step falls through to the next layer
+    with a best-effort warning — the dispatcher must never crash because a
+    user hand-edited a file or removed a board directory.
     """
     env = os.environ.get("HERMES_KANBAN_BOARD", "").strip()
     if env:
@@ -212,7 +212,7 @@ def get_current_board() -> str:
             if val:
                 try:
                     normed = _normalize_board_slug(val)
-                    if normed:
+                    if normed and board_exists(normed):
                         return normed
                 except ValueError:
                     pass

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -160,6 +160,15 @@ class TestCurrentBoard:
         kb.set_current_board("filepick")
         assert kb.get_current_board() == "filepick"
 
+    def test_stale_file_pointer_falls_back_to_default(self, fresh_home):
+        current = fresh_home / "kanban" / "current"
+        current.parent.mkdir(parents=True, exist_ok=True)
+        current.write_text("missing-board\n", encoding="utf-8")
+
+        assert kb.get_current_board() == "default"
+        assert not kb.board_exists("missing-board")
+        assert [b["slug"] for b in kb.list_boards()] == ["default"]
+
     def test_env_beats_file(self, fresh_home, monkeypatch):
         kb.create_board("a")
         kb.create_board("b")


### PR DESCRIPTION
## Summary
- Ignore stale `<root>/kanban/current` board pointers when resolving the active board
- Fall back to `default` instead of treating a missing board slug as active
- Add regression coverage so read/list flows do not synthesize a missing board from a stale pointer

Fixes #20055

## Test Plan
- `venv/bin/python -m pytest tests/hermes_cli/test_kanban_boards.py::TestCurrentBoard::test_stale_file_pointer_falls_back_to_default -q -o 'addopts='`
- `venv/bin/python -m pytest tests/hermes_cli/test_kanban_boards.py -q -o 'addopts='`
- `venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_kanban_tools.py tests/plugins/test_kanban_dashboard_plugin.py -q -o 'addopts='`
- `venv/bin/python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_boards.py`
