### PR TITLE
fix(acp_adapter): make approval callback accept allow_permanent kwarg (silently breaks every ACP-mode dangerous-approval gate)

### DIFF
--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -28,10 +28,23 @@ def make_approval_callback(
     loop: asyncio.AbstractEventLoop,
     session_id: str,
     timeout: float = 60.0,
-) -> Callable[[str, str], str]:
+) -> Callable[..., str]:
     """
-    Return a hermes-compatible ``approval_callback(command, description) -> str``
-    that bridges to the ACP client's ``request_permission`` call.
+    Return a hermes-compatible approval callback that bridges to the ACP
+    client's ``request_permission`` call.
+
+    Hermes' core ``tools/approval.py:prompt_dangerous_approval`` invokes the
+    callback with the signature documented in its own docstring:
+    ``approval_callback(command, description, *, allow_permanent=True) -> str``.
+    The previous implementation only accepted ``(command, description)``,
+    causing every approval request to fail with a TypeError, which Hermes
+    then logged and treated as auto-deny — silently blocking legitimate
+    tool use whenever a dangerous-approval gate fired.
+
+    This implementation accepts ``allow_permanent`` and surfaces it as a
+    UI gate (suppress the "Allow always" option when False, per Hermes'
+    tirith-warning contract). It also accepts ``**_kwargs`` to absorb any
+    future kwargs Hermes core may add without crashing.
 
     Args:
         request_permission_fn: The ACP connection's ``request_permission`` coroutine.
@@ -40,12 +53,20 @@ def make_approval_callback(
         timeout: Seconds to wait for a response before auto-denying.
     """
 
-    def _callback(command: str, description: str) -> str:
+    def _callback(command: str, description: str, *, allow_permanent: bool = True, **_kwargs) -> str:
+        # When allow_permanent is False (e.g. tirith warnings present per
+        # Hermes' contract), suppress the "Allow always" option so the user
+        # can't broadly allowlist a content-level-flagged command.
         options = [
             PermissionOption(option_id="allow_once", kind="allow_once", name="Allow once"),
-            PermissionOption(option_id="allow_always", kind="allow_always", name="Allow always"),
-            PermissionOption(option_id="deny", kind="reject_once", name="Deny"),
         ]
+        if allow_permanent:
+            options.append(
+                PermissionOption(option_id="allow_always", kind="allow_always", name="Allow always"),
+            )
+        options.append(
+            PermissionOption(option_id="deny", kind="reject_once", name="Deny"),
+        )
         import acp as _acp
 
         tool_call = _acp.start_tool_call("perm-check", command, kind="execute")

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -87,3 +87,82 @@ class TestApprovalMapping:
             result = cb("echo hi", "demo")
 
         assert result == "deny"
+
+
+def _setup_callback_inspectable(outcome, *, callback_kwargs=None, timeout=60.0):
+    """
+    Like ``_setup_callback`` but also returns the mock ``request_permission``
+    so callers can introspect how the callback invoked it (e.g. to verify the
+    ``options`` list passed in).
+
+    ``callback_kwargs`` is the mapping of kwargs the test wants to pass to
+    the callback itself (e.g. ``{"allow_permanent": False}``).
+    """
+    loop = MagicMock(spec=asyncio.AbstractEventLoop)
+    mock_rp = MagicMock(name="request_permission")
+    response = _make_response(outcome)
+    future = MagicMock(spec=Future)
+    future.result.return_value = response
+
+    with patch("acp_adapter.permissions.asyncio.run_coroutine_threadsafe", return_value=future):
+        cb = make_approval_callback(mock_rp, loop, session_id="s1", timeout=timeout)
+        result = cb("rm -rf /", "dangerous command", **(callback_kwargs or {}))
+
+    return result, mock_rp
+
+
+class TestHermesCallingConventionContract:
+    """The callback must match Hermes core's calling convention:
+
+        approval_callback(command, description, *, allow_permanent=True) -> str
+
+    See ``tools/approval.py:prompt_dangerous_approval``. Any signature drift
+    causes Hermes to log a TypeError and silently auto-deny the operation,
+    which breaks legitimate tool use.
+    """
+
+    def test_callback_accepts_allow_permanent_kwarg(self):
+        """No TypeError when called with ``allow_permanent=True`` (Hermes' default)."""
+        outcome = AllowedOutcome(option_id="allow_once", outcome="selected")
+        result, _ = _setup_callback_inspectable(outcome, callback_kwargs={"allow_permanent": True})
+        assert result == "once"
+
+    def test_callback_suppresses_always_option_when_allow_permanent_false(self):
+        """When ``allow_permanent=False`` (e.g. tirith warning present), the
+        ``allow_always`` option must NOT be offered to the user — broad
+        permanent allowlisting is inappropriate for content-flagged commands."""
+        outcome = AllowedOutcome(option_id="allow_once", outcome="selected")
+        _, mock_rp = _setup_callback_inspectable(outcome, callback_kwargs={"allow_permanent": False})
+        options = mock_rp.call_args.kwargs["options"]
+        option_ids = {opt.option_id for opt in options}
+        assert "allow_always" not in option_ids
+        # The other two options stay so the user can still allow once or deny.
+        assert "allow_once" in option_ids
+        assert "deny" in option_ids
+
+    def test_callback_includes_always_option_when_allow_permanent_true(self):
+        """When ``allow_permanent=True`` (default), all three options offered."""
+        outcome = AllowedOutcome(option_id="allow_once", outcome="selected")
+        _, mock_rp = _setup_callback_inspectable(outcome, callback_kwargs={"allow_permanent": True})
+        options = mock_rp.call_args.kwargs["options"]
+        option_ids = {opt.option_id for opt in options}
+        assert option_ids == {"allow_once", "allow_always", "deny"}
+
+    def test_callback_tolerates_unknown_kwargs(self):
+        """Forward-compat: future Hermes-side kwarg additions must not crash
+        the callback. ``**_kwargs`` swallows them silently."""
+        outcome = AllowedOutcome(option_id="allow_once", outcome="selected")
+        result, _ = _setup_callback_inspectable(
+            outcome, callback_kwargs={"future_hermes_addition": "ignored"}
+        )
+        assert result == "once"
+
+    def test_callback_still_works_with_positional_only_args(self):
+        """Backward-compat: existing callers passing only ``(command, description)``
+        still get the default behaviour (allow_permanent=True, all 3 options)."""
+        outcome = AllowedOutcome(option_id="allow_once", outcome="selected")
+        # No callback_kwargs → defaults
+        result, mock_rp = _setup_callback_inspectable(outcome)
+        assert result == "once"
+        options = mock_rp.call_args.kwargs["options"]
+        assert {opt.option_id for opt in options} == {"allow_once", "allow_always", "deny"}


