### PR TITLE
docs(cli): expand hermes import reference (salvage #14711)

### DIFF
--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -585,11 +585,21 @@ hermes backup --quick --label "pre-upgrade"  # Quick snapshot with label
 hermes import <zipfile> [options]
 ```
 
-Restore a previously created Hermes backup into your Hermes home directory.
+Restore a previously created Hermes backup into your Hermes home directory. All files in the archive overwrite existing files in your Hermes home; `--force` only skips the confirmation prompt that fires when the target already has a Hermes installation.
 
 | Option | Description |
 |--------|-------------|
-| `-f`, `--force` | Overwrite existing files without confirmation. |
+| `-f`, `--force` | Skip the existing-installation confirmation prompt. |
+
+:::warning
+Stop the gateway before importing to avoid conflicts with running processes.
+:::
+
+### Examples
+```bash
+hermes import ~/hermes-backup-20260423.zip           # Prompts before overwriting existing config
+hermes import ~/hermes-backup-20260423.zip --force   # Overwrite without prompting
+```
 
 ## `hermes logs`
 


### PR DESCRIPTION
Expands the `hermes import` CLI reference with description, safety warning, and examples.

Changes:
- `website/docs/reference/cli-commands.md` (+11/-1)

Corrected one line from the original PR: the `--force` flag only skips the confirmation prompt; the import loop always overwrites existing files (`hermes_cli/backup.py:383` opens every target as `"wb"`). Updated the description and example comments to match.

Closes #14711 via salvage.

Original PR by @Sertug17 — authorship preserved.