### PR TITLE
feat(cli,tui): highlight submitted user messages

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2073,6 +2073,20 @@ class HermesCLI:
             _ump_last_lines = 2
         self.user_message_preview_first_lines = max(1, _ump_first_lines)
         self.user_message_preview_last_lines = max(0, _ump_last_lines)
+        self.user_message_preview_boxed = bool(_ump.get("boxed", True))
+        self.user_message_preview_box_style = str(_ump.get("box_style", "round") or "round").strip().lower()
+        self.user_message_preview_accent_color = str(_ump.get("accent_color", "#B084FF") or "#B084FF").strip()
+        self.user_message_preview_text_color = str(_ump.get("text_color", "#F2EAFE") or "#F2EAFE").strip()
+        try:
+            _ump_margin_top = int(_ump.get("margin_top", 2))
+        except (TypeError, ValueError):
+            _ump_margin_top = 2
+        try:
+            _ump_margin_bottom = int(_ump.get("margin_bottom", 2))
+        except (TypeError, ValueError):
+            _ump_margin_bottom = 2
+        self.user_message_preview_margin_top = max(0, _ump_margin_top)
+        self.user_message_preview_margin_bottom = max(0, _ump_margin_bottom)
 
         # Streaming display state
         self._stream_buf = ""        # Partial line buffer for line-buffered rendering
@@ -2945,9 +2959,11 @@ class HermesCLI:
 
     def _format_submitted_user_message_preview(self, user_input: str) -> str:
         """Format the submitted user-message scrollback preview."""
+        accent = getattr(self, "user_message_preview_accent_color", "#B084FF") or "#B084FF"
+        text_color = getattr(self, "user_message_preview_text_color", "#F2EAFE") or "#F2EAFE"
         lines = user_input.split("\n")
         if len(lines) <= 1:
-            return f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]"
+            return f"[bold {accent}]●[/] [bold {text_color}]{_escape(user_input)}[/]"
 
         first_lines = int(getattr(self, "user_message_preview_first_lines", 2))
         last_lines = int(getattr(self, "user_message_preview_last_lines", 2))
@@ -2964,15 +2980,15 @@ class HermesCLI:
             tail = []
 
         preview_lines = [
-            f"[bold {_accent_hex()}]●[/] [bold]{_escape(head[0])}[/]"
+            f"[bold {accent}]●[/] [bold {text_color}]{_escape(head[0])}[/]"
         ]
-        preview_lines.extend(f"[bold]{_escape(line)}[/]" for line in head[1:])
+        preview_lines.extend(f"[bold {text_color}]{_escape(line)}[/]" for line in head[1:])
 
         if hidden_middle_count > 0:
             noun = "line" if hidden_middle_count == 1 else "lines"
             preview_lines.append(f"[dim]... (+{hidden_middle_count} more {noun})[/]")
 
-        preview_lines.extend(f"[bold]{_escape(line)}[/]" for line in tail)
+        preview_lines.extend(f"[bold {text_color}]{_escape(line)}[/]" for line in tail)
         return "\n".join(preview_lines)
 
     def _expand_paste_references(self, text: str | None) -> str:
@@ -2995,13 +3011,42 @@ class HermesCLI:
         return paste_ref_re.sub(_expand_ref, text)
 
     def _print_user_message_preview(self, user_input: str) -> None:
-        """Render a user message using the normal chat scrollback style."""
-        ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+        """Render a submitted user message as a visible scrollback anchor."""
+        console = ChatConsole()
         text = str(user_input or "")
-        if "\n" in text:
-            ChatConsole().print(self._format_submitted_user_message_preview(text))
+        body = self._format_submitted_user_message_preview(text)
+        accent = getattr(self, "user_message_preview_accent_color", "#B084FF") or "#B084FF"
+        text_color = getattr(self, "user_message_preview_text_color", "#F2EAFE") or "#F2EAFE"
+
+        for _ in range(int(getattr(self, "user_message_preview_margin_top", 2))):
+            console.print()
+
+        if getattr(self, "user_message_preview_boxed", True):
+            box_style = getattr(self, "user_message_preview_box_style", "round") or "round"
+            box_map = {
+                "round": rich_box.ROUNDED,
+                "rounded": rich_box.ROUNDED,
+                "square": rich_box.SQUARE,
+                "heavy": rich_box.HEAVY,
+                "ascii": rich_box.ASCII,
+            }
+            console.print(
+                Panel(
+                    body,
+                    title=" Command ",
+                    title_align="left",
+                    border_style=accent,
+                    style=text_color,
+                    box=box_map.get(str(box_style).strip().lower(), rich_box.ROUNDED),
+                    padding=(1, 2),
+                )
+            )
         else:
-            ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(text)}[/]")
+            console.print(f"[{accent}]{'─' * 40}[/]")
+            console.print(body)
+
+        for _ in range(int(getattr(self, "user_message_preview_margin_bottom", 2))):
+            console.print()
 
     def _stream_reasoning_delta(self, text: str) -> None:
         """Stream reasoning/thinking tokens into a dim box above the response.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -784,9 +784,15 @@ DEFAULT_CONFIG = {
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.
         "tui_status_indicator": "kaomoji",
-        "user_message_preview": {  # CLI: how many submitted user-message lines to echo back in scrollback
+        "user_message_preview": {  # CLI: submitted user-message visual anchor in scrollback
             "first_lines": 2,
             "last_lines": 2,
+            "boxed": True,
+            "box_style": "round",
+            "accent_color": "#B084FF",
+            "text_color": "#F2EAFE",
+            "margin_top": 2,
+            "margin_bottom": 2,
         },
         "interim_assistant_messages": True,  # Gateway: show natural mid-turn assistant status messages
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway

--- a/tests/cli/test_cli_user_message_preview.py
+++ b/tests/cli/test_cli_user_message_preview.py
@@ -90,3 +90,24 @@ class TestSubmittedUserMessagePreview:
         assert "line3" in rendered
         assert "line4" in rendered
         assert "(+1 more line)" in rendered
+
+    def test_preview_uses_configured_purple_anchor_colors(self):
+        cli = _make_cli(
+            {
+                "first_lines": 2,
+                "last_lines": 2,
+                "accent_color": "#B084FF",
+                "text_color": "#F2EAFE",
+                "boxed": True,
+                "margin_top": 2,
+                "margin_bottom": 2,
+            }
+        )
+
+        rendered = cli._format_submitted_user_message_preview("hello")
+
+        assert "#B084FF" in rendered
+        assert "#F2EAFE" in rendered
+        assert getattr(cli, "user_message_preview_boxed") is True
+        assert getattr(cli, "user_message_preview_margin_top") == 2
+        assert getattr(cli, "user_message_preview_margin_bottom") == 2

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -653,7 +653,13 @@ class TestDiscordChannelPromptsConfig:
 
 
 class TestUserMessagePreviewConfig:
-    def test_default_config_preview_line_counts(self):
+    def test_default_config_preview_anchor_style(self):
         preview = DEFAULT_CONFIG["display"]["user_message_preview"]
         assert preview["first_lines"] == 2
         assert preview["last_lines"] == 2
+        assert preview["boxed"] is True
+        assert preview["box_style"] == "round"
+        assert preview["accent_color"] == "#B084FF"
+        assert preview["text_color"] == "#F2EAFE"
+        assert preview["margin_top"] == 2
+        assert preview["margin_bottom"] == 2

--- a/ui-tui/src/__tests__/userPromptAnchor.test.ts
+++ b/ui-tui/src/__tests__/userPromptAnchor.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { userPromptAnchorStyle } from '../domain/userPromptAnchor.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+describe('userPromptAnchorStyle', () => {
+  it('uses a purple user-only anchor that does not reuse the active theme accent by default', () => {
+    const style = userPromptAnchorStyle(DEFAULT_THEME)
+
+    expect(style?.borderColor).toBe('#B084FF')
+    expect(style?.titleColor).toBe('#B084FF')
+    expect(style?.textColor).toBe('#F2EAFE')
+    expect(style?.borderStyle).toBe('round')
+    expect(style?.title).toBe('You')
+    expect(style?.marginTop).toBe(2)
+    expect(style?.marginBottom).toBe(2)
+
+    expect(style?.borderColor).not.toBe(DEFAULT_THEME.color.primary)
+    expect(style?.borderColor).not.toBe(DEFAULT_THEME.color.accent)
+    expect(style?.textColor).not.toBe(DEFAULT_THEME.color.label)
+  })
+
+  it('honors global user_message_preview colors for blue-themed machines', () => {
+    const style = userPromptAnchorStyle(DEFAULT_THEME, {
+      accent_color: '#FFD700',
+      margin_bottom: 2,
+      margin_top: 2,
+      text_color: '#FFF8DC'
+    })
+
+    expect(style?.borderColor).toBe('#FFD700')
+    expect(style?.titleColor).toBe('#FFD700')
+    expect(style?.textColor).toBe('#FFF8DC')
+    expect(style?.marginTop).toBe(2)
+    expect(style?.marginBottom).toBe(2)
+  })
+
+  it('can disable the TUI user anchor when boxed is false', () => {
+    const style = userPromptAnchorStyle(DEFAULT_THEME, { boxed: false })
+
+    expect(style).toBeNull()
+  })
+})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -4,6 +4,7 @@ import type { MutableRefObject, ReactNode, RefObject, SetStateAction } from 'rea
 import type { PasteEvent } from '../components/textInput.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { ImageAttachResponse } from '../gatewayTypes.js'
+import type { UserPromptAnchorStyle } from '../domain/userPromptAnchor.js'
 import type { ParsedVoiceRecordKey } from '../lib/platform.js'
 import type { RpcResult } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
@@ -115,6 +116,7 @@ export interface UiState {
   streaming: boolean
   theme: Theme
   usage: Usage
+  userPromptAnchor: null | UserPromptAnchorStyle
 }
 
 export interface VirtualHistoryState {

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -2,6 +2,7 @@ import { atom } from 'nanostores'
 
 import { MOUSE_TRACKING } from '../config/env.js'
 import { ZERO } from '../domain/usage.js'
+import { userPromptAnchorStyle } from '../domain/userPromptAnchor.js'
 import { DEFAULT_THEME } from '../theme.js'
 
 import { DEFAULT_INDICATOR_STYLE, type UiState } from './interfaces.js'
@@ -25,7 +26,8 @@ const buildUiState = (): UiState => ({
   statusBar: 'top',
   streaming: true,
   theme: DEFAULT_THEME,
-  usage: ZERO
+  usage: ZERO,
+  userPromptAnchor: userPromptAnchorStyle(DEFAULT_THEME)
 })
 
 export const $uiState = atom<UiState>(buildUiState())

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 
 import { resolveDetailsMode, resolveSections } from '../domain/details.js'
+import { userPromptAnchorStyle } from '../domain/userPromptAnchor.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type {
   ConfigFullResponse,
@@ -147,7 +148,8 @@ export const applyDisplay = (
     showCost: !!d.show_cost,
     showReasoning: !!d.show_reasoning,
     statusBar: normalizeStatusBar(d.tui_statusbar),
-    streaming: d.streaming !== false
+    streaming: d.streaming !== false,
+    userPromptAnchor: userPromptAnchorStyle(undefined, d.user_message_preview ?? {})
   })
 }
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -113,6 +113,7 @@ const TranscriptPane = memo(function TranscriptPane({
                   msg={row.msg}
                   sections={ui.sections}
                   t={ui.theme}
+                  userPromptAnchor={ui.userPromptAnchor}
                 />
               )}
 

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -5,6 +5,7 @@ import { LONG_MSG } from '../config/limits.js'
 import { sectionMode } from '../domain/details.js'
 import { userDisplay } from '../domain/messages.js'
 import { ROLE } from '../domain/roles.js'
+import type { UserPromptAnchorStyle } from '../domain/userPromptAnchor.js'
 import { transcriptBodyWidth, transcriptGutterWidth } from '../lib/inputMetrics.js'
 import {
   boundedHistoryRenderText,
@@ -32,7 +33,8 @@ export const MessageLine = memo(function MessageLine({
   msg,
   sections,
   t,
-  tools = []
+  tools = [],
+  userPromptAnchor
 }: MessageLineProps) {
   // Per-section overrides win over the global mode, so resolve each section
   // we might consume here once and gate visibility on the *content-bearing*
@@ -96,6 +98,7 @@ export const MessageLine = memo(function MessageLine({
   }
 
   const { body, glyph, prefix } = ROLE[msg.role](t)
+  const userBody = msg.role === 'user' && userPromptAnchor ? userPromptAnchor.textColor : body
   const gutterWidth = transcriptGutterWidth(msg.role, t.brand.prompt)
 
   const showDetails =
@@ -125,7 +128,7 @@ export const MessageLine = memo(function MessageLine({
       const [head, ...rest] = userDisplay(msg.text).split('[long message]')
 
       return (
-        <Text color={body}>
+        <Text color={userBody}>
           {head}
           <Text color={t.color.muted} dimColor>
             [long message]
@@ -135,8 +138,26 @@ export const MessageLine = memo(function MessageLine({
       )
     }
 
-    return <Text {...(body ? { color: body } : {})}>{msg.text}</Text>
+    return <Text {...(userBody ? { color: userBody } : {})}>{msg.text}</Text>
   })()
+
+  if (msg.role === 'user' && userPromptAnchor) {
+    return (
+      <Box flexDirection="column" marginBottom={userPromptAnchor.marginBottom} marginTop={userPromptAnchor.marginTop}>
+        <Box
+          borderColor={userPromptAnchor.borderColor}
+          borderStyle={userPromptAnchor.borderStyle}
+          flexDirection="column"
+          paddingX={1}
+        >
+          <Text bold color={userPromptAnchor.titleColor}>
+            {userPromptAnchor.title}
+          </Text>
+          <Box>{content}</Box>
+        </Box>
+      </Box>
+    )
+  }
 
   // Diff segments (emitted by pushInlineDiffSegment between narration
   // segments) need a blank line on both sides so the patch doesn't butt up
@@ -188,4 +209,5 @@ interface MessageLineProps {
   sections?: SectionVisibility
   t: Theme
   tools?: ActiveTool[]
+  userPromptAnchor?: null | UserPromptAnchorStyle
 }

--- a/ui-tui/src/components/streamingAssistant.tsx
+++ b/ui-tui/src/components/streamingAssistant.tsx
@@ -44,6 +44,7 @@ export const StreamingAssistant = memo(function StreamingAssistant({
           msg={msg}
           sections={sections}
           t={ui.theme}
+          userPromptAnchor={ui.userPromptAnchor}
         />
       ))}
 
@@ -74,6 +75,7 @@ export const StreamingAssistant = memo(function StreamingAssistant({
           }}
           sections={sections}
           t={ui.theme}
+          userPromptAnchor={ui.userPromptAnchor}
         />
       )}
 
@@ -86,6 +88,7 @@ export const StreamingAssistant = memo(function StreamingAssistant({
           msg={{ kind: 'trail', role: 'system', text: '', tools: streamPendingTools }}
           sections={sections}
           t={ui.theme}
+          userPromptAnchor={ui.userPromptAnchor}
         />
       )}
     </>

--- a/ui-tui/src/domain/userPromptAnchor.ts
+++ b/ui-tui/src/domain/userPromptAnchor.ts
@@ -1,0 +1,63 @@
+import type { Theme } from '../theme.js'
+
+export const USER_PROMPT_ANCHOR_PURPLE = '#B084FF'
+export const USER_PROMPT_ANCHOR_TEXT = '#F2EAFE'
+
+const VALID_BOX_STYLES = new Set(['round'])
+
+export interface UserPromptAnchorStyle {
+  borderColor: string
+  borderStyle: 'round'
+  marginBottom: number
+  marginTop: number
+  textColor: string
+  title: string
+  titleColor: string
+}
+
+export interface UserPromptAnchorConfig {
+  accent_color?: unknown
+  boxed?: unknown
+  box_style?: unknown
+  margin_bottom?: unknown
+  margin_top?: unknown
+  text_color?: unknown
+}
+
+const normalizeColor = (raw: unknown, fallback: string): string => {
+  if (typeof raw !== 'string') {
+    return fallback
+  }
+
+  const value = raw.trim()
+  return value || fallback
+}
+
+const normalizeMargin = (raw: unknown, fallback: number): number => {
+  const value = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number.parseInt(raw, 10) : Number.NaN
+
+  return Number.isFinite(value) ? Math.max(0, value) : fallback
+}
+
+export function userPromptAnchorStyle(
+  _theme?: Theme,
+  config: UserPromptAnchorConfig = {}
+): UserPromptAnchorStyle | null {
+  if (config.boxed === false) {
+    return null
+  }
+
+  const requestedBoxStyle = typeof config.box_style === 'string' ? config.box_style.trim().toLowerCase() : 'round'
+  const borderStyle = VALID_BOX_STYLES.has(requestedBoxStyle) ? 'round' : 'round'
+  const borderColor = normalizeColor(config.accent_color, USER_PROMPT_ANCHOR_PURPLE)
+
+  return {
+    borderColor,
+    borderStyle,
+    marginBottom: normalizeMargin(config.margin_bottom, 2),
+    marginTop: normalizeMargin(config.margin_top, 2),
+    textColor: normalizeColor(config.text_color, USER_PROMPT_ANCHOR_TEXT),
+    title: 'You',
+    titleColor: borderColor
+  }
+}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -1,3 +1,4 @@
+import type { UserPromptAnchorConfig } from './domain/userPromptAnchor.js'
 import type { SessionInfo, SlashCategory, Usage } from './types.js'
 
 export interface GatewaySkin {
@@ -73,6 +74,7 @@ export interface ConfigDisplayConfig {
   // validation anyway.
   tui_status_indicator?: string
   tui_statusbar?: 'bottom' | 'off' | 'on' | 'top' | boolean
+  user_message_preview?: UserPromptAnchorConfig
 }
 
 export interface ConfigVoiceConfig {


### PR DESCRIPTION
## Summary

- Adds a boxed visual anchor for submitted user messages in the classic CLI.
- Applies the same user-message anchor concept to the TUI transcript.
- Makes anchor colors, box mode, and vertical spacing configurable through `display.user_message_preview`.

## Motivation

Long assistant responses can make it hard to find the user's original command in terminal scrollback or a full-screen TUI transcript.

This change makes submitted user messages stand out as a stable visual anchor without shortening model output or changing conversation history.

## Changes

- Extends `display.user_message_preview` with:
  - `boxed`
  - `box_style`
  - `accent_color`
  - `text_color`
  - `margin_top`
  - `margin_bottom`
- Updates the classic CLI Rich renderer to use a boxed submitted-message preview.
- Adds a TUI user-prompt anchor style helper and wires it into transcript rendering.
- Hydrates the TUI anchor style from the same global config used by the classic CLI.
- Adds Python and Vitest coverage for the new defaults and configurable colors.

## Configuration example

```yaml
display:
  user_message_preview:
    first_lines: 2
    last_lines: 2
    boxed: true
    box_style: round
    accent_color: "#B084FF"
    text_color: "#F2EAFE"
    margin_top: 2
    margin_bottom: 2
```

## Theme notes

The default example uses purple because the default Hermes CLI skin is yellow/gold-heavy.

Users can override these values per machine or theme. For example, a blue theme can use a yellow anchor:

```yaml
display:
  user_message_preview:
    accent_color: "#FFD700"
    text_color: "#FFF8DC"
```

## Test Plan

- [x] `.venv/bin/python -m pytest tests/cli/test_cli_user_message_preview.py tests/hermes_cli/test_config.py -q`
- [x] `.venv/bin/python -m py_compile cli.py hermes_cli/config.py`
- [x] `npm --prefix ui-tui test -- userPromptAnchor.test.ts useConfigSync.test.ts`
- [x] `npm --prefix ui-tui run type-check`
- [x] `npm --prefix ui-tui run build`

Also verified the same targeted Python and TUI checks on the Mac mini after applying the global yellow-anchor config for its blue `q-poseidon` theme.

## Notes for Reviewers

- The classic CLI and TUI use separate rendering stacks, so both paths are covered explicitly.
- The TUI reuses the existing rendered user content node so long-message/paste display behavior is preserved.
- Existing assistant/tool/system transcript rows are intentionally unchanged.
