### PR TITLE
fix(irc): use correct default port based on use_tls setting

### DIFF
--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -113,14 +113,15 @@ class IRCAdapter(BasePlatformAdapter):
 
         # Connection settings (env vars override config.yaml)
         self.server = os.getenv("IRC_SERVER") or extra.get("server", "")
-        self.port = int(os.getenv("IRC_PORT") or extra.get("port", 6697))
-        self.nickname = os.getenv("IRC_NICKNAME") or extra.get("nickname", "hermes-bot")
-        self.channel = os.getenv("IRC_CHANNEL") or extra.get("channel", "")
         self.use_tls = (
             os.getenv("IRC_USE_TLS", "").lower() in ("1", "true", "yes")
             if os.getenv("IRC_USE_TLS")
             else extra.get("use_tls", True)
         )
+        default_port = 6697 if self.use_tls else 6667
+        self.port = int(os.getenv("IRC_PORT") or extra.get("port", default_port))
+        self.nickname = os.getenv("IRC_NICKNAME") or extra.get("nickname", "hermes-bot")
+        self.channel = os.getenv("IRC_CHANNEL") or extra.get("channel", "")
         self.server_password = os.getenv("IRC_SERVER_PASSWORD") or extra.get("server_password", "")
         self.nickserv_password = os.getenv("IRC_NICKSERV_PASSWORD") or extra.get("nickserv_password", "")
 


### PR DESCRIPTION
## Summary

Fixes #20161 — IRC adapter defaults to port 6697 even when `use_tls: false`.

## Root Cause

In `plugins/platforms/irc/adapter.py`, `self.port` was assigned with a hardcoded default of `6697` **before** `self.use_tls` was evaluated. This meant the TLS setting had no effect on the default port.

## Fix

Reorder initialization so `use_tls` is evaluated first, then derive the default port:
- `use_tls=True` → default port `6697`
- `use_tls=False` → default port `6667`

Explicit `port` in config or `IRC_PORT` env var still takes precedence.

## Changes

- `plugins/platforms/irc/adapter.py`: Move `use_tls` evaluation before port assignment; compute `default_port` dynamically.

## Testing

- All 64 existing IRC-related tests pass (1 pre-existing unrelated failure in `test_setup_irc` — stdin capture issue on main).
- Manual verification: with `use_tls: false` and no explicit port, adapter now correctly uses 6667.