### PR TITLE
fix(hindsight): support read-only memory provider mode

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -231,6 +231,7 @@ def _load_config() -> dict:
         "retain_source": os.environ.get("HINDSIGHT_RETAIN_SOURCE", ""),
         "retain_user_prefix": os.environ.get("HINDSIGHT_RETAIN_USER_PREFIX", "User"),
         "retain_assistant_prefix": os.environ.get("HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant"),
+        "read_only": os.environ.get("HINDSIGHT_READ_ONLY", ""),
         "banks": {
             "hermes": {
                 "bankId": os.environ.get("HINDSIGHT_BANK_ID", "hermes"),
@@ -380,6 +381,27 @@ def _sanitize_bank_segment(value: str) -> str:
     return "".join(out).strip("-_")
 
 
+def _as_bool(value: Any, default: bool = False) -> bool:
+    """Parse bool-like config/env values without Python truthiness surprises."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        if normalized in {"0", "false", "no", "off", "disabled", ""}:
+            return False
+        return default
+    if isinstance(value, (int, float)):
+        if value == 1:
+            return True
+        if value == 0:
+            return False
+    return default
+
+
 def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str) -> str:
     """Resolve a bank_id template string with the given placeholders.
 
@@ -429,6 +451,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._mode = "cloud"
         self._llm_base_url = ""
         self._memory_mode = "hybrid"  # "context", "tools", or "hybrid"
+        self._read_only = False
         self._prefetch_method = "recall"  # "recall" or "reflect"
         self._retain_tags: List[str] = []
         self._retain_source = ""
@@ -752,6 +775,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
             {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "context", "tools"]},
             {"key": "recall_prefetch_method", "description": "Auto-recall method", "default": "recall", "choices": ["recall", "reflect"]},
+            {"key": "read_only", "description": "Allow only recall/reflect. Disables automatic and explicit memory writes.", "default": False},
             {"key": "retain_tags", "description": "Default tags applied to retained memories (comma-separated)", "default": ""},
             {"key": "retain_source", "description": "Metadata source value attached to retained memories", "default": ""},
             {"key": "retain_user_prefix", "description": "Label used before user turns in retained transcripts", "default": "User"},
@@ -1014,6 +1038,10 @@ class HindsightMemoryProvider(MemoryProvider):
 
         memory_mode = self._config.get("memory_mode", "hybrid")
         self._memory_mode = memory_mode if memory_mode in ("context", "tools", "hybrid") else "hybrid"
+        self._read_only = _as_bool(
+            self._config.get("read_only", os.environ.get("HINDSIGHT_READ_ONLY")),
+            default=False,
+        )
 
         prefetch_method = self._config.get("recall_prefetch_method") or self._config.get("prefetch_method", "recall")
         self._prefetch_method = prefetch_method if prefetch_method in ("recall", "reflect") else "recall"
@@ -1041,12 +1069,13 @@ class HindsightMemoryProvider(MemoryProvider):
         ).strip() or "Assistant"
 
         # Retain controls
-        self._auto_retain = self._config.get("auto_retain", True)
+        configured_auto_retain = _as_bool(self._config.get("auto_retain"), True)
+        self._auto_retain = False if self._read_only else configured_auto_retain
         self._retain_every_n_turns = max(1, int(self._config.get("retain_every_n_turns", 1)))
         self._retain_context = self._config.get("retain_context", "conversation between Hermes Agent and the User")
 
         # Recall controls
-        self._auto_recall = self._config.get("auto_recall", True)
+        self._auto_recall = _as_bool(self._config.get("auto_recall"), True)
         self._recall_max_tokens = int(self._config.get("recall_max_tokens", 4096))
         self._recall_types = self._config.get("recall_types") or None
         self._recall_prompt_preamble = self._config.get("recall_prompt_preamble", "")
@@ -1059,8 +1088,8 @@ class HindsightMemoryProvider(MemoryProvider):
             _client_version = pkg_version("hindsight-client")
         except Exception:
             pass
