### PR TITLE
feat: add Anthropic WIF : Workload Identity Federation auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,22 @@ You can still bring your own keys per-tool whenever you want — the gateway is 
 
 ---
 
+### Advanced Anthropic auth: Workload Identity Federation
+
+For organizations that do not allow long-lived Anthropic API keys, Hermes can configure Anthropic Workload Identity Federation as an opt-in auth mode on the existing `anthropic` provider:
+
+```bash
+hermes auth add anthropic --type wif \
+  --organization-id <anthropic-organization-id> \
+  --service-account-id <anthropic-service-account-id> \
+  --federation-rule-id <anthropic-federation-rule-id> \
+  --identity-token-file /tmp/oidc-token.jwt
+```
+
+The identity token file must contain a short-lived OIDC JWT generated at runtime by your identity provider, not a workflow YAML or checked-in config file. Existing Anthropic API-key and OAuth setups continue to work unchanged; WIF is opt-in.
+
+---
+
 ## CLI vs Messaging Quick Reference
 
 Hermes has two entry points: start the terminal UI with `hermes`, or run the gateway and talk to it from Telegram, Discord, Slack, WhatsApp, Signal, or Email. Once you're in a conversation, many slash commands are shared across both interfaces.

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -11,6 +11,7 @@ Auth supports:
 """
 
 import copy
+import hashlib
 import json
 import logging
 import os
@@ -18,10 +19,12 @@ import platform
 import secrets
 import stat
 import subprocess
+import threading
+import uuid
 from pathlib import Path
 from urllib.parse import urlparse
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, secure_parent_dir
 from typing import Any, Dict, List, Optional, Tuple
 from utils import base_url_host_matches, normalize_proxy_env_vars
 
@@ -40,6 +43,7 @@ def _get_anthropic_sdk():
     if _anthropic_sdk is ...:
         try:
             from tools.lazy_deps import ensure as _lazy_ensure
+
             _lazy_ensure("provider.anthropic", prompt=False)
         except ImportError:
             pass
@@ -48,12 +52,21 @@ def _get_anthropic_sdk():
             pass
         try:
             import anthropic as _sdk
+
             _anthropic_sdk = _sdk
         except ImportError:
             _anthropic_sdk = None
     return _anthropic_sdk
 
+
 logger = logging.getLogger(__name__)
+
+_WIF_ACCESS_TOKEN_CACHE: dict[str, dict[str, Any]] = {}
+_WIF_TOKEN_PROVIDERS: dict[str, "AnthropicWIFTokenProvider"] = {}
+_WIF_PROVIDER_REGISTRY_LOCK = threading.RLock()
+_WIF_PROVIDER_GENERATION = 0
+_WIF_CACHE_SKEW_SECONDS = 60
+_WIF_CACHE_FILE_NAME = ".anthropic_wif_token_cache.json"
 
 THINKING_BUDGET = {"xhigh": 32000, "high": 16000, "medium": 8000, "low": 4000}
 # Hermes effort → Anthropic adaptive-thinking effort (output_config.effort).
@@ -65,12 +78,12 @@ THINKING_BUDGET = {"xhigh": 32000, "high": 16000, "medium": 8000, "low": 4000}
 # maps to low on every model.  See:
 # https://platform.claude.com/docs/en/about-claude/models/migration-guide
 ADAPTIVE_EFFORT_MAP = {
-    "ultra":   "max",
-    "max":     "max",
-    "xhigh":   "xhigh",
-    "high":    "high",
-    "medium":  "medium",
-    "low":     "low",
+    "ultra": "max",
+    "max": "max",
+    "xhigh": "xhigh",
+    "high": "high",
+    "medium": "medium",
+    "low": "low",
     "minimal": "low",
 }
 
@@ -96,21 +109,31 @@ ADAPTIVE_EFFORT_MAP = {
 # Older Claude families that DON'T support adaptive thinking (manual thinking
 # with budget_tokens only). Substring-matched against the model name.
 _LEGACY_MANUAL_THINKING_CLAUDE_SUBSTRINGS = (
-    "claude-3",          # 3, 3.5, 3.7
-    "claude-opus-4-0", "claude-opus-4.0", "claude-opus-4-1", "claude-opus-4.1",
-    "claude-sonnet-4-0", "claude-sonnet-4.0",
-    "claude-opus-4-2025", "claude-sonnet-4-2025",  # date-stamped 4.0 IDs
-    "claude-opus-4-5", "claude-opus-4.5",
-    "claude-sonnet-4-5", "claude-sonnet-4.5",
-    "claude-haiku-4-5", "claude-haiku-4.5",
+    "claude-3",  # 3, 3.5, 3.7
+    "claude-opus-4-0",
+    "claude-opus-4.0",
+    "claude-opus-4-1",
+    "claude-opus-4.1",
+    "claude-sonnet-4-0",
+    "claude-sonnet-4.0",
+    "claude-opus-4-2025",
+    "claude-sonnet-4-2025",  # date-stamped 4.0 IDs
+    "claude-opus-4-5",
+    "claude-opus-4.5",
+    "claude-sonnet-4-5",
+    "claude-sonnet-4.5",
+    "claude-haiku-4-5",
+    "claude-haiku-4.5",
 )
 
 # Older Claude families that DON'T accept the "xhigh" effort level (4.6 only
 # supports low/medium/high/max). xhigh arrived with Opus 4.7. Adaptive models
 # not in this list (4.7, 4.8, fable, future) accept xhigh.
 _NO_XHIGH_CLAUDE_SUBSTRINGS = (
-    "claude-opus-4-6", "claude-opus-4.6",
-    "claude-sonnet-4-6", "claude-sonnet-4.6",
+    "claude-opus-4-6",
+    "claude-opus-4.6",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4.6",
 )
 
 
@@ -126,35 +149,35 @@ _FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-6", "opus-4.6")
 # starves thinking-enabled models (thinking tokens count toward the limit).
 _ANTHROPIC_OUTPUT_LIMITS = {
     # Mythos-class named models (claude-fable-5, …) — 1M context, reasoning
-    "claude-fable":      128_000,
+    "claude-fable": 128_000,
     # Claude 4.8
-    "claude-opus-4-8":   128_000,
+    "claude-opus-4-8": 128_000,
     # Claude 4.7
-    "claude-opus-4-7":   128_000,
+    "claude-opus-4-7": 128_000,
     # Claude 4.6
-    "claude-opus-4-6":   128_000,
-    "claude-sonnet-4-6":  64_000,
+    "claude-opus-4-6": 128_000,
+    "claude-sonnet-4-6": 64_000,
     # Claude 4.5
-    "claude-opus-4-5":    64_000,
-    "claude-sonnet-4-5":  64_000,
-    "claude-haiku-4-5":   64_000,
+    "claude-opus-4-5": 64_000,
+    "claude-sonnet-4-5": 64_000,
+    "claude-haiku-4-5": 64_000,
     # Claude 4
-    "claude-opus-4":      32_000,
-    "claude-sonnet-4":    64_000,
+    "claude-opus-4": 32_000,
+    "claude-sonnet-4": 64_000,
     # Claude 3.7
     "claude-3-7-sonnet": 128_000,
     # Claude 3.5
-    "claude-3-5-sonnet":   8_192,
-    "claude-3-5-haiku":    8_192,
+    "claude-3-5-sonnet": 8_192,
+    "claude-3-5-haiku": 8_192,
     # Claude 3
-    "claude-3-opus":       4_096,
-    "claude-3-sonnet":     4_096,
-    "claude-3-haiku":      4_096,
+    "claude-3-opus": 4_096,
+    "claude-3-sonnet": 4_096,
+    "claude-3-haiku": 4_096,
     # Third-party Anthropic-compatible providers
-    "minimax":            131_072,
+    "minimax": 131_072,
     # Qwen models via DashScope Anthropic-compatible endpoint
     # DashScope enforces max_tokens ∈ [1, 65536]
-    "qwen3":               65_536,
+    "qwen3": 65_536,
 }
 
 # For any model not in the table, assume the highest current limit.
@@ -201,6 +224,7 @@ def _resolve_positive_anthropic_max_tokens(value) -> Optional[int]:
         return None
     try:
         import math
+
         if not math.isfinite(value):
             return None
     except Exception:
@@ -360,7 +384,9 @@ def _detect_claude_code_version() -> str:
         try:
             result = _sp.run(
                 [cmd, "--version"],
-                capture_output=True, text=True, timeout=5,
+                capture_output=True,
+                text=True,
+                timeout=5,
             )
             if result.returncode == 0 and result.stdout.strip():
                 # Output is like "2.1.74 (Claude Code)" or just "2.1.74"
@@ -454,11 +480,16 @@ def _is_kimi_coding_endpoint(base_url: str | None) -> bool:
 # so a caller's ``provider/vendor/model`` slug is handled the same as a
 # bare name.
 _KIMI_FAMILY_MODEL_PREFIXES = (
-    "kimi-", "kimi_",
-    "moonshot-", "moonshot_",
-    "k1.", "k1-",
-    "k2.", "k2-",
-    "k25", "k2.5",
+    "kimi-",
+    "kimi_",
+    "moonshot-",
+    "moonshot_",
+    "k1.",
+    "k1-",
+    "k2.",
+    "k2-",
+    "k25",
+    "k2.5",
 )
 
 
@@ -542,7 +573,10 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
         return False
     normalized = normalized.rstrip("/").lower()
     return (
-        normalized.startswith(("https://api.minimax.io/anthropic", "https://api.minimaxi.com/anthropic"))
+        normalized.startswith((
+            "https://api.minimax.io/anthropic",
+            "https://api.minimaxi.com/anthropic",
+        ))
         or "azure.com" in normalized
     )
 
@@ -565,9 +599,10 @@ def _is_minimax_anthropic_endpoint(base_url: str | None) -> bool:
     if not normalized:
         return False
     normalized = normalized.rstrip("/").lower()
-    return normalized.startswith(
-        ("https://api.minimax.io/anthropic", "https://api.minimaxi.com/anthropic")
-    )
+    return normalized.startswith((
+        "https://api.minimax.io/anthropic",
+        "https://api.minimaxi.com/anthropic",
+    ))
 
 
 def _is_azure_anthropic_endpoint(base_url: str | None) -> bool:
@@ -660,13 +695,16 @@ def _build_anthropic_client_with_bearer_hook(
     from httpx import Timeout
     from agent.azure_identity_adapter import build_bearer_http_client
 
-    _read_timeout = timeout if (isinstance(timeout, (int, float)) and timeout > 0) else 900.0
+    _read_timeout = (
+        timeout if (isinstance(timeout, (int, float)) and timeout > 0) else 900.0
+    )
     timeout_obj = Timeout(timeout=float(_read_timeout), connect=10.0)
 
     # Strip any trailing /v1 — the Anthropic SDK appends /v1/messages.
     normalized_base_url = _normalize_base_url_text(base_url)
     if normalized_base_url:
         import re as _re
+
         normalized_base_url = _re.sub(r"/v1/?$", "", normalized_base_url.rstrip("/"))
 
     http_client = build_bearer_http_client(token_provider, timeout=timeout_obj)
@@ -685,7 +723,10 @@ def _build_anthropic_client_with_bearer_hook(
     }
 
     if normalized_base_url:
-        if _is_azure_anthropic_endpoint(normalized_base_url) and "api-version" not in normalized_base_url:
+        if (
+            _is_azure_anthropic_endpoint(normalized_base_url)
+            and "api-version" not in normalized_base_url
+        ):
             kwargs["base_url"] = normalized_base_url
             kwargs["default_query"] = {"api-version": "2025-04-15"}
         else:
@@ -746,7 +787,9 @@ def build_anthropic_client(
     # helper so the existing static-key code below stays unchanged.
     if callable(api_key) and not isinstance(api_key, str):
         return _build_anthropic_client_with_bearer_hook(
-            api_key, base_url, timeout,
+            api_key,
+            base_url,
+            timeout,
             drop_context_1m_beta=drop_context_1m_beta,
         )
 
@@ -757,8 +800,11 @@ def build_anthropic_client(
     normalized_base_url = _normalize_base_url_text(base_url)
     if normalized_base_url:
         import re as _re
+
         normalized_base_url = _re.sub(r"/v1/?$", "", normalized_base_url.rstrip("/"))
-    _read_timeout = timeout if (isinstance(timeout, (int, float)) and timeout > 0) else 900.0
+    _read_timeout = (
+        timeout if (isinstance(timeout, (int, float)) and timeout > 0) else 900.0
+    )
     kwargs = {
         "timeout": Timeout(timeout=float(_read_timeout), connect=10.0),
         # Delegate all rate-limit / 5xx retry to hermes's outer conversation
@@ -773,7 +819,10 @@ def build_anthropic_client(
         # Pass it via default_query so the SDK appends it to every request URL
         # without corrupting the base_url (appending it directly produces
         # malformed paths like /anthropic?api-version=.../v1/messages).
-        if _is_azure_anthropic_endpoint(normalized_base_url) and "api-version" not in normalized_base_url:
+        if (
+            _is_azure_anthropic_endpoint(normalized_base_url)
+            and "api-version" not in normalized_base_url
+        ):
             kwargs["base_url"] = normalized_base_url.rstrip("/")
             kwargs["default_query"] = {"api-version": "2025-04-15"}
         else:
@@ -790,7 +839,7 @@ def build_anthropic_client(
         kwargs["api_key"] = api_key
         kwargs["default_headers"] = {
             "User-Agent": "claude-code/0.1.0",
-            **( {"anthropic-beta": ",".join(common_betas)} if common_betas else {} )
+            **({"anthropic-beta": ",".join(common_betas)} if common_betas else {}),
         }
     elif _requires_bearer_auth(normalized_base_url):
         # Some Anthropic-compatible providers (e.g. MiniMax) expect the API key in
@@ -865,7 +914,9 @@ def build_anthropic_bedrock_client(region: str):
         # Delegate retry to hermes's outer loop (honors Retry-After); the SDK
         # default max_retries=2 ignores it and double-retries. (#26293)
         max_retries=0,
-        default_headers={"anthropic-beta": ",".join([*_COMMON_BETAS, _CONTEXT_1M_BETA])},
+        default_headers={
+            "anthropic-beta": ",".join([*_COMMON_BETAS, _CONTEXT_1M_BETA])
+        },
     )
 
 
@@ -887,9 +938,13 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
     try:
         # Read the "Claude Code-credentials" generic password entry
         result = subprocess.run(
-            ["security", "find-generic-password",
-             "-s", "Claude Code-credentials",
-             "-w"],
+            [
+                "security",
+                "find-generic-password",
+                "-s",
+                "Claude Code-credentials",
+                "-w",
+            ],
             capture_output=True,
             text=True,
             timeout=5,
@@ -1010,7 +1065,9 @@ def is_claude_code_token_valid(creds: Dict[str, Any]) -> bool:
     return now_ms < (expires_at - 60_000)
 
 
-def refresh_anthropic_oauth_pure(refresh_token: str, *, use_json: bool = False) -> Dict[str, Any]:
+def refresh_anthropic_oauth_pure(
+    refresh_token: str, *, use_json: bool = False
+) -> Dict[str, Any]:
     """Refresh an Anthropic OAuth token without mutating local credential files."""
     import time
     import urllib.parse
@@ -1108,7 +1165,9 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
             logger.debug("Adopted Claude Code's already-refreshed OAuth token")
             return current_token
 
-    refresh_token = (current or {}).get("refreshToken", "") or creds.get("refreshToken", "")
+    refresh_token = (current or {}).get("refreshToken", "") or creds.get(
+        "refreshToken", ""
+    )
     if not refresh_token:
         logger.debug("No refresh token available — cannot refresh")
         return None
@@ -1195,7 +1254,9 @@ def _write_claude_code_credentials(
         logger.debug("Failed to write refreshed credentials: %s", e)
 
 
-def _resolve_claude_code_token_from_credentials(creds: Optional[Dict[str, Any]] = None) -> Optional[str]:
+def _resolve_claude_code_token_from_credentials(
+    creds: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
     """Resolve a token from Claude Code credential files, refreshing if needed."""
     creds = creds or read_claude_code_credentials()
     if creds and is_claude_code_token_valid(creds):
@@ -1206,11 +1267,15 @@ def _resolve_claude_code_token_from_credentials(creds: Optional[Dict[str, Any]] 
         refreshed = _refresh_oauth_token(creds)
         if refreshed:
             return refreshed
-        logger.debug("Token refresh failed — re-run 'claude setup-token' to reauthenticate")
+        logger.debug(
+            "Token refresh failed — re-run 'claude setup-token' to reauthenticate"
+        )
     return None
 
 
-def _prefer_refreshable_claude_code_token(env_token: str, creds: Optional[Dict[str, Any]]) -> Optional[str]:
+def _prefer_refreshable_claude_code_token(
+    env_token: str, creds: Optional[Dict[str, Any]]
+) -> Optional[str]:
     """Prefer Claude Code creds when a persisted env OAuth token would shadow refresh.
 
     Hermes historically persisted setup tokens into ANTHROPIC_TOKEN. That makes
@@ -1272,6 +1337,377 @@ def _resolve_anthropic_pool_token() -> Optional[str]:
     return None
 
 
