### PR TITLE
fix(tui): keep final assistant response pinned

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -17,7 +17,7 @@ vi.mock('../lib/openExternalUrl.js', () => ({
 
 const ref = <T>(current: T) => ({ current })
 
-const buildCtx = (appended: Msg[]) =>
+const buildCtx = (appended: Msg[], overrides: Record<string, any> = {}) =>
   ({
     composer: {
       dequeue: () => undefined,
@@ -54,16 +54,116 @@ const buildCtx = (appended: Msg[]) =>
       setProcessing: vi.fn(),
       setRecording: vi.fn(),
       setVoiceEnabled: vi.fn()
-    }
+    },
+    ...overrides
   }) as any
 
 describe('createGatewayEventHandler', () => {
   beforeEach(() => {
+    vi.useRealTimers()
     resetOverlayState()
     resetUiState()
     resetTurnState()
     turnController.fullReset()
     patchUiState({ showReasoning: true })
+  })
+
+  it('keeps sticky transcript pinned after final assistant text enters history', () => {
+    vi.useFakeTimers()
+
+    const appended: Msg[] = []
+
+    const scroll = {
+      getPendingDelta: vi.fn(() => 0),
+      getScrollHeight: vi.fn(() => 100),
+      getScrollTop: vi.fn(() => 70),
+      getViewportHeight: vi.fn(() => 20),
+      isSticky: vi.fn(() => true),
+      scrollToBottom: vi.fn()
+    }
+
+    const onEvent = createGatewayEventHandler(
+      buildCtx(appended, {
+        transcript: {
+          appendMessage: (msg: Msg) => appended.push(msg),
+          panel: vi.fn(),
+          scrollRef: ref(scroll),
+          setHistoryItems: vi.fn()
+        }
+      })
+    )
+
+    onEvent({ payload: { text: 'final answer' }, type: 'message.complete' } as any)
+
+    expect(scroll.scrollToBottom).not.toHaveBeenCalled()
+
+    vi.runOnlyPendingTimers()
+
+    expect(appended).toContainEqual({ role: 'assistant', text: 'final answer' })
+    expect(scroll.scrollToBottom).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps positionally-at-bottom transcript pinned even before sticky flag is restored', () => {
+    vi.useFakeTimers()
+
+    const appended: Msg[] = []
+
+    const scroll = {
+      getPendingDelta: vi.fn(() => 0),
+      getScrollHeight: vi.fn(() => 100),
+      getScrollTop: vi.fn(() => 79),
+      getViewportHeight: vi.fn(() => 20),
+      isSticky: vi.fn(() => false),
+      scrollToBottom: vi.fn()
+    }
+
+    const onEvent = createGatewayEventHandler(
+      buildCtx(appended, {
+        transcript: {
+          appendMessage: (msg: Msg) => appended.push(msg),
+          panel: vi.fn(),
+          scrollRef: ref(scroll),
+          setHistoryItems: vi.fn()
+        }
+      })
+    )
+
+    onEvent({ payload: { text: 'final answer' }, type: 'message.complete' } as any)
+    vi.runOnlyPendingTimers()
+
+    expect(scroll.scrollToBottom).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not yank transcript to bottom when sticky scroll was broken', () => {
+    vi.useFakeTimers()
+
+    const appended: Msg[] = []
+
+    const scroll = {
+      getPendingDelta: vi.fn(() => 0),
+      getScrollHeight: vi.fn(() => 100),
+      getScrollTop: vi.fn(() => 20),
+      getViewportHeight: vi.fn(() => 20),
+      isSticky: vi.fn(() => false),
+      scrollToBottom: vi.fn()
+    }
+
+    const onEvent = createGatewayEventHandler(
+      buildCtx(appended, {
+        transcript: {
+          appendMessage: (msg: Msg) => appended.push(msg),
+          panel: vi.fn(),
+          scrollRef: ref(scroll),
+          setHistoryItems: vi.fn()
+        }
+      })
+    )
+
+    onEvent({ payload: { text: 'final answer' }, type: 'message.complete' } as any)
+
+    vi.runOnlyPendingTimers()
+
+    expect(scroll.scrollToBottom).not.toHaveBeenCalled()
   })
 
   it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -74,6 +74,8 @@ describe('createGatewayEventHandler', () => {
     const appended: Msg[] = []
 
     const scroll = {
+      getFreshScrollHeight: vi.fn(() => 100),
+      getLastManualScrollAt: vi.fn(() => 0),
       getPendingDelta: vi.fn(() => 0),
       getScrollHeight: vi.fn(() => 100),
       getScrollTop: vi.fn(() => 70),
@@ -109,6 +111,8 @@ describe('createGatewayEventHandler', () => {
     const appended: Msg[] = []
 
     const scroll = {
+      getFreshScrollHeight: vi.fn(() => 100),
+      getLastManualScrollAt: vi.fn(() => 0),
       getPendingDelta: vi.fn(() => 0),
       getScrollHeight: vi.fn(() => 100),
       getScrollTop: vi.fn(() => 79),
@@ -140,6 +144,8 @@ describe('createGatewayEventHandler', () => {
     const appended: Msg[] = []
 
     const scroll = {
+      getFreshScrollHeight: vi.fn(() => 100),
+      getLastManualScrollAt: vi.fn(() => 0),
       getPendingDelta: vi.fn(() => 0),
       getScrollHeight: vi.fn(() => 100),
       getScrollTop: vi.fn(() => 20),
@@ -160,6 +166,87 @@ describe('createGatewayEventHandler', () => {
     )
 
     onEvent({ payload: { text: 'final answer' }, type: 'message.complete' } as any)
+
+    vi.runOnlyPendingTimers()
+
+    expect(scroll.scrollToBottom).not.toHaveBeenCalled()
+  })
+
+  it('detects at-bottom via fresh-height fallback when cached scroll height is stale', () => {
+    vi.useFakeTimers()
+
+    const appended: Msg[] = []
+
+    // The cached scroll height is stale (too large from a previous layout).
+    // The fresh height re-measures and shows the user IS at the bottom.
+    // Without the fresh-height fallback (getViewportSnapshot), the stale
+    // cached height would mask the at-bottom state and the snap would
+    // never fire — the regression this test guards against.
+    const scroll = {
+      getFreshScrollHeight: vi.fn(() => 100),
+      getLastManualScrollAt: vi.fn(() => 0),
+      getPendingDelta: vi.fn(() => 0),
+      getScrollHeight: vi.fn(() => 200), // stale cached height
+      getScrollTop: vi.fn(() => 80),
+      getViewportHeight: vi.fn(() => 20),
+      isSticky: vi.fn(() => false),
+      scrollToBottom: vi.fn()
+    }
+
+    const onEvent = createGatewayEventHandler(
+      buildCtx(appended, {
+        transcript: {
+          appendMessage: (msg: Msg) => appended.push(msg),
+          panel: vi.fn(),
+          scrollRef: ref(scroll),
+          setHistoryItems: vi.fn()
+        }
+      })
+    )
+
+    // Cached: bottom = 80 + 20 = 100 >= 200 - 2 = 198 → false.
+    // Fresh:  bottom = 100 >= 100 - 2 = 98 → true → snap fires.
+    onEvent({ payload: { text: 'final answer' }, type: 'message.complete' } as unknown as Parameters<typeof onEvent>[0])
+
+    vi.runOnlyPendingTimers()
+
+    expect(scroll.scrollToBottom).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not yank when user scrolls manually between snap schedule and callback', () => {
+    vi.useFakeTimers()
+
+    const appended: Msg[] = []
+
+    let lastManualScrollAt = 0
+
+    const scroll = {
+      getFreshScrollHeight: vi.fn(() => 100),
+      getLastManualScrollAt: vi.fn(() => lastManualScrollAt),
+      getPendingDelta: vi.fn(() => 0),
+      getScrollHeight: vi.fn(() => 100),
+      getScrollTop: vi.fn(() => 80),
+      getViewportHeight: vi.fn(() => 20),
+      isSticky: vi.fn(() => false),
+      scrollToBottom: vi.fn()
+    }
+
+    const onEvent = createGatewayEventHandler(
+      buildCtx(appended, {
+        transcript: {
+          appendMessage: (msg: Msg) => appended.push(msg),
+          panel: vi.fn(),
+          scrollRef: ref(scroll),
+          setHistoryItems: vi.fn()
+        }
+      })
+    )
+
+    onEvent({ payload: { text: 'final answer' }, type: 'message.complete' } as unknown as Parameters<typeof onEvent>[0])
+
+    // User scrolls manually after the snap was scheduled but before the
+    // deferred callback fires — the timestamp guard must prevent the yank.
+    lastManualScrollAt = Date.now() + 1
 
     vi.runOnlyPendingTimers()
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -82,7 +82,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
   const { rpc } = ctx.gateway
   const { STARTUP_RESUME_ID, newSession, recoverSidRef, resumeById, setCatalog } = ctx.session
   const { bellOnComplete, stdout, sys } = ctx.system
-  const { appendMessage, panel, setHistoryItems } = ctx.transcript
+  const { appendMessage, panel, scrollRef, setHistoryItems } = ctx.transcript
   const { setInput } = ctx.composer
   const { submitRef } = ctx.submission
   const { setProcessing: setVoiceProcessing, setRecording: setVoiceRecording, setVoiceEnabled } = ctx.voice
@@ -118,6 +118,30 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       text: formatAbandonedClarify(clarify.question, clarify.choices, 'timed out')
     })
     patchOverlayState({ clarify: null })
+  }
+
+  const transcriptAtBottom = () => {
+    const scroll = scrollRef?.current
+
+    if (!scroll) {
+      return false
+    }
+
+    const bottom = scroll.getScrollTop() + scroll.getPendingDelta() + scroll.getViewportHeight()
+
+    return scroll.isSticky() || bottom >= scroll.getScrollHeight() - 2
+  }
+
+  const snapStickyTranscriptToBottom = () => {
+    if (!transcriptAtBottom()) {
+      return
+    }
+
+    setTimeout(() => {
+      if (transcriptAtBottom()) {
+        scrollRef?.current?.scrollToBottom()
+      }
+    }, 0)
   }
 
   // Inject the disk-save callback into turnController so recordMessageComplete
@@ -952,6 +976,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         if (!wasInterrupted) {
           const msgs: Msg[] = finalMessages.length ? finalMessages : [{ role: 'assistant', text: finalText }]
           msgs.forEach(appendMessage)
+          snapStickyTranscriptToBottom()
 
           // Pet beat: celebrate a finished plan, otherwise a clean-finish wave.
           flashPet(isTodoDone(getTurnState().todos) ? 'jump' : 'wave')

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -14,6 +14,7 @@ import { openExternalUrl } from '../lib/openExternalUrl.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
 import { topLevelSubagents } from '../lib/subagentTree.js'
 import { formatAbandonedClarify, formatToolCall, stripAnsi } from '../lib/text.js'
+import { getViewportSnapshot } from '../lib/viewportStore.js'
 import { fromSkin } from '../theme.js'
 import type { Msg, SubagentProgress, SubagentStatus } from '../types.js'
 
@@ -120,26 +121,34 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
     patchOverlayState({ clarify: null })
   }
 
-  const transcriptAtBottom = () => {
-    const scroll = scrollRef?.current
-
-    if (!scroll) {
-      return false
-    }
-
-    const bottom = scroll.getScrollTop() + scroll.getPendingDelta() + scroll.getViewportHeight()
-
-    return scroll.isSticky() || bottom >= scroll.getScrollHeight() - 2
-  }
+  const transcriptAtBottom = () =>
+    getViewportSnapshot(scrollRef?.current).atBottom
 
   const snapStickyTranscriptToBottom = () => {
-    if (!transcriptAtBottom()) {
+    // Capture the pre-commit bottom-pinned state before the final-history
+    // layout update changes geometry.  The deferred callback uses a
+    // manual-scroll timestamp guard (same pattern as scheduleResumeScrollToBottom
+    // in useSessionLifecycle.ts) so a user scroll between capture and callback
+    // prevents the yank.
+    const wasAtBottom = transcriptAtBottom()
+
+    if (!wasAtBottom) {
       return
     }
 
+    const scheduledAt = Date.now()
+
     setTimeout(() => {
-      if (transcriptAtBottom()) {
-        scrollRef?.current?.scrollToBottom()
+      const scroll = scrollRef?.current
+
+      if (!scroll) {
+        return
+      }
+
+      const manuallyScrolledAfterSnap = scroll.getLastManualScrollAt() > scheduledAt
+
+      if (!manuallyScrolledAfterSnap) {
+        scroll.scrollToBottom()
       }
     }, 0)
   }

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -320,6 +320,7 @@ export interface GatewayEventHandlerContext {
   transcript: {
     appendMessage: (msg: Msg) => void
     panel: (title: string, sections: PanelSection[]) => void
+    scrollRef?: RefObject<ScrollBoxHandle | null>
     setHistoryItems: StateSetter<Msg[]>
   }
   voice: {

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -756,7 +756,7 @@ export function useMainApp(gw: GatewayClient) {
         },
         submission: { submitRef },
         system: { bellOnComplete, stdout, sys },
-        transcript: { appendMessage, panel, setHistoryItems },
+        transcript: { appendMessage, panel, scrollRef, setHistoryItems },
         voice: {
           setProcessing: setVoiceProcessing,
           setRecording: setVoiceRecording,


### PR DESCRIPTION
## Summary
- keep the TUI transcript pinned when the final assistant response moves from streaming state into committed history
- treat the documented sticky-false-but-positionally-at-bottom case as bottom-pinned before scheduling the deferred scroll
- add regression coverage for sticky, positionally-at-bottom, and manually-scrolled-away transcript behavior

## Tests
- `cd ui-tui && npm test -- --run src/__tests__/createGatewayEventHandler.test.ts` (39 passed)
- `cd ui-tui && npm run type-check` (passed)
- `cd ui-tui && env -u SSH_CONNECTION -u SSH_CLIENT -u SSH_TTY npm test` (609 passed)
- `scripts/run_tests.sh` (fails: 55 failed, 19398 passed, 128 skipped, 9 errors; broad pre-existing-looking failures outside the changed TUI files, including missing optional `acp`, Dingtalk SDK globals, Bedrock header expectations, gateway/platform tests, browser/Chromium checks, Dockerfile checks, and missing `faster_whisper`)

## Notes
- Commit author email `psikonetik@gmail.com` is present in `scripts/release.py` `AUTHOR_MAP` as `el-analista`.
