### PR TITLE
feat(tools/wot_engine): add Web-of-Thought multi-agent reasoning

### DIFF
--- a/skills/coordination/web-of-thought/SKILL.md
+++ b/skills/coordination/web-of-thought/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: web-of-thought
+description: When to invoke wot_chat (multi-agent reasoning) and how to design the inner agents — when this beats answering directly.
+metadata:
+  hermes:
+    tags: [debate, perspectives, critique, red-team, multi-agent, synthesize, wot, web-of-thought]
+---
+
+# Web-of-Thought (`wot_chat`)
+
+You have access to a multi-agent reasoning tool. Use it when a task genuinely benefits from multiple independent perspectives feeding into one synthesis. Don't use it for everything.
+
+## When to use it
+
+Reach for `wot_chat` when **at least two of** the following apply:
+
+- The question is **inherently multi-perspective**: design tradeoffs, policy/strategy decisions, code review across orthogonal dimensions (correctness × perf × security), risk assessment.
+- A single answer is likely **brittle or biased**: the model's first instinct is probably partial, and parallel takes catch what one pass misses.
+- The question carries **real downside cost** if you're wrong — recommendation that drives a purchase, a hire, a deploy, a clinical or regulatory decision.
+- You'd otherwise be tempted to **simulate "let me think from another angle"** in your own response — let actual independent agents do that instead.
+
+## When NOT to use it
+
+- Simple lookups, single-fact questions, definitions, casual chat.
+- Tasks the user already framed precisely enough that one good answer suffices.
+- Anything time-sensitive (each `wot_chat` round costs seconds-to-minutes; don't make a user wait for `2+2`).
+- Token-budget-constrained sessions — `wot_chat` multiplies token usage by `agents × rounds`.
+
+## Designing the inner agents — the only rule that matters
+
+**Don't pre-assign specialist roles.** Give each agent a **minimal** differentiating system prompt (1–2 sentences) and let the agent develop its own viewpoint from the conversation. Examples:
+
+✅ **Good** (low specification, high autonomy):
+```json
+{"name": "alpha", "system_prompt": "Argue the case for the change. Be direct, brief."}
+{"name": "beta",  "system_prompt": "Argue the case against. Be direct, brief."}
+{"name": "gamma", "system_prompt": "Synthesize alpha and beta into a single recommendation."}
+```
+
+❌ **Avoid** (over-scripted, role-cargo):
+```json
+{"name": "Senior_Fullstack_Architect_with_15_Years_Experience", "system_prompt": "You are a senior fullstack architect with 15 years of React experience who has built scalable production dashboards for Fortune 500 companies and you believe React is the most proven choice and you must defend it with examples from your career..."}
+```
+
+Long over-scripted prompts make agents perform a role rather than think. The point of WoT is *emergent disagreement and synthesis*, not theatre.
+
+**Naming**: alphanumeric / underscore / dash. Spaces in names are auto-sanitized to underscores.
+
+## Picking the mode
+
+| Mode | When |
+|---|---|
+| `parallel` (default) | All agents react to the task simultaneously. Best for independent perspectives that meet at the synthesis. |
+| `streaming` | Like parallel but agents see each other's tokens as they're generated. Use when you want emergent cross-influence within a round, not just at round boundaries. |
+| `sequential` | Round-robin; each agent sees the full prior transcript. Use for refinement chains where agent N improves on agent N-1's output. |
+| `queue` | Tag-driven pull. An agent only acts when an inbox message carries one of its declared `interests` tags. Use for asymmetric workloads where one agent is the "dispatcher" and others react conditionally. |
+
+If unsure, use `parallel` with 3 agents. It's the safest default.
+
+## Cost discipline
+
+- Default `max_rounds` is 5. For most tasks 2–3 is plenty. **Pass `max_rounds: 2` explicitly** if you want fast cheap output.
+- Default `token_budget: 0` means unbounded. **Set `token_budget: 8000` for hard caps** (cumulative chars × ~4 = tokens) — lets you bound per-call spend.
+- 3 agents × 3 rounds covers most cases. 7 agents × 5 rounds is rarely justified.
+
+## Reading the result
+
+`wot_chat` returns JSON with these fields you should look at, in order:
+
+1. **`errors`** — non-empty means at least one inner agent failed. Surface the count to the user; don't silently smooth over.
+2. **`agents_done`** — agents that emitted `DONE` on their own line (signaled they had nothing more to add). Empty list is fine.
+3. **`rounds_run`** vs **`stop_reason`** — `"all_done"` (clean), `"max_rounds"` (capped), `"budget"` (token cap hit).
+4. **`transcript`** — the actual messages. Each entry has `from` (agent name), `content`, and optionally `reasoning` (the agent's chain-of-thought, if `propagate_reasoning != "strip"`).
+
+Synthesize the user's answer **from the transcript**, not from the schema metadata. Cite which agent said what when relevant.
+
+## Example invocation
+
+```json
+{
+  "agents": [
+    {"name": "alpha", "system_prompt": "Argue the case for. Brief."},
+    {"name": "beta",  "system_prompt": "Argue the case against. Brief."},
+    {"name": "gamma", "system_prompt": "Synthesize alpha and beta into one recommendation."}
+  ],
+  "task": "Should the team migrate from REST to gRPC for the internal services this quarter?",
+  "mode": "parallel",
+  "max_rounds": 3,
+  "token_budget": 12000
+}
+```
+
+The tool returns a JSON transcript. Read it, then write the user a clean synthesis that names the tradeoffs and gives a clear recommendation with caveats.
+
+## Anti-patterns to avoid
+
+1. **Calling `wot_chat` for everything.** If you can answer in one paragraph confidently, just answer.
+2. **Specifying `model` per agent.** The engine ignores caller-supplied `model` and uses the configured backend default — don't waste tokens guessing model names.
+3. **Long ceremonial system prompts.** See "Designing the inner agents" above.
+4. **Ignoring the `errors` field.** A 3-agent run with 9 errors is a failed run; surface that to the user.
+5. **Using WoT to look authoritative on something that's just a guess.** Multi-agent doesn't manufacture truth; it surfaces tradeoffs.

--- a/skills/coordination/web-of-thought/SKILL.md
+++ b/skills/coordination/web-of-thought/SKILL.md
@@ -8,6 +8,14 @@ metadata:
 
 # Web-of-Thought (`wot_chat`)
 
+**Opt-in only.** The tool is unavailable unless `HERMES_ENABLE_WOT=1` (or
+`true`/`yes`/`on`) is set in the environment. Even then, include the `wot`
+toolset deliberately — do not assume every session has it.
+
+Inner agents call **`LLM_BASE_URL` / `LLM_API_KEY` / `LLM_DEFAULT_MODEL`**
+(or `OLLAMA_URL`), **not** the parent Hermes session provider. Configure those
+env vars before relying on `wot_chat`.
+
 You have access to a multi-agent reasoning tool. Use it when a task genuinely benefits from multiple independent perspectives feeding into one synthesis. Don't use it for everything.
 
 ## When to use it
@@ -51,9 +59,9 @@ Long over-scripted prompts make agents perform a role rather than think. The poi
 | Mode | When |
 |---|---|
 | `parallel` (default) | All agents react to the task simultaneously. Best for independent perspectives that meet at the synthesis. |
-| `streaming` | Like parallel but agents see each other's tokens as they're generated. Use when you want emergent cross-influence within a round, not just at round boundaries. |
+| `streaming` | Parallel rounds that surface peer *partials after/as each peer stream finishes in the round* — not true mid-token injection into another agent's still-open request (OpenAI-compat cannot do that client-side). Prefer `parallel` unless you specifically want chunked peer visibility. |
 | `sequential` | Round-robin; each agent sees the full prior transcript. Use for refinement chains where agent N improves on agent N-1's output. |
-| `queue` | Tag-driven pull. An agent only acts when an inbox message carries one of its declared `interests` tags. Use for asymmetric workloads where one agent is the "dispatcher" and others react conditionally. |
+| `queue` | Reserved for tag-driven pull. **Current engine does not yet route ordinary messages by `@name` / `interests`** — only `DONE` early-stop is implemented. Prefer `parallel` until routing lands. |
 
 If unsure, use `parallel` with 3 agents. It's the safest default.
 

--- a/skills/coordination/web-of-thought/SKILL.md
+++ b/skills/coordination/web-of-thought/SKILL.md
@@ -1,109 +1,103 @@
 ---
 name: web-of-thought
-description: When to invoke wot_chat (multi-agent reasoning) and how to design the inner agents — when this beats answering directly.
+description: "When to call wot_chat; design agents; modes & opt-in."
+version: 1.1.0
+author: Hermes Agent
+license: MIT
 metadata:
   hermes:
     tags: [debate, perspectives, critique, red-team, multi-agent, synthesize, wot, web-of-thought]
+    related_skills: []
 ---
 
 # Web-of-Thought (`wot_chat`)
 
-**Opt-in only.** The tool is unavailable unless `HERMES_ENABLE_WOT=1` (or
-`true`/`yes`/`on`) is set in the environment. Even then, include the `wot`
-toolset deliberately — do not assume every session has it.
+**Opt-in only.** Unavailable unless `HERMES_ENABLE_WOT=1` (or `true`/`yes`/`on`).
+Even then, include the `wot` toolset deliberately.
 
-Inner agents call **`LLM_BASE_URL` / `LLM_API_KEY` / `LLM_DEFAULT_MODEL`**
-(or `OLLAMA_URL`), **not** the parent Hermes session provider. Configure those
-env vars before relying on `wot_chat`.
+## Provider
 
-You have access to a multi-agent reasoning tool. Use it when a task genuinely benefits from multiple independent perspectives feeding into one synthesis. Don't use it for everything.
+Inner agents use **Hermes active session credentials** by default
+(`resolve_hermes_endpoint` → runtime / config / `resolve_provider_client`).
 
-## When to use it
+Override with env (lab multi-backend):
 
-Reach for `wot_chat` when **at least two of** the following apply:
+- `LLM_BASE_URL` + optional `LLM_API_KEY` + `LLM_DEFAULT_MODEL`
+- else `OLLAMA_URL` / localhost
 
-- The question is **inherently multi-perspective**: design tradeoffs, policy/strategy decisions, code review across orthogonal dimensions (correctness × perf × security), risk assessment.
-- A single answer is likely **brittle or biased**: the model's first instinct is probably partial, and parallel takes catch what one pass misses.
-- The question carries **real downside cost** if you're wrong — recommendation that drives a purchase, a hire, a deploy, a clinical or regulatory decision.
-- You'd otherwise be tempted to **simulate "let me think from another angle"** in your own response — let actual independent agents do that instead.
+Transcript `backend.endpoint_source` shows which source won.
 
-## When NOT to use it
+## When to use
 
-- Simple lookups, single-fact questions, definitions, casual chat.
-- Tasks the user already framed precisely enough that one good answer suffices.
-- Anything time-sensitive (each `wot_chat` round costs seconds-to-minutes; don't make a user wait for `2+2`).
-- Token-budget-constrained sessions — `wot_chat` multiplies token usage by `agents × rounds`.
+Reach for `wot_chat` when **at least two** apply:
 
-## Designing the inner agents — the only rule that matters
+- Multi-perspective question (tradeoffs, orthogonal review axes)
+- Single answer likely brittle/biased
+- Real downside cost if wrong
+- You would otherwise simulate “another angle” in one reply
 
-**Don't pre-assign specialist roles.** Give each agent a **minimal** differentiating system prompt (1–2 sentences) and let the agent develop its own viewpoint from the conversation. Examples:
+## When NOT to use
 
-✅ **Good** (low specification, high autonomy):
+Simple facts, casual chat, time-sensitive tiny asks, tight token budgets
+(`agents × rounds` multiplies spend).
+
+## Designing agents
+
+Minimal system prompts (1–2 sentences). No long role-play bios.
+
 ```json
-{"name": "alpha", "system_prompt": "Argue the case for the change. Be direct, brief."}
-{"name": "beta",  "system_prompt": "Argue the case against. Be direct, brief."}
-{"name": "gamma", "system_prompt": "Synthesize alpha and beta into a single recommendation."}
+{"name": "alpha", "system_prompt": "Argue the case for. Brief."}
+{"name": "beta",  "system_prompt": "Argue the case against. Brief."}
+{"name": "gamma", "system_prompt": "Synthesize alpha and beta."}
 ```
 
-❌ **Avoid** (over-scripted, role-cargo):
-```json
-{"name": "Senior_Fullstack_Architect_with_15_Years_Experience", "system_prompt": "You are a senior fullstack architect with 15 years of React experience who has built scalable production dashboards for Fortune 500 companies and you believe React is the most proven choice and you must defend it with examples from your career..."}
-```
+Names: alphanumeric / `_` / `-` (spaces auto-sanitized).
 
-Long over-scripted prompts make agents perform a role rather than think. The point of WoT is *emergent disagreement and synthesis*, not theatre.
+## Modes
 
-**Naming**: alphanumeric / underscore / dash. Spaces in names are auto-sanitized to underscores.
-
-## Picking the mode
-
-| Mode | When |
+| Mode | Behavior |
 |---|---|
-| `parallel` (default) | All agents react to the task simultaneously. Best for independent perspectives that meet at the synthesis. |
-| `streaming` | Parallel rounds that surface peer *partials after/as each peer stream finishes in the round* — not true mid-token injection into another agent's still-open request (OpenAI-compat cannot do that client-side). Prefer `parallel` unless you specifically want chunked peer visibility. |
-| `sequential` | Round-robin; each agent sees the full prior transcript. Use for refinement chains where agent N improves on agent N-1's output. |
-| `queue` | Reserved for tag-driven pull. **Current engine does not yet route ordinary messages by `@name` / `interests`** — only `DONE` early-stop is implemented. Prefer `parallel` until routing lands. |
+| `parallel` (default) | Concurrent rounds; peers see completed messages next round |
+| `streaming` | Concurrent + chunked peer partials absorbed **next turn only** — **not** mid-token injection into an in-flight peer request |
+| `sequential` | Round-robin full transcript |
+| `queue` | Wake on `@Name` DM, or `#tag` matching `interests`, or any inbox if interests empty. Round 1 wakes all |
 
-If unsure, use `parallel` with 3 agents. It's the safest default.
+Routing in content:
 
-## Cost discipline
+- `@Peer: …` → direct message (Channel delivers only to Peer)
+- `#topic` → tags for queue interests
 
-- Default `max_rounds` is 5. For most tasks 2–3 is plenty. **Pass `max_rounds: 2` explicitly** if you want fast cheap output.
-- Default `token_budget: 0` means unbounded. **Set `token_budget: 8000` for hard caps** (cumulative chars × ~4 = tokens) — lets you bound per-call spend.
-- 3 agents × 3 rounds covers most cases. 7 agents × 5 rounds is rarely justified.
+## Cost
 
-## Reading the result
+Prefer `max_rounds: 2–3`. Set `token_budget` for hard caps. 3×3 is usually enough.
 
-`wot_chat` returns JSON with these fields you should look at, in order:
+## Result fields
 
-1. **`errors`** — non-empty means at least one inner agent failed. Surface the count to the user; don't silently smooth over.
-2. **`agents_done`** — agents that emitted `DONE` on their own line (signaled they had nothing more to add). Empty list is fine.
-3. **`rounds_run`** vs **`stop_reason`** — `"all_done"` (clean), `"max_rounds"` (capped), `"budget"` (token cap hit).
-4. **`transcript`** — the actual messages. Each entry has `from` (agent name), `content`, and optionally `reasoning` (the agent's chain-of-thought, if `propagate_reasoning != "strip"`).
+1. `errors` — surface failures
+2. `agents_done` / `rounds_run` / `stop_reason`
+3. `transcript` — synthesize the user answer from this
+4. `backend.endpoint_source` / `default_model` — verify provider wiring
 
-Synthesize the user's answer **from the transcript**, not from the schema metadata. Cite which agent said what when relevant.
-
-## Example invocation
+## Example
 
 ```json
 {
   "agents": [
     {"name": "alpha", "system_prompt": "Argue the case for. Brief."},
     {"name": "beta",  "system_prompt": "Argue the case against. Brief."},
-    {"name": "gamma", "system_prompt": "Synthesize alpha and beta into one recommendation."}
+    {"name": "gamma", "system_prompt": "Synthesize. Brief."}
   ],
-  "task": "Should the team migrate from REST to gRPC for the internal services this quarter?",
+  "task": "Should we migrate internal services to gRPC this quarter?",
   "mode": "parallel",
   "max_rounds": 3,
   "token_budget": 12000
 }
 ```
 
-The tool returns a JSON transcript. Read it, then write the user a clean synthesis that names the tradeoffs and gives a clear recommendation with caveats.
+## Anti-patterns
 
-## Anti-patterns to avoid
-
-1. **Calling `wot_chat` for everything.** If you can answer in one paragraph confidently, just answer.
-2. **Specifying `model` per agent.** The engine ignores caller-supplied `model` and uses the configured backend default — don't waste tokens guessing model names.
-3. **Long ceremonial system prompts.** See "Designing the inner agents" above.
-4. **Ignoring the `errors` field.** A 3-agent run with 9 errors is a failed run; surface that to the user.
-5. **Using WoT to look authoritative on something that's just a guess.** Multi-agent doesn't manufacture truth; it surfaces tradeoffs.
+1. Calling WoT for everything
+2. Per-agent `model` in tool args (stripped at tool boundary)
+3. Long ceremonial prompts
+4. Ignoring `errors`
+5. Treating multi-agent output as manufactured truth

--- a/tests/tools/test_wot_engine.py
+++ b/tests/tools/test_wot_engine.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import sys
 import unittest
 from pathlib import Path
@@ -585,6 +586,145 @@ class EdgeCaseTests(unittest.IsolatedAsyncioTestCase):
             task="x", mode="parallel", max_rounds=1,
         )
         self.assertEqual(result["backend"]["kind"], "vllm")
+        self.assertIn("endpoint_source", result["backend"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Option B: routing (@name / #tags) + Hermes endpoint resolution
+# ─────────────────────────────────────────────────────────────────────────────
+class MessageRoutingParseTests(unittest.TestCase):
+    def test_at_mention_resolves_known_agent(self):
+        to_agent, tags = wot_engine.parse_message_routing(
+            "@bob: please review this", known_agents={"alice", "bob"}
+        )
+        self.assertEqual(to_agent, "bob")
+        self.assertEqual(tags, [])
+
+    def test_at_mention_case_insensitive_maps_to_canonical(self):
+        to_agent, tags = wot_engine.parse_message_routing(
+            "Hey @Bob check this", known_agents={"alice", "bob"}
+        )
+        self.assertEqual(to_agent, "bob")
+
+    def test_unknown_mention_ignored_when_known_set(self):
+        to_agent, tags = wot_engine.parse_message_routing(
+            "@eve: secret", known_agents={"alice", "bob"}
+        )
+        self.assertIsNone(to_agent)
+
+    def test_hashtags_extracted(self):
+        to_agent, tags = wot_engine.parse_message_routing(
+            "Discuss #math and #code please", known_agents={"a"}
+        )
+        self.assertIsNone(to_agent)
+        self.assertEqual(tags, ["math", "code"])
+
+    def test_combined_dm_and_tags(self):
+        to_agent, tags = wot_engine.parse_message_routing(
+            "@alice #security please audit", known_agents={"alice", "bob"}
+        )
+        self.assertEqual(to_agent, "alice")
+        self.assertEqual(tags, ["security"])
+
+
+class DirectMentionRoutingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_dm_only_lands_in_target_inbox(self):
+        scripts = {
+            "alice": ["@bob: only for you\nDONE"],
+            "bob": ["got it\nDONE"],
+            "carol": ["untouched\nDONE"],
+        }
+        engine = WoTEngine()
+        engine.client = MockLLMClient(scripts)
+        result = await engine.run(
+            [AgentSpec(name=n, system_prompt="...") for n in ("alice", "bob", "carol")],
+            task="dm", mode="sequential", max_rounds=1,
+        )
+        dm = next(m for m in result["transcript"] if m["from"] == "alice")
+        self.assertEqual(dm.get("to"), "bob")
+        # Carol's payload must not contain alice's DM body (sequential: alice first)
+        carol_payloads = [
+            p for p in engine.client.payloads
+            if "agent 'carol'" in p["messages"][0]["content"]
+        ]
+        self.assertTrue(carol_payloads)
+        flat = " ".join(m.get("content", "") for m in carol_payloads[0]["messages"])
+        self.assertNotIn("only for you", flat)
+
+
+class QueueInterestsTests(unittest.IsolatedAsyncioTestCase):
+    async def test_interest_agent_wakes_on_matching_tag(self):
+        # Round 1: broadcaster emits #math; math_agent wakes round 2; code_agent stays quiet
+        scripts = {
+            "broadcaster": ["Looking at #math problem\nDONE", "still done"],
+            "math_agent": ["I handle math\nDONE", "noop"],
+            "code_agent": ["I only care about code", "still idle"],
+        }
+        engine = WoTEngine()
+        engine.client = MockLLMClient(scripts)
+        result = await engine.run(
+            [
+                AgentSpec(name="broadcaster", system_prompt="..."),
+                AgentSpec(name="math_agent", system_prompt="...", interests=["math"]),
+                AgentSpec(name="code_agent", system_prompt="...", interests=["code"]),
+            ],
+            task="queue", mode="queue", max_rounds=2,
+        )
+        speakers = [m["from"] for m in result["transcript"]]
+        # broadcaster + both agents speak round 1; round 2 only math_agent (and maybe broadcaster if not DONE)
+        self.assertIn("math_agent", speakers)
+        # After round 1 DONE, code_agent with interests=["code"] should not get a round-2 turn
+        # Count turns via mock call log
+        code_calls = [c for c in engine.client.calls if c["agent"] == "code_agent"]
+        math_calls = [c for c in engine.client.calls if c["agent"] == "math_agent"]
+        self.assertEqual(len(code_calls), 1, "code_agent should only speak round 1")
+        self.assertGreaterEqual(len(math_calls), 1)
+
+    async def test_dm_wakes_interest_filtered_agent(self):
+        scripts = {
+            "alice": ["@bob: direct wake\nDONE"],
+            # bob must NOT DONE in round 1 so he can be woken by the DM in round 2
+            "bob": ["listening", "woken by DM\nDONE"],
+            "carol": ["I am done too\nDONE"],
+        }
+        engine = WoTEngine()
+        engine.client = MockLLMClient(scripts)
+        result = await engine.run(
+            [
+                AgentSpec(name="alice", system_prompt="..."),
+                AgentSpec(name="bob", system_prompt="...", interests=["security"]),
+                AgentSpec(name="carol", system_prompt="...", interests=["other"]),
+            ],
+            task="dm-wake", mode="queue", max_rounds=2,
+        )
+        bob_calls = [c for c in engine.client.calls if c["agent"] == "bob"]
+        # bob: round 1 always, round 2 because of DM
+        self.assertGreaterEqual(len(bob_calls), 2)
+        self.assertIn("bob", result["agents_done"])
+
+
+class HermesEndpointResolutionTests(unittest.TestCase):
+    def test_llm_base_url_env_wins(self):
+        with patch.dict(os.environ, {
+            "LLM_BASE_URL": "http://lab.example:8080",
+            "LLM_API_KEY": "sk-lab",
+            "LLM_DEFAULT_MODEL": "lab-model",
+        }, clear=False):
+            base, key, model, meta = wot_engine.resolve_hermes_endpoint()
+        self.assertEqual(base, "http://lab.example:8080")
+        self.assertEqual(key, "sk-lab")
+        self.assertEqual(model, "lab-model")
+        self.assertEqual(meta["source"], "env:LLM_BASE_URL")
+
+    def test_engine_records_endpoint_meta(self):
+        with patch.dict(os.environ, {
+            "LLM_BASE_URL": "http://only-for-test:9",
+            "LLM_API_KEY": "k",
+            "LLM_DEFAULT_MODEL": "m",
+        }, clear=False):
+            engine = WoTEngine()
+        self.assertEqual(engine.endpoint_meta.get("source"), "env:LLM_BASE_URL")
+        self.assertEqual(engine.default_model, "m")
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_wot_engine.py
+++ b/tests/tools/test_wot_engine.py
@@ -86,25 +86,29 @@ class MockLLMClient:
                                reasoning=item.get("reasoning", ""))
         raise ValueError(f"unsupported script item: {item!r}")
 
-    async def ensure_probed(self) -> BackendInfo:
+    async def ensure_probed(self, base_url_override=None) -> BackendInfo:
         return self.backend
 
     async def complete(self, model, messages, max_tokens=800, temperature=0.7,
-                       slot_id=None, stop=None) -> LLMResponse:
+                       slot_id=None, stop=None,
+                       base_url_override=None, api_key_override=None) -> LLMResponse:
         agent = self._agent_from_messages(messages)
         payload = self._payload(model, messages, max_tokens, temperature,
                                  stream=False, slot_id=slot_id, stop=stop)
         self.payloads.append(payload)
-        self.calls.append({"agent": agent, "mode": "complete", "slot_id": slot_id})
+        self.calls.append({"agent": agent, "mode": "complete", "slot_id": slot_id,
+                           "base_url_override": base_url_override})
         return self._resolve_response(agent)
 
     async def stream(self, model, messages, max_tokens=800, temperature=0.7,
-                     slot_id=None, stop=None) -> AsyncIterator[Tuple[str, str]]:
+                     slot_id=None, stop=None,
+                     base_url_override=None, api_key_override=None) -> AsyncIterator[Tuple[str, str]]:
         agent = self._agent_from_messages(messages)
         payload = self._payload(model, messages, max_tokens, temperature,
                                  stream=True, slot_id=slot_id, stop=stop)
         self.payloads.append(payload)
-        self.calls.append({"agent": agent, "mode": "stream", "slot_id": slot_id})
+        self.calls.append({"agent": agent, "mode": "stream", "slot_id": slot_id,
+                           "base_url_override": base_url_override})
         resp = self._resolve_response(agent)
         # Yield reasoning chunks first, then content chunks (mimics a real thinking-mode stream)
         for kind, text in (("reasoning", resp.reasoning), ("content", resp.content)):
@@ -389,6 +393,85 @@ class TokenBudgetTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(result["stop_reason"], "budget")
         self.assertLess(result["rounds_run"], 10)
+
+
+class MultiBackendMixTests(unittest.IsolatedAsyncioTestCase):
+    async def test_per_agent_base_url_override_threads_to_client(self):
+        # Two agents with different base_url overrides — verify each call
+        # to the client carries the right per-agent target.
+        client = MockLLMClient({"a": ["A says hi.\nDONE"], "b": ["B says hi.\nDONE"]})
+        engine = WoTEngine()
+        engine.client = client
+        await engine.run(
+            [AgentSpec(name="a", system_prompt="...",
+                       base_url="http://127.0.0.1:11434", api_key="ollama"),
+             AgentSpec(name="b", system_prompt="...",
+                       base_url="https://openrouter.ai/api/v1", api_key="sk-or-test")],
+            task="x", mode="parallel", max_rounds=1,
+        )
+        targets = {c["agent"]: c["base_url_override"] for c in client.calls}
+        self.assertEqual(targets["a"], "http://127.0.0.1:11434")
+        self.assertEqual(targets["b"], "https://openrouter.ai/api/v1")
+
+    async def test_default_base_url_is_None_when_not_set(self):
+        # When AgentSpec has no override, base_url_override should be None
+        client = MockLLMClient({"a": ["ok\nDONE"]})
+        engine = WoTEngine()
+        engine.client = client
+        await engine.run(
+            [AgentSpec(name="a", system_prompt="...")],
+            task="x", mode="parallel", max_rounds=1,
+        )
+        self.assertIsNone(client.calls[0]["base_url_override"])
+
+
+class WotChatToolStripsCallerControlFields(unittest.IsolatedAsyncioTestCase):
+    async def test_tool_boundary_strips_model_base_url_api_key(self):
+        # wot_chat_tool boundary should strip outer-Hermes-supplied backend
+        # control fields (Hermes hallucinates them). Direct Python callers
+        # using AgentSpec(base_url=..., api_key=...) still work.
+        from tools.wot_engine import wot_chat_tool, _LLMClient
+
+        captured_specs = []
+        from unittest.mock import patch
+
+        # Stub asyncio.run path: just inspect specs after sanitize
+        original_async_run = None
+
+        # Easier: capture by patching AgentSpec __init__ to save args
+        from tools import wot_engine as we
+        original_init = we.AgentSpec.__post_init__
+        seen = []
+
+        def capture_init(self):
+            original_init(self)
+            seen.append({"name": self.name, "model": self.model,
+                         "base_url": self.base_url, "api_key": self.api_key})
+
+        we.AgentSpec.__post_init__ = capture_init
+        try:
+            # Call should ignore the caller's model/base_url/api_key
+            try:
+                wot_chat_tool(
+                    agents=[{"name": "alpha", "system_prompt": "hi",
+                             "model": "gpt-4o-hallucinated",
+                             "base_url": "https://evil.example.com",
+                             "api_key": "sk-stolen"}],
+                    task="x", mode="parallel", max_rounds=1,
+                )
+            except Exception:
+                pass  # We don't care if the network call fails — we just want the spec inspection
+        finally:
+            we.AgentSpec.__post_init__ = original_init
+
+        self.assertGreaterEqual(len(seen), 1)
+        spec = seen[0]
+        # base_url + api_key stripped → both None
+        self.assertIsNone(spec["base_url"], "base_url should have been stripped at tool boundary")
+        self.assertIsNone(spec["api_key"], "api_key should have been stripped at tool boundary")
+        # model stripped → falls back to LLM_DEFAULT_MODEL (env-driven), NOT 'gpt-4o-hallucinated'
+        self.assertNotEqual(spec["model"], "gpt-4o-hallucinated",
+                              "model should have been stripped at tool boundary")
 
 
 class SlotPinningTests(unittest.IsolatedAsyncioTestCase):

--- a/tests/tools/test_wot_engine.py
+++ b/tests/tools/test_wot_engine.py
@@ -1,0 +1,508 @@
+"""Unit tests for tools/wot_engine.py — mock LLM client, deterministic, fast.
+
+Run:   python3 -m pytest test_wot_engine.py -v
+       OR (without pytest):  python3 test_wot_engine.py
+
+Covers:
+  - Channel pub/sub (broadcast + direct + sender-skip + history + seq counter)
+  - AgentSpec validation
+  - DONE detection (own-line vs inline)
+  - All 4 modes: parallel, streaming, sequential, queue
+  - Streaming chunks publish before final message
+  - Qwen3.5/3.6 chat_template_kwargs auto-injection
+  - DONE early-exit short-circuits remaining rounds
+  - Max-rounds boundary
+  - LLMResponse reasoning/content separation
+  - propagate_reasoning="strip" vs "raw" peer-message rendering
+  - token_budget enforces early stop
+  - per-agent turn_timeout
+  - backend probe is awaited on run()
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import unittest
+from pathlib import Path
+from typing import AsyncIterator, Dict, List, Tuple
+from unittest.mock import patch
+
+from tools import wot_engine
+from tools.wot_engine import (
+    AgentSpec, Agent, BackendInfo, Channel, LLMResponse, Message, WoTEngine, _LLMClient,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Mock LLM — returns scripted responses by agent name + round
+# ─────────────────────────────────────────────────────────────────────────────
+class MockLLMClient:
+    """Pretends to be _LLMClient. Caller provides per-agent scripted responses.
+
+    Scripts may be:
+      - str → becomes LLMResponse(content=str)
+      - dict {"content": ..., "reasoning": ...} → LLMResponse with both fields
+    """
+
+    def __init__(self, scripts: Dict[str, List], backend_kind: str = "openai-compat"):
+        self.scripts = {k: list(v) for k, v in scripts.items()}
+        self.calls: List[Dict] = []
+        self.payloads: List[Dict] = []
+        self.backend = BackendInfo(kind=backend_kind, base_url="mock://test")
+        self._probed = True
+
+    @staticmethod
+    def _is_qwen35_or_36(model: str) -> bool:
+        n = (model or "").lower().replace("_", ".")
+        return "qwen3.5" in n or "qwen3.6" in n
+
+    def _payload(self, model, messages, max_tokens, temperature, stream, slot_id=None, stop=None):
+        payload = {"model": model, "messages": messages,
+                   "max_tokens": max_tokens, "temperature": temperature, "stream": stream}
+        if self._is_qwen35_or_36(model):
+            payload["chat_template_kwargs"] = {"enable_thinking": False}
+        if stop:
+            payload["stop"] = stop
+        if self.backend.kind == "llama-server" and slot_id is not None:
+            payload["id_slot"] = slot_id
+            payload["cache_prompt"] = True
+        return payload
+
+    def _agent_from_messages(self, messages: List[Dict]) -> str:
+        sys_msg = messages[0]["content"] if messages and messages[0]["role"] == "system" else ""
+        import re
+        m = re.search(r"You are agent '([^']+)'", sys_msg)
+        return m.group(1) if m else "?"
+
+    def _resolve_response(self, agent: str) -> LLMResponse:
+        if not self.scripts.get(agent):
+            return LLMResponse(content="(empty)")
+        item = self.scripts[agent].pop(0)
+        if isinstance(item, str):
+            return LLMResponse(content=item)
+        if isinstance(item, dict):
+            return LLMResponse(content=item.get("content", ""),
+                               reasoning=item.get("reasoning", ""))
+        raise ValueError(f"unsupported script item: {item!r}")
+
+    async def ensure_probed(self) -> BackendInfo:
+        return self.backend
+
+    async def complete(self, model, messages, max_tokens=800, temperature=0.7,
+                       slot_id=None, stop=None) -> LLMResponse:
+        agent = self._agent_from_messages(messages)
+        payload = self._payload(model, messages, max_tokens, temperature,
+                                 stream=False, slot_id=slot_id, stop=stop)
+        self.payloads.append(payload)
+        self.calls.append({"agent": agent, "mode": "complete", "slot_id": slot_id})
+        return self._resolve_response(agent)
+
+    async def stream(self, model, messages, max_tokens=800, temperature=0.7,
+                     slot_id=None, stop=None) -> AsyncIterator[Tuple[str, str]]:
+        agent = self._agent_from_messages(messages)
+        payload = self._payload(model, messages, max_tokens, temperature,
+                                 stream=True, slot_id=slot_id, stop=stop)
+        self.payloads.append(payload)
+        self.calls.append({"agent": agent, "mode": "stream", "slot_id": slot_id})
+        resp = self._resolve_response(agent)
+        # Yield reasoning chunks first, then content chunks (mimics a real thinking-mode stream)
+        for kind, text in (("reasoning", resp.reasoning), ("content", resp.content)):
+            if not text:
+                continue
+            words = text.split()
+            chunk_size = max(1, len(words) // 4) if words else 1
+            for i in range(0, len(words), chunk_size):
+                yield (kind, " ".join(words[i:i+chunk_size]) + " ")
+
+    async def aclose(self):
+        pass
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Channel tests
+# ─────────────────────────────────────────────────────────────────────────────
+class ChannelTests(unittest.IsolatedAsyncioTestCase):
+    async def test_broadcast_skips_sender(self):
+        ch = Channel()
+        a_q = ch.subscribe("alice"); b_q = ch.subscribe("bob"); c_q = ch.subscribe("carol")
+        await ch.publish(Message(from_agent="alice", content="hi"))
+        self.assertTrue(a_q.empty())
+        self.assertEqual(b_q.qsize(), 1)
+        self.assertEqual(c_q.qsize(), 1)
+
+    async def test_direct_message_only_to_recipient(self):
+        ch = Channel()
+        a_q = ch.subscribe("alice"); b_q = ch.subscribe("bob"); c_q = ch.subscribe("carol")
+        await ch.publish(Message(from_agent="alice", content="hi", to_agent="bob"))
+        self.assertEqual(b_q.qsize(), 1)
+        self.assertTrue(a_q.empty())
+        self.assertTrue(c_q.empty())
+
+    async def test_history_preserves_order(self):
+        ch = Channel()
+        ch.subscribe("a"); ch.subscribe("b")
+        for i in range(5):
+            await ch.publish(Message(from_agent="a", content=str(i)))
+        self.assertEqual([m.content for m in ch.history], ["0","1","2","3","4"])
+
+    async def test_transcript_excludes_chunks_by_default(self):
+        ch = Channel()
+        ch.subscribe("a")
+        await ch.publish(Message(from_agent="a", content="full"))
+        await ch.publish(Message(from_agent="a", content="part", is_chunk=True))
+        self.assertEqual(len(ch.transcript(include_chunks=False)), 1)
+        self.assertEqual(len(ch.transcript(include_chunks=True)), 2)
+
+    async def test_seq_increments_per_agent(self):
+        ch = Channel()
+        ch.subscribe("a"); ch.subscribe("b")
+        await ch.publish(Message(from_agent="a", content="1"))
+        await ch.publish(Message(from_agent="a", content="2"))
+        await ch.publish(Message(from_agent="b", content="1"))
+        seqs_a = [m.seq for m in ch.history if m.from_agent == "a"]
+        seqs_b = [m.seq for m in ch.history if m.from_agent == "b"]
+        self.assertEqual(seqs_a, [1, 2])
+        self.assertEqual(seqs_b, [1])
+
+    async def test_total_chars_tracks_cumulative(self):
+        ch = Channel()
+        ch.subscribe("a")
+        await ch.publish(Message(from_agent="a", content="hello"))
+        await ch.publish(Message(from_agent="a", content="world", reasoning="thought"))
+        self.assertEqual(ch.total_chars, len("hello") + len("world") + len("thought"))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AgentSpec tests
+# ─────────────────────────────────────────────────────────────────────────────
+class AgentSpecTests(unittest.TestCase):
+    def test_name_with_spaces_is_auto_sanitized(self):
+        # Real LLM callers emit names like "Critical Thinker" or "agent A".
+        # AgentSpec normalizes whitespace to underscores rather than erroring.
+        spec = AgentSpec(name="agent with spaces", system_prompt="hi")
+        self.assertEqual(spec.name, "agent_with_spaces")
+
+    def test_name_with_disallowed_chars_is_stripped(self):
+        # Anything outside [A-Za-z0-9_-] is dropped after sanitization.
+        spec = AgentSpec(name="alice/v2!", system_prompt="hi")
+        self.assertEqual(spec.name, "alicev2")
+
+    def test_empty_after_sanitization_raises(self):
+        # If the name reduces to nothing usable, error explicitly.
+        with self.assertRaises(ValueError):
+            AgentSpec(name="!!!", system_prompt="hi")
+
+    def test_default_model_uses_env_default(self):
+        spec = AgentSpec(name="alice", system_prompt="hi")
+        self.assertEqual(spec.model, wot_engine.LLM_DEFAULT_MODEL)
+
+    def test_explicit_model_preserved(self):
+        spec = AgentSpec(name="alice", system_prompt="hi", model="custom:v1")
+        self.assertEqual(spec.model, "custom:v1")
+
+    def test_thinking_model_auto_bumps_max_tokens(self):
+        spec = AgentSpec(name="a", system_prompt="hi", model="deepseek-r1-distill-qwen-1.5b")
+        self.assertEqual(spec.max_tokens, 2500)
+
+    def test_explicit_max_tokens_not_clobbered_for_thinking_model(self):
+        spec = AgentSpec(name="a", system_prompt="hi",
+                          model="deepseek-r1-distill-qwen-1.5b", max_tokens=4096)
+        self.assertEqual(spec.max_tokens, 4096)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DONE detection
+# ─────────────────────────────────────────────────────────────────────────────
+class DoneDetectionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_done_on_own_line_marks_agent_done(self):
+        scripts = {"alice": ["I am done with my analysis.\nDONE"]}
+        engine = WoTEngine()
+        engine.client = MockLLMClient(scripts)
+        result = await engine.run(
+            [AgentSpec(name="alice", system_prompt="...")],
+            task="anything", mode="parallel", max_rounds=3,
+        )
+        self.assertEqual(result["agents_done"], ["alice"])
+        self.assertEqual(result["rounds_run"], 1)
+        self.assertEqual(result["transcript"][0]["content"], "I am done with my analysis.")
+
+    async def test_done_inline_does_NOT_trigger(self):
+        scripts = {"alice": ["I think we are DONE here.", "Final thoughts.\nDONE"]}
+        engine = WoTEngine()
+        engine.client = MockLLMClient(scripts)
+        result = await engine.run(
+            [AgentSpec(name="alice", system_prompt="...")],
+            task="anything", mode="parallel", max_rounds=3,
+        )
+        self.assertEqual(result["agents_done"], ["alice"])
+        self.assertEqual(result["rounds_run"], 2)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Mode tests — parallel, sequential, queue, streaming
+# ─────────────────────────────────────────────────────────────────────────────
+class ParallelModeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_three_agents_speak_in_parallel_round_one(self):
+        scripts = {"a": ["A says hi.\nDONE"], "b": ["B says hi.\nDONE"], "c": ["C says hi.\nDONE"]}
+        engine = WoTEngine()
+        engine.client = MockLLMClient(scripts)
+        result = await engine.run(
+            [AgentSpec(name=n, system_prompt="...") for n in ("a","b","c")],
+            task="say hi", mode="parallel", max_rounds=2,
+        )
+        self.assertEqual(set(result["agents_done"]), {"a", "b", "c"})
+        self.assertEqual(result["rounds_run"], 1)
+        self.assertEqual(len(result["transcript"]), 3)
+        self.assertEqual({m["from"] for m in result["transcript"]}, {"a", "b", "c"})
+
+
+class SequentialModeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_round_robin_order(self):
+        scripts = {"a": ["A1\nDONE"], "b": ["B1\nDONE"], "c": ["C1\nDONE"]}
+        engine = WoTEngine()
+        engine.client = MockLLMClient(scripts)
+        result = await engine.run(
+            [AgentSpec(name=n, system_prompt="...") for n in ("a","b","c")],
+            task="hello", mode="sequential", max_rounds=2,
+        )
+        self.assertEqual([m["from"] for m in result["transcript"]], ["a","b","c"])
+        self.assertEqual(set(result["agents_done"]), {"a", "b", "c"})
+
+
+class QueueModeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_round_one_all_eligible(self):
+        scripts = {"a": ["A1\nDONE"], "b": ["B1\nDONE"]}
+        engine = WoTEngine()
+        engine.client = MockLLMClient(scripts)
+        result = await engine.run(
+            [AgentSpec(name="a", system_prompt="...", interests=["math"]),
+             AgentSpec(name="b", system_prompt="...", interests=["code"])],
+            task="anything", mode="queue", max_rounds=2,
+        )
+        self.assertEqual(set(result["agents_done"]), {"a", "b"})
+
+
+class StreamingModeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_streaming_publishes_chunks_before_final(self):
+        scripts = {"alice": ["one two three four five six seven eight\nDONE"]}
+        engine = WoTEngine()
+        engine.client = MockLLMClient(scripts)
+        result = await engine.run(
+            [AgentSpec(name="alice", system_prompt="...")],
+            task="speak", mode="streaming", max_rounds=1,
+        )
+        chunks_xs = result["transcript_with_chunks"]
+        self.assertIsNotNone(chunks_xs)
+        chunks = [m for m in chunks_xs if m["is_chunk"]]
+        finals = [m for m in chunks_xs if not m["is_chunk"]]
+        self.assertGreater(len(chunks), 0)
+        self.assertEqual(len(finals), 1)
+        self.assertLessEqual(chunks[-1]["ts"], finals[0]["ts"])
+
+    async def test_streaming_separates_reasoning_and_content_chunk_kinds(self):
+        scripts = {"a": [{"content": "alpha beta gamma delta\nDONE",
+                          "reasoning": "let me think this over"}]}
+        engine = WoTEngine()
+        engine.client = MockLLMClient(scripts)
+        result = await engine.run(
+            [AgentSpec(name="a", system_prompt="...")],
+            task="x", mode="streaming", max_rounds=1,
+        )
+        chunks = [m for m in result["transcript_with_chunks"] if m["is_chunk"]]
+        kinds = {c["chunk_kind"] for c in chunks}
+        self.assertIn("reasoning", kinds)
+        self.assertIn("content", kinds)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Reasoning propagation tests
+# ─────────────────────────────────────────────────────────────────────────────
+class PropagateReasoningTests(unittest.IsolatedAsyncioTestCase):
+    async def test_strip_default_hides_reasoning_from_peers(self):
+        # Agent A produces reasoning; agent B's peer-render must NOT include <think> blocks
+        scripts = {
+            "a": [{"content": "answer A.\nDONE", "reasoning": "secret thought"}],
+            "b": ["B saw nothing of A's CoT.\nDONE"],
+        }
+        client = MockLLMClient(scripts)
+        engine = WoTEngine()
+        engine.client = client
+        await engine.run(
+            [AgentSpec(name="a", system_prompt="..."),
+             AgentSpec(name="b", system_prompt="...")],
+            task="x", mode="sequential", max_rounds=1,
+            propagate_reasoning="strip",
+        )
+        # Find B's request: peer message about A should be just content, no reasoning
+        b_payload = next(p for p in client.payloads
+                          if "agent 'b'" in p["messages"][0]["content"])
+        peer_msg = next(m for m in b_payload["messages"] if "[from a" in m.get("content", ""))
+        self.assertNotIn("<think>", peer_msg["content"])
+        self.assertNotIn("secret thought", peer_msg["content"])
+        self.assertIn("answer A.", peer_msg["content"])
+
+    async def test_raw_propagation_includes_reasoning(self):
+        scripts = {
+            "a": [{"content": "answer A.\nDONE", "reasoning": "shared thought"}],
+            "b": ["B saw A's CoT.\nDONE"],
+        }
+        client = MockLLMClient(scripts)
+        engine = WoTEngine()
+        engine.client = client
+        await engine.run(
+            [AgentSpec(name="a", system_prompt="..."),
+             AgentSpec(name="b", system_prompt="...")],
+            task="x", mode="sequential", max_rounds=1,
+            propagate_reasoning="raw",
+        )
+        b_payload = next(p for p in client.payloads
+                          if "agent 'b'" in p["messages"][0]["content"])
+        peer_msg = next(m for m in b_payload["messages"] if "[from a" in m.get("content", ""))
+        self.assertIn("<think>", peer_msg["content"])
+        self.assertIn("shared thought", peer_msg["content"])
+
+    async def test_message_to_dict_includes_reasoning_when_present(self):
+        m = Message(from_agent="a", content="answer", reasoning="thought")
+        d = m.to_dict()
+        self.assertEqual(d["reasoning"], "thought")
+
+    async def test_message_to_dict_omits_reasoning_when_empty(self):
+        m = Message(from_agent="a", content="answer")
+        self.assertNotIn("reasoning", m.to_dict())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Token budget + slot pinning + backend awareness
+# ─────────────────────────────────────────────────────────────────────────────
+class TokenBudgetTests(unittest.IsolatedAsyncioTestCase):
+    async def test_token_budget_aborts_run(self):
+        # Each turn produces ~50 chars; budget=10 tokens ≈ 40 chars → should stop after round 1
+        big = "x " * 30  # 60 chars
+        scripts = {"a": [big, big, big, big]}
+        engine = WoTEngine()
+        engine.client = MockLLMClient(scripts)
+        result = await engine.run(
+            [AgentSpec(name="a", system_prompt="...")],
+            task="x", mode="parallel", max_rounds=10,
+            token_budget=10,
+        )
+        self.assertEqual(result["stop_reason"], "budget")
+        self.assertLess(result["rounds_run"], 10)
+
+
+class SlotPinningTests(unittest.IsolatedAsyncioTestCase):
+    async def test_llama_server_passes_id_slot_per_agent(self):
+        client = MockLLMClient({"a": ["a1\nDONE"], "b": ["b1\nDONE"]},
+                                backend_kind="llama-server")
+        engine = WoTEngine()
+        engine.client = client
+        await engine.run(
+            [AgentSpec(name="a", system_prompt="..."),
+             AgentSpec(name="b", system_prompt="...")],
+            task="x", mode="parallel", max_rounds=1,
+        )
+        slot_ids = sorted(c["slot_id"] for c in client.calls if c["slot_id"] is not None)
+        self.assertEqual(slot_ids, [0, 1])
+        # Payloads should include cache_prompt: True for llama-server
+        self.assertTrue(all(p.get("cache_prompt") is True for p in client.payloads))
+
+    async def test_other_backends_do_not_pass_id_slot(self):
+        client = MockLLMClient({"a": ["a1\nDONE"]}, backend_kind="ollama")
+        engine = WoTEngine()
+        engine.client = client
+        await engine.run(
+            [AgentSpec(name="a", system_prompt="...")],
+            task="x", mode="parallel", max_rounds=1,
+        )
+        self.assertTrue(all(c["slot_id"] is None for c in client.calls))
+        self.assertTrue(all("id_slot" not in p for p in client.payloads))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Qwen3.5/3.6 chat_template_kwargs auto-injection
+# ─────────────────────────────────────────────────────────────────────────────
+class Qwen35DetectionTests(unittest.IsolatedAsyncioTestCase):
+    async def _capture_payload(self, model_name: str) -> dict:
+        client = MockLLMClient({"a": ["hi\nDONE"]})
+        engine = WoTEngine()
+        engine.client = client
+        await engine.run(
+            [AgentSpec(name="a", system_prompt="...", model=model_name)],
+            task="x", mode="parallel", max_rounds=1,
+        )
+        return client.payloads[0]
+
+    async def test_qwen35_triggers_enable_thinking_false(self):
+        payload = await self._capture_payload("qwen3.5-9b-q4_k_m")
+        self.assertEqual(payload.get("chat_template_kwargs"), {"enable_thinking": False})
+
+    async def test_qwen36_triggers_enable_thinking_false(self):
+        payload = await self._capture_payload("qwen3.6-27b")
+        self.assertEqual(payload.get("chat_template_kwargs"), {"enable_thinking": False})
+
+    async def test_qwen3_does_NOT_trigger(self):
+        payload = await self._capture_payload("qwen3:8b")
+        self.assertNotIn("chat_template_kwargs", payload)
+
+    async def test_llama_does_NOT_trigger(self):
+        payload = await self._capture_payload("llama3.1:8b")
+        self.assertNotIn("chat_template_kwargs", payload)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Edge cases
+# ─────────────────────────────────────────────────────────────────────────────
+class EdgeCaseTests(unittest.IsolatedAsyncioTestCase):
+    async def test_max_rounds_hit_without_done(self):
+        scripts = {"a": ["round 1", "round 2", "round 3"]}
+        engine = WoTEngine()
+        engine.client = MockLLMClient(scripts)
+        result = await engine.run(
+            [AgentSpec(name="a", system_prompt="...")],
+            task="x", mode="parallel", max_rounds=3,
+        )
+        self.assertEqual(result["rounds_run"], 3)
+        self.assertEqual(result["agents_done"], [])
+        self.assertEqual(result["stop_reason"], "max_rounds")
+
+    async def test_all_done_short_circuits(self):
+        scripts = {"a": ["one\nDONE"], "b": ["two\nDONE"]}
+        engine = WoTEngine()
+        engine.client = MockLLMClient(scripts)
+        result = await engine.run(
+            [AgentSpec(name="a", system_prompt="..."),
+             AgentSpec(name="b", system_prompt="...")],
+            task="x", mode="parallel", max_rounds=10,
+        )
+        self.assertEqual(result["rounds_run"], 1)
+        self.assertEqual(set(result["agents_done"]), {"a", "b"})
+        self.assertEqual(result["stop_reason"], "all_done")
+
+    async def test_invalid_mode_raises(self):
+        engine = WoTEngine()
+        engine.client = MockLLMClient({})
+        with self.assertRaises(ValueError):
+            await engine.run([AgentSpec(name="a", system_prompt="...")],
+                              task="x", mode="banana", max_rounds=1)
+
+    async def test_invalid_propagate_mode_raises(self):
+        engine = WoTEngine()
+        engine.client = MockLLMClient({})
+        with self.assertRaises(ValueError):
+            await engine.run([AgentSpec(name="a", system_prompt="...")],
+                              task="x", mode="parallel", max_rounds=1,
+                              propagate_reasoning="banana")
+
+    async def test_result_includes_backend_info(self):
+        engine = WoTEngine()
+        engine.client = MockLLMClient({"a": ["hi\nDONE"]}, backend_kind="vllm")
+        result = await engine.run(
+            [AgentSpec(name="a", system_prompt="...")],
+            task="x", mode="parallel", max_rounds=1,
+        )
+        self.assertEqual(result["backend"]["kind"], "vllm")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/wot_engine.py
+++ b/tools/wot_engine.py
@@ -1,0 +1,1034 @@
+"""
+wot_engine.py — Web-of-Thought multi-agent communication engine for Hermes.
+
+Generic agents talk to each other through a shared message bus. No role taxonomy
+hardcoded — agents are just (name, system_prompt) slots. Caller decides what each
+agent does via its system_prompt.
+
+Four communication modes:
+  - "parallel"   : all agents run concurrently; each sees others' completed
+                   messages on round boundaries
+  - "streaming"  : like parallel, but agents see PARTIAL CoT tokens from peers
+                   via chunked polling (works with any OpenAI-compat backend
+                   without requiring server-side mid-generation injection)
+  - "sequential" : round-robin; each agent gets the full prior transcript
+  - "queue"      : topic-driven; agents pull from a shared queue when they
+                   declare interest in a tag
+
+Backbone: any OpenAI-compatible /v1/chat/completions endpoint, plus Ollama's
+native /api/chat for thinking-mode models (where /v1/ silently drops thinking).
+Auto-detected at construction time:
+  Ollama, llama.cpp's llama-server, vLLM, LM Studio, OpenAI, OpenRouter, etc.
+
+Termination: 3 layers — explicit DONE marker, max_rounds cap, per-agent timeout.
+Cost control: optional token_budget per channel.
+CoT propagation: default "strip" (cross-family-safe). Opt in to "raw" for
+same-family debate where shared reasoning amplifies; this is informed by
+arxiv 2503.13657 and the MemoryTrap (Apr 2026) attack surface.
+
+Grounded in Artificial Neural Mesh V0 (Ali, 2026)
+  https://doi.org/10.5281/zenodo.18112435
+
+License: MIT
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Dict, List, Literal, Optional, Set, Tuple
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Configuration (env-overridable, OpenAI-compatible)
+# ─────────────────────────────────────────────────────────────────────────────
+LLM_BASE_URL = os.getenv("LLM_BASE_URL", os.getenv("OLLAMA_URL", "http://localhost:11434"))
+LLM_DEFAULT_MODEL = os.getenv("LLM_DEFAULT_MODEL", "qwen3:4b-instruct")
+LLM_API_KEY = os.getenv("LLM_API_KEY", "sk-no-key-required")  # most local backends don't check
+
+DEFAULT_MAX_TOKENS_PER_TURN = 800
+DEFAULT_STREAM_CHUNK_TOKENS = 32     # how many tokens of peer-stream a listener absorbs at a time
+DEFAULT_REQUEST_TIMEOUT = 300        # seconds — overall HTTP read timeout
+DEFAULT_AGENT_TURN_TIMEOUT = 240     # seconds — per-turn cap; sub-LL_REQUEST_TIMEOUT so we cancel before httpx
+DEFAULT_TOKEN_BUDGET = 0             # 0 = unbounded (in chars; ~4 chars/token estimate)
+
+# Type aliases
+PropagateMode = Literal["strip", "raw", "summary"]
+BackendKind = Literal["llama-server", "ollama", "vllm", "openai-compat"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Data model
+# ─────────────────────────────────────────────────────────────────────────────
+@dataclass
+class Message:
+    """One message on the bus.
+
+    `content` is the agent's user-facing answer. `reasoning` is the agent's
+    chain-of-thought (separately tracked so we can choose how / whether to
+    propagate it to peers — see PropagateMode).
+    """
+    from_agent: str
+    content: str
+    reasoning: str = ""                  # CoT, separate from final content
+    to_agent: Optional[str] = None       # None = broadcast
+    tags: List[str] = field(default_factory=list)
+    ts: float = field(default_factory=time.time)
+    round: int = 0
+    seq: int = 0                         # per-agent monotonic sequence for stream debugging
+    is_chunk: bool = False               # True = streaming partial; False = completed turn
+    chunk_index: int = 0
+    is_final_chunk: bool = False
+    chunk_kind: Literal["content", "reasoning"] = "content"  # which channel a streaming chunk came from
+
+    def to_dict(self, include_reasoning: bool = True) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "from": self.from_agent,
+            "to": self.to_agent,
+            "content": self.content,
+            "tags": self.tags,
+            "ts": datetime.datetime.fromtimestamp(self.ts).isoformat(timespec="seconds"),
+            "round": self.round,
+            "seq": self.seq,
+            "is_chunk": self.is_chunk,
+            "chunk_index": self.chunk_index,
+            "is_final_chunk": self.is_final_chunk,
+            "chunk_kind": self.chunk_kind,
+        }
+        if include_reasoning and self.reasoning:
+            d["reasoning"] = self.reasoning
+        return d
+
+    def char_len(self) -> int:
+        return len(self.content) + len(self.reasoning)
+
+
+def _is_thinking_model(name: str) -> bool:
+    """Detect models that emit <think>...</think> reasoning by default.
+
+    These need much higher max_tokens because budget is consumed inside
+    the thinking block before any answer is produced.
+    Covers: DeepSeek-R1 + distills, QwQ family, *-thinking. Does NOT match
+    Qwen3.5/3.6 — those default to thinking but we disable via
+    chat_template_kwargs.enable_thinking=false at the request layer.
+    """
+    n = (name or "").lower().replace("_", "-")
+    if "deepseek-r1" in n or "qwq" in n:
+        return True
+    if "thinking" in n and "qwen3.5" not in n and "qwen3.6" not in n:
+        return True
+    return False
+
+
+def _is_qwen35_or_36(model: str) -> bool:
+    n = (model or "").lower().replace("_", ".")
+    return "qwen3.5" in n or "qwen3.6" in n
+
+
+@dataclass
+class AgentSpec:
+    """Caller-supplied agent definition. NO role taxonomy — caller writes system_prompt."""
+    name: str
+    system_prompt: str
+    model: Optional[str] = None
+    interests: List[str] = field(default_factory=list)   # tags this agent listens for in queue mode
+    max_tokens: int = DEFAULT_MAX_TOKENS_PER_TURN
+    temperature: float = 0.7
+    turn_timeout: float = DEFAULT_AGENT_TURN_TIMEOUT     # per-turn cap
+
+    def __post_init__(self):
+        # Auto-sanitize: collapse whitespace runs to underscores, drop other
+        # disallowed characters. Real LLM callers emit names like
+        # "Critical Thinker" or "agent A" — we accept that and normalize
+        # rather than error-out, since name is a label not an identifier.
+        if isinstance(self.name, str):
+            sanitized = re.sub(r"\s+", "_", self.name.strip())
+            sanitized = re.sub(r"[^A-Za-z0-9_\-]", "", sanitized)
+            if sanitized:
+                self.name = sanitized
+        if not re.match(r"^[A-Za-z0-9_\-]+$", self.name or ""):
+            raise ValueError(f"agent name empty or invalid after sanitization: {self.name!r}")
+        if not self.model:
+            self.model = LLM_DEFAULT_MODEL
+        # Auto-bump max_tokens for thinking-mode models if caller used the default.
+        if (self.max_tokens == DEFAULT_MAX_TOKENS_PER_TURN
+                and _is_thinking_model(self.model)):
+            self.max_tokens = 2500
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Backend detection — probe once at construction
+# ─────────────────────────────────────────────────────────────────────────────
+@dataclass
+class BackendInfo:
+    """What we learned about the OpenAI-compat endpoint at the other end.
+
+    Drives per-backend code paths:
+      - llama-server: id_slot pinning, cache_prompt, /props for confirmation
+      - ollama:       /api/chat for thinking models (the /v1/ path drops
+                      reasoning_content for many models — issues #15293, #15635)
+      - vllm:         standard /v1/, reasoning_content reliable, no slot ctrl
+      - openai-compat: minimum-feature fallback
+    """
+    kind: BackendKind = "openai-compat"
+    base_url: str = ""
+    supports_slots: bool = False         # llama-server only
+    has_native_thinking_api: bool = False  # ollama only
+    raw_props: Optional[Dict[str, Any]] = None
+
+
+async def _probe_backend(base_url: str, api_key: str, client: httpx.AsyncClient) -> BackendInfo:
+    """Best-effort backend identification. Falls back to openai-compat on any failure."""
+    base = base_url.rstrip("/")
+    info = BackendInfo(base_url=base)
+    headers = {"Authorization": f"Bearer {api_key}"}
+    # Try llama-server's GET /props
+    try:
+        r = await client.get(f"{base}/props", headers=headers, timeout=5.0)
+        if r.status_code == 200:
+            data = r.json()
+            if isinstance(data, dict) and ("default_generation_settings" in data
+                                            or "build_info" in data
+                                            or "model_path" in data):
+                info.kind = "llama-server"
+                info.supports_slots = True
+                info.raw_props = {"detected": "llama-server"}
+                return info
+    except Exception:
+        pass
+    # Try Ollama's GET /api/version
+    try:
+        r = await client.get(f"{base}/api/version", timeout=5.0)
+        if r.status_code == 200:
+            data = r.json()
+            if isinstance(data, dict) and "version" in data:
+                info.kind = "ollama"
+                info.has_native_thinking_api = True
+                info.raw_props = {"detected": "ollama", "version": data.get("version")}
+                return info
+    except Exception:
+        pass
+    # Try vLLM's /version (vLLM exposes it; also returns at /v1/models with vllm-specific fields)
+    try:
+        r = await client.get(f"{base}/version", timeout=5.0)
+        if r.status_code == 200:
+            data = r.json()
+            if isinstance(data, dict) and "version" in data and "vllm" in str(data).lower():
+                info.kind = "vllm"
+                info.raw_props = {"detected": "vllm"}
+                return info
+    except Exception:
+        pass
+    # Default: assume OpenAI-compat
+    return info
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Message bus — async pub/sub with token-budget tracking
+# ─────────────────────────────────────────────────────────────────────────────
+class Channel:
+    """Async multi-subscriber message bus.
+
+    Each agent gets its own asyncio.Queue. Tracks cumulative chars (≈tokens÷4)
+    so the engine can abort runaway loops on a hard budget — which round-caps
+    alone don't bound (one round can blow up context).
+    """
+    def __init__(self) -> None:
+        self.history: List[Message] = []
+        self._subscribers: Dict[str, asyncio.Queue[Message]] = {}
+        self._seq_per_agent: Dict[str, int] = {}
+        self._lock = asyncio.Lock()
+        self.total_chars: int = 0   # cumulative across all messages, including chunks
+
+    def subscribe(self, agent_name: str) -> asyncio.Queue[Message]:
+        if agent_name not in self._subscribers:
+            self._subscribers[agent_name] = asyncio.Queue()
+        return self._subscribers[agent_name]
+
+    def next_seq(self, agent_name: str) -> int:
+        n = self._seq_per_agent.get(agent_name, 0) + 1
+        self._seq_per_agent[agent_name] = n
+        return n
+
+    async def publish(self, msg: Message) -> None:
+        async with self._lock:
+            if msg.seq == 0:
+                msg.seq = self.next_seq(msg.from_agent)
+            self.history.append(msg)
+            self.total_chars += msg.char_len()
+            for sub_name, queue in self._subscribers.items():
+                if sub_name == msg.from_agent:
+                    continue
+                if msg.to_agent is not None and msg.to_agent != sub_name:
+                    continue
+                await queue.put(msg)
+
+    def transcript(self, include_chunks: bool = False,
+                   include_reasoning: bool = True) -> List[Dict[str, Any]]:
+        return [m.to_dict(include_reasoning=include_reasoning)
+                for m in self.history if include_chunks or not m.is_chunk]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# LLM client — backend-aware async client
+# ─────────────────────────────────────────────────────────────────────────────
+@dataclass
+class LLMResponse:
+    """Structured response so the agent layer can keep reasoning + content separate."""
+    content: str = ""
+    reasoning: str = ""
+
+    def is_empty(self) -> bool:
+        return not (self.content.strip() or self.reasoning.strip())
+
+
+class _LLMClient:
+    """Async, streaming + non-streaming OpenAI-compat client with per-backend dispatch.
+
+    On llama-server: passes id_slot for KV-cache pinning + cache_prompt: true.
+    On Ollama with thinking models: uses /api/chat (think:true), reads
+    `message.thinking`, since the OpenAI-compat /v1/ endpoint drops thinking
+    output for several models (Ollama issues #15293, #15635 in May 2026).
+    """
+
+    def __init__(self, base_url: str = LLM_BASE_URL, api_key: str = LLM_API_KEY,
+                 timeout: float = DEFAULT_REQUEST_TIMEOUT):
+        # Normalize base_url: strip trailing "/" and "/v1" so we can always
+        # append "/v1/chat/completions" without doubling. Users tend to set
+        # LLM_BASE_URL to either form (e.g. "http://127.0.0.1:11434" for Ollama,
+        # "http://127.0.0.1:8088/v1" for llama-server, "https://openrouter.ai/api/v1"
+        # for OpenRouter); double "/v1/" lands on a 404 → empty body → JSONDecodeError.
+        self.base_url = base_url.rstrip("/")
+        if self.base_url.endswith("/v1"):
+            self.base_url = self.base_url[:-3].rstrip("/")
+        self.api_key = api_key
+        # Explicit timeouts per phase. read=None on streaming would let server
+        # hang forever; we keep a finite read but rely on per-turn asyncio
+        # timeouts upstairs. limits keepalive for proxy survival.
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=10.0, read=timeout, write=30.0, pool=10.0),
+            limits=httpx.Limits(
+                max_keepalive_connections=20,
+                max_connections=40,
+                keepalive_expiry=30.0,
+            ),
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        self.backend: BackendInfo = BackendInfo(base_url=self.base_url)
+        self._probed = False
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def ensure_probed(self) -> BackendInfo:
+        if not self._probed:
+            self.backend = await _probe_backend(self.base_url, self.api_key, self._client)
+            self._probed = True
+            logger.info("WoT backend probe: %s at %s", self.backend.kind, self.backend.base_url)
+        return self.backend
+
+    # ───────── payload builders ─────────
+    def _openai_payload(self, model: str, messages: List[Dict[str, Any]],
+                        max_tokens: int, temperature: float, stream: bool,
+                        slot_id: Optional[int], stop: Optional[List[str]]) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "stream": stream,
+        }
+        if _is_qwen35_or_36(model):
+            # Qwen3.5/3.6 default to thinking and ignore /think /no_think.
+            # Per official model card, only chat_template_kwargs disables it.
+            payload["chat_template_kwargs"] = {"enable_thinking": False}
+        if stop:
+            payload["stop"] = stop
+        # llama-server-only knobs: pin slot + reuse prompt prefix across turns.
+        if self.backend.kind == "llama-server" and slot_id is not None:
+            payload["id_slot"] = slot_id
+            payload["cache_prompt"] = True
+        return payload
+
+    def _ollama_native_payload(self, model: str, messages: List[Dict[str, Any]],
+                               max_tokens: int, temperature: float, stream: bool,
+                               think: bool) -> Dict[str, Any]:
+        """Ollama native /api/chat payload. `think` enables the structured thinking field."""
+        return {
+            "model": model,
+            "messages": messages,
+            "stream": stream,
+            "think": think,
+            "options": {
+                "temperature": temperature,
+                "num_predict": max_tokens,
+            },
+        }
+
+    # ───────── non-streaming complete ─────────
+    async def complete(self, model: str, messages: List[Dict[str, Any]],
+                       max_tokens: int = DEFAULT_MAX_TOKENS_PER_TURN,
+                       temperature: float = 0.7,
+                       slot_id: Optional[int] = None,
+                       stop: Optional[List[str]] = None) -> LLMResponse:
+        await self.ensure_probed()
+        thinking_model = _is_thinking_model(model)
+        # Ollama path for thinking models: /v1/ drops thinking, /api/chat keeps it.
+        if self.backend.kind == "ollama" and thinking_model:
+            payload = self._ollama_native_payload(model, messages, max_tokens,
+                                                  temperature, stream=False, think=True)
+            r = await self._client.post(f"{self.base_url}/api/chat", json=payload)
+            r.raise_for_status()
+            data = r.json()
+            msg = data.get("message", {}) if isinstance(data, dict) else {}
+            return LLMResponse(
+                content=(msg.get("content") or "").strip(),
+                reasoning=(msg.get("thinking") or "").strip(),
+            )
+        # OpenAI-compat path
+        payload = self._openai_payload(model, messages, max_tokens, temperature,
+                                        stream=False, slot_id=slot_id, stop=stop)
+        r = await self._client.post(f"{self.base_url}/v1/chat/completions", json=payload)
+        r.raise_for_status()
+        data = r.json()
+        msg = data["choices"][0]["message"]
+        content = (msg.get("content") or "").strip()
+        reasoning = (msg.get("reasoning_content") or "").strip()
+        # If the server didn't split out reasoning but content has raw <think> tags,
+        # split client-side so peers see clean content downstream.
+        if not reasoning and "<think>" in content:
+            m = re.search(r"<think>(.*?)</think>\s*", content, re.DOTALL)
+            if m:
+                reasoning = m.group(1).strip()
+                content = (content[:m.start()] + content[m.end():]).strip()
+        return LLMResponse(content=content, reasoning=reasoning)
+
+    # ───────── streaming ─────────
+    async def stream(self, model: str, messages: List[Dict[str, Any]],
+                     max_tokens: int = DEFAULT_MAX_TOKENS_PER_TURN,
+                     temperature: float = 0.7,
+                     slot_id: Optional[int] = None,
+                     stop: Optional[List[str]] = None
+                     ) -> AsyncIterator[Tuple[str, str]]:
+        """Yields (kind, delta) where kind ∈ {"content", "reasoning"}."""
+        await self.ensure_probed()
+        thinking_model = _is_thinking_model(model)
+        if self.backend.kind == "ollama" and thinking_model:
+            async for kv in self._stream_ollama_native(model, messages, max_tokens,
+                                                        temperature, think=True):
+                yield kv
+            return
+        async for kv in self._stream_openai(model, messages, max_tokens, temperature,
+                                             slot_id, stop):
+            yield kv
+
+    async def _stream_openai(self, model: str, messages: List[Dict[str, Any]],
+                             max_tokens: int, temperature: float,
+                             slot_id: Optional[int], stop: Optional[List[str]]
+                             ) -> AsyncIterator[Tuple[str, str]]:
+        payload = self._openai_payload(model, messages, max_tokens, temperature,
+                                        stream=True, slot_id=slot_id, stop=stop)
+        async with self._client.stream(
+            "POST", f"{self.base_url}/v1/chat/completions", json=payload,
+        ) as r:
+            r.raise_for_status()
+            async for raw in r.aiter_lines():
+                if not raw or not raw.startswith("data:"):
+                    continue
+                chunk_data = raw[5:].strip()
+                if chunk_data == "[DONE]":
+                    break
+                try:
+                    obj = json.loads(chunk_data)
+                except json.JSONDecodeError:
+                    continue
+                delta_obj = obj.get("choices", [{}])[0].get("delta", {})
+                # llama-server with --jinja for thinking-mode models routes thinking
+                # tokens to delta.reasoning_content. Both fields can appear within
+                # the same stream (reasoning during <think>, content after </think>).
+                rc = delta_obj.get("reasoning_content")
+                if rc:
+                    yield ("reasoning", rc)
+                c = delta_obj.get("content")
+                if c:
+                    yield ("content", c)
+
+    async def _stream_ollama_native(self, model: str, messages: List[Dict[str, Any]],
+                                     max_tokens: int, temperature: float, think: bool
+                                     ) -> AsyncIterator[Tuple[str, str]]:
+        """Ollama native /api/chat streams NDJSON, not SSE."""
+        payload = self._ollama_native_payload(model, messages, max_tokens, temperature,
+                                               stream=True, think=think)
+        async with self._client.stream(
+            "POST", f"{self.base_url}/api/chat", json=payload,
+        ) as r:
+            r.raise_for_status()
+            async for raw in r.aiter_lines():
+                if not raw:
+                    continue
+                try:
+                    obj = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                msg = obj.get("message") or {}
+                t = msg.get("thinking")
+                if t:
+                    yield ("reasoning", t)
+                c = msg.get("content")
+                if c:
+                    yield ("content", c)
+                if obj.get("done"):
+                    break
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Agent — generic LLM-backed slot that reads inbox, writes to channel
+# ─────────────────────────────────────────────────────────────────────────────
+class Agent:
+    """A named LLM slot. Behaviour determined entirely by spec.system_prompt."""
+
+    def __init__(self, spec: AgentSpec, channel: Channel, client: _LLMClient,
+                 task: str, slot_id: Optional[int] = None,
+                 propagate_reasoning: PropagateMode = "strip"):
+        self.spec = spec
+        self.channel = channel
+        self.client = client
+        self.task = task
+        self.slot_id = slot_id   # pinned KV-cache slot for llama-server (None elsewhere)
+        self.propagate_reasoning = propagate_reasoning
+        self.inbox = channel.subscribe(spec.name)
+        self.transcript_seen: List[Message] = []
+
+    def _drain_inbox(self) -> List[Message]:
+        out: List[Message] = []
+        while not self.inbox.empty():
+            try:
+                out.append(self.inbox.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+        return out
+
+    def _peer_render(self, m: Message) -> str:
+        """Render a peer message into this agent's context, respecting propagate_reasoning.
+
+        - "strip"  : final content only (cross-family-safe default; avoids style
+                     contamination + MemoryTrap-class CoT injection)
+        - "raw"    : show <think>...</think> + content (same-family debate / refinement)
+        - "summary": placeholder — currently same as "strip"; in production this
+                     would be a 1-2 sentence distill of m.reasoning by a small model.
+        """
+        tag = "chunk" if m.is_chunk else "msg"
+        body = m.content
+        if self.propagate_reasoning == "raw" and m.reasoning and not m.is_chunk:
+            body = f"<think>\n{m.reasoning}\n</think>\n\n{m.content}"
+        elif m.is_chunk and m.chunk_kind == "reasoning":
+            # Even in "raw" mode, streaming reasoning chunks are tagged distinctly
+            # so the receiver sees they're partial CoT not partial content.
+            if self.propagate_reasoning == "raw":
+                body = f"[partial CoT] {m.content}"
+            else:
+                # In strip/summary, we drop streaming reasoning chunks entirely.
+                return ""
+        return f"[from {m.from_agent} | {tag} | seq {m.seq}]: {body}"
+
+    def _build_messages(self, new_peer_msgs: List[Message]) -> List[Dict[str, Any]]:
+        sys_prompt = (
+            f"{self.spec.system_prompt}\n\n"
+            f"You are agent '{self.spec.name}' participating in a Web-of-Thought session "
+            f"with other agents. Other agents may speak via messages prefixed `[from X]: ...`. "
+            f"You can reply to them by addressing them as `@X: ...` in your output, "
+            f"or you can broadcast (just write normally). When you have nothing more to add, "
+            f"reply with the single word DONE on its own line."
+        )
+        msgs: List[Dict[str, Any]] = [
+            {"role": "system", "content": sys_prompt},
+            {"role": "user", "content": f"TASK: {self.task}"},
+        ]
+        all_seen = self.transcript_seen + new_peer_msgs
+        for m in all_seen:
+            rendered = self._peer_render(m)
+            if rendered:
+                msgs.append({"role": "user", "content": rendered})
+        self.transcript_seen = all_seen
+        return msgs
+
+    async def turn_batch(self, round_no: int) -> Tuple[Optional[Message], Optional[str]]:
+        """One non-streaming turn. Returns (Message, None) on success, (None, error_str) on failure."""
+        peer_msgs = self._drain_inbox()
+        messages = self._build_messages(peer_msgs)
+        try:
+            resp = await asyncio.wait_for(
+                self.client.complete(
+                    self.spec.model, messages,
+                    max_tokens=self.spec.max_tokens,
+                    temperature=self.spec.temperature,
+                    slot_id=self.slot_id,
+                ),
+                timeout=self.spec.turn_timeout,
+            )
+        except asyncio.TimeoutError:
+            return None, f"turn timed out after {self.spec.turn_timeout}s"
+        except Exception as e:
+            err = f"LLM call failed: {type(e).__name__}: {e}"
+            logger.warning("agent %s %s", self.spec.name, err)
+            return None, err
+        if resp.is_empty():
+            return None, ("empty response (likely max_tokens exhausted in <think>; "
+                          "raise max_tokens or pick a non-thinking model)")
+        content = resp.content
+        is_done = False
+        if content.strip().splitlines() and content.strip().splitlines()[-1].strip().upper() == "DONE":
+            content = "\n".join(content.strip().splitlines()[:-1]).strip() or "(no response)"
+            is_done = True
+        msg = Message(
+            from_agent=self.spec.name,
+            content=content,
+            reasoning=resp.reasoning,
+            round=round_no,
+            tags=["DONE"] if is_done else [],
+        )
+        await self.channel.publish(msg)
+        return msg, None
+
+    async def turn_streaming(self, round_no: int,
+                             chunk_size: int = DEFAULT_STREAM_CHUNK_TOKENS
+                             ) -> Tuple[Optional[Message], Optional[str]]:
+        """One streaming turn. Reasoning and content streams are tracked separately;
+        chunks are published with chunk_kind so peers can route accordingly."""
+        peer_msgs = self._drain_inbox()
+        messages = self._build_messages(peer_msgs)
+        content_buf: List[str] = []
+        reasoning_buf: List[str] = []
+        chunk_pending: Dict[str, List[str]] = {"content": [], "reasoning": []}
+        chunk_idx = 0
+
+        async def flush_chunk(kind: str, final: bool = False) -> None:
+            nonlocal chunk_idx
+            buf = chunk_pending[kind]
+            if not buf:
+                return
+            text = "".join(buf)
+            chunk_pending[kind] = []
+            await self.channel.publish(Message(
+                from_agent=self.spec.name,
+                content=text,
+                round=round_no,
+                is_chunk=True,
+                chunk_index=chunk_idx,
+                is_final_chunk=final,
+                chunk_kind="reasoning" if kind == "reasoning" else "content",
+            ))
+            chunk_idx += 1
+
+        try:
+            async def consume() -> None:
+                async for kind, delta in self.client.stream(
+                    self.spec.model, messages,
+                    max_tokens=self.spec.max_tokens,
+                    temperature=self.spec.temperature,
+                    slot_id=self.slot_id,
+                ):
+                    if kind == "reasoning":
+                        reasoning_buf.append(delta)
+                        chunk_pending["reasoning"].append(delta)
+                        if sum(len(c.split()) for c in chunk_pending["reasoning"]) >= chunk_size:
+                            await flush_chunk("reasoning")
+                    else:
+                        content_buf.append(delta)
+                        chunk_pending["content"].append(delta)
+                        if sum(len(c.split()) for c in chunk_pending["content"]) >= chunk_size:
+                            await flush_chunk("content")
+
+            await asyncio.wait_for(consume(), timeout=self.spec.turn_timeout)
+        except asyncio.TimeoutError:
+            await flush_chunk("reasoning", final=True)
+            await flush_chunk("content", final=True)
+            return None, f"stream timed out after {self.spec.turn_timeout}s"
+        except Exception as e:
+            err = f"stream failed: {type(e).__name__}: {e}"
+            logger.warning("agent %s %s", self.spec.name, err)
+            return None, err
+
+        # Tail flushes
+        await flush_chunk("reasoning")
+        await flush_chunk("content", final=True)
+
+        full_content = "".join(content_buf).strip()
+        full_reasoning = "".join(reasoning_buf).strip()
+        if not full_content and not full_reasoning:
+            return None, ("empty stream (likely max_tokens exhausted; "
+                          "raise max_tokens or pick a non-thinking model)")
+        is_done = False
+        if full_content.splitlines() and full_content.splitlines()[-1].strip().upper() == "DONE":
+            full_content = "\n".join(full_content.splitlines()[:-1]).strip() or "(no response)"
+            is_done = True
+        # If only reasoning came back (e.g. R1 ran out of budget mid-think with no
+        # final answer), surface reasoning as the content so peers see something.
+        if not full_content and full_reasoning:
+            full_content = "(no final content — agent ran out of budget mid-thinking)"
+        final = Message(
+            from_agent=self.spec.name,
+            content=full_content,
+            reasoning=full_reasoning,
+            round=round_no,
+            is_chunk=False,
+            tags=["DONE"] if is_done else [],
+        )
+        await self.channel.publish(final)
+        return final, None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Engine — orchestrates rounds across the four modes
+# ─────────────────────────────────────────────────────────────────────────────
+class WoTEngine:
+    """Multi-mode multi-agent orchestrator. No role enforcement.
+
+    Public entry: run(specs, task, mode, max_rounds, ...) → transcript dict.
+
+    Termination is enforced in three layers (recommended by 2026 multi-agent
+    literature, e.g. arxiv 2510.12697):
+      1. agent emits DONE on its own line → drops out of active set
+      2. max_rounds hard cap
+      3. asyncio.wait_for per turn (spec.turn_timeout)
+    Plus an optional 4th layer: cumulative token_budget per channel.
+
+    base_url defaults are RE-READ from env at construction time so callers can
+    set LLM_BASE_URL after import.
+    """
+
+    def __init__(self, base_url: Optional[str] = None, api_key: Optional[str] = None):
+        self.client = _LLMClient(
+            base_url=base_url or os.getenv("LLM_BASE_URL",
+                                            os.getenv("OLLAMA_URL", "http://localhost:11434")),
+            api_key=api_key or os.getenv("LLM_API_KEY", "sk-no-key-required"),
+        )
+
+    async def aclose(self) -> None:
+        await self.client.aclose()
+
+    async def run(
+        self,
+        specs: List[AgentSpec],
+        task: str,
+        mode: str = "parallel",
+        max_rounds: int = 5,
+        token_budget: int = DEFAULT_TOKEN_BUDGET,
+        propagate_reasoning: PropagateMode = "strip",
+    ) -> Dict[str, Any]:
+        if mode not in ("parallel", "streaming", "sequential", "queue"):
+            raise ValueError(f"unknown mode: {mode!r}")
+        if propagate_reasoning not in ("strip", "raw", "summary"):
+            raise ValueError(f"unknown propagate_reasoning: {propagate_reasoning!r}")
+
+        # Probe once up front so logging shows backend before first round.
+        await self.client.ensure_probed()
+        backend_kind = self.client.backend.kind
+
+        channel = Channel()
+        agents: List[Agent] = []
+        for i, s in enumerate(specs):
+            # Slot pinning only meaningful on llama-server; harmless elsewhere.
+            slot_id = i if backend_kind == "llama-server" else None
+            agents.append(Agent(s, channel, self.client, task,
+                                slot_id=slot_id,
+                                propagate_reasoning=propagate_reasoning))
+
+        done: Set[str] = set()
+        rounds_run = 0
+        errors: List[Dict[str, Any]] = []
+        budget_hit = False
+
+        for round_no in range(1, max_rounds + 1):
+            if token_budget and channel.total_chars >= token_budget * 4:  # ~4 chars/token
+                budget_hit = True
+                break
+            active_agents = [a for a in agents if a.spec.name not in done]
+            if not active_agents:
+                break
+
+            if mode in ("parallel", "streaming"):
+                turn_fn = (lambda a: a.turn_streaming(round_no)) if mode == "streaming" \
+                          else (lambda a: a.turn_batch(round_no))
+                results = await asyncio.gather(
+                    *[turn_fn(a) for a in active_agents],
+                    return_exceptions=True,
+                )
+                for a, r in zip(active_agents, results):
+                    if isinstance(r, Exception):
+                        errors.append({"agent": a.spec.name, "round": round_no,
+                                       "reason": f"{type(r).__name__}: {r}"})
+                        continue
+                    msg, err = r
+                    if err:
+                        errors.append({"agent": a.spec.name, "round": round_no, "reason": err})
+                    if msg and "DONE" in msg.tags:
+                        done.add(a.spec.name)
+
+            elif mode == "sequential":
+                for a in active_agents:
+                    if token_budget and channel.total_chars >= token_budget * 4:
+                        budget_hit = True
+                        break
+                    msg, err = await a.turn_batch(round_no)
+                    if err:
+                        errors.append({"agent": a.spec.name, "round": round_no, "reason": err})
+                    if msg and "DONE" in msg.tags:
+                        done.add(a.spec.name)
+                if budget_hit:
+                    break
+
+            elif mode == "queue":
+                for a in active_agents:
+                    if token_budget and channel.total_chars >= token_budget * 4:
+                        budget_hit = True
+                        break
+                    eligible = False
+                    if round_no == 1:
+                        eligible = True
+                    else:
+                        peek = list(a.inbox._queue)
+                        for m in peek:
+                            if not a.spec.interests:
+                                eligible = True
+                                break
+                            if any(t in a.spec.interests for t in m.tags):
+                                eligible = True
+                                break
+                    if eligible:
+                        msg, err = await a.turn_batch(round_no)
+                        if err:
+                            errors.append({"agent": a.spec.name, "round": round_no, "reason": err})
+                        if msg and "DONE" in msg.tags:
+                            done.add(a.spec.name)
+                if budget_hit:
+                    break
+
+            rounds_run = round_no
+
+        return {
+            "task": task,
+            "mode": mode,
+            "rounds_run": rounds_run,
+            "agents_done": sorted(done),
+            "errors": errors,
+            "backend": {
+                "kind": self.client.backend.kind,
+                "base_url": self.client.backend.base_url,
+            },
+            "stop_reason": ("budget" if budget_hit
+                            else "all_done" if not [a for a in agents if a.spec.name not in done]
+                            else "max_rounds"),
+            "total_chars": channel.total_chars,
+            "transcript": channel.transcript(include_chunks=False),
+            "transcript_with_chunks": channel.transcript(include_chunks=True)
+                                       if mode == "streaming" else None,
+        }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Hermes tool entry point
+# ─────────────────────────────────────────────────────────────────────────────
+def wot_chat_tool(
+    agents: List[Dict[str, Any]],
+    task: str,
+    mode: str = "parallel",
+    max_rounds: int = 5,
+    token_budget: int = DEFAULT_TOKEN_BUDGET,
+    propagate_reasoning: PropagateMode = "strip",
+) -> str:
+    """Hermes tool: run a Web-of-Thought multi-agent session and return JSON transcript.
+
+    Args:
+        agents: list of {"name", "system_prompt", "model"?, "interests"?, "max_tokens"?,
+                "temperature"?, "turn_timeout"?}. NO role taxonomy hardcoded.
+        task: initial task seed (broadcast to all agents).
+        mode: "parallel" | "streaming" | "sequential" | "queue".
+        max_rounds: max conversation rounds before forced termination.
+        token_budget: cumulative token cap across all messages (0 = unbounded).
+        propagate_reasoning: "strip" (cross-family-safe default) | "raw" (same-family
+                             debate) | "summary" (currently same as strip).
+    """
+    # Outer Hermes models tend to hallucinate inner-agent model names like
+    # "gpt-4o" when constructing the wot_chat tool call. We strip caller-
+    # supplied `model` fields and force every inner agent to use
+    # LLM_DEFAULT_MODEL (env-driven), so the WoT engine remains in control of
+    # its own backend rather than chasing whatever the outer model dreamed up.
+    sanitized: List[Dict[str, Any]] = []
+    for a in agents:
+        spec = dict(a)
+        spec.pop("model", None)
+        sanitized.append(spec)
+    specs = [AgentSpec(**a) for a in sanitized]
+
+    async def _run_and_close() -> Dict[str, Any]:
+        # CRITICAL: engine + run + aclose all share ONE event loop. Calling
+        # asyncio.run() twice (one for run, one for aclose) closes the loop
+        # between them and any resource (httpx client, asyncio.Queue) tied
+        # to the first loop fails with "Event loop is closed" on the second.
+        engine = WoTEngine()
+        try:
+            return await engine.run(
+                specs, task, mode=mode, max_rounds=max_rounds,
+                token_budget=token_budget, propagate_reasoning=propagate_reasoning,
+            )
+        finally:
+            await engine.aclose()
+
+    # Detect whether we're already inside a running loop (e.g. invoked from
+    # an async Hermes tool dispatcher). If yes, run on a separate thread so
+    # asyncio.run() doesn't conflict with the existing loop.
+    try:
+        running = asyncio.get_running_loop()
+    except RuntimeError:
+        running = None
+    if running is None:
+        result = asyncio.run(_run_and_close())
+    else:
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+            result = ex.submit(lambda: asyncio.run(_run_and_close())).result()
+    return json.dumps(result, ensure_ascii=False)
+
+
+wot_chat_tool_schema = {
+    "type": "function",
+    "function": {
+        "name": "wot_chat",
+        "description": (
+            "Run a Web-of-Thought multi-agent session: 2-7 named agents talk to each "
+            "other through a shared message bus over multiple rounds. No role "
+            "taxonomy — caller supplies system_prompt per agent. Returns full "
+            "transcript as JSON. Modes: parallel (batch concurrent), streaming "
+            "(see partial CoT from peers), sequential (round-robin), queue "
+            "(tag-driven pull). Auto-detects llama.cpp / Ollama / vLLM backends "
+            "and pins KV-cache slots on llama-server for performance."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "agents": {
+                    "type": "array",
+                    "minItems": 2,
+                    "maxItems": 7,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "system_prompt": {"type": "string"},
+                            "model": {"type": "string"},
+                            "interests": {"type": "array", "items": {"type": "string"}},
+                            "max_tokens": {"type": "integer", "default": 800},
+                            "temperature": {"type": "number", "default": 0.7},
+                            "turn_timeout": {"type": "number", "default": 240},
+                        },
+                        "required": ["name", "system_prompt"],
+                    },
+                },
+                "task": {"type": "string"},
+                "mode": {
+                    "type": "string",
+                    "enum": ["parallel", "streaming", "sequential", "queue"],
+                    "default": "parallel",
+                },
+                "max_rounds": {"type": "integer", "default": 5, "minimum": 1, "maximum": 20},
+                "token_budget": {"type": "integer", "default": 0, "minimum": 0,
+                                 "description": "0 = unbounded"},
+                "propagate_reasoning": {
+                    "type": "string",
+                    "enum": ["strip", "raw", "summary"],
+                    "default": "strip",
+                    "description": ("How to share peer CoT. 'strip' = final content only "
+                                    "(cross-family-safe default). 'raw' = full <think> "
+                                    "blocks (same-family debate / refinement). 'summary' "
+                                    "currently behaves as 'strip'."),
+                },
+            },
+            "required": ["agents", "task"],
+        },
+    },
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CLI smoke test
+# ─────────────────────────────────────────────────────────────────────────────
+async def _smoke_test() -> None:
+    print("# wot_engine smoke test — 3 agents, parallel, max_rounds=2\n")
+    specs = [
+        AgentSpec(name="optimist",
+                  system_prompt="You argue the optimistic case. Brief — 2-3 sentences per turn."),
+        AgentSpec(name="skeptic",
+                  system_prompt="You argue the skeptical case. Brief — 2-3 sentences per turn."),
+        AgentSpec(name="synthesizer",
+                  system_prompt="You synthesise the optimist and skeptic positions into a balanced view. Brief."),
+    ]
+    engine = WoTEngine()
+    try:
+        result = await engine.run(
+            specs,
+            task="Will small open-source language models become the dominant deployment paradigm in 2026?",
+            mode="parallel",
+            max_rounds=2,
+        )
+    finally:
+        await engine.aclose()
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(_smoke_test())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Hermes tool registration — must be top-level for AST auto-discovery
+# (tools/registry.py:_module_registers_tools scans tree.body only; wrapping
+# the registry.register() call in try/except hides it from the scanner and
+# the module is never imported into the registry).
+# ─────────────────────────────────────────────────────────────────────────────
+from tools.registry import registry  # noqa: E402
+
+try:
+    from toolsets import create_custom_toolset  # type: ignore
+    create_custom_toolset(
+        name="wot",
+        description="Web-of-Thought multi-agent reasoning (3-7 agents debate / collaborate)",
+        tools=["wot_chat"],
+    )
+except Exception:
+    pass
+
+
+def _wot_handler(args, **_kw):
+    return wot_chat_tool(
+        agents=args.get("agents", []),
+        task=args.get("task", ""),
+        mode=args.get("mode", "parallel"),
+        max_rounds=int(args.get("max_rounds", 5)),
+        token_budget=int(args.get("token_budget", 0)),
+        propagate_reasoning=args.get("propagate_reasoning", "strip"),
+    )
+
+
+registry.register(
+    name="wot_chat",
+    toolset="wot",
+    schema={
+        "name": wot_chat_tool_schema["function"]["name"],
+        "description": wot_chat_tool_schema["function"]["description"],
+        "parameters": wot_chat_tool_schema["function"]["parameters"],
+    },
+    handler=_wot_handler,
+    check_fn=lambda: True,
+    emoji="🕸",
+    max_result_size_chars=200_000,
+)

