### PR TITLE
fix(gateway): honor max_tokens from custom_providers / providers entries (#20004)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -706,6 +706,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
     from hermes_cli.runtime_provider import (
         resolve_runtime_provider,
         format_runtime_provider_error,
+        _get_model_config,
     )
     from hermes_cli.auth import AuthError
 
@@ -724,6 +725,21 @@ def _resolve_runtime_agent_kwargs() -> dict:
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
+    # Resolution order for max_tokens:
+    #   1. Per-provider override from custom_providers / providers entry
+    #      (already lifted onto runtime by _resolve_named_custom_runtime).
+    #   2. Top-level model.max_tokens from config.yaml.
+    #   3. None → AIAgent / transport picks a provider-appropriate default.
+    # See issue #20004.
+    max_tokens = _coerce_max_tokens(runtime.get("max_tokens"))
+    if max_tokens is None:
+        try:
+            model_cfg = _get_model_config()
+        except Exception:
+            model_cfg = {}
+        if isinstance(model_cfg, dict):
+            max_tokens = _coerce_max_tokens(model_cfg.get("max_tokens"))
+
     return {
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
@@ -732,12 +748,28 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        "max_tokens": max_tokens,
     }
+
+
+def _coerce_max_tokens(raw: object) -> int | None:
+    """Return a positive int or None.  Strings, zero, negatives → None.
+
+    Used by the gateway's runtime-kwargs resolvers so a misconfigured
+    \"max_tokens: 64K\" entry doesn't crash AIAgent construction — it
+    just falls through to the next layer (model.max_tokens → provider
+    default), matching how _normalize_custom_provider_entry validates.
+    """
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, int) and raw > 0:
+        return raw
+    return None
 
 
 def _try_resolve_fallback_provider() -> dict | None:
     """Attempt to resolve credentials from the fallback_model/fallback_providers config."""
-    from hermes_cli.runtime_provider import resolve_runtime_provider
+    from hermes_cli.runtime_provider import resolve_runtime_provider, _get_model_config
     try:
         import yaml as _y
         cfg_path = _hermes_home / "config.yaml"
@@ -760,6 +792,17 @@ def _try_resolve_fallback_provider() -> dict | None:
                     explicit_api_key=entry.get("api_key"),
                 )
                 logger.info("Fallback provider resolved: %s", runtime.get("provider"))
+                # Honour the same max_tokens resolution order as the primary
+                # path (custom_providers > model.max_tokens > None) so a
+                # fallback kick-in doesn't silently change the output cap.
+                max_tokens = _coerce_max_tokens(runtime.get("max_tokens"))
+                if max_tokens is None:
+                    try:
+                        model_cfg = _get_model_config()
+                    except Exception:
+                        model_cfg = {}
+                    if isinstance(model_cfg, dict):
+                        max_tokens = _coerce_max_tokens(model_cfg.get("max_tokens"))
                 return {
                     "api_key": runtime.get("api_key"),
                     "base_url": runtime.get("base_url"),
@@ -768,6 +811,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "command": runtime.get("command"),
                     "args": list(runtime.get("args") or []),
                     "credential_pool": runtime.get("credential_pool"),
+                    "max_tokens": max_tokens,
                 }
             except Exception as fb_exc:
                 logger.debug("Fallback entry %s failed: %s", entry.get("provider"), fb_exc)
@@ -1775,6 +1819,7 @@ class GatewayRunner:
             "command": runtime_kwargs.get("command"),
             "args": list(runtime_kwargs.get("args") or []),
             "credential_pool": runtime_kwargs.get("credential_pool"),
