### PR TITLE
fix(openrouter): treat xiaomi models as reasoning-capable (salvage #16984)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8582,6 +8582,7 @@ class AIAgent:
             "google/gemini-2",
             "qwen/qwen3",
             "tencent/hy3-preview",
+            "xiaomi/",
         )
         return any(model.startswith(prefix) for prefix in reasoning_model_prefixes)
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -57,6 +57,7 @@ AUTHOR_MAP = {
     "revar@users.noreply.github.com": "revaraver",
     "beardthelion@users.noreply.github.com": "beardthelion",
     "tangyuanjc@JCdeAIfenshendeMac-mini.local": "tangyuanjc",
+    "leon@agentlinker.ai": "agentlinker",
     "29756950+revaraver@users.noreply.github.com": "revaraver",
     "nexus@eptic.me": "TheEpTic",
     "74554762+wmagev@users.noreply.github.com": "wmagev",

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4990,6 +4990,28 @@ class TestDeadRetryCode:
         )
 
 
+class TestSupportsReasoningExtraBody:
+    def _make_agent(self):
+        agent = object.__new__(AIAgent)
+        agent.provider = "openrouter"
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = ""
+        return agent
+
+    def test_xiaomi_models_are_treated_as_reasoning_capable(self):
+        agent = self._make_agent()
+        for model in (
+            "xiaomi/mimo-v2.5-pro",
+            "xiaomi/mimo-v2.5",
+            "xiaomi/mimo-v2-omni",
+            "xiaomi/mimo-v2-pro",
+            "xiaomi/mimo-v2-flash",
+        ):
+            agent.model = model
+            assert agent._supports_reasoning_extra_body() is True, model
+
+
 class TestMemoryContextSanitization:
     """sanitize_context() helper correctness — used at provider boundaries."""
 


### PR DESCRIPTION
Salvages @agentlinker's PR #16984 onto current main.

## What it does
Adds `xiaomi/` to the OpenRouter reasoning-capable prefix list so MiMo models (v2, v2.5, v2-pro, v2-flash, v2-omni) get the `reasoning` extra_body enabled instead of being treated as non-reasoning.

Hermes already recognizes xiaomi as reasoning-capable elsewhere (`_PROVIDER_VISION_MODELS`, surrogate-pair scrubbing, native xiaomimimo.com detection), so this is just completing the OpenRouter-slug side.

## Changes
- `run_agent.py` — `xiaomi/` prefix added to `reasoning_model_prefixes` in `_supports_reasoning_extra_body()`.
- `tests/run_agent/test_run_agent.py` — new `TestSupportsReasoningExtraBody` test covering 5 MiMo model IDs.

## Validation
`tests/run_agent/test_run_agent.py::TestSupportsReasoningExtraBody` — passes.

Closes #16984 via salvage.