### PR TITLE
[codex] fix gateway max token routing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -563,6 +563,9 @@ def _resolve_runtime_agent_kwargs() -> dict:
     )
     from hermes_cli.auth import AuthError
 
+    cfg = _load_gateway_config()
+    max_tokens = _resolve_gateway_max_tokens(cfg)
+
     try:
         runtime = resolve_runtime_provider(
             requested=os.getenv("HERMES_INFERENCE_PROVIDER"),
@@ -571,7 +574,7 @@ def _resolve_runtime_agent_kwargs() -> dict:
         # Primary provider auth failed (expired token, revoked key, etc.).
         # Try the fallback provider chain before raising.
         logger.warning("Primary provider auth failed: %s — trying fallback", auth_exc)
-        fb_config = _try_resolve_fallback_provider()
+        fb_config = _try_resolve_fallback_provider(max_tokens=max_tokens)
         if fb_config is not None:
             return fb_config
         raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
@@ -586,10 +589,11 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        "max_tokens": max_tokens,
     }
 
 
-def _try_resolve_fallback_provider() -> dict | None:
+def _try_resolve_fallback_provider(max_tokens: Optional[int] = None) -> dict | None:
     """Attempt to resolve credentials from the fallback_model/fallback_providers config."""
     from hermes_cli.runtime_provider import resolve_runtime_provider
     try:
@@ -622,6 +626,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "command": runtime.get("command"),
                     "args": list(runtime.get("args") or []),
                     "credential_pool": runtime.get("credential_pool"),
+                    "max_tokens": max_tokens,
                 }
             except Exception as fb_exc:
                 logger.debug("Fallback entry %s failed: %s", entry.get("provider"), fb_exc)
@@ -850,6 +855,23 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     elif isinstance(model_cfg, dict):
         return model_cfg.get("default") or model_cfg.get("model") or ""
     return ""
+
+
+def _resolve_gateway_max_tokens(config: dict | None = None) -> Optional[int]:
+    """Read model.max_tokens from config.yaml for gateway-created agents."""
+    cfg = config if config is not None else _load_gateway_config()
+    raw_value = cfg_get(cfg, "model", "max_tokens", default=None)
+    if raw_value in (None, ""):
+        return None
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid model.max_tokens %r in config.yaml; ignoring", raw_value)
+        return None
+    if value <= 0:
+        logger.warning("Invalid model.max_tokens %r in config.yaml; ignoring", raw_value)
+        return None
+    return value
 
 
 def _resolve_hermes_bin() -> Optional[list[str]]:
@@ -1529,12 +1551,14 @@ class GatewayRunner:
         model = _resolve_gateway_model(user_config)
         override = self._session_model_overrides.get(resolved_session_key) if resolved_session_key else None
         if override:
+            max_tokens = _resolve_gateway_max_tokens(user_config)
             override_model = override.get("model", model)
             override_runtime = {
                 "provider": override.get("provider"),
                 "api_key": override.get("api_key"),
                 "base_url": override.get("base_url"),
                 "api_mode": override.get("api_mode"),
+                "max_tokens": max_tokens,
             }
             if override_runtime.get("api_key"):
                 logger.debug(
@@ -1598,6 +1622,7 @@ class GatewayRunner:
             "command": runtime_kwargs.get("command"),
             "args": list(runtime_kwargs.get("args") or []),
             "credential_pool": runtime_kwargs.get("credential_pool"),
+            "max_tokens": runtime_kwargs.get("max_tokens"),
         }
         route = {
             "model": model,
@@ -1609,6 +1634,7 @@ class GatewayRunner:
                 runtime["api_mode"],
                 runtime["command"],
                 tuple(runtime["args"]),
+                runtime["max_tokens"],
             ),
         }
 
