### PR TITLE
fix(title-gen): increase max_tokens for reasoning model compatibility

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -57,7 +57,7 @@ def generate_title(
         response = call_llm(
             task="title_generation",
             messages=messages,
-            max_tokens=500,
+            max_tokens=2000,
             temperature=0.3,
             timeout=timeout,
             main_runtime=main_runtime,
@@ -70,6 +70,8 @@ def generate_title(
         # Enforce reasonable length
         if len(title) > 80:
             title = title[:77] + "..."
+        if not title:
+            logger.warning("Title generation returned empty content (reasoning model may have exhausted token budget)")
         return title if title else None
     except Exception as e:
         # Log at WARNING so this shows up in agent.log without debug mode.


### PR DESCRIPTION
## Summary

Fixes #20305 — Session auto-title generation silently fails with reasoning models.

## Problem

Reasoning-capable LLMs (DeepSeek V4 Flash, Claude with thinking, QwQ, etc.) output a `reasoning_content` block before the actual response content. With only 500 tokens budgeted in `generate_title()`, these models exhaust the entire budget on reasoning alone, producing `finish_reason='length'` and empty `content`. The function strips the empty string and returns `None` — leaving session titles as NULL with no log warning.

## Changes

- **`agent/title_generator.py`**: Increase `max_tokens` from `500` to `2000` to provide enough headroom for the reasoning phase while still being lightweight for cost/latency
- Add a `WARNING`-level log message when title generation returns empty content, making the previously silent failure path visible in `agent.log`

## Testing

- All 21 existing `title_gen` tests pass (`pytest -k title_gen`: 21 passed, 4 skipped)
- The title itself is only 3–7 words, so 2000 tokens is generous but ensures reasoning models can complete both their thinking and the actual output

## Risk

Minimal — only affects the token budget for a fire-and-forget background task. No behavioral change for non-reasoning models (they don't use the extra headroom).