### PR TITLE
fix(honcho): pass user_message as search_query for topic-relevant context (salvage #17021)

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -626,14 +626,15 @@ class HonchoSessionManager:
         Pre-fetch user and AI peer context from Honcho.
 
         Fetches peer_representation and peer_card for both peers, plus the
-        session summary when available. search_query is intentionally omitted
-        — it would only affect additional excerpts that this code does not
-        consume, and passing the raw message exposes conversation content in
-        server access logs.
+        session summary when available. When user_message is provided, it is
+        passed as search_query to the peer context call so Honcho returns
+        conclusions relevant to the session topic rather than the full
+        observation dump.
 
         Args:
             session_key: The session key to get context for.
-            user_message: Unused; kept for call-site compatibility.
+            user_message: Optional first user message used as search_query for
+                          topic-relevant context retrieval.
 
         Returns:
             Dictionary with 'representation', 'card', 'ai_representation',
@@ -659,7 +660,7 @@ class HonchoSessionManager:
             logger.debug("Failed to fetch session summary from Honcho: %s", e)
 
         try:
-            user_ctx = self._fetch_peer_context(session.user_peer_id, target=session.user_peer_id)
+            user_ctx = self._fetch_peer_context(session.user_peer_id, search_query=user_message or None, target=session.user_peer_id)
             result["representation"] = user_ctx["representation"]
             result["card"] = "\n".join(user_ctx["card"])
         except Exception as e:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -61,6 +61,7 @@ AUTHOR_MAP = {
     "ashermorse@icloud.com": "ashermorse",
     "happy5318@users.noreply.github.com": "happy5318",
     "chengoak@users.noreply.github.com": "chengoak",
+    "mrhanoi@outlook.com": "qxxaa",
     "emelyanenko.kirill@gmail.com": "EmelyanenkoK",
     # Matrix parity salvage batch (April 2026)
     "sr@samirusani": "samrusani",


### PR DESCRIPTION
Salvages @qxxaa's PR #17021 onto current main.

## What it does
`get_prefetch_context()` accepted `user_message` but intentionally discarded it to avoid exposing content in access logs. The reasoning was inconsistent (Honcho persists every message via `saveMessages` anyway) and meant Honcho returned full peer representations in insertion order — so when `contextTokens` was set, raw observations filled the budget first and the most useful parts (peer card, dialectic conclusions) got truncated.

## Changes
- `plugins/memory/honcho/session.py` — pass `user_message` as `search_query` to `_fetch_peer_context` so Honcho's semantic retrieval returns topic-relevant conclusions on cold start.
- `scripts/release.py` — AUTHOR_MAP entry for qxxaa.

`_fetch_peer_context` already accepts `search_query` and passes it through to the Honcho API — this PR just connects the two.

## Validation
`tests/ -k honcho` — 290 passed locally.

Closes #17021 via salvage.