### PR TITLE
fix(tui): bound virtual history offset searches

### DIFF
--- a/ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts
+++ b/ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts
@@ -1,0 +1,119 @@
+import { Box, renderSync, ScrollBox, Text, type ScrollBoxHandle } from '@hermes/ink'
+import React, { useLayoutEffect, useRef } from 'react'
+import { PassThrough } from 'stream'
+import { describe, expect, it } from 'vitest'
+
+import { useVirtualHistory } from '../hooks/useVirtualHistory.js'
+
+interface Item {
+  height: number
+  key: string
+}
+
+interface Exposed {
+  scroll: ScrollBoxHandle | null
+  virtualHistory: ReturnType<typeof useVirtualHistory>
+}
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+const makeStreams = () => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 20 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', () => {})
+
+  return { stderr, stdin, stdout }
+}
+
+const mountedSpan = (items: readonly Item[], virtualHistory: ReturnType<typeof useVirtualHistory>) => {
+  let height = 0
+
+  for (let index = virtualHistory.start; index < virtualHistory.end; index++) {
+    height += items[index]?.height ?? 0
+  }
+
+  return { bottom: virtualHistory.topSpacer + height, top: virtualHistory.topSpacer }
+}
+
+const viewportIsMounted = (items: readonly Item[], virtualHistory: ReturnType<typeof useVirtualHistory>, scroll: ScrollBoxHandle) => {
+  const span = mountedSpan(items, virtualHistory)
+  const top = scroll.getScrollTop()
+  const bottom = top + scroll.getViewportHeight()
+
+  return top >= span.top && bottom <= span.bottom
+}
+
+function Harness({ expose, items }: { expose: React.MutableRefObject<Exposed | null>; items: readonly Item[] }) {
+  const scrollRef = useRef<ScrollBoxHandle | null>(null)
+  const virtualHistory = useVirtualHistory(scrollRef, items, 80, {
+    coldStartCount: 16,
+    estimateHeight: index => items[index]?.height ?? 1,
+    maxMounted: 16,
+    overscan: 2
+  })
+
+  useLayoutEffect(() => {
+    expose.current = { scroll: scrollRef.current, virtualHistory }
+  })
+
+  return React.createElement(
+    ScrollBox,
+    { flexDirection: 'column', height: 10, ref: scrollRef, stickyScroll: true },
+    React.createElement(
+      Box,
+      { flexDirection: 'column', width: '100%' },
+      virtualHistory.topSpacer > 0 ? React.createElement(Box, { height: virtualHistory.topSpacer }) : null,
+      ...items
+        .slice(virtualHistory.start, virtualHistory.end)
+        .map(item =>
+          React.createElement(
+            Box,
+            { height: item.height, key: item.key, ref: virtualHistory.measureRef(item.key) },
+            React.createElement(Text, null, item.key)
+          )
+        ),
+      virtualHistory.bottomSpacer > 0 ? React.createElement(Box, { height: virtualHistory.bottomSpacer }) : null
+    )
+  )
+}
+
+describe('useVirtualHistory offset cache reuse', () => {
+  it('ignores stale reused offset-array entries after the item count shrinks', async () => {
+    const beforeShrink = Array.from({ length: 1400 }, (_, index) => ({ height: 1, key: `old${index}` }))
+    const afterShrink = Array.from({ length: 800 }, (_, index) => ({ height: 7, key: `new${index}` }))
+    const expose = { current: null as Exposed | null }
+    const streams = makeStreams()
+    const instance = renderSync(React.createElement(Harness, { expose, items: beforeShrink }), {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    })
+
+    try {
+      await delay(20)
+      instance.rerender(React.createElement(Harness, { expose, items: afterShrink }))
+      await delay(20)
+
+      const scroll = expose.current!.scroll!
+      const transcriptHeight = expose.current!.virtualHistory.offsets[afterShrink.length] ?? 0
+
+      expect(transcriptHeight).toBe(5600)
+      expect(scroll.getScrollTop()).toBe(transcriptHeight - scroll.getViewportHeight())
+
+      scroll.scrollBy(-1)
+      await delay(80)
+
+      expect(scroll.getPendingDelta()).toBe(0)
+      expect(viewportIsMounted(afterShrink, expose.current!.virtualHistory, scroll)).toBe(true)
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+})

--- a/ui-tui/src/hooks/useVirtualHistory.ts
+++ b/ui-tui/src/hooks/useVirtualHistory.ts
@@ -51,9 +51,9 @@ const SLIDE_STEP = 12
 
 const NOOP = () => {}
 
-const upperBound = (arr: ArrayLike<number>, target: number) => {
+const upperBound = (arr: ArrayLike<number>, target: number, length = arr.length) => {
   let lo = 0
-  let hi = arr.length
+  let hi = length
 
   while (lo < hi) {
     const mid = (lo + hi) >> 1
@@ -282,8 +282,8 @@ export function useVirtualHistory(
 
       // Binary search — offsets is monotone. Linear walk was O(n) at n=10k+,
       // ~2ms per render during scroll.
-      start = Math.max(0, Math.min(n - 1, upperBound(offsets, lo) - 1))
-      end = Math.max(start + 1, Math.min(n, upperBound(offsets, hi)))
+      start = Math.max(0, Math.min(n - 1, upperBound(offsets, lo, n + 1) - 1))
+      end = Math.max(start + 1, Math.min(n, upperBound(offsets, hi, n + 1)))
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes TUI transcript blanking caused by virtual-history offset cache reuse after history capping.

`useVirtualHistory` reuses a `Float64Array` for virtual row offsets. When the active transcript item count shrinks, stale offsets beyond the active `n + 1` window can remain in the reusable backing array. The mounted-range binary searches were searching the full backing length, so stale offsets could push range selection beyond the active transcript and clamp the mounted range to the final/tail row.

This bounds the virtual-history binary searches to the active offsets window so stale backing-array entries cannot affect mounted range selection after `MAX_HISTORY` capping.

## Related Issue

Fixes #19944

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `ui-tui/src/hooks/useVirtualHistory.ts`
  - Adds an active-length bound to `upperBound()`.
  - Searches only the active `n + 1` offsets when calculating the mounted start/end range.
  - Prevents stale entries in a reused offset buffer from selecting a tail-only mounted range after history capping.
- `ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts`
  - Adds a regression covering reuse of a larger offset buffer after the active item count shrinks.
  - Verifies scrolling upward after the shrink keeps the viewport covered by mounted virtual rows.

## How to Test

```bash
pytest tests/ -v
scripts/run_tests.sh
npm --prefix ui-tui test -- src/__tests__/virtualHistoryOffsetCache.test.ts src/__tests__/virtualHistoryClamp.test.ts src/__tests__/useVirtualHistoryHeights.test.ts
npm --prefix ui-tui run type-check
npm --prefix ui-tui run build
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full test suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux
