### PR TITLE
fix(auxiliary): pass original base_url to _maybe_wrap_anthropic in compression path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2203,7 +2203,10 @@ def resolve_provider_client(
                     is_agent_turn=True, is_vision=is_vision
                 )
             client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
-            client = _wrap_if_needed(client, final_model, custom_base, custom_key)
+            # Pass explicit_base_url (original) to _wrap_if_needed, not the
+            # transformed custom_base.  _maybe_wrap_anthropic uses the original
+            # URL to detect /anthropic endpoints; passing /v1 would mis-detect.
+            client = _wrap_if_needed(client, final_model, explicit_base_url, custom_key)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))
         # Try custom first, then API-key providers (Codex excluded here:


### PR DESCRIPTION
## Problem

When a custom base_url is configured for the auxiliary provider, the compression context-length lookup path transforms the URL (via _clean_base_url) before passing it to _maybe_wrap_anthropic. Since _maybe_wrap_anthropic uses the original URL to detect /anthropic endpoints, passing the transformed URL causes misdetection and the anthropic wrapper is skipped.

## Solution

Pass explicit_base_url (the original URL) to _wrap_if_needed instead of the transformed custom_base. The wrapper needs the original URL for anthropic endpoint detection.

## Files changed

- agent/auxiliary_client.py