### PR TITLE
fix(kanban): dispatcher skips ready tasks whose assignee is not a real profile

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2506,6 +2506,23 @@ def dispatch_once(
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue
+        # Skip ready tasks whose assignee is not a real Hermes profile.
+        # `_default_spawn` invokes ``hermes -p <assignee>`` which fails
+        # with "Profile 'X' does not exist" when the assignee names a
+        # control-plane lane (e.g. an interactive Claude Code terminal
+        # like ``orion-cc`` / ``orion-research``) rather than a Hermes
+        # profile. Those task lanes are pulled by terminals via
+        # ``claim_task`` directly and should NEVER auto-spawn — the
+        # subprocess would crash on startup, get reaped as a zombie,
+        # the task would loop back to ``ready`` on next tick, and we'd
+        # burn CPU forever (#kanban-dispatcher-crash-loop 2026-05-05).
+        try:
+            from hermes_cli.profiles import profile_exists  # local import: avoids cycle
+        except Exception:
+            profile_exists = None  # type: ignore[assignment]
+        if profile_exists is not None and not profile_exists(row["assignee"]):
+            result.skipped_unassigned.append(row["id"])
+            continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
             continue


### PR DESCRIPTION
## Summary

The kanban dispatcher's `_default_spawn` invokes `hermes -p <task.assignee> chat -q ...`. When `assignee` names a control-plane lane (e.g. an interactive Claude Code terminal like `orion-cc` / `orion-research`) instead of a real Hermes profile, the subprocess fails on startup with `Profile 'X' does not exist`, gets reaped as a zombie, the TTL/crash detector reclaims the task back to `ready`, and the next tick re-spawns the same crashing worker.

**Result:** a permanent crash loop emitting `spawned=N reclaimed=0 crashed=N` in the gateway log every minute, two zombie processes per affected task, and CPU burn until someone notices.

## Reproduce

```bash
# 1. Create a kanban task whose assignee names a non-profile.
hermes kanban create --assignee orion-cc --status ready \
    --title "Review PR #N" --body "..."
# 2. Start the gateway with the embedded dispatcher.
hermes gateway run

# gateway.log emits every minute:
#   kanban dispatcher: tick spawned=1 reclaimed=0 crashed=1 ...
# Per-task log /home/<u>/.hermes/<profile>/kanban/logs/<task_id>.log:
#   Error: Profile 'orion-cc' does not exist. Create it with:
#       hermes profile create orion-cc
# ps -ef | grep '[h]ermes.*defunct' — zombies pile up until reaped.
```

## Fix

`dispatch_once()` now pre-checks `hermes_cli.profiles.profile_exists(assignee)` before claiming. If the profile does NOT exist, the row is appended to `skipped_unassigned` (semantically: it's unassigned to an _executable_ profile) and the dispatcher moves on without claiming, spawning, or counting a crash.

The import is locally scoped + try/except wrapped, so if `profile_exists` is missing or fails to import (test isolation, future module restructure) the original behaviour is preserved unchanged.

## Why profile-existence over a config flag

The kanban task body (`t_2bab06e3` on Brecht-H's local kanban) hinted at gating behind a config flag like `assignee=hermes|auto`. Profile-existence is a strictly tighter check:

- **Self-documenting** — the operator already knows whether they have an `orion-cc` profile; no allowlist to maintain.
- **Forward-compatible** — the moment a new lane gets a real `hermes profile create <name>`, it auto-qualifies for spawn.
- **No new config surface** — zero new keys in `config.yaml`.

Operators who want the "config flag" semantics can still opt in via creating an empty placeholder profile.

## Validated live (Orion machine)

Two `orion-research`-assigned tasks (`t_a14dc1d5` Bug-C investigation, `t_646c96f2` provider-routing validation) had been crash-looping since `2026-05-05 06:58 UTC` after Mac switched the lane workflow to kanban-pull-by-terminal. Pre-patch:

```
2026-05-05 07:30:05 INFO gateway.run: kanban dispatcher: tick spawned=2 reclaimed=0 crashed=2 timed_out=0 promoted=0 auto_blocked=0
2026-05-05 07:31:05 INFO gateway.run: kanban dispatcher: tick spawned=2 reclaimed=0 crashed=2 timed_out=0 promoted=0 auto_blocked=0
... (every minute, 2 hours+)
```

Post-patch (gateway restart at 07:41:39):

```
2026-05-05 07:41:39 INFO gateway.run: kanban dispatcher: embedded in gateway (interval=60.0s)
( silent — spawn_any=False on every tick, log line guarded behind `if res.spawned` )
```

Live state:
- Stale `running` claims auto-reclaimed to `ready` on the first post-patch tick.
- Tasks now sit at `status=ready, claim_lock=None, worker_pid=None, spawn_failures=0` — clean, ready for terminal pull.
- Dashboard / telegram / freqtrade / committee_listener all unaffected (only the dispatcher path changed).

## Test plan

- [x] Live verification on Orion: 2-hour crash loop terminated, dispatcher silent, no defuncts pile up
- [x] Tasks reclaim cleanly to `ready` post-restart
- [x] Existing well-behaved tasks (assignee=`daily`) still spawn (counterfactual: `profile_exists("daily") = True` confirmed via Python REPL)
- [x] Defensive import — if `hermes_cli.profiles` ever moves, fall-through to original behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)