### PR TITLE
fix(voice): strip sounddevice from playback paths to fix macOS segfault

### DIFF
--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -611,33 +611,34 @@ class TestWhisperHallucinationFilter:
 # ============================================================================
 
 class TestPlayAudioFile:
-    def test_play_wav_via_sounddevice(self, monkeypatch, sample_wav):
-        np = pytest.importorskip("numpy")
+    def test_play_wav_via_afplay_on_macos(self, monkeypatch, sample_wav):
+        """WAV files are played via afplay (macOS) subprocess, not sounddevice."""
+        popen_calls = []
 
-        mock_sd_obj = MagicMock()
-        # Simulate stream completing immediately (get_stream().active = False)
-        mock_stream = MagicMock()
-        mock_stream.active = False
-        mock_sd_obj.get_stream.return_value = mock_stream
+        class FakeProc:
+            returncode = 0
+            def wait(self, timeout=None):
+                return 0
+            def poll(self):
+                return 0
 
-        def _fake_import():
-            return mock_sd_obj, np
+        def fake_popen(cmd, **kwargs):
+            popen_calls.append(cmd)
+            return FakeProc()
 
-        monkeypatch.setattr("tools.voice_mode._import_audio", _fake_import)
+        monkeypatch.setattr("tools.voice_mode.platform.system", lambda: "Darwin")
+        monkeypatch.setattr("tools.voice_mode.shutil.which", lambda cmd: f"/usr/bin/{cmd}" if cmd == "afplay" else None)
+        monkeypatch.setattr("tools.voice_mode.subprocess.Popen", fake_popen)
 
         from tools.voice_mode import play_audio_file
 
         result = play_audio_file(sample_wav)
 
         assert result is True
-        mock_sd_obj.play.assert_called_once()
-        mock_sd_obj.stop.assert_called_once()
+        assert any(cmd[0] == "afplay" for cmd in popen_calls)
 
     def test_returns_false_when_no_player(self, monkeypatch, sample_wav):
-        def _fail_import():
-            raise ImportError("no sounddevice")
-        monkeypatch.setattr("tools.voice_mode._import_audio", _fail_import)
-        monkeypatch.setattr("shutil.which", lambda _: None)
+        monkeypatch.setattr("tools.voice_mode.shutil.which", lambda _: None)
 
         from tools.voice_mode import play_audio_file
 
@@ -707,49 +708,67 @@ class TestCleanupTempRecordings:
 # ============================================================================
 
 class TestPlayBeep:
-    def test_beep_calls_sounddevice_play(self, mock_sd):
+    def test_beep_calls_system_player(self, monkeypatch):
+        """play_beep writes a temp WAV and plays it via system player (no sounddevice)."""
         np = pytest.importorskip("numpy")
+
+        played_files = []
+
+        def fake_play_audio_file(path):
+            played_files.append(path)
+            return True
+
+        monkeypatch.setattr("tools.voice_mode.play_audio_file", fake_play_audio_file)
 
         from tools.voice_mode import play_beep
 
-        # play_beep uses polling (get_stream) + sd.stop() instead of sd.wait()
-        mock_stream = MagicMock()
-        mock_stream.active = False
-        mock_sd.get_stream.return_value = mock_stream
-
         play_beep(frequency=880, duration=0.1, count=1)
 
-        mock_sd.play.assert_called_once()
-        mock_sd.stop.assert_called()
-        # Verify audio data is int16 numpy array
-        audio_arg = mock_sd.play.call_args[0][0]
-        assert audio_arg.dtype == np.int16
-        assert len(audio_arg) > 0
+        assert len(played_files) == 1
+        # Temp file should be cleaned up after play
+        assert not os.path.exists(played_files[0])
 
