### PR TITLE
fix(wecom): pad base64 AES key before decode (salvage #17040)

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -1015,6 +1015,8 @@ class WeComAdapter(BasePlatformAdapter):
         if not aes_key:
             raise ValueError("aes_key is required")
 
+        # WeCom doesn't pad base64 keys; add padding if needed
+        aes_key = aes_key + '=' * ((4 - len(aes_key) % 4) % 4)
         key = base64.b64decode(aes_key)
         if len(key) != 32:
             raise ValueError(f"Invalid WeCom AES key length: expected 32 bytes, got {len(key)}")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -60,6 +60,7 @@ AUTHOR_MAP = {
     "74554762+wmagev@users.noreply.github.com": "wmagev",
     "ashermorse@icloud.com": "ashermorse",
     "happy5318@users.noreply.github.com": "happy5318",
+    "chengoak@users.noreply.github.com": "chengoak",
     "emelyanenko.kirill@gmail.com": "EmelyanenkoK",
     # Matrix parity salvage batch (April 2026)
     "sr@samirusani": "samrusani",


### PR DESCRIPTION
Salvages the AES padding fix from @chengoak's PR #17040. The SSRF whitelist entry for a contributor-specific COS bucket hostname (`ww-aibot-img-1258476243.cos.ap-guangzhou.myqcloud.com`, which looks like a private tenant ID baked into the repo) was dropped as it belongs in user config, not the built-in list. The INFO-level debug log of full message bodies was also dropped.

## What it does
WeCom doesn't pad base64 aeskey; Python's strict decoder rejects the unpadded key, so every media/image/file webhook fails to decrypt.

## Changes
- `gateway/platforms/wecom.py` — pad `aes_key` to a multiple of 4 before `base64.b64decode`.
- `scripts/release.py` — AUTHOR_MAP entry for chengoak.

## Validation
`py_compile` clean. Minimal change, 2 lines.

Closes #17040 via salvage.