### PR TITLE
fix(ssh-backend): preserve directory symlinks during bulk file extract

### DIFF
--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +11,17 @@ import pytest
 from tools.environments import ssh as ssh_env
 from tools.environments.file_sync import quoted_mkdir_command, unique_parent_dirs
 from tools.environments.ssh import SSHEnvironment
+
+
+def _has_gnu_tar() -> bool:
+    """Return True iff `tar` on PATH is GNU tar (needed for --keep-directory-symlink)."""
+    try:
+        out = subprocess.run(
+            ["tar", "--version"], capture_output=True, text=True, timeout=5
+        )
+        return out.returncode == 0 and "GNU tar" in out.stdout
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
 
 
 def _mock_proc(*, returncode=0, poll_return=0, communicate_return=(b"", b""),
@@ -167,10 +179,12 @@ class TestSSHBulkUpload:
         assert "-C" in tar_cmd
 
         # ssh: extract from stdin at /, preserving existing dir modes (#17767)
+        # and existing directory symlinks (e.g. ~/.hermes -> /data/hermes).
         ssh_str = " ".join(ssh_cmd)
         assert "ssh" in ssh_str
         assert "tar xf -" in ssh_str
         assert "--no-overwrite-dir" in ssh_str
+        assert "--keep-directory-symlink" in ssh_str
         assert "-C /" in ssh_str
         assert "testuser@example.com" in ssh_str
 
@@ -517,3 +531,74 @@ class TestSSHBulkUploadEdgeCases:
 
         mock_tar.kill.assert_called_once()
         mock_tar.wait.assert_called_once()
+
+
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="tar pipe is POSIX-only")
+@pytest.mark.skipif(not _has_gnu_tar(),
+                    reason="--keep-directory-symlink requires GNU tar >= 1.32")
+class TestSSHBulkUploadDirectorySymlinkPreservation:
+    """Regression test for the ~/.hermes directory-symlink clobber bug.
+
+    The production extract uses two flags: --no-overwrite-dir (mode
+    protection) and --keep-directory-symlink (symlink protection).
+    This test exercises the second flag against a real tar binary.
+
+    Without --keep-directory-symlink, a directory entry in the archive
+    whose path on the destination resolves to an existing symlink-to-
+    directory causes GNU tar to unlink the symlink and create a real
+    directory there — wiping the link target.
+    """
+
+    @pytest.mark.parametrize("extra_flags,symlink_should_survive", [
+        (["--no-overwrite-dir", "--keep-directory-symlink"], True),
+        (["--no-overwrite-dir"],                              False),
+    ])
+    def test_directory_symlink_preserved(self, tmp_path, extra_flags,
+                                         symlink_should_survive):
+        # Layout:
+        #   tmp_path/dest/foo/bar  -> tmp_path/real_target  (directory symlink)
+        #   tar archive contains:  foo/bar/inside.txt  (file inside the symlinked dir)
+        # Extract into tmp_path/dest with `extra_flags`.
+        # With production flags: dest/foo/bar must remain a symlink and
+        # inside.txt must land in real_target/.
+        # Without --keep-directory-symlink: the symlink is replaced by a
+        # real directory (this is the bug being fixed).
+        real_target = tmp_path / "real_target"
+        real_target.mkdir()
+        dest = tmp_path / "dest"
+        (dest / "foo").mkdir(parents=True)
+        os.symlink(real_target, dest / "foo" / "bar")
+
+        staging = tmp_path / "staging"
+        (staging / "foo" / "bar").mkdir(parents=True)
+        (staging / "foo" / "bar" / "inside.txt").write_text("payload")
+
+        tar_c = subprocess.Popen(
+            ["tar", "-cf", "-", "-C", str(staging), "."],
+            stdout=subprocess.PIPE,
+        )
+        try:
+            extract = subprocess.run(
+                ["tar", "xf", "-", *extra_flags, "-C", str(dest)],
+                stdin=tar_c.stdout, capture_output=True, timeout=10,
+            )
+        finally:
+            tar_c.stdout.close()
+            tar_c.wait(timeout=5)
+        assert extract.returncode == 0, extract.stderr.decode(errors="replace")
+
+        link_path = dest / "foo" / "bar"
+        assert link_path.exists(), "extraction destination must still exist"
+        if symlink_should_survive:
+            assert link_path.is_symlink(), (
+                "production flags must preserve the directory symlink"
+            )
+            assert (real_target / "inside.txt").read_text() == "payload", (
+                "file must be written through the symlink to the real target"
+            )
+        else:
+            assert not link_path.is_symlink(), (
+                "negative case: without --keep-directory-symlink, the "
+                "symlink should have been replaced (proves the bug is real)"
+            )

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -186,11 +186,16 @@ class SSHEnvironment(BaseEnvironment):
 
             tar_cmd = ["tar", "-chf", "-", "-C", staging, "."]
             ssh_cmd = self._build_ssh_command()