-    def test_beep_double_produces_longer_audio(self, mock_sd):
-        np = pytest.importorskip("numpy")
+    def test_beep_double_calls_player_once(self, monkeypatch):
+        """A two-count beep writes one concatenated WAV file."""
+        pytest.importorskip("numpy")
+
+        played_files = []
+
+        def fake_play_audio_file(path):
+            played_files.append(path)
+            return True
+
+        monkeypatch.setattr("tools.voice_mode.play_audio_file", fake_play_audio_file)
 
         from tools.voice_mode import play_beep
 
         play_beep(frequency=660, duration=0.1, count=2)
 
-        audio_arg = mock_sd.play.call_args[0][0]
-        single_beep_samples = int(16000 * 0.1)
-        # Double beep should be longer than a single beep
-        assert len(audio_arg) > single_beep_samples
+        assert len(played_files) == 1
 
-    def test_beep_noop_without_audio(self, monkeypatch):
-        def _fail_import():
-            raise ImportError("no sounddevice")
-        monkeypatch.setattr("tools.voice_mode._import_audio", _fail_import)
+    def test_beep_noop_without_numpy(self, monkeypatch):
+        import builtins
+        real_import = builtins.__import__
+
+        def _fail_numpy(name, *args, **kwargs):
+            if name == "numpy":
+                raise ImportError("no numpy")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _fail_numpy)
 
         from tools.voice_mode import play_beep
 
         # Should not raise
         play_beep()
 
-    def test_beep_handles_playback_error(self, mock_sd):
-        mock_sd.play.side_effect = Exception("device error")
+    def test_beep_handles_playback_error(self, monkeypatch):
+        pytest.importorskip("numpy")
+
+        def fake_play_audio_file(path):
+            raise Exception("device error")
+
+        monkeypatch.setattr("tools.voice_mode.play_audio_file", fake_play_audio_file)
 
         from tools.voice_mode import play_beep
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -98,11 +98,6 @@ def _import_mistral_client():
     from mistralai.client import Mistral
     return Mistral
 
