### PR TITLE
docs: remove dead papers.md link from saelens references (salvage #14569)

### DIFF
--- a/optional-skills/mlops/saelens/references/README.md
+++ b/optional-skills/mlops/saelens/references/README.md
@@ -6,7 +6,6 @@ This directory contains comprehensive reference materials for SAELens.
 
 - [api.md](api.md) - Complete API reference for SAE, TrainingSAE, and configuration classes
 - [tutorials.md](tutorials.md) - Step-by-step tutorials for training and analyzing SAEs
-- [papers.md](papers.md) - Key research papers on sparse autoencoders
 
 ## Quick Links
 


### PR DESCRIPTION
Removes a dead link to `papers.md` from `optional-skills/mlops/saelens/references/README.md`. Only `api.md`, `tutorials.md`, and `README.md` exist in the directory.

Changes:
- `optional-skills/mlops/saelens/references/README.md` (-1)

Closes #14569 via salvage.

Original PR by @WadydX — authorship preserved.