### PR TITLE
fix: preserve empty required arrays in schema sanitizer

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -126,6 +126,16 @@ def test_required_all_missing_is_dropped():
     assert "required" not in out[0]["function"]["parameters"]
 
 
+def test_empty_required_list_is_preserved_for_zero_arg_tools():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {},
+        "required": [],
+    })]
+    out = sanitize_tool_schemas(tools)
+    assert out[0]["function"]["parameters"]["required"] == []
+
+
 def test_well_formed_schema_unchanged():
     schema = {
         "type": "object",

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -248,10 +248,13 @@ def _sanitize_node(node: Any, path: str) -> Any:
     # built-in tools or plugin tools may not have been through that path).
     if out.get("type") == "object" and isinstance(out.get("required"), list):
         props = out.get("properties") or {}
-        valid = [r for r in out["required"] if isinstance(r, str) and r in props]
-        if not valid:
-            out.pop("required", None)
-        elif len(valid) != len(out["required"]):
-            out["required"] = valid
+        if out["required"] == []:
+            pass
+        else:
+            valid = [r for r in out["required"] if isinstance(r, str) and r in props]
+            if not valid:
+                out.pop("required", None)
+            elif len(valid) != len(out["required"]):
+                out["required"] = valid
 
     return out


### PR DESCRIPTION
## Summary

This PR fixes a schema-sanitization regression that dropped valid empty `required` arrays from zero-argument object tool schemas.

Specifically, this PR:

- Preserves `required: []` for valid zero-argument object schemas.
- Continues pruning invalid non-empty `required` entries that do not exist in `properties`.
- Adds a regression test covering zero-argument tools.

## Problem

Hermes emits OpenAI-style tool schemas for built-in tools and other tool sources, then runs them through `tools/schema_sanitizer.py` for backend compatibility.

For zero-argument tools, a valid schema shape is:

```json
{
  "type": "object",
  "properties": {},
  "required": []
}
```
Before this change, the sanitizer treated required: [] as falsy and removed it entirely while pruning invalid required entries.

As a result, valid zero-argument tool schemas lost their explicit empty-array form. On stricter OpenAI-compatible backends, this could surface as request validation failures such as:
```
Invalid schema for function 'browser_back': None is not of type 'array'
Invalid schema for function 'todo': None is not of type 'array'
```

## Root Cause

The pruning logic in tools/schema_sanitizer.py correctly intended to:
- Remove malformed required entries that reference properties that do not exist.
- Keep schemas backend-compatible.

However, it did not distinguish between:
- An invalid or fully-pruned non-empty required list.
- A valid empty required list for zero-argument tools.
Because [] is falsy, valid empty arrays were dropped along the same path used for malformed required lists.

## Fix

Update the sanitizer logic so that:
- required: [] is preserved as-is for object schemas.
- Only non-empty required lists are validated and pruned against properties.
- Invalid non-empty lists are still removed when nothing remains valid.
In other words, this PR keeps the original defensive behavior for malformed schemas while preserving the valid zero-argument schema form.

## Examples Affected

This bug was especially visible on tools whose parameter schema is intentionally:
```json
{
  "type": "object",
  "properties": {},
  "required": []
}
```

Examples include zero-argument tools such as:
- browser_back
- todo in read mode with no arguments
- skills_list with no category filter
- session_search in recent-session mode

## Tests
Added a regression test:
```
test_empty_required_list_is_preserved_for_zero_arg_tools
```
This verifies that sanitizing a schema with:
- type: object
- properties: {}
- required: []
still preserves:
```json
"required": []
```
## Verification

Ran:
```
python -m pytest tests/tools/test_schema_sanitizer.py -q -o addopts=''
```

Result:
```
18 passed
```

## Risk / Compatibility

Risk is low.

Why:
- The change is narrowly scoped to object-schema required pruning.
- Behavior for malformed non-empty required lists is preserved.
- The only changed behavior is retaining a valid explicit empty array form that should not have been removed in the first place.
This should improve compatibility with stricter OpenAI-compatible backends without changing intended behavior for existing well-formed non-zero-argument tool schemas.

## Files Changed
- tools/schema_sanitizer.py
- tests/tools/test_schema_sanitizer.py
- 
## Checklist
✅Preserves required: [] for zero-argument object schemas.
✅Keeps pruning behavior for invalid non-empty required lists.
✅Adds a focused regression test.
✅Runs the relevant test file successfully.
