### PR TITLE
fix(cli): expand ${VAR} references in load_env to match python-dotenv

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4035,6 +4035,44 @@ def save_config(config: Dict[str, Any]):
     _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
 
 
+# Matches ${VAR}, ${VAR:-default}, and bare $VAR references for .env
+# interpolation.  Mirrors the subset of POSIX/python-dotenv expansion we
+# need: an unescaped `$` followed by either `{NAME}` (optionally with
+# `:-default` or `-default`) or a bare identifier.
+_ENV_VAR_REF_RE = re.compile(
+    r"(?<!\\)\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)(?::?-(?P<default>[^}]*))?\}"
+    r"|(?P<bare>[A-Za-z_][A-Za-z0-9_]*))"
+)
+
+
+def _expand_env_refs(value: str, env_vars: Dict[str, str]) -> str:
+    """Expand ``${VAR}`` / ``$VAR`` references in a .env value.
+
+    Resolution order matches python-dotenv: values defined earlier in the
+    same .env file win over ``os.environ``.  Unresolved references with a
+    ``${VAR:-default}`` form fall back to the default; otherwise the
+    literal text is preserved so corrupted/incorrect references don't
+    silently become empty strings (which would mask copy-paste mistakes).
+    Escaped ``\\$VAR`` is left alone and the leading backslash stripped.
+    """
+    if "$" not in value:
+        return value.replace(r"\$", "$") if "\\$" in value else value
+
+    def _resolve(match: "re.Match[str]") -> str:
+        name = match.group("braced") or match.group("bare")
+        if name in env_vars:
+            return env_vars[name]
+        if name in os.environ:
+            return os.environ[name]
+        default = match.group("default")
+        if default is not None:
+            return default
+        return match.group(0)
+
+    expanded = _ENV_VAR_REF_RE.sub(_resolve, value)
+    return expanded.replace(r"\$", "$")
+
+
 def load_env() -> Dict[str, str]:
     """Load environment variables from ~/.hermes/.env.
 
@@ -4042,10 +4080,16 @@ def load_env() -> Dict[str, str]:
     concatenated KEY=VALUE pairs on a single line) are handled
     gracefully instead of producing mangled values such as duplicated
     bot tokens.  See #8908.
+
+    Expands ``${VAR}`` / ``$VAR`` references using earlier .env entries
+    and ``os.environ`` as the source — matching python-dotenv's
+    interpolation behavior.  Without this, a value like
+    ``ANTHROPIC_API_KEY=${OPENAI_API_KEY}`` would be returned as the
+    literal string and later persisted as an API key (see #20310).
     """
     env_path = get_env_path()
-    env_vars = {}
-    
+    env_vars: Dict[str, str] = {}
+
     if env_path.exists():
         # On Windows, open() defaults to the system locale (cp1252) which can
         # fail on UTF-8 .env files. Use explicit UTF-8 only on Windows.
@@ -4059,8 +4103,9 @@ def load_env() -> Dict[str, str]:
             line = line.strip()
             if line and not line.startswith('#') and '=' in line:
                 key, _, value = line.partition('=')
-                env_vars[key.strip()] = value.strip().strip('"\'')
-    
+                value = value.strip().strip('"\'')
+                env_vars[key.strip()] = _expand_env_refs(value, env_vars)
+
     return env_vars
 
 

