### PR TITLE
fix(tools): make browser_vision full-page capture opt-in via flag

### DIFF
--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -195,6 +195,75 @@ class TestBrowserVisionAnnotate:
                 assert "--annotate" in cmd_args
 
 
+class TestBrowserVisionFullPage:
+    """browser_vision supports full_page parameter to opt into viewport-only capture."""
+
+    def test_schema_has_full_page_param(self):
+        from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+
+        schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == "browser_vision")
+        props = schema["parameters"]["properties"]
+        assert "full_page" in props
+        assert props["full_page"]["type"] == "boolean"
+        assert props["full_page"]["default"] is True
+
+    def test_full_page_default_adds_full_flag(self):
+        """Default behaviour preserves --full for backward compatibility."""
+        from tools.browser_tool import browser_vision
+
+        with (
+            patch("tools.browser_tool._run_browser_command") as mock_cmd,
+            patch("tools.browser_tool.call_llm"),
+            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
+        ):
+            mock_cmd.return_value = {"success": True, "data": {}}
+            try:
+                browser_vision("test", task_id="test")
+            except Exception:
+                pass
+
+            assert mock_cmd.called
+            cmd_args = mock_cmd.call_args[0][2]
+            assert "--full" in cmd_args
+
+    def test_full_page_false_omits_full_flag(self):
+        """full_page=False captures viewport only — no --full flag."""
+        from tools.browser_tool import browser_vision
+
+        with (
+            patch("tools.browser_tool._run_browser_command") as mock_cmd,
+            patch("tools.browser_tool.call_llm"),
+            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
+        ):
+            mock_cmd.return_value = {"success": True, "data": {}}
+            try:
+                browser_vision("test", full_page=False, task_id="test")
+            except Exception:
+                pass
+
+            assert mock_cmd.called
+            cmd_args = mock_cmd.call_args[0][2]
+            assert "--full" not in cmd_args
+
+    def test_handler_threads_full_page_from_args(self):
+        """The registered tool handler forwards args['full_page'] to browser_vision."""
+        from tools import browser_tool
+        from tools.registry import registry
+
+        captured = {}
+
+        def fake_browser_vision(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        with patch.object(browser_tool, "browser_vision", side_effect=fake_browser_vision):
+            entry = registry.get_entry("browser_vision")
+            entry.handler({"question": "q", "full_page": False}, task_id="t")
+
+        assert captured["full_page"] is False
+        assert captured["question"] == "q"
+
+
 class TestBrowserVisionConfig:
     def _setup_screenshot(self, tmp_path):
         shots_dir = tmp_path / "browser_screenshots"

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -491,8 +491,15 @@ def camofox_get_images(task_id: Optional[str] = None) -> str:
 
 
 def camofox_vision(question: str, annotate: bool = False,
+                   full_page: bool = True,
                    task_id: Optional[str] = None) -> str:
-    """Take a screenshot and analyze it with vision AI via Camofox."""
+    """Take a screenshot and analyze it with vision AI via Camofox.
+
+    The Camofox `/tabs/{id}/screenshot` endpoint captures the current viewport
+    only; ``full_page`` is accepted for API parity with the local backend but
+    has no effect here.
+    """
+    del full_page
     try:
         session = _get_session(task_id)
         if not session["tab_id"]:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1115,6 +1115,11 @@ BROWSER_TOOL_SCHEMAS = [
                     "type": "boolean",
                     "default": False,
                     "description": "If true, overlay numbered [N] labels on interactive elements. Each [N] maps to ref @eN for subsequent browser commands. Useful for QA and spatial reasoning about page layout."
+                },
+                "full_page": {
+                    "type": "boolean",
+                    "default": True,
+                    "description": "If true (default), capture the full scrollable page. Set to false on long or infinite-scroll pages — vision APIs downscale very tall screenshots until text becomes unreadable, so viewport-only is preferable there."
                 }
             },
             "required": ["question"]
