### PR TITLE
feat(gateway): inherit parent chat tail when seeding thread sessions

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -494,6 +494,17 @@ session_reset:
 # explicitly want one shared "room brain" per group/channel.
 group_sessions_per_user: true
 
+# When a user opens a thread/topic on an earlier message (Feishu topic, Slack
+# thread, Discord thread, Telegram forum topic, ...) Hermes normally creates a
+# fresh session keyed by the thread_id and loses the parent chat's
+# conversation context. Set this to a positive integer N to seed the new
+# thread session with the last N user/assistant messages from the parent chat
+# session, so the agent can answer follow-ups about messages it sent before
+# the topic was opened (e.g. an interactive card it just posted).
+# Tool calls and tool results are intentionally skipped (their tool_call_id
+# linkage doesn't survive a session boundary). 0 = disabled (default).
+thread_inherit_messages: 0
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Gateway Streaming
 # ─────────────────────────────────────────────────────────────────────────────

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -420,6 +420,16 @@ class GatewayConfig:
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
     thread_sessions_per_user: bool = False  # When False (default), threads are shared across all participants
 
+    # Thread/topic context inheritance: when a user replies in a thread (Feishu
+    # topic, Slack thread, Discord thread, ...) Hermes normally creates a fresh
+    # session keyed by thread_id, losing the parent chat's conversation context.
+    # When set to a positive integer N, the new thread session is seeded with
+    # the last N messages from the parent chat session (same chat_id, no
+    # thread_id) so the agent can answer follow-up questions about earlier
+    # messages — e.g. an interactive card it posted before the topic was opened.
+    # 0 = disabled (default, original behavior).
+    thread_inherit_messages: int = 0
+
     # Unauthorized DM policy
     unauthorized_dm_behavior: str = "pair"  # "pair" or "ignore"
 
