### PR TITLE
fix(gateway): ignore non mapping platform extra config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -294,6 +294,9 @@ class PlatformConfig:
         home_channel = None
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
+        extra = data.get("extra", {})
+        if not isinstance(extra, dict):
+            extra = {}
         
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
@@ -301,7 +304,7 @@ class PlatformConfig:
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
-            extra=data.get("extra", {}),
+            extra=extra,
         )
 
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -57,6 +57,15 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"enabled": "false"})
         assert restored.enabled is False
 
+    def test_from_dict_ignores_non_mapping_extra(self):
+        restored = PlatformConfig.from_dict({"enabled": True, "extra": "oops"})
+        config = GatewayConfig(
+            platforms={Platform.DINGTALK: restored},
+        )
+
+        assert restored.extra == {}
+        assert config.get_connected_platforms() == []
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):


### PR DESCRIPTION
## What does this PR do?
This PR fixes a gateway config parsing bug where `PlatformConfig.from_dict()` accepted malformed `extra` values unchanged.

If a user config contained a non-mapping value such as `extra: "oops"`, that value was stored as a string. Later gateway code assumes `extra` is a dict and calls `config.extra.get(...)`, which can raise `AttributeError` during platform connectivity checks and other runtime paths.

The fix normalizes non-mapping `extra` values to `{}`. Valid configs are unchanged; only malformed input now fails safe instead of crashing.

## Related Issue
No linked issue; found via code inspection.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- Hardened `PlatformConfig.from_dict()` in `gateway/config.py` to coerce non-dict `extra` values to an empty dict
- Added a regression test in `tests/gateway/test_config.py` covering malformed `extra` input and the downstream `get_connected_platforms()` path

## How to Test
1. Before the fix, create a platform config from malformed input like `{"enabled": true, "extra": "oops"}` and use it in `GatewayConfig`.
2. Call `get_connected_platforms()`.
3. On the old code, this can crash because gateway checkers call `config.extra.get(...)` on a string.
4. Run the regression test:
   - `.\.venv\Scripts\python.exe -m pytest -o addopts='' tests\gateway\test_config.py -k non_mapping_extra -q`
5. Run the related gateway config tests:
   - `.\.venv\Scripts\python.exe -m pytest -o addopts='' tests\gateway\test_config.py tests\gateway\test_platform_connected_checkers.py -q`

## Checklist
- [x] Added a regression test
- [x] Tests pass
- [x] Cross-platform behavior considered
- [x] Only the relevant bug fix is included
