### PR TITLE
feat(i18n): add Turkish (tr) locale

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -50,7 +50,7 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "japanese": "ja", "jp": "ja", "ja-jp": "ja",
     "german": "de", "deutsch": "de", "de-de": "de",
     "spanish": "es", "español": "es", "espanol": "es", "es-es": "es", "es-mx": "es",
-    "Turkish": "tr", "Türkçe": "tr", "tr-tr": "tr",
+    "turkish": "tr", "türkçe": "tr", "tr-tr": "tr",
 }
 
 _catalog_cache: dict[str, dict[str, str]] = {}

--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -50,7 +50,7 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "japanese": "ja", "jp": "ja", "ja-jp": "ja",
     "german": "de", "deutsch": "de", "de-de": "de",
     "spanish": "es", "español": "es", "espanol": "es", "es-es": "es", "es-mx": "es",
-    "turkish": "tr", "Türkçe": "tr", "tr-tr": "tr",
+    "Turkish": "tr", "Türkçe": "tr", "tr-tr": "tr",
 }
 
 _catalog_cache: dict[str, dict[str, str]] = {}

--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -50,7 +50,7 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "japanese": "ja", "jp": "ja", "ja-jp": "ja",
     "german": "de", "deutsch": "de", "de-de": "de",
     "spanish": "es", "español": "es", "espanol": "es", "es-es": "es", "es-mx": "es",
-    "Turkish": "tr", "Türkçe": "tr", "tr-tr": "tr",
+    "turkish": "tr", "Türkçe": "tr", "tr-tr": "tr",
 }
 
 _catalog_cache: dict[str, dict[str, str]] = {}

--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -25,7 +25,7 @@ Language resolution order:
     3. ``display.language`` from config.yaml
     4. ``"en"`` (baseline)
 