@@ -2372,29 +2377,32 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
         }, ensure_ascii=False)
 
 
-def browser_vision(question: str, annotate: bool = False, task_id: Optional[str] = None) -> str:
+def browser_vision(question: str, annotate: bool = False, full_page: bool = True, task_id: Optional[str] = None) -> str:
     """
     Take a screenshot of the current page and analyze it with vision AI.
-    
+
     This tool captures what's visually displayed in the browser and sends it
     to Gemini for analysis. Useful for understanding visual content that the
     text-based snapshot may not capture (CAPTCHAs, verification challenges,
     images, complex layouts, etc.).
-    
+
     The screenshot is saved persistently and its file path is returned alongside
     the analysis, so it can be shared with users via MEDIA:<path> in the response.
-    
+
     Args:
         question: What you want to know about the page visually
         annotate: If True, overlay numbered [N] labels on interactive elements
+        full_page: If True (default), capture the full scrollable page. Set to
+            False on long or infinite-scroll pages — vision APIs downscale very
+            tall screenshots until text becomes unreadable.
         task_id: Task identifier for session isolation
-        
+
     Returns:
         JSON string with vision analysis results and screenshot_path
     """
     if _is_camofox_mode():
         from tools.browser_camofox import camofox_vision
-        return camofox_vision(question, annotate, task_id)
+        return camofox_vision(question, annotate, full_page, task_id)
 
     import base64
     import uuid as uuid_mod
@@ -2415,7 +2423,8 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         screenshot_args = []
         if annotate:
             screenshot_args.append("--annotate")
-        screenshot_args.append("--full")
+        if full_page:
+            screenshot_args.append("--full")
         screenshot_args.append(str(screenshot_path))
         result = _run_browser_command(
             effective_task_id, 
@@ -3033,7 +3042,7 @@ registry.register(
     name="browser_vision",
     toolset="browser",
     schema=_BROWSER_SCHEMA_MAP["browser_vision"],
-    handler=lambda args, **kw: browser_vision(question=args.get("question", ""), annotate=args.get("annotate", False), task_id=kw.get("task_id")),
+    handler=lambda args, **kw: browser_vision(question=args.get("question", ""), annotate=args.get("annotate", False), full_page=args.get("full_page", True), task_id=kw.get("task_id")),
     check_fn=check_browser_requirements,
     emoji="👁️",
 )


### PR DESCRIPTION
Add a `full_page` parameter to `browser_vision` so callers can opt into viewport-only screenshots on long pages where full-page capture produces unreadable images.

## What changed and why
- `browser_vision` previously always appended `--full` to `agent-browser screenshot`, producing a single image covering the entire scrollable page. On long pages (≈10k px tall), the resulting ~11k×40k PNGs are downscaled by vision APIs until text collapses into unreadable smears and the model refuses to extract data (issue #19620).
- Added a new `full_page: bool = True` parameter to `browser_vision`. The default preserves existing behavior; `full_page=False` omits the `--full` flag so the screenshot captures only the current viewport — verified to produce a crisp ~2880×1456 PNG that vision reads cleanly.
- Updated the tool schema (`BROWSER_TOOL_SCHEMAS`) and the registry handler to surface and forward the new argument.
- Threaded the parameter through `camofox_vision` for API parity. Camofox's REST screenshot endpoint already returns viewport-only, so the flag is a no-op on that backend; documented in the docstring.

## How to test
- `pytest tests/tools/test_browser_console.py -q` — exercises three new tests covering the schema entry, that the default still emits `--full`, that `full_page=False` suppresses it, and that the registry handler forwards `args["full_page"]`.
- Manual: open a long page (e.g. https://www.rbc.ru/) and call `browser_vision` with `full_page=False` — screenshot should be viewport-sized and the analysis should be readable.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #19620

<!-- autocontrib:worker-id=issue-new-5735f547 kind=pr-open -->