### PR TITLE
fix(skills): make Nix store skill copies writable

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -10,6 +10,8 @@ from tools.skills_sync import (
     _write_manifest,
     _discover_bundled_skills,
     _compute_relative_dest,
+    _copy_file_writable,
+    _copytree_writable,
     _dir_hash,
     sync_skills,
     reset_bundled_skill,
@@ -106,6 +108,83 @@ class TestDirHash:
     def test_nonexistent_dir(self, tmp_path):
         h = _dir_hash(tmp_path / "nope")
         assert isinstance(h, str)  # returns hash of empty content
+
+
+class TestCopyFileWritable:
+    """Tests for _copy_file_writable: verifies read-only source files end up writable."""
+
+    def test_readonly_source_becomes_writable(self, tmp_path):
+        import os
+        import stat
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("hello")
+        os.chmod(src, 0o444)  # read-only, like Nix store
+
+        _copy_file_writable(src, dst)
+
+        dst_mode = os.stat(dst).st_mode
+        assert dst_mode & stat.S_IWUSR, f"dst should be owner-writable, got {oct(dst_mode)}"
+
+    def test_writable_source_stays_writable(self, tmp_path):
+        import os
+        import stat
+
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("hello")
+        os.chmod(src, 0o644)
+
+        _copy_file_writable(src, dst)
+
+        dst_mode = os.stat(dst).st_mode
+        assert dst_mode & stat.S_IWUSR
+
+    def test_executable_source_keeps_executable_bit(self, tmp_path):
+        import os
+        import stat
+
+        src = tmp_path / "script.sh"
+        dst = tmp_path / "script-copy.sh"
+        src.write_text("#!/bin/sh\n")
+        os.chmod(src, 0o555)  # executable but not writable, like Nix store scripts
+
+        _copy_file_writable(src, dst)
+
+        dst_mode = stat.S_IMODE(os.stat(dst).st_mode)
+        assert dst_mode & stat.S_IWUSR
+        assert dst_mode & stat.S_IXUSR
+
+    def test_content_preserved(self, tmp_path):
+        src = tmp_path / "src.txt"
+        dst = tmp_path / "dst.txt"
+        src.write_text("some skill content")
+
+        _copy_file_writable(src, dst)
+
+        assert dst.read_text() == "some skill content"
+
+
+class TestCopytreeWritable:
+    """Tests for _copytree_writable: directories copied from read-only stores are editable."""
+
+    def test_readonly_directories_become_owner_writable(self, tmp_path):
+        import os
+        import stat
+
+        src = tmp_path / "src"
+        nested = src / "nested"
+        nested.mkdir(parents=True)
+        (nested / "file.txt").write_text("hello")
+        os.chmod(src, 0o555)
+        os.chmod(nested, 0o555)
+
+        dst = tmp_path / "dst"
+        _copytree_writable(src, dst)
+
+        assert os.stat(dst).st_mode & stat.S_IWUSR
+        assert os.stat(dst / "nested").st_mode & stat.S_IWUSR
 
 
 class TestDiscoverBundledSkills:
@@ -581,6 +660,45 @@ class TestSyncSkills:
         new_bundled_hash = _dir_hash(bundled / "old-skill")
         assert manifest["old-skill"] == new_bundled_hash
         assert manifest["old-skill"] != old_hash
+
+    def test_readonly_source_files_are_copied_writable(self, tmp_path):
+        """Files copied from read-only Nix store paths must end up owner-writable.
+
+        Nix store files have mode 444/555. Without the _copy_file_writable
+        helper, shutil.copy2 preserves those modes, leaving users unable to
+        edit or delete ~/.hermes/skills/ copies. This test simulates that
+        scenario by creating a source directory with mode 444 files and
+        verifying the destination copies are owner-writable.
+        """
+        import os
+        import stat
+
+        bundled = tmp_path / "bundled"
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        # Create a bundled skill with read-only files and directories (simulates Nix store)
+        skill_dir = bundled / "readonly-skill"
+        skill_dir.mkdir(parents=True)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text("---\nname: readonly-skill\n---\n# Skill")
+        os.chmod(skill_md, 0o444)  # read-only — like Nix store files
+        os.chmod(skill_dir, 0o555)  # read-only — like Nix store directories
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+
+        dest_dir = skills_dir / "readonly-skill"
+        dest_md = skills_dir / "readonly-skill" / "SKILL.md"
+        assert dest_md.exists(), f"Expected {dest_md} to exist"
+        dest_dir_mode = os.stat(dest_dir).st_mode
+        dest_mode = os.stat(dest_md).st_mode
+        assert dest_dir_mode & stat.S_IWUSR, (
+            f"Copied directory {dest_dir} should be owner-writable, got mode {oct(dest_dir_mode)}"
+        )
+        assert dest_mode & stat.S_IWUSR, (
+            f"Copied file {dest_md} should be owner-writable, got mode {oct(dest_mode)}"
+        )
 
 
 class TestGetBundledDir:

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -25,6 +25,7 @@ import hashlib
 import logging
 import os
 import shutil
+import stat
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, List, Tuple
@@ -160,6 +161,44 @@ def _compute_relative_dest(skill_dir: Path, bundled_dir: Path) -> Path:
     return SKILLS_DIR / rel
 
 
+def _ensure_owner_writable(path: Path):
+    """Ensure a copied path can be modified by its owner."""
+    try:
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        os.chmod(path, mode | stat.S_IWUSR)
+    except OSError:
+        pass
+
+
+def _copy_file_writable(src: Path, dst: Path):
+    """Copy a single file (like shutil.copy2) but ensure it is owner-writable.
+
+    Nix store paths contain files with mode 444 (read-only), and copy2
+    preserves those modes when copying into ~/.hermes/skills/.  This leaves
+    users unable to edit or delete the copied skill files without manually
+    running chmod.  This helper fixes that by ensuring the destination file
+    is always owner-writable after the copy, without dropping executable bits.
+    """
+    shutil.copy2(src, dst)
+    _ensure_owner_writable(dst)
+
+
+def _make_tree_owner_writable(root: Path):
+    """Ensure a copied tree does not inherit read-only Nix store directories."""
+    _ensure_owner_writable(root)
+    try:
+        for path in root.rglob("*"):
+            _ensure_owner_writable(path)
+    except OSError:
+        pass
+
+
+def _copytree_writable(src: Path, dst: Path):
+    """Copy a directory tree, preserving metadata while making it editable."""
+    shutil.copytree(src, dst, copy_function=_copy_file_writable)
+    _make_tree_owner_writable(dst)
+
+
 def _dir_hash(directory: Path) -> str:
     """Compute a hash of all file contents in a directory for change detection."""
     hasher = hashlib.md5()
@@ -228,7 +267,7 @@ def sync_skills(quiet: bool = False) -> dict:
                         )
                 else:
                     dest.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copytree(skill_src, dest)
