### PR TITLE
feat(i18n): add Turkish (tr) locale

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -25,7 +25,7 @@ Language resolution order:
     3. ``display.language`` from config.yaml
     4. ``"en"`` (baseline)
 
-Supported languages: en, zh, ja, de, es, fr, uk.  Unknown values fall back to en.
+Supported languages: en, zh, ja, de, es, fr, tr, uk.  Unknown values fall back to en.
 """
 
 from __future__ import annotations
@@ -39,7 +39,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "ja", "de", "es", "fr", "uk")
+SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "ja", "de", "es", "fr", "tr", "uk")
 DEFAULT_LANGUAGE = "en"
 
 # Accept a few natural aliases so users who type "chinese" / "zh-CN" / "jp"
@@ -52,6 +52,7 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "spanish": "es", "español": "es", "espanol": "es", "es-es": "es", "es-mx": "es",
     "french": "fr", "français": "fr", "france": "fr", "fr-fr": "fr", "fr-be": "fr", "fr-ca": "fr", "fr-ch": "fr",
     "ukrainian": "uk", "ukrainisch": "uk", "українська": "uk", "uk-ua": "uk", "ua": "uk",
+    "turkish": "tr", "türkçe": "tr", "tr-tr": "tr",
 }
 
 _catalog_cache: dict[str, dict[str, str]] = {}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -784,7 +784,7 @@ DEFAULT_CONFIG = {
         # UI language for static user-facing messages (approval prompts, a
         # handful of gateway slash-command replies).  Does NOT affect agent
         # responses, log lines, tool outputs, or slash-command descriptions.
-        # Supported: en, zh, ja, de, es, fr, uk.  Unknown values fall back to en.
+        # Supported: en, zh, ja, de, es, fr, tr, uk.  Unknown values fall back to en.
         "language": "en",
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -7,7 +7,7 @@
 #
 # Keys are dotted paths; nesting below is purely for readability.  Values may
 # contain {placeholder} tokens for str.format substitution.  When adding a
-# new key, add it to EVERY locale file (en/zh/ja/de/es/fr/uk) in the same commit --
+# new key, add it to EVERY locale file (en/zh/ja/de/es/fr/tr/uk) in the same commit --
 # tests/agent/test_i18n.py asserts catalog parity.
 
 approval:

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -1,0 +1,24 @@
+# Hermes statik mesaj katalogu -- Turkce
+# See locales/en.yaml for the source of truth; keep keys in sync.
+
+approval:
+  dangerous_header: "⚠️  TEHLİKELİ KOMUT: {description}"
+  choose_long:     "      [b]ir kez  |  [o]turum  |  [h]er zaman  |  [r]eddet"
+  choose_short:    "      [b]ir kez  |  [o]turum  |  [r]eddet"
+  prompt_long:     "      Seçim [b/o/h/R]: "
+  prompt_short:    "      Seçim [b/o/R]: "
+  timeout:         "      ⏱ Zaman aşımı — komut reddedildi"
+  allowed_once:    "      ✓ Bir kez izin verildi"
+  allowed_session: "      ✓ Bu oturum için izin verildi"
+  allowed_always:  "      ✓ Kalıcı izin listesine eklendi"
+  denied:          "      ✗ Reddedildi"
+  cancelled:       "      ✗ İptal edildi"
+  blocklist_message: "Bu komut koşulsuz engelleme listesinde ve onaylanamaz."
+
+gateway:
+  approval_expired: "⚠️ Onay süresi doldu (ajan artık beklemiyor). Ajanın tekrar denemesini isteyin."
+  draining:         "⏳ Yeniden başlatmadan önce {count} aktif ajan bekleniyor..."
+  goal_cleared:     "✓ Hedef temizlendi."
+  no_active_goal:   "Aktif hedef yok."
+  config_read_failed: "⚠️ config.yaml okunamadı: {error}"
+  config_save_failed: "⚠️ Yapılandırma kaydedilemedi: {error}"

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -92,6 +92,9 @@ def test_normalize_lang_accepts_aliases():
     assert i18n._normalize_lang("Ukrainian") == "uk"
     assert i18n._normalize_lang("uk-UA") == "uk"
     assert i18n._normalize_lang("ua") == "uk"
+    assert i18n._normalize_lang("Turkish") == "tr"
+    assert i18n._normalize_lang("tr-TR") == "tr"
+    assert i18n._normalize_lang("türkçe") == "tr"
 
 
 def test_normalize_lang_unknown_falls_back():
@@ -130,6 +133,7 @@ def test_t_explicit_lang():
     assert i18n.t("approval.denied", lang="en").endswith("Denied")
     assert i18n.t("approval.denied", lang="zh").endswith("已拒绝")
     assert i18n.t("approval.denied", lang="uk").endswith("Відхилено")
+    assert i18n.t("approval.denied", lang="tr").endswith("Reddedildi")
 
 
 def test_t_formats_placeholders():

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1167,14 +1167,14 @@ display:
   show_cost: false        # Show estimated $ cost in the CLI status bar
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
   runtime_metadata_footer: false  # Gateway: append a runtime-context footer to final replies
-  language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | ja | de | es | fr | uk
+  language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | ja | de | es | fr | tr | uk
 ```
 
 ### UI language for static messages
 
 The `display.language` setting translates a small set of static user-facing messages — the CLI approval prompt, a handful of gateway slash-command replies (e.g. restart-drain notices, "approval expired", "goal cleared"). It does **not** translate agent responses, log lines, tool output, error tracebacks, or slash-command descriptions — those stay in English. If you want the agent itself to reply in another language, just tell it in your prompt or system message.
 
-Supported values: `en` (default), `zh` (Simplified Chinese), `ja` (Japanese), `de` (German), `es` (Spanish), `fr` (French), `uk` (Ukrainian). Unknown values fall back to English.
+Supported values: `en` (default), `zh` (Simplified Chinese), `ja` (Japanese), `de` (German), `es` (Spanish), `fr` (French), `tr` (Turkish), `uk` (Ukrainian). Unknown values fall back to English.
 
 You can also set this per-session with the `HERMES_LANGUAGE` env var, which overrides the config value.
 


### PR DESCRIPTION
Salvages #20306 (@etherman-os) onto current main.

## Summary
Adds Turkish (`tr`) as the 8th supported UI locale alongside en/zh/ja/de/es/fr/uk. Catalog parity verified (18 keys each).

## Changes
- `locales/tr.yaml`: new catalog
- `agent/i18n.py`: add `tr` to `SUPPORTED_LANGUAGES` + aliases (`turkish`, `türkçe`, `tr-tr`)
- `hermes_cli/config.py`: update supported-language comment
- `tests/agent/test_i18n.py`: cover tr alias + translation round-trip
- `website/docs/user-guide/configuration.md`: document `tr`

## Salvage notes
The original PR predated the French and Ukrainian locales landing, so it regressed both `fr` and `uk` out of `SUPPORTED_LANGUAGES` / docs / config comments / test assertions. Resolved conflicts by keeping all three (`fr`, `tr`, `uk`). Skipped 5 small fix-up commits from the author that had been iterating on alias capitalization — the final lowercase form is what my conflict resolution kept (matches the existing file convention).

Credit: @etherman-os (original authorship preserved on both feature commits).

## Validation
- `tests/agent/test_i18n.py`: 27/27 passed
- E2E: all 8 locale catalogs load cleanly; `t('approval.denied', lang='tr')` → `✗ Reddedildi`; fr/uk still render correctly; case-insensitive aliases (`Turkish`, `TÜRKÇE`, `tr-TR`) all normalize to `tr`