### PR TITLE
docs(bedrock): quickstart entry + fallback comment + deployment link (salvage #11093)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3952,6 +3952,7 @@ _FALLBACK_COMMENT = """
 #   kimi-coding-cn (KIMI_CN_API_KEY)   — Kimi / Moonshot (China)
 #   minimax      (MINIMAX_API_KEY)     — MiniMax
 #   minimax-cn   (MINIMAX_CN_API_KEY)  — MiniMax (China)
+#   bedrock      (AWS IAM / boto3)     — AWS Bedrock (Converse API)
 #
 # For custom OpenAI-compatible endpoints, add base_url and key_env.
 #
@@ -3983,6 +3984,7 @@ _COMMENTED_SECTIONS = """
 #   kimi-coding-cn (KIMI_CN_API_KEY)   — Kimi / Moonshot (China)
 #   minimax      (MINIMAX_API_KEY)     — MiniMax
 #   minimax-cn   (MINIMAX_CN_API_KEY)  — MiniMax (China)
+#   bedrock      (AWS IAM / boto3)     — AWS Bedrock (Converse API)
 #
 # For custom OpenAI-compatible endpoints, add base_url and key_env.
 #

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -97,6 +97,7 @@ Good defaults:
 | **MiniMax China** | China-region MiniMax endpoint | Set `MINIMAX_CN_API_KEY` |
 | **Alibaba Cloud** | Qwen models via DashScope | Set `DASHSCOPE_API_KEY` |
 | **Hugging Face** | 20+ open models via unified router (Qwen, DeepSeek, Kimi, etc.) | Set `HF_TOKEN` |
+| **AWS Bedrock** | Claude, Nova, Llama, DeepSeek via native Converse API | IAM role or `aws configure` ([guide](../guides/aws-bedrock.md)) |
 | **Kilo Code** | KiloCode-hosted models | Set `KILOCODE_API_KEY` |
 | **OpenCode Zen** | Pay-as-you-go access to curated models | Set `OPENCODE_ZEN_API_KEY` |
 | **OpenCode Go** | $10/month subscription for open models | Set `OPENCODE_GO_API_KEY` |

--- a/website/docs/guides/aws-bedrock.md
+++ b/website/docs/guides/aws-bedrock.md
@@ -162,3 +162,9 @@ Use an **inference profile ID** (prefixed with `us.` or `global.`) instead of th
 ### "ThrottlingException"
 
 You've hit the Bedrock per-model rate limit. Hermes automatically retries with backoff. To increase limits, request a quota increase in the [AWS Service Quotas console](https://console.aws.amazon.com/servicequotas/).
+
+## One-Click AWS Deployment
+
+For a fully automated deployment on EC2 with CloudFormation:
+
+**[sample-hermes-agent-on-aws-with-bedrock](https://github.com/JiaDe-Wu/sample-hermes-agent-on-aws-with-bedrock)** — creates VPC, IAM role, EC2 instance, and configures Bedrock automatically. Deploy in any region with one click.


### PR DESCRIPTION
Adds Bedrock to the quickstart provider table, adds it to the fallback-providers comment list in config.yaml defaults, and links the contributor's one-click CloudFormation sample in the Bedrock guide.

Changes:
- `website/docs/getting-started/quickstart.md` (+1)
- `website/docs/guides/aws-bedrock.md` (+6)
- `hermes_cli/config.py` — bedrock entry in `_FALLBACK_COMMENT` + `_COMMENTED_SECTIONS` (+2)

Verified bedrock provider is registered in `hermes_cli/auth.py:401` and has a config section in `hermes_cli/config.py:660`.

Closes #11093 via salvage.

Original PR by @JiaDe-Wu — authorship preserved.