### PR TITLE
feat(feishu): let plugins return card-action callback cards

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2373,7 +2373,10 @@ class FeishuAdapter(BasePlatformAdapter):
         if hermes_action:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
 
+        plugin_response = self._build_plugin_card_action_response(event=event, action_value=action_value)
         self._submit_on_loop(loop, self._handle_card_action_event(data))
+        if plugin_response is not None:
+            return plugin_response
         if P2CardActionTriggerResponse is None:
             return None
         return P2CardActionTriggerResponse()
@@ -2411,6 +2414,45 @@ class FeishuAdapter(BasePlatformAdapter):
             card.data = self._build_resolved_approval_card(choice=choice, user_name=user_name)
             response.card = card
         return response
+
+    def _build_plugin_card_action_response(self, *, event: Any, action_value: Dict[str, Any]) -> Any:
+        """Let plugins provide an inline Feishu card response for custom card actions."""
+        if P2CardActionTriggerResponse is None:
+            return None
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+
+            context = getattr(event, "context", None)
+            operator = getattr(event, "operator", None)
+            open_id = str(getattr(operator, "open_id", "") or "")
+            results = _invoke_hook(
+                "feishu_card_action_response",
+                adapter=self,
+                event=event,
+                action=getattr(event, "action", None),
+                action_value=action_value,
+                chat_id=str(getattr(context, "open_chat_id", "") or ""),
+                operator_open_id=open_id,
+                operator_name=self._get_cached_sender_name(open_id) or open_id,
+            )
+        except Exception:
+            logger.debug("[Feishu] Plugin card action response hook failed", exc_info=True)
+            return None
+
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            card_data = result.get("card") or result.get("callback_card")
+            if not isinstance(card_data, dict):
+                continue
+            response = P2CardActionTriggerResponse()
+            if CallBackCard is not None:
+                card = CallBackCard()
+                card.type = "raw"
+                card.data = card_data
+                response.card = card
+            return response
+        return None
 
     async def _resolve_approval(self, approval_id: Any, choice: str, user_name: str) -> None:
         """Pop approval state and unblock the waiting agent thread."""

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -97,6 +97,13 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Feishu card-action callback hook. Fired synchronously by the Feishu
+    # adapter before custom card actions are routed as synthetic commands.
+    # Plugins may return {"card": <raw Feishu card dict>} to replace the
+    # clicked card inline while the synthetic command continues processing.
+    # Kwargs: adapter, event, action, action_value, chat_id, operator_open_id,
+    # operator_name.
+    "feishu_card_action_response",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs user approval -- fires BOTH for CLI-interactive prompts
     # and for gateway/ACP approvals (Telegram, Discord, Slack, TUI, etc.).

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -411,6 +411,39 @@ class TestCardActionCallbackResponse:
         assert response is not None
         assert response.card is None
 
+    def test_returns_plugin_inline_card_for_custom_action(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        data = _make_card_action_data(
+            {"custom_action": "approve", "task_id": "queued_1"},
+            open_id="ou_bob",
+        )
+        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+        plugin_card = {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "template": "green",
+                "title": {"tag": "plain_text", "content": "Custom action handled"},
+            },
+            "elements": [{"tag": "markdown", "content": "queued_1"}],
+        }
+
+        with (
+            patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro) as mock_submit,
+            patch("hermes_cli.plugins.invoke_hook", return_value=[{"card": plugin_card}]) as mock_hook,
+        ):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response is not None
+        assert response.card is not None
+        assert response.card.type == "raw"
+        assert response.card.data is plugin_card
+        mock_submit.assert_called_once()
+        mock_hook.assert_called_once()
+        assert mock_hook.call_args.kwargs["action_value"]["task_id"] == "queued_1"
+        assert mock_hook.call_args.kwargs["operator_name"] == "Bob"
+
     def test_falls_back_to_open_id_when_name_not_cached(self, _patch_callback_card_types):
         adapter = _make_adapter()
         adapter._loop = MagicMock()

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -334,6 +334,9 @@ class TestPluginHooks:
     def test_valid_hooks_include_pre_gateway_dispatch(self):
         assert "pre_gateway_dispatch" in VALID_HOOKS
 
+    def test_valid_hooks_include_feishu_card_action_response(self):
+        assert "feishu_card_action_response" in VALID_HOOKS
+
     def test_pre_gateway_dispatch_collects_action_dicts(self, tmp_path, monkeypatch):
         """pre_gateway_dispatch callbacks return action dicts (skip/rewrite/allow)."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"


### PR DESCRIPTION
## What does this PR do?

Draft PR for a small Feishu card-action hook that lets plugins return an inline Feishu callback card for custom interactive-card actions.

When a non-approval card action is clicked, the Feishu adapter now invokes `feishu_card_action_response` synchronously before routing the action as a synthetic command. If a plugin returns a raw Feishu card via `{card: ...}` or `{callback_card: ...}`, the adapter returns it as the clicked card's inline callback response while the synthetic command continues processing.

This is intentionally opened as a Draft because it is adjacent to #11740 and related Feishu card lifecycle work. Maintainer feedback is needed on the hook name, timing, and callback-card contract before this should be marked ready for review.

## Related Issue

Adjacent to #11740 and related Feishu card lifecycle work.

Depends on maintainer feedback before marking ready for review. The lower-level card update adapter API is tracked separately in #20081.

## External Validation / Downstream Consumer

The hook shape was validated against the external community plugin [Bigsunnyboy/hermes-codex-gateway](https://github.com/Bigsunnyboy/hermes-codex-gateway), published as [`v0.1.0`](https://github.com/Bigsunnyboy/hermes-codex-gateway/releases/tag/v0.1.0).

That plugin uses Feishu card actions for governed local Codex task approvals and status updates, while keeping Codex-specific queueing, approval policy, worktree isolation, and operator documentation outside Hermes core. This Draft PR proposes only the generic Feishu plugin callback surface needed by external integrations like that plugin.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins.py`: adds `feishu_card_action_response` to the valid plugin hook list
- `gateway/platforms/feishu.py`: calls the hook from Feishu custom card-action handling
- `gateway/platforms/feishu.py`: allows plugin hook results to provide raw Feishu callback cards
- `gateway/platforms/feishu.py`: preserves existing synthetic command dispatch behavior for custom actions
- `tests/gateway/test_feishu_approval_buttons.py`: adds regression coverage for inline plugin card responses
- `tests/hermes_cli/test_plugins.py`: adds hook registration coverage

## How to Test

1. Run the focused plugin and Feishu gateway regression tests:

```bash
pytest tests/hermes_cli/test_plugins.py tests/gateway/test_feishu_approval_buttons.py -q
```

2. Prior local Feishu gateway regression run for the adjacent card-action changes:

```bash
PYTHONDONTWRITEBYTECODE=1 /root/.hermes/hermes-agent/venv/bin/python -B -m pytest -p no:cacheprovider tests/gateway/test_feishu_approval_buttons.py -q
```

3. Confirm the prior focused result:

```text
19 passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(scope):`, etc.)
- [x] I searched for existing related PRs/issues and noted #11740 and #20081
- [x] My PR contains only changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: WSL2 / Linux Python environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- N/A for Draft hook proposal
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I've considered cross-platform impact (Windows, macOS) -- N/A, Feishu callback handling only
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A

## Screenshots / Logs

Prior focused local Feishu gateway regression result:

```text
19 passed
```

## Notes

This PR does not try to resolve the broader generic card-action routing discussion. It only proposes a narrow plugin extension point for inline Feishu callback-card updates on custom actions.

Please keep this as Draft until maintainers provide direction around #11740 or the callback-card hook contract.