+def _read_anthropic_provider_state() -> Optional[Dict[str, Any]]:
+    """Return the persisted ``providers.anthropic`` auth state, or None.
+
+    Delegates to ``hermes_cli.auth.get_provider_auth_state`` rather than
+    re-reading ``$HERMES_HOME/auth.json``: that accessor owns the profile →
+    global-root fallback (issue #18594 follow-up), so a profile process that
+    never ran ``hermes auth login anthropic`` locally still sees a WIF
+    identity configured at the global root. It also handles the corrupt-store
+    quarantine path. Imported lazily — ``hermes_cli.auth`` imports this
+    module.
+    """
+    try:
+        from hermes_cli.auth import get_provider_auth_state
+
+        state = get_provider_auth_state("anthropic")
+    except Exception:
+        logger.debug("Failed to read Anthropic provider auth state", exc_info=True)
+        return None
+    return dict(state) if isinstance(state, dict) else None
+
+
+def _complete_wif_config(config: Dict[str, Any]) -> bool:
+    return all(
+        str(config.get(field) or "").strip()
+        for field in (
+            "federation_rule_id",
+            "organization_id",
+            "service_account_id",
+            "identity_token_file",
+        )
+    )
+
+
+def _anthropic_wif_cache_file() -> Path:
+    return get_hermes_home() / _WIF_CACHE_FILE_NAME
+
+
+def clear_anthropic_wif_token_cache() -> None:
+    """Invalidate issued providers and forget cached WIF bearer material."""
+    global _WIF_PROVIDER_GENERATION
+    with _WIF_PROVIDER_REGISTRY_LOCK:
+        _WIF_PROVIDER_GENERATION += 1
+        providers = list(_WIF_TOKEN_PROVIDERS.values())
+        _WIF_TOKEN_PROVIDERS.clear()
+        # Keep provider construction blocked until every issued instance and
+        # both cache layers are gone. This closes the logout/reconfiguration
+        # race where a fresh provider could otherwise appear mid-purge.
+        for provider in providers:
+            provider.invalidate()
+        _WIF_ACCESS_TOKEN_CACHE.clear()
+        try:
+            _anthropic_wif_cache_file().unlink(missing_ok=True)
+        except OSError:
+            logger.debug("Failed to remove Anthropic WIF token cache", exc_info=True)
+
+
+class AnthropicWIFTokenProvider:
+    """Stable, invalidatable per-request WIF bearer provider."""
+
+    def __init__(
+        self, config: Dict[str, Any], *, verify_current_auth_state: bool = False
+    ) -> None:
+        self._config = dict(config)
+        self._verify_current_auth_state = verify_current_auth_state
+        self._lock = threading.RLock()
+        self._active = True
+
+    def __call__(self) -> str:
+        with self._lock:
+            if not self._active:
+                raise RuntimeError("Anthropic WIF credentials have been removed")
+            if self._verify_current_auth_state:
+                current = read_anthropic_wif_config()
+                if (
+                    not current
+                    or _wif_provider_registry_key(current)
+                    != _wif_provider_registry_key(self._config)
+                ):
+                    self._active = False
+                    raise RuntimeError("Anthropic WIF credentials have been removed")
+            # The exchange helper rereads the assertion file and includes its
+            # digest in the cache key, so rotations invalidate immediately.
+            exchanged = exchange_anthropic_wif_for_access_token(self._config)
+            token = str(exchanged.get("access_token") or "").strip()
+            if not token:
+                raise ValueError("Anthropic WIF exchange returned no access token")
+            return token
+
+    def invalidate(self) -> None:
+        with self._lock:
+            self._active = False
+
+
+def _wif_provider_registry_key(config: Dict[str, Any]) -> str:
+    normalized = json.dumps(config, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+class AnthropicWIFGenerationChanged(RuntimeError):
+    """The WIF auth state changed while a resolver was reading it."""
+
+
+def get_anthropic_wif_provider_generation() -> int:
+    with _WIF_PROVIDER_REGISTRY_LOCK:
+        return _WIF_PROVIDER_GENERATION
+
+
+def build_anthropic_wif_token_provider(
+    config: Optional[Dict[str, Any]] = None,
+    *,
+    expected_generation: Optional[int] = None,
+) -> AnthropicWIFTokenProvider:
+    """Return the stable per-request provider for a WIF configuration."""
+    resolved = dict(config or read_anthropic_wif_config() or {})
+    managed = expected_generation is not None
+    key = f"{_wif_provider_registry_key(resolved)}:{'managed' if managed else 'direct'}"
+    with _WIF_PROVIDER_REGISTRY_LOCK:
+        if (
+            expected_generation is not None
+            and expected_generation != _WIF_PROVIDER_GENERATION
+        ):
+            raise AnthropicWIFGenerationChanged(
+                "Anthropic WIF auth changed during provider resolution"
+            )
+        provider = _WIF_TOKEN_PROVIDERS.get(key)
+        if provider is None:
+            provider = AnthropicWIFTokenProvider(
+                resolved, verify_current_auth_state=managed
+            )
+            _WIF_TOKEN_PROVIDERS[key] = provider
+        return provider
+
+
+def _read_cached_wif_exchange(cache_key: str) -> Optional[Dict[str, Any]]:
+    cache_file = _anthropic_wif_cache_file()
+    try:
+        link_stat = cache_file.lstat()
+    except OSError:
+        return None
+    if not stat.S_ISREG(link_stat.st_mode):
+        return None
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(str(cache_file), flags)
+        with os.fdopen(fd, "r", encoding="utf-8") as handle:
+            opened_stat = os.fstat(handle.fileno())
+            if (
+                not stat.S_ISREG(opened_stat.st_mode)
+                or opened_stat.st_dev != link_stat.st_dev
+                or opened_stat.st_ino != link_stat.st_ino
+            ):
+                return None
+            payload = json.load(handle)
+    except (json.JSONDecodeError, OSError, IOError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if str(payload.get("cache_key") or "") != cache_key:
+        return None
+    return payload if isinstance(payload.get("access_token"), str) else None
+
+
+def _wif_cache_entry_is_fresh(cached: Dict[str, Any], now_ms: int) -> bool:
+    token = str(cached.get("access_token") or "").strip()
+    try:
+        expires_at_ms = int(cached.get("expires_at_ms") or 0)
+    except (TypeError, ValueError):
+        return False
+    return bool(token) and expires_at_ms - now_ms > (_WIF_CACHE_SKEW_SECONDS * 1000)
+
+
+def _write_cached_wif_exchange(cache_key: str, exchanged: Dict[str, Any]) -> None:
+    """Persist a WIF exchange result — a live bearer token — at 0o600.
+
+    Same TOCTOU-safe recipe as every other credential writer in the tree
+    (``hermes_cli.auth._save_auth_store``, #19673, #21148): the temp file is
+    created 0o600 via ``os.open(O_CREAT|O_EXCL)`` so the token is never on
+    disk at the process umask (typically 0o644) between create and chmod,
+    and its name carries pid + random suffix so concurrent agents refreshing
+    the same identity cannot truncate each other's in-flight write. Failures
+    are non-fatal: the cache is an optimization, and the caller can always
+    re-exchange.
+    """
+    cache_file = _anthropic_wif_cache_file()
+    payload = dict(exchanged)
+    payload["cache_key"] = cache_key
+    tmp_path: Optional[Path] = None
+    try:
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        # Tighten the parent dir to 0o700 so siblings can't traverse to the token.
+        secure_parent_dir(cache_file)
+        tmp_path = cache_file.with_name(
+            f"{cache_file.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
+        )
+        fd = os.open(
+            str(tmp_path),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, indent=2))
+            handle.flush()
+            os.fsync(handle.fileno())
+        # Replace a destination symlink itself. The generic atomic_replace()
+        # helper intentionally follows symlinks, which is unsafe for a bearer
+        # token cache because it could overwrite an arbitrary target.
+        os.replace(tmp_path, cache_file)
+    except (OSError, IOError):
+        logger.debug(
+            "Failed to persist Anthropic WIF token cache at %s",
+            cache_file,
+            exc_info=True,
+        )
+    finally:
+        if tmp_path is not None:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def read_anthropic_wif_config() -> Optional[Dict[str, Any]]:
+    """Resolve explicit Anthropic WIF configuration from env or auth.json.
+
+    Environment variables are treated as an atomic source: all four WIF
+    variables must be present before they override auth.json.  This avoids
+    accidentally combining a JWT file from one workload with organization or
+    service-account identifiers from a persisted auth store.
+    """
+    env_config = {
+        "auth_type": "wif",
+        "source": "env:wif",
+        "label": "anthropic-wif",
+        "api_base_url": "https://api.anthropic.com",
+        "federation_rule_id": os.getenv("ANTHROPIC_FEDERATION_RULE_ID", "").strip(),
+        "organization_id": os.getenv("ANTHROPIC_ORGANIZATION_ID", "").strip(),
+        "service_account_id": os.getenv("ANTHROPIC_SERVICE_ACCOUNT_ID", "").strip(),
+        "identity_token_file": os.getenv("ANTHROPIC_IDENTITY_TOKEN_FILE", "").strip(),
+    }
+    env_api_base_url = os.getenv("ANTHROPIC_API_BASE_URL", "").strip()
+    if env_api_base_url:
+        env_config["api_base_url"] = env_api_base_url
+    if _complete_wif_config(env_config):
+        return env_config
+
+    auth_state = _read_anthropic_provider_state() or {}
+    if str(auth_state.get("auth_type") or "").strip().lower() != "wif":
+        return None
+
+    auth_config = {
+        "auth_type": "wif",
+        "source": str(auth_state.get("source") or "auth_store:wif").strip()
+        or "auth_store:wif",
+        "label": str(auth_state.get("label") or "anthropic-wif").strip()
+        or "anthropic-wif",
+        "api_base_url": str(
+            auth_state.get("api_base_url") or "https://api.anthropic.com"
+        ).strip()
+        or "https://api.anthropic.com",
+        "federation_rule_id": str(auth_state.get("federation_rule_id") or "").strip(),
+        "organization_id": str(auth_state.get("organization_id") or "").strip(),
+        "service_account_id": str(auth_state.get("service_account_id") or "").strip(),
+        "identity_token_file": str(auth_state.get("identity_token_file") or "").strip(),
+    }
+    return auth_config if _complete_wif_config(auth_config) else None
+
+
+def exchange_anthropic_wif_for_access_token(
+    config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Exchange a workload identity JWT for a short-lived Anthropic access token."""
+    import time
+    import urllib.request
+
+    resolved = dict(config or read_anthropic_wif_config() or {})
+    required_fields = (
+        "federation_rule_id",
+        "organization_id",
+        "service_account_id",
+        "identity_token_file",
+    )
+    missing = [
+        field for field in required_fields if not str(resolved.get(field) or "").strip()
+    ]
+    if missing:
+        raise ValueError(
+            f"Anthropic WIF configuration is incomplete: {', '.join(missing)}"
+        )
+
+    identity_token_path = Path(
+        str(resolved["identity_token_file"]).strip()
+    ).expanduser()
+    try:
+        assertion = identity_token_path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise ValueError(
+            f"Anthropic WIF identity token file could not be read: {identity_token_path}"
+        ) from exc
+    if not assertion:
+        raise ValueError(
+            f"Anthropic WIF identity token file is empty: {identity_token_path}"
+        )
+
+    api_base_url = (
+        str(resolved.get("api_base_url") or "https://api.anthropic.com")
+        .strip()
+        .rstrip("/")
+    )
+    if not api_base_url.startswith("https://"):
+        raise ValueError("Anthropic WIF api_base_url must use https://")
+
+    cache_key = hashlib.sha256(
+        "\n".join([
+            api_base_url,
+            str(resolved["organization_id"]),
+            str(resolved["service_account_id"]),
+            str(resolved["federation_rule_id"]),
+            assertion,
+        ]).encode("utf-8")
+    ).hexdigest()
+    now_ms = int(time.time() * 1000)
+    cached = _WIF_ACCESS_TOKEN_CACHE.get(cache_key)
+    if cached and _wif_cache_entry_is_fresh(cached, now_ms):
+        return dict(cached)
+
+    cached = _read_cached_wif_exchange(cache_key)
+    if cached and _wif_cache_entry_is_fresh(cached, now_ms):
+        _WIF_ACCESS_TOKEN_CACHE[cache_key] = dict(cached)
+        return dict(cached)
+
+    payload = json.dumps({
+        "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        "assertion": assertion,
+        "organization_id": resolved["organization_id"],
+        "service_account_id": resolved["service_account_id"],
+        "federation_rule_id": resolved["federation_rule_id"],
+    }).encode("utf-8")
+
+    endpoint = f"{api_base_url}/v1/oauth/token"
+    req = urllib.request.Request(
+        endpoint,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": _OAUTH_TOKEN_USER_AGENT,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            result = json.loads(resp.read().decode())
+    except Exception as exc:
+        logger.debug("Anthropic WIF token exchange failed at %s: %s", endpoint, exc)
+        raise
+
+    access_token = str(result.get("access_token") or "").strip()
+    if not access_token:
+        raise ValueError("Anthropic WIF exchange response was missing access_token")
+    expires_in = int(result.get("expires_in") or 3600)
+    exchanged = {
+        "access_token": access_token,
+        "token_type": result.get("token_type") or "Bearer",
+        "scope": result.get("scope"),
+        "expires_in": expires_in,
+        "expires_at_ms": int(time.time() * 1000) + (expires_in * 1000),
+    }
+    _WIF_ACCESS_TOKEN_CACHE[cache_key] = dict(exchanged)
+    _write_cached_wif_exchange(cache_key, exchanged)
+    return exchanged
+
+
 def resolve_anthropic_token() -> Optional[str]:
     """Resolve an Anthropic token from all available sources.
 
@@ -1281,7 +1717,9 @@ def resolve_anthropic_token() -> Optional[str]:
       3. Claude Code credentials (~/.claude.json or ~/.claude/.credentials.json)
          — with automatic refresh if expired and a refresh token is available
       4. Anthropic credential_pool OAuth entry (~/.hermes/auth.json)
-      5. ANTHROPIC_API_KEY env var (regular API key, or legacy fallback)
+      5. Hermes dashboard OAuth file (~/.hermes/.anthropic_oauth.json), used as
+         the durable fallback when best-effort pool registration failed
+      6. ANTHROPIC_API_KEY env var (regular API key, or legacy fallback)
 
     Returns the token string or None.
     """
@@ -1313,7 +1751,19 @@ def resolve_anthropic_token() -> Optional[str]:
     if resolved_pool_token:
         return resolved_pool_token
 
-    # 5. Regular API key, or a legacy OAuth token saved in ANTHROPIC_API_KEY.
+    # 5. Dashboard PKCE credentials are written to a dedicated profile-scoped
+    # file before the best-effort credential-pool insert. Keep that file as a
+    # real runtime fallback so a transient pool write failure cannot leave the
+    # just-completed login unusable. Expired credentials are not revived here;
+    # the dashboard can reauthenticate, while normal pool entries retain their
+    # existing refresh/rotation path.
+    hermes_creds = read_hermes_oauth_credentials()
+    if hermes_creds and is_claude_code_token_valid(hermes_creds):
+        hermes_token = str(hermes_creds.get("accessToken") or "").strip()
+        if hermes_token:
+            return hermes_token
+
+    # 6. Regular API key, or a legacy OAuth token saved in ANTHROPIC_API_KEY.
     # This remains as a compatibility fallback for pre-migration Hermes configs.
     api_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
     if api_key:
@@ -1391,6 +1841,8 @@ _OAUTH_TOKEN_URL = _OAUTH_TOKEN_URLS[0]
 _OAUTH_TOKEN_USER_AGENT = "axios/1.7.9"
 _OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
 _OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
+
+
 def _get_hermes_oauth_file() -> Path:
     return get_hermes_home() / ".anthropic_oauth.json"
 
@@ -1402,9 +1854,12 @@ def _generate_pkce() -> tuple:
     import secrets
 
     verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
-    challenge = base64.urlsafe_b64encode(
-        hashlib.sha256(verifier.encode()).digest()
-    ).rstrip(b"=").decode()
+    challenge = (
+        base64
+        .urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
     return verifier, challenge
 
 
@@ -1515,8 +1970,10 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
                 continue
 
         if result is None:
-            raise last_error if last_error is not None else ValueError(
-                "Anthropic token exchange failed"
+            raise (
+                last_error
+                if last_error is not None
+                else ValueError("Anthropic token exchange failed")
             )
     except Exception as e:
         print(f"Token exchange failed: {e}")
@@ -1589,7 +2046,7 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
     """
     lower = model.lower()
     if lower.startswith("anthropic/"):
-        model = model[len("anthropic/"):]
+        model = model[len("anthropic/") :]
     if not preserve_dots:
         # Bedrock model IDs use dots as namespace separators
         # (e.g. "anthropic.claude-opus-4-7", "us.anthropic.claude-*").
@@ -1612,6 +2069,7 @@ def _sanitize_tool_id(tool_id: str) -> str:
     characters with underscores and ensure non-empty.
     """
     import re
+
     if not tool_id:
         return "tool_0"
     sanitized = re.sub(r"[^a-zA-Z0-9_-]", "_", tool_id)
@@ -1654,7 +2112,9 @@ def _normalize_tool_input_schema(schema: Any) -> Dict[str, Any]:
         normalized = {k: v for k, v in normalized.items() if k not in banned}
         if "type" not in normalized:
             normalized["type"] = "object"
-    if normalized.get("type") == "object" and not isinstance(normalized.get("properties"), dict):
+    if normalized.get("type") == "object" and not isinstance(
+        normalized.get("properties"), dict
+    ):
         normalized = {**normalized, "properties": {}}
     return normalized
 
@@ -1707,7 +2167,7 @@ def _image_source_from_openai_url(url: str) -> Dict[str, str]:
         header, _, data = url.partition(",")
         media_type = "image/jpeg"
         if header.startswith("data:"):
-            mime_part = header[len("data:"):].split(";", 1)[0].strip()
+            mime_part = header[len("data:") :].split(";", 1)[0].strip()
             if mime_part.startswith("image/"):
                 media_type = mime_part
         return {
@@ -1743,7 +2203,11 @@ def _convert_content_part_to_anthropic(part: Any) -> Optional[Dict[str, Any]]:
             block["citations"] = cits
     elif ptype in {"image_url", "input_image"}:
         image_value = part.get("image_url", {})
-        url = image_value.get("url", "") if isinstance(image_value, dict) else str(image_value or "")
+        url = (
+            image_value.get("url", "")
+            if isinstance(image_value, dict)
+            else str(image_value or "")
+        )
         block = {"type": "image", "source": _image_source_from_openai_url(url)}
     else:
         block = dict(part)
@@ -1779,7 +2243,10 @@ def _to_plain_data(value: Any, *, _depth: int = 0, _path: Optional[set] = None) 
         return result
     if isinstance(value, dict):
         _path.add(obj_id)
-        result = {k: _to_plain_data(v, _depth=_depth + 1, _path=_path) for k, v in value.items()}
+        result = {
+            k: _to_plain_data(v, _depth=_depth + 1, _path=_path)
+            for k, v in value.items()
+        }
         _path.discard(obj_id)
         return result
     if isinstance(value, (list, tuple)):
@@ -1888,7 +2355,9 @@ def _sanitize_replay_block(b: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         return out
     if btype == "redacted_thinking":
         # Only valid with its data payload; drop if missing.
-        return {"type": "redacted_thinking", "data": b["data"]} if b.get("data") else None
+        return (
+            {"type": "redacted_thinking", "data": b["data"]} if b.get("data") else None
+        )
     if btype == "tool_use":
         out = {
             "type": "tool_use",
@@ -1955,7 +2424,9 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
             fn = tc.get("function", {}) or {}
             raw_args = fn.get("arguments", "{}")
             try:
-                parsed_args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+                parsed_args = (
+                    json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+                )
             except (json.JSONDecodeError, ValueError):
                 parsed_args = {}
             redacted_input_by_id[_sanitize_tool_id(tc.get("id", ""))] = parsed_args
@@ -2053,9 +2524,7 @@ def _convert_tool_message_to_result(
         )
         # Fallback text if the conversion produced nothing usable.
         if not multimodal_blocks and content.get("text_summary"):
-            multimodal_blocks = [
-                {"type": "text", "text": str(content["text_summary"])}
-            ]
+            multimodal_blocks = [{"type": "text", "text": str(content["text_summary"])}]
     elif isinstance(content, list):
         converted = _content_parts_to_anthropic_blocks(content)
         if any(b.get("type") == "image" for b in converted):
@@ -2064,10 +2533,13 @@ def _convert_tool_message_to_result(
     if multimodal_blocks is None:
         stashed = m.get("_anthropic_content_blocks")
         if isinstance(stashed, list) and stashed:
-            text_content = content if isinstance(content, str) and content.strip() else None
+            text_content = (
+                content if isinstance(content, str) and content.strip() else None
+            )
             multimodal_blocks = (
                 [{"type": "text", "text": text_content}] + stashed
-                if text_content else list(stashed)
+                if text_content
+                else list(stashed)
             )
 
     if multimodal_blocks:
@@ -2156,7 +2628,11 @@ def _strip_orphaned_tool_blocks(result: List[Dict[str, Any]]) -> None:
         kept = [
             b
             for b in m["content"]
-            if not (isinstance(b, dict) and b.get("type") == "tool_use" and b.get("id") in orphaned)
+            if not (
+                isinstance(b, dict)
+                and b.get("type") == "tool_use"
+                and b.get("id") in orphaned
+            )
         ]
         # If stripping an orphaned tool_use mutated a turn that also carries a
         # signed thinking block, that block's Anthropic signature was computed
@@ -2171,7 +2647,9 @@ def _strip_orphaned_tool_blocks(result: List[Dict[str, Any]]) -> None:
             for b in m["content"]
         ):
             m["_thinking_signature_invalidated"] = True
-        m["content"] = kept if kept else [{"type": "text", "text": "(tool call removed)"}]
+        m["content"] = (
+            kept if kept else [{"type": "text", "text": "(tool call removed)"}]
+        )
 
     # Pass 2: Rebuild the set of tool_use IDs that survived pass 1, then
     # strip tool_result blocks that no longer have any matching tool_use
@@ -2193,7 +2671,11 @@ def _strip_orphaned_tool_blocks(result: List[Dict[str, Any]]) -> None:
             or b.get("tool_use_id") in surviving_tool_use_ids
         ]
         if len(new_content) != len(m["content"]):
-            m["content"] = new_content if new_content else [{"type": "text", "text": "(tool result removed)"}]
+            m["content"] = (
+                new_content
+                if new_content
+                else [{"type": "text", "text": "(tool result removed)"}]
+            )
 
 
 def _merge_consecutive_roles(result: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -2228,8 +2710,12 @@ def _merge_consecutive_roles(result: List[Dict[str, Any]]) -> List[Dict[str, Any
                 # and becomes invalid once merged.
                 if isinstance(m["content"], list):
                     m["content"] = [
-                        b for b in m["content"]
-                        if not (isinstance(b, dict) and b.get("type") in {"thinking", "redacted_thinking"})
+                        b
+                        for b in m["content"]
+                        if not (
+                            isinstance(b, dict)
+                            and b.get("type") in {"thinking", "redacted_thinking"}
+                        )
                     ]
                 prev_blocks = fixed[-1]["content"]
                 curr_blocks = m["content"]
@@ -2273,10 +2759,9 @@ def _manage_thinking_signatures(
     # Kimi / DeepSeek share a contract: strip signed Anthropic blocks
     # (neither upstream can validate Anthropic signatures), preserve unsigned
     # ones synthesised from reasoning_content.  See #13848, #16748.
-    _preserve_unsigned_thinking = (
-        _is_kimi_family_endpoint(base_url, model)
-        or _is_deepseek_anthropic_endpoint(base_url)
-    )
+    _preserve_unsigned_thinking = _is_kimi_family_endpoint(
+        base_url, model
+    ) or _is_deepseek_anthropic_endpoint(base_url)
 
     last_assistant_idx = None
     for i in range(len(result) - 1, -1, -1):
@@ -2304,7 +2789,8 @@ def _manage_thinking_signatures(
             # Third-party: strip ALL thinking blocks (signatures are proprietary).
             # Direct Anthropic: strip from non-latest assistant messages only.
             stripped = [
-                b for b in m["content"]
+                b
+                for b in m["content"]
                 if not (isinstance(b, dict) and b.get("type") in _THINKING_TYPES)
             ]
             m["content"] = stripped or [{"type": "text", "text": "(thinking elided)"}]
@@ -2375,16 +2861,19 @@ def _evict_old_screenshots(result: List[Dict[str, Any]]) -> None:
             if not isinstance(inner, list):
                 continue
             has_image = any(
-                isinstance(b, dict) and b.get("type") == "image"
-                for b in inner
+                isinstance(b, dict) and b.get("type") == "image" for b in inner
             )
             if not has_image:
                 continue
             _image_count += 1
             if _image_count > _MAX_KEEP_IMAGES:
                 block["content"] = [
-                    b if b.get("type") != "image"
-                    else {"type": "text", "text": "[screenshot removed to save context]"}
+                    b
+                    if b.get("type") != "image"
+                    else {
+                        "type": "text",
+                        "text": "[screenshot removed to save context]",
+                    }
                     for b in inner
                 ]
 
@@ -2572,7 +3061,7 @@ def build_anthropic_kwargs(
                 return name  # already correct, don't double-prefix
             if name.startswith("mcp_"):
                 # single-underscore native MCP tool -> promote to double
-                return "mcp__" + name[len("mcp_"):]
+                return "mcp__" + name[len("mcp_") :]
             return _MCP_TOOL_PREFIX + name  # bare name -> mcp__<name>
 
         if anthropic_tools:
@@ -2589,7 +3078,10 @@ def build_anthropic_kwargs(
                     if isinstance(block, dict):
                         if block.get("type") == "tool_use" and "name" in block:
                             block["name"] = _to_oauth_wire_name(block["name"])
-                        elif block.get("type") == "tool_result" and "tool_use_id" in block:
+                        elif (
+                            block.get("type") == "tool_result"
+                            and "tool_use_id" in block
+                        ):
                             pass  # tool_result uses ID, not name
 
     kwargs: Dict[str, Any] = {
@@ -2640,7 +3132,10 @@ def build_anthropic_kwargs(
     # 4.6 behavior and preserving the activity-feed UX during long tool runs.
     _is_kimi_coding = _is_kimi_family_endpoint(base_url, model)
     if reasoning_config and isinstance(reasoning_config, dict) and not _is_kimi_coding:
-        if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
+        if (
+            reasoning_config.get("enabled") is not False
+            and "haiku" not in model.lower()
+        ):
             effort = str(reasoning_config.get("effort", "medium")).lower()
             budget = THINKING_BUDGET.get(effort, 8000)
             if _supports_adaptive_thinking(model):
@@ -2685,10 +3180,12 @@ def build_anthropic_kwargs(
         kwargs.setdefault("extra_body", {})["speed"] = "fast"
         # Build extra_headers with ALL applicable betas (the per-request
         # extra_headers override the client-level anthropic-beta header).
-        betas = list(_common_betas_for_base_url(
-            base_url,
-            drop_context_1m_beta=drop_context_1m_beta,
-        ))
+        betas = list(
+            _common_betas_for_base_url(
+                base_url,
+                drop_context_1m_beta=drop_context_1m_beta,
+            )
+        )
         if is_oauth:
             betas.extend(_OAUTH_ONLY_BETAS)
         betas.append(_FAST_MODE_BETA)
@@ -2700,9 +3197,12 @@ def build_anthropic_kwargs(
 # Keys that belong exclusively to the OpenAI Responses / Codex API shape.
 # The Anthropic Messages SDK (``messages.create()`` / ``messages.stream()``)
 # raises ``TypeError: ... got an unexpected keyword argument`` on any of them.
-_RESPONSES_ONLY_KWARGS = frozenset(
-    {"instructions", "input", "store", "parallel_tool_calls"}
-)
+_RESPONSES_ONLY_KWARGS = frozenset({
+    "instructions",
+    "input",
+    "store",
+    "parallel_tool_calls",
+})
 
 
 def sanitize_anthropic_kwargs(api_kwargs: Any, *, log_prefix: str = "") -> Any:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2638,28 +2638,46 @@ def _try_azure_foundry(
     return client, final_model
 
 
-def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optional[str]]:
+def _try_anthropic(
+    explicit_api_key: Any = None,
+    explicit_base_url: Optional[str] = None,
+) -> Tuple[Optional[Any], Optional[str]]:
     try:
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
     except ImportError:
         return None, None
 
-    pool_present, entry = _select_pool_entry("anthropic")
-    if pool_present and entry is not None:
-        token = explicit_api_key or _pool_runtime_api_key(entry)
+    runtime: Dict[str, Any] = {}
+    entry = None
+    pool_present = False
+    if explicit_api_key:
+        # A credential inherited from the main runtime is an indivisible
+        # credential/endpoint bundle. Never combine it with a stale pool entry.
+        token = explicit_api_key
     else:
-        # Pool absent, OR pool present but no usable entry (expired token +
-        # stale refresh_token, all entries exhausted, etc). Fall through to the
-        # legacy resolver instead of hard-failing: a temporarily dead pool
-        # entry must not wedge auxiliary tasks when a valid standalone
-        # credential (ANTHROPIC_TOKEN, credentials file, API key) exists. This
-        # matches the openrouter and codex paths, which already fall back to
-        # their env/auth-store credential on (True, None). Without this, the
-        # goal judge and every other Anthropic-routed side channel died with
-        # "no auxiliary client configured" while the main session stayed
-        # healthy (it resolves the env token directly).
-        entry = None
-        token = explicit_api_key or resolve_anthropic_token()
+        pool_present, entry = _select_pool_entry("anthropic")
+        if pool_present and entry is not None:
+            token = _pool_runtime_api_key(entry)
+        else:
+            # Pool absent, OR pool present but no usable entry (expired token +
+            # stale refresh_token, all entries exhausted, etc). Fall through to the
+            # legacy resolver instead of hard-failing: a temporarily dead pool
+            # entry must not wedge auxiliary tasks when a valid standalone
+            # credential (ANTHROPIC_TOKEN, credentials file, API key) exists. This
+            # matches the openrouter and codex paths, which already fall back to
+            # their env/auth-store credential on (True, None). Without this, the
+            # goal judge and every other Anthropic-routed side channel died with
+            # "no auxiliary client configured" while the main session stayed
+            # healthy (it resolves the env token directly).
+            entry = None
+            token = None
+            try:
+                from hermes_cli.runtime_provider import resolve_runtime_provider
+
+                runtime = resolve_runtime_provider(requested="anthropic")
+                token = runtime.get("api_key")
+            except Exception:
+                token = resolve_anthropic_token()
     if not token:
         return None, None
 
@@ -2673,22 +2691,30 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
     # would have every auxiliary side-channel call (memory extractors,
     # reflection, vision, title generation) 401 from the foreign host —
     # see issue #52608.
-    base_url = _pool_runtime_base_url(entry, _ANTHROPIC_DEFAULT_BASE_URL) if pool_present else _ANTHROPIC_DEFAULT_BASE_URL
-    try:
-        from hermes_cli.config import load_config
-        cfg = load_config()
-        model_cfg = cfg.get("model")
-        if isinstance(model_cfg, dict):
-            cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
-            if cfg_provider == "anthropic":
-                cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
-                if cfg_base_url and _is_anthropic_compatible_host(cfg_base_url):
-                    base_url = cfg_base_url
-    except Exception:
-        pass
+    if explicit_api_key:
+        base_url = str(explicit_base_url or _ANTHROPIC_DEFAULT_BASE_URL).rstrip("/")
+    else:
+        base_url = (
+            _pool_runtime_base_url(entry, _ANTHROPIC_DEFAULT_BASE_URL)
+            if pool_present
+            else str(runtime.get("base_url") or _ANTHROPIC_DEFAULT_BASE_URL)
+        )
+    if not explicit_api_key:
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config()
+            model_cfg = cfg.get("model")
+            if isinstance(model_cfg, dict):
+                cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+                if cfg_provider == "anthropic":
+                    cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
+                    if cfg_base_url and _is_anthropic_compatible_host(cfg_base_url):
+                        base_url = cfg_base_url
+        except Exception:
+            pass
 
     from agent.anthropic_adapter import _is_oauth_token
-    is_oauth = _is_oauth_token(token)
+    is_oauth = _is_oauth_token(token) if isinstance(token, str) else False
     model = _get_aux_model_for_provider("anthropic") or "claude-haiku-4-5-20251001"
     logger.debug("Auxiliary client: Anthropic native (%s) at %s (oauth=%s)", model, base_url, is_oauth)
     try:
@@ -4909,7 +4935,10 @@ def resolve_provider_client(
 
     if pconfig.auth_type == "api_key":
         if provider == "anthropic":
-            client, default_model = _try_anthropic(explicit_api_key=explicit_api_key)
+            client, default_model = _try_anthropic(
+                explicit_api_key=explicit_api_key,
+                explicit_base_url=explicit_base_url,
+            )
             if client is None:
                 logger.warning("resolve_provider_client: anthropic requested but no Anthropic credentials found")
                 return None, None

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1554,16 +1554,49 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         _fb_timeout = get_provider_request_timeout(fb_provider, fb_model)
 
         if fb_api_mode == "anthropic_messages":
-            # Build native Anthropic client instead of using OpenAI client
-            from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token, _is_oauth_token
-            effective_key = (fb_client.api_key or resolve_anthropic_token() or "") if fb_provider == "anthropic" else (fb_client.api_key or "")
+            # Build native Anthropic client instead of using OpenAI client.
+            # Re-resolve native Anthropic here so a WIF fallback carries its
+            # per-request refresh callable rather than the static token baked
+            # into the compatibility client used during fallback discovery.
+            from agent.anthropic_adapter import (
+                build_anthropic_client,
+                resolve_anthropic_token,
+                _is_oauth_token,
+            )
+            resolved_key = None
+            resolved_base_url = None
+            if fb_provider == "anthropic":
+                try:
+                    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+                    fb_runtime = resolve_runtime_provider(
+                        requested="anthropic", target_model=fb_model
+                    )
+                    resolved_key = fb_runtime.get("api_key")
+                    resolved_base_url = fb_runtime.get("base_url")
+                except Exception:
+                    logger.debug(
+                        "Could not re-resolve Anthropic fallback runtime",
+                        exc_info=True,
+                    )
+            effective_key = (
+                resolved_key or fb_client.api_key or resolve_anthropic_token() or ""
+                if fb_provider == "anthropic"
+                else (fb_client.api_key or "")
+            )
             agent.api_key = effective_key
             agent._anthropic_api_key = effective_key
-            agent._anthropic_base_url = fb_base_url
+            agent._anthropic_base_url = resolved_base_url or fb_base_url
             agent._anthropic_client = build_anthropic_client(
-                effective_key, agent._anthropic_base_url, timeout=_fb_timeout,
+                effective_key,
+                agent._anthropic_base_url,
+                timeout=_fb_timeout,
             )
-            agent._is_anthropic_oauth = _is_oauth_token(effective_key) if fb_provider == "anthropic" else False
+            agent._is_anthropic_oauth = (
+                _is_oauth_token(effective_key)
+                if fb_provider == "anthropic" and isinstance(effective_key, str)
+                else False
+            )
             agent.client = None
             agent._client_kwargs = {}
         else:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1591,6 +1591,17 @@ def clear_provider_auth(provider_id: Optional[str] = None) -> bool:
             del pool[target]
             cleared = True
 
+        # A named profile must retain a local singleton tombstone after an
+        # Anthropic logout.  Deleting the local entry outright would make the
+        # generic profile fallback resurrect a global WIF identity on the next
+        # resolution, even though the user explicitly logged out here.
+        if target == "anthropic" and _global_auth_file_path() is not None:
+            providers[target] = {
+                "auth_type": "profile_shadow",
+                "source": "profile:logout",
+            }
+            cleared = True
+
         if auth_store.get("active_provider") == target:
             auth_store["active_provider"] = None
             cleared = True
@@ -1598,6 +1609,13 @@ def clear_provider_auth(provider_id: Optional[str] = None) -> bool:
         if not cleared:
             return False
         _save_auth_store(auth_store)
+    if target == "anthropic":
+        try:
+            from agent.anthropic_adapter import clear_anthropic_wif_token_cache
+
+            clear_anthropic_wif_token_cache()
+        except Exception:
+            logger.debug("Failed to purge Anthropic WIF cache on logout", exc_info=True)
     return True
 
 
@@ -6256,6 +6274,77 @@ def get_xai_oauth_auth_status() -> Dict[str, Any]:
         }
 
 
+def get_anthropic_auth_status() -> Dict[str, Any]:
+    """Combined status for Anthropic API auth sources, including WIF."""
+    try:
+        from agent.anthropic_adapter import read_anthropic_wif_config
+
+        wif_config = read_anthropic_wif_config()
+    except Exception:
+        wif_config = None
+
+    if isinstance(wif_config, dict):
+        identity_token_file = str(wif_config.get("identity_token_file") or "").strip()
+        file_exists = bool(identity_token_file) and Path(identity_token_file).expanduser().exists()
+        return {
+            "logged_in": file_exists,
+            "auth_type": "wif",
+            "source": str(wif_config.get("source") or "auth_store:wif"),
+            "label": wif_config.get("label") or "anthropic-wif",
+            "federation_rule_id": wif_config.get("federation_rule_id"),
+            "organization_id": wif_config.get("organization_id"),
+            "service_account_id": wif_config.get("service_account_id"),
+            "identity_token_file": identity_token_file,
+            "identity_token_file_exists": file_exists,
+            "api_base_url": str(wif_config.get("api_base_url") or "https://api.anthropic.com"),
+            **({"error": "identity token file not found"} if identity_token_file and not file_exists else {}),
+        }
+
+    try:
+        from agent import anthropic_adapter as _anthropic_adapter
+    except Exception:
+        _anthropic_adapter = None
+
+    hermes_creds = None
+    if _anthropic_adapter is not None:
+        try:
+            hermes_creds = _anthropic_adapter.read_hermes_oauth_credentials()
+        except Exception:
+            hermes_creds = None
+    if hermes_creds and hermes_creds.get("accessToken"):
+        return {
+            "logged_in": True,
+            "auth_type": "oauth",
+            "source": "hermes_pkce",
+            "expires_at": hermes_creds.get("expiresAt"),
+            "api_base_url": "https://api.anthropic.com",
+        }
+
+    cc_creds = None
+    if _anthropic_adapter is not None:
+        try:
+            cc_creds = _anthropic_adapter.read_claude_code_credentials()
+        except Exception:
+            cc_creds = None
+    if cc_creds and cc_creds.get("accessToken"):
+        return {
+            "logged_in": True,
+            "auth_type": "oauth",
+            "source": str(cc_creds.get("source") or "claude_code"),
+            "expires_at": cc_creds.get("expiresAt"),
+            "api_base_url": "https://api.anthropic.com",
+        }
+
+    api_key = get_anthropic_key()
+    return {
+        "logged_in": bool(api_key),
+        "auth_type": "api_key",
+        "source": "env",
+        "api_base_url": "https://api.anthropic.com",
+        **({"error": "no anthropic credentials configured"} if not api_key else {}),
+    }
+
+
 def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     """Status snapshot for API-key providers (z.ai, Kimi, MiniMax)."""
     pconfig = PROVIDER_REGISTRY.get(provider_id)
@@ -6324,6 +6413,8 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return {"logged_in": False}
     if target == "spotify":
         return get_spotify_auth_status()
+    if target == "anthropic":
+        return get_anthropic_auth_status()
     if target == "nous":
         return get_nous_auth_status()
     if target == "openai-codex":

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from pathlib import Path
 import sys
 import time
 from types import SimpleNamespace
@@ -113,6 +114,59 @@ def _display_source(source: str) -> str:
     return source.split(":", 1)[1] if source.startswith("manual:") else source
 
 
+def _anthropic_wif_status() -> dict | None:
+    try:
+        status = auth_mod.get_auth_status("anthropic")
+    except Exception:
+        return None
+    return status if status.get("auth_type") == "wif" else None
+
+
+def _print_anthropic_wif_entry(status: dict, *, index: int = 1) -> None:
+    label = str(status.get("label") or "anthropic-wif")
+    source = _display_source(str(status.get("source") or "wif"))
+    file_exists = status.get("identity_token_file_exists")
+    file_status = "file:ok" if file_exists else "file:missing"
+    marker = "← " if status.get("logged_in") else "  "
+    print(f"  #{index}  {label:<20} {'wif':<7} {source} {file_status} {marker}".rstrip())
+
+
+def _remove_anthropic_wif_state() -> bool:
+    """Replace exclusive WIF state without exposing a global fallback.
+
+    A named profile inherits provider singleton state from the global auth store
+    when it has no local entry.  Removing a local WIF entry (or finding only an
+    inherited one) must therefore leave an explicit local shadow marker when a
+    profile switches to API-key/OAuth credentials.  Otherwise the old global
+    WIF identity immediately becomes authoritative again.
+    """
+    with auth_mod._auth_store_lock():
+        auth_store = auth_mod._load_auth_store()
+        providers = auth_store.get("providers")
+        if not isinstance(providers, dict):
+            providers = {}
+            auth_store["providers"] = providers
+        state = providers.get("anthropic")
+        had_local_wif = isinstance(state, dict) and state.get("auth_type") == "wif"
+        in_profile = auth_mod._global_auth_file_path() is not None
+        if in_profile:
+            providers["anthropic"] = {
+                "auth_type": "profile_shadow",
+                "source": "profile:local-credential",
+            }
+        elif had_local_wif:
+            providers.pop("anthropic", None)
+        else:
+            return False
+        if auth_store.get("active_provider") == "anthropic":
+            auth_store.pop("active_provider", None)
+        auth_mod._save_auth_store(auth_store)
+    from agent.anthropic_adapter import clear_anthropic_wif_token_cache
+
+    clear_anthropic_wif_token_cache()
+    return True
+
+
 def _classify_exhausted_status(entry) -> tuple[str, bool]:
     code = getattr(entry, "last_error_code", None)
     reason = str(getattr(entry, "last_error_reason", "") or "").strip().lower()
@@ -218,7 +272,77 @@ def auth_add_command(args) -> None:
             base_url=_provider_base_url(provider),
         )
         pool.add_entry(entry)
+        if provider == "anthropic":
+            _remove_anthropic_wif_state()
         print(f'Added {provider} credential #{len(pool.entries())}: "{label}"')
+        return
+
+    if requested_type == "wif":
+        if provider != "anthropic":
+            raise SystemExit("Workload Identity Federation is currently supported only for provider 'anthropic'.")
+
+        prompts = {
+            "federation_rule_id": "Anthropic federation rule ID (fdrl_...)",
+            "organization_id": "Anthropic organization ID",
+            "service_account_id": "Anthropic service account ID (svac_...)",
+            "identity_token_file": "Path to identity token file",
+        }
+        values = {
+            "federation_rule_id": str(getattr(args, "federation_rule_id", None) or "").strip(),
+            "organization_id": str(getattr(args, "organization_id", None) or "").strip(),
+            "service_account_id": str(getattr(args, "service_account_id", None) or "").strip(),
+            "identity_token_file": str(getattr(args, "identity_token_file", None) or "").strip(),
+        }
+        missing = [key for key, value in values.items() if not value]
+        if missing and sys.stdin.isatty():
+            for key in missing:
+                try:
+                    values[key] = input(f"{prompts[key]}: ").strip()
+                except (EOFError, KeyboardInterrupt):
+                    raise SystemExit("Anthropic WIF setup cancelled.")
+        missing = [key for key, value in values.items() if not value]
+        if missing:
+            formatted = ", ".join(missing)
+            raise SystemExit(
+                "Missing required Anthropic WIF fields: "
+                f"{formatted}. Pass --federation-rule-id, --organization-id, "
+                "--service-account-id, and --identity-token-file."
+            )
+
+        label = (getattr(args, "label", None) or "").strip() or "anthropic-wif"
+        token_path = Path(values["identity_token_file"]).expanduser()
+        if token_path.exists():
+            try:
+                sample = token_path.read_text(encoding="utf-8").strip()
+            except OSError:
+                sample = ""
+            if sample and sample.count(".") < 2:
+                print(
+                    "Warning: identity token file does not look like a JWT. "
+                    "Use a short-lived OIDC token file, not a workflow YAML or config file."
+                )
+        else:
+            print(
+                "Note: identity token file does not exist yet. This is OK only "
+                "if your workload will create it before Hermes runs."
+            )
+        state = {
+            "auth_type": "wif",
+            "source": "manual:wif",
+            "label": label,
+            **values,
+            "api_base_url": _provider_base_url(provider),
+        }
+        with auth_mod._auth_store_lock():
+            auth_store = auth_mod._load_auth_store()
+            auth_mod._save_provider_state(auth_store, provider, state)
+            auth_mod._save_auth_store(auth_store)
+        from agent.anthropic_adapter import clear_anthropic_wif_token_cache
+
+        # Purge after persisting the replacement: any runtime that starts once
+        # the purge lock is released can only resolve the new identity.
+        clear_anthropic_wif_token_cache()
+        print(f'Configured {provider} Workload Identity Federation: "{label}"')
         return
 
     if provider == "anthropic":
@@ -244,6 +368,7 @@ def auth_add_command(args) -> None:
             base_url=_provider_base_url(provider),
         )
         pool.add_entry(entry)
+        _remove_anthropic_wif_state()
         print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
         return
 
@@ -425,11 +550,17 @@ def auth_list_command(args) -> None:
     for provider in providers:
         pool = load_pool(provider)
         entries = pool.entries()
-        if not entries:
+        wif_status = _anthropic_wif_status() if provider == "anthropic" else None
+        if not entries and not wif_status:
             continue
         current = pool.peek()
-        print(f"{provider} ({len(entries)} credentials):")
-        for idx, entry in enumerate(entries, start=1):
+        total = len(entries) + (1 if wif_status else 0)
+        print(f"{provider} ({total} credentials):")
+        next_index = 1
+        if wif_status:
+            _print_anthropic_wif_entry(wif_status, index=next_index)
+            next_index += 1
+        for idx, entry in enumerate(entries, start=next_index):
             marker = "  "
             if current is not None and entry.id == current.id:
                 marker = "← "
@@ -445,7 +576,17 @@ def auth_remove_command(args) -> None:
     if target is None:
         target = getattr(args, "index", None)
     pool = load_pool(provider)
-    index, matched, error = pool.resolve_target(target)
+    wif_status = _anthropic_wif_status() if provider == "anthropic" else None
+    if wif_status and str(target or "1").strip() in {"", "1", "anthropic-wif", str(wif_status.get("label") or "").strip()}:
+        if _remove_anthropic_wif_state():
+            print(f"Removed {provider} WIF credential ({wif_status.get('label') or 'anthropic-wif'})")
+            return
+    pool_target = target
+    if wif_status and isinstance(target, int):
+        pool_target = target - 1
+    elif wif_status and str(target or "").strip().isdigit():
+        pool_target = int(str(target).strip()) - 1
+    index, matched, error = pool.resolve_target(pool_target)
     if matched is None or index is None:
         raise SystemExit(f"{error} Provider: {provider}.")
     removed = pool.remove_index(index)
@@ -686,12 +827,17 @@ def _interactive_add() -> None:
 def _interactive_remove() -> None:
     provider = _pick_provider("Provider to remove credential from")
     pool = load_pool(provider)
-    if not pool.has_credentials():
+    wif_status = _anthropic_wif_status() if provider == "anthropic" else None
+    entries = pool.entries()
+    if not entries and not wif_status:
         print(f"No credentials for {provider}.")
         return
 
-    # Show entries with indices
-    for i, e in enumerate(pool.entries(), 1):
+    next_index = 1
+    if wif_status:
+        _print_anthropic_wif_entry(wif_status, index=next_index)
+        next_index += 1
+    for i, e in enumerate(entries, next_index):
         exhausted = _format_exhausted_status(e)
         print(f"  #{i}  {e.label:25s} {e.auth_type:10s} {e.source}{exhausted} [id:{e.id}]")
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -255,6 +255,44 @@ def _anthropic_base_url_override_ok(base_url: str) -> bool:
     return False
 
 
+def _resolve_anthropic_wif_or_legacy_token() -> tuple[Any, str]:
+    """Resolve Anthropic auth without reviving a concurrently removed WIF identity."""
+    from agent.anthropic_adapter import (
+        AnthropicWIFGenerationChanged,
+        build_anthropic_wif_token_provider,
+        get_anthropic_wif_provider_generation,
+        read_anthropic_wif_config,
+        resolve_anthropic_token,
+    )
+
+    # A generation change means logout/reconfiguration raced the auth-store
+    # read. Retry the complete read so a stale config can never be registered
+    # after the invalidation pass has completed.
+    for _attempt in range(3):
+        generation = get_anthropic_wif_provider_generation()
+        wif_config = read_anthropic_wif_config()
+        if not wif_config:
+            if generation != get_anthropic_wif_provider_generation():
+                continue
+            legacy_token = resolve_anthropic_token()
+            # The legacy resolution can read files, pools, and refresh OAuth,
+            # so a WIF reconfiguration may complete while it is running. Do not
+            # return the identity selected before that transition.
+            if generation != get_anthropic_wif_provider_generation():
+                continue
+            return legacy_token, "explicit"
+        try:
+            return (
+                build_anthropic_wif_token_provider(
+                    wif_config, expected_generation=generation
+                ),
+                "wif",
+            )
+        except AnthropicWIFGenerationChanged:
+            continue
+    raise AuthError("Anthropic WIF credentials changed during resolution; retry")
+
+
 def _auto_detect_local_model(base_url: str) -> str:
     """Query a local server for its model name when only one model is loaded."""
     if not base_url:
@@ -1379,13 +1417,12 @@ def _resolve_explicit_runtime(
                 cfg_base_url = ""
         base_url = explicit_base_url or cfg_base_url or "https://api.anthropic.com"
         api_key = explicit_api_key
+        auth_source = "explicit"
         if not api_key:
-            from agent.anthropic_adapter import resolve_anthropic_token
-
-            api_key = resolve_anthropic_token()
+            api_key, auth_source = _resolve_anthropic_wif_or_legacy_token()
             if not api_key:
                 raise AuthError(
-                    "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
+                    "No Anthropic credentials found. Configure WIF, set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
                     "run 'claude setup-token', or authenticate with 'claude /login'."
                 )
         return {
@@ -1393,7 +1430,7 @@ def _resolve_explicit_runtime(
             "api_mode": "anthropic_messages",
             "base_url": base_url,
             "api_key": api_key,
-            "source": "explicit",
+            "source": auth_source,
             "requested_provider": requested_provider,
         }
 
@@ -1672,6 +1709,17 @@ def resolve_runtime_provider(
         return explicit_runtime
 
     should_use_pool = provider != "openrouter"
+    if provider == "anthropic":
+        try:
+            from agent.anthropic_adapter import read_anthropic_wif_config
+
+            if read_anthropic_wif_config():
+                # Explicit WIF configuration is a runtime exchange, not a pooled
+                # static credential.  Do not let an older Anthropic pool entry
+                # shadow it.
+                should_use_pool = False
+        except Exception:
+            pass
     if provider == "openrouter":
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
         cfg_base_url = str(model_cfg.get("base_url") or "").strip()
@@ -1876,6 +1924,8 @@ def resolve_runtime_provider(
             if not _anthropic_base_url_override_ok(cfg_base_url):
                 cfg_base_url = ""
         base_url = cfg_base_url or "https://api.anthropic.com"
+        token = ""
+        auth_source = "env"
 
         # For Microsoft Foundry endpoints, use ANTHROPIC_API_KEY directly —
         # Claude Code OAuth tokens (sk-ant-oat01) are not accepted by Azure.
@@ -1917,11 +1967,12 @@ def resolve_runtime_provider(
                     "config.yaml model section at a custom env var."
                 )
         else:
-            from agent.anthropic_adapter import resolve_anthropic_token
-            token = resolve_anthropic_token()
+            token, auth_source = _resolve_anthropic_wif_or_legacy_token()
+            if auth_source == "explicit":
+                auth_source = "env"
             if not token:
                 raise AuthError(
-                    "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
+                    "No Anthropic credentials found. Configure WIF, set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
                     "run 'claude setup-token', or authenticate with 'claude /login'."
                 )
         return {
@@ -1929,7 +1980,7 @@ def resolve_runtime_provider(
             "api_mode": "anthropic_messages",
             "base_url": base_url,
             "api_key": token,
-            "source": "env",
+            "source": auth_source,
             "requested_provider": requested_provider,
         }
 

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -24,13 +24,17 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     auth_add.add_argument(
         "--type",
         dest="auth_type",
-        choices=["oauth", "api-key", "api_key"],
+        choices=["oauth", "api-key", "api_key", "wif"],
         help="Credential type to add",
     )
     auth_add.add_argument("--label", help="Optional display label")
     auth_add.add_argument(
         "--api-key", help="API key value (otherwise prompted securely)"
     )
+    auth_add.add_argument("--federation-rule-id", help="Anthropic WIF federation rule ID (fdrl_...)")
+    auth_add.add_argument("--organization-id", help="Anthropic organization ID for WIF")
+    auth_add.add_argument("--service-account-id", help="Anthropic service account ID for WIF (svac_...)")
+    auth_add.add_argument("--identity-token-file", help="Path to workload identity token file for Anthropic WIF")
     auth_add.add_argument("--portal-url", help="Nous portal base URL")
     auth_add.add_argument("--inference-url", help="Nous inference base URL")
     auth_add.add_argument("--client-id", help="OAuth client id")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8007,10 +8007,13 @@ def _truncate_token(value: Optional[str], visible: int = 6) -> str:
 def _anthropic_oauth_status() -> Dict[str, Any]:
     """Status for the "Anthropic API Key" catalog entry.
 
-    Two sources, in priority order:
-    1. ``~/.hermes/.anthropic_oauth.json`` — Hermes-managed PKCE flow (what
+    Sources, in priority order:
+    1. Workload Identity Federation — when the profile's Anthropic auth state
+       selects ``wif``, it wins outright: no static key or PKCE token is used
+       to call the API, so reporting either one here would be a lie.
+    2. ``~/.hermes/.anthropic_oauth.json`` — Hermes-managed PKCE flow (what
        this entry's Connect button writes)
-    2. ``ANTHROPIC_API_KEY`` → ``ANTHROPIC_TOKEN`` → ``CLAUDE_CODE_OAUTH_TOKEN``
+    3. ``ANTHROPIC_API_KEY`` → ``ANTHROPIC_TOKEN`` → ``CLAUDE_CODE_OAUTH_TOKEN``
        env vars (registry order) — from ``.env``, the shell, or an external
        secret source like Bitwarden (whose keys are injected into the process
        env during ``load_hermes_dotenv()``, so the same check covers them)
@@ -8020,6 +8023,27 @@ def _anthropic_oauth_status() -> Dict[str, Any]:
     ``_claude_code_only_status``). Reporting it under the API-key entry
     double-counts the token and shadows a real ANTHROPIC_API_KEY.
     """
+    try:
+        from hermes_cli import auth as hauth
+
+        unified = hauth.get_auth_status("anthropic")
+    except Exception:
+        unified = {}
+
+    if unified.get("auth_type") == "wif":
+        return {
+            "logged_in": bool(unified.get("logged_in")),
+            "source": "anthropic_wif",
+            "source_label": f"Anthropic WIF ({unified.get('identity_token_file') or 'token file not set'})",
+            "token_preview": None,
+            "expires_at": None,
+            "has_refresh_token": False,
+            "federation_rule_id": unified.get("federation_rule_id"),
+            "organization_id": unified.get("organization_id"),
+            "service_account_id": unified.get("service_account_id"),
+            **({"error": unified.get("error")} if unified.get("error") else {}),
+        }
+
     try:
         from agent.anthropic_adapter import (
             read_hermes_oauth_credentials,
@@ -8672,6 +8696,12 @@ def _save_anthropic_oauth_creds(access_token: str, refresh_token: str, expires_a
         pool.add_entry(entry)
     except Exception as e:
         _log.warning("anthropic pool add (dashboard) failed: %s", e)
+
+    # Dashboard OAuth replaces the exclusive persisted WIF mode even when the
+    # optional pool insert failed: the OAuth file above is already authoritative.
+    from hermes_cli.auth_commands import _remove_anthropic_wif_state
+
+    _remove_anthropic_wif_state()
 
 
 def _start_anthropic_pkce(profile: Optional[str] = None) -> Dict[str, Any]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -4378,6 +4378,13 @@ class AIAgent:
         # Other anthropic_messages providers (MiniMax, Alibaba, etc.) use their own keys.
         if self.provider != "anthropic":
             return False
+        # Callable credentials (WIF/Entra-style providers) refresh inside the
+        # per-request HTTP bearer hook. Resolving the legacy static/OAuth token
+        # here would replace the callable and silently change identities.
+        if callable(self._anthropic_api_key) and not isinstance(
+            self._anthropic_api_key, str
+        ):
+            return False
         # Azure endpoints use static API keys — OAuth token rotation doesn't apply.
         # Refreshing would pick up ~/.claude/.credentials.json OAuth token and break auth.
         _base = getattr(self, "_anthropic_base_url", "") or ""

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1,13 +1,17 @@
 """Tests for agent/anthropic_adapter.py — Anthropic Messages API adapter."""
 
 import json
+import os
+import stat
 import sys
+import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import pytest
 
+import agent.anthropic_adapter as anthropic_adapter
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.anthropic_adapter import (
     _is_azure_anthropic_endpoint,
@@ -20,6 +24,7 @@ from agent.anthropic_adapter import (
     build_anthropic_kwargs,
     convert_messages_to_anthropic,
     convert_tools_to_anthropic,
+    exchange_anthropic_wif_for_access_token,
     is_claude_code_token_valid,
     normalize_model_name,
     read_claude_code_credentials,
@@ -93,9 +98,9 @@ class TestBuildAnthropicClient:
 
     def test_api_key_uses_api_key(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
-            build_anthropic_client("sk-ant-api03-something")
+            build_anthropic_client("sk-ant-api03-test-key")
             kwargs = mock_sdk.Anthropic.call_args[1]
-            assert kwargs["api_key"] == "sk-ant-api03-something"
+            assert kwargs["api_key"] == "sk-ant-api03-test-key"
             assert "auth_token" not in kwargs
             # API key auth should still get common betas
             betas = kwargs["default_headers"]["anthropic-beta"]
@@ -103,6 +108,7 @@ class TestBuildAnthropicClient:
             assert "context-1m-2025-08-07" not in betas
             assert "oauth-2025-04-20" not in betas  # OAuth-only beta NOT present
             assert "claude-code-20250219" not in betas  # OAuth-only beta NOT present
+
 
     def test_custom_base_url(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
@@ -133,18 +139,26 @@ class TestBuildAnthropicClient:
             assert "context-1m-2025-08-07" in betas
 
     def test_azure_anthropic_endpoint_detection_is_host_and_path_scoped(self):
-        assert _is_azure_anthropic_endpoint(
-            "https://example.services.ai.azure.com/models/anthropic"
-        ) is True
-        assert _is_azure_anthropic_endpoint(
-            "https://example.services.ai.azure.us/anthropic"
-        ) is True
-        assert _is_azure_anthropic_endpoint(
-            "https://example.openai.azure.com/openai/v1"
-        ) is False
-        assert _is_azure_anthropic_endpoint(
-            "https://management.azure.com/anthropic"
-        ) is False
+        assert (
+            _is_azure_anthropic_endpoint(
+                "https://example.services.ai.azure.com/models/anthropic"
+            )
+            is True
+        )
+        assert (
+            _is_azure_anthropic_endpoint(
+                "https://example.services.ai.azure.us/anthropic"
+            )
+            is True
+        )
+        assert (
+            _is_azure_anthropic_endpoint("https://example.openai.azure.com/openai/v1")
+            is False
+        )
+        assert (
+            _is_azure_anthropic_endpoint("https://management.azure.com/anthropic")
+            is False
+        )
 
     def test_bedrock_client_keeps_context_1m_beta(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
@@ -235,13 +249,15 @@ class TestReadClaudeCodeCredentials:
     def test_reads_valid_credentials(self, tmp_path, monkeypatch):
         cred_file = tmp_path / ".claude" / ".credentials.json"
         cred_file.parent.mkdir(parents=True)
-        cred_file.write_text(json.dumps({
-            "claudeAiOauth": {
-                "accessToken": "sk-ant-oat01-token",
-                "refreshToken": "sk-ant-oat01-refresh",
-                "expiresAt": int(time.time() * 1000) + 3600_000,
-            }
-        }))
+        cred_file.write_text(
+            json.dumps({
+                "claudeAiOauth": {
+                    "accessToken": "sk-ant-oat01-token",
+                    "refreshToken": "sk-ant-oat01-refresh",
+                    "expiresAt": int(time.time() * 1000) + 3600_000,
+                }
+            })
+        )
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         creds = read_claude_code_credentials()
         assert creds is not None
@@ -249,7 +265,9 @@ class TestReadClaudeCodeCredentials:
         assert creds["refreshToken"] == "sk-ant-oat01-refresh"
         assert creds["source"] == "claude_code_credentials_file"
 
-    def test_ignores_primary_api_key_for_native_anthropic_resolution(self, tmp_path, monkeypatch):
+    def test_ignores_primary_api_key_for_native_anthropic_resolution(
+        self, tmp_path, monkeypatch
+    ):
         claude_json = tmp_path / ".claude.json"
         claude_json.write_text(json.dumps({"primaryApiKey": "sk-ant-api03-primary"}))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
@@ -271,9 +289,9 @@ class TestReadClaudeCodeCredentials:
     def test_returns_none_for_empty_access_token(self, tmp_path, monkeypatch):
         cred_file = tmp_path / ".claude" / ".credentials.json"
         cred_file.parent.mkdir(parents=True)
-        cred_file.write_text(json.dumps({
-            "claudeAiOauth": {"accessToken": "", "refreshToken": "x"}
-        }))
+        cred_file.write_text(
+            json.dumps({"claudeAiOauth": {"accessToken": "", "refreshToken": "x"}})
+        )
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         assert read_claude_code_credentials() is None
 
@@ -300,16 +318,22 @@ class TestResolveAnthropicToken:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         assert resolve_anthropic_token() == "sk-ant-oat01-mytoken"
 
-    def test_does_not_resolve_primary_api_key_as_native_anthropic_token(self, monkeypatch, tmp_path):
+    def test_does_not_resolve_primary_api_key_as_native_anthropic_token(
+        self, monkeypatch, tmp_path
+    ):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
-        (tmp_path / ".claude.json").write_text(json.dumps({"primaryApiKey": "sk-ant-api03-primary"}))
+        (tmp_path / ".claude.json").write_text(
+            json.dumps({"primaryApiKey": "sk-ant-api03-primary"})
+        )
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
         assert resolve_anthropic_token() is None
 
-    def test_falls_back_to_api_key_when_no_oauth_sources_exist(self, monkeypatch, tmp_path):
+    def test_falls_back_to_api_key_when_no_oauth_sources_exist(
+        self, monkeypatch, tmp_path
+    ):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-mykey")
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
@@ -343,13 +367,15 @@ class TestResolveAnthropicToken:
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         cred_file = tmp_path / ".claude" / ".credentials.json"
         cred_file.parent.mkdir(parents=True)
-        cred_file.write_text(json.dumps({
-            "claudeAiOauth": {
-                "accessToken": "cc-auto-token",
-                "refreshToken": "refresh",
-                "expiresAt": int(time.time() * 1000) + 3600_000,
-            }
-        }))
+        cred_file.write_text(
+            json.dumps({
+                "claudeAiOauth": {
+                    "accessToken": "cc-auto-token",
+                    "refreshToken": "refresh",
+                    "expiresAt": int(time.time() * 1000) + 3600_000,
+                }
+            })
+        )
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         assert resolve_anthropic_token() == "cc-auto-token"
 
@@ -361,7 +387,9 @@ class TestResolveAnthropicToken:
         # Isolate source #4 (credential_pool): ensure source #3 (Claude Code
         # creds, incl. the macOS keychain read which Path.home does not cover)
         # returns nothing, mirroring a Hermes-PKCE-only setup.
-        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+        )
 
         pool_entry = SimpleNamespace(
             auth_type="oauth",
@@ -374,7 +402,54 @@ class TestResolveAnthropicToken:
 
         assert resolve_anthropic_token() == "pool-oauth-token"
 
-    def test_prefers_anthropic_credential_pool_oauth_over_api_key(self, monkeypatch, tmp_path):
+    def test_falls_back_to_dashboard_oauth_when_pool_registration_failed(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._resolve_anthropic_pool_token", lambda: None
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_hermes_oauth_credentials",
+            lambda: {
+                "accessToken": "dashboard-oauth-token",
+                "refreshToken": "dashboard-refresh-token",
+                "expiresAt": int(time.time() * 1000) + 3_600_000,
+            },
+        )
+
+        assert resolve_anthropic_token() == "dashboard-oauth-token"
+
+    def test_expired_dashboard_oauth_is_not_revived(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "api-key-fallback")
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._resolve_anthropic_pool_token", lambda: None
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_hermes_oauth_credentials",
+            lambda: {
+                "accessToken": "expired-dashboard-token",
+                "expiresAt": int(time.time() * 1000) - 1,
+            },
+        )
+
+        assert resolve_anthropic_token() == "api-key-fallback"
+
+    def test_prefers_anthropic_credential_pool_oauth_over_api_key(
+        self, monkeypatch, tmp_path
+    ):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant...ykey")
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
@@ -382,7 +457,9 @@ class TestResolveAnthropicToken:
         # Pool (source #4) must win over ANTHROPIC_API_KEY (source #5); also
         # isolate source #3 so a machine-local Claude Code creds / keychain
         # entry can't short-circuit before the pool.
-        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+        )
 
         pool_entry = SimpleNamespace(
             auth_type="oauth",
@@ -395,7 +472,9 @@ class TestResolveAnthropicToken:
 
         assert resolve_anthropic_token() == "pool-oauth-token"
 
-    def test_pool_entry_with_null_access_token_does_not_crash(self, monkeypatch, tmp_path):
+    def test_pool_entry_with_null_access_token_does_not_crash(
+        self, monkeypatch, tmp_path
+    ):
         """A persisted OAuth entry with access_token=None must not crash the
         resolver (None.strip() would escape the helper's try/excepts and take
         down the whole resolver incl. the ANTHROPIC_API_KEY fallback). It should
@@ -404,7 +483,9 @@ class TestResolveAnthropicToken:
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+        )
 
         broken_entry = SimpleNamespace(auth_type="oauth", access_token=None)
         pool = SimpleNamespace(
@@ -415,7 +496,9 @@ class TestResolveAnthropicToken:
         # Must fall through to source #5 (ANTHROPIC_API_KEY), not raise.
         assert resolve_anthropic_token() == "sk-ant...ykey"
 
-    def test_pool_api_key_only_entry_is_not_returned_as_token(self, monkeypatch, tmp_path):
+    def test_pool_api_key_only_entry_is_not_returned_as_token(
+        self, monkeypatch, tmp_path
+    ):
         """resolve_anthropic_token() returns an OAuth bearer token; a pool entry
         whose auth_type is api_key (not oauth) must NOT be returned from the pool
         path — those are consumed via the aux client's _pool_runtime_api_key
@@ -424,9 +507,13 @@ class TestResolveAnthropicToken:
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+        )
 
-        api_key_entry = SimpleNamespace(auth_type="api_key", access_token="sk-pool-apikey")
+        api_key_entry = SimpleNamespace(
+            auth_type="api_key", access_token="sk-pool-apikey"
+        )
         pool = SimpleNamespace(
             _available_entries=lambda **_kwargs: [api_key_entry],
         )
@@ -442,7 +529,9 @@ class TestResolveAnthropicToken:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+        )
 
         pool_calls = []
 
@@ -463,7 +552,9 @@ class TestResolveAnthropicToken:
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+        )
 
         captured = {}
         pool_entry = SimpleNamespace(auth_type="oauth", access_token="pool-oauth-token")
@@ -478,29 +569,37 @@ class TestResolveAnthropicToken:
         assert resolve_anthropic_token() == "pool-oauth-token"
         assert captured == {"clear_expired": False, "refresh": False}
 
-    def test_prefers_refreshable_claude_code_credentials_over_static_anthropic_token(self, monkeypatch, tmp_path):
+    def test_prefers_refreshable_claude_code_credentials_over_static_anthropic_token(
+        self, monkeypatch, tmp_path
+    ):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-static-token")
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         cred_file = tmp_path / ".claude" / ".credentials.json"
         cred_file.parent.mkdir(parents=True)
-        cred_file.write_text(json.dumps({
-            "claudeAiOauth": {
-                "accessToken": "cc-auto-token",
-                "refreshToken": "refresh-token",
-                "expiresAt": int(time.time() * 1000) + 3600_000,
-            }
-        }))
+        cred_file.write_text(
+            json.dumps({
+                "claudeAiOauth": {
+                    "accessToken": "cc-auto-token",
+                    "refreshToken": "refresh-token",
+                    "expiresAt": int(time.time() * 1000) + 3600_000,
+                }
+            })
+        )
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
         assert resolve_anthropic_token() == "cc-auto-token"
 
-    def test_keeps_static_anthropic_token_when_only_non_refreshable_claude_key_exists(self, monkeypatch, tmp_path):
+    def test_keeps_static_anthropic_token_when_only_non_refreshable_claude_key_exists(
+        self, monkeypatch, tmp_path
+    ):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-static-token")
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
         claude_json = tmp_path / ".claude.json"
-        claude_json.write_text(json.dumps({"primaryApiKey": "sk-ant-api03-managed-key"}))
+        claude_json.write_text(
+            json.dumps({"primaryApiKey": "sk-ant-api03-managed-key"})
+        )
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
         assert resolve_anthropic_token() == "sk-ant-oat01-static-token"
@@ -538,9 +637,9 @@ class TestRefreshOauthToken:
 
         with patch("urllib.request.urlopen") as mock_urlopen:
             mock_ctx = MagicMock()
-            mock_ctx.__enter__ = MagicMock(return_value=MagicMock(
-                read=MagicMock(return_value=mock_response)
-            ))
+            mock_ctx.__enter__ = MagicMock(
+                return_value=MagicMock(read=MagicMock(return_value=mock_response))
+            )
             mock_ctx.__exit__ = MagicMock(return_value=False)
             mock_urlopen.return_value = mock_ctx
 
@@ -569,6 +668,387 @@ class TestRefreshOauthToken:
             assert _refresh_oauth_token(creds) is None
 
 
+class TestAnthropicWifExchangeCaching:
+    def test_reuses_cached_access_token_for_same_assertion(self, tmp_path, monkeypatch):
+        anthropic_adapter._WIF_ACCESS_TOKEN_CACHE.clear()
+        token_file = tmp_path / "oidc.jwt"
+        token_file.write_text("jwt-assertion", encoding="utf-8")
+
+        config = {
+            "federation_rule_id": "fdrl_test123",
+            "organization_id": "org_test456",
+            "service_account_id": "svac_test789",
+            "identity_token_file": str(token_file),
+            "api_base_url": "https://api.anthropic.com",
+        }
+
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._get_claude_code_version", lambda: "2.1.74"
+        )
+
+        calls = []
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return json.dumps({
+                    "access_token": "cached-wif-token",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                }).encode()
+
+        def _fake_urlopen(req, timeout=0):
+            calls.append((req.full_url, timeout, req.get_header("User-agent")))
+            return _Resp()
+
+        with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+            first = exchange_anthropic_wif_for_access_token(config)
+            second = exchange_anthropic_wif_for_access_token(config)
+
+        assert first["access_token"] == "cached-wif-token"
+        assert second["access_token"] == "cached-wif-token"
+        assert len(calls) == 1
+        assert calls[0][2] == anthropic_adapter._OAUTH_TOKEN_USER_AGENT
+
+    def test_reuses_persisted_wif_exchange_cache_across_processes(
+        self, monkeypatch, tmp_path
+    ):
+        token_file = tmp_path / "oidc.jwt"
+        token_file.write_text("gh-oidc-jwt")
+        monkeypatch.setattr("agent.anthropic_adapter.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._get_claude_code_version", lambda: "2.1.74"
+        )
+        anthropic_adapter._WIF_ACCESS_TOKEN_CACHE.clear()
+
+        config = {
+            "federation_rule_id": "fdrl_test123",
+            "organization_id": "org_test456",
+            "service_account_id": "svac_test789",
+            "identity_token_file": str(token_file),
+            "api_base_url": "https://api.anthropic.com",
+        }
+
+        calls = []
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return json.dumps({
+                    "access_token": "persisted-wif-token",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                }).encode()
+
+        def _fake_urlopen(req, timeout=0):
+            calls.append((req.full_url, timeout))
+            return _Resp()
+
+        with patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+            first = exchange_anthropic_wif_for_access_token(config)
+            anthropic_adapter._WIF_ACCESS_TOKEN_CACHE.clear()
+            second = exchange_anthropic_wif_for_access_token(config)
+
+        assert first["access_token"] == "persisted-wif-token"
+        assert second["access_token"] == "persisted-wif-token"
+        assert len(calls) == 1
+        assert (tmp_path / ".anthropic_wif_token_cache.json").exists()
+
+    def test_malformed_persisted_expiry_is_treated_as_cache_miss(
+        self, monkeypatch, tmp_path
+    ):
+        token_file = tmp_path / "oidc.jwt"
+        token_file.write_text("gh-oidc-jwt", encoding="utf-8")
+        monkeypatch.setattr("agent.anthropic_adapter.get_hermes_home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._get_claude_code_version", lambda: "2.1.74"
+        )
+        anthropic_adapter._WIF_ACCESS_TOKEN_CACHE.clear()
+        config = {
+            "federation_rule_id": "fdrl_test123",
+            "organization_id": "org_test456",
+            "service_account_id": "svac_test789",
+            "identity_token_file": str(token_file),
+            "api_base_url": "https://api.anthropic.com",
+        }
+        responses = iter(("first-token", "fresh-token"))
+
+        class _Resp:
+            def __init__(self, token):
+                self.token = token
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return json.dumps({
+                    "access_token": self.token,
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                }).encode()
+
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=lambda *_args, **_kwargs: _Resp(next(responses)),
+        ):
+            first = exchange_anthropic_wif_for_access_token(config)
+            cache_file = tmp_path / ".anthropic_wif_token_cache.json"
+            persisted = json.loads(cache_file.read_text(encoding="utf-8"))
+            persisted["expires_at_ms"] = "not-an-integer"
+            cache_file.write_text(json.dumps(persisted), encoding="utf-8")
+            anthropic_adapter._WIF_ACCESS_TOKEN_CACHE.clear()
+            second = exchange_anthropic_wif_for_access_token(config)
+
+        assert first["access_token"] == "first-token"
+        assert second["access_token"] == "fresh-token"
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="POSIX mode bits not enforced on Windows",
+)
+class TestAnthropicWifCacheFileSecurity:
+    """The WIF cache persists a live Anthropic bearer token to disk.
+
+    It must get the same TOCTOU-safe treatment as every other credential
+    writer in the tree (``hermes_cli.auth._save_auth_store``, #19673,
+    #21148): created 0o600 via ``O_CREAT|O_EXCL`` under a unique temp name,
+    never chmod'd into safety after the fact and never sharing a temp path
+    with a concurrent writer.
+    """
+
+    CACHE_NAME = ".anthropic_wif_token_cache.json"
+
+    @classmethod
+    def _temp_leftovers(cls, home) -> list:
+        """Temp files the writer failed to clean up (the conftest's own
+        HERMES_HOME sandbox dir also lives under ``tmp_path``, so match on
+        the cache's temp prefix rather than asserting the dir is empty)."""
+        return sorted(
+            p.name for p in home.iterdir() if p.name.startswith(f"{cls.CACHE_NAME}.tmp")
+        )
+
+    @staticmethod
+    def _exchanged(token: str = "wif-bearer-secret") -> dict:
+        return {
+            "access_token": token,
+            "token_type": "Bearer",
+            "scope": None,
+            "expires_in": 3600,
+            "expires_at_ms": 1_900_000_000_000,
+        }
+
+    def test_temp_file_is_0600_from_creation_never_at_umask(
+        self, tmp_path, monkeypatch
+    ):
+        """The token must never touch disk world-readable, not even briefly."""
+        monkeypatch.setattr("agent.anthropic_adapter.get_hermes_home", lambda: tmp_path)
+
+        observed = {}
+        real_replace = os.replace
+
+        def _spy_replace(src, dst):
+            # Inspect the temp file at the last instant before it lands.
+            observed["tmp_mode"] = stat.S_IMODE(os.stat(src).st_mode)
+            observed["tmp_name"] = os.path.basename(str(src))
+            return real_replace(src, dst)
+
+        monkeypatch.setattr(os, "replace", _spy_replace)
+
+        old_umask = os.umask(0o022)  # makes the race observable if it regresses
+        try:
+            anthropic_adapter._write_cached_wif_exchange(
+                "cache-key-1", self._exchanged()
+            )
+        finally:
+            os.umask(old_umask)
+
+        assert observed["tmp_mode"] == 0o600, (
+            f"WIF cache temp file created at 0o{observed['tmp_mode']:o} — the bearer "
+            "token was exposed to other local users before the chmod landed"
+        )
+        assert str(os.getpid()) in observed["tmp_name"], (
+            f"temp name {observed['tmp_name']!r} is not process-unique — "
+            "concurrent writers collide on it"
+        )
+
+        cache_file = tmp_path / self.CACHE_NAME
+        assert stat.S_IMODE(cache_file.stat().st_mode) == 0o600
+        assert stat.S_IMODE(tmp_path.stat().st_mode) == 0o700
+        payload = json.loads(cache_file.read_text())
+        assert payload["access_token"] == "wif-bearer-secret"
+        assert payload["cache_key"] == "cache-key-1"
+        assert self._temp_leftovers(tmp_path) == [], "a temp file was left behind"
+
+    def test_concurrent_writers_do_not_share_a_temp_path(self, tmp_path, monkeypatch):
+        """Parallel agents refreshing the same WIF token must not clobber each other."""
+        monkeypatch.setattr("agent.anthropic_adapter.get_hermes_home", lambda: tmp_path)
+
+        writers = 8
+        seen_temp_names: list = []
+        errors: list = []
+        lock = threading.Lock()
+        barrier = threading.Barrier(writers)
+        real_replace = os.replace
+
+        def _spy_replace(src, dst):
+            with lock:
+                seen_temp_names.append(os.path.basename(str(src)))
+            return real_replace(src, dst)
+
+        monkeypatch.setattr(os, "replace", _spy_replace)
+
+        def _writer(index: int) -> None:
+            try:
+                barrier.wait(timeout=10)
+                anthropic_adapter._write_cached_wif_exchange(
+                    f"cache-key-{index}", self._exchanged(f"wif-bearer-{index}")
+                )
+            except Exception as exc:  # pragma: no cover - surfaced via assert below
+                with lock:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=_writer, args=(i,)) for i in range(writers)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=15)
+
+        assert not errors, f"concurrent writers raised: {errors}"
+        assert len(set(seen_temp_names)) == writers, (
+            f"{writers} writers produced {len(set(seen_temp_names))} distinct temp "
+            f"names ({sorted(set(seen_temp_names))}) — a shared temp path lets one "
+            "writer truncate another's in-flight token"
+        )
+
+        cache_file = tmp_path / self.CACHE_NAME
+        assert self._temp_leftovers(tmp_path) == []
+        assert stat.S_IMODE(cache_file.stat().st_mode) == 0o600
+        # Last writer wins atomically — the file is never a torn mix of two payloads.
+        payload = json.loads(cache_file.read_text())
+        index = payload["access_token"].removeprefix("wif-bearer-")
+        assert payload["cache_key"] == f"cache-key-{index}"
+
+    def test_preexisting_temp_symlink_is_not_followed(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("agent.anthropic_adapter.get_hermes_home", lambda: tmp_path)
+
+        class _FixedUuid:
+            hex = "known"
+
+        monkeypatch.setattr("agent.anthropic_adapter.uuid.uuid4", lambda: _FixedUuid())
+        victim = tmp_path / "victim"
+        victim.write_text("do-not-overwrite", encoding="utf-8")
+        temp_path = tmp_path / f"{self.CACHE_NAME}.tmp.{os.getpid()}.known"
+        temp_path.symlink_to(victim)
+
+        anthropic_adapter._write_cached_wif_exchange("cache-key", self._exchanged())
+
+        assert victim.read_text(encoding="utf-8") == "do-not-overwrite"
+        assert not (tmp_path / self.CACHE_NAME).exists()
+        assert not temp_path.exists()
+
+
+class TestAnthropicWifProviderState:
+    """WIF state must be read through the auth store's own accessor.
+
+    ``get_provider_auth_state`` carries the profile → global-root fallback
+    (issue #18594 follow-up): a profile process that never ran
+    ``hermes auth login anthropic`` locally still sees the WIF identity
+    configured at the global root. Re-reading ``$HERMES_HOME/auth.json`` by
+    hand skips that fallback and silently drops WIF in every profile.
+    """
+
+    WIF_ENV_VARS = (
+        "ANTHROPIC_FEDERATION_RULE_ID",
+        "ANTHROPIC_ORGANIZATION_ID",
+        "ANTHROPIC_SERVICE_ACCOUNT_ID",
+        "ANTHROPIC_IDENTITY_TOKEN_FILE",
+        "ANTHROPIC_API_BASE_URL",
+    )
+
+    @staticmethod
+    def _wif_state(token_file, rule_id: str) -> dict:
+        return {
+            "auth_type": "wif",
+            "federation_rule_id": rule_id,
+            "organization_id": "org_test456",
+            "service_account_id": "svac_test789",
+            "identity_token_file": str(token_file),
+        }
+
+    def _profile_mode(self, tmp_path, monkeypatch):
+        """Put the process in profile mode: HERMES_HOME=<root>/profiles/work."""
+        for var in self.WIF_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        root = tmp_path / "hermes"
+        profile = root / "profiles" / "work"
+        profile.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        token_file = tmp_path / "oidc.jwt"
+        token_file.write_text("gh-oidc-jwt", encoding="utf-8")
+        return root, profile, token_file
+
+    def test_falls_back_to_global_root_state_in_profile_mode(
+        self, tmp_path, monkeypatch
+    ):
+        root, profile, token_file = self._profile_mode(tmp_path, monkeypatch)
+        (root / "auth.json").write_text(
+            json.dumps({
+                "version": 1,
+                "providers": {"anthropic": self._wif_state(token_file, "fdrl_global")},
+            }),
+            encoding="utf-8",
+        )
+        # Profile store exists but has no Anthropic entry — the global one must show through.
+        (profile / "auth.json").write_text(
+            json.dumps({"version": 1, "providers": {}}), encoding="utf-8"
+        )
+
+        config = anthropic_adapter.read_anthropic_wif_config()
+
+        assert config is not None, (
+            "WIF configured at the global root is invisible to a profile process"
+        )
+        assert config["auth_type"] == "wif"
+        assert config["federation_rule_id"] == "fdrl_global"
+        assert config["identity_token_file"] == str(token_file)
+
+    def test_profile_state_shadows_global_state(self, tmp_path, monkeypatch):
+        root, profile, token_file = self._profile_mode(tmp_path, monkeypatch)
+        (root / "auth.json").write_text(
+            json.dumps({
+                "version": 1,
+                "providers": {"anthropic": self._wif_state(token_file, "fdrl_global")},
+            }),
+            encoding="utf-8",
+        )
+        (profile / "auth.json").write_text(
+            json.dumps({
+                "version": 1,
+                "providers": {"anthropic": self._wif_state(token_file, "fdrl_profile")},
+            }),
+            encoding="utf-8",
+        )
+
+        config = anthropic_adapter.read_anthropic_wif_config()
+
+        assert config is not None
+        assert config["federation_rule_id"] == "fdrl_profile"
+
+
 class TestWriteClaudeCodeCredentials:
     def test_writes_new_file(self, tmp_path, monkeypatch):
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
@@ -591,7 +1071,9 @@ class TestWriteClaudeCodeCredentials:
         assert data["otherField"] == "keep-me"
         assert data["claudeAiOauth"]["accessToken"] == "new-tok"
 
-    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows"
+    )
     def test_credentials_file_created_with_0o600(self, tmp_path, monkeypatch):
         """Refreshed Claude Code credentials must land on disk at 0o600.
 
@@ -601,13 +1083,16 @@ class TestWriteClaudeCodeCredentials:
         the fix shipped in #19673 (google_oauth) and #21148 (mcp_oauth).
         """
         import stat as _stat
+
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         _write_claude_code_credentials("tok", "ref", 12345)
 
         cred_file = tmp_path / ".claude" / ".credentials.json"
         assert cred_file.exists()
         mode = _stat.S_IMODE(cred_file.stat().st_mode)
-        assert mode == 0o600, f"creds file mode {oct(mode)} != 0o600 — TOCTOU race regressed"
+        assert mode == 0o600, (
+            f"creds file mode {oct(mode)} != 0o600 — TOCTOU race regressed"
+        )
 
 
 class TestResolveWithRefresh:
@@ -620,38 +1105,50 @@ class TestResolveWithRefresh:
         # Set up expired creds with a refresh token
         cred_file = tmp_path / ".claude" / ".credentials.json"
         cred_file.parent.mkdir(parents=True)
-        cred_file.write_text(json.dumps({
-            "claudeAiOauth": {
-                "accessToken": "expired-tok",
-                "refreshToken": "valid-refresh",
-                "expiresAt": int(time.time() * 1000) - 3600_000,
-            }
-        }))
+        cred_file.write_text(
+            json.dumps({
+                "claudeAiOauth": {
+                    "accessToken": "expired-tok",
+                    "refreshToken": "valid-refresh",
+                    "expiresAt": int(time.time() * 1000) - 3600_000,
+                }
+            })
+        )
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
         # Mock refresh to succeed
-        with patch("agent.anthropic_adapter._refresh_oauth_token", return_value="refreshed-token"):
+        with patch(
+            "agent.anthropic_adapter._refresh_oauth_token",
+            return_value="refreshed-token",
+        ):
             result = resolve_anthropic_token()
 
         assert result == "refreshed-token"
 
-    def test_static_env_oauth_token_does_not_block_refreshable_claude_creds(self, monkeypatch, tmp_path):
+    def test_static_env_oauth_token_does_not_block_refreshable_claude_creds(
+        self, monkeypatch, tmp_path
+    ):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-expired-env-token")
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
 
         cred_file = tmp_path / ".claude" / ".credentials.json"
         cred_file.parent.mkdir(parents=True)
-        cred_file.write_text(json.dumps({
-            "claudeAiOauth": {
-                "accessToken": "expired-claude-creds-token",
-                "refreshToken": "valid-refresh",
-                "expiresAt": int(time.time() * 1000) - 3600_000,
-            }
-        }))
+        cred_file.write_text(
+            json.dumps({
+                "claudeAiOauth": {
+                    "accessToken": "expired-claude-creds-token",
+                    "refreshToken": "valid-refresh",
+                    "expiresAt": int(time.time() * 1000) - 3600_000,
+                }
+            })
+        )
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
-        with patch("agent.anthropic_adapter._refresh_oauth_token", return_value="refreshed-token"):
+        with patch(
+            "agent.anthropic_adapter._refresh_oauth_token",
+            return_value="refreshed-token",
+        ):
             result = resolve_anthropic_token()
 
         assert result == "refreshed-token"
@@ -672,13 +1169,15 @@ class TestRunOauthSetupToken:
         # Pre-create credential files that will be found after subprocess
         cred_file = tmp_path / ".claude" / ".credentials.json"
         cred_file.parent.mkdir(parents=True)
-        cred_file.write_text(json.dumps({
-            "claudeAiOauth": {
-                "accessToken": "from-cred-file",
-                "refreshToken": "refresh",
-                "expiresAt": int(time.time() * 1000) + 3600_000,
-            }
-        }))
+        cred_file.write_text(
+            json.dumps({
+                "claudeAiOauth": {
+                    "accessToken": "from-cred-file",
+                    "refreshToken": "refresh",
+                    "expiresAt": int(time.time() * 1000) + 3600_000,
+                }
+            })
+        )
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
         with patch("subprocess.run") as mock_run:
@@ -735,27 +1234,45 @@ class TestRunOauthSetupToken:
 
 class TestNormalizeModelName:
     def test_strips_anthropic_prefix(self):
-        assert normalize_model_name("anthropic/claude-sonnet-4-20250514") == "claude-sonnet-4-20250514"
+        assert (
+            normalize_model_name("anthropic/claude-sonnet-4-20250514")
+            == "claude-sonnet-4-20250514"
+        )
 
     def test_leaves_bare_name(self):
-        assert normalize_model_name("claude-sonnet-4-20250514") == "claude-sonnet-4-20250514"
+        assert (
+            normalize_model_name("claude-sonnet-4-20250514")
+            == "claude-sonnet-4-20250514"
+        )
 
     def test_converts_dots_to_hyphens(self):
         """OpenRouter uses dots (4.6), Anthropic uses hyphens (4-6)."""
         assert normalize_model_name("anthropic/claude-opus-4.6") == "claude-opus-4-6"
-        assert normalize_model_name("anthropic/claude-sonnet-4.5") == "claude-sonnet-4-5"
+        assert (
+            normalize_model_name("anthropic/claude-sonnet-4.5") == "claude-sonnet-4-5"
+        )
         assert normalize_model_name("claude-opus-4.6") == "claude-opus-4-6"
 
     def test_already_hyphenated_unchanged(self):
         """Names already in Anthropic format should pass through."""
         assert normalize_model_name("claude-opus-4-6") == "claude-opus-4-6"
-        assert normalize_model_name("claude-opus-4-5-20251101") == "claude-opus-4-5-20251101"
+        assert (
+            normalize_model_name("claude-opus-4-5-20251101")
+            == "claude-opus-4-5-20251101"
+        )
 
     def test_preserve_dots_for_alibaba_dashscope(self):
         """Alibaba/DashScope use dots in model names (e.g. qwen3.5-plus). Fixes #1739."""
-        assert normalize_model_name("qwen3.5-plus", preserve_dots=True) == "qwen3.5-plus"
-        assert normalize_model_name("anthropic/qwen3.5-plus", preserve_dots=True) == "qwen3.5-plus"
-        assert normalize_model_name("qwen3.5-flash", preserve_dots=True) == "qwen3.5-flash"
+        assert (
+            normalize_model_name("qwen3.5-plus", preserve_dots=True) == "qwen3.5-plus"
+        )
+        assert (
+            normalize_model_name("anthropic/qwen3.5-plus", preserve_dots=True)
+            == "qwen3.5-plus"
+        )
+        assert (
+            normalize_model_name("qwen3.5-flash", preserve_dots=True) == "qwen3.5-flash"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -842,7 +1359,10 @@ class TestConvertMessages:
                 "role": "user",
                 "content": [
                     {"type": "text", "text": "Can you see this?"},
-                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/cat.png"},
+                    },
                 ],
             }
         ]
@@ -854,7 +1374,10 @@ class TestConvertMessages:
                 "role": "user",
                 "content": [
                     {"type": "text", "text": "Can you see this?"},
-                    {"type": "image", "source": {"type": "url", "url": "https://example.com/cat.png"}},
+                    {
+                        "type": "image",
+                        "source": {"type": "url", "url": "https://example.com/cat.png"},
+                    },
                 ],
             }
         ]
