### PR TITLE
feat: auto-inject recent sessions summary for context recovery

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1178,3 +1178,125 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
     if not sections:
         return ""
     return "# Project Context\n\nThe following project context files have been loaded and should be followed:\n\n" + "\n".join(sections)
+
+
+# =========================================================================
+# Recent Sessions Summary — auto-inject on context reset
+# =========================================================================
+
+def build_recent_sessions_prompt(
+    db_path: Optional[str] = None,
+    limit: int = 2,
+    current_session_id: Optional[str] = None,
+    platform_filter: Optional[str] = None,
+) -> str:
+    """Build a summary of recent sessions for context recovery.
+
+    This is injected into the system prompt to help the agent recover context
+    after a restart or context reset. The agent doesn't need to "know" it
+    lost context — the summary is simply there.
+
+    Args:
+        db_path: Path to state.db. Defaults to ~/.hermes/state.db
+        limit: Number of recent sessions to include (default 2)
+        current_session_id: Exclude this session from results
+        platform_filter: Only include sessions from this platform (e.g., "telegram")
+
+    Returns:
+        Formatted string with recent session summaries, or empty string if none.
+    """
+    from hermes_constants import get_hermes_home
+
+    if db_path is None:
+        db_path = os.path.join(get_hermes_home(), "state.db")
+
+    if not os.path.exists(db_path):
+        return ""
+
+    try:
+        import sqlite3
+
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+
+        # Get recent sessions with last activity
+        query = """
+            SELECT s.id, s.source, s.started_at, s.model,
+                   COALESCE(m.last_active, s.started_at) AS last_active
+            FROM sessions s
+            LEFT JOIN (
+                SELECT session_id, MAX(timestamp) AS last_active
+                FROM messages GROUP BY session_id
+            ) m ON m.session_id = s.id
+            WHERE 1=1
+        """
+        params = []
+
+        if current_session_id:
+            query += " AND s.id != ?"
+            params.append(current_session_id)
+
+        if platform_filter:
+            query += " AND s.source = ?"
+            params.append(platform_filter)
+
+        query += " ORDER BY last_active DESC LIMIT ?"
+        params.append(limit)
+
+        cursor = conn.execute(query, params)
+        sessions = [dict(row) for row in cursor.fetchall()]
+        conn.close()
+
+        if not sessions:
+            return ""
+
+        lines = ["# Recent Sessions (Context Recovery)", ""]
+        lines.append("The following recent sessions may contain relevant context from prior conversations.")
+        lines.append("If the user refers to past work, check these sessions first with `session_search`.")
+        lines.append("")
+
+        for sess in sessions:
+            session_id = sess.get("id", "unknown")
+            source = sess.get("source", "unknown")
+            last_active = sess.get("last_active", "unknown")
+            model = sess.get("model", "unknown")
+
+            # Get a brief preview from messages
+            try:
+                conn2 = sqlite3.connect(db_path)
+                conn2.row_factory = sqlite3.Row
+                cursor2 = conn2.execute("""
+                    SELECT role, content FROM messages
+                    WHERE session_id = ?
+                    ORDER BY timestamp ASC
+                    LIMIT 10
+                """, (session_id,))
+                messages = [dict(row) for row in cursor2.fetchall()]
+                conn2.close()
+
+                # Extract first user message as preview
+                preview = ""
+                for msg in messages:
+                    if msg.get("role") == "user":
+                        content = msg.get("content", "")
+                        if content:
+                            preview = content[:200] + "..." if len(content) > 200 else content
+                            break
+
+            except Exception:
+                preview = "(unable to load preview)"
+
+            lines.append(f"## Session: {session_id[:16]}...")
+            lines.append(f"- **Platform:** {source}")
+            lines.append(f"- **Last active:** {last_active}")
+            lines.append(f"- **First message:** {preview}")
+            lines.append("")
+
+        lines.append("**Recovery instruction:** If context was lost, use `session_search(query=\"...\")` to find relevant past conversations.")
+        lines.append("")
+
+        return "\n".join(lines)
+
+    except Exception as e:
+        logger.debug("Could not build recent sessions prompt: %s", e)
+        return ""

--- a/run_agent.py
+++ b/run_agent.py
@@ -5039,6 +5039,22 @@ class AIAgent:
         if _env_hints:
             prompt_parts.append(_env_hints)
 
+        # ── Recent Sessions Summary (Context Recovery) ───────────────────────
+        # Auto-inject summaries of recent sessions so the agent can recover
+        # context after a restart or context reset WITHOUT needing to "realize"
+        # it lost context. The summary is simply there in the system prompt.
+        try:
+            from agent.prompt_builder import build_recent_sessions_prompt
+            _recent_sessions = build_recent_sessions_prompt(
+                current_session_id=self.session_id if self.pass_session_id else None,
+                platform_filter=self.platform if self.platform else None,
+                limit=2,
+            )
+            if _recent_sessions:
+                prompt_parts.append(_recent_sessions)
+        except Exception as _e:
+            logger.debug("Could not inject recent sessions: %s", _e)
+
         platform_key = (self.platform or "").lower().strip()
         if platform_key in PLATFORM_HINTS:
             prompt_parts.append(PLATFORM_HINTS[platform_key])


### PR DESCRIPTION
## Problem

When Hermes gateway restarts or context is compressed/reset, the agent loses all conversation context. Unlike humans who can "check their notes", the agent has no way to recover because:

1. It doesn\'t "know" it lost context (amnesia paradox)
2. No automatic mechanism exists to restore recent session context
3. Users must manually remind the agent what was being worked on

This leads to:
- Misunderstandings and incorrect actions
- Lost work progress
- Frustrating user experience
- Potential destructive operations when context is unclear

## Solution

Auto-inject a summary of recent sessions into the system prompt at startup. The agent doesn\'t need to "realize" it lost context — the summary is simply there in every conversation.

### Implementation

Added `build_recent_sessions_prompt()` function that:
- Queries the local SQLite session database
- Extracts the 2 most recent sessions
- Includes session ID, platform, last active time, and first message preview
- Injects this into the system prompt automatically

### Example Output

```
# Recent Sessions (Context Recovery)

The following recent sessions may contain relevant context from prior conversations.
If the user refers to past work, check these sessions first with session_search.

## Session: 20260505_185948_...
- **Platform:** telegram
- **Last active:** 2026-05-05 19:30:00
- **First message:** 你每次跟我聊天，经常会出现上下文长度如果不够...

## Session: 20260505_181420_...
- **Platform:** cli
- **Last active:** 2026-05-05 18:15:00
- **First message:** 帮我解决 Chrome 源配置问题...

**Recovery instruction:** If context was lost, use session_search(query="...") to find relevant past conversations.
```

## Benefits

- **Zero user intervention** — Works automatically
- **No cognitive overhead** — Agent doesn\'t need to "remember" to check
- **Works after restart** — Survives gateway crashes and restarts
- **Works after context reset** — Survives context compression
- **Minimal token cost** — Only 2 sessions by default, ~300 tokens

## Files Changed

- `agent/prompt_builder.py` — Added `build_recent_sessions_prompt()` function
- `run_agent.py` — Call the function in `_build_system_prompt()`

## Testing

Tested locally on Debian 13 with Hermes v0.12.0:
- ✅ Function compiles and runs correctly
- ✅ Summary correctly formatted in system prompt
- ✅ Database queries work with existing state.db schema
- ✅ Graceful fallback when no sessions exist