### PR TITLE
fix(cron): fail-closed delivery when deliver=origin and origin is missing

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -162,21 +162,19 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
                 "chat_id": str(origin["chat_id"]),
                 "thread_id": origin.get("thread_id"),
             }
-        # Origin missing (e.g. job created via API/script) — try each
-        # platform's home channel as a fallback instead of silently dropping.
-        for platform_name in _HOME_TARGET_ENV_VARS:
-            chat_id = _get_home_target_chat_id(platform_name)
-            if chat_id:
-                logger.info(
-                    "Job '%s' has deliver=origin but no origin; falling back to %s home channel",
-                    job.get("name", job.get("id", "?")),
-                    platform_name,
-                )
-                return {
-                    "platform": platform_name,
-                    "chat_id": chat_id,
-                    "thread_id": None,
-                }
+        # Fail closed. The previous behaviour fell back to the first
+        # configured *_HOME_CHANNEL env var, which on multi-platform hosts can
+        # cross-post work originating on platform A into platform B's home
+        # channel — e.g. a Slack-originated cron job whose origin metadata is
+        # null landing in the operator's Telegram DM. Refusing is safer than
+        # guessing. Callers that want a specific destination should pass an
+        # explicit deliver value like "telegram" (uses TELEGRAM_HOME_CHANNEL)
+        # or "telegram:<chat_id>".
+        logger.warning(
+            "Job '%s' has deliver=origin but no origin; refusing fallback "
+            "(set deliver explicitly or attach origin to the job)",
+            job.get("name", job.get("id", "?")),
+        )
         return None
 
     if ":" in deliver_value:
