### PR TITLE
fix(minimax-oauth): correct authorize URL domain and handle ms timestamps

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4503,7 +4503,9 @@ def _minimax_oauth_login(
             client_id=pconfig.client_id,
             code_challenge=challenge, state=state,
         )
-        verification_url = str(code_data["verification_uri"])
+        verification_url = str(code_data["verification_uri"]).replace(
+            "https://www.minimax.io/", "https://platform.minimax.io/"
+        )
         user_code = str(code_data["user_code"])
 
         print()
@@ -4529,7 +4531,14 @@ def _minimax_oauth_login(
         )
 
     now = datetime.now(timezone.utc)
-    expires_in_s = int(token_data["expired_in"])
+    raw_expired = int(token_data["expired_in"])
+    import time as _time
+    now_ms = int(_time.time() * 1000)
+    if raw_expired > now_ms // 2:
+        # Looks like a unix-ms timestamp — convert to seconds-from-now
+        expires_in_s = max(1, int((raw_expired / 1000.0) - _time.time()))
+    else:
+        expires_in_s = raw_expired
     expires_at = now.timestamp() + expires_in_s
 
     auth_state = {
@@ -4605,7 +4614,13 @@ def _refresh_minimax_oauth_state(
             relogin_required=True,
         )
     now_dt = datetime.now(timezone.utc)
-    expires_in_s = int(payload["expired_in"])
+    raw_expired = int(payload["expired_in"])
+    import time as _time
+    now_ms = int(_time.time() * 1000)
+    if raw_expired > now_ms // 2:
+        expires_in_s = max(1, int((raw_expired / 1000.0) - _time.time()))
+    else:
+        expires_in_s = raw_expired
     new_state = dict(state)
     new_state.update({
         "access_token": payload["access_token"],


### PR DESCRIPTION
Fixes #19337

## What

Fixes two bugs in the MiniMax OAuth login flow that prevent `hermes model` → MiniMax (OAuth) from completing.

## Bug 1: Authorize URL redirects to homepage

The `/oauth/code` endpoint returns `verification_uri` pointing to `www.minimax.io/oauth-authorize`, but that route returns a `307` redirect to `/` (the homepage). The correct domain is `platform.minimax.io`, which serves the actual authorize page with the user code input.

**Reproduction:**
```bash
curl -sI "https://www.minimax.io/oauth-authorize?user_code=TEST&client=OpenClaw"
# → 307 → /
curl -sI "https://platform.minimax.io/oauth-authorize?user_code=TEST&client=OpenClaw"
# → 200 (page loads)
```

**Fix:** Replace `www.minimax.io` → `platform.minimax.io` in the verification URL before presenting it to the user.

## Bug 2: `expired_in` parsed as seconds but is unix-ms timestamp

The token endpoint returns `expired_in` as a unix-ms timestamp (e.g. `1778010274711`), not a duration in seconds. The code added this directly to `datetime.timestamp()` (seconds), causing:

```
Login failed: year 58374 is out of range
```

**Fix:** Detect ms timestamps (value > `now_ms // 2`) and convert to seconds-from-now. Applied in both `_minimax_oauth_login` and `_refresh_minimax_oauth_state`.

## Testing

- OAuth login completes successfully
- Token stored with correct `expires_at` (~48h from now)
- `hermes chat -q "Say OK" -m m27` responds via Token Plan
- Token refresh logic uses same ms→s conversion

## Related

- #19337 — tracking issue
- #19461, #19466 — URL-only fixes (no expired_in handling)
- #20106 — similar scope but different implementation