--- a/tests/hermes_cli/test_load_env_var_expansion.py
+++ b/tests/hermes_cli/test_load_env_var_expansion.py
@@ -1,0 +1,138 @@
+"""Tests for ``${VAR}`` interpolation in ``load_env`` (#20310).
+
+When a ``~/.hermes/.env`` value references another variable, ``load_env``
+must expand it instead of returning the raw ``${VAR}`` literal — otherwise
+the credential pool seeds the unresolved string into ``auth.json`` and
+auxiliary requests send it as the ``x-api-key`` header.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _write_env(content: str) -> Path:
+    fp = tempfile.NamedTemporaryFile(
+        mode="w", suffix=".env", delete=False, encoding="utf-8"
+    )
+    fp.write(content)
+    fp.close()
+    return Path(fp.name)
+
+
+def test_load_env_expands_braced_reference_from_os_environ():
+    """``ANTHROPIC_API_KEY=${OPENAI_API_KEY}`` resolves via os.environ."""
+    from hermes_cli.config import load_env
+
+    env_path = _write_env("ANTHROPIC_API_KEY=${OPENAI_API_KEY}\n")
+    try:
+        with patch("hermes_cli.config.get_env_path", return_value=env_path), \
+             patch.dict(os.environ, {"OPENAI_API_KEY": "sk-real-key"}, clear=False):
+            result = load_env()
+        assert result["ANTHROPIC_API_KEY"] == "sk-real-key"
+    finally:
+        env_path.unlink(missing_ok=True)
+
+
+def test_load_env_expands_bare_reference_from_os_environ():
+    """``KEY=$OTHER`` (no braces) expansion."""
+    from hermes_cli.config import load_env
+
+    env_path = _write_env("ANTHROPIC_API_KEY=$OPENAI_API_KEY\n")
+    try:
+        with patch("hermes_cli.config.get_env_path", return_value=env_path), \
+             patch.dict(os.environ, {"OPENAI_API_KEY": "sk-bare"}, clear=False):
+            result = load_env()
+        assert result["ANTHROPIC_API_KEY"] == "sk-bare"
+    finally:
+        env_path.unlink(missing_ok=True)
+
+
+def test_load_env_resolves_chained_reference_within_file():
+    """Earlier .env entries take precedence over os.environ for expansion."""
+    from hermes_cli.config import load_env
+
+    content = (
+        "OPENAI_API_KEY=sk-from-file\n"
+        "ANTHROPIC_API_KEY=${OPENAI_API_KEY}\n"
+    )
+    env_path = _write_env(content)
+    try:
+        with patch("hermes_cli.config.get_env_path", return_value=env_path), \
+             patch.dict(
+                 os.environ, {"OPENAI_API_KEY": "sk-from-shell"}, clear=False
+             ):
+            result = load_env()
+        assert result["ANTHROPIC_API_KEY"] == "sk-from-file"
+    finally:
+        env_path.unlink(missing_ok=True)
+
+
+def test_load_env_unresolved_reference_falls_back_to_default():
+    """``${VAR:-default}`` returns the default when VAR is missing."""
+    from hermes_cli.config import load_env
+
+    env_path = _write_env("ANTHROPIC_API_KEY=${MISSING_VAR:-fallback}\n")
+    try:
+        with patch("hermes_cli.config.get_env_path", return_value=env_path), \
+             patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MISSING_VAR", None)
+            result = load_env()
+        assert result["ANTHROPIC_API_KEY"] == "fallback"
+    finally:
+        env_path.unlink(missing_ok=True)
+
+
+def test_load_env_preserves_literal_when_reference_unresolved():
+    """An unresolvable ``${VAR}`` is left as-is (does not silently empty)."""
+    from hermes_cli.config import load_env
+
+    env_path = _write_env("ANTHROPIC_API_KEY=${TOTALLY_UNDEFINED_VAR_XYZ}\n")
+    try:
+        with patch("hermes_cli.config.get_env_path", return_value=env_path):
+            os.environ.pop("TOTALLY_UNDEFINED_VAR_XYZ", None)
+            result = load_env()
+        assert result["ANTHROPIC_API_KEY"] == "${TOTALLY_UNDEFINED_VAR_XYZ}"
+    finally:
+        env_path.unlink(missing_ok=True)
+
+
+def test_load_env_preserves_dollar_signs_in_passwords():
+    """A literal ``$`` not followed by a valid identifier stays intact."""
+    from hermes_cli.config import load_env
+
+    env_path = _write_env("DB_PASSWORD=p@ss$123word\n")
+    try:
+        with patch("hermes_cli.config.get_env_path", return_value=env_path):
+            result = load_env()
+        assert result["DB_PASSWORD"] == "p@ss$123word"
+    finally:
+        env_path.unlink(missing_ok=True)
+
+
+def test_load_env_escaped_dollar_passes_through_literally():
+    """``\\$VAR`` keeps the dollar sign and is not interpolated."""
+    from hermes_cli.config import load_env
+
+    env_path = _write_env(r"PASSWORD=\$NOT_A_VAR" + "\n")
+    try:
+        with patch("hermes_cli.config.get_env_path", return_value=env_path), \
+             patch.dict(os.environ, {"NOT_A_VAR": "should-not-appear"}, clear=False):
+            result = load_env()
+        assert result["PASSWORD"] == "$NOT_A_VAR"
+    finally:
+        env_path.unlink(missing_ok=True)
+
+
+def test_load_env_no_dollar_sign_unchanged():
+    """Values without ``$`` are returned verbatim (regression guard)."""
+    from hermes_cli.config import load_env
+
+    env_path = _write_env("KEY=plain-value-no-substitution\n")
+    try:
+        with patch("hermes_cli.config.get_env_path", return_value=env_path):
+            result = load_env()
+        assert result["KEY"] == "plain-value-no-substitution"
+    finally:
+        env_path.unlink(missing_ok=True)

--- a/tests/tools/test_credential_pool_env_fallback.py
+++ b/tests/tools/test_credential_pool_env_fallback.py
@@ -120,6 +120,31 @@ class TestCredentialPoolSeedsFromDotEnv:
         assert len(seeded) == 1
         assert seeded[0].access_token == "sk-env-fresh-xyz"
 
+    def test_dotenv_var_reference_is_expanded_not_stored_literally(
+        self, isolated_hermes_home, monkeypatch
+    ):
+        """Regression for #20310: ``KEY=${OTHER}`` must seed the resolved value.
+
+        Without expansion the literal ``${OTHER}`` was persisted into
+        ``auth.json`` and sent as the ``x-api-key`` header for auxiliary
+        requests, producing 401s.
+        """
+        _write_env_file(
+            isolated_hermes_home,
+            ANTHROPIC_API_KEY="${OPENAI_API_KEY}",
+        )
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-resolved-real-key")
+
+        from agent.credential_pool import _seed_from_env
+        entries = []
+        changed, active_sources = _seed_from_env("anthropic", entries)
+
+        assert changed is True
+        seeded = [e for e in entries if e.source == "env:ANTHROPIC_API_KEY"]
+        assert len(seeded) == 1
+        assert seeded[0].access_token == "sk-resolved-real-key"
+        assert "${" not in seeded[0].access_token
+
 
 class TestAuthResolvesFromDotEnv:
     """_resolve_api_key_provider_secret must also read from ~/.hermes/.env."""


### PR DESCRIPTION
Resolve `${VAR}` references in `~/.hermes/.env` so the credential pool stops seeding literal `${OPENAI_API_KEY}` strings into `auth.json`.

## What changed and why
- `hermes_cli/config.py` — `load_env()` now expands `${VAR}`, `$VAR`, and `${VAR:-default}` references using earlier .env entries first, then `os.environ`. Unresolvable refs are preserved verbatim so copy-paste mistakes stay visible (rather than silently becoming empty strings).
- `python-dotenv` already does this when it loads `.env` into `os.environ`. The manual reader in `load_env()` did not, causing a divergence: `os.environ['ANTHROPIC_API_KEY']` was the resolved value, but `load_env()['ANTHROPIC_API_KEY']` was the literal `${OPENAI_API_KEY}`. After #18755 made `_get_env_prefer_dotenv` prefer the `.env` file, that literal won — and the credential pool persisted it into `auth.json`, breaking auxiliary requests (title generation, compression) with `Invalid X-Api-Key header format`.
- Tests: 8 unit tests for the new interpolation + 1 integration test in `test_credential_pool_env_fallback.py` reproducing the exact `ANTHROPIC_API_KEY=${OPENAI_API_KEY}` scenario from the issue.

## How to test
1. In `~/.hermes/.env`, set `ANTHROPIC_API_KEY=${OPENAI_API_KEY}` with a valid `OPENAI_API_KEY` exported in the shell.
2. Delete `~/.hermes/auth.json` and `~/.hermes/auth.lock`.
3. Run `hermes` and trigger an auxiliary task (e.g. session title generation).
4. Confirm `auth.json` contains the resolved key, not the literal `${OPENAI_API_KEY}`.
5. `pytest tests/hermes_cli/test_load_env_var_expansion.py tests/tools/test_credential_pool_env_fallback.py` — all green.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #20310

<!-- autocontrib:worker-id=issue-new-ce040990 kind=pr-open -->