@@ -332,8 +330,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     """
     targets = _resolve_delivery_targets(job)
     if not targets:
-        if job.get("deliver", "local") != "local":
-            msg = f"no delivery target resolved for deliver={job.get('deliver', 'local')}"
+        deliver = _normalize_deliver_value(job.get("deliver", "local"))
+        if deliver != "local":
+            if "origin" in [p.strip() for p in deliver.split(",")] and not _resolve_origin(job):
+                msg = "deliver=origin but job has no origin (fail-closed)"
+            else:
+                msg = f"no delivery target resolved for deliver={job.get('deliver', 'local')}"
             logger.warning("Job '%s': %s", job["id"], msg)
             return msg
         return None  # local-only jobs don't deliver — not a failure

--- a/dd_obs.py
+++ b/dd_obs.py
@@ -1,0 +1,304 @@
+"""DecisionData observability client for Hermes.
+
+Posts spawn / generation / keepalive / complete events to the OpenClaw
+obs-ingest service so Hermes runs appear in the MC live agents tab.
+
+Most HTTP calls run on a daemon thread and never raise into the caller —
+instrumentation must NEVER block or fail Hermes responses. The single
+exception is :func:`log_generation_sync`, used by run_agent.py's per-API-
+call emit path: it MUST return a real success/failure signal so the
+gateway can decide whether to skip the synthetic completion fallback
+without risking a "no rows at all" outcome.
+
+Service discovery happens once at import time via the dd-registry-service
+on :8500 with a fallback to localhost:8511 (current obs-ingest port).
+This must resolve to the SAME obs-ingest as gateway/run.py's
+``_dd_observability_post`` (which defaults to ``127.0.0.1:8511`` and
+honors HERMES_DECISIONDATA_OBSERVABILITY_URL). If those drift in
+production, the per-call success → "skip synthetic" decision becomes
+unsafe; both should be pinned to the canonical obs-ingest port.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, Optional
+
+try:
+    import urllib.request
+    import urllib.error
+    import json as _json
+except Exception:  # pragma: no cover
+    urllib = None  # type: ignore
+
+logger = logging.getLogger("hermes.dd_obs")
+
+_REGISTRY_URL = os.getenv("DD_REGISTRY_URL", "http://localhost:8500")
+_OBS_INGEST_BASE: Optional[str] = None
+_OBS_DISCOVERY_LOCK = threading.Lock()
+_HTTP_TIMEOUT = float(os.getenv("DD_OBS_HTTP_TIMEOUT", "2.0"))
+
+
+def _resolve_obs_ingest_base() -> Optional[str]:
+    """Resolve obs-ingest base URL via dd-registry. Cache after first success."""
+    global _OBS_INGEST_BASE
+    if _OBS_INGEST_BASE:
+        return _OBS_INGEST_BASE
+    with _OBS_DISCOVERY_LOCK:
+        if _OBS_INGEST_BASE:
+            return _OBS_INGEST_BASE
+        # Try registry first
+        try:
+            req = urllib.request.Request(f"{_REGISTRY_URL}/services/discover/obs-ingest")
+            with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
+                data = _json.loads(resp.read().decode("utf-8"))
+                base = data.get("base_url")
+                if base:
+                    _OBS_INGEST_BASE = base
+                    return _OBS_INGEST_BASE
+        except Exception:
+            pass
+        # Fallback to env var or localhost:8511
+        env_base = os.getenv("DD_OBS_INGEST_URL")
+        if env_base:
+            _OBS_INGEST_BASE = env_base.rstrip("/")
+            return _OBS_INGEST_BASE
+        _OBS_INGEST_BASE = "http://localhost:8511"
+        return _OBS_INGEST_BASE
+
+
+def _post_async(path: str, payload: Dict[str, Any]) -> None:
+    """Fire-and-forget POST to obs-ingest."""
+    base = _resolve_obs_ingest_base()
+    if not base:
+        return
+
+    def _send() -> None:
+        try:
+            url = f"{base}{path}"
+            body = _json.dumps(payload).encode("utf-8")
+            req = urllib.request.Request(
+                url, data=body, method="POST",
+                headers={"Content-Type": "application/json"},
+            )
+            with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
+                _ = resp.read()
+        except Exception as e:
+            logger.debug("dd_obs POST %s failed: %s", path, e)
+
+    t = threading.Thread(target=_send, daemon=True, name=f"dd_obs:{path.lstrip('/')}")
+    t.start()
+
+
+def _post_sync(path: str, payload: Dict[str, Any]) -> bool:
+    """Synchronous POST to obs-ingest. Returns True on 2xx, False on any failure.
+
+    Used by per-call generation emit where the caller must know whether
+    the row landed before flipping ``per_call_generation_emitted`` (so a
+    failed POST does not silently suppress the synthetic fallback row).
+    """
+    base = _resolve_obs_ingest_base()
+    if not base:
+        return False
+    try:
+        url = f"{base}{path}"
+        body = _json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            url, data=body, method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:
+            status = getattr(resp, "status", None) or resp.getcode()
+            _ = resp.read()
+            return 200 <= int(status) < 300
+    except Exception as e:
+        logger.debug("dd_obs sync POST %s failed: %s", path, e)
+        return False
+
+
+def log_spawn(
+    *,
+    run_id: str,
+    session_key: str,
+    parent_run_id: Optional[str] = None,
+    task_prompt: str = "",
+    label: str = "Hermes Worker",
+    model: str = "",
+    provider: str = "",
+    channel: str = "hermes",
+    spawn_context: str = "",
+) -> None:
+    payload = {
+        "run_id": run_id,
+        "parent_run_id": parent_run_id,
+        "session_key": session_key,
+        "task_prompt": (task_prompt or "")[:500],
+        "label": label,
+        "model": model,
+        "provider": provider,
+        "spawned_at": _iso_now(),
+        "channel": channel,
+        "spawn_context": spawn_context,
+    }
+    _post_async("/log_spawn", payload)
+
+
+def log_keepalive(*, run_id: str) -> None:
+    _post_async("/log_keepalive", {"run_id": run_id})
+
+
+def log_complete(
+    *,
+    run_id: str,
+    status: str = "done",
+    result_summary: str = "",
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    cost_usd: float = 0.0,
+) -> None:
+    payload = {
+        "run_id": run_id,
+        "status": status,
+        "result_summary": (result_summary or "")[:200],
+        "input_tokens": int(input_tokens or 0),
+        "output_tokens": int(output_tokens or 0),
+        "cache_read_tokens": int(cache_read_tokens or 0),
+        "cost_usd": float(cost_usd or 0),
+        "completed_at": _iso_now(),
+    }
+    _post_async("/log_complete", payload)
+
+
+def log_generation(
+    *,
+    generation_id: str,
+    session_id: str,
+    model: str,
+    requested_at: str,
+    run_id: Optional[str] = None,
+    provider: Optional[str] = None,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+    cost_total_usd: float = 0.0,
+    completed_at: Optional[str] = None,
+    latency_ms: Optional[int] = None,
+    stop_reason: Optional[str] = None,
+    cwd: Optional[str] = None,
+) -> None:
+    payload: Dict[str, Any] = {
+        "generation_id": generation_id,
+        "session_id": session_id,
+        "model": model or "",
+        "requested_at": requested_at,
+        "input_tokens": int(input_tokens or 0),
+        "output_tokens": int(output_tokens or 0),
+        "cache_read_tokens": int(cache_read_tokens or 0),
+        "cache_creation_tokens": int(cache_creation_tokens or 0),
+        "cost_total_usd": float(cost_total_usd or 0),
+        "ingest_source": "hermes-gateway",
+        "agent_class": "Hermes",
+    }
+    if run_id:
+        payload["run_id"] = run_id
+    if provider:
+        # provider is not a top-level GenerationRequest field; encode in cwd-adjacent
+        # fields the schema accepts. The agent_class + ingest_source is enough to
+        # identify Hermes; provider lives on agent_runs (set by /log_spawn).
+        pass
+    if completed_at:
+        payload["completed_at"] = completed_at
+    if latency_ms is not None:
+        payload["latency_ms"] = int(latency_ms)
+    if stop_reason:
+        payload["stop_reason"] = stop_reason
+    if cwd:
+        payload["cwd"] = cwd
+    _post_async("/log_generation", payload)
+
+
+def log_generation_sync(
+    *,
+    generation_id: str,
+    session_id: str,
+    model: str,
+    requested_at: str,
+    run_id: Optional[str] = None,
+    provider: Optional[str] = None,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+    cost_total_usd: float = 0.0,
+    completed_at: Optional[str] = None,
+    latency_ms: Optional[int] = None,
+    stop_reason: Optional[str] = None,
+    cwd: Optional[str] = None,
+) -> bool:
+    """Synchronous /log_generation. Returns True iff obs-ingest accepted (2xx).
+
+    Same payload contract as :func:`log_generation`, but the caller can
+    branch on the return value — used by the per-call emit path where a
+    real success signal is required before suppressing the synthetic
+    fallback row.
+    """
+    payload: Dict[str, Any] = {
+        "generation_id": generation_id,
+        "session_id": session_id,
+        "model": model or "",
+        "requested_at": requested_at,
+        "input_tokens": int(input_tokens or 0),
+        "output_tokens": int(output_tokens or 0),
+        "cache_read_tokens": int(cache_read_tokens or 0),
+        "cache_creation_tokens": int(cache_creation_tokens or 0),
+        "cost_total_usd": float(cost_total_usd or 0),
+        "ingest_source": "hermes-gateway",
+        "agent_class": "Hermes",
+    }
+    if run_id:
+        payload["run_id"] = run_id
+    if completed_at:
+        payload["completed_at"] = completed_at
+    if latency_ms is not None:
+        payload["latency_ms"] = int(latency_ms)
+    if stop_reason:
+        payload["stop_reason"] = stop_reason
+    if cwd:
+        payload["cwd"] = cwd
+    return _post_sync("/log_generation", payload)
+
+
+def _iso_now() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class KeepaliveLoop:
+    """Periodic background keepalive — every 20 seconds while Hermes is running."""
+
+    def __init__(self, run_id: str, interval_s: float = 20.0) -> None:
+        self.run_id = run_id
+        self.interval = interval_s
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._thread = threading.Thread(target=self._run, daemon=True, name=f"dd_obs:keepalive:{self.run_id[:8]}")
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def _run(self) -> None:
+        while not self._stop.wait(self.interval):
+            try:
+                log_keepalive(run_id=self.run_id)
+            except Exception:
+                pass

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -537,6 +537,24 @@ def _derive_chat_session_id(
     return f"api-{digest}"
 
 
+def _resolve_dd_session_key(headers, session_id: str) -> str:
+    """Resolve the DecisionData MC observability session_key for an api_server turn.
+
+    When a caller (e.g. hermes-dispatcher) supplies ``X-DD-Session-Key``,
+    use it verbatim so the spawn row's session_key matches the
+    generation rows that will be logged for the same run_id. Without
+    this, agent_runs.session_key would be ``agent:hermes:gateway:<run>``
+    (set by the dispatcher's /log_spawn) while generations.session_id
+    would be ``agent:hermes:api_server:<session>`` — splitting MC Live
+    drilldowns and breaking joins.
+
+    Falls back to the derived ``agent:hermes:api_server:<session_id>``
+    when the header is absent or blank.
+    """
+    val = (headers.get("X-DD-Session-Key") or "").strip()
+    return val or f"agent:hermes:api_server:{session_id}"
+
+
 _CRON_AVAILABLE = False
 try:
     from cron.jobs import (
@@ -717,6 +735,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
+        dd_obs_meta: Optional[Dict[str, str]] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -760,6 +779,15 @@ class APIServerAdapter(BasePlatformAdapter):
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
         )
+        # DecisionData observability — propagate run lineage from caller.
+        if dd_obs_meta:
+            try:
+                agent._dd_run_id = dd_obs_meta.get("run_id")
+                agent._dd_parent_run_id = dd_obs_meta.get("parent_run_id")
+                agent._dd_session_key = dd_obs_meta.get("session_key")
+                agent._dd_wts_task_id = dd_obs_meta.get("wts_task_id")
+            except Exception:
+                pass
         return agent
 
     # ------------------------------------------------------------------
@@ -966,6 +994,59 @@ class APIServerAdapter(BasePlatformAdapter):
         model_name = body.get("model", self._model_name)
         created = int(time.time())
 
+        # ── DecisionData observability handshake ─────────────────────────
+        # If a caller (e.g. hermes-dispatcher) supplies X-DD-Run-Id, that
+        # caller already posted /log_spawn and will post /log_complete; we
+        # only forward the run_id so per-call /log_generation rows attribute
+        # to the right run. Otherwise, api_server owns the lifecycle and
+        # makes Hermes self-spawn for direct callers (Open WebUI, CLI, etc.).
+        _dd_run_id = (request.headers.get("X-DD-Run-Id") or "").strip()
+        _dd_parent_run_id = (request.headers.get("X-DD-Parent-Run-Id") or "").strip() or None
+        _dd_wts_task_id = (request.headers.get("X-DD-WTS-Task-Id") or "").strip() or None
+        _dd_caller_supplied_run_id = bool(_dd_run_id)
+        _dd_owns_lifecycle = False
+        if not _dd_run_id:
+            _dd_run_id = uuid.uuid4().hex
+            _dd_owns_lifecycle = True
+        _dd_session_key = _resolve_dd_session_key(request.headers, session_id)
+        _dd_meta = {
+            "run_id": _dd_run_id,
+            "parent_run_id": _dd_parent_run_id,
+            "session_key": _dd_session_key,
+            "wts_task_id": _dd_wts_task_id,
+        }
+        _dd_keepalive = None
+        # Only own lifecycle for non-streaming; streaming path completion is
+        # handled by the dispatcher when it supplies a run_id.
+        if _dd_owns_lifecycle and not stream:
+            try:
+                import dd_obs
+                _user_text_for_log = ""
+                if isinstance(user_message, str):
+                    _user_text_for_log = user_message
+                elif isinstance(user_message, list):
+                    for _part in user_message:
+                        if isinstance(_part, dict) and _part.get("type") == "text":
+                            _user_text_for_log = str(_part.get("text") or "")
+                            break
+                dd_obs.log_spawn(
+                    run_id=_dd_run_id,
+                    session_key=_dd_session_key,
+                    parent_run_id=_dd_parent_run_id,
+                    task_prompt=_user_text_for_log[:500],
+                    label="Hermes Worker",
+                    model=model_name or "",
+                    provider=getattr(self, "_provider", "") or "openai-codex",
+                    channel="hermes",
+                    spawn_context=(f"wts_task_id={_dd_wts_task_id}; api_server" if _dd_wts_task_id else "api_server"),
+                )
+                _dd_keepalive = dd_obs.KeepaliveLoop(run_id=_dd_run_id)
+                _dd_keepalive.start()
+            except Exception:
+                pass  # observability never blocks
+        else:
+            _dd_owns_lifecycle = False  # disable complete-on-return for streaming
+
         if stream:
             import queue as _q
             _stream_q: _q.Queue = _q.Queue()
@@ -1038,6 +1119,13 @@ class APIServerAdapter(BasePlatformAdapter):
             # The structured callbacks are strictly richer (they carry the
             # tool_call id), so they own the chat-completions SSE channel.
             agent_ref = [None]
+            # Streaming path: api_server does NOT own /log_spawn or /log_complete
+            # for streaming completions. Only forward dd_obs_meta when the
+            # caller (e.g. hermes-dispatcher) supplied X-DD-Run-Id and is
+            # running its own spawn/complete handshake — otherwise per-call
+            # /log_generation rows would attach to a run that never existed
+            # in agent_runs (orphan rows).
+            _dd_meta_for_stream = _dd_meta if _dd_caller_supplied_run_id else None
             agent_task = asyncio.ensure_future(self._run_agent(
                 user_message=user_message,
                 conversation_history=history,
@@ -1047,6 +1135,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
+                dd_obs_meta=_dd_meta_for_stream,
             ))
 
             return await self._write_sse_chat_completion(
@@ -1061,56 +1150,89 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=history,
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
+                dd_obs_meta=_dd_meta,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
-        if idempotency_key:
-            fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream"])
-            try:
-                result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
-            except Exception as e:
-                logger.error("Error running agent for chat completions: %s", e, exc_info=True)
-                return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
-                    status=500,
-                )
-        else:
-            try:
-                result, usage = await _compute_completion()
-            except Exception as e:
-                logger.error("Error running agent for chat completions: %s", e, exc_info=True)
-                return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
-                    status=500,
-                )
+        # ── DecisionData lifecycle invariant ─────────────────────────────
+        # When api_server owns the spawn/complete handshake, KeepaliveLoop
+        # MUST be stopped and /log_complete MUST fire on every exit path
+        # — including exceptions from _run_agent — otherwise MC Live shows
+        # a phantom "running" agent forever (keepalive thread alive,
+        # agent_runs.completed_at never set). The try/finally below makes
+        # that guarantee; the success branch later upgrades the status
+        # from "error" → "done" when the response is built.
+        _dd_complete_status = "error"
+        _dd_complete_summary = ""
+        _dd_input_tokens = 0
+        _dd_output_tokens = 0
+        try:
+            if idempotency_key:
+                fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream"])
+                try:
+                    result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
+                except Exception as e:
+                    logger.error("Error running agent for chat completions: %s", e, exc_info=True)
+                    return web.json_response(
+                        _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                        status=500,
+                    )
+            else:
+                try:
+                    result, usage = await _compute_completion()
+                except Exception as e:
+                    logger.error("Error running agent for chat completions: %s", e, exc_info=True)
+                    return web.json_response(
+                        _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                        status=500,
+                    )
 
-        final_response = result.get("final_response", "")
-        if not final_response:
-            final_response = result.get("error", "(No response generated)")
+            final_response = result.get("final_response", "")
+            if not final_response:
+                final_response = result.get("error", "(No response generated)")
 
-        response_data = {
-            "id": completion_id,
-            "object": "chat.completion",
-            "created": created,
-            "model": model_name,
-            "choices": [
-                {
-                    "index": 0,
-                    "message": {
-                        "role": "assistant",
-                        "content": final_response,
-                    },
-                    "finish_reason": "stop",
-                }
-            ],
-            "usage": {
-                "prompt_tokens": usage.get("input_tokens", 0),
-                "completion_tokens": usage.get("output_tokens", 0),
-                "total_tokens": usage.get("total_tokens", 0),
-            },
-        }
+            response_data = {
+                "id": completion_id,
+                "object": "chat.completion",
+                "created": created,
+                "model": model_name,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": final_response,
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": usage.get("input_tokens", 0),
+                    "completion_tokens": usage.get("output_tokens", 0),
+                    "total_tokens": usage.get("total_tokens", 0),
+                },
+            }
 
