### PR TITLE
Fix AES key decoding issue with WeCom API response

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1015,7 +1015,9 @@ class WeComAdapter(BasePlatformAdapter):
         if not aes_key:
             raise ValueError("aes_key is required")
 
-        key = base64.b64decode(aes_key)
+        # WeCom may return aeskey without base64 padding chars; add them if missing
+        padded_key = aes_key + '=' * (-len(aes_key) % 4)
+        key = base64.b64decode(padded_key)
         if len(key) != 32:
             raise ValueError(f"Invalid WeCom AES key length: expected 32 bytes, got {len(key)}")
 


### PR DESCRIPTION
…ring (missing the = padding character). Directly using base64.b64decode() will result in an 'Incorrect padding' error, preventing the image from being decrypted

## What does this PR do?

Fix the issue where Hermes cannot decrypt images sent via WeCom (企业微信). WeCom returns aeskey as Base64-encoded but missing padding (43 chars instead of 44), causing base64.b64decode() to throw Incorrect padding error. The exception is caught and the image is skipped, making Hermes reply “没有看到图片”.


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change


- [ x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

gateway/platforms/wecom.py - _decrypt_file_bytes function (~line 1018)
# Before
key_bytes = base64.b64decode(aeskey)

# After
key_bytes = base64.b64decode(aeskey + '=' * (-len(aeskey) % 4))

- 

## How to Test


1. Start Hermes and connect to WeCom WebSocket
2. Send an image to Hermes via WeCom
3. Verify the log shows Decrypted image ok, decrypted_len=xxxx and the image is successfully sent to the LLM



## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping


- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I’ve considered cross-platform impact (Windows, macOS) — N/A (base64 padding fix works cross-platform)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


## Screenshots / Logs

Failed to decrypt image from URL: Incorrect padding
Empty WeCom message skipped
issue Screenshot
<img width="1260" height="2720" alt="b587e08b56e8199c0ec81a04af8b37f3" src="https://github.com/user-attachments/assets/9d1ad492-9a68-4ddb-be85-0a67417f6c8f" />
fixed Screenshot
<img width="1260" height="2720" alt="6d0b44ff37c2613c1f103d4d81d44a76" src="https://github.com/user-attachments/assets/3f7534e2-bdf1-4b14-956a-d48cc7ce8401" />



