### PR TITLE
feat: change default busy_input_mode from interrupt to queue

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -996,7 +996,7 @@ class GatewayRunner:
     # Class-level defaults so partial construction in tests doesn't
     # blow up on attribute access.
     _running_agents_ts: Dict[str, float] = {}
-    _busy_input_mode: str = "interrupt"
+    _busy_input_mode: str = "queue"
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     _exit_code: Optional[int] = None
     _draining: bool = False
@@ -2063,7 +2063,7 @@ class GatewayRunner:
             return "queue"
         if mode == "steer":
             return "steer"
-        return "interrupt"
+        return "queue"
 
     @staticmethod
     def _load_restart_drain_timeout() -> float:

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -109,7 +109,7 @@ TIPS = [
     "Set display.streaming: true to see tokens appear in real time as the model generates.",
     "Set display.show_reasoning: true to watch the model's chain-of-thought reasoning.",
     "Set display.compact: true to reduce whitespace in output for denser information.",
-    "Set display.busy_input_mode: queue to queue messages instead of interrupting the agent, or steer to inject them mid-run via /steer.",
+    "Default: messages are queued when Hermes is busy. Set display.busy_input_mode: interrupt to make new messages stop the current task, or steer to inject mid-run via /steer.",
     "Set display.resume_display: minimal to skip the full conversation recap on session resume.",
     "Set compression.threshold: 0.50 to control when auto-compression fires (default: 50% of context).",
     "Set agent.max_turns: 200 to let the agent take more tool-calling steps per turn.",

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -83,7 +83,7 @@ def test_load_busy_input_mode_prefers_env_then_config_then_default(tmp_path, mon
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("HERMES_GATEWAY_BUSY_INPUT_MODE", raising=False)
 
-    assert gateway_run.GatewayRunner._load_busy_input_mode() == "interrupt"
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "queue"
 
     (tmp_path / "config.yaml").write_text(
         "display:\n  busy_input_mode: queue\n", encoding="utf-8"
@@ -103,7 +103,7 @@ def test_load_busy_input_mode_prefers_env_then_config_then_default(tmp_path, mon
 
     # Unknown values fall through to the safe default
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "bogus")
-    assert gateway_run.GatewayRunner._load_busy_input_mode() == "interrupt"
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "queue"
 
 
 def test_load_restart_drain_timeout_prefers_env_then_config_then_default(


### PR DESCRIPTION
## Summary

When users send a message while Hermes is executing a task, the current default (`interrupt`) immediately kills the running work. This is disruptive for multi-step workflows like code generation, image creation, or research tasks where the user simply wants to queue a follow-up.

**Change the default to `queue`** so messages are processed after the current task completes, unless the user explicitly sends `/stop`.

## Changes

- `gateway/run.py`: Changed class-level default `_busy_input_mode` from `"interrupt"` to `"queue"`
- `gateway/run.py`: Changed `_load_busy_input_mode()` fallback from `"interrupt"` to `"queue"`
- `hermes_cli/tips.py`: Updated onboarding tip to reflect the new default
- `tests/gateway/test_restart_drain.py`: Updated default-value assertions

## Motivation

The `interrupt` default means any message sent during a long-running task (image generation, code compilation, research) immediately kills the workflow. Users must then restart from scratch. This is especially painful on messaging platforms where users may send follow-up thoughts without realizing it interrupts the agent.

The `queue` mode is a safer default:
- Messages are queued and processed after the current task
- Users can still `/stop` to explicitly interrupt
- Users can set `display.busy_input_mode: interrupt` to restore old behavior
- No data loss — queued messages are always processed