### PR TITLE
feat(discord): add channel workspace routes

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -759,6 +759,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_allow_from"] = platform_cfg["group_allow_from"]
                 if plat in (Platform.DISCORD, Platform.SLACK) and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
+                if "channel_routes" in platform_cfg:
+                    bridged["channel_routes"] = platform_cfg["channel_routes"]
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]
                     if isinstance(channel_prompts, dict):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -517,6 +517,7 @@ from gateway.session import (
     build_session_context_prompt,
     build_session_key,
     is_shared_multi_user_session,
+    resolve_channel_route,
 )
 from gateway.delivery import DeliveryRouter
 from gateway.platforms.base import (
@@ -883,8 +884,8 @@ def _parse_session_key(session_key: str) -> "dict | None":
     """Parse a session key into its component parts.
 
     Session keys follow the format
-    ``agent:main:{platform}:{chat_type}:{chat_id}[:{extra}...]``.
-    Returns a dict with ``platform``, ``chat_type``, ``chat_id``, and
+    ``agent:{agent_id}:{platform}:{chat_type}:{chat_id}[:{extra}...]``.
+    Returns a dict with ``agent_id``, ``platform``, ``chat_type``, ``chat_id``, and
     optionally ``thread_id`` keys, or None if the key doesn't match.
 
     The 6th element is only returned as ``thread_id`` for chat types where
@@ -893,8 +894,9 @@ def _parse_session_key(session_key: str) -> "dict | None":
     thread_id, so we leave ``thread_id`` out to avoid mis-routing.
     """
     parts = session_key.split(":")
-    if len(parts) >= 5 and parts[0] == "agent" and parts[1] == "main":
+    if len(parts) >= 5 and parts[0] == "agent" and parts[1]:
         result = {
+            "agent_id": parts[1],
             "platform": parts[2],
             "chat_type": parts[3],
             "chat_id": parts[4],
@@ -1388,10 +1390,13 @@ class GatewayRunner:
             except Exception:
                 pass
         config = getattr(self, "config", None)
+        route = resolve_channel_route(source, config) if config is not None else None
+        agent_id = (route or {}).get("agent_id") or "main"
         return build_session_key(
             source,
             group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+            agent_id=agent_id,
         )
 
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
@@ -3127,7 +3132,7 @@ class GatewayRunner:
 
                 if _expired_entries:
                     # Extract platform names from session keys for a compact summary.
-                    # Keys look like "agent:main:telegram:dm:12345" — platform is field [2].
+                    # Keys look like "agent:<agent_id>:telegram:dm:12345" — platform is field [2].
                     _platforms: dict[str, int] = {}
                     for _k, _e in _expired_entries:
                         _parts = _k.split(":")
@@ -8911,6 +8916,8 @@ class GatewayRunner:
                 return
 
             platform_key = _platform_config_key(source.platform)
+            route_cfg = resolve_channel_route(source, self.config)
+            routed_cwd = (route_cfg or {}).get("cwd")
 
             from hermes_cli.tools_config import _get_platform_tools
             enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
@@ -8954,10 +8961,20 @@ class GatewayRunner:
                     fallback_model=self._fallback_model,
                 )
                 try:
-                    return agent.run_conversation(
-                        user_message=prompt,
-                        task_id=task_id,
+                    from tools.terminal_tool import (
+                        clear_task_env_overrides,
+                        register_task_env_overrides,
                     )
+                    if routed_cwd:
+                        register_task_env_overrides(task_id, {"cwd": routed_cwd})
+                    try:
+                        return agent.run_conversation(
+                            user_message=prompt,
+                            task_id=task_id,
+                        )
+                    finally:
+                        if routed_cwd:
+                            clear_task_env_overrides(task_id)
                 finally:
                     self._cleanup_agent_resources(agent)
 
@@ -12704,6 +12721,8 @@ class GatewayRunner:
         
         user_config = _load_gateway_config()
         platform_key = _platform_config_key(source.platform)
+        route_cfg = resolve_channel_route(source, self.config)
+        routed_cwd = (route_cfg or {}).get("cwd")
 
         from hermes_cli.tools_config import _get_platform_tools
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
@@ -13675,6 +13694,13 @@ class GatewayRunner:
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
+            from tools.terminal_tool import (
+                clear_task_env_overrides,
+                register_task_env_overrides,
+            )
+
+            if routed_cwd:
+                register_task_env_overrides(session_id, {"cwd": routed_cwd})
             try:
                 # If _prepare_inbound_message_text buffered image paths for native
                 # attachment, wrap the user turn as an OpenAI-style multimodal
@@ -13709,6 +13735,8 @@ class GatewayRunner:
 
                 result = agent.run_conversation(_run_message, conversation_history=agent_history, task_id=session_id)
             finally:
+                if routed_cwd:
+                    clear_task_env_overrides(session_id)
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -12,6 +12,7 @@ import hashlib
 import logging
 import os
 import json
+import re
 import threading
 import uuid
 from pathlib import Path
@@ -20,6 +21,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
+_CHANNEL_ROUTE_AGENT_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def _now() -> datetime:
@@ -595,6 +597,7 @@ def build_session_key(
     source: SessionSource,
     group_sessions_per_user: bool = True,
     thread_sessions_per_user: bool = False,
+    agent_id: str = "main",
 ) -> str:
     """Build a deterministic session key from a message source.
 
@@ -620,6 +623,7 @@ def build_session_key(
       - Without identifiers, messages fall back to one session per platform/chat_type.
     """
     platform = source.platform.value
+    agent_prefix = f"agent:{agent_id or 'main'}"
     if source.chat_type == "dm":
         dm_chat_id = source.chat_id
         if source.platform == Platform.WHATSAPP:
@@ -627,11 +631,11 @@ def build_session_key(
 
         if dm_chat_id:
             if source.thread_id:
-                return f"agent:main:{platform}:dm:{dm_chat_id}:{source.thread_id}"
-            return f"agent:main:{platform}:dm:{dm_chat_id}"
+                return f"{agent_prefix}:{platform}:dm:{dm_chat_id}:{source.thread_id}"
+            return f"{agent_prefix}:{platform}:dm:{dm_chat_id}"
         if source.thread_id:
-            return f"agent:main:{platform}:dm:{source.thread_id}"
-        return f"agent:main:{platform}:dm"
+            return f"{agent_prefix}:{platform}:dm:{source.thread_id}"
+        return f"{agent_prefix}:{platform}:dm"
 
     participant_id = source.user_id_alt or source.user_id
     if participant_id and source.platform == Platform.WHATSAPP:
@@ -639,7 +643,7 @@ def build_session_key(
         # single group member gets two isolated per-user sessions when the
         # bridge reshuffles alias forms.
         participant_id = canonical_whatsapp_identifier(str(participant_id)) or participant_id
-    key_parts = ["agent:main", platform, source.chat_type]
+    key_parts = [agent_prefix, platform, source.chat_type]
 
     if source.chat_id:
         key_parts.append(source.chat_id)
@@ -657,6 +661,65 @@ def build_session_key(
         key_parts.append(str(participant_id))
 
     return ":".join(key_parts)
+
+
+def resolve_channel_route(source: SessionSource, config: GatewayConfig) -> Dict[str, Any] | None:
+    """Return a platform-specific channel route, if one matches this source.
+
+    Expected config shape (under ``platform.extra``):
+
+    ``channel_routes``:
+      - ``id``: channel/thread identifier to match
+      - ``agent_id`` / ``agentId``: logical route name used in session keys
+      - ``cwd`` / ``workspace``: workspace path for context files and tools
+    """
+    try:
+        platform_cfg = config.platforms.get(source.platform)
+    except Exception:
+        platform_cfg = None
+    if not platform_cfg or not isinstance(getattr(platform_cfg, "extra", None), dict):
+        return None
+
+    routes = platform_cfg.extra.get("channel_routes") or []
+    if not isinstance(routes, list):
+        return None
+
+    ids_to_check = set()
+    if source.chat_id:
+        ids_to_check.add(str(source.chat_id))
+    if source.thread_id:
+        ids_to_check.add(str(source.thread_id))
+
+    for entry in routes:
+        if not isinstance(entry, dict):
+            continue
+        entry_id = str(entry.get("id", "") or "")
+        if entry_id and entry_id in ids_to_check:
+            route = dict(entry)
+            agent_id = str(route.get("agent_id") or route.get("agentId") or "main")
+            if not _CHANNEL_ROUTE_AGENT_ID_RE.fullmatch(agent_id):
+                logger.warning(
+                    "Ignoring channel route %r with invalid agent_id %r; "
+                    "agent_id may only contain letters, numbers, underscores, and hyphens",
+                    entry_id,
+                    agent_id,
+                )
+                continue
+            route["agent_id"] = agent_id
+            cwd = route.get("cwd") or route.get("workspace")
+            if cwd:
+                cwd_path = Path(str(cwd)).expanduser()
+                if not cwd_path.is_absolute():
+                    logger.warning("Ignoring relative cwd for channel route %r: %r", entry_id, cwd)
+                    cwd = None
+                elif not cwd_path.is_dir():
+                    logger.warning("Ignoring missing/non-directory cwd for channel route %r: %s", entry_id, cwd_path)
+                    cwd = None
+                else:
+                    cwd = str(cwd_path.resolve())
+            route["cwd"] = cwd
+            return route
+    return None
 
 
 class SessionStore:
@@ -737,10 +800,13 @@ class SessionStore:
     
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
+        route = resolve_channel_route(source, self.config)
+        agent_id = (route or {}).get("agent_id") or "main"
         return build_session_key(
             source,
             group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+            agent_id=agent_id,
         )
     
     def _is_session_expired(self, entry: SessionEntry) -> bool:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1072,6 +1072,7 @@ DEFAULT_CONFIG = {
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
+        "channel_routes": [],           # Per-channel logical agent/workspace routes (id, agent_id, cwd/workspace)
         # discord / discord_admin tools: restrict which actions the agent may call.
         # Default (empty) = all actions allowed (subject to bot privileged intents).
         # Accepts comma-separated string ("list_guilds,list_channels,fetch_messages")

--- a/run_agent.py
+++ b/run_agent.py
@@ -5021,11 +5021,18 @@ class AIAgent:
             prompt_parts.append(skills_prompt)
 
         if not self.skip_context_files:
-            # Use TERMINAL_CWD for context file discovery when set (gateway
-            # mode).  The gateway process runs from the hermes-agent install
-            # dir, so os.getcwd() would pick up the repo's AGENTS.md and
-            # other dev files — inflating token usage by ~10k for no benefit.
-            _context_cwd = os.getenv("TERMINAL_CWD") or None
+            # Prefer task-specific cwd overrides registered by the gateway for
+            # this session. Fall back to TERMINAL_CWD for CLI/global flows.
+            _context_cwd = None
+            try:
+                if self.session_id:
+                    from tools.terminal_tool import (
+                        _task_env_overrides as _task_env_overrides_registry,
+                    )
+                    _context_cwd = (_task_env_overrides_registry.get(self.session_id) or {}).get("cwd")
+            except Exception:
+                _context_cwd = None
+            _context_cwd = _context_cwd or os.getenv("TERMINAL_CWD") or None
             context_files_prompt = build_context_files_prompt(
                 cwd=_context_cwd, skip_soul=_soul_loaded)
             if context_files_prompt:

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -379,31 +379,36 @@ def test_build_process_event_source_returns_none_for_short_session_key(monkeypat
 
 def test_parse_session_key_valid():
     result = _parse_session_key("agent:main:telegram:group:-100")
-    assert result == {"platform": "telegram", "chat_type": "group", "chat_id": "-100"}
+    assert result == {"agent_id": "main", "platform": "telegram", "chat_type": "group", "chat_id": "-100"}
+
+
+def test_parse_session_key_valid_custom_agent_id():
+    result = _parse_session_key("agent:research:discord:group:chan123:user99")
+    assert result == {"agent_id": "research", "platform": "discord", "chat_type": "group", "chat_id": "chan123"}
 
 
 def test_parse_session_key_with_extra_parts():
     """6th part in a group key may be a user_id, not a thread_id — omit it."""
     result = _parse_session_key("agent:main:discord:group:chan123:thread456")
-    assert result == {"platform": "discord", "chat_type": "group", "chat_id": "chan123"}
+    assert result == {"agent_id": "main", "platform": "discord", "chat_type": "group", "chat_id": "chan123"}
 
 
 def test_parse_session_key_with_user_id_part():
     """Group keys with per-user isolation have user_id as 6th part — don't return as thread_id."""
     result = _parse_session_key("agent:main:telegram:group:chat1:user99")
-    assert result == {"platform": "telegram", "chat_type": "group", "chat_id": "chat1"}
+    assert result == {"agent_id": "main", "platform": "telegram", "chat_type": "group", "chat_id": "chat1"}
 
 
 def test_parse_session_key_dm_with_thread():
     """DM keys use parts[5] as thread_id unambiguously."""
     result = _parse_session_key("agent:main:telegram:dm:chat1:topic42")
-    assert result == {"platform": "telegram", "chat_type": "dm", "chat_id": "chat1", "thread_id": "topic42"}
+    assert result == {"agent_id": "main", "platform": "telegram", "chat_type": "dm", "chat_id": "chat1", "thread_id": "topic42"}
 
 
 def test_parse_session_key_thread_chat_type():
     """Thread-typed keys use parts[5] as thread_id unambiguously."""
     result = _parse_session_key("agent:main:discord:thread:chan1:thread99")
-    assert result == {"platform": "discord", "chat_type": "thread", "chat_id": "chan1", "thread_id": "thread99"}
+    assert result == {"agent_id": "main", "platform": "discord", "chat_type": "thread", "chat_id": "chan1", "thread_id": "thread99"}
 
 
 def test_parse_session_key_too_short():
@@ -413,4 +418,3 @@ def test_parse_session_key_too_short():
 
 def test_parse_session_key_wrong_prefix():
     assert _parse_session_key("cron:main:telegram:dm:123") is None
-    assert _parse_session_key("agent:cron:telegram:dm:123") is None

--- a/tests/gateway/test_channel_routes.py
+++ b/tests/gateway/test_channel_routes.py
@@ -1,0 +1,121 @@
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource, SessionStore, build_session_key, resolve_channel_route
+
+
+def _make_source(
+    *,
+    chat_id: str = "1234567890",
+    thread_id: str | None = None,
+    chat_type: str = "group",
+    user_id: str = "user-1",
+):
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        chat_type=chat_type,
+        user_id=user_id,
+        user_name="Alice",
+    )
+
+
+def _make_config(routes):
+    return GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                extra={"channel_routes": routes},
+            )
+        }
+    )
+
+
+def test_build_session_key_uses_custom_agent_id():
+    key = build_session_key(_make_source(), agent_id="research")
+    assert key == "agent:research:discord:group:1234567890:user-1"
+
+
+def test_resolve_channel_route_matches_channel_id(tmp_path):
+    workspace = tmp_path / "research-workspace"
+    workspace.mkdir()
+    config = _make_config(
+        [
+            {
+                "id": "1234567890",
+                "agent_id": "research",
+                "cwd": str(workspace),
+            }
+        ]
+    )
+
+    route = resolve_channel_route(_make_source(), config)
+
+    assert route is not None
+    assert route["agent_id"] == "research"
+    assert route["cwd"] == str(workspace.resolve())
+
+
+def test_resolve_channel_route_matches_thread_id_and_workspace_alias(tmp_path):
+    workspace = tmp_path / "support-workspace"
+    workspace.mkdir()
+    config = _make_config(
+        [
+            {
+                "id": "thread-123",
+                "agentId": "support",
+                "workspace": str(workspace),
+            }
+        ]
+    )
+
+    route = resolve_channel_route(_make_source(thread_id="thread-123"), config)
+
+    assert route is not None
+    assert route["agent_id"] == "support"
+    assert route["cwd"] == str(workspace.resolve())
+
+
+def test_resolve_channel_route_ignores_malformed_routes():
+    config = _make_config(
+        [
+            "not-a-route",
+            {"id": ""},
+            {"id": "1234567890", "agent_id": "bad:agent"},
+            {"id": "different", "agent_id": "other"},
+        ]
+    )
+
+    assert resolve_channel_route(_make_source(), config) is None
+
+
+def test_resolve_channel_route_ignores_invalid_cwd_but_keeps_agent_id():
+    config = _make_config(
+        [
+            {"id": "1234567890", "agent_id": "relative", "cwd": "relative/path"},
+        ]
+    )
+
+    route = resolve_channel_route(_make_source(), config)
+
+    assert route is not None
+    assert route["agent_id"] == "relative"
+    assert route["cwd"] is None
+
+
+def test_session_store_generate_session_key_uses_routed_agent_id(tmp_path):
+    workspace = tmp_path / "research-workspace"
+    workspace.mkdir()
+    config = _make_config(
+        [
+            {
+                "id": "1234567890",
+                "agent_id": "research",
+                "cwd": str(workspace),
+            }
+        ]
+    )
+    store = SessionStore(sessions_dir=tmp_path, config=config)
+
+    session_key = store._generate_session_key(_make_source())
+
+    assert session_key == "agent:research:discord:group:1234567890:user-1"

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -359,6 +359,31 @@ class TestLoadGatewayConfig:
             "456": "Therapist mode",
         }
 
+    def test_bridges_discord_channel_routes_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  channel_routes:\n"
+            "    - id: \"123\"\n"
+            "      agent_id: research\n"
+            "      cwd: /tmp/research-workspace\n"
+            "    - id: \"456\"\n"
+            "      agentId: support\n"
+            "      workspace: /tmp/support-workspace\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].extra["channel_routes"] == [
+            {"id": "123", "agent_id": "research", "cwd": "/tmp/research-workspace"},
+            {"id": "456", "agentId": "support", "workspace": "/tmp/support-workspace"},
+        ]
+
     def test_bridges_telegram_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -634,6 +634,7 @@ class TestInterimAssistantMessageConfig:
 class TestDiscordChannelPromptsConfig:
     def test_default_config_includes_discord_channel_prompts(self):
         assert DEFAULT_CONFIG["discord"]["channel_prompts"] == {}
+        assert DEFAULT_CONFIG["discord"]["channel_routes"] == []
 
     def test_migrate_adds_discord_channel_prompts_default(self, tmp_path):
         config_path = tmp_path / "config.yaml"
@@ -650,6 +651,7 @@ class TestDiscordChannelPromptsConfig:
         assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
         assert raw["discord"]["auto_thread"] is True
         assert raw["discord"]["channel_prompts"] == {}
+        assert raw["discord"]["channel_routes"] == []
 
 
 class TestUserMessagePreviewConfig:

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -308,6 +308,7 @@ discord:
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading
   channel_prompts: {}             # Per-channel ephemeral system prompts
+  channel_routes: []              # Per-channel logical agent/workspace routes
   allow_mentions:                 # What the bot is allowed to ping (safe defaults)
     everyone: false               # @everyone / @here pings (default: false)
     roles: false                  # @role pings (default: false)
@@ -420,6 +421,34 @@ Behavior:
 - Exact thread/channel ID matches win.
 - If a message arrives inside a thread or forum post and that thread has no explicit entry, Hermes falls back to the parent channel/forum ID.
 - Prompts are applied ephemerally at runtime, so changing them affects future turns immediately without rewriting past session history.
+
+#### `discord.channel_routes`
+
+**Type:** list — **Default:** `[]`
+
+Per-channel logical agent and workspace routes. A route lets one Discord gateway behave like multiple dedicated agents by giving matching channels their own session namespace and project working directory.
+
+```yaml
+discord:
+  channel_routes:
+    - id: "1234567890"          # Channel, thread, or forum-post ID
+      agent_id: research         # Logical route name used in session keys
+      cwd: /home/me/research     # Project directory for context files and tools
+    - id: "9876543210"
+      agentId: support           # camelCase alias is accepted
+      workspace: /home/me/helpdesk  # alias for cwd
+```
+
+Route validation:
+- `agent_id` may only contain letters, numbers, underscores, and hyphens.
+- `cwd` / `workspace`, when provided, must be an absolute path to an existing directory. Invalid paths are ignored for that route so Hermes falls back to normal gateway cwd behavior.
+
+Behavior:
+- Hermes matches `id` against the incoming Discord channel ID and, when present, the thread/forum-post ID.
+- Matching routes prefix session keys with `agent:<agent_id>`, so two channels can keep separate history even if their Discord/user IDs would otherwise collide.
+- `cwd` / `workspace` is passed to the agent for context-file discovery (`AGENTS.md`, `CLAUDE.md`, `.cursorrules`) and to terminal-backed tools as their default working directory for that turn.
+- If no route matches, Hermes uses the default `agent:main` session namespace and normal gateway working-directory behavior.
+- Routes are intentionally orthogonal to `channel_prompts` and `channel_skill_bindings`; combine them when you want a channel to have a workspace, prompt, and auto-loaded skills.
 
 #### `group_sessions_per_user`
 


### PR DESCRIPTION
## Summary
- Add `discord.channel_routes` for per-channel logical agent/workspace routing
- Route matching Discord channel/thread/forum-post IDs to an `agent_id` session namespace
- Apply routed `cwd` to context-file discovery and terminal-backed tools
- Document route validation and usage

## Validation
- `agent_id` is restricted to letters, numbers, underscores, and hyphens
- `cwd` / `workspace` must be an absolute existing directory; invalid paths are ignored
- Existing unmatched sessions keep the default `agent:main` namespace

## Test Plan
- `python -m pytest -o 'addopts=' -q tests/gateway/test_channel_routes.py tests/gateway/test_background_process_notifications.py tests/gateway/test_config.py tests/hermes_cli/test_config.py tests/tools/test_shared_container_task_id.py`
- Result: 136 passed
