### PR TITLE
fix(runtime-provider): ensure /v1 suffix for local OpenAI-compatible base URLs (#7516)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -341,6 +341,41 @@ def _is_known_provider_base_url(base_url: str) -> bool:
     return _infer_provider_from_url(base_url) is not None
 
 
+def ensure_v1_suffix(base_url: str) -> str:
+    """Ensure ``base_url`` ends with ``/v1``.
+
+    The OpenAI Python SDK appends ``/chat/completions`` directly to the
+    configured ``base_url`` without inserting a version segment, so callers
+    pointing at OpenAI-compatible endpoints whose API root lives under
+    ``/v1`` (Ollama, llama.cpp server, vLLM, LM Studio, ...) must already
+    include the version segment. Users naturally configure
+    ``base_url: http://127.0.0.1:11434`` and hit HTTP 404 because the SDK
+    requests ``/chat/completions`` instead of ``/v1/chat/completions``.
+
+    See [GitHub #7516].
+    """
+    url = (base_url or "").rstrip("/")
+    if not url:
+        return url
+    if url.endswith("/v1"):
+        return url
+    return f"{url}/v1"
+
+
+def strip_v1_suffix(base_url: str) -> str:
+    """Strip a trailing ``/v1`` so callers reach the server root.
+
+    Inverse of :func:`ensure_v1_suffix`. Used when calling native
+    (non-OpenAI-compatible) endpoints on the same local server, e.g.
+    Ollama's ``/api/show`` or ``/api/tags`` which live under the root,
+    not under ``/v1``.
+    """
+    url = (base_url or "").rstrip("/")
+    if url.endswith("/v1"):
+        return url[: -len("/v1")]
+    return url
+
+
 def is_local_endpoint(base_url: str) -> bool:
     """Return True if base_url points to a local machine.
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 from hermes_cli import auth as auth_mod
 from agent.credential_pool import CredentialPool, PooledCredential, get_custom_provider_pool_key, load_pool
+from agent.model_metadata import ensure_v1_suffix, is_local_endpoint
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
@@ -539,11 +540,21 @@ def _resolve_named_custom_runtime(
     ]
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
 
+    api_mode = (
+        custom_provider.get("api_mode")
+        or _detect_api_mode_for_url(base_url)
+        or "chat_completions"
+    )
+    # Same /v1 normalization as _resolve_openrouter_runtime — see #7516.
+    # Named custom providers pointing at a local OpenAI-compatible server
+    # (e.g. custom_providers: { name: ollama-local, base_url:
+    # http://127.0.0.1:11434 }) hit the identical SDK path bug.
+    if api_mode == "chat_completions" and is_local_endpoint(base_url):
+        base_url = ensure_v1_suffix(base_url)
+
     result = {
         "provider": "custom",
-        "api_mode": custom_provider.get("api_mode")
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": api_mode,
         "base_url": base_url,
         "api_key": api_key or "no-key-required",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
@@ -649,11 +660,22 @@ def _resolve_openrouter_runtime(
     if effective_provider == "custom" and not api_key and not _is_openrouter_url:
         api_key = "no-key-required"
 
+    api_mode = (
+        _parse_api_mode(model_cfg.get("api_mode"))
+        or _detect_api_mode_for_url(base_url)
+        or "chat_completions"
+    )
+    # Local OpenAI-compatible servers (Ollama, llama.cpp, vLLM, LM Studio)
+    # serve their OpenAI-compatible API under /v1, but users naturally
+    # configure base_url: http://127.0.0.1:11434 without the version
+    # segment. The OpenAI SDK appends /chat/completions directly, so the
+    # request 404s without the /v1 segment. See [GitHub #7516].
+    if api_mode == "chat_completions" and is_local_endpoint(base_url):
+        base_url = ensure_v1_suffix(base_url)
+
     return {
         "provider": effective_provider,
-        "api_mode": _parse_api_mode(model_cfg.get("api_mode"))
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": api_mode,
         "base_url": base_url,
         "api_key": api_key,
         "source": source,

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -23,6 +23,7 @@ from agent.model_metadata import (
     CONTEXT_PROBE_TIERS,
     DEFAULT_CONTEXT_LENGTHS,
     _strip_provider_prefix,
+    ensure_v1_suffix,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
     get_model_context_length,
@@ -30,6 +31,7 @@ from agent.model_metadata import (
     get_cached_context_length,
     parse_context_limit_from_error,
     save_context_length,
+    strip_v1_suffix,
     fetch_model_metadata,
     _MODEL_CACHE_TTL,
 )
@@ -1022,3 +1024,60 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+
+# =========================================================================
+# /v1 suffix normalization helpers (#7516)
+# =========================================================================
+
+class TestEnsureV1Suffix:
+    """Pin the helper that rescues local OpenAI-compatible base URLs."""
+
+    def test_appends_v1_when_absent(self):
+        # The user's exact #7516 scenario: Ollama on localhost without /v1.
+        assert ensure_v1_suffix("http://127.0.0.1:11434") == "http://127.0.0.1:11434/v1"
+
+    def test_idempotent_when_already_v1(self):
+        assert ensure_v1_suffix("http://127.0.0.1:11434/v1") == "http://127.0.0.1:11434/v1"
+
+    def test_strips_trailing_slash_then_appends(self):
+        # Users sometimes write trailing slashes; the OpenAI SDK then
+        # produces //chat/completions which 404s on stricter servers.
+        assert ensure_v1_suffix("http://127.0.0.1:11434/") == "http://127.0.0.1:11434/v1"
+
+    def test_strips_trailing_slash_after_v1(self):
+        assert ensure_v1_suffix("http://127.0.0.1:11434/v1/") == "http://127.0.0.1:11434/v1"
+
+    def test_empty_string_returns_empty(self):
+        # Defensive: caller is responsible for is_local_endpoint check, but
+        # the helper must not invent a URL when there is none.
+        assert ensure_v1_suffix("") == ""
+
+    def test_none_returns_empty(self):
+        assert ensure_v1_suffix(None) == ""  # type: ignore[arg-type]
+
+
+class TestStripV1Suffix:
+    """Pin the inverse helper used to reach native (non-OpenAI) endpoints
+    on the same local server (e.g. Ollama's /api/show)."""
+
+    def test_strips_v1_when_present(self):
+        assert strip_v1_suffix("http://127.0.0.1:11434/v1") == "http://127.0.0.1:11434"
+
+    def test_no_op_when_absent(self):
+        assert strip_v1_suffix("http://127.0.0.1:11434") == "http://127.0.0.1:11434"
+
+    def test_strips_trailing_slash_then_v1(self):
+        assert strip_v1_suffix("http://127.0.0.1:11434/v1/") == "http://127.0.0.1:11434"
+
+    def test_does_not_strip_v1_in_path_segment(self):
+        # Only the trailing /v1 should go; an intermediate /v1/ in the
+        # path means the server lives there and must be preserved.
+        assert strip_v1_suffix("http://127.0.0.1:8000/v1/proxy") == "http://127.0.0.1:8000/v1/proxy"
+
+    def test_empty_string_returns_empty(self):
+        assert strip_v1_suffix("") == ""
+
+    def test_round_trip_through_ensure_then_strip(self):
+        original = "http://127.0.0.1:11434"
+        assert strip_v1_suffix(ensure_v1_suffix(original)) == original

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1759,6 +1759,109 @@ class TestOllamaUrlSubstringLeak:
 
 
 # =============================================================================
+# Local OpenAI-compatible endpoint /v1 normalization (#7516)
+#
+# Users naturally configure base_url: http://127.0.0.1:11434 for Ollama, but
+# the OpenAI SDK appends /chat/completions directly to base_url so the request
+# 404s without the /v1 segment. resolve_runtime_provider must normalize at
+# the runtime resolution boundary so callers downstream (run_agent.py's
+# OpenAI(**client_kwargs) construction) see the corrected URL.
+# =============================================================================
+
+class TestLocalEndpointV1Normalization:
+    """Pin the #7516 fix at the runtime-resolver boundary."""
+
+    def _make_cfg(self, base_url, api_mode=None):
+        cfg = {"base_url": base_url, "api_key": "", "provider": "custom"}
+        if api_mode:
+            cfg["api_mode"] = api_mode
+        return cfg
+
+    def test_local_loopback_base_url_gets_v1_appended(self, monkeypatch):
+        """The reporter's exact #7516 scenario — Ollama on 127.0.0.1:11434
+        without /v1 in config. Must come back with /v1 so the OpenAI SDK
+        produces /v1/chat/completions instead of /chat/completions."""
+        monkeypatch.setenv("OPENAI_API_KEY", "oa-secret")
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+        monkeypatch.setattr(rp, "_get_model_config", lambda: self._make_cfg(
+            "http://127.0.0.1:11434"
+        ))
+        monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+        monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+        resolved = rp.resolve_runtime_provider(requested="custom")
+
+        assert resolved["base_url"] == "http://127.0.0.1:11434/v1"
+        assert resolved["api_mode"] == "chat_completions"
+
+    def test_local_localhost_base_url_gets_v1_appended(self, monkeypatch):
+        """`localhost` hostname must get the same treatment as `127.0.0.1`."""
+        monkeypatch.setenv("OPENAI_API_KEY", "oa-secret")
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+        monkeypatch.setattr(rp, "_get_model_config", lambda: self._make_cfg(
+            "http://localhost:11434"
+        ))
+        monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+        monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+        resolved = rp.resolve_runtime_provider(requested="custom")
+
+        assert resolved["base_url"] == "http://localhost:11434/v1"
+
+    def test_local_base_url_already_with_v1_is_idempotent(self, monkeypatch):
+        """Users following the workaround (manually appending /v1) must
+        not get a double /v1/v1 path."""
+        monkeypatch.setenv("OPENAI_API_KEY", "oa-secret")
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+        monkeypatch.setattr(rp, "_get_model_config", lambda: self._make_cfg(
+            "http://127.0.0.1:11434/v1"
+        ))
+        monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+        monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+        resolved = rp.resolve_runtime_provider(requested="custom")
+
+        assert resolved["base_url"] == "http://127.0.0.1:11434/v1"
+
+    def test_remote_base_url_is_not_modified(self, monkeypatch):
+        """Negative pin: remote (non-local) custom endpoints must NOT have
+        /v1 force-appended. Only local endpoints have the SDK quirk that
+        the reporter hit, and adding /v1 to e.g. https://api.openrouter.ai
+        would break the URL."""
+        monkeypatch.setenv("OPENAI_API_KEY", "oa-secret")
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+        monkeypatch.setattr(rp, "_get_model_config", lambda: self._make_cfg(
+            "https://api.openrouter.ai"
+        ))
+        monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+        monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+        resolved = rp.resolve_runtime_provider(requested="custom")
+
+        # Remote URL — no /v1 appended.
+        assert resolved["base_url"] == "https://api.openrouter.ai"
+
+    def test_anthropic_messages_local_endpoint_is_not_modified(self, monkeypatch):
+        """Negative pin: `anthropic_messages` mode does NOT need /v1 — the
+        Anthropic SDK appends /v1/messages itself, so /v1 + /v1/messages
+        would produce /v1/v1/messages and 404. The normalization is
+        gated on api_mode == 'chat_completions' precisely to avoid this."""
+        monkeypatch.setenv("OPENAI_API_KEY", "oa-secret")
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+        monkeypatch.setattr(rp, "_get_model_config", lambda: self._make_cfg(
+            "http://127.0.0.1:8080",
+            api_mode="anthropic_messages",
+        ))
+        monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+        monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+        resolved = rp.resolve_runtime_provider(requested="custom")
+
+        assert resolved["api_mode"] == "anthropic_messages"
+        assert resolved["base_url"] == "http://127.0.0.1:8080"
+
+
+# =============================================================================
 # Azure Foundry — both OpenAI-style and Anthropic-style endpoints
 # =============================================================================
 


### PR DESCRIPTION
````
### Summary

Reported by @hexart in #7516: configuring a local Ollama server as a custom provider with `base_url: http://127.0.0.1:11434` causes every chat call to fail with HTTP 404 because the OpenAI Python SDK appends `/chat/completions` directly to the configured `base_url` (`POST http://127.0.0.1:11434/chat/completions`), but Ollama's OpenAI-compatible API lives at `/v1/chat/completions`.

Users naturally write the bare host (`http://127.0.0.1:11434`) because that's what Ollama prints in its docs. The OpenAI SDK contract requires the `/v1` segment, so the resolver must normalize before passing the URL downstream.

Same root cause for any OpenAI-compatible local server (llama.cpp `server`, vLLM, LM Studio, text-generation-webui) — the SDK has no version-segment auto-insert, only the configured root.

### Fix

`agent/model_metadata.py` — two new helper functions colocated with the existing `is_local_endpoint()`:

- `ensure_v1_suffix(base_url)` — returns `base_url` with a single trailing `/v1`. Idempotent for already-`/v1` URLs and tolerant of trailing slashes. Defensive on empty / `None` inputs (returns `""`).
- `strip_v1_suffix(base_url)` — inverse, used when reaching native (non-OpenAI) endpoints on the same local server (e.g. Ollama's `/api/show`).

`hermes_cli/runtime_provider.py` — applies `ensure_v1_suffix()` at the two custom-endpoint resolution sites that produce the user-facing base URL passed to `OpenAI(**client_kwargs)`:

1. **`_resolve_openrouter_runtime`** (the main path for `model.provider: custom + model.base_url: http://127.0.0.1:11434`). Normalization is gated on `api_mode == "chat_completions" AND is_local_endpoint(base_url)` — both halves matter:
   - `chat_completions` only: `anthropic_messages` mode must NOT get `/v1` because the Anthropic SDK appends `/v1/messages` itself, so a pre-existing `/v1` would produce `/v1/v1/messages`. The same gate already protects the Anthropic strip path at lines 248-249 and 285-286.
   - `is_local_endpoint` only: remote OpenAI-compatible endpoints (api.openrouter.ai, api.deepseek.com, etc.) already have the correct path in their advertised base URLs and must not be touched.

2. **`_resolve_named_custom_runtime`** (the path for `custom_providers:` config with a local URL — same SDK-quirk bug surface, same fix). Same gating.

### Verification

`tests/agent/test_model_metadata.py` — new `TestEnsureV1Suffix` and `TestStripV1Suffix` classes, **12 helper unit tests** covering:
- The reporter's exact `http://127.0.0.1:11434` input → `http://127.0.0.1:11434/v1`
- Idempotent on already-`/v1` URLs (no `/v1/v1` double append)
- Trailing-slash tolerance (both `/` and `/v1/`)
- Empty + `None` defensive returns
- `strip_v1_suffix` doesn't strip intermediate `/v1/` path segments — only the trailing one (`http://127.0.0.1:8000/v1/proxy` stays unchanged)
- Round-trip `strip(ensure(url)) == url`

`tests/hermes_cli/test_runtime_provider_resolution.py` — new `TestLocalEndpointV1Normalization` class, **5 integration tests** covering the resolver-level fix:
- Reporter's `127.0.0.1:11434` scenario → `/v1` appended at runtime resolution boundary
- `localhost:11434` → same treatment
- Already-`/v1` config → idempotent (no `/v1/v1`)
- **Negative pin: remote URL** (`https://api.openrouter.ai`) → NOT modified (would break the URL otherwise)
- **Negative pin: `anthropic_messages` mode + local URL** → NOT modified (would break Anthropic SDK path construction)

Test results:

```
$ pytest tests/agent/test_model_metadata.py::TestEnsureV1Suffix tests/agent/test_model_metadata.py::TestStripV1Suffix tests/hermes_cli/test_runtime_provider_resolution.py::TestLocalEndpointV1Normalization -v
…
12 passed (helpers)
5 passed (integration)

$ pytest tests/agent/test_model_metadata.py tests/hermes_cli/test_runtime_provider_resolution.py
219 passed
```