### PR TITLE
fix(auxiliary): pass original base_url to _maybe_wrap_anthropic in compression path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2203,7 +2203,10 @@ def resolve_provider_client(
                     is_agent_turn=True, is_vision=is_vision
                 )
             client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
-            client = _wrap_if_needed(client, final_model, custom_base, custom_key)
+            # Pass original URL for anthropic detection (not the rewritten /v1 one).
+            # _maybe_wrap_anthropic checks _endpoint_speaks_anthropic_messages(base_url)
+            # which looks for /anthropic suffix — rewritten URL loses that signal.
+            client = _wrap_if_needed(client, final_model, explicit_base_url, custom_key)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))
         # Try custom first, then API-key providers (Codex excluded here:


### PR DESCRIPTION
## Bug

_wrap_if_needed checks _endpoint_speaks_anthropic_messages() which looks for the /anthropic suffix. But _to_openai_base_url() already rewrites /anthropic → /v1 before this point, causing the anthropic wrapper to never trigger for custom endpoints (e.g. MiniMax) that require it.

## Fix

Pass explicit_base_url (original, e.g. /anthropic) instead of custom_base (already rewritten to /v1) to _wrap_if_needed, so the anthropic transport detection works correctly.

## Testing

Context compression now succeeds with MiniMax and similar custom endpoints that require AnthropicMessages format.

## Related

Upstream #17467 fixed a similar issue in _resolve_custom_runtime() but missed the _resolve_auto() Step 1 path used during compression.