### PR TITLE
feat: add priority-aware message notifications for Telegram and Discord

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -416,7 +416,7 @@ def is_host_excluded_by_no_proxy(hostname: str, no_proxy_value: str | None = Non
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union
+from typing import Dict, List, Optional, Any, Literal, Callable, Awaitable, Tuple, Union
 from enum import Enum
 
 from pathlib import Path as _Path
@@ -1426,7 +1426,8 @@ class BasePlatformAdapter(ABC):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
+        priority: Literal["silent", "normal", "urgent"] = "normal"
     ) -> SendResult:
         """
         Send a message to a chat.
@@ -1436,6 +1437,7 @@ class BasePlatformAdapter(ABC):
             content: Message content (may be markdown)
             reply_to: Optional message ID to reply to
             metadata: Additional platform-specific options
+            priority: Message priority - "silent" (no notification), "normal" (standard notification), "urgent" (high priority)
         
         Returns:
             SendResult with success status and message ID

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -18,7 +18,7 @@ import tempfile
 import threading
 import time
 from collections import defaultdict
-from typing import Callable, Dict, List, Optional, Any, Tuple
+from typing import Callable, Dict, List, Optional, Any, Tuple, Literal
 
 logger = logging.getLogger(__name__)
 
@@ -1097,7 +1097,8 @@ class DiscordAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
+        priority: Literal["silent", "normal", "urgent"] = "normal"
     ) -> SendResult:
         """Send a message to a Discord channel or thread.
 
@@ -1109,6 +1110,14 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         if not self._client:
             return SendResult(success=False, error="Not connected")
+        
+        # Support priority via parameter or metadata (metadata takes precedence for backward compat)
+        effective_priority = priority
+        if metadata and "priority" in metadata:
+            effective_priority = metadata["priority"]
+        
+        # Discord: flags=4096 suppresses notifications (EMBED_LINKS)
+        suppress_notification = effective_priority == "silent"
 
         try:
             # Determine target channel: thread_id in metadata takes precedence.
@@ -1158,10 +1167,18 @@ class DiscordAdapter(BasePlatformAdapter):
                 else:  # "first" (default) or "off"
                     chunk_reference = reference if i == 0 else None
                 try:
-                    msg = await channel.send(
-                        content=chunk,
-                        reference=chunk_reference,
-                    )
+                    # Build send kwargs
+                    send_kwargs: Dict[str, Any] = {
+                        "content": chunk,
+                        "reference": chunk_reference,
+                    }
+                    # Add suppress_notification flag for silent priority
+                    if suppress_notification:
+                        # Import here to avoid top-level issues if discord isn't available
+                        import discord
+                        send_kwargs["flags"] = discord.MessageFlags(4096)  # SUPPRESS_EMBEDS
+                    
+                    msg = await channel.send(**send_kwargs)
                 except Exception as e:
                     err_text = str(e)
                     if (
@@ -1180,10 +1197,15 @@ class DiscordAdapter(BasePlatformAdapter):
                             reply_to,
                         )
                         reference = None
-                        msg = await channel.send(
-                            content=chunk,
-                            reference=None,
-                        )
+                        # Build send kwargs for fallback
+                        send_kwargs: Dict[str, Any] = {
+                            "content": chunk,
+                            "reference": None,
+                        }
+                        if suppress_notification:
+                            import discord
+                            send_kwargs["flags"] = discord.MessageFlags(4096)
+                        msg = await channel.send(**send_kwargs)
                     else:
                         raise
                 message_ids.append(str(msg.id))

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1202,6 +1202,36 @@ class TelegramAdapter(BasePlatformAdapter):
         if metadata and "priority" in metadata:
             effective_priority = metadata["priority"]
         
