### PR TITLE
fix(gateway): tolerate malformed HERMES_HUMAN_DELAY_* env vars (salvage #16933)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2675,10 +2675,11 @@ class BasePlatformAdapter(ABC):
         mode = os.getenv("HERMES_HUMAN_DELAY_MODE", "off").lower()
         if mode == "off":
             return 0.0
-        min_ms = int(os.getenv("HERMES_HUMAN_DELAY_MIN_MS", "800"))
-        max_ms = int(os.getenv("HERMES_HUMAN_DELAY_MAX_MS", "2500"))
         if mode == "natural":
             min_ms, max_ms = 800, 2500
+            return random.uniform(min_ms / 1000.0, max_ms / 1000.0)
+        min_ms = int(os.getenv("HERMES_HUMAN_DELAY_MIN_MS", "800"))
+        max_ms = int(os.getenv("HERMES_HUMAN_DELAY_MAX_MS", "2500"))
         return random.uniform(min_ms / 1000.0, max_ms / 1000.0)
 
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2678,8 +2678,15 @@ class BasePlatformAdapter(ABC):
         if mode == "natural":
             min_ms, max_ms = 800, 2500
             return random.uniform(min_ms / 1000.0, max_ms / 1000.0)
-        min_ms = int(os.getenv("HERMES_HUMAN_DELAY_MIN_MS", "800"))
-        max_ms = int(os.getenv("HERMES_HUMAN_DELAY_MAX_MS", "2500"))
+        # custom mode — tolerate malformed env vars instead of crashing.
+        try:
+            min_ms = int(os.getenv("HERMES_HUMAN_DELAY_MIN_MS", "800"))
+        except (TypeError, ValueError):
+            min_ms = 800
+        try:
+            max_ms = int(os.getenv("HERMES_HUMAN_DELAY_MAX_MS", "2500"))
+        except (TypeError, ValueError):
+            max_ms = 2500
         return random.uniform(min_ms / 1000.0, max_ms / 1000.0)
 
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -60,6 +60,7 @@ AUTHOR_MAP = {
     "leon@agentlinker.ai": "agentlinker",
     "santoshhumagain1887@gmail.com": "npmisantosh",
     "novax635@gmail.com": "novax635",
+    "krionex1@gmail.com": "Krionex",
     "29756950+revaraver@users.noreply.github.com": "revaraver",
     "nexus@eptic.me": "TheEpTic",
     "74554762+wmagev@users.noreply.github.com": "wmagev",

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -512,6 +512,17 @@ class TestGetHumanDelay:
             delay = BasePlatformAdapter._get_human_delay()
             assert 0.1 <= delay <= 0.2
 
+    def test_custom_mode_tolerates_malformed_env_vars(self):
+        env = {
+            "HERMES_HUMAN_DELAY_MODE": "custom",
+            "HERMES_HUMAN_DELAY_MIN_MS": "oops",
+            "HERMES_HUMAN_DELAY_MAX_MS": "still-bad",
+        }
+        with patch.dict(os.environ, env):
+            # falls back to the custom-mode defaults instead of crashing
+            delay = BasePlatformAdapter._get_human_delay()
+            assert 0.8 <= delay <= 2.5
+
 
 # ---------------------------------------------------------------------------
 # utf16_len / _prefix_within_utf16_limit / truncate_message with len_fn

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -492,6 +492,16 @@ class TestGetHumanDelay:
             delay = BasePlatformAdapter._get_human_delay()
             assert 0.8 <= delay <= 2.5
 
+    def test_natural_mode_ignores_malformed_custom_env_vars(self):
+        env = {
+            "HERMES_HUMAN_DELAY_MODE": "natural",
+            "HERMES_HUMAN_DELAY_MIN_MS": "oops",
+            "HERMES_HUMAN_DELAY_MAX_MS": "still-bad",
+        }
+        with patch.dict(os.environ, env):
+            delay = BasePlatformAdapter._get_human_delay()
+            assert 0.8 <= delay <= 2.5
+
     def test_custom_mode_uses_env_vars(self):
         env = {
             "HERMES_HUMAN_DELAY_MODE": "custom",


### PR DESCRIPTION
Salvages @Krionex's PR #16933 onto current main and widens it to sibling site per never-merge-incomplete-fixes.

## What it does
`_get_human_delay()` called `int(os.getenv(...))` on HERMES_HUMAN_DELAY_MIN_MS / MAX_MS before dispatching on mode. A typo crashed the gateway regardless of mode.

## Changes
- `gateway/platforms/base.py` — natural mode no longer reads the custom env vars at all (PR #16933's fix); custom mode wraps its int() calls in try/except/fallback to match (widening).
- `tests/gateway/test_platform_base.py` — regression tests for both modes.
- `scripts/release.py` — AUTHOR_MAP entry for Krionex.

## Validation
`tests/gateway/test_platform_base.py -k 'human_delay or HumanDelay'` — 6 passed locally.

Closes #16933 via salvage.