### PR TITLE
fix(acp): atomic session persistence via replace_messages (salvage #13675)

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -466,17 +466,10 @@ class SessionManager:
                 except Exception:
                     logger.debug("Failed to update ACP session metadata", exc_info=True)
 
-            # Replace stored messages with current history.
-            db.clear_messages(state.session_id)
-            for msg in state.history:
-                db.append_message(
-                    session_id=state.session_id,
-                    role=msg.get("role", "user"),
-                    content=msg.get("content"),
-                    tool_name=msg.get("tool_name") or msg.get("name"),
-                    tool_calls=msg.get("tool_calls"),
-                    tool_call_id=msg.get("tool_call_id"),
-                )
+            # Replace stored messages with current history atomically so a
+            # mid-rewrite failure rolls back and the previously persisted
+            # conversation is preserved (salvaged from #13675).
+            db.replace_messages(state.session_id, state.history)
         except Exception:
             logger.warning("Failed to persist ACP session %s", state.session_id, exc_info=True)
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -56,6 +56,7 @@ AUTHOR_MAP = {
     "657290301@qq.com": "IMHaoyan",
     "revar@users.noreply.github.com": "revaraver",
     "dengtaoyuan@dengtaoyuandeMac-mini.local": "dengtaoyuan450-a11y",
+    "ysfalweshcan@gmail.com": "Junass1",
     "beardthelion@users.noreply.github.com": "beardthelion",
     "tangyuanjc@JCdeAIfenshendeMac-mini.local": "tangyuanjc",
     "leon@agentlinker.ai": "agentlinker",

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -188,6 +188,31 @@ class TestListAndCleanup:
         manager.create_session(cwd="/empty")
         assert manager.list_sessions() == []
 
+    def test_save_session_preserves_existing_messages_on_encode_failure(self, manager):
+        """Regression for #13675: a bad message in state.history must not
+        clobber the previously-persisted transcript.  replace_messages()
+        wraps DELETE + INSERT in a single rolled-back-on-exception txn.
+        """
+        state = manager.create_session()
+        state.history.append({"role": "user", "content": "original"})
+        manager.save_session(state.session_id)
+
+        # Now swap history with a message whose tool_calls is non-JSON-serializable.
+        # _execute_write rolls back; the previously persisted "original" stays.
+        state.history = [
+            {"role": "user", "content": "replacement"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"bad": object()}],
+            },
+        ]
+        manager.save_session(state.session_id)
+
+        db = manager._get_db()
+        messages = db.get_messages_as_conversation(state.session_id)
+        assert messages == [{"role": "user", "content": "original"}]
+
     def test_cleanup_clears_all(self, manager):
         s1 = manager.create_session()
         s2 = manager.create_session()


### PR DESCRIPTION
Salvages @Junass1's PR #13675 onto current main with a simpler implementation.

## What it does
ACP's `save_session()` rewrote the transcript via `clear_messages()` + a loop of `append_message()` calls. If any message hit an exception mid-loop (bad `tool_calls` shape, encoding error, etc.), the DELETE had already committed and the persisted conversation was lost.

## Changes
- `acp_adapter/session.py` — replace the clear+loop with a single `db.replace_messages(state.session_id, state.history)` call. `SessionDB.replace_messages()` already exists on current main (added for /retry, /undo, /compress) and wraps DELETE + bulk INSERT in a `BEGIN IMMEDIATE` transaction that rolls back on exception.
- `tests/acp/test_session.py` — new regression test asserting a mid-encode failure leaves the previously-persisted transcript intact.
- `scripts/release.py` — AUTHOR_MAP entry for Junass1.

## Reshape vs. original
The original PR added its own `replace_messages` to `hermes_state.py`. Main now already has a more comprehensive `replace_messages` (handles `codex_message_items`, `reasoning_content`, role-gated fields). Re-wiring ACP to use the existing helper gives the contributor's safety guarantee with less code and no duplication.

Authorship preserved on the `acp_adapter/session.py` commit.

## Validation
`tests/acp/test_session.py` — 40 passed locally.

Closes #13675 via salvage.