### PR TITLE
feat(openai): support Responses text verbosity

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -675,7 +675,7 @@ def _preflight_codex_api_kwargs(
         "model", "instructions", "input", "tools", "store",
         "reasoning", "include", "max_output_tokens", "temperature",
         "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier",
-        "extra_headers",
+        "text", "extra_headers",
     }
     normalized: Dict[str, Any] = {
         "model": model,
@@ -696,6 +696,25 @@ def _preflight_codex_api_kwargs(
     service_tier = api_kwargs.get("service_tier")
     if isinstance(service_tier, str) and service_tier.strip():
         normalized["service_tier"] = service_tier.strip()
+    text = api_kwargs.get("text")
+    if text is not None:
+        if not isinstance(text, dict):
+            raise ValueError("Codex Responses request 'text' must be an object.")
+        normalized_text: Dict[str, Any] = {}
+        verbosity = text.get("verbosity")
+        if verbosity is not None:
+            verbosity_value = str(verbosity).strip().lower()
+            if verbosity_value not in {"low", "medium", "high"}:
+                raise ValueError("Codex Responses request 'text.verbosity' must be low, medium, or high.")
+            normalized_text["verbosity"] = verbosity_value
+        for key, value in text.items():
+            if key == "verbosity" or value is None:
+                continue
+            if not isinstance(key, str) or not key.strip():
+                raise ValueError("Codex Responses request 'text' keys must be non-empty strings.")
+            normalized_text[key.strip()] = value
+        if normalized_text:
+            normalized["text"] = normalized_text
 
     # Pass through max_output_tokens and temperature
     max_output_tokens = api_kwargs.get("max_output_tokens")

--- a/agent/text_verbosity.py
+++ b/agent/text_verbosity.py
@@ -1,0 +1,59 @@
+"""OpenAI Responses API text verbosity helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from utils import base_url_hostname
+
+VALID_TEXT_VERBOSITIES = ("low", "medium", "high")
+
+
+def parse_text_verbosity(raw: Any) -> str | None:
+    """Parse agent.text_verbosity into a Responses API verbosity value."""
+    value = str(raw or "").strip().lower()
+    if not value:
+        return None
+    if value in VALID_TEXT_VERBOSITIES:
+        return value
+    return None
+
+
+def supports_openai_text_verbosity(
+    *, provider: str | None, api_mode: str | None, base_url: str | None
+) -> bool:
+    """Return True when the runtime should receive Responses text.verbosity."""
+    if api_mode != "codex_responses":
+        return False
+    provider_name = str(provider or "").strip().lower()
+    if provider_name == "xai":
+        return False
+    hostname = base_url_hostname(str(base_url or ""))
+    if hostname == "api.openai.com":
+        return True
+    return provider_name in {"openai", "openai-codex"} and hostname not in {"api.x.ai"}
+
+
+def merge_text_verbosity_override(
+    overrides: Mapping[str, Any] | None,
+    text_verbosity: Any,
+    *,
+    provider: str | None,
+    api_mode: str | None,
+    base_url: str | None,
+) -> dict[str, Any]:
+    """Merge text.verbosity into request overrides only for OpenAI Responses runtimes."""
+    merged = dict(overrides or {})
+    verbosity = parse_text_verbosity(text_verbosity)
+    if not verbosity:
+        return merged
+    if not supports_openai_text_verbosity(
+        provider=provider, api_mode=api_mode, base_url=base_url
+    ):
+        return merged
+
+    text = merged.get("text")
+    text_obj = dict(text) if isinstance(text, Mapping) else {}
+    text_obj["verbosity"] = verbosity
+    merged["text"] = text_obj
+    return merged

--- a/cli.py
+++ b/cli.py
@@ -244,6 +244,17 @@ def _parse_service_tier_config(raw: str) -> str | None:
     logger.warning("Unknown service_tier '%s', ignoring", raw)
     return None
 
+
+def _parse_text_verbosity_config(raw: str) -> str | None:
+    """Parse agent.text_verbosity for OpenAI Responses API requests."""
+    from agent.text_verbosity import parse_text_verbosity
+
+    result = parse_text_verbosity(raw)
+    if raw and str(raw).strip() and result is None:
+        logger.warning("Unknown text_verbosity '%s', ignoring", raw)
+    return result
+
+
 def load_cli_config() -> Dict[str, Any]:
     """
     Load CLI configuration from config files.
@@ -2197,6 +2208,9 @@ class HermesCLI:
         self.service_tier = _parse_service_tier_config(
             CLI_CONFIG["agent"].get("service_tier", "")
         )
+        self.text_verbosity = _parse_text_verbosity_config(
+            CLI_CONFIG["agent"].get("text_verbosity", "")
+        )
         
         # OpenRouter provider routing preferences
         pr = CLI_CONFIG.get("provider_routing", {}) or {}
@@ -3539,15 +3553,22 @@ class HermesCLI:
         }
 
         service_tier = getattr(self, "service_tier", None)
-        if not service_tier:
-            route["request_overrides"] = None
-            return route
+        overrides = None
+        if service_tier:
+            try:
+                overrides = resolve_fast_mode_overrides(route["model"])
+            except Exception:
+                overrides = None
 
-        try:
-            overrides = resolve_fast_mode_overrides(route["model"])
-        except Exception:
-            overrides = None
-        route["request_overrides"] = overrides
+        from agent.text_verbosity import merge_text_verbosity_override
+
+        route["request_overrides"] = merge_text_verbosity_override(
+            overrides,
+            getattr(self, "text_verbosity", None),
+            provider=runtime["provider"],
+            api_mode=runtime["api_mode"],
+            base_url=runtime["base_url"],
+        )
         return route
 
     def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, request_overrides: dict | None = None) -> bool:
