### PR TITLE
docs(acp): update VS Code setup for ACP Client extension (salvage #12495)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -99,6 +99,7 @@ AUTHOR_MAP = {
     "1581133593@qq.com": "liu-collab",
     "haidaoe@proton.me": "haidao1919",
     "50561768+zhanggttry@users.noreply.github.com": "zhanggttry",
+    "formulahendry@gmail.com": "formulahendry",
     # Matrix parity salvage batch (April 2026)
     "sr@samirusani": "samrusani",
     "angelclaw@AngelMacBook.local": "angel12",

--- a/website/docs/user-guide/features/acp.md
+++ b/website/docs/user-guide/features/acp.md
@@ -67,18 +67,24 @@ Hermes logs to stderr so stdout remains reserved for ACP JSON-RPC traffic.
 
 ### VS Code
 
-Install an ACP client extension, then point it at the repo's `acp_registry/` directory.
+Install the [ACP Client](https://marketplace.visualstudio.com/items?itemName=formulahendry.acp-client) extension.
 
-Example settings snippet:
+To connect:
+
+1. Open the ACP Client panel from the Activity Bar.
+2. Select **Hermes Agent** from the built-in agent list.
+3. Connect and start chatting.
+
+If you want to define Hermes manually, add it through VS Code settings under `acp.agents`:
 
 ```json
 {
-  "acpClient.agents": [
-    {
-      "name": "hermes-agent",
-      "registryDir": "/path/to/hermes-agent/acp_registry"
+  "acp.agents": {
+    "Hermes Agent": {
+      "command": "hermes",
+      "args": ["acp"]
     }
-  ]
+  }
 }
 ```
 


### PR DESCRIPTION
Updates the ACP VS Code section to reflect the now-available [ACP Client extension by @formulahendry](https://marketplace.visualstudio.com/items?itemName=formulahendry.acp-client) — built-in agent picker, `acp.agents` settings shape (`command` + `args`) instead of the old `acpClient.agents` + `registryDir` pattern.

Changes:
- `website/docs/user-guide/features/acp.md` (+13/-7)
- `scripts/release.py` — AUTHOR_MAP entry for formulahendry

Verified `hermes acp` is a real subcommand (`hermes_cli/main.py:7992`).

Closes #12495 via salvage.

Original PR by @formulahendry (the extension author) — authorship preserved.