### PR TITLE
feat: add opt-in knowledge ledger toolset

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -63,6 +63,7 @@ CONFIGURABLE_TOOLSETS = [
     ("skills",          "📚 Skills",                    "list, view, manage"),
     ("todo",            "📋 Task Planning",             "todo"),
     ("memory",          "💾 Memory",                    "persistent memory across sessions"),
+    ("knowledge",       "🗃️ Knowledge Ledger",          "cold source-attributed recall; opt-in"),
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
@@ -77,9 +78,10 @@ CONFIGURABLE_TOOLSETS = [
 ]
 
 # Toolsets that are OFF by default for new installs.
-# They're still in _HERMES_CORE_TOOLS (available at runtime if enabled),
-# but the setup checklist won't pre-select them for first-time users.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "rl", "spotify", "discord", "discord_admin", "video"}
+# Some are still in _HERMES_CORE_TOOLS and are removed from fresh defaults;
+# others (like knowledge) are configurable opt-ins that are intentionally not
+# part of the platform composite defaults to avoid surprise schema/token tax.
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "rl", "spotify", "discord", "discord_admin", "video", "knowledge"}
 
 # Platform-scoped toolsets: only appear in the `hermes tools` checklist for
 # these platforms, and only resolve/save for these platforms.  A toolset

--- a/model_tools.py
+++ b/model_tools.py
@@ -32,6 +32,11 @@ from toolsets import resolve_toolset, validate_toolset
 
 logger = logging.getLogger(__name__)
 
+# Toolsets here are available only when explicitly requested.  They are not
+# included by the legacy enabled_toolsets=None path, which otherwise means
+# "walk every registered toolset" for older direct AIAgent callers.
+_OPT_IN_ONLY_TOOLSETS = {"knowledge"}
+
 
 # =============================================================================
 # Async Bridging  (single source of truth -- used by registry.dispatch too)
