### PR TITLE
feat: expose ACP model state extension

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1423,6 +1423,21 @@ class HermesACPAgent(acp.Agent):
             options = {}
         options[str(config_id)] = value
         setattr(state, "config_options", options)
+
+        if str(config_id) == "reasoning_effort":
+            try:
+                from hermes_constants import parse_reasoning_effort
+
+                state.agent.reasoning_config = parse_reasoning_effort(str(value or ""))
+            except Exception:
+                logger.warning(
+                    "Session %s: failed to apply reasoning effort %s",
+                    session_id,
+                    value,
+                    exc_info=True,
+                )
+                return None
+
         self.session_manager.save_session(session_id)
         logger.info("Session %s: config option %s updated", session_id, config_id)
         return SetSessionConfigOptionResponse(config_options=[])

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -449,6 +449,14 @@ class HermesACPAgent(acp.Agent):
 
     # ---- ACP lifecycle ------------------------------------------------------
 
+    async def ext_method(self, name: str, payload: dict[str, Any]) -> Any:
+        """Handle Hermes-specific ACP extension requests."""
+        if name != "model_state":
+            return None
+        cwd = str((payload or {}).get("cwd") or ".")
+        state = self.session_manager.create_model_state_probe(cwd=cwd)
+        return self._build_model_state(state)
+
     async def initialize(
         self,
         protocol_version: int | None = None,

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -207,6 +207,22 @@ class SessionManager:
 
     # ---- public API ---------------------------------------------------------
 
+    def create_model_state_probe(self, cwd: str = ".") -> SessionState:
+        """Create a transient session state for capability/model discovery without persistence."""
+        import threading
+
+        cwd = _translate_acp_cwd(cwd)
+        session_id = f"model-probe-{uuid.uuid4()}"
+        agent = self._make_agent(session_id=session_id, cwd=cwd)
+        _clear_task_cwd(session_id)
+        return SessionState(
+            session_id=session_id,
+            agent=agent,
+            cwd=cwd,
+            model=getattr(agent, "model", "") or "",
+            cancel_event=threading.Event(),
+        )
+
     def create_session(self, cwd: str = ".") -> SessionState:
         """Create a new session with a unique ID and a fresh AIAgent."""
         import threading

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -171,6 +171,28 @@ class TestSessionOps:
         assert resp.models.available_models[0].description is not None
         assert "Provider:" in resp.models.available_models[0].description
 
+
+    @pytest.mark.asyncio
+    async def test_model_state_extension_returns_models_without_creating_session(self):
+        manager = SessionManager(
+            agent_factory=lambda: SimpleNamespace(model="claude-sonnet-4-5", provider="anthropic")
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+
+        with patch(
+            "hermes_cli.models.curated_models_for_provider",
+            return_value=[("claude-sonnet-4-5", "recommended"), ("claude-opus-4-5", "")],
+        ):
+            result = await acp_agent.ext_method("model_state", {"cwd": "/tmp/project"})
+
+        assert result is not None
+        assert result.current_model_id == "anthropic:claude-sonnet-4-5"
+        assert [model.model_id for model in result.available_models] == [
+            "anthropic:claude-sonnet-4-5",
+            "anthropic:claude-opus-4-5",
+        ]
+        assert manager.list_sessions() == []
+
     @pytest.mark.asyncio
     async def test_available_commands_include_help(self, agent):
         help_cmd = next(

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -13,6 +13,7 @@ class FakeAgent:
         self.provider = "fake-provider"
         self.enabled_toolsets = ["hermes-acp"]
         self.disabled_toolsets = []
+        self.reasoning_config = None
         self.tools = []
         self.valid_tool_names = set()
         self.steers = []
@@ -148,3 +149,25 @@ async def test_acp_prompt_drains_queued_turns_after_current_run():
     assert state.queued_prompts == []
     agent_messages = [u for _sid, u in conn.updates if getattr(u, "session_update", None) == "agent_message_chunk"]
     assert len(agent_messages) >= 2
+
+
+@pytest.mark.asyncio
+async def test_acp_set_reasoning_effort_updates_session_agent_config():
+    acp_agent, state, fake, _conn = make_agent_and_state()
+
+    response = await acp_agent.set_config_option(
+        session_id=state.session_id,
+        config_id="reasoning_effort",
+        value="high",
+    )
+
+    assert response is not None
+    assert fake.reasoning_config == {"enabled": True, "effort": "high"}
+    assert getattr(state, "config_options") == {"reasoning_effort": "high"}
+
+    await acp_agent.set_config_option(
+        session_id=state.session_id,
+        config_id="reasoning_effort",
+        value="none",
+    )
+    assert fake.reasoning_config == {"enabled": False}


### PR DESCRIPTION
## Summary
- Adds a Hermes ACP `_model_state` extension for pre-session model discovery.
- Creates a transient model-state probe so clients can list models without creating or persisting a chat session.
- Adds regression coverage for extension-based model discovery.

## Validation
- `/home/wstone/Documents/hermes-agent/venv/bin/python -m pytest tests/acp/test_server.py -k model_state_extension -q`
- `/home/wstone/Documents/hermes-agent/venv/bin/python -m pytest tests/acp_adapter/test_acp_commands.py -q`
- `git diff --check`
