### PR TITLE
feat(api-server): add config-driven tool_progress_events and reasoning_content

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -581,6 +581,8 @@ class APIServerAdapter(BasePlatformAdapter):
         self._model_name: str = self._resolve_model_name(
             extra.get("model_name", os.getenv("API_SERVER_MODEL_NAME", "")),
         )
+        self._tool_progress_events: bool = extra.get("tool_progress_events", True)
+        self._show_reasoning: bool = extra.get("show_reasoning", False)
         self._app: Optional["web.Application"] = None
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
@@ -1044,8 +1046,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
-                tool_start_callback=_on_tool_start,
-                tool_complete_callback=_on_tool_complete,
+                tool_start_callback=_on_tool_start if self._tool_progress_events else None,
+                tool_complete_callback=_on_tool_complete if self._tool_progress_events else None,
                 agent_ref=agent_ref,
             ))
 
@@ -1088,6 +1090,14 @@ class APIServerAdapter(BasePlatformAdapter):
         if not final_response:
             final_response = result.get("error", "(No response generated)")
 
+        message = {
+            "role": "assistant",
+            "content": final_response,
+        }
+        last_reasoning = result.get("last_reasoning", "")
+        if self._show_reasoning and last_reasoning:
+            message["reasoning_content"] = last_reasoning
+
         response_data = {
             "id": completion_id,
             "object": "chat.completion",
@@ -1096,10 +1106,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "choices": [
                 {
                     "index": 0,
-                    "message": {
-                        "role": "assistant",
-                        "content": final_response,
-                    },
+                    "message": message,
                     "finish_reason": "stop",
                 }
             ],
@@ -1211,6 +1218,22 @@ class APIServerAdapter(BasePlatformAdapter):
                 usage = agent_usage or usage
             except Exception:
                 pass
+
+            # Reasoning chunk (if enabled and available)
+            if self._show_reasoning:
+                try:
+                    reasoning = None
+                    if isinstance(result, dict):
+                        reasoning = result.get("last_reasoning")
+                    if reasoning:
+                        reasoning_chunk = {
+                            "id": completion_id, "object": "chat.completion.chunk",
+                            "created": created, "model": model,
+                            "choices": [{"index": 0, "delta": {"reasoning_content": reasoning}, "finish_reason": None}],
+                        }
+                        await response.write(f"data: {json.dumps(reasoning_chunk)}\n\n".encode())
+                except Exception:
+                    pass
 
             # Finish chunk
             finish_chunk = {


### PR DESCRIPTION
## Summary

Adds two new config options to `platforms.api_server.extra`:

- `tool_progress_events` (default `true`) — controls whether tool progress SSE events
  (`event: hermes.tool.progress`) are emitted. Set to `false` for compatibility with
  OpenAI-compatible clients (CherryStudio, etc.) that don't understand custom events.

- `show_reasoning` (default `false`) — when enabled, includes `reasoning_content` in
  both streaming and non-streaming chat completion responses, following the DeepSeek convention.

Both options are config-driven and fully backward compatible.

## Changes

`gateway/platforms/api_server.py`: +29/-6 lines across 4 change groups:

1. Config reads in `__init__`
2. Conditional callback registration for tool progress
3. `reasoning_content` in non-streaming response
4. `reasoning_content` in streaming SSE