@@ -919,7 +1442,10 @@ class TestConvertMessages:
                 "role": "assistant",
                 "content": "",
                 "tool_calls": [
-                    {"id": "tc_1", "function": {"name": "test_tool", "arguments": "{}"}},
+                    {
+                        "id": "tc_1",
+                        "function": {"name": "test_tool", "arguments": "{}"},
+                    },
                 ],
             },
             {"role": "tool", "tool_call_id": "tc_1", "content": "result data"},
@@ -984,10 +1510,9 @@ class TestConvertMessages:
         # tc_gone has no matching tool_use — its tool_result should be stripped
         for m in result:
             if m["role"] == "user" and isinstance(m["content"], list):
-                assert all(
-                    b.get("type") != "tool_result"
-                    for b in m["content"]
-                ), "Orphaned tool_result should have been stripped"
+                assert all(b.get("type") != "tool_result" for b in m["content"]), (
+                    "Orphaned tool_result should have been stripped"
+                )
 
     def test_strips_orphaned_tool_result_preserves_valid(self):
         """Orphaned tool_results are stripped while valid ones survive."""
@@ -996,7 +1521,10 @@ class TestConvertMessages:
                 "role": "assistant",
                 "content": "",
                 "tool_calls": [
-                    {"id": "tc_valid", "function": {"name": "search", "arguments": "{}"}},
+                    {
+                        "id": "tc_valid",
+                        "function": {"name": "search", "arguments": "{}"},
+                    },
                 ],
             },
             {"role": "tool", "tool_call_id": "tc_valid", "content": "good result"},
