### PR TITLE
fix(cli): pin HERMES_KANBAN_BOARD at chat boot to stop subprocess board drift (salvages #20094)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1216,6 +1216,26 @@ def _launch_tui(
     sys.exit(code)
 
 
+def _pin_kanban_board_env() -> None:
+    """Pin the active kanban board into ``HERMES_KANBAN_BOARD`` for the chat session.
+
+    Without this, in-process tools (``kanban_*``) and shelled-out CLI calls
+    (``hermes kanban …``) resolve the board on different paths: the env-pin if
+    set, otherwise the global ``<root>/kanban/current`` file. A concurrent
+    ``hermes kanban boards switch`` from another session can flip the file
+    mid-turn, so the same chat sees its tool calls hit board A while its shell
+    calls hit board B (#20074). Pinning at chat boot mirrors what the
+    dispatcher already does for spawned workers.
+    """
+    if os.environ.get("HERMES_KANBAN_BOARD"):
+        return
+    try:
+        from hermes_cli.kanban_db import get_current_board
+        os.environ["HERMES_KANBAN_BOARD"] = get_current_board()
+    except Exception:
+        pass
+
+
 def cmd_chat(args):
     """Run interactive chat CLI."""
     use_tui = getattr(args, "tui", False) or os.environ.get("HERMES_TUI") == "1"
@@ -1323,6 +1343,8 @@ def cmd_chat(args):
     # --source: tag session source for filtering (e.g. 'tool' for third-party integrations)
     if getattr(args, "source", None):
         os.environ["HERMES_SESSION_SOURCE"] = args.source
+
+    _pin_kanban_board_env()
 
     if use_tui:
         _launch_tui(

--- a/tests/hermes_cli/test_pin_kanban_board_env.py
+++ b/tests/hermes_cli/test_pin_kanban_board_env.py
@@ -1,0 +1,54 @@
+"""Tests for `_pin_kanban_board_env` helper invoked by `cmd_chat`.
+
+Regression coverage for #20074: a chat session must export the active kanban
+board into `HERMES_KANBAN_BOARD` at boot so subprocess shell-outs (e.g.
+`hermes kanban …`) inherit the same board the in-process kanban tools resolve.
+Without this, a concurrent `hermes kanban boards switch` from another session
+can flip the global current-board file mid-turn and silently divert the
+shell calls to a different DB.
+"""
+import importlib
+
+
+def test_pin_writes_resolved_board_when_env_unset(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    main_mod = importlib.import_module("hermes_cli.main")
+
+    import hermes_cli.kanban_db as kdb
+    monkeypatch.setattr(kdb, "get_current_board", lambda: "space")
+
+    main_mod._pin_kanban_board_env()
+
+    assert main_mod.os.environ.get("HERMES_KANBAN_BOARD") == "space"
+
+
+def test_pin_does_not_overwrite_existing_env(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "preset")
+    main_mod = importlib.import_module("hermes_cli.main")
+
+    import hermes_cli.kanban_db as kdb
+
+    def _explode():
+        raise AssertionError("get_current_board must not be called when env is set")
+
+    monkeypatch.setattr(kdb, "get_current_board", _explode)
+
+    main_mod._pin_kanban_board_env()
+
+    assert main_mod.os.environ.get("HERMES_KANBAN_BOARD") == "preset"
+
+
+def test_pin_swallows_resolution_failures(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    main_mod = importlib.import_module("hermes_cli.main")
+
+    import hermes_cli.kanban_db as kdb
+
+    def _boom():
+        raise RuntimeError("disk gone")
+
+    monkeypatch.setattr(kdb, "get_current_board", _boom)
+
+    main_mod._pin_kanban_board_env()
+
+    assert "HERMES_KANBAN_BOARD" not in main_mod.os.environ

--- a/tests/hermes_cli/test_pin_kanban_board_env.py
+++ b/tests/hermes_cli/test_pin_kanban_board_env.py
@@ -8,10 +8,32 @@ can flip the global current-board file mid-turn and silently divert the
 shell calls to a different DB.
 """
 import importlib
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_kanban_board_env():
+    """Snapshot `HERMES_KANBAN_BOARD` and restore it after the test.
+
+    `_pin_kanban_board_env()` writes to ``os.environ`` directly, bypassing
+    any ``monkeypatch.setenv`` tracking. Without this fixture the mutation
+    leaks into subsequent tests and breaks anything that resolves a kanban
+    path from the env (e.g. ``TestSharedBoardPaths`` in test_kanban_db.py).
+    """
+    prev = os.environ.get("HERMES_KANBAN_BOARD")
+    os.environ.pop("HERMES_KANBAN_BOARD", None)
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("HERMES_KANBAN_BOARD", None)
+        else:
+            os.environ["HERMES_KANBAN_BOARD"] = prev
 
 
 def test_pin_writes_resolved_board_when_env_unset(monkeypatch):
-    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
     main_mod = importlib.import_module("hermes_cli.main")
 
     import hermes_cli.kanban_db as kdb
@@ -39,7 +61,6 @@ def test_pin_does_not_overwrite_existing_env(monkeypatch):
 
 
 def test_pin_swallows_resolution_failures(monkeypatch):
-    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
     main_mod = importlib.import_module("hermes_cli.main")
 
     import hermes_cli.kanban_db as kdb


### PR DESCRIPTION
Chat sessions now pin `HERMES_KANBAN_BOARD` into the process env at boot, so in-process `kanban_*` tools and shelled-out `hermes kanban …` subprocesses always resolve to the same board even if a concurrent session runs `hermes kanban boards switch` mid-turn.

Salvaged from #20094 (@0xDevNinja).

Root cause: `kanban_db.connect()` resolves the active board via a two-source chain — `HERMES_KANBAN_BOARD` env var, then the global `<root>/kanban/current` file. Agent tool calls run in the chat process where env may be set; shell-outs spawn fresh subprocesses with no env inherited, so they fall through to the `current` file. The `current` file is global mutable state — another session's `boards switch` flips it — so mid-turn the same chat routes tool calls to board A while its shell calls hit board B. Symptom: `kanban_create` returns a task id, immediately followed by `hermes kanban show <id>` reporting "no such task."

Mirrors the pin the dispatcher already does for spawned workers (`kanban_db.py:2622-2623`), so every code path resolves the same DB consistently.

## Changes
- `hermes_cli/main.py`: new `_pin_kanban_board_env()` helper, called from `cmd_chat` after the existing env-flag block, before forking to TUI vs CLI. Idempotent — no-op if `HERMES_KANBAN_BOARD` is already set; swallows `get_current_board()` failures so chat boot never crashes because the kanban dir is unreadable.
- `tests/hermes_cli/test_pin_kanban_board_env.py`: three tests covering pin-when-unset, no-op-when-set, and swallow-on-failure. Autouse fixture snapshots and restores `HERMES_KANBAN_BOARD` around each test (the helper writes to `os.environ` directly, bypassing monkeypatch tracking — without the fixture the mutation leaked into `TestSharedBoardPaths` in the same suite).

## Validation
| | Before | After |
|---|---|---|
| Concurrent `boards switch` mid-turn | `kanban_create` and `hermes kanban show <id>` hit different boards → "no such task" | both resolve to the chat's boot-time board |
| `HERMES_KANBAN_BOARD` already set | unchanged | unchanged (idempotent no-op) |
| Kanban dir missing/unreadable | could crash chat boot | swallowed, chat proceeds |
| Targeted tests | — | 3/3 in new test file, 339/339 across full kanban suite |

Includes a small follow-up commit fixing env-var leakage in the test file — the original test used `monkeypatch.delenv` but the helper writes `os.environ[...]` directly, so the mutation survived teardown and broke 9 unrelated tests in the same suite. Added an autouse snapshot/restore fixture.

Closes #20074

Co-authored-by: 0xDevNinja <manmit0x@gmail.com>
