### PR TITLE
feat(i18n): add French (fr) locale support

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -25,7 +25,7 @@ Language resolution order:
     3. ``display.language`` from config.yaml
     4. ``"en"`` (baseline)
 
-Supported languages: en, zh, ja, de, es.  Unknown values fall back to en.
+Supported languages: en, zh, ja, de, es, fr.  Unknown values fall back to en.
 """
 
 from __future__ import annotations
@@ -39,7 +39,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "ja", "de", "es")
+SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "ja", "de", "es", "fr")
 DEFAULT_LANGUAGE = "en"
 
 # Accept a few natural aliases so users who type "chinese" / "zh-CN" / "jp"
@@ -50,6 +50,7 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "japanese": "ja", "jp": "ja", "ja-jp": "ja",
     "german": "de", "deutsch": "de", "de-de": "de",
     "spanish": "es", "español": "es", "espanol": "es", "es-es": "es", "es-mx": "es",
+    "french": "fr", "français": "fr", "france": "fr", "fr-fr": "fr", "fr-be": "fr", "fr-ca": "fr", "fr-ch": "fr",
 }
 
 _catalog_cache: dict[str, dict[str, str]] = {}

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -7,7 +7,7 @@
 #
 # Keys are dotted paths; nesting below is purely for readability.  Values may
 # contain {placeholder} tokens for str.format substitution.  When adding a
-# new key, add it to EVERY locale file (en/zh/ja/de/es) in the same commit --
+# new key, add it to EVERY locale file (en/zh/ja/de/es/fr) in the same commit --
 # tests/agent/test_i18n.py asserts catalog parity.
 
 approval:

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -1,0 +1,24 @@
+# Hermes static-message catalog -- French (français)
+# See locales/en.yaml for the source of truth; keep keys in sync.
+
+approval:
+  dangerous_header: "⚠️  COMMANDE DANGEREUSE : {description}"
+  choose_long:     "      [o]ne fois  |  [s]ession  |  [t]oujours  |  [r]efuser"
+  choose_short:    "      [o]ne fois  |  [s]ession  |  [r]efuser"
+  prompt_long:     "      Choix [o/s/t/R] : "
+  prompt_short:    "      Choix [o/s/R] : "
+  timeout:         "      ⏱ Délai dépassé — commande refusée"
+  allowed_once:    "      ✓ Autorisé une fois"
+  allowed_session: "      ✓ Autorisé pour cette session"
+  allowed_always:  "      ✓ Ajouté à la liste d'autorisation permanente"
+  denied:          "      ✗ Refusé"
+  cancelled:       "      ✗ Annulé"
+  blocklist_message: "Cette commande est sur la liste de blocage inconditionnel et ne peut pas être approuvée."
+
+gateway:
+  approval_expired: "⚠️ Approbation expirée (l'agent n'attend plus). Demandez à l'agent de réessayer."
+  draining:         "⏳ Vidage de {count} agent(s) actif(s) avant redémarrage..."
+  goal_cleared:     "✓ Objectif effacé."
+  no_active_goal:   "Aucun objectif actif."
+  config_read_failed: "⚠️ Impossible de lire config.yaml : {error}"
+  config_save_failed: "⚠️ Impossible de sauvegarder la configuration : {error}"


### PR DESCRIPTION
## Summary

Add French language support to the Hermes Agent i18n system.

## Changes

- **New file:** `locales/fr.yaml` — French translations for approval prompts and gateway messages
- **Modified:** `agent/i18n.py` — registered `fr` in `SUPPORTED_LANGUAGES` and added French aliases (`french`, `français`, `fr-fr`, `fr-be`, `fr-ca`, `fr-ch`)
- **Modified:** `locales/en.yaml` — updated locale sync comment to include `fr`

## How to use

```bash
hermes config set display.language fr
```

Then restart or run `/reset`. Approval prompts and gateway messages will appear in French.

## Testing

Verified locally — French translations load correctly and all aliases resolve properly.
