### PR TITLE
fix: restore Hermes full-suite green

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -62,6 +62,7 @@ CONFIGURABLE_TOOLSETS = [
     ("skills",          "📚 Skills",                    "list, view, manage"),
     ("todo",            "📋 Task Planning",             "todo"),
     ("memory",          "💾 Memory",                    "persistent memory across sessions"),
+    ("knowledge",       "🗃️ Knowledge Ledger",          "cold source-attributed recall; opt-in"),
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
@@ -76,9 +77,10 @@ CONFIGURABLE_TOOLSETS = [
 ]
 
 # Toolsets that are OFF by default for new installs.
-# They're still in _HERMES_CORE_TOOLS (available at runtime if enabled),
-# but the setup checklist won't pre-select them for first-time users.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "rl", "spotify", "discord", "discord_admin"}
+# Some are still in _HERMES_CORE_TOOLS and are removed from fresh defaults;
+# others (like knowledge) are configurable opt-ins that are intentionally not
+# part of the platform composite defaults to avoid surprise schema/token tax.
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "rl", "spotify", "discord", "discord_admin", "knowledge"}
 
 # Platform-scoped toolsets: only appear in the `hermes tools` checklist for
 # these platforms, and only resolve/save for these platforms.  A toolset

--- a/model_tools.py
+++ b/model_tools.py
@@ -32,6 +32,11 @@ from toolsets import resolve_toolset, validate_toolset
 
 logger = logging.getLogger(__name__)
 
+# Toolsets here are available only when explicitly requested.  They are not
+# included by the legacy enabled_toolsets=None path, which otherwise means
+# "walk every registered toolset" for older direct AIAgent callers.
+_OPT_IN_ONLY_TOOLSETS = {"knowledge"}
+
 
 # =============================================================================
 # Async Bridging  (single source of truth -- used by registry.dispatch too)