@@ -523,6 +533,7 @@ class GatewayConfig:
             "stt_enabled": self.stt_enabled,
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
+            "thread_inherit_messages": self.thread_inherit_messages,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
@@ -568,6 +579,12 @@ class GatewayConfig:
 
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
+        try:
+            thread_inherit_messages = int(data.get("thread_inherit_messages", 0))
+            if thread_inherit_messages < 0:
+                thread_inherit_messages = 0
+        except (TypeError, ValueError):
+            thread_inherit_messages = 0
         unauthorized_dm_behavior = _normalize_unauthorized_dm_behavior(
             data.get("unauthorized_dm_behavior"),
             "pair",
@@ -592,6 +609,7 @@ class GatewayConfig:
             stt_enabled=_coerce_bool(stt_enabled, True),
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
+            thread_inherit_messages=thread_inherit_messages,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
@@ -681,6 +699,9 @@ def load_gateway_config() -> GatewayConfig:
 
             if "thread_sessions_per_user" in yaml_cfg:
                 gw_data["thread_sessions_per_user"] = yaml_cfg["thread_sessions_per_user"]
+
+            if "thread_inherit_messages" in yaml_cfg:
+                gw_data["thread_inherit_messages"] = yaml_cfg["thread_inherit_messages"]
 
             streaming_cfg = yaml_cfg.get("streaming")
             if isinstance(streaming_cfg, dict):

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -591,6 +591,57 @@ def is_shared_multi_user_session(
     return not group_sessions_per_user
 
 
+def build_parent_chat_session_key(
+    source: SessionSource,
+    group_sessions_per_user: bool = True,
+) -> Optional[str]:
+    """Build the session key of the *parent* chat for a thread message.
+
+    A thread session (Feishu topic, Slack thread, Discord thread, ...) lives
+    under its own session key because :func:`build_session_key` mixes
+    ``thread_id`` into the key.  This helper reconstructs the key the same
+    chat would use **without** the thread, so callers can fetch the
+    pre-thread conversation history and seed the new thread session with it.
+
+    Parent-key construction mirrors :func:`build_session_key` exactly
+    (chat_type, chat_id, per-user isolation) but with ``thread_id`` stripped.
+    The participant id is preserved when ``group_sessions_per_user`` is True
+    so the parent points at *this user's* slice of the chat — which matches
+    the typical "user opens a topic on a private message Hermes sent them"
+    scenario.
+
+    Returns ``None`` for sources that have no thread_id (no parent to inherit
+    from) or DM sources (DM thread semantics are handled inside
+    :func:`build_session_key` directly — the caller already has the right
+    history loaded).
+    """
+    if not source.thread_id:
+        return None
+    if source.chat_type == "dm":
+        return None
+    parent = SessionSource(
+        platform=source.platform,
+        chat_id=source.chat_id,
+        chat_name=source.chat_name,
+        chat_type=source.chat_type,
+        user_id=source.user_id,
+        user_name=source.user_name,
+        thread_id=None,
+        chat_topic=source.chat_topic,
+        user_id_alt=source.user_id_alt,
+        chat_id_alt=source.chat_id_alt,
+        is_bot=source.is_bot,
+        guild_id=source.guild_id,
+        parent_chat_id=source.parent_chat_id,
+        message_id=None,
+    )
+    return build_session_key(
+        parent,
+        group_sessions_per_user=group_sessions_per_user,
+        thread_sessions_per_user=False,
+    )
+
+
 def build_session_key(
     source: SessionSource,
     group_sessions_per_user: bool = True,
@@ -932,6 +983,28 @@ class SessionStore:
                 "source": source.platform.value,
                 "user_id": source.user_id,
             }
+            # First-time creation of a thread/topic session — capture the
+            # parent chat session_id (if any) so we can inherit its tail
+            # outside the lock.  Only fires on truly fresh sessions: an
+            # auto-reset means a prior thread session existed and was already
+            # seeded once; force_new is the user explicitly asking for a
+            # blank slate.
+            should_inherit = (
+                bool(source.thread_id)
+                and not was_auto_reset
+                and not force_new
+                and getattr(self.config, "thread_inherit_messages", 0) > 0
+            )
+            inherit_parent_session_id = None
+            if should_inherit:
+                parent_key = build_parent_chat_session_key(
+                    source,
+                    group_sessions_per_user=getattr(
+                        self.config, "group_sessions_per_user", True
+                    ),
+                )
+                if parent_key and parent_key in self._entries:
+                    inherit_parent_session_id = self._entries[parent_key].session_id
 
         # SQLite operations outside the lock
         if self._db and db_end_session_id:
@@ -946,7 +1019,104 @@ class SessionStore:
             except Exception as e:
                 print(f"[gateway] Warning: Failed to create SQLite session: {e}")
 
+        # Inherit parent chat context into the new thread session.  Runs
+        # outside the lock so SQLite writes don't deadlock against concurrent
+        # session lookups; failures degrade gracefully (the new session just
+        # starts empty, original behavior).
+        if inherit_parent_session_id:
+            try:
+                self._seed_thread_session_from_parent(
+                    new_session_id=entry.session_id,
+                    parent_session_id=inherit_parent_session_id,
+                    limit=int(getattr(self.config, "thread_inherit_messages", 0)),
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Failed to inherit thread context for session %s from %s: %s",
+                    entry.session_id,
+                    inherit_parent_session_id,
+                    exc,
+                )
+
         return entry
+
+    def _seed_thread_session_from_parent(
+        self,
+        *,
+        new_session_id: str,
+        parent_session_id: str,
+        limit: int,
+    ) -> None:
+        """Copy the tail of ``parent_session_id`` into ``new_session_id``.
+
+        Only ``user`` and plain ``assistant`` messages are carried over —
+        tool calls and tool results are skipped on purpose because their
+        ``tool_call_id`` linkage is fragile across session boundaries (a
+        copied ``tool`` row pointing at an ``assistant`` whose ``tool_calls``
+        we dropped would break replay).  The agent still gets the
+        conversational substance, which is what the user typically refers
+        to when opening a topic.
+
+        Prepends a single ``system`` marker so the model can tell inherited
+        history apart from the live thread turn.
+        """
+        if limit <= 0 or self._db is None:
+            return
+
+        try:
+            history = self._db.get_messages_as_conversation(parent_session_id)
+        except Exception as exc:
+            logger.debug(
+                "Could not load parent transcript for inheritance: %s", exc
+            )
+            return
+        if not history:
+            return
+
+        carry: List[Dict[str, Any]] = []
+        for msg in history:
+            role = msg.get("role")
+            if role not in {"user", "assistant"}:
+                continue
+            if role == "assistant" and msg.get("tool_calls"):
+                continue
+            content = msg.get("content")
+            if content in (None, ""):
+                continue
+            carry.append({"role": role, "content": content})
+
+        if not carry:
+            return
+
+        # Tail-trim: keep the last ``limit`` messages, but never split a
+        # user→assistant pair across the boundary so the model sees a
+        # coherent prefix.
+        if len(carry) > limit:
+            carry = carry[-limit:]
+            if carry and carry[0].get("role") == "assistant":
+                carry = carry[1:]
+        if not carry:
+            return
+
+        marker = {
+            "role": "system",
+            "content": (
+                "[Inherited context — the next "
+                f"{len(carry)} message(s) are the tail of the parent chat "
+                "conversation that preceded this thread/topic. Treat them as "
+                "background, not as the user's current request.]"
+            ),
+        }
+        for msg in [marker, *carry]:
+            try:
+                self.append_to_transcript(new_session_id, msg)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to append inherited message into %s: %s",
+                    new_session_id,
+                    exc,
+                )
+                return
 
     def update_session(
         self,

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -8,6 +8,7 @@ from gateway.config import Platform, HomeChannel, GatewayConfig, PlatformConfig
 from gateway.session import (
     SessionSource,
     SessionStore,
+    build_parent_chat_session_key,
     build_session_context,
     build_session_context_prompt,
     build_session_key,
@@ -1284,3 +1285,268 @@ class TestRewriteTranscriptPreservesReasoning:
             "before user",
             "before assistant",
         ]
+
+
+# ---------------------------------------------------------------------------
+# Thread/topic context inheritance — when a user replies in a thread, the
+# fresh thread session should be seeded with the tail of the parent chat
+# session so the agent can answer follow-ups about earlier messages
+# (e.g. an interactive card it posted before the topic was opened).
+# ---------------------------------------------------------------------------
+class TestBuildParentChatSessionKey:
+    def test_returns_none_for_source_without_thread(self):
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_grp",
+            chat_type="group",
+            user_id="u1",
+        )
+        assert build_parent_chat_session_key(source) is None
+
+    def test_returns_none_for_dm_thread(self):
+        # DMs already include thread_id in their primary session key when
+        # present, but the inheritance feature does not apply (the user
+        # already sees their own DM history end-to-end).
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_dm",
+            chat_type="dm",
+            thread_id="topic-1",
+            user_id="u1",
+        )
+        assert build_parent_chat_session_key(source) is None
+
+    def test_strips_thread_id_for_group_topic(self):
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_grp",
+            chat_type="group",
+            thread_id="topic-1",
+            user_id="u1",
+        )
+        parent = build_parent_chat_session_key(source, group_sessions_per_user=True)
+        live = build_session_key(source, group_sessions_per_user=True)
+        # Parent must be the same chat without the thread_id segment.
+        assert parent == "agent:main:feishu:group:oc_grp:u1"
+        assert live != parent
+        assert "topic-1" not in parent
+
+    def test_preserves_per_user_isolation_when_enabled(self):
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_grp",
+            chat_type="group",
+            thread_id="topic-1",
+            user_id="alice",
+        )
+        parent = build_parent_chat_session_key(source, group_sessions_per_user=True)
+        assert parent.endswith(":alice")
+
+    def test_returns_shared_parent_when_isolation_disabled(self):
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_grp",
+            chat_type="group",
+            thread_id="topic-1",
+            user_id="alice",
+        )
+        parent = build_parent_chat_session_key(
+            source, group_sessions_per_user=False
+        )
+        assert parent == "agent:main:feishu:group:oc_grp"
+
+
+class TestThreadContextInheritance:
+    """When ``thread_inherit_messages > 0``, opening a thread/topic seeds
+    the fresh session with the tail of the parent chat conversation."""
+
+    @pytest.fixture()
+    def store_with_db(self, tmp_path):
+        from hermes_state import SessionDB
+
+        config = GatewayConfig(thread_inherit_messages=5)
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+        store._db = SessionDB(db_path=tmp_path / "state.db")
+        store._loaded = True
+        return store
+
+    @staticmethod
+    def _parent_source() -> SessionSource:
+        return SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_chat",
+            chat_type="group",
+            user_id="alice",
+            user_name="Alice",
+        )
+
+    @staticmethod
+    def _thread_source(thread_id: str = "topic-1") -> SessionSource:
+        return SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_chat",
+            chat_type="group",
+            thread_id=thread_id,
+            user_id="alice",
+            user_name="Alice",
+        )
+
+    def _seed_parent(self, store, messages):
+        parent_entry = store.get_or_create_session(self._parent_source())
+        for msg in messages:
+            store.append_to_transcript(parent_entry.session_id, msg)
+        return parent_entry
+
+    def test_inherits_parent_tail_into_new_thread_session(self, store_with_db):
+        self._seed_parent(
+            store_with_db,
+            [
+                {"role": "user", "content": "What's the diagnostic status?"},
+                {"role": "assistant", "content": "Here's the report card..."},
+                {"role": "user", "content": "Anything urgent?"},
+                {"role": "assistant", "content": "Two warnings, no errors."},
+            ],
+        )
+
+        thread_entry = store_with_db.get_or_create_session(self._thread_source())
+
+        carried = store_with_db.load_transcript(thread_entry.session_id)
+        # 1 system marker + 4 inherited user/assistant messages
+        assert len(carried) == 5
+        assert carried[0]["role"] == "system"
+        assert "Inherited context" in carried[0]["content"]
+        assert carried[1] == {
+            "role": "user",
+            "content": "What's the diagnostic status?",
+        }
+        assert carried[-1] == {
+            "role": "assistant",
+            "content": "Two warnings, no errors.",
+        }
+
+    def test_disabled_when_thread_inherit_messages_is_zero(self, tmp_path):
+        from hermes_state import SessionDB
+
+        config = GatewayConfig(thread_inherit_messages=0)
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+        store._db = SessionDB(db_path=tmp_path / "state.db")
+        store._loaded = True
+
+        # Seed parent
+        parent_entry = store.get_or_create_session(self._parent_source())
+        store.append_to_transcript(
+            parent_entry.session_id, {"role": "user", "content": "hi"}
+        )
+        store.append_to_transcript(
+            parent_entry.session_id, {"role": "assistant", "content": "hello"}
+        )
+
+        thread_entry = store.get_or_create_session(self._thread_source())
+        assert store.load_transcript(thread_entry.session_id) == []
+
+    def test_no_inheritance_when_parent_session_does_not_exist(self, store_with_db):
+        """Opening a topic without prior chat history starts empty."""
+        thread_entry = store_with_db.get_or_create_session(self._thread_source())
+        assert store_with_db.load_transcript(thread_entry.session_id) == []
+
+    def test_skips_tool_calls_and_tool_messages(self, store_with_db):
+        """Inheritance must not carry tool_call_id linkage across sessions —
+        a copied ``tool`` row whose paired ``assistant.tool_calls`` got
+        dropped would break replay.  We only carry plain user/assistant text."""
+        self._seed_parent(
+            store_with_db,
+            [
+                {"role": "user", "content": "run the check"},
+                {
+                    "role": "assistant",
+                    "content": "calling tool",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "diag", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call-1",
+                    "tool_name": "diag",
+                    "content": "OK",
+                },
+                {"role": "assistant", "content": "All systems green."},
+                {"role": "user", "content": "thanks"},
+            ],
+        )
+
+        thread_entry = store_with_db.get_or_create_session(self._thread_source())
+        carried = store_with_db.load_transcript(thread_entry.session_id)
+        roles = [m["role"] for m in carried]
+        # marker + user + assistant(plain) + user — no tool/tool_calls rows
+        assert roles == ["system", "user", "assistant", "user"]
+        contents = [m["content"] for m in carried[1:]]
+        assert contents == [
+            "run the check",
+            "All systems green.",
+            "thanks",
+        ]
+
+    def test_tail_trims_to_configured_limit(self, store_with_db):
+        # 8 plain messages, limit=5 → keep last 5 (and drop a leading
+        # assistant if present so the prefix opens with a user turn).
+        msgs = []
+        for i in range(4):
+            msgs.append({"role": "user", "content": f"q{i}"})
+            msgs.append({"role": "assistant", "content": f"a{i}"})
+        self._seed_parent(store_with_db, msgs)
+
+        thread_entry = store_with_db.get_or_create_session(self._thread_source())
+        carried = store_with_db.load_transcript(thread_entry.session_id)
+        # marker + at most 5 inherited messages, prefix never starts with
+        # an assistant turn.
+        assert carried[0]["role"] == "system"
+        assert len(carried) - 1 <= 5
+        assert carried[1]["role"] == "user"
+        assert carried[-1]["content"] == "a3"
+
+    def test_force_new_skips_inheritance(self, store_with_db):
+        """``/new`` should produce a clean slate — no inherited prefix."""
+        self._seed_parent(
+            store_with_db,
+            [
+                {"role": "user", "content": "earlier"},
+                {"role": "assistant", "content": "earlier reply"},
+            ],
+        )
+        thread_entry = store_with_db.get_or_create_session(
+            self._thread_source(), force_new=True
+        )
+        assert store_with_db.load_transcript(thread_entry.session_id) == []
+
+    def test_subsequent_access_does_not_reinherit(self, store_with_db):
+        """Returning to an existing thread session must not duplicate
+        inherited messages — inheritance only seeds the *first* creation."""
+        self._seed_parent(
+            store_with_db,
+            [
+                {"role": "user", "content": "earlier"},
+                {"role": "assistant", "content": "earlier reply"},
+            ],
+        )
+        first = store_with_db.get_or_create_session(self._thread_source())
+        seeded = store_with_db.load_transcript(first.session_id)
+
+        # Append a real thread turn so the next access has something to find.
+        store_with_db.append_to_transcript(
+            first.session_id, {"role": "user", "content": "thread turn"}
+        )
+        second = store_with_db.get_or_create_session(self._thread_source())
+        assert second.session_id == first.session_id
+
+        after = store_with_db.load_transcript(first.session_id)
+        # Just the original seed + the new turn — no second copy of the
+        # inherited prefix.
+        assert len(after) == len(seeded) + 1
+        assert after[-1]["content"] == "thread turn"