-Supported languages: en, zh, ja, de, es.  Unknown values fall back to en.
+Supported languages: en, zh, ja, de, es, tr.  Unknown values fall back to en.
 """
 
 from __future__ import annotations
@@ -39,7 +39,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "ja", "de", "es")
+SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "ja", "de", "es", "tr")
 DEFAULT_LANGUAGE = "en"
 
 # Accept a few natural aliases so users who type "chinese" / "zh-CN" / "jp"
@@ -50,6 +50,7 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "japanese": "ja", "jp": "ja", "ja-jp": "ja",
     "german": "de", "deutsch": "de", "de-de": "de",
     "spanish": "es", "español": "es", "espanol": "es", "es-es": "es", "es-mx": "es",
+    "turkish": "tr", "türkçe": "tr", "tr-tr": "tr",
 }
 
 _catalog_cache: dict[str, dict[str, str]] = {}

--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -50,7 +50,7 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "japanese": "ja", "jp": "ja", "ja-jp": "ja",
     "german": "de", "deutsch": "de", "de-de": "de",
     "spanish": "es", "español": "es", "espanol": "es", "es-es": "es", "es-mx": "es",
-    "turkish": "tr", "türkçe": "tr", "tr-tr": "tr",
+    "Turkish": "tr", "Türkçe": "tr", "tr-tr": "tr",
 }
 
 _catalog_cache: dict[str, dict[str, str]] = {}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -784,7 +784,7 @@ DEFAULT_CONFIG = {
         # UI language for static user-facing messages (approval prompts, a
         # handful of gateway slash-command replies).  Does NOT affect agent
         # responses, log lines, tool outputs, or slash-command descriptions.
-        # Supported: en, zh, ja, de, es.  Unknown values fall back to en.
+        # Supported: en, zh, ja, de, es, tr.  Unknown values fall back to en.
         "language": "en",
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -7,7 +7,7 @@
 #
 # Keys are dotted paths; nesting below is purely for readability.  Values may
 # contain {placeholder} tokens for str.format substitution.  When adding a
-# new key, add it to EVERY locale file (en/zh/ja/de/es) in the same commit --
+# new key, add it to EVERY locale file (en/zh/ja/de/es/tr) in the same commit --
 # tests/agent/test_i18n.py asserts catalog parity.
 
 approval:

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -1,0 +1,24 @@
+# Hermes statik mesaj katalogu -- Turkce
+# See locales/en.yaml for the source of truth; keep keys in sync.
+
+approval:
+  dangerous_header: "⚠️  TEHLİKELİ KOMUT: {description}"
+  choose_long:     "      [b]ir kez  |  [o]turum  |  [h]er zaman  |  [r]eddet"
+  choose_short:    "      [b]ir kez  |  [o]turum  |  [r]eddet"
+  prompt_long:     "      Seçim [b/o/h/R]: "
+  prompt_short:    "      Seçim [b/o/R]: "
+  timeout:         "      ⏱ Zaman aşımı — komut reddedildi"
+  allowed_once:    "      ✓ Bir kez izin verildi"
+  allowed_session: "      ✓ Bu oturum için izin verildi"
+  allowed_always:  "      ✓ Kalıcı izin listesine eklendi"
+  denied:          "      ✗ Reddedildi"
+  cancelled:       "      ✗ İptal edildi"
+  blocklist_message: "Bu komut koşulsuz engelleme listesinde ve onaylanamaz."
+
+gateway:
+  approval_expired: "⚠️ Onay süresi doldu (ajan artık beklemiyor). Ajanın tekrar denemesini isteyin."
+  draining:         "⏳ Yeniden başlatmadan önce {count} aktif ajan bekleniyor..."
+  goal_cleared:     "✓ Hedef temizlendi."
+  no_active_goal:   "Aktif hedef yok."
+  config_read_failed: "⚠️ config.yaml okunamadı: {error}"
+  config_save_failed: "⚠️ Yapılandırma kaydedilemedi: {error}"

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -89,6 +89,9 @@ def test_normalize_lang_accepts_aliases():
     assert i18n._normalize_lang("Deutsch") == "de"
     assert i18n._normalize_lang("español") == "es"
     assert i18n._normalize_lang("jp") == "ja"
+    assert i18n._normalize_lang("Turkish") == "tr"
+    assert i18n._normalize_lang("tr-TR") == "tr"
+    assert i18n._normalize_lang("türkçe") == "tr"
 
 
 def test_normalize_lang_unknown_falls_back():
@@ -126,6 +129,7 @@ def test_default_when_nothing_set(monkeypatch):
 def test_t_explicit_lang():
     assert i18n.t("approval.denied", lang="en").endswith("Denied")
     assert i18n.t("approval.denied", lang="zh").endswith("已拒绝")
+    assert i18n.t("approval.denied", lang="tr").endswith("Reddedildi")
 
 
 def test_t_formats_placeholders():

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -89,9 +89,9 @@ def test_normalize_lang_accepts_aliases():
     assert i18n._normalize_lang("Deutsch") == "de"
     assert i18n._normalize_lang("español") == "es"
     assert i18n._normalize_lang("jp") == "ja"
-    assert i18n._normalize_lang("turkish") == "tr"
+    assert i18n._normalize_lang("Turkish") == "tr"
     assert i18n._normalize_lang("tr-TR") == "tr"
-    assert i18n._normalize_lang("türkçe") == "tr"
+    assert i18n._normalize_lang("Türkçe") == "tr"
 
 
 def test_normalize_lang_unknown_falls_back():

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -89,7 +89,7 @@ def test_normalize_lang_accepts_aliases():
     assert i18n._normalize_lang("Deutsch") == "de"
     assert i18n._normalize_lang("español") == "es"
     assert i18n._normalize_lang("jp") == "ja"
-    assert i18n._normalize_lang("Turkish") == "tr"
+    assert i18n._normalize_lang("turkish") == "tr"
     assert i18n._normalize_lang("tr-TR") == "tr"
     assert i18n._normalize_lang("türkçe") == "tr"
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1167,14 +1167,14 @@ display:
   show_cost: false        # Show estimated $ cost in the CLI status bar
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
   runtime_metadata_footer: false  # Gateway: append a runtime-context footer to final replies
-  language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | ja | de | es
+  language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | ja | de | es | tr
 ```
 
 ### UI language for static messages
 
 The `display.language` setting translates a small set of static user-facing messages — the CLI approval prompt, a handful of gateway slash-command replies (e.g. restart-drain notices, "approval expired", "goal cleared"). It does **not** translate agent responses, log lines, tool output, error tracebacks, or slash-command descriptions — those stay in English. If you want the agent itself to reply in another language, just tell it in your prompt or system message.
 
-Supported values: `en` (default), `zh` (Simplified Chinese), `ja` (Japanese), `de` (German), `es` (Spanish). Unknown values fall back to English.
+Supported values: `en` (default), `zh` (Simplified Chinese), `ja` (Japanese), `de` (German), `es` (Spanish), `tr` (Turkish). Unknown values fall back to English.
 
 You can also set this per-session with the `HERMES_LANGUAGE` env var, which overrides the config value.
 


### PR DESCRIPTION
## Summary
- Add Turkish locale file `locales/tr.yaml` with translations for all static user-facing messages
- Add `"tr"` to `SUPPORTED_LANGUAGES` in `agent/i18n.py`
- Add Turkish language aliases (`turkish`, `türkçe`, `tr-tr`) to `_LANGUAGE_ALIASES`

## Changes
- `locales/tr.yaml` — new file with Turkish translations for `approval.*` and `gateway.*` keys
- `agent/i18n.py` — register `tr` as a supported language + aliases

## Translation notes
- All `{placeholder}` tokens preserved exactly as in English (`{description}`, `{count}`, `{error}`)
- Shortcut keys adapted to Turkish: `[b]ir kez`, `[o]turum`, `[h]er zaman`, `[r]eddet`
- `prompt_long/short` uses `R` (uppercase) as default key for "reddet" (deny)

## Review checklist
- [x] All translations natural and clear for Turkish speakers
- [x] Shortcut key choices make sense
- [x] Placeholder tokens match English exactly