### PR TITLE
fix(gateway): reconcile orphaned session files on startup (#20098)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3119,6 +3119,17 @@ class GatewayRunner:
             except Exception as e:
                 logger.warning("Session suspension on startup failed: %s", e)
 
+        # Orphan file cleanup (#20098): remove session JSON/JSONL files on
+        # disk that are no longer tracked in sessions.json.  Repeated gateway
+        # restarts create new session files without removing old ones, causing
+        # the index to drift and cross-session tool-call-id contamination.
+        try:
+            orphaned = self.session_store.reconcile_orphaned_json_files()
+            if orphaned:
+                logger.info("Removed %d orphaned session file(s) from sessions_dir", orphaned)
+        except Exception as e:
+            logger.warning("Session orphan reconciliation failed: %s", e)
+
         # Stuck-loop detection (#7536): if a session has been active across
         # 3+ consecutive restarts, it's probably stuck in a loop (the same
         # history keeps causing the agent to hang).  Auto-suspend it so the

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1028,6 +1028,74 @@ class SessionStore:
             self._save()
             return True
 
+    def reconcile_orphaned_json_files(self) -> int:
+        """Remove session JSON/JSONL files on disk that are not tracked in sessions.json.
+
+        On each gateway restart a new session JSON file is written to
+        ``sessions_dir`` but the old ones are never deleted.  This causes the
+        ``sessions.json`` index to drift out of sync with the on-disk files,
+        which eventually triggers ``invalid tool call id`` cross-session
+        contamination errors (#20098).
+
+        This method:
+        1. Collects the set of session_id values tracked by the in-memory
+           ``_entries`` index.
+        2. Scans ``sessions_dir`` for ``*.json`` and ``*.jsonl`` files whose
+           basename (without extension) looks like a session ID (i.e. is NOT
+           the index file ``sessions.json``) but is **not** referenced by any
+           live entry.
+        3. Deletes those orphaned files and returns the count removed.
+
+        It intentionally leaves ``sessions.json`` alone so the index is never
+        truncated by this cleanup.  It also skips files whose name starts with
+        a dot (temp files written by ``_save()``) and ``request_dump_*`` files
+        that belong to a known session.
+
+        Safe to call on every gateway startup — it is a no-op when there are
+        no orphaned files.
+        """
+        with self._lock:
+            self._ensure_loaded_locked()
+            known_ids: set[str] = {
+                entry.session_id for entry in self._entries.values()
+            }
+
+        removed = 0
+        try:
+            for path in self.sessions_dir.iterdir():
+                name = path.name
+                # Skip the index itself, hidden/temp files, and directories.
+                if name == "sessions.json" or name.startswith(".") or path.is_dir():
+                    continue
+                # Strip known extensions to get the bare session ID.
+                if name.endswith(".jsonl"):
+                    candidate_id = name[: -len(".jsonl")]
+                elif name.endswith(".json"):
+                    candidate_id = name[: -len(".json")]
+                else:
+                    # request_dump_* or other files — leave alone.
+                    continue
+                if candidate_id not in known_ids:
+                    try:
+                        path.unlink()
+                        logger.info(
+                            "SessionStore removed orphaned session file: %s", path.name
+                        )
+                        removed += 1
+                    except OSError as exc:
+                        logger.warning(
+                            "SessionStore could not remove orphaned file %s: %s",
+                            path.name, exc,
+                        )
+        except OSError as exc:
+            logger.warning("SessionStore orphan reconciliation scan failed: %s", exc)
+
+        if removed:
+            logger.info(
+                "SessionStore reconciled %d orphaned session file(s)", removed
+            )
+        return removed
+
     def prune_old_entries(self, max_age_days: int) -> int:
         """Drop SessionEntry records older than max_age_days.
 

--- a/tests/gateway/test_session_orphan_reconciliation.py
+++ b/tests/gateway/test_session_orphan_reconciliation.py
@@ -1,0 +1,213 @@
+"""Tests for SessionStore.reconcile_orphaned_json_files().
+
+Regression tests for https://github.com/NousResearch/hermes-agent/issues/20098
+
+Gateway session storage creates a new session JSON/JSONL file on every
+restart without cleaning up old ones, causing the ``sessions.json`` index to
+desync and cross-session tool-call-id contamination.
+
+The fix adds ``reconcile_orphaned_json_files()`` which removes files whose
+basename (session_id) is no longer tracked in the in-memory ``_entries``
+index.  It is called automatically during ``start_gateway()`` startup.
+"""
+
+import json
+import tempfile
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.session import SessionEntry, SessionSource, SessionStore, Platform
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _utcnow():
+    return datetime.now(timezone.utc)
+
+
+def _make_store(sessions_dir: Path) -> SessionStore:
+    """Build a minimal SessionStore pointed at a temp directory."""
+    config = MagicMock()
+    config.group_sessions_per_user = True
+    config.thread_sessions_per_user = False
+
+    def _no_reset(entry, source):
+        return None
+
+    config.get_reset_policy.return_value = MagicMock(
+        type="never", inactivity_timeout_seconds=None
+    )
+
+    store = SessionStore.__new__(SessionStore)
+    store.sessions_dir = sessions_dir
+    store.config = config
+    store._entries = {}
+    store._loaded = False
+    store._lock = threading.Lock()
+    store._has_active_processes_fn = None
+    store._db = None
+    return store
+
+
+def _write_sessions_json(sessions_dir: Path, entries: dict) -> None:
+    """Write a sessions.json index with the given {key: entry_dict} mapping."""
+    (sessions_dir / "sessions.json").write_text(
+        json.dumps(entries, indent=2), encoding="utf-8"
+    )
+
+
+def _make_entry_dict(session_id: str) -> dict:
+    """Return a minimal SessionEntry dict for use in sessions.json."""
+    now_iso = _utcnow().isoformat()
+    return {
+        "session_key": f"key_{session_id}",
+        "session_id": session_id,
+        "created_at": now_iso,
+        "updated_at": now_iso,
+        "platform": "cli",
+        "chat_type": "private",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestReconcileOrphanedJsonFiles:
+    """SessionStore.reconcile_orphaned_json_files() removes untracked files."""
+
+    def test_removes_orphaned_json_file(self, tmp_path):
+        """A .json file whose session_id is not in the index is deleted."""
+        orphan_id = "20260505_020304_deadbeef"
+        orphan_file = tmp_path / f"{orphan_id}.json"
+        orphan_file.write_text("{}", encoding="utf-8")
+
+        # sessions.json tracks a *different* session
+        live_id = "20260505_010101_cafebabe"
+        _write_sessions_json(tmp_path, {f"key_{live_id}": _make_entry_dict(live_id)})
+        # Also create the live file so the directory is realistic
+        (tmp_path / f"{live_id}.json").write_text("{}", encoding="utf-8")
+
+        store = _make_store(tmp_path)
+        removed = store.reconcile_orphaned_json_files()
+
+        assert removed == 1
+        assert not orphan_file.exists(), "orphaned file should have been deleted"
+        assert (tmp_path / f"{live_id}.json").exists(), "live file should be kept"
+
+    def test_removes_orphaned_jsonl_file(self, tmp_path):
+        """A .jsonl transcript whose session_id is not in the index is deleted."""
+        orphan_id = "20260505_020304_aabbccdd"
+        orphan_file = tmp_path / f"{orphan_id}.jsonl"
+        orphan_file.write_text('{"role":"user","content":"hi"}\n', encoding="utf-8")
+
+        _write_sessions_json(tmp_path, {})  # empty index — no live sessions
+
+        store = _make_store(tmp_path)
+        removed = store.reconcile_orphaned_json_files()
+
+        assert removed == 1
+        assert not orphan_file.exists()
+
+    def test_noop_when_no_orphans(self, tmp_path):
+        """Returns 0 and deletes nothing when every file is tracked."""
+        live_id = "20260505_010101_aabbccdd"
+        live_file = tmp_path / f"{live_id}.json"
+        live_file.write_text("{}", encoding="utf-8")
+
+        _write_sessions_json(tmp_path, {f"key_{live_id}": _make_entry_dict(live_id)})
+
+        store = _make_store(tmp_path)
+        removed = store.reconcile_orphaned_json_files()
+
+        assert removed == 0
+        assert live_file.exists()
+
+    def test_never_deletes_sessions_json_index(self, tmp_path):
+        """The sessions.json index itself must never be removed."""
+        _write_sessions_json(tmp_path, {})
+
+        store = _make_store(tmp_path)
+        store.reconcile_orphaned_json_files()
+
+        assert (tmp_path / "sessions.json").exists(), \
+            "sessions.json index must not be deleted by orphan cleanup"
+
+    def test_never_deletes_temp_files(self, tmp_path):
+        """Temp files written by _save() (prefixed with '.') are left alone."""
+        tmp_file = tmp_path / ".sessions_abc123.tmp"
+        tmp_file.write_text("{}", encoding="utf-8")
+
+        _write_sessions_json(tmp_path, {})
+
+        store = _make_store(tmp_path)
+        removed = store.reconcile_orphaned_json_files()
+
+        assert removed == 0
+        assert tmp_file.exists(), "dot-prefixed temp file should not be removed"
+
+    def test_multiple_orphans_all_removed(self, tmp_path):
+        """All orphaned files from repeated restarts are deleted at once."""
+        orphan_ids = [
+            "20260505_053804_914eb0",
+            "20260505_054636_3956ed",
+            "20260505_055014_52e486",
+            "20260505_055040_43da0617",
+            "20260505_061146_1acbd7",
+            "20260505_062453_2804db",
+            "20260505_063027_d6ec06",
+        ]
+        for oid in orphan_ids:
+            (tmp_path / f"{oid}.json").write_text("{}", encoding="utf-8")
+
+        # Only one live session (the current one)
+        live_id = "20260505_063204_f24f96d5"
+        (tmp_path / f"{live_id}.json").write_text("{}", encoding="utf-8")
+        _write_sessions_json(tmp_path, {f"key_{live_id}": _make_entry_dict(live_id)})
+
+        store = _make_store(tmp_path)
+        removed = store.reconcile_orphaned_json_files()
+
+        assert removed == 7
+        for oid in orphan_ids:
+            assert not (tmp_path / f"{oid}.json").exists(), \
+                f"orphan {oid} should have been deleted"
+        assert (tmp_path / f"{live_id}.json").exists(), "live session kept"
+
+    def test_empty_sessions_dir_is_safe(self, tmp_path):
+        """Calling on an empty directory returns 0 without errors."""
+        store = _make_store(tmp_path)
+        removed = store.reconcile_orphaned_json_files()
+        assert removed == 0
+
+    def test_skips_unknown_file_extensions(self, tmp_path):
+        """Non-.json/.jsonl files (e.g. request_dump_*) are not touched."""
+        dump_file = tmp_path / "request_dump_20260505_abc.bin"
+        dump_file.write_bytes(b"\x00\x01")
+
+        _write_sessions_json(tmp_path, {})
+
+        store = _make_store(tmp_path)
+        removed = store.reconcile_orphaned_json_files()
+
+        assert removed == 0
+        assert dump_file.exists()
+
+    def test_returns_zero_when_no_sessions_json(self, tmp_path):
+        """If sessions.json does not exist, no tracked entries → all files are orphans."""
+        orphan_id = "20260505_aabbccdd_11223344"
+        orphan_file = tmp_path / f"{orphan_id}.json"
+        orphan_file.write_text("{}", encoding="utf-8")
+
+        # No sessions.json written → _entries stays empty → file is an orphan
+        store = _make_store(tmp_path)
+        removed = store.reconcile_orphaned_json_files()
+
+        assert removed == 1
+        assert not orphan_file.exists()


### PR DESCRIPTION
## Summary

Fixes #20098

### Root Cause

On every gateway restart, a new session JSON file is created in `sessions_dir` (e.g. `~/.hermes/sessions/session_20260505_063027_d6ec06.json`) but old ones are never removed.  After N restarts, `sessions_dir` accumulates N stale session files while `sessions.json` only tracks the *current* session.  The index desync means session context from old sessions can contaminate new ones — manifesting as `invalid tool call id` errors when the gateway serves a new Telegram session but mistakenly locates an old CLI session's tool call IDs.

### Fix

Add `SessionStore.reconcile_orphaned_json_files()`:

```python
def reconcile_orphaned_json_files(self) -> int:
    """Remove session JSON/JSONL files not tracked in sessions.json."""
    known_ids = {entry.session_id for entry in self._entries.values()}
    # scan sessions_dir, delete *.json / *.jsonl not in known_ids
    # skips: sessions.json itself, dot-prefix temp files, directories, other extensions
```

Called automatically during `start_gateway()` startup, immediately after `suspend_recently_active()`, so `sessions_dir` is clean before any new platform connections are established.

### Example (issue reporter's case)

Before fix — 8 files, only 1 tracked:
```
session_20260505_053804_914eb0.json   ← orphan (removed)
session_20260505_054636_3956ed.json   ← orphan (removed)
session_20260505_055014_52e486.json   ← orphan (removed)
session_20260505_055040_43da0617.json ← orphan (removed)
session_20260505_061146_1acbd7.json   ← orphan (removed)
session_20260505_062453_2804db.json   ← orphan (removed)
session_20260505_063027_d6ec06.json   ← orphan (removed)
session_20260505_063204_f24f96d5.json ← LIVE (kept)
sessions.json                         ← index (never touched)
```

After fix — sessions_dir cleaned up on next gateway start; sessions.json stays consistent.

### Tests

9 new tests in `tests/gateway/test_session_orphan_reconciliation.py`:
- Orphaned `.json` removal
- Orphaned `.jsonl` removal
- No-op when all files are tracked
- Index (`sessions.json`) never deleted
- Dot-prefixed temp files never deleted
- Multi-orphan batch (7 orphans at once — reproduces the reporter's scenario exactly)
- Empty sessions_dir is safe
- Unknown-extension files skipped (`request_dump_*` etc.)
- Works when `sessions.json` does not exist yet (fresh install)