### PR TITLE
fix: resolve model.aliases from config.yaml in /model alias resolution (salvage #16987)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -190,11 +190,18 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
             model: "minimax-m2.7"
             provider: custom
             base_url: "https://ollama.com/v1"
+
+    Also reads ``model.aliases`` (set by ``hermes config set model.aliases.xxx``)
+    and converts simple string entries (``ds-flash: deepseek/deepseek-v4-flash``)
+    into DirectAlias objects.  The provider is parsed from the ``provider/``
+    prefix in the value; if no slash, the current provider is used.
     """
     merged = dict(_BUILTIN_DIRECT_ALIASES)
     try:
         from hermes_cli.config import load_config
         cfg = load_config()
+
+        # --- model_aliases (dict-based format) ---
         user_aliases = cfg.get("model_aliases")
         if isinstance(user_aliases, dict):
             for name, entry in user_aliases.items():
@@ -206,6 +213,30 @@ def _load_direct_aliases() -> dict[str, DirectAlias]:
                 if model:
                     merged[name.strip().lower()] = DirectAlias(
                         model=model, provider=provider, base_url=base_url,
+                    )
+
+        # --- model.aliases (string-based format, from config set) ---
+        model_section = cfg.get("model", {})
+        if isinstance(model_section, dict):
+            simple_aliases = model_section.get("aliases")
+            if isinstance(simple_aliases, dict):
+                current_provider = model_section.get("provider", "")
+                for name, value in simple_aliases.items():
+                    if not isinstance(value, str) or not value.strip():
+                        continue
+                    key = name.strip().lower()
+                    if key in merged:
+                        continue  # don't override explicit model_aliases entries
+                    val = value.strip()
+                    if "/" in val:
+                        provider, model = val.split("/", 1)
+                    else:
+                        provider = current_provider
+                        model = val
+                    merged[key] = DirectAlias(
+                        model=model.strip(),
+                        provider=provider.strip() or current_provider,
+                        base_url="",
                     )
     except Exception:
         pass


### PR DESCRIPTION
Salvages @nazirulhafiy's PR #16987 onto current main.

## What it does
`hermes config set model.aliases.xxx value` writes to the `model.aliases` nested key (standard dotted-path behavior of `_set_nested`). But `_load_direct_aliases()` only read `model_aliases` at the top level. Result: aliases set via `hermes config set` were invisible to `/model`, and unrecognised inputs fell through to the DeepSeek normaliser which mapped everything to `deepseek-chat`.

Adds a second pass that reads `model.aliases` and converts simple string entries (`ds-flash: deepseek/deepseek-v4-flash`) into `DirectAlias` objects. Provider parsed from slash prefix; no slash → current default provider.

Top-level `model_aliases` entries win over `model.aliases` entries with the same key (explicit dict-format config wins over simple-string config).

## Changes
- `hermes_cli/model_switch.py` — second pass over `model.aliases`.

## Validation
- `tests/hermes_cli/` (model_switch + alias scope) — 227 passed locally.
- E2E test with real imports and temp HERMES_HOME:
  - `ds-flash: deepseek/deepseek-v4-flash` → `DirectAlias(model='deepseek-v4-flash', provider='deepseek')`
  - `minimax-cn: minimax-cn/minimax-m2.7` → `DirectAlias(model='minimax-m2.7', provider='minimax-cn')`
  - `bare-name: gpt-5.4` (no slash) → `DirectAlias(model='gpt-5.4', provider='openrouter')` (current provider)

Closes #16987 via salvage.