### PR TITLE
feat(feishu): expose interactive card update API

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -97,6 +97,8 @@ try:
         GetMessageRequest,
         GetMessageResourceRequest,
         P2ImMessageMessageReadV1,
+        PatchMessageRequest,
+        PatchMessageRequestBody,
         ReplyMessageRequest,
         ReplyMessageRequestBody,
         UpdateMessageRequest,
@@ -116,6 +118,8 @@ try:
 except ImportError:
     FEISHU_AVAILABLE = False
     lark = None  # type: ignore[assignment]
+    PatchMessageRequest = None  # type: ignore[assignment]
+    PatchMessageRequestBody = None  # type: ignore[assignment]
     CallBackCard = None  # type: ignore[assignment]
     P2CardActionTriggerResponse = None  # type: ignore[assignment]
     EventDispatcherHandler = None  # type: ignore[assignment]
@@ -1781,6 +1785,30 @@ class FeishuAdapter(BasePlatformAdapter):
             return result
         except Exception as exc:
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
+            return SendResult(success=False, error=str(exc))
+
+    async def edit_interactive_card(
+        self,
+        chat_id: str,
+        message_id: str,
+        card: Dict[str, Any],
+        *,
+        finalize: bool = False,
+    ) -> SendResult:
+        """Edit a previously sent Feishu interactive card with raw card JSON."""
+        del chat_id, finalize
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+        try:
+            body = self._build_patch_message_body(content=json.dumps(card, ensure_ascii=False))
+            request = self._build_patch_message_request(message_id=message_id, request_body=body)
+            response = await asyncio.to_thread(self._client.im.v1.message.patch, request)
+            result = self._finalize_send_result(response, "interactive card update failed")
+            if result.success:
+                result.message_id = message_id
+            return result
+        except Exception as exc:
+            logger.error("[Feishu] Failed to edit interactive card %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
     async def send_exec_approval(
@@ -4366,6 +4394,23 @@ class FeishuAdapter(BasePlatformAdapter):
         if "UpdateMessageRequest" in globals():
             return (
                 UpdateMessageRequest.builder()
+                .message_id(message_id)
+                .request_body(request_body)
+                .build()
+            )
+        return SimpleNamespace(message_id=message_id, request_body=request_body)
+
+    @staticmethod
+    def _build_patch_message_body(*, content: str) -> Any:
+        if "PatchMessageRequestBody" in globals() and PatchMessageRequestBody is not None:
+            return PatchMessageRequestBody.builder().content(content).build()
+        return SimpleNamespace(content=content)
+
+    @staticmethod
+    def _build_patch_message_request(message_id: str, request_body: Any) -> Any:
+        if "PatchMessageRequest" in globals() and PatchMessageRequest is not None:
+            return (
+                PatchMessageRequest.builder()
                 .message_id(message_id)
                 .request_body(request_body)
                 .build()

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -207,6 +207,37 @@ class TestFeishuExecApproval:
         ids = list(adapter._approval_state.keys())
         assert ids[0] != ids[1]
 
+    @pytest.mark.asyncio
+    async def test_edit_interactive_card_updates_raw_card(self):
+        adapter = _make_adapter()
+        response = SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="ignored"))
+        request_holder = {}
+
+        def build_body(*, content):
+            return SimpleNamespace(content=content)
+
+        def build_request(message_id, request_body):
+            request_holder["message_id"] = message_id
+            request_holder["body"] = request_body
+            return SimpleNamespace(message_id=message_id, request_body=request_body)
+
+        adapter._build_patch_message_body = build_body
+        adapter._build_patch_message_request = build_request
+        adapter._client.im.v1.message.patch.return_value = response
+        card = {"config": {"wide_screen_mode": True}, "elements": []}
+
+        async def run_sync(func, *args):
+            return func(*args)
+
+        with patch.object(feishu_module.asyncio, "to_thread", side_effect=run_sync):
+            result = await adapter.edit_interactive_card("oc_123", "om_card", card)
+
+        assert result.success is True
+        assert result.message_id == "om_card"
+        assert request_holder["message_id"] == "om_card"
+        assert json.loads(request_holder["body"].content) == card
+        adapter._client.im.v1.message.patch.assert_called_once()
+
 
 # ===========================================================================
 # _resolve_approval — approval state pop + gateway resolution


### PR DESCRIPTION
## What does this PR do?

Adds `FeishuAdapter.edit_interactive_card(...)`, backed by Feishu's message patch API, so integrations can update an existing Feishu interactive card instead of sending separate lifecycle messages.

This is useful for long-running approval/workflow cards that move through queued, running, done, and failed states.

This PR is intentionally limited to exposing a generic Feishu adapter method. It does not change Feishu approval routing or generic card-action dispatch behavior.

## Related Issue

Related to Feishu card lifecycle issues discussed in #7675 and adjacent to #11600 / #11740.

Card-action routing work is tracked separately in #20082.

## External Validation / Downstream Consumer

This generic adapter API was validated against the external community plugin [Bigsunnyboy/hermes-codex-gateway](https://github.com/Bigsunnyboy/hermes-codex-gateway), published as [`v0.1.0`](https://github.com/Bigsunnyboy/hermes-codex-gateway/releases/tag/v0.1.0).

That plugin keeps Codex-specific queueing, approval policy, worktree isolation, and operator documentation outside Hermes core. This PR only adds the reusable Feishu card update primitive needed by that kind of external integration.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/platforms/feishu.py`: imports `PatchMessageRequest` and `PatchMessageRequestBody`
- `gateway/platforms/feishu.py`: adds `edit_interactive_card(...)`
- `gateway/platforms/feishu.py`: adds patch request/body helper builders
- `tests/gateway/test_feishu_approval_buttons.py`: adds regression coverage for raw card update behavior

## How to Test

1. Run the focused Feishu gateway regression test:

```bash
PYTHONDONTWRITEBYTECODE=1 /root/.hermes/hermes-agent/venv/bin/python -B -m pytest -p no:cacheprovider tests/gateway/test_feishu_approval_buttons.py -q
```

2. Confirm the result:

```text
19 passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(scope):`, etc.)
- [x] I searched for existing related PRs/issues and noted #7675, #11600, #11740, and #20082
- [x] My PR contains only changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: WSL2 / Linux Python environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- N/A, adapter API only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I've considered cross-platform impact (Windows, macOS) -- N/A, Feishu API adapter request construction only
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A

## Screenshots / Logs

Focused local regression result:

```text
19 passed
```

## Notes

This PR intentionally does not change Feishu approval routing or generic card-action dispatch. It only provides a small adapter API for updating an already-sent interactive card.