@@ -11913,6 +11939,7 @@ class GatewayRunner:
     # Add more here as new baked-at-construction config settings are added.
     _CACHE_BUSTING_CONFIG_KEYS: tuple = (
         ("model", "context_length"),
+        ("model", "max_tokens"),
         ("compression", "enabled"),
         ("compression", "threshold"),
         ("compression", "target_ratio"),
@@ -11989,6 +12016,7 @@ class GatewayRunner:
                 runtime.get("base_url", ""),
                 runtime.get("provider", ""),
                 runtime.get("api_mode", ""),
+                runtime.get("max_tokens"),
                 sorted(enabled_toolsets) if enabled_toolsets else [],
                 # reasoning_config excluded — it's set per-message on the
                 # cached agent and doesn't affect system prompt or tools.

--- a/run_agent.py
+++ b/run_agent.py
@@ -3022,10 +3022,15 @@ class AIAgent:
         OpenAI's newer models (gpt-4o, o-series, gpt-5+) require
         'max_completion_tokens'. Azure OpenAI also requires
         'max_completion_tokens' for gpt-5.x models served via the
-        OpenAI-compatible endpoint. OpenRouter, local models, and older
-        OpenAI models use 'max_tokens'.
+        OpenAI-compatible endpoint. Custom OpenAI-compatible proxies that
+        serve GPT-5-family models need the same Chat Completions parameter.
+        OpenRouter, local non-OpenAI models, and older OpenAI models use
+        'max_tokens'.
         """
+        provider = (self.provider or "").strip().lower()
         if self._is_direct_openai_url() or self._is_azure_openai_url():
+            return {"max_completion_tokens": value}
+        if provider == "custom" and self._model_requires_responses_api(self.model or ""):
             return {"max_completion_tokens": value}
         return {"max_tokens": value}
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -98,6 +98,17 @@ class TestAgentConfigSignature:
         sig2 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-telegram"], "")
         assert sig1 == sig2
 
+    def test_max_tokens_change_different_signature(self):
+        """model.max_tokens is baked into AIAgent and must bust cached agents."""
+        from gateway.run import GatewayRunner
+
+        rt1 = {"api_key": "k", "base_url": "u", "provider": "p", "max_tokens": 4096}
+        rt2 = {"api_key": "k", "base_url": "u", "provider": "p", "max_tokens": 65536}
+        sig1 = GatewayRunner._agent_config_signature("m", rt1, [], "")
+        sig2 = GatewayRunner._agent_config_signature("m", rt2, [], "")
+
+        assert sig1 != sig2
+
     # ---------------------------------------------------------------
     # cache_keys (compression/context config cache-busting)
     # ---------------------------------------------------------------
@@ -191,13 +202,20 @@ class TestExtractCacheBustingConfig:
     """Verify _extract_cache_busting_config pulls the documented subset of
     config values that must invalidate the cached agent on change."""
 
-    def test_reads_model_context_length(self):
+    def test_reads_model_context_length_and_max_tokens(self):
         from gateway.run import GatewayRunner
 
         out = GatewayRunner._extract_cache_busting_config(
-            {"model": {"context_length": 272_000, "provider": "openrouter"}}
+            {
+                "model": {
+                    "context_length": 272_000,
+                    "max_tokens": 65_536,
+                    "provider": "openrouter",
+                }
+            }
         )
         assert out["model.context_length"] == 272_000
+        assert out["model.max_tokens"] == 65_536
 
     def test_reads_compression_subkeys(self):
         from gateway.run import GatewayRunner

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -121,6 +121,31 @@ def test_turn_route_skips_priority_processing_for_unsupported_models():
     assert route["request_overrides"] == {}
 
 
+def test_turn_route_carries_max_tokens_into_agent_runtime():
+    runner = _make_runner()
+    runner._service_tier = None
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "http://127.0.0.1:2455/v1",
+        "provider": "custom",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "max_tokens": 65536,
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "hi",
+        "gpt-5.5",
+        runtime_kwargs,
+    )
+
+    assert route["runtime"]["max_tokens"] == 65536
+    assert route["signature"][-1] == 65536
+
+
 @pytest.mark.asyncio
 async def test_handle_fast_command_persists_config(monkeypatch, tmp_path):
     runner = _make_runner()

--- a/tests/run_agent/test_max_tokens_param.py
+++ b/tests/run_agent/test_max_tokens_param.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def _make_agent(*, provider: str, base_url: str, model: str) -> AIAgent:
+    with patch("run_agent.OpenAI"), patch(
+        "hermes_cli.config.load_config",
+        return_value={"agent": {}},
+    ):
+        return AIAgent(
+            api_key="test-key",
+            provider=provider,
+            base_url=base_url,
+            model=model,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            enabled_toolsets=[],
+            disabled_toolsets=[],
+        )
+
+
+def test_custom_gpt5_chat_completions_uses_max_completion_tokens():
+    agent = _make_agent(
+        provider="custom",
+        base_url="http://127.0.0.1:2455/v1",
+        model="gpt-5.5",
+    )
+
+    assert agent._max_tokens_param(65536) == {"max_completion_tokens": 65536}
+
+
+def test_custom_gpt5_vendor_prefix_uses_max_completion_tokens():
+    agent = _make_agent(
+        provider="custom",
+        base_url="http://127.0.0.1:2455/v1",
+        model="openai/gpt-5.5",
+    )
+
+    assert agent._max_tokens_param(65536) == {"max_completion_tokens": 65536}
+
+
+def test_custom_non_gpt5_keeps_max_tokens():
+    agent = _make_agent(
+        provider="custom",
+        base_url="http://127.0.0.1:2455/v1",
+        model="local/llama-3.3",
+    )
+
+    assert agent._max_tokens_param(8192) == {"max_tokens": 8192}


### PR DESCRIPTION
## Summary

- Carries model.max_tokens from config.yaml into gateway-created AIAgent instances, including session model override and fallback-provider paths.
- Includes max_tokens in gateway turn/runtime cache signatures so config edits rebuild cached agents instead of reusing stale output caps.
- Uses max_completion_tokens for GPT-5-family models served by custom OpenAI-compatible Chat Completions proxies, while keeping max_tokens for non-GPT-5 custom/local models.
- Adds regression coverage for custom GPT-5 parameter selection, cache busting, and turn runtime propagation.

## Root Cause

Gateway-created agents were not receiving the configured model.max_tokens value, and custom OpenAI-compatible GPT-5 routes were still sending max_tokens. That can leave routers/backends using a small default output cap or returning finish_reason=length during tool calls, surfacing as Response truncated due to output length limit.

## Validation

- /home/sass/.hermes/hermes-agent/venv/bin/python -m py_compile run_agent.py gateway/run.py
- /home/sass/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/run_agent/test_max_tokens_param.py tests/gateway/test_agent_cache.py::TestAgentConfigSignature::test_max_tokens_change_different_signature tests/gateway/test_agent_cache.py::TestExtractCacheBustingConfig::test_reads_model_context_length_and_max_tokens tests/gateway/test_fast_command.py::test_turn_route_carries_max_tokens_into_agent_runtime
- git diff --check

## Notes

A broader gateway test slice also passed most tests but hit an existing 30s timeout in an unrelated cache spillover concurrency test under network-restricted sandbox conditions.