--- a/tools/wot_engine.py
+++ b/tools/wot_engine.py
@@ -8,27 +8,25 @@ agent does via its system_prompt.
 Four communication modes:
   - "parallel"   : all agents run concurrently; each sees others' completed
                    messages on round boundaries
-  - "streaming"  : parallel rounds with chunked *post-completion* peer
-                   partials exposed to listeners between / after peer
-                   streams finish in that round — NOT mid-generation
-                   injection into another agent's still-in-flight request
-                   (OpenAI-compat backends cannot do that client-side)
+  - "streaming"  : parallel rounds with chunked peer partials published as each
+                   peer stream finishes *within that round*. Listeners absorb
+                   those chunks on the *next* turn only — this is **not**
+                   mid-generation injection into another agent's still-open
+                   request (OpenAI-compat cannot do that client-side)
   - "sequential" : round-robin; each agent gets the full prior transcript
-  - "queue"      : agents run in parallel-like rounds; optional `interests`
-                   tags are reserved for future inbox routing. Current
-                   implementation does not yet route ordinary messages by
-                   @name / interests — only explicit DONE markers stop an
-                   agent early
+  - "queue"      : agents wake when their inbox has work: a directed `@Name`
+                   message, a `#tag` matching their `interests`, or (with empty
+                   interests) any broadcast. Round 1 always wakes everyone.
 
