### PR TITLE
fix(mcp): add periodic keepalive to _wait_for_lifecycle_event (salvage #17016)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1038,14 +1038,43 @@ class MCPServerTask:
                         with a fresh signal.
 
         Shutdown takes precedence if both events are set simultaneously.
+
+        Periodically sends a lightweight keepalive (``list_tools``) to
+        prevent TCP connections from going stale during long idle
+        periods (#17003).  If the keepalive fails, triggers a reconnect.
         """
+        # Keepalive interval in seconds.  Must be shorter than typical
+        # LB / NAT idle-timeout (commonly 300-600s).
+        _KEEPALIVE_INTERVAL = 180  # 3 minutes
+
         shutdown_task = asyncio.create_task(self._shutdown_event.wait())
         reconnect_task = asyncio.create_task(self._reconnect_event.wait())
         try:
-            await asyncio.wait(
-                {shutdown_task, reconnect_task},
-                return_when=asyncio.FIRST_COMPLETED,
-            )
+            while True:
+                done, _pending = await asyncio.wait(
+                    {shutdown_task, reconnect_task},
+                    timeout=_KEEPALIVE_INTERVAL,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if done:
+                    break
+
+                # Timeout — no lifecycle event fired.  Send a keepalive
+                # to exercise the connection and detect stale sockets.
+                if self.session:
+                    try:
+                        await asyncio.wait_for(
+                            self.session.list_tools(),
+                            timeout=30.0,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "MCP server '%s' keepalive failed, "
+                            "triggering reconnect: %s",
+                            self.name, exc,
+                        )
+                        self._reconnect_event.set()
+                        break
         finally:
             for t in (shutdown_task, reconnect_task):
                 if not t.done():


### PR DESCRIPTION
Salvages the keepalive portion of @vominh1919's PR #17016. Fixes #17003.

## What it does
During long idle periods, the MCP session's TCP connection goes stale behind NAT / LB idle timeouts (commonly 300–600s). Sends a lightweight `list_tools` probe every 3 minutes; if it fails, triggers a reconnect cleanly instead of leaving the agent stuck on a dead socket.

## Changes
- `tools/mcp_tool.py` — `_wait_for_lifecycle_event` wraps `asyncio.wait` in a loop with a 180s timeout; on timeout, probes `session.list_tools()` with a 30s deadline and fires `_reconnect_event` on failure.

## Dropped vs original
The original PR #17016 also added half-open state to the circuit breaker, but that feature was already landed on main via @benbarclay's commit 8cc3cebca ("fix(mcp): add half-open state to circuit breaker", Apr 21). Only the keepalive is salvaged here.

## Validation
`tests/tools/test_mcp_tool.py` — 182 passed locally.

Closes #17016 via salvage.