### PR TITLE
feat(arcee): Trinity Large Thinking temperature + compression overrides

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -196,6 +196,12 @@ def _is_kimi_model(model: Optional[str]) -> bool:
     return bare.startswith("kimi-") or bare == "kimi"
 
 
+def _is_arcee_trinity_thinking(model: Optional[str]) -> bool:
+    """True for Arcee Trinity Large Thinking (direct or via OpenRouter)."""
+    bare = (model or "").strip().lower().rsplit("/", 1)[-1]
+    return bare == "trinity-large-thinking"
+
+
 def _fixed_temperature_for_model(
     model: Optional[str],
     base_url: Optional[str] = None,
@@ -213,6 +219,23 @@ def _fixed_temperature_for_model(
     if _is_kimi_model(model):
         logger.debug("Omitting temperature for Kimi model %r (server-managed)", model)
         return OMIT_TEMPERATURE
+    if _is_arcee_trinity_thinking(model):
+        return 0.5
+    return None
+
+
+def _compression_threshold_for_model(model: Optional[str]) -> Optional[float]:
+    """Return a context-compression threshold override for specific models.
+
+    The threshold is the fraction of the model's context window that must be
+    consumed before Hermes triggers summarization.  Higher values delay
+    compression and preserve more raw context.
+
+    Returns a float in (0, 1] to override the global ``compression.threshold``
+    config value, or ``None`` to leave the user's config value unchanged.
+    """
+    if _is_arcee_trinity_thinking(model):
+        return 0.75
     return None
 
 # Default auxiliary models for direct API-key providers (cheap/fast for side tasks)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1868,6 +1868,13 @@ class AIAgent:
         if not isinstance(_compression_cfg, dict):
             _compression_cfg = {}
         compression_threshold = float(_compression_cfg.get("threshold", 0.50))
+        try:
+            from agent.auxiliary_client import _compression_threshold_for_model as _cthresh_fn
+            _model_cthresh = _cthresh_fn(self.model)
+            if _model_cthresh is not None:
+                compression_threshold = _model_cthresh
+        except Exception:
+            pass
         compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in ("true", "1", "yes")
         compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
         compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -102,6 +102,7 @@ AUTHOR_MAP = {
     "50561768+zhanggttry@users.noreply.github.com": "zhanggttry",
     "formulahendry@gmail.com": "formulahendry",
     "93757150+bogerman1@users.noreply.github.com": "bogerman1",
+    "132852777+rob-maron@users.noreply.github.com": "rob-maron",
     # Matrix parity salvage batch (April 2026)
     "sr@samirusani": "samrusani",
     "angelclaw@AngelMacBook.local": "angel12",

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -1,0 +1,76 @@
+"""Tests for Arcee Trinity Large Thinking per-model overrides.
+
+Arcee Trinity Large Thinking is a reasoning model that wants:
+- Fixed temperature=0.5 (vs the global default)
+- Compression threshold=0.75 (delay compression to preserve reasoning context)
+
+The helpers must match the bare model name, including when it arrives via
+OpenRouter as ``arcee-ai/trinity-large-thinking``, but must NOT hit sibling
+Arcee models like trinity-large-preview or trinity-mini.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.auxiliary_client import (
+    _compression_threshold_for_model,
+    _fixed_temperature_for_model,
+    _is_arcee_trinity_thinking,
+)
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "trinity-large-thinking",
+        "arcee-ai/trinity-large-thinking",
+        "Arcee-AI/Trinity-Large-Thinking",  # case-insensitive
+        "  trinity-large-thinking  ",  # whitespace tolerant
+    ],
+)
+def test_is_arcee_trinity_thinking_matches(model: str) -> None:
+    assert _is_arcee_trinity_thinking(model) is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        None,
+        "",
+        "trinity-large-preview",
+        "arcee-ai/trinity-large-preview:free",
+        "trinity-mini",
+        "arcee-ai/trinity-mini",
+        "trinity-large",  # prefix-only must not match
+        "claude-sonnet-4.6",
+        "gpt-5.4",
+    ],
+)
+def test_is_arcee_trinity_thinking_rejects_non_matches(model) -> None:
+    assert _is_arcee_trinity_thinking(model) is False
+
+
+def test_fixed_temperature_for_trinity_thinking() -> None:
+    assert _fixed_temperature_for_model("trinity-large-thinking") == 0.5
+    assert _fixed_temperature_for_model("arcee-ai/trinity-large-thinking") == 0.5
+
+
+def test_fixed_temperature_sibling_arcee_models_unaffected() -> None:
+    # Preview and mini do not pin temperature — caller chooses its default.
+    assert _fixed_temperature_for_model("trinity-large-preview") is None
+    assert _fixed_temperature_for_model("trinity-mini") is None
+
+
+def test_compression_threshold_for_trinity_thinking() -> None:
+    assert _compression_threshold_for_model("trinity-large-thinking") == 0.75
+    assert _compression_threshold_for_model("arcee-ai/trinity-large-thinking") == 0.75
+
+
+def test_compression_threshold_default_none_for_other_models() -> None:
+    # None means "leave the user's config value unchanged".
+    assert _compression_threshold_for_model(None) is None
+    assert _compression_threshold_for_model("") is None
+    assert _compression_threshold_for_model("trinity-large-preview") is None
+    assert _compression_threshold_for_model("claude-sonnet-4.6") is None
+    assert _compression_threshold_for_model("kimi-k2") is None


### PR DESCRIPTION
Salvage of #20344 by @rob-maron onto current main.

## Summary
Trinity Large Thinking (Arcee reasoning model) now pins temperature to 0.5 and bumps the compression threshold to 0.75, so more raw reasoning context survives before summarization kicks in.

## Changes
- `agent/auxiliary_client.py`: `_is_arcee_trinity_thinking()`, temperature override wired into existing `_fixed_temperature_for_model()` (auto-fans out to transports, trajectory compressor, mini_swe_runner, and run_agent init — no new wiring needed). New `_compression_threshold_for_model()` helper.
- `run_agent.py`: 6-line plug-in right after `compression.threshold` is read from config, wrapped in try/except so import failures stay non-fatal.
- `scripts/release.py`: AUTHOR_MAP entry for rob-maron.
- `tests/agent/test_arcee_trinity_overrides.py`: 17 parametrized tests — bare + OpenRouter-slugged + case/whitespace variants, plus sibling-model negatives (`trinity-large-preview`, `trinity-mini`) to confirm overrides don't leak.

## Validation
`scripts/run_tests.sh tests/agent/test_arcee_trinity_overrides.py` → 17 passed.

Closes #20344. Original commit authored by @rob-maron preserved via rebase-merge.