+        # Auto-classify priority if still default "normal" - check content for silent indicators
+        if effective_priority == "normal" and content:
+            content_lower = content.lower()
+            
+            # Check for system message indicators
+            
+            # 1. Check for leading emoji (system messages often start with emoji)
+            system_emoji_prefixes = ['⏳', '🔄', '📊', '⏲️', '🔁', '⏱️', '📡', '🧠', '🤔', '💭', '⚙️', '🔧', '📝', '🔎', '🌐', '💻', '📥', '📤']
+            for emoji in system_emoji_prefixes:
+                if content.startswith(emoji):
+                    effective_priority = "silent"
+                    break
+            if effective_priority != "normal":
+                pass  # Already classified as silent
+            # 2. Check for silent patterns in content
+            elif any(pattern in content_lower for pattern in [
+                "still working", "iterating", "iteration", "checking ",
+                "analyzing", "processing", "searching", "running ",
+                "waiting for", "provider:", "retrying", "elapsed",
+                "thinking...", "working on this", "in progress",
+            ]):
+                effective_priority = "silent"
+            # 3. Check for urgent patterns
+            elif any(pattern in content_lower for pattern in [
+                "error", "failed", "exception", "crashed", "blocked",
+                "abort", "critical", "urgent", "requires approval",
+                "api key", "authentication", "unauthorized", "forbidden",
+            ]):
+                effective_priority = "urgent"
+        
         # Determine notification setting based on priority
         disable_notification = effective_priority == "silent"
         

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -14,7 +14,7 @@ import os
 import tempfile
 import html as _html
 import re
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Literal
 
 logger = logging.getLogger(__name__)
 
@@ -1190,11 +1190,20 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id: str,
         content: str,
         reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
+        priority: Literal["silent", "normal", "urgent"] = "normal"
     ) -> SendResult:
         """Send a message to a Telegram chat."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+        
+        # Support priority via parameter or metadata (metadata takes precedence for backward compat)
+        effective_priority = priority
+        if metadata and "priority" in metadata:
+            effective_priority = metadata["priority"]
+        
+        # Determine notification setting based on priority
+        disable_notification = effective_priority == "silent"
         
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
@@ -1249,6 +1258,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
                                 message_thread_id=effective_thread_id,
+                                disable_notification=disable_notification,
                                 **self._link_preview_kwargs(),
                             )
                         except Exception as md_error:
@@ -1262,6 +1272,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
                                     message_thread_id=effective_thread_id,
+                                    disable_notification=disable_notification,
                                     **self._link_preview_kwargs(),
                                 )
                             else:
@@ -1456,6 +1467,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self, chat_id: str, prompt: str, default: str = "",
         session_key: str = "",
         metadata: Optional[Dict[str, Any]] = None,
+        priority: Literal["silent", "normal", "urgent"] = "normal"
     ) -> SendResult:
         """Send an inline-keyboard update prompt (Yes / No buttons).
 
@@ -1464,6 +1476,11 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+        
+        # Determine notification setting - these prompts always notify
+        effective_priority = metadata.get("priority", priority) if metadata else priority
+        disable_notification = effective_priority == "silent"
+        
         try:
             default_hint = f" (default: {default})" if default else ""
             text = f"⚕ *Update needs your input:*\n\n{prompt}{default_hint}"
@@ -1481,6 +1498,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 parse_mode=ParseMode.MARKDOWN,
                 reply_markup=keyboard,
                 message_thread_id=message_thread_id,
+                disable_notification=disable_notification,
                 **self._link_preview_kwargs(),
             )
             return SendResult(success=True, message_id=str(msg.message_id))
@@ -1492,6 +1510,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None,
+        priority: Literal["silent", "normal", "urgent"] = "normal"
     ) -> SendResult:
         """Send an inline-keyboard approval prompt with interactive buttons.
 
@@ -1500,6 +1519,10 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+        
+        # Determine notification setting - approval prompts always notify
+        effective_priority = metadata.get("priority", priority) if metadata else priority
+        disable_notification = effective_priority == "silent"
 
         try:
             cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
@@ -1536,6 +1559,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 "text": text,
                 "parse_mode": ParseMode.HTML,
                 "reply_markup": keyboard,
+                "disable_notification": disable_notification,
                 **self._link_preview_kwargs(),
             }
             message_thread_id = self._message_thread_id_for_send(thread_id)
@@ -1555,10 +1579,15 @@ class TelegramAdapter(BasePlatformAdapter):
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str,
         confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
+        priority: Literal["silent", "normal", "urgent"] = "normal"
     ) -> SendResult:
         """Render a three-button slash-command confirmation prompt."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+        
