### PR TITLE
fix(dashboard): resolve unreadable low contrast in kanban JSON payload boxes

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -437,6 +437,7 @@
 }
 .hermes-kanban-event-payload {
   color: var(--color-muted-foreground);
+  background: transparent;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -785,6 +786,7 @@
 }
 .hermes-kanban-run-meta {
   display: block;
+  background: transparent;
   font-size: 0.72rem;
   line-height: 1.5;
   padding: 0.15rem 0 0;


### PR DESCRIPTION
The Kanban UI was previously rendering event payloads and run history JSON blobs with a bright lilac/purple background and white text, making them completely unreadable.

This happens because the global `code` element in many themes (or fallbacks) has a background, and the specific `hermes-kanban-event-payload` and `hermes-kanban-run-meta` classes didn't reset it.

This PR adds `background: transparent;` to both classes, which restores readability and allows the JSON to fall back to the intended `muted-foreground` color against the standard card background.