### PR TITLE
fix(telegram): reject messages that @mention a different bot in group chats

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2829,17 +2829,35 @@ class TelegramAdapter(BasePlatformAdapter):
         reply_user = getattr(message.reply_to_message, "from_user", None)
         return bool(reply_user and getattr(reply_user, "id", None) == getattr(self._bot, "id", None))
 
-    def _message_mentions_bot(self, message: Message) -> bool:
+    @staticmethod
+    def _iter_entity_sources(message: Message):
+        """Yield (source_text, entities) pairs for text and caption."""
+        yield getattr(message, "text", None) or "", getattr(message, "entities", None) or []
+        yield getattr(message, "caption", None) or "", getattr(message, "caption_entities", None) or []
+
+    def _resolve_entity_targets(self, message: Message) -> tuple:
+        """Scan all entities and return (self_mentioned, other_mentioned, other_command).
+
+        Single-pass analysis of ``mention``, ``text_mention``, and
+        ``bot_command`` entities across both text and caption, resolving
+        whether this bot is mentioned, whether another entity is mentioned,
+        and whether a ``/command@otherbot`` targets a different bot.
+
+        Returns:
+            (self_mentioned, other_mentioned, other_command) — three bools.
+            ``other_command`` is set immediately on the first non-self
+            ``bot_command`` entity (can short-circuit the caller).
+        """
         if not self._bot:
-            return False
+            return (False, False, False)
 
         bot_username = (getattr(self._bot, "username", None) or "").lstrip("@").lower()
         bot_id = getattr(self._bot, "id", None)
         expected = f"@{bot_username}" if bot_username else None
 
-        def _iter_sources():
-            yield getattr(message, "text", None) or "", getattr(message, "entities", None) or []
-            yield getattr(message, "caption", None) or "", getattr(message, "caption_entities", None) or []
+        self_mentioned = False
+        other_mentioned = False
+        other_command = False
 
         # Telegram parses mentions server-side and emits MessageEntity objects
         # (type=mention for @username, type=text_mention for @FirstName targeting
@@ -2847,7 +2865,7 @@ class TelegramAdapter(BasePlatformAdapter):
         # raw substring matches like "foo@hermes_bot.example" are not mentions
         # (bug #12545). Entities also correctly handle @handles inside URLs, code
         # blocks, and quoted text, where a regex scan would over-match.
-        for source_text, entities in _iter_sources():
+        for source_text, entities in self._iter_entity_sources(message):
             for entity in entities:
                 entity_type = str(getattr(entity, "type", "")).split(".")[-1].lower()
                 if entity_type == "mention" and expected:
@@ -2855,22 +2873,25 @@ class TelegramAdapter(BasePlatformAdapter):
                     length = int(getattr(entity, "length", 0))
                     if offset < 0 or length <= 0:
                         continue
-                    if source_text[offset:offset + length].strip().lower() == expected:
-                        return True
+                    mention_text = source_text[offset:offset + length].strip().lower()
+                    if mention_text == expected:
+                        self_mentioned = True
+                    else:
+                        other_mentioned = True
                 elif entity_type == "text_mention":
                     user = getattr(entity, "user", None)
-                    if user and getattr(user, "id", None) == bot_id:
-                        return True
+                    mentioned_id = getattr(user, "id", None) if user else None
+                    if mentioned_id == bot_id:
+                        self_mentioned = True
+                    elif mentioned_id is not None:
+                        other_mentioned = True
                 elif entity_type == "bot_command" and expected:
                     # Telegram's official group-disambiguation form for slash
                     # commands (``/cmd@botname``) is emitted as a single
                     # ``bot_command`` entity covering the whole span — there
-                    # is no accompanying ``mention`` entity. Treat it as a
-                    # direct address to this bot when the ``@botname`` suffix
-                    # matches. This is the form Telegram's own command menu
-                    # autocomplete produces in groups, so dropping it at the
-                    # mention gate would break /new, /reset, /help, ... for
-                    # every group that has ``require_mention`` enabled (#15415).
+                    # is no accompanying ``mention`` entity.  This is the
+                    # form Telegram's own command menu autocomplete produces
+                    # in groups (#15415).
                     offset = int(getattr(entity, "offset", -1))
                     length = int(getattr(entity, "length", 0))
                     if offset < 0 or length <= 0:
@@ -2879,9 +2900,31 @@ class TelegramAdapter(BasePlatformAdapter):
                     at_index = command_text.find("@")
                     if at_index < 0:
                         continue