-Backbone: any OpenAI-compatible /v1/chat/completions endpoint, plus Ollama's
-native /api/chat for thinking-mode models (where /v1/ silently drops thinking).
-Auto-detected at construction time:
-  Ollama, llama.cpp's llama-server, vLLM, LM Studio, OpenAI, OpenRouter, etc.
+Backbone: Hermes active session provider + credential resolution first, then
+explicit LLM_BASE_URL / LLM_API_KEY / LLM_DEFAULT_MODEL overrides, then
+OLLAMA_URL / localhost. OpenAI-compatible /v1/chat/completions plus Ollama
+native /api/chat for thinking-mode models.
 
-Provider note: this engine currently uses LLM_BASE_URL / LLM_API_KEY /
-LLM_DEFAULT_MODEL (or OLLAMA_URL) — it does **not** yet share Hermes's
-active session provider + credential pool. Point those env vars at the
-backend you want the inner agents to call.
+Routing:
+  - `@AgentName` (or `@AgentName:`) in content → Message.to_agent (DM)
+  - `#tag` tokens → Message.tags (queue interests matching)
+  - Channel delivers DMs only to the named peer; broadcasts to all others
 
 Termination: 3 layers — explicit DONE marker, max_rounds cap, per-agent timeout.
 Cost control: optional token_budget per channel.
