### PR TITLE
feat(i18n): add Italian locale

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -25,7 +25,7 @@ Language resolution order:
     3. ``display.language`` from config.yaml
     4. ``"en"`` (baseline)
 
-Supported languages: en, zh, ja, de, es.  Unknown values fall back to en.
+Supported languages: en, zh, ja, de, es, it.  Unknown values fall back to en.
 """
 
 from __future__ import annotations
@@ -39,7 +39,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "ja", "de", "es")
+SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "ja", "de", "es", "it")
 DEFAULT_LANGUAGE = "en"
 
 # Accept a few natural aliases so users who type "chinese" / "zh-CN" / "jp"
@@ -50,6 +50,7 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "japanese": "ja", "jp": "ja", "ja-jp": "ja",
     "german": "de", "deutsch": "de", "de-de": "de",
     "spanish": "es", "español": "es", "espanol": "es", "es-es": "es", "es-mx": "es",
+    "italian": "it", "italiano": "it", "it-it": "it",
 }
 
 _catalog_cache: dict[str, dict[str, str]] = {}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -784,7 +784,7 @@ DEFAULT_CONFIG = {
         # UI language for static user-facing messages (approval prompts, a
         # handful of gateway slash-command replies).  Does NOT affect agent
         # responses, log lines, tool outputs, or slash-command descriptions.
-        # Supported: en, zh, ja, de, es.  Unknown values fall back to en.
+        # Supported: en, zh, ja, de, es, it.  Unknown values fall back to en.
         "language": "en",
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -7,7 +7,7 @@
 #
 # Keys are dotted paths; nesting below is purely for readability.  Values may
 # contain {placeholder} tokens for str.format substitution.  When adding a
-# new key, add it to EVERY locale file (en/zh/ja/de/es) in the same commit --
+# new key, add it to EVERY locale file (en/zh/ja/de/es/it) in the same commit --
 # tests/agent/test_i18n.py asserts catalog parity.
 
 approval:

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -1,0 +1,24 @@
+# Catalogo dei messaggi statici di Hermes -- Italiano
+# See locales/en.yaml for the source of truth; keep keys in sync.
+
+approval:
+  dangerous_header: "⚠️  COMANDO PERICOLOSO: {description}"
+  choose_long:     "      [o]una volta  |  [s]sessione  |  [a]sempre  |  [d]nega"
+  choose_short:    "      [o]una volta  |  [s]sessione  |  [d]nega"
+  prompt_long:     "      Scelta [o/s/a/D]: "
+  prompt_short:    "      Scelta [o/s/D]: "
+  timeout:         "      ⏱ Timeout - comando negato"
+  allowed_once:    "      ✓ Consentito una volta"
+  allowed_session: "      ✓ Consentito per questa sessione"
+  allowed_always:  "      ✓ Aggiunto alla allowlist permanente"
+  denied:          "      ✗ Negato"
+  cancelled:       "      ✗ Annullato"
+  blocklist_message: "Questo comando è nella blocklist incondizionata e non può essere approvato."
+
+gateway:
+  approval_expired: "⚠️ Approvazione scaduta (l'agente non è più in attesa). Chiedi all'agente di riprovare."
+  draining:         "⏳ Attendo il completamento di {count} agente/i attivo/i prima del riavvio..."
+  goal_cleared:     "✓ Obiettivo cancellato."
+  no_active_goal:   "Nessun obiettivo attivo."
+  config_read_failed: "⚠️ Impossibile leggere config.yaml: {error}"
+  config_save_failed: "⚠️ Impossibile salvare la configurazione: {error}"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -102,6 +102,7 @@ AUTHOR_MAP = {
     "daixin1204@gmail.com": "SimbaKingjoe",
     "maxence@groine.fr": "MaxyMoos",
     "61830395+leprincep35700@users.noreply.github.com": "leprincep35700",
+    "leprincep35700@users.noreply.github.com": "leprincep35700",
     # OpenViking viking_read salvage (April 2026)
     "hitesh@gmail.com": "htsh",
     "pty819@outlook.com": "pty819",

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -88,6 +88,8 @@ def test_normalize_lang_accepts_aliases():
     assert i18n._normalize_lang("zh-CN") == "zh"
     assert i18n._normalize_lang("Deutsch") == "de"
     assert i18n._normalize_lang("español") == "es"
+    assert i18n._normalize_lang("italiano") == "it"
+    assert i18n._normalize_lang("it-IT") == "it"
     assert i18n._normalize_lang("jp") == "ja"
 
 


### PR DESCRIPTION
## Summary

- Add an Italian (`it`) catalog for Hermes static user-facing messages.
- Register `it` in the i18n language list and add common aliases (`italian`, `italiano`, `it-IT`).
- Update the locale-sync comments/config hint to include Italian.
- Add regression coverage for Italian alias normalization and catalog parity.
- Add the missing AUTHOR_MAP entry for this commit email so attribution checks can resolve the contributor.

## Scope

This follows the existing thin i18n layer from #20231. It translates the same static message surface only:

- CLI dangerous-command approval prompt strings
- Gateway approval/restart/goal/config status replies

It does not translate agent-generated responses, logs, tracebacks, tool output, slash-command names, or setup flows.

## Testing

- [x] Verified the new Italian alias regression fails before registering `it`.
- [x] `/opt/venv/bin/python -m py_compile agent/i18n.py hermes_cli/config.py tests/agent/test_i18n.py scripts/release.py`
- [x] `/opt/venv/bin/python -m pytest tests/agent/test_i18n.py -q -o addopts=''`

Result: `23 passed, 1 warning`.

## Usage

```bash
hermes config set display.language it
```

Then restart or run `/reset` so the process reloads the language cache.

This work was done with Hermes Agent.