+        # Determine notification setting - confirmation prompts always notify
+        effective_priority = metadata.get("priority", priority) if metadata else priority
+        disable_notification = effective_priority == "silent"
 
         try:
             # Message body: render as plain text (message already contains
@@ -1581,6 +1610,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 "text": preview,
                 "parse_mode": ParseMode.MARKDOWN,
                 "reply_markup": keyboard,
+                "disable_notification": disable_notification,
                 **self._link_preview_kwargs(),
             }
             message_thread_id = self._message_thread_id_for_send(thread_id)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13159,6 +13159,7 @@ class GatewayRunner:
                         _status_chat_id,
                         message,
                         metadata=_status_thread_metadata,
+                        priority="silent",
                     ),
                     _loop_for_step,
                 )
@@ -14026,6 +14027,7 @@ class GatewayRunner:
                         source.chat_id,
                         f"⏳ Still working... ({_elapsed_mins} min elapsed{_status_detail})",
                         metadata=_status_thread_metadata,
+                        priority="silent",
                     )
                 except Exception as _ne:
                     logger.debug("Long-running notification error: %s", _ne)
@@ -14120,6 +14122,7 @@ class GatewayRunner:
                                     f"be timed out in {_remaining_mins} min. "
                                     f"You can continue waiting or use /reset.",
                                     metadata=_status_thread_metadata,
+                                    priority="silent",
                                 )
                             except Exception as _warn_err:
                                 logger.debug("Inactivity warning send error: %s", _warn_err)

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -21,9 +21,65 @@ import queue
 import re
 import time
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, Literal
 
 logger = logging.getLogger("gateway.stream_consumer")
+
+# Priority levels for message delivery
+MessagePriority = Literal["silent", "normal", "urgent"]
+
+
+def _classify_priority(
+    text: str,
+    is_final: bool = False,
+    is_segment_break: bool = False,
+    metadata: Optional[dict] = None
+) -> MessagePriority:
+    """
+    Classify message priority based on content and context.
+    
+    Rules:
+    - is_final=True: always "normal" (task complete, user attention needed)
+    - is_segment_break=True (tool boundary): usually "normal" but can be "silent" for routine tools
+    - Error indicators in text: "urgent"
+    - Progress/iteration indicators: "silent"
+    - Metadata can override: metadata.get("priority") takes precedence
+    """
+    # Allow metadata to override
+    if metadata and metadata.get("priority"):
+        return metadata["priority"]
+    
+    # Final response always gets normal priority (user attention)
+    if is_final:
+        return "normal"
+    
+    # Check for urgent indicators in the text
+    text_lower = text.lower() if text else ""
+    urgent_keywords = [
+        "error", "failed", "exception", "crashed", "blocked",
+        "abort", "critical", "urgent", "requires approval",
+        "api key", "authentication", "unauthorized", "forbidden",
+    ]
+    for keyword in urgent_keywords:
+        if keyword in text_lower:
+            return "urgent"
+    
+    # Check for routine/silent indicators
+    silent_keywords = [
+        "still working", "iterating", "iteration", "checking",
+        "analyzing", "processing", "searching", "running",
+        "waiting for", "provider:", "retrying",
+    ]
+    for keyword in silent_keywords:
+        if keyword in text_lower:
+            return "silent"
+    
+    # Segment breaks after tool calls are usually informational
+    if is_segment_break:
+        return "silent"
+    
+    # Default to normal for any other content that needs attention
+    return "normal"
 
 # Sentinel to signal the stream is complete
 _DONE = object()
@@ -362,8 +418,14 @@ class GatewayStreamConsumer:
                         chunks = self.adapter.truncate_message(
                             self._accumulated, _safe_limit
                         )
