### PR TITLE
fix(config): dedupe duplicate KEY= lines in save_env_value

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -7990,12 +7990,22 @@ def save_env_value(key: str, value: str):
     # writer didn't match it, a save would append a SECOND line and a later
     # delete of that line would silently resurrect the old exported value
     # (#40041: "token detected but cannot be replaced through the UI").
+    # python-dotenv resolves duplicate keys last-occurrence-wins, so updating
+    # only the first match and leaving stale duplicates further down means the
+    # wrong value still loads at startup (#8270 — a fresh key written at the
+    # top of .env while a stale one from a prior `hermes model` add lingered at
+    # the bottom). Replace the first hit in place, drop the rest.
     found = False
-    for i, line in enumerate(lines):
+    deduped: list = []
+    for line in lines:
         if _env_line_defines_key(line, key):
-            lines[i] = f"{key}={serialized_value}\n"
-            found = True
-            break
+            if not found:
+                deduped.append(f"{key}={serialized_value}\n")
+                found = True
+            # Subsequent definitions are dropped so the saved value wins.
+            continue
+        deduped.append(line)
+    lines = deduped
 
     if not found:
         # Ensure there's a newline at the end of the file before appending

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -937,6 +937,94 @@ class TestSaveConfigAtomicity:
             assert raw["agent"]["max_turns"] == 77
 
 
