### PR TITLE
fix: add PLATFORM_HINTS entry for api_server platform (salvage #17136)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -513,6 +513,12 @@ PLATFORM_HINTS = {
         "image and is the WRONG path. Bare Unicode emoji in text is also not a substitute "
         "— when a sticker is the right response, use yb_send_sticker."
     ),
+    "api_server": (
+        "You're responding through an API server. The rendering layer is unknown — "
+        "assume plain text. No markdown formatting (no asterisks, bullets, headers, "
+        "code fences). Treat this like a conversation, not a document. Keep responses "
+        "brief and natural."
+    ),
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -55,6 +55,7 @@ AUTHOR_MAP = {
     "14046872+tmimmanuel@users.noreply.github.com": "tmimmanuel",
     "657290301@qq.com": "IMHaoyan",
     "revar@users.noreply.github.com": "revaraver",
+    "beardthelion@users.noreply.github.com": "beardthelion",
     "29756950+revaraver@users.noreply.github.com": "revaraver",
     "nexus@eptic.me": "TheEpTic",
     "74554762+wmagev@users.noreply.github.com": "wmagev",

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -788,6 +788,7 @@ class TestPromptBuilderConstants:
         assert "discord" in PLATFORM_HINTS
         assert "cron" in PLATFORM_HINTS
         assert "cli" in PLATFORM_HINTS
+        assert "api_server" in PLATFORM_HINTS
 
     def test_cli_hint_does_not_suggest_media_tags(self):
         # Regression: MEDIA:/path tags are intercepted only by messaging


### PR DESCRIPTION
Salvages @beardthelion's PR #17136 onto current main.

## What it does
`api_server` is a first-class gateway platform but the only one missing from `PLATFORM_HINTS`. Without a hint, the agent defaults to markdown-heavy document-style output — which breaks on the plain-text frontends most API server consumers wrap (custom agents, third-party bridges). Adds a plain-text-defaulting hint. Markdown-aware consumers (Open WebUI etc.) can layer their own guidance via an ephemeral system prompt.

## Changes
- `agent/prompt_builder.py` — new `api_server` hint.
- `tests/agent/test_prompt_builder.py` — assertion in the platform-hints-present test.
- `scripts/release.py` — AUTHOR_MAP entry for beardthelion.

## Validation
`tests/agent/test_prompt_builder.py` — 116 passed locally.

Closes #17136 via salvage.