### PR TITLE
fix(kanban): validate worker profile before spawn

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2576,6 +2576,35 @@ def _rotate_worker_log(log_path: Path, max_bytes: int) -> None:
         pass
 
 
+def _validate_worker_profile_ready(profile_arg: str) -> None:
+    """Raise a clear error when a Kanban assignee profile cannot be spawned.
+
+    Kanban workers run as ``hermes -p <assignee> chat ...``. A stale or
+    half-created profile directory can otherwise get all the way to a child
+    process before failing with confusing model/provider/auth errors. Keep the
+    check intentionally cheap and local: name/existence + config.yaml presence.
+    Credential validity is provider-specific and still belongs to worker
+    startup, but missing profile/config is deterministic enough to fail fast.
+    """
+    from hermes_cli.profiles import get_profile_dir, profile_exists
+
+    if profile_arg == "default":
+        return
+    if not profile_exists(profile_arg):
+        raise RuntimeError(
+            f"Profile {profile_arg!r} does not exist. "
+            f"Create it with: hermes profile create {profile_arg} --clone"
+        )
+    profile_dir = get_profile_dir(profile_arg)
+    config_path = profile_dir / "config.yaml"
+    if not config_path.is_file():
+        raise RuntimeError(
+            f"Profile {profile_arg!r} is not runnable: missing {config_path}. "
+            f"Create it with `hermes profile create {profile_arg} --clone` "
+            "or add a profile config.yaml before assigning Kanban work."
+        )
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -2601,6 +2630,7 @@ def _default_spawn(
     from hermes_cli.profiles import normalize_profile_name
 
     profile_arg = normalize_profile_name(task.assignee)
+    _validate_worker_profile_ready(profile_arg)
 
     prompt = f"work kanban task {task.id}"
     env = dict(os.environ)

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -317,6 +317,43 @@ class TestWorkerSpawnEnv:
     actually spawning anything.
     """
 
+    def _write_profile_config(self, home: Path, name: str = "teknium") -> None:
+        profile_dir = home / "profiles" / name
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        (profile_dir / "config.yaml").write_text(
+            "model:\n  provider: openrouter\n  model: test-model\n",
+            encoding="utf-8",
+        )
+
+    def test_default_spawn_rejects_half_created_profile(self, fresh_home, monkeypatch):
+        profile_dir = fresh_home / "profiles" / "halfmade"
+        profile_dir.mkdir(parents=True)
+
+        def fail_popen(*args, **kwargs):  # pragma: no cover - should never be reached
+            raise AssertionError("Popen should not be called for an unrunnable profile")
+
+        monkeypatch.setattr(subprocess, "Popen", fail_popen)
+        task = kb.Task(
+            id="t_half",
+            title="half-created profile",
+            body=None,
+            assignee="halfmade",
+            status="ready",
+            priority=0,
+            created_by="user",
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="scratch",
+            workspace_path=None,
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+        )
+
+        with pytest.raises(RuntimeError, match="halfmade.*config.yaml"):
+            kb._default_spawn(task, str(fresh_home / "ws"), board=None)
+
     def test_default_spawn_sets_env_vars(self, fresh_home, monkeypatch):
         captured = {}
 
@@ -329,6 +366,7 @@ class TestWorkerSpawnEnv:
             return FakeProc()
 
         monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        self._write_profile_config(fresh_home)
         kb.create_board("spawntest")
 
         task = kb.Task(
@@ -371,6 +409,7 @@ class TestWorkerSpawnEnv:
             return FakeProc()
 
         monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        self._write_profile_config(fresh_home)
         task = kb.Task(
             id="t_def",
             title="",

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -702,6 +702,12 @@ class TestSharedBoardPaths:
                 self.pid = 4242
 
         monkeypatch.setattr("subprocess.Popen", _FakePopen)
+        profile_dir = default_home / "profiles" / "coder"
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "config.yaml").write_text(
+            "model:\n  provider: openrouter\n  model: test-model\n",
+            encoding="utf-8",
+        )
 
         task = kb.Task(
             id="t_dispatch_env",


### PR DESCRIPTION
## Summary
- Add a cheap pre-spawn readiness guard for Kanban worker profiles
- Fail fast when a non-default assignee profile does not exist or lacks `config.yaml`
- Prevent `_default_spawn` from launching `hermes -p <profile>` for half-created profile directories
- Update spawn-env tests to model runnable profiles explicitly

Fixes #20054

## Scope
This intentionally checks deterministic local readiness only:
- profile exists
- profile has `config.yaml`

It does not attempt provider-specific credential validation; bad/expired credentials can still fail during worker startup and are reported through the existing spawn-failure path.

## Test Plan
- `venv/bin/python -m pytest tests/hermes_cli/test_kanban_boards.py::TestWorkerSpawnEnv::test_default_spawn_rejects_half_created_profile -q -o 'addopts='` — watched fail before implementation, then pass
- `venv/bin/python -m pytest tests/hermes_cli/test_kanban_boards.py::TestWorkerSpawnEnv -q -o 'addopts='` → 3 passed
- `venv/bin/python -m pytest tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py -q -o 'addopts='` → 124 passed
- `venv/bin/python -m pytest tests/tools/test_kanban_tools.py tests/plugins/test_kanban_dashboard_plugin.py -q -o 'addopts='` → 89 passed, 2 unrelated deprecation warnings
- `venv/bin/python -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_boards.py tests/hermes_cli/test_kanban_db.py` → passed
