### PR TITLE
fix(acp): preserve assistant reasoning metadata in session persistence (salvage #13575)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -66,6 +66,7 @@ AUTHOR_MAP = {
     "e.silacandmr@gmail.com": "Es1la",
     "154585401+LeonSGP43@users.noreply.github.com": "LeonSGP43",
     "zjtan1@gmail.com": "zeejaytan",
+    "asslaenn5@gmail.com": "Aslaaen",
     "beardthelion@users.noreply.github.com": "beardthelion",
     "tangyuanjc@JCdeAIfenshendeMac-mini.local": "tangyuanjc",
     "leon@agentlinker.ai": "agentlinker",

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -480,6 +480,39 @@ class TestPersistence:
         assert restored.history[0].get("tool_calls") is not None
         assert restored.history[1].get("tool_call_id") == "tc_1"
 
+    def test_assistant_reasoning_fields_persisted(self, manager):
+        """ACP session restore should preserve assistant reasoning context."""
+        state = manager.create_session()
+        state.history.append({
+            "role": "assistant",
+            "content": "hello",
+            "reasoning": "step-by-step",
+            "reasoning_details": [
+                {"type": "thinking", "thinking": "first thought"},
+            ],
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_123", "encrypted_content": "enc_blob"},
+            ],
+        })
+        manager.save_session(state.session_id)
+
+        with manager._lock:
+            del manager._sessions[state.session_id]
+
+        restored = manager.get_session(state.session_id)
+        assert restored is not None
+        assert restored.history == [{
+            "role": "assistant",
+            "content": "hello",
+            "reasoning": "step-by-step",
+            "reasoning_details": [
+                {"type": "thinking", "thinking": "first thought"},
+            ],
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_123", "encrypted_content": "enc_blob"},
+            ],
+        }]
+
     def test_restore_preserves_persisted_provider_snapshot(self, tmp_path, monkeypatch):
         """Restored ACP sessions should keep their original runtime provider."""
         runtime_choice = {"provider": "anthropic"}


### PR DESCRIPTION
Salvages @Aslaaen's PR #13575 onto current main.

## What it does
ACP `save_session()` called `db.append_message()` without the `reasoning` / `reasoning_details` / `codex_reasoning_items` kwargs, so those fields were dropped on every session save and resumed sessions lost their thinking/reasoning context.

## Changes
- `acp_adapter/session.py` — pass the three reasoning fields to `append_message`.
- `tests/acp/test_session.py` — round-trip regression test.
- `scripts/release.py` — AUTHOR_MAP entry for Aslaaen.

## Relationship to #20279
Salvage PR #20279 (for #13675) rewrites save_session to use `replace_messages` instead of `clear_messages` + `append_message` loop. Once #20279 lands, `replace_messages` already handles these reasoning fields and this fix becomes a no-op. Both PRs are safe to land in either order.

## Validation
`tests/acp/test_session.py` — 40 passed locally.

Closes #13575 via salvage.