### PR TITLE
fix(cli): validate kanban current-board pointer to stop silent synth/create

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -115,6 +115,12 @@ _CTX_MAX_COMMENT_BYTES  = 2 * 1024   # 2 KB per comment
 
 DEFAULT_BOARD = "default"
 
+# Slugs we've already warned about for a stale current-board pointer in
+# this process. Read-only commands (boards list, list, stats) call
+# get_current_board() once or twice each — the dedupe just avoids
+# double-printing within a single CLI invocation.
+_STALE_CURRENT_BOARD_WARNED: set[str] = set()
+
 # Slug validator: lowercase alphanumerics, digits, hyphens; 1–64 chars.
 # Strict enough to stop traversal (`..`) and embedded path separators, loose
 # enough that kebab-case names like ``atm10-server`` or ``hermes-agent``
@@ -213,7 +219,29 @@ def get_current_board() -> str:
                 try:
                     normed = _normalize_board_slug(val)
                     if normed:
-                        return normed
+                        # Validate the pointer references a real board.
+                        # Without this, a stale pointer (board removed
+                        # outside ``boards rm``, slug typo, etc.) would
+                        # cause read-only commands like ``stats`` / ``list``
+                        # to silently materialize an empty board on disk
+                        # via kb.connect()'s mkdir+sqlite3.connect, hiding
+                        # the user's real board behind a synthetic one.
+                        if board_exists(normed):
+                            return normed
+                        if normed not in _STALE_CURRENT_BOARD_WARNED:
+                            _STALE_CURRENT_BOARD_WARNED.add(normed)
+                            try:
+                                print(
+                                    f"warning: kanban current-board pointer "
+                                    f"references missing board {normed!r}; "
+                                    f"falling back to {DEFAULT_BOARD!r}. "
+                                    f"Recreate it with `hermes kanban boards "
+                                    f"create {normed}` or switch with "
+                                    f"`hermes kanban boards switch <slug>`.",
+                                    file=sys.stderr,
+                                )
+                            except OSError:
+                                pass
                 except ValueError:
                     pass
     except OSError:

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -61,6 +61,8 @@ def fresh_home(tmp_path, monkeypatch):
         pass
     # Kanban module-level init cache must not leak between tests.
     kb._INITIALIZED_PATHS.clear()
+    # Stale-pointer warning dedupe is also process-global.
+    kb._STALE_CURRENT_BOARD_WARNED.clear()
     return home
 
 
@@ -184,6 +186,66 @@ class TestCurrentBoard:
         kb.set_current_board("my-proj")
         expected = fresh_home / "kanban" / "boards" / "my-proj" / "kanban.db"
         assert kb.kanban_db_path() == expected
+
+
+class TestStaleCurrentBoardPointer:
+    """A ``<root>/kanban/current`` pointing at a missing board must not
+    cause kanban to silently synthesize/create that board on read.
+
+    Otherwise a stale pointer (board removed outside ``boards rm``, slug
+    typo, etc.) hides the user's real boards behind a synthetic empty one.
+    """
+
+    def _seed_stale(self, home, slug="missing-board"):
+        ptr = home / "kanban" / "current"
+        ptr.parent.mkdir(parents=True, exist_ok=True)
+        ptr.write_text(slug + "\n", encoding="utf-8")
+
+    def test_get_current_board_falls_back_to_default(self, fresh_home, capsys):
+        self._seed_stale(fresh_home)
+        assert kb.get_current_board() == "default"
+        err = capsys.readouterr().err
+        assert "missing-board" in err
+        assert "falling back to 'default'" in err
+
+    def test_warning_is_deduped_within_process(self, fresh_home, capsys):
+        self._seed_stale(fresh_home)
+        kb.get_current_board()
+        kb.get_current_board()
+        kb.get_current_board()
+        assert capsys.readouterr().err.count("warning:") == 1
+
+    def test_no_implicit_board_creation(self, fresh_home, capsys):
+        self._seed_stale(fresh_home)
+        # Touching the DB through the regular CLI code path must not
+        # create the missing board's directory or DB file.
+        with kb.connect() as conn:
+            kb.recompute_ready(conn)
+            kb.list_tasks(conn)
+        capsys.readouterr()  # discard warning
+        assert not (fresh_home / "kanban" / "boards" / "missing-board").exists()
+
+    def test_pointer_preserved_for_recovery(self, fresh_home, capsys):
+        """The stale pointer is left on disk so the user can `boards
+        create <slug>` and recover the original selection without having
+        to re-switch."""
+        self._seed_stale(fresh_home, slug="recoverable")
+        assert kb.get_current_board() == "default"
+        capsys.readouterr()
+        ptr = fresh_home / "kanban" / "current"
+        assert ptr.exists()
+        assert ptr.read_text(encoding="utf-8").strip() == "recoverable"
+        # Once the user creates the board, the pointer becomes valid again.
+        kb.create_board("recoverable")
+        assert kb.get_current_board() == "recoverable"
+
+    def test_boards_list_does_not_include_stale_slug(self, fresh_home, capsys):
+        self._seed_stale(fresh_home)
+        with kb.connect() as conn:
+            kb.recompute_ready(conn)
+        capsys.readouterr()
+        slugs = [b["slug"] for b in kb.list_boards()]
+        assert slugs == ["default"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Stop kanban from silently synthesizing/creating a board when `<root>/kanban/current` points at a missing slug.

## What changed and why
- `hermes_cli/kanban_db.py::get_current_board()` now validates the on-disk pointer via `board_exists()` and falls back to `default` (with a deduped stderr warning) when the slug doesn't resolve. Previously the slug was returned unchecked, so downstream `kb.connect()` calls would `mkdir` the board directory and `sqlite3.connect()` would create the DB file — making the missing slug appear in `boards list` as a real, active workspace and hiding the user's real boards behind a synthetic empty one.
- The pointer file itself is left in place. Users can recover their selection by running `hermes kanban boards create <slug>` and the next read honours the pointer again.
- `HERMES_KANBAN_BOARD` env-var resolution is intentionally not validated: it's written by the dispatcher on worker spawn (which already knows the board exists), so a runtime existence check there would only mask dispatcher bugs.
- Added five unit tests in `tests/hermes_cli/test_kanban_boards.py::TestStaleCurrentBoardPointer` covering: fallback to `default`, warning dedupe within a process, no implicit board-directory creation through `kb.connect()`, recovery via `boards create`, and absence from `list_boards()`.

## How to test
- Reproduce the issue's exact scenario:
  ```bash
  tmp=$(mktemp -d)
  mkdir -p "$tmp/kanban"
  printf 'missing-board\n' > "$tmp/kanban/current"
  HERMES_HOME="$tmp" hermes kanban boards show
  HERMES_HOME="$tmp" hermes kanban stats
  HERMES_HOME="$tmp" hermes kanban list
  HERMES_HOME="$tmp" hermes kanban boards list
  find "$tmp/kanban" -mindepth 1
  ```
  After the fix, every command emits the stale-pointer warning and reports `default`. `kanban/boards/missing-board/` is never created.
- Run the kanban suite: `pytest tests/hermes_cli/test_kanban_boards.py -q` (54 passed locally).

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #20055

<!-- autocontrib:worker-id=issue-new-e9c1271a kind=pr-open -->