@@ -3656,6 +3677,7 @@ class HermesCLI:
                 prefill_messages=self.prefill_messages or None,
                 reasoning_config=self.reasoning_config,
                 service_tier=self.service_tier,
+                text_verbosity=self.text_verbosity,
                 request_overrides=request_overrides,
                 providers_allowed=self._providers_only,
                 providers_ignored=self._providers_ignore,
@@ -6825,6 +6847,7 @@ class HermesCLI:
                     session_db=self._session_db,
                     reasoning_config=self.reasoning_config,
                     service_tier=self.service_tier,
+                    text_verbosity=self.text_verbosity,
                     request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=self._providers_only,
                     providers_ignored=self._providers_ignore,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1103,8 +1103,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
         # Reasoning config from config.yaml
         from hermes_constants import parse_reasoning_effort
-        effort = str(_cfg.get("agent", {}).get("reasoning_effort", "")).strip()
+        from agent.text_verbosity import parse_text_verbosity
+        agent_cfg = _cfg.get("agent", {}) if isinstance(_cfg.get("agent", {}), dict) else {}
+        effort = str(agent_cfg.get("reasoning_effort", "")).strip()
         reasoning_config = parse_reasoning_effort(effort)
+        text_verbosity = parse_text_verbosity(agent_cfg.get("text_verbosity", ""))
 
         # Prefill messages from env or config.yaml
         prefill_messages = None
@@ -1200,6 +1203,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             acp_args=runtime.get("args"),
             max_iterations=max_iterations,
             reasoning_config=reasoning_config,
+            text_verbosity=text_verbosity,
             prefill_messages=prefill_messages,
             fallback_model=fallback_model,
             credential_pool=credential_pool,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -974,6 +974,7 @@ class GatewayRunner:
         self._ephemeral_system_prompt = self._load_ephemeral_system_prompt()
         self._reasoning_config = self._load_reasoning_config()
         self._service_tier = self._load_service_tier()
+        self._text_verbosity = self._load_text_verbosity()
         self._show_reasoning = self._load_show_reasoning()
         self._busy_input_mode = self._load_busy_input_mode()
         self._restart_drain_timeout = self._load_restart_drain_timeout()
@@ -1612,15 +1613,22 @@ class GatewayRunner:
         }
 
         service_tier = getattr(self, "_service_tier", None)
-        if not service_tier:
-            route["request_overrides"] = {}
-            return route
+        overrides = None
+        if service_tier:
+            try:
+                overrides = resolve_fast_mode_overrides(route["model"])
+            except Exception:
+                overrides = None
 
-        try:
-            overrides = resolve_fast_mode_overrides(route["model"])
-        except Exception:
-            overrides = None
-        route["request_overrides"] = overrides or {}
+        from agent.text_verbosity import merge_text_verbosity_override
+
+        route["request_overrides"] = merge_text_verbosity_override(
+            overrides,
+            getattr(self, "_text_verbosity", None),
+            provider=runtime["provider"],
+            api_mode=runtime["api_mode"],
+            base_url=runtime["base_url"],
+        )
         return route
 
     async def _handle_adapter_fatal_error(self, adapter: BasePlatformAdapter) -> None:
@@ -1980,6 +1988,26 @@ class GatewayRunner:
             return "priority"
         logger.warning("Unknown service_tier '%s', ignoring", raw)
         return None
+
+    @staticmethod
+    def _load_text_verbosity() -> str | None:
+        """Load OpenAI Responses API text verbosity from config.yaml."""
+        from agent.text_verbosity import parse_text_verbosity
+
+        raw = ""
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                raw = str(cfg_get(cfg, "agent", "text_verbosity", default="") or "").strip()
+        except Exception:
+            pass
+        result = parse_text_verbosity(raw)
+        if raw and result is None:
+            logger.warning("Unknown text_verbosity '%s', ignoring", raw)
+        return result
 
     @staticmethod
     def _load_show_reasoning() -> bool:
@@ -8933,6 +8961,7 @@ class GatewayRunner:
                     disabled_toolsets=disabled_toolsets,
                     reasoning_config=reasoning_config,
                     service_tier=self._service_tier,
+                    text_verbosity=self._text_verbosity,
                     request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=pr.get("only"),
                     providers_ignored=pr.get("ignore"),
@@ -13343,6 +13372,7 @@ class GatewayRunner:
                     prefill_messages=self._prefill_messages or None,
                     reasoning_config=reasoning_config,
                     service_tier=self._service_tier,
+                    text_verbosity=self._text_verbosity,
                     request_overrides=turn_route.get("request_overrides"),
                     providers_allowed=pr.get("only"),
                     providers_ignored=pr.get("ignore"),