-                    if command_text[at_index:].strip().lower() == expected:
-                        return True
-        return False
+                    target = command_text[at_index:].strip().lower()
+                    if target == expected:
+                        self_mentioned = True
+                    else:
+                        other_command = True
+
+        return (self_mentioned, other_mentioned, other_command)
+
+    def _message_mentions_bot(self, message: Message) -> bool:
+        """Return True if the message contains an entity targeting this bot."""
+        self_mentioned, _, _ = self._resolve_entity_targets(message)
+        return self_mentioned
+
+    def _message_targets_other_bot(self, message: Message) -> bool:
+        """Return True if the message explicitly targets a *different* entity.
+
+        True when:
+        - a ``/command@otherbot`` targets a different bot (short-circuit), or
+        - a ``@mention`` / ``text_mention`` targets another entity without this
+          bot also being mentioned (multi-mention messages may include us).
+        """
+        self_mentioned, other_mentioned, other_command = self._resolve_entity_targets(message)
+        if other_command:
+            return True
+        return other_mentioned and not self_mentioned
 
     def _message_matches_mention_patterns(self, message: Message) -> bool:
         if not self._mention_patterns:
@@ -2917,6 +2960,12 @@ class TelegramAdapter(BasePlatformAdapter):
         the Telegram bot menu (``/command@botname``) or by explicitly
         mentioning the bot (``@botname /command``), both of which are
         recognised as mentions by :meth:`_message_mentions_bot`.