@@ -1024,7 +1552,10 @@ class TestConvertMessages:
                 "role": "assistant",
                 "content": "",
                 "tool_calls": [
-                    {"id": "tc_late", "function": {"name": "search", "arguments": "{}"}},
+                    {
+                        "id": "tc_late",
+                        "function": {"name": "search", "arguments": "{}"},
+                    },
                 ],
             },
             {"role": "user", "content": "actually, something else"},
@@ -1066,7 +1597,11 @@ class TestConvertMessages:
             {
                 "role": "system",
                 "content": [
-                    {"type": "text", "text": "System prompt", "cache_control": {"type": "ephemeral"}},
+                    {
+                        "type": "text",
+                        "text": "System prompt",
+                        "cache_control": {"type": "ephemeral"},
+                    },
                 ],
             },
             {"role": "user", "content": "Hi"},
@@ -1090,18 +1625,24 @@ class TestConvertMessages:
         assert assistant_blocks[0]["cache_control"] == {"type": "ephemeral"}
 
     def test_assistant_tool_use_cache_control_is_preserved(self):
-        messages = apply_anthropic_cache_control([
-            {"role": "system", "content": "System prompt"},
-            {"role": "user", "content": "Run the tool"},
-            {
-                "role": "assistant",
-                "content": "",
-                "tool_calls": [
-                    {"id": "tc_1", "function": {"name": "test_tool", "arguments": "{}"}},
-                ],
-            },
-            {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
-        ], native_anthropic=True)
+        messages = apply_anthropic_cache_control(
+            [
+                {"role": "system", "content": "System prompt"},
+                {"role": "user", "content": "Run the tool"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "tc_1",
+                            "function": {"name": "test_tool", "arguments": "{}"},
+                        },
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
+            ],
+            native_anthropic=True,
+        )
 
         _, result = convert_messages_to_anthropic(messages)
         assistant_msg = [m for m in result if m["role"] == "assistant"][0]
@@ -1112,37 +1653,40 @@ class TestConvertMessages:
         assert tool_use["cache_control"] == {"type": "ephemeral"}
 
     def test_ordered_replay_tool_use_cache_control_is_preserved(self):
-        messages = apply_anthropic_cache_control([
-            {"role": "system", "content": "System prompt"},
-            {"role": "user", "content": "Run the tool"},
-            {
-                "role": "assistant",
-                "content": "",
-                "anthropic_content_blocks": [
-                    {
-                        "type": "thinking",
-                        "thinking": "Need a tool.",
-                        "signature": "sig_1",
-                    },
-                    {
-                        "type": "tool_use",
-                        "id": "tc_1",
-                        "name": "test_tool",
-                        "input": {"query": "raw"},
-                    },
-                ],
-                "tool_calls": [
-                    {
-                        "id": "tc_1",
-                        "function": {
-                            "name": "test_tool",
-                            "arguments": '{"query":"redacted"}',
+        messages = apply_anthropic_cache_control(
+            [
+                {"role": "system", "content": "System prompt"},
+                {"role": "user", "content": "Run the tool"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "anthropic_content_blocks": [
+                        {
+                            "type": "thinking",
+                            "thinking": "Need a tool.",
+                            "signature": "sig_1",
                         },
-                    },
-                ],
-            },
-            {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
-        ], native_anthropic=True)
+                        {
+                            "type": "tool_use",
+                            "id": "tc_1",
+                            "name": "test_tool",
+                            "input": {"query": "raw"},
+                        },
+                    ],
+                    "tool_calls": [
+                        {
+                            "id": "tc_1",
+                            "function": {
+                                "name": "test_tool",
+                                "arguments": '{"query":"redacted"}',
+                            },
+                        },
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
+            ],
+            native_anthropic=True,
+        )
 
         _, result = convert_messages_to_anthropic(messages)
         assistant_msg = [m for m in result if m["role"] == "assistant"][0]
@@ -1156,17 +1700,23 @@ class TestConvertMessages:
         assert tool_use["cache_control"] == {"type": "ephemeral"}
 
     def test_tool_cache_control_is_preserved_on_tool_result_block(self):
-        messages = apply_anthropic_cache_control([
-            {"role": "system", "content": "System prompt"},
-            {
-                "role": "assistant",
-                "content": "",
-                "tool_calls": [
-                    {"id": "tc_1", "function": {"name": "test_tool", "arguments": "{}"}},
-                ],
-            },
-            {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
-        ], native_anthropic=True)
+        messages = apply_anthropic_cache_control(
+            [
+                {"role": "system", "content": "System prompt"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "tc_1",
+                            "function": {"name": "test_tool", "arguments": "{}"},
+                        },
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
+            ],
+            native_anthropic=True,
+        )
 
         _, result = convert_messages_to_anthropic(messages)
         user_msg = [m for m in result if m["role"] == "user"][0]
@@ -1183,7 +1733,10 @@ class TestConvertMessages:
                 "role": "assistant",
                 "content": "",
                 "tool_calls": [
-                    {"id": "tc_1", "function": {"name": "test_tool", "arguments": "{}"}},
+                    {
+                        "id": "tc_1",
+                        "function": {"name": "test_tool", "arguments": "{}"},
+                    },
                 ],
                 "reasoning_details": [
                     {
@@ -1197,10 +1750,14 @@ class TestConvertMessages:
         ]
 
         _, result = convert_messages_to_anthropic(messages)
-        assistant_blocks = next(msg for msg in result if msg["role"] == "assistant")["content"]
+        assistant_blocks = next(msg for msg in result if msg["role"] == "assistant")[
+            "content"
+        ]
 
         assert assistant_blocks[0]["type"] == "thinking"
-        assert assistant_blocks[0]["thinking"] == "Need to inspect the tool result first."
+        assert (
+            assistant_blocks[0]["thinking"] == "Need to inspect the tool result first."
+        )
         assert assistant_blocks[0]["signature"] == "sig_123"
         assert assistant_blocks[1]["type"] == "tool_use"
 
@@ -1262,7 +1819,10 @@ class TestConvertMessages:
                 "role": "assistant",
                 "content": "",
                 "tool_calls": [
-                    {"id": "tc_1", "function": {"name": "skill_view", "arguments": "{}"}},
+                    {
+                        "id": "tc_1",
+                        "function": {"name": "skill_view", "arguments": "{}"},
+                    },
                 ],
             },
             {"role": "tool", "tool_call_id": "tc_1", "content": "result"},
@@ -1273,7 +1833,10 @@ class TestConvertMessages:
         assistant_turn = next(msg for msg in result if msg["role"] == "assistant")
         assistant_blocks = assistant_turn["content"]
 
-        assert all(not (b.get("type") == "text" and b.get("text") == "") for b in assistant_blocks)
+        assert all(
+            not (b.get("type") == "text" and b.get("text") == "")
+            for b in assistant_blocks
+        )
         assert any(b.get("type") == "tool_use" for b in assistant_blocks)
 
     def test_empty_user_message_string_gets_placeholder(self):
@@ -1311,7 +1874,13 @@ class TestConvertMessages:
     def test_user_message_with_empty_text_blocks_gets_placeholder(self):
         """User message with only empty text blocks should get placeholder."""
         messages = [
-            {"role": "user", "content": [{"type": "text", "text": ""}, {"type": "text", "text": "  "}]},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": ""},
+                    {"type": "text", "text": "  "},
+                ],
+            },
         ]
         _, result = convert_messages_to_anthropic(messages)
         assert result[0]["role"] == "user"
@@ -1485,6 +2054,7 @@ class TestBuildAnthropicKwargs:
         # params through its signature, we exercise the strip behavior by
         # calling the internal predicate directly.
         from agent.anthropic_adapter import _forbids_sampling_params
+
         assert _forbids_sampling_params("claude-opus-4-8") is True
         assert _forbids_sampling_params("claude-opus-4-8-fast") is True
         assert _forbids_sampling_params("claude-opus-4-7") is True
@@ -1501,6 +2071,7 @@ class TestBuildAnthropicKwargs:
         False for both opus-4-8 and opus-4-8-fast.
         """
         from agent.anthropic_adapter import _supports_fast_mode
+
         assert _supports_fast_mode("claude-opus-4-6") is True
         assert _supports_fast_mode("anthropic/claude-opus-4-6") is True
         assert _supports_fast_mode("claude-opus-4-7") is False
@@ -1523,11 +2094,12 @@ class TestBuildAnthropicKwargs:
             _forbids_sampling_params,
             _get_anthropic_max_output,
         )
+
         # New / unknown Claude models → modern contract by default.
         for m in (
             "claude-fable-5",
             "anthropic/claude-fable-5",
-            "claude-saga-2",            # hypothetical future named model
+            "claude-saga-2",  # hypothetical future named model
             "anthropic/claude-opus-9",  # hypothetical future numbered model
         ):
             assert _supports_adaptive_thinking(m) is True, m
@@ -1542,6 +2114,7 @@ class TestBuildAnthropicKwargs:
             _supports_adaptive_thinking,
             _forbids_sampling_params,
         )
+
         for m in (
             "claude-3-5-sonnet",
             "claude-3-7-sonnet",
@@ -1559,6 +2132,7 @@ class TestBuildAnthropicKwargs:
             _supports_xhigh_effort,
             _forbids_sampling_params,
         )
+
         for m in ("claude-opus-4.6", "claude-sonnet-4-6"):
             assert _supports_adaptive_thinking(m) is True, m
             assert _supports_xhigh_effort(m) is False, m
@@ -1572,6 +2146,7 @@ class TestBuildAnthropicKwargs:
             _supports_xhigh_effort,
             _forbids_sampling_params,
         )
+
         for m in ("minimax-m2", "qwen3-max", "moonshotai/kimi-k2.5", "glm-4.6"):
             assert _supports_adaptive_thinking(m) is False, m
             assert _supports_xhigh_effort(m) is False, m
@@ -1723,35 +2298,43 @@ class TestBuildAnthropicKwargs:
 class TestGetAnthropicMaxOutput:
     def test_opus_4_6(self):
         from agent.anthropic_adapter import _get_anthropic_max_output
+
         assert _get_anthropic_max_output("claude-opus-4-6") == 128_000
 
     def test_opus_4_6_variant(self):
         from agent.anthropic_adapter import _get_anthropic_max_output
+
         assert _get_anthropic_max_output("claude-opus-4-6:1m:fast") == 128_000
 
     def test_sonnet_4_6(self):
         from agent.anthropic_adapter import _get_anthropic_max_output
+
         assert _get_anthropic_max_output("claude-sonnet-4-6") == 64_000
 
     def test_sonnet_4_date_stamped(self):
         from agent.anthropic_adapter import _get_anthropic_max_output
+
         assert _get_anthropic_max_output("claude-sonnet-4-20250514") == 64_000
 
     def test_claude_3_5_sonnet(self):
         from agent.anthropic_adapter import _get_anthropic_max_output
+
         assert _get_anthropic_max_output("claude-3-5-sonnet-20241022") == 8_192
 
     def test_claude_3_opus(self):
         from agent.anthropic_adapter import _get_anthropic_max_output
+
         assert _get_anthropic_max_output("claude-3-opus-20240229") == 4_096
 
     def test_unknown_future_model(self):
         from agent.anthropic_adapter import _get_anthropic_max_output
+
         assert _get_anthropic_max_output("claude-ultra-5-20260101") == 128_000
 
     def test_longest_prefix_wins(self):
         """'claude-3-5-sonnet' should match before 'claude-3-5'."""
         from agent.anthropic_adapter import _get_anthropic_max_output
+
         # claude-3-5-sonnet (8192) should win over a hypothetical shorter match
         assert _get_anthropic_max_output("claude-3-5-sonnet-20241022") == 8_192
 
@@ -1824,7 +2407,9 @@ class TestNormalizeResponse:
 
     def test_text_response(self):
         block = SimpleNamespace(type="text", text="Hello world")
-        nr = get_transport("anthropic_messages").normalize_response(self._make_response([block]))
+        nr = get_transport("anthropic_messages").normalize_response(
+            self._make_response([block])
+        )
         assert nr.content == "Hello world"
         assert nr.finish_reason == "stop"
         assert nr.tool_calls is None
@@ -1853,10 +2438,14 @@ class TestNormalizeResponse:
             SimpleNamespace(type="thinking", thinking="Let me reason about this..."),
             SimpleNamespace(type="text", text="The answer is 42."),
         ]
-        nr = get_transport("anthropic_messages").normalize_response(self._make_response(blocks))
+        nr = get_transport("anthropic_messages").normalize_response(
+            self._make_response(blocks)
+        )
         assert nr.content == "The answer is 42."
         assert nr.reasoning == "Let me reason about this..."
-        assert nr.provider_data["reasoning_details"] == [{"type": "thinking", "thinking": "Let me reason about this..."}]
+        assert nr.provider_data["reasoning_details"] == [
+            {"type": "thinking", "thinking": "Let me reason about this..."}
+        ]
 
     def test_thinking_response_preserves_signature(self):
         blocks = [
@@ -1867,9 +2456,16 @@ class TestNormalizeResponse:
                 redacted=False,
             ),
         ]
-        nr = get_transport("anthropic_messages").normalize_response(self._make_response(blocks))
-        assert nr.provider_data["reasoning_details"][0]["signature"] == "opaque_signature"
-        assert nr.provider_data["reasoning_details"][0]["thinking"] == "Let me reason about this..."
+        nr = get_transport("anthropic_messages").normalize_response(
+            self._make_response(blocks)
+        )
+        assert (
+            nr.provider_data["reasoning_details"][0]["signature"] == "opaque_signature"
+        )
+        assert (
+            nr.provider_data["reasoning_details"][0]["thinking"]
+            == "Let me reason about this..."
+        )
 
     def test_stop_reason_mapping(self):
         block = SimpleNamespace(type="text", text="x")
@@ -1959,7 +2555,11 @@ class TestThinkingBlockSignatureManagement:
                     {"id": "tc_1", "function": {"name": "tool1", "arguments": "{}"}},
                 ],
                 "reasoning_details": [
-                    {"type": "thinking", "thinking": "Old reasoning.", "signature": "sig_old"},
+                    {
+                        "type": "thinking",
+                        "thinking": "Old reasoning.",
+                        "signature": "sig_old",
+                    },
                 ],
             },
             {"role": "tool", "tool_call_id": "tc_1", "content": "result 1"},
@@ -1970,7 +2570,11 @@ class TestThinkingBlockSignatureManagement:
                     {"id": "tc_2", "function": {"name": "tool2", "arguments": "{}"}},
                 ],
                 "reasoning_details": [
-                    {"type": "thinking", "thinking": "Latest reasoning.", "signature": "sig_new"},
+                    {
+                        "type": "thinking",
+                        "thinking": "Latest reasoning.",
+                        "signature": "sig_new",
+                    },
                 ],
             },
             {"role": "tool", "tool_call_id": "tc_2", "content": "result 2"},
@@ -2001,7 +2605,11 @@ class TestThinkingBlockSignatureManagement:
                 "role": "assistant",
                 "content": "The answer is 42.",
                 "reasoning_details": [
-                    {"type": "thinking", "thinking": "Deep thought.", "signature": "sig_valid"},
+                    {
+                        "type": "thinking",
+                        "thinking": "Deep thought.",
+                        "signature": "sig_valid",
+                    },
                 ],
             },
         ]
@@ -2098,14 +2706,22 @@ class TestThinkingBlockSignatureManagement:
                 "role": "assistant",
                 "content": "First response.",
                 "reasoning_details": [
-                    {"type": "thinking", "thinking": "First thought.", "signature": "sig_1"},
+                    {
+                        "type": "thinking",
+                        "thinking": "First thought.",
+                        "signature": "sig_1",
+                    },
                 ],
             },
             {
                 "role": "assistant",
                 "content": "Second response.",
                 "reasoning_details": [
-                    {"type": "thinking", "thinking": "Second thought.", "signature": "sig_2"},
+                    {
+                        "type": "thinking",
+                        "thinking": "Second thought.",
+                        "signature": "sig_2",
+                    },
                 ],
             },
         ]
@@ -2185,7 +2801,8 @@ class TestThinkingBlockSignatureManagement:
 
         # Last one: thinking preserved
         last_thinking = [
-            b for b in assistants[2]["content"]
+            b
+            for b in assistants[2]["content"]
             if isinstance(b, dict) and b.get("type") == "thinking"
         ]
         assert len(last_thinking) == 1
@@ -2210,11 +2827,21 @@ class TestThinkingBlockSignatureManagement:
                 "role": "assistant",
                 "content": "",
                 "tool_calls": [
-                    {"id": "tc_kept", "function": {"name": "tool_a", "arguments": "{}"}},
-                    {"id": "tc_orphan", "function": {"name": "tool_b", "arguments": "{}"}},
+                    {
+                        "id": "tc_kept",
+                        "function": {"name": "tool_a", "arguments": "{}"},
+                    },
+                    {
+                        "id": "tc_orphan",
+                        "function": {"name": "tool_b", "arguments": "{}"},
+                    },
                 ],
                 "reasoning_details": [
-                    {"type": "thinking", "thinking": "Plan: call A and B.", "signature": "sig_dead"},
+                    {
+                        "type": "thinking",
+                        "thinking": "Plan: call A and B.",
+                        "signature": "sig_dead",
+                    },
                 ],
             },
             # Only one of the two parallel tool_use blocks got a result back.
@@ -2252,7 +2879,11 @@ class TestThinkingBlockSignatureManagement:
                     {"id": "tc_1", "function": {"name": "tool_a", "arguments": "{}"}},
                 ],
                 "reasoning_details": [
-                    {"type": "thinking", "thinking": "Valid plan.", "signature": "sig_live"},
+                    {
+                        "type": "thinking",
+                        "thinking": "Valid plan.",
+                        "signature": "sig_live",
+                    },
                 ],
             },
             {"role": "tool", "tool_call_id": "tc_1", "content": "result A"},
@@ -2316,7 +2947,6 @@ class TestToolChoice:
         assert kwargs["tool_choice"] == {"type": "tool", "name": "search"}
 
 
-
 # ---------------------------------------------------------------------------
 # max_tokens resolver — openclaw/openclaw#66664 port
 # ---------------------------------------------------------------------------
@@ -2374,9 +3004,7 @@ class TestResolveMessagesMaxTokens:
     """Integration tests for the full Messages resolver."""
 
     def test_positive_requested_wins(self):
-        assert _resolve_anthropic_messages_max_tokens(
-            8192, "claude-opus-4-6"
-        ) == 8192
+        assert _resolve_anthropic_messages_max_tokens(8192, "claude-opus-4-6") == 8192
 
     def test_zero_falls_back_to_model_default(self):
         # Should use _get_anthropic_max_output(model), not crash
@@ -2393,9 +3021,7 @@ class TestResolveMessagesMaxTokens:
         assert result > 0
 
     def test_fractional_positive_floored(self):
-        assert _resolve_anthropic_messages_max_tokens(
-            8192.5, "claude-opus-4-6"
-        ) == 8192
+        assert _resolve_anthropic_messages_max_tokens(8192.5, "claude-opus-4-6") == 8192
 
     def test_sub_one_float_falls_back(self):
         # 0.5 floors to 0 -> not positive -> falls back to model ceiling
@@ -2407,6 +3033,7 @@ class TestResolveMessagesMaxTokens:
 # ---------------------------------------------------------------------------
 # convert_tools_to_anthropic — tool dedup at API boundary
 # ---------------------------------------------------------------------------
+
 
 class TestConvertToolsToAnthropicDedup:
     """convert_tools_to_anthropic must deduplicate tool names.
@@ -2444,9 +3071,7 @@ class TestConvertToolsToAnthropicDedup:
         ]
         result = convert_tools_to_anthropic(tools)
         names = [t["name"] for t in result]
-        assert len(names) == len(set(names)), (
-            f"Duplicate tool names found: {names}"
-        )
+        assert len(names) == len(set(names)), f"Duplicate tool names found: {names}"
         assert len(result) == 3  # lcm_grep, lcm_describe, lcm_expand
 
     def test_empty_tools_returns_empty(self):

--- a/tests/agent/test_anthropic_wif_refresh.py
+++ b/tests/agent/test_anthropic_wif_refresh.py
@@ -1,0 +1,152 @@
+import json
+from unittest.mock import patch
+
+from agent import anthropic_adapter
+
+
+def _config(tmp_path):
+    token_file = tmp_path / "identity.jwt"
+    token_file.write_text("identity-assertion", encoding="utf-8")
+    return {
+        "federation_rule_id": "fdrl_test",
+        "organization_id": "org_test",
+        "service_account_id": "svac_test",
+        "identity_token_file": str(token_file),
+        "api_base_url": "https://api.anthropic.com",
+    }
+
+
+def test_wif_token_provider_rechecks_exchange_for_every_request(tmp_path):
+    config = _config(tmp_path)
+    with patch.object(
+        anthropic_adapter,
+        "exchange_anthropic_wif_for_access_token",
+        side_effect=[{"access_token": "first"}, {"access_token": "refreshed"}],
+    ) as exchange:
+        provider = anthropic_adapter.build_anthropic_wif_token_provider(config)
+
+        assert provider() == "first"
+        assert provider() == "refreshed"
+
+    assert exchange.call_count == 2
+    assert exchange.call_args_list[0].args[0] == config
+
+
+def test_wif_token_provider_rejects_empty_exchange_result(tmp_path):
+    with patch.object(
+        anthropic_adapter,
+        "exchange_anthropic_wif_for_access_token",
+        return_value={},
+    ):
+        provider = anthropic_adapter.build_anthropic_wif_token_provider(_config(tmp_path))
+        try:
+            provider()
+        except ValueError as exc:
+            assert "no access token" in str(exc).lower()
+        else:  # pragma: no cover
+            raise AssertionError("empty WIF exchange must fail")
+
+
+def test_clear_wif_token_cache_purges_memory_and_disk(tmp_path, monkeypatch):
+    monkeypatch.setattr(anthropic_adapter, "get_hermes_home", lambda: tmp_path)
+    config = _config(tmp_path)
+    provider = anthropic_adapter.build_anthropic_wif_token_provider(config)
+    cache_file = tmp_path / anthropic_adapter._WIF_CACHE_FILE_NAME
+    cache_file.write_text('{"access_token":"secret"}', encoding="utf-8")
+    anthropic_adapter._WIF_ACCESS_TOKEN_CACHE["key"] = {"access_token": "secret"}
+
+    anthropic_adapter.clear_anthropic_wif_token_cache()
+
+    assert anthropic_adapter._WIF_ACCESS_TOKEN_CACHE == {}
+    assert anthropic_adapter._WIF_TOKEN_PROVIDERS == {}
+    assert not cache_file.exists()
+    try:
+        provider()
+    except RuntimeError as exc:
+        assert "removed" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("an issued provider must be invalidated on logout")
+
+
+def test_wif_provider_is_stable_for_unchanged_config(tmp_path):
+    config = _config(tmp_path)
+    first = anthropic_adapter.build_anthropic_wif_token_provider(config)
+    second = anthropic_adapter.build_anthropic_wif_token_provider(dict(config))
+    assert first is second
+
+
+def test_wif_stale_config_cannot_register_after_invalidation(tmp_path):
+    config = _config(tmp_path)
+    generation = anthropic_adapter.get_anthropic_wif_provider_generation()
+
+    anthropic_adapter.clear_anthropic_wif_token_cache()
+
+    try:
+        anthropic_adapter.build_anthropic_wif_token_provider(
+            config, expected_generation=generation
+        )
+    except anthropic_adapter.AnthropicWIFGenerationChanged:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("stale WIF config must not survive invalidation")
+    assert anthropic_adapter._WIF_TOKEN_PROVIDERS == {}
+
+
+def test_managed_wif_provider_rechecks_persisted_identity_on_each_call(
+    tmp_path, monkeypatch
+):
+    config = _config(tmp_path)
+    current = {"value": dict(config)}
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "read_anthropic_wif_config",
+        lambda: current["value"],
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "exchange_anthropic_wif_for_access_token",
+        lambda _config: {"access_token": "managed-token"},
+    )
+    provider = anthropic_adapter.build_anthropic_wif_token_provider(
+        config,
+        expected_generation=anthropic_adapter.get_anthropic_wif_provider_generation(),
+    )
+
+    assert provider() == "managed-token"
+    current["value"] = None
+    try:
+        provider()
+    except RuntimeError as exc:
+        assert "removed" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("managed provider must reject removed auth state")
+
+
+def test_wif_cache_read_refuses_destination_symlink(tmp_path, monkeypatch):
+    monkeypatch.setattr(anthropic_adapter, "get_hermes_home", lambda: tmp_path)
+    target = tmp_path / "target.json"
+    target.write_text(
+        json.dumps({"cache_key": "key", "access_token": "stolen"}),
+        encoding="utf-8",
+    )
+    cache_file = tmp_path / anthropic_adapter._WIF_CACHE_FILE_NAME
+    cache_file.symlink_to(target)
+
+    assert anthropic_adapter._read_cached_wif_exchange("key") is None
+
+
+def test_wif_cache_write_replaces_symlink_not_its_target(tmp_path, monkeypatch):
+    monkeypatch.setattr(anthropic_adapter, "get_hermes_home", lambda: tmp_path)
+    target = tmp_path / "valuable.txt"
+    target.write_text("must-survive", encoding="utf-8")
+    cache_file = tmp_path / anthropic_adapter._WIF_CACHE_FILE_NAME
+    cache_file.symlink_to(target)
+
+    anthropic_adapter._write_cached_wif_exchange(
+        "key",
+        {"access_token": "bearer", "expires_at_ms": 9_999_999_999_999},
+    )
+
+    assert target.read_text(encoding="utf-8") == "must-survive"
+    assert not cache_file.is_symlink()
+    assert json.loads(cache_file.read_text(encoding="utf-8"))["cache_key"] == "key"

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -633,6 +633,82 @@ class TestAnthropicOAuthFlag:
             adapter = client.chat.completions
             assert adapter._is_oauth is False
 
+    def test_wif_uses_refresh_callable_without_oauth_identity(self):
+        token_provider = lambda: "fresh-wif-token"
+        with (
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                return_value={
+                    "api_key": token_provider,
+                    "base_url": "https://api.anthropic.com",
+                },
+            ),
+            patch(
+                "agent.anthropic_adapter.resolve_anthropic_token",
+                side_effect=AssertionError("WIF runtime should win"),
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                return_value=MagicMock(),
+            ) as mock_build,
+        ):
+            from agent.auxiliary_client import _try_anthropic
+
+            client, _model = _try_anthropic()
+
+        assert client is not None
+        assert mock_build.call_args.args[0] is token_provider
+        assert ("force_bearer_" + "auth") not in mock_build.call_args.kwargs
+        assert client.chat.completions._is_oauth is False
+
+    def test_explicit_wif_bundle_bypasses_stale_pool_url(self):
+        token_provider = lambda: "fresh-wif-token"
+        with (
+            patch(
+                "agent.auxiliary_client._select_pool_entry",
+                side_effect=AssertionError("explicit WIF must bypass the pool"),
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                return_value=MagicMock(),
+            ) as mock_build,
+        ):
+            from agent.auxiliary_client import _try_anthropic
+
+            client, _model = _try_anthropic(
+                explicit_api_key=token_provider,
+                explicit_base_url="https://wif.example/anthropic",
+            )
+
+        assert client is not None
+        assert mock_build.call_args.args == (
+            token_provider,
+            "https://wif.example/anthropic",
+        )
+
+    def test_resolve_provider_client_forwards_explicit_anthropic_bundle(self):
+        token_provider = lambda: "fresh-wif-token"
+        wrapped = MagicMock()
+        with patch(
+            "agent.auxiliary_client._try_anthropic",
+            return_value=(wrapped, "claude-haiku-4-5-20251001"),
+        ) as try_anthropic:
+            from agent.auxiliary_client import resolve_provider_client
+
+            client, _model = resolve_provider_client(
+                "anthropic",
+                model="claude-haiku-4-5-20251001",
+                explicit_api_key=token_provider,
+                explicit_base_url="https://wif.example/anthropic",
+            )
+
+        assert client is wrapped
+        try_anthropic.assert_called_once_with(
+            explicit_api_key=token_provider,
+            explicit_base_url="https://wif.example/anthropic",
+        )
+
     def test_pool_entry_takes_priority_over_legacy_resolution(self):
         class _Entry:
             access_token = "sk-ant-oat01-pooled"

--- a/tests/agent/test_bedrock_1m_context.py
+++ b/tests/agent/test_bedrock_1m_context.py
@@ -61,3 +61,28 @@ class TestBedrockContext1MBeta:
         # Other common betas still present — no regression.
         assert "interleaved-thinking-2025-05-14" in beta_header
         assert "fine-grained-tool-streaming-2025-05-14" in beta_header
+
+    def test_build_anthropic_kwargs_omits_1m_for_native_fastmode(self):
+        """Native fast-mode requests avoid the 1M beta by default.
+
+        Bedrock/Azure clients opt into 1M at client construction. Native Anthropic
+        subscriptions that lack long-context access can reject even short requests
+        if the beta is sent unnecessarily.
+        """
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+            is_oauth=False,
+            base_url=None,
+            fast_mode=True,
+        )
+        beta_header = kwargs.get("extra_headers", {}).get("anthropic-beta", "")
+        assert "context-1m-2025-08-07" not in beta_header, (
+            "native fast-mode requests should not opt into context-1m unless "
+            "a long-context endpoint specifically requires it"
+        )

