### PR TITLE
fix(cli): tolerate cron jobs without repeat metadata

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -62,7 +62,7 @@ def cron_list(show_all: bool = False):
         state = job.get("state", "scheduled" if job.get("enabled", True) else "paused")
         next_run = job.get("next_run_at", "?")
 
-        repeat_info = job.get("repeat", {})
+        repeat_info = job.get("repeat") or {}
         repeat_times = repeat_info.get("times")
         repeat_completed = repeat_info.get("completed", 0)
         repeat_str = f"{repeat_completed}/{repeat_times}" if repeat_times else "∞"

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -4,7 +4,7 @@ from argparse import Namespace
 
 import pytest
 
-from cron.jobs import create_job, get_job, list_jobs
+from cron.jobs import create_job, get_job, list_jobs, save_jobs
 from hermes_cli.cron import cron_command
 
 
@@ -105,3 +105,21 @@ class TestCronCommandLifecycle:
         assert len(jobs) == 1
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
+
+    def test_list_tolerates_null_and_missing_repeat_metadata(self, tmp_cron_dir, capsys):
+        null_repeat = create_job(prompt="Null repeat", schedule="every 1h", name="Null repeat")
+        missing_repeat = create_job(prompt="Missing repeat", schedule="every 2h", name="Missing repeat")
+
+        jobs = list_jobs(include_disabled=True)
+        for job in jobs:
+            if job["id"] == null_repeat["id"]:
+                job["repeat"] = None
+            elif job["id"] == missing_repeat["id"]:
+                del job["repeat"]
+        save_jobs(jobs)
+
+        assert cron_command(Namespace(cron_command="list", all=True)) == 0
+        out = capsys.readouterr().out
+        assert "Null repeat" in out
+        assert "Missing repeat" in out
+        assert out.count("Repeat:    ∞") == 2


### PR DESCRIPTION
## Summary
- treat null or absent cron `repeat` metadata as infinite when rendering `hermes cron list`
- add a regression test covering both `repeat: null` and missing `repeat` keys

## Verification
- `PYTEST_ADDOPTS= PYTEST_PLUGINS= /home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_cron.py::TestCronCommandLifecycle::test_list_tolerates_null_and_missing_repeat_metadata -q`
- `PYTEST_ADDOPTS= PYTEST_PLUGINS= /home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_cron.py -q`
- `HERMES_HOME=/home/ubuntu/.hermes PYTHONPATH=$PWD /home/ubuntu/.hermes/hermes-agent/venv/bin/python hermes_cli/main.py cron list --all` (exit 0, printed 14 jobs / 14 repeat lines)

Related cron suite note: the broader cron-related subset currently has pre-existing failures on upstream main in this homelab test environment (delivery target thread id leakage / scheduler tests), so I kept the green gate to the directly touched CLI test module plus the live-list smoke above.