### PR TITLE
docs: fix broken nix-setup anchor for container-aware CLI (salvage #14596)

### DIFF
--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -122,7 +122,9 @@ services.hermes-agent.environmentFiles = [ "/var/lib/hermes/env" ];
 Setting `addToSystemPackages = true` does two things: puts the `hermes` CLI on your system PATH **and** sets `HERMES_HOME` system-wide so the interactive CLI shares state (sessions, skills, cron) with the gateway service. Without it, running `hermes` in your shell creates a separate `~/.hermes/` directory.
 :::
 
-:::info Container-aware CLI
+### Container-aware CLI
+
+:::info
 When `container.enable = true` and `addToSystemPackages = true`, **every** `hermes` command on the host automatically routes into the managed container. This means your interactive CLI session runs inside the same environment as the gateway service — with access to all container-installed packages and tools.
 
 - The routing is transparent: `hermes chat`, `hermes sessions list`, `hermes version`, etc. all exec into the container under the hood


### PR DESCRIPTION
Splits the `:::info Container-aware CLI` admonition into a proper `### Container-aware CLI` heading so the anchor link resolves. Admonition titles aren't emitted as anchors by Docusaurus.

Changes:
- `website/docs/getting-started/nix-setup.md` (+3/-1)

Closes #14596 via salvage.

Original PR by @WadydX — authorship preserved.