### PR TITLE
fix(kanban): ignore stale current board pointers (salvages #20063)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -190,12 +190,12 @@ def get_current_board() -> str:
     1. ``HERMES_KANBAN_BOARD`` env var (set by the dispatcher on worker
        spawn, or manually for ad-hoc overrides).
     2. ``<root>/kanban/current`` on disk (set by ``hermes kanban boards
-       switch``).
+       switch``), but only when that board still exists.
     3. ``DEFAULT_BOARD`` (``"default"``).
 
-    A malformed slug at any step falls through to the next layer with a
-    best-effort warning — the dispatcher must never crash because a user
-    hand-edited a file.
+    A malformed or stale slug at any step falls through to the next layer
+    with a best-effort warning — the dispatcher must never crash because a
+    user hand-edited a file or removed a board directory.
     """
     env = os.environ.get("HERMES_KANBAN_BOARD", "").strip()
     if env:
@@ -212,7 +212,7 @@ def get_current_board() -> str:
             if val:
                 try:
                     normed = _normalize_board_slug(val)
-                    if normed:
+                    if normed and board_exists(normed):
                         return normed
                 except ValueError:
                     pass

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -81,6 +81,7 @@ AUTHOR_MAP = {
     # Curator fixes (Apr 30 2026)
     "yuxiangl490@gmail.com": "y0shua1ee",
     "manmit0x@gmail.com": "0xDevNinja",
+    "stevekelly622@gmail.com": "steezkelly",
     "aamirjawaid@microsoft.com": "heyitsaamir",
     "johnnncenaaa77@gmail.com": "johnncenae",
     "thomasjhon6666@gmail.com": "ThomassJonax",

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -160,6 +160,15 @@ class TestCurrentBoard:
         kb.set_current_board("filepick")
         assert kb.get_current_board() == "filepick"
 
+    def test_stale_file_pointer_falls_back_to_default(self, fresh_home):
+        current = fresh_home / "kanban" / "current"
+        current.parent.mkdir(parents=True, exist_ok=True)
+        current.write_text("missing-board\n", encoding="utf-8")
+
+        assert kb.get_current_board() == "default"
+        assert not kb.board_exists("missing-board")
+        assert [b["slug"] for b in kb.list_boards()] == ["default"]
+
     def test_env_beats_file(self, fresh_home, monkeypatch):
         kb.create_board("a")
         kb.create_board("b")


### PR DESCRIPTION
Stale `<root>/kanban/current` pointers no longer make `hermes kanban boards show / stats / list` silently synthesize and create a phantom board directory for a slug that was never created.

Salvaged from #20063 (@steezkelly).

Root cause: `get_current_board()` read the `<root>/kanban/current` file and returned its slug without checking whether that board actually existed on disk. Downstream callers (`read_board_metadata`, `connect`) happily synthesized metadata and created the DB directory for the missing slug, so a hand-edited or leftover pointer made it look like a real active board.

## Changes
- `hermes_cli/kanban_db.py`: `get_current_board()` now gates the file-pointer branch on `board_exists(normed)`. Stale slugs fall through to `DEFAULT_BOARD`. Env var (`HERMES_KANBAN_BOARD`) still wins as before, even against a stale file.
- `tests/hermes_cli/test_kanban_boards.py`: new `test_stale_file_pointer_falls_back_to_default` covers the regression.
- `scripts/release.py`: AUTHOR_MAP entry for @steezkelly.

## Validation
| | Before | After |
|---|---|---|
| Stale `current` pointing at `missing-board` | `get_current_board() → "missing-board"`, `boards show` synthesizes metadata, `stats`/`list` creates `kanban/boards/missing-board/kanban.db`, `boards list` shows it as active | `get_current_board() → "default"`, no synthesis, no directory creation, `list_boards()` → `["default"]` |
| Env var `HERMES_KANBAN_BOARD=x` with stale file | env wins | env still wins (unchanged) |
| `hermes kanban boards switch <slug>` | already validated `board_exists`, unaffected | unchanged |
| Targeted tests | - | 247/247 pass (`test_kanban_{boards,db,cli,core_functionality}`) |
| E2E repro from issue #20055 | phantom `missing-board` board synthesized | clean fallback to `default`, no directory created |

Closes #20055

Co-authored-by: Steve Kelly <stevekelly622@gmail.com>
