### PR TITLE
fix(cron): pass arguments to job scripts

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1378,6 +1378,13 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     )
                 updated["next_run_at"] = next_run
 
+            # Validate the fully merged job at the data-layer chokepoint so
+            # direct callers, the model tool, and dashboard updates cannot
+            # bypass the lifecycle guard by changing only prompt or script.
+            from cron.lifecycle_guard import check_gateway_lifecycle
+
+            check_gateway_lifecycle(updated.get("prompt"), updated.get("script"))
+
             jobs[i] = updated
             save_jobs(jobs)
             return _normalize_job_record(jobs[i])

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -37,6 +37,8 @@ import re
 from pathlib import Path
 from typing import Optional
 
+from cron.script_command import parse_script_command
+
 
 class GatewayLifecycleBlocked(ValueError):
     """Raised when a cron job spec contains a gateway-lifecycle command."""
@@ -73,7 +75,7 @@ def contains_gateway_lifecycle_command(text: str) -> bool:
     return bool(_GATEWAY_LIFECYCLE_PATTERN.search(text))
 
 
-def _resolve_script_path(script_path: str) -> Path:
+def _resolve_script_path(script_command: str) -> Path:
     """Resolve a cron ``script`` value the same way the scheduler does.
 
     The scheduler (``cron.scheduler``) resolves a bare/relative script path
@@ -86,10 +88,15 @@ def _resolve_script_path(script_path: str) -> Path:
     """
     from hermes_constants import get_hermes_home
 
-    raw = Path(script_path).expanduser()
+    scripts_dir = get_hermes_home() / "scripts"
+    try:
+        executable, _argv = parse_script_command(script_command, scripts_dir)
+    except ValueError as exc:
+        raise ValueError(f"Invalid script command: {exc}") from exc
+    raw = Path(executable).expanduser()
     if raw.is_absolute():
         return raw
-    return get_hermes_home() / "scripts" / raw
+    return scripts_dir / raw
 
 
 def _read_script_for_scanning(script_path: str) -> str:
@@ -107,6 +114,24 @@ def _read_script_for_scanning(script_path: str) -> str:
         )
     except OSError:
         return ""
