### PR TITLE
fix(gateway): guard GatewayConfig.from_dict against non-dict platforms

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -531,7 +531,10 @@ class GatewayConfig:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "GatewayConfig":
         platforms = {}
-        for platform_name, platform_data in data.get("platforms", {}).items():
+        platforms_data = data.get("platforms", {})
+        if not isinstance(platforms_data, dict):
+            platforms_data = {}
+        for platform_name, platform_data in platforms_data.items():
             try:
                 platform = Platform(platform_name)
                 platforms[platform] = PlatformConfig.from_dict(platform_data)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -213,6 +213,10 @@ class TestGatewayConfigRoundtrip:
         restored = GatewayConfig.from_dict({"always_log_local": "false"})
         assert restored.always_log_local is False
 
+    def test_from_dict_ignores_non_mapping_platforms(self):
+        restored = GatewayConfig.from_dict({"platforms": []})
+        assert restored.platforms == {}
+
     def test_get_notice_delivery_defaults_to_public(self):
         config = GatewayConfig(
             platforms={Platform.SLACK: PlatformConfig(enabled=True, token="***")}


### PR DESCRIPTION
## Summary

This fixes a small config-loading bug in the gateway fallback path for legacy `gateway.json`.

`GatewayConfig.from_dict()` assumed `platforms` was always a mapping and called `.items()` directly. If `gateway.json` contained an invalid shape such as:

`{"platforms": []}`

gateway config loading crashed with:

`AttributeError: 'list' object has no attribute 'items'`

This change makes the loader treat non-mapping `platforms` values as empty, which matches the existing "invalid config falls back to safe defaults" behavior elsewhere in the config layer.

## Root Cause

In `gateway/config.py`, `GatewayConfig.from_dict()` did:

`for platform_name, platform_data in data.get("platforms", {}).items():`

That is safe only when `platforms` is a dict. Legacy `gateway.json` content is passed through this path without a shape guard.

## Fix

Added a minimal type check before iterating:

- if `platforms` is a dict, load it normally
- otherwise, treat it as `{}`

No valid config behavior changes.

## Test

Added a targeted regression test to cover:

- `GatewayConfig.from_dict({"platforms": []})` does not raise
- the resulting `platforms` value is `{}`

## Why this is low risk

- single behavior change
- only affects invalid config input
- valid `platforms` mappings are unchanged
- no runtime/tool/gateway flow changes beyond config parsing hardening

## Verification

Verified locally with a direct Python repro against the real config-loading code path.

