### PR TITLE
fix(auxiliary): avoid locking into custom path when api_key is empty (salvage #16944)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3132,8 +3132,14 @@ def _resolve_task_provider_model(
 
     if task:
         # Config.yaml is the primary source for per-task overrides.
-        if cfg_base_url:
+        if cfg_base_url and cfg_api_key:
+            # Both base_url and api_key explicitly set → custom endpoint.
             return "custom", resolved_model, cfg_base_url, cfg_api_key, resolved_api_mode
+        if cfg_base_url and cfg_provider and cfg_provider != "auto":
+            # base_url set without api_key but with a known provider — use
+            # the provider so it can resolve credentials from env vars
+            # (e.g. OPENROUTER_API_KEY) instead of locking into "custom".
+            return cfg_provider, resolved_model, cfg_base_url, None, resolved_api_mode
         if cfg_provider and cfg_provider != "auto":
             return cfg_provider, resolved_model, None, None, resolved_api_mode
 


### PR DESCRIPTION
Salvages @vominh1919's PR #16944 onto current main. Fixes #16829.

## What it does
When `auxiliary.<task>` config had `base_url` set but `api_key` empty (common: user expects env-var fallback), `_resolve_task_provider_model()` returned `provider="custom"` with `api_key=None`. Downstream client construction then made API calls with no `Authorization` header → HTTP 401.

Fix: only route to `custom` when BOTH `cfg_base_url` AND `cfg_api_key` are non-empty. `base_url` without `api_key` but with a known provider → pass through to that provider so it can resolve credentials from env vars.

## Changes
- `agent/auxiliary_client.py` — two-branch split (custom when both set vs. provider passthrough when only base_url set).

## Validation
`tests/agent/test_auxiliary_client.py` — 120 passed locally.

Closes #16944 via salvage.