### PR TITLE
fix(streaming): pass reply_to on first chunk so Slack respects reply_in_thread

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12794,6 +12794,7 @@ class GatewayRunner:
                         chat_id=source.chat_id,
                         config=_consumer_cfg,
                         metadata=_thread_metadata,
+                        reply_to=event_message_id,
                     )
             except Exception as _sc_err:
                 logger.debug("Proxy: could not set up stream consumer: %s", _sc_err)

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -92,11 +92,13 @@ class GatewayStreamConsumer:
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
         on_new_message: Optional[callable] = None,
+        reply_to: Optional[str] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
         self.cfg = config or StreamConsumerConfig()
         self.metadata = metadata
+        self.reply_to = reply_to
         # Fired whenever a fresh content bubble is created on the platform
         # (first-send of a new message, commentary, overflow chunk, or
         # fallback continuation). The gateway uses this to linearize the
@@ -536,12 +538,18 @@ class GatewayStreamConsumer:
         text = self._clean_for_display(text)
         if not text.strip():
             return reply_to_id
+        # When reply_to_id is None (first chunk), fall back to the
+        # reply_to passed at construction time so that platform adapters
+        # which distinguish synthetic thread IDs from real ones (e.g.,
+        # Slack's _resolve_thread_ts) receive the original message ID
+        # even in streaming mode.
+        effective_reply_to = reply_to_id if reply_to_id is not None else self.reply_to
         try:
             meta = dict(self.metadata) if self.metadata else {}
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
-                reply_to=reply_to_id,
+                reply_to=effective_reply_to,
                 metadata=meta,
             )
             if result.success and result.message_id:


### PR DESCRIPTION
## Problem

When `reply_in_thread: false` is set in the Slack platform config, the Slack adapter's `_resolve_thread_ts()` should detect synthetic thread IDs (where `metadata.thread_id` equals the inbound message's own `ts`) and return `None` so the reply is sent as a direct channel message instead of a thread reply.

This detection requires `reply_to` to be set, because the check is:

```python
if existing_thread and reply_to and existing_thread == reply_to:
    existing_thread = None  # synthetic → no thread
```

The **non-streaming** path already passes `reply_to=event.message_id` (see `run.py:2483`), so it works correctly. But the **streaming** path (`GatewayStreamConsumer`) sends its first chunk with `reply_to=None` because `self._message_id` hasn't been assigned yet. With `reply_to=None`, the condition above is never satisfied, so `_resolve_thread_ts` falls through and returns the synthetic thread ID — causing every streaming reply to land in a thread even when the user has explicitly disabled thread replies.

### Before (streaming, `reply_in_thread: false`)

```
GatewayStreamConsumer._send_new_chunk(chunk, self._message_id)   # self._message_id = None
  → adapter.send(reply_to=None, metadata={"thread_id": ts})
    → _resolve_thread_ts(None, metadata)
      → existing_thread = ts, reply_to = None
      → ts and None and ts == None → False ×
      → returns ts  ← THREAD REPLY (bug!)
```

### After

```
GatewayStreamConsumer._send_new_chunk(chunk, self._message_id)   # self._message_id = None
  → effective_reply_to = event.message_id   # ← falls back to construction-time reply_to
  → adapter.send(reply_to=event.message_id, metadata={"thread_id": ts})
    → _resolve_thread_ts(event.message_id, metadata)
      → existing_thread = ts, reply_to = event.message_id
      → ts and event.message_id and ts == event.message_id → True ✓
      → returns None  ← DIRECT CHANNEL REPLY (correct!)
```

## Changes

### `gateway/stream_consumer.py`
- Add optional `reply_to` parameter to `GatewayStreamConsumer.__init__` (default `None`)
- In `_send_new_chunk`, fall back to `self.reply_to` when `reply_to_id` is `None` (first chunk)

### `gateway/run.py`
- Pass `event_message_id` as `reply_to` when constructing `GatewayStreamConsumer` in `_run_agent_via_proxy`

## Scope

- Only the in-proxy streaming path is affected (the one that already has `event_message_id`)
- The second `GatewayStreamConsumer` usage (progress messages) retains the default `None`
- All other platforms receive `reply_to` on the first streaming chunk just like they already do on the non-streaming path — behavioral regression risk is minimal

## Testing

- Verified that with `reply_in_thread: false`, top-level Slack channel messages get direct channel replies in streaming mode
- Non-streaming path unchanged (already correct)
- Progress-message stream consumer unaffected (defaults to `reply_to=None`)