### PR TITLE
fix: stale stash ref in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -805,48 +805,56 @@ clone_repo() {
             log_info "Existing installation found, updating..."
             cd "$INSTALL_DIR"
 
-            local autostash_ref=""
+            local autostash_name=""
             if [ -n "$(git status --porcelain)" ]; then
-                local stash_name
-                stash_name="hermes-install-autostash-$(date -u +%Y%m%d-%H%M%S)"
+                autostash_name="hermes-install-autostash-$(date -u +%Y%m%d-%H%M%S)"
                 log_info "Local changes detected, stashing before update..."
-                git stash push --include-untracked -m "$stash_name"
-                autostash_ref="$(git rev-parse --verify refs/stash)"
+                git stash push --include-untracked -m "$autostash_name"
             fi
 
             git fetch origin
             git checkout "$BRANCH"
             git pull --ff-only origin "$BRANCH"
 
-            if [ -n "$autostash_ref" ]; then
-                local restore_now="yes"
-                if [ -t 0 ] && [ -t 1 ]; then
-                    echo
-                    log_warn "Local changes were stashed before updating."
-                    log_warn "Restoring them may reapply local customizations onto the updated codebase."
-                    printf "Restore local changes now? [Y/n] "
-                    read -r restore_answer
-                    case "$restore_answer" in
-                        ""|y|Y|yes|YES|Yes) restore_now="yes" ;;
-                        *) restore_now="no" ;;
-                    esac
-                fi
-
-                if [ "$restore_now" = "yes" ]; then
-                    log_info "Restoring local changes..."
-                    if git stash apply "$autostash_ref"; then
-                        git stash drop "$autostash_ref" >/dev/null
-                        log_warn "Local changes were restored on top of the updated codebase."
-                        log_warn "Review git diff / git status if Hermes behaves unexpectedly."
-                    else
-                        log_error "Update succeeded, but restoring local changes failed. Your changes are still preserved in git stash."
-                        log_info "Resolve manually with: git stash apply $autostash_ref"
-                        exit 1
-                    fi
+            if [ -n "$autostash_name" ]; then
+                # Look up stash entry by its unique message instead of raw SHA.
+                # Using refs/stash SHA broke when prior stashes accumulated
+                # across failed install attempts (see hermes-desktop#69).
+                local autostash_ref=""
+                autostash_ref="$(git stash list --format=%gd %s | grep "$autostash_name" | head -1 | cut -d  -f1)"
+                if [ -z "$autostash_ref" ]; then
+                    log_warn "Could not find stash entry . It may have been dropped."
+                    log_info "Your local changes may need to be re-applied manually."
                 else
-                    log_info "Skipped restoring local changes."
-                    log_info "Your changes are still preserved in git stash."
-                    log_info "Restore manually with: git stash apply $autostash_ref"
+                    local restore_now="yes"
+                    if [ -t 0 ] && [ -t 1 ]; then
+                        echo
+                        log_warn "Local changes were stashed before updating."
+                        log_warn "Restoring them may reapply local customizations onto the updated codebase."
+                        printf "Restore local changes now? [Y/n] "
+                        read -r restore_answer
+                        case "$restore_answer" in
+                            ""|y|Y|yes|YES|Yes) restore_now="yes" ;;
+                            *) restore_now="no" ;;
+                        esac
+                    fi
+
+                    if [ "$restore_now" = "yes" ]; then
+                        log_info "Restoring local changes..."
+                        if git stash apply "$autostash_ref"; then
+                            git stash drop "$autostash_ref" >/dev/null
+                            log_warn "Local changes were restored on top of the updated codebase."
+                            log_warn "Review git diff / git status if Hermes behaves unexpectedly."
+                        else
+                            log_error "Update succeeded, but restoring local changes failed. Your changes are still preserved in git stash."
+                            log_info "Resolve manually with: git stash apply $autostash_ref"
+                            exit 1
+                        fi
+                    else
+                        log_info "Skipped restoring local changes."
+                        log_info "Your changes are still preserved in git stash."
+                        log_info "Restore manually with: git stash apply $autostash_ref"
+                    fi
                 fi
             fi
         else


### PR DESCRIPTION
The update path in `scripts/install.sh` saves local changes with `git stash push` then looks up the stash using `git rev-parse --verify refs/stash`. When prior stashes exist from previous install attempts, `refs/stash` points at the wrong entry after `git pull` shifts the stash list. This causes `git stash apply` to fail with:

    error: '<sha>' is not a stash reference

Fix: look up our stash entry by its unique timestamp-based message (hermes-install-autostash-YYYYMMDD-HHMMSS) using `git stash list` instead of relying on the raw SHA. Also adds a fallback warning if the stash entry cannot be found at all.

Fixes fathah/hermes-desktop#69