-                        for chunk in chunks:
-                            await self._send_new_chunk(chunk, self._message_id)
+                        for i, chunk in enumerate(chunks):
+                            # Last chunk of overflow gets final/segment_break flags
+                            is_last = (i == len(chunks) - 1)
+                            await self._send_new_chunk(
+                                chunk, self._message_id,
+                                is_final=is_last and got_done,
+                                is_segment_break=is_last and got_segment_break,
+                            )
                         self._accumulated = ""
                         self._last_sent_text = ""
                         self._last_edit_time = time.monotonic()
@@ -387,7 +449,14 @@ class GatewayStreamConsumer:
                         if split_at < _safe_limit // 2:
                             split_at = _safe_limit
                         chunk = self._accumulated[:split_at]
-                        ok = await self._send_or_edit(chunk)
+                        # In overflow, determine if we're at the last chunk
+                        remaining_after = self._accumulated[split_at:].lstrip("\n")
+                        is_last_chunk = not remaining_after
+                        ok = await self._send_or_edit(
+                            chunk,
+                            is_final=is_last_chunk and got_done,
+                            is_segment_break=is_last_chunk and got_segment_break,
+                        )
                         if self._fallback_final_send or not ok:
                             # Edit failed (or backed off due to flood control)
                             # while attempting to split an oversized message.
@@ -412,6 +481,8 @@ class GatewayStreamConsumer:
                     current_update_visible = await self._send_or_edit(
                         display_text,
                         finalize=got_segment_break,
+                        is_final=got_done,
+                        is_segment_break=got_segment_break,
                     )
                     self._last_edit_time = time.monotonic()
 
@@ -437,10 +508,15 @@ class GatewayStreamConsumer:
                             # visible update this tick) OR the adapter needs
                             # explicit finalize=True to close the stream.
                             self._final_response_sent = await self._send_or_edit(
-                                self._accumulated, finalize=True,
+                                self._accumulated, 
+                                finalize=True,
+                                is_final=True,
                             )
                         elif not self._already_sent:
-                            self._final_response_sent = await self._send_or_edit(self._accumulated)
+                            self._final_response_sent = await self._send_or_edit(
+                                self._accumulated,
+                                is_final=True,
+                            )
                     return
 
                 if commentary_text is not None:
@@ -488,7 +564,10 @@ class GatewayStreamConsumer:
             _best_effort_ok = False
             if self._accumulated and self._message_id:
                 try:
-                    _best_effort_ok = bool(await self._send_or_edit(self._accumulated))
+                    _best_effort_ok = bool(await self._send_or_edit(
+                        self._accumulated, 
+                        is_final=True,
+                    ))
                 except Exception:
                     pass
             # Only confirm final delivery if the best-effort send above
@@ -528,7 +607,13 @@ class GatewayStreamConsumer:
         # Strip trailing whitespace/newlines but preserve leading content
         return cleaned.rstrip()
 
