### PR TITLE
fix(terminal): stop false-positive on quoted nohup/disown/setsid (#20064)

### DIFF
--- a/tests/tools/test_terminal_quoted_background_wrapper_filter.py
+++ b/tests/tools/test_terminal_quoted_background_wrapper_filter.py
@@ -1,0 +1,174 @@
+"""Regression tests for issue #20064.
+
+`_foreground_background_guidance()` previously used a naive
+`\\b(?:nohup|disown|setsid)\\b` regex that fired on any occurrence of
+those words anywhere in the command string, including inside quoted
+arguments. This blocked legitimate commands such as commit messages,
+`echo` text, and Python code passed via `-c`.
+
+These tests pin down the fix:
+
+* The four representative false-positive cases from the bug report MUST
+  pass through the filter unblocked.
+* Genuine `setsid`/`nohup`/`disown` usage at command position MUST still
+  be redirected to `background=true`.
+* The unit-level helpers `_strip_shell_quoted_spans` and
+  `_SHELL_LEVEL_BACKGROUND_RE` are exercised directly so future
+  refactors that drop quote-stripping will fail loudly.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests (pure functions, no terminal_tool mocking required).
+# ---------------------------------------------------------------------------
+class TestForegroundGuidanceQuotedFalsePositives:
+    """`_foreground_background_guidance` should ignore keywords inside quotes."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # The four canonical false-positive cases from issue #20064.
+            "python3 -c \"x = 'preexec_fn=os.setsid'\"",
+            'git commit -m "fix: replace preexec_fn=os.setsid with process_group=0"',
+            'gh pr create --body "We removed preexec_fn=os.setsid..."',
+            'echo "The function os.setsid() creates a new session"',
+            # A few extra plausible cases that were collateral damage.
+            "echo 'use nohup ./server &'",
+            'grep -r "disown" src/',
+            "git log --grep='nohup'",
+            'python3 -c "import os; help(os.setsid)"',
+        ],
+    )
+    def test_quoted_keywords_do_not_trigger_background_wrapper_guidance(self, command):
+        from tools.terminal_tool import _foreground_background_guidance
+
+        guidance = _foreground_background_guidance(command)
+
+        # Either no guidance at all, or guidance that is NOT the
+        # nohup/disown/setsid wrapper warning. (Some commands like
+        # `nohup ./server &` inside quotes still contain a literal `&`
+        # which we don't pretend to parse — but the *wrapper* warning
+        # must not fire.)
+        if guidance is not None:
+            assert "nohup/disown/setsid" not in guidance, (
+                f"Filter false-positive: {command!r} → {guidance!r}"
+            )
+
+
+class TestForegroundGuidanceGenuineWrappers:
+    """Genuine command-position usage must still be flagged."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "setsid my_server",
+            "nohup ./script.sh &",
+            "nohup pnpm dev > /tmp/sg-server.log 2>&1 &",
+            "disown %1",
+            # After common shell separators.
+            "cmd1; setsid foo",
+            "cmd1 && nohup foo",
+            "cmd1 || setsid foo",
+            "cmd1 | nohup foo",
+            # Inside a subshell.
+            "(setsid foo)",
+            # After a newline (multi-line command).
+            "echo hi\nsetsid foo",
+            # Trailing disown after a real command.
+            "echo hi; disown",
+            # Mixed case still matches (regex is IGNORECASE).
+            "NoHuP ./script.sh",
+        ],
+    )
+    def test_command_position_wrapper_still_flagged(self, command):
+        from tools.terminal_tool import _foreground_background_guidance
+
+        guidance = _foreground_background_guidance(command)
+        assert guidance is not None, (
+            f"Genuine wrapper not flagged: {command!r}"
+        )
+        # We accept either the wrapper-specific warning or the inline-`&`
+        # warning, since `nohup foo &` legitimately matches both.
+        assert (
+            "nohup/disown/setsid" in guidance
+            or "'&' backgrounding" in guidance
+        ), f"Unexpected guidance for {command!r}: {guidance!r}"
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for the helpers, so a future refactor that drops
+# quote-stripping or weakens the boundary regex fails loudly here.
+# ---------------------------------------------------------------------------
+class TestStripShellQuotedSpans:
+    def test_blanks_double_quoted_content_only(self):
+        from tools.terminal_tool import _strip_shell_quoted_spans
+
+        out = _strip_shell_quoted_spans('echo "setsid"')
+        assert out == 'echo "      "'
+
+    def test_blanks_single_quoted_content_only(self):
+        from tools.terminal_tool import _strip_shell_quoted_spans
+
+        out = _strip_shell_quoted_spans("echo 'setsid'")
+        assert out == "echo '      '"
+
+    def test_preserves_unquoted_content(self):
+        from tools.terminal_tool import _strip_shell_quoted_spans
+
+        out = _strip_shell_quoted_spans('setsid foo')
+        assert out == 'setsid foo'
+
+    def test_preserves_string_length(self):
+        from tools.terminal_tool import _strip_shell_quoted_spans
+
+        cmd = 'git commit -m "fix: os.setsid stuff"'
+        assert len(_strip_shell_quoted_spans(cmd)) == len(cmd)
+
+    def test_handles_escaped_double_quote_inside_string(self):
+        from tools.terminal_tool import _strip_shell_quoted_spans
+
+        cmd = r'echo "she said \"setsid\" out loud"'
+        out = _strip_shell_quoted_spans(cmd)
+        # The whole double-quoted span should be blanked — the escaped
+        # inner quotes must NOT terminate the string prematurely.
+        assert "setsid" not in out
+        assert out.startswith('echo "') and out.endswith('"')
+
+
+class TestShellLevelBackgroundRegex:
+    """Direct regex tests so failures point at the regex, not the wrapper."""
+
+    @pytest.mark.parametrize(
+        "command,should_match",
+        [
+            # Quoted-string false positives (post quote-stripping these
+            # have no command-position keyword).
+            ('echo "setsid foo"', False),
+            ("echo 'nohup bar'", False),
+            ('git commit -m "fix os.setsid"', False),
+            # Unquoted command-position usage.
+            ("setsid foo", True),
+            ("nohup foo", True),
+            ("foo; setsid bar", True),
+            ("foo && nohup bar", True),
+            ("foo || setsid bar", True),
+            ("foo | nohup bar", True),
+            ("(setsid foo)", True),
+        ],
+    )
+    def test_regex_only_matches_command_position_after_strip(
+        self, command, should_match
+    ):
+        from tools.terminal_tool import (
+            _SHELL_LEVEL_BACKGROUND_RE,
+            _strip_shell_quoted_spans,
+        )
+
+        scannable = _strip_shell_quoted_spans(command)
+        match = _SHELL_LEVEL_BACKGROUND_RE.search(scannable)
+        assert bool(match) is should_match, (
+            f"command={command!r} stripped={scannable!r} match={match!r}"
+        )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1539,7 +1539,19 @@ def _command_requires_pipe_stdin(command: str) -> bool:
     )
 
 
-_SHELL_LEVEL_BACKGROUND_RE = re.compile(r"\b(?:nohup|disown|setsid)\b", re.IGNORECASE)
+# Match shell-level background wrappers only when they appear in a
+# *command position* — at the start of the line, after a separator
+# (`;`, `&`, `&&`, `||`, `|`, newline) or inside a subshell. This avoids
+# firing on the same word when it appears inside a quoted argument such as
+# a commit message, `echo` text, or Python code passed via `-c`.
+#
+# We also strip out single-/double-quoted spans before matching so things
+# like `git commit -m "replace preexec_fn=os.setsid with ..."` no longer
+# trip the filter. See `_strip_shell_quoted_spans` below.
+_SHELL_LEVEL_BACKGROUND_RE = re.compile(
+    r"(?:^|[;&|\n]\s*|&&\s*|\|\|\s*|\(\s*)(?:nohup|disown|setsid)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
 _INLINE_BACKGROUND_AMP_RE = re.compile(r"\s&\s")
 _TRAILING_BACKGROUND_AMP_RE = re.compile(r"\s&\s*(?:#.*)?$")
 _LONG_LIVED_FOREGROUND_PATTERNS = (
@@ -1552,6 +1564,45 @@ _LONG_LIVED_FOREGROUND_PATTERNS = (
     re.compile(r"\bgunicorn\b", re.IGNORECASE),
     re.compile(r"\bpython(?:3)?\s+-m\s+http\.server\b", re.IGNORECASE),
 )
+
+
+_SHELL_QUOTED_SPAN_RE = re.compile(
+    r"""
+    '(?:\\.|[^'\\])*'      # single-quoted span (no escape processing in sh,
+                            # but we accept \' here as a courtesy)
+    |
+    "(?:\\.|[^"\\])*"      # double-quoted span with backslash escapes
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+
+def _strip_shell_quoted_spans(command: str) -> str:
+    """Replace single-/double-quoted spans with whitespace placeholders.
+
+    The goal is to neutralise the *contents* of quoted arguments before we
+    scan for shell-level background wrappers, while preserving overall
+    string length and surrounding token boundaries so a regex with `^`,
+    `$`, or `\b` still matches the same positions in the unquoted parts.
+
+    Examples:
+        >>> _strip_shell_quoted_spans("git commit -m 'fix: os.setsid'")
+        "git commit -m '              '"
+        >>> _strip_shell_quoted_spans('echo "setsid"')
+        'echo "      "'
+
+    Heredocs and ANSI-C `$'...'` strings are not handled specially; they
+    fall through unchanged. That's fine — the boundary regex still
+    requires a command-position prefix, so plain occurrences inside an
+    unquoted heredoc body would not be in command position anyway.
+    """
+    def _blank(match: re.Match) -> str:
+        span = match.group(0)
+        # Keep the surrounding quote characters so token boundaries are
+        # preserved, but blank out the interior.
+        return span[0] + (" " * (len(span) - 2)) + span[-1]
+
+    return _SHELL_QUOTED_SPAN_RE.sub(_blank, command)
 
 
 def _looks_like_help_or_version_command(command: str) -> bool:
