### PR TITLE
fix(gateway): harden malformed env port overrides

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1413,7 +1413,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "token": os.getenv("WECOM_CALLBACK_TOKEN", ""),
             "encoding_aes_key": os.getenv("WECOM_CALLBACK_ENCODING_AES_KEY", ""),
             "host": os.getenv("WECOM_CALLBACK_HOST", "0.0.0.0"),
-            "port": int(os.getenv("WECOM_CALLBACK_PORT", "8645")),
+            "port": _coerce_int(os.getenv("WECOM_CALLBACK_PORT"), 8645),
         })
 
     # Weixin (personal WeChat via iLink Bot API)
@@ -1469,7 +1469,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "server_url": bluebubbles_server_url.rstrip("/"),
             "password": bluebubbles_password,
             "webhook_host": os.getenv("BLUEBUBBLES_WEBHOOK_HOST", "127.0.0.1"),
-            "webhook_port": int(os.getenv("BLUEBUBBLES_WEBHOOK_PORT", "8645")),
+            "webhook_port": _coerce_int(os.getenv("BLUEBUBBLES_WEBHOOK_PORT"), 8645),
             "webhook_path": os.getenv("BLUEBUBBLES_WEBHOOK_PATH", "/bluebubbles-webhook"),
             "send_read_receipts": os.getenv("BLUEBUBBLES_SEND_READ_RECEIPTS", "true").lower() in ("true", "1", "yes"),
         })

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -609,3 +609,27 @@ class TestHomeChannelEnvOverrides:
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
             assert (home.chat_id, home.name) == expected, platform.value
+
+
+class TestMalformedEnvPortOverrides:
+    def test_invalid_bluebubbles_webhook_port_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("BLUEBUBBLES_SERVER_URL", "http://localhost:1234")
+        monkeypatch.setenv("BLUEBUBBLES_PASSWORD", "secret")
+        monkeypatch.setenv("BLUEBUBBLES_WEBHOOK_PORT", "not-a-port")
+
+        config = GatewayConfig()
+
+        _apply_env_overrides(config)
+
+        assert config.platforms[Platform.BLUEBUBBLES].extra["webhook_port"] == 8645
+
+    def test_invalid_wecom_callback_port_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("WECOM_CALLBACK_CORP_ID", "corp-id")
+        monkeypatch.setenv("WECOM_CALLBACK_CORP_SECRET", "corp-secret")
+        monkeypatch.setenv("WECOM_CALLBACK_PORT", "not-a-port")
+
+        config = GatewayConfig()
+
+        _apply_env_overrides(config)
+
+        assert config.platforms[Platform.WECOM_CALLBACK].extra["port"] == 8645


### PR DESCRIPTION
## What does this PR do?
This PR fixes a gateway config parsing bug where malformed environment values for `BLUEBUBBLES_WEBHOOK_PORT` or `WECOM_CALLBACK_PORT` could crash `_apply_env_overrides()` with a `ValueError`.

`gateway/config.py` already has `_coerce_int()` for defensive numeric parsing, but these two env override paths were still using raw `int(...)`. This change switches them to `_coerce_int(..., 8645)` so invalid values fall back to the documented default port instead of crashing gateway startup or config loading.

## Related Issue
No linked issue; found via code inspection.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- Updated `gateway/config.py` to use `_coerce_int()` for `WECOM_CALLBACK_PORT` and `BLUEBUBBLES_WEBHOOK_PORT`
- Added regression tests in `tests/gateway/test_config.py` covering malformed env values for both ports

## How to Test
1. Before the fix, set either:
   - `BLUEBUBBLES_SERVER_URL=http://localhost:1234`
   - `BLUEBUBBLES_PASSWORD=secret`
   - `BLUEBUBBLES_WEBHOOK_PORT=not-a-port`

   or:

   - `WECOM_CALLBACK_CORP_ID=corp-id`
   - `WECOM_CALLBACK_CORP_SECRET=corp-secret`
   - `WECOM_CALLBACK_PORT=not-a-port`

2. Call `_apply_env_overrides(GatewayConfig())` or load gateway config. Before the fix, it raises `ValueError`. After the fix, it falls back to `8645`.

3. Run:
   - `pytest tests/gateway/test_config.py -k MalformedEnvPortOverrides -q`
   - `pytest tests/gateway/test_config.py -q`

## Checklist
- [x] test added
- [x] tests passing
- [x] cross-platform behavior considered
- [x] only relevant changes included