-def _import_sounddevice():
-    """Lazy import sounddevice. Returns the module or raises ImportError/OSError."""
-    import sounddevice as sd
-    return sd
-
 
 def _import_kittentts():
     """Lazy import KittenTTS. Returns the class or raises ImportError."""

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1929,7 +1929,6 @@ def stream_tts_to_speaker(
     try:
         # --- TTS client setup (optional -- display_callback works without it) ---
         client = None
-        output_stream = None
         voice_id = DEFAULT_ELEVENLABS_VOICE_ID
         model_id = DEFAULT_ELEVENLABS_STREAMING_MODEL_ID
 
@@ -1956,23 +1955,6 @@ def stream_tts_to_speaker(
                 client = ElevenLabs(api_key=api_key)
             except ImportError:
                 logger.warning("elevenlabs package not installed; streaming TTS disabled")
-
-            # Open a single sounddevice output stream for the lifetime of
-            # this function.  ElevenLabs pcm_24000 produces signed 16-bit
-            # little-endian mono PCM at 24 kHz.
-            if client is not None:
-                try:
-                    sd = _import_sounddevice()
-                    output_stream = sd.OutputStream(
-                        samplerate=24000, channels=1, dtype="int16",
-                    )
-                    output_stream.start()
-                except (ImportError, OSError) as exc:
-                    logger.debug("sounddevice not available: %s", exc)
-                    output_stream = None
-                except Exception as exc:
-                    logger.warning("sounddevice OutputStream failed: %s", exc)
-                    output_stream = None
 
         sentence_buf = ""
         min_sentence_len = 20
@@ -2011,16 +1993,7 @@ def stream_tts_to_speaker(
                     model_id=model_id,
                     output_format="pcm_24000",
                 )
-                if output_stream is not None:
-                    for chunk in audio_iter:
-                        if stop_event.is_set():
-                            break
-                        import numpy as _np
-                        audio_array = _np.frombuffer(chunk, dtype=_np.int16)
-                        output_stream.write(audio_array.reshape(-1, 1))
-                else:
-                    # Fallback: write chunks to temp file and play via system player
-                    _play_via_tempfile(audio_iter, stop_event)
+                _play_via_tempfile(audio_iter, stop_event)
             except Exception as exc:
                 logger.warning("Streaming TTS sentence failed: %s", exc)
 
@@ -2106,13 +2079,6 @@ def stream_tts_to_speaker(
     except Exception as exc:
         logger.warning("Streaming TTS pipeline error: %s", exc)
     finally:
-        # Always close the audio output stream to avoid locking the device
-        if output_stream is not None:
-            try:
-                output_stream.stop()
-                output_stream.close()
-            except Exception:
-                pass
         tts_done_event.set()
 
 

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -2,7 +2,7 @@
 
 Provides audio capture via sounddevice, WAV encoding via stdlib wave,
 STT dispatch via tools.transcription_tools, and TTS playback via
-sounddevice or system audio players.
+system audio players (afplay / ffplay / aplay).
 
 Dependencies (optional):
     pip install sounddevice numpy
@@ -199,7 +199,7 @@ _TEMP_DIR = os.path.join(tempfile.gettempdir(), "hermes_voice")
 # Audio cues (beep tones)
 # ============================================================================
 def play_beep(frequency: int = 880, duration: float = 0.12, count: int = 1) -> None:
-    """Play a short beep tone using numpy + sounddevice.
+    """Play a short beep tone using numpy (synthesis) + system audio player.
 
     Args:
         frequency: Tone frequency in Hz (default 880 = A5).
@@ -207,9 +207,10 @@ def play_beep(frequency: int = 880, duration: float = 0.12, count: int = 1) -> N
         count: Number of beeps to play (with short gap between).
     """
     try:
-        sd, np = _import_audio()
-    except (ImportError, OSError):
+        import numpy as np
+    except ImportError:
         return
+    tmp_path = None
     try:
         gap = 0.06  # seconds between beeps
         samples_per_beep = int(SAMPLE_RATE * duration)
@@ -228,15 +229,26 @@ def play_beep(frequency: int = 880, duration: float = 0.12, count: int = 1) -> N
                 parts.append(np.zeros(samples_per_gap, dtype=np.int16))
 
         audio = np.concatenate(parts)
-        sd.play(audio, samplerate=SAMPLE_RATE)
-        # sd.wait() calls Event.wait() without timeout — hangs forever if the
-        # audio device stalls.  Poll with a 2s ceiling and force-stop.
-        deadline = time.monotonic() + 2.0
-        while sd.get_stream() and sd.get_stream().active and time.monotonic() < deadline:
-            time.sleep(0.01)
-        sd.stop()
+        # Write to a temp WAV and play via subprocess.  sounddevice's sd.play()
+        # on the output path races with CoreAudio on macOS (EXC_BAD_ACCESS in
+        # AdaptingOutputOnlyProcess / libportaudio) when a concurrent
+        # InputStream is open for STT capture.
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+            tmp_path = tmp.name
+        with wave.open(tmp_path, "wb") as wf:
+            wf.setnchannels(CHANNELS)
+            wf.setsampwidth(SAMPLE_WIDTH)
+            wf.setframerate(SAMPLE_RATE)
+            wf.writeframes(audio.tobytes())
+        play_audio_file(tmp_path)
     except Exception as e:
         logger.debug("Beep playback failed: %s", e)
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
 
 # ============================================================================
@@ -832,21 +844,13 @@ def stop_playback() -> None:
             logger.info("Audio playback interrupted")
         except Exception:
             pass
-    # Also stop sounddevice playback if active
-    try:
-        sd, _ = _import_audio()
-        sd.stop()
-    except Exception:
-        pass
 
 
 def play_audio_file(file_path: str) -> bool:
     """Play an audio file through the default output device.
 
-    Strategy:
-    1. WAV files via ``sounddevice.play()`` when available.
-    2. System commands: ``afplay`` (macOS), ``ffplay`` (cross-platform),
-       ``aplay`` (Linux ALSA).
+    Uses system commands: ``afplay`` (macOS), ``ffplay`` (cross-platform),
+    ``aplay`` (Linux ALSA).
 
     Playback can be interrupted by calling ``stop_playback()``.
 
@@ -859,30 +863,7 @@ def play_audio_file(file_path: str) -> bool:
         logger.warning("Audio file not found: %s", file_path)
         return False
 
-    # Try sounddevice for WAV files
-    if file_path.endswith(".wav"):
-        try:
-            sd, np = _import_audio()
-            with wave.open(file_path, "rb") as wf:
-                frames = wf.readframes(wf.getnframes())
-                audio_data = np.frombuffer(frames, dtype=np.int16)
-                sample_rate = wf.getframerate()
-
-            sd.play(audio_data, samplerate=sample_rate)
-            # sd.wait() calls Event.wait() without timeout — hangs forever if
-            # the audio device stalls.  Poll with a ceiling and force-stop.
-            duration_secs = len(audio_data) / sample_rate
-            deadline = time.monotonic() + duration_secs + 2.0
-            while sd.get_stream() and sd.get_stream().active and time.monotonic() < deadline:
-                time.sleep(0.01)
-            sd.stop()
-            return True
-        except (ImportError, OSError):
-            pass  # audio libs not available, fall through to system players
-        except Exception as e:
-            logger.debug("sounddevice playback failed: %s", e)
-
-    # Fall back to system audio players (using Popen for interruptability)
+    # Use system audio players (using Popen for interruptability)
     system = platform.system()
     players = []
 


### PR DESCRIPTION
## What changed and why

The macOS crash (EXC_BAD_ACCESS at 0x4 on `com.apple.audio.IOThread.client`) was confirmed by the reporter's `Python-2026-05-05-065550.ips` crash report: the faulting frames are `AdaptingOutputOnlyProcess` → `AudioIOProc` → CoreAudio IOThread — the sounddevice **output** path, not the recording input stream.

Root cause: when ElevenLabs TTS is active, `tts_tool.stream_tts_to_speaker()` opens a concurrent `sd.OutputStream` (24 kHz PCM) while `AudioRecorder._ensure_stream()` already holds an `sd.InputStream` for STT capture. The CFFI/PortAudio callbacks race in CoreAudio, producing a dangling-pointer dereference. The same race occurs when `play_beep()` or `play_audio_file()` call `sd.play()` alongside the live input stream.

**Changes:**

- `tools/voice_mode.py`
  - `play_beep()`: synthesises the tone with numpy, writes a temp WAV, plays via `play_audio_file()` — no `sd.play()` or `sd.stop()`
  - `play_audio_file()`: removed the WAV-via-sounddevice primary path; subprocess players (afplay / ffplay / aplay) are now the only path
  - `stop_playback()`: removed the `sd.stop()` call; subprocess termination already handles interruption

- `tools/tts_tool.py`
  - `stream_tts_to_speaker()`: removed the `sd.OutputStream` block; always uses the existing `_play_via_tempfile()` helper (writes PCM chunks to a temp WAV, plays via `play_audio_file()`). The `output_stream` variable and its `finally` cleanup are gone.
  - `_import_sounddevice()`: removed — dead code after the OutputStream block was deleted (no callers remain).

`AudioRecorder._ensure_stream()` and its `sd.InputStream` are untouched — the crash report confirms the fault was exclusively on the output side.

## How to test

1. `pytest tests/tools/test_voice_mode.py tests/tools/test_tts_command_providers.py -q` — all pass
2. Manual: start a voice session with ElevenLabs TTS enabled, use tool calls during conversation — no segfault should occur
3. Verify beep tones play via `afplay` on macOS (check Console.app for any process spawns)

## What platforms tested on

- macOS (target platform for the bug)
- Linux subprocess fallback paths (afplay absent, ffplay/aplay used instead) are unchanged

Fixes #20002

<!-- autocontrib:worker-id=issue-followup-3337ac82 kind=pr-open -->