### PR TITLE
fix: harden Discord first voice transcription

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -17,6 +17,7 @@ import subprocess
 import tempfile
 import threading
 import time
+import wave
 from collections import defaultdict
 from typing import Callable, Dict, List, Optional, Any, Tuple
 
@@ -24,6 +25,18 @@ logger = logging.getLogger(__name__)
 
 VALID_THREAD_AUTO_ARCHIVE_MINUTES = {60, 1440, 4320, 10080}
 _DISCORD_COMMAND_SYNC_POLICIES = {"safe", "bulk", "off"}
+
+
+def _float_env(name: str, default: float) -> float:
+    """Parse a float environment variable without breaking module import."""
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; using default %.2f", name, raw, default)
+        return default
 
 try:
     import discord
@@ -144,7 +157,7 @@ class VoiceReceiver:
 
         # SSRC -> user_id mapping (populated from SPEAKING events)
         self._ssrc_to_user: Dict[int, int] = {}
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
 
         # Per-user audio buffers
         self._buffers: Dict[int, bytearray] = defaultdict(bytearray)
@@ -346,6 +359,13 @@ class VoiceReceiver:
         if self._dave_session:
             with self._lock:
                 user_id = self._ssrc_to_user.get(ssrc, 0)
+            if not user_id:
+                # Discord often does not deliver a SPEAKING event before the
+                # first post-join audio packets.  Waiting until silence to infer
+                # the SSRC is too late for DAVE: those packets must be decrypted
+                # with the user id before Opus sees them, or the first utterance
+                # can decode to silence/garbage and STT returns empty text.
+                user_id = self._infer_user_for_ssrc(ssrc)
             if user_id:
                 try:
                     import davey
@@ -358,9 +378,9 @@ class VoiceReceiver:
                         if self._packet_debug_count <= 10:
                             logger.warning("DAVE decrypt failed for ssrc=%d: %s", ssrc, e)
                         return
-            # If SSRC unknown (no SPEAKING event yet), skip DAVE and try
-            # Opus decode directly — audio may be in passthrough mode.
-            # Buffer will get a user_id when SPEAKING event arrives later.
+            # If SSRC remains unknown, skip DAVE and try Opus decode directly —
+            # audio may be in passthrough mode.  If it is actually DAVE audio,
+            # decode will fail or STT will later produce empty text.
 
         # --- Opus decode -> PCM ---
         try:
@@ -397,7 +417,8 @@ class VoiceReceiver:
             ]
             if len(candidates) == 1:
                 uid = candidates[0]
-                self._ssrc_to_user[ssrc] = uid
+                with self._lock:
+                    self._ssrc_to_user[ssrc] = uid
                 logger.info("Auto-mapped ssrc=%d -> user=%d (sole allowed member)", ssrc, uid)
                 return uid
         except Exception:
@@ -490,6 +511,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
     # Auto-disconnect from voice channel after this many seconds of inactivity
     VOICE_TIMEOUT = 300
+    VOICE_STT_WARMUP_SECONDS = _float_env("HERMES_DISCORD_VOICE_STT_WARMUP_SECONDS", 0.75)
+    VOICE_STT_WARMUP_TIMEOUT = _float_env("HERMES_DISCORD_VOICE_STT_WARMUP_TIMEOUT", 10.0)
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
@@ -1632,7 +1655,14 @@ class DiscordAdapter(BasePlatformAdapter):
             try:
                 receiver = VoiceReceiver(vc, allowed_user_ids=self._allowed_user_ids)
                 receiver.start()
+                receiver.pause()
                 self._voice_receivers[guild_id] = receiver
+                try:
+                    await self._warm_stt_before_voice_input(guild_id)
+                except Exception as e:
+                    logger.debug("Voice STT warmup failed for guild %s: %s", guild_id, e, exc_info=True)
+                finally:
+                    receiver.resume()
                 self._voice_listen_tasks[guild_id] = asyncio.ensure_future(
                     self._voice_listen_loop(guild_id)
                 )
