### PR TITLE
fix(bedrock): preserve reasoningContent in normalized responses

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -631,11 +631,18 @@ def normalize_converse_response(response: Dict) -> SimpleNamespace:
     stop_reason = response.get("stopReason", "end_turn")
 
     text_parts = []
+    reasoning_parts = []
     tool_calls = []
 
     for block in content_blocks:
         if "text" in block:
             text_parts.append(block["text"])
+        elif "reasoningContent" in block:
+            reasoning = block["reasoningContent"]
+            if isinstance(reasoning, dict):
+                thinking_text = reasoning.get("text", "")
+                if thinking_text:
+                    reasoning_parts.append(str(thinking_text))
         elif "toolUse" in block:
             tu = block["toolUse"]
             tool_calls.append(SimpleNamespace(
@@ -652,6 +659,7 @@ def normalize_converse_response(response: Dict) -> SimpleNamespace:
         role="assistant",
         content="\n".join(text_parts) if text_parts else None,
         tool_calls=tool_calls if tool_calls else None,
+        reasoning_content="\n\n".join(reasoning_parts) if reasoning_parts else None,
     )
 
     # Build usage stats
@@ -732,6 +740,7 @@ def stream_converse_with_callbacks(
         ``normalize_converse_response()``.
     """
     text_parts: List[str] = []
+    reasoning_parts: List[str] = []
     tool_calls: List[SimpleNamespace] = []
     current_tool: Optional[Dict] = None
     current_text_buffer: List[str] = []
@@ -777,8 +786,10 @@ def stream_converse_with_callbacks(
                 reasoning = delta["reasoningContent"]
                 if isinstance(reasoning, dict):
                     thinking_text = reasoning.get("text", "")
-                    if thinking_text and on_reasoning_delta:
-                        on_reasoning_delta(thinking_text)
+                    if thinking_text:
+                        reasoning_parts.append(str(thinking_text))
+                        if on_reasoning_delta:
+                            on_reasoning_delta(thinking_text)
 
         elif "contentBlockStop" in event:
             if current_tool is not None:
@@ -817,6 +828,7 @@ def stream_converse_with_callbacks(
         role="assistant",
         content="\n".join(text_parts) if text_parts else None,
         tool_calls=tool_calls if tool_calls else None,
+        reasoning_content="\n\n".join(reasoning_parts) if reasoning_parts else None,
     )
 
     usage = SimpleNamespace(

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -994,6 +994,7 @@ class TestStreamConverseWithCallbacks:
             events, on_reasoning_delta=lambda t: reasoning.append(t),
         )
         assert reasoning == ["Let me think..."]
+        assert result.choices[0].message.reasoning_content == "Let me think..."
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/transports/test_bedrock_transport.py
+++ b/tests/agent/transports/test_bedrock_transport.py
@@ -142,6 +142,24 @@ class TestBedrockNormalize:
         assert len(nr.tool_calls) == 1
         assert nr.tool_calls[0].name == "terminal"
 
+    def test_raw_reasoning_content_response(self, transport):
+        raw = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"reasoningContent": {"text": "Let me think..."}},
+                        {"text": "Answer."},
+                    ],
+                }
+            },
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
+        }
+        nr = transport.normalize_response(raw)
+        assert nr.reasoning == "Let me think..."
+        assert nr.content == "Answer."
+
     def test_already_normalized_response(self, transport):
         """Test normalize_response handles already-normalized SimpleNamespace (from dispatch site)."""
         pre_normalized = SimpleNamespace(


### PR DESCRIPTION
## What does this PR do?

Preserves Bedrock `reasoningContent` when normalizing Converse responses.

Before this change, Bedrock thinking text could appear in the streaming callback path, but it was dropped from the normalized assistant message shape. That caused downstream transport normalization to produce `NormalizedResponse.reasoning=None` even when Bedrock had returned reasoning content.

This change fixes both paths:
- Raw `converse()` responses now collect `reasoningContent` blocks into the normalized message.
- Streaming `converse_stream()` responses now persist reasoning text onto the normalized message instead of only forwarding it to the callback.

As a result, Bedrock reasoning now survives normalization consistently across raw and streaming flows.

## Related Issue

Fixes #<fill-if-you-have-one>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Updated `agent/bedrock_adapter.py`
- Preserved `reasoningContent` blocks in `normalize_converse_response()`
- Preserved streamed reasoning deltas in `stream_converse_with_callbacks()`
- Attached normalized reasoning onto the assistant message as `reasoning_content`

- Updated `tests/agent/test_bedrock_adapter.py`
- Added an assertion that streamed reasoning is persisted on the normalized message, not only emitted via callback

- Updated `tests/agent/transports/test_bedrock_transport.py`
- Added regression coverage for raw Converse responses containing `reasoningContent`

## How to Test

```text
1. Run:
   uv run pytest tests/agent/test_bedrock_adapter.py -q

2. Run:
   uv run pytest tests/agent/transports/test_bedrock_transport.py -q

3. Verify both pass, and confirm Bedrock normalized responses now retain reasoning text.

## Test Results

uv run pytest tests/agent/test_bedrock_adapter.py -q -> 118 passed
uv run pytest tests/agent/transports/test_bedrock_transport.py -q -> 19 passed
