### PR TITLE
docs: remove dead reference links in flash-attention skill (salvage #14567)

### DIFF
--- a/optional-skills/mlops/flash-attention/SKILL.md
+++ b/optional-skills/mlops/flash-attention/SKILL.md
@@ -345,10 +345,6 @@ Flash Attention uses float16/bfloat16 for speed. Float32 not supported.
 
 **Performance benchmarks**: See [references/benchmarks.md](references/benchmarks.md) for detailed speed and memory comparisons across GPUs and sequence lengths.
 
-**Algorithm details**: See [references/algorithm.md](references/algorithm.md) for tiling strategy, recomputation, and IO complexity analysis.
-
-**Advanced features**: See [references/advanced-features.md](references/advanced-features.md) for rotary embeddings, ALiBi, paged KV cache, and custom attention masks.
-
 ## Hardware requirements
 
 - **GPU**: NVIDIA Ampere+ (A100, A10, A30) or AMD MI200+


### PR DESCRIPTION
Removes two links in `optional-skills/mlops/flash-attention/SKILL.md` that point to `references/algorithm.md` and `references/advanced-features.md` — neither file exists in the skill directory (only `benchmarks.md` and `transformers-integration.md` are present).

Changes:
- `optional-skills/mlops/flash-attention/SKILL.md` (-4)

Closes #14567 via salvage.

Original PR by @WadydX — authorship preserved.