-        return web.json_response(response_data, headers={"X-Hermes-Session-Id": session_id})
+            _dd_complete_status = "done"
+            _dd_complete_summary = (final_response or "")[:200]
+            _dd_input_tokens = int(usage.get("input_tokens", 0) or 0)
+            _dd_output_tokens = int(usage.get("output_tokens", 0) or 0)
+            return web.json_response(response_data, headers={"X-Hermes-Session-Id": session_id})
+        finally:
+            if _dd_owns_lifecycle:
+                try:
+                    if _dd_keepalive is not None:
+                        _dd_keepalive.stop()
+                    import dd_obs
+                    dd_obs.log_complete(
+                        run_id=_dd_run_id,
+                        status=_dd_complete_status,
+                        result_summary=_dd_complete_summary,
+                        input_tokens=_dd_input_tokens,
+                        output_tokens=_dd_output_tokens,
+                    )
+                except Exception:
+                    pass  # observability never blocks
 
     async def _write_sse_chat_completion(
         self, request: "web.Request", completion_id: str, model: str,
@@ -2326,6 +2448,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_start_callback=None,
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
+        dd_obs_meta: Optional[Dict[str, str]] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -2348,6 +2471,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_progress_callback=tool_progress_callback,
                 tool_start_callback=tool_start_callback,
                 tool_complete_callback=tool_complete_callback,
+                dd_obs_meta=dd_obs_meta,
             )
             if agent_ref is not None:
                 agent_ref[0] = agent

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25,10 +25,13 @@ import signal
 import tempfile
 import threading
 import time
+import urllib.error
+import urllib.request
+import uuid
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Optional, Any, List
 
 # account_usage imports the OpenAI SDK chain (~230 ms). Only needed by
@@ -700,6 +703,136 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     elif isinstance(model_cfg, dict):
         return model_cfg.get("default") or model_cfg.get("model") or ""
     return ""
+
+
+def _utc_iso() -> str:
+    """Return a compact UTC ISO-8601 timestamp for observability payloads."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _truthy_config_value(value: Any, *, default: bool = False) -> bool:
+    """Parse common bool-ish config/env values."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def _dd_observability_config(config: dict | None = None) -> dict:
+    """Resolve DecisionData observability settings for gateway runs.
+
+    The integration is best-effort and intentionally local by default: if the
+    ingest service is absent, calls time out quickly and Hermes continues.
+    """
+    cfg = config if config is not None else _load_gateway_config()
+    obs_cfg = cfg.get("observability", {}) if isinstance(cfg, dict) else {}
+    dd_cfg = {}
+    if isinstance(obs_cfg, dict):
+        dd_cfg = obs_cfg.get("decisiondata", {}) or obs_cfg.get("mc_live", {}) or {}
+    if not isinstance(dd_cfg, dict):
+        dd_cfg = {}
+
+    enabled_raw = os.getenv("HERMES_DECISIONDATA_OBSERVABILITY_ENABLED")
+    enabled = _truthy_config_value(
+        enabled_raw if enabled_raw is not None else dd_cfg.get("enabled"),
+        default=True,
+    )
+    endpoint = (
+        os.getenv("HERMES_DECISIONDATA_OBSERVABILITY_URL")
+        or os.getenv("DECISIONDATA_OBSERVABILITY_URL")
+        or dd_cfg.get("url")
+        or dd_cfg.get("endpoint")
+        or "http://127.0.0.1:8511"
+    )
+    try:
+        timeout = float(
+            os.getenv("HERMES_DECISIONDATA_OBSERVABILITY_TIMEOUT")
+            or dd_cfg.get("timeout")
+            or 1.0
+        )
+    except Exception:
+        timeout = 1.0
+    return {
+        "enabled": bool(enabled),
+        "url": str(endpoint).rstrip("/"),
+        "timeout": max(0.1, min(timeout, 10.0)),
+    }
+
+
+def _dd_observability_post(path: str, payload: dict, config: dict | None = None) -> bool:
+    """Best-effort POST to DecisionData observability ingest.
+
+    Never raises: observability must not break user-facing Hermes turns.
+    """
+    obs = _dd_observability_config(config)
+    if not obs["enabled"]:
+        return False
+    try:
+        data = json.dumps(payload, ensure_ascii=False, default=str).encode("utf-8")
+        req = urllib.request.Request(
+            obs["url"] + path,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=obs["timeout"]) as resp:
+            resp.read()
+        return True
+    except Exception as exc:
+        logger.debug("DecisionData observability POST %s failed: %s", path, exc)
+        return False
+
+
+def _dd_observability_run_id(session_id: str | None, generation: Optional[int] = None) -> str:
+    """Build a non-sensitive Hermes observability run id."""
+    base = re.sub(r"[^A-Za-z0-9_.:-]+", "-", session_id or "session").strip("-")[:80]
+    suffix = f"g{generation}" if generation is not None else uuid.uuid4().hex[:8]
+    return f"hermes-{base}-{suffix}"
+
+
+def _dd_observability_session_key(session_id: str | None) -> str:
+    """Build the MC Live grouping key expected by the Hermes tree mapper."""
+    base = re.sub(r"[^A-Za-z0-9_.:-]+", "-", session_id or "session").strip("-")[:96]
+    return f"agent:hermes:gateway:{base or uuid.uuid4().hex[:8]}"
+
+
+def _attach_dd_context_for_turn(
+    agent: Any,
+    *,
+    run_id: str,
+    session_key: str,
+    parent_run_id: Optional[str] = None,
+    wts_task_id: Optional[str] = None,
+) -> dict:
+    """Attach the per-turn DecisionData identity context to a (cached) AIAgent.
+
+    Hermes caches AIAgent instances per session_key; the same instance
+    can be reused across turns. Each turn must overwrite the agent's
+    DD identity AND replace the context dict so a stale
+    ``per_call_generation_emitted=True`` from the prior turn cannot
+    cause the gateway to skip the synthetic completion fallback when
+    the new turn never emitted a per-call row.
+
+    Returns the fresh context dict so the caller can inspect
+    ``per_call_generation_emitted`` after ``run_conversation`` returns
+    to decide whether to write the synthetic summary.
+    """
+    ctx = {
+        "run_id": run_id,
+        "session_key": session_key,
+        "parent_run_id": parent_run_id,
+        "wts_task_id": wts_task_id,
+        "agent_class": "Hermes",
+        "ingest_source": "hermes-gateway",
+        "per_call_generation_emitted": False,
+    }
+    agent._dd_run_id = run_id
+    agent._dd_session_key = session_key
+    agent._dd_parent_run_id = parent_run_id
+    agent._dd_wts_task_id = wts_task_id
+    agent._dd_context = ctx
+    return ctx
 
 
 def _resolve_hermes_bin() -> Optional[list[str]]:
@@ -10391,6 +10524,14 @@ class GatewayRunner:
         result_holder = [None]  # Mutable container for the result
         tools_holder = [None]   # Mutable container for the tool definitions
         stream_consumer_holder = [None]  # Mutable container for stream consumer
+
+        # DecisionData / MC Live observability for real Hermes gateway runs.
+        # Use a non-sensitive synthetic grouping key instead of the raw platform
+        # session key, which can contain chat/user identifiers.
+        _dd_run_id = _dd_observability_run_id(session_id, run_generation)
+        _dd_session_key = _dd_observability_session_key(session_id)
+        _dd_generation_logged = False
+        _dd_context: dict | None = None
         
         # Bridge sync step_callback → async hooks.emit for agent:step events
         _loop_for_step = asyncio.get_running_loop()
@@ -10450,7 +10591,7 @@ class GatewayRunner:
             # read *and* reassign the outer `_run_agent` parameter without
             # triggering an UnboundLocalError on the earlier read at
             # `_resolve_turn_agent_config(message, …)`.
-            nonlocal message
+            nonlocal message, _dd_generation_logged, _dd_context
 
             # session_key is now set via contextvars in _set_session_env()
             # (concurrency-safe). Keep os.environ as fallback for CLI/cron.
@@ -10610,6 +10751,24 @@ class GatewayRunner:
 
             turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
 
+            _dd_provider = (turn_route.get("runtime") or {}).get("provider") or runtime_kwargs.get("provider")
+            _dd_model = turn_route.get("model") or model
+            _dd_observability_post("/log_spawn", {
+                "run_id": _dd_run_id,
+                "session_key": _dd_session_key,
+                "task_prompt": str(message)[:1000],
+                "label": f"Hermes {platform_key} turn",
+                "model": _dd_model,
+                "provider": _dd_provider,
+                "spawned_at": _utc_iso(),
+                "channel": "hermes",
+                "spawn_context": json.dumps({
+                    "platform": platform_key,
+                    "history_messages": len(history or []),
+                    "source": "hermes_gateway",
+                }, ensure_ascii=False),
+            }, user_config)
+
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
             # schemas for prompt cache hits.
@@ -10678,6 +10837,14 @@ class GatewayRunner:
 
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
+            # DecisionData identity must be re-attached per turn so a cached
+            # agent reused across turns never inherits the prior turn's run_id
+            # or its per_call_generation_emitted flag (#hermes-mc-live-handoff).
+            _dd_context = _attach_dd_context_for_turn(
+                agent,
+                run_id=_dd_run_id,
+                session_key=_dd_session_key,
+            )
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
@@ -11029,6 +11196,31 @@ class GatewayRunner:
                 _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
             _resolved_model = getattr(_agent, "model", None) if _agent else None
 
