### PR TITLE
fix(send_message): resolve thread_id from session context for text/media/file sends

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -258,6 +258,19 @@ def _handle_send(args):
     media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
 
+    # If no thread_id was supplied in the target string, fall back to the
+    # current session's thread_id so replies stay in the originating topic/
+    # thread. Voice messages already do this via the gateway adapter path;
+    # text/media/file sends were missing this step (issue #20104).
+    if thread_id is None and not target_ref:
+        try:
+            from gateway.session_context import get_session_env
+            _session_thread = get_session_env("HERMES_SESSION_THREAD_ID", "").strip()
+            if _session_thread:
+                thread_id = _session_thread
+        except Exception:
+            pass
+
     used_home_channel = False
     if not chat_id:
         home = config.get_home_channel(platform)


### PR DESCRIPTION
## Problem

When `send_message` is called with just a platform name (e.g. `telegram`), `thread_id` was left as `None`, causing text/media/file messages to be delivered to the general topic instead of the originating thread. Voice messages were unaffected because they use the gateway adapter path (`send_voice()`) which already carries the thread context.

## Fix

When no `thread_id` is present in the target string, fall back to `HERMES_SESSION_THREAD_ID` from the session context — the same mechanism already used by `cronjob_tools.py` for auto-delivery.

Fixes #20104