### PR TITLE
fix(gateway): honor custom_providers max_tokens when constructing AIAgent

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -724,6 +724,14 @@ def _resolve_runtime_agent_kwargs() -> dict:
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
+    # max_tokens precedence (#20004): custom_providers[].max_tokens (carried on
+    # the runtime dict) wins; otherwise fall back to top-level model.max_tokens
+    # so a user-set global cap is still honoured. None means "let the provider
+    # transport pick its native ceiling".
+    max_tokens = runtime.get("max_tokens")
+    if not (isinstance(max_tokens, int) and max_tokens > 0):
+        max_tokens = _resolve_model_max_tokens()
+
     return {
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
@@ -732,7 +740,22 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        "max_tokens": max_tokens,
     }
+
+
+def _resolve_model_max_tokens() -> Optional[int]:
+    """Read ``model.max_tokens`` from the loaded gateway config."""
+    try:
+        cfg = _load_gateway_config() or {}
+        model_cfg = cfg.get("model")
+        if isinstance(model_cfg, dict):
+            value = model_cfg.get("max_tokens")
+            if isinstance(value, int) and value > 0:
+                return value
+    except Exception:
+        pass
+    return None
 
 
 def _try_resolve_fallback_provider() -> dict | None:
@@ -760,6 +783,9 @@ def _try_resolve_fallback_provider() -> dict | None:
                     explicit_api_key=entry.get("api_key"),
                 )
                 logger.info("Fallback provider resolved: %s", runtime.get("provider"))
+                fb_max_tokens = runtime.get("max_tokens")
+                if not (isinstance(fb_max_tokens, int) and fb_max_tokens > 0):
+                    fb_max_tokens = _resolve_model_max_tokens()
                 return {
                     "api_key": runtime.get("api_key"),
                     "base_url": runtime.get("base_url"),
@@ -768,6 +794,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "command": runtime.get("command"),
                     "args": list(runtime.get("args") or []),
                     "credential_pool": runtime.get("credential_pool"),
+                    "max_tokens": fb_max_tokens,
                 }
             except Exception as fb_exc:
                 logger.debug("Fallback entry %s failed: %s", entry.get("provider"), fb_exc)
@@ -1776,6 +1803,12 @@ class GatewayRunner:
             "args": list(runtime_kwargs.get("args") or []),
             "credential_pool": runtime_kwargs.get("credential_pool"),
         }
