### PR TITLE
feat(email): add EMAIL_VERIFY_SSL option to skip TLS cert verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -311,6 +311,7 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # EMAIL_POLL_INTERVAL=15
 # EMAIL_ALLOWED_USERS=your@email.com
 # EMAIL_HOME_ADDRESS=your@email.com
+# EMAIL_VERIFY_SSL=1              # Set to 0 to skip TLS cert verification (self-signed certs)
 
 # Gateway-wide: allow ALL users without an allowlist (default: false = deny)
 # Only set to true if you intentionally want open access.

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -13,6 +13,7 @@ Environment variables:
     EMAIL_PASSWORD      — Email password or app-specific password
     EMAIL_POLL_INTERVAL — Seconds between mailbox checks (default: 15)
     EMAIL_ALLOWED_USERS — Comma-separated list of allowed sender addresses
+    EMAIL_VERIFY_SSL    — Set to "0" or "false" to skip TLS cert verification (default: 1)
 """
 
 import asyncio
@@ -232,6 +233,7 @@ class EmailAdapter(BasePlatformAdapter):
         self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
         self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
         self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
+        self._verify_ssl = os.getenv("EMAIL_VERIFY_SSL", "1").lower() not in ("0", "false", "no")
 
         # Skip attachments — configured via config.yaml:
         #   platforms:
@@ -249,6 +251,14 @@ class EmailAdapter(BasePlatformAdapter):
         self._thread_context: Dict[str, Dict[str, str]] = {}
 
         logger.info("[Email] Adapter initialized for %s", self._address)
+
+    def _make_ssl_context(self) -> ssl.SSLContext:
+        """Create an SSL context, optionally disabling cert verification."""
+        ctx = ssl.create_default_context()
+        if not self._verify_ssl:
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+        return ctx
 
     def _trim_seen_uids(self) -> None:
         """Keep only the most recent UIDs to prevent unbounded memory growth.
@@ -274,7 +284,7 @@ class EmailAdapter(BasePlatformAdapter):
         """Connect to the IMAP server and start polling for new messages."""
         try:
             # Test IMAP connection
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30, ssl_context=self._make_ssl_context())
             imap.login(self._address, self._password)
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
@@ -293,7 +303,7 @@ class EmailAdapter(BasePlatformAdapter):
         try:
             # Test SMTP connection
             smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
-            smtp.starttls(context=ssl.create_default_context())
+            smtp.starttls(context=self._make_ssl_context())
             smtp.login(self._address, self._password)
             smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
@@ -341,7 +351,7 @@ class EmailAdapter(BasePlatformAdapter):
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
         results = []
         try:
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30, ssl_context=self._make_ssl_context())
             try:
                 imap.login(self._address, self._password)
                 imap.select("INBOX")
@@ -513,7 +523,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
-            smtp.starttls(context=ssl.create_default_context())
+            smtp.starttls(context=self._make_ssl_context())
             smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:
@@ -635,7 +645,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
-            smtp.starttls(context=ssl.create_default_context())
+            smtp.starttls(context=self._make_ssl_context())
             smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:
@@ -714,7 +724,7 @@ class EmailAdapter(BasePlatformAdapter):
 
         smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
         try:
-            smtp.starttls(context=ssl.create_default_context())
+            smtp.starttls(context=self._make_ssl_context())
             smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -256,6 +256,7 @@ class EmailAdapter(BasePlatformAdapter):
         """Create an SSL context, optionally disabling cert verification."""
         ctx = ssl.create_default_context()
         if not self._verify_ssl:
+            logger.warning("[Email] TLS certificate verification is DISABLED via EMAIL_VERIFY_SSL")
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
         return ctx

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -72,6 +72,7 @@ EMAIL_IMAP_PORT=993                    # Default: 993 (IMAP SSL)
 EMAIL_SMTP_PORT=587                    # Default: 587 (SMTP STARTTLS)
 EMAIL_POLL_INTERVAL=15                 # Seconds between inbox checks (default: 15)
 EMAIL_HOME_ADDRESS=your@email.com      # Default delivery target for cron jobs
+EMAIL_VERIFY_SSL=1                     # Set to 0 to skip TLS cert verification (self-signed certs)
 ```
 
 ---
@@ -158,6 +159,7 @@ Email access follows the same pattern as all other Hermes platforms:
 | **Duplicate replies** | Ensure only one gateway instance is running. Check `hermes gateway status`. |
 | **Slow response** | The default poll interval is 15 seconds. Reduce with `EMAIL_POLL_INTERVAL=5` for faster response (but more IMAP connections). |
 | **Replies not threading** | The adapter uses In-Reply-To headers. Some email clients (especially web-based) may not thread correctly with automated messages. |
+| **SSL certificate error** | If using a self-signed certificate or a CA not in the system trust store, set `EMAIL_VERIFY_SSL=0` to disable verification. Only use on trusted networks. |
 
 ---
 
@@ -171,6 +173,7 @@ Email access follows the same pattern as all other Hermes platforms:
 - Set `EMAIL_ALLOWED_USERS` to restrict who can interact with the agent
 - The password is stored in `~/.hermes/.env` — protect this file (`chmod 600`)
 - IMAP uses SSL (port 993) and SMTP uses STARTTLS (port 587) by default — connections are encrypted
+- `EMAIL_VERIFY_SSL=0` disables certificate verification — only use this for self-signed certs on trusted networks
 
 ---
 
@@ -188,3 +191,4 @@ Email access follows the same pattern as all other Hermes platforms:
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
 | `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |
+| `EMAIL_VERIFY_SSL` | No | `1` | Set to `0`/`false`/`no` to skip TLS cert verification (self-signed certs) |


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
- Adds `EMAIL_VERIFY_SSL` environment variable (set to `0`/`false`/`no` to disable TLS certificate verification for IMAP and SMTP)
- Supports self-signed or untrusted certificates (e.g. Let's Encrypt on systems without updated CA bundles, private CAs)
- Defaults to enabled (verify) for security — opt-in insecure mode only
- All 5 SSL usage sites (2 IMAP, 3 SMTP) now go through a shared `_make_ssl_context()` helper

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->
Fixes #12236

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- gateway/platforms/email.py

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->
- [ ] Verify default behavior (no env var set) still enforces certificate verification
- [ ] Verify `EMAIL_VERIFY_SSL=0` allows connection to servers with self-signed certs
- [ ] Verify `EMAIL_VERIFY_SSL=false` and `EMAIL_VERIFY_SSL=no` also disable verification
- [ ] Verify IMAP polling and all SMTP send paths use the relaxed context

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->