@@ -1640,6 +1670,52 @@ class DiscordAdapter(BasePlatformAdapter):
                 logger.warning("Voice receiver failed to start: %s", e)
 
             return True
+
+    async def _warm_stt_before_voice_input(self, guild_id: int) -> None:
+        """Warm STT and let the receiver settle before accepting voice input.
+
+        The first voice-channel utterance after join can hit two cold paths at
+        once: Discord's SSRC/decoder setup and the local STT model.  Keep the
+        receiver paused, wait briefly for the voice socket to settle, then send
+        a tiny silent WAV through the configured STT backend and discard the
+        result.  Failures are non-fatal; they should not prevent joining.
+        """
+        try:
+            if self.VOICE_STT_WARMUP_SECONDS > 0:
+                await asyncio.sleep(self.VOICE_STT_WARMUP_SECONDS)
+            timeout = max(0.1, float(self.VOICE_STT_WARMUP_TIMEOUT))
+            await asyncio.wait_for(
+                asyncio.to_thread(self._run_stt_warmup_probe),
+                timeout=timeout,
+            )
+            logger.info("Voice STT warmup completed for guild %s", guild_id)
+        except asyncio.TimeoutError:
+            logger.debug(
+                "Voice STT warmup timed out for guild %s after %.1fs",
+                guild_id, self.VOICE_STT_WARMUP_TIMEOUT,
+            )
+        except Exception as e:
+            logger.debug("Voice STT warmup failed for guild %s: %s", guild_id, e, exc_info=True)
+
+    @staticmethod
+    def _run_stt_warmup_probe() -> None:
+        """Call the configured STT backend with disposable silence."""
+        tmp_f = tempfile.NamedTemporaryFile(suffix=".wav", prefix="vc_stt_warmup_", delete=False)
+        wav_path = tmp_f.name
+        tmp_f.close()
+        try:
+            with wave.open(wav_path, "wb") as wf:
+                wf.setnchannels(1)
+                wf.setsampwidth(2)
+                wf.setframerate(16000)
+                wf.writeframes(b"\x00\x00" * 16000)
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(wav_path)
+        finally:
+            try:
+                os.unlink(wav_path)
+            except OSError:
+                pass
 
     async def leave_voice_channel(self, guild_id: int) -> None:
         """Disconnect from the voice channel in a guild."""
@@ -1879,7 +1955,11 @@ class DiscordAdapter(BasePlatformAdapter):
             if not result.get("success"):
                 return
             transcript = result.get("transcript", "").strip()
-            if not transcript or is_whisper_hallucination(transcript):
+            if not transcript:
+                logger.info("Voice input from user %d produced empty transcript", user_id)
+                return
+            if is_whisper_hallucination(transcript):
+                logger.info("Filtered voice STT hallucination from user %d: %s", user_id, transcript[:100])
                 return
 
             logger.info("Voice input from user %d: %s", user_id, transcript[:100])

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1,5 +1,6 @@
 """Tests for the /voice command and auto voice reply in the gateway."""
 
+import asyncio
 import importlib.util
 import json
 import os
@@ -544,6 +545,13 @@ class TestDiscordPlayTtsSkip:
 
 class TestVoiceInHelp:
 
+    def test_float_env_invalid_uses_default(self, monkeypatch):
+        """Bad warmup env values should not break Discord module import/use."""
+        from gateway.platforms.discord import _float_env
+
+        monkeypatch.setenv("HERMES_TEST_FLOAT_ENV", "bad-goblin")
+        assert _float_env("HERMES_TEST_FLOAT_ENV", 1.25) == 1.25
+
     def test_voice_in_help_output(self):
         """The gateway help text includes /voice (generated from registry)."""
         from hermes_cli.commands import gateway_help_lines
@@ -609,6 +617,18 @@ class TestVoiceReceiver:
         receiver.map_ssrc(100, 42)
         receiver.map_ssrc(100, 99)
         assert receiver._ssrc_to_user[100] == 99
