### PR TITLE
docs(skill/hermes-agent): sync slash commands + add durable-systems section

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hermes-agent
 description: "Configure, extend, or contribute to Hermes Agent."
-version: 2.0.0
+version: 2.1.0
 author: Hermes Agent + Teknium
 license: MIT
 metadata:
@@ -227,7 +227,11 @@ hermes uninstall            Uninstall Hermes
 
 ## Slash Commands (In-Session)
 
-Type these during an interactive chat session.
+Type these during an interactive chat session. New commands land fairly
+often; if something below looks stale, run `/help` in-session for the
+authoritative list or see the [live slash commands reference](https://hermes-agent.nousresearch.com/docs/reference/slash-commands).
+The registry of record is `hermes_cli/commands.py` — every consumer
+(autocomplete, Telegram menu, Slack mapping, `/help`) derives from it.
 
 ### Session Control
 ```
@@ -239,9 +243,15 @@ Type these during an interactive chat session.
 /compress            Manually compress context
 /stop                Kill background processes
 /rollback [N]        Restore filesystem checkpoint
+/snapshot [sub]      Create or restore state snapshots of Hermes config/state (CLI)
 /background <prompt> Run prompt in background
 /queue <prompt>      Queue for next turn
+/steer <prompt>      Inject a message after the next tool call without interrupting
+/agents (/tasks)     Show active agents and running tasks
 /resume [name]       Resume a named session
+/goal [text|sub]     Set a standing goal Hermes works on across turns until achieved
+                     (subcommands: status, pause, resume, clear)
+/redraw              Force a full UI repaint (CLI)
 ```
 
 ### Configuration
@@ -253,6 +263,11 @@ Type these during an interactive chat session.
 /verbose             Cycle: off → new → all → verbose
 /voice [on|off|tts]  Voice mode
 /yolo                Toggle approval bypass
+/busy [sub]          Control what Enter does while Hermes is working (CLI)
+                     (subcommands: queue, steer, interrupt, status)
+/indicator [style]   Pick the TUI busy-indicator style (CLI)
+                     (styles: kaomoji, emoji, unicode, ascii)
+/footer [on|off]     Toggle gateway runtime-metadata footer on final replies
 /skin [name]         Change theme (CLI)
 /statusbar           Toggle status bar (CLI)
 ```
@@ -263,8 +278,12 @@ Type these during an interactive chat session.
 /toolsets            List toolsets (CLI)
 /skills              Search/install skills (CLI)
 /skill <name>        Load a skill into session
-/cron                Manage cron jobs (CLI)
+/reload-skills       Re-scan ~/.hermes/skills/ for added/removed skills
+/reload              Reload .env variables into the running session (CLI)
 /reload-mcp          Reload MCP servers
+/cron                Manage cron jobs (CLI)
+/curator [sub]       Background skill maintenance (status, run, pin, archive, …)
+/kanban [sub]        Multi-profile collaboration board (tasks, links, comments)
 /plugins             List plugins (CLI)
 ```
 
@@ -275,6 +294,7 @@ Type these during an interactive chat session.
 /restart             Restart gateway (gateway)
 /sethome             Set current chat as home channel (gateway)
 /update              Update Hermes to latest (gateway)
+/topic [sub]         Enable or inspect Telegram DM topic sessions (gateway)
 /platforms (/gateway) Show platform connection status (gateway)
 ```
 
@@ -285,6 +305,7 @@ Type these during an interactive chat session.
 /browser             Open CDP browser connection
 /history             Show conversation history (CLI)
 /save                Save conversation to file (CLI)
+/copy [N]            Copy the last assistant response to clipboard (CLI)
 /paste               Attach clipboard image (CLI)
 /image               Attach local image file (CLI)
 ```
@@ -295,8 +316,10 @@ Type these during an interactive chat session.
 /commands [page]     Browse all commands (gateway)
 /usage               Token usage
 /insights [days]     Usage analytics
+/gquota              Show Google Gemini Code Assist quota usage (CLI)
 /status              Session info (gateway)
 /profile             Active profile info
+/debug               Upload debug report (system info + logs) and get shareable links
 ```
 
 ### Exit
@@ -378,12 +401,14 @@ Enable/disable via `hermes tools` (interactive) or `hermes tools enable/disable 
 | Toolset | What it provides |
 |---------|-----------------|
 | `web` | Web search and content extraction |
+| `search` | Web search only (subset of `web`) |
 | `browser` | Browser automation (Browserbase, Camofox, or local Chromium) |
 | `terminal` | Shell commands and process management |
 | `file` | File read/write/search/patch |
 | `code_execution` | Sandboxed Python execution |
 | `vision` | Image analysis |
 | `image_gen` | AI image generation |
+| `video` | Video analysis and generation |
 | `tts` | Text-to-speech |
 | `skills` | Skill browsing and management |
 | `memory` | Persistent cross-session memory |
@@ -392,11 +417,21 @@ Enable/disable via `hermes tools` (interactive) or `hermes tools enable/disable 
 | `cronjob` | Scheduled task management |
 | `clarify` | Ask user clarifying questions |
 | `messaging` | Cross-platform message sending |
-| `search` | Web search only (subset of `web`) |
 | `todo` | In-session task planning and tracking |
+| `kanban` | Multi-agent work-queue tools (gated to workers) |
+| `debugging` | Extra introspection/debug tools (off by default) |
+| `safe` | Minimal, low-risk toolset for locked-down sessions |
+| `spotify` | Spotify playback and playlist control |
+| `homeassistant` | Smart home control (off by default) |
+| `discord` | Discord integration tools |
+| `discord_admin` | Discord admin/moderation tools |
+| `feishu_doc` | Feishu (Lark) document tools |
+| `feishu_drive` | Feishu (Lark) drive tools |
+| `yuanbao` | Yuanbao integration tools |
 | `rl` | Reinforcement learning tools (off by default) |
 | `moa` | Mixture of Agents (off by default) |
-| `homeassistant` | Smart home control (off by default) |
+
+Full enumeration lives in `toolsets.py` as the `TOOLSETS` dict; `_HERMES_CORE_TOOLS` is the default bundle most platforms inherit from.
 
 Tool changes take effect on `/reset` (new session). They do NOT apply mid-conversation to preserve prompt caching.
 
@@ -573,6 +608,95 @@ terminal(command="tmux new-session -d -s resumed 'hermes --resume 20260225_14305
 - **Use `hermes chat -q` for fire-and-forget** — no PTY needed
 - **Use tmux for interactive sessions** — raw PTY mode has `\r` vs `\n` issues with prompt_toolkit
 - **For scheduled tasks**, use the `cronjob` tool instead of spawning — handles delivery and retry
+
+---
+
+## Durable & Background Systems
+
+Four systems run alongside the main conversation loop. Quick reference
+here; full developer notes live in `AGENTS.md`, user-facing docs under
+`website/docs/user-guide/features/`.
+
+### Delegation (`delegate_task`)
+
+Synchronous subagent spawn — the parent waits for the child's summary
+before continuing its own loop. Isolated context + terminal session.
+
+- **Single:** `delegate_task(goal, context, toolsets)`.
+- **Batch:** `delegate_task(tasks=[{goal, ...}, ...])` runs children in
+  parallel, capped by `delegation.max_concurrent_children` (default 3).
+- **Roles:** `leaf` (default; cannot re-delegate) vs `orchestrator`
+  (can spawn its own workers, bounded by `delegation.max_spawn_depth`).
+- **Not durable.** If the parent is interrupted, the child is
+  cancelled. For work that must outlive the turn, use `cronjob` or
+  `terminal(background=True, notify_on_complete=True)`.
+
+Config: `delegation.*` in `config.yaml`.
+
+### Cron (scheduled jobs)
+
+Durable scheduler — `cron/jobs.py` + `cron/scheduler.py`. Drive it via
+the `cronjob` tool, the `hermes cron` CLI (`list`, `add`, `edit`,
+`pause`, `resume`, `run`, `remove`), or the `/cron` slash command.
+
+- **Schedules:** duration (`"30m"`, `"2h"`), "every" phrase
+  (`"every monday 9am"`), 5-field cron (`"0 9 * * *"`), or ISO timestamp.
+- **Per-job knobs:** `skills`, `model`/`provider` override, `script`
+  (pre-run data collection; `no_agent=True` makes the script the whole
+  job), `context_from` (chain job A's output into job B), `workdir`
+  (run in a specific dir with its `AGENTS.md` / `CLAUDE.md` loaded),
+  multi-platform delivery.
+- **Invariants:** 3-minute hard interrupt per run, `.tick.lock` file
+  prevents duplicate ticks across processes, cron sessions pass
+  `skip_memory=True` by default, and cron deliveries are framed with a
+  header/footer instead of being mirrored into the target gateway
+  session (keeps role alternation intact).
+
+User docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/cron
+
+### Curator (skill lifecycle)
+
+Background maintenance for agent-created skills. Tracks usage, marks
+idle skills stale, archives stale ones, keeps a pre-run tar.gz backup
+so nothing is lost.
+
+- **CLI:** `hermes curator <verb>` — `status`, `run`, `pause`, `resume`,
+  `pin`, `unpin`, `archive`, `restore`, `prune`, `backup`, `rollback`.
+- **Slash:** `/curator <subcommand>` mirrors the CLI.
+- **Scope:** only touches skills with `created_by: "agent"` provenance.
+  Bundled + hub-installed skills are off-limits. **Never deletes** —
+  max destructive action is archive. Pinned skills are exempt from
+  every auto-transition and every LLM review pass.
+- **Telemetry:** sidecar at `~/.hermes/skills/.usage.json` holds
+  per-skill `use_count`, `view_count`, `patch_count`,
+  `last_activity_at`, `state`, `pinned`.
+
+Config: `curator.*` (`enabled`, `interval_hours`, `min_idle_hours`,
+`stale_after_days`, `archive_after_days`, `backup.*`).
+User docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/curator
+
+### Kanban (multi-agent work queue)
+
+Durable SQLite board for multi-profile / multi-worker collaboration.
+Users drive it via `hermes kanban <verb>`; dispatcher-spawned workers
+see a focused `kanban_*` toolset gated by `HERMES_KANBAN_TASK` so the
+schema footprint is zero outside worker processes.
+
+- **CLI verbs (common):** `init`, `create`, `list` (alias `ls`),
+  `show`, `assign`, `link`, `unlink`, `comment`, `complete`, `block`,
+  `unblock`, `archive`, `tail`. Less common: `watch`, `stats`, `runs`,
+  `log`, `dispatch`, `daemon`, `gc`.
+- **Worker toolset:** `kanban_show`, `kanban_complete`, `kanban_block`,
+  `kanban_heartbeat`, `kanban_comment`, `kanban_create`, `kanban_link`.
+- **Dispatcher** runs inside the gateway by default
+  (`kanban.dispatch_in_gateway: true`) — reclaims stale claims,
+  promotes ready tasks, atomically claims, spawns assigned profiles.
+  Auto-blocks a task after ~5 consecutive spawn failures.
+- **Isolation:** board is the hard boundary (workers get
+  `HERMES_KANBAN_BOARD` pinned in env); tenant is a soft namespace
+  within a board for workspace-path + memory-key isolation.
+
+User docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/kanban
 
 ---
 


### PR DESCRIPTION
## Summary
Sync the `hermes-agent` skill with the in-repo slash command registry and the AGENTS.md #20226 additions, so "does `/goal` exist?" (and anything like it) stops returning a confident wrong answer.

Addresses the user report from wxrrior in Discord: on a freshly-updated session, asking `/hermes-agent do you have any info on /goal` returned "no such command" because the skill's static slash-command list hadn't been touched since `/goal` (and 15 others) landed.

## Changes
- `skills/autonomous-ai-agents/hermes-agent/SKILL.md`:
  - Slash Commands header now points to `/help` + the [live slash commands reference](https://hermes-agent.nousresearch.com/docs/reference/slash-commands) as the source of truth, and names `hermes_cli/commands.py` as the registry of record. Future drift gets flagged honestly instead of answered confidently wrong.
  - Added the 16 missing commands: `/goal`, `/agents`, `/busy`, `/copy`, `/curator`, `/debug`, `/footer`, `/gquota`, `/indicator`, `/kanban`, `/redraw`, `/reload`, `/reload-skills`, `/snapshot`, `/steer`, `/topic`.
  - Toolsets table: grew from 20 to the authoritative 30 keys in `toolsets.py` (added `kanban`, `yuanbao`, `spotify`, `safe`, `debugging`, `video`, `feishu_doc`, `feishu_drive`, `discord`, `discord_admin`, `clarify`).
  - New "Durable & Background Systems" section before Troubleshooting — short user-facing rundowns of Delegation, Cron, Curator, and Kanban, each pointing to the full docs. Mirrors the developer-facing sections added to AGENTS.md in #20226.
  - Bumped version 2.0.0 → 2.1.0.

## Validation
| | Before | After |
|---|---|---|
| Registry commands missing from skill's slash list | 16 | 0 |
| Toolset rows in skill | 20 | 30 |
| Mentions of `/goal` in skill | 0 | 2 |
| Mentions of Curator/Cron/Kanban as first-class systems | 0 | 3 sections |

Drift re-check script (`CommandDef` names vs skill's `/slash` mentions) reports zero registry commands missing after the patch.

## Note on future drift
Per the Discord thread, the cleanest future-proofing is to have the skill defer entirely to live-generated slash-command text. This PR does the "fix the immediate stale info + point at the live source" half explicitly, without rewriting the skill layout. If we want the stronger version (skill pulls from `/help` output directly or regenerates the block at build/install time), I'm happy to do that as a follow-up.