@@ -357,9 +362,12 @@ def _compute_tool_definitions(
                 if not quiet_mode:
                     print(f"⚠️  Unknown toolset: {toolset_name}")
     else:
-        # Default: start with everything
+        # Default: start with broadly available toolsets, excluding cold opt-ins
+        # whose schema/storage side effects must require an explicit toolset.
         from toolsets import get_all_toolsets
         for ts_name in get_all_toolsets():
+            if ts_name in _OPT_IN_ONLY_TOOLSETS:
+                continue
             tools_to_include.update(resolve_toolset(ts_name))
 
     # Always apply disabled toolsets as a subtraction step at the end.

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -41,10 +41,14 @@ fi
 
 PYTHON="$VENV/bin/python"
 
-# ── Ensure pytest-split is installed (required for shard-equivalent runs) ──
+# ── Ensure pytest-split is installed when possible (required for shard-equivalent runs) ──
 if ! "$PYTHON" -c "import pytest_split" 2>/dev/null; then
-  echo "→ installing pytest-split into $VENV"
-  "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  if "$PYTHON" -m pip --version >/dev/null 2>&1; then
+    echo "→ installing pytest-split into $VENV"
+    "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  else
+    echo "⚠ pytest-split is not installed and this venv has no pip; continuing without it" >&2
+  fi
 fi
 
 # ── Hermetic environment ────────────────────────────────────────────────────
@@ -72,6 +76,17 @@ unset HERMES_YOLO_MODE HERMES_INTERACTIVE HERMES_QUIET HERMES_TOOL_PROGRESS \
       HERMES_REDACT_SECRETS HERMES_BACKGROUND_NOTIFICATIONS HERMES_EXEC_ASK \
       HERMES_HOME_MODE 2>/dev/null || true
 
+# Force an isolated Hermes home before pytest imports/collects anything.
+# Per-test fixtures replace this with narrower temp dirs, but this session-level
+# home protects collection-time imports and subprocesses from touching the real
+# ~/.hermes (auth.json, sessions, logs, history, etc.).
+HERMES_TEST_HOME="$(mktemp -d "${TMPDIR:-/tmp}/hermes_pytest_home.XXXXXX")"
+export HERMES_HOME="$HERMES_TEST_HOME"
+cleanup_hermes_test_home() {
+  rm -rf "$HERMES_TEST_HOME"
+}
+trap cleanup_hermes_test_home EXIT
+
 # Pin deterministic runtime.
 export TZ=UTC
 export LANG=C.UTF-8
@@ -95,10 +110,16 @@ echo "▶ running pytest with $WORKERS workers, hermetic env, in $REPO_ROOT"
 echo "  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)"
 
 # -o "addopts=" clears pyproject.toml's `-n auto` so our -n wins.
-exec "$PYTHON" -m pytest \
+set +e
+"$PYTHON" -m pytest \
   -o "addopts=" \
   -n "$WORKERS" \
   --ignore=tests/integration \
   --ignore=tests/e2e \
   -m "not integration" \
   "${ARGS[@]}"
+status=$?
+set -e
+cleanup_hermes_test_home
+trap - EXIT
+exit "$status"

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -26,6 +26,15 @@ from agent.anthropic_adapter import (
 from agent.transports import get_transport
 
 
+@pytest.fixture(autouse=True)
+def _disable_real_claude_code_keychain(monkeypatch):
+    """Keep auth tests isolated from the developer's real macOS Keychain."""
+    monkeypatch.setattr(
+        "agent.anthropic_adapter._read_claude_code_credentials_from_keychain",
+        lambda: None,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Auth helpers
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,9 +20,11 @@ test runner at ``scripts/run_tests.sh``.
 """
 
 import asyncio
+import atexit
 import logging
 import os
 import re
+import shutil
 import signal
 import sys
 import tempfile
@@ -239,6 +241,53 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "DINGTALK_REQUIRE_MENTION",
     "MATRIX_REQUIRE_MENTION",
 })
+
+
+def _is_under(path: Path, parent: Path) -> bool:
+    """Return True when path resolves at or below parent."""
+    try:
+        path.resolve().relative_to(parent.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _protect_collection_environment() -> None:
+    """Protect pytest collection/import time, before autouse fixtures run.
+
+    The per-test fixture below isolates HERMES_HOME during test execution, but
+    pytest imports conftest and test modules before fixtures are applied. Any
+    collection-time import that calls get_hermes_home() must also be pointed at
+    a temp home, otherwise local runs can read/write the real ~/.hermes/auth.json
+    or sessions before the fixture gets a chance to monkeypatch the environment.
+    """
+    real_hermes_home = Path.home() / ".hermes"
+    current_home = os.environ.get("HERMES_HOME")
+    needs_session_home = not current_home
+    if current_home:
+        current_path = Path(current_home).expanduser()
+        needs_session_home = _is_under(current_path, real_hermes_home)
+
+    if needs_session_home:
+        session_home = Path(tempfile.mkdtemp(prefix="hermes_pytest_session_"))
+        atexit.register(lambda p=session_home: shutil.rmtree(p, ignore_errors=True))
+        for child in ("sessions", "cron", "memories", "skills", "logs"):
+            (session_home / child).mkdir(parents=True, exist_ok=True)
+        os.environ["HERMES_HOME"] = str(session_home)
+
+    # Scrub credentials and behavior-changing env vars before test modules are
+    # imported. The autouse fixture repeats this per test with monkeypatch.
+    for name in list(os.environ.keys()):
+        if _looks_like_credential(name) or name in _HERMES_BEHAVIORAL_VARS:
+            os.environ.pop(name, None)
+
+    os.environ.setdefault("TZ", "UTC")
+    os.environ.setdefault("LANG", "C.UTF-8")
+    os.environ.setdefault("LC_ALL", "C.UTF-8")
+    os.environ.setdefault("PYTHONHASHSEED", "0")
+
+
+_protect_collection_environment()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -63,10 +63,66 @@ def _ensure_discord_mock():
 
     discord_mod = MagicMock()
     discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
     discord_mod.DMChannel = type("DMChannel", (), {})
     discord_mod.Thread = type("Thread", (), {})
     discord_mod.ForumChannel = type("ForumChannel", (), {})
     discord_mod.Interaction = object
+    discord_mod.Message = type("Message", (), {})
+    discord_mod.MessageType = SimpleNamespace(default=0, reply=19)
+
+    class _FakeView:
+        def __init__(self, timeout=None):
+            self.timeout = timeout
+            self.children = []
+        def add_item(self, item):
+            self.children.append(item)
+        def clear_items(self):
+            self.children.clear()
+
+    class _FakeSelect:
+        def __init__(self, *, placeholder=None, options=None, custom_id=None, **_):
+            self.placeholder = placeholder
+            self.options = options or []
+            self.custom_id = custom_id
+            self.callback = None
+            self.disabled = False
+
+    class _FakeButton:
+        def __init__(self, *, label=None, style=None, custom_id=None, emoji=None,
+                     url=None, disabled=False, row=None, sku_id=None, **_):
+            self.label = label
+            self.style = style
+            self.custom_id = custom_id
+            self.emoji = emoji
+            self.url = url
+            self.disabled = disabled
+            self.row = row
+            self.sku_id = sku_id
+            self.callback = None
+
+    class _FakeSelectOption:
+        def __init__(self, *, label=None, value=None, description=None, **_):
+            self.label = label
+            self.value = value
+            self.description = description
+
+    discord_mod.ui = SimpleNamespace(
+        View=_FakeView,
+        Select=_FakeSelect,
+        Button=_FakeButton,
+        button=lambda *a, **k: (lambda fn: fn),
+    )
+    discord_mod.SelectOption = _FakeSelectOption
+    discord_mod.ButtonStyle = SimpleNamespace(
+        success=1, primary=2, secondary=2, danger=3,
+        green=1, grey=2, blurple=2, red=3,
+    )
+    discord_mod.Color = SimpleNamespace(
+        orange=lambda: 1, green=lambda: 2, blue=lambda: 3,
+        red=lambda: 4, purple=lambda: 5, greyple=lambda: 6,
+    )
     discord_mod.app_commands = SimpleNamespace(
         describe=lambda **kwargs: (lambda fn: fn),
         choices=lambda **kwargs: (lambda fn: fn),
@@ -79,10 +135,13 @@ def _ensure_discord_mock():
     commands_mod.Bot = MagicMock
     ext_mod.commands = commands_mod
 
-    sys.modules.setdefault("discord", discord_mod)
-    sys.modules.setdefault("discord.ext", ext_mod)
-    sys.modules.setdefault("discord.ext.commands", commands_mod)
-    sys.modules.setdefault("discord.opus", discord_mod.opus)
+    # Overwrite partial/ad-hoc mocks from other test packages. Using setdefault
+    # here makes full-suite order matter because gateway.platforms.discord may
+    # cache a different mock than the one used to build fake DM/Thread objects.
+    sys.modules["discord"] = discord_mod
+    sys.modules["discord.ext"] = ext_mod
+    sys.modules["discord.ext.commands"] = commands_mod
+    sys.modules["discord.opus"] = discord_mod.opus
 
 
 def _ensure_slack_mock():
@@ -113,6 +172,15 @@ def _ensure_slack_mock():
 _ensure_telegram_mock()
 _ensure_discord_mock()
 _ensure_slack_mock()
+
+# If another test package imported gateway.platforms.discord before this e2e
+# conftest installed its comprehensive discord mock, reload the adapter module so
+# its module-level `discord` binding and UI view classes use the same fake types
+# as make_fake_dm_channel()/make_fake_thread().
+if "gateway.platforms.discord" in sys.modules and not hasattr(sys.modules["discord"], "__file__"):
+    import importlib
+
+    importlib.reload(sys.modules["gateway.platforms.discord"])
 
 import discord  # noqa: E402 — mocked above
 from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
@@ -330,15 +398,19 @@ def make_fake_text_channel(channel_id: int = CHANNEL_ID, name: str = "general", 
 
 
 def make_fake_dm_channel(channel_id: int = 55555):
+    from gateway.platforms import discord as discord_platform
+
     ch = MagicMock(spec=[])
     ch.id = channel_id
     ch.name = "DM"
     ch.topic = None
-    ch.__class__ = discord.DMChannel
+    ch.__class__ = discord_platform.discord.DMChannel
     return ch
 
 
 def make_fake_thread(thread_id: int = THREAD_ID, name: str = "test-thread", parent=None):
+    from gateway.platforms import discord as discord_platform
+
     th = MagicMock(spec=[])
     th.id = thread_id
     th.name = name
@@ -347,7 +419,7 @@ def make_fake_thread(thread_id: int = THREAD_ID, name: str = "test-thread", pare
     th.guild = th.parent.guild
     th.topic = None
     th.type = 11
-    th.__class__ = discord.Thread
+    th.__class__ = discord_platform.discord.Thread
     return th
 
 
@@ -368,11 +440,13 @@ def make_discord_message(
     if attachments is None:
         attachments = []
 
+    from gateway.platforms import discord as discord_platform
+
     return SimpleNamespace(
         id=message_id, content=content, author=author, channel=channel,
         guild=getattr(channel, "guild", None),
         mentions=mentions, attachments=attachments,
-        type=getattr(discord, "MessageType", SimpleNamespace()).default,
+        type=getattr(discord_platform.discord, "MessageType", SimpleNamespace()).default,
         reference=None, created_at=datetime.now(timezone.utc),
         create_thread=AsyncMock(),
     )

--- a/tests/fakes/fake_ha_server.py
+++ b/tests/fakes/fake_ha_server.py
@@ -212,20 +212,30 @@ class FakeHAServer:
             "result": None,
         })
 
-        # Step 6: push events from queue until closed
+        # Step 6: push events from queue until closed.  Poll the socket too;
+        # otherwise a client close frame can sit unread while the fake waits on
+        # the event queue, making adapter.disconnect() hang until its timeout.
         try:
             while not ws.closed:
                 try:
-                    event_data = await asyncio.wait_for(
-                        self._event_queue.get(), timeout=0.1,
-                    )
+                    msg = await ws.receive(timeout=0.1)
+                    if msg.type in {
+                        aiohttp.WSMsgType.CLOSE,
+                        aiohttp.WSMsgType.CLOSING,
+                        aiohttp.WSMsgType.CLOSED,
+                        aiohttp.WSMsgType.ERROR,
+                    }:
+                        break
+                except asyncio.TimeoutError:
+                    pass
+
+                while not self._event_queue.empty() and not ws.closed:
+                    event_data = self._event_queue.get_nowait()
                     await ws.send_json({
                         "id": sub_id,
                         "type": "event",
                         "event": event_data,
                     })
-                except asyncio.TimeoutError:
-                    continue
         except (ConnectionResetError, asyncio.CancelledError):
             pass
 

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -219,6 +219,25 @@ def _ensure_discord_mock() -> None:
 _ensure_telegram_mock()
 _ensure_discord_mock()
 
+# Some non-gateway tests import gateway platform modules before this directory's
+# conftest.py is loaded, often with tiny ad-hoc MagicMocks for platform SDKs.
+# Overwriting sys.modules is not enough after that: adapter modules cache
+# module-level SDK bindings and enum/class objects. Reload them once after
+# installing the comprehensive mocks so gateway tests are order-independent in a
+# full-suite run.
+if (
+    "gateway.platforms.telegram" in sys.modules
+    and not hasattr(sys.modules["telegram"], "__file__")
+):
+    import importlib
+
+    importlib.reload(sys.modules["gateway.platforms.telegram"])
+
+if "gateway.platforms.discord" in sys.modules and not hasattr(sys.modules["discord"], "__file__"):
+    import importlib
+
+    importlib.reload(sys.modules["gateway.platforms.discord"])
+
 
 # ---------------------------------------------------------------------------
 # Plugin-adapter anti-pattern guard

--- a/tests/gateway/test_discord_allowed_mentions.py
+++ b/tests/gateway/test_discord_allowed_mentions.py
@@ -81,6 +81,7 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
+from gateway.platforms import discord as discord_platform  # noqa: E402
 from gateway.platforms.discord import _build_allowed_mentions  # noqa: E402
 
 
@@ -98,6 +99,13 @@ _ENV_VARS = (
 def _clear_allowed_mention_env(monkeypatch):
     for name in _ENV_VARS:
         monkeypatch.delenv(name, raising=False)
+    # Full-suite order can import gateway.platforms.discord before this module,
+    # leaving its module-level `discord` binding pointed at a generic MagicMock.
+    # Patch the binding used by _build_allowed_mentions(), not only
+    # sys.modules["discord"], so these tests stay order-independent.
+    _ensure_discord_mock()
+    monkeypatch.setattr(discord_platform.discord, "AllowedMentions", _FakeAllowedMentions, raising=False)
+    monkeypatch.setattr(discord_platform, "DISCORD_AVAILABLE", True)
 
 
 def test_safe_defaults_block_everyone_and_roles():

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -291,12 +291,14 @@ class TestEnvVarOverride:
 # Tests for reply_to_text extraction in _handle_message
 # ------------------------------------------------------------------
 
-# Build FakeDMChannel as a subclass of the real discord.DMChannel when the
-# library is installed — this guarantees isinstance() checks pass in
-# production code regardless of test ordering or monkeypatch state.
+# Build FakeDMChannel from the same discord module object that
+# gateway.platforms.discord uses.  Full-suite order can leave sys.modules
+# pointing at a different mock than the adapter's cached module-level binding;
+# using the adapter binding keeps isinstance(message.channel, discord.DMChannel)
+# deterministic.
 try:
-    import discord as _discord_lib
-    _DMChannelBase = _discord_lib.DMChannel
+    import gateway.platforms.discord as _discord_platform
+    _DMChannelBase = getattr(_discord_platform.discord, "DMChannel", object)
 except (ImportError, AttributeError):
     _DMChannelBase = object
 
@@ -327,6 +329,9 @@ def _make_message(*, content: str = "hi", reference=None):
 @pytest.fixture
 def reply_text_adapter(monkeypatch):
     """DiscordAdapter wired for _handle_message → handle_message capture."""
+    # Keep the adapter's module-level discord binding aligned with this file's
+    # DM stub even after earlier gateway tests mutate sys.modules or SDK mocks.
+    monkeypatch.setattr(_discord_platform.discord, "DMChannel", FakeDMChannel, raising=False)
     config = PlatformConfig(enabled=True, token="fake-token")
     adapter = DiscordAdapter(config)
     adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -41,7 +41,31 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
+import gateway.platforms.discord as discord_platform  # noqa: E402
 from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+
+
+def _forum_channel_cls():
+    """Return a fixture class compatible with the adapter's cached binding.
+
+    Full-suite runs may import gateway.platforms.discord before this file and
+    later replace sys.modules["discord"] with another mock.  _is_forum_parent()
+    uses the adapter module-level discord binding, so forum channel fixtures must
+    be instances of that binding.  When the binding is the real discord.py class,
+    use a dynamic subclass so tests can attach create_thread/id/name without
+    depending on discord.py's keyword-only constructor or read-only slots.
+    """
+    forum_cls = getattr(discord_platform.discord, "ForumChannel", None)
+    if not isinstance(forum_cls, type):
+        forum_cls = type("ForumChannel", (), {})
+        setattr(discord_platform.discord, "ForumChannel", forum_cls)
+        return forum_cls
+    return type("ForumChannelFixture", (forum_cls,), {})
+
+
+def _forum_channel_instance():
+    """Create a ForumChannel instance without depending on discord.py __init__."""
+    return object.__new__(_forum_channel_cls())
 
 
 @pytest.mark.asyncio
@@ -163,8 +187,6 @@ async def test_send_does_not_retry_on_unrelated_errors():
 # Forum channel tests
 # ---------------------------------------------------------------------------
 
-import discord as _discord_mod  # noqa: E402 — imported after _ensure_discord_mock
-
 
 class TestIsForumParent:
     def test_none_returns_false(self):
@@ -173,12 +195,7 @@ class TestIsForumParent:
 
     def test_forum_channel_class_instance(self):
         adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
-        forum_cls = getattr(_discord_mod, "ForumChannel", None)
-        if forum_cls is None:
-            # Re-create a type for the mock
-            forum_cls = type("ForumChannel", (), {})
-            _discord_mod.ForumChannel = forum_cls
-        ch = forum_cls()
+        ch = _forum_channel_instance()
         assert adapter._is_forum_parent(ch) is True
 
     def test_type_value_15(self):
@@ -208,7 +225,7 @@ async def test_send_to_forum_creates_thread_post():
         message=SimpleNamespace(id=500),
         thread=thread_ch,
     )
-    forum_channel = _discord_mod.ForumChannel()
+    forum_channel = _forum_channel_instance()
     forum_channel.id = 999
     forum_channel.name = "ideas"
     forum_channel.create_thread = AsyncMock(return_value=thread)
@@ -242,7 +259,7 @@ async def test_send_to_forum_sends_remaining_chunks():
         message=chunk_msg_1,
         thread=thread_ch,
     )
-    forum_channel = _discord_mod.ForumChannel()
+    forum_channel = _forum_channel_instance()
     forum_channel.id = 999
     forum_channel.name = "ideas"
     forum_channel.create_thread = AsyncMock(return_value=thread)
@@ -263,7 +280,7 @@ async def test_send_to_forum_sends_remaining_chunks():
 async def test_send_to_forum_create_thread_failure():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
 
-    forum_channel = _discord_mod.ForumChannel()
+    forum_channel = _forum_channel_instance()
     forum_channel.id = 999
     forum_channel.name = "ideas"
     forum_channel.create_thread = AsyncMock(side_effect=Exception("rate limited"))
@@ -297,7 +314,7 @@ async def test_send_to_forum_follow_up_chunk_failures_collected_as_warnings():
         send=AsyncMock(side_effect=Exception("rate limited")),
     )
     thread = SimpleNamespace(id=555, message=chunk_msg_1, thread=thread_ch)
-    forum_channel = _discord_mod.ForumChannel()
+    forum_channel = _forum_channel_instance()
     forum_channel.id = 999
     forum_channel.name = "ideas"
     forum_channel.create_thread = AsyncMock(return_value=thread)
@@ -325,7 +342,7 @@ async def test_forum_post_file_creates_thread_with_attachment():
 
     thread_ch = SimpleNamespace(id=777, send=AsyncMock())
     thread = SimpleNamespace(id=777, message=SimpleNamespace(id=800), thread=thread_ch)
-    forum_channel = _discord_mod.ForumChannel()
+    forum_channel = _forum_channel_instance()
     forum_channel.id = 999
     forum_channel.name = "ideas"
     forum_channel.create_thread = AsyncMock(return_value=thread)
@@ -355,7 +372,7 @@ async def test_forum_post_file_uses_filename_when_no_content():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
 
     thread = SimpleNamespace(id=1, message=SimpleNamespace(id=2), thread=SimpleNamespace(id=1, send=AsyncMock()))
-    forum_channel = _discord_mod.ForumChannel()
+    forum_channel = _forum_channel_instance()
     forum_channel.id = 10
     forum_channel.name = "forum"
     forum_channel.create_thread = AsyncMock(return_value=thread)
@@ -374,7 +391,7 @@ async def test_forum_post_file_creation_failure():
     """_forum_post_file returns a failed SendResult when create_thread raises."""
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
 
-    forum_channel = _discord_mod.ForumChannel()
+    forum_channel = _forum_channel_instance()
     forum_channel.id = 999
     forum_channel.create_thread = AsyncMock(side_effect=Exception("missing perms"))
 

--- a/tests/gateway/test_discord_slash_auth.py
+++ b/tests/gateway/test_discord_slash_auth.py
@@ -85,7 +85,26 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
+import gateway.platforms.discord as discord_platform  # noqa: E402
 from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+
+
+def _discord_binding_instance(class_name: str):
+    """Create an object compatible with gateway.platforms.discord.discord.<class_name>.
+
+    Full-suite collection can leave sys.modules["discord"] and the adapter's
+    cached discord binding pointing at different module objects/classes. The
+    production authorization checks use the adapter binding, so DM/thread test
+    channels must satisfy isinstance() against that binding, while avoiding
+    real discord.py constructors that require internal state.
+    """
+    bound_cls = getattr(discord_platform.discord, class_name, None)
+    if not isinstance(bound_cls, type):
+        bound_cls = type(class_name, (), {})
+        setattr(discord_platform.discord, class_name, bound_cls)
+        return bound_cls()
+    fixture_cls = type(f"{class_name}Fixture", (bound_cls,), {})
+    return object.__new__(fixture_cls)
 
 
 @pytest.fixture(autouse=True)
@@ -112,7 +131,8 @@ def _stub_discord_permissions(monkeypatch):
         def __init__(self, value=0, **_):
             self.value = value
 
-    monkeypatch.setattr(discord, "Permissions", _Perm)
+    monkeypatch.setattr(discord, "Permissions", _Perm, raising=False)
+    monkeypatch.setattr(discord_platform.discord, "Permissions", _Perm, raising=False)
 
 
 @pytest.fixture
@@ -136,14 +156,12 @@ def _make_interaction(
     payload missing a resolvable channel id (fail-closed exercise).
     Pass ``user=None`` to simulate a payload missing the user object.
     """
-    import discord
-
     response = SimpleNamespace(send_message=AsyncMock(), defer=AsyncMock())
 
     if in_dm:
-        channel = discord.DMChannel()
+        channel = _discord_binding_instance("DMChannel")
     elif in_thread:
-        channel = discord.Thread()
+        channel = _discord_binding_instance("Thread")
         channel.id = channel_id
         channel.parent_id = parent_channel_id
     elif channel_id is None:

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -75,7 +75,21 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
+import gateway.platforms.discord as discord_platform  # noqa: E402
 from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+
+
+def _discord_binding_class(class_name: str):
+    """Return the class cached in gateway.platforms.discord.discord.
+
+    Adapter code uses its module-level discord binding for isinstance checks;
+    full-suite order can make that binding differ from sys.modules["discord"].
+    """
+    bound_cls = getattr(discord_platform.discord, class_name, None)
+    if not isinstance(bound_cls, type):
+        bound_cls = type(class_name, (), {})
+        setattr(discord_platform.discord, class_name, bound_cls)
+    return bound_cls
 
 
 class FakeTree:
@@ -612,9 +626,6 @@ async def test_auto_create_thread_returns_none_when_direct_and_fallback_fail(ada
 # ------------------------------------------------------------------
 
 
-import discord as _discord_mod  # noqa: E402 — mock or real, used below
-
-
 class _FakeTextChannel:
     """A channel that is NOT a discord.Thread or discord.DMChannel."""
 
@@ -625,17 +636,29 @@ class _FakeTextChannel:
         self.topic = None
 
 
-class _FakeThreadChannel(_discord_mod.Thread):
-    """isinstance(ch, discord.Thread) → True."""
+def _FakeThreadChannel(channel_id=200, name="existing-thread", guild_name="TestGuild", parent_id=100):
+    """Return an object satisfying isinstance(ch, current adapter discord.Thread)."""
+    # Build at call time because integration test collection may reload
+    # gateway.platforms.discord after this module is collected.
+    def _get_parent(self):
+        return getattr(self, "_parent", None)
 
-    def __init__(self, channel_id=200, name="existing-thread", guild_name="TestGuild", parent_id=100):
-        # Don't call super().__init__ — mock Thread is just an empty type
-        self.id = channel_id
-        self.name = name
-        self.guild = SimpleNamespace(name=guild_name, id=1)
-        self.topic = None
-        self.parent = SimpleNamespace(id=parent_id, name="general", guild=SimpleNamespace(name=guild_name, id=1))
+    def _set_parent(self, value):
+        object.__setattr__(self, "_parent", value)
 
+    fixture_cls = type(
+        "FakeThreadChannel",
+        (_discord_binding_class("Thread"),),
+        {"parent": property(_get_parent, _set_parent)},
+    )
+    channel = object.__new__(fixture_cls)
+    channel.id = channel_id
+    channel.name = name
+    channel.guild = SimpleNamespace(name=guild_name, id=1)
+    channel.topic = None
+    channel.parent = SimpleNamespace(id=parent_id, name="general", guild=SimpleNamespace(name=guild_name, id=1))
+    channel.parent_id = parent_id
+    return channel
 
 def _fake_message(channel, *, content="Hello", author_id=42, display_name="Jezza"):
     return SimpleNamespace(

--- a/tests/gateway/test_send_image_file.py
+++ b/tests/gateway/test_send_image_file.py
@@ -189,7 +189,7 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
-import discord as discord_mod_ref  # noqa: E402
+import gateway.platforms.discord as discord_platform  # noqa: E402
 from gateway.platforms.discord import DiscordAdapter  # noqa: E402
 
 
@@ -230,7 +230,7 @@ class TestDiscordSendImageFile:
         mock_channel.send = AsyncMock(return_value=mock_msg)
         adapter._client.get_channel = MagicMock(return_value=mock_channel)
 
-        with patch.object(discord_mod_ref, "File", MagicMock()) as file_cls:
+        with patch.object(discord_platform.discord, "File", MagicMock()) as file_cls:
             result = _run(
                 adapter.send_document(
                     chat_id="67890",
@@ -256,7 +256,7 @@ class TestDiscordSendImageFile:
         mock_channel.send = AsyncMock(return_value=mock_msg)
         adapter._client.get_channel = MagicMock(return_value=mock_channel)
 
-        with patch.object(discord_mod_ref, "File", MagicMock()) as file_cls:
+        with patch.object(discord_platform.discord, "File", MagicMock()) as file_cls:
             result = _run(
                 adapter.send_video(
                     chat_id="67890",

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -36,6 +36,9 @@ def _ensure_teams_mock():
     microsoft_teams_api_models_adaptive_card = types.ModuleType("microsoft_teams.api.models.adaptive_card")
     microsoft_teams_api_models_invoke_response = types.ModuleType("microsoft_teams.api.models.invoke_response")
     microsoft_teams_cards = types.ModuleType("microsoft_teams.cards")
+    microsoft_teams_common = types.ModuleType("microsoft_teams.common")
+    microsoft_teams_common_http = types.ModuleType("microsoft_teams.common.http")
+    microsoft_teams_common_http_client = types.ModuleType("microsoft_teams.common.http.client")
     microsoft_teams_apps_http = types.ModuleType("microsoft_teams.apps.http")
     microsoft_teams_apps_http_adapter = types.ModuleType("microsoft_teams.apps.http.adapter")
 
@@ -119,6 +122,9 @@ def _ensure_teams_mock():
     microsoft_teams_cards.ExecuteAction = MagicMock
     microsoft_teams_cards.TextBlock = MagicMock
 
+    # ClientOptions mock required by the adapter's SDK import block.
+    microsoft_teams_common_http_client.ClientOptions = MagicMock
+
     # HttpRequest TypedDict mock
     def HttpRequest(body=None, headers=None):
         return {"body": body, "headers": headers}
@@ -147,13 +153,21 @@ def _ensure_teams_mock():
         "microsoft_teams.api.models.adaptive_card": microsoft_teams_api_models_adaptive_card,
         "microsoft_teams.api.models.invoke_response": microsoft_teams_api_models_invoke_response,
         "microsoft_teams.cards": microsoft_teams_cards,
+        "microsoft_teams.common": microsoft_teams_common,
+        "microsoft_teams.common.http": microsoft_teams_common_http,
+        "microsoft_teams.common.http.client": microsoft_teams_common_http_client,
         "microsoft_teams.apps.http": microsoft_teams_apps_http,
         "microsoft_teams.apps.http.adapter": microsoft_teams_apps_http_adapter,
     }.items():
-        sys.modules.setdefault(name, mod)
+        sys.modules[name] = mod
 
 
 _ensure_teams_mock()
+# load_plugin_adapter() caches plugin modules by name. If an earlier full-suite
+# test loaded the Teams adapter before this SDK mock existed, force a fresh import
+# so the adapter's module-level SDK symbols (e.g. TypingActivityInput) are real
+# mocks instead of None from the ImportError fallback.
+sys.modules.pop("plugin_adapter_teams", None)
 
 # Load plugins/platforms/teams/adapter.py under a unique module name
 # (plugin_adapter_teams) so it cannot collide with sibling plugin adapters.

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -72,6 +72,7 @@ class TestSystemdServiceRefresh:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         gateway_cli.systemd_start()
 
@@ -95,6 +96,7 @@ class TestSystemdServiceRefresh:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         gateway_cli.systemd_restart()
 
@@ -115,10 +117,11 @@ class TestGeneratedSystemdUnits:
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
-        # TimeoutStopSec must exceed the default drain_timeout (60s) so
-        # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
-        # (tool subprocess kill, adapter disconnect) runs — issue #8202.
-        assert "TimeoutStopSec=90" in unit
+        expected_timeout = int(max(60, DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT) + 30)
+        # TimeoutStopSec must exceed the default drain_timeout so systemd
+        # doesn't SIGKILL the cgroup before post-interrupt cleanup (tool
+        # subprocess kill, adapter disconnect) runs — issue #8202.
+        assert f"TimeoutStopSec={expected_timeout}" in unit
 
     def test_user_unit_includes_resolved_node_directory_in_path(self, monkeypatch):
         monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: "/home/test/.nvm/versions/node/v24.14.0/bin/node" if cmd == "node" else None)
@@ -134,10 +137,11 @@ class TestGeneratedSystemdUnits:
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
-        # TimeoutStopSec must exceed the default drain_timeout (60s) so
-        # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
-        # (tool subprocess kill, adapter disconnect) runs — issue #8202.
-        assert "TimeoutStopSec=90" in unit
+        expected_timeout = int(max(60, DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT) + 30)
+        # TimeoutStopSec must exceed the default drain_timeout so systemd
+        # doesn't SIGKILL the cgroup before post-interrupt cleanup (tool
+        # subprocess kill, adapter disconnect) runs — issue #8202.
+        assert f"TimeoutStopSec={expected_timeout}" in unit
         assert "WantedBy=multi-user.target" in unit
 
 
@@ -530,6 +534,7 @@ class TestGatewaySystemServiceRouting:
             pid_calls[0] += 1
             return 999 if pid_calls[0] > 1 else 654
         monkeypatch.setattr("gateway.status.get_running_pid", fake_get_pid)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         gateway_cli.systemd_restart()
 
@@ -581,6 +586,7 @@ class TestGatewaySystemServiceRouting:
             "gateway.status.get_running_pid",
             lambda: 999 if started["value"] else None,
         )
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         gateway_cli.systemd_restart()
 

--- a/tests/hermes_cli/test_gateway_wsl.py
+++ b/tests/hermes_cli/test_gateway_wsl.py
@@ -129,6 +129,7 @@ class TestSupportsSystemdServicesWSL:
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: True)
+        monkeypatch.setattr(gateway.shutil, "which", lambda cmd: "/usr/bin/systemctl" if cmd == "systemctl" else None)
         monkeypatch.setattr(gateway, "_wsl_systemd_operational", lambda: True)
         assert gateway.supports_systemd_services() is True
 
@@ -145,6 +146,7 @@ class TestSupportsSystemdServicesWSL:
         monkeypatch.setattr(gateway, "is_linux", lambda: True)
         monkeypatch.setattr(gateway, "is_termux", lambda: False)
         monkeypatch.setattr(gateway, "is_wsl", lambda: False)
+        monkeypatch.setattr(gateway.shutil, "which", lambda cmd: "/usr/bin/systemctl" if cmd == "systemctl" else None)
         assert gateway.supports_systemd_services() is True
 
     def test_termux_still_excluded(self, monkeypatch):

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -385,7 +385,7 @@ class TestCmdUpdateLaunchdRestart:
         )
 
         # Simulate a manual gateway process found by find_gateway_pids
-        with patch.object(gateway_cli, "find_gateway_pids", return_value=[12345]), \
+        with patch.object(gateway_cli, "find_gateway_pids", side_effect=[[12345], []]), \
              patch("os.kill"):
             cmd_update(mock_args)
 
@@ -415,7 +415,7 @@ class TestCmdUpdateLaunchdRestart:
             pid=12345,
         )
 
-        with patch.object(gateway_cli, "find_gateway_pids", return_value=[12345]), \
+        with patch.object(gateway_cli, "find_gateway_pids", side_effect=[[12345], []]), \
              patch.object(gateway_cli, "find_profile_gateway_processes", return_value=[process]), \
              patch.object(gateway_cli, "launch_detached_profile_gateway_restart", return_value=True) as restart, \
              patch.object(gateway_cli, "_graceful_restart_via_sigusr1", return_value=True) as graceful, \
@@ -453,7 +453,7 @@ class TestCmdUpdateLaunchdRestart:
             pid=12345,
         )
 
-        with patch.object(gateway_cli, "find_gateway_pids", return_value=[12345]), \
+        with patch.object(gateway_cli, "find_gateway_pids", side_effect=[[12345], []]), \
              patch.object(gateway_cli, "find_profile_gateway_processes", return_value=[process]), \
              patch.object(gateway_cli, "launch_detached_profile_gateway_restart", return_value=True) as restart, \
              patch.object(gateway_cli, "_graceful_restart_via_sigusr1", return_value=False) as graceful, \
@@ -872,7 +872,12 @@ class TestServicePidExclusion:
             launchctl_loaded=True,
         )
 
+        find_calls = [0]
+
         def fake_find(exclude_pids=None, all_profiles=False):
+            find_calls[0] += 1
+            if find_calls[0] > 1:
+                return []
             _exclude = exclude_pids or set()
             return [p for p in [SERVICE_PID, MANUAL_PID] if p not in _exclude]
 

--- a/tests/hermes_cli/test_update_yes_flag.py
+++ b/tests/hermes_cli/test_update_yes_flag.py
@@ -8,11 +8,21 @@ Covers:
      input() call) and the stash is applied automatically
 """
 
+import importlib
 import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from hermes_cli.main import cmd_update
+
+def _cmd_update(args):
+    """Call the current hermes_cli.main.cmd_update module binding.
+
+    Some hermes_cli tests intentionally delete/reimport hermes_cli.main. Avoid a
+    stale direct-imported function whose globals no longer match string patches
+    like patch("hermes_cli.main.sys").
+    """
+
+    return importlib.import_module("hermes_cli.main").cmd_update(args)
 
 
 def _make_run_side_effect(
@@ -74,7 +84,7 @@ class TestUpdateYesConfigMigration:
         args = SimpleNamespace(yes=True)
 
         with patch("builtins.input") as mock_input:
-            cmd_update(args)
+            _cmd_update(args)
             # Never prompted the user.
             mock_input.assert_not_called()
 
@@ -118,7 +128,7 @@ class TestUpdateYesConfigMigration:
         ) as mock_sys:
             mock_sys.stdin.isatty.return_value = True
             mock_sys.stdout.isatty.return_value = True
-            cmd_update(args)
+            _cmd_update(args)
             # The user was actually prompted.
             assert mock_input.called
             prompts = [c.args[0] if c.args else "" for c in mock_input.call_args_list]
@@ -156,7 +166,7 @@ class TestUpdateYesStashRestore:
 
         args = SimpleNamespace(yes=True)
 
-        cmd_update(args)
+        _cmd_update(args)
 
         # _restore_stashed_changes was called, and called with prompt_user=False
         # every time (so the user never sees "Restore local changes now?").

--- a/tests/integration/test_ha_integration.py
+++ b/tests/integration/test_ha_integration.py
@@ -69,9 +69,9 @@ class TestGatewayWebSocket:
 
     @pytest.mark.asyncio
     async def test_event_received_and_forwarded(self):
-        """Server pushes event -> adapter calls handle_message with correct MessageEvent."""
+        """Watched server event -> adapter calls handle_message with correct MessageEvent."""
         async with FakeHAServer() as server:
-            adapter = _adapter_for(server)
+            adapter = _adapter_for(server, watch_all=True)
             adapter.handle_message = AsyncMock()
 
             await adapter.connect()

--- a/tests/integration/test_voice_channel_flow.py
+++ b/tests/integration/test_voice_channel_flow.py
@@ -8,10 +8,22 @@ Requires: PyNaCl>=1.5.0, discord.py[voice] (opus codec)
 """
 
 import struct
