### PR TITLE
fix(cli): dedupe duplicate keys in save_env_value

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4229,13 +4229,20 @@ def save_env_value(key: str, value: str):
         # Sanitize on every read: split concatenated keys, drop stale placeholders
         lines = _sanitize_env_lines(lines)
 
-    # Find and update or append
+    # python-dotenv resolves duplicate keys with last-occurrence-wins, so we
+    # must drop any duplicates after the first match — otherwise a stale entry
+    # further down would silently override the value we write here.
+    new_lines: list[str] = []
     found = False
-    for i, line in enumerate(lines):
+    for line in lines:
         if line.strip().startswith(f"{key}="):
-            lines[i] = f"{key}={value}\n"
-            found = True
-            break
+            if not found:
+                new_lines.append(f"{key}={value}\n")
+                found = True
+            # else: drop subsequent duplicates
+            continue
+        new_lines.append(line)
+    lines = new_lines
 
     if not found:
         # Ensure there's a newline at the end of the file before appending

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -151,6 +151,32 @@ class TestSaveEnvValueSecure:
             env_mode = (tmp_path / ".env").stat().st_mode & 0o777
             assert env_mode == 0o600
 
+    def test_save_env_value_dedupes_existing_duplicates(self, tmp_path):
+        """A stale duplicate further down in .env must not survive an update.
+
+        python-dotenv resolves duplicate keys with last-occurrence-wins, so a
+        stale OPENROUTER_API_KEY at the bottom of the file would silently
+        override a fresh value written at the top (issue #8270).
+        """
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "OPENROUTER_API_KEY=stale-top\n"
+            "FAL_KEY=other\n"
+            "OPENROUTER_API_KEY=stale-bottom\n"
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_env_value("OPENROUTER_API_KEY", "fresh-key")
+
+            content = env_file.read_text()
+            assert content.count("OPENROUTER_API_KEY=") == 1
+            assert "OPENROUTER_API_KEY=fresh-key\n" in content
+            assert "stale-top" not in content
+            assert "stale-bottom" not in content
+            assert "FAL_KEY=other" in content
+
+            env_values = load_env()
+            assert env_values["OPENROUTER_API_KEY"] == "fresh-key"
+
 
 class TestRemoveEnvValue:
     def test_removes_key_from_env_file(self, tmp_path):


### PR DESCRIPTION
Drop stale duplicate `KEY=...` lines when `save_env_value` updates a key, so the value we write actually wins at load time.

## What changed and why
- `hermes_cli/config.py`: `save_env_value` now updates the first matching line and removes any later duplicates, instead of breaking on the first match. python-dotenv resolves duplicates with last-occurrence-wins, so a stale `OPENROUTER_API_KEY` (or any other key) further down in `~/.hermes/.env` would silently override the freshly written value, surfacing as `HTTP 400` from OpenRouter / other providers even though `hermes model` reported success.
- `tests/hermes_cli/test_config.py`: added a regression test that seeds two `OPENROUTER_API_KEY=` lines, calls `save_env_value`, and asserts the file ends up with exactly one entry holding the new value (and that `load_env` agrees).
- Scope is intentionally narrow: this addresses the duplicate-key slice of #8270 only. Other root causes already discussed in that thread (mis-pasted keys with non-printable noise, OpenRouter tool-format 400s) are separate and out of scope.

## How to test
- `pytest tests/hermes_cli/test_config.py -q` (53 passed locally including the new `test_save_env_value_dedupes_existing_duplicates`).
- Manual: create `~/.hermes/.env` with two `OPENROUTER_API_KEY=` lines; run `hermes model` and pick OpenRouter to set a fresh key; verify `~/.hermes/.env` now contains exactly one `OPENROUTER_API_KEY=` line with the new value.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #8270

<!-- autocontrib:worker-id=issue-new-718492e4 kind=pr-open -->