### PR TITLE
fix(transport): insert synthetic assistant between tool and user for Mistral

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -99,6 +99,76 @@ def _is_gemini_openai_compat_base_url(base_url: Any) -> bool:
     return normalized.endswith("/openai")
 
 
+def _is_mistral_model(model: Optional[str]) -> bool:
+    """Return True for Mistral model slugs, including aggregator prefixes.
+
+    Matches bare names (``mistral-large-latest``), vendor-prefixed slugs
+    (``mistralai/Mistral-Small-3.1-24B-Instruct``), and aggregator-prefixed
+    slugs (``openrouter/mistralai/...``, ``nvidia/mistralai/...``,
+    ``nim/mistral-...``). Detection by slug covers OpenRouter / NVIDIA NIM /
+    other aggregators where the base URL is the aggregator's, not
+    ``api.mistral.ai``. (#20154)
+    """
+    if not model:
+        return False
+
+    normalized = model.strip().lower()
+    if not normalized:
+        return False
+
+    parts = [part for part in normalized.split("/") if part]
+    tail = parts[-1] if parts else normalized
+
+    return (
+        tail == "mistral"
+        or tail.startswith("mistral-")
+        or tail.startswith("mistralai-")
+        or "mistralai" in parts
+    )
+
+
+def _ensure_mistral_role_alternation(
+    messages: List[Dict[str, Any]],
+    model: Optional[str],
+) -> List[Dict[str, Any]]:
+    """Insert a synthetic assistant turn between any ``tool`` -> ``user`` pair.
+
+    Mistral's chat template strictly enforces role alternation and rejects a
+    user message that directly follows a tool result with::
+
+        HTTP 400: Unexpected role 'user' after role 'tool'
+
+    Other OpenAI-compatible providers tolerate the same sequence, so we only
+    patch when the target model is a Mistral variant. The synthetic message uses
+    a single space for ``content`` because some Mistral endpoints reject empty
+    strings. (#20154)
+    """
+    if not _is_mistral_model(model) or not messages:
+        return messages
+
+    previous_role: Optional[str] = None
+    needs_fix = False
+    for msg in messages:
+        role = msg.get("role") if isinstance(msg, dict) else None
+        if previous_role == "tool" and role == "user":
+            needs_fix = True
+            break
+        previous_role = role
+
+    if not needs_fix:
+        return messages
+
+    patched: List[Dict[str, Any]] = []
+    previous_role = None
+    for msg in messages:
+        role = msg.get("role") if isinstance(msg, dict) else None
+        if previous_role == "tool" and role == "user":
+            patched.append({"role": "assistant", "content": " "})
+        patched.append(msg)
+        previous_role = role
+    return patched
+
+
 class ChatCompletionsTransport(ProviderTransport):
     """Transport for api_mode='chat_completions'.
 
@@ -264,6 +334,11 @@ class ChatCompletionsTransport(ProviderTransport):
         ):
             sanitized = list(sanitized)
             sanitized[0] = {**sanitized[0], "role": "developer"}
+
+        # Mistral: insert synthetic assistant between tool and user (#20154).
+        # No-op for non-Mistral models and Mistral conversations without a
+        # ``tool`` -> ``user`` transition.
+        sanitized = _ensure_mistral_role_alternation(sanitized, model)
 
         api_kwargs: dict[str, Any] = {
             "model": model,
@@ -443,6 +518,12 @@ class ChatCompletionsTransport(ProviderTransport):
         ):
             sanitized = list(sanitized)
             sanitized[0] = {**sanitized[0], "role": "developer"}
+
+        # Mistral: insert synthetic assistant between tool and user (#20154).
+        # This must run on the provider-profile path too, because known
+        # OpenAI-compatible aggregators (NVIDIA NIM, OpenRouter, Nous, etc.)
+        # now bypass the legacy flag path.
+        sanitized = _ensure_mistral_role_alternation(sanitized, model)
 
         api_kwargs: dict[str, Any] = {
             "model": model,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -821,3 +821,103 @@ class TestChatCompletionsCacheStats:
         r = SimpleNamespace(usage=SimpleNamespace(prompt_tokens_details=details))
         result = transport.extract_cache_stats(r)
         assert result == {"cached_tokens": 500, "creation_tokens": 100}
+
+
+class TestChatCompletionsMistralRoleAlternation:
+    """Mistral rejects ``tool`` -> ``user`` transitions with HTTP 400.
+
+    Insert a synthetic single-space assistant turn between any tool result and
+    the next user message when the model is a Mistral variant. Other providers
+    tolerate the same sequence, so the patch must NOT fire for them. (#20154)
+    """
+
+    @pytest.fixture
+    def tool_then_user(self):
+        return [
+            {"role": "user", "content": "find me README"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "search_files", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "README.md"},
+            {"role": "user", "content": "now open it"},
+        ]
+
+    def test_mistral_inserts_assistant_between_tool_and_user(self, transport, tool_then_user):
+        kw = transport.build_kwargs(
+            model="mistralai/mistral-small-4-119b-2603",
+            messages=tool_then_user,
+        )
+        roles = [m["role"] for m in kw["messages"]]
+        assert roles == ["user", "assistant", "tool", "assistant", "user"]
+        # Synthetic message uses a non-empty space — some Mistral endpoints
+        # reject empty content.
+        assert kw["messages"][3] == {"role": "assistant", "content": " "}
+
+    def test_bare_mistral_slug_also_patched(self, transport, tool_then_user):
+        kw = transport.build_kwargs(
+            model="mistral-large-latest",
+            messages=tool_then_user,
+        )
+        roles = [m["role"] for m in kw["messages"]]
+        assert roles == ["user", "assistant", "tool", "assistant", "user"]
+
+    def test_aggregator_prefix_mistral_also_patched(self, transport, tool_then_user):
+        kw = transport.build_kwargs(
+            model="openrouter/mistralai/mistral-large-2411",
+            messages=tool_then_user,
+        )
+        roles = [m["role"] for m in kw["messages"]]
+        assert roles == ["user", "assistant", "tool", "assistant", "user"]
+
+    def test_provider_profile_path_mistral_is_patched(self, transport, tool_then_user):
+        from providers import get_provider_profile
+
+        kw = transport.build_kwargs(
+            model="mistralai/mistral-small-4-119b-2603",
+            messages=tool_then_user,
+            provider_profile=get_provider_profile("nvidia"),
+        )
+        roles = [m["role"] for m in kw["messages"]]
+        assert roles == ["user", "assistant", "tool", "assistant", "user"]
+
+    def test_openai_not_patched(self, transport, tool_then_user):
+        kw = transport.build_kwargs(model="gpt-4o", messages=tool_then_user)
+        roles = [m["role"] for m in kw["messages"]]
+        assert roles == ["user", "assistant", "tool", "user"]
+
+    def test_anthropic_not_patched(self, transport, tool_then_user):
+        kw = transport.build_kwargs(
+            model="anthropic/claude-sonnet-4.6",
+            messages=tool_then_user,
+        )
+        roles = [m["role"] for m in kw["messages"]]
+        assert roles == ["user", "assistant", "tool", "user"]
+
+    def test_nemotron_not_patched(self, transport, tool_then_user):
+        kw = transport.build_kwargs(
+            model="nvidia/llama-3.3-nemotron-super-49b-v1",
+            messages=tool_then_user,
+        )
+        roles = [m["role"] for m in kw["messages"]]
+        assert roles == ["user", "assistant", "tool", "user"]
+
+    def test_mistral_no_tool_user_pair_is_passthrough(self, transport):
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "bye"},
+        ]
+        kw = transport.build_kwargs(
+            model="mistralai/mistral-small-4-119b-2603",
+            messages=msgs,
+        )
+        # No insertion — no tool->user transition exists.
+        assert [m["role"] for m in kw["messages"]] == ["user", "assistant", "user"]


### PR DESCRIPTION
## Summary
- Insert a synthetic assistant message between tool output and the next user message for Mistral-compatible role sequencing.
- Keep the change scoped to chat completions transport message normalization.
- Add regression coverage for the role sequence behavior.

## Tests
- Not run in this session; PR-opening only, branch was already pushed.