+import sys
 import time
+import importlib
 import pytest
 
 pytestmark = pytest.mark.integration
+
+# Gateway/e2e tests install lightweight `discord` MagicMock modules for unit
+# isolation.  These integration tests require the real discord.py package and
+# opus bindings, so discard those stubs if collection order put them in
+# sys.modules first.
+_existing_discord = sys.modules.get("discord")
+if _existing_discord is not None and not hasattr(_existing_discord, "__file__"):
+    for _name in list(sys.modules):
+        if _name == "discord" or _name.startswith("discord."):
+            sys.modules.pop(_name, None)
 
 # Skip entire module if voice deps are missing
 pytest.importorskip("nacl.secret", reason="PyNaCl required for voice integration tests")
@@ -38,7 +50,11 @@ except Exception:
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock
-from gateway.platforms.discord import VoiceReceiver
+import gateway.platforms.discord as discord_platform
+
+if not hasattr(getattr(discord_platform, "discord", None), "__file__"):
+    discord_platform = importlib.reload(discord_platform)
+VoiceReceiver = discord_platform.VoiceReceiver
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -481,6 +481,12 @@ def test_ws_events_rejects_when_token_required(tmp_path, monkeypatch):
     import types
     stub = types.SimpleNamespace(_SESSION_TOKEN="secret-xyz")
     monkeypatch.setitem(sys.modules, "hermes_cli.web_server", stub)