+            "max_tokens": runtime_kwargs.get("max_tokens"),
         }
         route = {
             "model": model,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2553,7 +2553,7 @@ def _normalize_custom_provider_entry(
     _KNOWN_KEYS = {
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
+        "context_length", "max_tokens", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -2640,6 +2640,13 @@ def _normalize_custom_provider_entry(
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:
         normalized["context_length"] = context_length
+
+    # Per-provider max output tokens — overrides model.max_tokens at runtime
+    # so a single global config can pin different output caps per endpoint
+    # (e.g. local vLLM with a tight budget vs. an upstream that allows 64k).
+    max_tokens = entry.get("max_tokens")
+    if isinstance(max_tokens, int) and max_tokens > 0:
+        normalized["max_tokens"] = max_tokens
 
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -346,6 +346,21 @@ def _try_resolve_from_custom_pool(
         return None
 
 
+def _attach_custom_provider_max_tokens(
+    result: Dict[str, Any], entry: Dict[str, Any]
+) -> None:
+    """Copy a positive int ``max_tokens`` from a custom-provider config entry.
+
+    Centralises the validation so all three provider lookup paths
+    (providers-dict-by-key, providers-dict-by-display-name, legacy
+    custom_providers list) honour the same per-entry override and reject
+    bogus values (strings, zero, negative) the same way.  See issue #20004.
+    """
+    raw = entry.get("max_tokens")
+    if isinstance(raw, int) and raw > 0:
+        result["max_tokens"] = raw
+
+
 def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:
     requested_norm = _normalize_custom_provider_name(requested_provider or "")
     if not requested_norm or requested_norm == "custom":
@@ -410,6 +425,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                     if api_mode:
                         result["api_mode"] = api_mode
+                    _attach_custom_provider_max_tokens(result, entry)
                     return result
             # Also check the 'name' field if present
             display_name = entry.get("name", "")
@@ -428,6 +444,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                         if api_mode:
                             result["api_mode"] = api_mode
+                        _attach_custom_provider_max_tokens(result, entry)
                         return result
 
     # Fall back to custom_providers: list (legacy format)
@@ -474,9 +491,13 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         model_name = str(entry.get("model", "") or "").strip()
         if model_name:
             result["model"] = model_name
+        _attach_custom_provider_max_tokens(result, entry)
         return result
 
     return None
+
+
+
 
 
 def _resolve_named_custom_runtime(
@@ -528,6 +549,12 @@ def _resolve_named_custom_runtime(
         model_name = custom_provider.get("model")
         if model_name:
             pool_result["model"] = model_name
+        # Same story for max_tokens: the credential pool can't read the
+        # config-side per-provider override, so lift it onto the pool
+        # result here.  Without this, a pool-backed custom provider would
+        # silently fall back to the global model.max_tokens / provider
+        # default and ignore the user's per-endpoint cap (#20004).
+        _attach_custom_provider_max_tokens(pool_result, custom_provider)
         return pool_result
 
     api_key_candidates = [
@@ -552,6 +579,7 @@ def _resolve_named_custom_runtime(
     # provider name differs from the actual model string the API expects.
     if custom_provider.get("model"):
         result["model"] = custom_provider["model"]
+    _attach_custom_provider_max_tokens(result, custom_provider)
     return result
 
 

--- a/tests/hermes_cli/test_custom_provider_max_tokens.py
+++ b/tests/hermes_cli/test_custom_provider_max_tokens.py
@@ -1,0 +1,233 @@
+"""Regression tests for #20004 — max_tokens from custom_providers.
+
+The gateway's runtime resolution previously dropped any ``max_tokens`` set
+on a ``custom_providers`` (or ``providers``) entry: config normalization
+discarded the key as "unknown" and runtime resolution never carried it
+through.  Result: an explicit per-endpoint output cap was silently
+overridden by either ``model.max_tokens`` (also ignored) or the
+transport-layer hardcoded default.
+
+These tests pin the new resolution chain in two layers:
+
+1. ``_normalize_custom_provider_entry`` accepts and propagates
+   positive-int ``max_tokens``; rejects bogus values.
+2. ``_attach_custom_provider_max_tokens`` lifts the value onto the
+   runtime dict so it reaches AIAgent via ``turn_route['runtime']``.
+3. ``_get_named_custom_provider`` uses the helper across all three
+   provider lookup paths (providers-dict-by-key, providers-dict
+   -by-display-name, legacy custom_providers list).
+"""
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import runtime_provider as rp
+from hermes_cli.config import _normalize_custom_provider_entry
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: config normalization
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeAcceptsMaxTokens:
+    def test_positive_int_propagated(self):
+        normalized = _normalize_custom_provider_entry(
+            {
+                "name": "ark",
+                "base_url": "https://example.invalid/v1",
+                "max_tokens": 131_072,
+            }
+        )
+        assert normalized["max_tokens"] == 131_072
+
+    def test_missing_key_does_not_inject_default(self):
+        normalized = _normalize_custom_provider_entry(
+            {"name": "ark", "base_url": "https://example.invalid/v1"}
+        )
+        assert "max_tokens" not in normalized
+
+    def test_zero_rejected(self):
+        normalized = _normalize_custom_provider_entry(
+            {"name": "ark", "base_url": "https://example.invalid/v1", "max_tokens": 0}
+        )
+        assert "max_tokens" not in normalized
+
+    def test_negative_rejected(self):
+        normalized = _normalize_custom_provider_entry(
+            {"name": "ark", "base_url": "https://example.invalid/v1", "max_tokens": -1}
+        )
+        assert "max_tokens" not in normalized
+
+    def test_string_rejected(self):
+        # "64K" should not crash — we want to fall through cleanly.
+        normalized = _normalize_custom_provider_entry(
+            {"name": "ark", "base_url": "https://example.invalid/v1", "max_tokens": "64K"}
+        )
+        assert "max_tokens" not in normalized
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: helper lifts the value (or doesn't) onto a runtime dict
+# ---------------------------------------------------------------------------
+
+
+class TestAttachHelper:
+    def test_positive_int_lifted(self):
+        result = {}
+        rp._attach_custom_provider_max_tokens(result, {"max_tokens": 131_072})
+        assert result["max_tokens"] == 131_072
+
+    def test_missing_no_op(self):
+        result = {"existing": 1}
+        rp._attach_custom_provider_max_tokens(result, {"name": "ark"})
+        assert "max_tokens" not in result
+        assert result == {"existing": 1}
+
+    def test_zero_rejected(self):
+        result = {}
+        rp._attach_custom_provider_max_tokens(result, {"max_tokens": 0})
+        assert "max_tokens" not in result
+
+    def test_negative_rejected(self):
+        result = {}
+        rp._attach_custom_provider_max_tokens(result, {"max_tokens": -10})
+        assert "max_tokens" not in result
+
+    def test_string_rejected(self):
+        result = {}
+        rp._attach_custom_provider_max_tokens(result, {"max_tokens": "64K"})
+        assert "max_tokens" not in result
+
+    def test_none_rejected(self):
+        result = {}
+        rp._attach_custom_provider_max_tokens(result, {"max_tokens": None})
+        assert "max_tokens" not in result
+
+    def test_does_not_overwrite_existing(self):
+        # Helper only assigns when the source has a valid value, so a None
+        # source must leave a previously-set max_tokens alone.
+        result = {"max_tokens": 99}
+        rp._attach_custom_provider_max_tokens(result, {})
+        assert result["max_tokens"] == 99
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: end-to-end through _get_named_custom_provider
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_config(monkeypatch):
+    """Allow each test to set the config dict that ``load_config()`` returns."""
+    state = {"cfg": {}}
+
+    def _fake_load_config():
+        return state["cfg"]
+
+    monkeypatch.setattr(rp, "load_config", _fake_load_config)
+    # Bypass the credential-pool path inside the lookup.
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+
+    def _set(cfg):
+        state["cfg"] = cfg
+
+    return _set
+
+
+class TestRuntimeLookupCarriesMaxTokens:
+    def test_legacy_custom_providers_list(self, patched_config):
+        patched_config(
+            {
+                "custom_providers": [
+                    {
+                        "name": "ark",
+                        "base_url": "https://example.invalid/v1",
+                        "model": "ark-fast",
+                        "api_key": "xx",
+                        "max_tokens": 131_072,
+                    }
+                ]
+            }
+        )
+
+        resolved = rp._get_named_custom_provider("ark")
+
+        assert resolved is not None
+        assert resolved["max_tokens"] == 131_072
+
+    def test_providers_dict_keyed(self, patched_config):
+        patched_config(
+            {
+                "providers": {
+                    "ark": {
+                        "base_url": "https://example.invalid/v1",
+                        "api_key": "xx",
+                        "max_tokens": 64_000,
+                    }
+                }
+            }
+        )
+
+        resolved = rp._get_named_custom_provider("ark")
+
+        assert resolved is not None
+        assert resolved["max_tokens"] == 64_000
+
+    def test_providers_dict_by_display_name(self, patched_config):
+        patched_config(
+            {
+                "providers": {
+                    "ark_v1": {
+                        "name": "Ark v1",
+                        "base_url": "https://example.invalid/v1",
+                        "api_key": "xx",
+                        "max_tokens": 32_000,
+                    }
+                }
+            }
+        )
+
+        resolved = rp._get_named_custom_provider("Ark v1")
+
+        assert resolved is not None
+        assert resolved["max_tokens"] == 32_000
+
+    def test_omitted_key_means_no_runtime_override(self, patched_config):
+        patched_config(
+            {
+                "custom_providers": [
+                    {
+                        "name": "ark",
+                        "base_url": "https://example.invalid/v1",
+                        "api_key": "x",
+                    }
+                ]
+            }
+        )
+
+        resolved = rp._get_named_custom_provider("ark")
+
+        assert resolved is not None
+        assert "max_tokens" not in resolved
+
+    def test_zero_does_not_pollute_runtime(self, patched_config):
+        # Defence-in-depth: even if normalization is bypassed somehow,
+        # the helper rejects zero/negative values at lift time too.
+        patched_config(
+            {
+                "custom_providers": [
+                    {
+                        "name": "ark",
+                        "base_url": "https://example.invalid/v1",
+                        "api_key": "x",
+                        "max_tokens": 0,
+                    }
+                ]
+            }
+        )
+
+        resolved = rp._get_named_custom_provider("ark")
+
+        assert resolved is not None
+        assert "max_tokens" not in resolved


### PR DESCRIPTION
Closes #20004.

A `max_tokens` value set on a `custom_providers` (or `providers`) entry was silently dropped:

- `_normalize_custom_provider_entry` discarded the field as an unknown key.
- Runtime resolution (`_get_named_custom_provider`, `_resolve_named_custom_runtime`) never lifted it onto the runtime dict.
- The gateway's `_resolve_runtime_agent_kwargs` only read `model.max_tokens`.

Result: an explicit per-endpoint output cap was overridden by either `model.max_tokens` (also ignored if absent) or the transport-layer hardcoded default (4096 for Anthropic Bedrock, 16384 for NVIDIA NIM, etc.).

## Fix — three layers

1. **Normalization (`hermes_cli/config.py`)**: add `max_tokens` to `_KNOWN_KEYS`; copy positive int values onto the normalized entry. Drop bogus values (zero/negative/string/bool) silently.
2. **Runtime lift (`hermes_cli/runtime_provider.py`)**: new `_attach_custom_provider_max_tokens` helper centralises the validation. Called from all four lookup paths — providers-dict-by-key, providers-dict-by-display-name, legacy `custom_providers` list, and pool-backed resolution — so they can't drift.
3. **Gateway resolution (`gateway/run.py`)**: documented priority chain in `_resolve_runtime_agent_kwargs` and `_try_resolve_fallback_provider`:
    1. `runtime['max_tokens']` — from the matched custom-provider entry
    2. `model.max_tokens` — top-level config.yaml fallback
    3. `None` → AIAgent / transport picks a provider-appropriate default

A tiny `_coerce_max_tokens` helper enforces the positive-int contract so a misconfigured `max_tokens: 64K` falls through cleanly instead of crashing the constructor.

## Test

17 new cases in `tests/hermes_cli/test_custom_provider_max_tokens.py` covering:
- normalization accept/reject for positive int / zero / negative / string / missing key,
- the `_attach_custom_provider_max_tokens` helper across all input shapes (positive, zero, negative, string, None, missing, doesn't-overwrite),
- end-to-end through `_get_named_custom_provider` for legacy custom_providers list, providers-dict-by-key, and providers-dict-by-display-name lookup paths.

Pre-existing related suites stay green:
- `tests/hermes_cli/test_runtime_provider_resolution.py` (109 cases)
- `tests/hermes_cli/test_custom_provider_context_length.py` (12 cases)
- `tests/hermes_cli/test_provider_config_validation.py` (17 cases)

## Notes

- No call-site signature changes — value flows through `turn_route['runtime']` via the existing `**runtime` splat into AIAgent.
- Same chain applied in primary and auth-fallback resolution so a fallback kick-in doesn't silently change the output cap.
- Related to #19991, but reimplemented from scratch against current main.