### PR TITLE
fix(cli): fall back on invalid HERMES_MAX_ITERATIONS (salvage #16940)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2145,7 +2145,10 @@ class HermesCLI:
         elif CLI_CONFIG.get("max_turns"):  # Backwards compat: root-level max_turns
             self.max_turns = CLI_CONFIG["max_turns"]
         elif os.getenv("HERMES_MAX_ITERATIONS"):
-            self.max_turns = int(os.getenv("HERMES_MAX_ITERATIONS"))
+            try:
+                self.max_turns = int(os.getenv("HERMES_MAX_ITERATIONS", ""))
+            except (TypeError, ValueError):
+                self.max_turns = 90
         else:
             self.max_turns = 90
         

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -59,6 +59,7 @@ AUTHOR_MAP = {
     "tangyuanjc@JCdeAIfenshendeMac-mini.local": "tangyuanjc",
     "leon@agentlinker.ai": "agentlinker",
     "santoshhumagain1887@gmail.com": "npmisantosh",
+    "novax635@gmail.com": "novax635",
     "29756950+revaraver@users.noreply.github.com": "revaraver",
     "nexus@eptic.me": "TheEpTic",
     "74554762+wmagev@users.noreply.github.com": "wmagev",

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -75,6 +75,11 @@ class TestMaxTurnsResolution:
         cli_obj = _make_cli(env_overrides={"HERMES_MAX_ITERATIONS": "42"})
         assert cli_obj.max_turns == 42
 
+    def test_invalid_env_var_max_turns_falls_back_to_default(self):
+        """Invalid env values should not crash CLI init."""
+        cli_obj = _make_cli(env_overrides={"HERMES_MAX_ITERATIONS": "not-a-number"})
+        assert cli_obj.max_turns == 90
+
     def test_legacy_root_max_turns_is_used_when_agent_key_exists_without_value(self):
         cli_obj = _make_cli(config_overrides={"agent": {}, "max_turns": 77})
         assert cli_obj.max_turns == 77


### PR DESCRIPTION
Salvages @novax635's PR #16940 onto current main.

## What it does
`HERMES_MAX_ITERATIONS` was passed straight into `int()` at CLI init. A typo (`HERMES_MAX_ITERATIONS=foo`) crashed startup with `ValueError`. Wrap in `try/except` and fall back to the default 90.

## Changes
- `cli.py` — try/except around `int(os.getenv(...))`.
- `tests/cli/test_cli_init.py` — regression test for a non-numeric env value.

## Validation
`tests/cli/test_cli_init.py` — 32 passed locally.

Closes #16940 via salvage.