@@ -64,6 +62,7 @@ logger = logging.getLogger(__name__)
 # ─────────────────────────────────────────────────────────────────────────────
 # Configuration (env-overridable, OpenAI-compatible)
 # ─────────────────────────────────────────────────────────────────────────────
+# Module-level defaults used when Hermes resolution is unavailable / tests.
 LLM_BASE_URL = os.getenv("LLM_BASE_URL", os.getenv("OLLAMA_URL", "http://localhost:11434"))
 LLM_DEFAULT_MODEL = os.getenv("LLM_DEFAULT_MODEL", "qwen3:4b-instruct")
 LLM_API_KEY = os.getenv("LLM_API_KEY", "sk-no-key-required")  # most local backends don't check
@@ -77,6 +76,135 @@ DEFAULT_TOKEN_BUDGET = 0             # 0 = unbounded (in chars; ~4 chars/token e
 # Type aliases
 PropagateMode = Literal["strip", "raw", "summary"]
 BackendKind = Literal["llama-server", "ollama", "vllm", "openai-compat"]
+
+# @Name or @Name:  — first match that resolves to a known agent becomes to_agent
+_AT_MENTION_RE = re.compile(r"(?:^|[\s\[(])@([A-Za-z0-9_\-]+)\b")
+# #tag tokens for queue interests
+_HASHTAG_RE = re.compile(r"(?:^|[\s\[(])#([A-Za-z0-9_\-]+)\b")
+
+
+def resolve_hermes_endpoint() -> Tuple[str, str, str, Dict[str, Any]]:
+    """Resolve (base_url, api_key, model, meta) for WoT inner agents.
+
+    Priority:
+      1. Explicit ``LLM_BASE_URL`` env (escape hatch for multi-backend labs)
+      2. Hermes active runtime / main provider credentials
+         (``set_runtime_main``, config.yaml model.*, ``resolve_runtime_provider``,
+         ``resolve_provider_client``)
+      3. ``OLLAMA_URL`` / localhost defaults
+
+    Returns a 4-tuple; ``meta`` records which source won (for transcripts / debug).
+    """
+    meta: Dict[str, Any] = {"source": "fallback"}
+    env_base = (os.getenv("LLM_BASE_URL") or "").strip()
+    env_key = (os.getenv("LLM_API_KEY") or "").strip()
+    env_model = (os.getenv("LLM_DEFAULT_MODEL") or "").strip()
+
+    if env_base:
+        meta["source"] = "env:LLM_BASE_URL"
+        return (
+            env_base,
+            env_key or "sk-no-key-required",
+            env_model or LLM_DEFAULT_MODEL,
+            meta,
+        )
+
+    # Hermes session / config
+    try:
+        from agent.auxiliary_client import (
+            _read_main_api_key,
+            _read_main_base_url,
+            _read_main_model,
+            _read_main_provider,
+            resolve_provider_client,
+        )
+
+        base = (_read_main_base_url() or "").strip()
+        key = (_read_main_api_key() or "").strip()
+        model = (_read_main_model() or "").strip()
+        provider = (_read_main_provider() or "").strip()
+
+        if base:
+            meta.update({"source": "hermes:runtime_base_url", "provider": provider or None})
+            return base, key or "sk-no-key-required", model or env_model or LLM_DEFAULT_MODEL, meta
+
+        if provider:
+            client, resolved_model = resolve_provider_client(provider, model or "")
+            if client is not None:
+                c_base = str(getattr(client, "base_url", "") or "").rstrip("/")
+                c_key = str(getattr(client, "api_key", "") or "").strip()
+                if c_base:
+                    meta.update({"source": "hermes:resolve_provider_client", "provider": provider})
+                    return (
+                        c_base,
+                        c_key or "sk-no-key-required",
+                        (resolved_model or model or env_model or LLM_DEFAULT_MODEL),
+                        meta,
+                    )
+
+        try:
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+
+            rt = resolve_runtime_provider()
+            if isinstance(rt, dict):
+                rt_base = str(rt.get("base_url") or "").strip().rstrip("/")
+                rt_key = str(rt.get("api_key") or "").strip()
+                rt_model = str(rt.get("model") or "").strip()
+                if rt_base:
+                    meta.update({
+                        "source": "hermes:resolve_runtime_provider",
+                        "provider": rt.get("provider") or provider or None,
+                    })
+                    return (
+                        rt_base,
+                        rt_key or "sk-no-key-required",
+                        rt_model or model or env_model or LLM_DEFAULT_MODEL,
+                        meta,
+                    )
+        except Exception as exc:
+            logger.debug("resolve_runtime_provider failed: %s", exc)
+    except Exception as exc:
+        logger.debug("Hermes endpoint resolution failed: %s", exc)
+
+    ollama = (os.getenv("OLLAMA_URL") or "http://localhost:11434").strip()
+    meta["source"] = "env:OLLAMA_URL" if os.getenv("OLLAMA_URL") else "fallback:localhost"
+    return ollama, env_key or "sk-no-key-required", env_model or LLM_DEFAULT_MODEL, meta
+
+
+def parse_message_routing(
+    content: str,
+    known_agents: Optional[Set[str]] = None,
+) -> Tuple[Optional[str], List[str]]:
+    """Extract ``to_agent`` (@mention) and interest ``tags`` (#hashtags) from content.
+
+    First @mention that matches a known agent name (case-sensitive, then
+    case-insensitive) becomes the DM target. Hashtags become tags for queue
+    interests. ``DONE`` is *not* inferred here — callers handle the own-line
+    DONE marker separately.
+    """
+    text = content or ""
+    tags = list(dict.fromkeys(_HASHTAG_RE.findall(text)))  # stable unique
+    to_agent: Optional[str] = None
+    mentions = _AT_MENTION_RE.findall(text)
+    if not mentions:
+        return None, tags
+    if known_agents:
+        lower_map = {n.lower(): n for n in known_agents}
+        for raw in mentions:
+            if raw in known_agents:
+                to_agent = raw
+                break
+            if raw.lower() in lower_map:
+                to_agent = lower_map[raw.lower()]
+                break
+    else:
+        to_agent = mentions[0]
+    return to_agent, tags
+
+
+def get_default_model() -> str:
+    """Default model for AgentSpec when caller omits model."""
+    return (os.getenv("LLM_DEFAULT_MODEL") or "").strip() or LLM_DEFAULT_MODEL
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -177,7 +305,7 @@ class AgentSpec:
         if not re.match(r"^[A-Za-z0-9_\-]+$", self.name or ""):
             raise ValueError(f"agent name empty or invalid after sanitization: {self.name!r}")
         if not self.model:
-            self.model = LLM_DEFAULT_MODEL
+            self.model = get_default_model()
         # Auto-bump max_tokens for thinking-mode models if caller used the default.
         if (self.max_tokens == DEFAULT_MAX_TOKENS_PER_TURN
                 and _is_thinking_model(self.model)):
@@ -565,13 +693,15 @@ class Agent:
 
     def __init__(self, spec: AgentSpec, channel: Channel, client: _LLMClient,
                  task: str, slot_id: Optional[int] = None,
-                 propagate_reasoning: PropagateMode = "strip"):
+                 propagate_reasoning: PropagateMode = "strip",
+                 known_agents: Optional[Set[str]] = None):
         self.spec = spec
         self.channel = channel
         self.client = client
         self.task = task
         self.slot_id = slot_id   # pinned KV-cache slot for llama-server (None elsewhere)
         self.propagate_reasoning = propagate_reasoning
+        self.known_agents: Set[str] = set(known_agents or ())
         self.inbox = channel.subscribe(spec.name)
         self.transcript_seen: List[Message] = []
 
@@ -583,6 +713,27 @@ class Agent:
             except asyncio.QueueEmpty:
                 break
         return out
+
+    def _finalize_message(self, content: str, reasoning: str, round_no: int,
+                          is_chunk: bool = False) -> Message:
+        """Build a Message with DONE / @mention / #tag routing applied."""
+        is_done = False
+        body = content
+        if body.splitlines() and body.splitlines()[-1].strip().upper() == "DONE":
+            body = "\n".join(body.splitlines()[:-1]).strip() or "(no response)"
+            is_done = True
+        to_agent, tags = parse_message_routing(body, self.known_agents)
+        if is_done and "DONE" not in tags:
+            tags = list(tags) + ["DONE"]
+        return Message(
+            from_agent=self.spec.name,
+            content=body,
+            reasoning=reasoning,
+            to_agent=to_agent,
+            tags=tags,
+            round=round_no,
+            is_chunk=is_chunk,
+        )
 
     def _peer_render(self, m: Message) -> str:
         """Render a peer message into this agent's context, respecting propagate_reasoning.
@@ -612,8 +763,9 @@ class Agent:
             f"{self.spec.system_prompt}\n\n"
             f"You are agent '{self.spec.name}' participating in a Web-of-Thought session "
             f"with other agents. Other agents may speak via messages prefixed `[from X]: ...`. "
-            f"You can reply to them by addressing them as `@X: ...` in your output, "
-            f"or you can broadcast (just write normally). When you have nothing more to add, "
+            f"Address a specific peer with `@Name: ...` (direct message). Tag topics with "
+            f"`#tag` so queue-mode agents whose interests match can wake. "
+            f"Broadcast by writing normally without @. When you have nothing more to add, "
             f"reply with the single word DONE on its own line."
         )
         msgs: List[Dict[str, Any]] = [
@@ -653,18 +805,7 @@ class Agent:
         if resp.is_empty():
             return None, ("empty response (likely max_tokens exhausted in <think>; "
                           "raise max_tokens or pick a non-thinking model)")
-        content = resp.content
-        is_done = False
-        if content.strip().splitlines() and content.strip().splitlines()[-1].strip().upper() == "DONE":
-            content = "\n".join(content.strip().splitlines()[:-1]).strip() or "(no response)"
-            is_done = True
-        msg = Message(
-            from_agent=self.spec.name,
-            content=content,
-            reasoning=resp.reasoning,
-            round=round_no,
-            tags=["DONE"] if is_done else [],
-        )
+        msg = self._finalize_message(resp.content, resp.reasoning, round_no)
         await self.channel.publish(msg)
         return msg, None
 
@@ -738,22 +879,11 @@ class Agent:
         if not full_content and not full_reasoning:
             return None, ("empty stream (likely max_tokens exhausted; "
                           "raise max_tokens or pick a non-thinking model)")
-        is_done = False
-        if full_content.splitlines() and full_content.splitlines()[-1].strip().upper() == "DONE":
-            full_content = "\n".join(full_content.splitlines()[:-1]).strip() or "(no response)"
-            is_done = True
         # If only reasoning came back (e.g. R1 ran out of budget mid-think with no
         # final answer), surface reasoning as the content so peers see something.
         if not full_content and full_reasoning:
             full_content = "(no final content — agent ran out of budget mid-thinking)"
-        final = Message(
-            from_agent=self.spec.name,
-            content=full_content,
-            reasoning=full_reasoning,
-            round=round_no,
-            is_chunk=False,
-            tags=["DONE"] if is_done else [],
-        )
+        final = self._finalize_message(full_content, full_reasoning, round_no)
         await self.channel.publish(final)
         return final, None
 
@@ -773,15 +903,17 @@ class WoTEngine:
       3. asyncio.wait_for per turn (spec.turn_timeout)
     Plus an optional 4th layer: cumulative token_budget per channel.
 
-    base_url defaults are RE-READ from env at construction time so callers can
-    set LLM_BASE_URL after import.
+    Credentials default from Hermes active provider resolution
+    (``resolve_hermes_endpoint``). Pass base_url/api_key explicitly to override.
     """
 
     def __init__(self, base_url: Optional[str] = None, api_key: Optional[str] = None):
