### PR TITLE
feat(tui): remove /provider alias for /model

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -18,14 +18,6 @@ describe('createSlashHandler', () => {
     expect(getOverlayState().picker).toBe(true)
   })
 
-  it('treats /provider as a local /model alias', () => {
-    const ctx = buildCtx()
-
-    expect(createSlashHandler(ctx)('/provider')).toBe(true)
-    expect(getOverlayState().modelPicker).toBe(true)
-    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
-  })
-
   it('keeps typed /model switches session-scoped by default', async () => {
     patchUiState({ sid: 'sid-abc' })
 

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -62,7 +62,6 @@ export const sessionCommands: SlashCommand[] = [
 
   {
     help: 'change or show model',
-    aliases: ['provider'],
     name: 'model',
     run: (arg, ctx) => {
       if (ctx.session.guardBusySessionSwitch('change models')) {

--- a/ui-tui/src/hooks/useCompletion.ts
+++ b/ui-tui/src/hooks/useCompletion.ts
@@ -21,9 +21,9 @@ export function completionRequestForInput(
     return null
   }
 
-  // `/model` / `/provider` use the two-step ModelPicker (real curated IDs).
+  // `/model` uses the two-step ModelPicker (real curated IDs).
   // Slash completion here only showed short aliases + vendor/family meta.
-  if (isSlashCommand && /^\/(?:model|provider)(?:\s|$)/.test(input)) {
+  if (isSlashCommand && /^\/model(?:\s|$)/.test(input)) {
     return null
   }
 


### PR DESCRIPTION
## Summary
Drops the `/provider` slash alias from the TUI. `/model` is the canonical command; `/provider` dispatched to the same ModelPicker overlay, so removing the alias just trims a duplicate.

## Changes
- `ui-tui/src/app/slash/commands/session.ts`: remove `aliases: ['provider']` from the `/model` command
- `ui-tui/src/hooks/useCompletion.ts`: narrow the ModelPicker-bypass regex from `/(model|provider)/` to `/model/`
- `ui-tui/src/__tests__/createSlashHandler.test.ts`: drop the alias-coverage test

## Validation
- `npx vitest run createSlashHandler useCompletion` → 51/51 pass
- Full TUI suite unchanged (same 9 pre-existing terminalSetup failures on main)