@@ -1574,7 +1625,10 @@ def _foreground_background_guidance(command: str) -> str | None:
     if _looks_like_help_or_version_command(command):
         return None
 
-    if _SHELL_LEVEL_BACKGROUND_RE.search(command):
+    # Strip quoted content before scanning so the keyword inside a commit
+    # message, `echo` argument, or `-c "..."` snippet doesn't false-positive.
+    scannable = _strip_shell_quoted_spans(command)
+    if _SHELL_LEVEL_BACKGROUND_RE.search(scannable):
         return (
             "Foreground command uses shell-level background wrappers (nohup/disown/setsid). "
             "Use terminal(background=true) so Hermes can track the process, then run "


### PR DESCRIPTION
Closes #20064.

The terminal tool's `_foreground_background_guidance()` regex was matching `nohup`/`disown`/`setsid` anywhere in the command string, including inside quoted strings, Python `-c` code, commit messages, and PR bodies. Legit commands like `git commit -m "replace preexec_fn=os.setsid with process_group=0"` got blocked with a request to use `terminal(background=true)`.

## Fix

Two-layer match:

1. **Strip single/double-quoted spans** before matching, so quoted occurrences don't fire the filter.
2. **Boundary-anchored regex** — only matches at start of command, after `;`, `|`, `&&`, `||`, newline, or open-paren. So even unquoted text like `xargs setsid foo` doesn't accidentally re-fire.

The issue suggested either approach; this PR uses both because each catches cases the other misses.

## Verified

- All 4 false-positive cases from the issue body now pass the filter.
- Genuine `setsid foo`, `nohup ./script.sh &`, `cmd && nohup foo`, `(setsid foo)`, multi-line, and mixed-case still get redirected to `background=true`.
- 35 new pinned cases in `tests/tools/test_terminal_quoted_background_wrapper_filter.py`.
- Pre-existing terminal tests (114 tests across `test_terminal_tool.py`, `test_terminal_compound_background.py`, `test_terminal_requirements.py`, `test_terminal_foreground_timeout_cap.py`) still pass.

## Notes

- Quote-stripping doesn't special-case ANSI-C `$'...'` or heredocs; the boundary regex handles those by requiring a command-position prefix, keeping false-positive risk low. Documented in the helper docstring.
- No CHANGELOG.md exists in this repo — release notes are auto-generated from conventional commits, so the `fix(terminal):` prefix is enough.