### PR TITLE
fix(gateway/telegram): skip messages that explicitly @mention another agent

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2881,6 +2881,53 @@ class TelegramAdapter(BasePlatformAdapter):
                         return True
         return False
 
+    def _message_targets_other_bot(self, message: Message) -> bool:
+        """Return True when the message explicitly @-mentions another account
+        but does NOT mention this bot.
+
+        In multi-agent group chats with ``require_mention`` disabled every bot
+        would normally respond to every message.  When a message carries an
+        explicit ``@mention`` or ``text_mention`` entity that targets a
+        *different* account, the message is clearly addressed to someone else
+        and should be skipped — regardless of the ``require_mention`` setting.
+        This mirrors the cross-talk guard implemented in the Discord adapter.
+        """
+        if not self._bot:
+            return False
+
+        bot_username = (getattr(self._bot, "username", None) or "").lstrip("@").lower()
+        bot_id = getattr(self._bot, "id", None)
+
+        self_mentioned = False
+        other_mentioned = False
+
+        def _iter_sources():
+            yield getattr(message, "text", None) or "", getattr(message, "entities", None) or []
+            yield getattr(message, "caption", None) or "", getattr(message, "caption_entities", None) or []
+
+        for source_text, entities in _iter_sources():
+            for entity in entities:
+                entity_type = str(getattr(entity, "type", "")).split(".")[-1].lower()
+                if entity_type == "mention" and bot_username:
+                    offset = int(getattr(entity, "offset", -1))
+                    length = int(getattr(entity, "length", 0))
+                    if offset < 0 or length <= 0:
+                        continue
+                    mentioned = source_text[offset:offset + length].lstrip("@").lower()
+                    if mentioned == bot_username:
+                        self_mentioned = True
+                    else:
+                        other_mentioned = True
+                elif entity_type == "text_mention":
+                    user = getattr(entity, "user", None)
+                    if user:
+                        if getattr(user, "id", None) == bot_id:
+                            self_mentioned = True
+                        elif getattr(user, "is_bot", False):
+                            other_mentioned = True
+
+        return other_mentioned and not self_mentioned
+
     def _message_matches_mention_patterns(self, message: Message) -> bool:
         if not self._mention_patterns:
             return False
@@ -2909,6 +2956,10 @@ class TelegramAdapter(BasePlatformAdapter):
         - the bot is @mentioned
         - the text/caption matches a configured regex wake-word pattern
 
+        Messages are skipped when another agent is explicitly @mentioned but
+        this bot is not — preventing cross-talk in multi-agent group chats even
+        when ``require_mention`` is disabled.  See :meth:`_message_targets_other_bot`.
+
         When ``require_mention`` is enabled, slash commands are not given
         special treatment — they must pass the same mention/reply checks
         as any other group message.  Users can still trigger commands via
@@ -2927,6 +2978,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 logger.warning("[%s] Ignoring non-numeric Telegram message_thread_id: %r", self.name, thread_id)
         if str(getattr(getattr(message, "chat", None), "id", "")) in self._telegram_free_response_chats():
             return True
+        if self._message_targets_other_bot(message):
+            return False
         if not self._telegram_require_mention():
             return True
         if self._is_reply_to_bot(message):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2827,76 +2827,27 @@ class TelegramAdapter(BasePlatformAdapter):
         reply_user = getattr(message.reply_to_message, "from_user", None)
         return bool(reply_user and getattr(reply_user, "id", None) == getattr(self._bot, "id", None))
 
-    def _message_mentions_bot(self, message: Message) -> bool:
+    def _resolve_mention_targets(self, message: Message) -> tuple[bool, bool]:
+        """Scan all message entities once and return ``(self_mentioned, other_mentioned)``.
+
+        ``self_mentioned`` is True when this bot is @-mentioned, text_mentioned,
+        or addressed via the ``/cmd@botname`` group-disambiguation form.
+        ``other_mentioned`` is True when any other @-mentioned username, any
+        other text_mentioned bot, or a ``/cmd@other_bot`` form is found.
+
+        Both values may be True simultaneously (e.g. ``@this_bot @other_bot help``).
+
+        Only Telegram-parsed MessageEntity objects are consulted — not raw
+        substring scans — for the same reasons documented in the original
+        mention guard (bug #12545): entities correctly handle @handles inside
+        URLs, code blocks, and quoted text where a regex scan would over-match.
+        """
         if not self._bot:
-            return False
+            return False, False
 
         bot_username = (getattr(self._bot, "username", None) or "").lstrip("@").lower()
         bot_id = getattr(self._bot, "id", None)
         expected = f"@{bot_username}" if bot_username else None
