### PR TITLE
feat(xai): add grok-4.3 to static fallback and context-length map

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -203,6 +203,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "grok-4-1-fast": 2000000,   # grok-4-1-fast-(non-)reasoning
     "grok-2-vision": 8192,      # grok-2-vision, -1212, -latest
     "grok-4-fast": 2000000,     # grok-4-fast-(non-)reasoning
+    "grok-4.3": 1000000,        # grok-4.3, grok-4.3-latest
     "grok-4.20": 2000000,       # grok-4.20-0309-(non-)reasoning, -multi-agent-0309
     "grok-4": 256000,           # grok-4, grok-4-0709
     "grok-3": 131072,           # grok-3, grok-3-mini, grok-3-fast, grok-3-mini-fast

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -114,6 +114,7 @@ def _codex_curated_models() -> list[str]:
 # or retires a model, the disk cache picks it up on the next refresh and the
 # fallback here only matters until that refresh lands.
 _XAI_STATIC_FALLBACK: list[str] = [
+    "grok-4.3",
     "grok-4.20-0309-reasoning",
     "grok-4.20-0309-non-reasoning",
     "grok-4.20-multi-agent-0309",


### PR DESCRIPTION
## Summary

xAI launched Grok 4.3 on 2026-04-30 (model ID `grok-4.3`, with a `grok-4.3-latest` alias and a 1M-token context window). This PR closes the cold-start and metadata gaps so xAI-direct callers see the model immediately on a fresh install, and so context-length probes against `https://api.x.ai/v1` resolve to the correct value instead of the global default.

The runtime `_xai_curated_models()` resolver added in #16925 already self-heals from the on-disk `models.dev` cache, so the `/model` picker will pick `grok-4.3` up automatically once the cache refreshes — this PR just covers the windows that resolver does not: fresh install / offline first run, and the metadata gap (xAI's `/v1/models` does not return `context_length`, so `DEFAULT_CONTEXT_LENGTHS` is the source of truth there).

## Changes

- `hermes_cli/models.py` — add `grok-4.3` to `_XAI_STATIC_FALLBACK` (the cold-start fallback used when `$HERMES_HOME/models_dev_cache.json` is empty or unreadable).
- `agent/model_metadata.py` — add `"grok-4.3": 1000000` to `DEFAULT_CONTEXT_LENGTHS`. Substring matching is longest-first, so the new key matches `grok-4.3` and `grok-4.3-latest` before falling through to the existing `grok-4` (256k) entry.

Two lines, no behavior changes for existing models.

## Why not also add `-fast` / `-mini` variants?

xAI's 4.3 release shipped one model + a `-latest` alias. There is no `grok-4.3-fast` or `grok-4.3-mini` on xAI-direct, on `models.dev`, or in the xAI Console at the time of writing. The `-fast` lineage exists only on Grok 4 / 4.1 (`grok-4-fast`, `grok-4-1-fast`) and `-mini` only on Grok 3 (`grok-3-mini`). Adding speculative IDs would reproduce the exact regression #16925 fixed (HTTP 400 \"Unknown Model\" from xAI-direct).

## Testing

- Verified the existing `_xai_curated_models()` resolver still prefers the disk cache when present (a fresh `models_dev_cache.json` already lists `grok-4.3` locally, so the picker exposes it via the live path).
- Verified longest-first lookup in `DEFAULT_CONTEXT_LENGTHS`: `grok-4.3` (len 8) matches before `grok-4` (len 6) for the literal model ID `grok-4.3`, and before `grok` (len 4) for `grok-4.3-latest`.
- Did not add a `assert \"grok-4.3\" in _XAI_STATIC_FALLBACK`-style test — `AGENTS.md` explicitly classifies catalog-snapshot tests as change-detectors and rejects them.
- Platform: macOS (Darwin 25.3.0). The change is pure-Python data, no OS-specific paths.

## References

- xAI docs: https://docs.x.ai/developers/models (\"For everything else, use Grok 4.3\")
- Oracle OCI listing for `grok-4.3`: https://docs.oracle.com/en-us/iaas/Content/generative-ai/xai-grok-4-3.htm
- Prior art / pattern: #16925 (auto-derive xAI list from `models.dev` + static fallback)
- Prior art / pattern: #7093 (xAI Grok context-length fallbacks)