+        h_base, h_key, h_model, h_meta = resolve_hermes_endpoint()
+        self.default_model = h_model
+        self.endpoint_meta = h_meta
         self.client = _LLMClient(
-            base_url=base_url or os.getenv("LLM_BASE_URL",
-                                            os.getenv("OLLAMA_URL", "http://localhost:11434")),
-            api_key=api_key or os.getenv("LLM_API_KEY", "sk-no-key-required"),
+            base_url=base_url or h_base,
+            api_key=api_key or h_key,
         )
 
     async def aclose(self) -> None:
@@ -801,18 +933,30 @@ class WoTEngine:
         if propagate_reasoning not in ("strip", "raw", "summary"):
             raise ValueError(f"unknown propagate_reasoning: {propagate_reasoning!r}")
 
+        # Fill missing per-agent models from Hermes-resolved default.
+        for s in specs:
+            if not s.model:
+                s.model = self.default_model
+            elif s.model == LLM_DEFAULT_MODEL and self.default_model:
+                # AgentSpec fell back to module env default — prefer live Hermes model
+                s.model = self.default_model
+
         # Probe once up front so logging shows backend before first round.
         await self.client.ensure_probed()
         backend_kind = self.client.backend.kind
 
         channel = Channel()
+        known = {s.name for s in specs}
         agents: List[Agent] = []
         for i, s in enumerate(specs):
             # Slot pinning only meaningful on llama-server; harmless elsewhere.
             slot_id = i if backend_kind == "llama-server" else None
