### PR TITLE
fix(openrouter): use canonical X-Title attribution header (salvage #13649)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -259,10 +259,12 @@ _PROVIDERS_WITHOUT_VISION: frozenset = frozenset({
     "kimi-coding-cn",
 })
 
-# OpenRouter app attribution headers (base — always sent)
+# OpenRouter app attribution headers (base — always sent).
+# `X-Title` is the canonical attribution header OpenRouter's dashboard
+# reads; the previous `X-OpenRouter-Title` label was not recognized there.
 _OR_HEADERS_BASE = {
     "HTTP-Referer": "https://hermes-agent.nousresearch.com",
-    "X-OpenRouter-Title": "Hermes Agent",
+    "X-Title": "Hermes Agent",
     "X-OpenRouter-Categories": "productivity,cli-agent",
 }
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -59,6 +59,7 @@ AUTHOR_MAP = {
     "ysfalweshcan@gmail.com": "Junass1",
     "bartokmagic@proton.me": "Bartok9",
     "25840394+Bongulielmi@users.noreply.github.com": "Bongulielmi",
+    "jonathan.troyer@overmatch.com": "JTroyerOvermatch",
     "beardthelion@users.noreply.github.com": "beardthelion",
     "tangyuanjc@JCdeAIfenshendeMac-mini.local": "tangyuanjc",
     "leon@agentlinker.ai": "agentlinker",

--- a/tests/agent/test_openrouter_response_cache.py
+++ b/tests/agent/test_openrouter_response_cache.py
@@ -19,7 +19,7 @@ class TestBuildOrHeaders:
 
         headers = build_or_headers(or_config={"response_cache": False})
         assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
-        assert headers["X-OpenRouter-Title"] == "Hermes Agent"
+        assert headers["X-Title"] == "Hermes Agent"
         assert headers["X-OpenRouter-Categories"] == "productivity,cli-agent"
 
     def test_cache_enabled(self):

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -24,7 +24,7 @@ def test_openrouter_base_url_applies_or_headers(mock_openai):
 
     headers = agent._client_kwargs["default_headers"]
     assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
-    assert headers["X-OpenRouter-Title"] == "Hermes Agent"
+    assert headers["X-Title"] == "Hermes Agent"
 
 
 @patch("run_agent.OpenAI")


### PR DESCRIPTION
Salvages the core fix from @JTroyerOvermatch's PR #13649. Dropped the env-var override portion per the '.env is for secrets only' policy.

## What it does
OpenRouter's dashboard attributes usage via the `X-Title` header. Hermes was sending `X-OpenRouter-Title`, which OpenRouter doesn't recognize, so our usage showed up unlabeled. Same file already uses the canonical `X-Title` name in `_AI_GATEWAY_HEADERS`.

## Changes
- `agent/auxiliary_client.py` — `_OR_HEADERS_BASE` renamed `X-OpenRouter-Title` → `X-Title`.
- `tests/run_agent/test_provider_attribution_headers.py`, `tests/agent/test_openrouter_response_cache.py` — assertions updated.
- `scripts/release.py` — AUTHOR_MAP entry for JTroyerOvermatch.

## What was dropped vs original
The original PR added `HERMES_OPENROUTER_TITLE` / `HERMES_OPENROUTER_REFERER` env-var overrides so downstream packagers could differentiate per-deployment attribution. Dropped per skill policy: .env is for secrets only, non-secret behavioral config goes in config.yaml. If that feature is wanted later, it should come back under `openrouter.title` / `openrouter.referer` in config.yaml, not as new `HERMES_*` env vars.

## Validation
`tests/run_agent/test_provider_attribution_headers.py tests/agent/test_openrouter_response_cache.py` — 52 passed locally.

Closes #13649 via salvage.