### PR TITLE
fix(dashboard): refresh sidebar when plugin visibility or state changes

### DIFF
--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -92,6 +92,7 @@ export default function PluginsPage() {
         showToast(`${t.pluginsPage.missingEnvWarn} ${r.missing_env!.join(", ")}`, "error");
       setInstallId("");
       await loadHub();
+      window.dispatchEvent(new CustomEvent("hermes:plugins:changed"));
     } catch (e) {
       showToast(e instanceof Error ? e.message : "Install failed", "error");
     } finally {
@@ -108,6 +109,7 @@ export default function PluginsPage() {
         "success",
       );
       await loadHub();
+      window.dispatchEvent(new CustomEvent("hermes:plugins:changed"));
     } catch (e) {
       showToast(e instanceof Error ? e.message : "Rescan failed", "error");
     } finally {
@@ -137,6 +139,9 @@ export default function PluginsPage() {
     try {
       await fn();
       await loadHub();
+      // Notify the sidebar (usePlugins) to re-fetch manifests so visibility
+      // and enable/disable changes are reflected without a page reload.
+      window.dispatchEvent(new CustomEvent("hermes:plugins:changed"));
     } catch (e) {
       showToast(e instanceof Error ? e.message : "Failed", "error");
     } finally {

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -7,7 +7,7 @@
  * 4. Waits for plugins to call register() and resolves them
  */
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { api } from "@/lib/api";
 import type { PluginManifest, RegisteredPlugin } from "./types";
 import {
@@ -19,6 +19,8 @@ import {
 
 export function usePlugins() {
   const [manifests, setManifests] = useState<PluginManifest[]>([]);
+  // Monotonically increasing counter — bump to trigger a manifest re-fetch.
+  const [fetchGen, setFetchGen] = useState(0);
   const [plugins, setPlugins] = useState<RegisteredPlugin[]>([]);
   const [loading, setLoading] = useState(true);
   const loadedScripts = useRef<Set<string>>(new Set());
@@ -32,7 +34,19 @@ export function usePlugins() {
         if (list.length === 0) setLoading(false);
       })
       .catch(() => setLoading(false));
+  }, [fetchGen]);
+
+  // Expose a stable callback so callers (or event listeners) can trigger a
+  // manifest re-fetch — e.g. after toggling plugin visibility.
+  const refetchManifests = useCallback(() => {
+    setFetchGen((g) => g + 1);
   }, []);
+
+  // Re-fetch manifests whenever any code dispatches "hermes:plugins:changed".
+  useEffect(() => {
+    window.addEventListener("hermes:plugins:changed", refetchManifests);
+    return () => window.removeEventListener("hermes:plugins:changed", refetchManifests);
+  }, [refetchManifests]);
 
   // Load plugin assets when manifests arrive.
   useEffect(() => {
@@ -119,5 +133,5 @@ export function usePlugins() {
     return unsub;
   }, [manifests]);
 
-  return { plugins, manifests, loading };
+  return { plugins, manifests, loading, refetchManifests };
 }


### PR DESCRIPTION
## Summary

Fixes the sidebar not updating after toggling plugin visibility, enable/disable, install, or rescan on the Plugins page — previously required a manual F5 reload.

## Root Cause

`usePlugins()` fetched manifests from `GET /api/dashboard/plugins` once on mount (empty dependency array) and never re-fetched. The sidebar therefore rendered stale `manifest.tab.hidden` values for the rest of the session, even though the backend change was applied correctly.

## Changes

| File | Change |
|------|--------|
| `web/src/plugins/usePlugins.ts` | Added `fetchGen` state counter + `refetchManifests()` callback; listens for `hermes:plugins:changed` CustomEvent to auto-refetch manifests |
| `web/src/pages/PluginsPage.tsx` | Dispatches `hermes:plugins:changed` after every successful mutation (visibility toggle, enable/disable, install, rescan) |

## Design Notes

- Uses the `CustomEvent` pattern suggested in the issue — decoupled from internal hook state, so third-party plugins can also trigger a sidebar refresh by dispatching the same event.
- `refetchManifests()` is exported from the hook for programmatic use.
- No new dependencies.

## Testing

- `npx tsc --noEmit` passes with zero errors
- All 817 plugin-related pytest tests pass (1 pre-existing flaky test in discord slash commands unrelated to this change)

Closes #20193