### PR TITLE
fix(curator): protect hub skills by frontmatter name

### DIFF
--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -225,6 +225,47 @@ def test_agent_created_excludes_hub_installed(skills_home):
     assert "hub-skill" not in names
 
 
+def test_agent_created_excludes_hub_installed_frontmatter_name(skills_home):
+    from tools.skill_usage import is_agent_created, list_agent_created_skill_names
+
+    skills_dir = skills_home / "skills"
+    hub_skill = skills_dir / "productivity" / "getnote"
+    hub_skill.mkdir(parents=True)
+    (hub_skill / "SKILL.md").write_text(
+        """---
+name: Get笔记
+description: test skill
+---
+
+# body
+""",
+        encoding="utf-8",
+    )
+    _write_skill(skills_dir, "my-skill")
+    hub_dir = skills_dir / ".hub"
+    hub_dir.mkdir()
+    (hub_dir / "lock.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "installed": {
+                    "getnote": {
+                        "source": "taps/main",
+                        "install_path": "productivity/getnote",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    names = list_agent_created_skill_names()
+    assert "my-skill" in names
+    assert "Get笔记" not in names
+    assert is_agent_created("Get笔记") is False
+    assert is_agent_created("getnote") is False
+
+
 def test_is_agent_created(skills_home):
     from tools.skill_usage import is_agent_created
     skills_dir = skills_home / "skills"

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -226,7 +226,11 @@ def test_agent_created_excludes_hub_installed(skills_home):
 
 
 def test_agent_created_excludes_hub_installed_frontmatter_name(skills_home):
-    from tools.skill_usage import is_agent_created, list_agent_created_skill_names
+    from tools.skill_usage import (
+        is_agent_created,
+        list_agent_created_skill_names,
+        mark_agent_created,
+    )
 
     skills_dir = skills_home / "skills"
     hub_skill = skills_dir / "productivity" / "getnote"
@@ -242,6 +246,7 @@ description: test skill
         encoding="utf-8",
     )
     _write_skill(skills_dir, "my-skill")
+    mark_agent_created("my-skill")
     hub_dir = skills_dir / ".hub"
     hub_dir.mkdir()
     (hub_dir / "lock.json").write_text(

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -143,7 +143,26 @@ def _read_hub_installed_names() -> Set[str]:
         if isinstance(data, dict):
             installed = data.get("installed") or {}
             if isinstance(installed, dict):
-                return {str(k) for k in installed.keys()}
+                names = {str(k) for k in installed.keys()}
+                skills_dir = _skills_dir()
+                for entry in installed.values():
+                    if not isinstance(entry, dict):
+                        continue
+                    install_path = entry.get("install_path")
+                    if not isinstance(install_path, str) or not install_path.strip():
+                        continue
+                    skill_dir = Path(install_path)
+                    if not skill_dir.is_absolute():
+                        skill_dir = skills_dir / skill_dir
+                    try:
+                        resolved = skill_dir.resolve()
+                        resolved.relative_to(skills_dir.resolve())
+                    except (OSError, ValueError):
+                        continue
+                    skill_md = resolved / "SKILL.md"
+                    if skill_md.exists():
+                        names.add(_read_skill_name(skill_md, fallback=resolved.name))
+                return names
     except (OSError, json.JSONDecodeError) as e:
         logger.debug("Failed to read hub lock file: %s", e)
     return set()


### PR DESCRIPTION
Salvage of #19460 by @LeonSGP43 onto current main, plus a test follow-up.

## Summary
`_read_hub_installed_names()` returned only hub slug keys (e.g. `"getnote"`). When a hub-installed skill's SKILL.md `name:` is non-ASCII (e.g. `"Get笔记"`), the slug-only set didn't protect it, so `hermes curator archive "Get笔记"` and other curator operations would treat the hub skill as agent-created and archive it.

## Changes
- `tools/skill_usage.py`: walk each hub lock entry's `install_path`, resolve under `skills/` (with traversal guard), read the SKILL.md `name:`, and add it to the off-limits set alongside the slug.
- `tests/tools/test_skill_usage.py`: regression test for the `getnote`/`Get笔记` repro. Test follow-up adds `mark_agent_created("my-skill")` — the original cherry-picked test predates #19618/#19621, which rewrote `list_agent_created_skill_names()` to require the `created_by: "agent"` provenance marker.

## Validation
- `scripts/run_tests.sh tests/tools/test_skill_usage.py` → 40 passed
- E2E with real imports + isolated HERMES_HOME:
  - `is_agent_created("Get笔记")` → False (was True)
  - `is_agent_created("getnote")` → False (unchanged)
  - `archive_skill("Get笔记")` → rejected with "bundled or hub-installed; never archive" (was archived)
  - `list_agent_created_skill_names()` → excludes hub, includes agent-authored
  - Path traversal guard: `install_path: "../../../etc"` silently skipped, no crash

Closes #19641, #19293.

Credits: @LeonSGP43 for the fix.