+            def _log_dd_generation_once(stop_reason: str | None = None) -> None:
+                nonlocal _dd_generation_logged
+                if _dd_generation_logged:
+                    return
+                _dd_generation_logged = True
+                _dd_observability_post("/log_generation", {
+                    "generation_id": f"{_dd_run_id}:generation:1",
+                    "session_id": _dd_session_key,
+                    "run_id": _dd_run_id,
+                    "agent_id": "hermes-gateway",
+                    "model": _resolved_model or _dd_model or "unknown",
+                    "requested_at": _utc_iso(),
+                    "stop_reason": stop_reason,
+                    "tool_count": len(tools_holder[0] or []),
+                    "input_message_count": len(agent_history) + 1,
+                }, user_config)
+
+            # Skip the synthetic completion-time generation when the agent's
+            # per-API-call logger has already emitted at least one row for
+            # this turn — otherwise we double-count tokens/cost. The
+            # synthetic row only fires as a fallback for turns that never
+            # reached a successful provider response.
+            if not (isinstance(_dd_context, dict) and _dd_context.get("per_call_generation_emitted")):
+                _log_dd_generation_once("completed" if final_response else "empty_response")
+
             if not final_response:
                 error_msg = f"⚠️ {result['error']}" if result.get("error") else ""
                 return {
@@ -11290,6 +11482,25 @@ class GatewayRunner:
 
         _notify_task = asyncio.create_task(_notify_long_running())
 
+        try:
+            _dd_keepalive_interval = float(os.getenv("HERMES_DECISIONDATA_KEEPALIVE_INTERVAL", "10"))
+        except Exception:
+            _dd_keepalive_interval = 10.0
+        _dd_keepalive_interval = max(1.0, _dd_keepalive_interval)
+
+        async def _dd_keepalive_loop():
+            while True:
+                await asyncio.sleep(_dd_keepalive_interval)
+                await asyncio.to_thread(
+                    _dd_observability_post,
+                    "/log_keepalive",
+                    {"run_id": _dd_run_id},
+                    user_config,
+                )
+
+        _dd_keepalive_task = asyncio.create_task(_dd_keepalive_loop())
+
+        response = None
         try:
             # Run in thread pool to not block.  Use an *inactivity*-based
             # timeout instead of a wall-clock limit: the agent can run for
@@ -11688,11 +11899,37 @@ class GatewayRunner:
                     channel_prompt=next_channel_prompt,
                 )
         finally:
-            # Stop progress sender, interrupt monitor, and notification task
+            # Complete the MC Live run before tearing down keepalive.
+            try:
+                _result_obj = response if isinstance(response, dict) else (result_holder[0] or {})
+                _failed = bool(_result_obj.get("failed")) if isinstance(_result_obj, dict) else False
+                _interrupted = bool(_result_obj.get("interrupted")) if isinstance(_result_obj, dict) else False
+                _status = "error" if _failed else "interrupted" if _interrupted else "done"
+                _summary = ""
+                if isinstance(_result_obj, dict):
+                    _summary = str(_result_obj.get("final_response") or _result_obj.get("error") or "")[:1000]
+                await asyncio.to_thread(
+                    _dd_observability_post,
+                    "/log_complete",
+                    {
+                        "run_id": _dd_run_id,
+                        "status": _status,
+                        "result_summary": _summary,
+                        "input_tokens": _result_obj.get("input_tokens") if isinstance(_result_obj, dict) else None,
+                        "output_tokens": _result_obj.get("output_tokens") if isinstance(_result_obj, dict) else None,
+                        "completed_at": _utc_iso(),
+                    },
+                    user_config,
+                )
+            except Exception as _dd_complete_err:
+                logger.debug("DecisionData observability complete failed: %s", _dd_complete_err)
+
+            # Stop progress sender, interrupt monitor, notification, and keepalive tasks
             if progress_task:
                 progress_task.cancel()
             interrupt_monitor.cancel()
             _notify_task.cancel()
+            _dd_keepalive_task.cancel()
 
             # Wait for stream consumer to finish its final edit
             if stream_task:
@@ -11720,7 +11957,7 @@ class GatewayRunner:
                 self._update_runtime_status("draining")
             
             # Wait for cancelled tasks
-            for task in [progress_task, interrupt_monitor, tracking_task, _notify_task]:
+            for task in [progress_task, interrupt_monitor, tracking_task, _notify_task, _dd_keepalive_task]:
                 if task:
                     try:
                         await task

--- a/run_agent.py
+++ b/run_agent.py
@@ -837,6 +837,67 @@ def _pool_may_recover_from_rate_limit(pool) -> bool:
     return len(pool.entries()) > 1
 
 
+def _emit_dd_per_call_generation(
+    *,
+    dd_obs_module,
+    run_id: str,
+    session_key: Optional[str],
+    session_id_fallback: Optional[str],
+    model: str,
+    provider: Optional[str],
+    requested_at: str,
+    completed_at: Optional[str],
+    latency_ms: Optional[int],
+    canonical_usage: Any,
+    cost_amount_usd: Optional[float],
+    dd_context: Optional[dict],
+) -> None:
+    """Emit a per-API-call /log_generation row for a Hermes gateway turn.
+
+    Caller MUST pass identity (run_id/session_key/dd_context) via kwargs
+    after capturing them into locals at API-call start, NOT by reading
+    ``self._dd_*`` at write time. This keeps turn N from writing under
+    turn N+1's run_id when the cached AIAgent is reused across turns.
+
+    Uses ``log_generation_sync`` so the helper has a real accepted/failed
+    signal from obs-ingest. The flag is flipped ONLY on a 2xx response so
+    that a transport/registry/schema failure leaves the synthetic
+    fallback row intact (otherwise MC Live would lose both rows). Any
+    exception is swallowed — observability must never block the agent
+    loop — but a False return likewise leaves the flag untouched.
+    """
+    try:
+        import uuid as _uuid
+
+        _input = int(getattr(canonical_usage, "input_tokens", 0) or 0)
+        _output = int(getattr(canonical_usage, "output_tokens", 0) or 0)
+        _cache_read = int(getattr(canonical_usage, "cache_read_tokens", 0) or 0)
+        _cache_write = int(getattr(canonical_usage, "cache_write_tokens", 0) or 0)
+        _cost = float(cost_amount_usd) if cost_amount_usd is not None else 0.0
+        _latency = int(latency_ms) if latency_ms is not None else None
+        ok = dd_obs_module.log_generation_sync(
+            generation_id=_uuid.uuid4().hex,
+            session_id=session_key or session_id_fallback or "",
+            run_id=run_id,
+            model=model,
+            provider=provider,
+            requested_at=requested_at,
+            input_tokens=_input,
+            output_tokens=_output,
+            cache_read_tokens=_cache_read,
+            cache_creation_tokens=_cache_write,
+            cost_total_usd=_cost,
+            completed_at=completed_at,
+            latency_ms=_latency,
+        )
+        if ok and isinstance(dd_context, dict):
+            dd_context["per_call_generation_emitted"] = True
+    except Exception:
+        # Never block the agent loop; leave per_call_generation_emitted
+        # untouched so the gateway still writes its synthetic fallback.
+        pass
+
+
 def _qwen_portal_headers() -> dict:
     """Return default HTTP headers required by Qwen Portal API."""
     import platform as _plat
@@ -1583,7 +1644,16 @@ class AIAgent:
         self.logs_dir = hermes_home / "sessions"
         self.logs_dir.mkdir(parents=True, exist_ok=True)
         self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
-        
+
+        # DecisionData observability — populated by gateway (api_server) when
+        # X-DD-Run-Id / X-DD-Parent-Run-Id headers are present on the request.
+        # When _dd_run_id is set, every API call emits /log_generation to
+        # obs-ingest (fire-and-forget, never blocks).
+        self._dd_run_id: Optional[str] = None
+        self._dd_parent_run_id: Optional[str] = None
+        self._dd_session_key: Optional[str] = None
+        self._dd_wts_task_id: Optional[str] = None
+
         # Track conversation messages for session logging
         self._session_messages: List[Dict[str, Any]] = []
         self._memory_write_origin = "assistant_tool"
@@ -10718,6 +10788,14 @@ class AIAgent:
                 logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
             
             api_start_time = time.time()
+            # Capture DecisionData identity locally at API-call start so a
+            # cached AIAgent reused for a subsequent turn (which mutates
+            # self._dd_run_id/_dd_session_key) cannot cause this in-flight
+            # call to write its /log_generation under the wrong run_id.
+            _dd_call_run_id = getattr(self, "_dd_run_id", None)
+            _dd_call_session_key = getattr(self, "_dd_session_key", None)
+            _dd_call_session_id = getattr(self, "session_id", None)
+            _dd_call_context = getattr(self, "_dd_context", None)
             retry_count = 0
             max_retries = self._api_max_retries
             primary_recovery_attempted = False
@@ -11406,7 +11484,35 @@ class AIAgent:
                                 )
                             except Exception:
                                 pass  # never block the agent loop