+
+
+def _script_command_for_scanning(script_command: str) -> str:
+    """Return parsed executable and argv as command-shaped text.
+
+    A generic dispatcher such as ``exec \"$@\"`` is safe only if its arguments
+    are safe. Scanning the file alone would let
+    ``dispatch.sh hermes gateway restart`` bypass the lifecycle guard.
+    """
+    from hermes_constants import get_hermes_home
+
+    try:
+        executable, argv = parse_script_command(
+            script_command, get_hermes_home() / "scripts"
+        )
+    except ValueError as exc:
+        raise ValueError(f"Invalid script command: {exc}") from exc
+    return " ".join((Path(executable).name, *argv))
 
 
 def check_gateway_lifecycle(
@@ -127,9 +152,9 @@ def check_gateway_lifecycle(
     """
     combined = prompt or ""
     if script:
+        command_text = _script_command_for_scanning(script)
         script_text = _read_script_for_scanning(script)
-        if script_text:
-            combined = f"{combined}\n{script_text}"
+        combined = f"{combined}\n{command_text}\n{script_text}"
 
     if contains_gateway_lifecycle_command(combined):
         raise GatewayLifecycleBlocked(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -39,6 +39,7 @@ from typing import Any, List, Optional
 # the module) fail with ModuleNotFoundError for hermes_time et al.
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from cron.script_command import parse_script_command
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import load_config, _expand_env_vars
@@ -2034,9 +2035,10 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     (SECURITY.md §2.3), matching terminal and MCP child processes.
 
     Args:
-        script_path: Path to the script.  Relative paths are resolved
-            against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
-            are also validated to ensure they stay within the scripts dir.
+        script_path: Path to the script, optionally followed by CLI arguments.
+            Relative paths are resolved against HERMES_HOME/scripts/.
+            Absolute and ~-prefixed paths are also validated to ensure they stay
+            within the scripts dir.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -2046,7 +2048,12 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     scripts_dir.mkdir(parents=True, exist_ok=True)
     scripts_dir_resolved = scripts_dir.resolve()
 
-    raw = Path(script_path).expanduser()
+    try:
+        executable, script_args = parse_script_command(script_path, scripts_dir)
+    except ValueError as exc:
+        return False, f"Invalid script command: {exc}"
+
+    raw = Path(executable).expanduser()
     if raw.is_absolute():
         path = raw.resolve()
     else:
@@ -2089,9 +2096,9 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
             )
-        argv = [_bash, str(path)]
+        argv = [_bash, str(path), *script_args]
     else:
-        argv = [sys.executable, str(path)]
+        argv = [sys.executable, str(path), *script_args]
 
     try:
         from tools.environments.local import _sanitize_subprocess_env

--- a/cron/script_command.py
+++ b/cron/script_command.py
@@ -1,0 +1,103 @@
+"""Parsing helpers for cron script command strings."""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _split_windows_command_line(command: str) -> list[str]:
+    """Parse the quoting emitted by ``subprocess.list2cmdline`` into argv."""
+    args: list[str] = []
+    length = len(command)
+    index = 0
+    while index < length:
+        while index < length and command[index] in " \t":
+            index += 1
+        if index >= length:
+            break
+
+        arg: list[str] = []
+        in_quotes = False
+        while index < length:
+            if command[index] in " \t" and not in_quotes:
+                break
+            if command[index] == "\\":
+                start = index
+                while index < length and command[index] == "\\":
+                    index += 1
+                backslashes = index - start
+                if index < length and command[index] == '"':
+                    arg.extend("\\" * (backslashes // 2))
+                    if backslashes % 2:
+                        arg.append('"')
+                    else:
+                        in_quotes = not in_quotes
+                    index += 1
+                else:
+                    arg.extend("\\" * backslashes)
+                continue
+            if command[index] == '"':
+                in_quotes = not in_quotes
+                index += 1
+                continue
+            arg.append(command[index])
+            index += 1
+
+        if in_quotes:
+            raise ValueError("No closing quotation")
+        args.append("".join(arg))
+        while index < length and command[index] in " \t":
+            index += 1
+    return args
+
+
+def parse_script_command(
+    script_command: str,
+    scripts_dir: Path | None = None,
+) -> tuple[str, list[str]]:
+    """Split a cron script command into its executable path and arguments.
+
+    Existing literal filenames are checked first to preserve legacy jobs whose
+    paths contain unquoted spaces. Otherwise the command is split without ever
+    invoking a shell. Windows uses its native argv quoting rules so backslashes
+    and embedded apostrophes survive a format/parse round trip.
+    """
+    text = script_command.strip()
+    if scripts_dir is not None and text:
+        root = scripts_dir.expanduser().resolve()
+        raw_literal = Path(text).expanduser()
+        literal = (
+            raw_literal.resolve()
+            if raw_literal.is_absolute()
+            else (root / raw_literal).resolve()
+        )
+        try:
+            literal.relative_to(root)
+        except ValueError:
+            pass
+        else:
+            if literal.is_file():
+                return text, []
+
+    try:
+        parts = (
+            _split_windows_command_line(text)
+            if sys.platform == "win32"
+            else shlex.split(text, posix=True)
+        )
+    except ValueError as exc:
+        raise ValueError(f"invalid script command: {exc}") from exc
+    if not parts:
+        raise ValueError("empty script path")
+    return parts[0], parts[1:]
+
+
+def format_script_command(executable: str, args: list[str]) -> str:
+    """Return a stable shell-free storage representation of an argv list."""
+    argv = [executable, *args]
+    if sys.platform == "win32":
+        return subprocess.list2cmdline(argv)
+    return shlex.join(argv)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -52,6 +52,7 @@ PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from cron.script_command import format_script_command, parse_script_command
 from hermes_cli import __version__, __release_date__
 from hermes_cli.config import (
     cfg_get,
@@ -10137,7 +10138,13 @@ def _normalize_dashboard_cron_script(value: Any, profile_home: Path) -> Optional
         return None
 
     scripts_root = (profile_home / "scripts").resolve()
-    raw_path = Path(text).expanduser()
+    try:
+        executable, script_args = parse_script_command(text, scripts_root)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400, detail=f"invalid script command: {exc}"
+        ) from exc
+    raw_path = Path(executable).expanduser()
     candidate = raw_path.resolve() if raw_path.is_absolute() else (scripts_root / raw_path).resolve()
     try:
         relative = candidate.relative_to(scripts_root)
@@ -10150,7 +10157,7 @@ def _normalize_dashboard_cron_script(value: Any, profile_home: Path) -> Optional
         raise HTTPException(status_code=400, detail=f"script does not exist: {candidate}")
     if not candidate.is_file():
         raise HTTPException(status_code=400, detail=f"script is not a file: {candidate}")
-    return str(relative)
+    return format_script_command(str(relative), script_args)
 
 
 def _validate_dashboard_cron_effective_job(job: Dict[str, Any]) -> None:

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -211,6 +211,67 @@ class TestRunJobScript:
         parsed = json.loads(output)
         assert parsed["new_prs"][0]["number"] == 42
 
+    def test_script_relative_path_with_arguments(self, cron_env):
+        """Cron scripts preserve quoted paths and CLI arguments."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "args file.py"
+        script.write_text(textwrap.dedent("""\
+            import sys
+            print("|".join(sys.argv[1:]))
+        """))
+
+        success, output = _run_job_script(
+            '"args file.py" expire "check only"'
+        )
+        assert success is True
+        assert output == "expire|check only"
+
+    def test_legacy_unquoted_script_path_with_spaces(self, cron_env):
+        """An existing legacy filename containing spaces is not split into argv."""
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "legacy report.py"
+        script.write_text("import sys\nprint(len(sys.argv) - 1)\n")
+
+        success, output = _run_job_script("legacy report.py")
+
+        assert success is True
+        assert output == "0"
+
+
+class TestParseScriptCommand:
+    def test_windows_backslashes_are_preserved(self, monkeypatch):
+        from cron import script_command
+
+        monkeypatch.setattr(script_command.sys, "platform", "win32")
+
+        executable, args = script_command.parse_script_command(
+            'C:\\Users\\alice\\job.py --mode "full scan"'
+        )
+
+        assert executable == r"C:\Users\alice\job.py"
+        assert args == ["--mode", "full scan"]
+
+    def test_unbalanced_quotes_raise_clean_error(self):
+        from cron.script_command import parse_script_command
+
+        with pytest.raises(ValueError, match="invalid script command"):
+            parse_script_command('\"broken.py --flag')
+
+    def test_windows_format_round_trips_argv_without_a_shell(self, monkeypatch):
+        from cron import script_command
+
+        monkeypatch.setattr(script_command.sys, "platform", "win32")
+        expected = (
+            r"C:\Program Files\Hermes\job.py",
+            ["O'Brien", r"C:\reports\weekly scan.json", "say \"hello\"", ""],
+        )
+
+        stored = script_command.format_script_command(expected[0], expected[1])
+
+        assert script_command.parse_script_command(stored) == expected
+
 
 class TestBuildJobPromptWithScript:
     """Test that script output is injected into the prompt."""

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -166,6 +166,33 @@ class TestCronCreateLifecycleBlock:
         out = capsys.readouterr().out
         assert "Blocked" in out
 
+    def test_block_lifecycle_command_passed_through_script_arguments(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        scripts_dir = tmp_path / ".hermes" / "scripts"
+        scripts_dir.mkdir(parents=True)
+        (scripts_dir / "dispatch.sh").write_text(
+            '#!/bin/bash\n"$@"\n', encoding="utf-8"
+        )
+        args = Namespace(
+            cron_command="create",
+            schedule="1h",
+            prompt=None,
+            name=None,
+            deliver=None,
+            repeat=None,
+            skill=None,
+            skills=None,
+            script="dispatch.sh hermes gateway restart",
+            workdir=None,
+            profile=None,
+            no_agent=True,
+        )
+
+        assert cron_command(args) == 1
+        assert "Blocked" in capsys.readouterr().out
+
     def test_allow_safe_prompt(self, capsys):
         args = Namespace(
             cron_command="create",
@@ -464,6 +491,36 @@ class TestCreateJobBlocksLifecycleCommands:
         with pytest.raises(GatewayLifecycleBlocked):
             create_job(prompt="then run hermes gateway restart", schedule="30m")
 
+    def test_create_job_blocks_argument_bearing_lifecycle_script(
+        self, tmp_path, monkeypatch
+    ):
+        """The guard scans the executable, not the full script command string."""
+        from cron.jobs import create_job
+        from cron.lifecycle_guard import GatewayLifecycleBlocked
+
+        hermes_home = tmp_path / ".hermes"
+        scripts_dir = hermes_home / "scripts"
+        scripts_dir.mkdir(parents=True)
+        (scripts_dir / "restart script.sh").write_text("hermes gateway restart\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with pytest.raises(GatewayLifecycleBlocked):
+            create_job(
+                prompt="daily ops",
+                schedule="30m",
+                script='"restart script.sh" --flag',
+            )
+
+    def test_create_job_reports_unbalanced_script_quotes(self):
+        from cron.jobs import create_job
+
+        with pytest.raises(ValueError, match="Invalid script command"):
+            create_job(
+                prompt="daily ops",
+                schedule="30m",
+                script='"broken.py --flag',
+            )
+
     def test_create_job_allows_benign_prompt(self):
         from cron.jobs import create_job
         job = create_job(prompt="summarize the API gateway logs and note restart events",
@@ -482,6 +539,61 @@ class TestCreateJobBlocksLifecycleCommands:
         ))
         assert result.get("success") is False
         assert "#30719" in result.get("error", "")
+
+
+class TestUpdateJobBlocksLifecycleCommands:
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        scripts_dir = hermes_home / "scripts"
+        scripts_dir.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("cron.jobs.CRON_DIR", hermes_home / "cron")
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", hermes_home / "cron" / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", hermes_home / "cron" / "output")
+        self.scripts_dir = scripts_dir
+
+    def test_update_prompt_checks_effective_existing_script_before_save(self):
+        from cron.jobs import create_job, get_job, update_job
+        from cron.lifecycle_guard import GatewayLifecycleBlocked
+
+        script = self.scripts_dir / "ops.sh"
+        script.write_text("echo safe\n")
+        job = create_job(prompt="daily ops", schedule="30m", script="ops.sh")
+        script.write_text("hermes gateway restart\n")
+
+        with pytest.raises(GatewayLifecycleBlocked):
+            update_job(job["id"], {"prompt": "updated daily ops"})
+
+        assert get_job(job["id"])["prompt"] == "daily ops"
+
+    def test_update_script_checks_effective_prompt_before_save(self):
+        from cron.jobs import create_job, get_job, update_job
+        from cron.lifecycle_guard import GatewayLifecycleBlocked
+
+        script = self.scripts_dir / "restart.sh"
+        script.write_text("hermes gateway restart\n")
+        job = create_job(prompt="daily ops", schedule="30m")
+
+        with pytest.raises(GatewayLifecycleBlocked):
+            update_job(job["id"], {"script": "restart.sh"})
+
+        assert get_job(job["id"]).get("script") is None
+
+    def test_cronjob_tool_update_surfaces_script_block(self):
+        from cron.jobs import create_job
+        from tools.cronjob_tools import cronjob
+
+        script = self.scripts_dir / "restart.sh"
+        script.write_text("hermes gateway restart\n")
+        job = create_job(prompt="daily ops", schedule="30m")
+
+        result = json.loads(
+            cronjob(action="update", job_id=job["id"], script="restart.sh")
+        )
+
+        assert result["success"] is False
+        assert "#30719" in result["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -391,6 +391,65 @@ async def test_update_cron_job_normalizes_dashboard_core_fields(isolated_profile
 
 
 @pytest.mark.asyncio
+async def test_create_cron_job_preserves_dashboard_script_arguments(isolated_profiles):
+    from hermes_cli import web_server
+
+    scripts_dir = isolated_profiles["worker_alpha"] / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "collect report.py").write_text("print('ok')\n", encoding="utf-8")
+
+    created = await web_server.create_cron_job(
+        web_server.CronJobCreate(
+            schedule="every 1h",
+            script='"collect report.py" --mode "full scan"',
+            no_agent=True,
+        ),
+        profile="worker_alpha",
+    )
+
+    from cron.script_command import parse_script_command
+
+    assert parse_script_command(created["script"]) == (
+        "collect report.py",
+        ["--mode", "full scan"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_cron_job_checks_effective_script_lifecycle_guard(
+    isolated_profiles,
+):
+    from hermes_cli import web_server
+
+    scripts_dir = isolated_profiles["worker_alpha"] / "scripts"
+    scripts_dir.mkdir()
+    script = scripts_dir / "ops.sh"
+    script.write_text("echo safe\n", encoding="utf-8")
+    job = web_server._call_cron_for_profile(
+        "worker_alpha",
+        "create_job",
+        prompt="daily ops",
+        schedule="every 1h",
+        script="ops.sh",
+    )
+    script.write_text("hermes gateway restart\n", encoding="utf-8")
+
+    with pytest.raises(HTTPException) as exc:
+        await web_server.update_cron_job(
+            job["id"],
+            web_server.CronJobUpdate(updates={"prompt": "updated daily ops"}),
+            profile="worker_alpha",
+        )
+
+    assert exc.value.status_code == 400
+    assert "#30719" in exc.value.detail
+    unchanged = web_server._call_cron_for_profile(
+        "worker_alpha", "get_job", job["id"]
+    )
+    assert unchanged["prompt"] == "daily ops"
+
+
+@pytest.mark.asyncio
 async def test_create_cron_job_rejects_script_outside_profile_scripts(
     isolated_profiles, tmp_path
 ):

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -5,9 +5,17 @@ import pytest
 
 from tools.cronjob_tools import (
     _scan_cron_prompt,
+    _validate_cron_script_path,
     check_cronjob_requirements,
     cronjob,
 )
+
+
+def test_validate_cron_script_path_rejects_quoted_absolute_executable():
+    error = _validate_cron_script_path('"/tmp/outside script.py" --flag')
+
+    assert error is not None
+    assert "must be relative" in error
 
 
 # =========================================================================

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -33,6 +33,7 @@ from cron.jobs import (
     resume_job,
     update_job,
 )
+from cron.script_command import parse_script_command
 
 
 def _notify_provider_jobs_changed_safe() -> None:
@@ -539,7 +540,12 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
 
     from hermes_constants import get_hermes_home
 
-    raw = script.strip()
+    scripts_dir = get_hermes_home() / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        raw, _args = parse_script_command(script, scripts_dir)
+    except ValueError as exc:
+        return f"Invalid script command: {exc}"
 
     # Reject absolute paths and ~ expansion at the API boundary.
     # Only relative paths within ~/.hermes/scripts/ are allowed.
@@ -553,8 +559,6 @@ def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     # Validate containment after resolution
     from tools.path_security import validate_within_dir
 
-    scripts_dir = get_hermes_home() / "scripts"
-    scripts_dir.mkdir(parents=True, exist_ok=True)
     containment_error = validate_within_dir(scripts_dir / raw, scripts_dir)
     if containment_error:
         return (


### PR DESCRIPTION
## Summary

- Parse cron `script` commands into an executable plus arguments without invoking a shell.
- Pass arguments to both Python and bash scripts while keeping the executable inside `HERMES_HOME/scripts/`.
- Preserve legacy jobs whose existing unquoted filenames contain spaces.
- Preserve Windows backslashes and quoted Windows arguments.
- Use the same shared parser in scheduler execution, lifecycle-guard scanning, agent/tool validation, and dashboard validation.
- Let the dashboard accept valid script arguments while validating the parsed executable against the selected profile’s scripts sandbox.

## Why

Cron scripts are stored as one string, so values such as `memory-ttl.py expire` or `monitor.py --check-only` are natural. Previously the whole string was interpreted as the filename. A naive `shlex.split()` fix would break existing unquoted filenames with spaces, Windows paths, lifecycle-guard file inspection, and dashboard/tool validation. The shared parser keeps those paths aligned.

## Security model

- No shell is invoked; execution remains an explicit argv list.
- Only the parsed executable path is resolved and sandboxed; arguments cannot bypass path containment.
- Symlink/path-traversal escape remains blocked by resolved-path containment.
- The Gateway lifecycle guard reads the same executable file the scheduler will run.
- Provider credentials remain removed from the script subprocess environment and output redaction remains unchanged.

## Validation

Fresh validation on rebased head `f8cf9f62780a` (`main` base `c44de9985`):

```text
Cron/Gateway/web/tool suites: 852 passed
Ruff: passed
py_compile: passed
Windows footgun scan: 758 files, no findings
git diff --check: passed
```

Regression coverage includes quoted paths/arguments, existing unquoted filenames with spaces, Windows backslashes, malformed quotes, lifecycle-guard executable resolution, agent/tool validation, dashboard profile sandboxing, and Python/bash argv propagation.

GitHub checks: 23 success, 7 skipped, 1 neutral, no failures or pending checks.

Closes #20300.
