### PR TITLE
fix: limit pre-update state snapshots

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -503,6 +503,7 @@ def _quick_snapshot_root(hermes_home: Optional[Path] = None) -> Path:
 def create_quick_snapshot(
     label: Optional[str] = None,
     hermes_home: Optional[Path] = None,
+    keep: Optional[int] = None,
 ) -> Optional[str]:
     """Create a quick state snapshot of critical files.
 
@@ -576,8 +577,10 @@ def create_quick_snapshot(
     with open(snap_dir / "manifest.json", "w") as f:
         json.dump(meta, f, indent=2)
 
-    # Auto-prune
-    _prune_quick_snapshots(root, keep=_QUICK_DEFAULT_KEEP)
+    # Auto-prune. Defaults preserve historical manual /snapshot behavior; callers
+    # with known high-churn safety snapshots (for example pre-update) can pass a
+    # smaller keep value so large state.db copies do not accumulate indefinitely.
+    _prune_quick_snapshots(root, keep=_QUICK_DEFAULT_KEEP if keep is None else keep)
 
     logger.info("State snapshot created: %s (%d files)", snap_id, len(manifest))
     return snap_id

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6971,7 +6971,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         try:
             from hermes_cli.backup import create_quick_snapshot
 
-            snap_id = create_quick_snapshot(label="pre-update")
+            snap_id = create_quick_snapshot(label="pre-update", keep=1)
             if snap_id:
                 print(f"  ✓ Pre-update snapshot: {snap_id}")
         except Exception as exc:


### PR DESCRIPTION
## Summary
- add an optional `keep` argument to quick state snapshot creation
- keep default manual `/snapshot` behavior unchanged
- limit `hermes update` pre-update safety snapshots to the latest one so large state.db copies do not accumulate

## Tests
- `python -m pytest tests/hermes_cli/test_backup.py::TestQuickSnapshot -q -o addopts=`
