### PR TITLE
fix(matrix): route text-only send_message through adapter for E2EE support

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -528,10 +528,10 @@ class TestSendToPlatformChunking:
         finally:
             doc_path.unlink(missing_ok=True)
 
-    def test_matrix_text_only_uses_lightweight_path(self):
-        """Text-only Matrix sends should NOT go through the heavy adapter path."""
-        helper = AsyncMock()
-        lightweight = AsyncMock(return_value={"success": True, "platform": "matrix", "chat_id": "!room:ex.com", "message_id": "$txt"})
+    def test_matrix_text_only_uses_adapter_path(self):
+        """Text-only Matrix sends should go through the adapter path for E2EE support."""
+        helper = AsyncMock(return_value={"success": True, "platform": "matrix", "chat_id": "!room:ex.com", "message_id": "$txt"})
+        lightweight = AsyncMock()
         with patch("tools.send_message_tool._send_matrix_via_adapter", helper), \
              patch("tools.send_message_tool._send_matrix", lightweight):
             result = asyncio.run(
@@ -544,8 +544,8 @@ class TestSendToPlatformChunking:
             )
 
         assert result["success"] is True
-        helper.assert_not_awaited()
-        lightweight.assert_awaited_once()
+        helper.assert_awaited_once()
+        lightweight.assert_not_awaited()
 
     def test_send_matrix_via_adapter_sends_document(self, tmp_path):
         file_path = tmp_path / "report.pdf"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -541,8 +541,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
-    # --- Matrix: use the native adapter helper when media is present ---
-    if platform == Platform.MATRIX and media_files:
+    # --- Matrix: use the native adapter helper for all sends (E2EE support) ---
+    if platform == Platform.MATRIX:
         last_result = None
         for i, chunk in enumerate(chunks):
             is_last = (i == len(chunks) - 1)
@@ -635,8 +635,6 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_sms(pconfig.api_key, chat_id, chunk)
         elif platform == Platform.MATTERMOST:
             result = await _send_mattermost(pconfig.token, pconfig.extra, chat_id, chunk)
-        elif platform == Platform.MATRIX:
-            result = await _send_matrix(pconfig.token, pconfig.extra, chat_id, chunk)
         elif platform == Platform.HOMEASSISTANT:
             result = await _send_homeassistant(pconfig.token, pconfig.extra, chat_id, chunk)
         elif platform == Platform.DINGTALK:


### PR DESCRIPTION
## What does this PR do?

Fixes text-only Matrix messages sent via `send_message` arriving unencrypted (red padlock) in E2EE rooms.

The `send_message` tool had two Matrix send paths:
- **Media sends**: routed through `_send_matrix_via_adapter` (mautrix adapter, E2EE supported)
- **Text-only sends**: routed through `_send_matrix` (raw HTTP PUT, no E2EE)

This change routes all Matrix sends through the adapter path, so text messages are properly encrypted in E2EE rooms.

## Related

- Commit `276ed5c39` added `_send_matrix_via_adapter` specifically for media delivery
- PR #9822 fixed outbound attachment encryption in E2EE rooms
- The text-only path was never updated to use the adapter

## Changes

- `tools/send_message_tool.py`: Remove `media_files` condition from Matrix adapter routing — all Matrix sends now use the adapter
- Remove dead `_send_matrix` fallback case from text-only routing block
- Update test to expect adapter path for text-only Matrix sends

## Test Plan

- [x] Verified `_send_matrix_via_adapter` works for text-only messages against a live E2EE Matrix room (message delivered without red padlock)
- [x] All 95 tests in `tests/tools/test_send_message_tool.py` pass
- [x] All 19 tests in `tests/tools/test_send_message_missing_platforms.py` pass