### PR TITLE
docs(docker): document API_SERVER_* env vars (salvage #11758)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -89,6 +89,7 @@ AUTHOR_MAP = {
     "tony@tonysimons.dev": "asimons81",
     "jetha@google.com": "jethac",
     "jani@0xhoneyjar.xyz": "deep-name",
+    "xiangyong@zspace.cn": "CES4751",
     # Matrix parity salvage batch (April 2026)
     "sr@samirusani": "samrusani",
     "angelclaw@AngelMacBook.local": "angel12",

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -41,6 +41,21 @@ docker run -d \
 
 Port 8642 exposes the gateway's [OpenAI-compatible API server](./features/api-server.md) and health endpoint. It's optional if you only use chat platforms (Telegram, Discord, etc.), but required if you want the dashboard or external tools to reach the gateway.
 
+Note: the API server is gated on `API_SERVER_ENABLED=true`. To expose it beyond `127.0.0.1` inside the container, also set `API_SERVER_HOST=0.0.0.0` and an `API_SERVER_KEY` (minimum 8 characters — generate one with `openssl rand -hex 32`). Example:
+
+```sh
+docker run -d \
+  --name hermes \
+  --restart unless-stopped \
+  -v ~/.hermes:/opt/data \
+  -p 8642:8642 \
+  -e API_SERVER_ENABLED=true \
+  -e API_SERVER_HOST=0.0.0.0 \
+  -e API_SERVER_KEY=your_api_key_here \
+  -e API_SERVER_CORS_ORIGINS='*' \
+  nousresearch/hermes-agent gateway run
+```
+
 Opening any port on an internet facing machine is a security risk. You should not do it unless you understand the risks.
 
 ## Running the dashboard


### PR DESCRIPTION
Documents that the OpenAI-compatible API server on port 8642 is gated on `API_SERVER_ENABLED=true` and needs `API_SERVER_HOST=0.0.0.0` + `API_SERVER_KEY` to reach it from outside the container.

Changes:
- `website/docs/user-guide/docker.md` — API_SERVER_* env var note on the basic `docker run` example (+15)
- `scripts/release.py` — AUTHOR_MAP entry for CES4751

The PR's original diff was stale (main's Docker Compose section has been heavily refactored — dashboard is now an embedded side-process via `HERMES_DASHBOARD=1`, not a separate service, and the entrypoint auto-passes `--insecure`). The useful bit (API_SERVER_* env var requirements) is applied as a note on the basic `docker run` block.

Verified against `gateway/config.py:1309` — `API_SERVER_ENABLED` env var gates the API server.

Closes #11758 via salvage.

Original PR by @CES4751 — authorship preserved.