--- a/tests/hermes_cli/test_anthropic_provider_persistence.py
+++ b/tests/hermes_cli/test_anthropic_provider_persistence.py
@@ -39,8 +39,90 @@ def test_save_anthropic_api_key_uses_api_key_slot_and_clears_token(tmp_path, mon
 
     from hermes_cli.config import save_anthropic_api_key
 
-    save_anthropic_api_key("sk-ant-api03-key")
+    save_anthropic_api_key("not-a-placeholder-key")
 
     env_vars = load_env()
-    assert env_vars["ANTHROPIC_API_KEY"] == "sk-ant-api03-key"
+    assert env_vars["ANTHROPIC_API_KEY"] == "not-a-placeholder-key"
     assert env_vars["ANTHROPIC_TOKEN"] == ""
+
+
+def test_get_auth_status_reports_anthropic_wif(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    identity_file = tmp_path / "identity.jwt"
+    identity_file.write_text("header.payload.signature", encoding="utf-8")
+    auth_payload = {
+        "version": 1,
+        "providers": {
+            "anthropic": {
+                "auth_type": "wif",
+                "source": "manual:wif",
+                "label": "anthropic-wif",
+                "federation_rule_id": "fdrl_test123",
+                "organization_id": "org_test456",
+                "service_account_id": "svac_test789",
+                "identity_token_file": str(identity_file),
+                "api_base_url": "https://api.anthropic.com",
+            }
+        },
+    }
+    (home / "auth.json").write_text(__import__("json").dumps(auth_payload), encoding="utf-8")
+
+    from hermes_cli.auth import get_auth_status
+
+    status = get_auth_status("anthropic")
+    assert status["auth_type"] == "wif"
+    assert status["logged_in"] is True
+    assert status["identity_token_file"] == str(identity_file)
+    assert status["identity_token_file_exists"] is True
+    assert status["federation_rule_id"] == "fdrl_test123"
+    assert status["service_account_id"] == "svac_test789"
+
+
+def test_read_anthropic_wif_config_does_not_mix_partial_env_with_auth_store(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("ANTHROPIC_IDENTITY_TOKEN_FILE", "/tmp/env-token.jwt")
+    auth_payload = {
+        "version": 1,
+        "providers": {
+            "anthropic": {
+                "auth_type": "wif",
+                "source": "manual:wif",
+                "federation_rule_id": "fdrl_auth",
+                "organization_id": "org_auth",
+                "service_account_id": "svac_auth",
+                "identity_token_file": "/tmp/auth-token.jwt",
+            }
+        },
+    }
+    (home / "auth.json").write_text(__import__("json").dumps(auth_payload), encoding="utf-8")
+
+    from agent.anthropic_adapter import read_anthropic_wif_config
+
+    config = read_anthropic_wif_config()
+    assert config is not None
+    assert config["source"] == "manual:wif"
+    assert config["identity_token_file"] == "/tmp/auth-token.jwt"
+    assert config["federation_rule_id"] == "fdrl_auth"
+
+
+def test_read_anthropic_wif_config_prefers_complete_env_atomically(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("ANTHROPIC_FEDERATION_RULE_ID", "fdrl_env")
+    monkeypatch.setenv("ANTHROPIC_ORGANIZATION_ID", "org_env")
+    monkeypatch.setenv("ANTHROPIC_SERVICE_ACCOUNT_ID", "svac_env")
+    monkeypatch.setenv("ANTHROPIC_IDENTITY_TOKEN_FILE", "/tmp/env-token.jwt")
+
+    from agent.anthropic_adapter import read_anthropic_wif_config
+
+    config = read_anthropic_wif_config()
+    assert config is not None
+    assert config["source"] == "env:wif"
+    assert config["federation_rule_id"] == "fdrl_env"
+    assert config["identity_token_file"] == "/tmp/env-token.jwt"

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -178,6 +178,215 @@ def test_auth_add_qwen_oauth_sets_active_provider(tmp_path, monkeypatch):
     assert entry["access_token"] == "qwen-test-token"
 
 
+def test_auth_add_anthropic_wif_persists_provider_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    cleared = []
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.clear_anthropic_wif_token_cache",
+        lambda: cleared.append(True),
+    )
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "anthropic"
+        auth_type = "wif"
+        label = "prod-wif"
+        federation_rule_id = "fdrl_test123"
+        organization_id = "org_test456"
+        service_account_id = "svac_test789"
+        identity_token_file = "/tmp/anthropic-identity.jwt"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    state = payload["providers"]["anthropic"]
+    assert state["auth_type"] == "wif"
+    assert state["source"] == "manual:wif"
+    assert state["label"] == "prod-wif"
+    assert state["federation_rule_id"] == "fdrl_test123"
+    assert state["organization_id"] == "org_test456"
+    assert state["service_account_id"] == "svac_test789"
+    assert state["identity_token_file"] == "/tmp/anthropic-identity.jwt"
+    assert state["api_base_url"] == "https://api.anthropic.com"
+    assert payload.get("credential_pool", {}).get("anthropic") in (None, [])
+    assert cleared == [True]
+
+
+def test_auth_add_anthropic_api_key_replaces_wif_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "active_provider": "anthropic",
+            "providers": {"anthropic": {"auth_type": "wif"}},
+        },
+    )
+    cleared = []
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.clear_anthropic_wif_token_cache",
+        lambda: cleared.append(True),
+    )
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "anthropic"
+        auth_type = "api-key"
+        api_key = "sk-ant-replacement"
+        label = "replacement"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert "anthropic" not in payload.get("providers", {})
+    assert payload.get("active_provider") != "anthropic"
+    assert cleared == [True]
+    assert any(
+        entry.get("access_token") == "sk-ant-replacement"
+        for entry in payload["credential_pool"]["anthropic"]
+    )
+
+
+def test_auth_add_anthropic_oauth_replaces_wif_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {"version": 1, "providers": {"anthropic": {"auth_type": "wif"}}},
+    )
+    cleared = []
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.clear_anthropic_wif_token_cache",
+        lambda: cleared.append(True),
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.run_hermes_oauth_login_pure",
+        lambda: {
+            "access_token": "oauth-access",
+            "refresh_token": "oauth-refresh",
+            "expires_at_ms": 9_999_999_999_999,
+        },
+    )
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "anthropic"
+        auth_type = "oauth"
+        label = "oauth replacement"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert "anthropic" not in payload.get("providers", {})
+    assert cleared == [True]
+    assert any(
+        entry.get("access_token") == "oauth-access"
+        for entry in payload["credential_pool"]["anthropic"]
+    )
+
+
+def test_auth_add_anthropic_wif_warns_when_file_is_not_jwt(tmp_path, monkeypatch, capsys):
+    home = tmp_path / "hermes"
+    token_file = tmp_path / "test-wif.yml"
+    token_file.write_text("name: not-a-jwt\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "anthropic"
+        auth_type = "wif"
+        label = "prod-wif"
+        federation_rule_id = "fdrl_test123"
+        organization_id = "org_test456"
+        service_account_id = "svac_test789"
+        identity_token_file = str(token_file)
+
+    auth_add_command(_Args())
+    assert "does not look like a JWT" in capsys.readouterr().out
+
+
+def test_auth_list_shows_anthropic_wif_provider_state(tmp_path, monkeypatch, capsys):
+    token_file = tmp_path / "identity.jwt"
+    token_file.write_text("header.payload.signature")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "providers": {
+            "anthropic": {
+                "auth_type": "wif",
+                "source": "manual:wif",
+                "label": "prod-wif",
+                "federation_rule_id": "fdrl_test123",
+                "organization_id": "org_test456",
+                "service_account_id": "svac_test789",
+                "identity_token_file": str(token_file),
+                "api_base_url": "https://api.anthropic.com",
+            }
+        },
+        "credential_pool": {},
+    })
+
+    from hermes_cli.auth_commands import auth_list_command
+
+    class _Args:
+        provider = "anthropic"
+
+    auth_list_command(_Args())
+    out = capsys.readouterr().out
+    assert "anthropic (1 credentials):" in out
+    assert "prod-wif" in out
+    assert "wif" in out
+    assert "file:ok" in out
+
+
+def test_auth_remove_anthropic_wif_provider_state(tmp_path, monkeypatch, capsys):
+    token_file = tmp_path / "identity.jwt"
+    token_file.write_text("header.payload.signature")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "active_provider": "anthropic",
+        "providers": {
+            "anthropic": {
+                "auth_type": "wif",
+                "source": "manual:wif",
+                "label": "prod-wif",
+                "federation_rule_id": "fdrl_test123",
+                "organization_id": "org_test456",
+                "service_account_id": "svac_test789",
+                "identity_token_file": str(token_file),
+                "api_base_url": "https://api.anthropic.com",
+            }
+        },
+        "credential_pool": {},
+    })
+    from agent import anthropic_adapter
+
+    cache_file = tmp_path / "hermes" / ".anthropic_wif_token_cache.json"
+    cache_file.write_text('{"access_token":"cached-secret"}', encoding="utf-8")
+    anthropic_adapter._WIF_ACCESS_TOKEN_CACHE["test"] = {
+        "access_token": "cached-secret"
+    }
+
+    from hermes_cli.auth_commands import auth_remove_command
+
+    class _Args:
+        provider = "anthropic"
+        target = "1"
+
+    auth_remove_command(_Args())
+    out = capsys.readouterr().out
+    assert "Removed anthropic WIF credential" in out
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert "anthropic" not in payload.get("providers", {})
+    assert payload.get("active_provider") is None
+    assert not cache_file.exists()
+    assert anthropic_adapter._WIF_ACCESS_TOKEN_CACHE == {}
+
+
 def test_auth_add_nous_oauth_persists_pool_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(tmp_path, {"version": 1, "providers": {}})

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -50,6 +50,18 @@ def _write(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2))
 
 
+def _wif_state(identity_token_file: Path) -> dict:
+    return {
+        "auth_type": "wif",
+        "source": "manual:wif",
+        "federation_rule_id": "fdrl_global",
+        "organization_id": "org_global",
+        "service_account_id": "svac_global",
+        "identity_token_file": str(identity_token_file),
+        "api_base_url": "https://api.anthropic.com",
+    }
+
+
 # ---------------------------------------------------------------------------
 # read_credential_pool — provider-slice reads
 # ---------------------------------------------------------------------------
