### PR TITLE
fix(cli): validate assignee profile readiness before kanban dispatch

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2499,6 +2499,11 @@ def dispatch_once(
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
+    # Only validate assignee profile readiness when the default spawn is in
+    # use: the default path runs ``hermes -p <profile> chat -q ...`` so the
+    # assignee MUST resolve to a runnable profile. Custom spawn_fns (tests,
+    # remote workers, simulators) may have unrelated assignee semantics.
+    check_profile = spawn_fn is None and not dry_run
     spawned = 0
     for row in ready_rows:
         if max_spawn is not None and spawned >= max_spawn:
@@ -2509,6 +2514,26 @@ def dispatch_once(
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
             continue
+        if check_profile:
+            from hermes_cli.profiles import profile_readiness_error
+            ready_err = profile_readiness_error(row["assignee"])
+            if ready_err is not None:
+                # Profile readiness failures don't fix themselves between
+                # ticks — a half-created profile dir would otherwise burn
+                # through the spawn-failure circuit breaker N ticks at a
+                # time. Auto-block on the first detection so the task
+                # surfaces the precise reason instead of cascading into
+                # opaque provider/auth errors (see issue #20054).
+                claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
+                if claimed is None:
+                    continue
+                _record_spawn_failure(
+                    conn, claimed.id,
+                    f"profile_not_runnable: {ready_err}",
+                    failure_limit=1,
+                )
+                result.auto_blocked.append(claimed.id)
+                continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
             continue

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -231,6 +231,40 @@ def profile_exists(name: str) -> bool:
     return get_profile_dir(canon).is_dir()
 
 
+def profile_readiness_error(name: str) -> Optional[str]:
+    """Return ``None`` if the profile is runnable, else a diagnostic string.
+
+    A profile directory can exist while still being un-runnable: skills /
+    SOUL.md may be present but ``config.yaml`` (provider/model resolution)
+    is missing.  The Kanban dispatcher uses this check to fail fast with a
+    precise error instead of spawning a worker that will die later through
+    provider/auth fallback (see issue #20054).
+
+    The ``default`` profile is always considered runnable: it IS the
+    HERMES_HOME root and may legitimately resolve provider/model from
+    other sources (env, ``cli-config.yaml``).
+    """
+    try:
+        canon = normalize_profile_name(name)
+    except (TypeError, ValueError) as exc:
+        return f"invalid profile name: {exc}"
+
+    if canon == "default":
+        return None
+
+    profile_dir = get_profile_dir(canon)
+    if not profile_dir.is_dir():
+        return f"profile {canon!r} does not exist (expected at {profile_dir})"
+
+    config_path = profile_dir / "config.yaml"
+    if not config_path.is_file():
+        return (
+            f"profile {canon!r} is not runnable: missing {config_path}"
+        )
+
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Alias / wrapper script management
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -141,6 +141,13 @@ def test_successful_spawn_resets_failure_counter(kanban_home):
 def test_workspace_resolution_failure_also_counts(kanban_home):
     """`dir:` workspace with no path should fail workspace resolution AND
     count against the failure budget — not just crash the tick."""
+    # Default spawn validates assignee profile readiness first (issue #20054),
+    # so seed a runnable profile for "worker" before exercising the
+    # workspace-resolution failure path.
+    worker_profile = kanban_home / "profiles" / "worker"
+    worker_profile.mkdir(parents=True)
+    (worker_profile / "config.yaml").write_text("model: x\n")
+
     conn = kb.connect()
     try:
         # Manually insert a broken task: dir workspace but workspace_path is NULL

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -380,6 +380,64 @@ def test_dispatch_spawn_failure_releases_claim(kanban_home):
         assert kb.get_task(conn, t).claim_lock is None
 
 
+def test_dispatch_blocks_unrunnable_assignee_profile(kanban_home, tmp_path):
+    """Default-spawn dispatch must auto-block tasks whose assignee profile
+    is not runnable (issue #20054). A half-created profile dir without
+    config.yaml is the canonical repro: previously the worker would spawn
+    and fail later through opaque provider/auth fallback.
+    """
+    # Create a half-baked profile dir at ~/.hermes/profiles/debugger-v1/
+    # without config.yaml — mimicking the bug's reproduction case.
+    partial = tmp_path / ".hermes" / "profiles" / "debugger-v1"
+    partial.mkdir(parents=True)
+    (partial / "SOUL.md").write_text("# soul")
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="debugger-v1")
+        # spawn_fn is omitted on purpose — the readiness gate only fires
+        # for the default spawn path.
+        res = kb.dispatch_once(conn)
+
+    assert t in res.auto_blocked
+    assert not res.spawned
+    with kb.connect() as conn:
+        task = kb.get_task(conn, t)
+    assert task.status == "blocked"
+    assert "profile_not_runnable" in (task.last_spawn_error or "")
+    assert "debugger-v1" in (task.last_spawn_error or "")
+
+
+def test_dispatch_allows_runnable_assignee_profile(kanban_home, tmp_path):
+    """A profile with config.yaml passes the readiness gate and reaches
+    the spawn path. Use a no-op subprocess.Popen so we don't actually
+    fork hermes here.
+    """
+    import subprocess
+
+    full_profile = tmp_path / ".hermes" / "profiles" / "coder"
+    full_profile.mkdir(parents=True)
+    (full_profile / "config.yaml").write_text("model: x\n")
+
+    captured = {}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kwargs):
+            captured["cmd"] = cmd
+            self.pid = 9999
+
+    orig_popen = subprocess.Popen
+    subprocess.Popen = _FakePopen
+    try:
+        with kb.connect() as conn:
+            t = kb.create_task(conn, title="ok", assignee="coder")
+            res = kb.dispatch_once(conn)
+    finally:
+        subprocess.Popen = orig_popen
+
+    assert not res.auto_blocked
+    assert any(s[0] == t for s in res.spawned)
+
+
 def test_dispatch_reclaims_stale_before_spawning(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="x", assignee="alice")

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -31,6 +31,7 @@ from hermes_cli.profiles import (
     import_profile,
     generate_bash_completion,
     generate_zsh_completion,
+    profile_readiness_error,
     _get_profiles_root,
     _get_default_hermes_home,
 )