-            agents.append(Agent(s, channel, self.client, task,
-                                slot_id=slot_id,
-                                propagate_reasoning=propagate_reasoning))
+            agents.append(Agent(
+                s, channel, self.client, task,
+                slot_id=slot_id,
+                propagate_reasoning=propagate_reasoning,
+                known_agents=known,
+            ))
 
         done: Set[str] = set()
         rounds_run = 0
@@ -867,14 +1011,40 @@ class WoTEngine:
                     if round_no == 1:
                         eligible = True
                     else:
-                        peek = list(a.inbox._queue)
-                        for m in peek:
-                            if not a.spec.interests:
+                        # History-based (not inbox): round-1 drain would otherwise
+                        # consume DMs/tags before round-2 eligibility ran.
+                        prior = [
+                            m for m in channel.history
+                            if (not m.is_chunk
+                                and m.from_agent != a.spec.name
+                                and m.round < round_no)
+                        ]
+                        for m in prior:
+                            if m.to_agent == a.spec.name:
                                 eligible = True
                                 break
-                            if any(t in a.spec.interests for t in m.tags):
+                            if not a.spec.interests and m.to_agent is None:
+                                # empty interests → any prior broadcast wakes
                                 eligible = True
                                 break
+                            if a.spec.interests and any(
+                                t in a.spec.interests for t in m.tags
+                            ):
+                                eligible = True
+                                break
+                        # Also honor still-unread inbox (e.g. same-round race)
+                        if not eligible:
+                            peek = list(a.inbox._queue)  # noqa: SLF001
+                            for m in peek:
+                                if m.to_agent == a.spec.name:
+                                    eligible = True
+                                    break
+                                if not a.spec.interests:
+                                    eligible = True
+                                    break
+                                if any(t in a.spec.interests for t in m.tags):
+                                    eligible = True
+                                    break
                     if eligible:
                         msg, err = await a.turn_batch(round_no)
                         if err:
@@ -895,6 +1065,9 @@ class WoTEngine:
             "backend": {
                 "kind": self.client.backend.kind,
                 "base_url": self.client.backend.base_url,
+                "endpoint_source": self.endpoint_meta.get("source"),
+                "provider": self.endpoint_meta.get("provider"),
+                "default_model": self.default_model,
             },
             "stop_reason": ("budget" if budget_hit
                             else "all_done" if not [a for a in agents if a.spec.name not in done]
@@ -978,13 +1151,12 @@ wot_chat_tool_schema = {
     "function": {
         "name": "wot_chat",
         "description": (
-            "Run a Web-of-Thought multi-agent session: 2-7 named agents talk to each "
-            "other through a shared message bus over multiple rounds. No role "
-            "taxonomy — caller supplies system_prompt per agent. Returns full "
-            "transcript as JSON. Modes: parallel (batch concurrent), streaming "
-            "(see partial CoT from peers), sequential (round-robin), queue "
-            "(tag-driven pull). Auto-detects llama.cpp / Ollama / vLLM backends "
-            "and pins KV-cache slots on llama-server for performance."
+            "Run a Web-of-Thought multi-agent session: 2-7 named agents talk over "
+            "a shared message bus. Opt-in (HERMES_ENABLE_WOT=1). Uses Hermes "
+            "session provider by default (override with LLM_BASE_URL). Modes: "
+            "parallel, streaming (round-boundary peer partials — not mid-token "
+            "injection), sequential, queue (@Name DMs + #tag interests). "
+            "Returns full transcript as JSON."
         ),
         "parameters": {
             "type": "object",
@@ -999,7 +1171,14 @@ wot_chat_tool_schema = {
                             "name": {"type": "string"},
                             "system_prompt": {"type": "string"},
                             "model": {"type": "string"},
-                            "interests": {"type": "array", "items": {"type": "string"}},
+                            "interests": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": (
+                                    "Queue mode: wake when a peer message carries "
+                                    "a matching #tag, or when @this_agent is used."
+                                ),
+                            },
                             "max_tokens": {"type": "integer", "default": 800},
                             "temperature": {"type": "number", "default": 0.7},
                             "turn_timeout": {"type": "number", "default": 240},
@@ -1012,6 +1191,12 @@ wot_chat_tool_schema = {
                     "type": "string",
                     "enum": ["parallel", "streaming", "sequential", "queue"],
                     "default": "parallel",
+                    "description": (
+                        "parallel: concurrent rounds. streaming: concurrent + "
+                        "chunked peer partials absorbed next turn (not mid-generation "
+                        "injection). sequential: round-robin. queue: wake on @Name "
+                        "or #tag matching interests."
+                    ),
                 },
                 "max_rounds": {"type": "integer", "default": 5, "minimum": 1, "maximum": 20},
                 "token_budget": {"type": "integer", "default": 0, "minimum": 0,
@@ -1093,8 +1278,7 @@ try:
         name="wot",
         description=(
             "Web-of-Thought multi-agent reasoning (opt-in; requires "
-            "HERMES_ENABLE_WOT=1). Inner agents use LLM_BASE_URL / "
-            "LLM_API_KEY, not the parent session provider."
+            "HERMES_ENABLE_WOT=1). Uses Hermes session provider by default."
         ),
         tools=["wot_chat"],
     )

--- a/tools/wot_engine.py
+++ b/tools/wot_engine.py
@@ -8,23 +8,37 @@ agent does via its system_prompt.
 Four communication modes:
   - "parallel"   : all agents run concurrently; each sees others' completed
                    messages on round boundaries
-  - "streaming"  : like parallel, but agents see PARTIAL CoT tokens from peers
-                   via chunked polling (works with any OpenAI-compat backend
-                   without requiring server-side mid-generation injection)
+  - "streaming"  : parallel rounds with chunked *post-completion* peer
+                   partials exposed to listeners between / after peer
+                   streams finish in that round — NOT mid-generation
+                   injection into another agent's still-in-flight request
+                   (OpenAI-compat backends cannot do that client-side)
   - "sequential" : round-robin; each agent gets the full prior transcript
-  - "queue"      : topic-driven; agents pull from a shared queue when they
-                   declare interest in a tag
+  - "queue"      : agents run in parallel-like rounds; optional `interests`
+                   tags are reserved for future inbox routing. Current
+                   implementation does not yet route ordinary messages by
+                   @name / interests — only explicit DONE markers stop an
+                   agent early
 
 Backbone: any OpenAI-compatible /v1/chat/completions endpoint, plus Ollama's
 native /api/chat for thinking-mode models (where /v1/ silently drops thinking).
 Auto-detected at construction time:
   Ollama, llama.cpp's llama-server, vLLM, LM Studio, OpenAI, OpenRouter, etc.
 
+Provider note: this engine currently uses LLM_BASE_URL / LLM_API_KEY /
+LLM_DEFAULT_MODEL (or OLLAMA_URL) — it does **not** yet share Hermes's
+active session provider + credential pool. Point those env vars at the
+backend you want the inner agents to call.
+
 Termination: 3 layers — explicit DONE marker, max_rounds cap, per-agent timeout.
 Cost control: optional token_budget per channel.
 CoT propagation: default "strip" (cross-family-safe). Opt in to "raw" for
 same-family debate where shared reasoning amplifies; this is informed by
 arxiv 2503.13657 and the MemoryTrap (Apr 2026) attack surface.
+
+Opt-in: the `wot` toolset / `wot_chat` tool is disabled unless
+HERMES_ENABLE_WOT=1 (or true/yes/on). Do not leave it on the default
+toolset surface for ordinary sessions.
 
 Grounded in Artificial Neural Mesh V0 (Ali, 2026)
   https://doi.org/10.5281/zenodo.18112435
@@ -1057,11 +1071,31 @@ if __name__ == "__main__":
 # ─────────────────────────────────────────────────────────────────────────────
 from tools.registry import registry  # noqa: E402
 
+
+def _wot_enabled() -> bool:
+    """Gate: WoT must be deliberately enabled — never a default session tool.
+
+    Ordinary Hermes sessions load available toolsets broadly; leaving wot_chat
+    always-checkable would inject a multi-agent schema into every chat.
+    Set HERMES_ENABLE_WOT=1 (or true/yes/on) to opt in.
+    """
+    return os.getenv("HERMES_ENABLE_WOT", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 try:
     from toolsets import create_custom_toolset  # type: ignore
     create_custom_toolset(
         name="wot",
-        description="Web-of-Thought multi-agent reasoning (3-7 agents debate / collaborate)",
+        description=(
+            "Web-of-Thought multi-agent reasoning (opt-in; requires "
+            "HERMES_ENABLE_WOT=1). Inner agents use LLM_BASE_URL / "
+            "LLM_API_KEY, not the parent session provider."
+        ),
         tools=["wot_chat"],
     )
 except Exception:
@@ -1088,7 +1122,7 @@ registry.register(
         "parameters": wot_chat_tool_schema["function"]["parameters"],
     },
     handler=_wot_handler,
-    check_fn=lambda: True,
+    check_fn=_wot_enabled,
     emoji="🕸",
     max_result_size_chars=200_000,
 )

--- a/tools/wot_engine.py
+++ b/tools/wot_engine.py
@@ -143,6 +143,12 @@ class AgentSpec:
     max_tokens: int = DEFAULT_MAX_TOKENS_PER_TURN
     temperature: float = 0.7
     turn_timeout: float = DEFAULT_AGENT_TURN_TIMEOUT     # per-turn cap
+    # Per-agent backend override. When set, this agent calls the override
+    # base_url + api_key instead of the WoTEngine's defaults. Lets one WoT
+    # session mix backends (e.g. one agent on Ollama localhost, another on
+    # OpenRouter). Backend probe results are cached per-base_url.
+    base_url: Optional[str] = None
+    api_key: Optional[str] = None
 
     def __post_init__(self):
         # Auto-sanitize: collapse whitespace runs to underscores, drop other
@@ -323,22 +329,44 @@ class _LLMClient:
             headers={"Authorization": f"Bearer {api_key}"},
         )
         self.backend: BackendInfo = BackendInfo(base_url=self.base_url)
+        # Cache backend probes per-base_url so multi-backend mix (per-agent
+        # base_url override) doesn't re-probe each call.
+        self._probe_cache: Dict[str, BackendInfo] = {}
         self._probed = False
 
     async def aclose(self) -> None:
         await self._client.aclose()
 
-    async def ensure_probed(self) -> BackendInfo:
-        if not self._probed:
-            self.backend = await _probe_backend(self.base_url, self.api_key, self._client)
+    @staticmethod
+    def _normalize_base(base_url: str) -> str:
+        """Strip trailing `/` and `/v1` so chat-endpoint URL composes cleanly."""
+        b = base_url.rstrip("/")
+        if b.endswith("/v1"):
+            b = b[:-3].rstrip("/")
+        return b
+
+    async def ensure_probed(self, base_url_override: Optional[str] = None) -> BackendInfo:
+        """Probe the backend once per unique base_url; cached thereafter."""
+        target = self._normalize_base(base_url_override) if base_url_override else self.base_url
+        if target not in self._probe_cache:
+            info = await _probe_backend(target,
+                                         self.api_key, self._client)
+            self._probe_cache[target] = info
+            logger.info("WoT backend probe: %s at %s", info.kind, info.base_url)
+        if not base_url_override:
+            # Default-path callers want self.backend to reflect the canonical probe
+            self.backend = self._probe_cache[target]
             self._probed = True
-            logger.info("WoT backend probe: %s at %s", self.backend.kind, self.backend.base_url)
-        return self.backend
+        return self._probe_cache[target]
 
     # ───────── payload builders ─────────
-    def _openai_payload(self, model: str, messages: List[Dict[str, Any]],
-                        max_tokens: int, temperature: float, stream: bool,
-                        slot_id: Optional[int], stop: Optional[List[str]]) -> Dict[str, Any]:
+    def _openai_payload_for(self, backend: BackendInfo, model: str,
+                             messages: List[Dict[str, Any]],
+                             max_tokens: int, temperature: float, stream: bool,
+                             slot_id: Optional[int], stop: Optional[List[str]]) -> Dict[str, Any]:
+        """Backend-aware payload builder. Takes BackendInfo explicitly so per-agent
+        base_url overrides land on the right backend's knobs (e.g. id_slot only
+        makes sense if THIS request is going to llama-server)."""
         payload: Dict[str, Any] = {
             "model": model,
             "messages": messages,
@@ -347,16 +375,20 @@ class _LLMClient:
             "stream": stream,
         }
         if _is_qwen35_or_36(model):
-            # Qwen3.5/3.6 default to thinking and ignore /think /no_think.
-            # Per official model card, only chat_template_kwargs disables it.
             payload["chat_template_kwargs"] = {"enable_thinking": False}
         if stop:
             payload["stop"] = stop
-        # llama-server-only knobs: pin slot + reuse prompt prefix across turns.
-        if self.backend.kind == "llama-server" and slot_id is not None:
+        if backend.kind == "llama-server" and slot_id is not None:
             payload["id_slot"] = slot_id
             payload["cache_prompt"] = True
         return payload
+
+    # Kept for unit-test backward compatibility — delegates to _openai_payload_for.
+    def _openai_payload(self, model: str, messages: List[Dict[str, Any]],
+                        max_tokens: int, temperature: float, stream: bool,
+                        slot_id: Optional[int], stop: Optional[List[str]]) -> Dict[str, Any]:
+        return self._openai_payload_for(self.backend, model, messages, max_tokens,
+                                         temperature, stream, slot_id, stop)
 
     def _ollama_native_payload(self, model: str, messages: List[Dict[str, Any]],
                                max_tokens: int, temperature: float, stream: bool,
@@ -373,19 +405,33 @@ class _LLMClient:
             },
         }
 
+    def _resolve_target(self, base_url_override: Optional[str],
+                        api_key_override: Optional[str]) -> Tuple[str, Dict[str, str]]:
+        """Return (normalized_base_url, headers) for a single request, honoring overrides."""
+        if base_url_override:
+            base = self._normalize_base(base_url_override)
+            api_key = api_key_override or self.api_key
+        else:
+            base = self.base_url
+            api_key = self.api_key
+        return base, {"Authorization": f"Bearer {api_key}"}
+
     # ───────── non-streaming complete ─────────
     async def complete(self, model: str, messages: List[Dict[str, Any]],
                        max_tokens: int = DEFAULT_MAX_TOKENS_PER_TURN,
                        temperature: float = 0.7,
                        slot_id: Optional[int] = None,
-                       stop: Optional[List[str]] = None) -> LLMResponse:
-        await self.ensure_probed()
+                       stop: Optional[List[str]] = None,
+                       base_url_override: Optional[str] = None,
+                       api_key_override: Optional[str] = None) -> LLMResponse:
+        backend = await self.ensure_probed(base_url_override)
+        base, headers = self._resolve_target(base_url_override, api_key_override)
         thinking_model = _is_thinking_model(model)
         # Ollama path for thinking models: /v1/ drops thinking, /api/chat keeps it.
