### PR TITLE
fix: merge _get_hermes_home() dynamic resolution + feishu receive_id_type (salvage #13725)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -114,12 +114,20 @@ from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
 
-# Resolve Hermes home directory (respects HERMES_HOME override)
-_hermes_home = get_hermes_home()
+# Backward-compatible module override used by tests and emergency monkeypatches.
+_hermes_home: Path | None = None
 
-# File-based lock prevents concurrent ticks from gateway + daemon + systemd timer
-_LOCK_DIR = _hermes_home / "cron"
-_LOCK_FILE = _LOCK_DIR / ".tick.lock"
+
+def _get_hermes_home() -> Path:
+    """Resolve Hermes home dynamically while preserving test monkeypatch hooks."""
+    return _hermes_home or get_hermes_home()
+
+
+def _get_lock_paths() -> tuple[Path, Path]:
+    """Resolve cron lock paths at call time so profile/env changes are honored."""
+    hermes_home = _get_hermes_home()
+    lock_dir = hermes_home / "cron"
+    return lock_dir, lock_dir / ".tick.lock"
 
 
 def _resolve_origin(job: dict) -> Optional[dict]:
@@ -597,7 +605,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     """
     from hermes_constants import get_hermes_home
 
-    scripts_dir = get_hermes_home() / "scripts"
+    scripts_dir = _get_hermes_home() / "scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)
     scripts_dir_resolved = scripts_dir.resolve()
 
@@ -1058,9 +1066,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # changes take effect without a gateway restart.
         from dotenv import load_dotenv
         try:
-            load_dotenv(str(_hermes_home / ".env"), override=True, encoding="utf-8")
+            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="utf-8")
         except UnicodeDecodeError:
-            load_dotenv(str(_hermes_home / ".env"), override=True, encoding="latin-1")
+            load_dotenv(str(_get_hermes_home() / ".env"), override=True, encoding="latin-1")
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
@@ -1078,7 +1086,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         _cfg = {}
         try:
             import yaml
-            _cfg_path = str(_hermes_home / "config.yaml")
+            _cfg_path = str(_get_hermes_home() / "config.yaml")
             if os.path.exists(_cfg_path):
                 with open(_cfg_path) as _f:
                     _cfg = yaml.safe_load(_f) or {}
@@ -1112,7 +1120,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         if prefill_file:
             pfpath = Path(prefill_file).expanduser()
             if not pfpath.is_absolute():
-                pfpath = _hermes_home / pfpath
+                pfpath = _get_hermes_home() / pfpath
             if pfpath.exists():
                 try:
                     with open(pfpath, "r", encoding="utf-8") as _pf:
@@ -1436,12 +1444,13 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
     Returns:
         Number of jobs executed (0 if another tick is already running)
     """
-    _LOCK_DIR.mkdir(parents=True, exist_ok=True)
+    lock_dir, lock_file = _get_lock_paths()
+    lock_dir.mkdir(parents=True, exist_ok=True)
 
     # Cross-platform file locking: fcntl on Unix, msvcrt on Windows
     lock_fd = None
     try:
-        lock_fd = open(_LOCK_FILE, "w")
+        lock_fd = open(lock_file, "w")
         if fcntl:
             fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
         elif msvcrt:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4090,7 +4090,14 @@ class FeishuAdapter(BasePlatformAdapter):
             content=payload,
             uuid_value=str(uuid.uuid4()),
         )
-        request = self._build_create_message_request("chat_id", body)
+        # Detect whether chat_id is an open_id (private message) or a group chat_id.
+        # Feishu API requires receive_id_type="open_id" for user DMs (oc_/ou_ prefix)
+        # and receive_id_type="chat_id" for group chats (ch_ prefix).
+        if chat_id.startswith(("oc_", "ou_")):
+            receive_id_type = "open_id"
+        else:
+            receive_id_type = "chat_id"
+        request = self._build_create_message_request(receive_id_type, body)
         return await asyncio.to_thread(self._client.im.v1.message.create, request)
 
     @staticmethod

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4090,10 +4090,11 @@ class FeishuAdapter(BasePlatformAdapter):
             content=payload,
             uuid_value=str(uuid.uuid4()),
         )
-        # Detect whether chat_id is an open_id (private message) or a group chat_id.
-        # Feishu API requires receive_id_type="open_id" for user DMs (oc_/ou_ prefix)
-        # and receive_id_type="chat_id" for group chats (ch_ prefix).
-        if chat_id.startswith(("oc_", "ou_")):
+        # Detect whether chat_id is a user open_id (DM) or a chat_id (group).
+        # Feishu API expects receive_id_type="open_id" for user DMs (ou_ prefix)
+        # and receive_id_type="chat_id" for group chats (oc_ prefix, which IS
+        # the chat_id format — see https://open.feishu.cn/document/).
+        if chat_id.startswith("ou_"):
             receive_id_type = "open_id"
         else:
             receive_id_type = "chat_id"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -55,6 +55,7 @@ AUTHOR_MAP = {
     "14046872+tmimmanuel@users.noreply.github.com": "tmimmanuel",
     "657290301@qq.com": "IMHaoyan",
     "revar@users.noreply.github.com": "revaraver",
+    "dengtaoyuan@dengtaoyuandeMac-mini.local": "dengtaoyuan450-a11y",
     "beardthelion@users.noreply.github.com": "beardthelion",
     "tangyuanjc@JCdeAIfenshendeMac-mini.local": "tangyuanjc",
     "leon@agentlinker.ai": "agentlinker",

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2055,8 +2055,8 @@ class TestParallelTick:
         """Point the tick file lock at a per-test temp dir to avoid xdist contention."""
         lock_dir = tmp_path / "cron"
         lock_dir.mkdir()
-        with patch("cron.scheduler._LOCK_DIR", lock_dir), \
-             patch("cron.scheduler._LOCK_FILE", lock_dir / ".tick.lock"):
+        lock_file = lock_dir / ".tick.lock"
+        with patch("cron.scheduler._get_lock_paths", return_value=(lock_dir, lock_file)):
             yield
 
     def test_parallel_jobs_run_concurrently(self):


### PR DESCRIPTION
Salvages @dengtaoyuan450-a11y's PR #13725 onto current main.

## What it does
Two independent fixes:
1. **cron/scheduler.py** — replaces static module-level `_hermes_home`/`_LOCK_DIR`/`_LOCK_FILE` (captured at import time) with lazy `_get_hermes_home()` / `_get_lock_paths()` helpers so runtime `HERMES_HOME` / profile switches take effect without a restart.
2. **gateway/platforms/feishu.py** — private-message send was hardcoded to `receive_id_type="chat_id"`, so DMs to users (whose chat_id starts with `ou_`) failed with Feishu's `[230001] ext=invalid receive_id`. Now routes `ou_` → `open_id`, everything else (including `oc_` group chat_ids) → `chat_id`.

## Changes
- `cron/scheduler.py` — dynamic helpers + all in-module callers updated.
- `gateway/platforms/feishu.py` — receive_id_type detection.
- `tests/cron/test_scheduler.py` — fixture updated to patch the new `_get_lock_paths` helper.
- `scripts/release.py` — AUTHOR_MAP entry.

## Fix on top of the contributor commit
The contributor's original check was `chat_id.startswith(("oc_", "ou_"))` which would have incorrectly classified `oc_` group chat_ids as open_ids. Tightened to `ou_` only; `oc_` stays on the `chat_id` path where it belongs (oc_ prefix IS the chat_id format per Feishu docs).

## Validation
`tests/cron/test_scheduler.py tests/gateway/test_feishu.py` — 311 passed locally.

Closes #13725 via salvage.