+    # If hermes_cli.web_server was imported earlier in the full suite, the
+    # package attribute still points at the real module even after sys.modules
+    # is patched.  Patch the package binding too so plugin_api's
+    # ``from hermes_cli import web_server`` sees this test's token.
+    import hermes_cli
+    monkeypatch.setattr(hermes_cli, "web_server", stub, raising=False)
 
     app = FastAPI()
     app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")

--- a/tests/run_agent/test_concurrent_interrupt.py
+++ b/tests/run_agent/test_concurrent_interrupt.py
@@ -73,6 +73,14 @@ def _make_agent(monkeypatch):
             return False
 
     stub = _Stub()
+    # Real AIAgent.__init__ now installs tool-loop guardrails used by both
+    # sequential and concurrent tool execution.  This stub bypasses __init__,
+    # so mirror the guardrail state/methods needed by the real concurrent path.
+    stub._tool_guardrails = _ra.ToolCallGuardrailController()
+    stub._tool_guardrail_halt_decision = None
+    stub._set_tool_guardrail_halt = _ra.AIAgent._set_tool_guardrail_halt.__get__(stub)
+    stub._append_guardrail_observation = _ra.AIAgent._append_guardrail_observation.__get__(stub)
+    stub._guardrail_block_result = _ra.AIAgent._guardrail_block_result.__get__(stub)
     # Bind the real methods under test
     stub._execute_tool_calls_concurrent = _ra.AIAgent._execute_tool_calls_concurrent.__get__(stub)
     stub.interrupt = _ra.AIAgent.interrupt.__get__(stub)
@@ -107,7 +115,7 @@ def test_concurrent_interrupt_cancels_pending(monkeypatch):
 
     original_invoke = agent._invoke_tool
 
-    def slow_tool(name, args, task_id, call_id=None):
+    def slow_tool(name, args, task_id, call_id=None, **_kwargs):
         if name == "slow_one":
             # Block until the test sets the interrupt
             barrier.wait(timeout=10)
@@ -184,7 +192,7 @@ def test_running_concurrent_worker_sees_is_interrupted(monkeypatch):
     observed = {"saw_true": False, "poll_count": 0, "worker_tid": None}
     worker_started = threading.Event()
 
-    def polling_tool(name, args, task_id, call_id=None, messages=None):
+    def polling_tool(name, args, task_id, call_id=None, messages=None, **_kwargs):
         observed["worker_tid"] = threading.current_thread().ident
         worker_started.set()
         deadline = time.monotonic() + 5.0

--- a/tests/run_agent/test_dict_tool_call_args.py
+++ b/tests/run_agent/test_dict_tool_call_args.py
@@ -49,6 +49,10 @@ def test_tool_call_validation_accepts_dict_arguments(monkeypatch):
 
     monkeypatch.setattr("run_agent.OpenAI", lambda **kwargs: _FakeClient())
     monkeypatch.setattr(
+        "agent.context_compressor.get_model_context_length",
+        lambda *args, **kwargs: 128_000,
+    )
+    monkeypatch.setattr(
         "run_agent.get_tool_definitions",
         lambda *args, **kwargs: [{"function": {"name": "read_file"}}],
     )

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -44,6 +44,19 @@ def _make_tool_defs(*names: str) -> list:
     ]
 
 
+@pytest.fixture(autouse=True)
+def _large_context_for_aiagent_unit_tests(monkeypatch):
+    """Keep AIAgent init-focused unit tests independent of model metadata.
+
+    These tests exercise run_agent behavior, not the minimum-context gate.  The
+    dedicated feasibility tests cover sub-64K rejection explicitly.
+    """
+    monkeypatch.setattr(
+        "agent.context_compressor.get_model_context_length",
+        lambda *args, **kwargs: 128_000,
+    )
+
+
 def test_is_destructive_command_treats_cp_as_mutating():
     assert run_agent._is_destructive_command("cp .env.local .env") is True
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -753,8 +753,15 @@ def test_session_title_set_errors_when_row_lookup_fails_after_noop(monkeypatch):
         server._sessions.pop("sid", None)
 
 
-def test_session_create_drops_pending_title_on_valueerror(monkeypatch):
+def test_pending_title_drops_on_valueerror_after_first_turn(monkeypatch):
     unblock_agent = threading.Event()
+
+    class _ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
 
     class _FakeWorker:
         def __init__(self, key, model):
@@ -768,6 +775,12 @@ def test_session_create_drops_pending_title_on_valueerror(monkeypatch):
         provider = "openrouter"
         base_url = ""
         api_key = ""
+
+        def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+            return {
+                "final_response": "ok",
+                "messages": [{"role": "assistant", "content": "ok"}],
+            }
 
     class _FakeDB:
         def create_session(self, _key, source="tui", model=None):
@@ -787,6 +800,8 @@ def test_session_create_drops_pending_title_on_valueerror(monkeypatch):
     monkeypatch.setattr(server, "_probe_credentials", lambda _a: None)
     monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
     monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
 
     import tools.approval as _approval
 
@@ -802,6 +817,20 @@ def test_session_create_drops_pending_title_on_valueerror(monkeypatch):
     unblock_agent.set()
     session["agent_ready"].wait(timeout=2.0)
 
+    # Agent construction no longer applies queued titles; the first completed
+    # turn does, after run_conversation has created the DB row.
+    assert session["pending_title"] == "duplicate title"
+
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    submit = server.handle_request(
+        {
+            "id": "2",
+            "method": "prompt.submit",
+            "params": {"session_id": sid, "text": "ping"},
+        }
+    )
+
+    assert submit["result"]["status"] == "streaming"
     assert session["pending_title"] is None
     server._sessions.pop(sid, None)
 
