### PR TITLE
fix(telegram): keep DM topic typing scoped

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2516,11 +2516,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 except Exception as e:
                     if message_thread_id is not None and self._is_thread_not_found_error(e):
-                        await self._bot.send_chat_action(
-                            chat_id=int(chat_id),
-                            action="typing",
-                            message_thread_id=None,
-                        )
+                        if str(_typing_thread) == self._GENERAL_TOPIC_THREAD_ID:
+                            await self._bot.send_chat_action(
+                                chat_id=int(chat_id),
+                                action="typing",
+                                message_thread_id=None,
+                            )
                     else:
                         raise
             except Exception as e:

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -180,6 +180,25 @@ async def test_send_typing_retries_without_general_thread_when_not_found():
 
 
 @pytest.mark.asyncio
+async def test_send_typing_does_not_fall_back_to_root_for_dm_topic():
+    """Typing failures in DM topics should not show an indicator in All Messages."""
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_chat_action(**kwargs):
+        call_log.append(dict(kwargs))
+        raise FakeBadRequest("Message thread not found")
+
+    adapter._bot = SimpleNamespace(send_chat_action=mock_send_chat_action)
+
+    await adapter.send_typing("12345", metadata={"thread_id": "22182"})
+
+    assert call_log == [
+        {"chat_id": 12345, "action": "typing", "message_thread_id": 22182},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_send_retries_without_thread_on_thread_not_found():
     """When message_thread_id causes 'thread not found', retry without it."""
     adapter = _make_adapter()


### PR DESCRIPTION
## What does this PR do?

Fixes Telegram DM topic typing indicators so a rejected topic-specific `send_chat_action` does not fall back to the root/All Messages chat.

The existing fallback remains for Telegram forum General topic typing, where `message_thread_id=1` can be rejected and retrying without a thread id is the correct behavior. For user-created DM topics, typing is nonessential and falling back to `message_thread_id=None` shows the indicator in the wrong place, so Hermes now suppresses that typing tick instead.

## Related Issue

Discord support report: Telegram DM Topic Mode typing indicator appears in All Messages instead of the active topic.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `gateway/platforms/telegram.py` so `send_typing()` only retries without `message_thread_id` for Telegram General topic typing.
- Added a regression test in `tests/gateway/test_telegram_thread_fallback.py` proving DM topic typing does not fall back to root/All Messages after a thread-not-found response.

## How to Test

1. In Telegram DM topic mode, send a message in a user-created topic.
2. Have Telegram reject `send_chat_action(..., message_thread_id=<topic>)` with `Message thread not found`.
3. Verify Hermes does not retry typing with `message_thread_id=None`, while forum General topic typing still keeps its existing fallback.

Targeted test run:

```text
scripts/run_tests.sh tests/gateway/test_telegram_thread_fallback.py -q
11 passed in 7.40s
```

Full suite run:

```text
HERMES_TEST_WORKERS=4 scripts/run_tests.sh
45 failed, 19852 passed, 51 skipped, 227 warnings in 638.69s (0:10:38)
```

`HERMES_HOME` guard for the full suite:

```text
before_env_HERMES_HOME=
before_sane_HERMES_HOME=/home/gille/.hermes
after_env_HERMES_HOME=
after_resolved_HERMES_HOME=/home/gille/.hermes
```


Full-suite failures reported:

```text
FAILED tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_approve_once
FAILED tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_deny
FAILED tests/cron/test_cron_script.py::TestBuildJobPromptWithScript::test_script_empty_output_noted
FAILED tests/agent/test_auxiliary_client.py::TestGetTextAuxiliaryClient::test_custom_endpoint_uses_codex_wrapper_when_runtime_requests_responses_api
FAILED tests/gateway/test_config.py::TestLoadGatewayConfig::test_bridges_quoted_false_platform_enabled_from_config_yaml
FAILED tests/agent/test_bedrock_1m_context.py::TestBedrockContext1MBeta::test_build_anthropic_kwargs_includes_1m_for_bedrock_fastmode
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_final_reply_finalizes_card
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_intermediate_send_stays_streaming
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_done_fires_only_when_reply_to_is_set
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_edit_message_finalize_fires_done
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_edit_message_finalize_false_tracks_sibling
FAILED tests/gateway/test_dingtalk.py::TestCardLifecycle::test_next_send_auto_closes_sibling_streaming_cards
FAILED tests/gateway/test_dingtalk.py::TestDingTalkAdapterAICards::test_send_uses_ai_card_if_configured
FAILED tests/gateway/test_discord_bot_filter.py::TestDiscordBotFilter::test_default_is_none
FAILED tests/gateway/test_restart_drain.py::test_restart_command_while_busy_requests_drain_without_interrupt
FAILED tests/gateway/test_api_server.py::TestAdapterInit::test_default_config
FAILED tests/gateway/test_discord_free_response.py::test_discord_free_channel_skips_auto_thread
FAILED tests/hermes_cli/test_model_provider_persistence.py::TestProviderPersistsAfterModelSave::test_lmstudio_provider_saved_when_selected
FAILED tests/hermes_cli/test_model_provider_persistence.py::TestBaseUrlValidation::test_stepfun_provider_saved_with_selected_region
FAILED tests/hermes_cli/test_update_gateway_restart.py::TestCmdUpdateLaunchdRestart::test_update_restarts_profile_manual_gateways
FAILED tests/hermes_cli/test_update_gateway_restart.py::TestCmdUpdateLaunchdRestart::test_update_profile_manual_gateway_falls_back_to_sigterm
FAILED tests/hermes_cli/test_update_gateway_restart.py::TestServicePidExclusion::test_update_kills_manual_pid_but_not_service_pid
FAILED tests/hermes_cli/test_model_validation.py::TestValidateCodexAutoCorrection::test_very_different_name_falls_to_suggestions
FAILED tests/hermes_cli/test_cmd_update.py::TestCmdUpdateBranchFallback::test_update_refreshes_repo_and_tui_node_dependencies
FAILED tests/run_agent/test_concurrent_interrupt.py::test_concurrent_interrupt_cancels_pending
FAILED tests/run_agent/test_concurrent_interrupt.py::test_running_concurrent_worker_sees_is_interrupted
FAILED tests/test_tui_gateway_server.py::test_session_create_drops_pending_title_on_valueerror
FAILED tests/tools/test_browser_chromium_check.py::TestChromiumInstalled::test_false_when_dir_empty
FAILED tests/tools/test_browser_chromium_check.py::TestChromiumInstalled::test_false_when_only_unrelated_browsers
FAILED tests/tools/test_browser_chromium_check.py::TestChromiumInstalled::test_false_when_path_not_a_dir
FAILED tests/tools/test_browser_chromium_check.py::TestCheckBrowserRequirementsChromium::test_local_mode_missing_chromium_returns_false
FAILED tests/tools/test_browser_chromium_check.py::TestRunBrowserCommandChromiumGuard::test_local_mode_missing_chromium_returns_error_immediately
FAILED tests/tools/test_browser_chromium_check.py::TestRunBrowserCommandChromiumGuard::test_docker_hint_mentions_image_pull
FAILED tests/tools/test_browser_chromium_check.py::TestRunBrowserCommandChromiumGuard::test_non_docker_hint_mentions_agent_browser_install
FAILED tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_nous_provider_resolves_nous_credentials
FAILED tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_provider_resolution_uses_runtime_model_when_config_model_missing
FAILED tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_provider_resolves_full_credentials
FAILED tests/tools/test_delegate.py::TestDelegateHeartbeat::test_heartbeat_still_trips_idle_stale_when_no_tool
FAILED tests/tools/test_dockerfile_pid1_reaping.py::test_dockerfile_installs_tui_dependencies
FAILED tests/tools/test_dockerfile_pid1_reaping.py::test_dockerfile_materializes_local_tui_ink_package
FAILED tests/tools/test_credential_pool_env_fallback.py::TestCredentialPoolSeedsFromDotEnv::test_os_environ_still_wins_over_dotenv
FAILED tests/tools/test_daytona_environment.py::TestExecute::test_custom_cwd_in_command_wrapper
FAILED tests/tools/test_skill_provenance.py::test_default_origin_is_foreground
FAILED tests/tools/test_tirith_security.py::TestDiskFailureMarker::test_cosign_missing_marker_clears_when_cosign_appears
FAILED tests/tools/test_vercel_sandbox_environment.py::TestExecute::test_execute_runs_command_from_workspace_root_and_updates_cwd
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: targeted pytest and full-suite attempt on Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

The regression is covered by `test_send_typing_does_not_fall_back_to_root_for_dm_topic`.