-        if self.backend.kind == "ollama" and thinking_model:
+        if backend.kind == "ollama" and thinking_model:
             payload = self._ollama_native_payload(model, messages, max_tokens,
                                                   temperature, stream=False, think=True)
-            r = await self._client.post(f"{self.base_url}/api/chat", json=payload)
+            r = await self._client.post(f"{base}/api/chat", json=payload, headers=headers)
             r.raise_for_status()
             data = r.json()
             msg = data.get("message", {}) if isinstance(data, dict) else {}
@@ -394,9 +440,10 @@ class _LLMClient:
                 reasoning=(msg.get("thinking") or "").strip(),
             )
         # OpenAI-compat path
-        payload = self._openai_payload(model, messages, max_tokens, temperature,
-                                        stream=False, slot_id=slot_id, stop=stop)
-        r = await self._client.post(f"{self.base_url}/v1/chat/completions", json=payload)
+        payload = self._openai_payload_for(backend, model, messages, max_tokens,
+                                            temperature, stream=False,
+                                            slot_id=slot_id, stop=stop)
+        r = await self._client.post(f"{base}/v1/chat/completions", json=payload, headers=headers)
         r.raise_for_status()
         data = r.json()
         msg = data["choices"][0]["message"]
@@ -416,28 +463,34 @@ class _LLMClient:
                      max_tokens: int = DEFAULT_MAX_TOKENS_PER_TURN,
                      temperature: float = 0.7,
                      slot_id: Optional[int] = None,
-                     stop: Optional[List[str]] = None
+                     stop: Optional[List[str]] = None,
+                     base_url_override: Optional[str] = None,
+                     api_key_override: Optional[str] = None
                      ) -> AsyncIterator[Tuple[str, str]]:
         """Yields (kind, delta) where kind ∈ {"content", "reasoning"}."""
-        await self.ensure_probed()
+        backend = await self.ensure_probed(base_url_override)
+        base, headers = self._resolve_target(base_url_override, api_key_override)
         thinking_model = _is_thinking_model(model)
-        if self.backend.kind == "ollama" and thinking_model:
-            async for kv in self._stream_ollama_native(model, messages, max_tokens,
-                                                        temperature, think=True):
+        if backend.kind == "ollama" and thinking_model:
+            async for kv in self._stream_ollama_native(base, headers, model, messages,
+                                                        max_tokens, temperature, think=True):
                 yield kv
             return
-        async for kv in self._stream_openai(model, messages, max_tokens, temperature,
-                                             slot_id, stop):
+        async for kv in self._stream_openai(backend, base, headers, model, messages,
+                                             max_tokens, temperature, slot_id, stop):
             yield kv
 
-    async def _stream_openai(self, model: str, messages: List[Dict[str, Any]],
+    async def _stream_openai(self, backend: BackendInfo, base: str,
+                             headers: Dict[str, str], model: str,
+                             messages: List[Dict[str, Any]],
                              max_tokens: int, temperature: float,
                              slot_id: Optional[int], stop: Optional[List[str]]
                              ) -> AsyncIterator[Tuple[str, str]]:
-        payload = self._openai_payload(model, messages, max_tokens, temperature,
-                                        stream=True, slot_id=slot_id, stop=stop)
+        payload = self._openai_payload_for(backend, model, messages, max_tokens,
+                                            temperature, stream=True,
+                                            slot_id=slot_id, stop=stop)
         async with self._client.stream(
-            "POST", f"{self.base_url}/v1/chat/completions", json=payload,
+            "POST", f"{base}/v1/chat/completions", json=payload, headers=headers,
         ) as r:
             r.raise_for_status()
             async for raw in r.aiter_lines():
@@ -461,14 +514,15 @@ class _LLMClient:
                 if c:
                     yield ("content", c)
 
-    async def _stream_ollama_native(self, model: str, messages: List[Dict[str, Any]],
+    async def _stream_ollama_native(self, base: str, headers: Dict[str, str],
+                                     model: str, messages: List[Dict[str, Any]],
                                      max_tokens: int, temperature: float, think: bool
                                      ) -> AsyncIterator[Tuple[str, str]]:
         """Ollama native /api/chat streams NDJSON, not SSE."""
         payload = self._ollama_native_payload(model, messages, max_tokens, temperature,
                                                stream=True, think=think)
         async with self._client.stream(
-            "POST", f"{self.base_url}/api/chat", json=payload,
+            "POST", f"{base}/api/chat", json=payload, headers=headers,
         ) as r:
             r.raise_for_status()
             async for raw in r.aiter_lines():
@@ -571,6 +625,8 @@ class Agent:
                     max_tokens=self.spec.max_tokens,
                     temperature=self.spec.temperature,
                     slot_id=self.slot_id,
+                    base_url_override=self.spec.base_url,
+                    api_key_override=self.spec.api_key,
                 ),
                 timeout=self.spec.turn_timeout,
             )
@@ -635,6 +691,8 @@ class Agent:
                     max_tokens=self.spec.max_tokens,
                     temperature=self.spec.temperature,
                     slot_id=self.slot_id,
+                    base_url_override=self.spec.base_url,
+                    api_key_override=self.spec.api_key,
                 ):
                     if kind == "reasoning":
                         reasoning_buf.append(delta)
@@ -857,15 +915,17 @@ def wot_chat_tool(
         propagate_reasoning: "strip" (cross-family-safe default) | "raw" (same-family
                              debate) | "summary" (currently same as strip).
     """
-    # Outer Hermes models tend to hallucinate inner-agent model names like
-    # "gpt-4o" when constructing the wot_chat tool call. We strip caller-
-    # supplied `model` fields and force every inner agent to use
-    # LLM_DEFAULT_MODEL (env-driven), so the WoT engine remains in control of
-    # its own backend rather than chasing whatever the outer model dreamed up.
+    # Outer Hermes models hallucinate inner-agent backend config (model names
+    # like "gpt-4o", random base_urls, fake api_keys). At the tool boundary we
+    # strip all backend-control fields so the WoT engine controls its own
+    # backend. Per-agent backend overrides are still available to direct Python
+    # callers via AgentSpec(base_url=..., api_key=...) — the field exists on
+    # the dataclass but is not exposed through the tool schema.
     sanitized: List[Dict[str, Any]] = []
     for a in agents:
         spec = dict(a)
-        spec.pop("model", None)
+        for k in ("model", "base_url", "api_key"):
+            spec.pop(k, None)
         sanitized.append(spec)
     specs = [AgentSpec(**a) for a in sanitized]
 


### PR DESCRIPTION
## Summary

Adds a self-contained multi-agent reasoning engine that coordinates 3-7 LLM agents through a shared message bus. Generic agents (no role taxonomy hardcoded) talk to each other across four communication modes — `parallel`, `streaming`, `sequential`, `queue` — over any OpenAI-compatible backend. Exposed as a single Hermes tool (`wot_chat`) under a new `wot` toolset, plus a methodology skill at `skills/coordination/web-of-thought/`.

This is a separate concern from PRs #19607 / #19796 (free-tier search backends). They touch different surfaces and are independently reviewable.

## Files

- `tools/wot_engine.py` — engine + tool registration (1,034 lines)
- `tests/tools/test_wot_engine.py` — 36 unit tests, all green
- `skills/coordination/web-of-thought/SKILL.md` — methodology guidance for callers (when to invoke, how to design agents, mode selection, cost discipline)

## Engine design

- **No role taxonomy.** Agents are differentiated only by caller-supplied `name + system_prompt`. Engine is content-agnostic; the model decides agent personalities dynamically.
- **Four communication modes:**
  - `parallel` — all agents react to the task simultaneously, see peers' completed messages on round boundaries
  - `streaming` — same as parallel but agents see partial CoT tokens as they're generated
  - `sequential` — round-robin; each agent gets full prior transcript
  - `queue` — tag-driven pull (agents declare `interests`, only act when relevant tag appears)
- **Backend probe at startup.** Detects llama.cpp / Ollama / vLLM / OpenAI-compat. Uses `id_slot` pinning + `cache_prompt: true` on llama.cpp for KV-cache reuse across agents. Strips trailing `/v1` from `base_url` so callers can pass either form.
- **Reasoning content extraction.** Reads `delta.reasoning_content` separately from `delta.content` for thinking-mode models (DeepSeek-R1, QwQ, Qwen3.5/3.6 with thinking on). Stored in `Message.reasoning` so peer messages can choose to propagate raw / strip / summarize CoT (the `propagate_reasoning` knob; `summary` is currently stubbed to `strip` — flagged in the docstring).
- **Cost rails.** Per-channel `token_budget`, per-agent `turn_timeout` via `asyncio.wait_for`, monotonic `seq` per agent on `Message` envelope.
- **AgentSpec auto-sanitization** — real LLM callers emit names like "Critical Thinker" or "Agent A". Whitespace becomes `_`, disallowed characters dropped. Raises only if the result is empty.
- **Caller-supplied `model` field is stripped** from inner agent specs at `wot_chat_tool` boundary — outer Hermes tends to hallucinate names like `gpt-4o`. Engine uses `LLM_DEFAULT_MODEL` (env-driven) for all inner agents.

## Hermes integration

- Tool registration is at module top-level (not wrapped in `try/except`) so `tools/registry.py:_module_registers_tools` AST scanner picks it up.
- `wot` toolset is auto-created at module load time via `toolsets.create_custom_toolset(...)` so `-t wot` validates without modifying `toolsets.py`.
- Skill loads via `--skills coordination/web-of-thought` and prefixes the system prompt with methodology guidance.

## How this fits next to existing Hermes multi-agent surfaces

Hermes already ships several multi-agent / delegation primitives. WoT is **additive, not redundant** — it fills a specific gap none of them serve.

| Capability | `delegate_task` | `mixture_of_agents` | Kanban | **WoT (`wot_chat`)** |
|---|---|---|---|---|
| Parent sees children's intermediate outputs | summary only | aggregator-only | polled comments | **full transcript every turn** |
| Children talk to each other | no (per #344) | no cross-reference | polling comments | **direct `@name`-mentions** |
| Children see each other's CoT | no | no | no | **streaming mode pipes partial CoT** |
| Multi-round refinement | one-shot per child | one-shot per reference model | heavyweight (board cycle) | **native, default 5 rounds** |
| Process model | subprocess per child | parallel HTTP calls | cross-process, durable | in-process asyncio |
| Latency floor | process spawn time | API round-trip | DB persist + claim | single API round-trip per agent per round |
| State persistence | none (ephemeral) | none (ephemeral) | SQLite-backed | none (live in-memory) |
| Best for | durable cross-process delegation with isolation | Best-of-N synthesis via aggregator | long-running multi-profile workflows | **live multi-perspective reasoning within one task** |

What WoT specifically adds: **in-process live multi-agent reasoning where inner agents can address each other directly and the outer agent sees the full transcript as it forms.** That's the niche the existing surfaces don't fill — `delegate_task` deliberately hides intermediate output, MoA's reference models don't see each other, and Kanban's polling comments aren't real-time. Several long-open feature requests (#412 consensus/voting, #376 adversarial debate, #479 best-of-N + judge, #5876 multi-agent council) all reduce to this missing primitive.

WoT does not replace any of the above. Compose: outer Hermes can call `delegate_task` for durable cross-process work, dispatch `wot_chat` for live debate within its own turn, and use Kanban for cross-session orchestration. They're complementary.

## Validated end-to-end

**Setup**: Ubuntu 24.04 + RTX 4050. Isolated Hermes install (separate `HERMES_HOME`, no overlap with any production setup).

**1. Local llama.cpp + Qwen3-4B-Instruct-Q4_K_M (`--parallel 4 --jinja --ctx-size 65536`):**
- 5/5 sessions completed, 48 WoT messages across runs, 0 inner errors
- Range of behaviors: deep multi-round debate (18 msgs over 6 rounds), smart short-circuit on triviality (3 msgs in 1 round when all agents emit DONE), self-healing on bad arg shapes (Hermes retried with corrected payload)

**2. OpenRouter + DeepSeek-V4-Flash (with skill loaded):**
- 5/5 sessions completed, 23 WoT messages, 1 inner error (token truncation mid-thinking on round 3 of one run; engine surfaced it cleanly via `errors[]`)
- Skill methodology measurably moved model behavior toward leaner invocations: avg agent name length ~10 chars (vs ~22 unloaded), `max_rounds: 3` explicitly set on 5/5, `token_budget` on 3/5, ~43% latency drop vs no-skill baseline

## Coverage — honest framing

**Integration-validated end-to-end** (with V4 Flash via OpenRouter as inner agents, full session JSONL captured):
- `parallel` mode — 5/5 sessions clean, 48 WoT messages, multi-round @-mention emergence
- `streaming` mode — 22 streaming chunks + 3 final messages produced, `stop_reason=all_done` clean
- `sequential` mode — agent ordering preserved across 2 rounds with cross-round @-mentions (round-2 alpha addresses round-1 beta)
- `queue` mode — interests tags drove tag-prefixed output (`[design]` → `[code]` → `[review]`), 3 rounds completed
- Per-agent `turn_timeout` — standalone test, 2/2 agents timed out at 2.0s as configured, errors surfaced via `errors[]`
- Backend probe (llama.cpp + OpenRouter), slot pinning on llama.cpp
- Reasoning content extraction (R1 + V4 Flash thinking traces visible in transcripts)
- AgentSpec auto-sanitization (model-emitted role-y names sanitized cleanly)
- Caller-supplied `model` stripping (saved a run when V4 Flash hallucinated `gpt-4o`)
- `/v1` suffix doubling fix (caught the OpenRouter 404)
- Hermes tool auto-discovery + custom toolset registration
- Skill load + methodology effect on model behavior (43% latency drop, lean invocations)

**Routing-validated (engine routes correctly; downstream model output quality is upstream's concern)**:
- Ollama native `/api/chat` path for thinking models — backend probe identifies `kind='ollama'`, request hits `/api/chat` (not `/v1/`), parses both `message.content` and `message.thinking` fields. Tested live with `deepseek-r1:1.5b` and `deepseek-r1:7b`. Output quality of small R1 distills + Ollama template handling is broken upstream (well-known) — engine correctly returns whatever Ollama emits.

**Unit-test only (no integration run on this PR)**:
- vLLM backend branch — code path exists, would need a vLLM-serving instance to validate. Same probe + dispatcher pattern as the validated paths, low risk.

**Multi-backend mix — integration-validated** (added in second commit `b1e8872`):
- `AgentSpec` now has optional `base_url` + `api_key` fields for per-agent backend override
- `_LLMClient` caches backend probes per-base_url so each unique target is only probed once
- Validated live with one session running two agents on different backends simultaneously:
  - alpha on DeepSeek-V4-Flash via OpenRouter (`https://openrouter.ai/api/v1`)
  - beta on `deepseek-r1:1.5b` via local Ollama (`http://127.0.0.1:11434`)
- Probe cache after run showed both: `https://openrouter.ai/api → openai-compat` and `http://127.0.0.1:11434 → ollama`
- 0 engine errors; both responses assembled into the transcript with correct `from`-attribution
- Defensive design: `wot_chat_tool` boundary strips `model` + `base_url` + `api_key` from outer-Hermes-supplied args (Hermes hallucinates them); direct Python callers using `AgentSpec(base_url=..., api_key=...)` still work

**Stubbed**:
- `propagate_reasoning="summary"` — currently behaves identically to `"strip"`. A real summary mode would distill peer CoT through a small model; deferred to a follow-up. Docstring is honest about this.

## Linked issues

**Closes** (auto-close on merge):
- Closes #412 — Consensus & Voting Engine for Multi-Agent Decision Making. WoT's `parallel` mode + a synthesizer agent delivers exactly the AgentWorkflows-style consensus pattern.
- Closes #376 — Adversarial Debate Mode for Delegation. WoT's `sequential` mode with two agents is iterative-refinement debate.
- Closes #5876 — Multi-Agent Council Skill. The `coordination/web-of-thought` skill is the council methodology; the engine is the substrate.
- Closes #479 — Best-of-N Competitive Evaluation. `parallel` mode with a synthesizer/judge agent is the Best-of-N pattern.

**Refs** (does not auto-close — partial coverage):
- #377 — Shared Memory Pools Between Sub-Agents. The `Channel` primitive is the shared memory pool; CAMEL-AI-specific patterns are out of scope here.
- #488 — Multi-Agent Blind Validation. Closely related pattern; a thin wrapper skill on top of WoT could deliver this.
- #11922 — Multi-agent communication & per-channel persona. Engine provides the comm primitive (`Channel`) and per-agent persona (`system_prompt`).

## Test plan

- [x] `pytest -p no:xdist tests/tools/test_wot_engine.py` — 36/36 passing on this branch
- [x] Engine integration tested against llama.cpp + Qwen3-4B-Instruct (5/5 sessions, 0 errors)
- [x] Engine integration tested against OpenRouter + DeepSeek-V4-Flash (5/5 sessions, 1 truncation surfaced honestly)
- [x] Skill load + invocation-pattern A/B tested (skill measurably moves model behavior)
- [ ] CI green (will fix anything `pytest tests/` flags)

## Backwards compatibility

Pure-add. New tool, new toolset, new skill, new test file. Zero changes to existing code paths.

## License

MIT (auto per `CONTRIBUTING.md`).



