### PR TITLE
Fix empty conversation history handling in _handle_runs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2644,6 +2644,19 @@ class APIServerAdapter(BasePlatformAdapter):
 
         run_id = f"run_{uuid.uuid4().hex}"
         session_id = body.get("session_id") or stored_session_id or run_id
+
+        # Load conversation history from SessionDB when a session_id is provided
+        # but no history was supplied via conversation_history or previous_response_id.
+        if not conversation_history and body.get("session_id"):
+            try:
+                db = self._ensure_session_db()
+                if db is not None:
+                    loaded = db.get_messages_as_conversation(session_id)
+                    if loaded:
+                        conversation_history = loaded
+            except Exception as e:
+                logger.warning("Failed to load session history for run %s: %s", session_id, e)
+
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()
         q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

When POST /v1/runs is called with a session_id but without an explicit conversation_history or previous_response_id, the handler was silently starting the agent with an empty history. This meant that multi-turn conversations via the /v1/runs endpoint didn't benefit from session continuity that was already working on /v1/chat/completions.
This fix loads the conversation history from SessionDB in _handle_runs when a session_id is provided but no history was supplied — matching the behaviour of the chat completions handler.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)


## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

•	api_server.py — In _handle_runs, added a SessionDB lookup after session_id is resolved: if no conversation_history was provided (neither via the request body nor via previous_response_id chaining), the handler now loads the history from SessionDB using the supplied session_id, with a graceful warning on failure. 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.	Start the API server with a valid config (API_SERVER_KEY set).
2.	Send a first POST /v1/runs with {"input": "Remember the word: banana", "session_id": "test-session"}.
3.	Wait for the run to complete.
4.	Send a second POST /v1/runs with {"input": "What word did I ask you to remember?", "session_id": "test-session"} — no conversation_history or previous_response_id.
5.	Verify the agent correctly recalls "banana", confirming history was loaded from SessionDB.
Before the fix: step 5 produces a response with no memory of step 2 (empty history).
After the fix: step 5 correctly recalls the prior turn.

## Checklist

<!-- Complete these before requesting review. -->

•	[x] I've read the Contributing Guide
•	[x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
•	[x] I searched for existing PRs to make sure this isn't a duplicate
•	[x] My PR contains only changes related to this fix/feature (no unrelated commits)
•	[x] I've run pytest tests/ -q and all tests pass
•	[ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
•	[x] I've tested on my platform: Ubuntu

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
N/A — the fix is a silent correctness improvement; no visual output changes.
