### PR TITLE
feat(agent): smart model routing (pre-turn task-difficulty router)

### DIFF
--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -1,0 +1,356 @@
+"""Pre-turn smart model routing.
+
+Decides whether the upcoming turn should run on the configured primary
+model or be routed to a cheaper local model (for simple tasks) or a
+smarter cloud model (for hard tasks).  Routing is **turn scoped** — the
+existing fallback restoration path puts the agent back on its primary
+runtime at the start of the next user turn.
+
+This module is intentionally pure.  It does not import any provider SDK,
+make HTTP calls, or touch the AIAgent runtime.  All side effects live in
+``run_agent.py``.  The decision logic is deterministic and exhaustively
+unit-tested so behavior changes are easy to reason about.
+
+Two operating modes:
+
+- ``local-first`` — primary is a cheap/local model.  Hard tasks route to
+  ``smart_model`` (or to the first ``fallback_providers``/``fallback_model``
+  entry when ``smart_model`` is omitted).  Simple tasks stay on primary.
+- ``smart-primary`` — primary is a smart cloud model.  Simple tasks route
+  to ``cheap_model`` when configured.  Hard tasks stay on primary.
+
+Mode auto-detection (when ``mode`` is unset or ``auto``):
+
+- Both ``cheap_model`` and ``smart_model`` configured → look at the
+  primary provider; local-like providers map to ``local-first``, anything
+  else maps to ``smart-primary``.
+- Only ``smart_model`` configured → ``local-first``.
+- Only ``cheap_model`` configured → ``smart-primary``.
+- Neither → routing is disabled regardless of ``enabled``.
+
+Fallback compatibility: when no ``smart_model`` is configured but
+``fallback_providers`` / ``fallback_model`` exists, the first entry of the
+chain is used as the smart target.  This preserves the existing fallback
+configuration surface for users who only want hard-task escalation.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Defaults (mirrors profile-config stub) ───────────────────────────────
+DEFAULT_MAX_SIMPLE_CHARS = 160
+DEFAULT_MAX_SIMPLE_WORDS = 28
+
+# Providers we treat as "local/cheap" by default.  Used for mode
+# auto-detection when both cheap_model and smart_model are configured and
+# the user did not pin ``mode`` explicitly.  Conservative on purpose —
+# misidentifying a smart provider as local would route hard tasks away
+# from a perfectly capable primary.
+LOCAL_LIKE_PROVIDERS: frozenset = frozenset({
+    "custom",
+    "ollama",
+    "ollama-cloud",
+    "lmstudio",
+    "lm-studio",
+    "llamacpp",
+    "llama-cpp",
+    "llama-swap",
+    "vllm",
+    "local",
+    "localai",
+    "localhost",
+    "fred",
+})
+
+# Hard-task signals.  Lowercased word matches inside tokenized message.
+HARD_KEYWORDS: frozenset = frozenset({
+    "debug",
+    "build",
+    "code",
+    "coding",
+    "refactor",
+    "architect",
+    "architecture",
+    "design",
+    "plan",
+    "investigate",
+    "investigation",
+    "strategy",
+    "lawsuit",
+    "contract",
+    "financial",
+    "finance",
+    "risk",
+    "compliance",
+    "legal",
+    "complex",
+    "hard",
+    "root-cause",
+    "rca",
+    "test-failure",
+    "regression",
+    "stacktrace",
+    "traceback",
+    "exception",
+    "permit",
+    "escalation",
+    "audit",
+})
+
+# Multi-word hard phrases (compiled once).  Each pattern is tested against
+# the lowercased raw message so phrases that span tokens are caught.
+HARD_PHRASE_PATTERNS: List[re.Pattern] = [
+    re.compile(r"\broot[\s-]?cause\b"),
+    re.compile(r"\btest\s+fail(?:ure|ing|ed)?\b"),
+    re.compile(r"\bbuild\s+fail(?:ure|ing|ed)?\b"),
+    re.compile(r"\bstack\s+trace\b"),
+    re.compile(r"\bdebug\s+(?:this|the|my|that)\b"),
+    re.compile(r"\bwhy\s+is\s+this\s+(?:broken|failing)\b"),
+    re.compile(r"\bcontract\s+review\b"),
+    re.compile(r"\bsecurity\s+(?:audit|review)\b"),
+    re.compile(r"\bmulti[\s-]?step\b"),
+]
+
+# ── Data classes ─────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RoutingTarget:
+    provider: str
+    model: str
+    base_url: Optional[str] = None
+    api_key: Optional[str] = None
+
+    def is_valid(self) -> bool:
+        return bool(self.provider and self.model)
+
+    def to_fallback_entry(self) -> Dict[str, Any]:
+        """Render as a fallback_providers-style dict consumable by
+        ``_try_activate_fallback`` and friends."""
+        out: Dict[str, Any] = {"provider": self.provider, "model": self.model}
+        if self.base_url:
+            out["base_url"] = self.base_url
+        if self.api_key:
+            out["api_key"] = self.api_key
+        return out
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    route: str  # "primary" | "cheap" | "smart"
+    target: Optional[RoutingTarget]
+    reason: str
+    mode: str  # "local-first" | "smart-primary" | "disabled"
+    classification: str  # "simple" | "hard" | "unknown"
+
+
+# ── Heuristic classifier ─────────────────────────────────────────────────
+
+
+def _word_count(text: str) -> int:
+    return len(re.findall(r"\b\w+\b", text or ""))
+
+
+def _normalize(text: str) -> str:
+    return (text or "").strip().lower()
+
+
+def classify_difficulty(
+    text: str,
+    *,
+    max_simple_chars: int = DEFAULT_MAX_SIMPLE_CHARS,
+    max_simple_words: int = DEFAULT_MAX_SIMPLE_WORDS,
+    extra_hard_keywords: Optional[Iterable[str]] = None,
+) -> str:
+    """Deterministic heuristic returning ``"simple"`` or ``"hard"``.
+
+    Hard signals (any one wins):
+    - any HARD_KEYWORD token appears in the message
+    - any HARD_PHRASE_PATTERNS regex matches
+    - message is longer than ``max_simple_chars`` or ``max_simple_words``
+    - message contains a fenced code block, a stack trace marker, or
+      multiple sentences ending in question marks (suggests multi-part
+      reasoning)
+
+    Otherwise the message is ``"simple"``.  Empty/whitespace-only text is
+    treated as ``"simple"``.
+    """
+    if not text or not text.strip():
+        return "simple"
+
+    raw = text
+    norm = _normalize(text)
+
+    # Length triggers
+    if len(raw) > max_simple_chars:
+        return "hard"
+    if _word_count(raw) > max_simple_words:
+        return "hard"
+
+    # Code fences / tracebacks → almost always coding/debugging
+    if "```" in raw or "Traceback (most recent call last)" in raw:
+        return "hard"
+
+    # Multiple question marks → multi-part reasoning request
+    if raw.count("?") >= 3:
+        return "hard"
+
+    # Keyword token match.  Tokenize on word boundaries so partial
+    # matches (e.g. "encoded" → "code") don't over-trigger.
+    tokens = set(re.findall(r"[a-z][a-z0-9_-]*", norm))
+    haystack = HARD_KEYWORDS
+    if extra_hard_keywords:
+        haystack = haystack | {k.lower() for k in extra_hard_keywords}
+    if tokens & haystack:
+        return "hard"
+
+    # Phrase patterns
+    for pat in HARD_PHRASE_PATTERNS:
+        if pat.search(norm):
+            return "hard"
+
+    return "simple"
+
+
+# ── Mode + target resolution ─────────────────────────────────────────────
+
+
+def _coerce_target(raw: Any) -> Optional[RoutingTarget]:
+    if not isinstance(raw, dict):
+        return None
+    provider = (raw.get("provider") or "").strip()
+    model = (raw.get("model") or "").strip()
+    if not provider or not model:
+        return None
+    base_url = (raw.get("base_url") or "").strip() or None
+    api_key = (raw.get("api_key") or "").strip() or None
+    return RoutingTarget(provider=provider, model=model, base_url=base_url, api_key=api_key)
+
+
+def _first_valid_fallback(fallback_chain: Optional[List[Dict[str, Any]]]) -> Optional[RoutingTarget]:
+    if not fallback_chain:
+        return None
+    for entry in fallback_chain:
+        target = _coerce_target(entry)
+        if target is not None:
+            return target
+    return None
+
+
+def _resolve_mode(
+    *,
+    explicit_mode: Optional[str],
+    primary_provider: str,
+    has_cheap: bool,
+    has_smart: bool,
+) -> str:
+    if explicit_mode and explicit_mode in {"local-first", "smart-primary"}:
+        return explicit_mode
+
+    if has_cheap and has_smart:
+        # Auto: derive from primary.  If primary looks local, we want
+        # local-first behavior so hard tasks escalate.  Otherwise
+        # smart-primary so simple tasks fall back to cheap.
+        if (primary_provider or "").strip().lower() in LOCAL_LIKE_PROVIDERS:
+            return "local-first"
+        return "smart-primary"
+    if has_smart:
+        return "local-first"
+    if has_cheap:
+        return "smart-primary"
+    return "disabled"
+
+
+def decide_route(
+    *,
+    user_message: str,
+    primary_provider: str,
+    primary_model: str,  # accepted for log context, unused in heuristic
+    config: Optional[Dict[str, Any]],
+    fallback_chain: Optional[List[Dict[str, Any]]] = None,
+) -> RoutingDecision:
+    """Compute a routing decision for the upcoming turn.
+
+    Safe on bad config: any unrecognized shape returns the ``primary``
+    decision with a descriptive ``reason``.  Never raises.
+    """
+    cfg = config or {}
+    if not cfg.get("enabled"):
+        return RoutingDecision("primary", None, "disabled", "disabled", "unknown")
+
+    # Coerce optional cheap/smart targets.
+    cheap_target = _coerce_target(cfg.get("cheap_model"))
+    smart_target = _coerce_target(cfg.get("smart_model"))
+
+    # If smart_model is missing, fall back to first fallback entry.
+    if smart_target is None:
+        smart_target = _first_valid_fallback(fallback_chain)
+        smart_from_fallback = smart_target is not None
+    else:
+        smart_from_fallback = False
+
+    mode = _resolve_mode(
+        explicit_mode=(cfg.get("mode") or cfg.get("strategy_mode") or "").strip().lower() or None,
+        primary_provider=primary_provider,
+        has_cheap=cheap_target is not None,
+        has_smart=smart_target is not None,
+    )
+    if mode == "disabled":
+        return RoutingDecision(
+            "primary", None,
+            "no cheap_model or smart_model configured (and no fallback target)",
+            "disabled", "unknown",
+        )
+
+    classification = classify_difficulty(
+        user_message,
+        max_simple_chars=int(cfg.get("max_simple_chars") or DEFAULT_MAX_SIMPLE_CHARS),
+        max_simple_words=int(cfg.get("max_simple_words") or DEFAULT_MAX_SIMPLE_WORDS),
+        extra_hard_keywords=cfg.get("extra_hard_keywords") or None,
+    )
+
+    if mode == "local-first":
+        if classification == "hard" and smart_target is not None:
+            reason = (
+                "hard task; routing to smart_model"
+                + (" (sourced from fallback chain)" if smart_from_fallback else "")
+            )
+            return RoutingDecision("smart", smart_target, reason, mode, classification)
+        return RoutingDecision(
+            "primary", None,
+            "simple task; primary local model is appropriate"
+            if classification == "simple" else "no smart target available",
+            mode, classification,
+        )
+
+    # smart-primary
+    if classification == "simple" and cheap_target is not None:
+        return RoutingDecision(
+            "cheap", cheap_target,
+            "simple task; routing to cheap_model", mode, classification,
+        )
+    return RoutingDecision(
+        "primary", None,
+        "hard task; primary smart model is appropriate"
+        if classification == "hard" else "no cheap target available",
+        mode, classification,
+    )
+
+
+__all__ = [
+    "DEFAULT_MAX_SIMPLE_CHARS",
+    "DEFAULT_MAX_SIMPLE_WORDS",
+    "HARD_KEYWORDS",
+    "HARD_PHRASE_PATTERNS",
+    "LOCAL_LIKE_PROVIDERS",
+    "RoutingDecision",
+    "RoutingTarget",
+    "classify_difficulty",
+    "decide_route",
+]

--- a/cli.py
+++ b/cli.py
@@ -2109,6 +2109,11 @@ class HermesCLI:
             fb = [fb] if fb.get("provider") and fb.get("model") else []
         self._fallback_model = fb
 
+        # Smart model routing — pre-turn task-difficulty router.  Stored
+        # raw and forwarded to AIAgent; the runtime decides per-turn.
+        smr = CLI_CONFIG.get("smart_model_routing") or {}
+        self._smart_model_routing = smr if isinstance(smr, dict) else {}
+
         # Signature of the currently-initialised agent's runtime.  Used to
         # rebuild the agent when provider / model / base_url changes across
         # turns (e.g. after /model or credential rotation).
@@ -3518,6 +3523,7 @@ class HermesCLI:
                 reasoning_callback=self._current_reasoning_callback(),
 
                 fallback_model=self._fallback_model,
+                smart_model_routing=self._smart_model_routing,
                 thinking_callback=self._on_thinking,
                 checkpoints_enabled=self.checkpoints_enabled,
                 checkpoint_max_snapshots=self.checkpoint_max_snapshots,
@@ -6505,6 +6511,7 @@ class HermesCLI:
                     provider_require_parameters=self._provider_require_params,
                     provider_data_collection=self._provider_data_collection,
                     fallback_model=self._fallback_model,
+                    smart_model_routing=self._smart_model_routing,
                 )
                 # Silence raw spinner; route thinking through TUI widget when no foreground agent is active.
                 bg_agent._print_fn = lambda *_a, **_kw: None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -790,6 +790,7 @@ class GatewayRunner:
         self._restart_drain_timeout = self._load_restart_drain_timeout()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
+        self._smart_model_routing = self._load_smart_model_routing()
 
         # Wire process registry into session store for reset protection
         from tools.process_registry import process_registry
@@ -1768,6 +1769,26 @@ class GatewayRunner:
         except Exception:
             pass
         return None
+
+    @staticmethod
+    def _load_smart_model_routing() -> dict:
+        """Load smart_model_routing block from config.yaml (or {}).
+
+        AIAgent.__init__ treats an empty/invalid block as disabled, so a
+        missing config or parse failure is safe.
+        """
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                smr = cfg.get("smart_model_routing") or {}
+                if isinstance(smr, dict):
+                    return smr
+        except Exception:
+            pass
+        return {}
 
     def _snapshot_running_agents(self) -> Dict[str, Any]:
         return {
@@ -7154,6 +7175,7 @@ class GatewayRunner:
                     thread_id=source.thread_id,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    smart_model_routing=self._smart_model_routing,
                 )
                 try:
                     return agent.run_conversation(
@@ -10588,6 +10610,7 @@ class GatewayRunner:
                     gateway_session_key=session_key,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    smart_model_routing=self._smart_model_routing,
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2515,7 +2515,7 @@ _KNOWN_ROOT_KEYS = {
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
-    "sessions",
+    "sessions", "smart_model_routing",
 }
 
 # Valid fields inside a custom_providers list entry

--- a/run_agent.py
+++ b/run_agent.py
@@ -899,6 +899,7 @@ class AIAgent:
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 50,
         pass_session_id: bool = False,
+        smart_model_routing: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize the AI Agent.
@@ -1476,6 +1477,19 @@ class AIAgent:
             else:
                 print(f"🔄 Fallback chain ({len(self._fallback_chain)} providers): " +
                       " → ".join(f"{f['model']} ({f['provider']})" for f in self._fallback_chain))
+
+        # ── Smart model routing (pre-turn task-difficulty router) ─────
+        # Pure config blob; the runtime decision is computed at the top of
+        # run_conversation() via _maybe_apply_smart_routing().  Disabled
+        # when missing/invalid so existing fallback semantics are preserved.
+        if isinstance(smart_model_routing, dict):
+            self._smart_routing_config = dict(smart_model_routing)
+        else:
+            self._smart_routing_config = {}
+        # Set when a routed turn is active so _restore_primary_runtime
+        # treats the swap as turn-scoped (same path as fallback).
+        self._smart_routing_active = False
+        self._last_smart_routing_decision: Optional[Dict[str, Any]] = None
 
         # Get available tools with filtering
         self.tools = get_tool_definitions(
@@ -7325,6 +7339,190 @@ class AIAgent:
             logging.error("Failed to activate fallback %s: %s", fb_model, e)
             return self._try_activate_fallback()  # try next in chain
 
+    # ── Smart model routing (pre-turn) ───────────────────────────────────
+
+    def _maybe_apply_smart_routing(self, user_message: str) -> bool:
+        """Compute and apply a smart-routing decision for this turn.
+
+        Runs at the top of ``run_conversation()`` AFTER any fallback
+        restoration has put us back on the primary runtime, so the
+        decision is made against the user-configured primary model.
+
+        Returns True if a routed runtime was activated.  On any error
+        (bad config, runtime resolution failure) we log and stay on the
+        primary — never crashing the turn.
+
+        No live HTTP requests are made here beyond constructing an SDK
+        client object via the existing ``resolve_provider_client`` helper
+        (the same path fallback uses).  Tests mock that helper so unit
+        coverage never reaches a network.
+        """
+        cfg = getattr(self, "_smart_routing_config", None) or {}
+        if not cfg.get("enabled"):
+            return False
+
+        try:
+            from agent.smart_model_routing import decide_route
+        except Exception as e:  # pragma: no cover - defensive import
+            logging.warning("smart_model_routing import failed: %s", e)
+            return False
+
+        try:
+            decision = decide_route(
+                user_message=user_message or "",
+                primary_provider=(self._primary_runtime or {}).get("provider", self.provider) or "",
+                primary_model=(self._primary_runtime or {}).get("model", self.model) or "",
+                config=cfg,
+                fallback_chain=list(getattr(self, "_fallback_chain", []) or []),
+            )
+        except Exception as e:
+            logging.warning("smart_model_routing decision failed: %s", e)
+            return False
+
+        self._last_smart_routing_decision = {
+            "route": decision.route,
+            "mode": decision.mode,
+            "classification": decision.classification,
+            "reason": decision.reason,
+            "target": decision.target.to_fallback_entry() if decision.target else None,
+        }
+
+        if decision.route == "primary" or decision.target is None:
+            logging.debug(
+                "smart_model_routing: stay on primary (%s, %s)",
+                decision.classification, decision.reason,
+            )
+            return False
+
+        if not decision.target.is_valid():
+            logging.warning(
+                "smart_model_routing: invalid target for route=%s — staying on primary",
+                decision.route,
+            )
+            return False
+
+        # Inline runtime swap.  Mirrors the client/runtime bookkeeping
+        # done by _try_activate_fallback (resolve client, determine
+        # api_mode, swap fields, refresh prompt-cache + context engine)
+        # without consuming a real fallback chain slot.  Sets
+        # _fallback_activated=True so the next turn's
+        # _restore_primary_runtime puts us back on the primary.
+        target = decision.target
+        try:
+            from agent.auxiliary_client import resolve_provider_client
+            target_provider = target.provider.strip().lower()
+            target_model = target.model.strip()
+            base_hint = target.base_url
+            key_hint = target.api_key
+            client, _resolved = resolve_provider_client(
+                target_provider, model=target_model, raw_codex=True,
+                explicit_base_url=base_hint,
+                explicit_api_key=key_hint,
+            )
+            if client is None:
+                logging.warning(
+                    "smart_model_routing: provider %s not configured — staying on primary",
+                    target_provider,
+                )
+                return False
+
+            try:
+                from hermes_cli.model_normalize import normalize_model_for_provider
+                target_model = normalize_model_for_provider(target_model, target_provider)
+            except Exception:
+                pass
+
+            target_base_url = str(client.base_url)
+
+            target_api_mode = "chat_completions"
+            if target_provider == "openai-codex":
+                target_api_mode = "codex_responses"
+            elif target_provider == "anthropic" or target_base_url.rstrip("/").lower().endswith("/anthropic"):
+                target_api_mode = "anthropic_messages"
+            elif self._is_azure_openai_url(target_base_url):
+                target_api_mode = "chat_completions"
+            elif self._is_direct_openai_url(target_base_url):
+                target_api_mode = "codex_responses"
+            elif self._provider_model_requires_responses_api(target_model, provider=target_provider):
+                target_api_mode = "codex_responses"
+
+            old_model = self.model
+            self.model = target_model
+            self.provider = target_provider
+            self.base_url = target_base_url
+            self.api_mode = target_api_mode
+            if hasattr(self, "_transport_cache"):
+                self._transport_cache.clear()
+            self._fallback_activated = True
+
+            _timeout = get_provider_request_timeout(target_provider, target_model)
+            if target_api_mode == "anthropic_messages":
+                from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token, _is_oauth_token
+                effective_key = (
+                    (client.api_key or resolve_anthropic_token() or "")
+                    if target_provider == "anthropic"
+                    else (client.api_key or "")
+                )
+                self.api_key = effective_key
+                self._anthropic_api_key = effective_key
+                self._anthropic_base_url = target_base_url
+                self._anthropic_client = build_anthropic_client(
+                    effective_key, self._anthropic_base_url, timeout=_timeout,
+                )
+                self._is_anthropic_oauth = _is_oauth_token(effective_key) if target_provider == "anthropic" else False
+                self.client = None
+                self._client_kwargs = {}
+            else:
+                self.api_key = client.api_key
+                self.client = client
+                target_headers = getattr(client, "_custom_headers", None) or getattr(client, "default_headers", None)
+                self._client_kwargs = {
+                    "api_key": client.api_key,
+                    "base_url": target_base_url,
+                    **({"default_headers": dict(target_headers)} if target_headers else {}),
+                }
+                if _timeout is not None:
+                    self._client_kwargs["timeout"] = _timeout
+
+            self._use_prompt_caching, self._use_native_cache_layout = (
+                self._anthropic_prompt_cache_policy(
+                    provider=target_provider,
+                    base_url=target_base_url,
+                    api_mode=target_api_mode,
+                    model=target_model,
+                )
+            )
+
+            if hasattr(self, "context_compressor") and self.context_compressor:
+                from agent.model_metadata import get_model_context_length
+                target_context_length = get_model_context_length(
+                    self.model, base_url=self.base_url,
+                    api_key=self.api_key, provider=self.provider,
+                    config_context_length=getattr(self, "_config_context_length", None),
+                )
+                self.context_compressor.update_model(
+                    model=self.model,
+                    context_length=target_context_length,
+                    base_url=self.base_url,
+                    api_key=getattr(self, "api_key", ""),
+                    provider=self.provider,
+                )
+
+            self._smart_routing_active = True
+            logging.info(
+                "smart_model_routing: %s → %s/%s (was %s) [%s, %s]",
+                decision.route, target_provider, target_model, old_model,
+                decision.classification, decision.reason,
+            )
+            self._emit_status(
+                f"🧭 Smart routing → {target_model} ({target_provider}) "
+                f"[{decision.classification}]"
+            )
+            return True
+        except Exception as e:
+            logging.warning("smart_model_routing activation raised: %s", e)
+            return False
+
     # ── Per-turn primary restoration ─────────────────────────────────────
 
     def _restore_primary_runtime(self) -> bool:
@@ -9811,6 +10009,15 @@ class AIAgent:
         # runtime so this turn gets a fresh attempt with the preferred model.
         # No-op when _fallback_activated is False (gateway, first turn, etc.).
         self._restore_primary_runtime()
+
+        # Smart model routing: pre-turn task-difficulty router that may
+        # swap to cheap_model (for trivial tasks) or smart_model (for hard
+        # ones).  Disabled by default; turn-scoped so the next turn starts
+        # back on the primary via _restore_primary_runtime above.
+        try:
+            self._maybe_apply_smart_routing(user_message)
+        except Exception as _smr_err:
+            logger.warning("smart_model_routing failed unexpectedly: %s", _smr_err)
 
         # Sanitize surrogate characters from user input.  Clipboard paste from
         # rich-text editors (Google Docs, Word, etc.) can inject lone surrogates

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -1,0 +1,295 @@
+"""Unit tests for ``agent/smart_model_routing.py``.
+
+These tests are deliberately pure: they do not import ``run_agent`` or
+construct ``AIAgent``, so no provider SDK, HTTP client, or local model
+endpoint is touched.  Integration is exercised by
+``tests/run_agent/test_smart_model_routing_runtime.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.smart_model_routing import (
+    DEFAULT_MAX_SIMPLE_CHARS,
+    DEFAULT_MAX_SIMPLE_WORDS,
+    LOCAL_LIKE_PROVIDERS,
+    RoutingDecision,
+    RoutingTarget,
+    classify_difficulty,
+    decide_route,
+)
+
+
+# ── classify_difficulty ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "   ",
+        "what time is it",
+        "summarize this email",
+        "show me my latest invoice",
+        "open the doc",
+        "draft a quick reply saying yes",
+    ],
+)
+def test_classify_simple(text):
+    assert classify_difficulty(text) == "simple"
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "debug this build failure",
+        "investigate why the deploy is failing",
+        "refactor the auth module so it composes",
+        "design a multi-step rollout plan",
+        "stack trace says NoneType",
+        "review the contract risk for this lawsuit",
+        "root cause for the regression?",
+        "permit escalation across multiple agencies",
+    ],
+)
+def test_classify_hard_keywords(text):
+    assert classify_difficulty(text) == "hard"
+
+
+def test_classify_hard_by_length_chars():
+    text = "a" * (DEFAULT_MAX_SIMPLE_CHARS + 1)
+    assert classify_difficulty(text) == "hard"
+
+
+def test_classify_hard_by_length_words():
+    text = " ".join(["word"] * (DEFAULT_MAX_SIMPLE_WORDS + 1))
+    assert classify_difficulty(text) == "hard"
+
+
+def test_classify_hard_code_fence():
+    assert classify_difficulty("look at this:\n```py\nprint('x')\n```") == "hard"
+
+
+def test_classify_hard_traceback():
+    assert classify_difficulty("Traceback (most recent call last)\n  File 'x.py'") == "hard"
+
+
+def test_classify_hard_three_questions():
+    assert classify_difficulty("a? b? c?") == "hard"
+
+
+def test_classify_extra_keywords_extends_hard_set():
+    assert classify_difficulty("zelda quest") == "simple"
+    assert classify_difficulty("zelda quest", extra_hard_keywords={"zelda"}) == "hard"
+
+
+def test_classify_partial_token_does_not_trigger():
+    # "encoded" should NOT match HARD keyword "code"
+    assert classify_difficulty("the message was encoded") == "simple"
+
+
+# ── decide_route ─────────────────────────────────────────────────────────
+
+
+SMART = {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}
+CHEAP = {"provider": "custom", "model": "fast-local", "base_url": "http://fred:9069/v1"}
+
+
+def test_disabled_config_returns_primary():
+    d = decide_route(
+        user_message="debug the build",
+        primary_provider="custom",
+        primary_model="fast-local",
+        config={"enabled": False, "smart_model": SMART},
+    )
+    assert d.route == "primary"
+    assert d.target is None
+    assert d.mode == "disabled"
+
+
+def test_no_routes_configured_returns_primary():
+    d = decide_route(
+        user_message="hard task: debug",
+        primary_provider="custom",
+        primary_model="fast-local",
+        config={"enabled": True},
+        fallback_chain=[],
+    )
+    assert d.route == "primary"
+    assert d.mode == "disabled"
+
+
+def test_local_first_hard_routes_to_smart_model():
+    d = decide_route(
+        user_message="please debug this build failure",
+        primary_provider="custom",
+        primary_model="fast-local",
+        config={"enabled": True, "smart_model": SMART},
+    )
+    assert d.route == "smart"
+    assert d.target is not None
+    assert d.target.provider == "openrouter"
+    assert d.target.model == "anthropic/claude-sonnet-4"
+    assert d.mode == "local-first"
+    assert d.classification == "hard"
+
+
+def test_local_first_hard_uses_fallback_when_smart_missing():
+    d = decide_route(
+        user_message="root cause investigation needed",
+        primary_provider="custom",
+        primary_model="fast-local",
+        config={"enabled": True},
+        fallback_chain=[SMART, {"provider": "anthropic", "model": "claude-3-5-haiku"}],
+    )
+    assert d.route == "smart"
+    assert d.target.provider == "openrouter"
+    assert d.mode == "local-first"
+    assert "fallback" in d.reason.lower()
+
+
+def test_local_first_simple_stays_on_primary():
+    d = decide_route(
+        user_message="what time is it",
+        primary_provider="custom",
+        primary_model="fast-local",
+        config={"enabled": True, "smart_model": SMART},
+    )
+    assert d.route == "primary"
+    assert d.target is None
+    assert d.mode == "local-first"
+    assert d.classification == "simple"
+
+
+def test_smart_primary_simple_routes_to_cheap_model():
+    d = decide_route(
+        user_message="summarize this thread",
+        primary_provider="openrouter",
+        primary_model="anthropic/claude-sonnet-4",
+        config={"enabled": True, "cheap_model": CHEAP},
+    )
+    assert d.route == "cheap"
+    assert d.target is not None
+    assert d.target.provider == "custom"
+    assert d.target.base_url == "http://fred:9069/v1"
+    assert d.mode == "smart-primary"
+
+
+def test_smart_primary_hard_stays_on_primary():
+    d = decide_route(
+        user_message="please debug this build failure",
+        primary_provider="openrouter",
+        primary_model="anthropic/claude-sonnet-4",
+        config={"enabled": True, "cheap_model": CHEAP},
+    )
+    assert d.route == "primary"
+    assert d.mode == "smart-primary"
+    assert d.classification == "hard"
+
+
+def test_both_targets_local_primary_picks_local_first_mode():
+    # Auto-detection picks local-first when primary provider is local-like
+    d = decide_route(
+        user_message="debug the build",
+        primary_provider="custom",
+        primary_model="fast-local",
+        config={"enabled": True, "smart_model": SMART, "cheap_model": CHEAP},
+    )
+    assert d.mode == "local-first"
+    assert d.route == "smart"
+
+
+def test_both_targets_cloud_primary_picks_smart_primary_mode():
+    d = decide_route(
+        user_message="quick question",
+        primary_provider="openrouter",
+        primary_model="anthropic/claude-sonnet-4",
+        config={"enabled": True, "smart_model": SMART, "cheap_model": CHEAP},
+    )
+    assert d.mode == "smart-primary"
+    assert d.route == "cheap"
+
+
+def test_explicit_mode_overrides_auto():
+    d = decide_route(
+        user_message="quick question",
+        primary_provider="custom",  # would auto → local-first
+        primary_model="fast-local",
+        config={
+            "enabled": True,
+            "mode": "smart-primary",
+            "smart_model": SMART,
+            "cheap_model": CHEAP,
+        },
+    )
+    assert d.mode == "smart-primary"
+
+
+def test_invalid_cheap_model_treated_as_missing():
+    d = decide_route(
+        user_message="hi",
+        primary_provider="openrouter",
+        primary_model="anthropic/claude-sonnet-4",
+        config={"enabled": True, "cheap_model": {"provider": "", "model": ""}},
+    )
+    assert d.route == "primary"
+    assert d.mode == "disabled"
+
+
+def test_invalid_smart_model_treated_as_missing_falls_back_to_chain():
+    d = decide_route(
+        user_message="debug this",
+        primary_provider="custom",
+        primary_model="fast-local",
+        config={"enabled": True, "smart_model": {"provider": "openrouter"}},
+        fallback_chain=[SMART],
+    )
+    assert d.route == "smart"
+    assert d.target.provider == "openrouter"
+
+
+def test_local_like_providers_constant_includes_expected_names():
+    assert "ollama" in LOCAL_LIKE_PROVIDERS
+    assert "custom" in LOCAL_LIKE_PROVIDERS
+    assert "vllm" in LOCAL_LIKE_PROVIDERS
+    assert "openrouter" not in LOCAL_LIKE_PROVIDERS
+    assert "anthropic" not in LOCAL_LIKE_PROVIDERS
+
+
+def test_routing_target_to_fallback_entry_round_trip():
+    t = RoutingTarget(
+        provider="custom", model="x", base_url="http://h:1/v1", api_key="k"
+    )
+    d = t.to_fallback_entry()
+    assert d == {
+        "provider": "custom",
+        "model": "x",
+        "base_url": "http://h:1/v1",
+        "api_key": "k",
+    }
+
+
+def test_routing_target_skips_optional_fields_when_empty():
+    t = RoutingTarget(provider="p", model="m")
+    assert t.to_fallback_entry() == {"provider": "p", "model": "m"}
+
+
+def test_decide_route_never_raises_on_garbage():
+    # Garbage config values should not crash; the function returns a
+    # primary decision for safety.
+    d = decide_route(
+        user_message="x",
+        primary_provider="x",
+        primary_model="x",
+        config={"enabled": True, "smart_model": "not-a-dict", "cheap_model": 42},
+    )
+    assert d.route == "primary"
+
+
+def test_routing_decision_dataclass_is_immutable():
+    d = RoutingDecision(
+        route="primary", target=None, reason="r", mode="disabled", classification="unknown"
+    )
+    with pytest.raises(Exception):
+        d.route = "smart"  # type: ignore[misc]

