### PR TITLE
fix(acp): drop shadowing import json in build_tool_start (#20250)

### DIFF
--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -1123,7 +1123,14 @@ def build_tool_start(
         )
 
     # Generic fallback
-    import json
+    # NOTE: Do not re-import json here. ``json`` is already imported at module
+    # scope (see top of file). A function-scope ``import json`` would make
+    # ``json`` a local in this entire function, which then shadows the
+    # module-level binding for *every* reference -- including the
+    # ``json.dumps`` call inside the ``_POLISHED_TOOLS`` branch above. That
+    # raises ``UnboundLocalError`` for any polished tool that isn't matched
+    # by an earlier specific branch (discord, kanban_*, ha_*, browser_*,
+    # feishu_*, yb_*, etc.). See issue #20250.
     try:
         args_text = json.dumps(arguments, indent=2, default=str)
     except (TypeError, ValueError):

--- a/tests/acp/test_tools.py
+++ b/tests/acp/test_tools.py
@@ -264,6 +264,46 @@ class TestBuildToolStart:
         assert isinstance(result, ToolCallStart)
         assert result.kind == "other"
 
+    @pytest.mark.parametrize(
+        "tool_name",
+        [
+            # Tools listed in _POLISHED_TOOLS that have no dedicated
+            # branch in build_tool_start and previously fell through to the
+            # generic-fallback branch. A function-scope ``import json`` in
+            # that branch caused ``json`` to be treated as a local for the
+            # entire function, raising UnboundLocalError on the json.dumps
+            # call inside the _POLISHED_TOOLS branch above. Issue #20250.
+            "discord",
+            "discord_admin",
+            "kanban_create",
+            "kanban_show",
+            "kanban_block",
+            "kanban_heartbeat",
+            "ha_get_state",
+            "ha_call_service",
+            "browser_navigate",
+            "browser_click",
+            "browser_snapshot",
+            "feishu_doc_read",
+            "yb_send_dm",
+            "yb_query_group_info",
+            "mixture_of_agents",
+            "send_message",
+            "cronjob",
+            "vision_analyze",
+            "image_generate",
+            "text_to_speech",
+        ],
+    )
+    def test_build_tool_start_polished_tool_does_not_raise_unbound_local(self, tool_name):
+        """Polished tools that fall through to the generic branch must not
+        trigger UnboundLocalError on ``json`` — regression for issue #20250.
+        """
+        result = build_tool_start("tc-poli", tool_name, {"foo": "bar"})
+        assert isinstance(result, ToolCallStart)
+        # Polished tools should suppress raw_input.
+        assert result.raw_input is None
+
 
 # ---------------------------------------------------------------------------
 # build_tool_complete


### PR DESCRIPTION
## Summary

- The generic-fallback branch of `acp_adapter.tools.build_tool_start` had a function-scope `import json` even though `json` is imported at module scope. Python treats it as a local binding for the entire function body, which made the earlier `json.dumps` call in the `_POLISHED_TOOLS` branch raise `UnboundLocalError` for any polished tool without a dedicated branch.
- Affected tools include `discord`, `discord_admin`, `kanban_*`, `ha_*`, `browser_*` (the ones not given dedicated rendering branches), `feishu_*`, `yb_*`, `vision_analyze`, `image_generate`, `text_to_speech`, `cronjob`, `send_message`, `mixture_of_agents`, `clarify`, etc.
- This matches the secondary error reported in #20250:
  ```
  UnboundLocalError: cannot access local variable 'json' where it is not associated with a value
    File ".../acp_adapter/server.py", line 622, in _replay_session_history
      if not await _send(build_tool_start(tool_call_id, tool_name, args)):
    File ".../acp_adapter/tools.py", line 1128, in build_tool_start
  ```
- Removed the redundant import, kept a comment explaining the foot-gun, and added a parametrized regression test covering 20 affected polished tool names.

Refs #20250 (this is the secondary `build_tool_start` error; the primary lifecycle issue is not addressed here).

## Testing

- `scripts/run_tests.sh tests/acp/test_tools.py::TestBuildToolStart -q`
- `scripts/run_tests.sh tests/acp/test_tools.py -q` (full file)
- Manual repro before fix: `build_tool_start("tc", "discord", {})` → `UnboundLocalError`. After fix: returns a `ToolCallStart`.

## Test output

```
▶ running pytest with 4 workers, hermetic env, in /tmp/hermes-20250a-fix
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)
bringing up nodes...
bringing up nodes...

...............................                                          [100%]
31 passed in 2.48s
```

Full file:
```
........................................................................ [ 96%]
...                                                                      [100%]
75 passed in 2.70s
```