### PR TITLE
docs(cli): document hermes skills reset subcommand (salvage #11544)

### DIFF
--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -709,6 +709,7 @@ Subcommands:
 | `update` | Reinstall hub skills with upstream changes when available. |
 | `audit` | Re-scan installed hub skills. |
 | `uninstall` | Remove a hub-installed skill. |
+| `reset` | Un-stick a bundled skill flagged as `user_modified` by clearing its manifest entry. With `--restore`, also replaces the user copy with the bundled version. |
 | `publish` | Publish a skill to a registry. |
 | `snapshot` | Export/import skill configurations. |
 | `tap` | Manage custom skill sources. |
@@ -730,6 +731,8 @@ hermes skills install https://example.com/SKILL.md --name my-skill        # Over
 hermes skills check
 hermes skills update
 hermes skills config
+hermes skills reset google-workspace
+hermes skills reset google-workspace --restore --yes
 ```
 
 Notes:


### PR DESCRIPTION
Adds `hermes skills reset` (with `--restore` / `--yes` flags) to the CLI reference. Subcommand exists in `hermes_cli/main.py:9305` but wasn't listed in the docs.

Changes:
- `website/docs/reference/cli-commands.md` (+3)

Closes #11544 via salvage.

Original PR by @r266-tech — authorship preserved.