### PR TITLE
fix(api_server): return effective session_id after context compression (salvage #17019)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2488,7 +2488,9 @@ class APIServerAdapter(BasePlatformAdapter):
             # Include the effective session ID in the result so callers
             # (e.g. X-Hermes-Session-Id header) can track compression-
             # triggered session rotations. (#16938)
-            result["session_id"] = getattr(agent, "session_id", session_id)
+            _eff_sid = getattr(agent, "session_id", session_id)
+            if isinstance(_eff_sid, str) and _eff_sid:
+                result["session_id"] = _eff_sid
             return result, usage
 
         return await loop.run_in_executor(None, _run)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1209,7 +1209,9 @@ class APIServerAdapter(BasePlatformAdapter):
             },
         }
 
-        response_headers = {"X-Hermes-Session-Id": session_id}
+        response_headers = {
+            "X-Hermes-Session-Id": result.get("session_id", session_id),
+        }
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
         return web.json_response(response_data, headers=response_headers)
@@ -2483,6 +2485,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
                 "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
             }
+            # Include the effective session ID in the result so callers
+            # (e.g. X-Hermes-Session-Id header) can track compression-
+            # triggered session rotations. (#16938)
+            result["session_id"] = getattr(agent, "session_id", session_id)
             return result, usage
 
         return await loop.run_in_executor(None, _run)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -395,7 +395,12 @@ class TestAgentExecution:
                 session_id="session-123",
             )
 
-        assert result == {"final_response": "ok"}
+        # _run_agent annotates result with the effective agent.session_id
+        # when it's a real string, so the response-header writer can track
+        # compression-triggered session rotations (#16938). The mock agent
+        # here doesn't set an explicit session_id string so the guard skips
+        # the annotation — header will fall back to the provided session_id.
+        assert result["final_response"] == "ok"
         assert usage == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
         mock_agent.run_conversation.assert_called_once_with(
             user_message="hello",


### PR DESCRIPTION
Salvages @vominh1919's PR #17019 onto current main. Fixes #16938.

## What it does
When context compression rotates the agent's `session_id` to a new child session, the API server was still returning the stale parent `session_id` in the `X-Hermes-Session-Id` response header. External clients kept sending the old session_id, loading uncompressed parent history instead of the compressed continuation.

## Changes
- `gateway/platforms/api_server.py` — `_run_agent` now includes the effective `session_id` in its result dict; the non-streaming response uses it in the header (falls back to the provided one). SSE paths unchanged — headers are committed before the agent runs and can't track mid-stream rotation.
- `tests/gateway/test_api_server.py` — loosened one assertion to accept the new `session_id` field in the result dict.

## Validation
`tests/gateway/test_api_server.py` — 126 passed locally.

Closes #17019 via salvage.