### PR TITLE
docs(kanban): document recommended handoff evidence metadata (salvage #19512)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -91,6 +91,7 @@ AUTHOR_MAP = {
     "jani@0xhoneyjar.xyz": "deep-name",
     "xiangyong@zspace.cn": "CES4751",
     "harish.kukreja@gmail.com": "counterposition",
+    "35294173+Fearvox@users.noreply.github.com": "Fearvox",
     # Matrix parity salvage batch (April 2026)
     "sr@samirusani": "samrusani",
     "angelclaw@AngelMacBook.local": "angel12",

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -292,6 +292,40 @@ Three reasons:
 
 The `kanban-worker` and `kanban-orchestrator` skills teach the model which tool to call when and in what order.
 
+### Recommended handoff evidence
+
+`kanban_complete(summary=..., metadata={...})` is intentionally flexible:
+the summary is the human-readable closeout, and `metadata` is the
+machine-readable handoff that downstream agents, reviewers, or dashboards can
+reuse without scraping prose.
+
+For engineering and review tasks, prefer this optional metadata shape:
+
+```json
+{
+  "changed_files": ["path/to/file.py"],
+  "verification": ["pytest tests/hermes_cli/test_kanban_db.py -q"],
+  "dependencies": ["parent task id or external issue, if any"],
+  "blocked_reason": null,
+  "retry_notes": "what failed before, if this was a retry",
+  "residual_risk": ["what was not tested or still needs human review"]
+}
+```
+
+These keys are a convention, not a schema requirement. The useful property is
+that every worker leaves enough evidence for the next reader to answer four
+questions quickly:
+
+1. What changed?
+2. How was it verified?
+3. What can unblock or retry this if it fails?
+4. What risk is still deliberately left open?
+
+Keep secrets, raw logs, tokens, OAuth material, and unrelated transcripts out of
+`metadata`. Store pointers and summaries instead. If a task has no files or
+tests, say so explicitly in `summary` and use `metadata` for the evidence that
+does exist, such as source URLs, issue ids, or manual review steps.
+
 ### The worker skill
 
 Any profile that should be able to work kanban tasks must load the `kanban-worker` skill. It teaches the worker the full lifecycle in **tool calls**, not CLI commands:


### PR DESCRIPTION
Documents a convention for the `metadata` dict on `kanban_complete()` — `changed_files`, `verification`, `dependencies`, `blocked_reason`, `retry_notes`, `residual_risk`. Keys are a convention, not a schema (the underlying `complete_task(metadata=dict)` on `hermes_cli/kanban_db.py:2051` stays free-form).

Changes:
- `website/docs/user-guide/features/kanban.md` (+34)
- `scripts/release.py` — AUTHOR_MAP entry for Fearvox

Closes #19512 via salvage.

Original PR by @Fearvox — authorship preserved.