### PR TITLE
fix(cron): fail jobs when pre-run script fails instead of greenwashing as ok

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -990,7 +990,30 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     if script_path:
         prerun_script = _run_job_script(script_path)
         _ran_ok, _script_output = prerun_script
-        if _ran_ok and not _parse_wake_gate(_script_output):
+        if not _ran_ok:
+            # Pre-run script failed (non-zero exit / timeout / not-found).
+            # Don't waste an LLM call on a polluted prompt and don't greenwash
+            # the failure as ok — surface it as a job error so operators see
+            # last_status=error instead of a misleading ok (#20301).
+            now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
+            alert = (
+                f"⚠ Cron job '{job_name}' pre-run script failed\n\n"
+                f"{_script_output}\n\n"
+                f"Time: {now_iso}"
+            )
+            doc = (
+                f"# Cron Job: {job_name}\n\n"
+                f"**Job ID:** {job_id}\n"
+                f"**Run Time:** {now_iso}\n"
+                f"**Status:** pre-run script failed\n\n"
+                f"{_script_output}\n"
+            )
+            logger.error(
+                "Job '%s' (ID: %s): pre-run script failed — %s",
+                job_name, job_id, _script_output,
+            )
+            return False, doc, alert, _script_output
+        if not _parse_wake_gate(_script_output):
             logger.info(
                 "Job '%s' (ID: %s): wakeAgent=false, skipping agent run",
                 job_name, job_id,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1877,13 +1877,17 @@ class TestRunJobWakeGate:
 
         assert call_count == 1, f"script ran {call_count}x, expected exactly 1"
 
-    def test_script_failure_does_not_trigger_gate(self):
-        """If _run_job_script returns success=False, the gate is NOT evaluated
-        and the agent still runs (the failure is reported as context)."""
+    def test_script_failure_fails_job_without_invoking_agent(self):
+        """If _run_job_script returns success=False, the job fails fast — the
+        agent is NOT invoked, the gate is NOT evaluated, and run_job returns
+        success=False with the script's error captured as the job error.
+
+        This guards against #20301: a failed pre-run script must not be
+        greenwashed as last_status=ok just because the LLM produced output
+        from a polluted prompt. It also prevents a malicious or broken
+        script from honoring a gate-like JSON in its stderr."""
         import cron.scheduler as scheduler
 
-        # Malicious or broken script whose stderr happens to contain the
-        # gate JSON — we must NOT honor it because ran_ok is False.
         agent = MagicMock()
         agent.run_conversation = MagicMock(return_value={
             "final_response": "ok", "messages": []
@@ -1893,7 +1897,11 @@ class TestRunJobWakeGate:
              patch("run_agent.AIAgent", return_value=agent) as agent_cls:
             success, doc, final, err = scheduler.run_job(self._make_job())
 
-        agent_cls.assert_called_once()  # Agent DID wake despite the gate-like text
+        agent_cls.assert_not_called()
+        assert success is False
+        assert err == '{"wakeAgent": false}'
+        assert "pre-run script failed" in doc
+        assert "pre-run script failed" in final
 
     def test_no_script_path_runs_agent_normally(self):
         """Regression: jobs without a script still work."""


### PR DESCRIPTION
Stop marking cron jobs as `last_status=ok` when their pre-run `script` failed.

## What changed and why
- `cron/scheduler.py::run_job` now short-circuits on pre-run script failure — when `_run_job_script` returns `success=False`, the job exits with `success=False`, the script output as the error, and a "pre-run script failed" status doc, instead of injecting the error into an agent prompt and burning an LLM call. `mark_job_run` already records `last_status=error` for `success=False`, and `_process_job` already delivers the failure message to the configured target.
- This mirrors the existing `no_agent` path's failed-script handling (`cron/scheduler.py:912-929`), so both paths now behave consistently: a broken pre-run script always surfaces as `error`, never as `ok`.
- Updated `TestRunJobWakeGate.test_script_failure_does_not_trigger_gate` (which previously asserted the old greenwashing behavior — "agent DID wake despite the gate-like text") to assert the new contract: agent is not invoked, `success is False`, and the script error is captured. The gate-bypass safety property the original test cared about (don't honor `wakeAgent: false` from a failed script's stderr) is still upheld — we just fail-fast instead of waking the agent.

## How to test
- `pytest tests/cron/ -q` — all 318 cron tests pass (one pre-existing failure on `test_script_empty_output_noted` reproduces on main, unrelated to this fix).
- `pytest tests/run_agent/test_exit_cleanup_interrupt.py -q` — passes (these tests patch `_build_job_prompt` and exercise `run_job` cleanup paths).
- Manual repro: create a cron job with `script` pointing to a script that `exit 1`s, run a tick, and check `cron list` — `last_status` is now `error` with the script's stderr in `last_error`.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #20301

<!-- autocontrib:worker-id=issue-new-4cc4be9c kind=pr-open -->