### PR TITLE
fix(gateway): skip home-channel shutdown ping when idle (#20103)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2796,6 +2796,21 @@ class GatewayRunner:
                     platform_str, chat_id, e,
                 )
 
+        # On a plain shutdown (not a user-initiated /restart) with no active
+        # sessions, skip the home-channel broadcast: the warning only
+        # carries useful information when a task is actually being
+        # interrupted, and a scheduled/idle reboot (e.g. systemd timer)
+        # otherwise produces a daily ping in every configured home channel
+        # with nothing to warn about. The /restart path keeps the
+        # always-broadcast behaviour because users explicitly opted into it
+        # and ops watchers depend on the heartbeat — see
+        # ``test_restart_notifies_home_channel_even_without_active_sessions``.
+        if not active and not self._restart_requested:
+            logger.info(
+                "No active sessions at shutdown — skipping home-channel notification"
+            )
+            return
+
         # Snapshot adapters up front: adapter.send() can hit a fatal error
         # path that pops the adapter from self.adapters (see _handle_fatal
         # elsewhere), which would otherwise trigger

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -623,3 +623,68 @@ async def test_shutdown_notifications_use_cached_live_thread_source_when_origin_
         "⚠️ Gateway shutting down — Your current task will be interrupted.",
         metadata={"thread_id": "topic-7"},
     )
+
+
+# ── plain-shutdown notification: home-channel idle-skip (#20103) ───────────
+
+
+@pytest.mark.asyncio
+async def test_plain_shutdown_skips_home_channel_when_idle():
+    """A plain (non-/restart) shutdown with no active sessions does not ping
+    configured home channels.
+
+    The interrupted-task warning carries no useful signal when nothing was
+    being interrupted; a scheduled systemd-driven reboot of an idle gateway
+    was producing a daily "your current task will be interrupted" ping.
+    """
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = False
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m-1"))
+    runner._running_agents = {}
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_still_pings_home_channel_when_active():
+    """Active sessions at shutdown still trigger the home-channel broadcast.
+
+    Regression guard: the idle-skip must only suppress the home-channel loop
+    when no session is active. With at least one running agent whose
+    delivery target differs from the home channel, the home channel must
+    still receive the notification (so an ops alert lands even when the
+    interrupted session was a different chat).
+    """
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = False
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="m-1"))
+
+    source = make_restart_source(chat_id="user-7")
+    session_key = build_session_key(source)
+    runner._running_agents = {session_key: object()}
+    entry = MagicMock()
+    entry.origin = source
+    runner.session_store._entries = {session_key: entry}
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    sent_chat_ids = [call.args[0] for call in adapter.send.await_args_list]
+    assert "home-42" in sent_chat_ids, (
+        f"Home channel should still receive shutdown notification when "
+        f"a session is active; sent to: {sent_chat_ids}"
+    )
+    assert "user-7" in sent_chat_ids, (
+        f"Active session chat should be notified; sent to: {sent_chat_ids}"
+    )


### PR DESCRIPTION
## Summary

- Skip the home-channel shutdown broadcast when no session was active **and** the shutdown is not a user-initiated `/restart`.
- Preserves the existing `/restart` behaviour: home channels are still notified even when idle (existing test enshrines this for ops-watcher heartbeat reasons).
- Mirrors the symmetric startup gate at `_send_home_channel_startup_notifications` (gateway/run.py:3332), which only fires when `/restart` was pending.

## The bug

`_notify_active_sessions_of_shutdown` broadcasts `\"⚠️ Gateway shutting down — Your current task will be interrupted.\"` to every configured home channel unconditionally. For deployments with a daily systemd-timed reboot of an idle gateway, this produced a spurious daily ping in every home channel — there was no task to interrupt, so the warning carried no signal.

The reporter ([#20103](https://github.com/NousResearch/hermes-agent/issues/20103)) hits this on a Weixin home-channel deployment with a 4 AM systemd reboot.

## The fix

In `gateway/run.py:_notify_active_sessions_of_shutdown`, after the active-session loop and before the home-channel loop, skip the home-channel broadcast when:

- `active == {}` (no running agents) **and**
- `self._restart_requested` is False (plain shutdown, not `/restart`)

```python
if not active and not self._restart_requested:
    logger.info(
        \"No active sessions at shutdown — skipping home-channel notification\"
    )
    return
```

The `/restart` path is intentionally preserved because:
- An existing test (`tests/gateway/test_restart_resume_pending.py::test_restart_notifies_home_channel_even_without_active_sessions`) explicitly asserts the home channel is notified even with no active sessions on `/restart`.
- `/restart` is user-initiated; ops watchers depend on the heartbeat to know the gateway will be back.

This matches the issue reporter's recommended Option A: a one-shot guarded early-return, no new config knobs.

## Test plan

- [x] Two new tests in `tests/gateway/test_restart_notification.py`:
  - `test_plain_shutdown_skips_home_channel_when_idle` — asserts `adapter.send` is **not** called when `_restart_requested=False` and `_running_agents={}`.
  - `test_shutdown_still_pings_home_channel_when_active` — asserts the home channel **is** still notified when at least one session is active in a different chat (regression guard for the home-channel loop entry).
- [x] Existing test `test_restart_notifies_home_channel_even_without_active_sessions` still passes — the `/restart` path is unchanged.
- [x] Adjacent suites pass: `tests/gateway/test_restart_notification.py` (23), `tests/gateway/test_gateway_shutdown.py`, `tests/gateway/test_shutdown_cache_cleanup.py`, `tests/gateway/test_restart_drain.py`, `tests/gateway/test_restart_resume_pending.py` — 114 passed.
- [x] Regression guard verified: stashing the production fix causes only `test_plain_shutdown_skips_home_channel_when_idle` to fail with the exact bug behaviour (\`adapter.send\` called once with the home-channel ping); restoring the fix passes both tests.

## Related

- Fixes [#20103](https://github.com/NousResearch/hermes-agent/issues/20103)

> Sibling code paths that may need the same fix: none. The startup-side already gates home-channel notifications on `restart_notification_pending or delivered_restart_target is not None` (gateway/run.py:3332); this PR brings the shutdown side into the same shape. Happy to widen if any other gateway broadcast sites need the same idle-skip treatment.