### PR TITLE
fix(auxiliary): fall back to credential pool for Copilot when env+gh CLI yield no token

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -515,6 +515,40 @@ def _resolve_api_key_provider_secret(
             logger.warning("Copilot token validation failed: %s", exc)
         except Exception:
             pass
+
+        # Fallback: credential pool (e.g. token stored via `hermes login copilot`
+        # or seeded into auth.json by setup).  Without this, auxiliary tasks
+        # (compression, vision, session_search) silently fail for users whose
+        # only Copilot credential lives in the credential pool — even though
+        # the main agent loop happily uses the same pool entry for chat.
+        try:
+            from agent.credential_pool import load_pool
+            from hermes_cli.copilot_auth import (
+                get_copilot_api_token,
+                validate_copilot_token,
+            )
+            pool = load_pool(provider_id)
+            if pool and pool.has_credentials():
+                entry = pool.peek()
+                if entry:
+                    raw = (
+                        getattr(entry, "access_token", "")
+                        or getattr(entry, "runtime_api_key", "")
+                    )
+                    raw = str(raw).strip()
+                    if has_usable_secret(raw):
+                        valid, msg = validate_copilot_token(raw)
+                        if valid:
+                            return (
+                                get_copilot_api_token(raw),
+                                f"credential_pool:{provider_id}",
+                            )
+                        logger.debug(
+                            "Copilot credential pool entry rejected: %s", msg
+                        )
+        except Exception:
+            pass
+
         return "", ""
 
     from hermes_cli.config import get_env_value

--- a/tests/tools/test_credential_pool_env_fallback.py
+++ b/tests/tools/test_credential_pool_env_fallback.py
@@ -208,3 +208,104 @@ class TestAuthCredentialPoolFallback:
         assert key == "sk-dotenv-priority-xyz"
         assert source == "DEEPSEEK_API_KEY"
         mp.assert_not_called()
+
+
+class TestCopilotCredentialPoolFallback:
+    """For provider_id='copilot', the pool fallback must also fire when the
+    dedicated copilot resolver (env vars + `gh auth token`) yields nothing.
+
+    Without this, auxiliary tasks (compression, vision, session_search)
+    silently fail for users whose only Copilot credential lives in the
+    credential pool — even though the main agent loop happily uses the
+    same pool entry for chat.
+    """
+
+    def test_copilot_pool_fallback_when_resolve_token_empty(self, isolated_hermes_home):
+        # Strip env vars consulted by resolve_copilot_token().
+        for v in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+            os.environ.pop(v, None)
+
+        mock_entry = MagicMock()
+        mock_entry.access_token = "github_pat_11ABCDEFGHIJ_pool_token_xyz"
+        mock_entry.runtime_api_key = ""
+
+        mock_pool = MagicMock()
+        mock_pool.has_credentials.return_value = True
+        mock_pool.peek.return_value = mock_entry
+
+        from hermes_cli.auth import _resolve_api_key_provider_secret, PROVIDER_REGISTRY
+        with patch(
+            "hermes_cli.copilot_auth.resolve_copilot_token",
+            return_value=("", ""),
+        ), patch(
+            "agent.credential_pool.load_pool", return_value=mock_pool,
+        ), patch(
+            "hermes_cli.copilot_auth.get_copilot_api_token",
+            side_effect=lambda t: t,
+        ), patch(
+            "hermes_cli.copilot_auth.validate_copilot_token",
+            return_value=(True, "OK"),
+        ):
+            key, source = _resolve_api_key_provider_secret(
+                provider_id="copilot",
+                pconfig=PROVIDER_REGISTRY["copilot"],
+            )
+
+        assert key == "github_pat_11ABCDEFGHIJ_pool_token_xyz"
+        assert source == "credential_pool:copilot"
+
+    def test_copilot_pool_skipped_when_classic_pat(self, isolated_hermes_home):
+        """Classic PATs (ghp_*) are unsupported by the Copilot API → pool
+        entry must be rejected rather than returned."""
+        for v in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+            os.environ.pop(v, None)
+
+        mock_entry = MagicMock()
+        mock_entry.access_token = "ghp_classic_pat_unsupported"
+        mock_entry.runtime_api_key = ""
+
+        mock_pool = MagicMock()
+        mock_pool.has_credentials.return_value = True
+        mock_pool.peek.return_value = mock_entry
+
+        from hermes_cli.auth import _resolve_api_key_provider_secret, PROVIDER_REGISTRY
+        with patch(
+            "hermes_cli.copilot_auth.resolve_copilot_token",
+            return_value=("", ""),
+        ), patch(
+            "agent.credential_pool.load_pool", return_value=mock_pool,
+        ):
+            key, source = _resolve_api_key_provider_secret(
+                provider_id="copilot",
+                pconfig=PROVIDER_REGISTRY["copilot"],
+            )
+
+        assert key == ""
+        assert source == ""
+
+    def test_copilot_resolve_token_takes_priority_over_pool(self, isolated_hermes_home):
+        """When resolve_copilot_token() succeeds, the pool must NOT be touched."""
+        for v in ("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"):
+            os.environ.pop(v, None)
+
+        mock_pool = MagicMock()
+        mock_pool.has_credentials.return_value = True
+
+        from hermes_cli.auth import _resolve_api_key_provider_secret, PROVIDER_REGISTRY
+        with patch(
+            "hermes_cli.copilot_auth.resolve_copilot_token",
+            return_value=("gho_env_token", "GH_TOKEN"),
+        ), patch(
+            "hermes_cli.copilot_auth.get_copilot_api_token",
+            side_effect=lambda t: t,
+        ), patch(
+            "agent.credential_pool.load_pool", return_value=mock_pool,
+        ) as mp:
+            key, source = _resolve_api_key_provider_secret(
+                provider_id="copilot",
+                pconfig=PROVIDER_REGISTRY["copilot"],
+            )
+
+        assert key == "gho_env_token"
+        assert source == "GH_TOKEN"
+        mp.assert_not_called()


### PR DESCRIPTION
# fix(auxiliary): fall back to credential pool for Copilot when env + gh CLI yield no token

## Summary

When the main provider is GitHub Copilot, auxiliary tasks (compression, vision, `session_search`) silently fail for users whose only Copilot credential lives in the `auth.json` credential pool — for example after running `hermes login copilot` on a host that has no `gh` CLI and no `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` in the environment.

`_resolve_api_key_provider_secret` short-circuits for `provider_id == "copilot"` and returns `("", "")` if `resolve_copilot_token()` (env-vars + `gh auth token`) finds nothing — even though the rest of the codebase (chat path, doctor, runtime credential-pool selector) happily reads the same pool entry.

The resulting UX is confusing:

```
⚠ No auxiliary LLM provider configured — context compression will drop
   middle turns without a summary. Run `hermes setup` or set
   OPENROUTER_API_KEY.
```

…recommending OpenRouter while a perfectly good Copilot token is sitting in `~/.hermes/auth.json`.

## Reproduction

1. Run `hermes login copilot` on a fresh host (no `gh` CLI, no `*_TOKEN` env vars).
2. The token lands in `auth.json` under `credential_pool.copilot[*].access_token`.
3. Start `hermes` — main chat works (chat path reads the pool).
4. Compression / vision / `session_search` all warn `No auxiliary LLM provider configured` and the auxiliary log shows:
   ```
   resolve_provider_client: provider copilot has no API key configured
     (tried: COPILOT_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN, gh auth token)
   ```

## Fix

Mirror the generic credential-pool fallback used by all other `api_key` providers, but route the candidate token through the existing Copilot-specific validators (`validate_copilot_token`, `get_copilot_api_token`) so unsupported classic PATs (`ghp_*`) are still rejected.

New resolution order for `provider_id == "copilot"`:

1. `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` (env or `~/.hermes/.env`) — unchanged
2. `gh auth token` — unchanged
3. **NEW**: `auth.json` credential pool, after `validate_copilot_token` and `get_copilot_api_token` exchange

Env vars and `gh auth token` continue to take strict priority over the pool.

## Tests

`tests/tools/test_credential_pool_env_fallback.py::TestCopilotCredentialPoolFallback`:

- `test_copilot_pool_fallback_when_resolve_token_empty` — happy path: pool token returned with `source="credential_pool:copilot"`.
- `test_copilot_pool_skipped_when_classic_pat` — a `ghp_*` entry must NOT be returned (Copilot API rejects classic PATs).
- `test_copilot_resolve_token_takes_priority_over_pool` — when env / `gh auth token` succeed, `load_pool` is never called.

```
tests/tools/test_credential_pool_env_fallback.py::TestCopilotCredentialPoolFallback
  test_copilot_pool_fallback_when_resolve_token_empty   PASSED
  test_copilot_pool_skipped_when_classic_pat            PASSED
  test_copilot_resolve_token_takes_priority_over_pool   PASSED
```

## Out of scope

- The deeper `auth_type=external_process` (`copilot-acp`) auxiliary story — spawning an ACP subprocess per compression call is heavy. A follow-up could route auxiliary requests through a shared `CopilotACPClient` instance owned by the main agent, or transparently fall back from `copilot-acp` to the api-key `copilot` path when a token is discoverable. Filed as a separate concern.
- Reading the GitHub Copilot CLI's OAuth keyring entry directly. Out of scope here; the credential pool already covers the documented `hermes login copilot` flow.

## Related

- Closes the auxiliary side of the gap noted alongside #15017 (which only fixed the `github-copilot` → `copilot` slug normalisation).
