### PR TITLE
fix(cli): pin HERMES_KANBAN_BOARD at chat boot to stop subprocess board drift

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1216,6 +1216,26 @@ def _launch_tui(
     sys.exit(code)
 
 
+def _pin_kanban_board_env() -> None:
+    """Pin the active kanban board into ``HERMES_KANBAN_BOARD`` for the chat session.
+
+    Without this, in-process tools (``kanban_*``) and shelled-out CLI calls
+    (``hermes kanban …``) resolve the board on different paths: the env-pin if
+    set, otherwise the global ``<root>/kanban/current`` file. A concurrent
+    ``hermes kanban boards switch`` from another session can flip the file
+    mid-turn, so the same chat sees its tool calls hit board A while its shell
+    calls hit board B (#20074). Pinning at chat boot mirrors what the
+    dispatcher already does for spawned workers.
+    """
+    if os.environ.get("HERMES_KANBAN_BOARD"):
+        return
+    try:
+        from hermes_cli.kanban_db import get_current_board
+        os.environ["HERMES_KANBAN_BOARD"] = get_current_board()
+    except Exception:
+        pass
+
+
 def cmd_chat(args):
     """Run interactive chat CLI."""
     use_tui = getattr(args, "tui", False) or os.environ.get("HERMES_TUI") == "1"
@@ -1323,6 +1343,8 @@ def cmd_chat(args):
     # --source: tag session source for filtering (e.g. 'tool' for third-party integrations)
     if getattr(args, "source", None):
         os.environ["HERMES_SESSION_SOURCE"] = args.source
+
+    _pin_kanban_board_env()
 
     if use_tui:
         _launch_tui(

--- a/tests/hermes_cli/test_pin_kanban_board_env.py
+++ b/tests/hermes_cli/test_pin_kanban_board_env.py
@@ -1,0 +1,54 @@
+"""Tests for `_pin_kanban_board_env` helper invoked by `cmd_chat`.
+
+Regression coverage for #20074: a chat session must export the active kanban
+board into `HERMES_KANBAN_BOARD` at boot so subprocess shell-outs (e.g.
+`hermes kanban …`) inherit the same board the in-process kanban tools resolve.
+Without this, a concurrent `hermes kanban boards switch` from another session
+can flip the global current-board file mid-turn and silently divert the
+shell calls to a different DB.
+"""
+import importlib
+
+
+def test_pin_writes_resolved_board_when_env_unset(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    main_mod = importlib.import_module("hermes_cli.main")
+
+    import hermes_cli.kanban_db as kdb
+    monkeypatch.setattr(kdb, "get_current_board", lambda: "space")
+
+    main_mod._pin_kanban_board_env()
+
+    assert main_mod.os.environ.get("HERMES_KANBAN_BOARD") == "space"
+
+
+def test_pin_does_not_overwrite_existing_env(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "preset")
+    main_mod = importlib.import_module("hermes_cli.main")
+
+    import hermes_cli.kanban_db as kdb
+
+    def _explode():
+        raise AssertionError("get_current_board must not be called when env is set")
+
+    monkeypatch.setattr(kdb, "get_current_board", _explode)
+
+    main_mod._pin_kanban_board_env()
+
+    assert main_mod.os.environ.get("HERMES_KANBAN_BOARD") == "preset"
+
+
+def test_pin_swallows_resolution_failures(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    main_mod = importlib.import_module("hermes_cli.main")
+
+    import hermes_cli.kanban_db as kdb
+
+    def _boom():
+        raise RuntimeError("disk gone")
+
+    monkeypatch.setattr(kdb, "get_current_board", _boom)
+
+    main_mod._pin_kanban_board_env()
+
+    assert "HERMES_KANBAN_BOARD" not in main_mod.os.environ


### PR DESCRIPTION
## What does this PR do?

In `cmd_chat`, pin the resolved kanban board into `HERMES_KANBAN_BOARD` once at boot when the env var isn't already set. Without this, in-process `kanban_*` tools and shelled-out `hermes kanban …` subprocesses resolve the board on different paths — env-var pin if present, otherwise the global `<root>/kanban/current` file. A concurrent `hermes kanban boards switch` from another session can flip that file mid-turn, so the same chat ends up routing tool calls to board A while its shell calls hit board B, surfacing as phantom "no such task" errors when an orchestrator immediately tries to `harness kanban show <id>` after `kanban_create`.

This mirrors the behaviour the dispatcher already has for spawned workers (`hermes_cli/kanban_db.py:2622-2623`) — pin the board into the child env so every code path resolves the same DB. Idempotent and a no-op when the caller has already exported the env (e.g. dispatcher-spawned worker, ad-hoc shell pin).

## Related Issue

Fixes #20074

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`: add `_pin_kanban_board_env()` helper and call it from `cmd_chat` after the existing env-flag block, before forking to TUI vs CLI.
- `tests/hermes_cli/test_pin_kanban_board_env.py`: cover the three branches — pin when unset, no-op when already set, swallow `get_current_board()` failures (boot must never crash because the kanban dir is missing or unreadable).

## How to Test

1. `harness kanban boards switch space` (Terminal 1)
2. `harness -p space-orchestrator chat` (Terminal 1) — leave it sitting at the prompt.
3. `harness kanban boards switch harness-facet` (Terminal 2, concurrent).
4. Back in Terminal 1's chat, ask the orchestrator to `kanban_create` a task and then immediately shell `harness kanban show <id>`. Before the fix, the shell-out lands on `harness-facet` and reports "no such task". After the fix, both calls resolve to `space` because `HERMES_KANBAN_BOARD=space` was pinned at chat boot.
5. Unit tests: `pytest tests/hermes_cli/test_pin_kanban_board_env.py -v` (3/3 pass).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (15 pre-existing failures in gateway/web_server/bedrock unrelated to this change; full hermes_cli suite green except those)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 14.2 (Darwin 23.2.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (helper docstring covers the rationale; no user-facing surface added)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — env-pin is platform-agnostic; mirrors existing dispatcher behaviour.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