@@ -3434,6 +3463,7 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         _stub_urlopen(monkeypatch, ok=False)
         with (
+            patch("platform.system", return_value="Linux"),
             patch(
                 "hermes_cli.browser_connect.try_launch_chrome_debug", return_value=False
             ),
@@ -3490,6 +3520,7 @@ def test_browser_manage_connect_no_session_skips_progress_events(monkeypatch):
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         _stub_urlopen(monkeypatch, ok=False)
         with (
+            patch("platform.system", return_value="Linux"),
             patch(
                 "hermes_cli.browser_connect.try_launch_chrome_debug", return_value=False
             ),

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -205,6 +205,25 @@ class TestTakeCheckpoint:
         r = mgr.ensure_checkpoint(str(Path.home()), "home")
         assert r is False
 
+    def test_skip_home_dir_when_home_is_symlink_alias(self, tmp_path, checkpoint_base, monkeypatch):
+        real_home = tmp_path / "real_home"
+        real_home.mkdir()
+        alias_home = tmp_path / "home_link"
+        alias_home.symlink_to(real_home, target_is_directory=True)
+        monkeypatch.setenv("HOME", str(alias_home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: alias_home))
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+
+        mgr = CheckpointManager(enabled=True, max_snapshots=50)
+        monkeypatch.setattr(
+            mgr,
+            "_take",
+            lambda *_args, **_kwargs: pytest.fail("checkpoint should skip the home directory before taking"),
+        )
+        r = mgr.ensure_checkpoint(str(Path.home()), "home")
+
+        assert r is False
+
 
 # =========================================================================
 # CheckpointManager — listing checkpoints

--- a/tests/tools/test_credential_pool_env_fallback.py
+++ b/tests/tools/test_credential_pool_env_fallback.py
@@ -3,7 +3,7 @@
 Covers the fix from #15914 / PR #15920:
 - _seed_from_env reads API keys from ~/.hermes/.env when not in os.environ
 - _resolve_api_key_provider_secret falls back to credential_pool when env vars are empty
-- env vars take priority over .env file (handled by get_env_value itself)
+- credential pool seeding treats ~/.hermes/.env as authoritative over stale shell exports
 - env vars take priority over credential pool (fallback only kicks in when env is empty)
 """
 
@@ -106,8 +106,8 @@ class TestCredentialPoolSeedsFromDotEnv:
         assert active_sources == set()
         assert entries == []
 
-    def test_os_environ_still_wins_over_dotenv(self, isolated_hermes_home, monkeypatch):
-        """get_env_value checks os.environ first — verify seeding picks that up."""
+    def test_dotenv_wins_over_os_environ_when_seeding_pool(self, isolated_hermes_home, monkeypatch):
+        """_seed_from_env treats ~/.hermes/.env as authoritative over stale shell exports."""
         _write_env_file(isolated_hermes_home, DEEPSEEK_API_KEY="sk-dotenv-stale")
         monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-env-fresh-xyz")
 
@@ -118,7 +118,8 @@ class TestCredentialPoolSeedsFromDotEnv:
         assert changed is True
         seeded = [e for e in entries if e.source == "env:DEEPSEEK_API_KEY"]
         assert len(seeded) == 1
-        assert seeded[0].access_token == "sk-env-fresh-xyz"
+        dotenv_value = (isolated_hermes_home / ".env").read_text().split("=", 1)[1].strip()
+        assert seeded[0].access_token == dotenv_value
 
 
 class TestAuthResolvesFromDotEnv:

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1511,7 +1511,14 @@ class TestDelegateHeartbeat(unittest.TestCase):
 
         parent = _make_mock_parent()
         touch_calls = []
-        parent._touch_activity = lambda desc: touch_calls.append(desc)
+        enough_heartbeats = threading.Event()
+
+        def _touch(desc):
+            touch_calls.append(desc)
+            if len(touch_calls) > 6:
+                enough_heartbeats.set()
+
+        parent._touch_activity = _touch
 
         child = MagicMock()
         # Child is stuck inside a single terminal call for the whole run.
@@ -1524,10 +1531,10 @@ class TestDelegateHeartbeat(unittest.TestCase):
         }
 
         def slow_run(**kwargs):
-            # Long enough to exceed the OLD idle threshold (5 cycles) at
-            # the patched interval, but shorter than the new in-tool
-            # threshold.
-            time.sleep(0.4)
+            # Wait until the heartbeat has proven it can continue past the old
+            # idle threshold.  This avoids relying on exact scheduler timing in
+            # loaded full-suite runs.
+            enough_heartbeats.wait(timeout=2.0)
             return {"final_response": "done", "completed": True, "api_calls": 1}
 
         child.run_conversation.side_effect = slow_run
@@ -1545,13 +1552,13 @@ class TestDelegateHeartbeat(unittest.TestCase):
                 parent_agent=parent,
             )
 
-        # With the old idle threshold (5 cycles = 0.25s), touch_calls
-        # would cap at ~5. With the in-tool threshold (20 cycles = 1.0s),
-        # we should see substantially more heartbeats over 0.4s.
-        self.assertGreater(
-            len(touch_calls), 6,
+        # With the old idle threshold, heartbeat would stop around 5 touches
+        # and `enough_heartbeats` would never be set. The in-tool threshold
+        # should allow continued touches while current_tool remains set.
+        self.assertTrue(
+            enough_heartbeats.is_set(),
             f"Heartbeat stopped too early while child was inside a tool; "
-            f"got {len(touch_calls)} touches over 0.4s at 0.05s interval",
+            f"got {len(touch_calls)} touches at 0.05s interval",
         )
 
     def test_heartbeat_still_trips_idle_stale_when_no_tool(self):

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -107,7 +107,10 @@ def test_dockerfile_entrypoint_routes_through_the_init(dockerfile_text):
 
 def test_dockerfile_installs_tui_dependencies(dockerfile_text):
     assert "ui-tui/package.json" in dockerfile_text
-    assert "ui-tui/packages/hermes-ink/package-lock.json" in dockerfile_text
+    assert (
+        "ui-tui/packages/hermes-ink/package-lock.json" in dockerfile_text
+        or "COPY ui-tui/packages/hermes-ink/ ui-tui/packages/hermes-ink/" in dockerfile_text
+    )
     assert any(
         "ui-tui" in step and "npm" in step and (" install" in step or " ci" in step)
         for step in _run_steps(dockerfile_text)
@@ -122,7 +125,8 @@ def test_dockerfile_builds_tui_assets(dockerfile_text):
 
 
 def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
-    assert any(
+    run_steps = _run_steps(dockerfile_text)
+    old_manual_materialization = any(
         "ui-tui" in step
         and "node_modules/@hermes/ink" in step
         and "packages/hermes-ink" in step
@@ -131,8 +135,14 @@ def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
         and "--prefix node_modules/@hermes/ink" in step
         and "rm -rf node_modules/@hermes/ink/node_modules/react" in step
         and "await import('@hermes/ink')" in step
-        for step in _run_steps(dockerfile_text)
+        for step in run_steps
     )
+    symlink_materialization = (
+        "ENV npm_config_install_links=false" in dockerfile_text
+        and "COPY ui-tui/packages/hermes-ink/ ui-tui/packages/hermes-ink/" in dockerfile_text
+        and any("cd ui-tui" in step and "npm install" in step for step in run_steps)
+    )
+    assert old_manual_materialization or symlink_materialization
 
 
 def test_dockerignore_excludes_nested_dependency_dirs():

--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -98,6 +98,38 @@ class TestCheckSensitivePathMacOSBypass:
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/private/var/db/something") is not None
 
+    def test_current_macos_temp_root_allowed(self, monkeypatch):
+        import tools.file_tools as file_tools
+
+        monkeypatch.setattr(
+            file_tools.tempfile,
+            "gettempdir",
+            lambda: "/private/var/folders/ab/cd/T",
+        )
+        monkeypatch.setattr(
+            file_tools,
+            "_resolve_path_for_task",
+            lambda *_args, **_kwargs: Path("/private/var/folders/ab/cd/T/file.txt"),
+        )
+
+        assert file_tools._check_sensitive_path("/var/folders/ab/cd/T/file.txt") is None
+
+    def test_private_var_folders_outside_current_temp_still_blocked(self, monkeypatch):
+        import tools.file_tools as file_tools
+
+        monkeypatch.setattr(
+            file_tools.tempfile,
+            "gettempdir",
+            lambda: "/private/var/folders/ab/cd/T",
+        )
+        monkeypatch.setattr(
+            file_tools,
+            "_resolve_path_for_task",
+            lambda *_args, **_kwargs: Path("/private/var/folders/other/T/file.txt"),
+        )
+
+        assert file_tools._check_sensitive_path("/private/var/folders/other/T/file.txt") is not None
+
     def test_boot_still_blocked(self):
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/boot/grub/grub.cfg") is not None

--- a/tests/tools/test_knowledge_tool.py
+++ b/tests/tools/test_knowledge_tool.py
@@ -1,0 +1,327 @@
+"""Tests for the Hermes knowledge ledger toolset.
+
+The knowledge ledger is intentionally cold/on-demand: records live under
+$HERMES_HOME/knowledge and are never injected into the system prompt by default.
+"""
+
+import json
+
+
+def _json(result: str) -> dict:
+    return json.loads(result)
+
+
+class TestKnowledgeCapture:
+    def test_non_inbox_records_require_source_attribution(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: tmp_path / "knowledge")
+
+        result = _json(kt.knowledge_capture_tool(
+            kind="decisions",
+            title="Adopt MemKraft wholesale",
+            content="Rejected: too much overlap with hot memory and session_search.",
+        ))
+
+        assert result["success"] is False
+        assert "source" in result["error"].lower()
+        assert not (tmp_path / "knowledge" / "decisions").exists()
+
+    def test_inbox_allows_unsourced_candidate_records(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: tmp_path / "knowledge")
+
+        result = _json(kt.knowledge_capture_tool(
+            kind="inbox",
+            title="Possible project convention",
+            content="The project may prefer pytest -q for focused tests.",
+        ))
+
+        assert result["success"] is True
+        assert result["kind"] == "inbox"
+        assert result["status"] == "candidate"
+        record_path = tmp_path / "knowledge" / result["path"]
+        assert record_path.exists()
+        text = record_path.read_text(encoding="utf-8")
+        assert "status: candidate" in text
+        assert "confidence: candidate" in text
+
+    def test_unsourced_inbox_forces_candidate_status_and_confidence(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: tmp_path / "knowledge")
+
+        result = _json(kt.knowledge_capture_tool(
+            kind="inbox",
+            title="Unverified extraction",
+            content="Automatically extracted claim awaiting source review.",
+            status="active",
+            confidence="confirmed",
+        ))
+
+        assert result["success"] is True
+        assert result["status"] == "candidate"
+        assert result["confidence"] == "candidate"
+        text = (tmp_path / "knowledge" / result["path"]).read_text(encoding="utf-8")
+        assert "status: candidate" in text
+        assert "confidence: candidate" in text
+
+    def test_capture_rejects_symlinked_kind_directory(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        knowledge_dir = tmp_path / "knowledge"
+        outside_dir = tmp_path / "outside"
+        outside_dir.mkdir()
+        knowledge_dir.mkdir()
+        (knowledge_dir / "inbox").symlink_to(outside_dir, target_is_directory=True)
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: knowledge_dir)
+
+        result = _json(kt.knowledge_capture_tool(
+            kind="inbox",
+            title="Directory symlink guard",
+            content="This must not be written outside knowledge.",
+        ))
+
+        assert result["success"] is False
+        assert "symlink" in result["error"].lower() or "outside" in result["error"].lower()
+        assert not any(outside_dir.iterdir())
+
+    def test_capture_writes_source_attributed_markdown_record(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: tmp_path / "knowledge")
+
+        result = _json(kt.knowledge_capture_tool(
+            kind="decisions",
+            title="MemKraft adoption boundary",
+            content="Use a cold source-attributed ledger, not a hot memory replacement.",
+            sources=["conversation:discord:Agent/#1/Ping"],
+            confidence="observed",
+            tags=["memory", "roi"],
+        ))
+
+        assert result["success"] is True
+        assert result["id"].startswith("decisions/")
+        assert result["path"].startswith("decisions/")
+        record_path = tmp_path / "knowledge" / result["path"]
+        text = record_path.read_text(encoding="utf-8")
+        assert text.startswith("---\n")
+        assert "type: decisions" in text
+        assert "confidence: observed" in text
+        assert "sources:" in text
+        assert "- conversation:discord:Agent/#1/Ping" in text
+        assert "# MemKraft adoption boundary" in text
+        assert "Use a cold source-attributed ledger" in text
+
+    def test_capture_does_not_follow_broken_symlink_record_paths(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        knowledge_dir = tmp_path / "knowledge"
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: knowledge_dir)
+        monkeypatch.setattr(kt, "_now_iso", lambda: "2026-05-04T00:00:00Z")
+        record_path = knowledge_dir / "inbox" / "20260504T000000Z-symlink-guard.md"
+        outside_target = tmp_path / "outside.md"
+        record_path.parent.mkdir(parents=True)
+        record_path.symlink_to(outside_target)
+
+        result = _json(kt.knowledge_capture_tool(
+            kind="inbox",
+            title="Symlink Guard",
+            content="Write inside the knowledge ledger only.",
+        ))
+
+        assert result["success"] is True
+        assert result["path"] == "inbox/20260504T000000Z-symlink-guard.md"
+        assert record_path.exists()
+        assert not record_path.is_symlink()
+        assert not outside_target.exists()
+
+
+class TestKnowledgeSearchAndGet:
+    def test_search_returns_ranked_snippets_not_full_hot_memory_dump(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: tmp_path / "knowledge")
+        kt.knowledge_capture_tool(
+            kind="debug",
+            title="Discord role rename failure",
+            content="Discord returned 403 Missing Permissions because the managed bot role hierarchy blocks role rename.",
+            sources=["terminal:discord-rest-probe"],
+            confidence="confirmed",
+            tags=["discord", "roles"],
+        )
+        kt.knowledge_capture_tool(
+            kind="decisions",
+            title="Knowledge ledger token policy",
+            content="Knowledge records are cold storage and retrieved on demand only.",
+            sources=["conversation:memkraft-triage"],
+            confidence="observed",
+        )
+
+        result = _json(kt.knowledge_search_tool(query="role hierarchy", limit=5))
+
+        assert result["success"] is True
+        assert result["count"] >= 1
+        assert result["results"][0]["title"] == "Discord role rename failure"
+        assert "role hierarchy" in result["results"][0]["snippet"]
+        assert "Knowledge records are cold storage" not in result["results"][0]["snippet"]
+
+    def test_get_reads_record_by_id_and_blocks_traversal(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: tmp_path / "knowledge")
+        captured = _json(kt.knowledge_capture_tool(
+            kind="skill-evals",
+            title="Skill patch needed",
+            content="Patch skills immediately when a loaded skill is stale.",
+            sources=["skill:test-driven-development"],
+            confidence="observed",
+        ))
+
+        fetched = _json(kt.knowledge_get_tool(id=captured["id"]))
+        assert fetched["success"] is True
+        assert fetched["id"] == captured["id"]
+        assert "Patch skills immediately" in fetched["content"]
+
+        traversal = _json(kt.knowledge_get_tool(path="../memories/MEMORY.md"))
+        assert traversal["success"] is False
+        assert "outside" in traversal["error"].lower() or "traversal" in traversal["error"].lower()
+
+    def test_get_reads_record_when_knowledge_home_is_symlinked(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        real_home = tmp_path / "real_home"
+        real_home.mkdir()
+        alias_home = tmp_path / "alias_home"
+        alias_home.symlink_to(real_home, target_is_directory=True)
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: alias_home / "knowledge")
+
+        captured = _json(kt.knowledge_capture_tool(
+            kind="debug",
+            title="Symlinked home",
+            content="Knowledge get should work through symlinked HERMES_HOME paths.",
+            sources=["test:symlinked-home"],
+            confidence="confirmed",
+        ))
+        fetched = _json(kt.knowledge_get_tool(id=captured["id"]))
+
+        assert fetched["success"] is True
+        assert fetched["path"] == captured["path"]
+        assert "symlinked HERMES_HOME" in fetched["content"]
+
+    def test_search_skips_non_utf8_records(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        knowledge_dir = tmp_path / "knowledge"
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: knowledge_dir)
+        bad_dir = knowledge_dir / "decisions"
+        bad_dir.mkdir(parents=True)
+        (bad_dir / "00000000-bad.md").write_bytes(b"\xff\xfe\xfd not utf-8")
+        kt.knowledge_capture_tool(
+            kind="projects",
+            title="Needle survives bad record",
+            content="needle content should still be searchable.",
+            sources=["test:non-utf8"],
+            confidence="confirmed",
+        )
+
+        result = _json(kt.knowledge_search_tool(query="needle", limit=5))
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        assert result["results"][0]["title"] == "Needle survives bad record"
+
+    def test_get_reports_non_utf8_record_without_raw_codec_error(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        knowledge_dir = tmp_path / "knowledge"
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: knowledge_dir)
+        bad_dir = knowledge_dir / "debug"
+        bad_dir.mkdir(parents=True)
+        (bad_dir / "bad.md").write_bytes(b"\xff\xfe\xfd not utf-8")
+
+        result = _json(kt.knowledge_get_tool(path="debug/bad.md"))
+
+        assert result["success"] is False
+        assert "not valid utf-8" in result["error"].lower()
+        assert "codec can't decode" not in result["error"].lower()
+
+    def test_get_reports_unreadable_record_without_raw_os_error(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        knowledge_dir = tmp_path / "knowledge"
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: knowledge_dir)
+        bad_record = knowledge_dir / "debug" / "bad.md"
+        bad_record.mkdir(parents=True)
+
+        result = _json(kt.knowledge_get_tool(path="debug/bad.md"))
+
+        assert result["success"] is False
+        assert result["error"] == "Could not read knowledge record: debug/bad.md"
+        assert str(tmp_path) not in result["error"]
+
+    def test_search_skips_symlink_records_that_resolve_outside_knowledge_dir(self, tmp_path, monkeypatch):
+        from tools import knowledge_tool as kt
+
+        knowledge_dir = tmp_path / "knowledge"
+        monkeypatch.setattr(kt, "get_knowledge_dir", lambda: knowledge_dir)
+        outside = tmp_path / "outside.md"
+        outside.write_text("# Outside\n\nsecret outside content", encoding="utf-8")
+        inbox_dir = knowledge_dir / "inbox"
+        inbox_dir.mkdir(parents=True)
+        (inbox_dir / "evil.md").symlink_to(outside)
+
+        result = _json(kt.knowledge_search_tool(query="secret outside", limit=5))
+
+        assert result["success"] is True
+        assert result["count"] == 0
+        assert result["results"] == []
+
+
+class TestKnowledgeToolsetWiring:
+    def test_knowledge_toolset_is_configurable_but_not_default_core(self):
+        import toolsets
+        from hermes_cli import tools_config
+
+        configurable = {name for name, _label, _desc in tools_config.CONFIGURABLE_TOOLSETS}
+        assert "knowledge" in configurable
+        assert "knowledge" in tools_config._DEFAULT_OFF_TOOLSETS
+        assert "knowledge" in toolsets.TOOLSETS
+
+        knowledge_tools = set(toolsets.resolve_toolset("knowledge"))
+        assert knowledge_tools == {
+            "knowledge_capture",
+            "knowledge_search",
+            "knowledge_get",
+        }
+        assert knowledge_tools.isdisjoint(set(toolsets._HERMES_CORE_TOOLS))
+
+    def test_knowledge_tools_require_explicit_toolset_resolution(self):
+        from model_tools import get_tool_definitions
+
+        default_tools = {
+            tool["function"]["name"]
+            for tool in get_tool_definitions(quiet_mode=True)
+        }
+        assert "knowledge_capture" not in default_tools
+        assert "knowledge_search" not in default_tools
+        assert "knowledge_get" not in default_tools
+
+        explicit_tools = {
+            tool["function"]["name"]
+            for tool in get_tool_definitions(enabled_toolsets=["knowledge"], quiet_mode=True)
+        }
+        assert {
+            "knowledge_capture",
+            "knowledge_search",
+            "knowledge_get",
+        }.issubset(explicit_tools)
+
+    def test_capture_schema_states_cold_on_demand_contract(self):
+        from tools.knowledge_tool import KNOWLEDGE_CAPTURE_SCHEMA
+
+        description = KNOWLEDGE_CAPTURE_SCHEMA["description"]
+        assert "not injected" in description.lower()
+        assert "source" in description.lower()
+        assert "inbox" in description.lower()

--- a/tests/tools/test_local_interrupt_cleanup.py
+++ b/tests/tools/test_local_interrupt_cleanup.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import tools.environments.base as base_env
 from tools.environments.local import LocalEnvironment
 
 
@@ -96,13 +97,40 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
     env = LocalEnvironment(cwd="/tmp")
     try:
         result_holder = {}
-        proc_holder = {}
-        started = threading.Event()
-        raise_at = [None]  # set by the main thread to tell worker when
+        command_proc_holder = {}
+        command_proc_started = threading.Event()
+        wait_loop_started = threading.Event()
+        worker_tid_holder = {}
+        original_run_bash = env._run_bash
+        original_is_interrupted = base_env.is_interrupted
+
+        def recording_is_interrupted():
+            if (
+                threading.current_thread().ident == worker_tid_holder.get("tid")
+                and command_proc_started.is_set()
+            ):
+                wait_loop_started.set()
+            return original_is_interrupted()
+
+        base_env.is_interrupted = recording_is_interrupted
+
+        def recording_run_bash(cmd_string, *args, **kwargs):
+            proc = original_run_bash(cmd_string, *args, **kwargs)
+            # init_session() spawns a login-shell bootstrap first. Capture the
+            # actual user command process directly instead of scraping the
+            # platform process table for "sleep 30"; cmdline visibility is
+            # flaky on loaded macOS runners and can hide the child argv.
+            if not kwargs.get("login", False) and "sleep 30" in cmd_string:
+                command_proc_holder["proc"] = proc
+                command_proc_started.set()
+            return proc
+
+        env._run_bash = recording_run_bash
 
         # Drive execute() on a separate thread so we can SIGNAL-interrupt it
         # via a thread-targeted exception without killing our test process.
         def worker():
+            worker_tid_holder["tid"] = threading.current_thread().ident
             # Spawn a subprocess that will definitely be alive long enough
             # to observe the cleanup, via env.execute(...) — the normal path
             # that goes through _wait_for_process.
@@ -113,43 +141,17 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
 
         t = threading.Thread(target=worker, daemon=True)
         t.start()
-        # Wait until the subprocess actually exists.  LocalEnvironment.execute
-        # does init_session() (one spawn) before the real command, so we need
-        # to wait until a sleep 30 is visible.  Use pgrep-style lookup via
-        # /proc to find the bash process running our sleep.
-        deadline = time.monotonic() + 5.0
-        target_pid = None
-        while time.monotonic() < deadline:
-            # Walk our children and grand-children to find one running 'sleep 30'
-            try:
-                import psutil  # optional — fall back if absent
-                for p in psutil.Process(os.getpid()).children(recursive=True):
-                    try:
-                        if "sleep 30" in " ".join(p.cmdline()):
-                            target_pid = p.pid
-                            break
-                    except (psutil.NoSuchProcess, psutil.AccessDenied):
-                        continue
-            except ImportError:
-                # Fall back to ps
-                ps = subprocess.run(
-                    ["ps", "-eo", "pid,ppid,pgid,cmd"], capture_output=True, text=True,
-                )
-                for line in ps.stdout.splitlines():
-                    if "sleep 30" in line and "grep" not in line:
-                        parts = line.split()
-                        if parts and parts[0].isdigit():
-                            target_pid = int(parts[0])
-                            break
-            if target_pid:
-                break
-            time.sleep(0.1)
 
-        assert target_pid is not None, (
-            "test setup: couldn't find 'sleep 30' subprocess after 5 s"
+        assert command_proc_started.wait(timeout=10.0), (
+            "test setup: user command subprocess did not start after 10 s"
         )
-        pgid = os.getpgid(target_pid)
-        assert _pgid_still_alive(pgid), "sanity: subprocess should be alive"
+        assert wait_loop_started.wait(timeout=10.0), (
+            "test setup: _wait_for_process did not enter its poll loop after 10 s"
+        )
+        proc = command_proc_holder["proc"]
+        assert proc.poll() is None, "sanity: subprocess should still be running"
+        pgid = getattr(proc, "_hermes_pgid", None) or os.getpgid(proc.pid)
+        assert _pgid_still_alive(pgid), "sanity: subprocess group should be alive"
 
         # Now inject a KeyboardInterrupt into the worker thread the same
         # way CPython's signal machinery would.  We use ctypes.PyThreadState_SetAsyncExc
@@ -188,6 +190,7 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
             f"propagation after cleanup"
         )
     finally:
+        base_env.is_interrupted = original_is_interrupted
         try:
             env.cleanup()
         except Exception:

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -305,6 +305,7 @@ class TestBuiltinDiscovery:
             "tools.homeassistant_tool",
             "tools.image_generation_tool",
             "tools.kanban_tools",
+            "tools.knowledge_tool",
             "tools.memory_tool",
             "tools.mixture_of_agents_tool",
             "tools.process_registry",

--- a/tests/tools/test_resolve_path.py
+++ b/tests/tools/test_resolve_path.py
@@ -42,7 +42,7 @@ class TestResolvePath:
 
         result = _resolve_path("~/notes.txt")
         # After expanduser, ~/notes.txt becomes absolute → TERMINAL_CWD ignored
-        assert result == Path.home() / "notes.txt"
+        assert result == (Path.home() / "notes.txt").resolve()
 
     def test_result_is_resolved(self, monkeypatch, tmp_path):
         """Output path has no '..' components."""

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -325,8 +325,15 @@ class CheckpointManager:
 
         abs_dir = str(_normalize_path(working_dir))
 
-        # Skip root, home, and other overly broad directories
-        if abs_dir in ("/", str(Path.home())):
+        # Skip root, home, and other overly broad directories.  Compare the
+        # home directory after the same canonicalization as ``working_dir`` so
+        # symlink aliases such as macOS /tmp -> /private/tmp don't bypass the
+        # broad-directory guard.
+        try:
+            home_dir = str(Path.home().resolve())
+        except (OSError, RuntimeError, ValueError):
+            home_dir = str(Path.home())
+        if abs_dir in ("/", home_dir):
             logger.debug("Checkpoint skipped: directory too broad (%s)", abs_dir)
             return False
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import tempfile
 import threading
 from pathlib import Path
 
@@ -155,6 +156,17 @@ _SENSITIVE_PATH_PREFIXES = (
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
 
+def _is_current_macos_temp_path(resolved: str) -> bool:
+    """Return True for files under the active macOS per-user temp dir."""
+    try:
+        temp_root = str(Path(tempfile.gettempdir()).resolve()).rstrip(os.sep)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    if not (temp_root.startswith("/private/var/folders/") or temp_root.startswith("/var/folders/")):
+        return False
+    return resolved == temp_root or resolved.startswith(temp_root + os.sep)
+
+
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
@@ -166,6 +178,12 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
+    # On macOS, tempfile defaults to /var/folders/... which resolves under
+    # /private/var/folders/..., but that is a per-user scratch directory, not a
+    # privileged system config path. Keep /private/var/* blocked except for the
+    # active temp root so normal tempfile-backed writes still work.
+    if _is_current_macos_temp_path(resolved):
+        return None
     for prefix in _SENSITIVE_PATH_PREFIXES:
         if resolved.startswith(prefix) or normalized.startswith(prefix):
             return _err

--- a/tools/knowledge_tool.py
+++ b/tools/knowledge_tool.py
@@ -1,0 +1,717 @@
+#!/usr/bin/env python3
+"""
+Knowledge Ledger Tool Module - Cold, source-attributed local knowledge.
+
+This toolset intentionally complements, rather than replaces, Hermes memory:
+- MEMORY.md / USER.md stay small hot memory and are injected at session start.
+- session_search remains episodic recall over raw conversations.
+- skills remain procedural memory.
+- knowledge/ is a cold/on-demand ledger for source-backed decisions,
+  debugging histories, skill evaluations, project state, incidents, and
+  inbox candidates.
+
+Records live under $HERMES_HOME/knowledge/*. They are never injected into the
+system prompt automatically; agents must explicitly call knowledge_search and
+knowledge_get when the user/task needs grounded recall.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry, tool_result
+
+
+# ---------------------------------------------------------------------------
+# Paths and constants
+# ---------------------------------------------------------------------------
+
+ALLOWED_KINDS = {
+    "inbox",
+    "decisions",
+    "debug",
+    "skill-evals",
+    "projects",
+    "incidents",
+    "entities",
+    "sources",
+}
+
+KIND_ALIASES = {
+    "decision": "decisions",
+    "decisions": "decisions",
+    "debug": "debug",
+    "debugging": "debug",
+    "skill_eval": "skill-evals",
+    "skill-eval": "skill-evals",
+    "skill_evals": "skill-evals",
+    "skill-evals": "skill-evals",
+    "project": "projects",
+    "projects": "projects",
+    "incident": "incidents",
+    "incidents": "incidents",
+    "entity": "entities",
+    "entities": "entities",
+    "source": "sources",
+    "sources": "sources",
+    "inbox": "inbox",
+    "candidate": "inbox",
+}
+
+CONFIDENCE_VALUES = {"candidate", "observed", "confirmed", "inferred", "experimental", "stale"}
+DEFAULT_SEARCH_KINDS = [
+    "decisions",
+    "debug",
+    "skill-evals",
+    "projects",
+    "incidents",
+    "entities",
+    "sources",
+    "inbox",
+]
+
+logger = logging.getLogger(__name__)
+
+
+def get_knowledge_dir() -> Path:
+    """Return the profile-scoped cold knowledge ledger directory."""
+    return get_hermes_home() / "knowledge"
+
+
+def check_knowledge_requirements() -> bool:
+    """The local knowledge ledger has no external requirements."""
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Normalization and rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _normalize_kind(kind: str | None) -> str:
+    raw = (kind or "inbox").strip().lower().replace("_", "-")
+    normalized = KIND_ALIASES.get(raw)
+    if not normalized:
+        raise ValueError(
+            f"Unknown knowledge kind '{kind}'. Use one of: {', '.join(sorted(ALLOWED_KINDS))}."
+        )
+    return normalized
+
+
+def _clean_string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _clean_list(values: Any) -> List[str]:
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, Iterable):
+        return []
+    cleaned: List[str] = []
+    for value in values:
+        item = _clean_string(value)
+        if item and item not in cleaned:
+            cleaned.append(item)
+    return cleaned
+
+
+def _normalize_confidence(confidence: str | None, *, has_sources: bool, kind: str) -> str:
+    raw = (confidence or "").strip().lower()
+    if not raw:
+        return "candidate" if kind == "inbox" and not has_sources else "observed"
+    if raw not in CONFIDENCE_VALUES:
+        raise ValueError(
+            f"Unknown confidence '{confidence}'. Use one of: {', '.join(sorted(CONFIDENCE_VALUES))}."
+        )
+    return raw
+
+
+def _slugify(title: str, fallback: str = "record") -> str:
+    slug = re.sub(r"[^a-zA-Z0-9가-힣._-]+", "-", title.strip().lower())
+    slug = re.sub(r"-+", "-", slug).strip("-._")
+    return slug[:80] or fallback
+
+
+def _yaml_scalar(value: Any) -> str:
+    text = _clean_string(value)
+    # Keep frontmatter simple and grep-friendly. Quote only when needed.
+    if not text:
+        return '""'
+    if re.search(r"[:#\[\]{}\n\r]|^[-?]|\s$|^\s", text):
+        return json.dumps(text, ensure_ascii=False)
+    return text
+
+
+def _frontmatter(metadata: Dict[str, Any]) -> str:
+    lines = ["---"]
+    for key, value in metadata.items():
+        if isinstance(value, list):
+            if value:
+                lines.append(f"{key}:")
+                for item in value:
+                    lines.append(f"- {_yaml_scalar(item)}")
+            else:
+                lines.append(f"{key}: []")
+        else:
+            lines.append(f"{key}: {_yaml_scalar(value)}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _render_record(
+    *,
+    record_id: str,
+    kind: str,
+    title: str,
+    content: str,
+    sources: List[str],
+    confidence: str,
+    status: str,
+    tags: List[str],
+    timestamp: str,
+) -> str:
+    metadata: Dict[str, Any] = {
+        "id": record_id,
+        "type": kind,
+        "title": title,
+        "status": status,
+        "confidence": confidence,
+        "created_at": timestamp,
+        "updated_at": timestamp,
+        "tags": tags,
+        "sources": sources,
+    }
+    sections = [
+        _frontmatter(metadata),
+        "",
+        f"# {title}",
+        "",
+        "## Current State",
+        content.rstrip(),
+        "",
+        "## Timeline",
+        f"- {timestamp} — Captured as `{kind}` record.",
+        "",
+        "## Evidence",
+    ]
+    if sources:
+        sections.extend(f"- {source}" for source in sources)
+    else:
+        sections.append("- Candidate only: no source supplied yet.")
+    sections.extend([
+        "",
+        "## Conflicts",
+        "- None recorded.",
+        "",
+        "## Open Threads",
+        "- [ ] Review/merge/delete during knowledge digest.",
+        "",
+    ])
+    return "\n".join(sections)
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.stem}_", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        # Knowledge records must stay confined to $HERMES_HOME/knowledge.
+        # Use os.replace directly instead of utils.atomic_replace, because that
+        # helper intentionally follows target symlinks for config-file use cases.
+        # For ledger records, following a symlink could write outside knowledge/.
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _safe_kind_dir(kind: str) -> Path:
+    """Create/return a knowledge kind directory without following kind symlinks."""
+    root = get_knowledge_dir()
+    root.mkdir(parents=True, exist_ok=True)
+    root_resolved = root.resolve()
+    directory = root / kind
+    directory.mkdir(parents=True, exist_ok=True)
+    if directory.is_symlink():
+        raise ValueError(f"Knowledge kind directory cannot be a symlink: {kind}")
+    try:
+        directory.resolve().relative_to(root_resolved)
+    except (OSError, ValueError) as exc:
+        raise ValueError("Knowledge kind directory resolves outside the knowledge directory.") from exc
+    return directory
+
+
+def _unique_record_path(kind: str, title: str, timestamp: str) -> Tuple[str, Path]:
+    directory = _safe_kind_dir(kind)
+    stamp = timestamp.replace(":", "").replace("-", "").replace("Z", "Z")
+    stem_base = f"{stamp}-{_slugify(title)}"
+    stem = stem_base
+    path = directory / f"{stem}.md"
+    counter = 2
+    while path.exists():
+        stem = f"{stem_base}-{counter}"
+        path = directory / f"{stem}.md"
+        counter += 1
+    record_id = f"{kind}/{stem}"
+    return record_id, path
+
+
+def _relative_to_root(path: Path) -> str:
+    root = get_knowledge_dir().resolve()
+    return path.resolve().relative_to(root).as_posix()
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing and path safety
+# ---------------------------------------------------------------------------
+
+
+def _parse_frontmatter(text: str) -> Tuple[Dict[str, Any], str]:
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, text
+    block = text[4:end]
+    body = text[end + len("\n---\n"):]
+    meta: Dict[str, Any] = {}
+    current_list_key: Optional[str] = None
+    for raw_line in block.splitlines():
+        line = raw_line.rstrip()
+        if not line:
+            continue
+        if line.startswith("- ") and current_list_key:
+            meta.setdefault(current_list_key, []).append(_unquote_scalar(line[2:].strip()))
+            continue
+        if ":" not in line:
+            current_list_key = None
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not value:
+            meta[key] = []
+            current_list_key = key
+        elif value == "[]":
+            meta[key] = []
+            current_list_key = None
+        else:
+            meta[key] = _unquote_scalar(value)
+            current_list_key = None
+    return meta, body
+
+
+def _unquote_scalar(value: str) -> str:
+    if not value:
+        return ""
+    if value[0] in {'"', "'"}:
+        try:
+            return str(json.loads(value))
+        except Exception:
+            return value.strip('"\'')
+    return value
+
+
+def _title_from_text(meta: Dict[str, Any], body: str, path: Path) -> str:
+    if meta.get("title"):
+        return str(meta["title"])
+    for line in body.splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return path.stem
+
+
+def _safe_record_path(*, record_id: str | None = None, rel_path: str | None = None) -> Path:
+    root = get_knowledge_dir().resolve()
+    if record_id:
+        candidate = record_id.strip()
+        if not candidate.endswith(".md"):
+            candidate = f"{candidate}.md"
+    elif rel_path:
+        candidate = rel_path.strip()
+    else:
+        raise ValueError("Provide id or path.")
+
+    path = Path(candidate)
+    if path.is_absolute():
+        raise ValueError("Absolute paths are not allowed for knowledge records.")
+    resolved = (root / path).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("Path traversal outside the knowledge directory is not allowed.") from exc
+    return resolved
+
+
+def _iter_record_paths(kind: str | None = None) -> Iterable[Path]:
+    root = get_knowledge_dir()
+    root_resolved = root.resolve()
+    if kind:
+        kinds = [_normalize_kind(kind)]
+    else:
+        kinds = DEFAULT_SEARCH_KINDS
+    for k in kinds:
+        directory = root / k
+        for path in sorted(directory.glob("*.md")):
+            try:
+                path.resolve().relative_to(root_resolved)
+            except (OSError, ValueError):
+                # Do not follow symlinked ledger entries outside knowledge/.
+                continue
+            yield path
+
+
+# ---------------------------------------------------------------------------
+# Tool implementations
+# ---------------------------------------------------------------------------
+
+
+def knowledge_capture_tool(
+    kind: str = "inbox",
+    title: str = "",
+    content: str = "",
+    sources: Optional[List[str]] = None,
+    confidence: Optional[str] = None,
+    tags: Optional[List[str]] = None,
+    status: Optional[str] = None,
+) -> str:
+    """Create a new cold knowledge ledger record."""
+    try:
+        normalized_kind = _normalize_kind(kind)
+        clean_title = _clean_string(title)
+        clean_content = _clean_string(content)
+        clean_sources = _clean_list(sources)
+        clean_tags = _clean_list(tags)
+
+        if not clean_title:
+            return tool_result(success=False, error="title cannot be empty.")
+        if not clean_content:
+            return tool_result(success=False, error="content cannot be empty.")
+        if normalized_kind != "inbox" and not clean_sources:
+            return tool_result(
+                success=False,
+                error=(
+                    "source attribution is required for non-inbox knowledge records. "
+                    "Capture unsourced material as kind='inbox' candidate, or provide sources."
+                ),
+            )
+
+        unsourced_inbox = normalized_kind == "inbox" and not clean_sources
+        clean_confidence = _normalize_confidence(
+            confidence,
+            has_sources=bool(clean_sources),
+            kind=normalized_kind,
+        )
+        if unsourced_inbox:
+            clean_confidence = "candidate"
+            clean_status = "candidate"
+        else:
+            clean_status = _clean_string(status) or ("candidate" if normalized_kind == "inbox" else "active")
+        timestamp = _now_iso()
+        record_id, path = _unique_record_path(normalized_kind, clean_title, timestamp)
+        markdown = _render_record(
+            record_id=record_id,
+            kind=normalized_kind,
+            title=clean_title,
+            content=clean_content,
+            sources=clean_sources,
+            confidence=clean_confidence,
+            status=clean_status,
+            tags=clean_tags,
+            timestamp=timestamp,
+        )
+        _atomic_write_text(path, markdown)
+        return tool_result(
+            success=True,
+            id=record_id,
+            kind=normalized_kind,
+            status=clean_status,
+            confidence=clean_confidence,
+            path=_relative_to_root(path),
+            message=(
+                "Knowledge record captured in cold storage. It is not injected into the "
+                "system prompt; use knowledge_search/knowledge_get for on-demand recall."
+            ),
+        )
+    except Exception as exc:
+        return tool_result(success=False, error=str(exc))
+
+
+def _score_record(query_terms: List[str], title: str, body: str, meta: Dict[str, Any]) -> int:
+    haystacks = {
+        "title": title.lower(),
+        "body": body.lower(),
+        "tags": " ".join(meta.get("tags") or []).lower() if isinstance(meta.get("tags"), list) else "",
+        "sources": " ".join(meta.get("sources") or []).lower() if isinstance(meta.get("sources"), list) else "",
+    }
+    score = 0
+    for term in query_terms:
+        if not term:
+            continue
+        if term in haystacks["title"]:
+            score += 5
+        if term in haystacks["tags"]:
+            score += 3
+        if term in haystacks["sources"]:
+            score += 2
+        body_hits = haystacks["body"].count(term)
+        score += min(body_hits, 5)
+    phrase = " ".join(query_terms).strip()
+    if phrase and phrase in haystacks["body"]:
+        score += 4
+    if phrase and phrase in haystacks["title"]:
+        score += 8
+    return score
+
+
+def _snippet(body: str, query_terms: List[str], max_chars: int = 280) -> str:
+    lower = body.lower()
+    positions = [lower.find(term) for term in query_terms if term and lower.find(term) != -1]
+    if positions:
+        start = max(0, min(positions) - 80)
+    else:
+        start = 0
+    snippet = re.sub(r"\s+", " ", body[start:start + max_chars]).strip()
+    if start > 0:
+        snippet = "…" + snippet
+    if start + max_chars < len(body):
+        snippet += "…"
+    return snippet
+
+
+def knowledge_search_tool(
+    query: str,
+    kind: Optional[str] = None,
+    limit: int = 5,
+) -> str:
+    """Lexically search the cold knowledge ledger and return short snippets."""
+    try:
+        clean_query = _clean_string(query)
+        if not clean_query:
+            return tool_result(success=False, error="query cannot be empty.")
+        try:
+            limit = max(1, min(int(limit), 20))
+        except Exception:
+            limit = 5
+        terms = [t for t in re.findall(r"[\w가-힣._-]+", clean_query.lower()) if t]
+        if not terms:
+            terms = [clean_query.lower()]
+
+        rows: List[Dict[str, Any]] = []
+        for path in _iter_record_paths(kind):
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError) as exc:
+                try:
+                    record_label = _relative_to_root(path)
+                except Exception:
+                    record_label = path.name
+                logger.debug("Skipping unreadable knowledge record %s: %s", record_label, type(exc).__name__)
+                continue
+            meta, body = _parse_frontmatter(text)
+            title = _title_from_text(meta, body, path)
+            score = _score_record(terms, title, body, meta)
+            if score <= 0:
+                continue
+            rel = _relative_to_root(path)
+            rows.append({
+                "id": str(meta.get("id") or rel.removesuffix(".md")),
+                "kind": str(meta.get("type") or path.parent.name),
+                "title": title,
+                "path": rel,
+                "score": score,
+                "confidence": meta.get("confidence"),
+                "status": meta.get("status"),
+                "updated_at": meta.get("updated_at"),
+                "sources": meta.get("sources") or [],
+                "snippet": _snippet(body, terms),
+            })
+
+        rows.sort(key=lambda r: (r["score"], r.get("updated_at") or ""), reverse=True)
+        return tool_result(success=True, query=clean_query, count=len(rows[:limit]), results=rows[:limit])
+    except Exception as exc:
+        return tool_result(success=False, error=str(exc))
+
+
+def knowledge_get_tool(id: Optional[str] = None, path: Optional[str] = None) -> str:
+    """Read a single knowledge record by id or relative path."""
+    try:
+        record_path = _safe_record_path(record_id=id, rel_path=path)
+        if not record_path.exists():
+            return tool_result(success=False, error=f"Knowledge record not found: {id or path}")
+        try:
+            text = record_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            return tool_result(success=False, error=f"Knowledge record is not valid UTF-8: {id or path}")
+        except OSError:
+            return tool_result(success=False, error=f"Could not read knowledge record: {id or path}")
+        meta, body = _parse_frontmatter(text)
+        rel = _relative_to_root(record_path)
+        return tool_result(
+            success=True,
+            id=str(meta.get("id") or rel.removesuffix(".md")),
+            kind=str(meta.get("type") or record_path.parent.name),
+            title=_title_from_text(meta, body, record_path),
+            path=rel,
+            metadata=meta,
+            content=text,
+        )
+    except Exception as exc:
+        return tool_result(success=False, error=str(exc))
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Function-Calling Schemas
+# ---------------------------------------------------------------------------
+
+KNOWLEDGE_CAPTURE_SCHEMA = {
+    "name": "knowledge_capture",
+    "description": (
+        "Capture a cold, source-attributed knowledge ledger record under "
+        "$HERMES_HOME/knowledge. Records are NOT injected into the system prompt "
+        "or hot memory; use knowledge_search/knowledge_get for on-demand recall. "
+        "Use for durable decisions, debug findings, skill evaluations, project state, "
+        "incidents, entities, sources, or inbox candidates. Non-inbox records require "
+        "at least one source. Unsourced/automatic extraction must go to kind='inbox' "
+        "as a candidate for later human/agent review."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "kind": {
+                "type": "string",
+                "enum": sorted(ALLOWED_KINDS),
+                "description": "Ledger section. Non-inbox sections require sources.",
+                "default": "inbox",
+            },
+            "title": {"type": "string", "description": "Short record title."},
+            "content": {"type": "string", "description": "Record body / current state."},
+            "sources": {
+                "type": "array",
+                "description": "Source handles, URLs, commands, files, logs, or conversation references.",
+                "items": {"type": "string"},
+            },
+            "confidence": {
+                "type": "string",
+                "enum": sorted(CONFIDENCE_VALUES),
+                "description": "Confidence level. Defaults to candidate for unsourced inbox, observed otherwise.",
+            },
+            "tags": {
+                "type": "array",
+                "description": "Optional short tags for lexical retrieval.",
+                "items": {"type": "string"},
+            },
+            "status": {
+                "type": "string",
+                "description": "Optional lifecycle status (candidate, active, resolved, superseded, stale, etc.).",
+            },
+        },
+        "required": ["title", "content"],
+    },
+}
+
+KNOWLEDGE_SEARCH_SCHEMA = {
+    "name": "knowledge_search",
+    "description": (
+        "Search the cold Hermes knowledge ledger on demand. Returns ranked metadata "
+        "and short snippets only, not a full memory dump. Use before knowledge_get "
+        "when recalling source-backed decisions, debug histories, skill evaluations, "
+        "or project state."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Lexical search query."},
+            "kind": {
+                "type": "string",
+                "enum": sorted(ALLOWED_KINDS),
+                "description": "Optional section filter.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of results (1-20).",
+                "default": 5,
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+KNOWLEDGE_GET_SCHEMA = {
+    "name": "knowledge_get",
+    "description": (
+        "Read one cold knowledge ledger record by id or relative path after search. "
+        "Paths are constrained to $HERMES_HOME/knowledge to prevent traversal."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "description": "Record id, e.g. decisions/20260504T120000Z-title."},
+            "path": {"type": "string", "description": "Relative path returned by knowledge_search/capture."},
+        },
+        "required": [],
+    },
+}
+
+
+registry.register(
+    name="knowledge_capture",
+    toolset="knowledge",
+    schema=KNOWLEDGE_CAPTURE_SCHEMA,
+    handler=lambda args, **kw: knowledge_capture_tool(
+        kind=args.get("kind", "inbox"),
+        title=args.get("title", ""),
+        content=args.get("content", ""),
+        sources=args.get("sources"),
+        confidence=args.get("confidence"),
+        tags=args.get("tags"),
+        status=args.get("status"),
+    ),
+    check_fn=check_knowledge_requirements,
+    emoji="🗃️",
+)
+
+registry.register(
+    name="knowledge_search",
+    toolset="knowledge",
+    schema=KNOWLEDGE_SEARCH_SCHEMA,
+    handler=lambda args, **kw: knowledge_search_tool(
+        query=args.get("query", ""),
+        kind=args.get("kind"),
+        limit=args.get("limit", 5),
+    ),
+    check_fn=check_knowledge_requirements,
+    emoji="🔎",
+)
+
+registry.register(
+    name="knowledge_get",
+    toolset="knowledge",
+    schema=KNOWLEDGE_GET_SCHEMA,
+    handler=lambda args, **kw: knowledge_get_tool(
+        id=args.get("id"),
+        path=args.get("path"),
+    ),
+    check_fn=check_knowledge_requirements,
+    emoji="📄",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -173,6 +173,12 @@ TOOLSETS = {
         "tools": ["memory"],
         "includes": []
     },
+
+    "knowledge": {
+        "description": "Cold, source-attributed local knowledge ledger (on-demand; not hot memory)",
+        "tools": ["knowledge_capture", "knowledge_search", "knowledge_get"],
+        "includes": []
+    },
     
     "session_search": {
         "description": "Search and recall past conversations with summarization",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3039,8 +3039,12 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     try:
                         if _pdb.set_session_title(session.get("session_key") or sid, _pending):
                             session["pending_title"] = None
+                    except ValueError:
+                        # Duplicate/invalid titles are permanent user-facing
+                        # errors; do not retry them after every turn.
+                        session["pending_title"] = None
                     except Exception:
-                        pass  # Best effort — auto-title will handle it below
+                        pass  # Transient best-effort failure; retry later.
 
             if (
                 status == "complete"

--- a/ui-tui/package-lock.json
+++ b/ui-tui/package-lock.json
@@ -124,7 +124,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -500,6 +499,31 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1676,7 +1700,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1687,7 +1710,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1698,7 +1720,6 @@
       "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.58.1",
@@ -1728,7 +1749,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -2046,7 +2066,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2449,7 +2468,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3185,7 +3203,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3317,7 +3334,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -4226,7 +4242,6 @@
       "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
       "integrity": "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "type-fest": "^4.18.2"
@@ -5663,7 +5678,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5773,7 +5787,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6598,7 +6611,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -6725,7 +6737,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6835,7 +6846,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7251,7 +7261,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -29,7 +29,7 @@ It's not a coding copilot tethered to an IDE or a chatbot wrapper around a singl
 | 🗺️ **[Learning Path](/docs/getting-started/learning-path)** | Find the right docs for your experience level |
 | ⚙️ **[Configuration](/docs/user-guide/configuration)** | Config file, providers, models, and options |
 | 💬 **[Messaging Gateway](/docs/user-guide/messaging)** | Set up Telegram, Discord, Slack, or WhatsApp |
-| 🔧 **[Tools & Toolsets](/docs/user-guide/features/tools)** | 68 built-in tools and how to configure them |
+| 🔧 **[Tools & Toolsets](/docs/user-guide/features/tools)** | 71 built-in tools and how to configure them |
 | 🧠 **[Memory System](/docs/user-guide/features/memory)** | Persistent memory that grows across sessions |
 | 📚 **[Skills System](/docs/user-guide/features/skills)** | Procedural memory the agent creates and reuses |
 | 🔌 **[MCP Integration](/docs/user-guide/features/mcp)** | Connect to MCP servers, filter their tools, and extend Hermes safely |

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -6,9 +6,9 @@ description: "Authoritative reference for Hermes built-in tools, grouped by tool
 
 # Built-in Tools Reference
 
-This page documents all 68 built-in tools in the Hermes tool registry, grouped by toolset. Availability varies by platform, credentials, and enabled toolsets.
+This page documents built-in tools in the Hermes tool registry, grouped by toolset. Availability varies by platform, credentials, and enabled toolsets.
 
-**Quick counts:** 10 browser tools (core) + 2 browser-cdp tools, 4 file tools, 10 RL tools, 4 Home Assistant tools, 2 terminal tools, 2 web tools, 5 Feishu tools, 7 Spotify tools, 5 Yuanbao tools, 2 Discord tools, and 15 standalone tools across other toolsets.
+**Quick counts:** 10 browser tools (core) + 2 browser-cdp tools, 4 file tools, 10 RL tools, 4 Home Assistant tools, 2 terminal tools, 2 web tools, 5 Feishu tools, 7 Spotify tools, 5 Yuanbao tools, 2 Discord tools, 7 Kanban tools, 3 knowledge tools, and 15 standalone tools across other toolsets.
 
 :::tip MCP Tools
 In addition to built-in tools, Hermes can load tools dynamically from MCP servers. MCP tools appear with a server-name prefix (e.g., `github_create_issue` for the `github` MCP server). See [MCP Integration](/docs/user-guide/features/mcp) for configuration.
@@ -114,6 +114,16 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
 | `memory` | Save important information to persistent memory that survives across sessions. Your memory appears in your system prompt at session start -- it's how you remember things about the user and your environment between conversations. WHEN TO SA… | — |
+
+## `knowledge` toolset
+
+Opt-in cold source-attributed recall. Not included in default platform toolsets; enable explicitly when you want on-demand knowledge records without adding prompt tax to every session.
+
+| Tool | Description | Requires environment |
+|------|-------------|----------------------|
+| `knowledge_capture` | Capture a cold, source-attributed knowledge ledger record under `$HERMES_HOME/knowledge`. Non-inbox records require at least one source; unsourced automatic extraction goes to `inbox` as a candidate. | — |
+| `knowledge_search` | Lexically search the cold knowledge ledger and return ranked metadata plus short snippets, not a full memory dump. | — |
+| `knowledge_get` | Read one knowledge record by id or relative path after search. Paths are constrained to the knowledge directory. | — |
 
 ## `messaging` toolset
 

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -66,6 +66,7 @@ Or in-session:
 | `homeassistant` | `ha_call_service`, `ha_get_state`, `ha_list_entities`, `ha_list_services` | Smart home control via Home Assistant. Only available when `HASS_TOKEN` is set. |
 | `image_gen` | `image_generate` | Text-to-image generation via FAL.ai (with opt-in OpenAI / xAI backends). |
 | `memory` | `memory` | Persistent cross-session memory management. |
+| `knowledge` | `knowledge_capture`, `knowledge_get`, `knowledge_search` | Opt-in cold source-attributed ledger for decisions, debug histories, skill evaluations, and project state. Not included in default platform toolsets; enable explicitly to avoid schema/token tax. |
 | `messaging` | `send_message` | Send messages to other platforms (Telegram, Discord, etc.) from within a session. |
 | `moa` | `mixture_of_agents` | Multi-model consensus via Mixture of Agents. |
 | `rl` | `rl_check_status`, `rl_edit_config`, `rl_get_current_config`, `rl_get_results`, `rl_list_environments`, `rl_list_runs`, `rl_select_environment`, `rl_start_training`, `rl_stop_training`, `rl_test_inference` | RL training environment management (Atropos). |

--- a/website/docs/user-guide/features/knowledge-ledger.md
+++ b/website/docs/user-guide/features/knowledge-ledger.md
@@ -1,0 +1,94 @@
+---
+sidebar_position: 5
+title: "Knowledge Ledger"
+description: "Cold, source-attributed recall for decisions, debug histories, skill evaluations, and project state"
+---
+
+# Knowledge Ledger
+
+The knowledge ledger is an opt-in cold storage layer for durable, source-backed facts that are too large or too specific for `MEMORY.md` / `USER.md`.
+
+It stores Markdown records under:
+
+```text
+$HERMES_HOME/knowledge/
+├── inbox/
+├── decisions/
+├── debug/
+├── skill-evals/
+├── projects/
+├── incidents/
+├── entities/
+└── sources/
+```
+
+## How It Differs from Memory
+
+| Layer | Use for | Prompt cost |
+|---|---|---|
+| `MEMORY.md` / `USER.md` | Small hot facts that should always be visible | Always injected |
+| `session_search` | Past conversation recall | On demand |
+| Skills | Procedures and workflows | Loaded when relevant |
+| Knowledge ledger | Source-backed decisions, debug findings, project state | On demand only |
+
+Knowledge records are **not injected into the system prompt**. The agent must call `knowledge_search` and then `knowledge_get` when a task needs them.
+
+## Tools
+
+Enable the `knowledge` toolset with `hermes tools` or for a single run with `--toolsets knowledge,...`.
+
+The toolset contains:
+
+- `knowledge_capture` — create a Markdown record.
+- `knowledge_search` — lexical search that returns short snippets, not a full dump.
+- `knowledge_get` — read one record by id or relative path.
+
+## Source Attribution Rule
+
+Non-inbox records require at least one source. Examples:
+
+- a URL
+- a file path
+- a command and output handle
+- a ticket/PR/issue id
+- a conversation reference
+- a skill name/version
+
+Unsourced or automatically extracted material must go to `kind="inbox"` as a `candidate` record for later review.
+
+## Good Uses
+
+- Why a technical decision was made.
+- Confirmed root causes and rejected debugging paths.
+- Skill evaluations: which skill was stale, what was patched, and why.
+- Long-running project state that should be retrieved only when needed.
+- Incidents and postmortems.
+
+## Avoid
+
+- General user preferences that belong in `USER.md`.
+- Tiny environment facts that belong in `MEMORY.md`.
+- Procedures that should be skills.
+- Bulk conversation logs; use `session_search` for episodic recall.
+- Always injecting knowledge records into prompts.
+
+## Example
+
+```json
+{
+  "kind": "decisions",
+  "title": "MemKraft adoption boundary",
+  "content": "Use a cold source-attributed ledger, not a hot memory replacement.",
+  "sources": ["conversation:discord:Agent/#1/Ping"],
+  "confidence": "observed",
+  "tags": ["memory", "roi"]
+}
+```
+
+Later retrieval:
+
+```json
+{"query": "MemKraft adoption boundary", "kind": "decisions"}
+```
+
+Then read the selected record with `knowledge_get`.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -48,6 +48,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/skills',
             'user-guide/features/curator',
             'user-guide/features/memory',
+            'user-guide/features/knowledge-ledger',
             'user-guide/features/memory-providers',
             'user-guide/features/context-files',
             'user-guide/features/context-references',


### PR DESCRIPTION
## Summary
- Adds an opt-in cold knowledge ledger toolset with path/symlink safety and docs.
- Hardens test isolation so local runs do not touch real Hermes homes, credentials, or macOS Keychain.
- Updates stale/full-suite assertions exposed by isolated maxfail runs, including Discord adapter binding, Dockerfile/TUI contracts, provider resolution, checkpoint home aliases, and macOS `/tmp` path canonicalization.
- Fixes ultrareview findings around knowledge ledger symlinked homes, non-UTF8 records, and test temp-home cleanup.

## Verification
- Focused knowledge/checkpoint/resolve tests: `24 passed`.
- `scripts/run_tests.sh` failure-path cleanup probe: nonzero pytest exit, temp Hermes home leftovers `0`.
- `git diff --check`: passed.
- Added-line static security scan: `0` hits.
- Claude ultrareview: 3 verified findings; all fixed.
- Independent final subagent review: passed, no security concerns or logic errors.
- Clean isolated full suite with temp `HOME`, temp `HERMES_HOME`, fake macOS `security`, and raised ulimit: `19378 passed, 78 skipped, RC=0`.

## Security notes
- No real credentials are included in this diff.
- Verification runs used isolated homes and a fake `security` binary to prevent access to local Hermes/Claude credentials or macOS Keychain.