@@ -357,9 +362,12 @@ def _compute_tool_definitions(
                 if not quiet_mode:
                     print(f"⚠️  Unknown toolset: {toolset_name}")
     else:
-        # Default: start with everything
+        # Default: start with broadly available toolsets, excluding cold opt-ins
+        # whose schema/storage side effects must require an explicit toolset.
         from toolsets import get_all_toolsets
         for ts_name in get_all_toolsets():
+            if ts_name in _OPT_IN_ONLY_TOOLSETS:
+                continue
             tools_to_include.update(resolve_toolset(ts_name))
 
     # Always apply disabled toolsets as a subtraction step at the end.

--- a/tests/tools/test_knowledge_tool.py
+++ b/tests/tools/test_knowledge_tool.py
@@ -1,0 +1,273 @@
+"""Tests for the Hermes knowledge ledger toolset.
+
+The knowledge ledger is intentionally cold/on-demand: records live under
+$HERMES_HOME/knowledge and are never injected into the system prompt by default.
+"""
+
+import json
+
+
+def _json(result: str) -> dict:
+    return json.loads(result)
+
+
+class TestKnowledgeCapture:
+    def test_non_inbox_records_require_source_attribution(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: tmp_path / "knowledge")
+
+        result = _json(kt.knowledge_capture_tool(
+            kind="decisions",
+            title="Adopt MemKraft wholesale",
+            content="Rejected: too much overlap with hot memory and session_search.",
+        ))
+
+        assert result["success"] is False
+        assert "source" in result["error"].lower()
+        assert not (tmp_path / "knowledge" / "decisions").exists()
+
+    def test_inbox_allows_unsourced_candidate_records(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: tmp_path / "knowledge")
+
+        result = _json(kt.knowledge_capture_tool(
+            kind="inbox",
+            title="Possible project convention",
+            content="The project may prefer pytest -q for focused tests.",
+        ))
+
+        assert result["success"] is True
+        assert result["kind"] == "inbox"
+        assert result["status"] == "candidate"
+        record_path = tmp_path / "knowledge" / result["path"]
+        assert record_path.exists()
+        text = record_path.read_text(encoding="utf-8")
+        assert "status: candidate" in text
+        assert "confidence: candidate" in text
+
+    def test_unsourced_inbox_forces_candidate_status_and_confidence(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: tmp_path / "knowledge")
+
+        result = _json(kt.knowledge_capture_tool(
+            kind="inbox",
+            title="Unverified extraction",
+            content="Automatically extracted claim awaiting source review.",
+            status="active",
+            confidence="confirmed",
+        ))
+
+        assert result["success"] is True
+        assert result["status"] == "candidate"
+        assert result["confidence"] == "candidate"
+        text = (tmp_path / "knowledge" / result["path"]).read_text(encoding="utf-8")
+        assert "status: candidate" in text
+        assert "confidence: candidate" in text
+
+    def test_capture_rejects_symlinked_kind_directory(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        knowledge_dir = tmp_path / "knowledge"
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        knowledge_dir.mkdir()
+        (knowledge_dir / "inbox").symlink_to(outside_dir, target_is_directory=True)
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: knowledge_dir)
+
+        result = _json(kt.knowledge_capture_tool(
+            kind="inbox",
+            title="Directory symlink guard",
+            content="This must not be written outside knowledge.",
+        ))
+
+        assert result["success"] is False
+        assert "symlink" in result["error"].lower() or "outside" in result["error"].lower()
+        assert not any(outside_dir.iterdir())
+
+    def test_capture_rejects_symlinked_knowledge_root(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        real_root = tmp_path / "real-knowledge"
+        real_root.mkdir()
+        symlink_root = tmp_path / "knowledge"
+        symlink_root.symlink_to(real_root, target_is_directory=True)
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: symlink_root)
+
+        result = _json(kt.knowledge_capture_tool(
+            kind="inbox",
+            title="Root symlink guard",
+            content="This must not be written through a symlinked knowledge root.",
+        ))
+
+        assert result["success"] is False
+        assert "symlink" in result["error"].lower()
+        assert not any(real_root.iterdir())
+
+    def test_capture_writes_source_attributed_markdown_record(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: tmp_path / "knowledge")
+
+        result = _json(kt.knowledge_capture_tool(
+            kind="decisions",
+            title="MemKraft adoption boundary",
+            content="Use a cold source-attributed ledger, not a hot memory replacement.",
+            sources=["conversation:discord:Agent/#1/Ping"],
+            confidence="observed",
+            tags=["memory", "roi"],
+        ))
+
+        assert result["success"] is True
+        assert result["id"].startswith("decisions/")
+        assert result["path"].startswith("decisions/")
+        record_path = tmp_path / "knowledge" / result["path"]
+        text = record_path.read_text(encoding="utf-8")
+        assert text.startswith("---\n")
+        assert "type: decisions" in text
+        assert "confidence: observed" in text
+        assert "sources:" in text
+        assert "- conversation:discord:Agent/#1/Ping" in text
+        assert "# MemKraft adoption boundary" in text
+        assert "Use a cold source-attributed ledger" in text
+
+    def test_capture_does_not_follow_broken_symlink_record_paths(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        knowledge_dir = tmp_path / "knowledge"
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: knowledge_dir)
+        monkeypatch.setattr(kt, "_now_iso", lambda: "2026-05-04T00:00:00Z")
+        record_path = knowledge_dir / "inbox" / "20260504T000000Z-symlink-guard.md"
+        outside_target = tmp_path / "outside.md"
+        record_path.parent.mkdir(parents=True)
+        record_path.symlink_to(outside_target)
+
+        result = _json(kt.knowledge_capture_tool(
+            kind="inbox",
+            title="Symlink Guard",
+            content="Write inside the knowledge ledger only.",
+        ))
+
+        assert result["success"] is True
+        assert result["path"] == "inbox/20260504T000000Z-symlink-guard.md"
+        assert record_path.exists()
+        assert not record_path.is_symlink()
+        assert not outside_target.exists()
+
+
+class TestKnowledgeSearchAndGet:
+    def test_search_returns_ranked_snippets_not_full_hot_memory_dump(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: tmp_path / "knowledge")
+        kt.knowledge_capture_tool(
+            kind="debug",
+            title="Discord role rename failure",
+            content="Discord returned 403 Missing Permissions because the managed bot role hierarchy blocks role rename.",
+            sources=["terminal:discord-rest-probe"],
+            confidence="confirmed",
+            tags=["discord", "roles"],
+        )
+        kt.knowledge_capture_tool(
+            kind="decisions",
+            title="Knowledge ledger token policy",
+            content="Knowledge records are cold storage and retrieved on demand only.",
+            sources=["conversation:memkraft-triage"],
+            confidence="observed",
+        )
+
+        result = _json(kt.knowledge_search_tool(query="role hierarchy", limit=5))
+
+        assert result["success"] is True
+        assert result["count"] >= 1
+        assert result["results"][0]["title"] == "Discord role rename failure"
+        assert "role hierarchy" in result["results"][0]["snippet"]
+        assert "Knowledge records are cold storage" not in result["results"][0]["snippet"]
+
+    def test_get_reads_record_by_id_and_blocks_traversal(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: tmp_path / "knowledge")
+        captured = _json(kt.knowledge_capture_tool(
+            kind="skill-evals",
+            title="Skill patch needed",
+            content="Patch skills immediately when a loaded skill is stale.",
+            sources=["skill:test-driven-development"],
+            confidence="observed",
+        ))
+
+        fetched = _json(kt.knowledge_get_tool(id=captured["id"]))
+        assert fetched["success"] is True
+        assert fetched["id"] == captured["id"]
+        assert "Patch skills immediately" in fetched["content"]
+
+        traversal = _json(kt.knowledge_get_tool(path="../memories/MEMORY.md"))
+        assert traversal["success"] is False
+        assert "outside" in traversal["error"].lower() or "traversal" in traversal["error"].lower()
+
+    def test_search_skips_symlink_records_that_resolve_outside_knowledge_dir(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        knowledge_dir = tmp_path / "knowledge"
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: knowledge_dir)
+        outside = tmp_path / "outside.md"
+        outside.write_text("# Outside\n\nsecret outside content", encoding="utf-8")
+        inbox_dir = knowledge_dir / "inbox"
+        inbox_dir.mkdir(parents=True)
+        (inbox_dir / "evil.md").symlink_to(outside)
+
+        result = _json(kt.knowledge_search_tool(query="secret outside", limit=5))
+
+        assert result["success"] is True
+        assert result["count"] == 0
+        assert result["results"] == []
+
+
+class TestKnowledgeToolsetWiring:
+    def test_knowledge_toolset_is_configurable_but_not_default_core(self):
+        import toolsets
+        from hermes_cli import tools_config
+
+        configurable = {name for name, _label, _desc in tools_config.CONFIGURABLE_TOOLSETS}
+        assert "knowledge" in configurable
+        assert "knowledge" in tools_config._DEFAULT_OFF_TOOLSETS
+        assert "knowledge" in toolsets.TOOLSETS
+
+        knowledge_tools = set(toolsets.resolve_toolset("knowledge"))
+        assert knowledge_tools == {
+            "knowledge_capture",
+            "knowledge_search",
+            "knowledge_get",
+        }
+        assert knowledge_tools.isdisjoint(set(toolsets._HERMES_CORE_TOOLS))
+
+    def test_knowledge_tools_require_explicit_toolset_resolution(self):
+        from model_tools import get_tool_definitions
+
+        default_tools = {
+            tool["function"]["name"]
+            for tool in get_tool_definitions(quiet_mode=True)
+        }
+        assert "knowledge_capture" not in default_tools
+        assert "knowledge_search" not in default_tools
+        assert "knowledge_get" not in default_tools
+
+        explicit_tools = {
+            tool["function"]["name"]
+            for tool in get_tool_definitions(enabled_toolsets=["knowledge"], quiet_mode=True)
+        }
+        assert {
+            "knowledge_capture",
+            "knowledge_search",
+            "knowledge_get",
+        }.issubset(explicit_tools)
+
+    def test_capture_schema_states_cold_on_demand_contract(self):
+        from tools.knowledge_tool import KNOWLEDGE_CAPTURE_SCHEMA
+
+        description = KNOWLEDGE_CAPTURE_SCHEMA["description"]
+        assert "not injected" in description.lower()
+        assert "source" in description.lower()
+        assert "inbox" in description.lower()

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -305,6 +305,7 @@ class TestBuiltinDiscovery:
             "tools.homeassistant_tool",
             "tools.image_generation_tool",
             "tools.kanban_tools",
+            "tools.knowledge_tool",
             "tools.memory_tool",
             "tools.mixture_of_agents_tool",
             "tools.process_registry",

--- a/tools/knowledge_tool.py
+++ b/tools/knowledge_tool.py
@@ -1,0 +1,714 @@
+#!/usr/bin/env python3
+"""
+Knowledge Ledger Tool Module - Cold, source-attributed local knowledge.
+
+This toolset intentionally complements, rather than replaces, Hermes memory:
+- MEMORY.md / USER.md stay small hot memory and are injected at session start.
+- session_search remains episodic recall over raw conversations.
+- skills remain procedural memory.
+- knowledge/ is a cold/on-demand ledger for source-backed decisions,
+  debugging histories, skill evaluations, project state, incidents, and
+  inbox candidates.
+
+Records live under $HERMES_HOME/knowledge/*. They are never injected into the
+system prompt automatically; agents must explicitly call knowledge_search and
+knowledge_get when the user/task needs grounded recall.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry, tool_result
+
+
+# ---------------------------------------------------------------------------
+# Paths and constants
+# ---------------------------------------------------------------------------
+
+ALLOWED_KINDS = {
+    "inbox",
+    "decisions",
+    "debug",
+    "skill-evals",
+    "projects",
+    "incidents",
+    "entities",
+    "sources",
+}
+
+KIND_ALIASES = {
+    "decision": "decisions",
+    "decisions": "decisions",
+    "debug": "debug",
+    "debugging": "debug",
+    "skill_eval": "skill-evals",
+    "skill-eval": "skill-evals",
+    "skill_evals": "skill-evals",
+    "skill-evals": "skill-evals",
+    "project": "projects",
+    "projects": "projects",
+    "incident": "incidents",
+    "incidents": "incidents",
+    "entity": "entities",
+    "entities": "entities",
+    "source": "sources",
+    "sources": "sources",
+    "inbox": "inbox",
+    "candidate": "inbox",
+}
+
+CONFIDENCE_VALUES = {"candidate", "observed", "confirmed", "inferred", "experimental", "stale"}
+DEFAULT_SEARCH_KINDS = [
+    "decisions",
+    "debug",
+    "skill-evals",
+    "projects",
+    "incidents",
+    "entities",
+    "sources",
+    "inbox",
+]
+
+
+def get_knowledge_dir() -> Path:
+    """Return the profile-scoped cold knowledge ledger directory."""
+    return get_hermes_home() / "knowledge"
+
+
+def check_knowledge_requirements() -> bool:
+    """The local knowledge ledger has no external requirements."""
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Normalization and rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _normalize_kind(kind: str | None) -> str:
+    raw = (kind or "inbox").strip().lower().replace("_", "-")
+    normalized = KIND_ALIASES.get(raw)
+    if not normalized:
+        raise ValueError(
+            f"Unknown knowledge kind '{kind}'. Use one of: {', '.join(sorted(ALLOWED_KINDS))}."
+        )
+    return normalized
+
+
+def _clean_string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _clean_list(values: Any) -> List[str]:
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, Iterable):
+        return []
+    cleaned: List[str] = []
+    for value in values:
+        item = _clean_string(value)
+        if item and item not in cleaned:
+            cleaned.append(item)
+    return cleaned
+
+
+def _normalize_confidence(confidence: str | None, *, has_sources: bool, kind: str) -> str:
+    raw = (confidence or "").strip().lower()
+    if not raw:
+        return "candidate" if kind == "inbox" and not has_sources else "observed"
+    if raw not in CONFIDENCE_VALUES:
+        raise ValueError(
+            f"Unknown confidence '{confidence}'. Use one of: {', '.join(sorted(CONFIDENCE_VALUES))}."
+        )
+    return raw
+
+
+def _slugify(title: str, fallback: str = "record") -> str:
+    slug = re.sub(r"[^a-zA-Z0-9가-힣._-]+", "-", title.strip().lower())
+    slug = re.sub(r"-+", "-", slug).strip("-._")
+    return slug[:80] or fallback
+
+
+def _yaml_scalar(value: Any) -> str:
+    text = _clean_string(value)
+    # Keep frontmatter simple and grep-friendly. Quote only when needed.
+    if not text:
+        return '""'
+    if re.search(r"[:#\[\]{}\n\r]|^[-?]|\s$|^\s", text):
+        return json.dumps(text, ensure_ascii=False)
+    return text
+
+
+def _frontmatter(metadata: Dict[str, Any]) -> str:
+    lines = ["---"]
+    for key, value in metadata.items():
+        if isinstance(value, list):
+            if value:
+                lines.append(f"{key}:")
+                for item in value:
+                    lines.append(f"- {_yaml_scalar(item)}")
+            else:
+                lines.append(f"{key}: []")
+        else:
+            lines.append(f"{key}: {_yaml_scalar(value)}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _render_record(
+    *,
+    record_id: str,
+    kind: str,
+    title: str,
+    content: str,
+    sources: List[str],
+    confidence: str,
+    status: str,
+    tags: List[str],
+    timestamp: str,
+) -> str:
+    metadata: Dict[str, Any] = {
+        "id": record_id,
+        "type": kind,
+        "title": title,
+        "status": status,
+        "confidence": confidence,
+        "created_at": timestamp,
+        "updated_at": timestamp,
+        "tags": tags,
+        "sources": sources,
+    }
+    sections = [
+        _frontmatter(metadata),
+        "",
+        f"# {title}",
+        "",
+        "## Current State",
+        content.rstrip(),
+        "",
+        "## Timeline",
+        f"- {timestamp} — Captured as `{kind}` record.",
+        "",
+        "## Evidence",
+    ]
+    if sources:
+        sections.extend(f"- {source}" for source in sources)
+    else:
+        sections.append("- Candidate only: no source supplied yet.")
+    sections.extend([
+        "",
+        "## Conflicts",
+        "- None recorded.",
+        "",
+        "## Open Threads",
+        "- [ ] Review/merge/delete during knowledge digest.",
+        "",
+    ])
+    return "\n".join(sections)
+
+
+def _safe_knowledge_root(*, create: bool = False) -> Path:
+    """Return the ledger root without accepting a symlinked root directory."""
+    root = get_knowledge_dir()
+    if root.is_symlink():
+        raise ValueError("Knowledge directory cannot be a symlink.")
+    if create:
+        root.mkdir(parents=True, exist_ok=True)
+        if root.is_symlink():
+            raise ValueError("Knowledge directory cannot be a symlink.")
+    return root
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.stem}_", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        # Knowledge records must stay confined to $HERMES_HOME/knowledge.
+        # Use os.replace directly instead of utils.atomic_replace, because that
+        # helper intentionally follows target symlinks for config-file use cases.
+        # For ledger records, following a symlink could write outside knowledge/.
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _safe_kind_dir(kind: str) -> Path:
+    """Create/return a knowledge kind directory without following kind symlinks."""
+    root = _safe_knowledge_root(create=True)
+    root_resolved = root.resolve()
+    directory = root / kind
+    directory.mkdir(parents=True, exist_ok=True)
+    if directory.is_symlink():
+        raise ValueError(f"Knowledge kind directory cannot be a symlink: {kind}")
+    try:
+        directory.resolve().relative_to(root_resolved)
+    except (OSError, ValueError) as exc:
+        raise ValueError("Knowledge kind directory resolves outside the knowledge directory.") from exc
+    return directory
+
+
+def _unique_record_path(kind: str, title: str, timestamp: str) -> Tuple[str, Path]:
+    directory = _safe_kind_dir(kind)
+    stamp = timestamp.replace(":", "").replace("-", "").replace("Z", "Z")
+    stem_base = f"{stamp}-{_slugify(title)}"
+    stem = stem_base
+    path = directory / f"{stem}.md"
+    counter = 2
+    while path.exists():
+        stem = f"{stem_base}-{counter}"
+        path = directory / f"{stem}.md"
+        counter += 1
+    record_id = f"{kind}/{stem}"
+    return record_id, path
+
+
+def _relative_to_root(path: Path) -> str:
+    return path.relative_to(get_knowledge_dir()).as_posix()
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing and path safety
+# ---------------------------------------------------------------------------
+
+
+def _parse_frontmatter(text: str) -> Tuple[Dict[str, Any], str]:
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, text
+    block = text[4:end]
+    body = text[end + len("\n---\n"):]
+    meta: Dict[str, Any] = {}
+    current_list_key: Optional[str] = None
+    for raw_line in block.splitlines():
+        line = raw_line.rstrip()
+        if not line:
+            continue
+        if line.startswith("- ") and current_list_key:
+            meta.setdefault(current_list_key, []).append(_unquote_scalar(line[2:].strip()))
+            continue
+        if ":" not in line:
+            current_list_key = None
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not value:
+            meta[key] = []
+            current_list_key = key
+        elif value == "[]":
+            meta[key] = []
+            current_list_key = None
+        else:
+            meta[key] = _unquote_scalar(value)
+            current_list_key = None
+    return meta, body
+
+
+def _unquote_scalar(value: str) -> str:
+    if not value:
+        return ""
+    if value[0] in {'"', "'"}:
+        try:
+            return str(json.loads(value))
+        except Exception:
+            return value.strip('"\'')
+    return value
+
+
+def _title_from_text(meta: Dict[str, Any], body: str, path: Path) -> str:
+    if meta.get("title"):
+        return str(meta["title"])
+    for line in body.splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return path.stem
+
+
+def _safe_record_path(*, record_id: str | None = None, rel_path: str | None = None) -> Path:
+    root = _safe_knowledge_root(create=False).resolve()
+    if record_id:
+        candidate = record_id.strip()
+        if not candidate.endswith(".md"):
+            candidate = f"{candidate}.md"
+    elif rel_path:
+        candidate = rel_path.strip()
+    else:
+        raise ValueError("Provide id or path.")
+
+    path = Path(candidate)
+    if path.is_absolute():
+        raise ValueError("Absolute paths are not allowed for knowledge records.")
+    resolved = (root / path).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("Path traversal outside the knowledge directory is not allowed.") from exc
+    return resolved
+
+
+def _iter_record_paths(kind: str | None = None) -> Iterable[Path]:
+    root = _safe_knowledge_root(create=False)
+    root_resolved = root.resolve()
+    if kind:
+        kinds = [_normalize_kind(kind)]
+    else:
+        kinds = DEFAULT_SEARCH_KINDS
+    for k in kinds:
+        directory = root / k
+        for path in sorted(directory.glob("*.md")):
+            try:
+                path.resolve().relative_to(root_resolved)
+            except (OSError, ValueError):
+                # Do not follow symlinked ledger entries outside knowledge/.
+                continue
+            yield path
+
+
+# ---------------------------------------------------------------------------
+# Tool implementations
+# ---------------------------------------------------------------------------
+
+
+def knowledge_capture_tool(
+    kind: str = "inbox",
+    title: str = "",
+    content: str = "",
+    sources: Optional[List[str]] = None,
+    confidence: Optional[str] = None,
+    tags: Optional[List[str]] = None,
+    status: Optional[str] = None,
+) -> str:
+    """Create a new cold knowledge ledger record."""
+    try:
+        normalized_kind = _normalize_kind(kind)
+        clean_title = _clean_string(title)
+        clean_content = _clean_string(content)
+        clean_sources = _clean_list(sources)
+        clean_tags = _clean_list(tags)
+
+        if not clean_title:
+            return tool_result(success=False, error="title cannot be empty.")
+        if not clean_content:
+            return tool_result(success=False, error="content cannot be empty.")
+        if normalized_kind != "inbox" and not clean_sources:
+            return tool_result(
+                success=False,
+                error=(
+                    "source attribution is required for non-inbox knowledge records. "
+                    "Capture unsourced material as kind='inbox' candidate, or provide sources."
+                ),
+            )
+
+        unsourced_inbox = normalized_kind == "inbox" and not clean_sources
+        clean_confidence = _normalize_confidence(
+            confidence,
+            has_sources=bool(clean_sources),
+            kind=normalized_kind,
+        )
+        if unsourced_inbox:
+            clean_confidence = "candidate"
+            clean_status = "candidate"
+        else:
+            clean_status = _clean_string(status) or ("candidate" if normalized_kind == "inbox" else "active")
+        timestamp = _now_iso()
+        record_id, path = _unique_record_path(normalized_kind, clean_title, timestamp)
+        markdown = _render_record(
+            record_id=record_id,
+            kind=normalized_kind,
+            title=clean_title,
+            content=clean_content,
+            sources=clean_sources,
+            confidence=clean_confidence,
+            status=clean_status,
+            tags=clean_tags,
+            timestamp=timestamp,
+        )
+        _atomic_write_text(path, markdown)
+        return tool_result(
+            success=True,
+            id=record_id,
+            kind=normalized_kind,
+            status=clean_status,
+            confidence=clean_confidence,
+            path=_relative_to_root(path),
+            message=(
+                "Knowledge record captured in cold storage. It is not injected into the "
+                "system prompt; use knowledge_search/knowledge_get for on-demand recall."
+            ),
+        )
+    except Exception as exc:
+        return tool_result(success=False, error=str(exc))
+
+
+def _score_record(query_terms: List[str], title: str, body: str, meta: Dict[str, Any]) -> int:
+    haystacks = {
+        "title": title.lower(),
+        "body": body.lower(),
+        "tags": " ".join(meta.get("tags") or []).lower() if isinstance(meta.get("tags"), list) else "",
+        "sources": " ".join(meta.get("sources") or []).lower() if isinstance(meta.get("sources"), list) else "",
+    }
+    score = 0
+    for term in query_terms:
+        if not term:
+            continue
+        if term in haystacks["title"]:
+            score += 5
+        if term in haystacks["tags"]:
+            score += 3
+        if term in haystacks["sources"]:
+            score += 2
+        body_hits = haystacks["body"].count(term)
+        score += min(body_hits, 5)
+    phrase = " ".join(query_terms).strip()
+    if phrase and phrase in haystacks["body"]:
+        score += 4
+    if phrase and phrase in haystacks["title"]:
+        score += 8
+    return score
+
+
+def _snippet(body: str, query_terms: List[str], max_chars: int = 280) -> str:
+    lower = body.lower()
+    positions = [lower.find(term) for term in query_terms if term and lower.find(term) != -1]
+    if positions:
+        start = max(0, min(positions) - 80)
+    else:
+        start = 0
+    snippet = re.sub(r"\s+", " ", body[start:start + max_chars]).strip()
+    if start > 0:
+        snippet = "…" + snippet
+    if start + max_chars < len(body):
+        snippet += "…"
+    return snippet
+
+
+def knowledge_search_tool(
+    query: str,
+    kind: Optional[str] = None,
+    limit: int = 5,
+) -> str:
+    """Lexically search the cold knowledge ledger and return short snippets."""
+    try:
+        clean_query = _clean_string(query)
+        if not clean_query:
+            return tool_result(success=False, error="query cannot be empty.")
+        try:
+            limit = max(1, min(int(limit), 20))
+        except Exception:
+            limit = 5
+        terms = [t for t in re.findall(r"[\w가-힣._-]+", clean_query.lower()) if t]
+        if not terms:
+            terms = [clean_query.lower()]
+
+        rows: List[Dict[str, Any]] = []
+        for path in _iter_record_paths(kind):
+            try:
+                text = path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            meta, body = _parse_frontmatter(text)
+            title = _title_from_text(meta, body, path)
+            score = _score_record(terms, title, body, meta)
+            if score <= 0:
+                continue
+            rel = _relative_to_root(path)
+            rows.append({
+                "id": str(meta.get("id") or rel.removesuffix(".md")),
+                "kind": str(meta.get("type") or path.parent.name),
+                "title": title,
+                "path": rel,
+                "score": score,
+                "confidence": meta.get("confidence"),
+                "status": meta.get("status"),
+                "updated_at": meta.get("updated_at"),
+                "sources": meta.get("sources") or [],
+                "snippet": _snippet(body, terms),
+            })
+
+        rows.sort(key=lambda r: (r["score"], r.get("updated_at") or ""), reverse=True)
+        return tool_result(success=True, query=clean_query, count=len(rows[:limit]), results=rows[:limit])
+    except Exception as exc:
+        return tool_result(success=False, error=str(exc))
+
+
+def knowledge_get_tool(id: Optional[str] = None, path: Optional[str] = None) -> str:
+    """Read a single knowledge record by id or relative path."""
+    try:
+        record_path = _safe_record_path(record_id=id, rel_path=path)
+        if not record_path.exists():
+            return tool_result(success=False, error=f"Knowledge record not found: {id or path}")
+        text = record_path.read_text(encoding="utf-8")
+        meta, body = _parse_frontmatter(text)
+        rel = _relative_to_root(record_path)
+        return tool_result(
+            success=True,
+            id=str(meta.get("id") or rel.removesuffix(".md")),
+            kind=str(meta.get("type") or record_path.parent.name),
+            title=_title_from_text(meta, body, record_path),
+            path=rel,
+            metadata=meta,
+            content=text,
+        )
+    except Exception as exc:
+        return tool_result(success=False, error=str(exc))
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Function-Calling Schemas
+# ---------------------------------------------------------------------------
+
+KNOWLEDGE_CAPTURE_SCHEMA = {
+    "name": "knowledge_capture",
+    "description": (
+        "Capture a cold, source-attributed knowledge ledger record under "
+        "$HERMES_HOME/knowledge. Records are NOT injected into the system prompt "
+        "or hot memory; use knowledge_search/knowledge_get for on-demand recall. "
+        "Use for durable decisions, debug findings, skill evaluations, project state, "
+        "incidents, entities, sources, or inbox candidates. Non-inbox records require "
+        "at least one source. Unsourced/automatic extraction must go to kind='inbox' "
+        "as a candidate for later human/agent review."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "kind": {
+                "type": "string",
+                "enum": sorted(ALLOWED_KINDS),
+                "description": "Ledger section. Non-inbox sections require sources.",
+                "default": "inbox",
+            },
+            "title": {"type": "string", "description": "Short record title."},
+            "content": {"type": "string", "description": "Record body / current state."},
+            "sources": {
+                "type": "array",
+                "description": "Source handles, URLs, commands, files, logs, or conversation references.",
+                "items": {"type": "string"},
+            },
+            "confidence": {
+                "type": "string",
+                "enum": sorted(CONFIDENCE_VALUES),
+                "description": "Confidence level. Defaults to candidate for unsourced inbox, observed otherwise.",
+            },
+            "tags": {
+                "type": "array",
+                "description": "Optional short tags for lexical retrieval.",
+                "items": {"type": "string"},
+            },
+            "status": {
+                "type": "string",
+                "description": "Optional lifecycle status (candidate, active, resolved, superseded, stale, etc.).",
+            },
+        },
+        "required": ["title", "content"],
+    },
+}
+
+KNOWLEDGE_SEARCH_SCHEMA = {
+    "name": "knowledge_search",
+    "description": (
+        "Search the cold Hermes knowledge ledger on demand. Returns ranked metadata "
+        "and short snippets only, not a full memory dump. Use before knowledge_get "
+        "when recalling source-backed decisions, debug histories, skill evaluations, "
+        "or project state."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Lexical search query."},
+            "kind": {
+                "type": "string",
+                "enum": sorted(ALLOWED_KINDS),
+                "description": "Optional section filter.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of results (1-20).",
+                "default": 5,
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+KNOWLEDGE_GET_SCHEMA = {
+    "name": "knowledge_get",
+    "description": (
+        "Read one cold knowledge ledger record by id or relative path after search. "
+        "Paths are constrained to $HERMES_HOME/knowledge to prevent traversal."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "description": "Record id, e.g. decisions/20260504T120000Z-title."},
+            "path": {"type": "string", "description": "Relative path returned by knowledge_search/capture."},
+        },
+        "required": [],
+    },
+}
+
+
+registry.register(
+    name="knowledge_capture",
+    toolset="knowledge",
+    schema=KNOWLEDGE_CAPTURE_SCHEMA,
+    handler=lambda args, **kw: knowledge_capture_tool(
+        kind=args.get("kind", "inbox"),
+        title=args.get("title", ""),
+        content=args.get("content", ""),
+        sources=args.get("sources"),
+        confidence=args.get("confidence"),
+        tags=args.get("tags"),
+        status=args.get("status"),
+    ),
+    check_fn=check_knowledge_requirements,
+    emoji="🗃️",
+)
+
+registry.register(
+    name="knowledge_search",
+    toolset="knowledge",
+    schema=KNOWLEDGE_SEARCH_SCHEMA,
+    handler=lambda args, **kw: knowledge_search_tool(
+        query=args.get("query", ""),
+        kind=args.get("kind"),
+        limit=args.get("limit", 5),
+    ),
+    check_fn=check_knowledge_requirements,
+    emoji="🔎",
+)
+
+registry.register(
+    name="knowledge_get",
+    toolset="knowledge",
+    schema=KNOWLEDGE_GET_SCHEMA,
+    handler=lambda args, **kw: knowledge_get_tool(
+        id=args.get("id"),
+        path=args.get("path"),
+    ),
+    check_fn=check_knowledge_requirements,
+    emoji="📄",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -179,6 +179,12 @@ TOOLSETS = {
         "tools": ["memory"],
         "includes": []
     },
+
+    "knowledge": {
+        "description": "Cold, source-attributed local knowledge ledger (on-demand; not hot memory)",
+        "tools": ["knowledge_capture", "knowledge_search", "knowledge_get"],
+        "includes": []
+    },
     
     "session_search": {
         "description": "Search and recall past conversations with summarization",

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -29,7 +29,7 @@ It's not a coding copilot tethered to an IDE or a chatbot wrapper around a singl
 | 🗺️ **[Learning Path](/docs/getting-started/learning-path)** | Find the right docs for your experience level |
 | ⚙️ **[Configuration](/docs/user-guide/configuration)** | Config file, providers, models, and options |
 | 💬 **[Messaging Gateway](/docs/user-guide/messaging)** | Set up Telegram, Discord, Slack, WhatsApp, Teams, or more |
-| 🔧 **[Tools & Toolsets](/docs/user-guide/features/tools)** | 68 built-in tools and how to configure them |
+| 🔧 **[Tools & Toolsets](/docs/user-guide/features/tools)** | Built-in tools and how to configure them |
 | 🧠 **[Memory System](/docs/user-guide/features/memory)** | Persistent memory that grows across sessions |
 | 📚 **[Skills System](/docs/user-guide/features/skills)** | Procedural memory the agent creates and reuses |
 | 🔌 **[MCP Integration](/docs/user-guide/features/mcp)** | Connect to MCP servers, filter their tools, and extend Hermes safely |

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -6,9 +6,9 @@ description: "Authoritative reference for Hermes built-in tools, grouped by tool
 
 # Built-in Tools Reference
 
-This page documents all 68 built-in tools in the Hermes tool registry, grouped by toolset. Availability varies by platform, credentials, and enabled toolsets.
+This page documents built-in tools in the Hermes tool registry, grouped by toolset. Availability varies by platform, credentials, and enabled toolsets.
 
-**Quick counts:** 10 browser tools (core) + 2 browser-cdp tools, 4 file tools, 10 RL tools, 4 Home Assistant tools, 2 terminal tools, 2 web tools, 5 Feishu tools, 7 Spotify tools, 5 Yuanbao tools, 2 Discord tools, and 15 standalone tools across other toolsets.
+**Quick overview:** Hermes ships built-in browser, file, terminal, web, RL, Home Assistant, Feishu, Spotify, Yuanbao, Discord, Kanban, knowledge-ledger, and standalone tools. Availability varies by platform, credentials, and enabled toolsets.
 
 :::tip MCP Tools
 In addition to built-in tools, Hermes can load tools dynamically from MCP servers. MCP tools appear with a server-name prefix (e.g., `github_create_issue` for the `github` MCP server). See [MCP Integration](/docs/user-guide/features/mcp) for configuration.
@@ -114,6 +114,16 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
 | `memory` | Save important information to persistent memory that survives across sessions. Your memory appears in your system prompt at session start -- it's how you remember things about the user and your environment between conversations. WHEN TO SA… | — |
+
+## `knowledge` toolset
+
+Opt-in cold source-attributed recall. Not included in default platform toolsets; enable explicitly when you want on-demand knowledge records without adding prompt tax to every session.
+
+| Tool | Description | Requires environment |
+|------|-------------|----------------------|
+| `knowledge_capture` | Capture a cold, source-attributed knowledge ledger record under `$HERMES_HOME/knowledge`. Non-inbox records require at least one source; unsourced automatic extraction goes to `inbox` as a candidate. | — |
+| `knowledge_search` | Lexically search the cold knowledge ledger and return ranked metadata plus short snippets, not a full memory dump. | — |
+| `knowledge_get` | Read one knowledge record by id or relative path after search. Paths are constrained to the knowledge directory. | — |
 
 ## `messaging` toolset
 

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -66,6 +66,7 @@ Or in-session:
 | `homeassistant` | `ha_call_service`, `ha_get_state`, `ha_list_entities`, `ha_list_services` | Smart home control via Home Assistant. Only available when `HASS_TOKEN` is set. |
 | `image_gen` | `image_generate` | Text-to-image generation via FAL.ai (with opt-in OpenAI / xAI backends). |
 | `memory` | `memory` | Persistent cross-session memory management. |
+| `knowledge` | `knowledge_capture`, `knowledge_get`, `knowledge_search` | Opt-in cold source-attributed ledger for decisions, debug histories, skill evaluations, and project state. Not included in default platform toolsets; enable explicitly to avoid schema/token tax. |
 | `messaging` | `send_message` | Send messages to other platforms (Telegram, Discord, etc.) from within a session. |
 | `moa` | `mixture_of_agents` | Multi-model consensus via Mixture of Agents. |
 | `rl` | `rl_check_status`, `rl_edit_config`, `rl_get_current_config`, `rl_get_results`, `rl_list_environments`, `rl_list_runs`, `rl_select_environment`, `rl_start_training`, `rl_stop_training`, `rl_test_inference` | RL training environment management (Atropos). |

--- a/website/docs/user-guide/features/knowledge-ledger.md
+++ b/website/docs/user-guide/features/knowledge-ledger.md
@@ -1,0 +1,94 @@
+---
+sidebar_position: 5
+title: "Knowledge Ledger"
+description: "Cold, source-attributed recall for decisions, debug histories, skill evaluations, and project state"
+---
+
+# Knowledge Ledger
+
+The knowledge ledger is an opt-in cold storage layer for durable, source-backed facts that are too large or too specific for `MEMORY.md` / `USER.md`.
+
+It stores Markdown records under:
+
+```text
+$HERMES_HOME/knowledge/
+├── inbox/
+├── decisions/
+├── debug/
+├── skill-evals/
+├── projects/
+├── incidents/
+├── entities/
+└── sources/
+```
+
+## How It Differs from Memory
+
+| Layer | Use for | Prompt cost |
+|---|---|---|
+| `MEMORY.md` / `USER.md` | Small hot facts that should always be visible | Always injected |
+| `session_search` | Past conversation recall | On demand |
+| Skills | Procedures and workflows | Loaded when relevant |
+| Knowledge ledger | Source-backed decisions, debug findings, project state | On demand only |
+
+Knowledge records are **not injected into the system prompt**. The agent must call `knowledge_search` and then `knowledge_get` when a task needs them.
+
+## Tools
+
+Enable the `knowledge` toolset with `hermes tools` or for a single run with `--toolsets knowledge,...`.
+
+The toolset contains:
+
+- `knowledge_capture` — create a Markdown record.
+- `knowledge_search` — lexical search that returns short snippets, not a full dump.
+- `knowledge_get` — read one record by id or relative path.
+
+## Source Attribution Rule
+
+Non-inbox records require at least one source. Examples:
+
+- a URL
+- a file path
+- a command and output handle
+- a ticket/PR/issue id
+- a conversation reference
+- a skill name/version
+
+Unsourced or automatically extracted material must go to `kind="inbox"` as a `candidate` record for later review.
+
+## Good Uses
+
+- Why a technical decision was made.
+- Confirmed root causes and rejected debugging paths.
+- Skill evaluations: which skill was stale, what was patched, and why.
+- Long-running project state that should be retrieved only when needed.
+- Incidents and postmortems.
+
+## Avoid
+
+- General user preferences that belong in `USER.md`.
+- Tiny environment facts that belong in `MEMORY.md`.
+- Procedures that should be skills.
+- Bulk conversation logs; use `session_search` for episodic recall.
+- Always injecting knowledge records into prompts.
+
+## Example
+
+```json
+{
+  "kind": "decisions",
+  "title": "MemKraft adoption boundary",
+  "content": "Use a cold source-attributed ledger, not a hot memory replacement.",
+  "sources": ["conversation:discord:Agent/#1/Ping"],
+  "confidence": "observed",
+  "tags": ["memory", "roi"]
+}
+```
+
+Later retrieval:
+
+```json
+{"query": "MemKraft adoption boundary", "kind": "decisions"}
+```
+
+Then read the selected record with `knowledge_get`.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -48,6 +48,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/skills',
             'user-guide/features/curator',
             'user-guide/features/memory',
+            'user-guide/features/knowledge-ledger',
             'user-guide/features/memory-providers',
             'user-guide/features/context-files',
             'user-guide/features/context-references',


### PR DESCRIPTION
## Summary
- Add an opt-in `knowledge` toolset with `knowledge_capture`, `knowledge_search`, and `knowledge_get`.
- Store cold, source-attributed records under `$HERMES_HOME/knowledge` without injecting them into hot memory/system prompts.
- Enforce MVP guardrails: non-inbox records require sources; unsourced material is forced to `inbox`/`candidate`; path traversal and symlink escapes are blocked.
- Wire the toolset into tool configuration as default-off/explicit opt-in and document the feature.

## Verification
- `HERMES_HOME="$(mktemp -d)" python -m pytest tests/tools/test_knowledge_tool.py tests/test_toolsets.py tests/test_toolset_distributions.py tests/hermes_cli/test_tools_config.py tests/gateway/test_api_server_toolset.py tests/tools/test_cronjob_tools.py tests/test_get_tool_definitions_cache_isolation.py tests/tools/test_registry.py::TestBuiltinDiscovery::test_matches_previous_manual_builtin_tool_set -q -o 'addopts=' --tb=short --maxfail=1`
  - `159 passed, 2 warnings`
- `python -m py_compile tools/knowledge_tool.py tests/tools/test_knowledge_tool.py toolsets.py hermes_cli/tools_config.py model_tools.py`
- `git diff --cached --check`
- Added-line static scan: 0 hits for secret-like assignments, `shell=True`/`os.system`, `eval`/`exec`, `pickle`, or unsafe `yaml.load`.

## Review
- Independent review found no blocking security or logic issues.
- A root-symlink guard and docs count cleanup were added after review feedback.

## Notes
- This is intentionally not part of default platform composites to avoid surprise schema/token tax.
- `knowledge_search` returns snippets; full content requires `knowledge_get`.