@@ -13377,6 +13407,7 @@ class GatewayRunner:
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
+            agent.text_verbosity = self._text_verbosity
             agent.request_overrides = turn_route.get("request_overrides") or {}
 
             _bg_review_release = threading.Event()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -416,6 +416,9 @@ DEFAULT_CONFIG = {
         # provider hiccups on a single provider.
         "api_max_retries": 3,
         "service_tier": "",
+        # OpenAI Responses API output verbosity. Empty/unset preserves the
+        # provider default. Valid values: "low", "medium", "high".
+        "text_verbosity": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.
         # Values: "auto" (default — applies to gpt/codex models), true/false

--- a/run_agent.py
+++ b/run_agent.py
@@ -58,6 +58,7 @@ from datetime import datetime
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
+from agent.text_verbosity import merge_text_verbosity_override
 
 
 _OPENAI_CLS_CACHE: Optional[type] = None
@@ -937,6 +938,7 @@ class AIAgent:
         max_tokens: int = None,
         reasoning_config: Dict[str, Any] = None,
         service_tier: str = None,
+        text_verbosity: str = None,
         request_overrides: Dict[str, Any] = None,
         prefill_messages: List[Dict[str, Any]] = None,
         platform: str = None,
@@ -1210,7 +1212,14 @@ class AIAgent:
         self.max_tokens = max_tokens  # None = use model default
         self.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
         self.service_tier = service_tier
-        self.request_overrides = dict(request_overrides or {})
+        self.text_verbosity = text_verbosity
+        self.request_overrides = merge_text_verbosity_override(
+            request_overrides,
+            text_verbosity,
+            provider=self.provider,
+            api_mode=self.api_mode,
+            base_url=self.base_url,
+        )
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
         self._force_ascii_payload = False
         

--- a/tests/agent/test_text_verbosity.py
+++ b/tests/agent/test_text_verbosity.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pytest
+
+from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+from agent.text_verbosity import merge_text_verbosity_override, parse_text_verbosity
+from agent.transports.codex import ResponsesApiTransport
+
+
+def test_parse_text_verbosity_accepts_only_openai_values():
+    assert parse_text_verbosity("") is None
+    assert parse_text_verbosity(" LOW ") == "low"
+    assert parse_text_verbosity("medium") == "medium"
+    assert parse_text_verbosity("high") == "high"
+    assert parse_text_verbosity("verbose") is None
+
+
+def test_merge_text_verbosity_only_for_openai_responses_runtime():
+    merged = merge_text_verbosity_override(
+        {"service_tier": "priority"},
+        "low",
+        provider="openai",
+        api_mode="codex_responses",
+        base_url="https://api.openai.com/v1",
+    )
+    assert merged == {"service_tier": "priority", "text": {"verbosity": "low"}}
+
+    unsupported = merge_text_verbosity_override(
+        {"service_tier": "priority"},
+        "high",
+        provider="xai",
+        api_mode="codex_responses",
+        base_url="https://api.x.ai/v1",
+    )
+    assert unsupported == {"service_tier": "priority"}
+
+
+def test_codex_transport_keeps_top_level_text_verbosity_override():
+    kwargs = ResponsesApiTransport().build_kwargs(
+        model="gpt-5.1",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=[],
+        request_overrides={"text": {"verbosity": "high"}},
+    )
+
+    assert kwargs["text"] == {"verbosity": "high"}
+
+
+def test_codex_preflight_allows_and_normalizes_text_verbosity():
+    payload = _preflight_codex_api_kwargs(
+        {
+            "model": "gpt-5.1",
+            "instructions": "system",
+            "input": [
+                {"role": "user", "content": [{"type": "input_text", "text": "hi"}]}
+            ],
+            "store": False,
+            "text": {"verbosity": "HIGH"},
+        }
+    )
+
+    assert payload["text"] == {"verbosity": "high"}
+
+
+def test_codex_preflight_rejects_invalid_text_verbosity():
+    with pytest.raises(ValueError, match="text.verbosity"):
+        _preflight_codex_api_kwargs(
+            {
+                "model": "gpt-5.1",
+                "instructions": "system",
+                "input": [
+                    {"role": "user", "content": [{"type": "input_text", "text": "hi"}]}
+                ],
+                "store": False,
+                "text": {"verbosity": "verbose"},
+            }
+        )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -870,6 +870,13 @@ def _load_service_tier() -> str | None:
     return None
 
 
+def _load_text_verbosity() -> str | None:
+    from agent.text_verbosity import parse_text_verbosity
+
+    raw = str((_load_cfg().get("agent") or {}).get("text_verbosity", "") or "").strip()
+    return parse_text_verbosity(raw)
+
+
 def _load_show_reasoning() -> bool:
     return bool((_load_cfg().get("display") or {}).get("show_reasoning", False))
 
@@ -1732,6 +1739,7 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "reasoning_config": getattr(agent, "reasoning_config", None)
         or _load_reasoning_config(),
         "service_tier": getattr(agent, "service_tier", None) or _load_service_tier(),
+        "text_verbosity": getattr(agent, "text_verbosity", None) or _load_text_verbosity(),
         "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
         "platform": "tui",
         "session_db": _get_db(),
@@ -1790,6 +1798,7 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
         verbose_logging=_load_tool_progress_mode() == "verbose",
         reasoning_config=_load_reasoning_config(),
         service_tier=_load_service_tier(),
+        text_verbosity=_load_text_verbosity(),
         enabled_toolsets=_load_enabled_toolsets(),
         platform="tui",
         session_id=session_id or key,

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1058,6 +1058,17 @@ agent:
 
 When unset (default), reasoning effort defaults to "medium" — a balanced level that works well for most tasks. Setting a value overrides it — higher reasoning effort gives better results on complex tasks at the cost of more tokens and latency.
 
+## OpenAI Responses Text Verbosity
+
+For OpenAI GPT models using the Responses API, control how terse or detailed final natural-language answers should be without changing reasoning depth or Hermes UI logging:
+
+```yaml
+agent:
+  text_verbosity: ""   # empty = provider default. Options: low, medium, high
+```
+
+Hermes only sends this as top-level `text: {"verbosity": ...}` for OpenAI Responses runtimes. It is not sent to Anthropic, xAI/Grok, chat-completions-only providers, or other non-supporting backends.
+
 You can also change the reasoning effort at runtime with the `/reasoning` command:
 
 ```


### PR DESCRIPTION
## Summary\n- Adds agent.text_verbosity config for OpenAI Responses API.\n- Sends top-level text.verbosity only for OpenAI Responses runtimes.\n- Leaves xAI/Grok and other non-supporting providers untouched.\n- Keeps service_tier and request_overrides merged.\n\n## Tests\n- uv run pytest tests/agent/test_text_verbosity.py -q\n- uv run ruff check agent/text_verbosity.py agent/codex_responses_adapter.py agent/transports/codex.py tests/agent/test_text_verbosity.py\n- python3 -m compileall agent/text_verbosity.py agent/codex_responses_adapter.py agent/transports/codex.py run_agent.py cli.py gateway/run.py tui_gateway/server.py cron/scheduler.py tests/agent/test_text_verbosity.py\n- git diff --check\n\nCloses #20203