### PR TITLE
docs(codex): clarify OAuth auth prerequisite (salvage #18688)

### DIFF
--- a/skills/autonomous-ai-agents/codex/SKILL.md
+++ b/skills/autonomous-ai-agents/codex/SKILL.md
@@ -26,9 +26,16 @@ Requires the codex CLI and a git repository.
 ## Prerequisites
 
 - Codex installed: `npm install -g @openai/codex`
-- OpenAI API key configured
+- OpenAI auth configured: either `OPENAI_API_KEY` or Codex OAuth credentials
+  from the Codex CLI login flow
 - **Must run inside a git repository** — Codex refuses to run outside one
 - Use `pty=true` in terminal calls — Codex is an interactive terminal app
+
+For Hermes itself, `model.provider: openai-codex` uses Hermes-managed Codex
+OAuth from `~/.hermes/auth.json` after `hermes auth add openai-codex`. For the
+standalone Codex CLI, a valid CLI OAuth session may live under
+`~/.codex/auth.json`; do not treat a missing `OPENAI_API_KEY` alone as proof
+that Codex auth is missing.
 
 ## One-Shot Tasks
 

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex.md
@@ -44,9 +44,16 @@ Requires the codex CLI and a git repository.
 ## Prerequisites
 
 - Codex installed: `npm install -g @openai/codex`
-- OpenAI API key configured
+- OpenAI auth configured: either `OPENAI_API_KEY` or Codex OAuth credentials
+  from the Codex CLI login flow
 - **Must run inside a git repository** — Codex refuses to run outside one
 - Use `pty=true` in terminal calls — Codex is an interactive terminal app
+
+For Hermes itself, `model.provider: openai-codex` uses Hermes-managed Codex
+OAuth from `~/.hermes/auth.json` after `hermes auth add openai-codex`. For the
+standalone Codex CLI, a valid CLI OAuth session may live under
+`~/.codex/auth.json`; do not treat a missing `OPENAI_API_KEY` alone as proof
+that Codex auth is missing.
 
 ## One-Shot Tasks
 


### PR DESCRIPTION
Clarifies that the Codex skill works with either `OPENAI_API_KEY` OR a Codex OAuth session, for both Hermes-managed (`model.provider: openai-codex` + `hermes auth add openai-codex` → `~/.hermes/auth.json`) and standalone CLI (`~/.codex/auth.json`) paths. Avoids the common false-alarm of "OPENAI_API_KEY not set = Codex will fail."

Changes:
- `skills/autonomous-ai-agents/codex/SKILL.md` (+8/-1)
- `website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex.md` — auto-generated equivalent (+8/-1)

Closes #18688 via salvage.

Original PR by @LeonSGP43 — authorship preserved.