### PR TITLE
fix: inject continuation prompt when no user messages remain after compression

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -11119,6 +11119,18 @@ class AIAgent:
             # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
             _sanitize_messages_surrogates(api_messages)
 
+            # Safety net: if context compression or session resume stripped all
+            # user messages, the upstream provider (e.g. Airrouter/litellm) will
+            # reject the request with 400 "No user query found in messages",
+            # which the jmunch gateway converts to a 502.  Detect this and
+            # inject a continuation prompt so the model can keep going.
+            if not any(m.get("role") == "user" for m in api_messages):
+                api_messages.append({"role": "user", "content": "[System: please continue the conversation from your last response, taking the next appropriate action or providing a final response to the user."})
+                request_logger.info(
+                    "Injected continuation prompt: no user messages found in api_messages (session=%s)",
+                    self.session_id or "-",
+                )
+
             # Calculate approximate request size for logging
             total_chars = sum(len(str(msg)) for msg in api_messages)
             approx_tokens = estimate_messages_tokens_rough(api_messages)


### PR DESCRIPTION
## Problem

When context compression or session resume strips all user messages from the conversation history, the resulting `api_messages` array contains only assistant/tool messages. Providers like Airrouter (via litellm) reject this with:

```
litellm.BadRequestError: OpenAIException - No user query found in messages.
```

The jmunch gateway converts this 400 into a 502, causing cron jobs and session continuations to fail with "RuntimeError: HTTP 502".

## Fix

After `_sanitize_messages_surrogates(api_messages)` and before the API call, check whether any `role: user` messages exist. If not, inject a continuation prompt:

```python
if not any(m.get("role") == "user" for m in api_messages):
    api_messages.append({"role": "user", "content": "[System: please continue the conversation from your last response, taking the next appropriate action or providing a final response to the user."})
```

## Impact

- **Reliability:** Cron jobs and session continuations no longer fail with 502 after aggressive context compression
- **Zero cost when not needed:** The check is a simple `any()` over the existing list — no token overhead
- **Minimal token cost when triggered:** ~25 tokens for the injected prompt, far cheaper than a failed retry cycle
- **Logged:** When the safety net fires, it's logged via `request_logger.info` for debugging