@@ -450,3 +462,98 @@ def test_write_credential_pool_targets_profile_not_global(profile_env):
 
     # Subsequent read returns profile (shadows global).
     assert [e["id"] for e in read_credential_pool("openrouter")] == ["prof-new"]
+
+
+def test_local_anthropic_credential_shadows_inherited_global_wif(
+    profile_env, monkeypatch
+):
+    token_file = profile_env["global"] / "global.jwt"
+    token_file.write_text("header.payload.signature")
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(providers={"anthropic": _wif_state(token_file)}),
+    )
+    _write(
+        profile_env["profile"] / "auth.json",
+        _make_auth_store(
+            pool={
+                "anthropic": [
+                    {
+                        "id": "profile-api",
+                        "auth_type": "api_key",
+                        "source": "manual",
+                        "access_token": "profile-key",
+                    }
+                ]
+            },
+            providers={},
+        ),
+    )
+    cleared = []
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.clear_anthropic_wif_token_cache",
+        lambda: cleared.append(True),
+    )
+
+    from agent.anthropic_adapter import read_anthropic_wif_config
+    from hermes_cli.auth import get_provider_auth_state, read_credential_pool
+    from hermes_cli.auth_commands import _remove_anthropic_wif_state
+
+    assert read_anthropic_wif_config()["federation_rule_id"] == "fdrl_global"
+    assert _remove_anthropic_wif_state() is True
+    assert read_anthropic_wif_config() is None
+    assert get_provider_auth_state("anthropic")["auth_type"] == "profile_shadow"
+    assert read_credential_pool("anthropic")[0]["id"] == "profile-api"
+    assert cleared == [True]
+
+
+def test_profile_logout_does_not_resurrect_inherited_global_wif(
+    profile_env, monkeypatch
+):
+    token_file = profile_env["global"] / "global.jwt"
+    token_file.write_text("header.payload.signature")
+    _write(
+        profile_env["global"] / "auth.json",
+        _make_auth_store(providers={"anthropic": _wif_state(token_file)}),
+    )
+    _write(
+        profile_env["profile"] / "auth.json",
+        {
+            **_make_auth_store(
+                pool={
+                    "anthropic": [
+                        {
+                            "id": "profile-oauth",
+                            "auth_type": "oauth",
+                            "source": "manual:hermes_pkce",
+                            "access_token": "profile-oauth-token",
+                        }
+                    ]
+                },
+                providers={
+                    "anthropic": {
+                        "auth_type": "profile_shadow",
+                        "source": "profile:local-credential",
+                    }
+                },
+            ),
+            "active_provider": "anthropic",
+        },
+    )
+    cleared = []
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.clear_anthropic_wif_token_cache",
+        lambda: cleared.append(True),
+    )
+
+    from agent.anthropic_adapter import read_anthropic_wif_config
+    from hermes_cli.auth import clear_provider_auth, get_provider_auth_state
+
+    assert clear_provider_auth("anthropic") is True
+    assert read_anthropic_wif_config() is None
+    state = get_provider_auth_state("anthropic")
+    assert state == {"auth_type": "profile_shadow", "source": "profile:logout"}
+    profile_data = json.loads((profile_env["profile"] / "auth.json").read_text())
+    assert "anthropic" not in profile_data.get("credential_pool", {})
+    assert profile_data.get("active_provider") is None
+    assert cleared == [True]

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -246,6 +246,184 @@ def test_resolve_runtime_provider_anthropic_explicit_override_skips_pool(monkeyp
     assert resolved.get("credential_pool") is None
 
 
+def test_resolve_runtime_provider_anthropic_prefers_wif_over_env_api_key(monkeypatch):
+    def _unexpected_resolve_token():
+        raise AssertionError("resolve_anthropic_token should not be called when WIF is configured")
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "stale-api-key")
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "anthropic",
+            "base_url": "https://proxy.example.com/anthropic",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_anthropic_wif_config",
+        lambda: {
+            "auth_type": "wif",
+            "federation_rule_id": "fdrl_test123",
+            "organization_id": "org_test456",
+            "service_account_id": "svac_test789",
+            "identity_token_file": "/tmp/identity.jwt",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.exchange_anthropic_wif_for_access_token",
+        lambda config=None: {"access_token": "wif-access-token", "expires_at_ms": 1711234567000},
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.resolve_anthropic_token",
+        _unexpected_resolve_token,
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert resolved["provider"] == "anthropic"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert callable(resolved["api_key"])
+    assert resolved["api_key"]() == "wif-access-token"
+    assert resolved["base_url"] == "https://proxy.example.com/anthropic"
+    assert resolved["source"] == "wif"
+    assert ("anthropic_force_" + "bearer_auth") not in resolved
+
+
+def test_anthropic_wif_resolution_retries_after_concurrent_invalidation(monkeypatch):
+    from agent import anthropic_adapter
+
+    config = {
+        "auth_type": "wif",
+        "federation_rule_id": "fdrl_new",
+        "organization_id": "org_new",
+        "service_account_id": "svac_new",
+        "identity_token_file": "/tmp/new.jwt",
+    }
+    generations = iter((10, 11))
+    reads = []
+    provider = object()
+
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "get_anthropic_wif_provider_generation",
+        lambda: next(generations),
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "read_anthropic_wif_config",
+        lambda: reads.append(dict(config)) or dict(config),
+    )
+
+    def _build(_config, *, expected_generation=None):
+        if expected_generation == 10:
+            raise anthropic_adapter.AnthropicWIFGenerationChanged("changed")
+        assert expected_generation == 11
+        return provider
+
+    monkeypatch.setattr(
+        anthropic_adapter, "build_anthropic_wif_token_provider", _build
+    )
+
+    resolved, source = rp._resolve_anthropic_wif_or_legacy_token()
+
+    assert resolved is provider
+    assert source == "wif"
+    assert len(reads) == 2
+
+
+def test_anthropic_legacy_resolution_retries_if_wif_changes_mid_read(monkeypatch):
+    from agent import anthropic_adapter
+
+    generation = {"value": 0}
+    provider = object()
+    wif_config = {
+        "auth_type": "wif",
+        "federation_rule_id": "fdrl_new",
+        "organization_id": "org_new",
+        "service_account_id": "svac_new",
+        "identity_token_file": "/tmp/new.jwt",
+    }
+
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "get_anthropic_wif_provider_generation",
+        lambda: generation["value"],
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "read_anthropic_wif_config",
+        lambda: None if generation["value"] == 0 else dict(wif_config),
+    )
+
+    def _resolve_stale_legacy():
+        generation["value"] = 1
+        return "stale-legacy-key"
+
+    monkeypatch.setattr(
+        anthropic_adapter, "resolve_anthropic_token", _resolve_stale_legacy
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "build_anthropic_wif_token_provider",
+        lambda config, *, expected_generation=None: (
+            provider
+            if config == wif_config and expected_generation == 1
+            else pytest.fail("unexpected WIF provider build")
+        ),
+    )
+
+    resolved, source = rp._resolve_anthropic_wif_or_legacy_token()
+
+    assert resolved is provider
+    assert source == "wif"
+
+
+def test_resolve_runtime_provider_anthropic_wif_bypasses_stale_pool(monkeypatch):
+    class _Entry:
+        access_token = "stale-pool-token"
+        source = "manual"
+        base_url = "https://api.anthropic.com"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "anthropic", "base_url": "https://api.anthropic.com"},
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_anthropic_wif_config",
+        lambda: {
+            "auth_type": "wif",
+            "federation_rule_id": "fdrl_test123",
+            "organization_id": "org_test456",
+            "service_account_id": "svac_test789",
+            "identity_token_file": "/tmp/identity.jwt",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.exchange_anthropic_wif_for_access_token",
+        lambda config=None: {"access_token": "wif-access-token", "expires_at_ms": 1711234567000},
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="anthropic")
+
+    assert callable(resolved["api_key"])
+    assert resolved["api_key"]() == "wif-access-token"
+    assert resolved["source"] == "wif"
+    assert ("anthropic_force_" + "bearer_auth") not in resolved
+    assert resolved.get("credential_pool") is None
+
+
 def test_resolve_runtime_provider_falls_back_when_pool_empty(monkeypatch):
     class _Pool:
         def has_credentials(self):