--- a/tests/run_agent/test_smart_model_routing_runtime.py
+++ b/tests/run_agent/test_smart_model_routing_runtime.py
@@ -1,0 +1,243 @@
+"""Runtime integration tests for AIAgent's smart_model_routing hook.
+
+These tests do NOT construct a real ``AIAgent`` (which would resolve
+provider credentials and import the full toolset).  Instead they bind
+``AIAgent._maybe_apply_smart_routing`` to a lightweight stub that mimics
+the agent attributes the method touches, and they patch
+``agent.auxiliary_client.resolve_provider_client`` so no HTTP request or
+local model endpoint is ever called.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── Stub plumbing ────────────────────────────────────────────────────────
+
+
+class FakeClient:
+    def __init__(self, base_url: str = "https://api.example.com/v1", api_key: str = "k"):
+        self.base_url = base_url
+        self.api_key = api_key
+        self._custom_headers = None
+        self.default_headers = None
+
+
+def _build_stub_agent(
+    *,
+    primary_provider: str = "custom",
+    primary_model: str = "fast-local",
+    smart_routing_config: dict | None = None,
+    fallback_chain: list | None = None,
+):
+    from run_agent import AIAgent
+
+    stub = types.SimpleNamespace()
+    stub.model = primary_model
+    stub.provider = primary_provider
+    stub.base_url = "http://fred:9069/v1"
+    stub.api_mode = "chat_completions"
+    stub.api_key = "local"
+    stub.client = FakeClient(stub.base_url, stub.api_key)
+    stub._anthropic_client = None
+    stub._anthropic_api_key = ""
+    stub._anthropic_base_url = None
+    stub._is_anthropic_oauth = False
+    stub._client_kwargs = {"api_key": stub.api_key, "base_url": stub.base_url}
+    stub._transport_cache = {}
+    stub._fallback_chain = list(fallback_chain or [])
+    stub._fallback_index = 0
+    stub._fallback_activated = False
+    stub._smart_routing_config = dict(smart_routing_config or {})
+    stub._smart_routing_active = False
+    stub._last_smart_routing_decision = None
+    stub._primary_runtime = {"provider": primary_provider, "model": primary_model}
+    stub._use_prompt_caching = False
+    stub._use_native_cache_layout = False
+    stub.context_compressor = None
+    stub._config_context_length = None
+
+    # Method stubs that the routing path may call.
+    stub._is_azure_openai_url = lambda url: False
+    stub._is_direct_openai_url = lambda url: False
+    stub._provider_model_requires_responses_api = lambda model, provider=None: False
+    stub._anthropic_prompt_cache_policy = lambda **kw: (False, False)
+    stub._emit_status = MagicMock()
+
+    # Bind the real method.
+    stub._maybe_apply_smart_routing = AIAgent._maybe_apply_smart_routing.__get__(stub)
+    return stub
+
+
+@pytest.fixture
+def patched_resolver():
+    """Patch resolve_provider_client to return a FakeClient — no HTTP."""
+    with patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        return_value=(FakeClient("https://openrouter.ai/api/v1", "rk"), "anthropic/claude-sonnet-4"),
+    ) as m:
+        yield m
+
+
+# ── Tests ────────────────────────────────────────────────────────────────
+
+
+def test_disabled_config_is_noop(patched_resolver):
+    stub = _build_stub_agent(smart_routing_config={"enabled": False})
+    assert stub._maybe_apply_smart_routing("debug this") is False
+    assert stub._smart_routing_active is False
+    assert stub.model == "fast-local"
+    assert patched_resolver.call_count == 0
+
+
+def test_local_first_hard_routes_to_smart(patched_resolver):
+    stub = _build_stub_agent(
+        primary_provider="custom",
+        primary_model="fast-local",
+        smart_routing_config={
+            "enabled": True,
+            "smart_model": {
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
+        },
+    )
+    assert stub._maybe_apply_smart_routing("debug this build failure") is True
+    assert stub._smart_routing_active is True
+    assert stub._fallback_activated is True
+    assert stub.provider == "openrouter"
+    assert stub.model == "anthropic/claude-sonnet-4"
+    assert patched_resolver.called
+    assert stub._last_smart_routing_decision["route"] == "smart"
+    assert stub._last_smart_routing_decision["classification"] == "hard"
+    stub._emit_status.assert_called_once()
+
+
+def test_local_first_simple_stays_on_primary(patched_resolver):
+    stub = _build_stub_agent(
+        primary_provider="custom",
+        primary_model="fast-local",
+        smart_routing_config={
+            "enabled": True,
+            "smart_model": {
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+            },
+        },
+    )
+    assert stub._maybe_apply_smart_routing("hi there") is False
+    assert stub._smart_routing_active is False
+    assert stub.model == "fast-local"
+    assert patched_resolver.call_count == 0
+
+
+def test_smart_primary_simple_routes_to_cheap(patched_resolver):
+    # patched_resolver returns the openrouter base; that's fine for
+    # cheap-routing too — we just need a non-None client.
+    stub = _build_stub_agent(
+        primary_provider="openrouter",
+        primary_model="anthropic/claude-sonnet-4",
+        smart_routing_config={
+            "enabled": True,
+            "cheap_model": {
+                "provider": "custom",
+                "model": "fast-local",
+                "base_url": "http://fred:9069/v1",
+                "api_key": "local",
+            },
+        },
+    )
+    assert stub._maybe_apply_smart_routing("summarize this thread") is True
+    assert stub._smart_routing_active is True
+    assert stub.provider == "custom"
+    assert stub.model == "fast-local"
+
+
+def test_local_first_uses_fallback_chain_when_smart_missing(patched_resolver):
+    stub = _build_stub_agent(
+        primary_provider="custom",
+        primary_model="fast-local",
+        smart_routing_config={"enabled": True},
+        fallback_chain=[
+            {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},
+        ],
+    )
+    assert stub._maybe_apply_smart_routing("root cause investigation") is True
+    assert stub._smart_routing_active is True
+    assert stub.provider == "openrouter"
+
+
+def test_invalid_target_does_not_activate(patched_resolver):
+    stub = _build_stub_agent(
+        primary_provider="custom",
+        primary_model="fast-local",
+        smart_routing_config={
+            "enabled": True,
+            "smart_model": {"provider": "", "model": ""},
+        },
+    )
+    assert stub._maybe_apply_smart_routing("debug this build failure") is False
+    assert stub._smart_routing_active is False
+    assert patched_resolver.call_count == 0
+
+
+def test_resolver_returns_none_keeps_primary():
+    with patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        return_value=(None, "anthropic/claude-sonnet-4"),
+    ):
+        stub = _build_stub_agent(
+            smart_routing_config={
+                "enabled": True,
+                "smart_model": {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-sonnet-4",
+                },
+            },
+        )
+        assert stub._maybe_apply_smart_routing("debug this build failure") is False
+        assert stub._smart_routing_active is False
+        assert stub.model == "fast-local"
+
+
+def test_resolver_raises_keeps_primary():
+    with patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        side_effect=RuntimeError("boom"),
+    ):
+        stub = _build_stub_agent(
+            smart_routing_config={
+                "enabled": True,
+                "smart_model": {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-sonnet-4",
+                },
+            },
+        )
+        # Should swallow and stay on primary.
+        assert stub._maybe_apply_smart_routing("debug this build failure") is False
+        assert stub._smart_routing_active is False
+        assert stub.model == "fast-local"
+
+
+def test_routing_does_not_make_http_calls(patched_resolver):
+    """Sanity: the only outbound call we permit is resolve_provider_client,
+    which is itself mocked.  No httpx, no requests, no socket activity."""
+    import httpx
+
+    with patch.object(httpx.Client, "send", side_effect=AssertionError("HTTP forbidden")):
+        stub = _build_stub_agent(
+            smart_routing_config={
+                "enabled": True,
+                "smart_model": {
+                    "provider": "openrouter",
+                    "model": "anthropic/claude-sonnet-4",
+                },
+            },
+        )
+        # Should not raise.
+        stub._maybe_apply_smart_routing("debug this build failure")

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -763,6 +763,8 @@ Each auxiliary task has a configurable `timeout` (in seconds). Defaults: vision 
 
 :::info
 Context compression has its own `compression:` block for thresholds and an `auxiliary.compression:` block for model/provider settings — see [Context Compression](#context-compression) above. The fallback model uses a `fallback_model:` block — see [Fallback Model](/docs/integrations/providers#fallback-model). All three follow the same provider/model/base_url pattern.
+
+For pre-turn task-difficulty routing (cheap-on-simple or smart-on-hard) see [Smart Model Routing](./features/smart-model-routing.md). It uses a `smart_model_routing:` block with the same provider/model shape and is independent of fallback (fallback handles provider *failure*; smart routing handles task *difficulty*).
 :::
 
 ### Session Search Tuning

--- a/website/docs/user-guide/features/smart-model-routing.md
+++ b/website/docs/user-guide/features/smart-model-routing.md
@@ -1,0 +1,141 @@
+---
+title: Smart Model Routing
+description: Route easy tasks to a cheap/local model and hard tasks to a smart cloud model, before each turn starts.
+sidebar_label: Smart Model Routing
+sidebar_position: 9
+---
+
+# Smart Model Routing
+
+Smart model routing decides — before each turn even starts — whether the
+upcoming user message should run on your configured primary model, on a
+cheaper local model, or on a smarter cloud model. It complements
+[fallback providers](./fallback-providers.md): fallback handles
+provider/runtime failure mid-turn, smart routing handles task-difficulty
+matching at turn start.
+
+Two operating modes are supported. Hermes auto-detects the right mode
+from your config:
+
+- **Local-first** (Chad's default) — primary model is a fast/cheap local
+  model. Hermes uses it for routine work and routes hard tasks to a
+  smart cloud model.
+- **Smart-primary** — primary model is a strong cloud model. Hermes uses
+  it for everything by default and routes simple tasks to a configured
+  cheap/local model to save cost and latency.
+
+Routing is **turn scoped**: each user turn re-evaluates the route, and
+the next turn always starts back on the configured primary model. If
+routing is disabled or misconfigured, behavior matches stock Hermes.
+
+## Configuration
+
+Add a `smart_model_routing` block to your `config.yaml`:
+
+```yaml
+smart_model_routing:
+  enabled: true
+
+  # Length thresholds used by the deterministic heuristic.  Anything over
+  # either limit is treated as "hard".  Default 160 / 28.
+  max_simple_chars: 160
+  max_simple_words: 28
+
+  # Optional: pin a mode.  When unset, mode is auto-detected from the
+  # configured cheap_model / smart_model and your primary provider.
+  # Values: auto | local-first | smart-primary
+  mode: auto
+
+  # Used in smart-primary mode when the upcoming task looks simple.
+  cheap_model:
+    provider: custom
+    model: fast-local-model
+    base_url: http://fred:9069/v1
+    api_key: local
+
+  # Used in local-first mode when the upcoming task looks hard.  If
+  # omitted, Hermes uses the first entry of fallback_providers /
+  # fallback_model as the smart target so a single config can drive both
+  # difficulty escalation and provider failover.
+  smart_model:
+    provider: openrouter
+    model: anthropic/claude-sonnet-4
+
+  # Optional list of additional words/phrases that should classify a
+  # turn as "hard" (e.g. internal codenames, project-specific terms).
+  extra_hard_keywords:
+    - permitting
+    - rezoning
+```
+
+Both `cheap_model` and `smart_model` use the same shape as
+`fallback_providers` entries (`provider`, `model`, optional `base_url`
+and `api_key`). Missing or invalid entries simply disable that route —
+they do not crash the session.
+
+## Heuristic
+
+The MVP heuristic is fully deterministic. A turn is classified as
+**hard** when any one of the following is true:
+
+- the message exceeds `max_simple_chars` characters or `max_simple_words`
+  words
+- the message contains a fenced code block, a Python traceback, or three
+  or more `?` characters (multi-part reasoning)
+- the message contains any hard keyword token, including:
+  `debug`, `build`, `code`, `refactor`, `architect`, `architecture`,
+  `design`, `plan`, `investigate`, `strategy`, `lawsuit`, `contract`,
+  `legal`, `financial`, `risk`, `complex`, `hard`, `regression`,
+  `traceback`, `audit`, `permit`, `escalation`, plus any
+  `extra_hard_keywords` you configure
+- the message matches a hard phrase pattern such as `root cause`,
+  `test failure`, `stack trace`, or `security review`
+
+Otherwise the turn is **simple**.
+
+There is no LLM classifier in the MVP, so routing decisions are free,
+deterministic, and reproducible. Tune behavior via thresholds and
+`extra_hard_keywords`.
+
+## Routing rules
+
+| Mode           | Hard task         | Simple task        |
+|----------------|-------------------|--------------------|
+| local-first    | route to smart    | stay on primary    |
+| smart-primary  | stay on primary   | route to cheap     |
+
+Mode auto-detection (when `mode: auto` or unset):
+
+- If only `smart_model` is configured → **local-first**.
+- If only `cheap_model` is configured → **smart-primary**.
+- If both are configured → **local-first** when the primary provider is
+  in the local-like set (`custom`, `ollama`, `vllm`, `lmstudio`,
+  `llamacpp`, `local`, `localhost`, `fred`, …), otherwise
+  **smart-primary**.
+- If neither is configured → smart routing is effectively disabled and
+  the primary model handles every turn (fallback providers still apply
+  to provider failures).
+
+## Interaction with fallback
+
+Smart routing runs *before* the API call. If the routed model later
+fails for provider reasons, the existing
+[fallback chain](./fallback-providers.md) still applies. Restoration to
+the primary model happens automatically at the start of the next user
+turn, just like fallback restoration. There is no additional
+configuration required to combine the two.
+
+## Observability
+
+Routing decisions are logged at INFO when a route activates and at
+DEBUG when the primary is kept. Each decision includes the route
+target, the classification (`simple` / `hard`), and the human-readable
+reason. The most recent decision is also stored on the agent as
+`_last_smart_routing_decision` for tooling inspection.
+
+## Constraints
+
+- The MVP makes no LLM classifier calls.
+- Hermes does not call any local model endpoint to decide a route.
+- Disabling `smart_model_routing` (or omitting it) reproduces stock
+  Hermes behavior exactly.


### PR DESCRIPTION
## Summary

Adds a deterministic, turn-scoped router that picks the right model **before each user turn starts**, complementing the existing fallback chain (which handles provider failure mid-turn). Two modes, auto-detected from config:

- **local-first** — primary is a fast/cheap local model; hard tasks escalate to a smart cloud model.
- **smart-primary** — primary is a strong cloud model; simple tasks demote to a configured cheap/local model.

When `smart_model` is omitted, the first `fallback_providers` entry is used as the smart target so a single config can drive both provider failover and difficulty escalation.

## Design

- New pure module `agent/smart_model_routing.py` — heuristic classifier (length / keywords / phrases / code-fence / traceback / multi-question), mode resolution, `decide_route()`. No network, no SDK imports.
- `AIAgent._maybe_apply_smart_routing()` runs at the top of `run_conversation()` after `_restore_primary_runtime()`. Inline runtime swap mirrors the bookkeeping in `_try_activate_fallback` (resolve client, determine api_mode, refresh prompt-cache + context engine), and sets `_fallback_activated=True` so the next turn restores primary the same way fallback does.
- New `smart_model_routing` config block with the same provider/model/base_url/api_key shape as fallback entries. Disabled by default; bad config logs and stays on primary.
- Wired through `cli.py` (both AIAgent construction sites) and `gateway/run.py` (`_load_smart_model_routing()` + both construction sites).

## Config

\`\`\`yaml
smart_model_routing:
  enabled: true
  mode: auto                # auto | local-first | smart-primary
  max_simple_chars: 160
  max_simple_words: 28
  cheap_model:
    provider: custom
    model: fast-local-model
    base_url: http://fred:9069/v1
    api_key: local
  smart_model:
    provider: openrouter    # if omitted, fallback_providers[0] is used
    model: anthropic/claude-sonnet-4
  extra_hard_keywords: [permitting, rezoning]
\`\`\`

Mode auto-detection (when \`mode: auto\` or unset):
- only \`smart_model\` configured → local-first
- only \`cheap_model\` configured → smart-primary
- both configured → local-first when primary provider is local-like (\`custom\`, \`ollama\`, \`vllm\`, \`lmstudio\`, \`llamacpp\`, \`local\`, \`localhost\`, \`fred\`, …), else smart-primary
- neither → routing effectively disabled

## Test plan

- [x] 39 unit tests on the pure decision module (\`tests/agent/test_smart_model_routing.py\`) — disabled config, both modes, fallback-as-smart, invalid targets, mode auto-detect, dataclass immutability, never-raises-on-garbage.
- [x] 9 runtime tests with stubbed AIAgent + mocked \`resolve_provider_client\` (\`tests/run_agent/test_smart_model_routing_runtime.py\`) — including a guard that fails the test if any \`httpx.Client.send\` call is made.
- [x] No HTTP and no local model endpoints touched anywhere in the test suite.
- [ ] Smoke-test on a real config when GPU is available (deferred per user request).

## Docs

- \`website/docs/user-guide/features/smart-model-routing.md\` — full feature page.
- Cross-link added in \`website/docs/user-guide/configuration.md\`.
- \`smart_model_routing\` added to \`_KNOWN_ROOT_KEYS\` in \`hermes_cli/config.py\` so the config validator accepts the new block.

## Risks / follow-ups

- Inline runtime swap duplicates ~80 lines of \`_try_activate_fallback\`'s bookkeeping. A future refactor could extract a shared \`_apply_runtime(target)\` helper.
- Heuristic is deterministic and intentionally simple. Tunable via \`max_simple_chars\`, \`max_simple_words\`, and \`extra_hard_keywords\`. An LLM classifier was scoped out of the MVP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)