### PR TITLE
fix: auto-discover model from local inference server in cron scheduler

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1172,6 +1172,52 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             message = format_runtime_provider_error(exc)
             raise RuntimeError(message) from exc
 
+        # Auto-discover model from local inference server when no explicit model
+        # is pinned.  This handles the common case where a user swaps the loaded
+        # model in llama.cpp / vLLM / Ollama without updating config.yaml.
+        _resolved_base_url = str(runtime.get("base_url") or "").strip()
+        if not job.get("model") and _resolved_base_url:
+            try:
+                import urllib.request as _urlreq
+                import json as _json
+                _models_url = _resolved_base_url.rstrip("/") + "/v1/models"
+                _req = _urlreq.Request(_models_url, headers={"User-Agent": "hermes-cron"})
+                with _urlreq.urlopen(_req, timeout=5) as _resp:
+                    _models_data = _json.loads(_resp.read())
+                    _available = _models_data.get("data", [])
+                    if _available and isinstance(_available, list):
+                        _discovered = _available[0].get("id", "")
+                        if _discovered:
+                            logger.info(
+                                "Job '%s': auto-discovered model '%s' from %s",
+                                job_id, _discovered, _models_url,
+                            )
+                            model = _discovered
+            except Exception as _disc_err:
+                logger.debug(
+                    "Job '%s': could not auto-discover models from %s: %s",
+                    job_id,
+                    _resolved_base_url.rstrip("/") + "/v1/models",
+                    _disc_err,
+                )
+
+        # Probe server reachability for local inference backends to produce a
+        # clear error instead of the generic "Connection error" from the SDK.
+        if _resolved_base_url and any(
+            h in _resolved_base_url for h in ("localhost", "127.0.0.1", "[::1]")
+        ):
+            try:
+                import urllib.request as _urlreq
+                _health_url = _resolved_base_url.rstrip("/") + "/v1/models"
+                _req = _urlreq.Request(_health_url, headers={"User-Agent": "hermes-cron"})
+                with _urlreq.urlopen(_req, timeout=5):
+                    pass
+            except Exception as _health_err:
+                raise RuntimeError(
+                    f"Local inference server not reachable at {_resolved_base_url}. "
+                    f"Is llama.cpp / Ollama / vLLM running?  Original error: {_health_err}"
+                ) from _health_err
+
         fallback_model = _cfg.get("fallback_providers") or _cfg.get("fallback_model") or None
         credential_pool = None
         runtime_provider = str(runtime.get("provider") or "").strip().lower()


### PR DESCRIPTION
## Problem

Cron jobs without an explicit `model` and `provider` pinned fail with a generic `RuntimeError: Connection error` when:

1. The llama.cpp / Ollama / vLLM server is running a **different model** than what's in `config.yaml`
2. The local inference server is **not running at all**

The current code hardcodes the model from `config.yaml` at cron job creation time (scheduler.py ~line 1075-1091). If the user swaps models in llama.cpp (very common — crashing, swapping, multiple profiles), cron jobs break silently with no actionable error message.

## Fix

Two changes in `cron/scheduler.py`, inserted after the runtime provider resolution block:

### 1. Auto-discover model from `/v1/models`

When no explicit model is pinned by the job (`job.get("model")` is empty), the scheduler now queries `{base_url}/v1/models` to discover what model is actually loaded on the inference server. Uses the first available model. This is a best-effort check — failures are logged at `debug` level and the existing fallback to `config.yaml` still applies.

### 2. Clear error for unreachable local servers

When the resolved `base_url` points to a local server (`localhost`, `127.0.0.1`, `[::1]`), the scheduler probes `/v1/models` with a 5-second timeout. If the server is unreachable, it raises a clear `RuntimeError`:

> Local inference server not reachable at http://localhost:8080. Is llama.cpp / Ollama / vLLM running?

Instead of the generic SDK "Connection error" that gives no diagnostic information.

## Why this matters

Local inference users frequently swap models:
- Server crashes → user loads a different model
- User switches models via `/model` command
- Multiple profiles with different models
- Ollama users pull new models regularly

Cron jobs should be resilient to this — they are scheduled background tasks, not interactive sessions.

Fixes #20125
