### PR TITLE
Fix tool runtime subprocess hangs in multithreaded gateway

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -449,7 +449,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 ],
                 stdout=bridge_log_fh,
                 stderr=bridge_log_fh,
-                preexec_fn=None if _IS_WINDOWS else os.setsid,
+                start_new_session=False if _IS_WINDOWS else True,
                 env=bridge_env,
             )
             

--- a/tests/tools/test_environment_execute_serialization.py
+++ b/tests/tools/test_environment_execute_serialization.py
@@ -1,0 +1,47 @@
+"""Regression tests for stateful terminal environment execution."""
+
+import threading
+import time
+
+from tools.environments.base import BaseEnvironment
+
+
+class _SerializedProbeEnvironment(BaseEnvironment):
+    def __init__(self):
+        self.active = 0
+        self.max_active = 0
+        self._probe_lock = threading.Lock()
+        super().__init__(cwd="/tmp", timeout=5)
+
+    def init_session(self):
+        self._snapshot_ready = False
+
+    def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+        with self._probe_lock:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+        time.sleep(0.05)
+        with self._probe_lock:
+            self.active -= 1
+        return object()
+
+    def _wait_for_process(self, proc, timeout=120):
+        return {"output": "", "returncode": 0}
+
+    def cleanup(self):
+        return None
+
+
+def test_environment_execute_is_serialized_per_environment():
+    env = _SerializedProbeEnvironment()
+
+    threads = [
+        threading.Thread(target=env.execute, args=(f"echo {i}",))
+        for i in range(6)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert env.max_active == 1

--- a/tests/tools/test_windows_compat.py
+++ b/tests/tools/test_windows_compat.py
@@ -30,6 +30,25 @@ def _get_preexec_fn_values(filepath: Path) -> list:
     return values
 
 
+def _get_popen_keyword_names(filepath: Path) -> list[str]:
+    """Find keyword names used on subprocess.Popen calls."""
+    source = filepath.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(filepath))
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if (
+            isinstance(func, ast.Attribute)
+            and func.attr == "Popen"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "subprocess"
+        ):
+            names.extend(kw.arg for kw in node.keywords if kw.arg)
+    return names
+
+
 class TestNoUnconditionalSetsid:
     """preexec_fn must never be a bare os.setsid reference."""
 
@@ -44,6 +63,27 @@ class TestNoUnconditionalSetsid:
             assert "attr='setsid'" not in val or "IfExp" in val or "None" in val, (
                 f"{relpath} has unconditional preexec_fn=os.setsid"
             )
+
+    @pytest.mark.parametrize("relpath", GUARDED_FILES)
+    def test_hot_paths_do_not_use_preexec_fn(self, relpath):
+        filepath = PROJECT_ROOT / relpath
+        if not filepath.exists():
+            pytest.skip(f"{relpath} not found")
+        values = _get_preexec_fn_values(filepath)
+        assert values == [], (
+            f"{relpath} uses preexec_fn in a gateway/process hot path. "
+            "Use start_new_session=True for POSIX process groups instead."
+        )
+
+    @pytest.mark.parametrize("relpath", GUARDED_FILES)
+    def test_posix_process_groups_use_start_new_session(self, relpath):
+        filepath = PROJECT_ROOT / relpath
+        if not filepath.exists():
+            pytest.skip(f"{relpath} not found")
+        keywords = _get_popen_keyword_names(filepath)
+        assert "start_new_session" in keywords, (
+            f"{relpath} must use start_new_session for POSIX process groups"
+        )
 
 
 class TestIsWindowsConstant:

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1067,7 +1067,10 @@ def execute_code(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            # Keep the sandbox in its own process group without preexec_fn.
+            # preexec_fn is unsafe in long-lived multithreaded gateway
+            # processes and can wedge before our poll loop/heartbeat starts.
+            start_new_session=False if _IS_WINDOWS else True,
         )
 
         # --- Poll loop: watch for exit, timeout, and interrupt ---

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -298,6 +298,7 @@ class BaseEnvironment(ABC):
         self._cwd_file = f"{temp_dir}/hermes-cwd-{self._session_id}.txt"
         self._cwd_marker = _cwd_marker(self._session_id)
         self._snapshot_ready = False
+        self._execute_lock = threading.RLock()
 
     # ------------------------------------------------------------------
     # Abstract methods
@@ -712,44 +713,49 @@ class BaseEnvironment(ABC):
         stdin_data: str | None = None,
     ) -> dict:
         """Execute a command, return {"output": str, "returncode": int}."""
-        self._before_execute()
+        # A terminal environment is stateful: each command can update the
+        # shared snapshot file and cwd marker. Run one command at a time per
+        # environment; parallelism belongs above this layer with independent
+        # environments or stateless tools.
+        with self._execute_lock:
+            self._before_execute()
 