--- a/tests/hermes_cli/test_web_server_oauth_write.py
+++ b/tests/hermes_cli/test_web_server_oauth_write.py
@@ -21,6 +21,7 @@ def oauth_file(monkeypatch, tmp_path):
     target = tmp_path / '.anthropic_oauth.json'
     monkeypatch.setattr('agent.anthropic_adapter._get_hermes_oauth_file', lambda: target)
     monkeypatch.setattr('agent.credential_pool.load_pool', lambda _provider: _DummyPool())
+    monkeypatch.setattr('hermes_cli.auth_commands._remove_anthropic_wif_state', lambda: False)
     return target
 
 
@@ -73,3 +74,47 @@ def test_dashboard_oauth_write_uses_atomic_json_write_with_owner_only_mode(oauth
     assert calls.get('mode') == 0o600, \
         'OAuth creds must be written 0o600 atomically (no chmod-after-replace window)'
     assert oauth_file.exists()
+
+
+def test_dashboard_oauth_write_replaces_persisted_wif(oauth_file, monkeypatch):
+    removed = []
+    monkeypatch.setattr(
+        'hermes_cli.auth_commands._remove_anthropic_wif_state',
+        lambda: removed.append(True),
+    )
+
+    _save_anthropic_oauth_creds('access-token', 'refresh-token', 123456)
+
+    assert removed == [True]
+
+
+def test_dashboard_oauth_remains_runtime_usable_when_pool_insert_fails(
+    oauth_file, monkeypatch
+):
+    import time
+
+    class _FailingPool(_DummyPool):
+        def add_entry(self, _entry):
+            raise OSError('simulated pool failure')
+
+        def _available_entries(self, **_kwargs):
+            return []
+
+    failing_pool = _FailingPool()
+    monkeypatch.setattr('agent.credential_pool.load_pool', lambda _provider: failing_pool)
+    monkeypatch.setattr(
+        'agent.anthropic_adapter.read_claude_code_credentials', lambda: None
+    )
+    monkeypatch.delenv('ANTHROPIC_TOKEN', raising=False)
+    monkeypatch.delenv('CLAUDE_CODE_OAUTH_TOKEN', raising=False)
+    monkeypatch.delenv('ANTHROPIC_API_KEY', raising=False)
+
+    _save_anthropic_oauth_creds(
+        'dashboard-local-token',
+        'dashboard-refresh-token',
+        int(time.time() * 1000) + 3_600_000,
+    )
+
+    from agent.anthropic_adapter import resolve_anthropic_token
+
+    assert resolve_anthropic_token() == 'dashboard-local-token'

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6907,6 +6907,34 @@ class TestAnthropicCredentialRefresh:
         old_client.close.assert_not_called()
         rebuild.assert_not_called()
 
+    def test_try_refresh_preserves_callable_wif_provider(self):
+        token_provider = MagicMock(return_value="fresh-wif-token")
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()),
+        ):
+            agent = AIAgent(
+                api_key=token_provider,
+                base_url="https://api.anthropic.com",
+                api_mode="anthropic_messages",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+        agent.provider = "anthropic"
+        agent._anthropic_api_key = token_provider
+
+        with (
+            patch("agent.anthropic_adapter.resolve_anthropic_token") as resolve,
+            patch("agent.anthropic_adapter.build_anthropic_client") as rebuild,
+        ):
+            assert agent._try_refresh_anthropic_client_credentials() is False
+
+        resolve.assert_not_called()
+        rebuild.assert_not_called()
+        assert agent._anthropic_api_key is token_provider
+
     def test_anthropic_messages_create_preflights_refresh(self):
         with (
             patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),

--- a/tests/test_wif_propagation_surfaces.py
+++ b/tests/test_wif_propagation_surfaces.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_wif_does_not_add_a_parallel_bearer_mode_flag():
+    """A callable api_key is the complete WIF credential and transport contract."""
+    forbidden = "anthropic_force_" + "bearer_auth"
+    offenders = []
+    for path in ROOT.rglob("*.py"):
+        if path == Path(__file__):
+            continue
+        if forbidden in path.read_text(encoding="utf-8"):
+            offenders.append(str(path.relative_to(ROOT)))
+    assert offenders == []
+
+
+def test_wif_callable_contract_is_used_by_runtime_and_client_builder():
+    runtime = (ROOT / "hermes_cli/runtime_provider.py").read_text(encoding="utf-8")
+    adapter = (ROOT / "agent/anthropic_adapter.py").read_text(encoding="utf-8")
+
+    assert '"api_key": token' in runtime
+    assert "build_anthropic_wif_token_provider" in runtime
+    assert "if callable(api_key) and not isinstance(api_key, str):" in adapter
+    assert "_build_anthropic_client_with_bearer_hook(" in adapter
+
+
+def test_fallback_re_resolves_anthropic_runtime_callable():
+    helper = (ROOT / "agent/chat_completion_helpers.py").read_text(encoding="utf-8")
+    assert 'resolve_runtime_provider(\n                        requested="anthropic"' in helper
+    assert 'resolved_key = fb_runtime.get("api_key")' in helper
+    assert "build_anthropic_client(\n                effective_key" in helper


### PR DESCRIPTION
1|## Summary
2|
3|I added Anthropic Workload Identity Federation (WIF) support as a first-class auth mode on the existing `anthropic` provider.
4|
5|This keeps Hermes' provider model unchanged (`provider=anthropic`) while allowing Anthropic credentials to be resolved from a short-lived OIDC workload identity token instead of a static API key.
6|
7|## What changed
8|
9|- Added `hermes auth add anthropic --type wif`.
10|- Added the interactive Anthropic auth choice:
11|  - API key
12|  - OAuth login
13|  - Workload Identity Federation (OIDC / short-lived workload tokens)
14|- Persist WIF configuration in the Anthropic provider state instead of storing exchanged access tokens as long-lived credentials.
15|- Resolve Anthropic WIF at runtime by exchanging the configured identity token file for a short-lived Anthropic access token.
16|- Force WIF-issued Anthropic access tokens through the standard Bearer authorization header instead of `x-api-key`.
17|- Preserve WIF/Bearer mode through runtime provider resolution, client rebuilds, cron, gateway, TUI, one-shot, ACP, and delegation/subagent paths.
18|- Prefer an explicit Anthropic WIF configuration over stray ambient `ANTHROPIC_API_KEY` values, so a stale local API key cannot silently override a configured WIF setup.
19|- Surface WIF in `hermes auth` even though it is provider-state-backed rather than credential-pool-backed.
20|- Allow `hermes auth remove anthropic anthropic-wif` / indexed removal to remove the WIF configuration cleanly.
21|- Add validation warnings when the configured identity token file is missing, empty, or does not look like a JWT. This helps catch the common mistake of passing a GitHub Actions workflow YAML file instead of the short-lived OIDC token file generated at runtime.
22|- Add a README user-facing note covering Anthropic WIF setup, identity token file expectations, and backwards compatibility.
23|
24|## Why this shape
25|
26|Anthropic WIF is not a separate model provider. It is another way to obtain Anthropic credentials. For that reason I kept the runtime on the existing Anthropic Messages path and made WIF an auth type under `anthropic`.
27|
28|The exchanged Anthropic token is short-lived and should not be treated like a static API key or stored in the credential pool. Hermes stores the federation configuration and resolves/exchanges the token when needed.
29|
30|Existing Anthropic API-key and OAuth setups continue to work unchanged. WIF is opt-in through the new Anthropic auth choice / `--type wif` path.
31|
32|If a long-running Hermes process needs to rebuild the Anthropic client or re-resolve credentials, the runtime preserves forced Bearer/WIF semantics instead of falling back to API-key semantics.
33|
34|## Testing / verification
35|
36|Rebased cleanly on current upstream `main` (`c44de9985`) with refreshed head `5ab589601a83`.
37|
38|Fresh local validation on the rebased implementation:
39|
40|```text
41|Affected auth/runtime/delegation suites: 1000 passed
42|Final WIF cache/provider/UA regression suite: 12 passed
43|Ruff: passed
44|py_compile: passed
45|Windows footgun scan: 757 files, no findings
46|git diff --check: passed
47|```
48|
49|The final WIF suite includes regression coverage for cache mode at creation, concurrent writers, pre-existing temporary-file symlinks, malformed persisted expiry values, profile-local precedence, global auth-state fallback, and the non-throttled token-exchange User-Agent required by current main.
50|
51|GitHub checks are green on this refreshed head: 23 success, 7 skipped, 1 neutral, no failures or pending checks.
52|
53|## Live WIF validation
54|
55|I validated the real WIF path with a private GitHub Actions workflow on my fork using GitHub Actions OIDC as the identity provider:
56|
57|```text
58|GitHub Actions OIDC JWT -> Anthropic WIF token exchange -> Anthropic Messages API
59|```
60|
61|The validation covered the previously problematic `hermes chat` path after the runtime fixes. Temporary diagnostic workflow/run artifacts were removed from my fork after validation so the PR does not depend on public diagnostic logs.
62|
63|## Notes for maintainers
64|
65|This implementation follows Anthropic/Claude's Workload Identity Federation model as documented in the Claude Code IAM documentation and the Anthropic OAuth token exchange API docs:
66|
67|- https://code.claude.com/docs/en/iam
68|- https://platform.claude.com/docs/en/api/oauth-token-exchange
69|
70|If you want to reproduce the live WIF test, you need an Anthropic organization with Workload Identity Federation enabled and a federation rule configured for your OIDC issuer.
71|
72|For GitHub Actions OIDC, the important pieces are:
73|
74|- `permissions: id-token: write` in the workflow
75|- issuer URL: `https://token.actions.githubusercontent.com`
76|- audience matching the workflow-requested audience, for example `anthropic`
77|- a subject pattern matching the repository/branch that dispatches the workflow, for example:
78|  - `repo:<owner>/<repo>:ref:refs/heads/main`, or
79|  - a broader approved pattern such as `repo:<owner>/<repo>:*`
80|- the workflow must write the short-lived OIDC JWT to a temporary file and pass that file to Hermes as `identity_token_file`
81|
82|The identity token file must contain the runtime OIDC JWT. It should not be a workflow YAML file and it should never be committed or printed in logs.
83|
84|If there are any questions about testing this end-to-end or about setting up the Anthropic/Claude-side WIF credential, please ask me. I can share the exact safe test workflow shape and the expected issuer/audience/subject checks without exposing tokens or secrets.
85|
86|## Security considerations
87|
88|- This PR does not store Anthropic WIF access tokens in the repo or credential pool; the short-lived exchange cache is written through a unique `O_CREAT|O_EXCL` 0600 temporary file, fsynced, and atomically replaced under a 0700 directory.
89|- The identity token file is treated as an external short-lived runtime input.
90|- Test fixtures use fake placeholder values only.
91|- WIF runtime calls use Bearer auth intentionally and avoid falling back to API-key semantics for WIF tokens.
92|- Anthropic provider state is resolved through the profile-aware auth accessor, preserving profile-local precedence with global fallback.
93|
94|## Current status
95|
96|Ready for maintainer review on head `5ab589601a83`. Both automated review threads have been addressed and resolved. The branch was rebased on `c44de9985`; GitHub checks are green on the refreshed head.
97|
98|This work was done with Hermes Agent.