### PR TITLE
fix(acp): accept allow_permanent kwarg in approval callback (#20250)

### DIFF
--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -28,10 +28,16 @@ def make_approval_callback(
     loop: asyncio.AbstractEventLoop,
     session_id: str,
     timeout: float = 60.0,
-) -> Callable[[str, str], str]:
+) -> Callable[..., str]:
     """
-    Return a hermes-compatible ``approval_callback(command, description) -> str``
-    that bridges to the ACP client's ``request_permission`` call.
+    Return a hermes-compatible ``approval_callback`` that bridges to the
+    ACP client's ``request_permission`` call.
+
+    The returned callable matches the signature documented in
+    :func:`tools.approval.prompt_dangerous_approval`:
+    ``(command, description, *, allow_permanent=True) -> str``. When
+    ``allow_permanent`` is ``False`` (e.g. tirith warnings present), the
+    "Allow always" option is suppressed.
 
     Args:
         request_permission_fn: The ACP connection's ``request_permission`` coroutine.
@@ -40,12 +46,18 @@ def make_approval_callback(
         timeout: Seconds to wait for a response before auto-denying.
     """
 
-    def _callback(command: str, description: str) -> str:
+    def _callback(command: str, description: str, *,
+                  allow_permanent: bool = True, **_unused) -> str:
         options = [
             PermissionOption(option_id="allow_once", kind="allow_once", name="Allow once"),
-            PermissionOption(option_id="allow_always", kind="allow_always", name="Allow always"),
-            PermissionOption(option_id="deny", kind="reject_once", name="Deny"),
         ]
+        if allow_permanent:
+            options.append(
+                PermissionOption(option_id="allow_always", kind="allow_always", name="Allow always"),
+            )
+        options.append(
+            PermissionOption(option_id="deny", kind="reject_once", name="Deny"),
+        )
         import acp as _acp
 
         tool_call = _acp.start_tool_call("perm-check", command, kind="execute")

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -87,3 +87,116 @@ class TestApprovalMapping:
             result = cb("echo hi", "demo")
 
         assert result == "deny"
