### PR TITLE
feat(image-gen,cli): image-to-image editing + multiline paste fix

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -132,14 +132,19 @@ class ImageGenProvider(abc.ABC):
         self,
         prompt: str,
         aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        image: Optional[str] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
-        """Generate an image.
+        """Generate or edit an image.
 
         Implementations should return the dict from :func:`success_response`
         or :func:`error_response`. ``kwargs`` may contain forward-compat
         parameters future versions of the schema will expose — implementations
         should ignore unknown keys.
+
+        ``image`` is an optional file path, URL, or base64 data URL of an
+        image to use as the starting point (image-to-image editing). When
+        omitted, the provider generates from scratch (text-to-image).
         """
 
 

--- a/cli.py
+++ b/cli.py
@@ -10177,6 +10177,13 @@ class HermesCLI:
                 return
 
             # --- Normal input routing ---
+            # Defer during rapid text input (paste without bracketed-paste support).
+            # When newlines arrive as individual Enter events, _on_text_changed fires
+            # for each character. If the last text change was < 50 ms ago, text is
+            # still arriving — skip submission and let the buffer accumulate.
+            if _last_text_change[0] and (time.monotonic() - _last_text_change[0]) < 0.05:
+                return
+
             text = event.app.current_buffer.text.strip()
             has_images = bool(self._attached_images)
             if text or has_images:
@@ -10940,6 +10947,7 @@ class HermesCLI:
         _prev_newline_count = [0]
         _paste_just_collapsed = [False]
         self._skip_paste_collapse = False
+        _last_text_change = [None]
 
         def _on_text_changed(buf):
             """Detect large pastes and collapse them to a file reference.
