### PR TITLE
fix: added default base_url_override for ollama-cloud provider

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -187,6 +187,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     ),
     "ollama-cloud": HermesOverlay(
         transport="openai_chat",
+        base_url_override="https://ollama.com/v1",
         base_url_env_var="OLLAMA_BASE_URL",
     ),
     # Azure Foundry: supports both OpenAI-style and Anthropic-style endpoints.


### PR DESCRIPTION
The ollama-cloud provider had no base_url_override, causing the setup 
wizard to cache https://ollama.com/api (wrong) in auth.json. The correct 
OpenAI-compatible endpoint is https://ollama.com/v1.

Editing model.base_url in config.yaml does not fix it because runtime 
resolution ignores it for this provider. The only workaround was manually 
setting OLLAMA_BASE_URL in ~/.hermes/.env.

This fix adds the correct default so it works out of the box.

Fixes #12703