### PR TITLE
fix(agent): skip unexpanded ${VAR} references when seeding credential pool

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1386,10 +1386,17 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
     # authoritative source for Hermes credentials. Stale env vars from parent
     # processes (Codex CLI, test scripts, etc.) should not override deliberate
     # changes to the .env file.
+    _UNEXPANDED_VAR_RE = re.compile(r"\$\{.+\}|\$[A-Za-z_][A-Za-z0-9_]*")
+
     def _get_env_prefer_dotenv(key: str) -> str:
         env_file = load_env()
-        val = env_file.get(key) or os.environ.get(key) or ""
-        return val.strip()
+        val = (env_file.get(key) or "").strip()
+        # load_env() reads the file raw without variable interpolation,
+        # so values like ${OTHER_VAR} are returned literally.  Fall back
+        # to os.environ where python-dotenv has already expanded them.
+        if val and _UNEXPANDED_VAR_RE.search(val):
+            val = ""
+        return val or (os.environ.get(key) or "").strip()
 
     # Honour user suppression — `hermes auth remove <provider> <N>` for an
     # env-seeded credential marks the env:<VAR> source as suppressed so it


### PR DESCRIPTION
## Summary

- `_get_env_prefer_dotenv()` in `agent/credential_pool.py` uses `load_env()` which reads `~/.hermes/.env` as raw text without variable interpolation
- When the `.env` contains `ANTHROPIC_API_KEY=${OPENAI_API_KEY}`, the literal string `${OPENAI_API_KEY}` is stored in `auth.json`
- Auxiliary tasks (title generation, compression, etc.) then send that raw string as the API key, causing 401 errors
- The main model path is unaffected because it calls `resolve_anthropic_token()` → `os.getenv()`, where `python-dotenv` has already expanded the variable

## Fix

Detect unexpanded variable patterns (`${...}` / `$VAR`) in the raw `.env` value and fall back to `os.environ` where `python-dotenv` has already expanded them. This preserves the existing preference for `.env` file values over stale shell env vars while fixing the interpolation gap.

## Test plan

- [ ] Set `ANTHROPIC_API_KEY=${OPENAI_API_KEY}` in `~/.hermes/.env` (with `OPENAI_API_KEY` valid in the environment)
- [ ] Delete `~/.hermes/auth.json` and `auth.lock`
- [ ] Run hermes — verify `auth.json` now stores the expanded key value, not the literal `${OPENAI_API_KEY}`
- [ ] Verify auxiliary tasks (e.g. title generation) succeed without 401 errors

Fixes #20310
Related: #15890 (same root cause in the cron path)