### PR TITLE
fix(whatsapp): pass fromMe group messages through bridge in self-chat mode (#20143)

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -29,6 +29,7 @@ import { execSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { shouldFilterFromMeMessage } from './from-me-filter.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -209,24 +210,16 @@ async function startSocket() {
       const isGroup = chatId.endsWith('@g.us');
       const senderNumber = senderId.replace(/@.*/, '');
 
-      // Handle fromMe messages based on mode
+      // Handle fromMe messages based on mode (#20143)
+      // WhatsApp uses LID (Linked Identity Device) format: 67427329167522@lid
+      // AND classic format: 34652029134@s.whatsapp.net
+      // sock.user has both: { id: "number:10@s.whatsapp.net", lid: "lid_number:10@lid" }
       if (msg.key.fromMe) {
-        if (isGroup || chatId.includes('status')) continue;
-
-        if (WHATSAPP_MODE === 'bot') {
-          // Bot mode: separate number. ALL fromMe are echo-backs of our own replies — skip.
-          continue;
-        }
-
-        // Self-chat mode: only allow messages in the user's own self-chat
-        // WhatsApp now uses LID (Linked Identity Device) format: 67427329167522@lid
-        // AND classic format: 34652029134@s.whatsapp.net
-        // sock.user has both: { id: "number:10@s.whatsapp.net", lid: "lid_number:10@lid" }
         const myNumber = (sock.user?.id || '').replace(/:.*@/, '@').replace(/@.*/, '');
         const myLid = (sock.user?.lid || '').replace(/:.*@/, '@').replace(/@.*/, '');
-        const chatNumber = chatId.replace(/@.*/, '');
-        const isSelfChat = (myNumber && chatNumber === myNumber) || (myLid && chatNumber === myLid);
-        if (!isSelfChat) continue;
+        if (shouldFilterFromMeMessage({ chatId, isGroup, mode: WHATSAPP_MODE, myNumber, myLid })) {
+          continue;
+        }
       }
 
       // Check allowlist for messages from others (resolve LID ↔ phone aliases)

--- a/scripts/whatsapp-bridge/from-me-filter.js
+++ b/scripts/whatsapp-bridge/from-me-filter.js
@@ -1,0 +1,52 @@
+/**
+ * Pure helper for the bridge's fromMe (sent-by-self) message filter.
+ *
+ * Extracted from bridge.js so the group-vs-DM filtering rules are
+ * unit-testable without booting Baileys / Express.
+ *
+ * @see scripts/whatsapp-bridge/from-me-filter.test.mjs
+ * @see https://github.com/NousResearch/hermes-agent/issues/20143
+ */
+
+/**
+ * Decide whether to drop a fromMe message at the bridge filter.
+ *
+ * Returns true when the message should be skipped (continue) and false when
+ * it should be forwarded to the gateway.
+ *
+ * Echo-back protection on forwarded fromMe messages is still handled
+ * downstream via REPLY_PREFIX startsWith() and recentlySentIds tracking
+ * (bridge.js around line ~329).  This filter is intentionally narrow so
+ * that group_policy / require_mention / group_allow_from rules in the
+ * Python gateway can decide group-message routing.
+ *
+ * @param {object} options
+ * @param {string} options.chatId - JID of the chat (e.g. ``120363001234@g.us``)
+ * @param {boolean} options.isGroup - chatId.endsWith('@g.us')
+ * @param {string} options.mode - ``'bot'`` or ``'self-chat'`` (WHATSAPP_MODE)
+ * @param {string} [options.myNumber] - phone number portion of ``sock.user.id``
+ * @param {string} [options.myLid] - lid portion of ``sock.user.lid``
+ * @returns {boolean} true ⇒ drop the message at the bridge
+ */
+export function shouldFilterFromMeMessage({ chatId, isGroup, mode, myNumber, myLid }) {
+  // Status broadcasts are always dropped — they're WhatsApp's broadcast
+  // channel, never an interactive conversation.
+  if (chatId.includes('status')) return true;
+
+  // Bot mode: bridge runs as a separate WhatsApp number, so every fromMe
+  // message is necessarily an echo of our own outgoing reply.
+  if (mode === 'bot') return true;
+
+  // Self-chat mode below this point.
+  // Group messages get forwarded to the gateway so group_policy /
+  // require_mention / group_allow_from can apply.  Echo-back protection
+  // is already handled downstream via REPLY_PREFIX + recentlySentIds. (#20143)
+  if (isGroup) return false;
+
+  // DM: only the user's own self-chat is allowed.
+  const chatNumber = chatId.replace(/@.*/, '');
+  const isSelfChat =
+    (myNumber && chatNumber === myNumber) ||
+    (myLid && chatNumber === myLid);
+  return !isSelfChat;
+}

--- a/scripts/whatsapp-bridge/from-me-filter.test.mjs
+++ b/scripts/whatsapp-bridge/from-me-filter.test.mjs
@@ -1,0 +1,138 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { shouldFilterFromMeMessage } from './from-me-filter.js';
+
+const SELF_NUMBER = '34652029134';
+const SELF_LID = '67427329167522';
+const SELF_CHAT_DM = `${SELF_NUMBER}@s.whatsapp.net`;
+const SELF_CHAT_LID_DM = `${SELF_LID}@lid`;
+const FRIEND_DM = '15551234567@s.whatsapp.net';
+const GROUP_CHAT = '120363001234567890@g.us';
+const STATUS_BROADCAST = 'status@broadcast';
+
+// --- Status broadcasts always dropped --------------------------------------
+
+test('status broadcast fromMe is always dropped (self-chat mode)', () => {
+  assert.equal(
+    shouldFilterFromMeMessage({
+      chatId: STATUS_BROADCAST,
+      isGroup: false,
+      mode: 'self-chat',
+      myNumber: SELF_NUMBER,
+      myLid: SELF_LID,
+    }),
+    true,
+  );
+});
+
+test('status broadcast fromMe is always dropped (bot mode)', () => {
+  assert.equal(
+    shouldFilterFromMeMessage({
+      chatId: STATUS_BROADCAST,
+      isGroup: false,
+      mode: 'bot',
+    }),
+    true,
+  );
+});
+
+// --- Bot mode drops everything --------------------------------------------
+
+test('bot mode drops all fromMe messages including groups', () => {
+  assert.equal(
+    shouldFilterFromMeMessage({ chatId: GROUP_CHAT, isGroup: true, mode: 'bot' }),
+    true,
+  );
+  assert.equal(
+    shouldFilterFromMeMessage({ chatId: FRIEND_DM, isGroup: false, mode: 'bot' }),
+    true,
+  );
+  assert.equal(
+    shouldFilterFromMeMessage({ chatId: SELF_CHAT_DM, isGroup: false, mode: 'bot' }),
+    true,
+  );
+});
+
+// --- Self-chat mode: groups must pass through (#20143) --------------------
+
+test('self-chat mode forwards fromMe group messages to gateway (#20143)', () => {
+  assert.equal(
+    shouldFilterFromMeMessage({
+      chatId: GROUP_CHAT,
+      isGroup: true,
+      mode: 'self-chat',
+      myNumber: SELF_NUMBER,
+      myLid: SELF_LID,
+    }),
+    false,
+    'group fromMe must NOT be filtered — gateway group_policy handles routing',
+  );
+});
+
+test('self-chat mode forwards fromMe group messages even without sock.user identity', () => {
+  // Even if sock.user is missing (e.g. early connection), groups still pass.
+  assert.equal(
+    shouldFilterFromMeMessage({
+      chatId: GROUP_CHAT,
+      isGroup: true,
+      mode: 'self-chat',
+    }),
+    false,
+  );
+});
+
+// --- Self-chat mode: DM filtering preserved ------------------------------
+
+test('self-chat mode forwards user own self-chat DM (classic format)', () => {
+  assert.equal(
+    shouldFilterFromMeMessage({
+      chatId: SELF_CHAT_DM,
+      isGroup: false,
+      mode: 'self-chat',
+      myNumber: SELF_NUMBER,
+      myLid: SELF_LID,
+    }),
+    false,
+  );
+});
+
+test('self-chat mode forwards user own self-chat DM (LID format)', () => {
+  assert.equal(
+    shouldFilterFromMeMessage({
+      chatId: SELF_CHAT_LID_DM,
+      isGroup: false,
+      mode: 'self-chat',
+      myNumber: SELF_NUMBER,
+      myLid: SELF_LID,
+    }),
+    false,
+  );
+});
+
+test('self-chat mode drops fromMe DMs to other contacts (echo prevention)', () => {
+  assert.equal(
+    shouldFilterFromMeMessage({
+      chatId: FRIEND_DM,
+      isGroup: false,
+      mode: 'self-chat',
+      myNumber: SELF_NUMBER,
+      myLid: SELF_LID,
+    }),
+    true,
+  );
+});
+
+test('self-chat mode drops fromMe DMs when sock.user identity is missing', () => {
+  // Without identity, can't recognise self-chat — fail closed for DMs.
+  assert.equal(
+    shouldFilterFromMeMessage({
+      chatId: SELF_CHAT_DM,
+      isGroup: false,
+      mode: 'self-chat',
+      myNumber: '',
+      myLid: '',
+    }),
+    true,
+  );
+});


### PR DESCRIPTION
## Summary
- ``scripts/whatsapp-bridge/bridge.js`` unconditionally dropped every ``fromMe`` message in a group chat, so self-chat-mode users could not interact with the agent in any WhatsApp group regardless of ``group_policy`` / ``group_allow_from`` / ``require_mention``.
- Filter logic moved into a pure ``shouldFilterFromMeMessage()`` helper. Self-chat mode now forwards group fromMe messages to the gateway so the existing Python-side group routing rules apply, while DM echo prevention and bot-mode behaviour are unchanged.
- Echo-loop protection on forwarded messages still relies on the existing ``REPLY_PREFIX`` startsWith() and ``recentlySentIds`` checks downstream in bridge.js.

Closes #20143

## Testing
- node --test scripts/whatsapp-bridge/from-me-filter.test.mjs
```
✔ status broadcast fromMe is always dropped (self-chat mode) (0.860583ms)
✔ status broadcast fromMe is always dropped (bot mode) (1.064667ms)
✔ bot mode drops all fromMe messages including groups (0.114625ms)
✔ self-chat mode forwards fromMe group messages to gateway (#20143) (0.095583ms)
✔ self-chat mode forwards fromMe group messages even without sock.user identity (0.088417ms)
✔ self-chat mode forwards user own self-chat DM (classic format) (0.132625ms)
✔ self-chat mode forwards user own self-chat DM (LID format) (0.134291ms)
✔ self-chat mode drops fromMe DMs to other contacts (echo prevention) (0.069208ms)
✔ self-chat mode drops fromMe DMs when sock.user identity is missing (0.097916ms)
ℹ tests 9
ℹ pass 9
ℹ fail 0
```
- node --test scripts/whatsapp-bridge/allowlist.test.mjs (existing tests still green)
```
ℹ tests 4
ℹ pass 4
ℹ fail 0
```
- node --check scripts/whatsapp-bridge/bridge.js (parses)