### PR TITLE
fix(web): bridge Tailwind font-sans/mono tokens to theme variables

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -108,6 +108,12 @@ code, kbd, pre, samp, .font-mono, .font-mono-ui {
    all proportionally in Tailwind v4. */
 @theme inline {
   --spacing: calc(0.25rem * var(--theme-spacing-mul, 1));
+
+  /* Bridge Tailwind's font tokens to Hermes theme variables so that both
+     inherited font-family (html/body) and explicit font-sans/mono classes
+     render the active theme's typeface. Fixes #20380. */
+  --font-sans: var(--theme-font-sans);
+  --font-mono: var(--theme-font-mono);
 }
 
 #root {


### PR DESCRIPTION
Fixes #20380.

**Bug:** When a Hermes theme sets a custom `--theme-font-sans` or `--theme-font-mono` via `ThemeProvider.applyTheme()`, Tailwind's `font-sans` / `font-mono` utility classes bypassed them entirely because Tailwind v4 resolves its own `--font-sans` / `--font-mono` tokens independently.

**Fix:** Add `--font-sans` and `--font-mono` to the existing `@theme inline {} block` in `web/src/index.css`, remapping Tailwind's tokens to follow `--theme-font-sans` / `--theme-font-mono`. Both inherited `font-family` (on `html`/`body`) and explicit `font-sans` class elements now render the correct theme typeface.