+        # Forward the resolved per-provider output cap (#20004) so it reaches
+        # AIAgent via ``**turn_route["runtime"]``. Drop the key entirely when
+        # unset so AIAgent uses its native default rather than ``None``.
+        rt_max_tokens = runtime_kwargs.get("max_tokens")
+        if isinstance(rt_max_tokens, int) and rt_max_tokens > 0:
+            runtime["max_tokens"] = rt_max_tokens
         route = {
             "model": model,
             "runtime": runtime,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2553,7 +2553,7 @@ def _normalize_custom_provider_entry(
     _KNOWN_KEYS = {
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
+        "context_length", "max_tokens", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -2640,6 +2640,10 @@ def _normalize_custom_provider_entry(
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:
         normalized["context_length"] = context_length
+
+    max_tokens = entry.get("max_tokens")
+    if isinstance(max_tokens, int) and max_tokens > 0:
+        normalized["max_tokens"] = max_tokens
 
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -410,6 +410,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                     if api_mode:
                         result["api_mode"] = api_mode
+                    max_tokens = entry.get("max_tokens")
+                    if isinstance(max_tokens, int) and max_tokens > 0:
+                        result["max_tokens"] = max_tokens
                     return result
             # Also check the 'name' field if present
             display_name = entry.get("name", "")
@@ -428,6 +431,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                         if api_mode:
                             result["api_mode"] = api_mode
+                        max_tokens = entry.get("max_tokens")
+                        if isinstance(max_tokens, int) and max_tokens > 0:
+                            result["max_tokens"] = max_tokens
                         return result
 
     # Fall back to custom_providers: list (legacy format)
@@ -474,6 +480,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         model_name = str(entry.get("model", "") or "").strip()
         if model_name:
             result["model"] = model_name
+        max_tokens = entry.get("max_tokens")
+        if isinstance(max_tokens, int) and max_tokens > 0:
+            result["max_tokens"] = max_tokens
         return result
 
     return None
@@ -528,6 +537,9 @@ def _resolve_named_custom_runtime(
         model_name = custom_provider.get("model")
         if model_name:
             pool_result["model"] = model_name
+        max_tokens = custom_provider.get("max_tokens")
+        if isinstance(max_tokens, int) and max_tokens > 0:
+            pool_result["max_tokens"] = max_tokens
         return pool_result
 
     api_key_candidates = [
@@ -552,6 +564,12 @@ def _resolve_named_custom_runtime(
     # provider name differs from the actual model string the API expects.
     if custom_provider.get("model"):
         result["model"] = custom_provider["model"]
+    # Propagate the per-provider output cap so the gateway/CLI can honour
+    # ``custom_providers[].max_tokens`` instead of falling back to the
+    # provider transport default. See #20004.
+    max_tokens = custom_provider.get("max_tokens")
+    if isinstance(max_tokens, int) and max_tokens > 0:
+        result["max_tokens"] = max_tokens
     return result
 
 

--- a/tests/hermes_cli/test_custom_provider_max_tokens.py
+++ b/tests/hermes_cli/test_custom_provider_max_tokens.py
@@ -1,0 +1,219 @@
+"""Regression tests for ``custom_providers[].max_tokens`` propagation.
+
+Covers the fix for #20004 — a per-provider output cap defined in
+``custom_providers`` (or the new-style ``providers`` dict) must reach the
+gateway's resolved runtime so AIAgent honours it instead of falling back to
+the provider transport default.
+"""
+from __future__ import annotations
+
+from hermes_cli import runtime_provider as rp
+from hermes_cli.config import _normalize_custom_provider_entry
+
+
+class TestNormalizeCustomProviderMaxTokens:
+    def test_preserves_positive_int(self):
+        normalized = _normalize_custom_provider_entry(
+            {
+                "name": "ark",
+                "base_url": "https://example.invalid/v1",
+                "max_tokens": 131072,
+            }
+        )
+        assert normalized is not None
+        assert normalized["max_tokens"] == 131072
+
+    def test_drops_zero_or_negative(self):
+        for bad in (0, -1, -100):
+            normalized = _normalize_custom_provider_entry(
+                {
+                    "name": "ark",
+                    "base_url": "https://example.invalid/v1",
+                    "max_tokens": bad,
+                }
+            )
+            assert normalized is not None
+            assert "max_tokens" not in normalized, f"value {bad!r} should be rejected"
+
+    def test_drops_non_int(self):
+        for bad in ("131072", 1.5, None, [1]):
+            normalized = _normalize_custom_provider_entry(
+                {
+                    "name": "ark",
+                    "base_url": "https://example.invalid/v1",
+                    "max_tokens": bad,
+                }
+            )
+            assert normalized is not None
+            assert "max_tokens" not in normalized, f"value {bad!r} should be rejected"
+
+    def test_does_not_warn_about_max_tokens_as_unknown_key(self, caplog):
+        """``max_tokens`` is now in ``_KNOWN_KEYS``; no 'unknown config keys' warning."""
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+            _normalize_custom_provider_entry(
+                {
+                    "name": "ark",
+                    "base_url": "https://example.invalid/v1",
+                    "max_tokens": 8192,
+                }
+            )
+        for record in caplog.records:
+            assert "max_tokens" not in record.message or "unknown" not in record.message
+
+
+class TestRuntimeResolutionPropagatesMaxTokens:
+    def test_named_custom_provider_legacy_list_propagates_max_tokens(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setattr(
+            rp,
+            "load_config",
+            lambda: {
+                "custom_providers": [
+                    {
+                        "name": "ark",
+                        "base_url": "https://ark.example.invalid/v1",
+                        "api_key": "ark-key",
+                        "max_tokens": 131072,
+                    }
+                ]
+            },
+        )
+        monkeypatch.setattr(
+            rp,
+            "resolve_provider",
+            lambda *a, **k: (_ for _ in ()).throw(
+                AssertionError("named custom provider should short-circuit resolve_provider")
+            ),
+        )
+
+        resolved = rp.resolve_runtime_provider(requested="ark")
+
+        assert resolved["provider"] == "custom"
+        assert resolved["max_tokens"] == 131072
+
+    def test_named_custom_provider_v12_dict_propagates_max_tokens(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setattr(
+            rp,
+            "load_config",
+            lambda: {
+                "providers": {
+                    "ark": {
+                        "api": "https://ark.example.invalid/v1",
+                        "api_key": "ark-key",
+                        "default_model": "ark-pro",
+                        "max_tokens": 131072,
+                    }
+                }
+            },
+        )
+        monkeypatch.setattr(
+            rp,
+            "resolve_provider",
+            lambda *a, **k: (_ for _ in ()).throw(
+                AssertionError("named custom provider should short-circuit resolve_provider")
+            ),
+        )
+
+        resolved = rp.resolve_runtime_provider(requested="ark")
+
+        assert resolved["provider"] == "custom"
+        assert resolved["max_tokens"] == 131072
+
+    def test_omitted_max_tokens_does_not_appear_in_runtime(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.setattr(
+            rp,
+            "load_config",
+            lambda: {
+                "custom_providers": [
+                    {
+                        "name": "ark",
+                        "base_url": "https://ark.example.invalid/v1",
+                        "api_key": "ark-key",
+                    }
+                ]
+            },
+        )
+        monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+
+        resolved = rp.resolve_runtime_provider(requested="ark")
+
+        assert resolved["provider"] == "custom"
+        assert "max_tokens" not in resolved
+
+
+class TestGatewayResolveRuntimeAgentKwargsMaxTokens:
+    def _isolate_module_state(self, monkeypatch):
+        from gateway import run as gateway_run
+
+        return gateway_run
+
+    def test_runtime_max_tokens_wins_over_model_max_tokens(self, monkeypatch):
+        gateway_run = self._isolate_module_state(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda **kwargs: {
+                "provider": "custom",
+                "api_mode": "chat_completions",
+                "base_url": "https://ark.example.invalid/v1",
+                "api_key": "ark-key",
+                "max_tokens": 131072,
+            },
+        )
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_config",
+            lambda: {"model": {"max_tokens": 8192}},
+        )
+
+        result = gateway_run._resolve_runtime_agent_kwargs()
+
+        assert result["max_tokens"] == 131072
+
+    def test_falls_back_to_model_max_tokens_when_runtime_unset(self, monkeypatch):
+        gateway_run = self._isolate_module_state(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda **kwargs: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "or-key",
+            },
+        )
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_config",
+            lambda: {"model": {"max_tokens": 8192}},
+        )
+
+        result = gateway_run._resolve_runtime_agent_kwargs()
+
+        assert result["max_tokens"] == 8192
+
+    def test_returns_none_when_neither_set(self, monkeypatch):
+        gateway_run = self._isolate_module_state(monkeypatch)
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda **kwargs: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "or-key",
+            },
+        )
+        monkeypatch.setattr(
+            gateway_run,
+            "_load_gateway_config",
+            lambda: {"model": {}},
+        )
+
+        result = gateway_run._resolve_runtime_agent_kwargs()
+
+        assert result["max_tokens"] is None


### PR DESCRIPTION
Per-provider `max_tokens` set under `custom_providers` (or the new-style `providers` dict) was dropped during config normalization and never reached `AIAgent`, so the gateway always used provider transport defaults regardless of the user's cap.

## What changed and why
- `hermes_cli/config.py`: add `max_tokens` to `_KNOWN_KEYS` in `_normalize_custom_provider_entry` and preserve positive int values in the normalized entry — without this, the key was dropped (and a spurious "unknown config keys" warning was logged).
- `hermes_cli/runtime_provider.py`: propagate `max_tokens` from `_get_named_custom_provider` (legacy list, v12 dict, and credential-pool branches) and from `_resolve_named_custom_runtime` so the resolved runtime dict carries the cap.
- `gateway/run.py`: include `max_tokens` in `_resolve_runtime_agent_kwargs` and the fallback-provider helper (with a fallback to top-level `model.max_tokens`), and forward it through `_resolve_turn_agent_config` so `AIAgent(**turn_route["runtime"])` receives the value.
- `tests/hermes_cli/test_custom_provider_max_tokens.py`: 10 new tests covering normalization (positive int, zero/negative rejection, non-int rejection, no spurious unknown-key warning), runtime propagation through the legacy list and v12 dict paths, omission semantics, and gateway precedence (runtime wins, falls back to `model.max_tokens`, returns `None` when neither is set).

Precedence is now: `custom_providers[].max_tokens` (carried on the runtime dict) → `model.max_tokens` (global) → `None` (provider transport default).

## How to test
- `pytest tests/hermes_cli/test_custom_provider_max_tokens.py -q` (10 passed locally)
- `pytest tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_custom_provider_context_length.py tests/hermes_cli/test_config.py -q` (173 passed)
- Broader sweep: `pytest tests/hermes_cli/ tests/gateway/ -q` shows only pre-existing platform/flaky failures (systemd D-Bus on macOS, whatsapp/discord adapter tests, an SSE-keepalive timing test) that also fail on `main`.
- Manual: set `custom_providers: [{name: ark, base_url: ..., max_tokens: 131072}]` and confirm via gateway logs that the agent's `max_tokens` is 131072 instead of the provider default.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #20004

<!-- autocontrib:worker-id=issue-new-ce3066c0 kind=pr-open -->