### PR TITLE
feat: add dry-run anticipation loops

### DIFF
--- a/agent/anticipation.py
+++ b/agent/anticipation.py
@@ -1,0 +1,142 @@
+"""Data types and validation helpers for trustworthy anticipation.
+
+This module is deliberately inert: it defines typed config structures and
+validation, but it does not schedule jobs, send messages, or call tools.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from math import isfinite
+from typing import Any, Mapping
+
+
+class AnticipationPermission(str, Enum):
+    """Permission ceiling for proactive anticipation candidates."""
+
+    SILENT_LOG = "silent_log"
+    SUGGEST = "suggest"
+    DRAFT = "draft"
+    ASK_TO_EXECUTE = "ask_to_execute"
+    EXECUTE_SAFE = "execute_safe"
+
+
+_PERMISSION_RANK = {
+    AnticipationPermission.SILENT_LOG: 0,
+    AnticipationPermission.SUGGEST: 1,
+    AnticipationPermission.DRAFT: 2,
+    AnticipationPermission.ASK_TO_EXECUTE: 3,
+    AnticipationPermission.EXECUTE_SAFE: 4,
+}
+
+
+@dataclass(frozen=True)
+class NotificationBudget:
+    max_per_day: int = 3
+    min_minutes_between: int = 120
+
+
+@dataclass(frozen=True)
+class QuietHours:
+    enabled: bool = False
+    start: str = "22:00"
+    end: str = "08:00"
+
+
+@dataclass(frozen=True)
+class AnticipationLoopConfig:
+    name: str
+    enabled: bool
+    schedule: str
+    permission: AnticipationPermission
+    min_confidence: float = 0.70
+    lookback_days: int = 14
+
+
+@dataclass(frozen=True)
+class AnticipationRuntimeConfig:
+    """Flattened policy inputs for one loop decision.
+
+    Keeping this flat makes the policy gate pure and easy to test. The code
+    that later wires config.yaml into loops can translate nested config into
+    this shape without dragging YAML-specific concerns into policy decisions.
+    """
+
+    enabled: bool
+    loop_enabled: bool
+    loop_permission: AnticipationPermission
+    min_confidence: float
+    quiet_hours_enabled: bool
+    quiet_hours_start: str
+    quiet_hours_end: str
+    max_per_day: int
+    min_minutes_between: int
+
+    def __post_init__(self) -> None:
+        if not isfinite(self.min_confidence) or not 0 <= self.min_confidence <= 1:
+            raise ValueError("Anticipation runtime min_confidence must be between 0 and 1")
+        if self.max_per_day < 0:
+            raise ValueError("Anticipation runtime max_per_day must be >= 0")
+        if self.min_minutes_between < 0:
+            raise ValueError("Anticipation runtime min_minutes_between must be >= 0")
+
+
+def parse_permission(value: str | AnticipationPermission) -> AnticipationPermission:
+    """Parse an anticipation permission string into its enum value."""
+
+    if isinstance(value, AnticipationPermission):
+        return value
+    try:
+        return AnticipationPermission(str(value).strip().lower())
+    except ValueError as exc:
+        allowed = ", ".join(permission.value for permission in AnticipationPermission)
+        raise ValueError(
+            f"Invalid anticipation permission {value!r}; expected one of: {allowed}"
+        ) from exc
+
+
+def permission_allows(ceiling: AnticipationPermission, requested: AnticipationPermission) -> bool:
+    """Return whether *ceiling* permits *requested* proactive action."""
+
+    return _PERMISSION_RANK[requested] <= _PERMISSION_RANK[ceiling]
+
+
+def parse_bool(value: Any, default: bool = False) -> bool:
+    """Parse config booleans without treating every non-empty string as true."""
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "n", "off", ""}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
+def parse_loop_config(name: str, raw: Mapping[str, Any] | None) -> AnticipationLoopConfig:
+    """Parse one loop config mapping into a typed config object."""
+
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"Anticipation loop {name!r} must be a mapping")
+
+    min_confidence = float(raw.get("min_confidence", 0.70))
+    if not isfinite(min_confidence) or not 0 <= min_confidence <= 1:
+        raise ValueError(f"Anticipation loop {name!r} min_confidence must be between 0 and 1")
+
+    lookback_days = int(raw.get("lookback_days", 14))
+    if lookback_days < 1:
+        raise ValueError(f"Anticipation loop {name!r} lookback_days must be >= 1")
+
+    return AnticipationLoopConfig(
+        name=name,
+        enabled=parse_bool(raw.get("enabled", False)),
+        schedule=str(raw.get("schedule", "")),
+        permission=parse_permission(raw.get("permission", AnticipationPermission.SUGGEST.value)),
+        min_confidence=min_confidence,
+        lookback_days=lookback_days,
+    )

--- a/agent/anticipation_log.py
+++ b/agent/anticipation_log.py
@@ -1,0 +1,83 @@
+"""Sanitized audit logging for anticipation decisions."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from hashlib import sha256
+from math import isfinite
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+from agent.anticipation_policy import AnticipationDecision
+
+
+LOG_DIR_NAME = "anticipation"
+LOG_FILE_NAME = "decisions.jsonl"
+
+
+def decision_log_path() -> Path:
+    return get_hermes_home() / LOG_DIR_NAME / LOG_FILE_NAME
+
+
+def append_decision_log(decision: AnticipationDecision, *, now: datetime | None = None) -> Path:
+    """Append one sanitized anticipation decision record and return the path."""
+
+    timestamp = now or datetime.now(timezone.utc)
+    path = decision_log_path()
+    _ensure_secure_parent(path.parent)
+
+    record = _decision_to_record(decision, timestamp)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True, allow_nan=False) + "\n")
+    _secure_file(path)
+    return path
+
+
+def read_recent_decision_logs(*, limit: int = 10) -> list[dict[str, Any]]:
+    """Read recent sanitized decision records, newest first."""
+
+    path = decision_log_path()
+    if not path.exists():
+        return []
+
+    records: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if not line.strip():
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return list(reversed(records))[: max(0, limit)]
+
+
+def _decision_to_record(decision: AnticipationDecision, timestamp: datetime) -> dict[str, Any]:
+    candidate = decision.candidate
+    return {
+        "ts": timestamp.isoformat(),
+        "loop_id": candidate.loop_id,
+        "action": decision.action,
+        "reason": decision.reason,
+        "confidence": candidate.confidence if isfinite(candidate.confidence) else None,
+        "dedupe_key_hash": sha256(candidate.dedupe_key.encode("utf-8")).hexdigest(),
+        "title_hash": sha256(candidate.title.encode("utf-8")).hexdigest(),
+    }
+
+
+def _ensure_secure_parent(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(path, 0o700)
+    except (OSError, NotImplementedError):
+        pass
+
+
+def _secure_file(path: Path) -> None:
+    try:
+        os.chmod(path, 0o600)
+    except (OSError, NotImplementedError):
+        pass

--- a/agent/anticipation_loops.py
+++ b/agent/anticipation_loops.py
@@ -1,0 +1,464 @@
+"""Anticipatory loop implementations.
+
+V0 is intentionally heuristic-only. No LLM calls, no delivery, no scheduling.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable, Mapping
+
+from agent.anticipation import AnticipationPermission
+from agent.anticipation_policy import AnticipationCandidate
+
+UNRESOLVED_PATTERNS: tuple[tuple[re.Pattern[str], float], ...] = (
+    (re.compile(r"\bTODO\b", re.IGNORECASE), 0.12),
+    (re.compile(r"\bnext step\b", re.IGNORECASE), 0.10),
+    (re.compile(r"\bnext I can\b", re.IGNORECASE), 0.10),
+    (re.compile(r"\bif you want\b", re.IGNORECASE), 0.08),
+    (re.compile(r"\bfollow up\b", re.IGNORECASE), 0.08),
+    (re.compile(r"\bshall I proceed\b", re.IGNORECASE), 0.08),
+    (re.compile(r"\bwe should\b", re.IGNORECASE), 0.06),
+    (re.compile(r"\blater\b", re.IGNORECASE), 0.04),
+    (re.compile(r"\bunresolved\b", re.IGNORECASE), 0.04),
+)
+
+_COMPLETION_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\b(done|completed|complete|finished|handled|resolved)\b", re.IGNORECASE),
+    re.compile(r"\b(already did|we did|that part is done)\b", re.IGNORECASE),
+    re.compile(r"\b(no|not now|skip it|nevermind|never mind)\b", re.IGNORECASE),
+)
+
+
+def build_stale_task_candidates(
+    db: Any,
+    *,
+    now: datetime | None = None,
+    lookback_days: int = 14,
+    limit: int = 5,
+    current_session_id: str | None = None,
+) -> list[AnticipationCandidate]:
+    """Build heuristic stale-task candidates from recent session history.
+
+    The returned candidates are suggestions only. Callers must pass them through
+    the anticipation policy gate before displaying, logging, or delivering.
+    """
+
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=max(1, lookback_days))
+    sessions = db.list_sessions_rich(limit=max(limit * 10, 20), exclude_sources=["tool"])
+
+    candidates: list[tuple[AnticipationCandidate, float]] = []
+    for session in sessions:
+        session_id = str(session.get("id") or "")
+        if not session_id or session_id == current_session_id:
+            continue
+        if session.get("parent_session_id"):
+            continue
+        last_active = _coerce_datetime(session.get("last_active") or session.get("started_at"))
+        if last_active and last_active < cutoff:
+            continue
+
+        messages = _conversation_messages(db, session_id)
+        signal = _find_latest_unresolved_signal(messages)
+        if not signal:
+            continue
+        signal_text, signal_score = signal
+        confidence = min(0.95, 0.62 + signal_score + _recency_bonus(last_active, now))
+        candidate = AnticipationCandidate(
+            loop_id="stale_task_resurfacer",
+            title=_candidate_title(session),
+            body=_candidate_body(session, signal_text),
+            confidence=round(confidence, 3),
+            proposed_permission=AnticipationPermission.SUGGEST,
+            dedupe_key=_dedupe_key(session_id, signal_text),
+            created_at=now,
+        )
+        candidates.append((candidate, last_active.timestamp() if last_active else 0.0))
+
+    candidates.sort(key=lambda item: (item[0].confidence, item[1]), reverse=True)
+    return [candidate for candidate, _ in candidates[: max(0, limit)]]
+
+
+def build_router_monitor_candidates(
+    snapshot: Mapping[str, Any],
+    *,
+    now: datetime | None = None,
+    stale_minutes: int = 30,
+    limit: int = 5,
+) -> list[AnticipationCandidate]:
+    """Build router-monitor anticipation candidates from a sanitized snapshot.
+
+    The snapshot is intentionally plain data. This loop does not SSH into the
+    router, mutate router state, send Telegram messages, or schedule itself.
+    """
+
+    now = now or datetime.now(timezone.utc)
+    candidates: list[AnticipationCandidate] = []
+
+    health = _router_health_candidate(snapshot, now=now, stale_minutes=stale_minutes)
+    if health:
+        candidates.append(health)
+
+    for device in _unknown_devices(snapshot):
+        candidate = _router_unknown_device_candidate(device, now=now)
+        if candidate:
+            candidates.append(candidate)
+
+    candidates.sort(
+        key=lambda candidate: (
+            _permission_sort_rank(candidate.proposed_permission),
+            candidate.confidence,
+        ),
+        reverse=True,
+    )
+    return candidates[: max(0, limit)]
+
+
+def _router_health_candidate(
+    snapshot: Mapping[str, Any],
+    *,
+    now: datetime,
+    stale_minutes: int,
+) -> AnticipationCandidate | None:
+    monitoring = snapshot.get("monitoring", {})
+    if not isinstance(monitoring, Mapping):
+        return None
+
+    findings: list[str] = []
+    cron_entries = [str(entry) for entry in monitoring.get("cron_entries", []) if str(entry).strip()]
+    if monitoring.get("quarantine_dir_exists") is False:
+        findings.append("/root/quarantine directory is missing")
+    if not any("quarantine-v3.sh run" in entry for entry in cron_entries):
+        findings.append("minutely quarantine cron job is missing")
+    if not any("gl-ngx-watchdog.sh" in entry for entry in cron_entries):
+        findings.append("GL.iNet watchdog cron job is missing")
+    if not any("cron-guard.sh" in entry for entry in cron_entries):
+        findings.append("cron guard job is missing")
+
+    cron_log_last_at = _coerce_datetime(monitoring.get("cron_log_last_at"))
+    if cron_log_last_at is None:
+        findings.append("cron log timestamp is unavailable")
+    elif now - cron_log_last_at > timedelta(minutes=max(1, stale_minutes)):
+        age = int((now - cron_log_last_at).total_seconds() // 60)
+        findings.append(f"cron log is stale by {age} minutes")
+
+    segfault_count = _safe_int(monitoring.get("segfault_count_7d"), 0)
+    if segfault_count > 0:
+        findings.append(f"cron log contains {segfault_count} segmentation fault lines in the last 7 days")
+
+    if not findings:
+        return None
+
+    confidence = 0.88
+    if monitoring.get("quarantine_dir_exists") is False or not cron_entries:
+        confidence = 0.94
+    elif cron_log_last_at and now - cron_log_last_at > timedelta(hours=1):
+        confidence = 0.91
+
+    body = "\n".join(
+        [
+            "Router monitoring may be degraded.",
+            "",
+            "Findings:",
+            *[f"- {finding}" for finding in findings],
+            "",
+            "Suggested next action: run a router status check, inspect cron/quarantine logs, and repair crond/watchdog only after confirmation.",
+            "I did not change router state.",
+        ]
+    )
+    return AnticipationCandidate(
+        loop_id="router_monitor",
+        title="Router monitoring may be degraded",
+        body=body,
+        confidence=confidence,
+        proposed_permission=AnticipationPermission.ASK_TO_EXECUTE,
+        dedupe_key="router_monitor:health:" + _hash_key("|".join(findings)),
+        created_at=now,
+    )
+
+
+def _router_unknown_device_candidate(
+    device: Mapping[str, Any],
+    *,
+    now: datetime,
+) -> AnticipationCandidate | None:
+    mac = _clean_mac(device.get("mac"))
+    if not mac:
+        return None
+    active = _safe_bool(device.get("active", False), False)
+    locally_administered = _safe_bool(device.get("locally_administered", False), False)
+    seen_count = _safe_int(device.get("seen_count_72h"), 1)
+    hostnames = _string_list(device.get("hostnames"))
+    ips = _string_list(device.get("ips"))
+    traffic_summary = _clean_router_text(device.get("traffic_summary"), default="no traffic summary available", max_length=160)
+
+    if active:
+        body = "\n".join(
+            [
+                "Router anticipation: active unknown device worth checking.",
+                "",
+                f"- MAC: {mac}",
+                f"- IPs: {', '.join(ips) if ips else 'unknown'}",
+                f"- Hostnames: {', '.join(hostnames) if hostnames else 'none reported'}",
+                f"- Seen count in 72h: {seen_count}",
+                f"- Traffic: {traffic_summary}",
+                "",
+                "Suggested next action: review router status before approving or blocking anything.",
+                "I did not block anything or change router state.",
+            ]
+        )
+        return AnticipationCandidate(
+            loop_id="router_monitor",
+            title=f"Router active unknown device: {mac[:8]}",
+            body=body,
+            confidence=0.89 if not locally_administered else 0.84,
+            proposed_permission=AnticipationPermission.ASK_TO_EXECUTE,
+            dedupe_key=f"router_monitor:active_unknown:{mac}",
+            created_at=now,
+        )
+
+    if locally_administered and seen_count >= 3:
+        body = "\n".join(
+            [
+                "Router anticipation: recurring randomized/private MAC.",
+                "",
+                f"- MAC: {mac}",
+                f"- Hostnames: {', '.join(hostnames) if hostnames else 'none reported'}",
+                f"- Seen count in 72h: {seen_count}",
+                f"- Traffic: {traffic_summary}",
+                "",
+                "Suggested next action: correlate it against guests, Deco logs, or a known phone using randomized Wi-Fi MACs.",
+                "I did not approve, block, or message anyone automatically.",
+            ]
+        )
+        return AnticipationCandidate(
+            loop_id="router_monitor",
+            title=f"Router recurring randomized unknown: {mac[:8]}",
+            body=body,
+            confidence=0.80,
+            proposed_permission=AnticipationPermission.SUGGEST,
+            dedupe_key=f"router_monitor:recurring_randomized:{mac}",
+            created_at=now,
+        )
+
+    if seen_count >= 3:
+        body = "\n".join(
+            [
+                "Router anticipation: recurring unknown device.",
+                "",
+                f"- MAC: {mac}",
+                f"- Hostnames: {', '.join(hostnames) if hostnames else 'none reported'}",
+                f"- Seen count in 72h: {seen_count}",
+                f"- Traffic: {traffic_summary}",
+                "",
+                "Suggested next action: correlate it against guests, Deco logs, or known household devices before approving or blocking.",
+                "I did not approve, block, or message anyone automatically.",
+            ]
+        )
+        return AnticipationCandidate(
+            loop_id="router_monitor",
+            title=f"Router recurring unknown: {mac[:8]}",
+            body=body,
+            confidence=0.78,
+            proposed_permission=AnticipationPermission.SUGGEST,
+            dedupe_key=f"router_monitor:recurring_unknown:{mac}",
+            created_at=now,
+        )
+
+    if locally_administered:
+        body = "\n".join(
+            [
+                "Router anticipation: one-time randomized/private MAC observed.",
+                "",
+                f"- MAC: {mac}",
+                f"- Seen count in 72h: {seen_count}",
+                f"- Traffic: {traffic_summary}",
+                "",
+                "Decision: silent log only. No Telegram-worthy interruption.",
+            ]
+        )
+        return AnticipationCandidate(
+            loop_id="router_monitor",
+            title=f"Router one-time randomized unknown: {mac[:8]}",
+            body=body,
+            confidence=0.72,
+            proposed_permission=AnticipationPermission.SILENT_LOG,
+            dedupe_key=f"router_monitor:one_time_randomized:{mac}",
+            created_at=now,
+        )
+
+    return None
+
+
+def _unknown_devices(snapshot: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    raw = snapshot.get("unknown_devices", [])
+    if not isinstance(raw, list):
+        return []
+    return [device for device in raw if isinstance(device, Mapping)]
+
+
+def _clean_mac(value: object) -> str:
+    text = str(value or "").strip().lower()
+    if re.fullmatch(r"([0-9a-f]{2}:){5}[0-9a-f]{2}", text):
+        return text
+    return ""
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    cleaned: list[str] = []
+    for item in value[:10]:
+        text = _clean_router_text(item, max_length=80)
+        if text:
+            cleaned.append(text)
+    return cleaned
+
+
+def _clean_router_text(value: object, *, default: str = "", max_length: int = 120) -> str:
+    text = str(value or "")
+    text = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", text)
+    text = "".join(char if char.isprintable() else " " for char in text)
+    text = re.sub(r"\s+", " ", text).strip()
+    if not text:
+        return default
+    if len(text) > max_length:
+        return text[: max(0, max_length - 1)].rstrip() + "…"
+    return text
+
+
+def _safe_bool(value: object, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "n", "off", ""}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
+def _safe_int(value: object, default: int) -> int:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _hash_key(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+
+
+def _permission_sort_rank(permission: AnticipationPermission) -> int:
+    return {
+        AnticipationPermission.SILENT_LOG: 0,
+        AnticipationPermission.SUGGEST: 1,
+        AnticipationPermission.DRAFT: 2,
+        AnticipationPermission.ASK_TO_EXECUTE: 3,
+        AnticipationPermission.EXECUTE_SAFE: 4,
+    }[permission]
+
+
+def _conversation_messages(db: Any, session_id: str) -> list[dict[str, Any]]:
+    if hasattr(db, "get_messages_as_conversation"):
+        messages = db.get_messages_as_conversation(session_id)
+    else:
+        messages = db.get_messages(session_id)
+    return [message for message in messages if isinstance(message, dict)]
+
+
+def _find_latest_unresolved_signal(messages: Iterable[dict[str, Any]]) -> tuple[str, float] | None:
+    ordered = list(messages)
+    best: tuple[int, str, float] | None = None
+    for index, message in enumerate(ordered):
+        if message.get("role") not in {"assistant", "user"}:
+            continue
+        content = str(message.get("content") or "").strip()
+        if not content:
+            continue
+        score = _unresolved_score(content)
+        if score <= 0:
+            continue
+        if _later_user_message_completes_thread(ordered[index + 1 :]):
+            continue
+        if best is None or index > best[0]:
+            best = (index, content, score)
+    if best is None:
+        return None
+    return best[1], best[2]
+
+
+def _unresolved_score(content: str) -> float:
+    return sum(weight for pattern, weight in UNRESOLVED_PATTERNS if pattern.search(content))
+
+
+def _later_user_message_completes_thread(messages: Iterable[dict[str, Any]]) -> bool:
+    for message in messages:
+        if message.get("role") != "user":
+            continue
+        content = str(message.get("content") or "")
+        if any(pattern.search(content) for pattern in _COMPLETION_PATTERNS):
+            return True
+    return False
+
+
+def _candidate_title(session: dict[str, Any]) -> str:
+    title = str(session.get("title") or session.get("preview") or session.get("id") or "Untitled session")
+    return f"Stale thread: {title[:80]}"
+
+
+def _candidate_body(session: dict[str, Any], signal_text: str) -> str:
+    title = str(session.get("title") or session.get("preview") or "previous conversation")
+    snippet = _single_line(signal_text)[:240]
+    return (
+        f"A previous Hermes session may have an unresolved next step.\n\n"
+        f"Session: {title}\n"
+        f"Signal: {snippet}\n\n"
+        f"I did not take action; this is only a resurfacing suggestion."
+    )
+
+
+def _dedupe_key(session_id: str, signal_text: str) -> str:
+    digest = hashlib.sha256(_single_line(signal_text).encode("utf-8")).hexdigest()[:16]
+    return f"stale_task_resurfacer:{session_id}:{digest}"
+
+
+def _single_line(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _recency_bonus(last_active: datetime | None, now: datetime) -> float:
+    if not last_active:
+        return 0.0
+    age_days = max(0.0, (now - last_active).total_seconds() / 86400)
+    if age_days <= 2:
+        return 0.05
+    if age_days <= 7:
+        return 0.03
+    return 0.0
+
+
+def _coerce_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        try:
+            dt = datetime.fromtimestamp(float(value), tz=timezone.utc)
+        except (TypeError, ValueError, OSError, OverflowError):
+            if not isinstance(value, str):
+                return None
+            try:
+                dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)

--- a/agent/anticipation_policy.py
+++ b/agent/anticipation_policy.py
@@ -1,0 +1,132 @@
+"""Pure policy gate for trustworthy anticipation candidates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, time, timedelta
+from math import isfinite
+from typing import Literal
+
+from agent.anticipation import (
+    AnticipationPermission,
+    AnticipationRuntimeConfig,
+    permission_allows,
+)
+
+DecisionAction = Literal["skip", "silent_log", "suggest", "draft", "ask_to_execute", "execute_safe"]
+
+
+@dataclass(frozen=True)
+class AnticipationCandidate:
+    loop_id: str
+    title: str
+    body: str
+    confidence: float
+    proposed_permission: AnticipationPermission
+    dedupe_key: str
+    created_at: datetime
+
+
+@dataclass(frozen=True)
+class AnticipationDecision:
+    action: DecisionAction
+    reason: str
+    candidate: AnticipationCandidate
+
+
+@dataclass(frozen=True)
+class AnticipationDecisionHistory:
+    """Minimal recent history needed for dedupe and notification budgets."""
+
+    recent_dedupe_keys: dict[str, datetime] = field(default_factory=dict)
+    notifications_today: int = 0
+    last_notification_at: datetime | None = None
+
+
+def decide_anticipation_action(
+    candidate: AnticipationCandidate,
+    config: AnticipationRuntimeConfig,
+    history: AnticipationDecisionHistory,
+    *,
+    now: datetime,
+) -> AnticipationDecision:
+    """Decide whether a proactive candidate may proceed.
+
+    This function is intentionally side-effect-free. It does not log, send,
+    schedule, query memory, or mutate state. That keeps proactive behavior
+    auditable and lets callers choose how to handle skip reasons.
+    """
+
+    if not config.enabled:
+        return _skip(candidate, "anticipation_disabled")
+    if not config.loop_enabled:
+        return _skip(candidate, "loop_disabled")
+    if not isfinite(candidate.confidence) or candidate.confidence < config.min_confidence:
+        return _skip(candidate, "below_confidence_threshold")
+    if not candidate.body.strip():
+        return _skip(candidate, "empty_candidate_body")
+    if _is_duplicate(candidate, history, config, now):
+        return _skip(candidate, "duplicate_dedupe_key")
+    is_notification = candidate.proposed_permission is not AnticipationPermission.SILENT_LOG
+    if is_notification and history.notifications_today >= config.max_per_day:
+        return _skip(candidate, "notification_budget_exhausted")
+    if is_notification and _too_soon_since_last_notification(history, config, now):
+        return _skip(candidate, "notification_budget_exhausted")
+    if is_notification and config.quiet_hours_enabled and _inside_quiet_hours(
+        now, config.quiet_hours_start, config.quiet_hours_end
+    ):
+        return _skip(candidate, "inside_quiet_hours")
+    if not permission_allows(config.loop_permission, candidate.proposed_permission):
+        return _skip(candidate, "permission_exceeds_ceiling")
+
+    return AnticipationDecision(
+        action=candidate.proposed_permission.value,  # type: ignore[return-value]
+        reason="passed",
+        candidate=candidate,
+    )
+
+
+def _skip(candidate: AnticipationCandidate, reason: str) -> AnticipationDecision:
+    return AnticipationDecision(action="skip", reason=reason, candidate=candidate)
+
+
+def _is_duplicate(
+    candidate: AnticipationCandidate,
+    history: AnticipationDecisionHistory,
+    config: AnticipationRuntimeConfig,
+    now: datetime,
+) -> bool:
+    last_seen = history.recent_dedupe_keys.get(candidate.dedupe_key)
+    if last_seen is None:
+        return False
+    return now - last_seen < timedelta(minutes=config.min_minutes_between)
+
+
+def _too_soon_since_last_notification(
+    history: AnticipationDecisionHistory,
+    config: AnticipationRuntimeConfig,
+    now: datetime,
+) -> bool:
+    if history.last_notification_at is None:
+        return False
+    return now - history.last_notification_at < timedelta(minutes=config.min_minutes_between)
+
+
+def _inside_quiet_hours(now: datetime, start_text: str, end_text: str) -> bool:
+    start = _parse_hhmm(start_text)
+    end = _parse_hhmm(end_text)
+    current = now.timetz().replace(tzinfo=None)
+
+    if start == end:
+        return True
+    if start < end:
+        return start <= current < end
+    return current >= start or current < end
+
+
+def _parse_hhmm(value: str) -> time:
+    try:
+        hour_text, minute_text = value.split(":", 1)
+        return time(hour=int(hour_text), minute=int(minute_text))
+    except Exception as exc:
+        raise ValueError(f"Invalid quiet-hours time {value!r}; expected HH:MM") from exc

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -722,6 +722,39 @@ DEFAULT_CONFIG = {
         "provider": "",
     },
 
+    # Trustworthy anticipation — low-noise proactive loops. Disabled by
+    # default; V0 provides config/policy/audit primitives only, with no
+    # automatic delivery unless the user explicitly enables loops later.
+    "anticipation": {
+        "enabled": False,
+        "default_permission": "suggest",
+        "quiet_hours": {
+            "enabled": False,
+            "start": "22:00",
+            "end": "08:00",
+        },
+        "notification_budget": {
+            "max_per_day": 3,
+            "min_minutes_between": 120,
+        },
+        "loops": {
+            "stale_task_resurfacer": {
+                "enabled": False,
+                "schedule": "0 9 * * *",
+                "permission": "suggest",
+                "min_confidence": 0.70,
+                "lookback_days": 14,
+            },
+            "router_monitor": {
+                "enabled": False,
+                "schedule": "manual",
+                "permission": "ask_to_execute",
+                "min_confidence": 0.70,
+                "lookback_days": 1,
+            },
+        },
+    },
+
     # Subagent delegation — override the provider:model used by delegate_task
     # so child agents can run on a different (cheaper/faster) provider and model.
     # Uses the same runtime provider resolution as CLI/gateway startup, so all

--- a/scripts/anticipation_run.py
+++ b/scripts/anticipation_run.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Manual dry-run runner for Hermes anticipation loops."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+# Let the script run directly via `python scripts/anticipation_run.py ...`.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agent.anticipation import AnticipationRuntimeConfig, parse_bool, parse_loop_config
+from agent.anticipation_log import append_decision_log, read_recent_decision_logs
+from agent.anticipation_loops import build_router_monitor_candidates, build_stale_task_candidates
+from agent.anticipation_policy import AnticipationDecision, AnticipationDecisionHistory, decide_anticipation_action
+from hermes_cli.config import load_config
+from hermes_state import SessionDB
+
+
+def format_dry_run_decisions(
+    decisions: Sequence[AnticipationDecision],
+    *,
+    empty_message: str = "No stale-task candidates found.",
+) -> str:
+    """Format dry-run decisions for terminal output without delivering anything."""
+
+    lines = ["# Anticipation DRY RUN", "", "No messages were delivered.", ""]
+    if not decisions:
+        lines.append(empty_message)
+        return "\n".join(lines)
+
+    for index, decision in enumerate(decisions, start=1):
+        candidate = decision.candidate
+        body = (
+            candidate.body
+            if decision.action != "skip"
+            else "[candidate body hidden because decision was skipped]"
+        )
+        lines.extend(
+            [
+                f"## {index}. {candidate.title}",
+                f"Action: {decision.action}",
+                f"Reason: {decision.reason}",
+                f"Confidence: {candidate.confidence:.2f}",
+                "",
+                body,
+                "",
+            ]
+        )
+    return "\n".join(lines).rstrip()
+
+
+def history_from_decision_logs(
+    logs: Sequence[dict],
+    candidates: Sequence,
+    *,
+    now: datetime | None = None,
+) -> AnticipationDecisionHistory:
+    """Hydrate policy history from sanitized decision logs for current candidates.
+
+    Logs intentionally store only dedupe hashes, not raw dedupe keys. To make
+    dedupe work without weakening log privacy, map hashes back only for the
+    candidates generated in this dry-run.
+    """
+
+    now = now or datetime.now(timezone.utc)
+    hash_to_key = {
+        hashlib.sha256(candidate.dedupe_key.encode("utf-8")).hexdigest(): candidate.dedupe_key
+        for candidate in candidates
+    }
+    recent_dedupe_keys: dict[str, datetime] = {}
+    notifications_today = 0
+    last_notification_at: datetime | None = None
+
+    for record in logs:
+        ts = _parse_log_timestamp(record.get("ts"))
+        if ts is None:
+            continue
+        dedupe_key = hash_to_key.get(str(record.get("dedupe_key_hash") or ""))
+        if dedupe_key:
+            prior = recent_dedupe_keys.get(dedupe_key)
+            if prior is None or ts > prior:
+                recent_dedupe_keys[dedupe_key] = ts
+        if _is_notification_action(str(record.get("action") or "")):
+            if ts.date() == now.date():
+                notifications_today += 1
+            if last_notification_at is None or ts > last_notification_at:
+                last_notification_at = ts
+
+    return AnticipationDecisionHistory(
+        recent_dedupe_keys=recent_dedupe_keys,
+        notifications_today=notifications_today,
+        last_notification_at=last_notification_at,
+    )
+
+
+def _runtime_config_for_loop(loop_name: str) -> AnticipationRuntimeConfig:
+    config = load_config()
+    anticipation = config.get("anticipation", {}) if isinstance(config, dict) else {}
+    loops = anticipation.get("loops", {}) if isinstance(anticipation, dict) else {}
+    loop_config = parse_loop_config(loop_name, loops.get(loop_name, {}))
+    quiet_hours = anticipation.get("quiet_hours", {}) if isinstance(anticipation, dict) else {}
+    budget = anticipation.get("notification_budget", {}) if isinstance(anticipation, dict) else {}
+
+    return AnticipationRuntimeConfig(
+        enabled=parse_bool(anticipation.get("enabled", False)),
+        loop_enabled=loop_config.enabled,
+        loop_permission=loop_config.permission,
+        min_confidence=loop_config.min_confidence,
+        quiet_hours_enabled=parse_bool(quiet_hours.get("enabled", False)),
+        quiet_hours_start=str(quiet_hours.get("start", "22:00")),
+        quiet_hours_end=str(quiet_hours.get("end", "08:00")),
+        max_per_day=int(budget.get("max_per_day", 3)),
+        min_minutes_between=int(budget.get("min_minutes_between", 120)),
+    )
+
+
+def run_stale_task_resurfacer_dry_run(*, db=None, limit: int = 5, lookback_days: int | None = None) -> list[AnticipationDecision]:
+    """Generate, gate, and audit stale-task decisions without delivery."""
+
+    config = load_config()
+    anticipation = config.get("anticipation", {}) if isinstance(config, dict) else {}
+    loops = anticipation.get("loops", {}) if isinstance(anticipation, dict) else {}
+    loop_config = parse_loop_config("stale_task_resurfacer", loops.get("stale_task_resurfacer", {}))
+    runtime = _runtime_config_for_loop("stale_task_resurfacer")
+
+    db = db or SessionDB()
+    candidates = build_stale_task_candidates(
+        db,
+        lookback_days=lookback_days or loop_config.lookback_days,
+        limit=limit,
+    )
+    history = history_from_decision_logs(read_recent_decision_logs(limit=200), candidates)
+    decisions = [
+        decide_anticipation_action(candidate, runtime, history, now=candidate.created_at)
+        for candidate in candidates
+    ]
+    for decision in decisions:
+        append_decision_log(decision)
+    return decisions
+
+
+def run_router_monitor_dry_run(
+    *,
+    snapshot: dict | None = None,
+    snapshot_path: str | Path | None = None,
+    limit: int = 5,
+    now: datetime | None = None,
+) -> list[AnticipationDecision]:
+    """Generate, gate, and audit router-monitor decisions without delivery."""
+
+    if snapshot is None:
+        snapshot = _load_router_snapshot(snapshot_path)
+    now = now or datetime.now(timezone.utc)
+    runtime = _runtime_config_for_loop("router_monitor")
+    candidates = build_router_monitor_candidates(snapshot, now=now, limit=limit)
+    history = history_from_decision_logs(read_recent_decision_logs(limit=200), candidates, now=now)
+    decisions = [
+        decide_anticipation_action(candidate, runtime, history, now=now)
+        for candidate in candidates
+    ]
+    for decision in decisions:
+        append_decision_log(decision)
+    return decisions
+
+
+def _load_router_snapshot(snapshot_path: str | Path | None) -> dict:
+    if snapshot_path is None:
+        return {"monitoring": {}, "unknown_devices": []}
+    with open(snapshot_path, "r", encoding="utf-8") as handle:
+        loaded = json.load(handle)
+    if not isinstance(loaded, dict):
+        raise ValueError("Router snapshot JSON must be an object")
+    return loaded
+
+
+def _emit_decisions(decisions: Sequence[AnticipationDecision], *, json_output: bool, empty_message: str) -> None:
+    if json_output:
+        payload = [
+            {
+                "action": decision.action,
+                "reason": decision.reason,
+                "title": decision.candidate.title,
+                "confidence": decision.candidate.confidence,
+            }
+            for decision in decisions
+        ]
+        print(json.dumps(payload, indent=2))
+    else:
+        print(format_dry_run_decisions(decisions, empty_message=empty_message))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run Hermes anticipation loops manually.")
+    subparsers = parser.add_subparsers(dest="loop")
+
+    stale = subparsers.add_parser("stale_task_resurfacer", help="Dry-run stale task resurfacing.")
+    stale.add_argument("--dry-run", action="store_true", help="Required for V0; no delivery is supported.")
+    stale.add_argument("--limit", type=int, default=5)
+    stale.add_argument("--lookback-days", type=int, default=None)
+    stale.add_argument("--json", action="store_true", help="Emit machine-readable decisions.")
+
+    router = subparsers.add_parser("router_monitor", help="Dry-run router monitoring anticipation.")
+    router.add_argument("--dry-run", action="store_true", help="Required for V0; no delivery is supported.")
+    router.add_argument("--limit", type=int, default=5)
+    router.add_argument("--snapshot", type=str, default=None, help="Optional sanitized router snapshot JSON file.")
+    router.add_argument("--json", action="store_true", help="Emit machine-readable decisions.")
+
+    logs = subparsers.add_parser("log", help="Show recent anticipation decision logs.")
+    logs.add_argument("--limit", type=int, default=10)
+
+    args = parser.parse_args(argv)
+    if args.loop == "log":
+        print(json.dumps(read_recent_decision_logs(limit=args.limit), indent=2))
+        return 0
+
+    if args.loop == "router_monitor":
+        if not args.dry_run:
+            print("V0 only supports --dry-run; no delivery was attempted.", file=sys.stderr)
+            return 2
+        try:
+            decisions = run_router_monitor_dry_run(limit=args.limit, snapshot_path=args.snapshot)
+        except (OSError, ValueError) as exc:
+            print(f"Unable to read router snapshot: {exc}", file=sys.stderr)
+            return 2
+        _emit_decisions(decisions, json_output=args.json, empty_message="No router-monitor candidates found.")
+        return 0
+
+    if args.loop != "stale_task_resurfacer":
+        parser.print_help()
+        return 2
+    if not args.dry_run:
+        print("V0 only supports --dry-run; no delivery was attempted.", file=sys.stderr)
+        return 2
+
+    decisions = run_stale_task_resurfacer_dry_run(limit=args.limit, lookback_days=args.lookback_days)
+    _emit_decisions(decisions, json_output=args.json, empty_message="No stale-task candidates found.")
+    return 0
+
+
+def _parse_log_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _is_notification_action(action: str) -> bool:
+    return action not in {"", "skip", "silent_log"}
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_anticipation.py
+++ b/tests/agent/test_anticipation.py
@@ -1,0 +1,143 @@
+"""Tests for anticipation data types and validation."""
+
+from math import inf, nan
+
+import pytest
+
+from agent.anticipation import (
+    AnticipationLoopConfig,
+    AnticipationPermission,
+    AnticipationRuntimeConfig,
+    parse_loop_config,
+    parse_permission,
+    parse_bool,
+)
+
+
+@pytest.mark.parametrize("permission", [permission.value for permission in AnticipationPermission])
+def test_parse_permission_accepts_all_permission_values(permission):
+    assert parse_permission(permission).value == permission
+
+
+def test_parse_permission_accepts_enum_value():
+    assert parse_permission(AnticipationPermission.DRAFT) is AnticipationPermission.DRAFT
+
+
+def test_parse_permission_rejects_invalid_value_with_allowed_values():
+    with pytest.raises(ValueError) as excinfo:
+        parse_permission("do_whatever")
+
+    message = str(excinfo.value)
+    assert "do_whatever" in message
+    assert "suggest" in message
+    assert "execute_safe" in message
+
+
+def test_parse_loop_config_builds_typed_loop_config():
+    loop = parse_loop_config(
+        "stale_task_resurfacer",
+        {
+            "enabled": True,
+            "schedule": "0 9 * * *",
+            "permission": "draft",
+            "min_confidence": 0.8,
+            "lookback_days": 21,
+        },
+    )
+
+    assert loop == AnticipationLoopConfig(
+        name="stale_task_resurfacer",
+        enabled=True,
+        schedule="0 9 * * *",
+        permission=AnticipationPermission.DRAFT,
+        min_confidence=0.8,
+        lookback_days=21,
+    )
+
+
+@pytest.mark.parametrize("value", ["false", "False", "0", "no", "off", ""])
+def test_parse_bool_treats_false_strings_as_false(value):
+    assert parse_bool(value) is False
+
+
+@pytest.mark.parametrize("value", ["true", "True", "1", "yes", "on"])
+def test_parse_bool_treats_true_strings_as_true(value):
+    assert parse_bool(value) is True
+
+
+def test_parse_loop_config_does_not_enable_quoted_false():
+    loop = parse_loop_config(
+        "router_monitor",
+        {
+            "enabled": "false",
+            "schedule": "manual",
+            "permission": "ask_to_execute",
+            "min_confidence": 0.8,
+            "lookback_days": 1,
+        },
+    )
+
+    assert loop.enabled is False
+
+
+@pytest.mark.parametrize("confidence", [-0.01, 1.01])
+def test_parse_loop_config_rejects_confidence_outside_unit_interval(confidence):
+    with pytest.raises(ValueError, match="min_confidence"):
+        parse_loop_config(
+            "stale_task_resurfacer",
+            {
+                "enabled": False,
+                "schedule": "",
+                "permission": "suggest",
+                "min_confidence": confidence,
+            },
+        )
+
+
+@pytest.mark.parametrize("confidence", [nan, inf, -inf])
+def test_parse_loop_config_rejects_non_finite_confidence(confidence):
+    with pytest.raises(ValueError, match="min_confidence"):
+        parse_loop_config(
+            "stale_task_resurfacer",
+            {
+                "enabled": False,
+                "schedule": "",
+                "permission": "suggest",
+                "min_confidence": confidence,
+            },
+        )
+
+
+def test_parse_loop_config_requires_mapping():
+    with pytest.raises(ValueError, match="must be a mapping"):
+        parse_loop_config("stale_task_resurfacer", None)
+
+
+def test_runtime_config_rejects_non_finite_min_confidence():
+    with pytest.raises(ValueError, match="min_confidence"):
+        AnticipationRuntimeConfig(
+            enabled=True,
+            loop_enabled=True,
+            loop_permission=AnticipationPermission.SUGGEST,
+            min_confidence=nan,
+            quiet_hours_enabled=False,
+            quiet_hours_start="22:00",
+            quiet_hours_end="08:00",
+            max_per_day=3,
+            min_minutes_between=120,
+        )
+
+
+def test_runtime_config_rejects_negative_budget_values():
+    with pytest.raises(ValueError, match="max_per_day"):
+        AnticipationRuntimeConfig(
+            enabled=True,
+            loop_enabled=True,
+            loop_permission=AnticipationPermission.SUGGEST,
+            min_confidence=0.7,
+            quiet_hours_enabled=False,
+            quiet_hours_start="22:00",
+            quiet_hours_end="08:00",
+            max_per_day=-1,
+            min_minutes_between=120,
+        )

--- a/tests/agent/test_anticipation_log.py
+++ b/tests/agent/test_anticipation_log.py
@@ -1,0 +1,80 @@
+"""Tests for sanitized anticipation decision logging."""
+
+import json
+from datetime import datetime, timezone
+from math import nan
+
+from agent.anticipation import AnticipationPermission
+from agent.anticipation_log import append_decision_log, decision_log_path, read_recent_decision_logs
+from agent.anticipation_policy import AnticipationCandidate, AnticipationDecision
+
+
+def make_decision(secret_body="body with private-token", secret_title="Potential stale task for private client"):
+    candidate = AnticipationCandidate(
+        loop_id="stale_task_resurfacer",
+        title=secret_title,
+        body=secret_body,
+        confidence=0.82,
+        proposed_permission=AnticipationPermission.SUGGEST,
+        dedupe_key="raw-session-id-with-secret",
+        created_at=datetime(2026, 5, 5, 18, 0, tzinfo=timezone.utc),
+    )
+    return AnticipationDecision(action="skip", reason="below_confidence_threshold", candidate=candidate)
+
+
+def test_append_decision_log_writes_sanitized_jsonl_with_secure_permissions():
+    path = append_decision_log(make_decision(), now=datetime(2026, 5, 5, 18, 1, tzinfo=timezone.utc))
+
+    assert path == decision_log_path()
+    assert path.exists()
+    raw_log = path.read_text(encoding="utf-8")
+    record = json.loads(raw_log.strip())
+
+    assert record["loop_id"] == "stale_task_resurfacer"
+    assert record["action"] == "skip"
+    assert record["reason"] == "below_confidence_threshold"
+    assert record["confidence"] == 0.82
+    assert "dedupe_key_hash" in record
+    assert "title_hash" in record
+    assert "raw-session-id-with-secret" not in raw_log
+    assert "private-token" not in raw_log
+    assert "Potential stale task for private client" not in raw_log
+
+    if path.parent.stat().st_mode & 0o777 != 0o700:
+        # Containerized test environments may not honor chmod on mounted paths.
+        return
+    assert path.stat().st_mode & 0o777 == 0o600
+
+
+def test_read_recent_decision_logs_returns_newest_records_first():
+    first = make_decision("first")
+    second = make_decision("second")
+    append_decision_log(first, now=datetime(2026, 5, 5, 18, 1, tzinfo=timezone.utc))
+    append_decision_log(second, now=datetime(2026, 5, 5, 18, 2, tzinfo=timezone.utc))
+
+    records = read_recent_decision_logs(limit=1)
+
+    assert len(records) == 1
+    assert records[0]["ts"] == "2026-05-05T18:02:00+00:00"
+
+
+def test_append_decision_log_sanitizes_non_finite_confidence():
+    decision = make_decision()
+    candidate = AnticipationCandidate(
+        loop_id=decision.candidate.loop_id,
+        title=decision.candidate.title,
+        body=decision.candidate.body,
+        confidence=nan,
+        proposed_permission=decision.candidate.proposed_permission,
+        dedupe_key=decision.candidate.dedupe_key,
+        created_at=decision.candidate.created_at,
+    )
+
+    path = append_decision_log(
+        AnticipationDecision(action="skip", reason="below_confidence_threshold", candidate=candidate),
+        now=datetime(2026, 5, 5, 18, 3, tzinfo=timezone.utc),
+    )
+
+    raw_log = path.read_text(encoding="utf-8")
+    assert "NaN" not in raw_log
+    assert json.loads(raw_log.splitlines()[-1])["confidence"] is None

--- a/tests/agent/test_anticipation_loops.py
+++ b/tests/agent/test_anticipation_loops.py
@@ -1,0 +1,126 @@
+"""Tests for stale-task anticipation candidate generation."""
+
+from datetime import datetime, timedelta, timezone
+
+from agent.anticipation import AnticipationPermission
+from agent.anticipation_loops import build_stale_task_candidates
+
+NOW = datetime(2026, 5, 5, 18, 0, tzinfo=timezone.utc)
+
+
+class FakeSessionDB:
+    def __init__(self, sessions, messages_by_session):
+        self.sessions = sessions
+        self.messages_by_session = messages_by_session
+
+    def list_sessions_rich(self, **kwargs):
+        self.list_kwargs = kwargs
+        return self.sessions
+
+    def get_messages_as_conversation(self, session_id):
+        return self.messages_by_session.get(session_id, [])
+
+
+def ts(days_ago):
+    return (NOW - timedelta(days=days_ago)).timestamp()
+
+
+def test_stale_task_resurfacer_builds_candidate_from_unanswered_offer():
+    db = FakeSessionDB(
+        sessions=[
+            {
+                "id": "sess-1",
+                "source": "telegram",
+                "title": "Hermes anticipation planning",
+                "last_active": ts(1),
+                "message_count": 2,
+                "preview": "Can we turn this into a plan?",
+            }
+        ],
+        messages_by_session={
+            "sess-1": [
+                {"role": "user", "content": "Can we turn this into a plan?"},
+                {"role": "assistant", "content": "If you want, I can turn this into a concrete implementation plan next."},
+            ]
+        },
+    )
+
+    candidates = build_stale_task_candidates(db, now=NOW, lookback_days=14, limit=5)
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.loop_id == "stale_task_resurfacer"
+    assert candidate.proposed_permission is AnticipationPermission.SUGGEST
+    assert candidate.confidence >= 0.7
+    assert "Hermes anticipation planning" in candidate.title
+    assert "If you want" in candidate.body
+    assert candidate.dedupe_key.startswith("stale_task_resurfacer:sess-1:")
+
+
+def test_stale_task_resurfacer_skips_when_later_user_response_completes_thread():
+    db = FakeSessionDB(
+        sessions=[{"id": "sess-1", "source": "telegram", "last_active": ts(1), "message_count": 3, "preview": ""}],
+        messages_by_session={
+            "sess-1": [
+                {"role": "assistant", "content": "Next I can wire the dry-run command."},
+                {"role": "user", "content": "Done, that part is complete."},
+            ]
+        },
+    )
+
+    assert build_stale_task_candidates(db, now=NOW, lookback_days=14, limit=5) == []
+
+
+def test_stale_task_resurfacer_ignores_tool_output_with_unresolved_language():
+    db = FakeSessionDB(
+        sessions=[{"id": "sess-1", "source": "telegram", "last_active": ts(1), "message_count": 2, "preview": ""}],
+        messages_by_session={
+            "sess-1": [
+                {"role": "user", "content": "Check the repo."},
+                {"role": "tool", "content": "TODO: internal fixture output with next step secrets."},
+            ]
+        },
+    )
+
+    assert build_stale_task_candidates(db, now=NOW, lookback_days=14, limit=5) == []
+
+
+def test_stale_task_resurfacer_skips_sessions_outside_lookback_and_current_session():
+    db = FakeSessionDB(
+        sessions=[
+            {"id": "old", "source": "telegram", "last_active": ts(30), "message_count": 2, "preview": ""},
+            {"id": "current", "source": "telegram", "last_active": ts(1), "message_count": 2, "preview": ""},
+        ],
+        messages_by_session={
+            "old": [{"role": "assistant", "content": "Next step: build this."}],
+            "current": [{"role": "assistant", "content": "Next step: build this."}],
+        },
+    )
+
+    candidates = build_stale_task_candidates(
+        db,
+        now=NOW,
+        lookback_days=14,
+        limit=5,
+        current_session_id="current",
+    )
+
+    assert candidates == []
+
+
+def test_stale_task_resurfacer_orders_by_confidence_then_recency_and_limits():
+    db = FakeSessionDB(
+        sessions=[
+            {"id": "low", "source": "telegram", "title": "Low", "last_active": ts(1), "message_count": 2, "preview": ""},
+            {"id": "high", "source": "telegram", "title": "High", "last_active": ts(3), "message_count": 2, "preview": ""},
+        ],
+        messages_by_session={
+            "low": [{"role": "assistant", "content": "We should revisit this later."}],
+            "high": [{"role": "assistant", "content": "TODO: next step is to add the dry-run command."}],
+        },
+    )
+
+    candidates = build_stale_task_candidates(db, now=NOW, lookback_days=14, limit=1)
+
+    assert len(candidates) == 1
+    assert "High" in candidates[0].title

--- a/tests/agent/test_anticipation_policy.py
+++ b/tests/agent/test_anticipation_policy.py
@@ -1,0 +1,191 @@
+"""Tests for anticipation policy decisions."""
+
+from datetime import datetime, timedelta, timezone
+from math import inf, nan
+
+import pytest
+
+from agent.anticipation import AnticipationPermission, AnticipationRuntimeConfig
+from agent.anticipation_policy import (
+    AnticipationCandidate,
+    AnticipationDecisionHistory,
+    decide_anticipation_action,
+)
+
+NOW = datetime(2026, 5, 5, 18, 0, tzinfo=timezone.utc)
+
+
+def runtime_config(**overrides):
+    values = {
+        "enabled": True,
+        "loop_enabled": True,
+        "loop_permission": AnticipationPermission.SUGGEST,
+        "min_confidence": 0.7,
+        "quiet_hours_enabled": False,
+        "quiet_hours_start": "22:00",
+        "quiet_hours_end": "08:00",
+        "max_per_day": 3,
+        "min_minutes_between": 120,
+    }
+    values.update(overrides)
+    return AnticipationRuntimeConfig(**values)
+
+
+def candidate(**overrides):
+    values = {
+        "loop_id": "stale_task_resurfacer",
+        "title": "Stale thread worth picking back up",
+        "body": "We paused at turning anticipation into a concrete Hermes plan.",
+        "confidence": 0.8,
+        "proposed_permission": AnticipationPermission.SUGGEST,
+        "dedupe_key": "session:123",
+        "created_at": NOW,
+    }
+    values.update(overrides)
+    return AnticipationCandidate(**values)
+
+
+def test_decision_suggests_when_candidate_passes_all_gates():
+    decision = decide_anticipation_action(candidate(), runtime_config(), AnticipationDecisionHistory(), now=NOW)
+
+    assert decision.action == "suggest"
+    assert decision.reason == "passed"
+
+
+def test_decision_skips_when_anticipation_disabled():
+    decision = decide_anticipation_action(
+        candidate(),
+        runtime_config(enabled=False),
+        AnticipationDecisionHistory(),
+        now=NOW,
+    )
+
+    assert decision.action == "skip"
+    assert decision.reason == "anticipation_disabled"
+
+
+def test_decision_skips_when_loop_disabled():
+    decision = decide_anticipation_action(
+        candidate(),
+        runtime_config(loop_enabled=False),
+        AnticipationDecisionHistory(),
+        now=NOW,
+    )
+
+    assert decision.action == "skip"
+    assert decision.reason == "loop_disabled"
+
+
+def test_decision_skips_when_confidence_below_threshold():
+    decision = decide_anticipation_action(
+        candidate(confidence=0.69),
+        runtime_config(min_confidence=0.7),
+        AnticipationDecisionHistory(),
+        now=NOW,
+    )
+
+    assert decision.action == "skip"
+    assert decision.reason == "below_confidence_threshold"
+
+
+@pytest.mark.parametrize("confidence", [nan, inf, -inf])
+def test_decision_skips_when_candidate_confidence_is_not_finite(confidence):
+    decision = decide_anticipation_action(
+        candidate(confidence=confidence),
+        runtime_config(min_confidence=0.7),
+        AnticipationDecisionHistory(),
+        now=NOW,
+    )
+
+    assert decision.action == "skip"
+    assert decision.reason == "below_confidence_threshold"
+
+
+def test_decision_skips_empty_candidate_body():
+    decision = decide_anticipation_action(
+        candidate(body="   "),
+        runtime_config(),
+        AnticipationDecisionHistory(),
+        now=NOW,
+    )
+
+    assert decision.action == "skip"
+    assert decision.reason == "empty_candidate_body"
+
+
+def test_decision_skips_duplicate_inside_quieting_window():
+    history = AnticipationDecisionHistory(
+        recent_dedupe_keys={"session:123": NOW - timedelta(minutes=10)},
+    )
+
+    decision = decide_anticipation_action(candidate(), runtime_config(), history, now=NOW)
+
+    assert decision.action == "skip"
+    assert decision.reason == "duplicate_dedupe_key"
+
+
+def test_decision_skips_when_notification_budget_exhausted():
+    history = AnticipationDecisionHistory(notifications_today=3)
+
+    decision = decide_anticipation_action(candidate(), runtime_config(max_per_day=3), history, now=NOW)
+
+    assert decision.action == "skip"
+    assert decision.reason == "notification_budget_exhausted"
+
+
+def test_decision_uses_budget_reason_when_last_notification_was_too_recent():
+    history = AnticipationDecisionHistory(last_notification_at=NOW - timedelta(minutes=10))
+
+    decision = decide_anticipation_action(candidate(), runtime_config(), history, now=NOW)
+
+    assert decision.action == "skip"
+    assert decision.reason == "notification_budget_exhausted"
+
+
+def test_decision_skips_inside_quiet_hours():
+    quiet_now = datetime(2026, 5, 5, 23, 0, tzinfo=timezone.utc)
+
+    decision = decide_anticipation_action(
+        candidate(created_at=quiet_now),
+        runtime_config(quiet_hours_enabled=True, quiet_hours_start="22:00", quiet_hours_end="08:00"),
+        AnticipationDecisionHistory(),
+        now=quiet_now,
+    )
+
+    assert decision.action == "skip"
+    assert decision.reason == "inside_quiet_hours"
+
+
+def test_decision_allows_silent_log_inside_quiet_hours_and_exhausted_budget():
+    quiet_now = datetime(2026, 5, 5, 23, 0, tzinfo=timezone.utc)
+
+    decision = decide_anticipation_action(
+        candidate(
+            created_at=quiet_now,
+            proposed_permission=AnticipationPermission.SILENT_LOG,
+        ),
+        runtime_config(
+            loop_permission=AnticipationPermission.SILENT_LOG,
+            quiet_hours_enabled=True,
+            quiet_hours_start="22:00",
+            quiet_hours_end="08:00",
+            max_per_day=0,
+        ),
+        AnticipationDecisionHistory(notifications_today=99),
+        now=quiet_now,
+    )
+
+    assert decision.action == "silent_log"
+    assert decision.reason == "passed"
+
+
+def test_decision_skips_when_candidate_permission_exceeds_loop_ceiling():
+    decision = decide_anticipation_action(
+        candidate(proposed_permission=AnticipationPermission.ASK_TO_EXECUTE),
+        runtime_config(loop_permission=AnticipationPermission.SUGGEST),
+        AnticipationDecisionHistory(),
+        now=NOW,
+    )
+
+    assert decision.action == "skip"
+    assert decision.reason == "permission_exceeds_ceiling"

--- a/tests/agent/test_router_anticipation_loop.py
+++ b/tests/agent/test_router_anticipation_loop.py
@@ -1,0 +1,217 @@
+"""Tests for router-monitor anticipation candidate generation."""
+
+from datetime import datetime, timezone
+
+from agent.anticipation import AnticipationPermission
+from agent.anticipation_loops import build_router_monitor_candidates
+
+NOW = datetime(2026, 5, 5, 18, 0, tzinfo=timezone.utc)
+
+
+def base_snapshot(**overrides):
+    snapshot = {
+        "collected_at": NOW.isoformat(),
+        "monitoring": {
+            "quarantine_dir_exists": True,
+            "cron_entries": [
+                "* * * * * /root/quarantine/quarantine-v3.sh run",
+                "*/5 * * * * /root/quarantine/gl-ngx-watchdog.sh",
+                "*/5 * * * * /root/quarantine/cron-guard.sh",
+            ],
+            "cron_log_last_at": NOW.isoformat(),
+            "segfault_count_7d": 0,
+        },
+        "counts": {"trusted": 36, "quarantined": 2, "blocked": 1, "active_dhcp": 20},
+        "unknown_devices": [],
+    }
+    snapshot.update(overrides)
+    return snapshot
+
+
+def test_router_monitor_candidates_detect_monitoring_degradation():
+    snapshot = base_snapshot(
+        monitoring={
+            "quarantine_dir_exists": True,
+            "cron_entries": ["0 9 * * 0 /root/quarantine/quarantine-v3.sh digest"],
+            "cron_log_last_at": "2026-05-05T16:30:00+00:00",
+            "segfault_count_7d": 0,
+        }
+    )
+
+    candidates = build_router_monitor_candidates(snapshot, now=NOW)
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.loop_id == "router_monitor"
+    assert candidate.proposed_permission is AnticipationPermission.ASK_TO_EXECUTE
+    assert candidate.confidence >= 0.85
+    assert "monitoring may be degraded" in candidate.title.lower()
+    assert "minutely quarantine cron job is missing" in candidate.body
+    assert "cron log is stale" in candidate.body
+    assert "I did not change router state" in candidate.body
+    assert candidate.dedupe_key.startswith("router_monitor:health:")
+
+
+def test_router_monitor_candidates_silent_log_one_time_randomized_mac():
+    snapshot = base_snapshot(
+        unknown_devices=[
+            {
+                "mac": "7a:11:22:33:44:55",
+                "active": False,
+                "locally_administered": True,
+                "seen_count_72h": 1,
+                "hostnames": [],
+                "traffic_summary": "no meaningful traffic",
+            }
+        ]
+    )
+
+    candidates = build_router_monitor_candidates(snapshot, now=NOW)
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.proposed_permission is AnticipationPermission.SILENT_LOG
+    assert candidate.confidence >= 0.7
+    assert "one-time randomized" in candidate.title.lower()
+    assert "7a:11:22" in candidate.body
+    assert "No Telegram-worthy interruption" in candidate.body
+
+
+def test_router_monitor_candidates_suggest_recurring_likely_phone():
+    snapshot = base_snapshot(
+        unknown_devices=[
+            {
+                "mac": "7a:11:22:33:44:55",
+                "active": False,
+                "locally_administered": True,
+                "seen_count_72h": 4,
+                "hostnames": ["Pixel-Guest"],
+                "traffic_summary": "Google connectivity checks",
+            }
+        ]
+    )
+
+    candidates = build_router_monitor_candidates(snapshot, now=NOW)
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.proposed_permission is AnticipationPermission.SUGGEST
+    assert candidate.confidence >= 0.78
+    assert "recurring randomized" in candidate.title.lower()
+    assert "Pixel-Guest" in candidate.body
+    assert "correlate it against guests" in candidate.body
+
+
+def test_router_monitor_candidates_suggest_recurring_normal_unknown():
+    snapshot = base_snapshot(
+        unknown_devices=[
+            {
+                "mac": "00:11:22:33:44:55",
+                "active": False,
+                "locally_administered": False,
+                "seen_count_72h": 4,
+                "hostnames": ["esp-sensor"],
+                "traffic_summary": "periodic DHCP only",
+            }
+        ]
+    )
+
+    candidates = build_router_monitor_candidates(snapshot, now=NOW)
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.proposed_permission is AnticipationPermission.SUGGEST
+    assert "recurring unknown" in candidate.title.lower()
+    assert "esp-sensor" in candidate.body
+
+
+def test_router_monitor_candidates_parse_string_booleans_without_escalating_false():
+    snapshot = base_snapshot(
+        unknown_devices=[
+            {
+                "mac": "7a:11:22:33:44:55",
+                "active": "false",
+                "locally_administered": "true",
+                "seen_count_72h": "1",
+            }
+        ]
+    )
+
+    candidates = build_router_monitor_candidates(snapshot, now=NOW)
+
+    assert len(candidates) == 1
+    assert candidates[0].proposed_permission is AnticipationPermission.SILENT_LOG
+
+
+def test_router_monitor_candidates_sanitize_snapshot_strings():
+    snapshot = base_snapshot(
+        unknown_devices=[
+            {
+                "mac": "00:11:22:33:44:55",
+                "active": True,
+                "locally_administered": False,
+                "seen_count_72h": 2,
+                "ips": ["192.168.8.240\x1b[31m"],
+                "hostnames": ["evil\x1b[2Jhost\nnext"],
+                "traffic_summary": "scan\x1b[99m" + ("x" * 400),
+            }
+        ]
+    )
+
+    candidates = build_router_monitor_candidates(snapshot, now=NOW)
+
+    body = candidates[0].body
+    assert "\x1b" not in body
+    assert "\nnext" not in body
+    assert len(body) < 900
+
+
+def test_router_monitor_candidates_ask_to_execute_for_active_unknown():
+    snapshot = base_snapshot(
+        unknown_devices=[
+            {
+                "mac": "00:11:22:33:44:55",
+                "active": True,
+                "locally_administered": False,
+                "seen_count_72h": 2,
+                "ips": ["192.168.8.240"],
+                "hostnames": ["unknown-laptop"],
+                "traffic_summary": "active LAN traffic",
+            }
+        ]
+    )
+
+    candidates = build_router_monitor_candidates(snapshot, now=NOW)
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.proposed_permission is AnticipationPermission.ASK_TO_EXECUTE
+    assert candidate.confidence >= 0.86
+    assert "active unknown" in candidate.title.lower()
+    assert "192.168.8.240" in candidate.body
+    assert "review router status before approving or blocking" in candidate.body
+    assert "I did not block anything" in candidate.body
+
+
+def test_router_monitor_candidates_order_health_before_device_noise():
+    snapshot = base_snapshot(
+        monitoring={
+            "quarantine_dir_exists": False,
+            "cron_entries": [],
+            "cron_log_last_at": "2026-05-05T17:55:00+00:00",
+        },
+        unknown_devices=[
+            {
+                "mac": "7a:11:22:33:44:55",
+                "active": False,
+                "locally_administered": True,
+                "seen_count_72h": 1,
+            }
+        ],
+    )
+
+    candidates = build_router_monitor_candidates(snapshot, now=NOW)
+
+    assert len(candidates) == 2
+    assert candidates[0].proposed_permission is AnticipationPermission.ASK_TO_EXECUTE
+    assert "monitoring" in candidates[0].title.lower()

--- a/tests/hermes_cli/test_config_anticipation.py
+++ b/tests/hermes_cli/test_config_anticipation.py
@@ -1,0 +1,58 @@
+"""Tests for anticipation configuration defaults and merging."""
+
+from unittest.mock import patch
+
+from hermes_cli.config import DEFAULT_CONFIG, load_config
+
+
+def test_default_config_has_anticipation_disabled():
+    anticipation = DEFAULT_CONFIG["anticipation"]
+
+    assert anticipation["enabled"] is False
+    assert anticipation["default_permission"] == "suggest"
+    assert anticipation["loops"]["stale_task_resurfacer"]["enabled"] is False
+    assert anticipation["loops"]["router_monitor"]["enabled"] is False
+    assert anticipation["loops"]["router_monitor"]["permission"] == "ask_to_execute"
+
+
+def test_load_config_adds_anticipation_defaults_for_existing_config(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("model: test/model\n", encoding="utf-8")
+
+    with patch.dict("os.environ", {"HERMES_HOME": str(tmp_path)}):
+        config = load_config()
+
+    assert config["model"] == "test/model"
+    assert config["anticipation"]["enabled"] is False
+    assert config["anticipation"]["notification_budget"]["max_per_day"] == 3
+    assert config["anticipation"]["loops"]["stale_task_resurfacer"]["lookback_days"] == 14
+    assert config["anticipation"]["loops"]["router_monitor"]["enabled"] is False
+    assert config["anticipation"]["loops"]["router_monitor"]["schedule"] == "manual"
+
+
+def test_load_config_preserves_user_anticipation_overrides(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+anticipation:
+  enabled: true
+  notification_budget:
+    max_per_day: 1
+  loops:
+    stale_task_resurfacer:
+      enabled: true
+      min_confidence: 0.9
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with patch.dict("os.environ", {"HERMES_HOME": str(tmp_path)}):
+        config = load_config()
+
+    assert config["anticipation"]["enabled"] is True
+    assert config["anticipation"]["notification_budget"]["max_per_day"] == 1
+    assert config["anticipation"]["notification_budget"]["min_minutes_between"] == 120
+    loop = config["anticipation"]["loops"]["stale_task_resurfacer"]
+    assert loop["enabled"] is True
+    assert loop["min_confidence"] == 0.9
+    assert loop["permission"] == "suggest"

--- a/tests/scripts/test_anticipation_run.py
+++ b/tests/scripts/test_anticipation_run.py
@@ -1,0 +1,178 @@
+"""Tests for the anticipation dry-run script helpers."""
+
+from datetime import datetime, timedelta, timezone
+
+from agent.anticipation import AnticipationPermission
+from agent.anticipation_policy import AnticipationCandidate, AnticipationDecision
+from scripts import anticipation_run
+from scripts.anticipation_run import (
+    format_dry_run_decisions,
+    history_from_decision_logs,
+    run_router_monitor_dry_run,
+    _runtime_config_for_loop,
+)
+
+NOW = datetime(2026, 5, 5, 18, 0, tzinfo=timezone.utc)
+
+
+def candidate(**overrides):
+    values = {
+        "loop_id": "stale_task_resurfacer",
+        "title": "Stale thread: Hermes anticipation",
+        "body": "Next I can add a dry-run command.",
+        "confidence": 0.82,
+        "proposed_permission": AnticipationPermission.SUGGEST,
+        "dedupe_key": "dedupe",
+        "created_at": NOW,
+    }
+    values.update(overrides)
+    return AnticipationCandidate(**values)
+
+
+def test_format_dry_run_decisions_reports_decision_without_delivery():
+    decision = AnticipationDecision(action="suggest", reason="passed", candidate=candidate())
+
+    output = format_dry_run_decisions([decision])
+
+    assert "DRY RUN" in output
+    assert "No messages were delivered" in output
+    assert "Stale thread: Hermes anticipation" in output
+    assert "suggest" in output
+    assert "0.82" in output
+    assert "Next I can add a dry-run command." in output
+
+
+def test_format_dry_run_decisions_handles_empty_candidates():
+    output = format_dry_run_decisions([])
+
+    assert "No stale-task candidates found" in output
+    assert "No messages were delivered" in output
+
+
+def test_format_dry_run_decisions_hides_body_for_skipped_candidates():
+    decision = AnticipationDecision(
+        action="skip",
+        reason="anticipation_disabled",
+        candidate=candidate(body="private raw snippet should not display"),
+    )
+
+    output = format_dry_run_decisions([decision])
+
+    assert "private raw snippet" not in output
+    assert "hidden because decision was skipped" in output
+
+
+def test_history_from_decision_logs_hydrates_matching_candidate_dedupe_and_budget():
+    prior_ts = NOW - timedelta(minutes=10)
+    logs = [
+        {
+            "ts": prior_ts.isoformat(),
+            "action": "suggest",
+            "dedupe_key_hash": "2cf2fb7f867feffafbfe66a5b8e8822da70738406dd3b85a28c83892da6e50a5",
+        }
+    ]
+
+    history = history_from_decision_logs(logs, [candidate()], now=NOW)
+
+    assert history.recent_dedupe_keys["dedupe"] == prior_ts
+    assert history.notifications_today == 1
+    assert history.last_notification_at == prior_ts
+
+
+def test_runtime_config_for_loop_parses_quoted_false_global_booleans(monkeypatch):
+    monkeypatch.setattr(
+        anticipation_run,
+        "load_config",
+        lambda: {
+            "anticipation": {
+                "enabled": "false",
+                "quiet_hours": {"enabled": "false", "start": "22:00", "end": "08:00"},
+                "notification_budget": {"max_per_day": 3, "min_minutes_between": 0},
+                "loops": {
+                    "router_monitor": {
+                        "enabled": "true",
+                        "schedule": "manual",
+                        "permission": "ask_to_execute",
+                        "min_confidence": 0.70,
+                        "lookback_days": 1,
+                    }
+                },
+            }
+        },
+    )
+
+    runtime = _runtime_config_for_loop("router_monitor")
+
+    assert runtime.enabled is False
+    assert runtime.loop_enabled is True
+    assert runtime.quiet_hours_enabled is False
+
+
+def test_run_router_monitor_dry_run_uses_policy_and_audit_log(monkeypatch):
+    appended = []
+    monkeypatch.setattr(
+        anticipation_run,
+        "load_config",
+        lambda: {
+            "anticipation": {
+                "enabled": True,
+                "quiet_hours": {"enabled": False, "start": "22:00", "end": "08:00"},
+                "notification_budget": {"max_per_day": 3, "min_minutes_between": 0},
+                "loops": {
+                    "router_monitor": {
+                        "enabled": True,
+                        "schedule": "manual",
+                        "permission": "ask_to_execute",
+                        "min_confidence": 0.70,
+                        "lookback_days": 1,
+                    }
+                },
+            }
+        },
+    )
+    monkeypatch.setattr(anticipation_run, "read_recent_decision_logs", lambda limit=200: [])
+    monkeypatch.setattr(anticipation_run, "append_decision_log", appended.append)
+    snapshot = {
+        "monitoring": {
+            "quarantine_dir_exists": True,
+            "cron_entries": [],
+            "cron_log_last_at": "2026-05-05T17:00:00+00:00",
+        },
+        "unknown_devices": [],
+    }
+
+    decisions = run_router_monitor_dry_run(snapshot=snapshot, limit=3, now=NOW)
+
+    assert len(decisions) == 1
+    assert decisions[0].action == "ask_to_execute"
+    assert decisions[0].candidate.loop_id == "router_monitor"
+    assert appended == decisions
+
+
+def test_router_monitor_cli_requires_dry_run():
+    assert anticipation_run.main(["router_monitor"]) == 2
+
+
+def test_router_monitor_cli_reports_bad_snapshot_path(capsys):
+    assert anticipation_run.main(["router_monitor", "--dry-run", "--snapshot", "/no/such/snapshot.json"]) == 2
+    captured = capsys.readouterr()
+    assert "Unable to read router snapshot" in captured.err
+
+
+def test_router_monitor_cli_json_outputs_decisions(monkeypatch, capsys):
+    monkeypatch.setattr(
+        anticipation_run,
+        "run_router_monitor_dry_run",
+        lambda **kwargs: [
+            AnticipationDecision(
+                action="silent_log",
+                reason="passed",
+                candidate=candidate(loop_id="router_monitor", title="Router one-time randomized unknown"),
+            )
+        ],
+    )
+
+    assert anticipation_run.main(["router_monitor", "--dry-run", "--snapshot", "dummy.json", "--json"]) == 0
+    output = capsys.readouterr().out
+    assert "Router one-time randomized unknown" in output
+    assert "silent_log" in output


### PR DESCRIPTION
## Summary
- add disabled-by-default anticipation config, permission parsing, and runtime validation
- add pure policy gate plus sanitized JSONL decision audit logging
- add manual dry-run stale-task and router-monitor anticipation loops
- keep router monitoring snapshot-driven with no delivery, scheduling, SSH, mutation, or automatic blocking

## Test Plan
- python -m pytest tests/hermes_cli/test_config.py tests/hermes_cli/test_config_drift.py tests/hermes_cli/test_config_anticipation.py tests/agent/test_anticipation.py tests/agent/test_anticipation_policy.py tests/agent/test_anticipation_log.py tests/agent/test_anticipation_loops.py tests/agent/test_router_anticipation_loop.py tests/scripts/test_anticipation_run.py -q
- python -m compileall agent/anticipation.py agent/anticipation_policy.py agent/anticipation_log.py agent/anticipation_loops.py scripts/anticipation_run.py hermes_cli/config.py tests/hermes_cli/test_config_anticipation.py tests/agent/test_anticipation.py tests/agent/test_router_anticipation_loop.py tests/scripts/test_anticipation_run.py

## Safety Notes
- anticipation.enabled defaults false
- all loops default disabled
- dry-run CLIs refuse non-dry-run execution
- router path does not deliver messages, schedule cron, SSH to the router, mutate router state, approve devices, or block devices
- audit log stores sanitized metadata/hashes only