-
-        def _iter_sources():
-            yield getattr(message, "text", None) or "", getattr(message, "entities", None) or []
-            yield getattr(message, "caption", None) or "", getattr(message, "caption_entities", None) or []
-
-        # Telegram parses mentions server-side and emits MessageEntity objects
-        # (type=mention for @username, type=text_mention for @FirstName targeting
-        # a user without a public username). Only those entities are authoritative —
-        # raw substring matches like "foo@hermes_bot.example" are not mentions
-        # (bug #12545). Entities also correctly handle @handles inside URLs, code
-        # blocks, and quoted text, where a regex scan would over-match.
-        for source_text, entities in _iter_sources():
-            for entity in entities:
-                entity_type = str(getattr(entity, "type", "")).split(".")[-1].lower()
-                if entity_type == "mention" and expected:
-                    offset = int(getattr(entity, "offset", -1))
-                    length = int(getattr(entity, "length", 0))
-                    if offset < 0 or length <= 0:
-                        continue
-                    if source_text[offset:offset + length].strip().lower() == expected:
-                        return True
-                elif entity_type == "text_mention":
-                    user = getattr(entity, "user", None)
-                    if user and getattr(user, "id", None) == bot_id:
-                        return True
-                elif entity_type == "bot_command" and expected:
-                    # Telegram's official group-disambiguation form for slash
-                    # commands (``/cmd@botname``) is emitted as a single
-                    # ``bot_command`` entity covering the whole span — there
-                    # is no accompanying ``mention`` entity. Treat it as a
-                    # direct address to this bot when the ``@botname`` suffix
-                    # matches. This is the form Telegram's own command menu
-                    # autocomplete produces in groups, so dropping it at the
-                    # mention gate would break /new, /reset, /help, ... for
-                    # every group that has ``require_mention`` enabled (#15415).
-                    offset = int(getattr(entity, "offset", -1))
-                    length = int(getattr(entity, "length", 0))
-                    if offset < 0 or length <= 0:
-                        continue
-                    command_text = source_text[offset:offset + length]
-                    at_index = command_text.find("@")
-                    if at_index < 0:
-                        continue
-                    if command_text[at_index:].strip().lower() == expected:
-                        return True
-        return False
-
-    def _message_targets_other_bot(self, message: Message) -> bool:
-        """Return True when the message explicitly @-mentions another account
-        but does NOT mention this bot.
-
-        In multi-agent group chats with ``require_mention`` disabled every bot
-        would normally respond to every message.  When a message carries an
-        explicit ``@mention`` or ``text_mention`` entity that targets a
-        *different* account, the message is clearly addressed to someone else
-        and should be skipped — regardless of the ``require_mention`` setting.
-        This mirrors the cross-talk guard implemented in the Discord adapter.
-        """
-        if not self._bot:
-            return False
-
-        bot_username = (getattr(self._bot, "username", None) or "").lstrip("@").lower()
-        bot_id = getattr(self._bot, "id", None)
 
         self_mentioned = False
         other_mentioned = False
@@ -2925,7 +2876,55 @@ class TelegramAdapter(BasePlatformAdapter):
                             self_mentioned = True
                         elif getattr(user, "is_bot", False):
                             other_mentioned = True
+                elif entity_type == "bot_command" and expected:
+                    # Telegram's official group-disambiguation form for slash
+                    # commands (``/cmd@botname``) is emitted as a single
+                    # ``bot_command`` entity covering the whole span — there
+                    # is no accompanying ``mention`` entity. Treat it as a
+                    # direct address to this bot when the ``@botname`` suffix
+                    # matches. This is the form Telegram's own command menu
+                    # autocomplete produces in groups, so dropping it at the
+                    # mention gate would break /new, /reset, /help, ... for
+                    # every group that has ``require_mention`` enabled (#15415).
+                    offset = int(getattr(entity, "offset", -1))
+                    length = int(getattr(entity, "length", 0))
+                    if offset < 0 or length <= 0:
+                        continue
+                    command_text = source_text[offset:offset + length]
+                    at_index = command_text.find("@")
+                    if at_index < 0:
+                        continue
+                    suffix = command_text[at_index:].strip().lower()
+                    if suffix == expected:
+                        self_mentioned = True
+                    else:
+                        other_mentioned = True
 
+        return self_mentioned, other_mentioned
+
+    def _message_mentions_bot(self, message: Message) -> bool:
+        """Return True if this bot is @-mentioned, text_mentioned, or addressed
+        via the ``/cmd@botname`` group-disambiguation form.
+
+        Delegates entity scanning to :meth:`_resolve_mention_targets`.
+        """
+        self_mentioned, _ = self._resolve_mention_targets(message)
+        return self_mentioned
+
+    def _message_targets_other_bot(self, message: Message) -> bool:
+        """Return True when the message explicitly @-mentions another account
+        but does NOT mention this bot.
+
+        In multi-agent group chats with ``require_mention`` disabled every bot
+        would normally respond to every message.  When a message carries an
+        explicit ``@mention`` or ``text_mention`` entity that targets a
+        *different* account, the message is clearly addressed to someone else
+        and should be skipped — regardless of the ``require_mention`` setting.
+        This mirrors the cross-talk guard implemented in the Discord adapter.
+
+        Delegates entity scanning to :meth:`_resolve_mention_targets`.
+        """
+        self_mentioned, other_mentioned = self._resolve_mention_targets(message)
         return other_mentioned and not self_mentioned
 
     def _message_matches_mention_patterns(self, message: Message) -> bool:


### PR DESCRIPTION
## Summary

- Adds `_message_targets_other_bot()` to the Telegram adapter, which scans `MessageEntity` objects for `@mention` and `text_mention` entities directed at a different account
- Wires it into `_should_process_message()` so that if another agent is explicitly @mentioned but this bot is not, the message is skipped early — regardless of the `require_mention` setting
- Updates the `_should_process_message` docstring to document the new cross-talk guard
- Mirrors the equivalent guard already present in the Discord adapter

## Root cause

`_should_process_message()` hit `return True` immediately when `require_mention: false`, before any check for whether the message was addressed to a *different* bot. In a multi-agent group this caused every bot to respond whenever any one of them was @mentioned.

## Test plan

- [ ] Single-bot group with `require_mention: false` — bot still responds to all messages with no @mention
- [ ] Multi-bot group: `@other_bot do this` — only `other_bot` responds, not this bot
- [ ] Multi-bot group: `@this_bot do this` — this bot responds normally
- [ ] Multi-bot group: `@this_bot @other_bot help` — both bots respond (both mentioned)
- [ ] DM to bot — unaffected, always responds

Fixes #20373

🤖 Generated with [Claude Code](https://claude.com/claude-code)