+
+    def test_infer_user_for_ssrc_is_lock_reentrant(self):
+        """SSRC inference can run while silence detection already holds the lock."""
+        receiver = self._make_receiver()
+        receiver._vc.user = SimpleNamespace(id=9999)
+        receiver._vc.channel = SimpleNamespace(members=[SimpleNamespace(id=42)])
+
+        with receiver._lock:
+            user_id = receiver._infer_user_for_ssrc(100)
+
+        assert user_id == 42
+        assert receiver._ssrc_to_user[100] == 42
 
     def test_pause_resume(self):
         receiver = self._make_receiver()
@@ -701,6 +721,40 @@ class TestVoiceReceiver:
         data[0] = 0x00  # version 0, not 2
         receiver._on_packet(bytes(data))
         assert len(receiver._buffers) == 0
+
+
+class TestWhisperHallucinationFilter:
+    """Test generic Whisper hallucination filtering."""
+
+    def test_repeated_sentence_loop_filtered(self):
+        from tools.voice_mode import is_whisper_hallucination
+
+        transcript = (
+            "I'm going to go and get my baby. "
+            "I'm going to go and get my baby. "
+            "I'm going to go and get my baby. "
+            "I'm going to go and get my baby."
+        )
+        assert is_whisper_hallucination(transcript) is True
+
+    def test_known_subtitle_credit_filtered(self):
+        from tools.voice_mode import is_whisper_hallucination
+
+        assert is_whisper_hallucination("Subtitles by SteamTeamExtra") is True
+
+    def test_short_repetition_not_filtered(self):
+        from tools.voice_mode import is_whisper_hallucination
+
+        assert is_whisper_hallucination("Yes. Yes. Yes.") is False
+
+    def test_substantial_non_repeated_content_not_filtered(self):
+        from tools.voice_mode import is_whisper_hallucination
+
+        transcript = (
+            "Start the server. Start the server. Start the server. "
+            "Then run the migration and read me the error."
+        )
+        assert is_whisper_hallucination(transcript) is False
 
 
 # =====================================================================
@@ -1164,6 +1218,99 @@ class TestDiscordVoiceChannelMethods:
         assert adapter._is_allowed_user("42") is False
 
     @pytest.mark.asyncio
