### PR TITLE
fix(hindsight): propagate embedded embeddings config

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -329,6 +329,25 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
     if current_base_url:
         env_values["HINDSIGHT_API_LLM_BASE_URL"] = str(current_base_url)
 
+    # Propagate daemon-side embedding config. The embedded Hindsight API runs
+    # in a separate process and only sees its profile .env; keeping these only
+    # in Hermes' JSON config makes the daemon silently fall back to local BGE.
+    env_key_map = {
+        "embeddings_provider": "HINDSIGHT_API_EMBEDDINGS_PROVIDER",
+        "embeddings_local_model": "HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL",
+        "embeddings_local_force_cpu": "HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU",
+        "embeddings_local_trust_remote_code": "HINDSIGHT_API_EMBEDDINGS_LOCAL_TRUST_REMOTE_CODE",
+        "embeddings_tei_url": "HINDSIGHT_API_EMBEDDINGS_TEI_URL",
+        "embeddings_openai_api_key": "HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY",
+        "embeddings_openai_model": "HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL",
+        "embeddings_openai_base_url": "HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL",
+        "embeddings_openai_batch_size": "HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE",
+    }
+    for config_key, env_key in env_key_map.items():
+        value = config.get(config_key)
+        if value is not None and value != "":
+            env_values[env_key] = str(value)
+
     idle_timeout = (
         config.get("idle_timeout")
         if config.get("idle_timeout") is not None

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -273,6 +273,23 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
+    def test_embedded_profile_env_propagates_embeddings_config(self):
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "embeddings_provider": "openai",
+            "embeddings_openai_api_key": "embed-key",
+            "embeddings_openai_model": "mistral/mistral-embed",
+            "embeddings_openai_base_url": "http://localhost:20128/v1",
+            "embeddings_openai_batch_size": 32,
+        })
+
+        assert env["HINDSIGHT_API_EMBEDDINGS_PROVIDER"] == "openai"
+        assert env["HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY"] == "embed-key"
+        assert env["HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL"] == "mistral/mistral-embed"
+        assert env["HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL"] == "http://localhost:20128/v1"
+        assert env["HINDSIGHT_API_EMBEDDINGS_OPENAI_BATCH_SIZE"] == "32"
+
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}
 


### PR DESCRIPTION
## Summary
- Propagate embedded Hindsight embedding settings into the generated daemon profile env.
- Cover OpenAI-compatible, TEI, and local embedding config keys.
- Add a regression test for the embedded profile env builder.

## Why
The embedded Hindsight API runs as a separate process and reads the generated profile `.env`. If embedding settings stay only in the Hermes plugin config, the daemon can silently fall back to its local default embedding provider even when Hermes is configured to use a custom provider/model/base URL.

This makes local embedded Hindsight setups harder to diagnose, especially when using OpenAI-compatible embedding endpoints.

## Test Plan
- `python -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='`
