### PR TITLE
feat: add account selector with usage limits

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import concurrent.futures
+import re
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
 import httpx
@@ -64,6 +66,40 @@ class AccountProviderChoice:
 
 
 _ACCOUNT_USAGE_LOOKUP_PROVIDERS = {"anthropic", "openai-codex", "openrouter"}
+_CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]")
+_LEGACY_MARKDOWN_RE = re.compile(r"([_*\[\]()`])")
+
+
+def safe_display_text(
+    value: Any,
+    *,
+    fallback: str = "account",
+    max_len: Optional[int] = 80,
+    markdown: bool = False,
+) -> str:
+    """Return compact, user-facing text that cannot break platform renderers.
+
+    This is intentionally conservative: credential labels and plan/provider
+    names may be user-controlled, so strip control characters, collapse
+    whitespace, shorten safely, and optionally escape legacy Markdown-sensitive
+    characters used by Telegram account-picker messages.
+    """
+    text = str(value or "").strip() or fallback
+    text = _CONTROL_CHAR_RE.sub("", text)
+    text = " ".join(text.split())
+    if max_len is not None and max_len > 1 and len(text) > max_len:
+        text = text[: max_len - 1].rstrip() + "…"
+    if markdown:
+        text = _LEGACY_MARKDOWN_RE.sub(r"\\\1", text)
+    return text
+
+
+def safe_identifier(value: Any, *, fallback: str = "credential") -> str:
+    """Display a credential id without exposing a long secret-bearing value."""
+    text = safe_display_text(value, fallback=fallback, max_len=None)
+    if len(text) <= 14:
+        return text
+    return f"{text[:6]}…{text[-4:]}"
 
 
 def _normalize_provider(provider: Optional[str]) -> str:
@@ -117,51 +153,75 @@ def _parse_dt(value: Any) -> Optional[datetime]:
     return None
 
 
-def _format_reset(dt: Optional[datetime]) -> str:
+def format_reset_countdown(
+    dt: Optional[datetime],
+    *,
+    now: Optional[datetime] = None,
+    verb: str = "renews",
+) -> str:
+    """Format reset/renewal time as a compact Hermes-style countdown."""
     if not dt:
-        return "unknown"
-    local_dt = dt.astimezone()
-    delta = dt - _utc_now()
+        return "renewal time unknown"
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    now = now or _utc_now()
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    dt = dt.astimezone(timezone.utc)
+    now = now.astimezone(timezone.utc)
+    delta = dt - now
     total_seconds = int(delta.total_seconds())
     if total_seconds <= 0:
-        return f"now ({local_dt.strftime('%Y-%m-%d %H:%M %Z')})"
-    hours, rem = divmod(total_seconds, 3600)
-    minutes = rem // 60
-    if hours >= 24:
-        days, hours = divmod(hours, 24)
-        rel = f"in {days}d {hours}h"
-    elif hours > 0:
-        rel = f"in {hours}h {minutes}m"
-    else:
-        rel = f"in {minutes}m"
-    return f"{rel} ({local_dt.strftime('%Y-%m-%d %H:%M %Z')})"
+        return f"{verb} now ✨"
+
+    if dt.date() == (now + timedelta(days=1)).date():
+        return f"{verb} tomorrow at {dt.strftime('%H:%M')} 🌙"
+
+    minutes_total = max(1, (total_seconds + 59) // 60)
+    hours, minutes = divmod(minutes_total, 60)
+    if hours == 0:
+        return f"{verb} in {minutes}m ⏳"
+    if dt.date() == now.date():
+        return f"{verb} in {hours}h {minutes}m ✨"
+    days, hours = divmod(hours, 24)
+    return f"{verb} in {days}d {hours}h 🗓️"
+
+
+def _format_reset(dt: Optional[datetime]) -> str:
+    return format_reset_countdown(dt, verb="resets")
 
 
 def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, markdown: bool = False) -> list[str]:
     if not snapshot:
         return []
-    header = f"📈 {'**' if markdown else ''}{snapshot.title}{'**' if markdown else ''}"
+    title = safe_display_text(snapshot.title, fallback="Account limits", markdown=markdown)
+    provider = safe_display_text(snapshot.provider, fallback="provider", markdown=markdown)
+    header = f"📈 {'**' if markdown else ''}{title}{'**' if markdown else ''}"
     lines = [header]
     if snapshot.plan:
-        lines.append(f"Provider: {snapshot.provider} ({snapshot.plan})")
+        plan = safe_display_text(snapshot.plan, fallback="plan", markdown=markdown)
+        lines.append(f"Provider: {provider} ({plan})")
     else:
-        lines.append(f"Provider: {snapshot.provider}")
+        lines.append(f"Provider: {provider}")
     for window in snapshot.windows:
         if window.used_percent is None:
-            base = f"{window.label}: unavailable"
+            label = safe_display_text(window.label, fallback="Limit", markdown=markdown)
+            base = f"{label}: unavailable"
         else:
             remaining = max(0, round(100 - float(window.used_percent)))
             used = max(0, round(float(window.used_percent)))
-            base = f"{window.label}: {remaining}% remaining ({used}% used)"
+            label = safe_display_text(window.label, fallback="Limit", markdown=markdown)
+            base = f"{label}: {remaining}% left {_usage_bar(remaining)} ({used}% used)"
         if window.reset_at:
-            base += f" • resets {_format_reset(window.reset_at)}"
+            base += f" · {format_reset_countdown(window.reset_at)}"
         elif window.detail:
-            base += f" • {window.detail}"
+            base += f" · {safe_display_text(window.detail, fallback='', markdown=markdown)}"
         lines.append(base)
     for detail in snapshot.details:
-        lines.append(detail)
+        lines.append(safe_display_text(detail, fallback="detail", markdown=markdown))
     if snapshot.unavailable_reason:
-        lines.append(f"Unavailable: {snapshot.unavailable_reason}")
+        reason = safe_display_text(snapshot.unavailable_reason, fallback="usage unavailable", markdown=markdown)
+        lines.append(f"Unavailable: {reason}")
     return lines
 
 
