### PR TITLE
fix(cli): sanitize bracketed paste markers during setup (salvage #16784)

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -15,6 +15,7 @@ import importlib.util
 import json
 import logging
 import os
+import re
 import shutil
 import sys
 import copy
@@ -208,10 +209,21 @@ def prompt(question: str, default: str = None, password: bool = False) -> str:
         else:
             value = input(color(display, Colors.YELLOW))
 
-        return value.strip() or default or ""
+        cleaned = _sanitize_pasted_input(value)
+        return cleaned.strip() or default or ""
     except (KeyboardInterrupt, EOFError):
         print()
         sys.exit(1)
+
+
+_BRACKETED_PASTE_PATTERN = re.compile(r"\x1b\[\s*200~|\x1b\[\s*201~")
+
+
+def _sanitize_pasted_input(value: str) -> str:
+    """Strip terminal bracketed-paste control markers from pasted text."""
+    if not isinstance(value, str) or not value:
+        return value
+    return _BRACKETED_PASTE_PATTERN.sub("", value)
 
 
 def _curses_prompt_choice(question: str, choices: list, default: int = 0, description: str | None = None) -> int:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -62,6 +62,7 @@ AUTHOR_MAP = {
     "novax635@gmail.com": "novax635",
     "krionex1@gmail.com": "Krionex",
     "rxdxxxx@users.noreply.github.com": "rxdxxxx",
+    "ma.haohao2@xydigit.com": "MaHaoHao-ch",
     "29756950+revaraver@users.noreply.github.com": "revaraver",
     "nexus@eptic.me": "TheEpTic",
     "74554762+wmagev@users.noreply.github.com": "wmagev",

--- a/tests/hermes_cli/test_setup_prompt_menus.py
+++ b/tests/hermes_cli/test_setup_prompt_menus.py
@@ -1,6 +1,28 @@
 from hermes_cli import setup as setup_mod
 
 
+def test_prompt_strips_bracketed_paste_markers(monkeypatch):
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt="": "\x1b[200~sk-ant-api-key\x1b[201~",
+    )
+
+    value = setup_mod.prompt("API key")
+
+    assert value == "sk-ant-api-key"
+
+
+def test_password_prompt_strips_bracketed_paste_markers(monkeypatch):
+    monkeypatch.setattr(
+        "getpass.getpass",
+        lambda _prompt="": "\x1b[200~secret-token\x1b[201~",
+    )
+
+    value = setup_mod.prompt("API key", password=True)
+
+    assert value == "secret-token"
+
+
 def test_prompt_choice_uses_curses_helper(monkeypatch):
     monkeypatch.setattr(setup_mod, "_curses_prompt_choice", lambda question, choices, default=0, description=None: 1)
 


### PR DESCRIPTION
Salvages @MaHaoHao-ch's PR #16784 onto current main. Closes #16491.

## What it does
Bracketed-paste mode (enabled by default on many Linux/WSL terminals) wraps pasted text in `ESC[200~...ESC[201~`. Hermes' setup wizard stored the wrapped text as-is, so pasted API keys ended up with literal escape sequences and failed auth.

## Changes
- `hermes_cli/setup.py` — strip `ESC[200~` / `ESC[201~` from prompt input via `_sanitize_pasted_input`.
- `tests/hermes_cli/test_setup_prompt_menus.py` — regression tests for normal and password prompts.

## Validation
`tests/hermes_cli/test_setup_prompt_menus.py` — 5 passed locally.

Closes #16784 via salvage.