### PR TITLE
fix(state): use session_ prefix in _remove_session_files for .json cleanup

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli.timeouts import get_provider_request_timeout
+from hermes_state_common import safe_session_filename_component
 from agent.message_sanitization import (
     _FULL_ARGS_LOG_BOUND,
     coalesce_tool_call_id,
@@ -2102,7 +2103,7 @@ def dump_api_request_debug(
         # Sanitize the session ID into a traversal-free path segment — it can
         # originate from untrusted input (X-Hermes-Session-Id header), and an
         # unsanitized "../"-shaped ID would write the dump outside logs_dir.
-        safe_sid = _ra()._safe_session_filename_component(agent.session_id)
+        safe_sid = safe_session_filename_component(agent.session_id)
         dump_file = agent.logs_dir / f"request_dump_{safe_sid}_{timestamp}.json"
 
         # Redact secrets before persisting/printing. This dump captures the

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2014,19 +2014,21 @@ class SessionDB:
     def _remove_session_files(sessions_dir: Optional[Path], session_id: str) -> None:
         """Remove on-disk transcript files for a session.
 
-        Cleans up ``session_{session_id}.json``, ``{session_id}.jsonl``, and
-        any ``request_dump_{session_id}_*.json`` files left by the gateway.
-        Silently skips files that don't exist and swallows OSError so a
-        filesystem hiccup never blocks a DB operation.
+        Cleans up ``session_{session_id}.json`` (new), legacy ``{session_id}.json``,
+        ``{session_id}.jsonl``, and any ``request_dump_{session_id}_*.json`` files left
+        by the gateway. Silently skips files that don't exist and swallows OSError
+        so a filesystem hiccup never blocks a DB operation.
         """
         if sessions_dir is None:
             return
         # The per-session JSON dump is written with a ``session_`` prefix
-        # (see run_agent.py session_log_file), while the .jsonl transcript
-        # uses the bare session id as its filename stem.
+        # (see run_agent.py session_log_file). Older sessions may have the
+        # legacy bare-{id}.json naming. The .jsonl transcript uses the bare
+        # session id as its filename stem.
         candidates = [
-            sessions_dir / f"session_{session_id}.json",
-            sessions_dir / f"{session_id}.jsonl",
+            sessions_dir / f"session_{session_id}.json",  # new naming (run_agent.py)
+            sessions_dir / f"{session_id}.json",  # legacy naming (backward compat)
+            sessions_dir / f"{session_id}.jsonl",  # transcript
         ]
         for p in candidates:
             try:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2014,15 +2014,21 @@ class SessionDB:
     def _remove_session_files(sessions_dir: Optional[Path], session_id: str) -> None:
         """Remove on-disk transcript files for a session.
 
-        Cleans up ``{session_id}.json``, ``{session_id}.jsonl``, and any
-        ``request_dump_{session_id}_*.json`` files left by the gateway.
+        Cleans up ``session_{session_id}.json``, ``{session_id}.jsonl``, and
+        any ``request_dump_{session_id}_*.json`` files left by the gateway.
         Silently skips files that don't exist and swallows OSError so a
         filesystem hiccup never blocks a DB operation.
         """
         if sessions_dir is None:
             return
-        for suffix in (".json", ".jsonl"):
-            p = sessions_dir / f"{session_id}{suffix}"
+        # The per-session JSON dump is written with a ``session_`` prefix
+        # (see run_agent.py session_log_file), while the .jsonl transcript
+        # uses the bare session id as its filename stem.
+        candidates = [
+            sessions_dir / f"session_{session_id}.json",
+            sessions_dir / f"{session_id}.jsonl",
+        ]
+        for p in candidates:
             try:
                 p.unlink(missing_ok=True)
             except OSError:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -18,6 +18,7 @@ import asyncio
 import atexit
 import contextlib
 import errno
+import glob
 import hashlib
 import json
 import logging
@@ -75,6 +76,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _sql_session_last_active,
     _sql_session_last_active_by_id,
     escape_like as _escape_like,
+    safe_session_filename_component as _safe_session_filename_component,
     DEFERRED_INDEX_SQL,
     FTS_CJK_STALE_KEY,
     FTS_REBUILD_DEFERRAL_KEY,
@@ -13441,32 +13443,44 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
     @staticmethod
     def _remove_session_files(sessions_dir: Optional[Path], session_id: str) -> None:
-        """Remove on-disk transcript files for a session.
+        """Remove on-disk artifact files a session may own under *sessions_dir*.
 
-        Cleans up ``session_{session_id}.json`` (new), legacy ``{session_id}.json``,
-        ``{session_id}.jsonl``, and any ``request_dump_{session_id}_*.json`` files left
-        by the gateway. Silently skips files that don't exist and swallows OSError
-        so a filesystem hiccup never blocks a DB operation.
+        Writers name artifacts with the shared path-safe session component
+        (:func:`hermes_state_common.safe_session_filename_component`):
+        snapshots as ``session_{safe}.json`` (run_agent) and gateway request
+        dumps as ``request_dump_{safe}_{timestamp}.json``. Legacy layouts
+        used the bare ID (``{id}.json`` / ``{id}.jsonl``); those names are
+        honored only when the raw ID is itself a validated single component,
+        so a path- or glob-shaped ID can never alias and remove another
+        session's files. Silently skips files that don't exist and swallows
+        OSError so a filesystem hiccup never blocks a DB operation.
         """
         if sessions_dir is None:
             return
-        # The per-session JSON dump is written with a ``session_`` prefix
-        # (see run_agent.py session_log_file). Older sessions may have the
-        # legacy bare-{id}.json naming. The .jsonl transcript uses the bare
-        # session id as its filename stem.
+        raw = str(session_id or "").strip()
+        safe_sid = _safe_session_filename_component(raw)
         candidates = [
-            sessions_dir / f"session_{session_id}.json",  # new naming (run_agent.py)
-            sessions_dir / f"{session_id}.json",  # legacy naming (backward compat)
-            sessions_dir / f"{session_id}.jsonl",  # transcript
+            sessions_dir / f"session_{safe_sid}.json",  # snapshot writer
         ]
+        if raw and safe_sid == raw:
+            # The raw ID survived sanitization unchanged, i.e. it is already
+            # a single traversal-free component, so the legacy bare-ID names
+            # are safe to touch. For any ID that had to be sanitized, its
+            # legacy files (if any) never existed under a raw-concatenated
+            # name reachable here — guessing at one could hit another
+            # session's files (``./victim`` aliasing ``victim.json``).
+            candidates.append(sessions_dir / f"{raw}.json")  # legacy snapshot
+            candidates.append(sessions_dir / f"{raw}.jsonl")  # legacy transcript
         for p in candidates:
             try:
                 p.unlink(missing_ok=True)
             except OSError:
                 pass
-        # request_dump files use session_id as a prefix component
+        # request_dump files embed the safe component as a prefix segment;
+        # glob.escape is defence-in-depth so metacharacters can never widen
+        # the match even if the component rule ever changes.
         try:
-            for p in sessions_dir.glob(f"request_dump_{session_id}_*.json"):
+            for p in sessions_dir.glob(f"request_dump_{glob.escape(safe_sid)}_*.json"):
                 try:
                     p.unlink(missing_ok=True)
                 except OSError:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -13443,19 +13443,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def _remove_session_files(sessions_dir: Optional[Path], session_id: str) -> None:
         """Remove on-disk transcript files for a session.
 
-        Cleans up ``session_{session_id}.json``, ``{session_id}.jsonl``, and
-        any ``request_dump_{session_id}_*.json`` files left by the gateway.
-        Silently skips files that don't exist and swallows OSError so a
-        filesystem hiccup never blocks a DB operation.
+        Cleans up ``session_{session_id}.json`` (new), legacy ``{session_id}.json``,
+        ``{session_id}.jsonl``, and any ``request_dump_{session_id}_*.json`` files left
+        by the gateway. Silently skips files that don't exist and swallows OSError
+        so a filesystem hiccup never blocks a DB operation.
         """
         if sessions_dir is None:
             return
         # The per-session JSON dump is written with a ``session_`` prefix
-        # (see run_agent.py session_log_file), while the .jsonl transcript
-        # uses the bare session id as its filename stem.
+        # (see run_agent.py session_log_file). Older sessions may have the
+        # legacy bare-{id}.json naming. The .jsonl transcript uses the bare
+        # session id as its filename stem.
         candidates = [
-            sessions_dir / f"session_{session_id}.json",
-            sessions_dir / f"{session_id}.jsonl",
+            sessions_dir / f"session_{session_id}.json",  # new naming (run_agent.py)
+            sessions_dir / f"{session_id}.json",  # legacy naming (backward compat)
+            sessions_dir / f"{session_id}.jsonl",  # transcript
         ]
         for p in candidates:
             try:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -13443,15 +13443,21 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def _remove_session_files(sessions_dir: Optional[Path], session_id: str) -> None:
         """Remove on-disk transcript files for a session.
 
-        Cleans up ``{session_id}.json``, ``{session_id}.jsonl``, and any
-        ``request_dump_{session_id}_*.json`` files left by the gateway.
+        Cleans up ``session_{session_id}.json``, ``{session_id}.jsonl``, and
+        any ``request_dump_{session_id}_*.json`` files left by the gateway.
         Silently skips files that don't exist and swallows OSError so a
         filesystem hiccup never blocks a DB operation.
         """
         if sessions_dir is None:
             return
-        for suffix in (".json", ".jsonl"):
-            p = sessions_dir / f"{session_id}{suffix}"
+        # The per-session JSON dump is written with a ``session_`` prefix
+        # (see run_agent.py session_log_file), while the .jsonl transcript
+        # uses the bare session id as its filename stem.
+        candidates = [
+            sessions_dir / f"session_{session_id}.json",
+            sessions_dir / f"{session_id}.jsonl",
+        ]
+        for p in candidates:
             try:
                 p.unlink(missing_ok=True)
             except OSError:

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -7,8 +7,10 @@ hermes_state re-imports every name here for backward compatibility.
 """
 
 import contextlib
+import hashlib
 import logging
 import os
+import re
 import sys
 import time
 from typing import Any
@@ -56,6 +58,33 @@ def escape_like(text: str) -> str:
     silently widen.
     """
     return text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def safe_session_filename_component(session_id: str) -> str:
+    """Return a stable, path-safe filename component for a session ID.
+
+    Shared by every on-disk session-artifact surface so writers and cleanup
+    agree on one naming contract. Session IDs can originate from untrusted
+    input (e.g. the ``X-Hermes-Session-Id`` API header) and are otherwise
+    interpolated raw into on-disk artifact filenames under
+    ``~/.hermes/sessions/``.  Without sanitization, a traversal-shaped ID
+    such as ``../../../../etc/pwned`` would let a caller write (or remove)
+    the session snapshot / request dump outside the sessions directory.
+    This collapses every non ``[A-Za-z0-9_-]`` character to ``_`` (so no
+    path separators or ``.`` survive), caps the length, and — when
+    sanitization changed the string — appends a short content hash so two
+    distinct IDs that sanitize to the same component don't collide.  The
+    result is always a single, traversal-free path segment.
+    """
+    raw = str(session_id or "").strip()
+    sanitized = re.sub(r"[^\w-]", "_", raw).strip("._")
+    sanitized = sanitized[:96] or "session"
+    if raw and sanitized == raw:
+        return sanitized
+    digest = hashlib.sha256(
+        raw.encode("utf-8", errors="surrogatepass")
+    ).hexdigest()[:12]
+    return f"{sanitized}_{digest}"
 
 
 _PREVIEW_CONTENT_SQL = "REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' ')"

--- a/run_agent.py
+++ b/run_agent.py
@@ -64,6 +64,9 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from hermes_constants import get_hermes_home
+from hermes_state_common import (
+    safe_session_filename_component as _safe_session_filename_component,
+)
 
 
 def _launch_cwd_for_session(source: str) -> Optional[str]:
@@ -353,31 +356,6 @@ def _qwen_portal_headers() -> dict:
         "X-DashScope-UserAgent": _ua,
         "X-DashScope-AuthType": "qwen-oauth",
     }
-
-
-def _safe_session_filename_component(session_id: str) -> str:
-    """Return a stable, path-safe filename component for a session ID.
-
-    Session IDs can originate from untrusted input (e.g. the
-    ``X-Hermes-Session-Id`` API header) and are otherwise interpolated raw
-    into on-disk artifact filenames under ``~/.hermes/sessions/``.  Without
-    sanitization, a traversal-shaped ID such as ``../../../../etc/pwned``
-    would let a caller write the session snapshot / request dump outside the
-    sessions directory.  This collapses every non ``[A-Za-z0-9_-]`` character
-    to ``_`` (so no path separators or ``.`` survive), caps the length, and —
-    when sanitization changed the string — appends a short content hash so two
-    distinct IDs that sanitize to the same component don't collide.  The
-    result is always a single, traversal-free path segment.
-    """
-    raw = str(session_id or "").strip()
-    sanitized = re.sub(r"[^\w-]", "_", raw).strip("._")
-    sanitized = sanitized[:96] or "session"
-    if raw and sanitized == raw:
-        return sanitized
-    digest = hashlib.sha256(
-        raw.encode("utf-8", errors="surrogatepass")
-    ).hexdigest()[:12]
-    return f"{sanitized}_{digest}"
 
 
 class _StreamErrorEvent(Exception):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2670,7 +2670,8 @@ class TestAutoMaintenance:
         db.create_session(session_id="new", source="cli")  # active
 
         # Transcript files mimicking real gateway/CLI layout
-        (sessions_dir / "session_old1.json").write_text("{}")
+        (sessions_dir / "session_old1.json").write_text("{}")  # new naming
+        (sessions_dir / "old2.json").write_text("{}")  # legacy naming
         (sessions_dir / "old1.jsonl").write_text("{}\n")
         (sessions_dir / "old2.jsonl").write_text("{}\n")
         (sessions_dir / "request_dump_old1_001.json").write_text("{}")
@@ -2681,8 +2682,9 @@ class TestAutoMaintenance:
         )
         assert result["pruned"] == 2
 
-        # Pruned transcript files are gone
+        # Pruned transcript files are gone (both new and legacy JSON naming)
         assert not (sessions_dir / "session_old1.json").exists()
+        assert not (sessions_dir / "old2.json").exists()
         assert not (sessions_dir / "old1.jsonl").exists()
         assert not (sessions_dir / "old2.jsonl").exists()
         assert not (sessions_dir / "request_dump_old1_001.json").exists()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2670,7 +2670,7 @@ class TestAutoMaintenance:
         db.create_session(session_id="new", source="cli")  # active
 
         # Transcript files mimicking real gateway/CLI layout
-        (sessions_dir / "old1.json").write_text("{}")
+        (sessions_dir / "session_old1.json").write_text("{}")
         (sessions_dir / "old1.jsonl").write_text("{}\n")
         (sessions_dir / "old2.jsonl").write_text("{}\n")
         (sessions_dir / "request_dump_old1_001.json").write_text("{}")
@@ -2682,7 +2682,7 @@ class TestAutoMaintenance:
         assert result["pruned"] == 2
 
         # Pruned transcript files are gone
-        assert not (sessions_dir / "old1.json").exists()
+        assert not (sessions_dir / "session_old1.json").exists()
         assert not (sessions_dir / "old1.jsonl").exists()
         assert not (sessions_dir / "old2.jsonl").exists()
         assert not (sessions_dir / "request_dump_old1_001.json").exists()
@@ -2714,6 +2714,40 @@ class TestAutoMaintenance:
         assert count == 1
         assert not (sessions_dir / "old.jsonl").exists()
         assert (sessions_dir / "active.jsonl").exists()
+
+    def test_delete_session_removes_session_prefixed_json(self, db, tmp_path):
+        """Regression: session_<id>.json must be cleaned up on delete.
+
+        The writer (run_agent.py) creates ``session_{id}.json`` but the
+        remover previously looked for ``{id}.json`` (missing the ``session_``
+        prefix), silently leaving the JSON dump orphaned on disk.
+        """
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        db.create_session(session_id="test123", source="cli")
+        # Writer creates session_<id>.json (not <id>.json)
+        json_file = sessions_dir / "session_test123.json"
+        json_file.write_text("{}")
+        jsonl_file = sessions_dir / "test123.jsonl"
+        jsonl_file.write_text("{}\n")
+
+        db.delete_session("test123", sessions_dir=sessions_dir)
+
+        assert not json_file.exists(), "session_<id>.json should be removed"
+        assert not jsonl_file.exists(), "<id>.jsonl should be removed"
+
+    def test_prune_removes_session_prefixed_json(self, db, tmp_path):
+        """Regression: prune must also clean up session_<id>.json files."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        self._make_old_ended(db, "old", days_old=100)
+        (sessions_dir / "session_old.json").write_text("{}")
+        (sessions_dir / "old.jsonl").write_text("{}\n")
+
+        db.prune_sessions(older_than_days=90, sessions_dir=sessions_dir)
+
+        assert not (sessions_dir / "session_old.json").exists()
+        assert not (sessions_dir / "old.jsonl").exists()
 
 
 # =========================================================================

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3148,7 +3148,8 @@ class TestAutoMaintenance:
         db.create_session(session_id="new", source="cli")  # active
 
         # Transcript files mimicking real gateway/CLI layout
-        (sessions_dir / "session_old1.json").write_text("{}")
+        (sessions_dir / "session_old1.json").write_text("{}")  # new naming
+        (sessions_dir / "old2.json").write_text("{}")  # legacy naming
         (sessions_dir / "old1.jsonl").write_text("{}\n")
         (sessions_dir / "old2.jsonl").write_text("{}\n")
         (sessions_dir / "request_dump_old1_001.json").write_text("{}")
@@ -3159,8 +3160,9 @@ class TestAutoMaintenance:
         )
         assert result["pruned"] == 2
 
-        # Pruned transcript files are gone
+        # Pruned transcript files are gone (both new and legacy JSON naming)
         assert not (sessions_dir / "session_old1.json").exists()
+        assert not (sessions_dir / "old2.json").exists()
         assert not (sessions_dir / "old1.jsonl").exists()
         assert not (sessions_dir / "old2.jsonl").exists()
         assert not (sessions_dir / "request_dump_old1_001.json").exists()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3148,7 +3148,7 @@ class TestAutoMaintenance:
         db.create_session(session_id="new", source="cli")  # active
 
         # Transcript files mimicking real gateway/CLI layout
-        (sessions_dir / "old1.json").write_text("{}")
+        (sessions_dir / "session_old1.json").write_text("{}")
         (sessions_dir / "old1.jsonl").write_text("{}\n")
         (sessions_dir / "old2.jsonl").write_text("{}\n")
         (sessions_dir / "request_dump_old1_001.json").write_text("{}")
@@ -3160,7 +3160,7 @@ class TestAutoMaintenance:
         assert result["pruned"] == 2
 
         # Pruned transcript files are gone
-        assert not (sessions_dir / "old1.json").exists()
+        assert not (sessions_dir / "session_old1.json").exists()
         assert not (sessions_dir / "old1.jsonl").exists()
         assert not (sessions_dir / "old2.jsonl").exists()
         assert not (sessions_dir / "request_dump_old1_001.json").exists()
@@ -3169,6 +3169,40 @@ class TestAutoMaintenance:
 
 
 
+
+    def test_delete_session_removes_session_prefixed_json(self, db, tmp_path):
+        """Regression: session_<id>.json must be cleaned up on delete.
+
+        The writer (run_agent.py) creates ``session_{id}.json`` but the
+        remover previously looked for ``{id}.json`` (missing the ``session_``
+        prefix), silently leaving the JSON dump orphaned on disk.
+        """
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        db.create_session(session_id="test123", source="cli")
+        # Writer creates session_<id>.json (not <id>.json)
+        json_file = sessions_dir / "session_test123.json"
+        json_file.write_text("{}")
+        jsonl_file = sessions_dir / "test123.jsonl"
+        jsonl_file.write_text("{}\n")
+
+        db.delete_session("test123", sessions_dir=sessions_dir)
+
+        assert not json_file.exists(), "session_<id>.json should be removed"
+        assert not jsonl_file.exists(), "<id>.jsonl should be removed"
+
+    def test_prune_removes_session_prefixed_json(self, db, tmp_path):
+        """Regression: prune must also clean up session_<id>.json files."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        self._make_old_ended(db, "old", days_old=100)
+        (sessions_dir / "session_old.json").write_text("{}")
+        (sessions_dir / "old.jsonl").write_text("{}\n")
+
+        db.prune_sessions(older_than_days=90, sessions_dir=sessions_dir)
+
+        assert not (sessions_dir / "session_old.json").exists()
+        assert not (sessions_dir / "old.jsonl").exists()
 
 
 # =========================================================================

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -12,6 +12,7 @@ import pytest
 import hermes_state
 from agent.session_activity import ActivityProvenance
 from hermes_state import SCHEMA_SQL, SCHEMA_VERSION, SessionDB
+from hermes_state_common import safe_session_filename_component
 
 
 class _NoFtsCursor(sqlite3.Cursor):
@@ -3205,6 +3206,143 @@ class TestAutoMaintenance:
 
         assert not (sessions_dir / "session_old.json").exists()
         assert not (sessions_dir / "old.jsonl").exists()
+
+    def test_delete_session_uses_shared_safe_component_mapping(self, db, tmp_path):
+        """Remover and writers must agree on one safe-component naming contract.
+
+        Snapshots are ``session_{safe}.json`` and request dumps
+        ``request_dump_{safe}_{ts}.json`` — both derived from the shared
+        ``hermes_state_common.safe_session_filename_component`` mapper.
+        Legacy bare-{id} names stay covered for ordinary IDs.
+        """
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        sid = "test123"
+        safe = safe_session_filename_component(sid)
+        assert safe == sid  # an ordinary ID passes through unchanged
+        db.create_session(session_id=sid, source="cli")
+
+        (sessions_dir / f"session_{safe}.json").write_text("{}")
+        (sessions_dir / f"request_dump_{safe}_001.json").write_text("{}")
+        (sessions_dir / f"{sid}.json").write_text("{}")  # legacy snapshot
+        (sessions_dir / f"{sid}.jsonl").write_text("{}\n")  # legacy transcript
+        (sessions_dir / "other.jsonl").write_text("{}\n")  # another session
+
+        assert db.delete_session(sid, sessions_dir=sessions_dir) is True
+
+        assert not (sessions_dir / f"session_{safe}.json").exists()
+        assert not (sessions_dir / f"request_dump_{safe}_001.json").exists()
+        assert not (sessions_dir / f"{sid}.json").exists()
+        assert not (sessions_dir / f"{sid}.jsonl").exists()
+        assert (sessions_dir / "other.jsonl").exists()
+
+    def test_delete_session_path_shaped_id_cannot_alias_other_session_files(
+        self, db, tmp_path
+    ):
+        """A traversal-shaped ID must never reach another session's files.
+
+        ``./victim`` used to be concatenated raw, aliasing
+        ``sessions/./victim.json`` onto session ``victim``'s legacy file
+        while leaving the path-shaped session's own safe-mapped artifacts
+        behind.
+        """
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        malicious = "./victim"
+        db.create_session(session_id=malicious, source="cli")
+        safe = safe_session_filename_component(malicious)
+        assert safe != malicious
+        assert "/" not in safe and "." not in safe
+
+        # Files the path-shaped session's own writers would have produced
+        (sessions_dir / f"session_{safe}.json").write_text("{}")
+        (sessions_dir / f"request_dump_{safe}_001.json").write_text("{}")
+        # Files belonging to the *other* session ("victim") — must survive
+        (sessions_dir / "victim.json").write_text("{}")
+        (sessions_dir / "victim.jsonl").write_text("{}\n")
+        (sessions_dir / "session_victim.json").write_text("{}")
+        (sessions_dir / "request_dump_victim_001.json").write_text("{}")
+
+        assert db.delete_session(malicious, sessions_dir=sessions_dir) is True
+
+        assert not (sessions_dir / f"session_{safe}.json").exists()
+        assert not (sessions_dir / f"request_dump_{safe}_001.json").exists()
+        assert (sessions_dir / "victim.json").exists()
+        assert (sessions_dir / "victim.jsonl").exists()
+        assert (sessions_dir / "session_victim.json").exists()
+        assert (sessions_dir / "request_dump_victim_001.json").exists()
+
+    def test_delete_session_parent_traversal_id_cannot_escape(self, db, tmp_path):
+        """``../victim`` must neither escape the directory nor alias inside it."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        malicious = "../victim"
+        db.create_session(session_id=malicious, source="cli")
+        safe = safe_session_filename_component(malicious)
+
+        # Where a raw ``../victim.json`` concatenation would have landed
+        (tmp_path / "victim.json").write_text("{}")
+        (sessions_dir / "victim.json").write_text("{}")
+        (sessions_dir / f"session_{safe}.json").write_text("{}")
+
+        assert db.delete_session(malicious, sessions_dir=sessions_dir) is True
+
+        assert (tmp_path / "victim.json").exists()  # no parent-directory escape
+        assert (sessions_dir / "victim.json").exists()  # no in-directory alias
+        assert not (sessions_dir / f"session_{safe}.json").exists()
+
+    def test_delete_session_glob_shaped_id_cannot_widen_request_dump_glob(
+        self, db, tmp_path
+    ):
+        """``a*b`` must not glob-match another session's request dumps.
+
+        The sanitizer maps ``a*b`` to ``a_b_<digest>``, so two distinct IDs
+        that normalize similarly keep disjoint file sets.
+        """
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        globby = "a*b"
+        db.create_session(session_id=globby, source="cli")
+        safe = safe_session_filename_component(globby)
+        assert safe.startswith("a_b_")  # sanitized stem + digest suffix
+
+        (sessions_dir / f"request_dump_{safe}_001.json").write_text("{}")
+        # Session "a_b"'s files — a raw-ID glob ``request_dump_a*b_*.json``
+        # would have swallowed these
+        (sessions_dir / "request_dump_a_b_001.json").write_text("{}")
+        (sessions_dir / "request_dump_aXb_002.json").write_text("{}")
+        (sessions_dir / "session_a_b.json").write_text("{}")
+
+        assert db.delete_session(globby, sessions_dir=sessions_dir) is True
+
+        assert not (sessions_dir / f"request_dump_{safe}_001.json").exists()
+        assert (sessions_dir / "request_dump_a_b_001.json").exists()
+        assert (sessions_dir / "request_dump_aXb_002.json").exists()
+        assert (sessions_dir / "session_a_b.json").exists()
+
+    def test_prune_uses_safe_component_mapping(self, db, tmp_path):
+        """Prune shares the hardened mapping: safe-mapped files go, a
+        similarly-normalizing neighbor's files stay."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        shaped = "old./x"
+        self._make_old_ended(db, shaped, days_old=100)
+        safe = safe_session_filename_component(shaped)
+        # "old./x" sanitizes to "old__x" + digest; plain session "old__x"
+        # normalizes to itself, so the two must not collide.
+        assert safe.startswith("old__x_")
+
+        (sessions_dir / f"session_{safe}.json").write_text("{}")
+        (sessions_dir / f"request_dump_{safe}_001.json").write_text("{}")
+        (sessions_dir / "session_old__x.json").write_text("{}")
+        (sessions_dir / "request_dump_old__x_001.json").write_text("{}")
+
+        db.prune_sessions(older_than_days=90, sessions_dir=sessions_dir)
+
+        assert not (sessions_dir / f"session_{safe}.json").exists()
+        assert not (sessions_dir / f"request_dump_{safe}_001.json").exists()
+        assert (sessions_dir / "session_old__x.json").exists()
+        assert (sessions_dir / "request_dump_old__x_001.json").exists()
 
 
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?
`hermes sessions delete` and `hermes sessions prune` remove the SQLite row, the `.jsonl` transcript, and `request_dump_*` files — but silently leave the per-session `session_<id>.json` dump orphaned on disk.

### Root Cause

**Filename prefix mismatch between writer and remover:**

- **Writer** (`run_agent.py:1666`, `cli.py:5305`): creates `session_{session_id}.json`
- **Remover** (`hermes_state.py::_remove_session_files`): looked for `{session_id}.json` (no `session_` prefix)

`Path.unlink(missing_ok=True)` swallowed the "file not found" error, so the orphan accumulated silently.

On a real system with 2400+ sessions, this means ~2400 orphaned `session_*.json` files never get cleaned up.

## Related Issue

Fixes #20334

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A