### PR TITLE
fix: scope reasoning-box extraction to the current turn (salvage #17055)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -13952,9 +13952,19 @@ class AIAgent:
             except Exception as exc:
                 logger.warning("post_llm_call hook failed: %s", exc)
 
-        # Extract reasoning from the last assistant message (if any)
+        # Extract reasoning from the CURRENT turn only.  Walk backwards
+        # but stop at the user message that started this turn — anything
+        # earlier is from a prior turn and must not leak into the reasoning
+        # box (confusing stale display; #17055).  Within the current turn
+        # we still want the *most recent* non-empty reasoning: many
+        # providers (Claude thinking, DeepSeek v4, Codex Responses) emit
+        # reasoning on the tool-call step and leave the final-answer step
+        # with reasoning=None, so picking only the last assistant would
+        # silently drop legitimate same-turn reasoning.
         last_reasoning = None
         for msg in reversed(messages):
+            if msg.get("role") == "user":
+                break  # turn boundary — don't cross into prior turns
             if msg.get("role") == "assistant" and msg.get("reasoning"):
                 last_reasoning = msg["reasoning"]
                 break

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -59,6 +59,7 @@ AUTHOR_MAP = {
     "nexus@eptic.me": "TheEpTic",
     "74554762+wmagev@users.noreply.github.com": "wmagev",
     "ashermorse@icloud.com": "ashermorse",
+    "happy5318@users.noreply.github.com": "happy5318",
     "emelyanenko.kirill@gmail.com": "EmelyanenkoK",
     # Matrix parity salvage batch (April 2026)
     "sr@samirusani": "samrusani",

--- a/tests/cli/test_reasoning_command.py
+++ b/tests/cli/test_reasoning_command.py
@@ -178,6 +178,8 @@ class TestLastReasoningInResult(unittest.TestCase):
         messages = self._build_messages(reasoning="Let me think...")
         last_reasoning = None
         for msg in reversed(messages):
+            if msg.get("role") == "user":
+                break
             if msg.get("role") == "assistant" and msg.get("reasoning"):
                 last_reasoning = msg["reasoning"]
                 break
@@ -187,6 +189,8 @@ class TestLastReasoningInResult(unittest.TestCase):
         messages = self._build_messages(reasoning=None)
         last_reasoning = None
         for msg in reversed(messages):
+            if msg.get("role") == "user":
+                break
             if msg.get("role") == "assistant" and msg.get("reasoning"):
                 last_reasoning = msg["reasoning"]
                 break
@@ -201,6 +205,8 @@ class TestLastReasoningInResult(unittest.TestCase):
         ]
         last_reasoning = None
         for msg in reversed(messages):
+            if msg.get("role") == "user":
+                break
             if msg.get("role") == "assistant" and msg.get("reasoning"):
                 last_reasoning = msg["reasoning"]
                 break
@@ -210,6 +216,8 @@ class TestLastReasoningInResult(unittest.TestCase):
         messages = self._build_messages(reasoning="")
         last_reasoning = None
         for msg in reversed(messages):
+            if msg.get("role") == "user":
+                break
             if msg.get("role") == "assistant" and msg.get("reasoning"):
                 last_reasoning = msg["reasoning"]
                 break
@@ -584,6 +592,8 @@ class TestEndToEndPipeline(unittest.TestCase):
 
         last_reasoning = None
         for msg in reversed(messages):
+            if msg.get("role") == "user":
+                break
             if msg.get("role") == "assistant" and msg.get("reasoning"):
                 last_reasoning = msg["reasoning"]
                 break

--- a/tests/run_agent/test_last_reasoning_per_turn.py
+++ b/tests/run_agent/test_last_reasoning_per_turn.py
@@ -1,0 +1,107 @@
+"""Tests for per-turn reasoning extraction in AIAgent.run_conversation.
+
+Verifies the reasoning field returned to display layers (CLI reasoning box,
+gateway reasoning footer, TUI reasoning event) only reflects the CURRENT
+turn's reasoning — never leaks from a prior turn — and is picked up
+correctly when reasoning is attached to a tool-calling assistant step
+rather than the final-answer assistant step.
+"""
+from __future__ import annotations
+
+
+def _extract_last_reasoning(messages):
+    """Replica of the extraction loop in run_agent.py (~line 13867).
+
+    Tests pin the loop's behaviour so that refactors can't silently
+    regress the per-turn semantic.
+    """
+    last_reasoning = None
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            break
+        if msg.get("role") == "assistant" and msg.get("reasoning"):
+            last_reasoning = msg["reasoning"]
+            break
+    return last_reasoning
+
+
+def test_simple_turn_reasoning_present():
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi", "reasoning": "greeting the user"},
+    ]
+    assert _extract_last_reasoning(messages) == "greeting the user"
+
+
+def test_simple_turn_no_reasoning():
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi", "reasoning": None},
+    ]
+    assert _extract_last_reasoning(messages) is None
+
+
+def test_tool_call_turn_reasoning_on_tool_call_step():
+    """When the model reasons on the tool-call step and the final-answer
+    step has no reasoning (Claude thinking / DeepSeek v4 / Codex Responses
+    pattern), the box must show the tool-call-step reasoning, not empty.
+    """
+    messages = [
+        {"role": "user", "content": "search the repo for X"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "I should use search_files",
+            "tool_calls": [{"id": "c1", "type": "function",
+                            "function": {"name": "search_files", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "3 matches"},
+        {"role": "assistant", "content": "Found 3 matches", "reasoning": None},
+    ]
+    assert _extract_last_reasoning(messages) == "I should use search_files"
+
+
+def test_no_stale_reasoning_across_turns():
+    """The regression the whole change exists for.  Prior turn had
+    reasoning; current turn has none.  The reasoning box must NOT show
+    the prior turn's text.
+    """
+    messages = [
+        # prior turn
+        {"role": "user", "content": "explain quantum tunneling"},
+        {"role": "assistant", "content": "It's when...",
+         "reasoning": "tunneling happens when particles..."},
+        # current turn
+        {"role": "user", "content": "thanks"},
+        {"role": "assistant", "content": "You're welcome!", "reasoning": None},
+    ]
+    assert _extract_last_reasoning(messages) is None
+
+
+def test_tool_call_turn_picks_latest_reasoning_within_turn():
+    """If BOTH the tool-call step and the final step have reasoning
+    (uncommon but possible), the final-step reasoning wins — it's the
+    most recent thought within the current turn.
+    """
+    messages = [
+        {"role": "user", "content": "search and summarize"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "initial plan",
+            "tool_calls": [{"id": "c1", "type": "function",
+                            "function": {"name": "search_files", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "results"},
+        {"role": "assistant", "content": "Here's the summary",
+         "reasoning": "synthesized view of results"},
+    ]
+    assert _extract_last_reasoning(messages) == "synthesized view of results"
+
+
+def test_empty_string_reasoning_treated_as_missing():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello", "reasoning": ""},
+    ]
+    assert _extract_last_reasoning(messages) is None


### PR DESCRIPTION
Salvages @happy5318's PR #17055 with a tighter fix.

## What the reasoning box shows (scope)
This is ONLY about the grey `┌─ Reasoning ─┐` box in the CLI (and the reasoning footer on gateway / reasoning event on TUI). Agent behaviour is unchanged.

## The bug
After a reply, the reasoning-extraction loop walked backwards through the ENTIRE message history looking for any assistant with a non-empty `reasoning` field. When the current turn had `reasoning=None` (common on providers that skip reasoning for trivial responses), the loop kept walking past the turn boundary and displayed reasoning from a PRIOR turn — stale text from minutes or hours ago shown as if it belonged to the current reply.

## Why the original PR wasn't merged as-is
The original patch stopped at the LAST assistant message regardless of reasoning truthiness. That fixed stale display, but introduced a NEW gap: on a tool-calling turn where reasoning lived on the tool-call step and the final-answer step had `reasoning=None` (the Claude thinking / DeepSeek v4 / Codex Responses pattern), the box went empty even though the model DID reason within the turn.

## The fix in this PR
Walk backwards but stop at the `role="user"` message that started the current turn. That picks the most recent in-turn reasoning (correct for tool-calling turns) and returns None cleanly when the current turn genuinely had none (no stale leak).

## Changes
- `run_agent.py` — turn-boundary guard on the extraction loop (+11 / -1).
- `tests/run_agent/test_last_reasoning_per_turn.py` — 6 focused tests covering simple turn / no-reasoning turn / tool-call turn / cross-turn leak / tool-call with reasoning on both steps / empty-string-as-missing.
- `tests/cli/test_reasoning_command.py` — 4 inline replica loops updated to match the new turn-boundary shape so the test file reflects production semantics.
- `scripts/release.py` — AUTHOR_MAP entry for happy5318.

## Validation
`tests/cli/test_reasoning_command.py` + `tests/run_agent/test_last_reasoning_per_turn.py` — 61 passed locally. Broader reasoning-related suite (`tests/run_agent/ -k reasoning`) — 186 passed.

Closes #17055 via salvage; authorship preserved on the core fix commit via `--author`.