### PR TITLE
docs(faq): use messaging extra for gateway deps (salvage #18038)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -93,6 +93,7 @@ AUTHOR_MAP = {
     "harish.kukreja@gmail.com": "counterposition",
     "35294173+Fearvox@users.noreply.github.com": "Fearvox",
     "hypnus.yuan@gmail.com": "Hypnus-Yuan",
+    "15558128926@qq.com": "xsfX20",
     # Matrix parity salvage batch (April 2026)
     "sr@samirusani": "samrusani",
     "angelclaw@AngelMacBook.local": "angel12",

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -418,8 +418,8 @@ Configure in `~/.hermes/config.yaml` under your gateway's settings. See the [Mes
 
 **Solution:**
 ```bash
-# Install messaging dependencies
-pip install "hermes-agent[telegram]"   # or [discord], [slack], [whatsapp]
+# Install core messaging gateway dependencies
+pip install "hermes-agent[messaging]"  # Telegram, Discord, Slack, and shared gateway deps
 
 # Check for port conflicts
 lsof -i :8080


### PR DESCRIPTION
Fixes the FAQ install hint to use the `[messaging]` extra that actually exists in `pyproject.toml` (covers Telegram + Discord + Slack + shared gateway deps), instead of the non-existent `[telegram]` / `[discord]` / `[whatsapp]` extras.

Changes:
- `website/docs/reference/faq.md` (+2/-2)
- `scripts/release.py` — AUTHOR_MAP entry for xsfX20

Verified against `pyproject.toml` — only `[messaging]` and `[slack]` exist as extras; the platform-specific ones the FAQ listed are not defined.

Closes #18038 via salvage.

Original PR by @xsfX20 — authorship preserved.