### PR TITLE
doctor: report Google Gemini API connectivity

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1084,6 +1084,32 @@ def run_doctor(args):
         except Exception as e:
             print(f"\r  {color('⚠', Colors.YELLOW)} Anthropic API {color(f'({e})', Colors.DIM)}                 ")
 
+    google_gemini_key = os.getenv("GOOGLE_API_KEY") or os.getenv("GEMINI_API_KEY")
+    if google_gemini_key:
+        print("  Checking Google / Gemini API...", end="", flush=True)
+        try:
+            import httpx
+
+            response = httpx.get(
+                "https://generativelanguage.googleapis.com/v1beta/models",
+                headers={"x-goog-api-key": google_gemini_key},
+                timeout=10,
+            )
+            if response.status_code == 200:
+                print(f"\r  {color('✓', Colors.GREEN)} Google / Gemini API                    ")
+            elif response.status_code == 401:
+                print(f"\r  {color('✗', Colors.RED)} Google / Gemini API {color('(invalid API key)', Colors.DIM)}      ")
+                issues.append("Check GOOGLE_API_KEY / GEMINI_API_KEY in .env")
+            else:
+                print(
+                    f"\r  {color('⚠', Colors.YELLOW)} Google / Gemini API "
+                    f"{color(f'(HTTP {response.status_code})', Colors.DIM)}      "
+                )
+        except Exception as e:
+            print(f"\r  {color('⚠', Colors.YELLOW)} Google / Gemini API {color(f'({e})', Colors.DIM)}      ")
+    else:
+        check_warn("Google / Gemini API", "(not configured)")
+
     # -- API-key providers --
     # Tuple: (name, env_vars, default_url, base_env, supports_models_endpoint)
     # If supports_models_endpoint is False, we skip the health check and just show "configured"

--- a/tests/hermes_cli/test_doctor_google_gemini_connectivity.py
+++ b/tests/hermes_cli/test_doctor_google_gemini_connectivity.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import sys
+import types
+from argparse import Namespace
+
+if "dotenv" not in sys.modules:
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = fake_dotenv
+
+from hermes_cli import doctor as doctor_mod
+
+
+def test_doctor_reports_google_gemini_api_connectivity(monkeypatch):
+    for env_name in (
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
+        "GOOGLE_API_KEY",
+        "GLM_API_KEY",
+        "ZAI_API_KEY",
+        "Z_AI_API_KEY",
+        "KIMI_API_KEY",
+        "KIMI_CN_API_KEY",
+        "STEPFUN_API_KEY",
+        "ARCEEAI_API_KEY",
+        "GMI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "HF_TOKEN",
+        "NVIDIA_API_KEY",
+        "DASHSCOPE_API_KEY",
+        "MINIMAX_API_KEY",
+        "MINIMAX_CN_API_KEY",
+        "AI_GATEWAY_API_KEY",
+        "KILOCODE_API_KEY",
+        "OPENCODE_ZEN_API_KEY",
+        "OPENCODE_GO_API_KEY",
+        "WECOM_BOT_ID",
+        "QQ_APP_ID",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as auth_mod
+
+        monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers, timeout))
+        return types.SimpleNamespace(status_code=200)
+
+    import httpx
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "Google / Gemini API" in out
+    assert any(
+        url == "https://generativelanguage.googleapis.com/v1beta/models"
+        and headers == {"x-goog-api-key": "gemini-test-key"}
+        and timeout == 10
+        for url, headers, timeout in calls
+    )


### PR DESCRIPTION
## Summary
- teach `hermes doctor` to show Google / Gemini API connectivity in the API Connectivity section
- probe the Gemini native models endpoint with `GOOGLE_API_KEY` or `GEMINI_API_KEY`
- add a regression test so Gemini keys do not silently disappear from doctor output again

Closes #19837
