### PR TITLE
fix(session): serialize JSONL transcript appends under existing lock (salvage #13695)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1276,8 +1276,9 @@ class SessionStore:
         
         # Also write legacy JSONL (keeps existing tooling working during transition)
         transcript_path = self.get_transcript_path(session_id)
-        with open(transcript_path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(message, ensure_ascii=False) + "\n")
+        with self._lock:
+            with open(transcript_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(message, ensure_ascii=False) + "\n")
     
     def rewrite_transcript(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Replace the entire transcript for a session with new messages.


### PR DESCRIPTION
Salvages @sprmn24's PR #13695 onto current main.

## What it does
`SessionStore` has a `_lock` that guards sessions-index mutations, but the JSONL transcript append path wrote unprotected — so two concurrent turns on the same session could interleave bytes mid-line and corrupt the transcript. Guard the append with the existing lock.

## Changes
- `gateway/session.py` — wrap the JSONL append in `with self._lock:`.

## Validation
`tests/gateway/test_session.py` — 77 passed locally.

Closes #13695 via salvage.