### PR DESCRIPTION
## What does this PR do?

\`tools/approval.py:prompt_dangerous_approval\` calls the registered approval callback as

\`\`\`python
approval_callback(command, description, allow_permanent=allow_permanent)
\`\`\`

per its own documented contract:

> \`approval_callback\`: Optional callback registered by the CLI for prompt_toolkit integration. Signature: \`(command, description, *, allow_permanent=True) -> str\`.

But \`acp_adapter.permissions.make_approval_callback\` returns a \`_callback\` that only accepts \`(command, description)\`. Every dangerous-approval gate in ACP mode therefore raises a \`TypeError\`, which Hermes catches and translates to auto-deny — silently breaking legitimate tool use whenever a permission gate fires (terminal commands matching dangerous patterns, tirith-flagged commands, etc.).

This PR brings the ACP callback into conformance with the documented contract.

## Repro

Run any Hermes ACP-mode session and trigger a dangerous command. Side-channel error in stderr:

\`\`\`
[ERROR] tools.approval: Approval callback failed: make_approval_callback.<locals>._callback() got an unexpected keyword argument 'allow_permanent'
Traceback (most recent call last):
  File ".../tools/approval.py", line 438, in prompt_dangerous_approval
    return approval_callback(command, description,
                             allow_permanent=allow_permanent)
TypeError: make_approval_callback.<locals>._callback() got an unexpected keyword argument 'allow_permanent'
\`\`\`

Bug present in upstream main (HEAD: \`de9238d37\`) and v2026.4.30 (latest tag).

## Related Issue

(no existing issue — surfacing here)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- \`acp_adapter/permissions.py\`:
  - \`_callback\` signature updated to \`(command, description, *, allow_permanent: bool = True, **_kwargs) -> str\` to match Hermes core's calling convention.
  - Honors \`allow_permanent\` semantics: when \`False\` (e.g. tirith warnings present, per \`prompt_dangerous_approval(... allow_permanent=not has_tirith)\`), suppresses the "Allow always" option so the user can't broadly allowlist a content-flagged command. Same UX semantics as the CLI path.
  - \`**_kwargs\` for forward-compat: any future Hermes-side kwarg addition won't silently break things again.
  - Updated docstring to document the contract + why the change is necessary.
- \`tests/acp/test_permissions.py\`:
  - 5 existing tests still pass (positional-only callers backward-compatible).
  - New \`TestHermesCallingConventionContract\` class with 5 tests:
    - \`test_callback_accepts_allow_permanent_kwarg\` — no TypeError on the documented kwarg
    - \`test_callback_suppresses_always_option_when_allow_permanent_false\` — verifies UI gate behavior
    - \`test_callback_includes_always_option_when_allow_permanent_true\` — verifies default behavior preserved
    - \`test_callback_tolerates_unknown_kwargs\` — forward-compat verified
    - \`test_callback_still_works_with_positional_only_args\` — backward-compat verified

## Test Plan

- [x] \`pytest tests/acp/test_permissions.py\` → 10/10 pass
- [x] Lint clean (ruff)
- [ ] Reviewer: please verify the \`allow_permanent\` UI gate semantics match Hermes' CLI path expectation

## Notes

Discovered during ACP-mode integration testing. Happy to iterate on any feedback — would prefer the fix landed upstream so all ACP integrators get correct dangerous-approval behavior.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>