@@ -393,6 +394,51 @@ class TestResolveProfileEnv:
     def test_invalid_name_raises_value_error(self, profile_env):
         with pytest.raises(ValueError):
             resolve_profile_env("INVALID!")
+
+
+# ===================================================================
+# TestProfileReadinessError
+# ===================================================================
+
+class TestProfileReadinessError:
+    """Tests for profile_readiness_error() — Kanban dispatcher gate."""
+
+    def test_default_is_always_runnable(self, profile_env):
+        # The default profile IS HERMES_HOME; no config.yaml requirement.
+        assert profile_readiness_error("default") is None
+        assert profile_readiness_error("DEFAULT") is None
+
+    def test_missing_profile_dir_reports_error(self, profile_env):
+        err = profile_readiness_error("ghost")
+        assert err is not None
+        assert "ghost" in err
+        assert "does not exist" in err
+
+    def test_profile_without_config_yaml_reports_error(self, profile_env):
+        # Mimic the issue's repro: directory exists with skills/SOUL.md
+        # but no config.yaml.
+        tmp_path = profile_env
+        partial = tmp_path / ".hermes" / "profiles" / "debugger-v1"
+        partial.mkdir(parents=True)
+        (partial / "SOUL.md").write_text("# soul")
+        (partial / "skills").mkdir()
+
+        err = profile_readiness_error("debugger-v1")
+        assert err is not None
+        assert "debugger-v1" in err
+        assert "config.yaml" in err
+
+    def test_runnable_profile_returns_none(self, profile_env):
+        create_profile("ready", no_alias=True)
+        # create_profile bootstraps the dir but does not seed config.yaml.
+        # Write a minimal one so the readiness gate passes.
+        (get_profile_dir("ready") / "config.yaml").write_text("model: x\n")
+        assert profile_readiness_error("ready") is None
+
+    def test_invalid_name_reports_error(self, profile_env):
+        err = profile_readiness_error("")
+        assert err is not None
+        assert "invalid profile name" in err.lower()
 
 
 # ===================================================================


### PR DESCRIPTION
Validate that the assignee profile is runnable (directory exists and contains config.yaml) before the Kanban dispatcher claims a task and spawns `hermes -p <profile> chat -q ...`. Half-created profile directories now fail fast with a precise diagnostic instead of cascading into opaque provider/auth errors.

## What changed and why
- Add `profile_readiness_error(name)` in `hermes_cli/profiles.py` that returns `None` for runnable profiles or a diagnostic string identifying what's missing (invalid name / dir missing / config.yaml missing). The `default` profile is always runnable since it IS HERMES_HOME.
- In `hermes_cli/kanban_db.py::dispatch_once`, validate the assignee profile before claiming for the default-spawn path. Unrunnable profiles are claimed and auto-blocked immediately via the existing `_record_spawn_failure` circuit breaker with `failure_limit=1` — readiness errors don't fix themselves between ticks, so retrying N times before blocking is wasted churn.
- The gate is skipped when a custom `spawn_fn` is passed (tests, simulators, alternate worker hosts) so existing assignee semantics are preserved.
- Updated `test_workspace_resolution_failure_also_counts` to seed a runnable `worker` profile so the new readiness gate doesn't pre-empt the workspace-resolution test path.

## How to test
- `pytest tests/hermes_cli/test_profiles.py::TestProfileReadinessError -q`
- `pytest tests/hermes_cli/test_kanban_db.py -q -k dispatch`
- `pytest tests/hermes_cli/test_kanban_core_functionality.py -q`
- New `test_dispatch_blocks_unrunnable_assignee_profile` reproduces the issue scenario (profile dir with SOUL.md but no config.yaml) and asserts the task ends in `blocked` with a `profile_not_runnable: ...` reason in `last_spawn_error`.
- New `test_dispatch_allows_runnable_assignee_profile` confirms a profile with config.yaml passes the gate and reaches the spawn path.

## What platforms tested on
- macOS on darwin-arm64 (local) — full `tests/hermes_cli/test_kanban*.py` and `tests/hermes_cli/test_profiles.py` pass (347 tests).

Fixes #20054

<!-- autocontrib:worker-id=issue-new-f392c31a kind=pr-open -->