-        exec_command, sudo_stdin = self._prepare_command(command)
-        # Guard against the `A && B &` subshell-wait trap: bash forks a
-        # subshell for the compound that then waits for an infinite B (a
-        # server, `yes > /dev/null`, etc.), leaking the subshell forever.
-        # Rewriting to `A && { B & }` runs B as a plain background in the
-        # current shell — no subshell wait.
-        from tools.terminal_tool import _rewrite_compound_background
-        exec_command = _rewrite_compound_background(exec_command)
-        effective_timeout = timeout or self.timeout
-        effective_cwd = cwd or self.cwd
+            exec_command, sudo_stdin = self._prepare_command(command)
+            # Guard against the `A && B &` subshell-wait trap: bash forks a
+            # subshell for the compound that then waits for an infinite B (a
+            # server, `yes > /dev/null`, etc.), leaking the subshell forever.
+            # Rewriting to `A && { B & }` runs B as a plain background in the
+            # current shell — no subshell wait.
+            from tools.terminal_tool import _rewrite_compound_background
+            exec_command = _rewrite_compound_background(exec_command)
+            effective_timeout = timeout or self.timeout
+            effective_cwd = cwd or self.cwd
 
-        # Merge sudo stdin with caller stdin
-        if sudo_stdin is not None and stdin_data is not None:
-            effective_stdin = sudo_stdin + stdin_data
-        elif sudo_stdin is not None:
-            effective_stdin = sudo_stdin
-        else:
-            effective_stdin = stdin_data
+            # Merge sudo stdin with caller stdin
+            if sudo_stdin is not None and stdin_data is not None:
+                effective_stdin = sudo_stdin + stdin_data
+            elif sudo_stdin is not None:
+                effective_stdin = sudo_stdin
+            else:
+                effective_stdin = stdin_data
 
-        # Embed stdin as heredoc for backends that need it
-        if effective_stdin and self._stdin_mode == "heredoc":
-            exec_command = self._embed_stdin_heredoc(exec_command, effective_stdin)
-            effective_stdin = None
+            # Embed stdin as heredoc for backends that need it
+            if effective_stdin and self._stdin_mode == "heredoc":
+                exec_command = self._embed_stdin_heredoc(exec_command, effective_stdin)
+                effective_stdin = None
 
-        wrapped = self._wrap_command(exec_command, effective_cwd)
+            wrapped = self._wrap_command(exec_command, effective_cwd)
 
-        # Use login shell if snapshot failed (so user's profile still loads)
-        login = not self._snapshot_ready
+            # Use login shell if snapshot failed (so user's profile still loads)
+            login = not self._snapshot_ready
 
-        proc = self._run_bash(
-            wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
-        )
-        result = self._wait_for_process(proc, timeout=effective_timeout)
-        self._update_cwd(result)
+            proc = self._run_bash(
+                wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
+            )
+            result = self._wait_for_process(proc, timeout=effective_timeout)
+            self._update_cwd(result)
 
-        return result
+            return result
 
     # ------------------------------------------------------------------
     # Shared helpers
@@ -770,4 +776,3 @@ class BaseEnvironment(ABC):
         from tools.terminal_tool import _transform_sudo_command
 
         return _transform_sudo_command(command)
-

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -360,7 +360,10 @@ class LocalEnvironment(BaseEnvironment):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            # Avoid preexec_fn in the gateway's multithreaded process. Python
+            # exposes start_new_session for this exact setsid use case without
+            # running arbitrary Python in the forked child.
+            start_new_session=False if _IS_WINDOWS else True,
             cwd=self.cwd,
         )
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -545,7 +545,7 @@ class ProcessRegistry:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            start_new_session=False if _IS_WINDOWS else True,
         )
 
         session.process = proc


### PR DESCRIPTION
## Summary

This hardens Hermes tool/runtime subprocess spawning for long-lived, multithreaded gateway processes.

- Replaces `preexec_fn=os.setsid` hot-path subprocess usage with `start_new_session=True` / Windows-safe equivalent.
- Serializes `BaseEnvironment.execute()` per environment because the terminal environment mutates shared snapshot/CWD state.
- Adds regression coverage so gateway/process hot paths do not reintroduce `preexec_fn`, and stateful environment execution stays per-environment serialized.

## Why

`preexec_fn` can deadlock or wedge child creation in multithreaded Python processes before the normal poll/timeout loop can observe the process. In gateway mode this can surface as terminal/code-execution tools appearing inactive until the gateway timeout fires.

`start_new_session=True` is the stdlib-supported replacement for the `setsid` use case here, without executing Python in the forked child.

## Verification

```bash
/home/lauratom/Asztal/ai/atado/hermes-latest-source-clean-20260504-003042/.venv/bin/python -m pytest \
  tests/tools/test_windows_compat.py \
  tests/tools/test_environment_execute_serialization.py \
  tests/tools/test_terminal_tool.py \
  tests/tools/test_code_execution.py \
  tests/tools/test_process_registry.py \
  -q
```

Result on the submitted branch:

```text
136 passed, 8 warnings in 21.20s
```

Merge compatibility against current upstream `main`:

```bash
git merge-tree --write-tree origin/main HEAD
```

Result: exit code `0`.