+    async def test_join_warms_stt_before_listening(self):
+        """Voice join pauses capture, warms STT, then starts listen loop."""
+        adapter = self._make_adapter()
+        adapter.VOICE_STT_WARMUP_SECONDS = 0
+
+        mock_channel = MagicMock()
+        mock_channel.guild.id = 111
+        mock_vc = MagicMock()
+        mock_vc.is_connected.return_value = True
+        mock_channel.connect = AsyncMock(return_value=mock_vc)
+
+        mock_receiver = MagicMock()
+
+        async def fake_warm(guild_id):
+            assert guild_id == 111
+            mock_receiver.pause.assert_called_once()
+            assert 111 in adapter._voice_receivers
+
+        scheduled = []
+
+        def fake_ensure_future(coro):
+            scheduled.append(coro)
+            close = getattr(coro, "close", None)
+            if callable(close):
+                close()
+            return MagicMock()
+
+        with patch("gateway.platforms.discord.VoiceReceiver", return_value=mock_receiver), \
+             patch.object(adapter, "_warm_stt_before_voice_input", side_effect=fake_warm) as warm, \
+             patch("asyncio.ensure_future", side_effect=fake_ensure_future):
+            result = await adapter.join_voice_channel(mock_channel)
+
+        assert result is True
+        warm.assert_awaited_once_with(111)
+        mock_receiver.start.assert_called_once()
+        mock_receiver.resume.assert_called_once()
+        assert any(getattr(coro, "cr_code", None) and coro.cr_code.co_name == "_voice_listen_loop" for coro in scheduled)
+
+    @pytest.mark.asyncio
+    async def test_join_resumes_receiver_when_warmup_raises(self):
+        """Capture is resumed even if warmup fails unexpectedly."""
+        adapter = self._make_adapter()
+
+        mock_channel = MagicMock()
+        mock_channel.guild.id = 111
+        mock_vc = MagicMock()
+        mock_vc.is_connected.return_value = True
+        mock_channel.connect = AsyncMock(return_value=mock_vc)
+
+        mock_receiver = MagicMock()
+
+        async def fake_warm(_guild_id):
+            raise RuntimeError("warmup exploded")
+
+        scheduled = []
+
+        def fake_ensure_future(coro):
+            scheduled.append(coro)
+            close = getattr(coro, "close", None)
+            if callable(close):
+                close()
+            return MagicMock()
+
+        with patch("gateway.platforms.discord.VoiceReceiver", return_value=mock_receiver), \
+             patch.object(adapter, "_warm_stt_before_voice_input", side_effect=fake_warm), \
+             patch("asyncio.ensure_future", side_effect=fake_ensure_future):
+            result = await adapter.join_voice_channel(mock_channel)
+
+        assert result is True
+        mock_receiver.start.assert_called_once()
+        mock_receiver.pause.assert_called_once()
+        mock_receiver.resume.assert_called_once()
+        assert any(getattr(coro, "cr_code", None) and coro.cr_code.co_name == "_voice_listen_loop" for coro in scheduled)
+
+    @pytest.mark.asyncio
+    async def test_stt_warmup_has_timeout(self, caplog):
+        """Hung STT warmup should not block voice join forever."""
+        import logging
+
+        adapter = self._make_adapter()
+        adapter.VOICE_STT_WARMUP_SECONDS = 0
+        adapter.VOICE_STT_WARMUP_TIMEOUT = 0.1
+
+        async def fake_to_thread(_fn):
+            await asyncio.sleep(1)
+
+        with caplog.at_level(logging.DEBUG, logger="gateway.platforms.discord"), \
+             patch("asyncio.to_thread", side_effect=fake_to_thread):
+            await adapter._warm_stt_before_voice_input(111)
+
+        assert "Voice STT warmup timed out for guild 111" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_process_voice_input_success(self):
         """Successful voice input: PCM->WAV->STT->callback."""
         adapter = self._make_adapter()
@@ -1182,19 +1329,23 @@ class TestDiscordVoiceChannelMethods:
         callback.assert_called_once_with(guild_id=111, user_id=42, transcript="Hello")
 
     @pytest.mark.asyncio
-    async def test_process_voice_input_hallucination_filtered(self):
-        """Whisper hallucination is filtered out."""
+    async def test_process_voice_input_hallucination_filtered(self, caplog):
+        """Whisper hallucination is filtered out and logged."""
+        import logging
+
         adapter = self._make_adapter()
         callback = AsyncMock()
         adapter._voice_input_callback = callback
 
-        with patch("gateway.platforms.discord.VoiceReceiver.pcm_to_wav"), \
+        with caplog.at_level(logging.INFO, logger="gateway.platforms.discord"), \
+             patch("gateway.platforms.discord.VoiceReceiver.pcm_to_wav"), \
              patch("tools.transcription_tools.transcribe_audio",
                    return_value={"success": True, "transcript": "Thank you."}), \
              patch("tools.voice_mode.is_whisper_hallucination", return_value=True):
             await adapter._process_voice_input(111, 42, b"\x00" * 96000)
 
         callback.assert_not_called()
+        assert "Filtered voice STT hallucination from user 42: Thank you." in caplog.text
 
     @pytest.mark.asyncio
     async def test_process_voice_input_stt_failure(self):
@@ -1281,6 +1432,17 @@ class TestVoiceReceiverThreadSafety:
         assert found_lock_with_extend, (
             "_on_packet must hold self._lock when extending buffers"
         )
