### PR TITLE
docs(cli): document hermes webhook subscribe --deliver-only (salvage #12612)

### DIFF
--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -431,6 +431,7 @@ hermes webhook subscribe <name> [options]
 | `--deliver` | Delivery target: `log` (default), `telegram`, `discord`, `slack`, `github_comment`. |
 | `--deliver-chat-id` | Target chat/channel ID for cross-platform delivery. |
 | `--secret` | Custom HMAC secret. Auto-generated if omitted. |
+| `--deliver-only` | Skip the agent — deliver the rendered `--prompt` as the literal message. Zero LLM cost, sub-second delivery. Requires `--deliver` to be a real target (not `log`). |
 
 Subscriptions persist to `~/.hermes/webhook_subscriptions.json` and are hot-reloaded by the webhook adapter without a gateway restart.
 


### PR DESCRIPTION
Adds the `--deliver-only` flag to the `hermes webhook subscribe` CLI reference. The flag was already implemented (`hermes_cli/webhook.py` + `hermes_cli/main.py:8880`) but wasn't in the docs.

Changes:
- `website/docs/reference/cli-commands.md` (+1)

Closes #12612 via salvage.

Original PR by @r266-tech — authorship preserved.