+class TestSaveEnvValueDeduplication:
+    """Regression coverage for #8270 — duplicate KEY= lines must not survive a write.
+
+    python-dotenv resolves duplicate keys with last-occurrence-wins. Several
+    users reported that adding an OpenRouter key via the model picker (which
+    appends to .env) didn't take effect because a stale entry from a prior
+    setup attempt lingered later in the file. save_env_value must replace the
+    first match and strip the rest so the freshly written value is the one
+    that loads at startup.
+    """
+
+    def test_dedupe_collapses_existing_duplicates(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "OPENROUTER_API_KEY=old-broken\n"
+            "FAL_KEY=keepme\n"
+            "OPENROUTER_API_KEY=stale-bottom\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_env_value("OPENROUTER_API_KEY", "fresh-good")
+
+            content = env_file.read_text()
+            lines = [ln for ln in content.splitlines() if ln.strip()]
+
+            assert lines.count("OPENROUTER_API_KEY=fresh-good") == 1
+            assert "OPENROUTER_API_KEY=old-broken" not in content
+            assert "OPENROUTER_API_KEY=stale-bottom" not in content
+            assert "FAL_KEY=keepme" in content
+
+            assert load_env()["OPENROUTER_API_KEY"] == "fresh-good"
+
+    def test_first_position_preserved_when_deduping(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "FOO=top\n"
+            "OPENROUTER_API_KEY=first\n"
+            "BAR=middle\n"
+            "OPENROUTER_API_KEY=second\n"
+            "BAZ=bottom\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_env_value("OPENROUTER_API_KEY", "winner")
+
+            lines = [ln for ln in env_file.read_text().splitlines() if ln.strip()]
+            assert lines == [
+                "FOO=top",
+                "OPENROUTER_API_KEY=winner",
+                "BAR=middle",
+                "BAZ=bottom",
+            ]
+
+    def test_dedupe_no_op_when_no_duplicates(self, tmp_path):
+        env_file = tmp_path / ".env"
+        env_file.write_text("FOO=a\nOPENROUTER_API_KEY=existing\nBAR=b\n")
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_env_value("OPENROUTER_API_KEY", "updated")
+
+            lines = [ln for ln in env_file.read_text().splitlines() if ln.strip()]
+            assert lines == ["FOO=a", "OPENROUTER_API_KEY=updated", "BAR=b"]
+
+    def test_dedupe_retains_quoted_serialization_and_round_trips(self, tmp_path):
+        # The retained first entry must be written through the same quoting the
+        # append path uses (serialized_value), not the raw value — otherwise a
+        # value needing dotenv quoting (spaces, a '#' comment char) would be
+        # corrupted on load while the stale duplicate is dropped.
+        needs_quoting = "sk live#not-a-comment with spaces"
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "OPENROUTER_API_KEY=old\n"
+            "KEEP=x\n"
+            "OPENROUTER_API_KEY=stale\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_env_value("OPENROUTER_API_KEY", needs_quoting)
+
+            content = env_file.read_text()
+            lines = [ln for ln in content.splitlines() if ln.strip()]
+            # Exactly one retained OPENROUTER_API_KEY line, stale copy gone.
+            assert sum(ln.startswith("OPENROUTER_API_KEY=") for ln in lines) == 1
+            assert "OPENROUTER_API_KEY=old" not in content
+            assert "OPENROUTER_API_KEY=stale" not in content
+            # The retained line is serialized (quoted), so the raw form doesn't
+            # appear verbatim...
+            assert f"OPENROUTER_API_KEY={needs_quoting}\n" not in content
+            # ...and a dotenv round trip recovers the exact original value.
+            assert load_env()["OPENROUTER_API_KEY"] == needs_quoting
+
+
 class TestSanitizeEnvLines:
     """Tests for .env file corruption repair."""
 


### PR DESCRIPTION
## What does this PR do?

Hardens `hermes_cli.config.save_env_value` to remove stale duplicate `KEY=` lines after replacing the first match. python-dotenv resolves duplicate keys with **last-occurrence-wins**, so updating only the first match (current behaviour) and leaving older duplicates further down the file means the wrong value still loads at startup.

Reproducer:

```python
>>> from dotenv import dotenv_values
>>> # .env contains:
>>> #   OPENROUTER_API_KEY=fresh-good
>>> #   OPENROUTER_API_KEY=stale-broken
>>> dotenv_values('.env')
{'OPENROUTER_API_KEY': 'stale-broken'}
```

This surfaced in #8270 — multiple users (urpid, healthymecd, dreamsmaner) reported `HTTP 400 on all OpenRouter models` despite a freshly-saved key, traced to a stale entry left at the bottom of `.env` by an earlier setup attempt or by `hermes model` re-adding the same key. The visible top-of-file entry looked correct; the invisible bottom-of-file entry was the one that loaded.

Fix: walk the file once, replace the first hit with the new value, drop the rest. Append-when-not-found path is unchanged. No behaviour change for the (overwhelming) clean-file case.

**Scope note:** #8270 has several distinct root causes in its comment thread (mis-pasted keys, OpenRouter tool-format 400s on certain models, etc.). This PR only addresses the duplicate-key class — the others are separate.

## Related Issue

Refs #8270

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py`: rewrite the find-or-append loop in `save_env_value` (lines 4232-4259) to replace the first match in place, drop subsequent occurrences of the same key, and only append when no match exists at all. Comment captures the dotenv last-wins rationale.
- `tests/hermes_cli/test_config.py`: new `TestSaveEnvValueDeduplication` with three cases — collapse-existing-duplicates (writes load back as the new value), preserve-first-position (other keys keep their order), and no-op-when-clean.

## How to Test

```bash
# 1. Reproduce the symptom on a clean checkout
printf 'OPENROUTER_API_KEY=stale-broken\nOTHER=keep\nOPENROUTER_API_KEY=also-stale\n' > /tmp/.env
HERMES_HOME=/tmp python -c "from hermes_cli.config import save_env_value, load_env; save_env_value('OPENROUTER_API_KEY', 'fresh-good'); print(open('/tmp/.env').read()); print('loaded:', load_env()['OPENROUTER_API_KEY'])"
# Before the fix: file still contains the stale-broken trailing duplicate, load_env returns 'also-stale'.
# After the fix:  only OPENROUTER_API_KEY=fresh-good remains, load_env returns 'fresh-good'.

# 2. Unit tests
pytest tests/hermes_cli/test_config.py::TestSaveEnvValueDeduplication -v   # 3 pass
pytest tests/hermes_cli/test_config.py::TestSaveEnvValueSecure tests/hermes_cli/test_config.py::TestSanitizeEnvLines -q   # all adjacent tests still green
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (pre-existing flakes in gateway_service / web_server / bedrock unrelated to this change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 14.2 (Darwin 23.2.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (rationale captured inline)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — string-only line-list manipulation, no platform-specific behaviour.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
