### PR TITLE
fix(cron): propagate pre-run script failure to job status

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3300,7 +3300,11 @@ def run_job(
         # If the pre-run script failed, mark the job as failed even though
         # the agent ran successfully.  The script failure means the agent
         # may have been working with stale or missing data.
-        return not _script_failed, output, final_response, None
+        # Return the script error as the job error so mark_job_run() can
+        # persist it and _process_job() can deliver a meaningful message.
+        if _script_failed:
+            return False, output, final_response, f"Pre-run script failed: {_script_output}"
+        return True, output, final_response, None
         
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2628,11 +2628,18 @@ def run_job(
     # the prompt so a ``{"wakeAgent": false}`` response can short-circuit
     # the whole agent run. We pass the result into _build_job_prompt so
     # the script is only executed once.
+    # Track whether the pre-run script failed so we can propagate the
+    # failure status to the job result.  Previously, a failed script would
+    # inject its error into the agent prompt but the job would still be
+    # reported as "ok" — hiding silent data-collection failures.
+    _script_failed = False
     prerun_script = None
     script_path = job.get("script")
     if script_path:
         prerun_script = _run_job_script(script_path)
         _ran_ok, _script_output = prerun_script
+        if not _ran_ok:
+            _script_failed = True
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(
                 "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
@@ -3290,7 +3297,10 @@ def run_job(
 """
         
         logger.info("Job '%s' completed successfully", job_name)
-        return True, output, final_response, None
+        # If the pre-run script failed, mark the job as failed even though
+        # the agent ran successfully.  The script failure means the agent
+        # may have been working with stale or missing data.
+        return not _script_failed, output, final_response, None
         
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -579,3 +579,135 @@ class TestRunJobEnvVarCleanup:
         assert os.environ.get("HERMES_SESSION_PLATFORM") is None
         assert os.environ.get("HERMES_SESSION_CHAT_ID") is None
         assert os.environ.get("HERMES_SESSION_CHAT_NAME") is None
+
+class TestRunJobScriptFailureStatus:
+    """Regression tests for script failure propagation to job status.
+
+    When a cron job's pre-run script fails (non-zero exit code), the job
+    should be marked as failed even though the agent runs successfully.
+    Previously, the job was always reported as "ok" regardless of script
+    failure — hiding silent data-collection failures.
+    """
+
+    def test_script_failure_marks_job_as_failed(self, cron_env, monkeypatch):
+        """Job status must be False when pre-run script exits non-zero."""
+        from cron.scheduler import run_job
+
+        # Create a failing script
+        script = cron_env / "scripts" / "fail.py"
+        script.write_text(textwrap.dedent("""\            import sys
+            print("error: data source unavailable", file=sys.stderr)
+            sys.exit(1)
+        """))
+
+        # Build a job with the failing script
+        job = {
+            "id": "test-script-fail",
+            "name": "script-fail-test",
+            "prompt": "Report status.",
+            "schedule_display": "every 1h",
+            "script": str(script),
+        }
+
+        # Mock the agent and runtime provider to avoid actual API calls
+        from unittest.mock import MagicMock, patch
+
+        mock_agent = MagicMock()
+        mock_result = {
+            "final_response": "The data-collection script failed. Here is the error...",
+            "messages": [],
+        }
+        mock_agent.run_conversation.return_value = mock_result
+
+        mock_runtime = {
+            "provider": "openai",
+            "api_key": "test-key",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "chat_completions",
+        }
+
+        with patch("run_agent.AIAgent", return_value=mock_agent),              patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=mock_runtime):
+            success, output, response, error = run_job(job)
+
+        # The job should be marked as failed because the script failed
+        assert success is False
+        assert "Script Error" in output or "script failed" in output.lower()
+        # The agent should have run (we get a response)
+        assert response is not None
+
+    def test_script_success_marks_job_as_ok(self, cron_env, monkeypatch):
+        """Job status must be True when pre-run script succeeds."""
+        from cron.scheduler import run_job
+
+        # Create a successful script
+        script = cron_env / "scripts" / "ok.py"
+        script.write_text('print("data collected successfully")\n')
+
+        # Build a job with the successful script
+        job = {
+            "id": "test-script-ok",
+            "name": "script-ok-test",
+            "prompt": "Report status.",
+            "schedule_display": "every 1h",
+            "script": str(script),
+        }
+
+        # Mock the agent and runtime provider to avoid actual API calls
+        from unittest.mock import MagicMock, patch
+
+        mock_agent = MagicMock()
+        mock_result = {
+            "final_response": "Data collected successfully.",
+            "messages": [],
+        }
+        mock_agent.run_conversation.return_value = mock_result
+
+        mock_runtime = {
+            "provider": "openai",
+            "api_key": "test-key",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "chat_completions",
+        }
+
+        with patch("run_agent.AIAgent", return_value=mock_agent),              patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=mock_runtime):
+            success, output, response, error = run_job(job)
+
+        # The job should be marked as successful
+        assert success is True
+        assert error is None
+
+    def test_no_script_marks_job_as_ok(self, cron_env, monkeypatch):
+        """Job status must be True when no script is configured."""
+        from cron.scheduler import run_job
+
+        # Build a job without a script
+        job = {
+            "id": "test-no-script",
+            "name": "no-script-test",
+            "prompt": "Hello.",
+            "schedule_display": "every 1h",
+        }
+
+        # Mock the agent and runtime provider to avoid actual API calls
+        from unittest.mock import MagicMock, patch
+
+        mock_agent = MagicMock()
+        mock_result = {
+            "final_response": "Hello!",
+            "messages": [],
+        }
+        mock_agent.run_conversation.return_value = mock_result
+
+        mock_runtime = {
+            "provider": "openai",
+            "api_key": "test-key",
+            "base_url": "https://api.openai.com/v1",
+            "api_mode": "chat_completions",
+        }
+
+        with patch("run_agent.AIAgent", return_value=mock_agent),              patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=mock_runtime):
+            success, output, response, error = run_job(job)
+
+        # The job should be marked as successful
+        assert success is True
+        assert error is None

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -631,7 +631,9 @@ class TestRunJobScriptFailureStatus:
 
         # The job should be marked as failed because the script failed
         assert success is False
-        assert "Script Error" in output or "script failed" in output.lower()
+        # The error should be non-empty and reference the script failure
+        assert error is not None
+        assert "script failed" in error.lower() or "script" in error.lower()
         # The agent should have run (we get a response)
         assert response is not None
 


### PR DESCRIPTION
## What does this PR do?

When a cron job's pre-run script exits non-zero, the error is injected into the agent prompt — but `run_job()` still reports success (`status=ok`). Operators see `ok` and assume the job ran correctly, when the data-collection step actually failed.


### Root Cause

In `run_job()`, the pre-run script result (`_ran_ok`) is only used to build the prompt content. The function always returns `True` at the end, regardless of whether the script succeeded or failed.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A