### PR TITLE
fix: normalize MiniMax OAuth authorize URL

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -8346,6 +8346,18 @@ def _minimax_pkce_pair() -> tuple:
     return verifier, challenge, state
 
 
+def _minimax_normalize_verification_uri(verification_uri: str) -> str:
+    """Return a browser-usable MiniMax OAuth authorization URL."""
+    stale_prefix = "https://www.minimax.io/oauth-authorize"
+    if verification_uri.startswith(stale_prefix):
+        return verification_uri.replace(
+            stale_prefix,
+            "https://platform.minimax.io/oauth-authorize",
+            1,
+        )
+    return verification_uri
+
+
 def _minimax_request_user_code(
     client: httpx.Client, *, portal_base_url: str, client_id: str,
     code_challenge: str, state: str,
@@ -8385,6 +8397,9 @@ def _minimax_request_user_code(
             "MiniMax OAuth state mismatch (possible CSRF).",
             provider="minimax-oauth", code="state_mismatch",
         )
+    payload["verification_uri"] = _minimax_normalize_verification_uri(
+        str(payload["verification_uri"])
+    )
     return payload
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -39,7 +39,7 @@ from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import httpx
 
@@ -8347,14 +8347,17 @@ def _minimax_pkce_pair() -> tuple:
 
 
 def _minimax_normalize_verification_uri(verification_uri: str) -> str:
-    """Return a browser-usable MiniMax OAuth authorization URL."""
-    stale_prefix = "https://www.minimax.io/oauth-authorize"
-    if verification_uri.startswith(stale_prefix):
-        return verification_uri.replace(
-            stale_prefix,
-            "https://platform.minimax.io/oauth-authorize",
-            1,
-        )
+    """Return a browser-usable MiniMax OAuth authorization URL.
+
+    MiniMax's device-code response has returned the deleted
+    ``www.minimax.io/oauth-authorize`` page even though the live authorize page
+    moved to ``platform.minimax.io``. Keep the workaround intentionally narrow:
+    only the stale host/path pair is rewritten, preserving query strings and
+    unrelated MiniMax URLs.
+    """
+    parsed = urlparse(verification_uri)
+    if parsed.scheme == "https" and parsed.netloc == "www.minimax.io" and parsed.path == "/oauth-authorize":
+        return urlunparse(parsed._replace(netloc="platform.minimax.io"))
     return verification_uri
 
 

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -23,7 +23,7 @@ import asyncio
 import json
 import time
 from datetime import datetime, timezone
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
@@ -68,19 +68,27 @@ def _invoke_scope_refusal():
     return httpx.HTTPStatusError("invalid scope", request=request, response=response)
 
 
-def test_minimax_login_does_not_launch_anthropic_flow():
-    """Click 'Login' on MiniMax → MUST NOT return claude.ai auth_url."""
+def test_minimax_dashboard_rewrites_stale_www_authorize_url():
+    """Dashboard MiniMax login returns the working platform URL, not stale www."""
     fake_user_code_resp = {
         "user_code": "ABCD-1234",
-        "verification_uri": "https://api.minimax.io/oauth/verify",
+        "verification_uri": (
+            "https://www.minimax.io/oauth-authorize?client_id=abc&state=xyz"
+        ),
         # `expired_in` < 1e12 so the heuristic treats it as seconds.
         "expired_in": 600,
         "interval": 2000,
         "state": "stub-state",
     }
+    fake_response = MagicMock(status_code=200, text="ok", reason_phrase="OK")
+    fake_response.json.return_value = fake_user_code_resp
+    fake_http_client = MagicMock()
+    fake_http_client.__enter__.return_value = fake_http_client
+    fake_http_client.post.return_value = fake_response
+
     with patch(
-        "hermes_cli.auth._minimax_request_user_code",
-        return_value=fake_user_code_resp,
+        "httpx.Client",
+        return_value=fake_http_client,
     ), patch(
         "hermes_cli.auth._minimax_pkce_pair",
         return_value=("verifier-stub", "challenge-stub", "stub-state"),
@@ -101,9 +109,11 @@ def test_minimax_login_does_not_launch_anthropic_flow():
     assert "auth_url" not in body
     assert "claude.ai" not in str(body).lower()
 
-    # And the response IS the device-code shape pointing at MiniMax.
+    # The shared MiniMax response boundary normalizes both CLI and dashboard.
     assert body["flow"] == "device_code"
-    assert "minimax" in body["verification_url"].lower()
+    assert body["verification_url"] == (
+        "https://platform.minimax.io/oauth-authorize?client_id=abc&state=xyz"
+    )
     assert body["user_code"] == "ABCD-1234"
     assert body["expires_in"] == 600
 

--- a/tests/test_minimax_oauth.py
+++ b/tests/test_minimax_oauth.py
@@ -128,7 +128,7 @@ def test_request_user_code_rewrites_stale_www_authorize_url():
     mock_response = _make_httpx_response(200, {
         "user_code": "ABC-123",
         "verification_uri": (
-            "https://www.minimax.io/oauth-authorize?client_id=abc&state=xyz"
+            "https://www.minimax.io/oauth-authorize?client_id=abc&state=xyz#device"
         ),
         "expired_in": 600,
         "state": state,
@@ -145,8 +145,30 @@ def test_request_user_code_rewrites_stale_www_authorize_url():
     )
 
     assert result["verification_uri"] == (
-        "https://platform.minimax.io/oauth-authorize?client_id=abc&state=xyz"
+        "https://platform.minimax.io/oauth-authorize?client_id=abc&state=xyz#device"
     )
+
+
+def test_request_user_code_preserves_unrelated_minimax_urls():
+    state = "test-state-abc"
+    mock_response = _make_httpx_response(200, {
+        "user_code": "ABC-123",
+        "verification_uri": "https://www.minimax.io/oauth-authorize-extra?next=/oauth-authorize",
+        "expired_in": 600,
+        "state": state,
+    })
+    client = MagicMock()
+    client.post.return_value = mock_response
+
+    result = _minimax_request_user_code(
+        client,
+        portal_base_url=MINIMAX_OAUTH_GLOBAL_BASE,
+        client_id=MINIMAX_OAUTH_CLIENT_ID,
+        code_challenge="test-challenge",
+        state=state,
+    )
+
+    assert result["verification_uri"] == "https://www.minimax.io/oauth-authorize-extra?next=/oauth-authorize"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_minimax_oauth.py
+++ b/tests/test_minimax_oauth.py
@@ -123,6 +123,32 @@ def test_pkce_pair_produces_valid_s256():
 
 
 
+def test_request_user_code_rewrites_stale_www_authorize_url():
+    state = "test-state-abc"
+    mock_response = _make_httpx_response(200, {
+        "user_code": "ABC-123",
+        "verification_uri": (
+            "https://www.minimax.io/oauth-authorize?client_id=abc&state=xyz"
+        ),
+        "expired_in": 600,
+        "state": state,
+    })
+    client = MagicMock()
+    client.post.return_value = mock_response
+
+    result = _minimax_request_user_code(
+        client,
+        portal_base_url=MINIMAX_OAUTH_GLOBAL_BASE,
+        client_id=MINIMAX_OAUTH_CLIENT_ID,
+        code_challenge="test-challenge",
+        state=state,
+    )
+
+    assert result["verification_uri"] == (
+        "https://platform.minimax.io/oauth-authorize?client_id=abc&state=xyz"
+    )
+
+
 # ---------------------------------------------------------------------------
 # 3. test_request_user_code_state_mismatch_raises
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Normalize stale `www.minimax.io/oauth-authorize` URLs to `platform.minimax.io` at the shared MiniMax response boundary.
- Cover both CLI and dashboard OAuth consumers with the same normalization.
- Drop the token-expiry changes because equivalent handling is already present on current `main`.
- Add focused request-boundary and dashboard-start regression tests.

## Test plan
- `scripts/run_tests.sh tests/test_minimax_oauth.py tests/hermes_cli/test_web_oauth_dispatch.py -q` — 52 passed
- `.venv/bin/ruff check hermes_cli/auth.py tests/test_minimax_oauth.py tests/hermes_cli/test_web_oauth_dispatch.py` — passed