### PR TITLE
fix: include plugin-registered tools in built-in toolsets (salvage #13637)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -61,6 +61,7 @@ AUTHOR_MAP = {
     "25840394+Bongulielmi@users.noreply.github.com": "Bongulielmi",
     "jonathan.troyer@overmatch.com": "JTroyerOvermatch",
     "harryykyle1@gmail.com": "hharry11",
+    "wysie@users.noreply.github.com": "wysie",
     "beardthelion@users.noreply.github.com": "beardthelion",
     "tangyuanjc@JCdeAIfenshendeMac-mini.local": "tangyuanjc",
     "leon@agentlinker.ai": "agentlinker",

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -32,6 +32,21 @@ class TestGetToolset:
         assert ts is not None
         assert "web_search" in ts["tools"]
 
+    def test_merges_registry_tools_into_builtin_toolset(self, monkeypatch):
+        reg = ToolRegistry()
+        reg.register(
+            name="web_search_plus",
+            toolset="web",
+            schema=_make_schema("web_search_plus", "Plugin web search"),
+            handler=_dummy_handler,
+        )
+
+        monkeypatch.setattr("tools.registry.registry", reg)
+
+        ts = get_toolset("web")
+        assert ts is not None
+        assert set(ts["tools"]) == {"web_search", "web_extract", "web_search_plus"}
+
     def test_unknown_returns_none(self):
         assert get_toolset("nonexistent") is None
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -521,13 +521,18 @@ def get_toolset(name: str) -> Optional[Dict[str, Any]]:
         None: If toolset not found
     """
     toolset = TOOLSETS.get(name)
-    if toolset:
-        return toolset
 
     try:
         from tools.registry import registry
     except Exception:
-        return None
+        return toolset if toolset else None
+
+    if toolset:
+        merged_tools = sorted(
+            set(toolset.get("tools", []))
+            | set(registry.get_tool_names_for_toolset(name))
+        )
+        return {**toolset, "tools": merged_tools}
 
     registry_toolset = name
     description = f"Plugin toolset: {name}"


### PR DESCRIPTION
Salvages @wysie's PR #13637 onto current main.

## What it does
Plugins can call `ctx.register_tool(name="foo", toolset="web")` to register a tool into an existing built-in toolset — enabling 'alternative backend for an existing tool category' (e.g. `web_search_brave` alongside the built-in `web_search`). But `get_toolset("web")` was returning the static `TOOLSETS` dict entry immediately, so plugin additions were silently dropped. The registration succeeded, the tool just never appeared in the agent's tool surface.

When a built-in toolset is requested, merge its static tools with any registry tools tagged for the same toolset.

## Changes
- `toolsets.py` — `get_toolset` merges `TOOLSETS` tools with `registry.get_tool_names_for_toolset(name)` before returning.
- `tests/test_toolsets.py` — regression test: a plugin tool registered with `toolset="web"` now appears in `get_toolset("web")['tools']`.
- `scripts/release.py` — AUTHOR_MAP entry for wysie.

## Validation
`tests/test_toolsets.py` — 25 passed locally.

Closes #13637 via salvage.