### PR TITLE
fix(skills): support category-qualified local skill_view lookups (salvage #13630)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -64,6 +64,7 @@ AUTHOR_MAP = {
     "wysie@users.noreply.github.com": "wysie",
     "jkausel@gmail.com": "jkausel-ai",
     "e.silacandmr@gmail.com": "Es1la",
+    "154585401+LeonSGP43@users.noreply.github.com": "LeonSGP43",
     "beardthelion@users.noreply.github.com": "beardthelion",
     "tangyuanjc@JCdeAIfenshendeMac-mini.local": "tangyuanjc",
     "leon@agentlinker.ai": "agentlinker",

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -241,6 +241,23 @@ class TestSkillViewQualifiedName:
         assert result["success"] is False
         assert "not found" in result["error"].lower()
 
+    def test_category_qualified_local_skill_falls_through(self, tmp_path, monkeypatch):
+        from tools.skills_tool import skill_view
+
+        local_skills = tmp_path / "local-skills"
+        skill_dir = local_skills / "productivity" / "ticktick"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: ticktick\ndescription: local categorized\n---\nTickTick body.\n"
+        )
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", local_skills)
+
+        result = json.loads(skill_view("productivity:ticktick"))
+
+        assert result["success"] is True
+        assert result["name"] == "ticktick"
+        assert "TickTick body." in result["content"]
+
     def test_stale_entry_self_heals(self, tmp_path):
         from tools.skills_tool import skill_view
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -868,6 +868,7 @@ def skill_view(
         JSON string with skill content or error message
     """
     try:
+        local_category_name: str | None = None
         # ── Qualified name dispatch (plugin skills) ──────────────────
         # Names containing ':' are routed to the plugin skill registry.
         # Bare names fall through to the existing flat-tree scan below.
@@ -928,8 +929,12 @@ def skill_view(
                     },
                     ensure_ascii=False,
                 )
-            # Plugin itself not found — fall through to flat-tree scan
-            # which will return a normal "not found" with suggestions.
+            # Plugin itself not found — fall through to flat-tree scan.
+            # Categorized local skills also use `category:skill` in config and
+            # gateway prompts, so preserve that form and translate it to the
+            # on-disk `category/skill` path during the local scan below.
+            if bare:
+                local_category_name = f"{namespace}/{bare}"
 
         from agent.skill_utils import get_external_skills_dirs
 
@@ -962,6 +967,15 @@ def skill_view(
             elif direct_path.with_suffix(".md").exists():
                 skill_md = direct_path.with_suffix(".md")
                 break
+            if local_category_name:
+                categorized_path = search_dir / local_category_name
+                if categorized_path.is_dir() and (categorized_path / "SKILL.md").exists():
+                    skill_dir = categorized_path
+                    skill_md = categorized_path / "SKILL.md"
+                    break
+                elif categorized_path.with_suffix(".md").exists():
+                    skill_md = categorized_path.with_suffix(".md")
+                    break
 
         # Search by directory name across all dirs
         if not skill_md:


### PR DESCRIPTION
Salvages @LeonSGP43's PR #13630 onto current main.

## What it does
When a user references a local (non-plugin) skill as `category:skill` (the same form used for plugin skills and in gateway prompts), the plugin-lookup path returned 'not found' instead of falling through to the on-disk `category/skill/SKILL.md` layout. Translate `namespace:bare` → `namespace/bare` during local fallback.

## Changes
- `tools/skills_tool.py` — when plugin lookup fails, remember the categorized name and check `search_dir/<category>/<skill>/SKILL.md` during local fallback.
- `tests/test_plugin_skills.py` — regression test.
- `scripts/release.py` — AUTHOR_MAP entry for LeonSGP43.

## Validation
`tests/test_plugin_skills.py` — 28 passed locally.

Closes #13630 via salvage.