### PR TITLE
fix: make models.dev metadata offline-first

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -207,45 +207,69 @@ def _save_disk_cache(data: Dict[str, Any]) -> None:
 
 
 def fetch_models_dev(force_refresh: bool = False) -> Dict[str, Any]:
-    """Fetch models.dev registry. In-memory cache (1hr) + disk fallback.
+    """Fetch models.dev registry with offline-first semantics.
+
+    Normal callers, including dashboard request handlers, should not block on a
+    live models.dev network request. Resolution order is:
+
+    1. fresh in-memory cache
+    2. disk cache
+    3. network fetch only when explicitly requested with ``force_refresh=True``
+       or when no local cache exists
 
     Returns the full registry dict keyed by provider ID, or empty dict on failure.
     """
     global _models_dev_cache, _models_dev_cache_time
 
-    # Check in-memory cache
+    now = time.time()
+
+    # Fresh in-memory cache: fastest path.
     if (
         not force_refresh
         and _models_dev_cache
-        and (time.time() - _models_dev_cache_time) < _MODELS_DEV_CACHE_TTL
+        and (now - _models_dev_cache_time) < _MODELS_DEV_CACHE_TTL
     ):
         return _models_dev_cache
 
-    # Try network fetch
+    # Disk cache is the primary cold-start source. This keeps UI/API hot paths
+    # responsive when models.dev is slow, unreachable, or DNS/network is wedged.
+    disk_cache: Dict[str, Any] = {}
     try:
-        response = requests.get(MODELS_DEV_URL, timeout=15)
-        response.raise_for_status()
-        data = response.json()
-        if isinstance(data, dict) and data:
-            _models_dev_cache = data
-            _models_dev_cache_time = time.time()
-            _save_disk_cache(data)
-            logger.debug(
-                "Fetched models.dev registry: %d providers, %d total models",
-                len(data),
-                sum(len(p.get("models", {})) for p in data.values() if isinstance(p, dict)),
-            )
-            return data
+        disk_cache = _load_disk_cache()
     except Exception as e:
-        logger.debug("Failed to fetch models.dev: %s", e)
+        logger.debug("Failed to load models.dev disk cache: %s", e)
 
-    # Fall back to disk cache — use a short TTL (5 min) so we retry
-    # the network fetch soon instead of serving stale data for a full hour.
-    if not _models_dev_cache:
-        _models_dev_cache = _load_disk_cache()
-        if _models_dev_cache:
-            _models_dev_cache_time = time.time() - _MODELS_DEV_CACHE_TTL + 300
-            logger.debug("Loaded models.dev from disk cache (%d providers)", len(_models_dev_cache))
+    if disk_cache and not force_refresh:
+        _models_dev_cache = disk_cache
+        _models_dev_cache_time = now
+        logger.debug("Loaded models.dev from disk cache (%d providers)", len(_models_dev_cache))
+        return _models_dev_cache
+
+    # Try network fetch only for explicit refreshes or when no disk cache exists.
+    if force_refresh or not disk_cache:
+        try:
+            response = requests.get(MODELS_DEV_URL, timeout=15)
+            response.raise_for_status()
+            data = response.json()
+            if isinstance(data, dict) and data:
+                _models_dev_cache = data
+                _models_dev_cache_time = time.time()
+                _save_disk_cache(data)
+                logger.debug(
+                    "Fetched models.dev registry: %d providers, %d total models",
+                    len(data),
+                    sum(len(p.get("models", {})) for p in data.values() if isinstance(p, dict)),
+                )
+                return data
+        except Exception as e:
+            logger.debug("Failed to fetch models.dev: %s", e)
+
+    # If a forced refresh failed, serve disk cache rather than returning empty.
+    if disk_cache:
+        _models_dev_cache = disk_cache
+        _models_dev_cache_time = now
+        logger.debug("Loaded models.dev from disk cache after refresh failure (%d providers)", len(_models_dev_cache))
+        return _models_dev_cache
 
     return _models_dev_cache
 

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -201,6 +201,78 @@ class TestFetchModelsDev:
         mock_get.assert_not_called()
         assert result == SAMPLE_REGISTRY
 
+    @patch("agent.models_dev.requests.get")
+    @patch("agent.models_dev._load_disk_cache")
+    def test_disk_cache_used_before_network_on_cold_start(self, mock_load_disk, mock_get):
+        """Cold normal calls should serve disk cache without blocking on network."""
+        import agent.models_dev as md
+        md._models_dev_cache = {}
+        md._models_dev_cache_time = 0
+
+        mock_load_disk.return_value = SAMPLE_REGISTRY
+
+        result = fetch_models_dev()
+
+        mock_load_disk.assert_called_once()
+        mock_get.assert_not_called()
+        assert result == SAMPLE_REGISTRY
+
+    @patch("agent.models_dev.requests.get")
+    @patch("agent.models_dev._load_disk_cache")
+    def test_network_called_when_disk_cache_absent(self, mock_load_disk, mock_get):
+        """Network is only a cold-start fallback when there is no disk cache."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = SAMPLE_REGISTRY
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        import agent.models_dev as md
+        md._models_dev_cache = {}
+        md._models_dev_cache_time = 0
+
+        mock_load_disk.return_value = {}
+
+        with patch.object(md, "_save_disk_cache"):
+            result = fetch_models_dev()
+
+        mock_load_disk.assert_called_once()
+        mock_get.assert_called_once()
+        assert result == SAMPLE_REGISTRY
+
+    @patch("agent.models_dev.requests.get")
+    @patch("agent.models_dev._load_disk_cache")
+    def test_force_refresh_falls_back_to_disk_cache_on_network_failure(self, mock_load_disk, mock_get):
+        """Explicit refresh failures should degrade to disk cache, not empty data."""
+        mock_get.side_effect = Exception("network error")
+
+        import agent.models_dev as md
+        md._models_dev_cache = {}
+        md._models_dev_cache_time = 0
+
+        mock_load_disk.return_value = SAMPLE_REGISTRY
+
+        result = fetch_models_dev(force_refresh=True)
+
+        mock_get.assert_called_once()
+        assert result == SAMPLE_REGISTRY
+
+    @patch("agent.models_dev.requests.get")
+    @patch("agent.models_dev._load_disk_cache")
+    def test_complete_failure_returns_empty_dict(self, mock_load_disk, mock_get):
+        """Cold memory + empty disk + network failure returns {}, not an exception."""
+        mock_get.side_effect = Exception("network error")
+
+        import agent.models_dev as md
+        md._models_dev_cache = {}
+        md._models_dev_cache_time = 0
+
+        mock_load_disk.return_value = {}
+
+        result = fetch_models_dev()
+
+        assert result == {}
+
 
 # ---------------------------------------------------------------------------
 # get_model_capabilities — vision via modalities.input


