### PR TITLE
fix: reduce false positives in terminal safety filter for nohup/disown/setsid

### DIFF
--- a/tests/tools/test_terminal_foreground_timeout_cap.py
+++ b/tests/tools/test_terminal_foreground_timeout_cap.py
@@ -63,6 +63,94 @@ class TestForegroundTimeoutCap:
         assert "background=true" in result["error"]
         assert "nohup" in result["error"].lower()
 
+    def test_foreground_allows_setsid_mentioned_in_string(self):
+        """Commands mentioning setsid inside quotes should NOT be blocked."""
+        from tools.terminal_tool import terminal_tool
+
+        with patch("tools.terminal_tool._get_env_config", return_value=_make_env_config()), \
+             patch("tools.terminal_tool._start_cleanup_thread"):
+
+            mock_env = MagicMock()
+            mock_env.execute.return_value = {"output": "done", "returncode": 0}
+
+            with patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
+                 patch("tools.terminal_tool._last_activity", {"default": 0}), \
+                 patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}):
+                result = json.loads(terminal_tool(
+                    command="git commit -m 'fix: replace setsid with process_group'",
+                ))
+
+        assert result.get("error") is None
+        assert mock_env.execute.called
+
+    def test_foreground_allows_setsid_in_python_code(self):
+        """Python code mentioning setsid in a string should NOT be blocked."""
+        from tools.terminal_tool import terminal_tool
+
+        with patch("tools.terminal_tool._get_env_config", return_value=_make_env_config()), \
+             patch("tools.terminal_tool._start_cleanup_thread"):
+
+            mock_env = MagicMock()
+            mock_env.execute.return_value = {"output": "done", "returncode": 0}
+
+            with patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
+                 patch("tools.terminal_tool._last_activity", {"default": 0}), \
+                 patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}):
+                result = json.loads(terminal_tool(
+                    command="python3 -c \"x = 'preexec_fn=os.setsid'\"",
+                ))
+
+        assert result.get("error") is None
+        assert mock_env.execute.called
+
+    def test_foreground_allows_setsid_in_echo(self):
+        """echo/grep mentioning setsid should NOT be blocked."""
+        from tools.terminal_tool import terminal_tool
+
+        with patch("tools.terminal_tool._get_env_config", return_value=_make_env_config()), \
+             patch("tools.terminal_tool._start_cleanup_thread"):
+
+            mock_env = MagicMock()
+            mock_env.execute.return_value = {"output": "done", "returncode": 0}
+
+            with patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
+                 patch("tools.terminal_tool._last_activity", {"default": 0}), \
+                 patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}):
+                result = json.loads(terminal_tool(
+                    command="echo 'The function os.setsid() creates a new session'",
+                ))
+
+        assert result.get("error") is None
+        assert mock_env.execute.called
+
+    def test_foreground_rejects_setsid_after_semicolon(self):
+        """setsid used as a command after ; should still be blocked."""
+        from tools.terminal_tool import terminal_tool
+
+        with patch("tools.terminal_tool._get_env_config", return_value=_make_env_config()), \
+             patch("tools.terminal_tool._start_cleanup_thread"):
+
+            result = json.loads(terminal_tool(
+                command="cd /tmp; setsid my_server",
+            ))
+
+        assert result["exit_code"] == -1
+        assert "background=true" in result["error"]
+
+    def test_foreground_rejects_setsid_after_pipe(self):
+        """setsid used as a command after | should still be blocked."""
+        from tools.terminal_tool import terminal_tool
+
+        with patch("tools.terminal_tool._get_env_config", return_value=_make_env_config()), \
+             patch("tools.terminal_tool._start_cleanup_thread"):
+
+            result = json.loads(terminal_tool(
+                command="echo config | setsid my_server",
+            ))
+
+        assert result["exit_code"] == -1
+        assert "background=true" in result["error"]
+
     def test_foreground_rejects_long_lived_server_command(self):
         """Foreground dev server commands should be redirected to background mode."""
         from tools.terminal_tool import terminal_tool

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1539,7 +1539,10 @@ def _command_requires_pipe_stdin(command: str) -> bool:
     )
 
 
-_SHELL_LEVEL_BACKGROUND_RE = re.compile(r"\b(?:nohup|disown|setsid)\b", re.IGNORECASE)
+_SHELL_LEVEL_BACKGROUND_RE = re.compile(
+    r"(?:^|[;&|]\s*|&&\s*|\|\|\s*|\(\s*)(?:nohup|disown|setsid)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
 _INLINE_BACKGROUND_AMP_RE = re.compile(r"\s&\s")
 _TRAILING_BACKGROUND_AMP_RE = re.compile(r"\s&\s*(?:#.*)?$")
 _LONG_LIVED_FOREGROUND_PATTERNS = (


### PR DESCRIPTION
## What

Fix the terminal tool's safety filter regex to only match `nohup`/`disown`/`setsid` when they are used as actual shell commands, not when they appear inside quoted strings, commit messages, or code.

Fixes #20064

## The Bug

The `_SHELL_LEVEL_BACKGROUND_RE` regex uses a naive `\b(?:nohup|disown|setsid)\b` pattern that matches these keywords **anywhere** in the command string. This causes false positives that block legitimate commands:

```bash
# All of these get incorrectly blocked:
git commit -m "fix: replace setsid with process_group"
python3 -c "x = 'preexec_fn=os.setsid'"
echo "The function os.setsid() creates a new session"
gh pr create --body "We removed setsid from the code"
grep -r setsid .
```

Users hit this frequently when:
- Writing commit messages about process management
- Reviewing PRs that mention these functions
- Running Python/Ruby code that references `os.setsid()`
- Using echo/grep to search for these terms

## Fix

Replace the naive regex with one that only matches when the keyword appears at the **start of a command** or after **shell operators** (`;`, `|`, `&&`, `||`, subshell `(`):

```python
# Before (matches anywhere in string):
_SHELL_LEVEL_BACKGROUND_RE = re.compile(r"\b(?:nohup|disown|setsid)\b", re.IGNORECASE)

# After (matches only as actual commands):
_SHELL_LEVEL_BACKGROUND_RE = re.compile(
    r"(?:^|[;&|]\s*|&&\s*|\|\|\s*|\(\s*)(?:nohup|disown|setsid)\b",
    re.IGNORECASE | re.MULTILINE,
)
```

## Before vs After

| Command | Before | After |
|---------|--------|-------|
| `setsid my_server` | Blocked | Blocked (actual usage) |
| `nohup ./script.sh &` | Blocked | Blocked (actual usage) |
| `cmd; setsid server` | Blocked | Blocked (after `;`) |
| `git commit -m "replace setsid"` | Blocked | Allowed (in string) |
| `python3 -c "os.setsid()"` | Blocked | Allowed (in string) |
| `echo 'os.setsid() creates'` | Blocked | Allowed (in string) |
| `grep -r setsid .` | Blocked | Allowed (argument) |

## Tests

Added 5 new tests to `tests/tools/test_terminal_foreground_timeout_cap.py`:
- `test_foreground_allows_setsid_mentioned_in_string` — commit message
- `test_foreground_allows_setsid_in_python_code` — Python code string
- `test_foreground_allows_setsid_in_echo` — echo text
- `test_foreground_rejects_setsid_after_semicolon` — actual `;` chaining
- `test_foreground_rejects_setsid_after_pipe` — actual pipe usage

All 16 tests pass (11 existing + 5 new).