### PR TITLE
fix(api-server): handle malformed HERMES_MAX_ITERATIONS values

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -70,6 +70,14 @@ def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
         return default
 
 
+def _coerce_int(value: Any, default: int) -> int:
+    """Parse integer config/env values without letting malformed input crash requests."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _normalize_chat_content(
     content: Any, *, _max_depth: int = 10, _depth: int = 0,
 ) -> str:
@@ -821,7 +829,7 @@ class APIServerAdapter(BasePlatformAdapter):
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
 
-        max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+        max_iterations = _coerce_int(os.getenv("HERMES_MAX_ITERATIONS", "90"), 90)
 
         # Load fallback provider chain so the API server platform has the
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -282,6 +282,36 @@ class TestAdapterInit:
         assert isinstance(agent, FakeAgent)
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
 
+    def test_create_agent_invalid_max_iterations_env_falls_back_to_default(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr("gateway.run._resolve_runtime_agent_kwargs", lambda: {})
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "gpt-5.5")
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_reasoning_config",
+            staticmethod(lambda: None),
+        )
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_fallback_model",
+            staticmethod(lambda: None),
+        )
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "not-a-number")
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        agent = adapter._create_agent(session_id="api-session")
+
+        assert isinstance(agent, FakeAgent)
+        assert captured["max_iterations"] == 90
+
 
 # ---------------------------------------------------------------------------
 # Auth checking


### PR DESCRIPTION
## What does this PR do?
`APIServerAdapter._create_agent()` parsed `HERMES_MAX_ITERATIONS` with a raw `int(...)` call. If the environment variable was malformed, API server requests could fail during agent creation with `ValueError`.

This PR switches that code path to a small defensive integer coercion helper local to `api_server.py`, preserving the existing default of `90` for invalid input. The change is intentionally narrow and only affects incorrect/malformed configuration values.

## Related Issue
No linked issue; found via code inspection.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- `gateway/platforms/api_server.py`: added a safe integer coercion helper and used it for `HERMES_MAX_ITERATIONS` in `_create_agent()`.
- `tests/gateway/test_api_server.py`: added a regression test proving malformed `HERMES_MAX_ITERATIONS` now falls back to `90` instead of crashing.

## How to Test
1. Before the fix, run:
   `uv run --extra dev --python "C:\Users\ysfdu\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe" python -m pytest tests\gateway\test_api_server.py -k invalid_max_iterations_env_falls_back_to_default -q`
   with `HERMES_MAX_ITERATIONS=not-a-number` and observe the `ValueError`.
2. After the fix, run:
   `uv run --extra dev --python "C:\Users\ysfdu\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe" python -m pytest tests\gateway\test_api_server.py -k invalid_max_iterations_env_falls_back_to_default -q -n 0 --basetemp C:\Users\ysfdu\AppData\Local\Temp\hermes-pytest`
   and confirm the test passes.
3. Run the nearby file:
   `uv run --extra dev --python "C:\Users\ysfdu\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe" python -m pytest tests\gateway\test_api_server.py -q -n 0 --basetemp C:\Users\ysfdu\AppData\Local\Temp\hermes-pytest-api-server`