-        logger.info("Hindsight initialized: mode=%s, api_url=%s, bank=%s, budget=%s, memory_mode=%s, prefetch_method=%s, client=%s",
-                     self._mode, self._api_url, self._bank_id, self._budget, self._memory_mode, self._prefetch_method, _client_version)
+        logger.info("Hindsight initialized: mode=%s, api_url=%s, bank=%s, budget=%s, memory_mode=%s, read_only=%s, prefetch_method=%s, client=%s",
+                     self._mode, self._api_url, self._bank_id, self._budget, self._memory_mode, self._read_only, self._prefetch_method, _client_version)
         if self._bank_id_template:
             logger.debug("Hindsight bank resolved from template %r: profile=%s workspace=%s platform=%s user=%s -> bank=%s",
                          self._bank_id_template, self._agent_identity, self._agent_workspace,
@@ -1118,6 +1147,18 @@ class HindsightMemoryProvider(MemoryProvider):
             t.start()
 
     def system_prompt_block(self) -> str:
+        if self._read_only:
+            if self._memory_mode == "context":
+                return (
+                    f"# Hindsight Memory\n"
+                    f"Active in read-only context mode. Bank: {self._bank_id}, budget: {self._budget}.\n"
+                    f"Relevant memories are automatically injected into context. Memory writes are disabled."
+                )
+            return (
+                f"# Hindsight Memory\n"
+                f"Active in read-only mode. Bank: {self._bank_id}, budget: {self._budget}.\n"
+                f"Use hindsight_recall to search and hindsight_reflect for synthesis. Memory writes are disabled."
+            )
         if self._memory_mode == "context":
             return (
                 f"# Hindsight Memory\n"
@@ -1352,10 +1393,14 @@ class HindsightMemoryProvider(MemoryProvider):
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._memory_mode == "context":
             return []
+        if self._read_only:
+            return [RECALL_SCHEMA, REFLECT_SCHEMA]
         return [RETAIN_SCHEMA, RECALL_SCHEMA, REFLECT_SCHEMA]
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if tool_name == "hindsight_retain":
+            if self._read_only:
+                return tool_error("Hindsight is configured read-only; memory writes are disabled.")
             content = args.get("content", "")
             if not content:
                 return tool_error("Missing required parameter: content")
@@ -1467,8 +1512,9 @@ class HindsightMemoryProvider(MemoryProvider):
 
         # 1. Flush any buffered turns under the OLD identifiers. Snapshot
         # everything before mutating self._* so metadata + tags + doc_id
-        # all reference the old session consistently.
-        if self._session_turns:
+        # all reference the old session consistently. In read-only mode,
+        # memory writes are disabled even for defensive lifecycle flushes.
+        if self._session_turns and not self._read_only:
             old_turns = list(self._session_turns)
             old_session_id = self._session_id
             old_document_id = self._document_id

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -18,6 +18,7 @@ from plugins.memory.hindsight import (
     RECALL_SCHEMA,
     REFLECT_SCHEMA,
     RETAIN_SCHEMA,
+    _as_bool,
     _load_config,
     _build_embedded_profile_env,
     _normalize_retain_tags,
@@ -40,6 +41,7 @@ def _clean_env(monkeypatch):
         "HINDSIGHT_IDLE_TIMEOUT", "HINDSIGHT_LLM_API_KEY",
         "HINDSIGHT_RETAIN_TAGS", "HINDSIGHT_RETAIN_SOURCE",
         "HINDSIGHT_RETAIN_USER_PREFIX", "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
+        "HINDSIGHT_READ_ONLY",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -182,6 +184,11 @@ class TestSchemas:
         p = provider_with_config(memory_mode="context")
         assert p.get_tool_schemas() == []
 
+    def test_read_only_mode_returns_recall_and_reflect_only(self, provider_with_config):
+        p = provider_with_config(read_only=True)
+        names = [s["name"] for s in p.get_tool_schemas()]
+        assert names == ["hindsight_recall", "hindsight_reflect"]
+
 
 # ---------------------------------------------------------------------------
 # Config tests
@@ -190,6 +197,7 @@ class TestSchemas:
 
 class TestConfig:
     def test_default_values(self, provider):
+        assert provider._read_only is False
         assert provider._auto_retain is True
         assert provider._auto_recall is True
         assert provider._retain_every_n_turns == 1
@@ -253,6 +261,37 @@ class TestConfig:
         assert cfg["apiKey"] == "env-key"
         assert cfg["banks"]["hermes"]["bankId"] == "env-bank"
         assert cfg["banks"]["hermes"]["budget"] == "high"
+
+    def test_config_from_env_includes_read_only(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home",
+            lambda: tmp_path / "nonexistent",
+        )
+        monkeypatch.setenv("HINDSIGHT_READ_ONLY", "true")
+
+        cfg = _load_config()
+        assert cfg["read_only"] == "true"
+
+    def test_as_bool_parses_config_strings_safely(self):
+        assert _as_bool("true") is True
+        assert _as_bool("1") is True
+        assert _as_bool("yes") is True
+        assert _as_bool("false", default=True) is False
+        assert _as_bool("0", default=True) is False
+        assert _as_bool("", default=True) is False
+        assert _as_bool("not-a-bool", default=True) is True
+
+    def test_read_only_forces_auto_retain_off(self, provider_with_config):
+        p = provider_with_config(read_only=True, auto_retain=True, auto_recall=True)
+        assert p._read_only is True
+        assert p._auto_retain is False
+        assert p._auto_recall is True
+
+    def test_read_only_config_accepts_string_values(self, provider_with_config):
+        p = provider_with_config(read_only="true", auto_retain="true", auto_recall="false")
+        assert p._read_only is True
+        assert p._auto_retain is False
+        assert p._auto_recall is False
 
     def test_embedded_profile_env_includes_idle_timeout_from_config(self):
         env = _build_embedded_profile_env({
@@ -474,6 +513,14 @@ class TestToolHandlers:
             "hindsight_retain", {}
         ))
         assert "error" in result
+
+    def test_read_only_blocks_direct_retain_tool_call(self, provider_with_config):
+        p = provider_with_config(read_only=True)
+        result = json.loads(p.handle_tool_call(
+            "hindsight_retain", {"content": "must not be stored"}
+        ))
+        assert result["error"] == "Hindsight is configured read-only; memory writes are disabled."
+        p._client.aretain.assert_not_called()
 
     def test_recall_success(self, provider):
         result = json.loads(provider.handle_tool_call(
@@ -703,6 +750,12 @@ class TestSyncTurn:
 
     def test_sync_turn_skipped_when_auto_retain_off(self, provider_with_config):
         p = provider_with_config(auto_retain=False)
+        p.sync_turn("hello", "hi")
+        assert p._sync_thread is None
+        p._client.aretain_batch.assert_not_called()
+
+    def test_sync_turn_skipped_when_read_only(self, provider_with_config):
+        p = provider_with_config(read_only=True, auto_retain=True)
         p.sync_turn("hello", "hi")
         assert p._sync_thread is None
         p._client.aretain_batch.assert_not_called()
@@ -972,6 +1025,26 @@ class TestSessionSwitchBufferFlush:
         assert p._document_id != old_doc
         assert p._document_id.startswith("new-sid-")
 
+    def test_read_only_switch_does_not_flush_buffered_turns(self, provider_with_config):
+        p = provider_with_config(read_only=True, auto_retain=True, retain_every_n_turns=3)
+        old_doc = p._document_id
+
+        p._session_turns = [
+            [
+                {"role": "user", "content": "must not flush"},
+                {"role": "assistant", "content": "still must not flush"},
+            ]
+        ]
+        p._turn_counter = 1
+
+        p.on_session_switch("new-sid", parent_session_id="test-session", reset=True)
+        p._retain_queue.join()
+
+        p._client.aretain_batch.assert_not_called()
+        assert p._session_id == "new-sid"
+        assert p._session_turns == []
+        assert p._document_id != old_doc
+
     def test_no_flush_when_buffer_empty(self, provider):
         """Switch with no buffered turns must not fire a spurious retain."""
         provider.on_session_switch("new-sid")
@@ -1096,6 +1169,22 @@ class TestSystemPrompt:
         assert "tools mode" in block
         assert "hindsight_recall" in block
 
+    def test_read_only_prompt_does_not_advertise_retain(self, provider_with_config):
+        p = provider_with_config(read_only=True)
+        block = p.system_prompt_block()
+        assert "read-only mode" in block
+        assert "hindsight_recall" in block
+        assert "hindsight_reflect" in block
+        assert "hindsight_retain" not in block
+        assert "Memory writes are disabled" in block
+
+    def test_read_only_context_prompt_mentions_disabled_writes_without_tools(self, provider_with_config):
+        p = provider_with_config(read_only=True, memory_mode="context")
+        block = p.system_prompt_block()
+        assert "read-only context mode" in block
+        assert "hindsight_recall" not in block
+        assert "Memory writes are disabled" in block
+
 
 # ---------------------------------------------------------------------------
 # Config schema tests
@@ -1110,7 +1199,7 @@ class TestConfigSchema:
             "mode", "api_url", "api_key", "llm_provider", "llm_api_key",
             "llm_model", "bank_id", "bank_id_template", "bank_mission", "bank_retain_mission",
             "recall_budget", "memory_mode", "recall_prefetch_method",
-            "retain_tags", "retain_source",
+            "read_only", "retain_tags", "retain_source",
             "retain_user_prefix", "retain_assistant_prefix",
             "recall_tags", "recall_tags_match",
             "auto_recall", "auto_retain",


### PR DESCRIPTION
## Summary

Adds an explicit read-only mode to the Hindsight memory provider.

When enabled, Hindsight can still recall and reflect, but all write paths are blocked. That includes the public tool surface, direct retain tool calls, automatic turn retention, prompt wording, and session-switch buffer flushes.

## Validation

```text
python -m compileall plugins/memory/hindsight tests/plugins/memory/test_hindsight_provider.py
python -m pytest tests/plugins/memory/test_hindsight_provider.py -q
python -m pytest tests/plugins/memory -q
git diff --check
```

The provider was also smoke-tested against a local-external Hindsight API in read-only mode: recall worked, retain returned a read-only error, and sync_turn did not start a writer.
