### PR TITLE
fix: use custom provider context for aux compression

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1945,6 +1945,7 @@ class AIAgent:
         # Persist for reuse on switch_model / fallback activation. Must come
         # AFTER the custom_providers branch so per-model overrides aren't lost.
         self._config_context_length = _config_context_length
+        self._custom_providers = _custom_providers
 
         self._ensure_lmstudio_runtime_loaded(_config_context_length)
 
@@ -2652,13 +2653,16 @@ class AIAgent:
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
 
-            aux_context = get_model_context_length(
-                aux_model,
-                base_url=aux_base_url,
-                api_key=aux_api_key,
-                config_context_length=getattr(self, "_aux_compression_context_length_config", None),
-                provider=getattr(self, "provider", ""),
-            )
+            aux_context_kwargs = {
+                "base_url": aux_base_url,
+                "api_key": aux_api_key,
+                "config_context_length": getattr(self, "_aux_compression_context_length_config", None),
+                "provider": getattr(self, "provider", ""),
+            }
+            _custom_providers = getattr(self, "_custom_providers", None)
+            if _custom_providers:
+                aux_context_kwargs["custom_providers"] = _custom_providers
+            aux_context = get_model_context_length(aux_model, **aux_context_kwargs)
 
             # Hard floor: the auxiliary compression model must have at least
             # MINIMUM_CONTEXT_LENGTH (64K) tokens of context.  The main model

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -185,6 +185,42 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
     )
 
 
+@patch("agent.model_metadata.get_model_context_length", return_value=1_000_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_feasibility_check_passes_custom_providers_for_aux_context(mock_get_client, mock_ctx_len):
+    """Named custom provider context_length overrides should be available
+    when probing the auxiliary compression model, not just the main model."""
+    agent = _make_agent(main_context=1_000_000, threshold_percent=0.65)
+    agent._custom_providers = [
+        {
+            "name": "modelhub",
+            "base_url": "https://aidp.example.com/v1",
+            "model": "gpt-5.5-2026-04-24",
+            "models": {
+                "gpt-5.5-2026-04-24": {
+                    "context_length": 1_000_000,
+                },
+            },
+        },
+    ]
+    mock_client = MagicMock()
+    mock_client.base_url = "https://aidp.example.com/v1"
+    mock_client.api_key = "sk-custom"
+    mock_get_client.return_value = (mock_client, "gpt-5.5-2026-04-24")
+
+    agent._emit_status = lambda msg: None
+    agent._check_compression_model_feasibility()
+
+    mock_ctx_len.assert_called_once_with(
+        "gpt-5.5-2026-04-24",
+        base_url="https://aidp.example.com/v1",
+        api_key="sk-custom",
+        config_context_length=None,
+        provider="openrouter",
+        custom_providers=agent._custom_providers,
+    )
+
+
 @patch("agent.model_metadata.get_model_context_length", return_value=128_000)
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_ctx_len):


### PR DESCRIPTION
## Summary
- persist resolved custom_providers on AIAgent
- pass custom_providers into auxiliary compression context-length detection
- add regression coverage for named custom provider per-model context_length

## Test Plan
- /Users/matthew/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_compression_feasibility.py tests/agent/test_model_metadata_local_ctx.py -q -o 'addopts='