### PR TITLE
feat(session-log): mirror token usage and cost counters into session JSON (#20253)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4032,6 +4032,22 @@ class AIAgent:
                 "system_prompt": self._cached_system_prompt or "",
                 "tools": self.tools or [],
                 "message_count": len(cleaned),
+                # Cumulative token usage / cost counters (#20253). These are
+                # already tracked in-memory and persisted to ``state.db`` via
+                # ``update_token_counts``; mirroring them into the session
+                # JSON makes the file self-contained for auditing, custom
+                # analytics, and post-mortem inspection without having to
+                # cross-reference the SQLite database.
+                "input_tokens": self.session_input_tokens,
+                "output_tokens": self.session_output_tokens,
+                "cache_read_tokens": self.session_cache_read_tokens,
+                "cache_write_tokens": self.session_cache_write_tokens,
+                "reasoning_tokens": self.session_reasoning_tokens,
+                "total_tokens": self.session_total_tokens,
+                "api_call_count": self.session_api_calls,
+                "estimated_cost_usd": self.session_estimated_cost_usd,
+                "cost_status": self.session_cost_status,
+                "cost_source": self.session_cost_source,
                 "messages": cleaned,
             }
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3727,6 +3727,66 @@ class TestSaveSessionLogAtomicWrite:
         assert call_args.kwargs["indent"] == 2
         assert call_args.kwargs["default"] is str
 
+    def test_payload_includes_token_usage_counters(self, agent, tmp_path):
+        """Session JSON must mirror the in-memory token / cost counters (#20253).
+
+        Without this, the raw session JSON is missing the data the SQLite
+        ``sessions`` table already stores, so anyone reading the JSON for
+        auditing or analytics has to cross-reference state.db.
+        """
+        agent.session_log_file = tmp_path / "session.json"
+        agent.session_input_tokens = 1234
+        agent.session_output_tokens = 567
+        agent.session_cache_read_tokens = 890
+        agent.session_cache_write_tokens = 12
+        agent.session_reasoning_tokens = 34
+        agent.session_total_tokens = 1834
+        agent.session_api_calls = 7
+        agent.session_estimated_cost_usd = 0.012345
+        agent.session_cost_status = "ok"
+        agent.session_cost_source = "models_dev"
+
+        messages = [{"role": "user", "content": "hello"}]
+        with patch("run_agent.atomic_json_write", create=True) as mock_atomic_write:
+            agent._save_session_log(messages)
+
+        payload = mock_atomic_write.call_args.args[1]
+        assert payload["input_tokens"] == 1234
+        assert payload["output_tokens"] == 567
+        assert payload["cache_read_tokens"] == 890
+        assert payload["cache_write_tokens"] == 12
+        assert payload["reasoning_tokens"] == 34
+        assert payload["total_tokens"] == 1834
+        assert payload["api_call_count"] == 7
+        assert payload["estimated_cost_usd"] == pytest.approx(0.012345)
+        assert payload["cost_status"] == "ok"
+        assert payload["cost_source"] == "models_dev"
+
+    def test_payload_includes_zeroed_counters_for_fresh_session(self, agent, tmp_path):
+        """A brand-new session (no API calls yet) still emits the counter fields,
+        zero-valued — readers can rely on the shape without checking presence."""
+        agent.session_log_file = tmp_path / "session.json"
+        messages = [{"role": "user", "content": "hello"}]
+        with patch("run_agent.atomic_json_write", create=True) as mock_atomic_write:
+            agent._save_session_log(messages)
+
+        payload = mock_atomic_write.call_args.args[1]
+        for key in (
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "reasoning_tokens",
+            "total_tokens",
+            "api_call_count",
+        ):
+            assert key in payload
+            assert payload[key] == 0
+        assert payload["estimated_cost_usd"] == 0.0
+        # Defaults from reset_session_state — see run_agent.py L2087-L2088.
+        assert payload["cost_status"] == "unknown"
+        assert payload["cost_source"] == "none"
+
 
 # ===================================================================
 # Anthropic adapter integration fixes


### PR DESCRIPTION
## Summary

\`_save_session_log\` only emitted message history and metadata, not the cumulative token / cost counters Hermes already tracks in-memory and persists to the SQLite \`sessions\` table. Anyone reading the raw session JSON for auditing, custom analytics, or post-mortem inspection had to cross-reference \`state.db\` to recover figures that were one \`json.dumps\` field away from being self-contained.

## Fix

Add the existing per-session counters into the entry dict that \`atomic_json_write\` writes out:

| New JSON field         | Source attribute                       |
|------------------------|----------------------------------------|
| \`input_tokens\`        | \`self.session_input_tokens\`           |
| \`output_tokens\`       | \`self.session_output_tokens\`          |
| \`cache_read_tokens\`   | \`self.session_cache_read_tokens\`      |
| \`cache_write_tokens\`  | \`self.session_cache_write_tokens\`     |
| \`reasoning_tokens\`    | \`self.session_reasoning_tokens\`       |
| \`total_tokens\`        | \`self.session_total_tokens\`           |
| \`api_call_count\`      | \`self.session_api_calls\`              |
| \`estimated_cost_usd\`  | \`self.session_estimated_cost_usd\`     |
| \`cost_status\`         | \`self.session_cost_status\`            |
| \`cost_source\`         | \`self.session_cost_source\`            |

The values come straight from instance state populated by \`reset_session_state\` (\`run_agent.py\` L2076–L2088) and accumulated per API call in the agent loop (L11050–L11077), so this is purely a serialise-side change with no behavioural risk. Fresh sessions (no API calls yet) emit zero-valued counters so downstream readers can rely on the shape without checking presence.

## Test plan

- [x] \`tests/run_agent/test_run_agent.py::TestSaveSessionLogAtomicWrite\` — 3 tests pass (1 existing + 2 new):
  - \`test_payload_includes_token_usage_counters\` — populated counters propagate through.
  - \`test_payload_includes_zeroed_counters_for_fresh_session\` — fresh sessions emit zeros, defaults match \`reset_session_state\`.
- [x] Adjacent token-tracking tests (\`test_context_token_tracking.py\`, \`test_session_reset_fix.py\`) — 9 tests pass.

Fixes #20253