-    async def _send_new_chunk(self, text: str, reply_to_id: Optional[str]) -> Optional[str]:
+    async def _send_new_chunk(
+        self, 
+        text: str, 
+        reply_to_id: Optional[str],
+        is_final: bool = False,
+        is_segment_break: bool = False,
+    ) -> Optional[str]:
         """Send a new message chunk, optionally threaded to a previous message.
 
         Returns the message_id so callers can thread subsequent chunks.
@@ -538,11 +623,19 @@ class GatewayStreamConsumer:
             return reply_to_id
         try:
             meta = dict(self.metadata) if self.metadata else {}
+            # Classify priority based on message context
+            priority = _classify_priority(
+                text, 
+                is_final=is_final, 
+                is_segment_break=is_segment_break,
+                metadata=meta,
+            )
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
                 reply_to=reply_to_id,
                 metadata=meta,
+                priority=priority,
             )
             if result.success and result.message_id:
                 self._message_id = str(result.message_id)
@@ -643,14 +736,22 @@ class GatewayStreamConsumer:
         last_message_id: Optional[str] = None
         last_successful_chunk = ""
         sent_any_chunk = False
-        for chunk in chunks:
+        # This is a final response, so always use normal priority
+        meta = dict(self.metadata) if self.metadata else {}
+        priority = _classify_priority(continuation, is_final=True, metadata=meta)
+        
+        for i, chunk in enumerate(chunks):
+            # Last chunk gets is_final=True
+            is_last = (i == len(chunks) - 1)
+            chunk_priority = priority if is_last else "silent"
             # Try sending with one retry on flood-control errors.
             result = None
             for attempt in range(2):
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=chunk,
-                    metadata=self.metadata,
+                    metadata=meta,
+                    priority=chunk_priority,
                 )
                 if result.success:
                     break
@@ -759,10 +860,14 @@ class GatewayStreamConsumer:
         if not text.strip():
             return False
         try:
+            meta = dict(self.metadata) if self.metadata else {}
+            # Commentary is an interim message between tool calls - usually silent
+            priority = _classify_priority(text, is_final=False, is_segment_break=True, metadata=meta)
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
-                metadata=self.metadata,
+                metadata=meta,
+                priority=priority,
             )
             # Note: do NOT set _already_sent = True here.
             # Commentary messages are interim status updates (e.g. "Using browser
@@ -854,7 +959,14 @@ class GatewayStreamConsumer:
         self._final_response_sent = True
         return True
 
-    async def _send_or_edit(self, text: str, *, finalize: bool = False) -> bool:
+    async def _send_or_edit(
+        self, 
+        text: str, 
+        *, 
+        finalize: bool = False,
+        is_final: bool = False,
+        is_segment_break: bool = False,
+    ) -> bool:
         """Send or edit the streaming message.
 
         Returns True if the text was successfully delivered (sent or edited),
@@ -863,6 +975,8 @@ class GatewayStreamConsumer:
 
         ``finalize`` is True when this is the last edit in a streaming
         sequence.
+        ``is_final`` is True when this is the final response.
+        ``is_segment_break`` is True when this is a new segment after tool call.
         """
         # Strip MEDIA: directives so they don't appear as visible text.
         # Media files are delivered as native attachments after the stream
@@ -980,10 +1094,19 @@ class GatewayStreamConsumer:
                     return False
             else:
                 # First message — send new
+                meta = dict(self.metadata) if self.metadata else {}
+                # Classify priority based on message context
+                priority = _classify_priority(
+                    text, 
+                    is_final=is_final, 
+                    is_segment_break=is_segment_break,
+                    metadata=meta,
+                )
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,
-                    metadata=self.metadata,
+                    metadata=meta,
+                    priority=priority,
                 )
                 if result.success:
                     if result.message_id:


### PR DESCRIPTION
## Summary

Adds a priority parameter to platform adapters allowing messages to be sent silently (no notification buzz) or with normal/urgent notification levels.

## Changes

### Platform Adapters
- **base.py**: Add `priority: Literal["silent", "normal", "urgent"]` to abstract `send()` method
- **telegram.py**: Implement priority using `disable_notification` Telegram API parameter
- **discord.py**: Implement priority using `MessageFlags(4096)` for silent messages

### Automatic Classification (stream_consumer.py)
- Add `_classify_priority()` function that analyzes message content and context
- **Silent** (no buzz): Progress updates, "still working", iterations, tool progress, segment breaks
- **Normal** (buzz): Final responses, completions, messages needing user attention
- **Urgent** (buzz): Errors, failures, authentication issues, blocked commands, approval requests

## Motivation

Users receive too many routine notifications (progress updates, iteration counts) when using Hermes in Telegram. This feature allows important messages to still buzz while routine messages arrive silently - all within the same conversation thread.

## Example Behavior

- "Still working on this..." → silent (no buzz)
- "Iteration 3/10..." → silent (no buzz)
- "Task completed!" → normal (buzz)
- "Error: API key invalid" → urgent (buzz)
- "Requires approval for this action" → urgent (buzz)

## Backward Compatibility

- Default priority is "normal" so existing behavior is unchanged
- Priority can be set via parameter or via `metadata["priority"]` for backward compat
