### PR TITLE
fix(telegram): keep DM topic typing scoped + symmetric thread-id resolver

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2516,11 +2516,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 except Exception as e:
                     if message_thread_id is not None and self._is_thread_not_found_error(e):
-                        await self._bot.send_chat_action(
-                            chat_id=int(chat_id),
-                            action="typing",
-                            message_thread_id=None,
-                        )
+                        if str(_typing_thread) == self._GENERAL_TOPIC_THREAD_ID:
+                            await self._bot.send_chat_action(
+                                chat_id=int(chat_id),
+                                action="typing",
+                                message_thread_id=None,
+                            )
                     else:
                         raise
             except Exception as e:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -353,7 +353,10 @@ class TelegramAdapter(BasePlatformAdapter):
 
     @classmethod
     def _message_thread_id_for_typing(cls, thread_id: Optional[str]) -> Optional[int]:
-        if not thread_id:
+        # Mirrors _message_thread_id_for_send: the General forum topic (thread id
+        # "1") is represented as "no thread id" on the wire. User-created topics
+        # keep their real id so typing stays scoped to that topic.
+        if not thread_id or str(thread_id) == cls._GENERAL_TOPIC_THREAD_ID:
             return None
         return int(thread_id)
 
@@ -2508,22 +2511,16 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 _typing_thread = self._metadata_thread_id(metadata)
                 message_thread_id = self._message_thread_id_for_typing(_typing_thread)
-                try:
-                    await self._bot.send_chat_action(
-                        chat_id=int(chat_id),
-                        action="typing",
-                        message_thread_id=message_thread_id,
-                    )
-                except Exception as e:
-                    if message_thread_id is not None and self._is_thread_not_found_error(e):
-                        if str(_typing_thread) == self._GENERAL_TOPIC_THREAD_ID:
-                            await self._bot.send_chat_action(
-                                chat_id=int(chat_id),
-                                action="typing",
-                                message_thread_id=None,
-                            )
-                    else:
-                        raise
+                # No retry-without-thread fallback here: _message_thread_id_for_typing
+                # already maps the forum General topic to None, so any non-None value
+                # reaching this call is a user-created topic. If Telegram rejects it
+                # (e.g. topic deleted mid-session), we swallow the failure rather than
+                # showing a typing indicator in the wrong chat/All Messages.
+                await self._bot.send_chat_action(
+                    chat_id=int(chat_id),
+                    action="typing",
+                    message_thread_id=message_thread_id,
+                )
             except Exception as e:
                 # Typing failures are non-fatal; log at debug level only.
                 logger.debug(

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -180,6 +180,25 @@ async def test_send_typing_retries_without_general_thread_when_not_found():
 
 
 @pytest.mark.asyncio
+async def test_send_typing_does_not_fall_back_to_root_for_dm_topic():
+    """Typing failures in DM topics should not show an indicator in All Messages."""
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_chat_action(**kwargs):
+        call_log.append(dict(kwargs))
+        raise FakeBadRequest("Message thread not found")
+
+    adapter._bot = SimpleNamespace(send_chat_action=mock_send_chat_action)
+
+    await adapter.send_typing("12345", metadata={"thread_id": "22182"})
+
+    assert call_log == [
+        {"chat_id": 12345, "action": "typing", "message_thread_id": 22182},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_send_retries_without_thread_on_thread_not_found():
     """When message_thread_id causes 'thread not found', retry without it."""
     adapter = _make_adapter()

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -159,22 +159,24 @@ async def test_send_omits_general_topic_thread_id():
 
 
 @pytest.mark.asyncio
-async def test_send_typing_retries_without_general_thread_when_not_found():
-    """Typing for forum General should fall back if Telegram rejects thread 1."""
+async def test_send_typing_general_topic_uses_none_thread_id():
+    """Typing for forum General should hit the API with message_thread_id=None directly.
+
+    _message_thread_id_for_typing() maps the General topic (thread id "1") to None
+    the same way _message_thread_id_for_send() does, so there's no retry path — the
+    first call is already correct.
+    """
     adapter = _make_adapter()
     call_log = []
 
     async def mock_send_chat_action(**kwargs):
         call_log.append(dict(kwargs))
-        if kwargs.get("message_thread_id") == 1:
-            raise FakeBadRequest("Message thread not found")
 
     adapter._bot = SimpleNamespace(send_chat_action=mock_send_chat_action)
 
     await adapter.send_typing("-100123", metadata={"thread_id": "1"})
 
     assert call_log == [
-        {"chat_id": -100123, "action": "typing", "message_thread_id": 1},
         {"chat_id": -100123, "action": "typing", "message_thread_id": None},
     ]
 


### PR DESCRIPTION
## Summary
Telegram DM topic typing indicators now stay inside the active topic instead of leaking into All Messages. Salvages @helix4u's #20370 and adds a small refactor so the typing and send paths treat the forum General topic the same way.

## Root cause
`send_typing()` retried `send_chat_action` with `message_thread_id=None` whenever Telegram rejected the topic-specific call. In DM topic mode that retry surfaced the typing indicator in the root/All Messages chat instead of the active topic.

## Changes
- **gateway/platforms/telegram.py**
  - `_message_thread_id_for_typing()` now returns `None` for the General topic (thread id `"1"`), matching `_message_thread_id_for_send()`. The two resolvers are now symmetric.
  - `send_typing()` drops the retry-without-thread fallback entirely. Any non-None thread id reaching the API call is a real user-created topic; falling back to the root chat is never correct. Telegram rejections are swallowed at debug level.
- **tests/gateway/test_telegram_thread_fallback.py**
  - Keeps @helix4u's DM-topic regression test (`test_send_typing_does_not_fall_back_to_root_for_dm_topic`).
  - Rewrites the old General-topic retry test to assert the new single-call contract (`test_send_typing_general_topic_uses_none_thread_id`).

## Validation
```
scripts/run_tests.sh tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_keep_typing_timeout.py -q
15 passed in 5.16s
```

## Credit
Salvaged from #20370 by @helix4u — authorship preserved via rebase-merge.

Closes #20370.