### PR TITLE
docs: document custom model aliases for /model command

### DIFF
--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -47,7 +47,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | Command | Description |
 |---------|-------------|
 | `/config` | Show current configuration |
-| `/model [model-name]` | Show or change the current model. Supports: `/model claude-sonnet-4`, `/model provider:model` (switch providers), `/model custom:model` (custom endpoint), `/model custom:name:model` (named custom provider), `/model custom` (auto-detect from endpoint). Use `--global` to persist the change to config.yaml. **Note:** `/model` can only switch between already-configured providers. To add a new provider, exit the session and run `hermes model` from your terminal. |
+| `/model [model-name]` | Show or change the current model. Supports: `/model claude-sonnet-4`, `/model provider:model` (switch providers), `/model custom:model` (custom endpoint), `/model custom:name:model` (named custom provider), `/model custom` (auto-detect from endpoint), and user-defined aliases (`/model fav`, `/model grok` — see [Custom model aliases](#custom-model-aliases)). Use `--global` to persist the change to config.yaml. **Note:** `/model` can only switch between already-configured providers. To add a new provider, exit the session and run `hermes model` from your terminal. |
 | `/personality` | Set a predefined personality |
 | `/verbose` | Cycle tool progress display: off → new → all → verbose. Can be [enabled for messaging](#notes) via config. |
 | `/fast [normal\|fast\|status]` | Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode. Options: `normal`, `fast`, `status`. |
@@ -124,6 +124,44 @@ Then type `/status`, `/deploy`, or `/inbox` in the CLI or a messaging platform. 
 
 String-only prompt shortcuts are not supported as quick commands. Put longer reusable prompts in a skill, or use `type: alias` to point at an existing slash command.
 
+### Custom model aliases
+
+Define your own short names for models you use often, then reach them with `/model <alias>` in the CLI or any messaging platform. Aliases work identically in both, on session-only (default) and `--global` switches.
+
+Two config formats are supported:
+
+**Full form** — pin an exact model, provider, and optionally a base URL. Put this in `~/.hermes/config.yaml`:
+
+```yaml
+model_aliases:
+  fav:
+    model: claude-sonnet-4.6
+    provider: anthropic
+  grok:
+    model: grok-4
+    provider: x-ai
+  ollama-qwen:
+    model: qwen3-coder:30b
+    provider: custom
+    base_url: http://localhost:11434/v1
+```
+
+**Short form** — `provider/model` in one string. Set from the shell without editing YAML:
+
+```bash
+hermes config set model.aliases.fav anthropic/claude-opus-4.6
+hermes config set model.aliases.grok x-ai/grok-4
+```
+
+Then in chat:
+
+```
+/model fav            # session-only
+/model grok --global  # also persists current-model change to config.yaml
+```
+
+User aliases take precedence over built-in short names, so naming an alias `sonnet`, `kimi`, `opus`, etc. will shadow the built-in. Alias names are case-insensitive.
+
 ### Alias Resolution
 
 Commands support prefix matching: typing `/h` resolves to `/help`, `/mod` resolves to `/model`. When a prefix is ambiguous (matches multiple commands), the first match in registry order wins. Full command names and registered aliases always take priority over prefix matches.
@@ -138,7 +176,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/reset` | Reset conversation history. |
 | `/status` | Show session info. |
 | `/stop` | Kill all running background processes and interrupt the running agent. |
-| `/model [provider:model]` | Show or change the model. Supports provider switches (`/model zai:glm-5`), custom endpoints (`/model custom:model`), named custom providers (`/model custom:local:qwen`), and auto-detect (`/model custom`). Use `--global` to persist the change to config.yaml. **Note:** `/model` can only switch between already-configured providers. To add a new provider or set up API keys, use `hermes model` from your terminal (outside the chat session). |
+| `/model [provider:model]` | Show or change the model. Supports provider switches (`/model zai:glm-5`), custom endpoints (`/model custom:model`), named custom providers (`/model custom:local:qwen`), auto-detect (`/model custom`), and user-defined aliases (`/model fav`, `/model grok` — see [Custom model aliases](#custom-model-aliases)). Use `--global` to persist the change to config.yaml. **Note:** `/model` can only switch between already-configured providers. To add a new provider or set up API keys, use `hermes model` from your terminal (outside the chat session). |
 | `/personality [name]` | Set a personality overlay for the session. |
 | `/fast [normal\|fast\|status]` | Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode. |
 | `/retry` | Retry the last message. |

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -161,6 +161,30 @@ Inside any `hermes chat` session:
 
 `--global` does the same thing the dashboard's **Change** button does, plus it switches the running session in-place.
 
+### Custom aliases
+
+Define your own short names for models you reach for often, then use `/model <alias>` in the CLI or any messaging platform:
+
+```yaml
+# ~/.hermes/config.yaml
+model_aliases:
+  fav:
+    model: claude-sonnet-4.6
+    provider: anthropic
+  grok:
+    model: grok-4
+    provider: x-ai
+```
+
+Or from the shell (short form, `provider/model`):
+
+```bash
+hermes config set model.aliases.fav anthropic/claude-opus-4.6
+hermes config set model.aliases.grok x-ai/grok-4
+```
+
+Then `/model fav` or `/model grok` in chat. User aliases shadow built-in short names (`sonnet`, `kimi`, `opus`, etc.). See [Custom model aliases](/docs/reference/slash-commands#custom-model-aliases) for the full reference.
+
 ### `hermes model` subcommand
 
 ```bash


### PR DESCRIPTION
## Summary
User-defined `/model` aliases work today but are undocumented. This PR documents them.

Flagged by @weehowe on Twitter — he asked for user-definable aliases (`/model fav`, `/model grok`, etc.), not realizing `config.yaml model_aliases:` and `hermes config set model.aliases.<name>` already handle this end-to-end.

## Changes
- `website/docs/reference/slash-commands.md`: new `### Custom model aliases` subsection with both YAML formats (full-form dict + short-form `provider/model` string) and the `hermes config set` shell form; cross-linked from the two `/model` table rows (CLI + gateway).
- `website/docs/user-guide/configuring-models.md`: shorter `### Custom aliases` subsection under "Alternative methods" linking back to the reference.

## Validation
E2E verified in the worktree with `_ensure_direct_aliases()` + `resolve_alias()` using both YAML formats in an isolated `HERMES_HOME`:

| Input | Resolved |
|---|---|
| `/model fav` | `('anthropic', 'claude-opus-4.6', 'fav')` |
| `/model grok4` | `('x-ai', 'grok-4', 'grok4')` |
| `/model myclaude` | `('anthropic', 'claude-sonnet-4.6', 'myclaude')` |
| `/model sonnet` (user-shadowed) | `('anthropic', 'claude-sonnet-4.6', 'sonnet')` — user alias wins over built-in |
| `/model opus` (no user alias) | built-in `('openrouter', 'anthropic/claude-opus-4.7', 'opus')` |

No code change.