### PR DESCRIPTION
## What does this PR do?

When a user opens a thread/topic on an earlier message (Feishu topic, Slack thread, Discord thread, Telegram forum topic, ...) Hermes creates a fresh session keyed by the `thread_id` and loses the parent chat's conversation context. The only bridge today is the 500-char `reply_to_text` snippet from the immediate parent message — for interactive cards (Feishu/Slack) the extracted text is at most 12 lines, so the agent often cannot answer follow-ups about its own card content.

**Concrete failure mode:** a Feishu user replies in a topic to a Hermes-posted diagnostic card and asks "expand on step 2", and Hermes responds "I can't see the card content" because the topic session has no link to the original chat history.

This PR adds an opt-in `thread_inherit_messages: int = 0` field on `GatewayConfig`. When set to a positive integer N, the first time a thread session is created for a given `(chat_id, thread_id)`, the new session is seeded with the last N plain user/assistant messages from the parent chat session (same `chat_id`, no `thread_id`), preceded by a single `system` marker so the model can distinguish inherited history from the live thread turn.

## Related Issue

No existing issue — surfaced from a real Feishu deployment where users routinely open topics on agent-posted cards. Happy to file a tracking issue if preferred.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/config.py` — new `thread_inherit_messages: int = 0` field on `GatewayConfig` with `to_dict`/`from_dict` round-trip and YAML config merge support.
- `gateway/session.py` — new public helper `build_parent_chat_session_key(source, group_sessions_per_user)` that mirrors `build_session_key` but strips `thread_id`, so callers can locate the pre-thread conversation. New `SessionStore._seed_thread_session_from_parent(...)` carries the parent transcript tail into a freshly-created thread session via the existing `append_to_transcript` path (SQLite + JSONL).
- `SessionStore.get_or_create_session(...)` — only the *first* creation of a thread session triggers seeding; auto-reset and `force_new` skip it (so `/new` still produces a clean slate and idle/daily reset doesn't double-seed). All inheritance work happens outside the `_lock`.
- `cli-config.yaml.example` — documents the new key alongside `group_sessions_per_user`.
- `tests/gateway/test_session.py` — 12 new tests in two classes (`TestBuildParentChatSessionKey`, `TestThreadContextInheritance`).

### Why drop tool calls / tool results during inheritance?

`tool_call_id` linkage is fragile across a session boundary. A copied `tool` row whose paired `assistant.tool_calls` got dropped (or vice-versa) would break the next turn at replay. The substance users actually reference when opening a topic is the conversation content (user questions + assistant answers), so the implementation only carries `role in {"user", "assistant"}` rows with non-empty content and skips assistant rows that contain `tool_calls`. The tail trim also guarantees the prefix never opens with an assistant turn, so the inherited slice is a coherent user→assistant alternation.

### Backward compatibility

Default is `0` (disabled) — existing deployments see no behavior change. Opt-in by setting the value in `~/.hermes/config.yaml` or `gateway.json`.

## How to Test

1. Set `thread_inherit_messages: 5` in `~/.hermes/config.yaml`.
2. In a group chat, send a few messages so Hermes builds a parent session transcript.
3. Open a topic/thread on one of Hermes' replies and ask a follow-up that depends on the earlier exchange ("expand on point 2", "what was the second card?").
4. The agent now sees the last 5 user/assistant turns from the parent chat as context (prefixed by a `[Inherited context — ...]` system note) and can answer the follow-up.
5. Set the value back to `0` (or leave unset) to confirm the original behavior — the topic session starts empty, only the `[Replying to: "..."]` snippet from `run.py` is available.

Automated:

```bash
pytest tests/gateway/test_session.py -q
```

Result on this branch: **89 passed** (77 pre-existing + 12 new). Wider sweep across `tests/gateway/test_session*.py`, `test_base_topic_sessions.py`, `test_session_dm_thread_seeding.py`, `test_discord_thread_persistence.py`, `test_telegram_thread_fallback.py`, `test_session_store_prune.py`, `test_session_reset_notify.py`, `test_session_race_guard.py`, `test_session_state_cleanup.py` and `tests/gateway/test_config*.py` — all green (164 + 69 = 233 passes).

The 12 failures observed on a full `pytest tests/gateway/ -q` are reproducible on a clean `origin/main` and unrelated to this change (`test_dingtalk.py` AI-card lifecycle, `test_whatsapp_connect.py` bridge-runtime mocks, `test_approve_deny_commands.py::test_blocking_approval_approve_once`, `test_discord_free_response.py::test_discord_free_channel_skips_auto_thread`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(gateway): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_session.py -q` and all tests pass
- [x] I've added tests for my changes (12 new test cases)
- [x] I've tested on my platform: macOS 15.x (Darwin 25.3.0), Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (config dataclass docstring + inline comment on the new field)
- [x] I've updated `cli-config.yaml.example` for the new config key
- [x] N/A — no architectural change, gated behind a default-off config flag
- [x] N/A — change is platform-agnostic, lives above the platform adapters
- [x] N/A — no tool behavior change

## Screenshots / Logs

Sample inherited-history transcript when opening a topic on an earlier reply:

```json
[
  {"role": "system",    "content": "[Inherited context — the next 4 message(s) are the tail of the parent chat conversation that preceded this thread/topic. Treat them as background, not as the user's current request.]"},
  {"role": "user",      "content": "What's the diagnostic status?"},
  {"role": "assistant", "content": "Here's the report card..."},
  {"role": "user",      "content": "Anything urgent?"},
  {"role": "assistant", "content": "Two warnings, no errors."},
  {"role": "user",      "content": "<the actual thread reply>"}
]
```