+                    _copytree_writable(skill_src, dest)
                     copied.append(skill_name)
                     manifest[skill_name] = bundled_hash
                     if not quiet:
@@ -268,7 +307,7 @@ def sync_skills(quiet: bool = False) -> dict:
                     backup = dest.with_suffix(".bak")
                     shutil.move(str(dest), str(backup))
                     try:
-                        shutil.copytree(skill_src, dest)
+                        _copytree_writable(skill_src, dest)
                         manifest[skill_name] = bundled_hash
                         updated.append(skill_name)
                         if not quiet:
@@ -302,7 +341,7 @@ def sync_skills(quiet: bool = False) -> dict:
         if not dest_desc.exists():
             try:
                 dest_desc.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(desc_md, dest_desc)
+                _copy_file_writable(desc_md, dest_desc)
             except (OSError, IOError) as e:
                 logger.debug("Could not copy %s: %s", desc_md, e)
 


### PR DESCRIPTION
## Summary
- make bundled skill files copied from Nix store paths owner-writable without dropping existing mode bits, including executable scripts
- make copied skill directories owner-writable after `copytree` reapplies source directory metadata
- cover read-only files, executable files, read-only directories, and end-to-end sync from a read-only bundled skill tree

## Root cause
Nix store paths are read-only. `shutil.copy2` preserves file modes, and `shutil.copytree` also reapplies directory metadata after copying. When `HERMES_BUNDLED_SKILLS` points at a Nix-managed bundled skills tree, synced copies under `~/.hermes/skills` could inherit unwritable files or directories.

## Validation
- `python3 -m py_compile tools/skills_sync.py tests/tools/test_skills_sync.py`
- minimal local permission reproduction for `0555` directories and executable files

Full pytest was not run in this checkout because no project virtualenv was available.