@@ -196,18 +256,61 @@ def _account_health(snapshot: Optional[AccountUsageSnapshot]) -> tuple[str, str,
     return "✅", "Healthy", lowest_remaining
 
 
-def _format_account_window_line(window: AccountUsageWindow) -> str:
+def _format_account_window_line(window: AccountUsageWindow, *, markdown: bool = False) -> str:
+    label = safe_display_text(window.label, fallback="Limit", markdown=markdown)
     remaining = _remaining_percent(window)
     if remaining is None or window.used_percent is None:
-        base = f"   {window.label}: unavailable {_usage_bar(None)}"
+        base = f"   {label}: unavailable {_usage_bar(None)}"
     else:
         used = max(0, min(100, round(float(window.used_percent))))
-        base = f"   {window.label}: {remaining}% remaining ({used}% used) {_usage_bar(remaining)}"
+        base = f"   {label}: {remaining}% left {_usage_bar(remaining)} ({used}% used)"
     if window.reset_at:
-        base += f" • resets {_format_reset(window.reset_at)}"
+        base += f" · {format_reset_countdown(window.reset_at)}"
     elif window.detail:
-        base += f" • {window.detail}"
+        base += f" · {safe_display_text(window.detail, fallback='', markdown=markdown)}"
     return base
+
+
+def compact_account_usage_description(
+    snapshot: Optional[AccountUsageSnapshot],
+    *,
+    max_len: int = 100,
+) -> str:
+    """Discord/Telegram option description based on snapshot.windows."""
+    if not snapshot:
+        return "usage unavailable"
+    if snapshot.unavailable_reason:
+        return safe_display_text(snapshot.unavailable_reason, fallback="usage unavailable", max_len=max_len)
+    parts: list[str] = []
+    for window in snapshot.windows[:2]:
+        remaining = _remaining_percent(window)
+        label = safe_display_text(window.label, fallback="Limit", max_len=22)
+        if remaining is not None:
+            parts.append(f"{label}: {remaining}% left")
+        elif window.detail:
+            parts.append(f"{label}: {safe_display_text(window.detail, max_len=42)}")
+    if not parts and snapshot.details:
+        parts.append(safe_display_text(snapshot.details[0], fallback="usage detail", max_len=max_len))
+    if not parts:
+        parts.append("usage available")
+    return safe_display_text(" · ".join(parts), fallback="usage unavailable", max_len=max_len)
+
+
+def discord_account_option_parts(result: ProviderAccountUsage, *, active: bool = False) -> tuple[str, str]:
+    """Return Discord-safe select option label and description."""
+    _emoji, health, _lowest_remaining = _account_health(result.snapshot)
+    raw_label = result.label or f"account-{result.index}"
+    label = safe_display_text(raw_label, fallback=f"account-{result.index}", max_len=62)
+    active_prefix = "✓ " if active else ""
+    option_label = safe_display_text(
+        f"{active_prefix}{result.index}. {label} · {health}",
+        fallback=f"{result.index}. account · {health}",
+        max_len=100,
+    )
+    desc = compact_account_usage_description(result.snapshot, max_len=100)
+    if result.unavailable_reason and not result.snapshot:
+        desc = safe_display_text(result.unavailable_reason, fallback="usage unavailable", max_len=100)
+    return option_label, desc
 
 
 def render_provider_account_usage_lines(
@@ -223,12 +326,17 @@ def render_provider_account_usage_lines(
         return []
     strong = "**" if markdown else ""
     lines = [f"📊 {strong}Hermes Account Center{strong}"]
-    lines.append(f"Provider: {normalized} • Accounts: {len(results)}")
+    provider_label = safe_display_text(normalized, fallback="provider", markdown=markdown)
+    lines.append(f"Provider: {provider_label} • Accounts: {len(results)}")
     hint = (select_hint or f"/account {normalized} <number>").strip()
     lines.append(f"Select: `{hint}`" if markdown else f"Select: {hint}")
     lines.append("")
     for result in results:
-        label = result.label or f"account-{result.index}"
+        label = safe_display_text(
+            result.label or f"account-{result.index}",
+            fallback=f"account-{result.index}",
+            markdown=markdown,
+        )
         snapshot = result.snapshot
         emoji, health, _lowest_remaining = _account_health(snapshot)
         active = active_index is not None and result.index == active_index
@@ -238,20 +346,26 @@ def render_provider_account_usage_lines(
             title = f"{strong}{title}{strong}"
         lines.append(f"{emoji} {title}{active_suffix} · {health}")
         if result.status:
-            lines.append(f"   Pool: {result.status}")
+            lines.append(f"   Pool: {safe_display_text(result.status, fallback='available', markdown=markdown)}")
         if not snapshot:
-            reason = result.unavailable_reason or "usage unavailable"
+            reason = safe_display_text(
+                result.unavailable_reason or "usage unavailable",
+                fallback="usage unavailable",
+                markdown=markdown,
+            )
             lines.append(f"   Unavailable: {reason}")
             lines.append("")
             continue
         if snapshot.plan:
-            lines.append(f"   Plan: {snapshot.plan}")
+            plan = safe_display_text(snapshot.plan, fallback="plan", markdown=markdown)
+            lines.append(f"   Plan: {plan}")
         for window in snapshot.windows:
-            lines.append(_format_account_window_line(window))
+            lines.append(_format_account_window_line(window, markdown=markdown))
         for detail in snapshot.details:
-            lines.append(f"   {detail}")
+            lines.append(f"   {safe_display_text(detail, fallback='detail', markdown=markdown)}")
         if snapshot.unavailable_reason:
-            lines.append(f"   Unavailable: {snapshot.unavailable_reason}")
+            reason = safe_display_text(snapshot.unavailable_reason, fallback="usage unavailable", markdown=markdown)
+            lines.append(f"   Unavailable: {reason}")
         lines.append("")
     if lines and lines[-1] == "":
         lines.pop()
@@ -543,17 +657,20 @@ def list_account_usage_providers(*, active_provider: Optional[str] = None) -> li
 
 
 def _entry_label(entry: Any, index: int) -> str:
-    for attr in ("label", "source", "id"):
+    for attr in ("label", "source"):
         value = getattr(entry, attr, None)
         if isinstance(value, str) and value.strip():
-            return value.strip()
+            return safe_display_text(value, fallback=f"account-{index}", max_len=64)
+    value = getattr(entry, "id", None)
+    if isinstance(value, str) and value.strip():
+        return safe_identifier(value, fallback=f"account-{index}")
     return f"account-{index}"
 
 
 def _entry_status(entry: Any) -> str:
     status = getattr(entry, "last_status", None)
     if isinstance(status, str) and status.strip():
-        return status.strip()
+        return safe_display_text(status, fallback="available", max_len=40)
     return "available"
 
 
@@ -648,80 +765,146 @@ def select_provider_account(
 def account_choice_label(result: ProviderAccountUsage, *, active: bool = False) -> str:
     """Compact one-line label for terminal account pickers."""
     emoji, health, lowest_remaining = _account_health(result.snapshot)
-    label = result.label or f"account-{result.index}"
+    label = safe_display_text(result.label or f"account-{result.index}", fallback=f"account-{result.index}", max_len=48)
     suffix = "  ← active" if active else ""
     parts: list[str] = [f"{emoji} {result.index}. {label}{suffix}", health]
     if result.status:
-        parts.append(f"status: {result.status}")
+        parts.append(f"status: {safe_display_text(result.status, fallback='available', max_len=32)}")
     if result.snapshot and result.snapshot.plan:
-        parts.append(f"plan: {result.snapshot.plan}")
+        parts.append(f"plan: {safe_display_text(result.snapshot.plan, fallback='plan', max_len=32)}")
     if lowest_remaining is not None:
         parts.append(f"limit: {lowest_remaining}% left {_usage_bar(lowest_remaining, width=8)}")
     if result.snapshot:
         window_bits: list[str] = []
         for window in result.snapshot.windows[:2]:
             remaining = _remaining_percent(window)
+            window_label = safe_display_text(window.label, fallback="Limit", max_len=18)
             if remaining is not None and window.used_percent is not None:
                 used = max(0, min(100, round(float(window.used_percent))))
-                window_bits.append(f"{window.label} {remaining}% left / {used}% used")
+                bit = f"{window_label} {remaining}% left / {used}% used"
+                if window.reset_at:
+                    bit += f" · {format_reset_countdown(window.reset_at)}"
+                window_bits.append(bit)
             elif window.detail:
-                window_bits.append(f"{window.label} {window.detail}")
+                window_bits.append(f"{window_label} {safe_display_text(window.detail, max_len=40)}")
         if window_bits:
             parts.append("; ".join(window_bits))
         elif result.snapshot.details:
-            parts.append(result.snapshot.details[0])
+            parts.append(safe_display_text(result.snapshot.details[0], fallback="detail", max_len=60))
     if result.unavailable_reason and not (result.snapshot and result.snapshot.windows):
-        parts.append(result.unavailable_reason)
+        parts.append(safe_display_text(result.unavailable_reason, fallback="usage unavailable", max_len=60))
     return " · ".join(part for part in parts if part)
 
 
-def fetch_provider_account_usages(provider: Optional[str]) -> list[ProviderAccountUsage]:
-    """Fetch usage for every credential in a provider's credential pool."""
+def _sync_entry_for_usage(provider: str, pool: Any, entry: Any) -> tuple[Any, Optional[str]]:
+    """Best-effort OAuth sync before informational usage lookup."""
+    try:
+        if provider == "openai-codex" and getattr(entry, "source", None) == "device_code":
+            sync = getattr(pool, "_sync_codex_entry_from_auth_store", None)
+            if callable(sync):
+                entry = sync(entry)
+        elif provider == "anthropic" and getattr(entry, "source", None) == "claude_code":
+            sync = getattr(pool, "_sync_anthropic_entry_from_credentials_file", None)
+            if callable(sync):
+                entry = sync(entry)
+    except Exception as exc:
+        return entry, f"credential sync failed: {type(exc).__name__}"
+    return entry, None
+
+
+def _fetch_provider_entry_usage(provider: str, index: int, entry: Any, pool: Any = None) -> ProviderAccountUsage:
+    label = _entry_label(entry, index)
+    status = _entry_status(entry)
+    if provider not in _ACCOUNT_USAGE_LOOKUP_PROVIDERS:
+        snapshot = _account_unavailable_snapshot(provider, "usage lookup not supported for this provider")
+        return ProviderAccountUsage(provider, index, label, status, snapshot, snapshot.unavailable_reason)
+
+    if pool is not None:
+        entry, sync_error = _sync_entry_for_usage(provider, pool, entry)
+        if sync_error:
+            snapshot = _account_unavailable_snapshot(provider, sync_error)
+            return ProviderAccountUsage(provider, index, label, status, snapshot, snapshot.unavailable_reason)
+
+    token = _entry_runtime_api_key(entry)
+    try:
+        if provider == "openai-codex":
+            snapshot = _fetch_codex_account_usage_for_token(
+                token,
+                base_url=_entry_runtime_base_url(entry),
+                account_id=_entry_account_id(entry, token),
+            )
+        elif provider == "anthropic":
+            snapshot = _fetch_anthropic_account_usage_for_token(token)
+        elif provider == "openrouter":
+            snapshot = _fetch_openrouter_account_usage(_entry_runtime_base_url(entry), token)
+        else:
+            snapshot = None
+    except Exception as exc:
+        snapshot = _account_unavailable_snapshot(provider, f"usage lookup failed: {type(exc).__name__}")
+    if snapshot is None:
+        snapshot = _account_unavailable_snapshot(provider, "usage unavailable")
+    return ProviderAccountUsage(provider, index, label, status, snapshot, snapshot.unavailable_reason)
+
+
+def fetch_provider_account_usages(
+    provider: Optional[str],
+    *,
+    timeout: float = 20.0,
+    max_concurrency: int = 4,
+) -> list[ProviderAccountUsage]:
+    """Fetch usage for every credential with bounded partial-failure safety."""
     normalized = _normalize_provider(provider)
     if not normalized:
         return []
     try:
-        entries = load_pool(normalized).entries()
+        pool = load_pool(normalized)
+        entries = list(pool.entries())
     except Exception:
+        pool = None
         entries = []
-    results: list[ProviderAccountUsage] = []
-    for index, entry in enumerate(entries, start=1):
-        token = _entry_runtime_api_key(entry)
-        label = _entry_label(entry, index)
-        status = _entry_status(entry)
-        try:
-            if normalized == "openai-codex":
-                snapshot = _fetch_codex_account_usage_for_token(
-                    token,
-                    base_url=_entry_runtime_base_url(entry),
-                    account_id=_entry_account_id(entry, token),
+    if not entries:
+        return []
+
+    results: list[Optional[ProviderAccountUsage]] = [None] * len(entries)
+    workers = max(1, min(int(max_concurrency or 1), 4, len(entries)))
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=workers)
+    future_to_pos: dict[concurrent.futures.Future, int] = {}
+    try:
+        for pos, entry in enumerate(entries):
+            future = executor.submit(_fetch_provider_entry_usage, normalized, pos + 1, entry, pool)
+            future_to_pos[future] = pos
+        done, not_done = concurrent.futures.wait(future_to_pos, timeout=max(0.1, float(timeout)))
+        for future in done:
+            pos = future_to_pos[future]
+            try:
+                results[pos] = future.result()
+            except Exception as exc:
+                entry = entries[pos]
+                snapshot = _account_unavailable_snapshot(normalized, f"usage lookup failed: {type(exc).__name__}")
+                results[pos] = ProviderAccountUsage(
+                    normalized,
+                    pos + 1,
+                    _entry_label(entry, pos + 1),
+                    _entry_status(entry),
+                    snapshot,
+                    snapshot.unavailable_reason,
                 )
-            elif normalized == "anthropic":
-                snapshot = _fetch_anthropic_account_usage_for_token(token)
-            elif normalized == "openrouter":
-                snapshot = _fetch_openrouter_account_usage(_entry_runtime_base_url(entry), token)
-            elif normalized not in _ACCOUNT_USAGE_LOOKUP_PROVIDERS:
-                snapshot = _account_unavailable_snapshot(normalized, "usage lookup not supported for this provider")
-            else:
-                snapshot = None
-        except Exception as exc:
-            snapshot = _account_unavailable_snapshot(
+        for future in not_done:
+            pos = future_to_pos[future]
+            future.cancel()
+            entry = entries[pos]
+            snapshot = _account_unavailable_snapshot(normalized, "usage lookup timed out")
+            results[pos] = ProviderAccountUsage(
                 normalized,
-                f"usage lookup failed: {type(exc).__name__}",
+                pos + 1,
+                _entry_label(entry, pos + 1),
+                _entry_status(entry),
+                snapshot,
+                snapshot.unavailable_reason,
             )
-        if snapshot is None:
-            snapshot = _account_unavailable_snapshot(normalized, "usage unavailable")
-        results.append(
-            ProviderAccountUsage(
-                provider=normalized,
-                index=index,
-                label=label,
-                status=status,
-                snapshot=snapshot,
-                unavailable_reason=snapshot.unavailable_reason,
-            )
-        )
-    return results
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+    return [result for result in results if result is not None]
 
 
 def fetch_account_usage(

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -465,7 +465,9 @@ def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
     creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
     token_data = _read_codex_tokens()
     tokens = token_data.get("tokens") or {}
-    account_id = str(tokens.get("account_id", "") or "").strip() or None
+    account_id = str(
+        tokens.get("chatgpt_account_id") or tokens.get("account_id") or ""
+    ).strip() or None
     return _fetch_codex_account_usage_for_token(
         str(creds.get("api_key", "") or ""),
         base_url=creds.get("base_url", ""),
@@ -799,7 +801,10 @@ def account_choice_label(result: ProviderAccountUsage, *, active: bool = False) 
 def _sync_entry_for_usage(provider: str, pool: Any, entry: Any) -> tuple[Any, Optional[str]]:
     """Best-effort OAuth sync before informational usage lookup."""
     try:
-        if provider == "openai-codex" and getattr(entry, "source", None) == "device_code":
+        if provider == "openai-codex" and (
+            getattr(entry, "source", None) == "device_code"
+            or str(getattr(entry, "source", "") or "").endswith(":device_code")
+        ):
             sync = getattr(pool, "_sync_codex_entry_from_auth_store", None)
             if callable(sync):
                 entry = sync(entry)

--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -7,7 +7,13 @@ from typing import Any, Optional
 import httpx
 
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
-from hermes_cli.auth import _read_codex_tokens, resolve_codex_runtime_credentials
+from agent.credential_pool import load_pool
+from hermes_cli.auth import (
+    _decode_jwt_claims,
+    _read_codex_tokens,
+    read_credential_pool,
+    resolve_codex_runtime_credentials,
+)
 from hermes_cli.runtime_provider import resolve_runtime_provider
 
 
@@ -37,6 +43,52 @@ class AccountUsageSnapshot:
     @property
     def available(self) -> bool:
         return bool(self.windows or self.details) and not self.unavailable_reason
+
+
+@dataclass(frozen=True)
+class ProviderAccountUsage:
+    provider: str
+    index: int
+    label: str
+    status: str
+    snapshot: Optional[AccountUsageSnapshot] = None
+    unavailable_reason: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class AccountProviderChoice:
+    slug: str
+    name: str
+    account_count: int
+    is_current: bool = False
+
+
+_ACCOUNT_USAGE_LOOKUP_PROVIDERS = {"anthropic", "openai-codex", "openrouter"}
+
+
+def _normalize_provider(provider: Optional[str]) -> str:
+    return str(provider or "").strip().lower()
+
+
+def _account_unavailable_snapshot(provider: str, reason: str) -> AccountUsageSnapshot:
+    return AccountUsageSnapshot(
+        provider=provider,
+        source="credential_pool",
+        fetched_at=_utc_now(),
+        unavailable_reason=reason,
+    )
+
+
+def _provider_display_name(provider: str) -> str:
+    try:
+        from hermes_cli.providers import get_label
+
+        label = get_label(provider)
+        if isinstance(label, str) and label.strip():
+            return label.strip()
+    except Exception:
+        pass
+    return _title_case_slug(provider) or provider
 
 
 def _title_case_slug(value: Optional[str]) -> Optional[str]:
@@ -113,33 +165,131 @@ def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, mark
     return lines
 
 
+def _remaining_percent(window: AccountUsageWindow) -> Optional[int]:
+    if window.used_percent is None:
+        return None
+    return max(0, min(100, round(100 - float(window.used_percent))))
+
+
+def _usage_bar(remaining_percent: Optional[int], *, width: int = 10) -> str:
+    if remaining_percent is None:
+        return "▱" * width
+    filled = max(0, min(width, round((remaining_percent / 100) * width)))
+    return "▰" * filled + "▱" * (width - filled)
+
+
+def _account_health(snapshot: Optional[AccountUsageSnapshot]) -> tuple[str, str, Optional[int]]:
+    if not snapshot or snapshot.unavailable_reason:
+        return "⚪", "Unknown", None
+    remaining_values = [
+        remaining
+        for remaining in (_remaining_percent(window) for window in snapshot.windows)
+        if remaining is not None
+    ]
+    if not remaining_values:
+        return "✅", "Available", None
+    lowest_remaining = min(remaining_values)
+    if lowest_remaining <= 5:
+        return "⛔", "Limited", lowest_remaining
+    if lowest_remaining <= 20:
+        return "⚠️", "Low", lowest_remaining
+    return "✅", "Healthy", lowest_remaining
+
+
+def _format_account_window_line(window: AccountUsageWindow) -> str:
+    remaining = _remaining_percent(window)
+    if remaining is None or window.used_percent is None:
+        base = f"   {window.label}: unavailable {_usage_bar(None)}"
+    else:
+        used = max(0, min(100, round(float(window.used_percent))))
+        base = f"   {window.label}: {remaining}% remaining ({used}% used) {_usage_bar(remaining)}"
+    if window.reset_at:
+        base += f" • resets {_format_reset(window.reset_at)}"
+    elif window.detail:
+        base += f" • {window.detail}"
+    return base
+
+
+def render_provider_account_usage_lines(
+    provider: str,
+    results: list[ProviderAccountUsage] | tuple[ProviderAccountUsage, ...],
+    *,
+    markdown: bool = False,
+    active_index: Optional[int] = None,
+    select_hint: Optional[str] = None,
+) -> list[str]:
+    normalized = _normalize_provider(provider)
+    if not results:
+        return []
+    strong = "**" if markdown else ""
+    lines = [f"📊 {strong}Hermes Account Center{strong}"]
+    lines.append(f"Provider: {normalized} • Accounts: {len(results)}")
+    hint = (select_hint or f"/account {normalized} <number>").strip()
+    lines.append(f"Select: `{hint}`" if markdown else f"Select: {hint}")
+    lines.append("")
+    for result in results:
+        label = result.label or f"account-{result.index}"
+        snapshot = result.snapshot
+        emoji, health, _lowest_remaining = _account_health(snapshot)
+        active = active_index is not None and result.index == active_index
+        active_suffix = " — active" if active else ""
+        title = f"{result.index}. {label}"
+        if markdown:
+            title = f"{strong}{title}{strong}"
+        lines.append(f"{emoji} {title}{active_suffix} · {health}")
+        if result.status:
+            lines.append(f"   Pool: {result.status}")
+        if not snapshot:
+            reason = result.unavailable_reason or "usage unavailable"
+            lines.append(f"   Unavailable: {reason}")
+            lines.append("")
+            continue
+        if snapshot.plan:
+            lines.append(f"   Plan: {snapshot.plan}")
+        for window in snapshot.windows:
+            lines.append(_format_account_window_line(window))
+        for detail in snapshot.details:
+            lines.append(f"   {detail}")
+        if snapshot.unavailable_reason:
+            lines.append(f"   Unavailable: {snapshot.unavailable_reason}")
+        lines.append("")
+    if lines and lines[-1] == "":
+        lines.pop()
+    return lines
+
+
 def _resolve_codex_usage_url(base_url: str) -> str:
     normalized = (base_url or "").strip().rstrip("/")
     if not normalized:
         normalized = "https://chatgpt.com/backend-api/codex"
-    if normalized.endswith("/codex"):
+    if normalized.endswith("/api/codex"):
+        normalized = normalized[: -len("/api/codex")]
+    elif normalized.endswith("/codex"):
         normalized = normalized[: -len("/codex")]
+    if "chatgpt.com" in normalized or "chat.openai.com" in normalized:
+        if "/backend-api" not in normalized:
+            normalized = normalized + "/backend-api"
+        return normalized + "/wham/usage"
     if "/backend-api" in normalized:
         return normalized + "/wham/usage"
     return normalized + "/api/codex/usage"
 
 
-def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
-    creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
-    token_data = _read_codex_tokens()
-    tokens = token_data.get("tokens") or {}
-    account_id = str(tokens.get("account_id", "") or "").strip() or None
-    headers = {
-        "Authorization": f"Bearer {creds['api_key']}",
-        "Accept": "application/json",
-        "User-Agent": "codex-cli",
-    }
-    if account_id:
-        headers["ChatGPT-Account-Id"] = account_id
-    with httpx.Client(timeout=15.0) as client:
-        response = client.get(_resolve_codex_usage_url(creds.get("base_url", "")), headers=headers)
-        response.raise_for_status()
-    payload = response.json() or {}
+def _codex_account_id_from_token(token: str) -> Optional[str]:
+    claims = _decode_jwt_claims(token)
+    nested = claims.get("https://api.openai.com/auth")
+    if isinstance(nested, dict):
+        value = nested.get("chatgpt_account_id") or nested.get("account_id")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    for key in ("chatgpt_account_id", "account_id"):
+        value = claims.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _parse_codex_usage_snapshot(payload: dict[str, Any]) -> AccountUsageSnapshot:
     rate_limit = payload.get("rate_limit") or {}
     windows: list[AccountUsageWindow] = []
     for key, label in (("primary_window", "Session"), ("secondary_window", "Weekly")):
@@ -172,8 +322,45 @@ def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
     )
 
 
-def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
-    token = (resolve_anthropic_token() or "").strip()
+def _fetch_codex_account_usage_for_token(
+    access_token: str,
+    *,
+    base_url: Optional[str] = None,
+    account_id: Optional[str] = None,
+) -> AccountUsageSnapshot:
+    token = str(access_token or "").strip()
+    if not token:
+        return _account_unavailable_snapshot("openai-codex", "missing access token")
+    account_id = (str(account_id or "").strip() or _codex_account_id_from_token(token))
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": "hermes-agent",
+    }
+    if account_id:
+        headers["ChatGPT-Account-Id"] = account_id
+    with httpx.Client(timeout=15.0) as client:
+        response = client.get(_resolve_codex_usage_url(base_url or ""), headers=headers)
+        response.raise_for_status()
+    payload = response.json() or {}
+    return _parse_codex_usage_snapshot(payload)
+
+
+def _fetch_codex_account_usage() -> Optional[AccountUsageSnapshot]:
+    creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+    token_data = _read_codex_tokens()
+    tokens = token_data.get("tokens") or {}
+    account_id = str(tokens.get("account_id", "") or "").strip() or None
+    return _fetch_codex_account_usage_for_token(
+        str(creds.get("api_key", "") or ""),
+        base_url=creds.get("base_url", ""),
+        account_id=account_id,
+    )
+
+
+def _fetch_anthropic_account_usage_for_token(token: str) -> Optional[AccountUsageSnapshot]:
+    token = (token or "").strip()
     if not token:
         return None
     if not _is_oauth_token(token):
@@ -231,6 +418,10 @@ def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
         windows=tuple(windows),
         details=tuple(details),
     )
+
+
+def _fetch_anthropic_account_usage() -> Optional[AccountUsageSnapshot]:
+    return _fetch_anthropic_account_usage_for_token(resolve_anthropic_token() or "")
 
 
 def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[str]) -> Optional[AccountUsageSnapshot]:
@@ -303,6 +494,234 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
         windows=tuple(windows),
         details=tuple(details),
     )
+
+
+def list_account_provider_choices(*, active_provider: Optional[str] = None) -> list[AccountProviderChoice]:
+    """Return providers that have one or more persisted credentials/accounts."""
+    choices: dict[str, AccountProviderChoice] = {}
+    normalized_active = _normalize_provider(active_provider)
+    try:
+        pool = read_credential_pool(None)
+    except Exception:
+        pool = {}
+    if isinstance(pool, dict):
+        for provider, entries in pool.items():
+            normalized = _normalize_provider(provider)
+            if not normalized or not isinstance(entries, list) or not entries:
+                continue
+            choices[normalized] = AccountProviderChoice(
+                slug=normalized,
+                name=_provider_display_name(normalized),
+                account_count=len(entries),
+                is_current=normalized == normalized_active,
+            )
+
+    # If the active provider is backed by env/config singletons, load_pool()
+    # may seed it into auth.json even when it was not in the raw store yet.
+    if normalized_active and normalized_active not in choices:
+        try:
+            seeded_entries = load_pool(normalized_active).entries()
+        except Exception:
+            seeded_entries = []
+        if seeded_entries:
+            choices[normalized_active] = AccountProviderChoice(
+                slug=normalized_active,
+                name=_provider_display_name(normalized_active),
+                account_count=len(seeded_entries),
+                is_current=True,
+            )
+
+    return sorted(
+        choices.values(),
+        key=lambda choice: (not choice.is_current, choice.name.lower(), choice.slug),
+    )
+
+
+def list_account_usage_providers(*, active_provider: Optional[str] = None) -> list[str]:
+    """Return provider slugs that have one or more credentials/accounts."""
+    return [choice.slug for choice in list_account_provider_choices(active_provider=active_provider)]
+
+
+def _entry_label(entry: Any, index: int) -> str:
+    for attr in ("label", "source", "id"):
+        value = getattr(entry, attr, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return f"account-{index}"
+
+
+def _entry_status(entry: Any) -> str:
+    status = getattr(entry, "last_status", None)
+    if isinstance(status, str) and status.strip():
+        return status.strip()
+    return "available"
+
+
+def _entry_runtime_api_key(entry: Any) -> str:
+    for attr in ("runtime_api_key", "access_token", "api_key"):
+        value = getattr(entry, attr, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _entry_runtime_base_url(entry: Any) -> Optional[str]:
+    for attr in ("runtime_base_url", "base_url", "inference_base_url"):
+        value = getattr(entry, attr, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _entry_account_id(entry: Any, token: str) -> Optional[str]:
+    for attr in ("account_id", "chatgpt_account_id"):
+        value = getattr(entry, attr, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    extra = getattr(entry, "extra", None)
+    if isinstance(extra, dict):
+        for key in ("account_id", "chatgpt_account_id"):
+            value = extra.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    id_token = getattr(entry, "id_token", None)
+    if isinstance(id_token, str) and id_token.strip():
+        from_id_token = _codex_account_id_from_token(id_token)
+        if from_id_token:
+            return from_id_token
+    return _codex_account_id_from_token(token)
+
+
+def _coerce_pool(provider: str, pool: Any = None) -> Any:
+    if pool is not None:
+        return pool
+    return load_pool(provider)
+
+
+def active_provider_account_index(provider: Optional[str], *, pool: Any = None) -> Optional[int]:
+    """Return the 1-based index of the currently selected pool entry, if known."""
+    normalized = _normalize_provider(provider)
+    if not normalized:
+        return None
+    try:
+        resolved_pool = _coerce_pool(normalized, pool)
+        if not hasattr(resolved_pool, "current") or not hasattr(resolved_pool, "entries"):
+            return None
+        entries = list(resolved_pool.entries())
+        if not entries:
+            return None
+        current = resolved_pool.current()
+        current_id = getattr(current, "id", None)
+        if not isinstance(current_id, str) or not current_id:
+            return 1
+        for index, entry in enumerate(entries, start=1):
+            if getattr(entry, "id", None) == current_id:
+                return index
+    except Exception:
+        return None
+    return None
+
+
+def select_provider_account(
+    provider: Optional[str],
+    target: str,
+    *,
+    pool: Any = None,
+) -> tuple[Optional[int], Any, Optional[str]]:
+    """Select one account in a provider credential pool by index, label, or id."""
+    normalized = _normalize_provider(provider)
+    if not normalized:
+        return None, None, "missing provider"
+    try:
+        resolved_pool = _coerce_pool(normalized, pool)
+    except Exception as exc:
+        return None, None, f"could not load {normalized} credential pool: {type(exc).__name__}"
+    if not hasattr(resolved_pool, "select_target"):
+        return None, None, f"{normalized} credential pool cannot select accounts"
+    try:
+        index, entry, error = resolved_pool.select_target(target)
+    except Exception as exc:
+        return None, None, f"could not select account: {type(exc).__name__}"
+    return index, entry, error
+
+
+def account_choice_label(result: ProviderAccountUsage, *, active: bool = False) -> str:
+    """Compact one-line label for terminal account pickers."""
+    emoji, health, lowest_remaining = _account_health(result.snapshot)
+    label = result.label or f"account-{result.index}"
+    suffix = "  ← active" if active else ""
+    parts: list[str] = [f"{emoji} {result.index}. {label}{suffix}", health]
+    if result.status:
+        parts.append(f"status: {result.status}")
+    if result.snapshot and result.snapshot.plan:
+        parts.append(f"plan: {result.snapshot.plan}")
+    if lowest_remaining is not None:
+        parts.append(f"limit: {lowest_remaining}% left {_usage_bar(lowest_remaining, width=8)}")
+    if result.snapshot:
+        window_bits: list[str] = []
+        for window in result.snapshot.windows[:2]:
+            remaining = _remaining_percent(window)
+            if remaining is not None and window.used_percent is not None:
+                used = max(0, min(100, round(float(window.used_percent))))
+                window_bits.append(f"{window.label} {remaining}% left / {used}% used")
+            elif window.detail:
+                window_bits.append(f"{window.label} {window.detail}")
+        if window_bits:
+            parts.append("; ".join(window_bits))
+        elif result.snapshot.details:
+            parts.append(result.snapshot.details[0])
+    if result.unavailable_reason and not (result.snapshot and result.snapshot.windows):
+        parts.append(result.unavailable_reason)
+    return " · ".join(part for part in parts if part)
+
+
+def fetch_provider_account_usages(provider: Optional[str]) -> list[ProviderAccountUsage]:
+    """Fetch usage for every credential in a provider's credential pool."""
+    normalized = _normalize_provider(provider)
+    if not normalized:
+        return []
+    try:
+        entries = load_pool(normalized).entries()
+    except Exception:
+        entries = []
+    results: list[ProviderAccountUsage] = []
+    for index, entry in enumerate(entries, start=1):
+        token = _entry_runtime_api_key(entry)
+        label = _entry_label(entry, index)
+        status = _entry_status(entry)
+        try:
+            if normalized == "openai-codex":
+                snapshot = _fetch_codex_account_usage_for_token(
+                    token,
+                    base_url=_entry_runtime_base_url(entry),
+                    account_id=_entry_account_id(entry, token),
+                )
+            elif normalized == "anthropic":
+                snapshot = _fetch_anthropic_account_usage_for_token(token)
+            elif normalized == "openrouter":
+                snapshot = _fetch_openrouter_account_usage(_entry_runtime_base_url(entry), token)
+            elif normalized not in _ACCOUNT_USAGE_LOOKUP_PROVIDERS:
+                snapshot = _account_unavailable_snapshot(normalized, "usage lookup not supported for this provider")
+            else:
+                snapshot = None
+        except Exception as exc:
+            snapshot = _account_unavailable_snapshot(
+                normalized,
+                f"usage lookup failed: {type(exc).__name__}",
+            )
+        if snapshot is None:
+            snapshot = _account_unavailable_snapshot(normalized, "usage unavailable")
+        results.append(
+            ProviderAccountUsage(
+                provider=normalized,
+                index=index,
+                label=label,
+                status=status,
+                snapshot=snapshot,
+                unavailable_reason=snapshot.unavailable_reason,
+            )
+        )
+    return results
 
 
 def fetch_account_usage(

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
-from hermes_cli.config import get_env_value, load_env
+from hermes_cli.config import load_env
 import hermes_cli.auth as auth_mod
 from hermes_cli.auth import (
     CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
@@ -385,6 +385,56 @@ class CredentialPool:
         if not self._current_id:
             return None
         return next((entry for entry in self._entries if entry.id == self._current_id), None)
+
+    def select_target(self, target: str) -> Tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
+        """Make a specific pool entry current and persist it as the first priority.
+
+        ``target`` accepts the 1-based display index, full label, full id, or a
+        unique id prefix.  The returned index is the entry's index before the
+        priority move so UI commands can acknowledge exactly what the user
+        selected.
+        """
+        needle = str(target or "").strip()
+        if not needle:
+            return None, None, "missing account selection"
+        needle_lower = needle.lower()
+        with self._lock:
+            matched_index: Optional[int] = None
+            matched_entry: Optional[PooledCredential] = None
+            if needle.isdigit():
+                idx = int(needle)
+                if 1 <= idx <= len(self._entries):
+                    matched_index = idx
+                    matched_entry = self._entries[idx - 1]
+                else:
+                    return None, None, f"account number {idx} is out of range"
+            else:
+                exact_matches: list[tuple[int, PooledCredential]] = []
+                prefix_matches: list[tuple[int, PooledCredential]] = []
+                for idx, entry in enumerate(self._entries, start=1):
+                    label = str(entry.label or "").strip().lower()
+                    entry_id = str(entry.id or "").strip().lower()
+                    if needle_lower in {label, entry_id}:
+                        exact_matches.append((idx, entry))
+                    elif entry_id.startswith(needle_lower):
+                        prefix_matches.append((idx, entry))
+                matches = exact_matches or prefix_matches
+                if len(matches) == 1:
+                    matched_index, matched_entry = matches[0]
+                elif len(matches) > 1:
+                    return None, None, f"account selection {needle!r} is ambiguous"
+                else:
+                    return None, None, f"account {needle!r} was not found"
+
+            if matched_entry is None or matched_index is None:
+                return None, None, f"account {needle!r} was not found"
+
+            reordered = [matched_entry] + [entry for entry in self._entries if entry.id != matched_entry.id]
+            self._entries = [replace(entry, priority=idx) for idx, entry in enumerate(reordered)]
+            self._current_id = matched_entry.id
+            self._persist()
+            selected = self.current() or self._entries[0]
+            return matched_index, selected, None
 
     def _replace_entry(self, old: PooledCredential, new: PooledCredential) -> None:
         """Swap an entry in-place by id, preserving sort order."""

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -84,6 +84,10 @@ _EXTRA_KEYS = frozenset({
     "token_type", "scope", "client_id", "portal_base_url", "obtained_at",
     "expires_in", "agent_key_id", "agent_key_expires_in", "agent_key_reused",
     "agent_key_obtained_at", "tls",
+    # Codex/ChatGPT account metadata.  These are secret-adjacent auth fields,
+    # so they belong in auth.json with the rest of the credential material and
+    # must round-trip through the pool for usage/account selection.
+    "id_token", "account_id", "chatgpt_account_id",
 })
 
 
@@ -186,6 +190,58 @@ def _next_priority(entries: List[PooledCredential]) -> int:
 def _is_manual_source(source: str) -> bool:
     normalized = (source or "").strip().lower()
     return normalized == SOURCE_MANUAL or normalized.startswith(f"{SOURCE_MANUAL}:")
+
+
+def _is_device_code_source(source: str) -> bool:
+    normalized = (source or "").strip().lower()
+    return normalized == "device_code" or normalized.endswith(":device_code")
+
+
+def _migrate_codex_legacy_device_code_entries(entries: List[PooledCredential]) -> bool:
+    """Collapse legacy manual:device_code Codex rows into canonical device_code."""
+    legacy_indices = [
+        idx
+        for idx, entry in enumerate(entries)
+        if entry.source != "device_code" and _is_device_code_source(entry.source)
+    ]
+    if not legacy_indices:
+        return False
+
+    changed = False
+    canonical_idx = next((idx for idx, entry in enumerate(entries) if entry.source == "device_code"), None)
+    if canonical_idx is None:
+        first_idx = legacy_indices[0]
+        entries[first_idx] = replace(entries[first_idx], source="device_code")
+        canonical_idx = first_idx
+        changed = True
+
+    legacy_label = entries[legacy_indices[0]].label if legacy_indices else None
+    canonical = entries[canonical_idx]
+    legacy_priorities = [entries[idx].priority for idx in legacy_indices]
+    target_priority = min([canonical.priority, *legacy_priorities]) if legacy_priorities else canonical.priority
+    updates: Dict[str, Any] = {}
+    if canonical.priority != target_priority:
+        updates["priority"] = target_priority
+    if legacy_label and canonical.label in {"device_code", "openai-codex"}:
+        updates["label"] = legacy_label
+    if updates:
+        entries[canonical_idx] = replace(canonical, **updates)
+        changed = True
+
+    remove_indices = {
+        idx for idx in legacy_indices if idx != canonical_idx
+    }
+    if remove_indices:
+        entries[:] = [entry for idx, entry in enumerate(entries) if idx not in remove_indices]
+        changed = True
+
+    # Keep priorities dense after removing the legacy duplicate(s).
+    ordered_indices = sorted(range(len(entries)), key=lambda idx: (entries[idx].priority, idx))
+    for priority, idx in enumerate(ordered_indices):
+        if entries[idx].priority != priority:
+            entries[idx] = replace(entries[idx], priority=priority)
+            changed = True
+    return changed
 
 
 def _exhausted_ttl(error_code: Optional[int]) -> int:
@@ -507,23 +563,19 @@ class CredentialPool:
         return entry
 
     def _sync_codex_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
-        """Sync a Codex device_code pool entry from auth.json if tokens differ.
+        """Sync a Codex device-code pool entry from auth.json if state differs.
 
-        When a Codex OAuth access token expires (or the ChatGPT account hits
-        its 5h/weekly quota), the pool entry gets marked ``STATUS_EXHAUSTED``
-        with a ``last_error_reset_at`` that can be many hours in the future.
-        Meanwhile the user may run ``hermes model`` / ``hermes auth`` which
-        performs a fresh device-code login and writes new tokens to
-        ``auth.json`` under ``_auth_store_lock``.  Without this sync the pool
-        entry stays frozen until ``last_error_reset_at`` elapses — even
-        though fresh credentials are sitting on disk — and every request
-        fails with "no available entries (all exhausted or empty)".
+        Codex OAuth state can be refreshed by another Hermes process through
+        ``resolve_codex_runtime_credentials()`` while an in-memory pool entry
+        still holds the old access/refresh pair.  Refresh tokens are single-use,
+        so trying the stale pair later can mark an otherwise healthy account as
+        exhausted.  Adopt the canonical auth-store state before retrying.
 
-        Mirrors the Nous/Anthropic resync paths above.  Only applies to
-        device_code-sourced entries; env/API-key-sourced entries have no
-        auth.json shadow to sync from.
+        The canonical source is ``device_code``.  Older versions of
+        ``hermes auth add openai-codex`` wrote ``manual:device_code`` rows, so
+        those legacy entries are also eligible for repair.
         """
-        if self.provider != "openai-codex" or entry.source != "device_code":
+        if self.provider != "openai-codex" or not _is_device_code_source(entry.source):
             return entry
         try:
             with _auth_store_lock():
@@ -534,34 +586,47 @@ class CredentialPool:
             tokens = state.get("tokens")
             if not isinstance(tokens, dict):
                 return entry
-            store_access = tokens.get("access_token", "")
-            store_refresh = tokens.get("refresh_token", "")
-            # Adopt auth.json tokens when either side differs.  Codex refresh
-            # tokens are single-use too, so a fresh refresh_token from
-            # another process means our entry's pair is consumed/stale.
-            entry_access = entry.access_token or ""
-            entry_refresh = entry.refresh_token or ""
-            if store_access and (
-                store_access != entry_access
-                or (store_refresh and store_refresh != entry_refresh)
-            ):
+            store_access = str(tokens.get("access_token", "") or "").strip()
+            store_refresh = str(tokens.get("refresh_token", "") or "").strip()
+            if not store_access:
+                return entry
+
+            field_updates: Dict[str, Any] = {}
+            extra_updates: Dict[str, Any] = dict(entry.extra)
+            credential_changed = False
+            if store_access != (entry.access_token or ""):
+                field_updates["access_token"] = store_access
+                credential_changed = True
+            if store_refresh and store_refresh != (entry.refresh_token or ""):
+                field_updates["refresh_token"] = store_refresh
+                credential_changed = True
+            if state.get("last_refresh") and state.get("last_refresh") != entry.last_refresh:
+                field_updates["last_refresh"] = state["last_refresh"]
+            store_base_url = str(state.get("base_url") or "").strip().rstrip("/")
+            if store_base_url and store_base_url != (entry.base_url or ""):
+                field_updates["base_url"] = store_base_url
+            for key in ("id_token", "account_id", "chatgpt_account_id"):
+                value = tokens.get(key) or state.get(key)
+                if isinstance(value, str) and value.strip() and extra_updates.get(key) != value.strip():
+                    extra_updates[key] = value.strip()
+
+            metadata_changed = extra_updates != entry.extra
+            if field_updates or metadata_changed:
                 logger.debug(
-                    "Pool entry %s: syncing Codex tokens from auth.json "
-                    "(refreshed by another process)",
+                    "Pool entry %s: syncing Codex auth/account state from auth.json",
                     entry.id,
                 )
-                field_updates: Dict[str, Any] = {
-                    "access_token": store_access,
-                    "refresh_token": store_refresh or entry.refresh_token,
-                    "last_status": None,
-                    "last_status_at": None,
-                    "last_error_code": None,
-                    "last_error_reason": None,
-                    "last_error_message": None,
-                    "last_error_reset_at": None,
-                }
-                if state.get("last_refresh"):
-                    field_updates["last_refresh"] = state["last_refresh"]
+                if credential_changed:
+                    field_updates.update({
+                        "last_status": None,
+                        "last_status_at": None,
+                        "last_error_code": None,
+                        "last_error_reason": None,
+                        "last_error_message": None,
+                        "last_error_reset_at": None,
+                    })
+                if metadata_changed:
+                    field_updates["extra"] = extra_updates
                 updated = replace(entry, **field_updates)
                 self._replace_entry(entry, updated)
                 self._persist()
@@ -637,7 +702,10 @@ class CredentialPool:
         Applies to any OAuth provider whose singleton lives in auth.json
         (currently Nous and OpenAI Codex).
         """
-        if entry.source != "device_code":
+        if self.provider == "openai-codex":
+            if not _is_device_code_source(entry.source):
+                return
+        elif entry.source != "device_code":
             return
         try:
             with _auth_store_lock():
@@ -675,8 +743,16 @@ class CredentialPool:
                     tokens["access_token"] = entry.access_token
                     if entry.refresh_token:
                         tokens["refresh_token"] = entry.refresh_token
+                    for key in ("id_token", "account_id", "chatgpt_account_id"):
+                        value = entry.extra.get(key)
+                        if isinstance(value, str) and value.strip():
+                            tokens[key] = value.strip()
                     if entry.last_refresh:
                         state["last_refresh"] = entry.last_refresh
+                    if entry.base_url:
+                        state["base_url"] = entry.base_url.rstrip("/")
+                    if entry.label:
+                        state["label"] = entry.label
                     _save_provider_state(auth_store, "openai-codex", state)
 
                 else:
@@ -724,11 +800,17 @@ class CredentialPool:
                     entry.access_token,
                     entry.refresh_token,
                 )
+                extra_updates = dict(entry.extra)
+                for key in ("id_token", "account_id", "chatgpt_account_id"):
+                    value = refreshed.get(key)
+                    if isinstance(value, str) and value.strip():
+                        extra_updates[key] = value.strip()
                 updated = replace(
                     entry,
                     access_token=refreshed["access_token"],
                     refresh_token=refreshed["refresh_token"],
                     last_refresh=refreshed.get("last_refresh"),
+                    extra=extra_updates,
                 )
             elif self.provider == "nous":
                 synced = self._sync_nous_entry_from_auth_store(entry)
@@ -808,6 +890,27 @@ class CredentialPool:
                     # Credentials file had a valid (non-expired) token — use it directly
                     logger.debug("Credentials file has valid token, using without refresh")
                     return synced
+            # For Codex: another Hermes process may have refreshed the
+            # auth-store singleton while this pool entry still has the old
+            # single-use refresh token.  Adopt the newer state instead of
+            # exhausting the account on a stale-token refresh failure.
+            if self.provider == "openai-codex":
+                synced = self._sync_codex_entry_from_auth_store(entry)
+                if synced.refresh_token != entry.refresh_token or synced.access_token != entry.access_token:
+                    logger.debug("Codex refresh failed but auth.json has newer tokens — adopting")
+                    updated = replace(
+                        synced,
+                        last_status=STATUS_OK,
+                        last_status_at=None,
+                        last_error_code=None,
+                        last_error_reason=None,
+                        last_error_message=None,
+                        last_error_reset_at=None,
+                    )
+                    self._replace_entry(synced, updated)
+                    self._persist()
+                    self._sync_device_code_entry_to_auth_store(updated)
+                    return updated
             # For nous: another process may have consumed the refresh token
             # between our proactive sync and the HTTP call.  Re-sync from
             # auth.json and adopt the fresh tokens if available.
@@ -908,7 +1011,7 @@ class CredentialPool:
             # frozen behind last_error_reset_at (can be hours in the
             # future for ChatGPT weekly windows).
             if (self.provider == "openai-codex"
-                    and entry.source == "device_code"
+                    and _is_device_code_source(entry.source)
                     and entry.last_status == STATUS_EXHAUSTED):
                 synced = self._sync_codex_entry_from_auth_store(entry)
                 if synced is not entry:
@@ -1143,6 +1246,7 @@ def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, p
     existing = entries[existing_idx]
     field_updates = {}
     extra_updates = {}
+    credential_changed = False
     _field_names = {f.name for f in fields(existing)}
     for key, value in payload.items():
         if key in {"id", "priority"} or value is None:
@@ -1152,10 +1256,21 @@ def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, p
         if key in _field_names:
             if getattr(existing, key) != value:
                 field_updates[key] = value
+                if key in {"access_token", "refresh_token", "agent_key"}:
+                    credential_changed = True
         elif key in _EXTRA_KEYS:
             if existing.extra.get(key) != value:
                 extra_updates[key] = value
     if field_updates or extra_updates:
+        if credential_changed:
+            field_updates.update({
+                "last_status": None,
+                "last_status_at": None,
+                "last_error_code": None,
+                "last_error_reason": None,
+                "last_error_message": None,
+                "last_error_reset_at": None,
+            })
         if extra_updates:
             field_updates["extra"] = {**existing.extra, **extra_updates}
         entries[existing_idx] = replace(existing, **field_updates)
@@ -1409,7 +1524,14 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # existing Codex CLI credentials get a one-time, explicit prompt
         # via `hermes auth openai-codex`.
         if isinstance(tokens, dict) and tokens.get("access_token"):
+            changed |= _migrate_codex_legacy_device_code_entries(entries)
             active_sources.add("device_code")
+            state_base_url = str(state.get("base_url") or "").strip().rstrip("/") or "https://chatgpt.com/backend-api/codex"
+            custom_label = str(state.get("label") or "").strip()
+            seeded_label = custom_label or label_from_token(
+                tokens.get("id_token") or tokens.get("access_token", ""),
+                "device_code",
+            )
             changed |= _upsert_entry(
                 entries,
                 provider,
@@ -1419,9 +1541,12 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                     "auth_type": AUTH_TYPE_OAUTH,
                     "access_token": tokens.get("access_token", ""),
                     "refresh_token": tokens.get("refresh_token"),
-                    "base_url": "https://chatgpt.com/backend-api/codex",
+                    "id_token": tokens.get("id_token"),
+                    "account_id": tokens.get("account_id"),
+                    "chatgpt_account_id": tokens.get("chatgpt_account_id"),
+                    "base_url": state_base_url,
                     "last_refresh": state.get("last_refresh"),
-                    "label": label_from_token(tokens.get("access_token", ""), "device_code"),
+                    "label": seeded_label,
                 },
             )
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -422,12 +422,12 @@ class CredentialPool:
                 if len(matches) == 1:
                     matched_index, matched_entry = matches[0]
                 elif len(matches) > 1:
-                    return None, None, f"account selection {needle!r} is ambiguous"
+                    return None, None, "account selection is ambiguous"
                 else:
-                    return None, None, f"account {needle!r} was not found"
+                    return None, None, "account was not found"
 
             if matched_entry is None or matched_index is None:
-                return None, None, f"account {needle!r} was not found"
+                return None, None, "account was not found"
 
             reordered = [matched_entry] + [entry for entry in self._entries if entry.id != matched_entry.id]
             self._entries = [replace(entry, priority=idx) for idx, entry in enumerate(reordered)]

--- a/cli.py
+++ b/cli.py
@@ -2286,6 +2286,7 @@ class HermesCLI:
         self._approval_deadline = 0
         self._approval_lock = threading.Lock()
         self._model_picker_state = None
+        self._account_picker_state = None
         self._secret_state = None
         self._secret_deadline = 0
         self._spinner_text: str = ""  # thinking spinner text for TUI
@@ -2671,7 +2672,7 @@ class HermesCLI:
             return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
 
     def _get_status_bar_fragments(self):
-        if not self._status_bar_visible or getattr(self, '_model_picker_state', None):
+        if not self._status_bar_visible or getattr(self, '_model_picker_state', None) or getattr(self, '_account_picker_state', None):
             return []
         try:
             snapshot = self._get_status_bar_snapshot()
@@ -5510,6 +5511,307 @@ class HermesCLI:
         self._restore_modal_input_snapshot()
         self._invalidate(min_interval=0.0)
 
+    def _open_account_picker(self, providers, current_provider: Optional[str] = None) -> None:
+        """Open prompt_toolkit-native /account picker modal."""
+        self._capture_modal_input_snapshot()
+        default_idx = next((i for i, p in enumerate(providers) if p.get("is_current")), 0)
+        self._account_picker_state = {
+            "stage": "provider",
+            "providers": providers,
+            "selected": default_idx,
+            "current_provider": current_provider or "unknown",
+        }
+        self._invalidate(min_interval=0.0)
+
+    def _close_account_picker(self) -> None:
+        self._account_picker_state = None
+        self._restore_modal_input_snapshot()
+        self._invalidate(min_interval=0.0)
+
+    def _active_account_pool_for_provider(self, provider: str):
+        agent = self.agent
+        if not agent:
+            return None
+        agent_provider = str(getattr(agent, "provider", "") or "").strip().lower()
+        if agent_provider != str(provider or "").strip().lower():
+            return None
+        return getattr(agent, "_credential_pool", None)
+
+    def _fetch_account_results_for_picker(self, provider: str):
+        from agent.account_usage import fetch_provider_account_usages
+        import concurrent.futures
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
+            try:
+                return _pool.submit(fetch_provider_account_usages, provider).result(timeout=20.0)
+            except (concurrent.futures.TimeoutError, Exception):
+                return []
+
+    def _begin_account_provider_loading(self, provider_data: dict) -> None:
+        """Switch /account picker into a non-blocking Hermes loading state."""
+        state = self._account_picker_state
+        if not state:
+            return
+        provider_slug = provider_data.get("slug", "")
+        state.update({
+            "stage": "loading",
+            "provider_data": provider_data,
+            "loading_provider": provider_slug,
+            "loading_frame": 0,
+            "selected": 0,
+        })
+        state.pop("_scroll_offset", None)
+        self._invalidate(min_interval=0.0)
+
+        def _spinner_loop():
+            while True:
+                time.sleep(0.12)
+                cur = self._account_picker_state
+                if not cur or cur.get("stage") != "loading" or cur.get("loading_provider") != provider_slug:
+                    return
+                cur["loading_frame"] = int(cur.get("loading_frame", 0)) + 1
+                self._invalidate(min_interval=0.0)
+
+        def _worker():
+            account_results = self._fetch_account_results_for_picker(provider_slug)
+            active_pool = self._active_account_pool_for_provider(provider_slug)
+            try:
+                from agent.account_usage import active_provider_account_index
+                active_index = active_provider_account_index(provider_slug, pool=active_pool)
+            except Exception:
+                active_index = None
+            cur = self._account_picker_state
+            if not cur or cur.get("stage") != "loading" or cur.get("loading_provider") != provider_slug:
+                return
+            cur.update({
+                "stage": "account",
+                "provider_data": provider_data,
+                "account_results": account_results,
+                "active_index": active_index,
+                "selected": max(0, min(len(account_results), (active_index or 1) - 1)),
+            })
+            cur.pop("loading_provider", None)
+            cur.pop("_scroll_offset", None)
+            self._invalidate(min_interval=0.0)
+
+        threading.Thread(target=_spinner_loop, daemon=True).start()
+        threading.Thread(target=_worker, daemon=True).start()
+
+    def _load_model_switch_context(self):
+        user_provs = None
+        custom_provs = None
+        try:
+            from hermes_cli.config import get_compatible_custom_providers, load_config
+            cfg = load_config()
+            user_provs = cfg.get("providers")
+            custom_provs = get_compatible_custom_providers(cfg)
+        except Exception:
+            pass
+        return user_provs, custom_provs
+
+    def _provider_model_picker_data(self, provider_slug: str, *, max_models: int = 50):
+        from hermes_cli.model_switch import list_authenticated_providers
+        from hermes_cli.providers import get_label
+
+        user_provs, custom_provs = self._load_model_switch_context()
+        try:
+            providers = list_authenticated_providers(
+                current_provider=provider_slug,
+                current_base_url=self.base_url or "",
+                current_model=self.model or "",
+                user_providers=user_provs,
+                custom_providers=custom_provs,
+                max_models=max_models,
+            )
+        except Exception:
+            providers = []
+        provider_data = next(
+            (p for p in providers if str(p.get("slug", "")).lower() == str(provider_slug or "").lower()),
+            None,
+        )
+        if provider_data is None:
+            try:
+                from hermes_cli.models import provider_model_ids
+                models = provider_model_ids(provider_slug)[:max_models]
+            except Exception:
+                models = []
+            provider_data = {
+                "slug": provider_slug,
+                "name": get_label(provider_slug),
+                "is_current": True,
+                "is_user_defined": False,
+                "models": models,
+                "total_models": len(models),
+                "source": "fallback",
+            }
+            providers = [provider_data]
+        return providers, provider_data, user_provs, custom_provs
+
+    def _open_model_picker_for_account_provider(self, provider_slug: str, *, reason: str = "") -> bool:
+        providers, provider_data, user_provs, custom_provs = self._provider_model_picker_data(provider_slug)
+        model_list = provider_data.get("models", []) or []
+        if not model_list:
+            try:
+                from hermes_cli.models import provider_model_ids
+                model_list = provider_model_ids(provider_slug)[:50]
+            except Exception:
+                model_list = []
+        if not getattr(self, "_app", None):
+            if model_list:
+                preview = ", ".join(model_list[:5])
+                more = f" (+{len(model_list) - 5} more)" if len(model_list) > 5 else ""
+                _cprint(f"    Suggested models: {preview}{more}")
+                _cprint(f"    Run /model <name> --provider {provider_slug} to continue.")
+            else:
+                _cprint(f"    Run /model --provider {provider_slug} to choose a compatible model.")
+            return False
+        self._capture_modal_input_snapshot()
+        self._model_picker_state = {
+            "stage": "model",
+            "providers": providers,
+            "provider_data": provider_data,
+            "model_list": model_list,
+            "selected": 0,
+            "current_model": self.model or "unknown",
+            "current_provider": self.provider or "unknown",
+            "user_provs": user_provs,
+            "custom_provs": custom_provs,
+            "hint_override": reason or "Current model is not available on this account provider — choose a model.",
+        }
+        self._invalidate(min_interval=0.0)
+        return True
+
+    def _account_provider_model_followup(self, provider: str) -> bool:
+        """Keep the current model on a newly selected provider or ask for a model."""
+        provider_norm = str(provider or "").strip().lower()
+        current_provider = str(self.provider or "").strip().lower()
+        if not provider_norm or provider_norm == current_provider:
+            return False
+        current_model = self.model or ""
+        user_provs, custom_provs = self._load_model_switch_context()
+        if current_model:
+            try:
+                from hermes_cli.model_switch import switch_model
+                result = switch_model(
+                    raw_input=current_model,
+                    current_provider=self.provider or "",
+                    current_model=current_model,
+                    current_base_url=self.base_url or "",
+                    current_api_key=self.api_key or "",
+                    is_global=False,
+                    explicit_provider=provider_norm,
+                    user_providers=user_provs,
+                    custom_providers=custom_provs,
+                )
+            except Exception:
+                result = None
+            if result is not None and result.success:
+                _cprint(f"  ⚙ Current model is available on {provider_norm}; keeping it active.")
+                self._apply_model_switch_result(result, persist_global=False)
+                return False
+        _cprint(
+            f"  ⚙ Current model `{current_model or 'unknown'}` is not available on {provider_norm}."
+        )
+        _cprint("    Choose a model for this account provider.")
+        return self._open_model_picker_for_account_provider(
+            provider_norm,
+            reason=f"Account provider switched to {provider_norm}; choose a compatible model.",
+        )
+
+    def _apply_account_switch(self, provider: str, target: str, *, active_pool=None) -> Optional[int]:
+        from agent.account_usage import select_provider_account
+
+        selected_index, selected_entry, select_error = select_provider_account(
+            provider,
+            target,
+            pool=active_pool,
+        )
+        if select_error:
+            _cprint(f"  ✗ Could not switch account: {select_error}")
+            return None
+        agent = self.agent
+        if selected_entry is not None and active_pool is not None and agent and hasattr(agent, "_swap_credential"):
+            try:
+                agent._swap_credential(selected_entry)
+            except Exception as exc:
+                _cprint(f"  ⚠ Selected account, but could not apply it to this running session: {type(exc).__name__}")
+                return None
+        label = getattr(selected_entry, "label", None) or getattr(selected_entry, "id", None) or target
+        _cprint(f"  ✓ Account switched: {label}")
+        _cprint(f"    Provider: {provider}")
+        _cprint("    Persisted as active credential for future usage")
+        return selected_index
+
+    def _print_account_results(self, provider: str, account_results, active_index=None) -> None:
+        from agent.account_usage import render_provider_account_usage_lines
+
+        account_lines = render_provider_account_usage_lines(
+            provider,
+            account_results,
+            active_index=active_index,
+            select_hint=f"/account {provider} <number>",
+        )
+        print()
+        if account_lines:
+            for line in account_lines:
+                print(f" {line}" if line else "")
+        else:
+            print(f" (no account usage data available for {provider})")
+
+    def _handle_account_picker_selection(self) -> None:
+        state = self._account_picker_state
+        if not state:
+            return
+        selected = state.get("selected", 0)
+        stage = state.get("stage", "provider")
+        if stage == "provider":
+            providers = state.get("providers") or []
+            if selected >= len(providers):
+                self._close_account_picker()
+                return
+            provider_data = providers[selected]
+            self._begin_account_provider_loading(provider_data)
+            return
+
+        if stage == "loading":
+            self._invalidate(min_interval=0.0)
+            return
+
+        provider_data = state.get("provider_data") or {}
+        provider_slug = provider_data.get("slug", "")
+        account_results = state.get("account_results") or []
+        back_idx = len(account_results)
+        cancel_idx = len(account_results) + 1
+        if selected == back_idx:
+            providers = state.get("providers") or []
+            state["stage"] = "provider"
+            state["selected"] = next((i for i, p in enumerate(providers) if p.get("slug") == provider_slug), 0)
+            state.pop("_scroll_offset", None)
+            self._invalidate(min_interval=0.0)
+            return
+        if selected >= cancel_idx:
+            self._close_account_picker()
+            return
+        if selected < len(account_results):
+            active_pool = self._active_account_pool_for_provider(provider_slug)
+            target = str(account_results[selected].index)
+            switched_index = self._apply_account_switch(provider_slug, target, active_pool=active_pool)
+            self._close_account_picker()
+            opened_model_picker = False
+            if switched_index is not None:
+                opened_model_picker = self._account_provider_model_followup(provider_slug)
+            if not opened_model_picker:
+                refreshed_results = self._fetch_account_results_for_picker(provider_slug)
+                refreshed_active = None
+                try:
+                    from agent.account_usage import active_provider_account_index
+                    refreshed_active = active_provider_account_index(provider_slug, pool=active_pool)
+                except Exception:
+                    refreshed_active = None
+                self._print_account_results(provider_slug, refreshed_results, active_index=refreshed_active or switched_index)
+            return
+        self._close_account_picker()
+
     @staticmethod
     def _compute_model_picker_viewport(
         selected: int,
@@ -5858,6 +6160,18 @@ class HermesCLI:
             base = text.split(None, 1)[0].lower().lstrip('/')
             cmd = resolve_command(base)
             return bool(cmd and cmd.name == "model")
+        except Exception:
+            return False
+
+    def _should_handle_account_command_inline(self, text: str, has_images: bool = False) -> bool:
+        """Return True when /account should open its prompt_toolkit picker inline."""
+        if not text or has_images or not _looks_like_slash_command(text):
+            return False
+        try:
+            from hermes_cli.commands import resolve_command
+            base = text.split(None, 1)[0].lower().lstrip('/')
+            cmd = resolve_command(base)
+            return bool(cmd and cmd.name == "account")
         except Exception:
             return False
 
@@ -6560,6 +6874,8 @@ class HermesCLI:
             self._manual_compress(cmd_original)
         elif canonical == "usage":
             self._show_usage()
+        elif canonical == "account":
+            self._show_account(cmd_original)
         elif canonical == "insights":
             self._show_insights(cmd_original)
         elif canonical == "copy":
@@ -7803,6 +8119,148 @@ class HermesCLI:
             logging.getLogger().setLevel(logging.INFO)
             for quiet_logger in ('tools', 'run_agent', 'trajectory_compressor', 'cron', 'hermes_cli'):
                 logging.getLogger(quiet_logger).setLevel(logging.ERROR)
+
+    def _show_account(self, cmd_original: str = ""):
+        """Select an account/API key in a provider credential pool."""
+        agent = self.agent
+        active_provider = None
+        if agent:
+            active_provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
+        else:
+            active_provider = getattr(self, "provider", None)
+
+        raw_args = ""
+        if cmd_original:
+            parts = str(cmd_original).split(maxsplit=1)
+            raw_args = parts[1].strip() if len(parts) > 1 else ""
+
+        from agent.account_usage import (
+            account_choice_label,
+            active_provider_account_index,
+            list_account_provider_choices,
+        )
+
+        provider_choices = [
+            {
+                "slug": choice.slug,
+                "name": choice.name,
+                "account_count": choice.account_count,
+                "is_current": choice.is_current,
+            }
+            for choice in list_account_provider_choices(active_provider=active_provider)
+        ]
+        providers = [choice["slug"] for choice in provider_choices]
+        selected_provider = ""
+        account_target = ""
+        tokens = raw_args.split() if raw_args else []
+
+        if not tokens:
+            if not provider_choices:
+                print("No account providers found. Add credentials with `hermes auth add` first.")
+                return
+            if getattr(self, "_app", None):
+                self._open_account_picker(provider_choices, current_provider=active_provider)
+                return
+            choices = []
+            default_idx = 0
+            for idx, provider_data in enumerate(provider_choices):
+                count = provider_data.get("account_count", 0)
+                plural = "s" if count != 1 else ""
+                marker = "  ← current" if provider_data.get("is_current") else ""
+                if marker:
+                    default_idx = idx
+                choices.append(f"{provider_data.get('name', provider_data['slug'])} ({count} account{plural}){marker}")
+            choices.append("Cancel")
+            picked = self._run_curses_picker("🔐 Account Picker — Select Provider", choices, default_index=default_idx)
+            if picked is None or picked >= len(provider_choices):
+                print("  /account cancelled.")
+                return
+            selected_provider = provider_choices[picked]["slug"]
+        else:
+            first_arg = tokens[0].strip().lower()
+            remaining_args = tokens[1:]
+            if first_arg.isdigit() and providers and len(providers) > 1:
+                idx = int(first_arg)
+                if 1 <= idx <= len(providers):
+                    selected_provider = providers[idx - 1]
+                else:
+                    selected_provider = first_arg
+            elif first_arg in providers:
+                selected_provider = first_arg
+            elif len(providers) == 1:
+                selected_provider = providers[0]
+                account_target = first_arg
+            else:
+                selected_provider = first_arg
+            if remaining_args:
+                account_target = remaining_args[0].strip()
+
+        if not selected_provider:
+            print("No account providers found. Add credentials with `hermes auth add` first.")
+            return
+
+        active_pool = self._active_account_pool_for_provider(selected_provider)
+
+        if account_target:
+            switched_index = self._apply_account_switch(selected_provider, account_target, active_pool=active_pool)
+            opened_model_picker = False
+            if switched_index is not None:
+                opened_model_picker = self._account_provider_model_followup(selected_provider)
+            if not opened_model_picker:
+                account_results = self._fetch_account_results_for_picker(selected_provider)
+                active_index = active_provider_account_index(selected_provider, pool=active_pool) or switched_index
+                self._print_account_results(selected_provider, account_results, active_index=active_index)
+        else:
+            if getattr(self, "_app", None):
+                provider_data = next(
+                    (choice for choice in provider_choices if choice.get("slug") == selected_provider),
+                    {
+                        "slug": selected_provider,
+                        "name": selected_provider,
+                        "account_count": 0,
+                        "is_current": selected_provider == str(active_provider or "").strip().lower(),
+                    },
+                )
+                self._capture_modal_input_snapshot()
+                self._account_picker_state = {
+                    "stage": "loading",
+                    "providers": provider_choices,
+                    "provider_data": provider_data,
+                    "loading_provider": selected_provider,
+                    "loading_frame": 0,
+                    "selected": 0,
+                    "current_provider": active_provider or "unknown",
+                }
+                self._begin_account_provider_loading(provider_data)
+                return
+            account_results = self._fetch_account_results_for_picker(selected_provider)
+            active_index = active_provider_account_index(selected_provider, pool=active_pool)
+            self._print_account_results(selected_provider, account_results, active_index=active_index)
+            if account_results:
+                choices = [
+                    account_choice_label(result, active=(active_index is not None and result.index == active_index))
+                    for result in account_results
+                ]
+                choices.append("← Back / cancel")
+                default_idx = min(len(choices) - 1, max(0, (active_index or 1) - 1))
+                picked = self._run_curses_picker("🔐 Account Picker — Select Account", choices, default_index=default_idx)
+                if picked is not None and picked < len(account_results):
+                    target = str(account_results[picked].index)
+                    switched_index = self._apply_account_switch(selected_provider, target, active_pool=active_pool)
+                    if switched_index is not None:
+                        opened_model_picker = self._account_provider_model_followup(selected_provider)
+                        if not opened_model_picker:
+                            refreshed_results = self._fetch_account_results_for_picker(selected_provider)
+                            refreshed_active = active_provider_account_index(selected_provider, pool=active_pool) or switched_index
+                            self._print_account_results(selected_provider, refreshed_results, active_index=refreshed_active)
+
+        if agent and hasattr(agent, "get_rate_limit_state"):
+            rl_state = agent.get_rate_limit_state()
+            if rl_state and getattr(rl_state, "has_data", False) is True:
+                from agent.rate_limit_tracker import format_rate_limit_display
+                print()
+                print(format_rate_limit_display(rl_state))
+
 
     def _show_insights(self, command: str = "/insights"):
         """Show usage insights and analytics from session history."""
@@ -9905,6 +10363,7 @@ class HermesCLI:
         approval_widget,
         clarify_widget,
         model_picker_widget=None,
+        account_picker_widget=None,
         spinner_widget=None,
         spacer,
         status_bar,
@@ -9929,6 +10388,7 @@ class HermesCLI:
                 approval_widget,
                 clarify_widget,
                 model_picker_widget,
+                account_picker_widget,
                 spinner_widget,
                 spacer,
                 *self._get_extra_tui_widgets(),
@@ -10157,6 +10617,13 @@ class HermesCLI:
                 event.app.invalidate()
                 return
 
+            # --- /account picker modal ---
+            if self._account_picker_state:
+                self._handle_account_picker_selection()
+                event.app.current_buffer.reset()
+                event.app.invalidate()
+                return
+
             # --- Clarify freetext mode: user typed their own answer ---
             if self._clarify_freetext and self._clarify_state:
                 text = event.app.current_buffer.text.strip()
@@ -10187,9 +10654,9 @@ class HermesCLI:
             text = event.app.current_buffer.text.strip()
             has_images = bool(self._attached_images)
             if text or has_images:
-                # Handle /model directly on the UI thread so interactive pickers
-                # can safely use prompt_toolkit terminal handoff helpers.
-                if self._should_handle_model_command_inline(text, has_images=has_images):
+                # Handle /model and /account directly on the UI thread so interactive pickers
+                # can safely update the prompt_toolkit modal state.
+                if self._should_handle_model_command_inline(text, has_images=has_images) or self._should_handle_account_command_inline(text, has_images=has_images):
                     if not self.process_command(text):
                         self._should_exit = True
                         if event.app.is_running:
@@ -10413,6 +10880,34 @@ class HermesCLI:
             event.app.current_buffer.reset()
             event.app.invalidate()
 
+        # --- /account picker: arrow-key navigation ---
+        @kb.add('up', filter=Condition(lambda: bool(self._account_picker_state)))
+        def account_picker_up(event):
+            if self._account_picker_state:
+                self._account_picker_state["selected"] = max(0, self._account_picker_state.get("selected", 0) - 1)
+                event.app.invalidate()
+
+        @kb.add('down', filter=Condition(lambda: bool(self._account_picker_state)))
+        def account_picker_down(event):
+            state = self._account_picker_state
+            if not state:
+                return
+            if state.get("stage") == "provider":
+                max_idx = len(state.get("providers") or [])
+            elif state.get("stage") == "loading":
+                max_idx = 0
+            else:
+                max_idx = len(state.get("account_results") or []) + 1
+            state["selected"] = min(max_idx, state.get("selected", 0) + 1)
+            event.app.invalidate()
+
+        @kb.add('escape', filter=Condition(lambda: bool(self._account_picker_state)), eager=True)
+        def account_picker_escape(event):
+            """ESC closes the /account picker."""
+            self._close_account_picker()
+            event.app.current_buffer.reset()
+            event.app.invalidate()
+
         # Number keys for quick approval selection (1-9, 0 for 10th item)
         def _make_approval_number_handler(idx):
             def handler(event):
@@ -10432,7 +10927,7 @@ class HermesCLI:
         # Buffer.auto_up/auto_down handle both: cursor movement when multi-line,
         # history browsing when on the first/last line (or single-line input).
         _normal_input = Condition(
-            lambda: not self._clarify_state and not self._approval_state and not self._sudo_state and not self._secret_state and not self._model_picker_state
+            lambda: not self._clarify_state and not self._approval_state and not self._sudo_state and not self._secret_state and not self._model_picker_state and not self._account_picker_state
         )
 
         @kb.add('up', filter=_normal_input)
@@ -10511,6 +11006,13 @@ class HermesCLI:
             # Cancel /model picker
             if self._model_picker_state:
                 self._close_model_picker()
+                event.app.current_buffer.reset()
+                event.app.invalidate()
+                return
+
+            # Cancel /account picker
+            if self._account_picker_state:
+                self._close_account_picker()
                 event.app.current_buffer.reset()
                 event.app.invalidate()
                 return
@@ -11430,6 +11932,8 @@ class HermesCLI:
                     hint = f"Select a model ({len(model_list)} available)"
                 else:
                     hint = "No models listed for this provider. Use Back or Cancel."
+                if state.get("hint_override"):
+                    hint = state.get("hint_override")
 
             box_width = _panel_box_width(title, [hint] + choices, min_width=46, max_width=84)
             inner_text_width = max(8, box_width - 6)
@@ -11472,6 +11976,93 @@ class HermesCLI:
                 wrap_lines=True,
             ),
             filter=Condition(lambda: cli_ref._model_picker_state is not None),
+        )
+
+        # --- /account picker: display widget ---
+        def _get_account_picker_display():
+            state = cli_ref._account_picker_state
+            if not state:
+                return []
+            stage = state.get("stage", "provider")
+            if stage == "provider":
+                title = "🔐 Account Picker — Select Provider"
+                choices = []
+                _providers = state.get("providers")
+                for p in _providers if isinstance(_providers, list) else []:
+                    count = p.get("account_count", 0)
+                    plural = "s" if count != 1 else ""
+                    label = f"{p.get('name', p.get('slug', 'Provider'))} ({count} account{plural})"
+                    if p.get("is_current"):
+                        label += "  ← current"
+                    choices.append(label)
+                choices.append("Cancel")
+                hint = f"Current provider: {state.get('current_provider', 'unknown')}"
+            elif stage == "loading":
+                provider_data = state.get("provider_data") or {}
+                pname = provider_data.get('name', provider_data.get('slug', 'Provider'))
+                title = f"🔐 Account Picker — {pname}"
+                frame = int(state.get("loading_frame", 0))
+                sigils = ["✦", "✧", "◆", "◇", "✶", "✷"]
+                bar_width = 14
+                head = frame % bar_width
+                bar = "".join("◆" if i == head else "◇" for i in range(bar_width))
+                hint = f"{sigils[frame % len(sigils)]} Fetching account limits and remaining quota..."
+                choices = [
+                    f"Hermes credential scanner  {bar}",
+                    "Preparing account selection screen — one moment.",
+                ]
+            else:
+                from agent.account_usage import account_choice_label
+
+                provider_data = state.get("provider_data") or {}
+                account_results = state.get("account_results") or []
+                active_index = state.get("active_index")
+                title = f"🔐 Account Picker — {provider_data.get('name', provider_data.get('slug', 'Provider'))}"
+                choices = [
+                    account_choice_label(result, active=(active_index is not None and result.index == active_index))
+                    for result in account_results
+                ] + ["← Back", "Cancel"]
+                if account_results:
+                    hint = f"Select an account/API key ({len(account_results)} available)"
+                else:
+                    hint = "No accounts listed for this provider. Use Back or Cancel."
+
+            box_width = _panel_box_width(title, [hint] + choices, min_width=54, max_width=100)
+            inner_text_width = max(8, box_width - 6)
+            selected = state.get("selected", 0)
+            try:
+                from prompt_toolkit.application import get_app
+                term_rows = get_app().output.get_size().rows
+            except Exception:
+                term_rows = shutil.get_terminal_size((100, 24)).lines
+            scroll_offset, visible = HermesCLI._compute_model_picker_viewport(
+                selected, state.get("_scroll_offset", 0), len(choices), term_rows,
+            )
+            state["_scroll_offset"] = scroll_offset
+
+            lines = []
+            lines.append(('class:clarify-border', '╭─ '))
+            lines.append(('class:clarify-title', title))
+            lines.append(('class:clarify-border', ' ' + ('─' * max(0, box_width - len(title) - 3)) + '╮\n'))
+            _append_blank_panel_line(lines, 'class:clarify-border', box_width)
+            _append_panel_line(lines, 'class:clarify-border', 'class:clarify-hint', hint, box_width)
+            _append_blank_panel_line(lines, 'class:clarify-border', box_width)
+            for idx in range(scroll_offset, scroll_offset + visible):
+                choice = choices[idx]
+                style = 'class:clarify-selected' if idx == selected else 'class:clarify-choice'
+                prefix = '❯ ' if idx == selected else '  '
+                for wrapped in _wrap_panel_text(prefix + choice, inner_text_width, subsequent_indent='  '):
+                    _append_panel_line(lines, 'class:clarify-border', style, wrapped, box_width)
+            _append_blank_panel_line(lines, 'class:clarify-border', box_width)
+            lines.append(('class:clarify-border', '╰' + ('─' * box_width) + '╯\n'))
+            return lines
+
+        account_picker_widget = ConditionalContainer(
+            Window(
+                FormattedTextControl(_get_account_picker_display),
+                wrap_lines=True,
+            ),
+            filter=Condition(lambda: cli_ref._account_picker_state is not None),
         )
 
         # Horizontal rules above and below the input.
@@ -11550,6 +12141,7 @@ class HermesCLI:
                     approval_widget=approval_widget,
                     clarify_widget=clarify_widget,
                     model_picker_widget=model_picker_widget,
+                    account_picker_widget=account_picker_widget,
                     spinner_widget=spinner_widget,
                     spacer=spacer,
                     status_bar=status_bar,

--- a/cli.py
+++ b/cli.py
@@ -5539,13 +5539,11 @@ class HermesCLI:
 
     def _fetch_account_results_for_picker(self, provider: str):
         from agent.account_usage import fetch_provider_account_usages
-        import concurrent.futures
 
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
-            try:
-                return _pool.submit(fetch_provider_account_usages, provider).result(timeout=20.0)
-            except (concurrent.futures.TimeoutError, Exception):
-                return []
+        try:
+            return fetch_provider_account_usages(provider, timeout=20.0)
+        except Exception:
+            return []
 
     def _begin_account_provider_loading(self, provider_data: dict) -> None:
         """Switch /account picker into a non-blocking Hermes loading state."""

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -4818,10 +4818,17 @@ if DISCORD_AVAILABLE:
                 count = p.get("account_count", 0)
                 plural = "s" if count != 1 else ""
                 desc = "current provider" if p.get("is_current") else f"{count} account{plural}"
+                try:
+                    from agent.account_usage import safe_display_text
+                    provider_name = safe_display_text(p.get("name", p.get("slug", "Provider")), fallback="Provider", max_len=84)
+                    provider_value = safe_display_text(p.get("slug", ""), fallback="provider", max_len=100)
+                except Exception:
+                    provider_name = str(p.get("name", p.get("slug", "Provider")))[:84]
+                    provider_value = str(p.get("slug", ""))[:100]
                 options.append(
                     discord.SelectOption(
-                        label=f"{p.get('name', p.get('slug', 'Provider'))} ({count})"[:100],
-                        value=str(p.get("slug", ""))[:100],
+                        label=f"{provider_name} ({count})"[:100],
+                        value=provider_value,
                         description=desc[:100],
                     )
                 )
@@ -4844,37 +4851,15 @@ if DISCORD_AVAILABLE:
 
         @staticmethod
         def _account_option_parts(result: Any, active: bool = False) -> tuple[str, str]:
-            label = getattr(result, "label", None) or f"account-{getattr(result, 'index', '?')}"
-            status = getattr(result, "status", None) or "unknown"
-            prefix = "✓ " if active else ""
             try:
-                from agent.account_usage import account_choice_label
+                from agent.account_usage import discord_account_option_parts
 
-                compact = account_choice_label(result, active=active)
-                if compact:
-                    label = compact
+                return discord_account_option_parts(result, active=active)
             except Exception:
-                label = f"{prefix}{label} · {status}"
-
-            parts = []
-            snapshot = getattr(result, "snapshot", None)
-            limits = getattr(snapshot, "limits", None) or []
-            for item in limits[:2]:
-                name = str(getattr(item, "name", "limit") or "limit")
-                remaining = getattr(item, "remaining", None)
-                limit = getattr(item, "limit", None)
-                used = getattr(item, "used", None)
-                if remaining is not None and limit is not None:
-                    parts.append(f"{name}: {remaining:g}/{limit:g} left")
-                elif used is not None and limit is not None:
-                    parts.append(f"{name}: {used:g}/{limit:g} used")
-            if not parts:
-                unavailable = getattr(result, "unavailable_reason", None)
-                if unavailable:
-                    parts.append(str(unavailable))
-                else:
-                    parts.append(str(status))
-            return label[:100], " · ".join(parts)[:100]
+                label = getattr(result, "label", None) or f"account-{getattr(result, 'index', '?')}"
+                status = getattr(result, "status", None) or "unknown"
+                prefix = "✓ " if active else ""
+                return f"{prefix}{label} · {status}"[:100], str(status)[:100]
 
         def _build_account_select(self):
             self.clear_items()
@@ -4958,9 +4943,26 @@ if DISCORD_AVAILABLE:
             shown = min(total, 25)
             extra = f"\n*{total - shown} more available — type `/account {provider_slug} <number>` directly*" if total > shown else ""
             if total:
-                desc = f"Provider: **{self._selected_provider_name}**\nSelect an account/API key:{extra}"
+                try:
+                    from agent.account_usage import render_provider_account_usage_lines, safe_display_text
+
+                    detail_lines = render_provider_account_usage_lines(
+                        provider_slug,
+                        self._account_results,
+                        active_index=active_index,
+                        select_hint=f"/account {provider_slug} <number>",
+                    )
+                    detail = "\n".join(
+                        safe_display_text(line, fallback="", max_len=260)
+                        for line in detail_lines[:35]
+                    )
+                    desc = f"Provider: **{safe_display_text(self._selected_provider_name, fallback=provider_slug, max_len=80)}**\nSelect an account/API key:{extra}\n\n{detail}"
+                except Exception:
+                    desc = f"Provider: **{self._selected_provider_name}**\nSelect an account/API key:{extra}"
             else:
                 desc = f"Provider: **{self._selected_provider_name}**\nNo accounts were found for this provider."
+            if len(desc) > 4096:
+                desc = desc[:4093] + "..."
 
             await interaction.edit_original_response(
                 embed=discord.Embed(

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3530,6 +3530,38 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception:
                 provider_label = current_provider
 
+            initial_provider = (metadata or {}).get("initial_provider")
+            if initial_provider:
+                provider = next(
+                    (p for p in providers if p.get("slug") == initial_provider),
+                    None,
+                )
+                if provider:
+                    view = ModelPickerView(
+                        providers=providers,
+                        current_model=current_model,
+                        current_provider=current_provider,
+                        session_key=session_key,
+                        on_model_selected=on_model_selected,
+                        allowed_user_ids=self._allowed_user_ids,
+                        allowed_role_ids=self._allowed_role_ids,
+                    )
+                    view._selected_provider = initial_provider
+                    view._build_model_select(initial_provider)
+                    total = provider.get("total_models", len(provider.get("models", [])))
+                    shown = min(len(provider.get("models", [])), 25)
+                    extra = f"\n*{total - shown} more available — type `/model <name>` directly*" if total > shown else ""
+                    embed = discord.Embed(
+                        title="⚙ Model Configuration",
+                        description=(
+                            f"Provider: **{provider.get('name', initial_provider)}**\n"
+                            f"Select a model:{extra}"
+                        ),
+                        color=discord.Color.blue(),
+                    )
+                    msg = await channel.send(embed=embed, view=view)
+                    return SendResult(success=True, message_id=str(msg.id))
+
             embed = discord.Embed(
                 title="⚙ Model Configuration",
                 description=(
@@ -3555,6 +3587,55 @@ class DiscordAdapter(BasePlatformAdapter):
 
         except Exception as e:
             logger.warning("[%s] send_model_picker failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    async def send_account_picker(
+        self,
+        chat_id: str,
+        providers: list,
+        current_provider: str,
+        session_key: str,
+        on_provider_selected,
+        on_account_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive select-menu account/API-key picker."""
+        if not self._client or not DISCORD_AVAILABLE:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            target_id = chat_id
+            if metadata and metadata.get("thread_id"):
+                target_id = metadata["thread_id"]
+
+            channel = self._client.get_channel(int(target_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(target_id))
+
+            embed = discord.Embed(
+                title="🔐 Hermes Account Picker",
+                description=(
+                    f"Current provider: `{current_provider or 'unknown'}`\n\n"
+                    "Select a credential provider:"
+                ),
+                color=discord.Color.gold(),
+            )
+
+            view = AccountPickerView(
+                providers=providers,
+                current_provider=current_provider,
+                session_key=session_key,
+                on_provider_selected=on_provider_selected,
+                on_account_selected=on_account_selected,
+                allowed_user_ids=self._allowed_user_ids,
+                allowed_role_ids=self._allowed_role_ids,
+            )
+
+            msg = await channel.send(embed=embed, view=view)
+            return SendResult(success=True, message_id=str(msg.id))
+
+        except Exception as e:
+            logger.warning("[%s] send_account_picker failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
     def _get_parent_channel_id(self, channel: Any) -> Optional[str]:
@@ -4676,6 +4757,299 @@ if DISCORD_AVAILABLE:
                 embed=discord.Embed(
                     title="⚙ Model Configuration",
                     description="Model selection cancelled.",
+                    color=discord.Color.greyple(),
+                ),
+                view=self,
+            )
+
+        async def on_timeout(self):
+            self.resolved = True
+            self.clear_items()
+
+
+    class AccountPickerView(discord.ui.View):
+        """Interactive select-menu view for account/API-key switching.
+
+        Mirrors ``ModelPickerView``: provider dropdown → account dropdown,
+        then persists the selected credential through the gateway callback.
+        """
+
+        def __init__(
+            self,
+            providers: list,
+            current_provider: str,
+            session_key: str,
+            on_provider_selected,
+            on_account_selected,
+            allowed_user_ids: set,
+            allowed_role_ids: Optional[set] = None,
+        ):
+            super().__init__(timeout=120)
+            self.providers = providers
+            self.current_provider = current_provider
+            self.session_key = session_key
+            self.on_provider_selected = on_provider_selected
+            self.on_account_selected = on_account_selected
+            self.allowed_user_ids = allowed_user_ids
+            self.allowed_role_ids = allowed_role_ids or set()
+            self.resolved = False
+            self._selected_provider: str = ""
+            self._selected_provider_name: str = ""
+            self._account_results: list = []
+            self._active_index: Optional[int] = None
+
+            self._build_provider_select()
+
+        def _check_auth(self, interaction: discord.Interaction) -> bool:
+            return _component_check_auth(
+                interaction, self.allowed_user_ids, self.allowed_role_ids,
+            )
+
+        def _provider_name(self, provider_slug: str) -> str:
+            provider = next(
+                (p for p in self.providers if p.get("slug") == provider_slug), None
+            )
+            return provider.get("name", provider_slug) if provider else provider_slug
+
+        def _build_provider_select(self):
+            self.clear_items()
+            options = []
+            for p in self.providers[:25]:
+                count = p.get("account_count", 0)
+                plural = "s" if count != 1 else ""
+                desc = "current provider" if p.get("is_current") else f"{count} account{plural}"
+                options.append(
+                    discord.SelectOption(
+                        label=f"{p.get('name', p.get('slug', 'Provider'))} ({count})"[:100],
+                        value=str(p.get("slug", ""))[:100],
+                        description=desc[:100],
+                    )
+                )
+            if not options:
+                return
+
+            select = discord.ui.Select(
+                placeholder="Choose a credential provider...",
+                options=options,
+                custom_id="account_provider_select",
+            )
+            select.callback = self._on_provider_selected
+            self.add_item(select)
+
+            cancel_btn = discord.ui.Button(
+                label="Cancel", style=discord.ButtonStyle.red, custom_id="account_cancel"
+            )
+            cancel_btn.callback = self._on_cancel
+            self.add_item(cancel_btn)
+
+        @staticmethod
+        def _account_option_parts(result: Any, active: bool = False) -> tuple[str, str]:
+            label = getattr(result, "label", None) or f"account-{getattr(result, 'index', '?')}"
+            status = getattr(result, "status", None) or "unknown"
+            prefix = "✓ " if active else ""
+            try:
+                from agent.account_usage import account_choice_label
+
+                compact = account_choice_label(result, active=active)
+                if compact:
+                    label = compact
+            except Exception:
+                label = f"{prefix}{label} · {status}"
+
+            parts = []
+            snapshot = getattr(result, "snapshot", None)
+            limits = getattr(snapshot, "limits", None) or []
+            for item in limits[:2]:
+                name = str(getattr(item, "name", "limit") or "limit")
+                remaining = getattr(item, "remaining", None)
+                limit = getattr(item, "limit", None)
+                used = getattr(item, "used", None)
+                if remaining is not None and limit is not None:
+                    parts.append(f"{name}: {remaining:g}/{limit:g} left")
+                elif used is not None and limit is not None:
+                    parts.append(f"{name}: {used:g}/{limit:g} used")
+            if not parts:
+                unavailable = getattr(result, "unavailable_reason", None)
+                if unavailable:
+                    parts.append(str(unavailable))
+                else:
+                    parts.append(str(status))
+            return label[:100], " · ".join(parts)[:100]
+
+        def _build_account_select(self):
+            self.clear_items()
+            options = []
+            for result in self._account_results[:25]:
+                idx = getattr(result, "index", len(options) + 1)
+                active = self._active_index is not None and idx == self._active_index
+                label, desc = self._account_option_parts(result, active=active)
+                options.append(
+                    discord.SelectOption(
+                        label=label,
+                        value=str(idx),
+                        description=desc,
+                    )
+                )
+            if options:
+                select = discord.ui.Select(
+                    placeholder=f"Choose an account from {self._selected_provider_name or self._selected_provider}...",
+                    options=options,
+                    custom_id="account_account_select",
+                )
+                select.callback = self._on_account_selected
+                self.add_item(select)
+
+            back_btn = discord.ui.Button(
+                label="◀ Back", style=discord.ButtonStyle.grey, custom_id="account_back"
+            )
+            back_btn.callback = self._on_back
+            self.add_item(back_btn)
+
+            cancel_btn = discord.ui.Button(
+                label="Cancel", style=discord.ButtonStyle.red, custom_id="account_cancel2"
+            )
+            cancel_btn.callback = self._on_cancel
+            self.add_item(cancel_btn)
+
+        async def _on_provider_selected(self, interaction: discord.Interaction):
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized~", ephemeral=True
+                )
+                return
+
+            provider_slug = interaction.data["values"][0]
+            self._selected_provider = provider_slug
+            self._selected_provider_name = self._provider_name(provider_slug)
+
+            await interaction.response.edit_message(
+                embed=discord.Embed(
+                    title="🔐 Loading Accounts",
+                    description=(
+                        f"✦ Fetching account limits for **{self._selected_provider_name}**...\n"
+                        "`◇◇◆◇◇◇◇◇◇◇◇◇◇◇`\n"
+                        "Preparing the account selection screen."
+                    ),
+                    color=discord.Color.gold(),
+                ),
+                view=None,
+            )
+
+            try:
+                account_results, active_index = await self.on_provider_selected(
+                    str(interaction.channel_id), provider_slug
+                )
+            except Exception as exc:
+                await interaction.edit_original_response(
+                    embed=discord.Embed(
+                        title="🔐 Account Picker",
+                        description=f"Could not load accounts: {exc}",
+                        color=discord.Color.red(),
+                    ),
+                    view=None,
+                )
+                return
+
+            self._account_results = account_results or []
+            self._active_index = active_index
+            self._build_account_select()
+
+            total = len(self._account_results)
+            shown = min(total, 25)
+            extra = f"\n*{total - shown} more available — type `/account {provider_slug} <number>` directly*" if total > shown else ""
+            if total:
+                desc = f"Provider: **{self._selected_provider_name}**\nSelect an account/API key:{extra}"
+            else:
+                desc = f"Provider: **{self._selected_provider_name}**\nNo accounts were found for this provider."
+
+            await interaction.edit_original_response(
+                embed=discord.Embed(
+                    title="🔐 Hermes Account Picker",
+                    description=desc,
+                    color=discord.Color.gold(),
+                ),
+                view=self,
+            )
+
+        async def _on_account_selected(self, interaction: discord.Interaction):
+            if self.resolved:
+                await interaction.response.send_message(
+                    "Already resolved~", ephemeral=True
+                )
+                return
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized~", ephemeral=True
+                )
+                return
+
+            self.resolved = True
+            account_index = interaction.data["values"][0]
+            self.clear_items()
+            await interaction.response.edit_message(
+                embed=discord.Embed(
+                    title="🔐 Switching Account",
+                    description=f"Switching **{self._selected_provider_name or self._selected_provider}** account `{account_index}`...",
+                    color=discord.Color.gold(),
+                ),
+                view=None,
+            )
+
+            try:
+                result_text = await self.on_account_selected(
+                    str(interaction.channel_id),
+                    self._selected_provider,
+                    account_index,
+                )
+            except Exception as exc:
+                result_text = f"Error switching account: {exc}"
+
+            await interaction.edit_original_response(
+                embed=discord.Embed(
+                    title="🔐 Account Switched",
+                    description=result_text,
+                    color=discord.Color.green(),
+                ),
+                view=None,
+            )
+
+        async def _on_back(self, interaction: discord.Interaction):
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized~", ephemeral=True
+                )
+                return
+
+            self._selected_provider = ""
+            self._selected_provider_name = ""
+            self._account_results = []
+            self._active_index = None
+            self._build_provider_select()
+
+            await interaction.response.edit_message(
+                embed=discord.Embed(
+                    title="🔐 Hermes Account Picker",
+                    description=(
+                        f"Current provider: `{self.current_provider or 'unknown'}`\n\n"
+                        "Select a credential provider:"
+                    ),
+                    color=discord.Color.gold(),
+                ),
+                view=self,
+            )
+
+        async def _on_cancel(self, interaction: discord.Interaction):
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized~", ephemeral=True
+                )
+                return
+            self.resolved = True
+            self.clear_items()
+            await interaction.response.edit_message(
+                embed=discord.Embed(
+                    title="🔐 Hermes Account Picker",
+                    description="Account selection cancelled.",
                     color=discord.Color.greyple(),
                 ),
                 view=self,

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -282,8 +282,9 @@ class TelegramAdapter(BasePlatformAdapter):
         self._dm_topics: Dict[str, int] = {}
         # DM Topics config from extra.dm_topics
         self._dm_topics_config: List[Dict[str, Any]] = self.config.extra.get("dm_topics", [])
-        # Interactive model picker state per chat
+        # Interactive model/account picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
+        self._account_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
@@ -1616,6 +1617,47 @@ class TelegramAdapter(BasePlatformAdapter):
                 return slug
 
         try:
+            initial_provider = (metadata or {}).get("initial_provider")
+            if initial_provider:
+                provider = next(
+                    (p for p in providers if p.get("slug") == initial_provider),
+                    None,
+                )
+                if provider:
+                    models = provider.get("models", [])
+                    keyboard, page_info = self._build_model_keyboard(models, 0)
+                    pname = provider.get("name", initial_provider)
+                    total = provider.get("total_models", len(models))
+                    shown = len(models)
+                    extra = f"\n_{total - shown} more available — type `/model <name>` directly_" if total > shown else ""
+                    text = (
+                        "⚙ *Model Configuration*\n\n"
+                        f"Provider: *{pname}*{page_info}\n"
+                        f"Select a model:{extra}"
+                    )
+                    thread_id = metadata.get("thread_id") if metadata else None
+                    msg = await self._bot.send_message(
+                        chat_id=int(chat_id),
+                        text=text,
+                        parse_mode=ParseMode.MARKDOWN,
+                        reply_markup=keyboard,
+                        message_thread_id=int(thread_id) if thread_id else None,
+                        **self._link_preview_kwargs(),
+                    )
+                    self._model_picker_state[str(chat_id)] = {
+                        "msg_id": msg.message_id,
+                        "providers": providers,
+                        "session_key": session_key,
+                        "on_model_selected": on_model_selected,
+                        "current_model": current_model,
+                        "current_provider": current_provider,
+                        "selected_provider": initial_provider,
+                        "selected_provider_name": pname,
+                        "model_list": models,
+                        "model_page": 0,
+                    }
+                    return SendResult(success=True, message_id=str(msg.message_id))
+
             # Build provider buttons — 2 per row
             buttons: list = []
             for p in providers:
@@ -1664,6 +1706,247 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.warning("[%s] send_model_picker failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
+
+    async def send_account_picker(
+        self,
+        chat_id: str,
+        providers: list,
+        current_provider: str,
+        session_key: str,
+        on_provider_selected,
+        on_account_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive inline-keyboard account/API-key picker."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            buttons: list = []
+            for p in providers:
+                count = p.get("account_count", 0)
+                label = f"{p.get('name', p.get('slug', 'Provider'))} ({count})"
+                if p.get("is_current"):
+                    label = f"✓ {label}"
+                buttons.append(
+                    InlineKeyboardButton(label, callback_data=f"ap:{p.get('slug', '')}")
+                )
+            rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
+            rows.append([InlineKeyboardButton("✗ Cancel", callback_data="ax")])
+            keyboard = InlineKeyboardMarkup(rows)
+
+            text = (
+                "🔐 *Hermes Account Picker*\n\n"
+                f"Current provider: `{current_provider or 'unknown'}`\n\n"
+                "Select a credential provider:"
+            )
+
+            thread_id = metadata.get("thread_id") if metadata else None
+            msg = await self._bot.send_message(
+                chat_id=int(chat_id),
+                text=text,
+                parse_mode=ParseMode.MARKDOWN,
+                reply_markup=keyboard,
+                message_thread_id=int(thread_id) if thread_id else None,
+                **self._link_preview_kwargs(),
+            )
+
+            self._account_picker_state[str(chat_id)] = {
+                "msg_id": msg.message_id,
+                "chat_id": str(chat_id),
+                "thread_id": str(thread_id) if thread_id is not None else None,
+                "providers": providers,
+                "session_key": session_key,
+                "on_provider_selected": on_provider_selected,
+                "on_account_selected": on_account_selected,
+                "current_provider": current_provider,
+            }
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_account_picker failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    def _build_account_keyboard(self, account_results: list, active_index: Optional[int] = None):
+        try:
+            from agent.account_usage import account_choice_label
+        except Exception:
+            account_choice_label = None
+
+        buttons: list = []
+        for result in account_results[:10]:
+            idx = getattr(result, "index", len(buttons) + 1)
+            label = getattr(result, "label", None) or f"account-{idx}"
+            if account_choice_label:
+                label = account_choice_label(result, active=(active_index is not None and idx == active_index))
+            if len(label) > 58:
+                label = label[:55] + "..."
+            buttons.append(InlineKeyboardButton(label, callback_data=f"am:{idx}"))
+        rows = [[button] for button in buttons]
+        rows.append([
+            InlineKeyboardButton("◀ Back", callback_data="ab"),
+            InlineKeyboardButton("✗ Cancel", callback_data="ax"),
+        ])
+        extra = ""
+        if len(account_results) > len(buttons):
+            extra = f"\n_{len(account_results) - len(buttons)} more available — type `/account <provider> <number>` directly_"
+        return InlineKeyboardMarkup(rows), extra
+
+    async def _handle_account_picker_callback(self, query, data: str, chat_id: str) -> None:
+        """Handle account picker inline keyboard callbacks (ap:/am:/ab/ax)."""
+        state = self._account_picker_state.get(chat_id)
+        if not state:
+            await query.answer(text="Picker expired — use /account again.")
+            return
+
+        query_message = getattr(query, "message", None)
+        state_msg_id = state.get("msg_id")
+        query_msg_id = getattr(query_message, "message_id", None)
+        if state_msg_id is not None and str(query_msg_id) != str(state_msg_id):
+            await query.answer(text="Picker expired — use /account again.")
+            return
+
+        state_thread_id = state.get("thread_id")
+        query_thread_id = getattr(query_message, "message_thread_id", None)
+        if state_thread_id is not None and str(query_thread_id) != str(state_thread_id):
+            await query.answer(text="Picker expired — use /account again.")
+            return
+
+        if data.startswith("ap:"):
+            provider_slug = data[3:]
+            provider = next((p for p in state.get("providers", []) if p.get("slug") == provider_slug), None)
+            if not provider:
+                await query.answer(text="Provider not found.")
+                return
+            callback = state.get("on_provider_selected")
+            if not callback:
+                await query.answer(text="Picker expired.")
+                return
+            try:
+                await query.answer(text="Loading accounts…")
+            except Exception:
+                pass
+            try:
+                await query.edit_message_text(
+                    text=(
+                        "🔐 *Hermes Account Picker*\n\n"
+                        f"Provider: *{provider.get('name', provider_slug)}*\n"
+                        "✦ Fetching account limits and remaining quota...\n"
+                        "`◇◇◆◇◇◇◇◇◇◇◇◇◇◇`"
+                    ),
+                    parse_mode=ParseMode.MARKDOWN,
+                    reply_markup=None,
+                )
+            except Exception:
+                pass
+            try:
+                account_results, active_index = await callback(chat_id, provider_slug)
+            except Exception as exc:
+                logger.error("Account picker provider load failed: %s", exc)
+                try:
+                    await query.edit_message_text(
+                        text="🔐 *Hermes Account Picker*\n\nCould not load accounts. Use /account again.",
+                        parse_mode=ParseMode.MARKDOWN,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+                return
+            state["selected_provider"] = provider_slug
+            state["selected_provider_name"] = provider.get("name", provider_slug)
+            state["account_results"] = account_results
+            state["active_index"] = active_index
+            keyboard, extra = self._build_account_keyboard(account_results, active_index)
+            await query.edit_message_text(
+                text=(
+                    "🔐 *Hermes Account Picker*\n\n"
+                    f"Provider: *{provider.get('name', provider_slug)}*\n"
+                    f"Select an account/API key:{extra}"
+                ),
+                parse_mode=ParseMode.MARKDOWN,
+                reply_markup=keyboard,
+            )
+            # Callback was already acknowledged before the usage fetch.
+
+        elif data.startswith("am:"):
+            try:
+                account_idx = int(data[3:])
+            except ValueError:
+                await query.answer(text="Invalid selection.")
+                return
+            provider_slug = state.get("selected_provider", "")
+            callback = state.get("on_account_selected")
+            if not provider_slug or not callback:
+                await query.answer(text="Picker expired.")
+                return
+            try:
+                await query.answer(text="Switching account…")
+            except Exception:
+                pass
+            try:
+                await query.edit_message_text(
+                    text=(
+                        "🔐 *Hermes Account Picker*\n\n"
+                        f"Switching `{provider_slug}` account `{account_idx}`...\n"
+                        "`◇◇◇◆◇◇◇◇◇◇◇◇◇◇`"
+                    ),
+                    parse_mode=ParseMode.MARKDOWN,
+                    reply_markup=None,
+                )
+            except Exception:
+                pass
+            try:
+                result_text = await callback(chat_id, provider_slug, str(account_idx))
+            except Exception as exc:
+                logger.error("Account picker switch failed: %s", exc)
+                result_text = f"Error switching account: {exc}"
+            try:
+                await query.edit_message_text(
+                    text=result_text,
+                    parse_mode=ParseMode.MARKDOWN,
+                    reply_markup=None,
+                )
+            except Exception:
+                try:
+                    await query.edit_message_text(
+                        text=result_text,
+                        parse_mode=None,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+            # Callback was already acknowledged before the account switch.
+            self._account_picker_state.pop(chat_id, None)
+
+        elif data == "ab":
+            buttons = []
+            for p in state.get("providers", []):
+                count = p.get("account_count", 0)
+                label = f"{p.get('name', p.get('slug', 'Provider'))} ({count})"
+                if p.get("is_current"):
+                    label = f"✓ {label}"
+                buttons.append(InlineKeyboardButton(label, callback_data=f"ap:{p.get('slug', '')}"))
+            rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
+            rows.append([InlineKeyboardButton("✗ Cancel", callback_data="ax")])
+            await query.edit_message_text(
+                text=(
+                    "🔐 *Hermes Account Picker*\n\n"
+                    f"Current provider: `{state.get('current_provider') or 'unknown'}`\n\n"
+                    "Select a credential provider:"
+                ),
+                parse_mode=ParseMode.MARKDOWN,
+                reply_markup=InlineKeyboardMarkup(rows),
+            )
+            await query.answer()
+
+        elif data == "ax":
+            self._account_picker_state.pop(chat_id, None)
+            await query.edit_message_text(
+                text="Account selection cancelled.",
+                reply_markup=None,
+            )
+            await query.answer()
+        else:
+            await query.answer()
 
     _MODEL_PAGE_SIZE = 8
 
@@ -1901,6 +2184,23 @@ class TelegramAdapter(BasePlatformAdapter):
         query_chat_type = getattr(query_chat, "type", None)
         query_thread_id = getattr(query_message, "message_thread_id", None)
         query_user_name = getattr(query.from_user, "first_name", None)
+
+        # --- Account picker callbacks ---
+        if data.startswith(("ap:", "am:", "ab", "ax")):
+            chat_id = str(query.message.chat_id) if query.message else None
+            if chat_id:
+                caller_id = str(getattr(query.from_user, "id", ""))
+                if not self._is_callback_user_authorized(
+                    caller_id,
+                    chat_id=query_chat_id,
+                    chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                    user_name=query_user_name,
+                ):
+                    await query.answer(text="⛔ You are not authorized to switch accounts.")
+                    return
+                await self._handle_account_picker_callback(query, data, chat_id)
+            return
 
         # --- Model picker callbacks ---
         if data.startswith(("mp:", "mm:", "mb", "mx", "mg:")):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1722,12 +1722,20 @@ class TelegramAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            from agent.account_usage import safe_display_text
+
             buttons: list = []
             for p in providers:
                 count = p.get("account_count", 0)
-                label = f"{p.get('name', p.get('slug', 'Provider'))} ({count})"
+                name = safe_display_text(
+                    p.get("name", p.get("slug", "Provider")),
+                    fallback="Provider",
+                    max_len=44,
+                )
+                label = f"{name} ({count})"
                 if p.get("is_current"):
                     label = f"✓ {label}"
+                label = safe_display_text(label, fallback="Provider", max_len=60)
                 buttons.append(
                     InlineKeyboardButton(label, callback_data=f"ap:{p.get('slug', '')}")
                 )
@@ -1735,9 +1743,14 @@ class TelegramAdapter(BasePlatformAdapter):
             rows.append([InlineKeyboardButton("✗ Cancel", callback_data="ax")])
             keyboard = InlineKeyboardMarkup(rows)
 
+            current_label = safe_display_text(
+                current_provider or "unknown",
+                fallback="unknown",
+                markdown=True,
+            )
             text = (
                 "🔐 *Hermes Account Picker*\n\n"
-                f"Current provider: `{current_provider or 'unknown'}`\n\n"
+                f"Current provider: `{current_label}`\n\n"
                 "Select a credential provider:"
             )
 
@@ -1768,9 +1781,10 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def _build_account_keyboard(self, account_results: list, active_index: Optional[int] = None):
         try:
-            from agent.account_usage import account_choice_label
+            from agent.account_usage import account_choice_label, safe_display_text
         except Exception:
             account_choice_label = None
+            safe_display_text = lambda value, **kwargs: str(value or kwargs.get("fallback", ""))[: kwargs.get("max_len", 58)]
 
         buttons: list = []
         for result in account_results[:10]:
@@ -1778,8 +1792,7 @@ class TelegramAdapter(BasePlatformAdapter):
             label = getattr(result, "label", None) or f"account-{idx}"
             if account_choice_label:
                 label = account_choice_label(result, active=(active_index is not None and idx == active_index))
-            if len(label) > 58:
-                label = label[:55] + "..."
+            label = safe_display_text(label, fallback=f"account-{idx}", max_len=58)
             buttons.append(InlineKeyboardButton(label, callback_data=f"am:{idx}"))
         rows = [[button] for button in buttons]
         rows.append([
@@ -1826,10 +1839,15 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception:
                 pass
             try:
+                from agent.account_usage import safe_display_text
+                provider_name = safe_display_text(provider.get("name", provider_slug), fallback=provider_slug, markdown=True)
+            except Exception:
+                provider_name = str(provider.get("name", provider_slug))
+            try:
                 await query.edit_message_text(
                     text=(
                         "🔐 *Hermes Account Picker*\n\n"
-                        f"Provider: *{provider.get('name', provider_slug)}*\n"
+                        f"Provider: *{provider_name}*\n"
                         "✦ Fetching account limits and remaining quota...\n"
                         "`◇◇◆◇◇◇◇◇◇◇◇◇◇◇`"
                     ),
@@ -1856,11 +1874,31 @@ class TelegramAdapter(BasePlatformAdapter):
             state["account_results"] = account_results
             state["active_index"] = active_index
             keyboard, extra = self._build_account_keyboard(account_results, active_index)
+            try:
+                from agent.account_usage import render_provider_account_usage_lines, safe_display_text
+
+                detail_lines = render_provider_account_usage_lines(
+                    provider_slug,
+                    account_results,
+                    active_index=active_index,
+                    select_hint=f"/account {provider_slug} <number>",
+                )
+                detail_text = "\n".join(
+                    safe_display_text(line, fallback="", max_len=320, markdown=True)
+                    for line in detail_lines[:40]
+                )
+                if extra:
+                    detail_text = f"{detail_text}\n{safe_display_text(extra, fallback='', max_len=180, markdown=True)}"
+                body = detail_text or "Select an account/API key:"
+                provider_name = safe_display_text(provider.get("name", provider_slug), fallback=provider_slug, markdown=True)
+            except Exception:
+                provider_name = str(provider.get("name", provider_slug))
+                body = f"Select an account/API key:{extra}"
             await query.edit_message_text(
                 text=(
                     "🔐 *Hermes Account Picker*\n\n"
-                    f"Provider: *{provider.get('name', provider_slug)}*\n"
-                    f"Select an account/API key:{extra}"
+                    f"Provider: *{provider_name}*\n\n"
+                    f"{body}"
                 ),
                 parse_mode=ParseMode.MARKDOWN,
                 reply_markup=keyboard,
@@ -1918,19 +1956,25 @@ class TelegramAdapter(BasePlatformAdapter):
             self._account_picker_state.pop(chat_id, None)
 
         elif data == "ab":
+            try:
+                from agent.account_usage import safe_display_text
+            except Exception:
+                safe_display_text = lambda value, **kwargs: str(value or kwargs.get("fallback", ""))[: kwargs.get("max_len", 60)]
             buttons = []
             for p in state.get("providers", []):
                 count = p.get("account_count", 0)
-                label = f"{p.get('name', p.get('slug', 'Provider'))} ({count})"
+                name = safe_display_text(p.get("name", p.get("slug", "Provider")), fallback="Provider", max_len=44)
+                label = f"{name} ({count})"
                 if p.get("is_current"):
                     label = f"✓ {label}"
+                label = safe_display_text(label, fallback="Provider", max_len=60)
                 buttons.append(InlineKeyboardButton(label, callback_data=f"ap:{p.get('slug', '')}"))
             rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
             rows.append([InlineKeyboardButton("✗ Cancel", callback_data="ax")])
             await query.edit_message_text(
                 text=(
                     "🔐 *Hermes Account Picker*\n\n"
-                    f"Current provider: `{state.get('current_provider') or 'unknown'}`\n\n"
+                    f"Current provider: `{safe_display_text(state.get('current_provider') or 'unknown', fallback='unknown', markdown=True)}`\n\n"
                     "Select a credential provider:"
                 ),
                 parse_mode=ParseMode.MARKDOWN,
@@ -2186,7 +2230,7 @@ class TelegramAdapter(BasePlatformAdapter):
         query_user_name = getattr(query.from_user, "first_name", None)
 
         # --- Account picker callbacks ---
-        if data.startswith(("ap:", "am:", "ab", "ax")):
+        if data.startswith(("ap:", "am:")) or data in {"ab", "ax"}:
             chat_id = str(query.message.chat_id) if query.message else None
             if chat_id:
                 caller_id = str(getattr(query.from_user, "id", ""))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -33,12 +33,19 @@ from datetime import datetime
 from typing import Dict, Optional, Any, List, Union
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
-# /usage; we still import it at module top in the gateway because test
-# patches (tests/gateway/test_usage_command.py) target
+# /usage and /account. It stays at module top because tests patch
 # `gateway.run.fetch_account_usage` as a module-level attribute. The
 # gateway is a long-running daemon, so its boot cost matters less than
 # preserving the established test-patch surface.
-from agent.account_usage import fetch_account_usage, render_account_usage_lines
+from agent.account_usage import (
+    active_provider_account_index,
+    fetch_account_usage,
+    fetch_provider_account_usages,
+    list_account_provider_choices,
+    render_account_usage_lines,
+    render_provider_account_usage_lines,
+    select_provider_account,
+)
 from agent.i18n import t
 from hermes_cli.config import cfg_get
 
@@ -5328,6 +5335,9 @@ class GatewayRunner:
         if canonical == "usage":
             return await self._handle_usage_command(event)
 
+        if canonical == "account":
+            return await self._handle_account_command(event)
+
         if canonical == "insights":
             return await self._handle_insights_command(event)
 
@@ -10359,6 +10369,457 @@ class GatewayRunner:
         if account_lines:
             return "\n".join(account_lines)
         return "No usage data available for this session."
+
+
+    async def _handle_account_command(self, event: MessageEvent) -> Optional[str]:
+        """Handle /account -- choose a provider, then show every account in it."""
+        source = event.source
+        session_key = self._session_key_for_source(source)
+
+        # Try running agent first (mid-turn), then cached agent (between turns)
+        agent = self._running_agents.get(session_key)
+        if not agent or agent is _AGENT_PENDING_SENTINEL:
+            _cache_lock = getattr(self, "_agent_cache_lock", None)
+            _cache = getattr(self, "_agent_cache", None)
+            if _cache_lock and _cache is not None:
+                with _cache_lock:
+                    cached = _cache.get(session_key)
+                    if cached:
+                        agent = cached[0]
+
+        active_provider = getattr(agent, "provider", None) if agent and agent is not _AGENT_PENDING_SENTINEL else None
+
+        if not active_provider and getattr(self, "_session_db", None) is not None:
+            try:
+                _entry = self.session_store.get_or_create_session(source)
+                persisted = self._session_db.get_session(_entry.session_id) or {}
+            except Exception:
+                persisted = {}
+            active_provider = active_provider or persisted.get("billing_provider")
+
+        try:
+            raw_args = event.get_command_args().strip()
+        except Exception:
+            raw_args = ""
+        provider_choices = [
+            {
+                "slug": choice.slug,
+                "name": choice.name,
+                "account_count": choice.account_count,
+                "is_current": choice.is_current,
+            }
+            for choice in list_account_provider_choices(active_provider=active_provider)
+        ]
+        providers = [choice["slug"] for choice in provider_choices]
+        selected_provider = ""
+        account_target = ""
+        tokens = raw_args.split() if raw_args else []
+        if tokens:
+            first_arg = tokens[0].strip().lower()
+            remaining_args = tokens[1:]
+            if first_arg.isdigit() and providers and len(providers) > 1:
+                idx = int(first_arg)
+                if 1 <= idx <= len(providers):
+                    selected_provider = providers[idx - 1]
+                else:
+                    selected_provider = first_arg
+            elif first_arg in providers:
+                selected_provider = first_arg
+            elif len(providers) == 1:
+                selected_provider = providers[0]
+                account_target = first_arg
+            else:
+                selected_provider = first_arg
+            if remaining_args:
+                account_target = remaining_args[0].strip()
+        elif provider_choices:
+            adapter = getattr(self, "adapters", {}).get(source.platform)
+            has_picker = (
+                adapter is not None
+                and getattr(type(adapter), "send_account_picker", None) is not None
+            )
+            if has_picker:
+                _agent = agent
+
+                def _active_pool_for(provider_slug: str):
+                    if not _agent or _agent is _AGENT_PENDING_SENTINEL:
+                        return None
+                    agent_provider = str(getattr(_agent, "provider", "") or "").strip().lower()
+                    if agent_provider != str(provider_slug or "").strip().lower():
+                        return None
+                    return getattr(_agent, "_credential_pool", None)
+
+                async def _on_account_provider_selected(_chat_id: str, provider_slug: str):
+                    results = await asyncio.to_thread(fetch_provider_account_usages, provider_slug)
+                    active_pool = _active_pool_for(provider_slug)
+                    active_index = active_provider_account_index(provider_slug, pool=active_pool)
+                    return results, active_index
+
+                async def _on_account_selected(_chat_id: str, provider_slug: str, account_target: str) -> str:
+                    active_pool = _active_pool_for(provider_slug)
+                    selected_index, selected_entry, select_error = await asyncio.to_thread(
+                        select_provider_account,
+                        provider_slug,
+                        account_target,
+                        pool=active_pool,
+                    )
+                    if select_error:
+                        return f"Could not switch account: {select_error}"
+                    if selected_entry is not None and active_pool is not None and _agent and hasattr(_agent, "_swap_credential"):
+                        try:
+                            _agent._swap_credential(selected_entry)
+                        except Exception as exc:
+                            return f"Selected account, but could not apply it to this running session: {type(exc).__name__}"
+                    active_index = active_provider_account_index(provider_slug, pool=active_pool)
+                    if active_index is None and selected_index is not None:
+                        active_index = selected_index
+                    try:
+                        account_results = await asyncio.to_thread(fetch_provider_account_usages, provider_slug)
+                    except Exception:
+                        account_results = []
+                    label = getattr(selected_entry, "label", None) or getattr(selected_entry, "id", None) or account_target
+                    lines = [f"✅ Switched account: {label}", ""]
+                    followup = await self._account_model_followup(source, session_key, provider_slug, adapter)
+                    if followup:
+                        lines.extend([followup, ""])
+                    account_lines = render_provider_account_usage_lines(
+                        provider_slug,
+                        account_results,
+                        markdown=True,
+                        active_index=active_index,
+                        select_hint=f"/account {provider_slug} <number>",
+                    )
+                    lines.extend(account_lines or [f"(no account usage data available for {provider_slug})"])
+                    return "\n".join(lines)
+
+                metadata = {"thread_id": source.thread_id} if source.thread_id else None
+                picker_result = await adapter.send_account_picker(
+                    chat_id=source.chat_id,
+                    providers=provider_choices,
+                    current_provider=active_provider or "",
+                    session_key=session_key,
+                    on_provider_selected=_on_account_provider_selected,
+                    on_account_selected=_on_account_selected,
+                    metadata=metadata,
+                )
+                if picker_result.success:
+                    return None
+
+            lines = [
+                "🔐 **Hermes Account Picker**",
+                "Select a credential provider:",
+                "",
+            ]
+            for idx, provider_data in enumerate(provider_choices, start=1):
+                count = provider_data.get("account_count", 0)
+                plural = "s" if count != 1 else ""
+                marker = " — current" if provider_data.get("is_current") else ""
+                name = provider_data.get("name") or provider_data.get("slug")
+                slug = provider_data.get("slug")
+                lines.append(f"[{idx}] **{name}** · {count} account{plural}{marker}")
+                lines.append(f"    `/account {slug}`")
+            lines.append("")
+            lines.append("Tip: send `/account <provider> <number>` to switch directly.")
+            return "\n".join(lines)
+
+        if not selected_provider:
+            return "No account providers found. Add credentials with `hermes auth add` first."
+
+        active_pool = None
+        if agent and agent is not _AGENT_PENDING_SENTINEL:
+            agent_provider = str(getattr(agent, "provider", "") or "").strip().lower()
+            if agent_provider == selected_provider:
+                active_pool = getattr(agent, "_credential_pool", None)
+
+        switched_line = ""
+        model_followup_line = ""
+        selected_index: Optional[int] = None
+        if account_target:
+            selected_index, selected_entry, select_error = await asyncio.to_thread(
+                select_provider_account,
+                selected_provider,
+                account_target,
+                pool=active_pool,
+            )
+            if select_error:
+                return f"Could not switch account: {select_error}"
+            if selected_entry is not None and active_pool is not None and agent and hasattr(agent, "_swap_credential"):
+                try:
+                    agent._swap_credential(selected_entry)
+                except Exception as exc:
+                    return f"Selected account, but could not apply it to this running session: {type(exc).__name__}"
+            label = getattr(selected_entry, "label", None) or getattr(selected_entry, "id", None) or account_target
+            switched_line = f"✅ Switched account: {label}"
+            adapter_for_followup = getattr(self, "adapters", {}).get(source.platform)
+            model_followup_line = await self._account_model_followup(
+                source,
+                session_key,
+                selected_provider,
+                adapter_for_followup,
+            )
+
+        active_index = active_provider_account_index(selected_provider, pool=active_pool)
+        if active_index is None and selected_index is not None:
+            active_index = selected_index
+
+        try:
+            account_results = await asyncio.to_thread(
+                fetch_provider_account_usages,
+                selected_provider,
+            )
+        except Exception:
+            account_results = []
+        account_lines = render_provider_account_usage_lines(
+            selected_provider,
+            account_results,
+            markdown=True,
+            active_index=active_index,
+            select_hint=f"/account {selected_provider} <number>",
+        )
+
+        lines: list[str] = []
+        if switched_line:
+            lines.append(switched_line)
+            lines.append("")
+        if model_followup_line:
+            lines.append(model_followup_line)
+            lines.append("")
+        if account_lines:
+            lines.extend(account_lines)
+        else:
+            lines.append(f"(no account usage data available for {selected_provider})")
+
+        # Preserve the recent API-call rate-limit hint for the active account.
+        if agent and hasattr(agent, "get_rate_limit_state"):
+            rl_state = agent.get_rate_limit_state()
+            if rl_state and getattr(rl_state, "has_data", False) is True:
+                from agent.rate_limit_tracker import format_rate_limit_compact
+                lines.append("")
+                lines.append(f"⏱️ **Active-session rate limits:** {format_rate_limit_compact(rl_state)}")
+
+        return "\n".join(lines) if lines else "No account data available."
+
+    def _gateway_model_switch_context(self, source: Any, session_key: str) -> dict:
+        """Return current model/provider context for account→model follow-up flows."""
+        current_model = ""
+        current_provider = "openrouter"
+        current_base_url = ""
+        current_api_key = ""
+        user_provs = None
+        custom_provs = None
+        try:
+            cfg = _load_gateway_config()
+            model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
+            if isinstance(model_cfg, dict):
+                current_model = model_cfg.get("default", "")
+                current_provider = model_cfg.get("provider", current_provider)
+                current_base_url = model_cfg.get("base_url", "")
+            if isinstance(cfg, dict):
+                user_provs = cfg.get("providers")
+                try:
+                    from hermes_cli.config import get_compatible_custom_providers
+                    custom_provs = get_compatible_custom_providers(cfg)
+                except Exception:
+                    custom_provs = cfg.get("custom_providers")
+        except Exception:
+            pass
+        try:
+            override = getattr(self, "_session_model_overrides", {}).get(session_key, {})
+        except Exception:
+            override = {}
+        if override:
+            current_model = override.get("model", current_model)
+            current_provider = override.get("provider", current_provider)
+            current_base_url = override.get("base_url", current_base_url)
+            current_api_key = override.get("api_key", current_api_key)
+        return {
+            "current_model": current_model,
+            "current_provider": current_provider,
+            "current_base_url": current_base_url,
+            "current_api_key": current_api_key,
+            "user_providers": user_provs,
+            "custom_providers": custom_provs,
+        }
+
+    def _apply_gateway_model_switch_result(self, session_key: str, current_model: str, result: Any) -> None:
+        """Apply a ModelSwitchResult to gateway cache/overrides."""
+        cached_entry = None
+        _cache_lock = getattr(self, "_agent_cache_lock", None)
+        _cache = getattr(self, "_agent_cache", None)
+        if _cache_lock and _cache is not None:
+            with _cache_lock:
+                cached_entry = _cache.get(session_key)
+        elif _cache is not None:
+            cached_entry = _cache.get(session_key)
+        if cached_entry and cached_entry[0] is not None:
+            try:
+                cached_entry[0].switch_model(
+                    new_model=result.new_model,
+                    new_provider=result.target_provider,
+                    api_key=result.api_key,
+                    base_url=result.base_url,
+                    api_mode=result.api_mode,
+                )
+            except Exception as exc:
+                logger.warning("Account follow-up model switch failed for cached agent: %s", exc)
+        if not hasattr(self, "_pending_model_notes"):
+            self._pending_model_notes = {}
+        self._pending_model_notes[session_key] = (
+            f"[Note: model was just switched from {current_model} to {result.new_model} "
+            f"via {result.provider_label or result.target_provider}. "
+            f"Adjust your self-identification accordingly.]"
+        )
+        if not hasattr(self, "_session_model_overrides"):
+            self._session_model_overrides = {}
+        self._session_model_overrides[session_key] = {
+            "model": result.new_model,
+            "provider": result.target_provider,
+            "api_key": result.api_key,
+            "base_url": result.base_url,
+            "api_mode": result.api_mode,
+        }
+        try:
+            self._evict_cached_agent(session_key)
+        except Exception:
+            pass
+
+    async def _account_model_followup(
+        self,
+        source: Any,
+        session_key: str,
+        provider_slug: str,
+        adapter: Any = None,
+    ) -> str:
+        """After account selection, keep the model if valid or ask for a compatible one."""
+        provider_slug = str(provider_slug or "").strip().lower()
+        if not provider_slug:
+            return ""
+        ctx = self._gateway_model_switch_context(source, session_key)
+        current_model = ctx["current_model"]
+        current_provider = str(ctx["current_provider"] or "").strip().lower()
+        if provider_slug == current_provider:
+            return ""
+
+        try:
+            from hermes_cli.model_switch import switch_model, list_authenticated_providers
+            from hermes_cli.providers import get_label
+        except Exception:
+            return f"⚙ Account provider changed to `{provider_slug}`. Use `/model` to choose a compatible model."
+
+        if current_model:
+            try:
+                result = switch_model(
+                    raw_input=current_model,
+                    current_provider=ctx["current_provider"] or "",
+                    current_model=current_model,
+                    current_base_url=ctx["current_base_url"] or "",
+                    current_api_key=ctx["current_api_key"] or "",
+                    is_global=False,
+                    explicit_provider=provider_slug,
+                    user_providers=ctx["user_providers"],
+                    custom_providers=ctx["custom_providers"],
+                )
+            except Exception:
+                result = None
+            if result is not None and result.success:
+                self._apply_gateway_model_switch_result(session_key, current_model, result)
+                return (
+                    f"⚙ Current model `{result.new_model}` is available on "
+                    f"{result.provider_label or result.target_provider}; continuing with it."
+                )
+
+        try:
+            providers = list_authenticated_providers(
+                current_provider=provider_slug,
+                current_base_url=ctx["current_base_url"] or "",
+                current_model=current_model or "",
+                user_providers=ctx["user_providers"],
+                custom_providers=ctx["custom_providers"],
+                max_models=50,
+            )
+        except Exception:
+            providers = []
+        provider_data = next(
+            (p for p in providers if str(p.get("slug", "")).lower() == provider_slug),
+            None,
+        )
+        if provider_data is None:
+            try:
+                from hermes_cli.models import provider_model_ids
+                models = provider_model_ids(provider_slug)[:50]
+            except Exception:
+                models = []
+            provider_data = {
+                "slug": provider_slug,
+                "name": get_label(provider_slug),
+                "is_current": True,
+                "models": models,
+                "total_models": len(models),
+                "source": "fallback",
+            }
+            providers = [provider_data]
+
+        has_picker = (
+            adapter is not None
+            and getattr(type(adapter), "send_model_picker", None) is not None
+            and bool(provider_data.get("models"))
+        )
+        if has_picker:
+            async def _on_model_selected(_chat_id: str, model_id: str, selected_provider: str) -> str:
+                result = switch_model(
+                    raw_input=model_id,
+                    current_provider=ctx["current_provider"] or "",
+                    current_model=current_model or "",
+                    current_base_url=ctx["current_base_url"] or "",
+                    current_api_key=ctx["current_api_key"] or "",
+                    is_global=False,
+                    explicit_provider=selected_provider,
+                    user_providers=ctx["user_providers"],
+                    custom_providers=ctx["custom_providers"],
+                )
+                if not result.success:
+                    return f"Error: {result.error_message}"
+                self._apply_gateway_model_switch_result(session_key, current_model, result)
+                return (
+                    f"Model switched to `{result.new_model}`\n"
+                    f"Provider: {result.provider_label or result.target_provider}\n"
+                    "_(session only — use `/model <name> --global` to persist)_"
+                )
+
+            metadata = {"initial_provider": provider_slug}
+            if source.thread_id:
+                metadata["thread_id"] = source.thread_id
+            try:
+                picker_result = await adapter.send_model_picker(
+                    chat_id=source.chat_id,
+                    providers=providers,
+                    current_model=current_model or "unknown",
+                    current_provider=provider_slug,
+                    session_key=session_key,
+                    on_model_selected=_on_model_selected,
+                    metadata=metadata,
+                )
+            except Exception:
+                picker_result = None
+            if picker_result is not None and getattr(picker_result, "success", False):
+                return (
+                    f"⚙ Current model `{current_model or 'unknown'}` is not available on `{provider_slug}`.\n"
+                    "I opened the model picker so you can choose a compatible model."
+                )
+
+        models = provider_data.get("models", []) or []
+        if models:
+            preview = ", ".join(f"`{m}`" for m in models[:5])
+            more = f" (+{len(models) - 5} more)" if len(models) > 5 else ""
+            return (
+                f"⚙ Current model `{current_model or 'unknown'}` is not available on `{provider_slug}`.\n"
+                f"Choose a compatible model with `/model <name> --provider {provider_slug}`.\n"
+                f"Suggested: {preview}{more}"
+            )
+        return (
+            f"⚙ Current model `{current_model or 'unknown'}` is not available on `{provider_slug}`.\n"
+            f"Use `/model --provider {provider_slug}` or `/model` to choose a compatible model."
+        )
 
     async def _handle_insights_command(self, event: MessageEvent) -> str:
         """Handle /insights command -- show usage insights and analytics."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -44,6 +44,7 @@ from agent.account_usage import (
     list_account_provider_choices,
     render_account_usage_lines,
     render_provider_account_usage_lines,
+    safe_display_text,
     select_provider_account,
 )
 from agent.i18n import t
@@ -10477,7 +10478,12 @@ class GatewayRunner:
                         account_results = await asyncio.to_thread(fetch_provider_account_usages, provider_slug)
                     except Exception:
                         account_results = []
-                    label = getattr(selected_entry, "label", None) or getattr(selected_entry, "id", None) or account_target
+                    label = safe_display_text(
+                        getattr(selected_entry, "label", None) or getattr(selected_entry, "id", None) or account_target,
+                        fallback="account",
+                        max_len=80,
+                        markdown=True,
+                    )
                     lines = [f"✅ Switched account: {label}", ""]
                     followup = await self._account_model_followup(source, session_key, provider_slug, adapter)
                     if followup:
@@ -10514,8 +10520,8 @@ class GatewayRunner:
                 count = provider_data.get("account_count", 0)
                 plural = "s" if count != 1 else ""
                 marker = " — current" if provider_data.get("is_current") else ""
-                name = provider_data.get("name") or provider_data.get("slug")
-                slug = provider_data.get("slug")
+                name = safe_display_text(provider_data.get("name") or provider_data.get("slug"), fallback="Provider", markdown=True)
+                slug = safe_display_text(provider_data.get("slug"), fallback="provider", markdown=True)
                 lines.append(f"[{idx}] **{name}** · {count} account{plural}{marker}")
                 lines.append(f"    `/account {slug}`")
             lines.append("")
@@ -10548,7 +10554,12 @@ class GatewayRunner:
                     agent._swap_credential(selected_entry)
                 except Exception as exc:
                     return f"Selected account, but could not apply it to this running session: {type(exc).__name__}"
-            label = getattr(selected_entry, "label", None) or getattr(selected_entry, "id", None) or account_target
+            label = safe_display_text(
+                getattr(selected_entry, "label", None) or getattr(selected_entry, "id", None) or account_target,
+                fallback="account",
+                max_len=80,
+                markdown=True,
+            )
             switched_line = f"✅ Switched account: {label}"
             adapter_for_followup = getattr(self, "adapters", {}).get(source.platform)
             model_followup_line = await self._account_model_followup(

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2181,6 +2181,77 @@ def _is_remote_session() -> bool:
 # where one app's refresh invalidates the other's session.
 # =============================================================================
 
+def _codex_account_id_from_claims(claims: Dict[str, Any]) -> Optional[str]:
+    """Extract the ChatGPT account id OpenAI expects in ChatGPT-Account-Id."""
+    nested = claims.get("https://api.openai.com/auth")
+    if isinstance(nested, dict):
+        value = nested.get("chatgpt_account_id") or nested.get("account_id")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    for key in ("chatgpt_account_id", "account_id"):
+        value = claims.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _codex_account_id_from_jwt(token: Any) -> Optional[str]:
+    if not isinstance(token, str) or not token.strip():
+        return None
+    return _codex_account_id_from_claims(_decode_jwt_claims(token.strip()))
+
+
+def _normalize_codex_tokens(
+    tokens: Dict[str, Any],
+    *,
+    previous_tokens: Optional[Dict[str, Any]] = None,
+    preserve_previous_metadata: bool = False,
+) -> Dict[str, str]:
+    """Return Codex tokens with stable account metadata attached.
+
+    OpenAI's Codex/ChatGPT endpoints need both the bearer token and, for
+    account-scoped backend calls such as usage, the ChatGPT account id.  The
+    OAuth responses are not perfectly consistent about where that id lives
+    (access token, id token, or explicit fields), so normalize it once at the
+    auth-store boundary and let the pool seed from that canonical state.
+    """
+    previous_tokens = previous_tokens if isinstance(previous_tokens, dict) else {}
+    normalized: Dict[str, str] = {}
+    for key in ("access_token", "refresh_token", "id_token"):
+        value = tokens.get(key)
+        if isinstance(value, str) and value.strip():
+            normalized[key] = value.strip()
+        elif key == "id_token" and preserve_previous_metadata:
+            previous = previous_tokens.get(key)
+            if isinstance(previous, str) and previous.strip():
+                normalized[key] = previous.strip()
+
+    account_id = None
+    for key in ("chatgpt_account_id", "account_id"):
+        value = tokens.get(key)
+        if isinstance(value, str) and value.strip():
+            account_id = value.strip()
+            break
+    if not account_id:
+        for key in ("id_token", "access_token"):
+            account_id = _codex_account_id_from_jwt(normalized.get(key))
+            if account_id:
+                break
+    if not account_id and preserve_previous_metadata:
+        for key in ("chatgpt_account_id", "account_id"):
+            value = previous_tokens.get(key)
+            if isinstance(value, str) and value.strip():
+                account_id = value.strip()
+                break
+
+    if account_id:
+        # Store both aliases because older code/tests used account_id while
+        # OpenAI's newer JWT claims call it chatgpt_account_id.
+        normalized["account_id"] = account_id
+        normalized["chatgpt_account_id"] = account_id
+    return normalized
+
+
 def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     """Read Codex OAuth tokens from Hermes auth store (~/.hermes/auth.json).
     
@@ -2227,19 +2298,42 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     return {
         "tokens": tokens,
         "last_refresh": state.get("last_refresh"),
+        "base_url": state.get("base_url"),
+        "label": state.get("label"),
+        "auth_mode": state.get("auth_mode"),
     }
 
 
-def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None:
+def _save_codex_tokens(
+    tokens: Dict[str, Any],
+    last_refresh: str = None,
+    *,
+    base_url: Optional[str] = None,
+    label: Optional[str] = None,
+    preserve_previous_metadata: bool = False,
+) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     with _auth_store_lock():
         auth_store = _load_auth_store()
         state = _load_provider_state(auth_store, "openai-codex") or {}
-        state["tokens"] = tokens
+        previous_tokens = state.get("tokens") if isinstance(state.get("tokens"), dict) else {}
+        state["tokens"] = _normalize_codex_tokens(
+            tokens,
+            previous_tokens=previous_tokens,
+            preserve_previous_metadata=preserve_previous_metadata,
+        )
         state["last_refresh"] = last_refresh
         state["auth_mode"] = "chatgpt"
+        if base_url is not None:
+            clean_base_url = str(base_url or "").strip().rstrip("/")
+            if clean_base_url:
+                state["base_url"] = clean_base_url
+        if label is not None:
+            clean_label = str(label or "").strip()
+            if clean_label:
+                state["label"] = clean_label
         _save_provider_state(auth_store, "openai-codex", state)
         _save_auth_store(auth_store)
 
@@ -2345,6 +2439,10 @@ def refresh_codex_oauth_pure(
     next_refresh = refresh_payload.get("refresh_token")
     if isinstance(next_refresh, str) and next_refresh.strip():
         updated["refresh_token"] = next_refresh.strip()
+    for token_key in ("id_token", "account_id", "chatgpt_account_id"):
+        value = refresh_payload.get(token_key)
+        if isinstance(value, str) and value.strip():
+            updated[token_key] = value.strip()
     return updated
 
 
@@ -2362,10 +2460,22 @@ def _refresh_codex_auth_tokens(
         timeout_seconds=timeout_seconds,
     )
     updated_tokens = dict(tokens)
-    updated_tokens["access_token"] = refreshed["access_token"]
-    updated_tokens["refresh_token"] = refreshed["refresh_token"]
+    for token_key in (
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "account_id",
+        "chatgpt_account_id",
+    ):
+        value = refreshed.get(token_key)
+        if isinstance(value, str) and value.strip():
+            updated_tokens[token_key] = value.strip()
 
-    _save_codex_tokens(updated_tokens)
+    _save_codex_tokens(
+        updated_tokens,
+        refreshed.get("last_refresh"),
+        preserve_previous_metadata=True,
+    )
     return updated_tokens
 
 
@@ -2435,8 +2545,12 @@ def resolve_codex_runtime_credentials(
 
     base_url = (
         os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/")
+        or str(data.get("base_url") or "").strip().rstrip("/")
         or DEFAULT_CODEX_BASE_URL
     )
+    account_id = str(
+        tokens.get("chatgpt_account_id") or tokens.get("account_id") or ""
+    ).strip()
 
     return {
         "provider": "openai-codex",
@@ -2445,6 +2559,8 @@ def resolve_codex_runtime_credentials(
         "source": "hermes-auth-store",
         "last_refresh": data.get("last_refresh"),
         "auth_mode": "chatgpt",
+        "account_id": account_id,
+        "chatgpt_account_id": account_id,
     }
 
 
@@ -4177,8 +4293,8 @@ def _login_openai_codex(
             except (EOFError, KeyboardInterrupt):
                 do_import = "n"
             if do_import in ("y", "yes"):
-                _save_codex_tokens(cli_tokens)
                 base_url = os.getenv("HERMES_CODEX_BASE_URL", "").strip().rstrip("/") or DEFAULT_CODEX_BASE_URL
+                _save_codex_tokens(cli_tokens, base_url=base_url)
                 config_path = _update_config_for_provider("openai-codex", base_url)
                 print()
                 print("Credentials imported. Note: if Codex CLI refreshes its token,")
@@ -4195,7 +4311,11 @@ def _login_openai_codex(
     creds = _codex_device_code_login()
 
     # Save tokens to Hermes auth store
-    _save_codex_tokens(creds["tokens"], creds.get("last_refresh"))
+    _save_codex_tokens(
+        creds["tokens"],
+        creds.get("last_refresh"),
+        base_url=creds.get("base_url", DEFAULT_CODEX_BASE_URL),
+    )
     config_path = _update_config_for_provider("openai-codex", creds.get("base_url", DEFAULT_CODEX_BASE_URL))
     print()
     print("Login successful!")
@@ -4337,11 +4457,17 @@ def _codex_device_code_login() -> Dict[str, Any]:
         or DEFAULT_CODEX_BASE_URL
     )
 
+    returned_tokens = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+    }
+    for token_key in ("id_token", "account_id", "chatgpt_account_id"):
+        value = tokens.get(token_key)
+        if isinstance(value, str) and value.strip():
+            returned_tokens[token_key] = value.strip()
+
     return {
-        "tokens": {
-            "access_token": access_token,
-            "refresh_token": refresh_token,
-        },
+        "tokens": returned_tokens,
         "base_url": base_url,
         "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "auth_mode": "chatgpt",

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -317,20 +317,44 @@ def auth_add_command(args) -> None:
             creds["tokens"]["access_token"],
             _oauth_default_label(provider, len(pool.entries()) + 1),
         )
-        entry = PooledCredential(
-            provider=provider,
-            id=uuid.uuid4().hex[:6],
-            label=label,
-            auth_type=AUTH_TYPE_OAUTH,
-            priority=0,
-            source=f"{SOURCE_MANUAL}:device_code",
-            access_token=creds["tokens"]["access_token"],
-            refresh_token=creds["tokens"].get("refresh_token"),
+        # Codex has a singleton Hermes auth store used by refresh/recovery and
+        # usage lookups.  Persist there first, then let load_pool() materialize
+        # the canonical device_code entry.  This avoids the old split-brain
+        # manual:device_code row that went stale after the auth store refreshed.
+        auth_mod._save_codex_tokens(
+            creds["tokens"],
+            creds.get("last_refresh"),
             base_url=creds.get("base_url"),
-            last_refresh=creds.get("last_refresh"),
+            label=label,
         )
-        pool.add_entry(entry)
-        print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        refreshed_pool = load_pool(provider)
+        entry = next((item for item in refreshed_pool.entries() if item.source == "device_code"), None)
+        if entry is None:
+            # Some tests and custom setups stub singleton seeding; still write
+            # the canonical device_code pool row so auth.json remains complete.
+            saved_tokens = auth_mod._read_codex_tokens().get("tokens", {})
+            extra = {
+                key: value
+                for key in ("id_token", "account_id", "chatgpt_account_id")
+                if isinstance((value := saved_tokens.get(key)), str) and value.strip()
+            }
+            entry = PooledCredential(
+                provider=provider,
+                id=uuid.uuid4().hex[:6],
+                label=label,
+                auth_type=AUTH_TYPE_OAUTH,
+                priority=0,
+                source="device_code",
+                access_token=saved_tokens.get("access_token") or creds["tokens"]["access_token"],
+                refresh_token=saved_tokens.get("refresh_token") or creds["tokens"].get("refresh_token"),
+                base_url=creds.get("base_url"),
+                last_refresh=creds.get("last_refresh"),
+                extra=extra,
+            )
+            refreshed_pool.add_entry(entry)
+        shown_label = entry.label if entry is not None else label
+        count = len(refreshed_pool.entries())
+        print(f'Saved {provider} OAuth device-code credentials #{count}: "{shown_label}"')
         return
 
     if provider == "google-gemini-cli":

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -184,6 +184,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session",
                gateway_only=True),
     CommandDef("usage", "Show token usage and rate limits for the current session", "Info"),
+    CommandDef("account", "Pick the active account/API key and show usage limits", "Info",
+               aliases=("acct",), args_hint="[provider] [account]"),
     CommandDef("insights", "Show usage insights and analytics", "Info",
                args_hint="[days]"),
     CommandDef("platforms", "Show gateway/messaging platform status", "Info",

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1494,7 +1494,10 @@ def _codex_auth_store(access: str, refresh: str) -> dict:
                     "access_token": access,
                     "refresh_token": refresh,
                     "id_token": "id-" + access,
+                    "account_id": "acct-" + access,
+                    "chatgpt_account_id": "acct-" + access,
                 },
+                "base_url": "https://chatgpt.com/backend-api/codex",
                 "last_refresh": "2026-04-28T00:00:00Z",
             }
         },
@@ -1521,6 +1524,9 @@ def test_sync_codex_entry_from_auth_store_adopts_newer_tokens(tmp_path, monkeypa
     assert synced is not entry
     assert synced.access_token == "access-NEW"
     assert synced.refresh_token == "refresh-NEW"
+    assert synced.id_token == "id-access-NEW"
+    assert synced.account_id == "acct-access-NEW"
+    assert synced.chatgpt_account_id == "acct-access-NEW"
     assert synced.last_status is None
     assert synced.last_error_code is None
     assert synced.last_error_reset_at is None
@@ -1619,6 +1625,113 @@ def test_codex_exhausted_entry_stays_stuck_without_auth_store_update(tmp_path, m
     # still skips it.
     available = pool._available_entries(clear_expired=True, refresh=False)
     assert available == []
+
+
+def test_codex_metadata_only_sync_preserves_exhausted_cooldown(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.credential_pool import load_pool, STATUS_EXHAUSTED
+    from dataclasses import replace as dc_replace
+
+    payload = _codex_auth_store("access-same", "refresh-same")
+    for key in ("id_token", "account_id", "chatgpt_account_id"):
+        payload["providers"]["openai-codex"]["tokens"].pop(key, None)
+    _write_auth_store(tmp_path, payload)
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+    assert entry is not None
+    now = time.time()
+    exhausted = dc_replace(
+        entry,
+        last_status=STATUS_EXHAUSTED,
+        last_status_at=now,
+        last_error_code=429,
+        last_error_reset_at=now + 3600,
+    )
+    pool._replace_entry(entry, exhausted)
+    pool._persist()
+
+    # Add account metadata only; tokens are unchanged, so the cooldown should
+    # remain in force even though metadata is synced into the pool entry.
+    updated_payload = _codex_auth_store("access-same", "refresh-same")
+    updated_payload["credential_pool"] = payload.get("credential_pool", {})
+    _write_auth_store(tmp_path, updated_payload)
+
+    available = pool._available_entries(clear_expired=True, refresh=False)
+    assert available == []
+    synced = next(item for item in pool.entries() if item.id == entry.id)
+    assert synced.account_id == "acct-access-same"
+    assert synced.last_status == STATUS_EXHAUSTED
+    assert synced.last_error_reset_at == exhausted.last_error_reset_at
+
+
+def test_load_pool_migrates_legacy_manual_codex_device_code_entry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _codex_auth_store("access-NEW", "refresh-NEW")
+    payload["credential_pool"] = {
+        "openai-codex": [
+            {
+                "id": "legacy-codex",
+                "label": "old-codex",
+                "auth_type": "oauth",
+                "priority": 0,
+                "source": "manual:device_code",
+                "access_token": "access-OLD",
+                "refresh_token": "refresh-OLD",
+            }
+        ]
+    }
+    _write_auth_store(tmp_path, payload)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entries = pool.entries()
+    assert [item.source for item in entries] == ["device_code"]
+    assert entries[0].id == "legacy-codex"
+    assert entries[0].label == "old-codex"
+    assert entries[0].priority == 0
+    assert entries[0].access_token == "access-NEW"
+    assert entries[0].refresh_token == "refresh-NEW"
+    assert entries[0].account_id == "acct-access-NEW"
+
+
+
+def test_sync_codex_legacy_manual_device_code_entry_from_auth_store(tmp_path, monkeypatch):
+    """Legacy manual:device_code rows should recover from canonical auth state."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = _codex_auth_store("access-NEW", "refresh-NEW")
+    payload["credential_pool"] = {
+        "openai-codex": [
+            {
+                "id": "legacy-codex",
+                "label": "old-codex",
+                "auth_type": "oauth",
+                "priority": 0,
+                "source": "manual:device_code",
+                "access_token": "access-OLD",
+                "refresh_token": "refresh-OLD",
+                "last_status": "exhausted",
+                "last_status_at": time.time(),
+                "last_error_code": 401,
+                "last_error_reset_at": time.time() + 86400,
+            }
+        ]
+    }
+    _write_auth_store(tmp_path, payload)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    legacy = next(item for item in pool.entries() if item.id == "legacy-codex")
+
+    synced = pool._sync_codex_entry_from_auth_store(legacy)
+
+    assert synced.access_token == "access-NEW"
+    assert synced.refresh_token == "refresh-NEW"
+    assert synced.account_id == "acct-access-NEW"
+    assert synced.last_status is None
+    assert synced.last_error_reset_at is None
 
 
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1619,3 +1619,69 @@ def test_codex_exhausted_entry_stays_stuck_without_auth_store_update(tmp_path, m
     # still skips it.
     available = pool._available_entries(clear_expired=True, refresh=False)
     assert available == []
+
+
+
+def test_select_target_accepts_index_label_id_and_unique_prefix(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    payload = {
+        "version": 1,
+        "credential_pool": {
+            "openai-codex": [
+                {"id": "cred-alpha-111", "label": "main", "auth_type": "oauth", "priority": 0, "source": "manual", "access_token": "tok-a"},
+                {"id": "cred-beta-222", "label": "backup", "auth_type": "oauth", "priority": 1, "source": "manual", "access_token": "tok-b"},
+                {"id": "cred-gamma-333", "label": "spare", "auth_type": "oauth", "priority": 2, "source": "manual", "access_token": "tok-c"},
+            ]
+        },
+    }
+    _write_auth_store(tmp_path, payload)
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    index, entry, error = pool.select_target("2")
+    assert (index, entry.id, error) == (2, "cred-beta-222", None)
+    assert [item.id for item in pool.entries()] == ["cred-beta-222", "cred-alpha-111", "cred-gamma-333"]
+
+    pool = load_pool("openai-codex")
+    index, entry, error = pool.select_target("spare")
+    assert (index, entry.id, error) == (3, "cred-gamma-333", None)
+    assert [item.id for item in pool.entries()] == ["cred-gamma-333", "cred-beta-222", "cred-alpha-111"]
+
+    pool = load_pool("openai-codex")
+    index, entry, error = pool.select_target("cred-beta-222")
+    assert (index, entry.id, error) == (2, "cred-beta-222", None)
+
+    pool = load_pool("openai-codex")
+    index, entry, error = pool.select_target("cred-gam")
+    assert (index, entry.id, error) == (2, "cred-gamma-333", None)
+
+
+def test_select_target_rejects_ambiguous_prefix_and_out_of_range_without_leaking_ids(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {"id": "secret-shared-alpha", "label": "main", "auth_type": "oauth", "priority": 0, "source": "manual", "access_token": "tok-a"},
+                    {"id": "secret-shared-beta", "label": "backup", "auth_type": "oauth", "priority": 1, "source": "manual", "access_token": "tok-b"},
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    index, entry, error = pool.select_target("secret-shared")
+    assert index is None
+    assert entry is None
+    assert error == "account selection is ambiguous"
+    assert "secret-shared" not in error
+
+    index, entry, error = pool.select_target("99")
+    assert index is None
+    assert entry is None
+    assert error == "account number 99 is out of range"

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 import json
 import time
 
-import pytest
-
-
 def _write_auth_store(tmp_path, payload: dict) -> None:
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)
@@ -90,6 +87,60 @@ def test_select_clears_expired_exhaustion(tmp_path, monkeypatch):
 
     assert entry is not None
     assert entry.last_status == "ok"
+
+
+def test_select_target_moves_credential_to_front_and_sets_current(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "main",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "tok-main",
+                    },
+                    {
+                        "id": "cred-2",
+                        "label": "backup",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "tok-backup",
+                    },
+                    {
+                        "id": "cred-3",
+                        "label": "spare",
+                        "auth_type": "oauth",
+                        "priority": 2,
+                        "source": "manual",
+                        "access_token": "tok-spare",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+    from hermes_cli.auth import read_credential_pool
+
+    pool = load_pool("openai-codex")
+    index, entry, error = pool.select_target("backup")
+
+    assert error is None
+    assert index == 2
+    assert entry is not None
+    assert entry.id == "cred-2"
+    assert pool.current().id == "cred-2"
+    assert [item.id for item in pool.entries()] == ["cred-2", "cred-1", "cred-3"]
+    persisted = read_credential_pool("openai-codex")
+    assert [item["id"] for item in persisted] == ["cred-2", "cred-1", "cred-3"]
+    assert [item["priority"] for item in persisted] == [0, 1, 2]
 
 
 def test_round_robin_strategy_rotates_priorities(tmp_path, monkeypatch):

--- a/tests/gateway/test_account_command.py
+++ b/tests/gateway/test_account_command.py
@@ -2,7 +2,7 @@
 
 import threading
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -115,3 +115,65 @@ async def test_account_command_with_provider_and_account_target_switches_then_re
     assert "Switched account" in result
     assert "Hermes Account Center" in result
     assert "2. beta" in result
+
+
+
+@pytest.mark.asyncio
+async def test_account_command_no_providers_guides_auth_add(monkeypatch):
+    runner = _make_runner()
+    event = MagicMock()
+    event.source = MagicMock()
+    event.get_command_args.return_value = ""
+    monkeypatch.setattr("gateway.run.list_account_provider_choices", lambda active_provider=None: [])
+
+    result = await runner._handle_account_command(event)
+
+    assert "No account providers found" in result
+    assert "hermes auth add" in result
+
+
+@pytest.mark.asyncio
+async def test_account_command_provider_switch_invokes_model_followup(monkeypatch):
+    runner = _make_runner()
+    runner._account_model_followup = AsyncMock(return_value="⚙ opened model picker")
+    agent = MagicMock()
+    agent.provider = "anthropic"
+    agent._credential_pool = None
+    runner._agent_cache[SK] = (agent, 0)
+
+    event = MagicMock()
+    event.source = MagicMock()
+    event.get_command_args.return_value = "openai-codex 1"
+
+    monkeypatch.setattr(
+        "gateway.run.list_account_provider_choices",
+        lambda active_provider=None: [SimpleNamespace(slug="openai-codex", name="OpenAI Codex", account_count=1, is_current=False)],
+    )
+    monkeypatch.setattr(
+        "gateway.run.select_provider_account",
+        lambda provider, target, pool=None: (1, SimpleNamespace(label="main", id="cred-1"), None),
+    )
+    monkeypatch.setattr("gateway.run.fetch_provider_account_usages", lambda provider: [])
+    monkeypatch.setattr("gateway.run.render_provider_account_usage_lines", lambda *a, **kw: ["Hermes Account Center"])
+
+    result = await runner._handle_account_command(event)
+
+    runner._account_model_followup.assert_called_once()
+    assert "opened model picker" in result
+
+
+@pytest.mark.asyncio
+async def test_account_model_followup_skips_when_provider_unchanged():
+    runner = _make_runner()
+    runner._gateway_model_switch_context = MagicMock(return_value={
+        "current_model": "gpt-5.5",
+        "current_provider": "openai-codex",
+        "current_base_url": "",
+        "current_api_key": "",
+        "user_providers": None,
+        "custom_providers": None,
+    })
+
+    result = await runner._account_model_followup(MagicMock(), SK, "openai-codex", None)
+
+    assert result == ""

--- a/tests/gateway/test_account_command.py
+++ b/tests/gateway/test_account_command.py
@@ -1,0 +1,117 @@
+"""Tests for gateway /account provider selection and all-account usage display."""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+SK = "agent:main:whatsapp:private:12345"
+
+
+def _make_runner(session_key=SK):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner.session_store = MagicMock()
+    runner._session_key_for_source = MagicMock(return_value=session_key)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_account_command_without_provider_asks_user_to_choose_provider(monkeypatch):
+    runner = _make_runner()
+    event = MagicMock()
+    event.source = MagicMock()
+    event.get_command_args.return_value = ""
+
+    monkeypatch.setattr(
+        "gateway.run.list_account_provider_choices",
+        lambda active_provider=None: [
+            SimpleNamespace(slug="anthropic", name="Anthropic", account_count=1, is_current=False),
+            SimpleNamespace(slug="openai-codex", name="OpenAI Codex", account_count=2, is_current=True),
+        ],
+    )
+
+    result = await runner._handle_account_command(event)
+
+    assert "Select a credential provider" in result
+    assert "1 account" in result
+    assert "2 accounts" in result
+    assert "/account anthropic" in result
+    assert "/account openai-codex" in result
+
+
+@pytest.mark.asyncio
+async def test_account_command_with_provider_shows_every_account_in_that_provider(monkeypatch):
+    runner = _make_runner()
+    event = MagicMock()
+    event.source = MagicMock()
+    event.get_command_args.return_value = "openai-codex"
+    calls = {}
+
+    def _fake_fetch(provider):
+        calls["provider"] = provider
+        return [object(), object()]
+
+    monkeypatch.setattr("gateway.run.fetch_provider_account_usages", _fake_fetch)
+    monkeypatch.setattr(
+        "gateway.run.render_provider_account_usage_lines",
+        lambda provider, results, markdown=False, **kwargs: [
+            "📈 **Account usage for provider: openai-codex**",
+            "1. alpha",
+            "Session: 90% remaining (10% used)",
+            "2. beta",
+            "Session: 5% remaining (95% used)",
+        ],
+    )
+
+    result = await runner._handle_account_command(event)
+
+    assert calls["provider"] == "openai-codex"
+    assert "1. alpha" in result
+    assert "2. beta" in result
+    assert "90% remaining" in result
+    assert "5% remaining" in result
+
+
+@pytest.mark.asyncio
+async def test_account_command_with_provider_and_account_target_switches_then_rerenders(monkeypatch):
+    runner = _make_runner()
+    agent = MagicMock()
+    agent.provider = "openai-codex"
+    agent._credential_pool = "active-pool"
+    runner._agent_cache[SK] = (agent, 0)
+
+    event = MagicMock()
+    event.source = MagicMock()
+    event.get_command_args.return_value = "openai-codex 2"
+    selected = {}
+
+    def _fake_select(provider, target, pool=None):
+        selected.update({"provider": provider, "target": target, "pool": pool})
+        return 2, SimpleNamespace(label="beta", id="cred-2"), None
+
+    monkeypatch.setattr(
+        "gateway.run.list_account_provider_choices",
+        lambda active_provider=None: [SimpleNamespace(slug="openai-codex", name="OpenAI Codex", account_count=2, is_current=True)],
+    )
+    monkeypatch.setattr("gateway.run.select_provider_account", _fake_select)
+    monkeypatch.setattr("gateway.run.fetch_provider_account_usages", lambda provider: [object(), object()])
+    monkeypatch.setattr(
+        "gateway.run.render_provider_account_usage_lines",
+        lambda provider, results, markdown=False, **kwargs: ["Hermes Account Center", "2. beta — active"],
+    )
+
+    result = await runner._handle_account_command(event)
+
+    assert selected == {"provider": "openai-codex", "target": "2", "pool": "active-pool"}
+    agent._swap_credential.assert_called_once()
+    assert "Switched account" in result
+    assert "Hermes Account Center" in result
+    assert "2. beta" in result

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -534,3 +534,85 @@ class TestTelegramApprovalCallback:
         query.answer.assert_called_once()
         query.edit_message_text.assert_called_once()
         assert (tmp_path / ".update_response").read_text() == "n"
+
+
+
+@pytest.mark.asyncio
+async def test_account_picker_callback_routing_does_not_capture_ab_prefix():
+    adapter = _make_adapter()
+
+    query = AsyncMock()
+    query.data = "abcd"
+    query.message = MagicMock()
+    query.message.chat_id = 12345
+    query.message.chat.type = "private"
+    query.from_user = MagicMock()
+    query.from_user.id = 111
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    update = MagicMock()
+    update.callback_query = query
+
+    with patch.object(adapter, "_handle_account_picker_callback", new_callable=AsyncMock) as account_cb:
+        await adapter._handle_callback_query(update, MagicMock())
+
+    account_cb.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_account_picker_rejects_wrong_thread_callback():
+    adapter = _make_adapter()
+    on_account_selected = AsyncMock()
+    adapter._account_picker_state["12345"] = {
+        "msg_id": 77,
+        "thread_id": "10",
+        "selected_provider": "openai-codex",
+        "on_account_selected": on_account_selected,
+    }
+
+    query = AsyncMock()
+    query.data = "am:1"
+    query.message = MagicMock()
+    query.message.chat_id = 12345
+    query.message.message_id = 77
+    query.message.message_thread_id = 11
+    query.message.chat.type = "supergroup"
+    query.from_user = MagicMock()
+    query.from_user.id = 111
+    query.from_user.first_name = "Alice"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+
+    update = MagicMock()
+    update.callback_query = query
+
+    await adapter._handle_callback_query(update, MagicMock())
+
+    on_account_selected.assert_not_called()
+    query.answer.assert_called_once()
+    assert "expired" in query.answer.call_args[1]["text"].lower()
+    query.edit_message_text.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_account_picker_markdown_sensitive_label_renders_safely():
+    adapter = _make_adapter()
+    on_provider_selected = AsyncMock()
+    on_account_selected = AsyncMock()
+    msg = MagicMock()
+    msg.message_id = 77
+    adapter._bot.send_message = AsyncMock(return_value=msg)
+
+    result = await adapter.send_account_picker(
+        chat_id="12345",
+        providers=[{"slug": "openai-codex", "name": "main_key_*[x]`", "account_count": 1, "is_current": True}],
+        current_provider="main_key_*[x]`",
+        session_key="sk",
+        on_provider_selected=on_provider_selected,
+        on_account_selected=on_account_selected,
+    )
+
+    assert result.success is True
+    sent = adapter._bot.send_message.call_args.kwargs
+    assert r"main\_key\_\*\[x\]\`" in sent["text"]

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -1,6 +1,5 @@
 """Tests for Telegram inline keyboard approval buttons."""
 
-import asyncio
 import os
 import sys
 from pathlib import Path
@@ -328,6 +327,100 @@ class TestTelegramApprovalCallback:
                 await adapter._handle_callback_query(update, context)
 
         mock_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_account_picker_callback_not_affected(self):
+        """Ensure account picker callbacks route before approval handling."""
+        adapter = _make_adapter()
+
+        query = AsyncMock()
+        query.data = "ap:openai-codex"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            with patch.object(adapter, "_handle_account_picker_callback", new_callable=AsyncMock):
+                await adapter._handle_callback_query(update, context)
+
+        mock_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_account_picker_callback_rejects_unauthorized_user(self):
+        """Account picker callbacks must honor gateway authorization."""
+        adapter = _make_adapter()
+        runner = _AuthRunner(authorized=False)
+        adapter._message_handler = runner._handle_message
+        adapter._account_picker_state["12345"] = {
+            "msg_id": 77,
+            "providers": [{"slug": "openai-codex", "name": "OpenAI Codex"}],
+            "on_provider_selected": AsyncMock(),
+            "on_account_selected": AsyncMock(),
+        }
+
+        query = AsyncMock()
+        query.data = "ap:openai-codex"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_id = 77
+        query.message.message_thread_id = None
+        query.message.chat.type = "private"
+        query.from_user = MagicMock()
+        query.from_user.id = 222
+        query.from_user.first_name = "Mallory"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+
+        await adapter._handle_callback_query(update, MagicMock())
+
+        adapter._account_picker_state["12345"]["on_provider_selected"].assert_not_called()
+        query.answer.assert_called_once()
+        assert "not authorized" in query.answer.call_args[1]["text"].lower()
+        query.edit_message_text.assert_not_called()
+        assert runner.last_source is not None
+        assert runner.last_source.user_id == "222"
+
+    @pytest.mark.asyncio
+    async def test_account_picker_rejects_stale_message_callback(self):
+        """Old account picker buttons must not act on the newest chat-level state."""
+        adapter = _make_adapter()
+        on_account_selected = AsyncMock()
+        adapter._account_picker_state["12345"] = {
+            "msg_id": 77,
+            "thread_id": None,
+            "selected_provider": "openai-codex",
+            "on_account_selected": on_account_selected,
+        }
+
+        query = AsyncMock()
+        query.data = "am:1"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_id = 78
+        query.message.message_thread_id = None
+        query.message.chat.type = "private"
+        query.from_user = MagicMock()
+        query.from_user.id = 111
+        query.from_user.first_name = "Alice"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+
+        await adapter._handle_callback_query(update, MagicMock())
+
+        on_account_selected.assert_not_called()
+        query.answer.assert_called_once()
+        assert "expired" in query.answer.call_args[1]["text"].lower()
+        query.edit_message_text.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_update_prompt_callback_not_affected(self, tmp_path):

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -144,6 +144,49 @@ def test_save_codex_tokens_roundtrip(tmp_path, monkeypatch):
     assert data["tokens"]["refresh_token"] == "rt456"
 
 
+def test_save_codex_tokens_does_not_reuse_stale_account_metadata(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    _save_codex_tokens({
+        "access_token": "old-access",
+        "refresh_token": "old-refresh",
+        "account_id": "acct-old",
+        "chatgpt_account_id": "acct-old",
+    })
+    _save_codex_tokens({"access_token": "new-access", "refresh_token": "new-refresh"})
+
+    data = _read_codex_tokens()
+    assert data["tokens"]["access_token"] == "new-access"
+    assert data["tokens"]["refresh_token"] == "new-refresh"
+    assert "account_id" not in data["tokens"]
+    assert "chatgpt_account_id" not in data["tokens"]
+
+
+def test_refresh_codex_oauth_pure_returns_account_metadata(monkeypatch):
+    response = _StubHTTPResponse(
+        200,
+        {
+            "access_token": "access-new",
+            "refresh_token": "refresh-new",
+            "id_token": "id-new",
+            "account_id": "acct-new",
+            "chatgpt_account_id": "acct-new",
+        },
+    )
+    _patch_httpx(monkeypatch, response)
+
+    refreshed = refresh_codex_oauth_pure("access-old", "refresh-old")
+
+    assert refreshed["access_token"] == "access-new"
+    assert refreshed["refresh_token"] == "refresh-new"
+    assert refreshed["id_token"] == "id-new"
+    assert refreshed["account_id"] == "acct-new"
+    assert refreshed["chatgpt_account_id"] == "acct-new"
+
+
 def test_import_codex_cli_tokens(tmp_path, monkeypatch):
     codex_home = tmp_path / "codex-cli"
     codex_home.mkdir(parents=True, exist_ok=True)
@@ -335,10 +378,11 @@ def test_login_openai_codex_force_new_login_skips_existing_reuse_prompt(monkeypa
         },
     )
 
-    def _fake_save(tokens, last_refresh=None):
+    def _fake_save(tokens, last_refresh=None, **kwargs):
         called["device_login"] += 1
         called["tokens"] = dict(tokens)
         called["last_refresh"] = last_refresh
+        called["save_kwargs"] = kwargs
 
     monkeypatch.setattr("hermes_cli.auth._save_codex_tokens", _fake_save)
     monkeypatch.setattr("hermes_cli.auth._update_config_for_provider", lambda *args, **kwargs: "/tmp/config.yaml")

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -17,11 +17,10 @@ def _write_auth_store(tmp_path, payload: dict) -> None:
     (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2))
 
 
-def _jwt_with_email(email: str) -> str:
+def _jwt_with_email(email: str, **extra_claims) -> str:
     header = base64.urlsafe_b64encode(b'{"alg":"RS256","typ":"JWT"}').rstrip(b"=").decode()
-    payload = base64.urlsafe_b64encode(
-        json.dumps({"email": email}).encode()
-    ).rstrip(b"=").decode()
+    claims = {"email": email, **extra_claims}
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=").decode()
     return f"{header}.{payload}.signature"
 
 
@@ -235,12 +234,14 @@ def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(tmp_path, {"version": 1, "providers": {}})
     token = _jwt_with_email("codex@example.com")
+    id_token = _jwt_with_email("codex@example.com", chatgpt_account_id="acct-codex-123")
     monkeypatch.setattr(
         "hermes_cli.auth._codex_device_code_login",
         lambda: {
             "tokens": {
                 "access_token": token,
                 "refresh_token": "refresh-token",
+                "id_token": id_token,
             },
             "base_url": "https://chatgpt.com/backend-api/codex",
             "last_refresh": "2026-03-23T10:00:00Z",
@@ -258,11 +259,23 @@ def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     auth_add_command(_Args())
 
     payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    provider_state = payload["providers"]["openai-codex"]
+    assert provider_state["base_url"] == "https://chatgpt.com/backend-api/codex"
+    assert provider_state["tokens"]["id_token"] == id_token
+    assert provider_state["tokens"]["account_id"] == "acct-codex-123"
+    assert provider_state["tokens"]["chatgpt_account_id"] == "acct-codex-123"
+
     entries = payload["credential_pool"]["openai-codex"]
-    entry = next(item for item in entries if item["source"] == "manual:device_code")
+    device_code_entries = [item for item in entries if item["source"] == "device_code"]
+    assert len(device_code_entries) == 1, entries
+    assert not any(item["source"] == "manual:device_code" for item in entries)
+    entry = device_code_entries[0]
     assert entry["label"] == "codex@example.com"
-    assert entry["source"] == "manual:device_code"
+    assert entry["source"] == "device_code"
     assert entry["refresh_token"] == "refresh-token"
+    assert entry["id_token"] == id_token
+    assert entry["account_id"] == "acct-codex-123"
+    assert entry["chatgpt_account_id"] == "acct-codex-123"
     assert entry["base_url"] == "https://chatgpt.com/backend-api/codex"
 
 
@@ -1125,9 +1138,10 @@ def test_auth_add_codex_clears_suppression_marker(tmp_path, monkeypatch):
     payload = json.loads((hermes_home / "auth.json").read_text())
     # Suppression marker must be cleared
     assert "openai-codex" not in payload.get("suppressed_sources", {})
-    # New pool entry must be present
+    # New canonical pool entry must be present
     entries = payload["credential_pool"]["openai-codex"]
-    assert any(e["source"] == "manual:device_code" for e in entries)
+    assert any(e["source"] == "device_code" for e in entries)
+    assert not any(e["source"] == "manual:device_code" for e in entries)
 
 
 def test_seed_from_singletons_respects_codex_suppression(tmp_path, monkeypatch):

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -849,7 +849,8 @@ class TestSyncTurn:
         """Non-ASCII text (CJK, ZWJ emoji) must survive JSON round-trip intact."""
         p = provider_with_config()
         p._client = _make_mock_client()
-        p.sync_turn("안녕 こんにちは 你好", "👨‍👩‍👧‍👦 family")
+        family = "\U0001f468\u200d\U0001f469\u200d\U0001f467\u200d\U0001f466"
+        p.sync_turn("안녕 こんにちは 你好", f"{family} family")
         p._retain_queue.join()
         p._client.aretain_batch.assert_called_once()
         item = p._client.aretain_batch.call_args.kwargs["items"][0]
@@ -859,7 +860,7 @@ class TestSyncTurn:
         assert "안녕" in raw_json
         assert "こんにちは" in raw_json
         assert "你好" in raw_json
-        assert "👨‍👩‍👧‍👦" in raw_json
+        assert family in raw_json
 
 
 # ---------------------------------------------------------------------------

--- a/tests/stress/test_atypical_scenarios.py
+++ b/tests/stress/test_atypical_scenarios.py
@@ -95,7 +95,7 @@ def _(home, kb):
             ("设计认证模式", "implement"),
             ("אימות משתמש חדש", "auth-rtl"),  # Hebrew RTL
             ("مهمة تصحيح الأخطاء", "bug-arabic"),
-            ("👨‍👩‍👧‍👦 family emoji ZWJ sequences 🏳️‍🌈", "emoji-stress"),
+            ("\U0001f468\u200d\U0001f469\u200d\U0001f467\u200d\U0001f466 family emoji ZWJ sequences 🏳️\ufe0f\u200d🌈", "emoji-stress"),
             ("control\x01chars\x02in\x03body", "ctrl"),
             ("null\x00bytes", "nullbyte"),
         ]

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -1,10 +1,17 @@
+import base64
+import json
 from datetime import datetime, timezone
 
 from agent.account_usage import (
     AccountUsageSnapshot,
     AccountUsageWindow,
+    ProviderAccountUsage,
+    active_provider_account_index,
     fetch_account_usage,
+    fetch_provider_account_usages,
+    list_account_usage_providers,
     render_account_usage_lines,
+    render_provider_account_usage_lines,
 )
 
 
@@ -47,6 +54,208 @@ class _RoutingClient:
 
     def get(self, url, headers=None):
         return _Response(self._payloads[url])
+
+
+class _HeaderRoutingClient:
+    def __init__(self, payloads):
+        self._payloads = payloads
+        self.calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url, headers=None):
+        headers = headers or {}
+        self.calls.append((url, dict(headers)))
+        return _Response(self._payloads[headers.get("ChatGPT-Account-Id")])
+
+
+class _Entry:
+    def __init__(
+        self,
+        *,
+        label,
+        token,
+        base_url="https://chatgpt.com/backend-api/codex",
+        source="manual",
+        id_token=None,
+        account_id=None,
+    ):
+        self.label = label
+        self.source = source
+        self.auth_type = "oauth"
+        self.access_token = token
+        self.runtime_api_key = token
+        self.runtime_base_url = base_url
+        self.id_token = id_token
+        self.account_id = account_id
+        self.last_status = None
+        self.last_error_reset_at = None
+
+
+class _Pool:
+    def __init__(self, entries):
+        self._entries = entries
+
+    def entries(self):
+        return list(self._entries)
+
+    def current(self):
+        return None
+
+
+def _jwt_with_account(account_id):
+    payload = {"https://api.openai.com/auth": {"chatgpt_account_id": account_id}}
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    return f"hdr.{body}.sig"
+
+
+def test_active_provider_account_index_defaults_to_priority_first_without_current_id():
+    first = _Entry(label="first", token="stub")
+    first.id = "cred-1"
+    second = _Entry(label="second", token="stub")
+    second.id = "cred-2"
+
+    assert active_provider_account_index("openai-codex", pool=_Pool([first, second])) == 1
+
+
+def test_list_account_usage_providers_reads_credential_pool(monkeypatch):
+    monkeypatch.setattr(
+        "agent.account_usage.read_credential_pool",
+        lambda provider_id=None: {
+            "openai-codex": [{"label": "codex-a"}],
+            "anthropic": [{"label": "claude-a"}],
+            "custom:local": [{"label": "local"}],
+            "openrouter": [],
+        } if provider_id is None else [],
+    )
+
+    assert list_account_usage_providers() == ["anthropic", "custom:local", "openai-codex"]
+
+
+def test_fetch_provider_account_usages_codex_fetches_every_pool_entry(monkeypatch):
+    entries = [
+        _Entry(label="alpha", token=_jwt_with_account("acct_alpha")),
+        _Entry(label="beta", token=_jwt_with_account("acct_beta")),
+    ]
+    client = _HeaderRoutingClient(
+        {
+            "acct_alpha": {
+                "plan_type": "pro",
+                "rate_limit": {
+                    "primary_window": {"used_percent": 10, "reset_at": 1_900_000_000},
+                    "secondary_window": {"used_percent": 20, "reset_at": 1_900_500_000},
+                },
+            },
+            "acct_beta": {
+                "plan_type": "plus",
+                "rate_limit": {
+                    "primary_window": {"used_percent": 95, "reset_at": 1_900_000_000},
+                    "secondary_window": {"used_percent": 80, "reset_at": 1_900_500_000},
+                },
+            },
+        }
+    )
+    monkeypatch.setattr("agent.account_usage.load_pool", lambda provider: _Pool(entries))
+    monkeypatch.setattr("agent.account_usage.httpx.Client", lambda timeout=15.0: client)
+
+    results = fetch_provider_account_usages("openai-codex")
+
+    assert [result.label for result in results] == ["alpha", "beta"]
+    assert [result.snapshot.plan for result in results] == ["Pro", "Plus"]
+    assert [result.snapshot.windows[0].used_percent for result in results] == [10.0, 95.0]
+    assert [call[1]["ChatGPT-Account-Id"] for call in client.calls] == ["acct_alpha", "acct_beta"]
+
+    rendered = "\n".join(render_provider_account_usage_lines("openai-codex", results))
+    assert "Provider: openai-codex" in rendered
+    assert "1. alpha" in rendered
+    assert "Session: 90% remaining (10% used)" in rendered
+    assert "2. beta" in rendered
+    assert "Session: 5% remaining (95% used)" in rendered
+
+
+def test_fetch_provider_account_usages_codex_uses_id_token_account_id_and_chatgpt_backend_url(monkeypatch):
+    entry = _Entry(
+        label="id-token-account",
+        token="stub",
+        id_token=_jwt_with_account("acct_from_id_token"),
+        base_url="https://chatgpt.com",
+    )
+    client = _HeaderRoutingClient(
+        {
+            "acct_from_id_token": {
+                "plan_type": "pro",
+                "rate_limit": {"primary_window": {"used_percent": 50}},
+            },
+        }
+    )
+    monkeypatch.setattr("agent.account_usage.load_pool", lambda provider: _Pool([entry]))
+    monkeypatch.setattr("agent.account_usage.httpx.Client", lambda timeout=15.0: client)
+
+    results = fetch_provider_account_usages("openai-codex")
+
+    assert results[0].snapshot.windows[0].used_percent == 50.0
+    assert client.calls[0][0] == "https://chatgpt.com/backend-api/wham/usage"
+    assert client.calls[0][1]["ChatGPT-Account-Id"] == "acct_from_id_token"
+
+
+def test_codex_usage_url_normalizes_chatgpt_and_codex_api_hosts():
+    from agent.account_usage import _resolve_codex_usage_url
+
+    assert _resolve_codex_usage_url("https://chatgpt.com") == "https://chatgpt.com/backend-api/wham/usage"
+    assert _resolve_codex_usage_url("https://chatgpt.com/backend-api/codex") == "https://chatgpt.com/backend-api/wham/usage"
+    assert _resolve_codex_usage_url("https://codex.openai.com/api/codex") == "https://codex.openai.com/api/codex/usage"
+
+
+def test_render_provider_account_usage_lines_flags_limited_accounts_with_selection_hint():
+    results = [
+        ProviderAccountUsage(
+            provider="openai-codex",
+            index=1,
+            label="main",
+            status="ok",
+            snapshot=AccountUsageSnapshot(
+                provider="openai-codex",
+                source="usage_api",
+                fetched_at=datetime.now(timezone.utc),
+                plan="Pro",
+                windows=(AccountUsageWindow(label="Session", used_percent=98),),
+            ),
+        ),
+        ProviderAccountUsage(
+            provider="openai-codex",
+            index=2,
+            label="backup",
+            status="ok",
+            snapshot=AccountUsageSnapshot(
+                provider="openai-codex",
+                source="usage_api",
+                fetched_at=datetime.now(timezone.utc),
+                plan="Plus",
+                windows=(AccountUsageWindow(label="Session", used_percent=20),),
+            ),
+        ),
+    ]
+
+    rendered = "\n".join(
+        render_provider_account_usage_lines(
+            "openai-codex",
+            results,
+            markdown=True,
+            active_index=2,
+            select_hint="/account openai-codex 1",
+        )
+    )
+
+    assert "Hermes Account Center" in rendered
+    assert "Limited" in rendered
+    assert "✅" in rendered
+    assert "active" in rendered.lower()
+    assert "▰" in rendered or "█" in rendered
+    assert "/account openai-codex 1" in rendered
 
 
 def test_fetch_account_usage_codex(monkeypatch):

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -1,17 +1,22 @@
 import base64
 import json
-from datetime import datetime, timezone
+import time
+from datetime import datetime, timedelta, timezone
 
 from agent.account_usage import (
     AccountUsageSnapshot,
     AccountUsageWindow,
     ProviderAccountUsage,
     active_provider_account_index,
+    compact_account_usage_description,
+    discord_account_option_parts,
     fetch_account_usage,
     fetch_provider_account_usages,
+    format_reset_countdown,
     list_account_usage_providers,
     render_account_usage_lines,
     render_provider_account_usage_lines,
+    safe_display_text,
 )
 
 
@@ -172,9 +177,9 @@ def test_fetch_provider_account_usages_codex_fetches_every_pool_entry(monkeypatc
     rendered = "\n".join(render_provider_account_usage_lines("openai-codex", results))
     assert "Provider: openai-codex" in rendered
     assert "1. alpha" in rendered
-    assert "Session: 90% remaining (10% used)" in rendered
+    assert "Session: 90% left" in rendered
     assert "2. beta" in rendered
-    assert "Session: 5% remaining (95% used)" in rendered
+    assert "Session: 5% left" in rendered
 
 
 def test_fetch_provider_account_usages_codex_uses_id_token_account_id_and_chatgpt_backend_url(monkeypatch):
@@ -323,7 +328,7 @@ def test_render_account_usage_lines_includes_reset_and_provider():
 
     assert lines[0] == "📈 Account limits"
     assert "openai-codex (Pro)" in lines[1]
-    assert "Session: 75% remaining (25% used)" in lines[2]
+    assert "Session: 75% left" in lines[2]
     assert "Credits balance: $9.99" in lines[3]
 
 
@@ -410,3 +415,136 @@ def test_fetch_account_usage_openrouter_omits_quota_window_when_key_has_no_limit
     assert snapshot.windows == ()
     assert "Credits balance: $74.50" in snapshot.details
     assert "API key usage: $25.50 total • $1.25 today • $4.50 this week • $18.00 this month" in snapshot.details
+
+
+
+def test_format_reset_countdown_is_friendly_and_deterministic():
+    now = datetime(2026, 5, 5, 8, 0, tzinfo=timezone.utc)
+
+    assert format_reset_countdown(now + timedelta(minutes=32), now=now) == "renews in 32m ⏳"
+    assert format_reset_countdown(now + timedelta(hours=2, minutes=14), now=now) == "renews in 2h 14m ✨"
+    assert format_reset_countdown(datetime(2026, 5, 6, 9, 0, tzinfo=timezone.utc), now=now) == "renews tomorrow at 09:00 🌙"
+    assert format_reset_countdown(now + timedelta(days=3, hours=4), now=now) == "renews in 3d 4h 🗓️"
+    assert format_reset_countdown(now - timedelta(seconds=1), now=now) == "renews now ✨"
+
+
+def test_discord_compact_description_uses_snapshot_windows():
+    snapshot = AccountUsageSnapshot(
+        provider="openai-codex",
+        source="usage_api",
+        fetched_at=datetime.now(timezone.utc),
+        windows=(
+            AccountUsageWindow(label="Session", used_percent=10),
+            AccountUsageWindow(label="Weekly", used_percent=20),
+        ),
+    )
+    result = ProviderAccountUsage("openai-codex", 1, "main", "ok", snapshot)
+
+    label, desc = discord_account_option_parts(result, active=True)
+
+    assert label == "✓ 1. main · Healthy"
+    assert desc == "Session: 90% left · Weekly: 80% left"
+    assert compact_account_usage_description(snapshot) == desc
+
+
+def test_markdown_sensitive_labels_are_sanitized_for_display():
+    result = ProviderAccountUsage(
+        provider="openai-codex",
+        index=1,
+        label="main_key_*[x]`",
+        status="ok_*[x]`",
+        snapshot=AccountUsageSnapshot(
+            provider="openai-codex",
+            source="usage_api",
+            fetched_at=datetime.now(timezone.utc),
+            plan="pro_*[x]`",
+            windows=(AccountUsageWindow(label="Session_*[x]`", used_percent=10),),
+        ),
+    )
+
+    rendered = "\n".join(render_provider_account_usage_lines("openai-codex", [result], markdown=True))
+
+    assert r"main\_key\_\*\[x\]\`" in rendered
+    assert r"pro\_\*\[x\]\`" in rendered
+    assert safe_display_text("main_key_*[x]`", markdown=True) == r"main\_key\_\*\[x\]\`"
+
+
+def test_fetch_provider_account_usages_preserves_order_when_one_entry_fails(monkeypatch):
+    entries = [
+        _Entry(label="alpha", token="alpha"),
+        _Entry(label="beta", token="beta"),
+        _Entry(label="gamma", token="gamma"),
+    ]
+    monkeypatch.setattr("agent.account_usage.load_pool", lambda provider: _Pool(entries))
+
+    def fake_fetch(provider, index, entry, pool=None):
+        if index == 2:
+            raise RuntimeError("boom")
+        return ProviderAccountUsage(
+            provider,
+            index,
+            entry.label,
+            "available",
+            AccountUsageSnapshot(
+                provider=provider,
+                source="test",
+                fetched_at=datetime.now(timezone.utc),
+                windows=(AccountUsageWindow(label="Session", used_percent=index),),
+            ),
+        )
+
+    monkeypatch.setattr("agent.account_usage._fetch_provider_entry_usage", fake_fetch)
+
+    results = fetch_provider_account_usages("openai-codex")
+
+    assert [result.label for result in results] == ["alpha", "beta", "gamma"]
+    assert results[1].snapshot.unavailable_reason == "usage lookup failed: RuntimeError"
+
+
+def test_fetch_provider_account_usages_timeout_returns_unavailable_snapshot(monkeypatch):
+    entries = [_Entry(label="slow", token="slow")]
+    monkeypatch.setattr("agent.account_usage.load_pool", lambda provider: _Pool(entries))
+
+    def slow_fetch(provider, index, entry, pool=None):
+        time.sleep(0.2)
+        return ProviderAccountUsage(provider, index, entry.label, "available")
+
+    monkeypatch.setattr("agent.account_usage._fetch_provider_entry_usage", slow_fetch)
+
+    results = fetch_provider_account_usages("openai-codex", timeout=0.01)
+
+    assert results[0].label == "slow"
+    assert results[0].snapshot.unavailable_reason == "usage lookup timed out"
+
+
+def test_fetch_provider_account_usages_unsupported_provider_is_informational(monkeypatch):
+    entries = [_Entry(label="local", token="token")]
+    monkeypatch.setattr("agent.account_usage.load_pool", lambda provider: _Pool(entries))
+
+    results = fetch_provider_account_usages("custom:local")
+
+    assert results[0].snapshot.unavailable_reason == "usage lookup not supported for this provider"
+
+
+def test_fetch_provider_account_usages_syncs_codex_entry_before_lookup(monkeypatch):
+    stale = _Entry(label="codex", token="stale", source="device_code")
+    fresh = _Entry(label="codex", token=_jwt_with_account("acct_fresh"), source="device_code")
+
+    class SyncPool(_Pool):
+        def _sync_codex_entry_from_auth_store(self, entry):
+            return fresh
+
+    client = _HeaderRoutingClient(
+        {
+            "acct_fresh": {
+                "plan_type": "pro",
+                "rate_limit": {"primary_window": {"used_percent": 1}},
+            },
+        }
+    )
+    monkeypatch.setattr("agent.account_usage.load_pool", lambda provider: SyncPool([stale]))
+    monkeypatch.setattr("agent.account_usage.httpx.Client", lambda timeout=15.0: client)
+
+    results = fetch_provider_account_usages("openai-codex")
+    assert results[0].snapshot.windows[0].used_percent == 1.0
+    assert client.calls[0][1]["ChatGPT-Account-Id"] == "acct_fresh"


### PR DESCRIPTION
## Summary
- Hardens `/account` into a polished provider/account picker aligned with the `/model` flow.
- Shows only credential providers with configured accounts and displays account counts plus current-provider markers.
- Renders account/API-key rows with safe labels, active markers, status/health, plan, remaining usage, used percentage, compact quota bars, and friendly reset/renewal countdowns.
- Keeps usage lookup informational only: failures/timeouts render unavailable snapshots and do not mark credentials exhausted.
- Bounds provider-account usage lookups with per-entry concurrency, timeout handling, and order preservation.
- Refreshes/syncs OpenAI Codex pooled credentials before usage lookup when possible, without exposing tokens or long credential IDs.
- Polishes CLI, Telegram, Discord, and text fallback output so the same account-limit information is visible across platforms.
- Hardens Telegram account-picker callback routing and message/thread binding, and sanitizes Markdown-sensitive provider/account labels.
- Sanitizes display text and truncates secret-bearing identifiers; raw API keys/tokens/long IDs are not shown.
- Removes hidden/zero-width Unicode from the scanned source/test paths by escaping legitimate ZWJ emoji fixtures.

## UX notes
- `/account` opens provider selection when multiple configured providers exist.
- Selecting a provider opens account/API-key selection with Hermes-style quota lines such as:
  - `Session: 90% left ▰▰▰▰▰▰▰▰▰▱ (10% used) · renews in 1h 24m ✨`
  - `Weekly: 42% left ▰▰▰▰▱▱▱▱▱▱ (58% used) · renews tomorrow at 09:00 🌙`
- Selecting an account persists it as the provider's active credential and applies it to the running session when safe.
- If the provider changes, the existing model is kept only when compatible; otherwise the flow opens/guides to a provider-scoped model selection fallback.

## Test Plan
- `python -m py_compile agent/account_usage.py agent/credential_pool.py cli.py gateway/run.py gateway/platforms/telegram.py gateway/platforms/discord.py hermes_cli/commands.py tests/agent/test_credential_pool.py tests/gateway/test_account_command.py tests/gateway/test_telegram_approval_buttons.py tests/test_account_usage.py tests/stress/test_atypical_scenarios.py tests/plugins/memory/test_hindsight_provider.py`
  - Result: passed
- `python -m pytest tests/test_account_usage.py tests/gateway/test_account_command.py tests/agent/test_credential_pool.py tests/hermes_cli/test_commands.py tests/gateway/test_gateway_command_help.py tests/gateway/test_usage_command.py tests/hermes_cli/test_model_picker_viewport.py tests/gateway/test_telegram_approval_buttons.py -q -o 'addopts='`
  - Result: `249 passed, 1 warning in 8.89s`
- Extra regression for escaped ZWJ fixture:
  - `python -m pytest tests/plugins/memory/test_hindsight_provider.py::TestSyncTurn::test_sync_turn_preserves_unicode -q -o 'addopts='`
  - Result: `1 passed, 1 warning in 1.44s`
- `ruff check --select F401 agent/credential_pool.py tests/agent/test_credential_pool.py tests/gateway/test_telegram_approval_buttons.py tests/test_account_usage.py tests/gateway/test_account_command.py`
  - Result: `All checks passed!`
- Hidden/bidirectional Unicode scan:
  - `grep -nP "[\x{202A}-\x{202E}\x{2066}-\x{2069}\x{200B}\x{200C}\x{200D}\x{FEFF}]" -r agent/account_usage.py agent/credential_pool.py cli.py gateway/ hermes_cli/commands.py tests/; test $? -eq 1`
  - Result: clean / no matches
- `git diff --check`
  - Result: clean

## CI status
- GitHub Actions are currently `action_required` for the latest PR head `b48b925a02a817e49ac56955e71570d8545892c5`, likely because workflows require repository/maintainer approval for this forked PR.
- Affected workflows shown by GitHub: `Tests`, `Supply Chain Audit`, `Contributor Attribution Check`, and `Nix`.
- Local verification above passed while CI is waiting for action.

## Latest update (account consistency)
- Rebased the branch onto current `main`, resolving the merge conflicts; PR is now mergeable.
- Canonicalizes OpenAI Codex device-code credentials to a single `device_code` pool source and migrates legacy `manual:device_code` rows.
- Syncs Codex pool entries from Hermes `auth.json` before stale-token retries, including access/refresh token, base URL, label, and account metadata.
- Preserves cooldowns for metadata-only syncs so exhausted accounts do not become selectable just because account metadata changed.
- Carries `id_token`, `account_id`, and `chatgpt_account_id` through login/import/refresh paths and avoids reusing stale previous account IDs on fresh token replacement.
- Uses `chatgpt_account_id` preferentially for Codex usage lookups.

## Latest targeted test run
- `pytest tests/agent/test_credential_pool.py tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_auth_commands.py tests/test_account_usage.py -q`
  - Result: `127 passed, 4 warnings in 4.30s`
- `python -m py_compile agent/credential_pool.py agent/account_usage.py hermes_cli/auth.py hermes_cli/auth_commands.py tests/agent/test_credential_pool.py tests/hermes_cli/test_auth_commands.py tests/hermes_cli/test_auth_codex_provider.py`
  - Result: passed
- `git diff --check`
  - Result: clean
