### PR TITLE
fix(gateway): handle Telegram start command

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -856,6 +856,48 @@ class TelegramAdapter(BasePlatformAdapter):
                             self.name, topic_name, seed_err,
                         )
 
+    async def _register_command_menu(self) -> None:
+        """Register Telegram slash commands and show the commands menu button."""
+        # Register bot commands so Telegram shows a hint menu when users type /
+        # List is derived from the central COMMAND_REGISTRY — adding a new
+        # gateway command there automatically adds it to the Telegram menu.
+        try:
+            from telegram import BotCommand
+            from hermes_cli.commands import telegram_menu_commands
+
+            # Telegram allows up to 100 commands but has an undocumented
+            # payload size limit. Skill descriptions are truncated to 40 chars
+            # in telegram_menu_commands() to fit 100 commands safely.
+            menu_commands, hidden_count = telegram_menu_commands(max_commands=100)
+            await self._bot.set_my_commands([
+                BotCommand(name, desc) for name, desc in menu_commands
+            ])
+            try:
+                from telegram import MenuButtonCommands
+                from telegram.error import TelegramError
+
+                await self._bot.set_chat_menu_button(
+                    menu_button=MenuButtonCommands()
+                )
+            except (ImportError, AttributeError, TelegramError):
+                logger.debug(
+                    "[%s] Could not force Telegram menu button to commands mode",
+                    self.name,
+                    exc_info=True,
+                )
+            if hidden_count:
+                logger.info(
+                    "[%s] Telegram menu: %d commands registered, %d hidden (over 100 limit). Use /commands for full list.",
+                    self.name, len(menu_commands), hidden_count,
+                )
+        except Exception as e:
+            logger.warning(
+                "[%s] Could not register Telegram command menu: %s",
+                self.name,
+                e,
+                exc_info=True,
+            )
+
     async def connect(self) -> bool:
         """Connect to Telegram via polling or webhook.
 
@@ -1082,31 +1124,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     error_callback=_polling_error_callback,
                 )
             
-            # Register bot commands so Telegram shows a hint menu when users type /
-            # List is derived from the central COMMAND_REGISTRY — adding a new
-            # gateway command there automatically adds it to the Telegram menu.
-            try:
-                from telegram import BotCommand
-                from hermes_cli.commands import telegram_menu_commands
-                # Telegram allows up to 100 commands but has an undocumented
-                # payload size limit.  Skill descriptions are truncated to 40
-                # chars in telegram_menu_commands() to fit 100 commands safely.
-                menu_commands, hidden_count = telegram_menu_commands(max_commands=100)
-                await self._bot.set_my_commands([
-                    BotCommand(name, desc) for name, desc in menu_commands
-                ])
-                if hidden_count:
-                    logger.info(
-                        "[%s] Telegram menu: %d commands registered, %d hidden (over 100 limit). Use /commands for full list.",
-                        self.name, len(menu_commands), hidden_count,
-                    )
-            except Exception as e:
-                logger.warning(
-                    "[%s] Could not register Telegram command menu: %s",
-                    self.name,
-                    e,
-                    exc_info=True,
-                )
+            await self._register_command_menu()
             
             self._mark_connected()
             mode = "webhook" if self._webhook_mode else "polling"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5316,6 +5316,16 @@ class GatewayRunner:
                 return self._telegram_topic_root_new_message()
             return await self._handle_reset_command(event)
 
+        if canonical == "start":
+            return (
+                "Jarvis is online.\n\n"
+                "Quick commands:\n"
+                "/new — start a fresh session\n"
+                "/model — switch model for this session\n"
+                "/commands — browse everything available\n"
+                "/help — show the compact help list"
+            )
+
         if canonical == "topic":
             return await self._handle_topic_command(event)
         

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -63,6 +63,8 @@ class CommandDef:
 
 COMMAND_REGISTRY: list[CommandDef] = [
     # Session
+    CommandDef("start", "Show Telegram quick-start help", "Session",
+               gateway_only=True),
     CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
                aliases=("reset",), args_hint="[name]"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",

--- a/tests/gateway/test_telegram_command_menu.py
+++ b/tests/gateway/test_telegram_command_menu.py
@@ -1,0 +1,106 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.commands import (
+    resolve_command,
+    telegram_bot_commands,
+    telegram_menu_commands,
+)
+from gateway.config import PlatformConfig
+from gateway.platforms.telegram import TelegramAdapter
+
+
+class _FakeBot:
+    def __init__(self):
+        self.command_calls = []
+        self.menu_button_calls = []
+
+    async def set_my_commands(self, commands, scope=None):
+        self.command_calls.append((commands, scope))
+
+    async def set_chat_menu_button(self, menu_button=None, **kwargs):
+        self.menu_button_calls.append((menu_button, kwargs))
+
+
+class _MenuButtonFailureBot(_FakeBot):
+    async def set_chat_menu_button(self, menu_button=None, **kwargs):
+        from telegram.error import TelegramError
+
+        raise TelegramError("menu button unavailable")
+
+
+@pytest.mark.asyncio
+async def test_telegram_menu_registration_sets_commands_and_menu_button(monkeypatch):
+    """Command menu registration uses production adapter code."""
+    monkeypatch.setattr(
+        "hermes_cli.commands.telegram_menu_commands",
+        lambda max_commands=100: ([("new", "Start a new session"), ("help", "Show help")], 0),
+    )
+
+    telegram_mod = sys.modules.get("telegram")
+    monkeypatch.setattr(
+        telegram_mod,
+        "BotCommand",
+        lambda name, description: SimpleNamespace(name=name, description=description),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        telegram_mod,
+        "MenuButtonCommands",
+        lambda: SimpleNamespace(type="commands"),
+        raising=False,
+    )
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    fake_bot = _FakeBot()
+    adapter._bot = fake_bot
+
+    await adapter._register_command_menu()
+
+    assert len(fake_bot.command_calls) == 1
+    commands, scope = fake_bot.command_calls[0]
+    assert scope is None
+    assert [cmd.name for cmd in commands] == ["new", "help"]
+    assert len(fake_bot.menu_button_calls) == 1
+    menu_button, kwargs = fake_bot.menu_button_calls[0]
+    assert menu_button.type == "commands"
+    assert kwargs == {}
+
+
+@pytest.mark.asyncio
+async def test_telegram_menu_button_failure_does_not_break_command_registration(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.commands.telegram_menu_commands",
+        lambda max_commands=100: ([("start", "Show Telegram quick-start help")], 0),
+    )
+
+    telegram_mod = sys.modules.get("telegram")
+    monkeypatch.setattr(
+        telegram_mod,
+        "BotCommand",
+        lambda name, description: SimpleNamespace(name=name, description=description),
+        raising=False,
+    )
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    fake_bot = _MenuButtonFailureBot()
+    adapter._bot = fake_bot
+
+    await adapter._register_command_menu()
+
+    assert len(fake_bot.command_calls) == 1
+    commands, _scope = fake_bot.command_calls[0]
+    assert [cmd.name for cmd in commands] == ["start"]
+
+
+def test_start_command_is_registered_for_gateway_and_telegram_menu():
+    start = resolve_command("start")
+
+    assert start is not None
+    assert start.name == "start"
+    assert start.gateway_only is True
+    assert any(name == "start" for name, _description in telegram_bot_commands())
+    menu_commands, _hidden_count = telegram_menu_commands(max_commands=100)
+    assert any(name == "start" for name, _description in menu_commands)


### PR DESCRIPTION
## Summary
- Register `/start` as a gateway-known command so Telegram's default Start button is handled instead of rejected as unknown.
- Add a Telegram command menu helper that also best-effort forces the chat menu button into command mode.
- Add focused tests covering menu registration, non-fatal menu-button failures, and gateway command recognition for `/start`.

## Verification
- `python -m pytest tests/gateway/test_telegram_command_menu.py -q`
- Secret scan of the clean outgoing diff found no credential literals; only inert `test-token` fixtures are present.

## Notes
- This clean branch is based on current `origin/main` and contains only the Telegram `/start` fix commit.