+
+
+class TestApprovalCallbackSignature:
+    """Regression tests for issue #20250 — the callback returned by
+    ``make_approval_callback`` must match the signature documented in
+    :func:`tools.approval.prompt_dangerous_approval`:
+    ``(command, description, *, allow_permanent=True) -> str``.
+
+    Previously, calling the callback with ``allow_permanent`` raised
+    ``TypeError: _callback() got an unexpected keyword argument 'allow_permanent'``,
+    which got swallowed inside ``prompt_dangerous_approval`` and returned
+    "deny" — masking the real bug while leaving the user with no way to
+    approve dangerous commands from VS Code/Zed ACP sessions.
+    """
+
+    def _make_cb_returning_none(self):
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        mock_rp = MagicMock(name="request_permission")
+        future = MagicMock(spec=Future)
+        future.result.return_value = None
+        return loop, mock_rp, future
+
+    def test_callback_accepts_allow_permanent_true_kwarg(self):
+        loop, mock_rp, future = self._make_cb_returning_none()
+        with patch("acp_adapter.permissions.asyncio.run_coroutine_threadsafe", return_value=future):
+            cb = make_approval_callback(mock_rp, loop, session_id="s1", timeout=1.0)
+            # Must not raise TypeError.
+            result = cb("rm -rf /", "dangerous", allow_permanent=True)
+        assert result == "deny"
+
+    def test_callback_accepts_allow_permanent_false_kwarg(self):
+        loop, mock_rp, future = self._make_cb_returning_none()
+        with patch("acp_adapter.permissions.asyncio.run_coroutine_threadsafe", return_value=future):
+            cb = make_approval_callback(mock_rp, loop, session_id="s1", timeout=1.0)
+            result = cb("rm -rf /", "dangerous", allow_permanent=False)
+        assert result == "deny"
+
+    def test_callback_omits_allow_always_when_allow_permanent_false(self):
+        """When allow_permanent=False, the ACP options list must not
+        include the ``allow_always`` option, mirroring the CLI behaviour
+        of suppressing the ``[a]lways`` choice.
+        """
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        mock_rp = MagicMock(name="request_permission")
+        future = MagicMock(spec=Future)
+        future.result.return_value = None
+
+        with patch("acp_adapter.permissions.asyncio.run_coroutine_threadsafe", return_value=future):
+            cb = make_approval_callback(mock_rp, loop, session_id="s1", timeout=1.0)
+            cb("rm -rf /", "dangerous", allow_permanent=False)
+
+        # Inspect the options that were passed to request_permission_fn
+        assert mock_rp.call_count == 1
+        kwargs = mock_rp.call_args.kwargs
+        option_kinds = {opt.kind for opt in kwargs["options"]}
+        assert "allow_always" not in option_kinds
+        # Sanity: still has at least allow_once + reject_once
+        assert "allow_once" in option_kinds
+        assert "reject_once" in option_kinds
+
+    def test_callback_includes_allow_always_when_allow_permanent_true(self):
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        mock_rp = MagicMock(name="request_permission")
+        future = MagicMock(spec=Future)
+        future.result.return_value = None
+
+        with patch("acp_adapter.permissions.asyncio.run_coroutine_threadsafe", return_value=future):
+            cb = make_approval_callback(mock_rp, loop, session_id="s1", timeout=1.0)
+            cb("rm -rf /", "dangerous", allow_permanent=True)
+
+        kwargs = mock_rp.call_args.kwargs
+        option_kinds = {opt.kind for opt in kwargs["options"]}
+        assert "allow_always" in option_kinds
+
+    def test_callback_default_allow_permanent_is_true(self):
+        """When called positionally (no kwarg), behaviour must match
+        ``allow_permanent=True``."""
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        mock_rp = MagicMock(name="request_permission")
+        future = MagicMock(spec=Future)
+        future.result.return_value = None
+
+        with patch("acp_adapter.permissions.asyncio.run_coroutine_threadsafe", return_value=future):
+            cb = make_approval_callback(mock_rp, loop, session_id="s1", timeout=1.0)
+            cb("rm -rf /", "dangerous")
+
+        kwargs = mock_rp.call_args.kwargs
+        option_kinds = {opt.kind for opt in kwargs["options"]}
+        assert "allow_always" in option_kinds
+
+    def test_callback_via_prompt_dangerous_approval_does_not_raise(self):
+        """End-to-end check: routing through prompt_dangerous_approval (which
+        is the real call site that triggered the original error in #20250)
+        must not surface a TypeError from the callback's signature.
+        """
+        from tools.approval import prompt_dangerous_approval
+
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        mock_rp = MagicMock(name="request_permission")
+        future = MagicMock(spec=Future)
+        future.result.return_value = None
+
+        with patch("acp_adapter.permissions.asyncio.run_coroutine_threadsafe", return_value=future):
+            cb = make_approval_callback(mock_rp, loop, session_id="s1", timeout=1.0)
+            result = prompt_dangerous_approval(
+                "rm -rf /",
+                "dangerous",
+                timeout_seconds=1,
+                allow_permanent=False,
+                approval_callback=cb,
+            )
+
+        assert result == "deny"


### PR DESCRIPTION
## Summary

- ``acp_adapter.permissions.make_approval_callback`` returned a callback whose signature was ``(command, description)`` only.
- ``tools.approval.prompt_dangerous_approval`` always invokes its callback with ``allow_permanent=`` (see ``tools/approval.py`` line 596), so the ACP callback raised:
  ```
  TypeError: make_approval_callback.<locals>._callback() got an unexpected keyword argument 'allow_permanent'
  ```
- The error was swallowed inside ``prompt_dangerous_approval`` and converted to a hard "deny", leaving VS Code/Zed ACP users unable to approve any dangerous command and only this log line to point at the cause:
  ```
  Approval callback failed: ... unexpected keyword argument 'allow_permanent'
  ```
- Updates the inner callback to accept ``*, allow_permanent=True`` and to drop the ``allow_always`` option from the ACP options list when ``allow_permanent`` is False (mirrors the CLI's ``[a]lways`` suppression behaviour for tirith-flagged commands).
- Adds 6 regression tests in ``tests/acp/test_permissions.py``.

Refs #20250 (this is the second of two secondary errors reported alongside the prompt-lifecycle issue; the first was the ``UnboundLocalError`` in ``build_tool_start``, addressed separately in #20356).

## Testing

- `scripts/run_tests.sh tests/acp/test_permissions.py -q`
- `scripts/run_tests.sh tests/acp/test_permissions.py::TestApprovalCallbackSignature -q`
- Verified that the new tests fail on ``origin/main`` (TypeError on the kwarg), and pass after the patch.

## Test output

```
▶ running pytest with 4 workers, hermetic env, in /tmp/hermes-20250b-fix
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)
bringing up nodes...
bringing up nodes...

...........                                                              [100%]
11 passed in 2.46s
```