### PR TITLE
fix(cli): discover plugin commands during CLI dispatch (salvage #13627)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1890,8 +1890,8 @@ _skill_commands = scan_skill_commands()
 def _get_plugin_cmd_handler_names() -> set:
     """Return plugin command names (without slash prefix) for dispatch matching."""
     try:
-        from hermes_cli.plugins import get_plugin_manager
-        return set(get_plugin_manager()._plugin_commands.keys())
+        from hermes_cli.plugins import get_plugin_commands
+        return set(get_plugin_commands().keys())
     except Exception:
         return set()
 


### PR DESCRIPTION
Salvages @jkausel-ai's PR #13627 onto current main.

## What it does
`_get_plugin_cmd_handler_names()` reached into `get_plugin_manager()._plugin_commands` directly — which works only if plugins have already been discovered. In processes that don't import `model_tools.py` first, `_plugin_commands` is empty and plugin slash commands don't dispatch. Route through the public `get_plugin_commands()` helper, which calls `_ensure_plugins_discovered()` and triggers a one-time discover-and-load if needed.

This is the discovery-timing pitfall documented in the skill — `get_plugin_manager()` creates the singleton but does NOT call `discover_and_load`. The public `get_plugin_commands` helper does.

## Changes
- `cli.py` — single-call migration from private attr access to public helper.

## Validation
`tests/hermes_cli/ -k plugin` — 166 passed locally.

Closes #13627 via salvage.