### PR TITLE
docs(discord): fix Server Members Intent + SSRC-mapping drift + /voice join slash Choice (salvage #11350)

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2654,9 +2654,14 @@ class DiscordAdapter(BasePlatformAdapter):
             await self._run_simple_slash(interaction, "/reload-skills")
 
         @tree.command(name="voice", description="Toggle voice reply mode")
-        @discord.app_commands.describe(mode="Voice mode: on, off, tts, channel, leave, or status")
+        @discord.app_commands.describe(mode="Voice mode: join, channel, leave, on, tts, off, or status")
         @discord.app_commands.choices(mode=[
-            discord.app_commands.Choice(name="channel — join your voice channel", value="channel"),
+            # `join` and `channel` both route to _handle_voice_channel_join in
+            # gateway/run.py — expose both in the slash UI so autocomplete
+            # matches what the docs advertise and what the runner accepts when
+            # the command is typed as plain text.
+            discord.app_commands.Choice(name="join — join your voice channel", value="join"),
+            discord.app_commands.Choice(name="channel — join your voice channel (alias)", value="channel"),
             discord.app_commands.Choice(name="leave — leave voice channel", value="leave"),
             discord.app_commands.Choice(name="on — voice reply to voice messages", value="on"),
             discord.app_commands.Choice(name="tts — voice reply to all messages", value="tts"),

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -281,10 +281,10 @@ In the [Developer Portal](https://discord.com/developers/applications) → your 
 | Intent | Purpose |
 |--------|---------|
 | **Presence Intent** | Detect user online/offline status |
-| **Server Members Intent** | Map voice SSRC identifiers to Discord user IDs |
+| **Server Members Intent** | Resolve usernames in `DISCORD_ALLOWED_USERS` to numeric IDs (conditional) |
 | **Message Content Intent** | Read text message content in channels |
 
-All three are required for full voice channel functionality. **Server Members Intent** is especially critical — without it, the bot cannot identify who is speaking in the voice channel.
+**Message Content Intent** is required. **Server Members Intent** is only needed if your `DISCORD_ALLOWED_USERS` list uses usernames — if you use numeric user IDs, you can leave it OFF. Voice-channel SSRC → user_id mapping comes from Discord's SPEAKING opcode on the voice websocket and does **not** require the Server Members Intent.
 
 #### 3. Opus Codec
 


### PR DESCRIPTION
Adds a `/voice join` explicit Choice on the Discord slash UI (runner already accepted both "join" and "channel", but only "channel" was in autocomplete). Fixes the Server Members Intent table in the voice-mode docs to match current code — intent is conditional (needed only when `DISCORD_ALLOWED_USERS` contains usernames), and SSRC → user_id mapping uses the voice websocket SPEAKING opcode rather than the Members intent.

Changes:
- `gateway/platforms/discord.py` — add /voice join Choice (+5/-1)
- `website/docs/user-guide/features/voice-mode.md` — fix Members Intent + SSRC description (+2/-2)

Dropped from the original PR — each with a specific reason:
- `HERMES_DISCORD_VOICE_PACKET_DUMP` env var — doesn't exist on main (landing in a different PR, not merged).
- `DISCORD_PROXY` docs additions — already on current main.
- `DISCORD_ALLOW_MENTION_*` docs additions — already on current main.
- "barge-in mode" rewrite — `VoiceReceiver.pause()` at `discord.py:192` actually does pause the listener during TTS on current main; there is no `barge_in_guard` / `barge_in_rms` code path.

Verified against `gateway/platforms/discord.py:600` (`intents.members = any(not entry.isdigit() …)`) and `:156` (`_paused` flag).

Closes #11350 via salvage.

Original PR by @malaiwah — authorship preserved.