### PR DESCRIPTION
## Summary
- make `agent.models_dev.fetch_models_dev()` offline-first for normal callers
- serve the local disk cache before attempting a live `models.dev` request
- keep `force_refresh=True` as the explicit network-refresh path, with disk-cache fallback if refresh fails
- add regression coverage for cold-start disk-cache behavior, network fallback, refresh failure fallback, and total failure

## Problem
Dashboard request handlers such as `/api/model/info` and `/api/analytics/models` resolve model metadata through `agent.models_dev`. On a cold in-memory cache, `fetch_models_dev()` currently attempts `https://models.dev/api.json` before reading the disk cache.

That means a slow DNS/network path or a degraded `models.dev` response can block dashboard request handling even when Hermes already has a usable local cache. In practice this can make the dashboard appear wedged while the process and port are still alive.

The module docstring already describes the intended resolution order as offline-first: bundled snapshot / disk cache, then network refresh. This PR aligns the implementation with that safer model.

## Solution path
Normal metadata lookups should prioritize responsiveness and resilience over absolute freshness. `models.dev` data is useful metadata, but it should not be a synchronous availability dependency for the dashboard or agent hot paths.

This PR changes `fetch_models_dev()` so:

1. fresh in-memory cache is still the fastest path
2. disk cache is the primary cold-start source for normal calls
3. live network fetch happens only when explicitly requested with `force_refresh=True` or when no local cache exists
4. failed explicit refreshes degrade to disk cache instead of returning empty data

A scheduler or startup/background task can call `fetch_models_dev(force_refresh=True)` to update the cache outside request hot paths.

## Test plan
- `python -m pytest tests/agent/test_models_dev.py -o 'addopts=' -q`

Result locally: `29 passed`.
