### PR TITLE
fix(claw): handle missing dir in _scan_workspace_state (salvage #16958)

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -235,6 +235,9 @@ def _scan_workspace_state(source_dir: Path) -> list[tuple[Path, str]]:
     """
     findings: list[tuple[Path, str]] = []
 
+    if not source_dir.exists():
+        return findings
+
     # Direct state files in the root
     for name in ("todo.json", "sessions", "logs"):
         candidate = source_dir / name
@@ -243,7 +246,12 @@ def _scan_workspace_state(source_dir: Path) -> list[tuple[Path, str]]:
             findings.append((candidate, f"Root {kind}: {name}"))
 
     # State files inside workspace directories
-    for child in sorted(source_dir.iterdir()):
+    try:
+        children = sorted(source_dir.iterdir())
+    except OSError:
+        return findings
+
+    for child in children:
         if not child.is_dir() or child.name.startswith("."):
             continue
         # Check for workspace-like subdirectories

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -58,6 +58,7 @@ AUTHOR_MAP = {
     "beardthelion@users.noreply.github.com": "beardthelion",
     "tangyuanjc@JCdeAIfenshendeMac-mini.local": "tangyuanjc",
     "leon@agentlinker.ai": "agentlinker",
+    "santoshhumagain1887@gmail.com": "npmisantosh",
     "29756950+revaraver@users.noreply.github.com": "revaraver",
     "nexus@eptic.me": "TheEpTic",
     "74554762+wmagev@users.noreply.github.com": "wmagev",


### PR DESCRIPTION
Salvages @npmisantosh's PR #16958 onto current main.

## What it does
`_scan_workspace_state` called `source_dir.iterdir()` unconditionally. If the directory didn't exist or wasn't readable, `hermes claw cleanup` crashed before reaching the OS-error handler at the later workspace-dirs scan (which already has `try/except OSError`). Adds `exists()` early-return and wraps `iterdir()` in `try/except OSError` for consistency with the sibling call site ~20 lines later.

## Changes
- `hermes_cli/claw.py` — `exists()` early-return + `try/except OSError` around `iterdir()`.

## Validation
`py_compile` clean. Defensive fix matching the pattern already used at the next call site.

Closes #16958 via salvage.