### PR TITLE
fix(dashboard): preserve remote gateway platforms

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -561,13 +561,15 @@ async def get_status():
     # Prefer the detailed health endpoint response (has full state) when the
     # local runtime status file is absent or stale (cross-container).
     runtime = read_runtime_status()
+    runtime_from_remote_health = False
     if runtime is None and remote_health_body and remote_health_body.get("gateway_state"):
         runtime = remote_health_body
+        runtime_from_remote_health = True
 
     if runtime:
         gateway_state = runtime.get("gateway_state")
         gateway_platforms = runtime.get("platforms") or {}
-        if configured_gateway_platforms is not None:
+        if configured_gateway_platforms is not None and not runtime_from_remote_health:
             gateway_platforms = {
                 key: value
                 for key, value in gateway_platforms.items()

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -161,6 +161,54 @@ class TestWebServerEndpoints:
             "telegram": {"state": "connected", "updated_at": "2026-04-12T00:00:00+00:00"},
         }
 
+    def test_get_status_preserves_remote_health_platforms(self, monkeypatch):
+        import gateway.config as gateway_config
+        import hermes_cli.web_server as web_server
+
+        class _Platform:
+            def __init__(self, value):
+                self.value = value
+
+        class _GatewayConfig:
+            def get_connected_platforms(self):
+                return [_Platform("telegram")]
+
+        monkeypatch.setattr(web_server, "get_running_pid", lambda: None)
+        monkeypatch.setattr(web_server, "read_runtime_status", lambda: None)
+        monkeypatch.setattr(web_server, "_GATEWAY_HEALTH_URL", "http://gateway:8642")
+        monkeypatch.setattr(
+            web_server,
+            "_probe_gateway_health",
+            lambda: (
+                True,
+                {
+                    "gateway_state": "running",
+                    "pid": 4321,
+                    "updated_at": "2026-04-12T00:00:00+00:00",
+                    "platforms": {
+                        "telegram": {
+                            "state": "connected",
+                            "updated_at": "2026-04-12T00:00:00+00:00",
+                        },
+                        "weixin": {
+                            "state": "connected",
+                            "updated_at": "2026-04-12T00:00:00+00:00",
+                        },
+                    },
+                },
+            ),
+        )
+        monkeypatch.setattr(web_server, "check_config_version", lambda: (1, 1))
+        monkeypatch.setattr(gateway_config, "load_gateway_config", lambda: _GatewayConfig())
+
+        resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        assert resp.json()["gateway_platforms"] == {
+            "telegram": {"state": "connected", "updated_at": "2026-04-12T00:00:00+00:00"},
+            "weixin": {"state": "connected", "updated_at": "2026-04-12T00:00:00+00:00"},
+        }
+
     def test_get_status_hides_stale_platforms_when_gateway_not_running(self, monkeypatch):
         import gateway.config as gateway_config
         import hermes_cli.web_server as web_server


### PR DESCRIPTION
## Summary
- preserve platform statuses reported by the remote gateway health endpoint instead of filtering them through the dashboard process's local config
- keep the existing local-runtime filtering behavior so stale local status files still hide unconfigured platforms
- add a regression covering remote Weixin visibility on `/api/status`

## Tests
- `uv run pytest tests/hermes_cli/test_web_server.py -q -k 'get_status'`
- `python3 -m compileall hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `git diff --check`

Closes #20187
