### PR TITLE
fix(gateway): deterministic thread eviction preserves newest entries (salvage #13639)

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -222,33 +222,37 @@ class ThreadParticipationTracker:
     def __init__(self, platform_name: str, max_tracked: int = 500):
         self._platform = platform_name
         self._max_tracked = max_tracked
-        self._threads: set = self._load()
+        self._threads: dict[str, None] = {
+            str(thread_id): None for thread_id in self._load()
+        }
 
     def _state_path(self) -> Path:
         from hermes_constants import get_hermes_home
         return get_hermes_home() / f"{self._platform}_threads.json"
 
-    def _load(self) -> set:
+    def _load(self) -> list[str]:
         path = self._state_path()
         if path.exists():
             try:
-                return set(json.loads(path.read_text(encoding="utf-8")))
+                data = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(data, list):
+                    return [str(thread_id) for thread_id in data]
             except Exception:
                 pass
-        return set()
+        return []
 
     def _save(self) -> None:
         path = self._state_path()
         thread_list = list(self._threads)
         if len(thread_list) > self._max_tracked:
             thread_list = thread_list[-self._max_tracked:]
-            self._threads = set(thread_list)
+            self._threads = {thread_id: None for thread_id in thread_list}
         atomic_json_write(path, thread_list, indent=None)
 
     def mark(self, thread_id: str) -> None:
         """Mark *thread_id* as participated and persist."""
         if thread_id not in self._threads:
-            self._threads.add(thread_id)
+            self._threads[thread_id] = None
             self._save()
 
     def __contains__(self, thread_id: str) -> bool:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -60,6 +60,7 @@ AUTHOR_MAP = {
     "bartokmagic@proton.me": "Bartok9",
     "25840394+Bongulielmi@users.noreply.github.com": "Bongulielmi",
     "jonathan.troyer@overmatch.com": "JTroyerOvermatch",
+    "harryykyle1@gmail.com": "hharry11",
     "beardthelion@users.noreply.github.com": "beardthelion",
     "tangyuanjc@JCdeAIfenshendeMac-mini.local": "tangyuanjc",
     "leon@agentlinker.ai": "agentlinker",

--- a/tests/gateway/test_discord_thread_persistence.py
+++ b/tests/gateway/test_discord_thread_persistence.py
@@ -67,6 +67,21 @@ class TestDiscordThreadPersistence:
 
         saved = json.loads((tmp_path / "discord_threads.json").read_text())
         assert len(saved) == 5
+        assert saved == ["5", "6", "7", "8", "9"]
+
+    def test_capacity_keeps_newest_thread_when_existing_state_is_full(self, tmp_path):
+        """A newly joined thread must not be evicted by unordered set iteration."""
+        state_file = tmp_path / "discord_threads.json"
+        state_file.write_text(json.dumps(["0", "1", "2", "3", "4"]), encoding="utf-8")
+        adapter = self._make_adapter(tmp_path)
+        adapter._threads._max_tracked = 5
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            adapter._threads.mark("newest")
+
+        saved = json.loads(state_file.read_text(encoding="utf-8"))
+        assert saved == ["1", "2", "3", "4", "newest"]
+        assert "newest" in adapter._threads
 
     def test_corrupted_state_file_falls_back_to_empty(self, tmp_path):
         state_file = tmp_path / "discord_threads.json"


### PR DESCRIPTION
Salvages @hharry11's PR #13639 onto current main.

## What it does
`ThreadParticipationTracker` stored threads in a `set` and relied on `list(set)` ordering for capacity eviction. Since Python sets are unordered, a newly `mark()`-ed thread could be evicted by the next capacity trim while older entries survived — non-deterministic, and specifically bad on Discord where a recently-joined thread might disappear from the participation cache.

Switch to a `dict[str, None]` which preserves insertion order; the newest `mark()`-ed thread is always at the end and survives `[-max_tracked:]` trimming.

## Changes
- `gateway/platforms/helpers.py` — `_threads` is now a dict keyed by thread id. `_load` returns an ordered list. Save still uses main's `atomic_json_write`.
- `tests/gateway/test_discord_thread_persistence.py` — assertion on evicted-set ordering + new test for the newest-survives case.
- `scripts/release.py` — AUTHOR_MAP entry for hharry11.

## Validation
`tests/gateway/test_discord_thread_persistence.py` — 8 passed locally.

Closes #13639 via salvage.