### PR TITLE
fix: harden install.sh against inherited Python env leakage

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2588,9 +2588,12 @@ class HermesCLI:
             elapsed = time.monotonic() - t0
             if elapsed >= 60:
                 _m, _s = int(elapsed // 60), int(elapsed % 60)
-                elapsed_str = f"{_m}m {_s}s"
+                # Fixed-width timer to avoid status-line wrap jitter while
+                # scrolling/repainting (e.g. 01m05s, 12m09s).
+                elapsed_str = f"{_m:02d}m{_s:02d}s"
             else:
-                elapsed_str = f"{elapsed:.1f}s"
+                # Keep width stable before the 60s rollover as well.
+                elapsed_str = f"{elapsed:5.1f}s"
             return f"  {txt}  ({elapsed_str})"
         return f"  {txt}"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,6 +15,19 @@
 
 set -e
 
+# Guard against environment leakage when the installer is launched from another
+# Python-driven tool session (e.g. Hermes terminal tool). A pre-set PYTHONPATH
+# can force pip/entrypoints to import a different checkout than the one being
+# installed, which makes fresh installs appear broken or stale.
+if [ -n "${PYTHONPATH:-}" ]; then
+    echo "⚠ Ignoring inherited PYTHONPATH during install to avoid module shadowing"
+    unset PYTHONPATH
+fi
+if [ -n "${PYTHONHOME:-}" ]; then
+    echo "⚠ Ignoring inherited PYTHONHOME during install"
+    unset PYTHONHOME
+fi
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -1047,9 +1060,17 @@ setup_path() {
     command_link_display_dir="$(get_command_link_display_dir)"
 
     # Create a user-facing shim for the hermes command.
+    # We intentionally clear PYTHONPATH/PYTHONHOME here so inherited env vars
+    # can't make this launcher import modules from another checkout.
     mkdir -p "$command_link_dir"
-    ln -sf "$HERMES_BIN" "$command_link_dir/hermes"
-    log_success "Symlinked hermes → $command_link_display_dir/hermes"
+    cat > "$command_link_dir/hermes" <<EOF
+#!/usr/bin/env bash
+unset PYTHONPATH
+unset PYTHONHOME
+exec "$HERMES_BIN" "\$@"
+EOF
+    chmod +x "$command_link_dir/hermes"
+    log_success "Installed hermes launcher → $command_link_display_dir/hermes"
 
     if [ "$DISTRO" = "termux" ]; then
         export PATH="$command_link_dir:$PATH"

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -243,6 +244,24 @@ class TestCLIStatusBar:
         cli_obj._tool_start_time = 0
 
         assert cli_obj._spinner_widget_height(width=64) == 2
+
+    def test_spinner_elapsed_format_is_fixed_width_to_reduce_wrap_jitter(self):
+        cli_obj = _make_cli()
+        cli_obj._spinner_text = "running tool"
+
+        # <60s path
+        cli_obj._tool_start_time = time.monotonic() - 9.2
+        short = cli_obj._render_spinner_text()
+
+        # >=60s path
+        cli_obj._tool_start_time = time.monotonic() - 65.2
+        long = cli_obj._render_spinner_text()
+
+        short_elapsed = short.split("(", 1)[1].rstrip(")")
+        long_elapsed = long.split("(", 1)[1].rstrip(")")
+
+        assert len(short_elapsed) == len(long_elapsed)
+        assert "m" in long_elapsed and "s" in long_elapsed
 
     def test_voice_status_bar_compacts_on_narrow_terminals(self):
         cli_obj = _make_cli()

--- a/tests/test_install_sh_pythonpath_sanitization.py
+++ b/tests/test_install_sh_pythonpath_sanitization.py
@@ -1,0 +1,30 @@
+"""Regression tests for install.sh Python environment sanitization.
+
+When install.sh is launched from another Python-driven tool session, inherited
+PYTHONPATH/PYTHONHOME can shadow the freshly installed checkout. The installer
+must sanitize those vars both during installation and at runtime launch.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def test_install_script_unsets_pythonpath_and_pythonhome_early() -> None:
+    text = INSTALL_SH.read_text()
+
+    # During install, inherited Python env must be sanitized before pip/venv use.
+    assert 'unset PYTHONPATH' in text
+    assert 'unset PYTHONHOME' in text
+
+
+def test_hermes_launcher_wrapper_clears_python_env_before_exec() -> None:
+    text = INSTALL_SH.read_text()
+
+    # Wrapper should clear env and forward args untouched to the venv entrypoint.
+    assert 'cat > "$command_link_dir/hermes" <<EOF' in text
+    assert 'unset PYTHONPATH' in text
+    assert 'unset PYTHONHOME' in text
+    assert 'exec "$HERMES_BIN" "\\$@"' in text

--- a/ui-tui/src/__tests__/statusBarTicker.test.ts
+++ b/ui-tui/src/__tests__/statusBarTicker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { padVerb, VERB_PAD_LEN } from '../components/appChrome.js'
+import { DURATION_PAD_LEN, padTickerDuration, padVerb, VERB_PAD_LEN } from '../components/appChrome.js'
 import { VERBS } from '../content/verbs.js'
 
 describe('FaceTicker verb padding', () => {
@@ -14,5 +14,14 @@ describe('FaceTicker verb padding', () => {
     for (const verb of VERBS) {
       expect(padVerb(verb).startsWith(`${verb}…`)).toBe(true)
     }
+  })
+})
+
+describe('FaceTicker duration padding', () => {
+  it('keeps elapsed segment width stable across second/minute boundaries', () => {
+    const samples = [9000, 10000, 59000, 60000, 61000, 3599000]
+    const lens = samples.map(ms => padTickerDuration(ms).length)
+
+    expect(new Set(lens)).toEqual(new Set([DURATION_PAD_LEN]))
   })
 })

--- a/ui-tui/src/__tests__/statusBarTicker.test.ts
+++ b/ui-tui/src/__tests__/statusBarTicker.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { padVerb, VERB_PAD_LEN } from '../components/appChrome.js'
+import { VERBS } from '../content/verbs.js'
+
+describe('FaceTicker verb padding', () => {
+  it('pads every verb to the same width', () => {
+    for (const verb of VERBS) {
+      expect(padVerb(verb)).toHaveLength(VERB_PAD_LEN)
+    }
+  })
+
+  it('keeps trailing ellipsis attached', () => {
+    for (const verb of VERBS) {
+      expect(padVerb(verb).startsWith(`${verb}…`)).toBe(true)
+    }
+  })
+})

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -23,7 +23,9 @@ const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
 // Keep verb segment width stable so status-bar content to the right doesn't
 // jitter when the ticker rotates between short/long verbs.
 export const VERB_PAD_LEN = VERBS.reduce((max, v) => Math.max(max, v.length), 0) + 1 // + ellipsis
+export const DURATION_PAD_LEN = 7 // e.g. "  9s", "1m 05s", "59m 59s"
 export const padVerb = (verb: string) => `${verb}…`.padEnd(VERB_PAD_LEN, ' ')
+export const padTickerDuration = (ms: number) => fmtDuration(ms).padStart(DURATION_PAD_LEN, ' ')
 
 // Compact alternates for the `emoji` and `ascii` indicator styles.
 // Each entry is a fixed-width (display-width) glyph.
@@ -108,7 +110,7 @@ function FaceTicker({ color, startedAt }: { color: string; startedAt?: null | nu
   const { frame } = renderIndicator(style, tick)
   const verb = VERBS[verbTick % VERBS.length] ?? ''
   const verbSegment = showVerb ? ` ${padVerb(verb)}` : ''
-  const durationSegment = startedAt ? `· ${fmtDuration(now - startedAt)}` : ''
+  const durationSegment = startedAt ? `· ${padTickerDuration(now - startedAt)}` : ''
 
   return (
     <Text color={color}>

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -20,6 +20,11 @@ import type { Msg, Usage } from '../types.js'
 const FACE_TICK_MS = 2500
 const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
 
+// Keep verb segment width stable so status-bar content to the right doesn't
+// jitter when the ticker rotates between short/long verbs.
+export const VERB_PAD_LEN = VERBS.reduce((max, v) => Math.max(max, v.length), 0) + 1 // + ellipsis
+export const padVerb = (verb: string) => `${verb}…`.padEnd(VERB_PAD_LEN, ' ')
+
 // Compact alternates for the `emoji` and `ascii` indicator styles.
 // Each entry is a fixed-width (display-width) glyph.
 const EMOJI_FRAMES = ['⚕ ', '🌀', '🤔', '✨', '🍵', '🔮']
@@ -102,8 +107,8 @@ function FaceTicker({ color, startedAt }: { color: string; startedAt?: null | nu
 
   const { frame } = renderIndicator(style, tick)
   const verb = VERBS[verbTick % VERBS.length] ?? ''
-  const verbSegment = showVerb ? ` ${verb}…` : ''
-  const durationSegment = startedAt ? ` · ${fmtDuration(now - startedAt)}` : ''
+  const verbSegment = showVerb ? ` ${padVerb(verb)}` : ''
+  const durationSegment = startedAt ? `· ${fmtDuration(now - startedAt)}` : ''
 
   return (
     <Text color={color}>


### PR DESCRIPTION
## What does this PR do?

Fixes a Termux install/run reliability bug caused by inherited Python environment variables.

When `scripts/install.sh` is launched from a Python-driven session, such as Hermes terminal tooling, inherited `PYTHONPATH` or `PYTHONHOME` values can shadow the freshly installed checkout. This can make a fresh install appear stale or broken because Python may import modules from a different Hermes checkout.

This PR hardens the installer by sanitizing inherited Python environment variables at install time and by replacing the `hermes` symlink with a small launcher wrapper that clears those variables before executing the venv entrypoint.

This approach is minimal, backward-compatible, and prevents module shadowing both during installation and at runtime launch.

## Related Issue

Fixes #

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `scripts/install.sh`:
  - Unset inherited `PYTHONPATH` and `PYTHONHOME` near script startup.
  - Replaced the direct `ln -sf "$HERMES_BIN"` symlink with a launcher wrapper script.
  - The launcher wrapper:
    - unsets `PYTHONPATH`
    - unsets `PYTHONHOME`
    - execs the intended `HERMES_BIN` with forwarded args
- Added regression tests in `tests/test_install_sh_pythonpath_sanitization.py`:
  - verifies install-time Python environment sanitization is present
  - verifies the launcher wrapper sanitizes the environment before exec

## How to Test

1. Run syntax and focused regression tests:

   ```bash
   bash -n scripts/install.sh
   scripts/run_tests.sh tests/test_install_sh_setup_wizard_tty_probe.py tests/test_install_sh_pythonpath_sanitization.py -q