-            # --no-overwrite-dir prevents tar from overwriting the mode of
-            # existing directories (e.g. /home/<user>) with the staging
-            # directory's mode.  Without this, a umask 002 produces 0775
-            # dirs which breaks sshd StrictModes (refuses authorized_keys).
-            ssh_cmd.append("tar xf - --no-overwrite-dir -C /")
+            # Two flags, two distinct concerns — keep both:
+            #   --no-overwrite-dir: don't overwrite the mode of existing
+            #     real directories (e.g. /home/<user>). umask 002 → 0775
+            #     breaks sshd StrictModes (refuses authorized_keys).
+            #   --keep-directory-symlink: when a path in the archive
+            #     resolves to an existing symlink-to-directory on the
+            #     remote (e.g. ~/.hermes -> /data/hermes), write through
+            #     the symlink instead of unlinking it and creating a real
+            #     directory. Requires GNU tar >= 1.32.
+            ssh_cmd.append("tar xf - --no-overwrite-dir --keep-directory-symlink -C /")
 
             tar_proc = subprocess.Popen(
                 tar_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE


### PR DESCRIPTION
## Summary

The SSH backend's bulk-upload pipeline (`_ssh_bulk_upload` in `tools/environments/ssh.py`) pipes a local `tar c` through SSH into `tar xf - --no-overwrite-dir -C /` on the remote. `--no-overwrite-dir` protects the *mode* of existing real directories, but it does not protect against symlink replacement: when a directory entry in the archive resolves to an existing symlink-to-directory on the remote, GNU tar by default unlinks the symlink and creates a real directory there before continuing extraction.

This bites any deployment with directory symlinks under `/` overlapping the bulk-upload manifest. Concrete example: `~/.hermes` mounted on a separate volume via `~/.hermes -> /data/hermes`. The first `_ssh_bulk_upload` call after a cold `SshBackend.__init__()` (where `_synced_files = {}` so every file is treated as new) tars up the full ~580-file manifest; an entry like `home/<user>/.hermes/skills/` causes GNU tar to unlink the `~/.hermes` symlink and create a real empty directory there, severing access to the state on the dedicated volume.

## Fix

Add `--keep-directory-symlink` (GNU tar >= 1.32) to the remote-side extract. With it, tar treats an existing directory-symlink at the destination as the directory it points to, preserves the symlink, and writes through it.

```diff
- ssh_cmd.append(\"tar xf - --no-overwrite-dir -C /\")
+ ssh_cmd.append(\"tar xf - --no-overwrite-dir --keep-directory-symlink -C /\")
```

The two flags solve different problems and both are needed:
- `--no-overwrite-dir` — mode protection on existing real directories.
- `--keep-directory-symlink` — symlink protection (this PR).

The comment block above the line is updated to document both.

## Why this flag, not another approach

- `tar -P` / `--absolute-names` affect path stripping, not symlink handling.
- Pre-creating directories with `mkdir -p` and then filtering directory entries from the archive would require parsing tar contents at extract time. Heavy.
- Symlink-aware staging on the local side doesn't help; the wipe happens on the *remote* extract, not the local archive build.

`--keep-directory-symlink` is the GNU tar maintainers' explicit answer to this case.

## Test plan

- New parametrized test class `TestSSHBulkUploadDirectorySymlinkPreservation` in `tests/tools/test_ssh_bulk_upload.py`. Builds a real directory-symlink layout in a temp dir, shells out to a real `tar` (no mocks), and asserts:
  - **Positive case** (production flags): the symlink survives extraction and the file payload lands at the link target.
  - **Negative case** (without `--keep-directory-symlink`): the symlink is replaced — demonstrates the bug is real, not theoretical.
- Test class is gated on `_has_gnu_tar()` (probes `tar --version` for `\"GNU tar\"`) and `sys.platform != \"win32\"`. macOS-without-gtar dev machines skip cleanly; Linux CI executes both cases.
- Plus a one-line assertion added to the existing `test_tar_pipe_commands` confirming the new flag is in the SSH command string (catches a future maintainer stripping the flag without running the real-tar regression).

## Compatibility

- `--keep-directory-symlink` requires GNU tar >= 1.32 (released Jan 2020). All currently-supported Linux distributions and macOS Homebrew `gnu-tar` ship a newer version.
- Behavior change is bounded and additive: directory symlinks are preserved; real directories continue to behave as before.