### PR TITLE
fix(run_agent): use aux provider for compression context length lookup (salvage #16918)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2667,7 +2667,10 @@ class AIAgent:
                 base_url=aux_base_url,
                 api_key=aux_api_key,
                 config_context_length=getattr(self, "_aux_compression_context_length_config", None),
-                provider=getattr(self, "provider", ""),
+                # Each model must be resolved with its own provider so that
+                # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
+                # are invoked for the correct client, not inherited from the main model.
+                provider=(_aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(self, "provider", "")),
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -61,6 +61,7 @@ AUTHOR_MAP = {
     "santoshhumagain1887@gmail.com": "npmisantosh",
     "novax635@gmail.com": "novax635",
     "krionex1@gmail.com": "Krionex",
+    "rxdxxxx@users.noreply.github.com": "rxdxxxx",
     "29756950+revaraver@users.noreply.github.com": "revaraver",
     "nexus@eptic.me": "TheEpTic",
     "74554762+wmagev@users.noreply.github.com": "wmagev",


### PR DESCRIPTION
Salvages @rxdxxxx's PR #16918 onto current main. Closes #12977.

## What it does
`get_model_context_length()` for the auxiliary compression model was called with `self.provider` (the MAIN model's provider). When the main model is on Bedrock, the Bedrock static-table hard-intercept fired for non-Bedrock auxiliary models and returned `BEDROCK_DEFAULT_CONTEXT_LENGTH=128K` instead of the aux model's real context window — triggering a false compression warning every session.

## Changes
- `run_agent.py` — pass `_aux_cfg_provider` (resolved a few lines above) when explicitly set, fall back to `self.provider` only when `_aux_cfg_provider` is unset or `auto`.

## Validation
`tests/run_agent/ -k 'compression or aux or context_length'` — 69 passed locally.

Closes #16918 via salvage.