### PR TITLE
feat(i18n): add Korean static message locale

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -25,7 +25,7 @@ Language resolution order:
     3. ``display.language`` from config.yaml
     4. ``"en"`` (baseline)
 
-Supported languages: en, zh, ja, de, es.  Unknown values fall back to en.
+Supported languages: en, zh, ja, de, es, ko.  Unknown values fall back to en.
 """
 
 from __future__ import annotations
@@ -39,7 +39,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "ja", "de", "es")
+SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "ja", "de", "es", "ko")
 DEFAULT_LANGUAGE = "en"
 
 # Accept a few natural aliases so users who type "chinese" / "zh-CN" / "jp"
@@ -50,6 +50,7 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "japanese": "ja", "jp": "ja", "ja-jp": "ja",
     "german": "de", "deutsch": "de", "de-de": "de",
     "spanish": "es", "español": "es", "espanol": "es", "es-es": "es", "es-mx": "es",
+    "korean": "ko", "한국어": "ko", "ko-kr": "ko",
 }
 
 _catalog_cache: dict[str, dict[str, str]] = {}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -784,7 +784,7 @@ DEFAULT_CONFIG = {
         # UI language for static user-facing messages (approval prompts, a
         # handful of gateway slash-command replies).  Does NOT affect agent
         # responses, log lines, tool outputs, or slash-command descriptions.
-        # Supported: en, zh, ja, de, es.  Unknown values fall back to en.
+        # Supported: en, zh, ja, de, es, ko.  Unknown values fall back to en.
         "language": "en",
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -7,7 +7,7 @@
 #
 # Keys are dotted paths; nesting below is purely for readability.  Values may
 # contain {placeholder} tokens for str.format substitution.  When adding a
-# new key, add it to EVERY locale file (en/zh/ja/de/es) in the same commit --
+# new key, add it to EVERY locale file (en/zh/ja/de/es/ko) in the same commit --
 # tests/agent/test_i18n.py asserts catalog parity.
 
 approval:

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -1,0 +1,24 @@
+# Hermes static-message catalog -- Korean
+# See locales/en.yaml for the source of truth; keep keys in sync.
+
+approval:
+  dangerous_header: "⚠️  위험한 명령: {description}"
+  choose_long:     "      [o]한 번만  |  [s]세션 동안  |  [a]항상 허용  |  [d]거부"
+  choose_short:    "      [o]한 번만  |  [s]세션 동안  |  [d]거부"
+  prompt_long:     "      선택 [o/s/a/D]: "
+  prompt_short:    "      선택 [o/s/D]: "
+  timeout:         "      ⏱ 시간 초과 — 명령을 거부했어요"
+  allowed_once:    "      ✓ 한 번만 허용했어요"
+  allowed_session: "      ✓ 이 세션 동안 허용했어요"
+  allowed_always:  "      ✓ 영구 허용 목록에 추가했어요"
+  denied:          "      ✗ 거부했어요"
+  cancelled:       "      ✗ 취소했어요"
+  blocklist_message: "이 명령은 무조건 차단 목록에 있어 승인할 수 없어요."
+
+gateway:
+  approval_expired: "⚠️ 승인이 만료됐어요(에이전트가 더 이상 대기 중이 아니에요). 에이전트에게 다시 시도해 달라고 요청하세요."
+  draining:         "⏳ 재시작하기 전에 활성 에이전트 {count}개가 끝나기를 기다리는 중이에요..."
+  goal_cleared:     "✓ 목표를 지웠어요."
+  no_active_goal:   "활성 목표가 없어요."
+  config_read_failed: "⚠️ config.yaml을 읽을 수 없어요: {error}"
+  config_save_failed: "⚠️ 설정을 저장할 수 없어요: {error}"

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -89,6 +89,9 @@ def test_normalize_lang_accepts_aliases():
     assert i18n._normalize_lang("Deutsch") == "de"
     assert i18n._normalize_lang("español") == "es"
     assert i18n._normalize_lang("jp") == "ja"
+    assert i18n._normalize_lang("Korean") == "ko"
+    assert i18n._normalize_lang("ko-KR") == "ko"
+    assert i18n._normalize_lang("한국어") == "ko"
 
 
 def test_normalize_lang_unknown_falls_back():
@@ -126,6 +129,7 @@ def test_default_when_nothing_set(monkeypatch):
 def test_t_explicit_lang():
     assert i18n.t("approval.denied", lang="en").endswith("Denied")
     assert i18n.t("approval.denied", lang="zh").endswith("已拒绝")
+    assert i18n.t("approval.denied", lang="ko").endswith("거부했어요")
 
 
 def test_t_formats_placeholders():

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1167,14 +1167,14 @@ display:
   show_cost: false        # Show estimated $ cost in the CLI status bar
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
   runtime_metadata_footer: false  # Gateway: append a runtime-context footer to final replies
-  language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | ja | de | es
+  language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | ja | de | es | ko
 ```
 
 ### UI language for static messages
 
 The `display.language` setting translates a small set of static user-facing messages — the CLI approval prompt, a handful of gateway slash-command replies (e.g. restart-drain notices, "approval expired", "goal cleared"). It does **not** translate agent responses, log lines, tool output, error tracebacks, or slash-command descriptions — those stay in English. If you want the agent itself to reply in another language, just tell it in your prompt or system message.
 
-Supported values: `en` (default), `zh` (Simplified Chinese), `ja` (Japanese), `de` (German), `es` (Spanish). Unknown values fall back to English.
+Supported values: `en` (default), `zh` (Simplified Chinese), `ja` (Japanese), `de` (German), `es` (Spanish), `ko` (Korean). Unknown values fall back to English.
 
 You can also set this per-session with the `HERMES_LANGUAGE` env var, which overrides the config value.
 


### PR DESCRIPTION
## Summary
- Add Korean (`ko`) to supported static-message i18n locales
- Add Korean aliases: `korean`, `ko-KR`, `한국어`
- Document `ko` in display.language configuration docs
- Add Korean locale parity and smoke coverage

## Scope
This follows the existing thin i18n slice: CLI dangerous-command approval prompts and selected gateway replies. It does not translate agent responses, logs, tool outputs, tracebacks, or slash-command descriptions.

## Test Plan
- `./scripts/run_tests.sh tests/agent/test_i18n.py tests/tools/test_approval.py tests/hermes_cli/test_config.py`