-                        
+
+                        # DecisionData obs-ingest: emit /log_generation per API
+                        # call when a gateway-provided run_id is set. Identity
+                        # was captured at api_start_time above so a cached
+                        # AIAgent reused for the next turn cannot redirect
+                        # this write to the wrong run_id.
+                        if _dd_call_run_id:
+                            try:
+                                from datetime import datetime as _dt, timezone as _tz
+                                import dd_obs
+                                _req_iso = _dt.fromtimestamp(api_start_time, tz=_tz.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                                _comp_iso = _dt.now(tz=_tz.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                                _emit_dd_per_call_generation(
+                                    dd_obs_module=dd_obs,
+                                    run_id=_dd_call_run_id,
+                                    session_key=_dd_call_session_key,
+                                    session_id_fallback=_dd_call_session_id,
+                                    model=self.model,
+                                    provider=self.provider,
+                                    requested_at=_req_iso,
+                                    completed_at=_comp_iso,
+                                    latency_ms=int(api_duration * 1000),
+                                    canonical_usage=canonical_usage,
+                                    cost_amount_usd=cost_result.amount_usd,
+                                    dd_context=_dd_call_context,
+                                )
+                            except Exception:
+                                pass  # never block the agent loop
+
                         if self.verbose_logging:
                             logging.debug(f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}")
                         

--- a/run_agent.py
+++ b/run_agent.py
@@ -837,6 +837,61 @@ def _pool_may_recover_from_rate_limit(pool) -> bool:
     return len(pool.entries()) > 1
 
 
+def _build_hermes_context_usage_payload(
+    *,
+    canonical_usage: Any,
+    model: str,
+) -> Dict[str, Any]:
+    """Build the MC `hermes_context_usage` payload from a normalised usage object.
+
+    Total context tokens is the full provider-reported prefill the model saw:
+    ``input_tokens + cache_read_tokens + cache_write_tokens``. Output tokens are
+    recorded in ``components`` for debugging but excluded from the bar count.
+    Limit/floor come from the same env vars mc-api reads, so a single source of
+    truth controls bar scale on both sides.
+    """
+    from datetime import datetime as _dt, timezone as _tz
+
+    _input = int(getattr(canonical_usage, "input_tokens", 0) or 0)
+    _output = int(getattr(canonical_usage, "output_tokens", 0) or 0)
+    _cache_read = int(getattr(canonical_usage, "cache_read_tokens", 0) or 0)
+    _cache_write = int(getattr(canonical_usage, "cache_write_tokens", 0) or 0)
+    total = _input + _cache_read + _cache_write
+
+    bar_limit = int(os.environ.get("HERMES_CONTEXT_LIMIT", 400_000))
+    floor = int(os.environ.get("HERMES_CONTEXT_FLOOR", 320_000))
+    pct = round(total / bar_limit * 100, 2) if bar_limit else 0.0
+    floor_pct = round(floor / bar_limit * 100, 2) if bar_limit else 0.0
+    if total >= floor:
+        status = "red"
+    elif total >= floor * 0.5:
+        status = "yellow"
+    else:
+        status = "green"
+
+    return {
+        "tokens": total,
+        "limit": bar_limit,
+        "floor": floor,
+        "remaining": max(0, floor - total),
+        "pct": pct,
+        "floor_pct": floor_pct,
+        "status": status,
+        "found": True,
+        "estimated": False,
+        "source": "provider_usage",
+        "model": model or "",
+        "updated_at": _dt.now(tz=_tz.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "components": {
+            "input_tokens": _input,
+            "cache_read_input_tokens": _cache_read,
+            "cache_creation_input_tokens": _cache_write,
+            "output_tokens": _output,
+            "total_context_tokens": total,
+        },
+    }
+
+
 def _emit_dd_per_call_generation(
     *,
     dd_obs_module,
@@ -2099,7 +2154,9 @@ class AIAgent:
         self.session_estimated_cost_usd = 0.0
         self.session_cost_status = "unknown"
         self.session_cost_source = "none"
-        
+
+        self._last_context_usage: Optional[Dict[str, Any]] = None
+
         # ── Ollama num_ctx injection ──
         # Ollama defaults to 2048 context regardless of the model's capabilities.
         # When running against an Ollama server, detect the model's max context
@@ -2201,7 +2258,9 @@ class AIAgent:
         self.session_estimated_cost_usd = 0.0
         self.session_cost_status = "unknown"
         self.session_cost_source = "none"
-        
+
+        self._last_context_usage = None
+
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
 
@@ -4289,6 +4348,9 @@ class AIAgent:
                 "message_count": len(cleaned),
                 "messages": cleaned,
             }
+
+            if self._last_context_usage is not None:
+                entry["context_usage"] = self._last_context_usage
 
             atomic_json_write(
                 self.session_log_file,
@@ -11431,6 +11493,14 @@ class AIAgent:
                         self.session_cache_read_tokens += canonical_usage.cache_read_tokens
                         self.session_cache_write_tokens += canonical_usage.cache_write_tokens
                         self.session_reasoning_tokens += canonical_usage.reasoning_tokens
+
+                        try:
+                            self._last_context_usage = _build_hermes_context_usage_payload(
+                                canonical_usage=canonical_usage,
+                                model=self.model,
+                            )
+                        except Exception:
+                            pass  # never block the agent loop
 
                         # Log API call details for debugging/observability
                         _cache_pct = ""

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -65,23 +65,31 @@ class TestResolveDeliveryTarget:
         }
 
     @pytest.mark.parametrize(
-        ("platform", "env_var", "chat_id"),
+        ("env_var", "chat_id"),
         [
-            ("matrix", "MATRIX_HOME_ROOM", "!bot-room:example.org"),
-            ("signal", "SIGNAL_HOME_CHANNEL", "+15551234567"),
-            ("mattermost", "MATTERMOST_HOME_CHANNEL", "team-town-square"),
-            ("sms", "SMS_HOME_CHANNEL", "+15557654321"),
-            ("email", "EMAIL_HOME_ADDRESS", "home@example.com"),
-            ("dingtalk", "DINGTALK_HOME_CHANNEL", "cidNNN"),
-            ("feishu", "FEISHU_HOME_CHANNEL", "oc_home"),
-            ("wecom", "WECOM_HOME_CHANNEL", "wecom-home"),
-            ("weixin", "WEIXIN_HOME_CHANNEL", "wxid_home"),
-            ("qqbot", "QQ_HOME_CHANNEL", "group-openid-home"),
+            ("MATRIX_HOME_ROOM", "!bot-room:example.org"),
+            ("TELEGRAM_HOME_CHANNEL", "8737984752"),
+            ("DISCORD_HOME_CHANNEL", "1001234"),
+            ("SLACK_HOME_CHANNEL", "C0HOMEHOME"),
+            ("SIGNAL_HOME_CHANNEL", "+15551234567"),
+            ("MATTERMOST_HOME_CHANNEL", "team-town-square"),
+            ("SMS_HOME_CHANNEL", "+15557654321"),
+            ("EMAIL_HOME_ADDRESS", "home@example.com"),
+            ("DINGTALK_HOME_CHANNEL", "cidNNN"),
+            ("FEISHU_HOME_CHANNEL", "oc_home"),
+            ("WECOM_HOME_CHANNEL", "wecom-home"),
+            ("WEIXIN_HOME_CHANNEL", "wxid_home"),
+            ("QQ_HOME_CHANNEL", "group-openid-home"),
         ],
     )
-    def test_origin_delivery_without_origin_falls_back_to_supported_home_channels(
-        self, monkeypatch, platform, env_var, chat_id
+    def test_origin_delivery_without_origin_returns_no_target_even_with_home_channel_set(
+        self, monkeypatch, env_var, chat_id
     ):
+        """Fail-closed: a missing origin must NOT fall back to a configured
+        ``*_HOME_CHANNEL`` env var. The previous behaviour cross-posted Slack-
+        originated work into Telegram (or whichever home channel happened to
+        be set first) when the cron tool could not capture an origin from the
+        session env."""
         for fallback_env in (
             "MATRIX_HOME_ROOM",
             "MATRIX_HOME_CHANNEL",
@@ -102,9 +110,46 @@ class TestResolveDeliveryTarget:
             monkeypatch.delenv(fallback_env, raising=False)
         monkeypatch.setenv(env_var, chat_id)
 
-        assert _resolve_delivery_target({"deliver": "origin"}) == {
-            "platform": platform,
-            "chat_id": chat_id,
+        assert _resolve_delivery_target({"deliver": "origin"}) is None
+        assert _resolve_delivery_target({"deliver": "origin", "origin": None}) is None
+        assert _resolve_delivery_target({"deliver": "origin", "origin": {}}) is None
+
+    def test_origin_delivery_does_not_leak_slack_origin_to_telegram(self, monkeypatch):
+        """Regression for the 2026-05-05 incident: a Slack-originated cron job
+        whose origin was lost between dd-slack-service and hermes-dispatcher
+        must not deliver to ``TELEGRAM_HOME_CHANNEL``. Pin this even when the
+        job prompt explicitly mentions Slack channel context."""
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "8737984752")
+        for other in (
+            "SLACK_HOME_CHANNEL", "DISCORD_HOME_CHANNEL", "MATRIX_HOME_ROOM",
+            "MATRIX_HOME_CHANNEL", "SIGNAL_HOME_CHANNEL",
+        ):
+            monkeypatch.delenv(other, raising=False)
+
+        leaky_job = {
+            "id": "59ee074897a6",
+            "name": "hyperscience-sow-first-draft-pdf",
+            "deliver": "origin",
+            "origin": None,
+            "prompt": "Slack channel #1prj-hs-sow-next-9f3c …",
+        }
+        assert _resolve_delivery_target(leaky_job) is None
+
+    def test_telegram_origin_with_valid_origin_still_delivers_normally(self, monkeypatch):
+        """Regression: Telegram-origin jobs with a real origin must keep
+        resolving to that origin, not the home env var."""
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "should-not-be-used")
+        job = {
+            "deliver": "origin",
+            "origin": {
+                "platform": "telegram",
+                "chat_id": "8737984752",
+                "thread_id": None,
+            },
+        }
+        assert _resolve_delivery_target(job) == {
+            "platform": "telegram",
+            "chat_id": "8737984752",
             "thread_id": None,
         }
 
@@ -320,6 +365,20 @@ class TestResolveDeliveryTarget:
 
 class TestDeliverResultWrapping:
     """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""
+
+    def test_delivery_records_specific_error_when_origin_is_missing(self, monkeypatch):
+        """``last_delivery_error`` must say origin is missing (not the generic
+        'no delivery target resolved') so operators can triage the leak class
+        from the previous fail-open fallback to a home channel."""
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "8737984752")
+        job = {
+            "id": "9f413f9b308b",
+            "name": "PTG intro call prep brief",
+            "deliver": "origin",
+            "origin": None,
+        }
+        err = _deliver_result(job, "anything")
+        assert err == "deliver=origin but job has no origin (fail-closed)"
 
     def test_delivery_wraps_content_with_header_and_footer(self):
         """Delivered content should include task name header and agent-invisible note."""

--- a/tests/gateway/test_dd_identity_wiring.py
+++ b/tests/gateway/test_dd_identity_wiring.py
@@ -1,0 +1,156 @@
+"""Tests for DecisionData identity wiring on gateway runs.
+
+Covers:
+- ``_attach_dd_context_for_turn`` writes a fresh per-turn DD identity
+  onto the (possibly cached/reused) AIAgent and returns the live
+  context dict the gateway can inspect after ``run_conversation``.
+- Reusing the helper on the same agent across turns overwrites the
+  prior run's identity and resets the per-call emitted flag — a cached
+  agent must never inherit the previous turn's DD context.
+- ``_resolve_dd_session_key`` honors ``X-DD-Session-Key`` from the
+  hermes-dispatcher and falls back to the derived
+  ``agent:hermes:api_server:<session_id>`` only when the header is
+  missing/blank.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — gateway/run.py: _attach_dd_context_for_turn
+# ---------------------------------------------------------------------------
+
+
+class TestAttachDdContextForTurn:
+    def _import_helper(self):
+        from gateway.run import _attach_dd_context_for_turn
+        return _attach_dd_context_for_turn
+
+    def test_sets_dd_attributes_on_agent(self):
+        attach = self._import_helper()
+        agent = SimpleNamespace()
+
+        ctx = attach(
+            agent,
+            run_id="hermes-sess-g1",
+            session_key="agent:hermes:gateway:sess",
+            parent_run_id=None,
+            wts_task_id=None,
+        )
+
+        assert agent._dd_run_id == "hermes-sess-g1"
+        assert agent._dd_session_key == "agent:hermes:gateway:sess"
+        assert agent._dd_parent_run_id is None
+        assert agent._dd_wts_task_id is None
+        assert agent._dd_context is ctx
+
+    def test_returns_fresh_per_turn_context_dict(self):
+        attach = self._import_helper()
+        agent = SimpleNamespace()
+
+        ctx = attach(
+            agent,
+            run_id="hermes-sess-g1",
+            session_key="agent:hermes:gateway:sess",
+        )
+
+        assert ctx["run_id"] == "hermes-sess-g1"
+        assert ctx["session_key"] == "agent:hermes:gateway:sess"
+        assert ctx["agent_class"] == "Hermes"
+        assert ctx["ingest_source"] == "hermes-gateway"
+        assert ctx["per_call_generation_emitted"] is False
+
+    def test_optional_parent_and_wts_task_ids_propagate(self):
+        attach = self._import_helper()
+        agent = SimpleNamespace()
+
+        ctx = attach(
+            agent,
+            run_id="hermes-sess-g1",
+            session_key="agent:hermes:gateway:sess",
+            parent_run_id="parent-run-xyz",
+            wts_task_id="wts-task-abc",
+        )
+
+        assert ctx["parent_run_id"] == "parent-run-xyz"
+        assert ctx["wts_task_id"] == "wts-task-abc"
+        assert agent._dd_parent_run_id == "parent-run-xyz"
+        assert agent._dd_wts_task_id == "wts-task-abc"
+
+    def test_reused_agent_gets_fresh_context_each_turn(self):
+        """A cached AIAgent reused across turns must NOT inherit the
+        previous turn's DD identity or the previous turn's
+        per_call_generation_emitted flag — that would either misattribute
+        new generations or silently skip the synthetic completion fallback
+        on a turn that never emitted per-call rows.
+        """
+        attach = self._import_helper()
+        agent = SimpleNamespace()
+
+        ctx_turn_1 = attach(
+            agent,
+            run_id="hermes-sess-g1",
+            session_key="agent:hermes:gateway:sess",
+        )
+        ctx_turn_1["per_call_generation_emitted"] = True
+
+        ctx_turn_2 = attach(
+            agent,
+            run_id="hermes-sess-g2",
+            session_key="agent:hermes:gateway:sess",
+        )
+
+        assert ctx_turn_2 is not ctx_turn_1
+        assert ctx_turn_2["per_call_generation_emitted"] is False
+        assert ctx_turn_2["run_id"] == "hermes-sess-g2"
+        assert agent._dd_run_id == "hermes-sess-g2"
+        # The prior turn's context dict must remain untouched (a still-
+        # in-flight per-call logger from turn 1 might still hold a
+        # reference and write to it).
+        assert ctx_turn_1["run_id"] == "hermes-sess-g1"
+        assert ctx_turn_1["per_call_generation_emitted"] is True
+
+
+# ---------------------------------------------------------------------------
+# Phase 7 — api_server.py: _resolve_dd_session_key
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDdSessionKey:
+    def _import_helper(self):
+        from gateway.platforms.api_server import _resolve_dd_session_key
+        return _resolve_dd_session_key
+
+    def test_uses_header_value_when_provided(self):
+        resolve = self._import_helper()
+        headers = {"X-DD-Session-Key": "agent:hermes:gateway:dispatcher-sess"}
+
+        result = resolve(headers, "abc123")
+
+        assert result == "agent:hermes:gateway:dispatcher-sess"
+
+    def test_falls_back_to_derived_when_header_absent(self):
+        resolve = self._import_helper()
+        headers: dict[str, str] = {}
+
+        result = resolve(headers, "abc123")
+
+        assert result == "agent:hermes:api_server:abc123"
+
+    def test_falls_back_to_derived_when_header_blank(self):
+        resolve = self._import_helper()
+        headers = {"X-DD-Session-Key": "   "}
+
+        result = resolve(headers, "abc123")
+
+        assert result == "agent:hermes:api_server:abc123"
+
+    def test_strips_surrounding_whitespace_on_header(self):
+        resolve = self._import_helper()
+        headers = {"X-DD-Session-Key": "  agent:hermes:gateway:dispatcher-sess  "}
+
+        result = resolve(headers, "abc123")
+
+        assert result == "agent:hermes:gateway:dispatcher-sess"

--- a/tests/run_agent/test_dd_per_call_generation.py
+++ b/tests/run_agent/test_dd_per_call_generation.py
@@ -1,0 +1,283 @@
+"""Tests for run_agent.py per-API-call /log_generation emission.
+
+The cornerstone fix for Hermes MC Live active-generation telemetry is:
+
+1. At API-call start, ``run_agent.py`` captures the current DD identity
+   (run_id, session_key, context) into LOCAL variables.
+2. After the provider call returns, it emits ``/log_generation`` using
+   those captured locals — not whatever ``self._dd_*`` happens to be at
+   write time. This prevents turn N from writing under turn N+1's
+   run_id when the cached AIAgent is reused across turns.
+3. On a synchronous success response from obs-ingest, the per-turn DD
+   context's ``per_call_generation_emitted`` flag flips to True so the
+   gateway can skip the synthetic completion-time generation and avoid
+   double-counting. CRITICAL: the helper must use the SYNC client
+   (``log_generation_sync`` returning bool) — fire-and-forget would
+   silently suppress the synthetic fallback when the underlying POST
+   actually failed (registry misresolved, ingest down, schema reject).
+
+These tests pin the contract on the helper that owns step 2+3
+(``_emit_dd_per_call_generation``) so the bulk of run_agent.py's API
+loop doesn't have to be stood up.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _import_helper():
+    from run_agent import _emit_dd_per_call_generation
+    return _emit_dd_per_call_generation
+
+
+def _make_canonical_usage(input_tokens=100, output_tokens=20, cache_read=5, cache_write=2):
+    return SimpleNamespace(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read,
+        cache_write_tokens=cache_write,
+    )
+
+
+def _make_dd_obs(sync_returns: bool = True):
+    """A dd_obs-shaped mock whose sync POST returns the given bool."""
+    mod = MagicMock()
+    mod.log_generation_sync.return_value = sync_returns
+    return mod
+
+
+class TestEmitDdPerCallGeneration:
+    def test_posts_log_generation_with_captured_run_id(self):
+        emit = _import_helper()
+        dd_obs = _make_dd_obs(sync_returns=True)
+        ctx = {
+            "run_id": "hermes-sess-g1",
+            "session_key": "agent:hermes:gateway:sess",
+            "per_call_generation_emitted": False,
+        }
+
+        emit(
+            dd_obs_module=dd_obs,
+            run_id="hermes-sess-g1",
+            session_key="agent:hermes:gateway:sess",
+            session_id_fallback="sess",
+            model="gpt-5.5",
+            provider="openai-codex",
+            requested_at="2026-04-30T07:48:07Z",
+            completed_at="2026-04-30T07:48:09Z",
+            latency_ms=2000,
+            canonical_usage=_make_canonical_usage(),
+            cost_amount_usd=0.0123,
+            dd_context=ctx,
+        )
+
+        dd_obs.log_generation_sync.assert_called_once()
+        kwargs = dd_obs.log_generation_sync.call_args.kwargs
+        assert kwargs["run_id"] == "hermes-sess-g1"
+        assert kwargs["session_id"] == "agent:hermes:gateway:sess"
+        assert kwargs["model"] == "gpt-5.5"
+        assert kwargs["provider"] == "openai-codex"
+        assert kwargs["requested_at"] == "2026-04-30T07:48:07Z"
+        assert kwargs["completed_at"] == "2026-04-30T07:48:09Z"
+        assert kwargs["latency_ms"] == 2000
+        assert kwargs["input_tokens"] == 100
+        assert kwargs["output_tokens"] == 20
+        assert kwargs["cache_read_tokens"] == 5
+        assert kwargs["cache_creation_tokens"] == 2
+        assert abs(kwargs["cost_total_usd"] - 0.0123) < 1e-9
+        # Must use a unique generation_id (not a deterministic suffix
+        # that would collide across calls in the same run).
+        assert kwargs["generation_id"]
+        assert kwargs["generation_id"] != "hermes-sess-g1:generation:1"
+
+    def test_falls_back_to_session_id_when_session_key_blank(self):
+        emit = _import_helper()
+        dd_obs = _make_dd_obs(sync_returns=True)
+
+        emit(
+            dd_obs_module=dd_obs,
+            run_id="hermes-sess-g1",
+            session_key=None,
+            session_id_fallback="legacy-session-id",
+            model="gpt-5.5",
+            provider="openai-codex",
+            requested_at="2026-04-30T07:48:07Z",
+            completed_at="2026-04-30T07:48:09Z",
+            latency_ms=1000,
+            canonical_usage=_make_canonical_usage(),
+            cost_amount_usd=0.0,
+            dd_context=None,
+        )
+
+        kwargs = dd_obs.log_generation_sync.call_args.kwargs
+        assert kwargs["session_id"] == "legacy-session-id"
+
+    def test_flips_per_call_emitted_flag_only_on_post_success(self):
+        emit = _import_helper()
+        dd_obs = _make_dd_obs(sync_returns=True)
+        ctx = {
+            "run_id": "hermes-sess-g1",
+            "session_key": "agent:hermes:gateway:sess",
+            "per_call_generation_emitted": False,
+        }
+
+        emit(
+            dd_obs_module=dd_obs,
+            run_id="hermes-sess-g1",
+            session_key="agent:hermes:gateway:sess",
+            session_id_fallback="sess",
+            model="gpt-5.5",
+            provider="openai-codex",
+            requested_at="2026-04-30T07:48:07Z",
+            completed_at="2026-04-30T07:48:09Z",
+            latency_ms=1000,
+            canonical_usage=_make_canonical_usage(),
+            cost_amount_usd=0.0,
+            dd_context=ctx,
+        )
+
+        assert ctx["per_call_generation_emitted"] is True
+
+    def test_no_context_does_not_raise(self):
+        emit = _import_helper()
+        dd_obs = _make_dd_obs(sync_returns=True)
+
+        emit(
+            dd_obs_module=dd_obs,
+            run_id="hermes-sess-g1",
+            session_key="agent:hermes:gateway:sess",
+            session_id_fallback="sess",
+            model="gpt-5.5",
+            provider="openai-codex",
+            requested_at="2026-04-30T07:48:07Z",
+            completed_at="2026-04-30T07:48:09Z",
+            latency_ms=1000,
+            canonical_usage=_make_canonical_usage(),
+            cost_amount_usd=0.0,
+            dd_context=None,
+        )
+
+        dd_obs.log_generation_sync.assert_called_once()
+
+    def test_uses_sync_client_not_fire_and_forget(self):
+        """The helper MUST use ``log_generation_sync`` (returns bool) —
+        not the fire-and-forget ``log_generation`` — so the flag-flip
+        decision is made on a real accepted/failed POST, not a daemon
+        thread that returns immediately while the HTTP call is still
+        in-flight or has already failed.
+        """
+        emit = _import_helper()
+        dd_obs = _make_dd_obs(sync_returns=True)
+
+        emit(
+            dd_obs_module=dd_obs,
+            run_id="hermes-sess-g1",
+            session_key="agent:hermes:gateway:sess",
+            session_id_fallback="sess",
+            model="gpt-5.5",
+            provider="openai-codex",
+            requested_at="2026-04-30T07:48:07Z",
+            completed_at="2026-04-30T07:48:09Z",
+            latency_ms=1000,
+            canonical_usage=_make_canonical_usage(),
+            cost_amount_usd=0.0,
+            dd_context=None,
+        )
+
+        dd_obs.log_generation_sync.assert_called_once()
+        dd_obs.log_generation.assert_not_called()
+
+    def test_post_failure_leaves_flag_false(self):
+        """If obs-ingest is down / wrong URL / schema rejection, the
+        sync POST returns False. The flag must stay False so the gateway
+        still writes its synthetic completion-time fallback row.
+        Otherwise MC Live ends up with NEITHER an active-generation row
+        NOR a fallback — the worst possible outcome.
+        """
+        emit = _import_helper()
+        dd_obs = _make_dd_obs(sync_returns=False)
+        ctx = {
+            "run_id": "hermes-sess-g1",
+            "session_key": "agent:hermes:gateway:sess",
+            "per_call_generation_emitted": False,
+        }
+
+        emit(
+            dd_obs_module=dd_obs,
+            run_id="hermes-sess-g1",
+            session_key="agent:hermes:gateway:sess",
+            session_id_fallback="sess",
+            model="gpt-5.5",
+            provider="openai-codex",
+            requested_at="2026-04-30T07:48:07Z",
+            completed_at="2026-04-30T07:48:09Z",
+            latency_ms=1000,
+            canonical_usage=_make_canonical_usage(),
+            cost_amount_usd=0.0,
+            dd_context=ctx,
+        )
+
+        # POST failed → flag stays False → synthetic fallback fires.
+        assert ctx["per_call_generation_emitted"] is False
+
+    def test_exception_in_dd_obs_is_swallowed(self):
+        """Per-call generation logging must NEVER block or fail the
+        agent loop — dd_obs failures are swallowed silently."""
+        emit = _import_helper()
+        dd_obs = MagicMock()
+        dd_obs.log_generation_sync.side_effect = RuntimeError("ingest down")
+        ctx = {
+            "run_id": "hermes-sess-g1",
+            "session_key": "agent:hermes:gateway:sess",
+            "per_call_generation_emitted": False,
+        }
+
+        # Should not raise.
+        emit(
+            dd_obs_module=dd_obs,
+            run_id="hermes-sess-g1",
+            session_key="agent:hermes:gateway:sess",
+            session_id_fallback="sess",
+            model="gpt-5.5",
+            provider="openai-codex",
+            requested_at="2026-04-30T07:48:07Z",
+            completed_at="2026-04-30T07:48:09Z",
+            latency_ms=1000,
+            canonical_usage=_make_canonical_usage(),
+            cost_amount_usd=0.0,
+            dd_context=ctx,
+        )
+
+        # Flag is NOT flipped if the post failed — gateway must still
+        # write the synthetic summary as a fallback.
+        assert ctx["per_call_generation_emitted"] is False
+
+
+class TestCaptureAtCallStartInvariant:
+    """The 'capture-at-API-call-start' invariant is what guarantees that
+    a turn N per-call write never lands under turn N+1's run_id when the
+    cached AIAgent is reused. The helper itself is the proof: it takes
+    run_id/session_key/dd_context as explicit arguments rather than
+    reading from a passed-in agent, so callers must capture into locals
+    before the provider call.
+    """
+
+    def test_helper_signature_takes_explicit_identity_not_agent(self):
+        """The helper must accept identity as kwargs — not as ``self``
+        or an ``agent`` arg — so it cannot accidentally read mid-flight
+        ``agent._dd_run_id`` mutations.
+        """
+        import inspect
+
+        emit = _import_helper()
+        sig = inspect.signature(emit)
+        params = sig.parameters
+
+        assert "run_id" in params
+        assert "session_key" in params
+        assert "dd_context" in params
+        # No ``agent`` or ``self`` parameter — capture must happen in caller.
+        assert "agent" not in params
+        assert "self" not in params

--- a/tests/test_context_usage_payload.py
+++ b/tests/test_context_usage_payload.py
@@ -1,0 +1,111 @@
+"""Coverage for the native Hermes context_usage telemetry payload.
+
+The helper in run_agent.py turns a CanonicalUsage from a successful API call
+into the `hermes_context_usage` block mc-api consumes for MC Live. The bar
+must reflect the full provider-reported prefill (input + cache_read +
+cache_creation), not just `input_tokens`, or long cached sessions show as
+falsely small.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class _Usage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+
+
+def test_payload_sums_full_prefill_including_cache(monkeypatch):
+    monkeypatch.setenv("HERMES_CONTEXT_LIMIT", "400000")
+    monkeypatch.setenv("HERMES_CONTEXT_FLOOR", "320000")
+    from run_agent import _build_hermes_context_usage_payload
+
+    usage = _Usage(
+        input_tokens=1000,
+        output_tokens=5000,
+        cache_read_tokens=120000,
+        cache_write_tokens=2000,
+    )
+    out = _build_hermes_context_usage_payload(canonical_usage=usage, model="claude-x")
+
+    assert out["tokens"] == 1000 + 120000 + 2000
+    assert out["estimated"] is False
+    assert out["found"] is True
+    assert out["source"] == "provider_usage"
+    assert out["model"] == "claude-x"
+    assert out["limit"] == 400_000
+    assert out["floor"] == 320_000
+    assert out["status"] == "green"
+    assert out["pct"] > 0
+    comp = out["components"]
+    assert comp["input_tokens"] == 1000
+    assert comp["cache_read_input_tokens"] == 120000
+    assert comp["cache_creation_input_tokens"] == 2000
+    assert comp["output_tokens"] == 5000
+    assert comp["total_context_tokens"] == out["tokens"]
+
+
+def test_payload_excludes_output_tokens_from_total(monkeypatch):
+    monkeypatch.setenv("HERMES_CONTEXT_LIMIT", "400000")
+    monkeypatch.setenv("HERMES_CONTEXT_FLOOR", "320000")
+    from run_agent import _build_hermes_context_usage_payload
+
+    usage = _Usage(input_tokens=10, output_tokens=999_999, cache_read_tokens=0, cache_write_tokens=0)
+    out = _build_hermes_context_usage_payload(canonical_usage=usage, model="m")
+
+    assert out["tokens"] == 10
+    assert out["components"]["output_tokens"] == 999_999
+
+
+def test_payload_status_thresholds(monkeypatch):
+    monkeypatch.setenv("HERMES_CONTEXT_LIMIT", "400000")
+    monkeypatch.setenv("HERMES_CONTEXT_FLOOR", "320000")
+    from run_agent import _build_hermes_context_usage_payload
+
+    # Green: under floor*0.5 = 160_000
+    out = _build_hermes_context_usage_payload(
+        canonical_usage=_Usage(input_tokens=100_000), model="m")
+    assert out["status"] == "green"
+
+    # Yellow: between 160_000 and 320_000
+    out = _build_hermes_context_usage_payload(
+        canonical_usage=_Usage(input_tokens=200_000), model="m")
+    assert out["status"] == "yellow"
+
+    # Red: at or above floor
+    out = _build_hermes_context_usage_payload(
+        canonical_usage=_Usage(input_tokens=320_000), model="m")
+    assert out["status"] == "red"
+
+
+def test_payload_response_shape_matches_frontend_contract(monkeypatch):
+    """Top-level keys must satisfy MC's hermes_context_usage TS interface."""
+    from run_agent import _build_hermes_context_usage_payload
+
+    out = _build_hermes_context_usage_payload(
+        canonical_usage=_Usage(input_tokens=1, cache_read_tokens=2, cache_write_tokens=3),
+        model="claude-opus-4-7",
+    )
+    required = {"tokens", "limit", "floor", "remaining", "pct",
+                "floor_pct", "status", "found", "estimated"}
+    assert required.issubset(out.keys())
+    assert out["status"] in ("green", "yellow", "red")
+
+
+def test_payload_handles_zero_cache_fields(monkeypatch):
+    """Models that don't report cache (e.g. local Ollama) still produce a valid payload."""
+    monkeypatch.setenv("HERMES_CONTEXT_LIMIT", "200000")
+    monkeypatch.setenv("HERMES_CONTEXT_FLOOR", "100000")
+    from run_agent import _build_hermes_context_usage_payload
+
+    usage = _Usage(input_tokens=42, output_tokens=10)  # cache_read/write default to 0
+    out = _build_hermes_context_usage_payload(canonical_usage=usage, model="gemma:26b")
+
+    assert out["tokens"] == 42
+    assert out["components"]["cache_read_input_tokens"] == 0
+    assert out["components"]["cache_creation_input_tokens"] == 0
+    assert out["limit"] == 200_000
+    assert out["floor"] == 100_000

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -288,3 +288,119 @@ class TestUnifiedCronjobTool:
         assert updated["success"] is True
         stored = get_job(created["job_id"])
         assert stored["deliver"] == "telegram"
+
+
+class TestCronjobOriginGuard:
+    """Fail-closed guard: deliver='origin' without a captured session origin
+    must be rejected at the API boundary so the leak case (Slack-originated
+    work landing in Telegram via the home-channel fallback) cannot create
+    a job at all."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_cron_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+
+    def _clear_session_env(self, monkeypatch):
+        for var in (
+            "HERMES_SESSION_PLATFORM",
+            "HERMES_SESSION_CHAT_ID",
+            "HERMES_SESSION_CHAT_NAME",
+            "HERMES_SESSION_THREAD_ID",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_create_rejects_explicit_deliver_origin_when_no_session_origin(self, monkeypatch):
+        self._clear_session_env(monkeypatch)
+        # Even with a TELEGRAM_HOME_CHANNEL set we must not allow the job to
+        # be created — otherwise the scheduler used to silently re-route to it.
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "8737984752")
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="Slack channel #1prj-hs-sow-next-9f3c — do work",
+                schedule="every 1h",
+                deliver="origin",
+            )
+        )
+        assert result["success"] is False
+        assert "origin" in result["error"].lower()
+        assert "session" in result["error"].lower()
+
+    def test_create_rejects_list_form_deliver_origin_without_session(self, monkeypatch):
+        self._clear_session_env(monkeypatch)
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="anything",
+                schedule="every 1h",
+                deliver=["origin"],
+            )
+        )
+        assert result["success"] is False
+
+    def test_create_accepts_explicit_deliver_origin_when_session_origin_present(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "123456")
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="task",
+                schedule="every 1h",
+                deliver="origin",
+            )
+        )
+        assert result["success"] is True
+
+    def test_create_accepts_local_when_no_session_origin(self, monkeypatch):
+        """deliver='local' is the safe escape hatch and must continue to work."""
+        self._clear_session_env(monkeypatch)
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="slack-context task",
+                schedule="every 1h",
+                deliver="local",
+            )
+        )
+        assert result["success"] is True
+
+    def test_create_with_no_explicit_deliver_and_no_session_defaults_to_local(self, monkeypatch):
+        """Implicit deliver — the safe default in jobs.create_job — must still
+        be allowed when there is no origin (it stores ``deliver='local'`` which
+        cannot leak)."""
+        self._clear_session_env(monkeypatch)
+        result = json.loads(
+            cronjob(
+                action="create",
+                prompt="task",
+                schedule="every 1h",
+            )
+        )
+        assert result["success"] is True
+        from cron.jobs import get_job
+        stored = get_job(result["job_id"])
+        assert stored["deliver"] == "local"
+
+    def test_update_rejects_flipping_to_deliver_origin_when_job_has_no_origin(self, monkeypatch):
+        self._clear_session_env(monkeypatch)
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="task",
+                schedule="every 1h",
+                deliver="local",
+            )
+        )
+        assert created["success"] is True
+
+        result = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                deliver="origin",
+            )
+        )
+        assert result["success"] is False
+        assert "origin" in result["error"].lower()

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -171,6 +171,14 @@ def _normalize_deliver_param(value: Any) -> Optional[str]:
     return text or None
 
 
+def _deliver_value_requests_origin(deliver: Optional[str]) -> bool:
+    """True iff a normalized deliver string asks the scheduler to deliver to origin."""
+    if not deliver:
+        return False
+    parts = [p.strip().lower() for p in deliver.split(",")]
+    return "origin" in parts
+
+
 def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     """Validate a cron job script path at the API boundary.
 
@@ -299,13 +307,36 @@ def cronjob(
                             success=False,
                         )
 
+            normalized_deliver = _normalize_deliver_param(deliver)
+            captured_origin = _origin_from_env()
+            # Fail closed: explicit deliver=origin without a captured session
+            # origin would store origin=null and at fire time the scheduler
+            # used to fall back to the first configured *_HOME_CHANNEL env
+            # var, which on multi-platform hosts cross-posts to the wrong
+            # surface (e.g. Slack-originated work landing in Telegram). The
+            # scheduler now refuses that fallback; reject the create up front
+            # so the operator can pick an explicit destination.
+            if (
+                _deliver_value_requests_origin(normalized_deliver)
+                and not captured_origin
+            ):
+                return tool_error(
+                    "deliver='origin' requires a captured session origin "
+                    "(HERMES_SESSION_PLATFORM + HERMES_SESSION_CHAT_ID). "
+                    "This Hermes session has no origin attached, so the job "
+                    "would have no safe delivery target. Use deliver='local' "
+                    "for file-only output, or pass an explicit destination "
+                    "like deliver='telegram:<chat_id>'.",
+                    success=False,
+                )
+
             job = create_job(
                 prompt=prompt or "",
                 schedule=schedule,
                 name=name,
                 repeat=repeat,
-                deliver=_normalize_deliver_param(deliver),
-                origin=_origin_from_env(),
+                deliver=normalized_deliver,
+                origin=captured_origin,
                 skills=canonical_skills,
                 model=_normalize_optional_job_value(model),
                 provider=_normalize_optional_job_value(provider),
@@ -385,7 +416,21 @@ def cronjob(
             if name is not None:
                 updates["name"] = name
             if deliver is not None:
-                updates["deliver"] = _normalize_deliver_param(deliver)
+                normalized_deliver = _normalize_deliver_param(deliver)
+                # Same fail-closed guard as create: refuse to flip an existing
+                # job to deliver=origin if the job has no origin attached.
+                if (
+                    _deliver_value_requests_origin(normalized_deliver)
+                    and not (job.get("origin") or _origin_from_env())
+                ):
+                    return tool_error(
+                        "deliver='origin' requires the job to have an origin. "
+                        "This job has none and the current session has no "
+                        "captured origin to attach. Use deliver='local' or an "
+                        "explicit destination like deliver='telegram:<chat_id>'.",
+                        success=False,
+                    )
+                updates["deliver"] = normalized_deliver
             if skills is not None or skill is not None:
                 canonical_skills = _canonical_skills(skill, skills)
                 updates["skills"] = canonical_skills


### PR DESCRIPTION
## Summary

When a cron job has `deliver=\"origin\"` but no `origin` block (e.g. created
by an MCP/API caller that did not set `HERMES_SESSION_PLATFORM`/`HERMES_SESSION_CHAT_ID`),
the resolver in `cron/scheduler.py` falls back to the first configured
`*_HOME_CHANNEL` env var. On hosts that have more than one home channel set,
this silently cross-posts work between platforms.

We hit this in production: a Slack-originated cron job (`hyperscience-sow-first-draft-pdf`,
job_id `59ee074897a6`) was created from a Slack workflow whose service-layer
adapter intentionally strips Slack identifiers before forwarding to the
agent (security boundary — adapter holds the Slack token, not the agent).
The agent ran the cron job; at fire time `_resolve_origin(job)` returned
`None`, the resolver iterated `_HOME_TARGET_ENV_VARS`, hit `TELEGRAM_HOME_CHANNEL`,
and posted the result (with the `Cronjob Response: …` wrapper) into the
operator's Telegram DM.

This PR makes the resolver fail closed:

- `cron/scheduler.py` — `_resolve_single_delivery_target(...)` for
  `deliver=\"origin\"` with missing origin returns `None` and logs a warning,
  rather than picking the first home channel it finds.
- `cron/scheduler.py` — `_deliver_result(...)` records a specific
  `last_delivery_error` (`\"deliver=origin but job has no origin (fail-closed)\"`)
  so operators can triage from the job record.
- `tools/cronjob_tools.py` — the `cronjob` tool's create and update branches
  reject explicit `deliver=\"origin\"` (and comma-list values containing
  `\"origin\"`) when the calling Hermes session has no captured origin.
  Callers without a session origin must pick `deliver=\"local\"` or an
  explicit destination like `deliver=\"telegram:<chat_id>\"`.

The bare-platform branch (`deliver=\"telegram\"`, `deliver=\"discord\"`, …)
still resolves to the platform's `*_HOME_CHANNEL` — that's an explicit
caller intent and is unchanged.

## Behaviour change

- `deliver=\"origin\"` jobs **with a valid origin block**: unchanged.
- `deliver=\"origin\"` jobs **with `origin=null`**: delivery skipped,
  `last_delivery_error` recorded. Output still saved to disk.
- `deliver=\"<platform>\"` (bare): unchanged.
- `deliver=\"<platform>:<chat_id>\"`: unchanged.

If you have callers that intentionally relied on the silent home-channel
fallback for null-origin `\"origin\"` jobs, they need to switch to bare-
platform or explicit-target deliver. We did not find any such callers in
our deployment; the fallback only matters in a multi-home-channel host.

## Test plan

- [x] New `TestCronjobOriginGuard` covers create/update accept and reject
      paths for the API-boundary check.
- [x] `test_origin_delivery_without_origin_falls_back_to_supported_home_channels`
      replaced by `test_origin_delivery_without_origin_returns_no_target_even_with_home_channel_set`
      (the inverse assertion that pins the new contract).
- [x] `test_origin_delivery_does_not_leak_slack_origin_to_telegram` — incident-shape regression.
- [x] `test_telegram_origin_with_valid_origin_still_delivers_normally` — happy-path regression.
- [x] `test_delivery_records_specific_error_when_origin_is_missing` — pins
      the new `last_delivery_error` text.
- [x] `pytest tests/cron/ tests/tools/test_cronjob_tools.py` — the changed
      and adjacent suites all pass. (Four pre-existing failures in
      `TestSilentDelivery` and `test_tick_marks_empty_response_as_error`
      reproduce on clean upstream `71f9bdcb2` and are unrelated to this
      change.)