@@ -10956,6 +10964,7 @@ class HermesCLI:
                still batch newlines.  Alt+Enter only adds 1 newline per
                event so it never triggers this.
             """
+            _last_text_change[0] = time.monotonic()
             text = _strip_leaked_bracketed_paste_wrappers(buf.text)
             text, _had_mouse_reports = _strip_leaked_terminal_responses_with_meta(text)
             if _had_mouse_reports:

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -19,7 +19,9 @@ Output is saved as PNG under ``$HERMES_HOME/cache/images/``.
 
 from __future__ import annotations
 
+import base64
 import logging
+import os
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.image_gen_provider import (
@@ -161,9 +163,70 @@ def _build_codex_client():
         return None
 
 
-def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> Optional[str]:
-    """Stream a Codex Responses image_generation call and return the b64 image."""
+def _to_data_url(image: str) -> str:
+    """Convert a file path, URL, or data URL to a base64 data URL.
+
+    - Already a ``data:`` URL → return as-is.
+    - ``http(s)://`` URL → return as-is (Codex can fetch it).
+    - Local file path → encode to ``data:<mime>;base64,...``.
+    """
+    if not image:
+        return ""
+    image = image.strip()
+    if image.startswith("data:"):
+        return image
+    if image.startswith("http://") or image.startswith("https://"):
+        return image
+    if not os.path.exists(image):
+        raise FileNotFoundError(f"Image not found: {image}")
+    ext = os.path.splitext(image)[1].lower().lstrip(".")
+    mime_map = {
+        "png": "image/png",
+        "jpg": "image/jpeg",
+        "jpeg": "image/jpeg",
+        "webp": "image/webp",
+    }
+    mime = mime_map.get(ext, "image/png")
+    with open(image, "rb") as f:
+        b64 = base64.b64encode(f.read()).decode("ascii")
+    return f"data:{mime};base64,{b64}"
+
+
+def _collect_image_b64(
+    client: Any,
+    *,
+    prompt: str,
+    size: str,
+    quality: str,
+    image_url: Optional[str] = None,
+) -> Optional[str]:
+    """Stream a Codex Responses image_generation call and return the b64 image.
+
+    When ``image_url`` is provided, it is included as an ``input_image`` in
+    the message content and the tool is configured with ``action: \"edit\"``,
+    enabling image-to-image editing.
+    """
     image_b64: Optional[str] = None
+
+    # Build message content — include input image if provided.
+    content: List[Dict[str, Any]] = [
+        {"type": "input_text", "text": prompt},
+    ]
+    if image_url:
+        content.append({"type": "input_image", "image_url": image_url})
+
+    # Build tool config — add edit action when an input image is provided.
+    tool_config: Dict[str, Any] = {
+        "type": "image_generation",
+        "model": API_MODEL,
+        "size": size,
+        "quality": quality,
+        "output_format": "png",
+        "background": "opaque",
+        "partial_images": 1,
+    }
+    if image_url:
+        tool_config["action"] = "edit"
 
     with client.responses.stream(
         model=_CODEX_CHAT_MODEL,
@@ -172,17 +235,9 @@ def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> 
         input=[{
             "type": "message",
             "role": "user",
-            "content": [{"type": "input_text", "text": prompt}],
+            "content": content,
         }],
-        tools=[{
-            "type": "image_generation",
-            "model": API_MODEL,
-            "size": size,
-            "quality": quality,
-            "output_format": "png",
-            "background": "opaque",
-            "partial_images": 1,
-        }],
+        tools=[tool_config],
         tool_choice={
             "type": "allowed_tools",
             "mode": "required",
@@ -270,6 +325,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
         self,
         prompt: str,
         aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        image: Optional[str] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         prompt = (prompt or "").strip()
@@ -307,6 +363,19 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
         tier_id, meta = _resolve_model()
         size = _SIZES.get(aspect, _SIZES["square"])
 
+        # Encode input image if provided (image-to-image editing).
+        input_image_url: Optional[str] = None
+        if image:
+            try:
+                input_image_url = _to_data_url(image)
+            except Exception as exc:
+                return error_response(
+                    error=f"Cannot read input image: {exc}",
+                    error_type="invalid_argument",
+                    provider="openai-codex",
+                    aspect_ratio=aspect,
+                )
+
         client = _build_codex_client()
         if client is None:
             return error_response(
@@ -324,6 +393,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 prompt=prompt,
                 size=size,
                 quality=meta["quality"],
+                image_url=input_image_url,
             )
         except Exception as exc:
             logger.debug("Codex image generation failed", exc_info=True)

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -618,6 +618,7 @@ def _upscale_image(image_url: str, original_prompt: str) -> Optional[Dict[str, A
 def image_generate_tool(
     prompt: str,
     aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+    image: Optional[str] = None,
     num_inference_steps: Optional[int] = None,
     guidance_scale: Optional[float] = None,
     num_images: Optional[int] = None,
@@ -873,6 +874,10 @@ IMAGE_GENERATE_SCHEMA = {
                 "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
                 "default": DEFAULT_ASPECT_RATIO,
             },
+            "image": {
+                "type": "string",
+                "description": "Optional: a file path, URL, or base64 data URL of an image to use as the starting point. When provided, the tool edits the image based on the prompt (image-to-image). When omitted, generates from scratch (text-to-image).",
+            },
         },
         "required": ["prompt"],
     },
@@ -900,7 +905,7 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str, image: Optional[str] = None):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -950,7 +955,7 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         })
 
     try:
-        result = provider.generate(prompt=prompt, aspect_ratio=aspect_ratio)
+        result = provider.generate(prompt=prompt, aspect_ratio=aspect_ratio, image=image)
     except Exception as exc:
         logger.warning(
             "Image gen provider '%s' raised: %s",
@@ -977,16 +982,18 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    image = args.get("image")  # optional image input for editing
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio, image)
     if dispatched is not None:
         return dispatched
 
     return image_generate_tool(
         prompt=prompt,
         aspect_ratio=aspect_ratio,
+        image=image,
     )
 
 


### PR DESCRIPTION
## Changes (2 commits)

### 1. feat(image-gen): add image-to-image editing support via Codex provider

Adds optional `image` parameter to `image_generate` tool that enables image-to-image editing when using the `openai-codex` provider.

**Architecture (3-layer change):**
- **ABC** (`agent/image_gen_provider.py`) — adds `image=None` to `generate()`. Providers that do not handle image input ignore it via `**kwargs`.
- **Tool surface** (`tools/image_generation_tool.py`) — adds `image` to schema, handler forwards it, dispatch passes it, FAL path ignores it.
- **Codex provider** (`plugins/image_gen/openai-codex/__init__.py`) — encodes local files to base64, includes as `input_image` in Responses API content, sets `action: "edit"` on the `image_generation` tool.

**Behavior:**
- No `image` param → text-to-image as before (all providers)
- With `image` + openai-codex → image-to-image editing via Codex OAuth (zero API credits for ChatGPT plan users)
- With `image` + FAL/Google → ignored, still text-to-image

**Testing:**
- Text-to-image: generated red apple → success
- Image-to-image: passed red apple + "turn it green" → green apple returned, composition preserved
- Syntax-validated all 3 modified files

### 2. fix(cli): defer Enter during rapid text input to prevent multiline paste splitting

**Problem:** When pasting multiline text into the Hermes CLI without bracketed paste support (Windows Terminal, tmux), newlines arrive as individual Enter key events, flooding the agent with fragmented messages. Closes #10994.

**Fix: 50ms timing guard** — tracks last text change timestamp, defers Enter when <50ms since last character (paste), allows Enter when >50ms (manual typing).

**Updated for the current codebase:** The original approach was proposed in #10997 for an older cli.py. This version has been adapted and validated against the current `main` branch, which includes newer `_on_text_changed` logic (bracketed-paste leak stripping in the input processor) that was not present when #10997 was filed. Tested and working on this codebase as of 2026-05-04.

**Tested across:** Windows Terminal (no bracketed paste), tmux (large 731+ line pastes), normal/fast manual typing.

**Impact:** 9 lines, zero behavioral change for normal typing or bracketed-paste terminals.