### PR TITLE
fix: avoid macOS TCC prompts during file search

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ source ~/.bashrc    # reload shell (or: source ~/.zshrc)
 hermes              # start chatting!
 ```
 
+### macOS permission prompts during file search
+
+macOS TCC privacy prompts (for example, "Terminal would like to access data from other apps") are OS-level permission checks, not dialogs Hermes can suppress. Hermes avoids the noisy case by excluding protected locations such as `~/Library/Containers`, `~/Library/Group Containers`, Mail, Messages, Calendars, Reminders, iCloud/Mobile Documents, and Photos Library from broad `search_files` walks by default.
+
+If you explicitly want Hermes to search those protected paths, grant Full Disk Access to the app that launches Hermes (Terminal, your terminal emulator, or the Mac app wrapper) in System Settings -> Privacy & Security -> Full Disk Access, or opt in for a single call with `include_tcc_paths=True`. A persistent opt-in is available with `agent.search.include_tcc_paths: true` in `~/.hermes/config.yaml`.
+
 ---
 
 ## Getting Started

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+import sys
 import threading
 from collections import OrderedDict
 from pathlib import Path
@@ -532,6 +533,16 @@ WSL_ENVIRONMENT_HINT = (
     "the Windows username if needed."
 )
 
+MACOS_TCC_FILE_SEARCH_HINT = (
+    "macOS file-search note: broad searches exclude ~/Library/Containers, "
+    "~/Library/Group Containers, ~/Library/Mail, ~/Library/Messages, "
+    "~/Library/Calendars, ~/Library/Reminders, iCloud/Mobile Documents, "
+    "and Photos Library by default to avoid repeated TCC permission prompts. "
+    "If the user explicitly needs those protected locations, ask them to grant "
+    "Full Disk Access to their terminal/Mac app or call search_files with "
+    "include_tcc_paths=True."
+)
+
 
 def build_environment_hints() -> str:
     """Return environment-specific guidance for the system prompt.
@@ -542,6 +553,8 @@ def build_environment_hints() -> str:
     hints: list[str] = []
     if is_wsl():
         hints.append(WSL_ENVIRONMENT_HINT)
+    if sys.platform == "darwin":
+        hints.append(MACOS_TCC_FILE_SEARCH_HINT)
     return "\n\n".join(hints)
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -463,6 +463,12 @@ DEFAULT_CONFIG = {
         # only controls how inbound user images are presented.
         "image_input_mode": "auto",
         "disabled_toolsets": [],
+        # File-search behavior knobs.
+        "search": {
+            # macOS TCC-protected paths are excluded from broad searches by default
+            # to avoid repeated permission prompts. Set true to restore old behavior.
+            "include_tcc_paths": False,
+        },
     },
     
     "terminal": {

--- a/tests/agent/test_macos_tcc_prompt_hint.py
+++ b/tests/agent/test_macos_tcc_prompt_hint.py
@@ -1,0 +1,21 @@
+"""Tests for macOS TCC file-search guidance in the system prompt."""
+
+import agent.prompt_builder as prompt_builder
+
+
+def test_macos_environment_hints_explain_tcc_search_defaults(monkeypatch):
+    monkeypatch.setattr(prompt_builder.sys, "platform", "darwin")
+    monkeypatch.setattr(prompt_builder, "is_wsl", lambda: False)
+
+    hints = prompt_builder.build_environment_hints()
+
+    assert "macOS file-search note" in hints
+    assert "~/Library/Containers" in hints
+    assert "include_tcc_paths=True" in hints
+
+
+def test_non_macos_environment_hints_do_not_include_tcc_note(monkeypatch):
+    monkeypatch.setattr(prompt_builder.sys, "platform", "linux")
+    monkeypatch.setattr(prompt_builder, "is_wsl", lambda: False)
+
+    assert "macOS file-search note" not in prompt_builder.build_environment_hints()

--- a/tests/tools/test_macos_tcc_search_exclusions.py
+++ b/tests/tools/test_macos_tcc_search_exclusions.py
@@ -1,0 +1,187 @@
+"""Regression tests for macOS TCC-protected search exclusions.
+
+Wide home-directory file walks on macOS can trigger repeated TCC permission
+prompts when they recurse into app containers and privacy-protected data stores.
+These tests use synthetic temp homes only; they never touch the real ~/Library.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import tools.file_operations as file_ops_mod
+from tools.file_operations import ShellFileOperations
+
+
+REQUIRED_TCC_GLOBS = {
+    "Library/Containers/**",
+    "Library/Group Containers/**",
+    "Library/Mail/**",
+    "Library/Messages/**",
+    "Library/Calendars/**",
+    "Library/Reminders/**",
+    "Library/Mobile Documents/**",
+    "Library/CloudStorage/**",
+    "Library/Application Support/com.apple.sharedfilelist/**",
+    "Library/Application Support/AddressBook/**",
+    "Pictures/Photos Library.photoslibrary/**",
+}
+
+
+@pytest.fixture
+def synthetic_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(file_ops_mod.sys, "platform", "darwin")
+    return home
+
+
+@pytest.fixture
+def file_ops():
+    env = MagicMock()
+    env.cwd = "/tmp/test"
+    env.execute.return_value = {"output": "", "returncode": 0}
+    return ShellFileOperations(env)
+
+
+def _exec_result(stdout="", exit_code=0, stderr=""):
+    return SimpleNamespace(stdout=stdout, exit_code=exit_code, stderr=stderr)
+
+
+def test_macos_home_search_default_excludes_required_tcc_globs(synthetic_home):
+    excludes = set(file_ops_mod._macos_tcc_excluded_globs_for_root(str(synthetic_home)))
+
+    assert REQUIRED_TCC_GLOBS.issubset(excludes)
+
+
+def test_macos_library_search_excludes_protected_children(synthetic_home):
+    excludes = set(
+        file_ops_mod._macos_tcc_excluded_globs_for_root(str(synthetic_home / "Library"))
+    )
+
+    assert "Containers/**" in excludes
+    assert "Group Containers/**" in excludes
+    assert "Messages/**" in excludes
+    assert "Mail/**" in excludes
+
+
+def test_explicit_protected_path_search_is_not_silently_hidden(synthetic_home):
+    excludes = file_ops_mod._macos_tcc_excluded_globs_for_root(
+        str(synthetic_home / "Library" / "Containers")
+    )
+
+    assert excludes == []
+
+
+def test_linux_does_not_add_macos_tcc_exclusions(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(file_ops_mod.sys, "platform", "linux")
+
+    assert file_ops_mod._macos_tcc_excluded_globs_for_root(str(tmp_path)) == []
+
+
+def test_rg_file_search_includes_tcc_exclusion_globs(file_ops, synthetic_home):
+    file_ops._exec = MagicMock(return_value=_exec_result(""))
+    file_ops._search_files_rg("config.yaml", str(synthetic_home), 10, 0, ["Library/Containers/**"])
+
+    cmd = file_ops._exec.call_args[0][0]
+    assert "--glob '!Library/Containers/**'" in cmd
+
+
+def test_rg_content_search_includes_tcc_exclusion_globs(file_ops, synthetic_home):
+    file_ops._exec = MagicMock(return_value=_exec_result(""))
+    file_ops._search_with_rg(
+        "needle",
+        str(synthetic_home),
+        None,
+        10,
+        0,
+        "content",
+        0,
+        ["Library/Containers/**"],
+    )
+
+    cmd = file_ops._exec.call_args[0][0]
+    assert "--glob '!Library/Containers/**'" in cmd
+
+
+def test_find_fallback_prunes_tcc_paths_by_default(file_ops, synthetic_home):
+    file_ops._has_command = MagicMock(side_effect=lambda cmd: cmd == "find")
+    file_ops._exec = MagicMock(return_value=_exec_result(""))
+
+    file_ops.search("config.yaml", path=str(synthetic_home), target="files")
+
+    cmd = file_ops._exec.call_args[0][0]
+    assert "-prune" in cmd
+    assert "Library/Containers" in cmd
+    assert "Library/Group Containers" in cmd
+
+
+def test_grep_fallback_uses_find_prefilter_for_tcc_paths(file_ops, synthetic_home):
+    file_ops._exec = MagicMock(return_value=_exec_result(""))
+    file_ops._search_with_grep(
+        "needle",
+        str(synthetic_home),
+        None,
+        10,
+        0,
+        "content",
+        0,
+        ["Library/Containers/**"],
+    )
+
+    cmd = file_ops._exec.call_args[0][0]
+    assert cmd.startswith("find ")
+    assert "-prune" in cmd
+    assert "Library/Containers" in cmd
+    assert "xargs -0 grep" in cmd
+
+
+def test_per_call_include_tcc_paths_disables_default_globs(file_ops, synthetic_home):
+    calls = []
+
+    def fake_exec(cmd, *args, **kwargs):
+        calls.append(cmd)
+        if "test -e" in cmd:
+            return _exec_result("exists\n")
+        return _exec_result("")
+
+    file_ops._has_command = MagicMock(side_effect=lambda cmd: cmd == "rg")
+    file_ops._exec = MagicMock(side_effect=fake_exec)
+
+    file_ops.search(
+        "config.yaml",
+        path=str(synthetic_home),
+        target="files",
+        include_tcc_paths=True,
+    )
+
+    rg_cmds = [cmd for cmd in calls if cmd.startswith("rg --files")]
+    assert rg_cmds
+    assert all("Library/Containers" not in cmd for cmd in rg_cmds)
+
+
+def test_config_include_tcc_paths_disables_default_globs(file_ops, synthetic_home, monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"agent": {"search": {"include_tcc_paths": True}}},
+    )
+    calls = []
+
+    def fake_exec(cmd, *args, **kwargs):
+        calls.append(cmd)
+        if "test -e" in cmd:
+            return _exec_result("exists\n")
+        return _exec_result("")
+
+    file_ops._has_command = MagicMock(side_effect=lambda cmd: cmd == "rg")
+    file_ops._exec = MagicMock(side_effect=fake_exec)
+
+    file_ops.search("config.yaml", path=str(synthetic_home), target="files")
+
+    rg_cmds = [cmd for cmd in calls if cmd.startswith("rg --files")]
+    assert rg_cmds
+    assert all("Library/Containers" not in cmd for cmd in rg_cmds)

--- a/tests/tools/test_search_files_schema.py
+++ b/tests/tools/test_search_files_schema.py
@@ -1,0 +1,12 @@
+"""Tests for the search_files tool schema."""
+
+from tools.file_tools import SEARCH_FILES_SCHEMA
+
+
+def test_search_files_schema_exposes_include_tcc_paths_override():
+    prop = SEARCH_FILES_SCHEMA["parameters"]["properties"]["include_tcc_paths"]
+
+    assert prop["type"] == "boolean"
+    assert prop["default"] is False
+    assert "macOS" in prop["description"]
+    assert "TCC" in prop["description"]

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -27,6 +27,7 @@ Usage:
 
 import os
 import re
+import sys
 import difflib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -55,6 +56,90 @@ WRITE_DENIED_PREFIXES = build_write_denied_prefixes(_HOME)
 
 _OSC_SEQUENCE_RE = re.compile(r"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
 _FENCE_MARKER_RE = re.compile(r"'?\x07?__HERMES_FENCE_[A-Za-z0-9]+__\x07?'?")
+
+# macOS Transparency, Consent, and Control (TCC) protected locations that can
+# trigger repeated permission prompts when a broad home-directory search recurses
+# into them. Values are relative to Path.home(); command-specific helpers convert
+# them to search-root-relative globs or absolute prune paths.
+_MACOS_TCC_HOME_RELATIVE_GLOBS = (
+    "Library/Containers/**",
+    "Library/Group Containers/**",
+    "Library/Mail/**",
+    "Library/Messages/**",
+    "Library/Calendars/**",
+    "Library/Reminders/**",
+    "Library/Mobile Documents/**",
+    "Library/CloudStorage/**",
+    "Library/Application Support/com.apple.sharedfilelist/**",
+    "Library/Application Support/AddressBook/**",
+    "Library/Application Support/CallHistoryTransactions/**",
+    "Library/Application Support/CallHistoryDB/**",
+    "Pictures/Photos Library.photoslibrary/**",
+)
+
+
+def _glob_base_path(glob: str) -> Path:
+    """Return the non-wildcard path prefix for a relative glob."""
+    parts = []
+    for part in Path(glob).parts:
+        if any(ch in part for ch in "*?["):
+            break
+        parts.append(part)
+    return Path(*parts) if parts else Path(".")
+
+
+def _macos_tcc_excluded_globs_for_root(search_root: str) -> list[str]:
+    """Return macOS TCC exclusion globs relative to ``search_root``.
+
+    Only broad searches whose root is an ancestor of a protected location get
+    exclusions. If the user explicitly searches inside a protected path such as
+    ``~/Library/Containers``, return no exclusions so intent is preserved.
+    """
+    if sys.platform != "darwin":
+        return []
+
+    try:
+        root = Path(os.path.realpath(os.path.expanduser(search_root))).resolve()
+        home = Path.home().resolve()
+    except Exception:
+        return []
+
+    excluded: list[str] = []
+    for home_glob in _MACOS_TCC_HOME_RELATIVE_GLOBS:
+        protected_base = (home / _glob_base_path(home_glob)).resolve()
+
+        if root == protected_base or protected_base in root.parents:
+            # Explicit search inside a protected location: respect user intent.
+            continue
+
+        try:
+            rel_base = protected_base.relative_to(root)
+        except ValueError:
+            continue
+
+        suffix = home_glob[len(_glob_base_path(home_glob).as_posix()):].lstrip("/")
+        rel_glob = rel_base.as_posix()
+        if suffix:
+            rel_glob = f"{rel_glob}/{suffix}"
+        if rel_glob and rel_glob != ".":
+            excluded.append(rel_glob)
+
+    return excluded
+
+
+def _include_macos_tcc_paths_enabled(include_tcc_paths: bool = False) -> bool:
+    """Return whether macOS TCC-protected search paths should be included."""
+    if include_tcc_paths:
+        return True
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config() or {}
+        agent_config = config.get("agent") or {}
+        search_config = agent_config.get("search") or {}
+        return bool(search_config.get("include_tcc_paths", False))
+    except Exception:
+        return False
 
 
 def _strip_terminal_fence_leaks(text: str) -> str:
@@ -291,7 +376,8 @@ class FileOperations(ABC):
     @abstractmethod
     def search(self, pattern: str, path: str = ".", target: str = "content",
                file_glob: Optional[str] = None, limit: int = 50, offset: int = 0,
-               output_mode: str = "content", context: int = 0) -> SearchResult:
+               output_mode: str = "content", context: int = 0,
+               include_tcc_paths: bool = False) -> SearchResult:
         """Search for content or files."""
         ...
 
@@ -516,6 +602,28 @@ class ShellFileOperations(FileOperations):
         """Escape a string for safe use in shell commands."""
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
+
+    def _find_prune_expr(
+        self,
+        search_root: str,
+        *,
+        exclude_hidden: bool = True,
+        macos_tcc_excludes: Optional[list[str]] = None,
+    ) -> str:
+        """Build a POSIX find prune expression for hidden/TCC directories."""
+        prune_terms: list[str] = []
+        if exclude_hidden:
+            prune_terms.append("-path '*/.*'")
+        for glob in macos_tcc_excludes or []:
+            base = _glob_base_path(glob)
+            if base == Path("."):
+                continue
+            prune_terms.append(
+                f"-path {self._escape_shell_arg(str(Path(search_root) / base))}"
+            )
+        if not prune_terms:
+            return ""
+        return f" \\( {' -o '.join(prune_terms)} \\) -prune -o"
     
     def _unified_diff(self, old_content: str, new_content: str, filename: str) -> str:
         """Generate unified diff between old and new content."""
@@ -943,7 +1051,8 @@ class ShellFileOperations(FileOperations):
     
     def search(self, pattern: str, path: str = ".", target: str = "content",
                file_glob: Optional[str] = None, limit: int = 50, offset: int = 0,
-               output_mode: str = "content", context: int = 0) -> SearchResult:
+               output_mode: str = "content", context: int = 0,
+               include_tcc_paths: bool = False) -> SearchResult:
         """
         Search for content or files.
         
@@ -956,6 +1065,8 @@ class ShellFileOperations(FileOperations):
             offset: Skip first N results
             output_mode: "content", "files_only", or "count"
             context: Lines of context around matches
+            include_tcc_paths: On macOS, include TCC-protected paths that are
+                excluded from broad searches by default to avoid permission prompts
         
         Returns:
             SearchResult with matches or file list
@@ -998,13 +1109,18 @@ class ShellFileOperations(FileOperations):
                 total_count=0
             )
         
+        macos_tcc_excludes = []
+        if not _include_macos_tcc_paths_enabled(include_tcc_paths):
+            macos_tcc_excludes = _macos_tcc_excluded_globs_for_root(path)
+
         if target == "files":
-            return self._search_files(pattern, path, limit, offset)
+            return self._search_files(pattern, path, limit, offset, macos_tcc_excludes)
         else:
             return self._search_content(pattern, path, file_glob, limit, offset, 
-                                        output_mode, context)
+                                        output_mode, context, macos_tcc_excludes)
     
-    def _search_files(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
+    def _search_files(self, pattern: str, path: str, limit: int, offset: int,
+                      macos_tcc_excludes: Optional[list[str]] = None) -> SearchResult:
         """Search for files by name pattern (glob-like)."""
         # Auto-prepend **/ for recursive search if not already present
         if not pattern.startswith('**/') and '/' not in pattern:
@@ -1018,11 +1134,13 @@ class ShellFileOperations(FileOperations):
             for part in search_root.parts
         )
 
+        macos_tcc_excludes = macos_tcc_excludes or []
+
         # Prefer ripgrep: respects .gitignore, excludes hidden dirs by
         # default, and has parallel directory traversal (~200x faster than
         # find on wide trees).  Mirrors _search_content which already uses rg.
         if self._has_command('rg'):
-            return self._search_files_rg(search_pattern, path, limit, offset)
+            return self._search_files_rg(search_pattern, path, limit, offset, macos_tcc_excludes)
 
         # Fallback: find (slower, no .gitignore awareness)
         if not self._has_command('find'):
@@ -1032,9 +1150,13 @@ class ShellFileOperations(FileOperations):
                       "https://github.com/BurntSushi/ripgrep#installation"
             )
 
-        # Exclude hidden directories (matching ripgrep's default behavior).
-        hidden_exclude = "-not -path '*/.*'" if not has_hidden_path_ancestor else ""
-        hidden_filter_expr = f" {hidden_exclude}" if hidden_exclude else ""
+        # Exclude hidden directories (matching ripgrep's default behavior) and
+        # prune macOS TCC-protected locations so find does not recurse into them.
+        prune_expr = self._find_prune_expr(
+            path,
+            exclude_hidden=not has_hidden_path_ancestor,
+            macos_tcc_excludes=macos_tcc_excludes,
+        )
 
         # Use shell pagination for standard roots. For hidden roots, gather full
         # output so we can re-apply hidden-descendant filtering while allowing
@@ -1043,14 +1165,14 @@ class ShellFileOperations(FileOperations):
         if not has_hidden_path_ancestor:
             pagination_expr = f" | tail -n +{offset + 1} | head -n {limit}"
 
-        cmd = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+        cmd = f"find {self._escape_shell_arg(path)}{prune_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
               f"-printf '%T@ %p\\n' 2>/dev/null | sort -rn{pagination_expr}"
 
         result = self._exec(cmd, timeout=60)
 
         if not result.stdout.strip():
             # Try without -printf (BSD find compatibility -- macOS)
-            cmd_simple = f"find {self._escape_shell_arg(path)}{hidden_filter_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
+            cmd_simple = f"find {self._escape_shell_arg(path)}{prune_expr} -type f -name {self._escape_shell_arg(search_pattern)} " \
                         f"2>/dev/null | sort -rn{pagination_expr}"
             result = self._exec(cmd_simple, timeout=60)
 
@@ -1086,7 +1208,8 @@ class ShellFileOperations(FileOperations):
             total_count=len(files)
         )
 
-    def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
+    def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int,
+                         macos_tcc_excludes: Optional[list[str]] = None) -> SearchResult:
         """Search for files by name using ripgrep's --files mode.
 
         rg --files respects .gitignore and excludes hidden directories by
@@ -1101,11 +1224,17 @@ class ShellFileOperations(FileOperations):
         else:
             glob_pattern = pattern
 
+        exclude_parts = []
+        for glob in macos_tcc_excludes or []:
+            exclude_parts.extend(["--glob", self._escape_shell_arg(f"!{glob}")])
+        exclude_flags = " ".join(exclude_parts)
+        exclude_flags = f" {exclude_flags}" if exclude_flags else ""
+
         fetch_limit = limit + offset
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
-            f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
+            f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)}"
+            f"{exclude_flags} {self._escape_shell_arg(path)} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
@@ -1114,8 +1243,8 @@ class ShellFileOperations(FileOperations):
         if not all_files:
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
-                f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
+                f"rg --files -g {self._escape_shell_arg(glob_pattern)}"
+                f"{exclude_flags} {self._escape_shell_arg(path)} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
@@ -1130,15 +1259,17 @@ class ShellFileOperations(FileOperations):
         )
     
     def _search_content(self, pattern: str, path: str, file_glob: Optional[str],
-                        limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+                        limit: int, offset: int, output_mode: str, context: int,
+                        macos_tcc_excludes: Optional[list[str]] = None) -> SearchResult:
         """Search for content inside files (grep-like)."""
+        macos_tcc_excludes = macos_tcc_excludes or []
         # Try ripgrep first (fast), fallback to grep (slower but works)
         if self._has_command('rg'):
             return self._search_with_rg(pattern, path, file_glob, limit, offset, 
-                                        output_mode, context)
+                                        output_mode, context, macos_tcc_excludes)
         elif self._has_command('grep'):
             return self._search_with_grep(pattern, path, file_glob, limit, offset,
-                                          output_mode, context)
+                                          output_mode, context, macos_tcc_excludes)
         else:
             # Neither rg nor grep available (Windows without Git Bash, etc.)
             return SearchResult(
@@ -1147,7 +1278,8 @@ class ShellFileOperations(FileOperations):
             )
     
     def _search_with_rg(self, pattern: str, path: str, file_glob: Optional[str],
-                        limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+                        limit: int, offset: int, output_mode: str, context: int,
+                        macos_tcc_excludes: Optional[list[str]] = None) -> SearchResult:
         """Search using ripgrep."""
         cmd_parts = ["rg", "--line-number", "--no-heading", "--with-filename"]
         
@@ -1158,6 +1290,11 @@ class ShellFileOperations(FileOperations):
         # Add file glob filter (must be quoted to prevent shell expansion)
         if file_glob:
             cmd_parts.extend(["--glob", self._escape_shell_arg(file_glob)])
+
+        # On macOS broad searches, skip TCC-protected paths to avoid repeated
+        # permission prompts from app containers and privacy-protected stores.
+        for glob in macos_tcc_excludes or []:
+            cmd_parts.extend(["--glob", self._escape_shell_arg(f"!{glob}")])
         
         # Output mode handling
         if output_mode == "files_only":
@@ -1245,21 +1382,29 @@ class ShellFileOperations(FileOperations):
             )
     
     def _search_with_grep(self, pattern: str, path: str, file_glob: Optional[str],
-                          limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
+                          limit: int, offset: int, output_mode: str, context: int,
+                          macos_tcc_excludes: Optional[list[str]] = None) -> SearchResult:
         """Fallback search using grep."""
-        cmd_parts = ["grep", "-rnH"]  # -H forces filename even for single-file searches
+        macos_tcc_excludes = macos_tcc_excludes or []
+        use_find_prefilter = bool(macos_tcc_excludes)
+        cmd_parts = ["grep", "-nH" if use_find_prefilter else "-rnH"]
         
         # Exclude hidden directories (matching ripgrep's default behavior).
         # This prevents searching inside .hub/index-cache/, .git/, etc.
-        cmd_parts.append("--exclude-dir='.*'")
+        if not use_find_prefilter:
+            cmd_parts.append("--exclude-dir='.*'")
         
         # Add context if requested
         if context > 0:
             cmd_parts.extend(["-C", str(context)])
         
         # Add file pattern filter (must be quoted to prevent shell expansion)
+        find_name_filter = ""
         if file_glob:
-            cmd_parts.extend(["--include", self._escape_shell_arg(file_glob)])
+            if use_find_prefilter:
+                find_name_filter = f" -name {self._escape_shell_arg(file_glob)}"
+            else:
+                cmd_parts.extend(["--include", self._escape_shell_arg(file_glob)])
         
         # Output mode handling
         if output_mode == "files_only":
@@ -1269,13 +1414,30 @@ class ShellFileOperations(FileOperations):
         
         # Add pattern and path
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        if not use_find_prefilter:
+            cmd_parts.append(self._escape_shell_arg(path))
         
         # Fetch generously so we can compute total before slicing
         fetch_limit = limit + offset + (200 if context > 0 else 0)
-        cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])
-        
-        cmd = " ".join(cmd_parts)
+        if use_find_prefilter:
+            search_root = Path(path)
+            has_hidden_path_ancestor = any(
+                part not in (".", "..") and part.startswith(".")
+                for part in search_root.parts
+            )
+            prune_expr = self._find_prune_expr(
+                path,
+                exclude_hidden=not has_hidden_path_ancestor,
+                macos_tcc_excludes=macos_tcc_excludes,
+            )
+            grep_cmd = " ".join(cmd_parts)
+            cmd = (
+                f"find {self._escape_shell_arg(path)}{prune_expr} -type f{find_name_filter} "
+                f"-print0 2>/dev/null | xargs -0 {grep_cmd} | head -n {fetch_limit}"
+            )
+        else:
+            cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])
+            cmd = " ".join(cmd_parts)
         result = self._exec(cmd, timeout=60)
         
         # grep exit codes: 0=matches found, 1=no matches, 2=error

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -946,6 +946,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,
+                include_tcc_paths: bool = False,
                 task_id: str = "default") -> str:
     """Search for content or files."""
     try:
@@ -962,6 +963,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             file_glob or "",
             limit,
             offset,
+            bool(include_tcc_paths),
         )
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
@@ -988,7 +990,8 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         file_ops = _get_file_ops(task_id)
         result = file_ops.search(
             pattern=pattern, path=path, target=target, file_glob=file_glob,
-            limit=limit, offset=offset, output_mode=output_mode, context=context
+            limit=limit, offset=offset, output_mode=output_mode, context=context,
+            include_tcc_paths=include_tcc_paths
         )
         if hasattr(result, 'matches'):
             for m in result.matches:
@@ -1083,7 +1086,8 @@ SEARCH_FILES_SCHEMA = {
             "limit": {"type": "integer", "description": "Maximum number of results to return (default: 50)", "default": 50},
             "offset": {"type": "integer", "description": "Skip first N results for pagination (default: 0)", "default": 0},
             "output_mode": {"type": "string", "enum": ["content", "files_only", "count"], "description": "Output format for grep mode: 'content' shows matching lines with line numbers, 'files_only' lists file paths, 'count' shows match counts per file", "default": "content"},
-            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0}
+            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0},
+            "include_tcc_paths": {"type": "boolean", "description": "macOS only: include TCC-protected paths (such as ~/Library/Containers, Mail, Messages, Calendars, Reminders, Mobile Documents/iCloud, and Photos Library) that broad searches exclude by default to avoid repeated permission prompts. Use only when the user explicitly wants those locations searched and understands macOS may prompt for access.", "default": False}
         },
         "required": ["pattern"]
     }
@@ -1134,7 +1138,8 @@ def _handle_search_files(args, **kw):
     return search_tool(
         pattern=args.get("pattern", ""), target=target, path=args.get("path", "."),
         file_glob=args.get("file_glob"), limit=args.get("limit", 50), offset=args.get("offset", 0),
-        output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
+        output_mode=args.get("output_mode", "content"), context=args.get("context", 0),
+        include_tcc_paths=args.get("include_tcc_paths", False), task_id=tid)
 
 
 registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)


### PR DESCRIPTION
## Summary
- add macOS-only TCC protected-path exclusions for broad `search_files` file and content searches across ripgrep, find, and grep fallback paths
- preserve explicit user intent with `include_tcc_paths=True` plus `agent.search.include_tcc_paths` config override
- add macOS prompt guidance and README docs for Full Disk Access / explicit opt-in behavior

## Context
Refs nesquena/hermes-webui#1485.

This covers the same problem space as #19651, but includes the full WebUI issue acceptance surface: Containers/Group Containers/Mail/Messages/Calendars/Reminders/Mobile Documents/CloudStorage/Photos Library, per-call and per-config opt-ins, prompt guidance, and grep/find pruning that avoids recursing into protected containers.

## Test Plan
- [x] `python -m pytest tests/tools/test_file_operations.py tests/tools/test_search_hidden_dirs.py tests/tools/test_macos_tcc_search_exclusions.py tests/tools/test_search_files_schema.py tests/agent/test_macos_tcc_prompt_hint.py -q`
- [x] `python -m py_compile tools/file_operations.py tools/file_tools.py agent/prompt_builder.py hermes_cli/config.py`
- [x] `git diff --check`
- [x] `git merge-tree --write-tree origin/main HEAD`