+
+        Regardless of ``require_mention``, messages that contain a
+        ``/command@otherbot`` entity targeting a different bot, or a ``@mention``
+        entity that targets a different entity without also mentioning this bot,
+        are always rejected.  This prevents every bot in a shared group from
+        responding to a message intended for one specific bot.
         """
         if not self._is_group_chat(message):
             return True
@@ -2929,6 +2978,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 logger.warning("[%s] Ignoring non-numeric Telegram message_thread_id: %r", self.name, thread_id)
         if str(getattr(getattr(message, "chat", None), "id", "")) in self._telegram_free_response_chats():
             return True
+        # Reject messages targeting other bots regardless of require_mention
+        if self._message_targets_other_bot(message):
+            return False
         if not self._telegram_require_mention():
             return True
         if self._is_reply_to_bot(message):

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -330,3 +330,141 @@ def test_config_bridges_telegram_ignored_threads(monkeypatch, tmp_path):
 
     assert config is not None
     assert __import__("os").environ["TELEGRAM_IGNORED_THREADS"] == "31,42"
+
+
+# ---------------------------------------------------------------------------
+# Multi-agent mention filtering — _message_targets_other_bot
+# ---------------------------------------------------------------------------
+
+def test_mention_of_other_bot_rejected_with_require_mention_false():
+    """With require_mention: false, @otherbot messages should be rejected."""
+    adapter = _make_adapter(require_mention=False)
+    text = "@otherbot help"
+    msg = _group_message(text, entities=[_mention_entity(text, "@otherbot")])
+    assert adapter._should_process_message(msg) is False
+
+
+def test_mention_of_other_bot_rejected_with_require_mention_true():
+    """With require_mention: true, @otherbot messages should also be rejected."""
+    adapter = _make_adapter(require_mention=True)
+    text = "@otherbot help"
+    msg = _group_message(text, entities=[_mention_entity(text, "@otherbot")])
+    assert adapter._should_process_message(msg) is False
+
+
+def test_mention_of_self_not_rejected():
+    """@hermes_bot (self) mention should NOT be rejected."""
+    adapter = _make_adapter(require_mention=False)
+    text = "@hermes_bot help"
+    msg = _group_message(text, entities=[_mention_entity(text, "@hermes_bot")])
+    assert adapter._should_process_message(msg) is True
+
+
+def test_mention_of_self_and_other_not_rejected():
+    """When both self and other bot are mentioned, should NOT be rejected."""
+    adapter = _make_adapter(require_mention=False)
+    text = "@hermes_bot @otherbot help"
+    msg = _group_message(
+        text,
+        entities=[
+            _mention_entity(text, "@hermes_bot"),
+            _mention_entity(text, "@otherbot"),
+        ],
+    )
+    assert adapter._should_process_message(msg) is True
+
+
+def test_general_message_no_mentions_accepted_when_no_require_mention():
+    """General messages with no mentions accepted when require_mention: false."""
+    adapter = _make_adapter(require_mention=False)
+    msg = _group_message("hello everyone")
+    assert adapter._should_process_message(msg) is True
+
+
+def test_general_message_no_mentions_rejected_when_require_mention():
+    """General messages with no mentions rejected when require_mention: true."""
+    adapter = _make_adapter(require_mention=True)
+    msg = _group_message("hello everyone")
+    assert adapter._should_process_message(msg) is False
+
+
+def test_mention_of_human_user_rejected():
+    """@mention of a human user should be rejected (targets other entity)."""
+    adapter = _make_adapter(require_mention=False)
+    text = "@john_doe hello"
+    msg = _group_message(text, entities=[_mention_entity(text, "@john_doe")])
+    assert adapter._should_process_message(msg) is False
+
+
+def test_bot_command_targeting_other_bot_rejected():
+    """With require_mention: false, /command@otherbot should be rejected."""
+    adapter = _make_adapter(require_mention=False)
+    text = "/status@other_bot"
+    msg = _group_message(
+        text,
+        entities=[_bot_command_entity(text, "/status@other_bot")],
+    )
+    assert adapter._should_process_message(msg) is False
+
+
+def test_mention_of_other_bot_in_caption():
+    """Mention entities in captions should also trigger filtering."""
+    adapter = _make_adapter(require_mention=False)
+    caption = "@otherbot check this image"
+    msg = SimpleNamespace(
+        text=None,
+        caption=caption,
+        entities=[],
+        caption_entities=[_mention_entity(caption, "@otherbot")],
+        message_thread_id=None,
+        chat=SimpleNamespace(id=-100, type="group"),
+        from_user=SimpleNamespace(id=111),
+        reply_to_message=None,
+    )
+    assert adapter._should_process_message(msg) is False
+
+
+def test_text_mention_of_other_user_rejected():
+    """text_mention entity targeting a different user should be rejected."""
+    adapter = _make_adapter(require_mention=False)
+    msg = SimpleNamespace(
+        text="hello",
+        caption=None,
+        entities=[
+            SimpleNamespace(
+                type="text_mention",
+                offset=0,
+                length=5,
+                user=SimpleNamespace(id=555),  # not bot_id (999)
+            ),
+        ],
+        caption_entities=[],
+        message_thread_id=None,
+        chat=SimpleNamespace(id=-100, type="group"),
+        from_user=SimpleNamespace(id=111),
+        reply_to_message=None,
+    )
+    assert adapter._should_process_message(msg) is False
+
+
+def test_text_mention_of_self_not_rejected():
+    """text_mention entity targeting this bot (by user ID) should NOT be rejected."""
+    adapter = _make_adapter(require_mention=False)
+    msg = SimpleNamespace(
+        text="hello",
+        caption=None,
+        entities=[
+            SimpleNamespace(
+                type="text_mention",
+                offset=0,
+                length=5,
+                user=SimpleNamespace(id=999),  # bot_id
+            ),
+        ],
+        caption_entities=[],
+        message_thread_id=None,
+        chat=SimpleNamespace(id=-100, type="group"),
+        from_user=SimpleNamespace(id=111),
+        reply_to_message=None,
+    )
+    assert adapter._should_process_message(msg) is True


### PR DESCRIPTION
## What does this PR do?

When multiple Hermes bots share a Telegram group and `require_mention: false`, every bot responds to all messages — including messages where a user explicitly `@mentions` a different bot. This adds filtering to reject such messages before processing, achieving parity with the Discord adapter which already handles this correctly.

## Root Cause

The Telegram `_should_process_message()` flow checked `free_response_chats` then `require_mention` — if false, it returned `True` immediately. There was no gate for messages that explicitly target another entity via `@mention` or `text_mention` entities (only `/command@otherbot` was handled).

Additionally, `_message_mentions_bot()` and the new filtering both needed to scan the same entities, causing duplicate iteration when called sequentially from `_should_process_message()`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`gateway/platforms/telegram.py`** — Extract `_iter_entity_sources()` (static) and `_resolve_entity_targets()` (single-pass scanner returning `(self_mentioned, other_mentioned, other_command)`). Refactor `_message_mentions_bot()` to delegate to the shared scanner. Add `_message_targets_other_bot()` that also delegates, positioned in `_should_process_message()` after `free_response_chats` but before `require_mention`.
- **`tests/gateway/test_telegram_group_gating.py`** — 11 new tests covering: @otherbot rejected (require_mention false/true), @self not rejected, @self+@other dual mention not rejected, general messages unchanged, @human_user rejected, /command@otherbot rejected, @otherbot in caption entities, text_mention of other user rejected, text_mention of self not rejected.

### Behavior

| Message | `require_mention: false` | `require_mention: true` |
|---------|--------------------------|-------------------------|
| `hello everyone` | ✅ accepted | ❌ rejected (no mention) |
| `@hermes_bot help` | ✅ accepted | ✅ accepted |
| `@otherbot help` | ❌ **rejected** (new) | ❌ rejected |
| `@hermes_bot @otherbot help` | ✅ accepted (self mentioned) | ✅ accepted |
| `@john_doe hello` | ❌ **rejected** (new) | ❌ rejected |
| `/status@other_bot` | ❌ **rejected** (new) | ❌ rejected |

### Discord Parity

Mirrors the multi-agent filtering in `discord.py` (~L710-730). Telegram does not provide `m.bot` for mention entities, so we use entity text comparison instead.

## How to Test

1. `pytest tests/gateway/test_telegram_group_gating.py -v` — all 25 tests pass (14 existing + 11 new)
2. Manual: deploy two Hermes bots to a shared group with `require_mention: false`. @mention one bot and verify only that bot responds.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: Ubuntu (Linux)

### Documentation and Housekeeping

- [x] Updated relevant docstrings — N/A for README/docs
- [x] Updated `cli-config.yaml.example` — N/A (no new config keys)
- [x] Updated `CONTRIBUTING.md`/`AGENTS.md` — N/A (no architecture change)
- [x] Cross-platform impact — N/A (Telegram gateway, no OS interaction)
- [x] Updated tool descriptions/schemas — N/A (no tool changes)

## Related Issue

Fixes #20373