### PR TITLE
fix(ui-tui): prevent React effect cleanup from killing python TUI gateway subprocess (salvage #17125)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -56,6 +56,7 @@ AUTHOR_MAP = {
     "657290301@qq.com": "IMHaoyan",
     "revar@users.noreply.github.com": "revaraver",
     "29756950+revaraver@users.noreply.github.com": "revaraver",
+    "nexus@eptic.me": "TheEpTic",
     "emelyanenko.kirill@gmail.com": "EmelyanenkoK",
     # Matrix parity salvage batch (April 2026)
     "sr@samirusani": "samrusani",

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -606,10 +606,10 @@ export function useMainApp(gw: GatewayClient) {
     gw.on('exit', exitHandler)
     gw.drain()
 
+    // entry.tsx's setupGracefulExit handles process cleanup on real exit.
     return () => {
       gw.off('event', handler)
       gw.off('exit', exitHandler)
-      gw.kill()
     }
   }, [gw, sys])
 


### PR DESCRIPTION
Salvages @TheEpTic's PR #17125 onto current main.

## What it does
The gateway-event `useEffect` in `useMainApp.ts` calls `gw.kill()` in its cleanup function. React fires cleanup on every re-render when the deps array shifts — which happens any time `sys` changes identity (any system message). Result: the TUI silently kills its own Python backend mid-session.

## Changes
- `ui-tui/src/app/useMainApp.ts` — remove `gw.kill()` from the effect's cleanup path.
- `scripts/release.py` — AUTHOR_MAP entry for TheEpTic.

Real app exits are already covered: `entry.tsx` wires `setupGracefulExit` for SIGINT/SIGTERM/uncaughtException, and the `die()` function in the same file calls `gw.kill()` directly for explicit user exits.

## Validation
1-line removal, no other call sites affected. Manual verification of remaining kill paths confirmed.

Closes #17125 via salvage.