+
+    def test_on_packet_infers_user_before_dave_decrypt(self):
+        """DAVE packets need SSRC->user inference before Opus decode."""
+        import inspect
+        from gateway.platforms.discord import VoiceReceiver
+
+        source = inspect.getsource(VoiceReceiver._on_packet)
+        infer_pos = source.index("user_id = self._infer_user_for_ssrc(ssrc)")
+        dave_decrypt_pos = source.index("self._dave_session.decrypt")
+        opus_decode_pos = source.index("self._decoders[ssrc].decode")
+        assert infer_pos < dave_decrypt_pos < opus_decode_pos
 
     def test_concurrent_buffer_access_safe(self):
         """Simulate concurrent buffer writes and reads under lock."""

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -745,6 +745,8 @@ WHISPER_HALLUCINATIONS = {
     "please subscribe",
     "thank you for watching.",
     "thank you for watching",
+    "subtitles by steamteamextra.",
+    "subtitles by steamteamextra",
     "bye.",
     "bye",
     "you",
@@ -768,9 +770,48 @@ _HALLUCINATION_REPEAT_RE = re.compile(
     flags=re.IGNORECASE,
 )
 
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+def _normalise_repeated_sentence_piece(text: str) -> str:
+    return re.sub(r"\s+", " ", text.strip().lower().strip(' \t\r\n.,!?;:\"“”‘’')).strip()
+
+
+def _is_repeated_sentence_hallucination(cleaned: str) -> bool:
+    """Detect arbitrary repeated-sentence Whisper loops.
+
+    Whisper sometimes turns low-signal or first-buffer audio into a plausible
+    sentence repeated several times.  The exact phrase varies, so the static
+    hallucination list above is not enough.  Require a sentence of at least
+    four words repeated at least three times to avoid suppressing ordinary
+    short confirmations like "yes, yes, yes".
+    """
+    pieces = [
+        _normalise_repeated_sentence_piece(piece)
+        for piece in _SENTENCE_SPLIT_RE.split(cleaned)
+    ]
+    pieces = [piece for piece in pieces if piece]
+    if len(pieces) < 3:
+        return False
+
+    counts: dict[str, int] = {}
+    for piece in pieces:
+        counts[piece] = counts.get(piece, 0) + 1
+
+    repeated_piece, repeat_count = max(counts.items(), key=lambda item: item[1])
+    if repeat_count < 3:
+        return False
+    if len(repeated_piece.split()) < 4:
+        return False
+
+    # Keep this conservative: the dominant repeated sentence should account
+    # for nearly all sentence chunks.  If there is substantial non-repeated
+    # content, pass it through.
+    return repeat_count / len(pieces) >= 0.75
+
 
 def is_whisper_hallucination(transcript: str) -> bool:
-    """Check if a transcript is a known Whisper hallucination on silence."""
+    """Check if a transcript is a known or repeated Whisper hallucination."""
     cleaned = transcript.strip().lower()
     if not cleaned:
         return True
@@ -779,6 +820,9 @@ def is_whisper_hallucination(transcript: str) -> bool:
         return True
     # Repetitive patterns (e.g. "Thank you. Thank you. Thank you. you")
     if _HALLUCINATION_REPEAT_RE.match(cleaned):
+        return True
+    # Arbitrary repeated sentence loops on bad/first voice buffers.
+    if _is_repeated_sentence_hallucination(cleaned):
         return True
     return False
 


### PR DESCRIPTION
## Summary

- Warm Discord voice STT after joining before accepting real voice input.
- Filter repeated-sentence and subtitle-credit Whisper hallucinations.
- Log empty/filtered transcripts and infer SSRC to user before DAVE decrypt for first packets.
- Add regression coverage for warmup, hallucination filtering, logging, and DAVE/SSRC ordering.

## Verification

- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_voice_command.py -q -o addopts=''`
- Result: `190 passed in 3.45s`

## Source

- Parent DEV issue: DEV-235, from DEV-227 fork drift reconciliation.
- Fork-staging PR: https://github.com/keegoid/hermes-agent/pull/1
- Fork commit: `1908a8012e8dcf023ad7045a8763dd39f6c6882e`
- Upstream PR branch commit: `72633aa3a`
