### PR TITLE
fix(ssh): add scp availability check to preflight validation (salvage #13702)

### DIFF
--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -27,6 +27,10 @@ def _ensure_ssh_available() -> None:
         raise RuntimeError(
             "SSH is not installed or not in PATH. Install OpenSSH client: apt install openssh-client"
         )
+    if not shutil.which("scp"):
+        raise RuntimeError(
+            "SCP is not installed or not in PATH. Install OpenSSH client: apt install openssh-client"
+        )
 
 
 class SSHEnvironment(BaseEnvironment):


### PR DESCRIPTION
Salvages @sprmn24's PR #13702 onto current main.

## What it does
`_ensure_ssh_available()` checked for the `ssh` binary but not `scp`. Users with a stripped OpenSSH install (ssh-only, no scp) got cryptic errors mid-operation instead of a clear preflight failure. Add a matching check for `scp`.

## Changes
- `tools/environments/ssh.py` — second `shutil.which("scp")` check with a matching error message.

## Note on the salvage
The original PR branch was very stale (based on a pre-reorganization snapshot of the repo) so the full branch can't be merged directly. Cherry-picked the substantive commit onto current main — 4-line additive change, no conflicts.

Closes #13702 via salvage.