### PR TITLE
Fix delivery mirrors and add durable background agents

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -12,7 +12,7 @@ the full SessionStore machinery.
 import json
 import logging
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from hermes_cli.config import get_hermes_home
 
@@ -20,6 +20,105 @@ logger = logging.getLogger(__name__)
 
 _SESSIONS_DIR = get_hermes_home() / "sessions"
 _SESSIONS_INDEX = _SESSIONS_DIR / "sessions.json"
+
+DELIVERY_EVENT_ROLE = "delivery"
+DELIVERY_EVENT_TYPE = "delivery_mirror"
+
+
+def build_mirror_message(
+    platform: str,
+    chat_id: str,
+    message_text: str,
+    *,
+    session_id: Optional[str] = None,
+    source_label: str = "cli",
+    thread_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    source_platform: Optional[str] = None,
+    source_chat_id: Optional[str] = None,
+    source_chat_name: Optional[str] = None,
+    source_user_id: Optional[str] = None,
+    source_user_name: Optional[str] = None,
+    source_session_key: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build the durable transcript record for a cross-chat delivery.
+
+    The record is deliberately *not* an ``assistant`` message. It represents an
+    external delivery event that happened in another chat/session, and keeping it
+    typed as such prevents future turns from mistaking it for a local assistant
+    reply to the recipient.
+    """
+
+    source = {
+        "label": source_label or source_platform or "unknown",
+        "platform": source_platform or source_label or "",
+        "chat_id": str(source_chat_id or ""),
+        "chat_name": str(source_chat_name or ""),
+        "user_id": str(source_user_id or ""),
+        "user_name": str(source_user_name or ""),
+        "session_key": str(source_session_key or ""),
+    }
+    target = {
+        "platform": str(platform or ""),
+        "chat_id": str(chat_id or ""),
+        "thread_id": str(thread_id or ""),
+        "user_id": str(user_id or ""),
+        "session_id": str(session_id or ""),
+    }
+    return {
+        "role": DELIVERY_EVENT_ROLE,
+        "content": message_text,
+        "timestamp": datetime.now().isoformat(),
+        "event_type": DELIVERY_EVENT_TYPE,
+        "mirror": True,
+        "mirror_source": source["label"],
+        "delivery": {
+            "source": source,
+            "target": target,
+        },
+    }
+
+
+def _compact_identity(*parts: Any) -> str:
+    seen: set[str] = set()
+    out: list[str] = []
+    for part in parts:
+        text = str(part or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+    return ", ".join(out)
+
+
+def mirror_to_agent_history_entry(message: dict[str, Any]) -> dict[str, str]:
+    """Convert a durable delivery event into safe model-facing context.
+
+    Model providers do not understand the internal ``delivery`` transcript role,
+    and treating a cross-chat delivery as ``assistant`` caused contamination: the
+    receiving session appeared to have authored the delivered text. Replay it as
+    a clearly-labelled system note instead.
+    """
+
+    content = str(message.get("content") or "")
+    delivery = message.get("delivery") if isinstance(message.get("delivery"), dict) else {}
+    source = delivery.get("source") if isinstance(delivery.get("source"), dict) else {}
+
+    label = source.get("label") or message.get("mirror_source") or "another session"
+    source_user = source.get("user_name") or source.get("user_id")
+    source_chat = source.get("chat_name") or source.get("chat_id")
+    source_platform = source.get("platform")
+    origin = _compact_identity(source_user, source_chat, source_platform, label) or str(label)
+
+    return {
+        "role": "system",
+        "content": (
+            f"[External delivery from {origin}: this message was sent into "
+            "this chat by the delivery/messaging tool. It is context only, "
+            "not a reply authored by this session.]\n"
+            f"{content}"
+        ),
+    }
 
 
 def mirror_to_session(
@@ -29,6 +128,12 @@ def mirror_to_session(
     source_label: str = "cli",
     thread_id: Optional[str] = None,
     user_id: Optional[str] = None,
+    source_platform: Optional[str] = None,
+    source_chat_id: Optional[str] = None,
+    source_chat_name: Optional[str] = None,
+    source_user_id: Optional[str] = None,
+    source_user_name: Optional[str] = None,
+    source_session_key: Optional[str] = None,
 ) -> bool:
     """
     Append a delivery-mirror message to the target session's transcript.
@@ -56,13 +161,21 @@ def mirror_to_session(
             )
             return False
 
-        mirror_msg = {
-            "role": "assistant",
-            "content": message_text,
-            "timestamp": datetime.now().isoformat(),
-            "mirror": True,
-            "mirror_source": source_label,
-        }
+        mirror_msg = build_mirror_message(
+            platform,
+            str(chat_id),
+            message_text,
+            session_id=session_id,
+            source_label=source_label,
+            thread_id=thread_id,
+            user_id=user_id,
+            source_platform=source_platform,
+            source_chat_id=source_chat_id,
+            source_chat_name=source_chat_name,
+            source_user_id=source_user_id,
+            source_user_name=source_user_name,
+            source_session_key=source_session_key,
+        )
 
         _append_to_jsonl(session_id, mirror_msg)
         _append_to_sqlite(session_id, mirror_msg)
@@ -166,10 +279,17 @@ def _append_to_sqlite(session_id: str, message: dict) -> None:
     try:
         from hermes_state import SessionDB
         db = SessionDB()
+        metadata = {
+            "mirror": message.get("mirror") is True,
+            "mirror_source": message.get("mirror_source"),
+            "delivery": message.get("delivery") or {},
+        }
         db.append_message(
             session_id=session_id,
-            role=message.get("role", "assistant"),
+            role=message.get("role", DELIVERY_EVENT_ROLE),
             content=message.get("content"),
+            event_type=message.get("event_type"),
+            metadata=metadata,
         )
     except Exception as e:
         logger.debug("Mirror SQLite write failed: %s", e)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13487,6 +13487,22 @@ class GatewayRunner:
                 if role in ("session_meta",):
                     continue
                 
+                # Delivery mirror records are external transcript events, not
+                # assistant replies from this chat. Replay them as labelled
+                # system context so they cannot contaminate role history.
+                if role == "delivery" or msg.get("event_type") == "delivery_mirror" or msg.get("mirror"):
+                    try:
+                        from gateway.mirror import mirror_to_agent_history_entry
+                        agent_history.append(mirror_to_agent_history_entry(msg))
+                    except Exception:
+                        content = msg.get("content")
+                        if content:
+                            agent_history.append({
+                                "role": "system",
+                                "content": f"[External delivery event; context only, not a local assistant reply.]\n{content}",
+                            })
+                    continue
+
                 # Skip system messages -- the agent rebuilds its own system prompt
                 if role == "system":
                     continue

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -33,7 +33,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 12
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -86,7 +86,9 @@ CREATE TABLE IF NOT EXISTS messages (
     reasoning_content TEXT,
     reasoning_details TEXT,
     codex_reasoning_items TEXT,
-    codex_message_items TEXT
+    codex_message_items TEXT,
+    event_type TEXT,
+    metadata_json TEXT
 );
 
 CREATE TABLE IF NOT EXISTS state_meta (
@@ -1273,6 +1275,8 @@ class SessionDB:
         reasoning_details: Any = None,
         codex_reasoning_items: Any = None,
         codex_message_items: Any = None,
+        event_type: str = None,
+        metadata: Any = None,
     ) -> int:
         """
         Append a message to a session. Returns the message row ID.
@@ -1294,6 +1298,7 @@ class SessionDB:
             if codex_message_items else None
         )
         tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+        metadata_json = json.dumps(metadata) if metadata else None
         # Multimodal content (list of parts) must be JSON-encoded: sqlite3
         # cannot bind list/dict parameters directly.
         stored_content = self._encode_content(content)
@@ -1308,8 +1313,8 @@ class SessionDB:
                 """INSERT INTO messages (session_id, role, content, tool_call_id,
                    tool_calls, tool_name, timestamp, token_count, finish_reason,
                    reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                   codex_message_items)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   codex_message_items, event_type, metadata_json)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     role,
@@ -1325,6 +1330,8 @@ class SessionDB:
                     reasoning_details_json,
                     codex_items_json,
                     codex_message_items_json,
+                    event_type,
+                    metadata_json,
                 ),
             )
             msg_id = cursor.lastrowid
@@ -1387,12 +1394,16 @@ class SessionDB:
                 )
                 tool_calls_json = json.dumps(tool_calls) if tool_calls else None
 
+                metadata_json = (
+                    json.dumps(msg.get("metadata"))
+                    if msg.get("metadata") else msg.get("metadata_json")
+                )
                 conn.execute(
                     """INSERT INTO messages (session_id, role, content, tool_call_id,
                        tool_calls, tool_name, timestamp, token_count, finish_reason,
                        reasoning, reasoning_content, reasoning_details, codex_reasoning_items,
-                       codex_message_items)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                       codex_message_items, event_type, metadata_json)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     (
                         session_id,
                         role,
@@ -1408,6 +1419,8 @@ class SessionDB:
                         reasoning_details_json,
                         codex_items_json,
                         codex_message_items_json,
+                        msg.get("event_type"),
+                        metadata_json,
                     ),
                 )
                 total_messages += 1
@@ -1443,6 +1456,16 @@ class SessionDB:
                 except (json.JSONDecodeError, TypeError):
                     logger.warning("Failed to deserialize tool_calls in get_messages, falling back to []")
                     msg["tool_calls"] = []
+            if msg.get("metadata_json"):
+                try:
+                    metadata = json.loads(msg["metadata_json"])
+                    msg["metadata"] = metadata
+                    if isinstance(metadata, dict):
+                        for key in ("mirror", "mirror_source", "delivery"):
+                            if key in metadata and key not in msg:
+                                msg[key] = metadata[key]
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning("Failed to deserialize message metadata in get_messages")
             result.append(msg)
         return result
 
@@ -1527,7 +1550,7 @@ class SessionDB:
             rows = self._conn.execute(
                 "SELECT role, content, tool_call_id, tool_calls, tool_name, "
                 "finish_reason, reasoning, reasoning_content, reasoning_details, "
-                "codex_reasoning_items, codex_message_items "
+                "codex_reasoning_items, codex_message_items, event_type, metadata_json "
                 f"FROM messages WHERE session_id IN ({placeholders}) ORDER BY timestamp, id",
                 tuple(session_ids),
             ).fetchall()
@@ -1535,6 +1558,34 @@ class SessionDB:
         messages = []
         for row in rows:
             content = self._decode_content(row["content"])
+            metadata = {}
+            if row["metadata_json"]:
+                try:
+                    metadata = json.loads(row["metadata_json"])
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning("Failed to deserialize message metadata in conversation replay")
+                    metadata = {}
+            if (
+                row["role"] == "delivery"
+                or row["event_type"] == "delivery_mirror"
+                or (isinstance(metadata, dict) and metadata.get("mirror") is True)
+            ):
+                try:
+                    from gateway.mirror import mirror_to_agent_history_entry
+                    messages.append(mirror_to_agent_history_entry({
+                        "role": row["role"],
+                        "content": content,
+                        "event_type": row["event_type"],
+                        "mirror": bool(metadata.get("mirror")) if isinstance(metadata, dict) else False,
+                        "mirror_source": metadata.get("mirror_source") if isinstance(metadata, dict) else None,
+                        "delivery": metadata.get("delivery") if isinstance(metadata, dict) else {},
+                    }))
+                except Exception:
+                    messages.append({
+                        "role": "system",
+                        "content": f"[External delivery event; context only, not a local assistant reply.]\n{content}",
+                    })
+                continue
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
                 content = sanitize_context(content).strip()
             msg = {"role": row["role"], "content": content}

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -9,6 +9,8 @@ from gateway.mirror import (
     mirror_to_session,
     _find_session_id,
     _append_to_jsonl,
+    build_mirror_message,
+    mirror_to_agent_history_entry,
 )
 
 
@@ -202,9 +204,14 @@ class TestMirrorToSession:
         assert transcript.exists()
         msg = json.loads(transcript.read_text().strip())
         assert msg["content"] == "Hello!"
-        assert msg["role"] == "assistant"
+        assert msg["role"] == "delivery"
+        assert msg["event_type"] == "delivery_mirror"
         assert msg["mirror"] is True
         assert msg["mirror_source"] == "cli"
+        assert msg["delivery"]["source"]["label"] == "cli"
+        assert msg["delivery"]["target"]["platform"] == "telegram"
+        assert msg["delivery"]["target"]["chat_id"] == "12345"
+        assert msg["delivery"]["target"]["session_id"] == "sess_abc"
 
     def test_successful_mirror_uses_thread_id(self, tmp_path):
         sessions_dir, index_file = _setup_sessions(tmp_path, {
@@ -272,6 +279,45 @@ class TestMirrorToSession:
             result = mirror_to_session("telegram", "123", "msg")
 
         assert result is False
+
+
+class TestMirrorHistoryEntry:
+    def test_delivery_event_becomes_labelled_user_context_not_assistant_reply(self):
+        msg = build_mirror_message(
+            "telegram",
+            "12345",
+            "GCB failure summary",
+            session_id="sess_target",
+            source_label="telegram",
+            source_chat_id="-1001",
+            source_chat_name="Editors Chat",
+            source_user_id="u-alan",
+            source_user_name="Alan",
+            source_session_key="agent:main:telegram:group:-1001:u-alan",
+        )
+
+        entry = mirror_to_agent_history_entry(msg)
+
+        assert entry["role"] == "system"
+        assert "External delivery" in entry["content"]
+        assert "Alan" in entry["content"]
+        assert "Editors Chat" in entry["content"]
+        assert "not a reply authored by this session" in entry["content"]
+        assert "GCB failure summary" in entry["content"]
+
+    def test_legacy_assistant_mirror_also_becomes_labelled_user_context(self):
+        legacy = {
+            "role": "assistant",
+            "content": "old mirror text",
+            "mirror": True,
+            "mirror_source": "telegram",
+        }
+
+        entry = mirror_to_agent_history_entry(legacy)
+
+        assert entry["role"] == "system"
+        assert "External delivery" in entry["content"]
+        assert "old mirror text" in entry["content"]
 
 
 class TestAppendToSqlite:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -153,6 +153,43 @@ class TestMessageStorage:
         assert messages[0]["content"] == "Hello"
         assert messages[1]["role"] == "assistant"
 
+    def test_delivery_metadata_round_trips_and_replays_as_system_context(self, db):
+        db.create_session(session_id="s1", source="telegram")
+        metadata = {
+            "mirror": True,
+            "mirror_source": "telegram",
+            "delivery": {
+                "source": {"label": "telegram", "user_name": "Alan", "chat_name": "Editors"},
+                "target": {"platform": "telegram", "chat_id": "12345", "session_id": "s1"},
+            },
+        }
+
+        db.append_message(
+            "s1",
+            role="delivery",
+            content="Failure summary",
+            event_type="delivery_mirror",
+            metadata=metadata,
+        )
+
+        messages = db.get_messages("s1")
+        assert messages[0]["role"] == "delivery"
+        assert messages[0]["event_type"] == "delivery_mirror"
+        assert messages[0]["metadata"] == metadata
+        assert messages[0]["mirror"] is True
+        assert messages[0]["delivery"]["source"]["user_name"] == "Alan"
+
+        conversation = db.get_messages_as_conversation("s1")
+        assert conversation == [{
+            "role": "system",
+            "content": (
+                "[External delivery from Alan, Editors, telegram: "
+                "this message was sent into this chat by the delivery/messaging "
+                "tool. It is context only, not a reply authored by this session.]\n"
+                "Failure summary"
+            ),
+        }]
+
     def test_message_increments_session_count(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="user", content="Hello")
@@ -1414,7 +1451,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 11
+        assert version == 12
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -1711,7 +1748,7 @@ class TestSchemaInit:
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 11
+        assert cursor.fetchone()[0] == 12
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -2906,7 +2943,7 @@ class TestFTS5ToolCallMigration:
                 "SELECT version FROM schema_version LIMIT 1"
             ).fetchone()
             version = row["version"] if hasattr(row, "keys") else row[0]
-            assert version == 11
+            assert version == 12
         finally:
             session_db.close()
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -56,6 +56,11 @@ class TestResolveToolset:
         tools = resolve_toolset("web")
         assert set(tools) == {"web_search", "web_extract"}
 
+    def test_delegation_toolset_includes_background_agent_helper(self):
+        tools = resolve_toolset("delegation")
+        assert "delegate_task" in tools
+        assert "spawn_background_agent" in tools
+
     def test_composite_toolset(self):
         tools = resolve_toolset("debugging")
         assert "terminal" in tools

--- a/tests/tools/test_background_agent_tool.py
+++ b/tests/tools/test_background_agent_tool.py
@@ -1,0 +1,47 @@
+"""Tests for tools/background_agent_tool.py."""
+
+import json
+from unittest.mock import patch
+
+
+def test_spawn_background_agent_writes_prompt_and_starts_tracked_process(tmp_path):
+    from tools import background_agent_tool as mod
+
+    def fake_terminal_tool(**kwargs):
+        assert kwargs["background"] is True
+        assert kwargs["notify_on_complete"] is True
+        assert kwargs["timeout"] == 10
+        assert "hermes chat -q" in kwargs["command"]
+        assert "--toolsets terminal,file" in kwargs["command"]
+        assert "--model gpt-5.5" in kwargs["command"]
+        return json.dumps({
+            "output": "Background process started",
+            "session_id": "proc_abc123",
+            "pid": 42,
+            "exit_code": 0,
+            "notify_on_complete": True,
+        })
+
+    with patch.object(mod, "get_hermes_home", return_value=tmp_path), \
+         patch.object(mod, "terminal_tool", side_effect=fake_terminal_tool):
+        result = json.loads(mod.spawn_background_agent(
+            prompt="Write the copy package to /tmp/job/copy.json",
+            toolsets=["terminal", "file"],
+            model="gpt-5.5",
+        ))
+
+    assert result["success"] is True
+    assert result["session_id"] == "proc_abc123"
+    assert result["prompt_path"].startswith(str(tmp_path / "background_agents" / "prompts"))
+    assert (tmp_path / "background_agents" / "prompts").exists()
+    prompt_path = next((tmp_path / "background_agents" / "prompts").glob("*.txt"))
+    assert prompt_path.read_text(encoding="utf-8") == "Write the copy package to /tmp/job/copy.json"
+
+
+def test_spawn_background_agent_rejects_empty_prompt():
+    from tools.background_agent_tool import spawn_background_agent
+
+    result = json.loads(spawn_background_agent(prompt="   "))
+
+    assert "error" in result
+    assert "prompt" in result["error"]

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -114,6 +114,17 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("parent agent", result["error"])
 
+    def test_rejects_durable_background_worker_language(self):
+        parent = _make_mock_parent()
+        parent.platform = "telegram"
+        result = json.loads(delegate_task(
+            goal="Spawn a mini you in the background so we can keep chatting while it works",
+            parent_agent=parent,
+        ))
+        self.assertIn("error", result)
+        self.assertIn("delegate_task runs synchronously", result["error"])
+        self.assertIn("spawn_background_agent", result["error"])
+
     def test_depth_limit(self):
         parent = _make_mock_parent(depth=2)
         result = json.loads(delegate_task(goal="test", parent_agent=parent))
@@ -727,7 +738,7 @@ class TestSubagentCostRollup(unittest.TestCase):
 
 class TestBlockedTools(unittest.TestCase):
     def test_blocked_tools_constant(self):
-        for tool in ["delegate_task", "clarify", "memory", "send_message", "execute_code"]:
+        for tool in ["delegate_task", "spawn_background_agent", "clarify", "memory", "send_message", "execute_code"]:
             self.assertIn(tool, DELEGATE_BLOCKED_TOOLS)
 
     def test_constants(self):

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -291,6 +291,7 @@ class TestCheckFnExceptionHandling:
 class TestBuiltinDiscovery:
     def test_matches_previous_manual_builtin_tool_set(self):
         expected = {
+            "tools.background_agent_tool",
             "tools.browser_cdp_tool",
             "tools.browser_dialog_tool",
             "tools.browser_tool",

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -211,6 +211,12 @@ class TestSendMessageTool:
             source_label="telegram",
             thread_id=None,
             user_id="user-123",
+            source_platform="telegram",
+            source_chat_id="",
+            source_chat_name="",
+            source_user_id="user-123",
+            source_user_name="",
+            source_session_key="",
         )
 
     def test_top_level_send_failure_redacts_query_token(self):

--- a/tools/background_agent_tool.py
+++ b/tools/background_agent_tool.py
@@ -1,0 +1,184 @@
+"""Durable background Hermes agent launcher.
+
+This complements ``delegate_task``: delegation is synchronous inside the parent
+turn, while this tool starts an independent Hermes process tracked by the
+terminal/process manager so long work can continue after the current chat turn.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry, tool_error
+from tools.terminal_tool import check_terminal_requirements, terminal_tool
+
+
+def _as_csv(value: Optional[str | Iterable[str]]) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        parts = [part.strip() for part in value.split(",")]
+    else:
+        parts = [str(part).strip() for part in value]
+    return ",".join(part for part in parts if part)
+
+
+def _write_prompt_file(prompt: str, name: str = "") -> Path:
+    root = get_hermes_home() / "background_agents" / "prompts"
+    root.mkdir(parents=True, exist_ok=True)
+    safe_name = "".join(ch if ch.isalnum() or ch in "-_" else "-" for ch in (name or "agent"))
+    safe_name = safe_name.strip("-")[:48] or "agent"
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = root / f"{stamp}-{safe_name}-{uuid.uuid4().hex[:8]}.txt"
+    path.write_text(prompt, encoding="utf-8")
+    return path
+
+
+def spawn_background_agent(
+    prompt: str,
+    toolsets: Optional[list[str] | str] = None,
+    skills: Optional[list[str] | str] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+    workdir: Optional[str] = None,
+    name: Optional[str] = None,
+    notify_on_complete: bool = True,
+    startup_timeout: int = 10,
+) -> str:
+    """Start a one-shot Hermes agent in a managed background process."""
+
+    if not isinstance(prompt, str) or not prompt.strip():
+        return tool_error("spawn_background_agent requires a non-empty prompt.")
+
+    prompt_path = _write_prompt_file(prompt, name or "agent")
+    prompt_arg = f'"$(cat {shlex.quote(str(prompt_path))})"'
+    cmd_parts = ["hermes", "chat", "-q", prompt_arg, "--quiet"]
+
+    toolsets_csv = _as_csv(toolsets)
+    if toolsets_csv:
+        cmd_parts.extend(["--toolsets", shlex.quote(toolsets_csv)])
+
+    skills_csv = _as_csv(skills)
+    if skills_csv:
+        cmd_parts.extend(["--skills", shlex.quote(skills_csv)])
+
+    if model:
+        cmd_parts.extend(["--model", shlex.quote(str(model))])
+    if provider:
+        cmd_parts.extend(["--provider", shlex.quote(str(provider))])
+
+    command = " ".join(cmd_parts)
+    raw = terminal_tool(
+        command=command,
+        background=True,
+        timeout=int(startup_timeout or 10),
+        workdir=workdir or None,
+        notify_on_complete=bool(notify_on_complete),
+    )
+
+    try:
+        result = json.loads(raw)
+    except Exception:
+        result = {"output": raw}
+
+    error = result.get("error") if isinstance(result, dict) else None
+    if error:
+        return json.dumps({
+            "success": False,
+            "error": error,
+            "prompt_path": str(prompt_path),
+            "terminal_result": result,
+        }, ensure_ascii=False)
+
+    return json.dumps({
+        "success": True,
+        "session_id": result.get("session_id") if isinstance(result, dict) else None,
+        "pid": result.get("pid") if isinstance(result, dict) else None,
+        "prompt_path": str(prompt_path),
+        "command": command,
+        "notify_on_complete": bool(notify_on_complete),
+        "terminal_result": result,
+    }, ensure_ascii=False)
+
+
+SPAWN_BACKGROUND_AGENT_SCHEMA = {
+    "name": "spawn_background_agent",
+    "description": (
+        "Spawn a durable one-shot Hermes agent in a managed background process. "
+        "Use this when work should continue after the current chat turn, when "
+        "the user says to spawn a mini/background agent, or when the user needs "
+        "to keep chatting while the worker runs. Unlike delegate_task, this does "
+        "not run synchronously inside the parent turn; manage it with the process "
+        "tool using the returned session_id."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Self-contained task instruction for the background Hermes agent.",
+            },
+            "toolsets": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional toolsets for the background agent, e.g. ['terminal','file'].",
+            },
+            "skills": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional skills to preload in the background agent.",
+            },
+            "model": {
+                "type": "string",
+                "description": "Optional model override passed to hermes chat --model.",
+            },
+            "provider": {
+                "type": "string",
+                "description": "Optional provider override passed to hermes chat --provider.",
+            },
+            "workdir": {
+                "type": "string",
+                "description": "Optional working directory for the background process.",
+            },
+            "name": {
+                "type": "string",
+                "description": "Optional short label used only for the saved prompt filename.",
+            },
+            "notify_on_complete": {
+                "type": "boolean",
+                "description": "If true, deliver one process notification when the worker exits.",
+            },
+            "startup_timeout": {
+                "type": "integer",
+                "description": "Seconds to wait for the background process to start (default 10).",
+            },
+        },
+        "required": ["prompt"],
+    },
+}
+
+
+registry.register(
+    name="spawn_background_agent",
+    toolset="delegation",
+    schema=SPAWN_BACKGROUND_AGENT_SCHEMA,
+    handler=lambda args, **kw: spawn_background_agent(
+        prompt=args.get("prompt", ""),
+        toolsets=args.get("toolsets"),
+        skills=args.get("skills"),
+        model=args.get("model"),
+        provider=args.get("provider"),
+        workdir=args.get("workdir"),
+        name=args.get("name"),
+        notify_on_complete=args.get("notify_on_complete", True),
+        startup_timeout=args.get("startup_timeout", 10),
+    ),
+    check_fn=check_terminal_requirements,
+    emoji="🧵",
+)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -40,12 +40,58 @@ from utils import base_url_hostname, is_truthy_value
 DELEGATE_BLOCKED_TOOLS = frozenset(
     [
         "delegate_task",  # no recursive delegation
+        "spawn_background_agent",  # no durable side-processes from children
         "clarify",  # no user interaction
         "memory",  # no writes to shared MEMORY.md
         "send_message",  # no cross-platform side effects
         "execute_code",  # children should reason step-by-step, not write scripts
     ]
 )
+
+
+_DURABLE_BACKGROUND_MARKERS = (
+    "mini you",
+    "mini-agent",
+    "mini agent",
+    "background agent",
+    "background worker",
+    "in the background",
+    "keep chatting",
+    "chat remains usable",
+    "while i keep chatting",
+    "while we keep chatting",
+    "outlive this turn",
+    "continue after this turn",
+    "fire and forget",
+    "fire-and-forget",
+)
+
+
+def _looks_like_durable_background_request(task_list: List[Dict[str, Any]]) -> bool:
+    """Return True when task text asks for a worker that outlives this turn."""
+    haystacks: list[str] = []
+    for task in task_list or []:
+        haystacks.append(str(task.get("goal") or ""))
+        haystacks.append(str(task.get("context") or ""))
+    text = "\n".join(haystacks).lower()
+    if not text:
+        return False
+    if "background information" in text and not any(
+        marker in text for marker in ("mini", "keep chatting", "outlive", "fire")
+    ):
+        return False
+    return any(marker in text for marker in _DURABLE_BACKGROUND_MARKERS)
+
+
+def _durable_background_request_error() -> str:
+    return tool_error(
+        "This request asks for a durable/background worker, but delegate_task "
+        "runs synchronously inside the parent turn and is cancelled if the "
+        "parent is interrupted by another live message. Use "
+        "spawn_background_agent for a real background Hermes process, or use "
+        "terminal(background=True, notify_on_complete=True) / cronjob for "
+        "non-agent background work."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1942,6 +1988,11 @@ def delegate_task(
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
 
+    # Durable/background work must not use delegate_task: children are tied to
+    # the current turn and are interrupted by live follow-up messages.
+    if _looks_like_durable_background_request(task_list):
+        return _durable_background_request_error()
+
     overall_start = time.monotonic()
     results = []
 
@@ -2398,9 +2449,11 @@ DELEGATE_TASK_SCHEMA = {
         "- Mechanical multi-step work with no reasoning needed -> use execute_code\n"
         "- Single tool call -> just call the tool directly\n"
         "- Tasks needing user interaction -> subagents cannot use clarify\n"
-        "- Durable long-running work that must outlive the current turn -> "
-        "use cronjob (action='create') or terminal(background=True, "
-        "notify_on_complete=True) instead. delegate_task runs SYNCHRONOUSLY "
+        "- Durable long-running work that must outlive the current turn or "
+        "let the user keep chatting -> use spawn_background_agent for a "
+        "background Hermes worker, or cronjob (action='create') / "
+        "terminal(background=True, notify_on_complete=True) for non-agent "
+        "background work. delegate_task runs SYNCHRONOUSLY "
         "inside the parent turn: if the parent is interrupted (user sends a "
         "new message, /stop, /new) the child is cancelled with status="
         "'interrupted' and its work is discarded. Children cannot continue "

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -288,7 +288,12 @@ def _handle_send(args):
                 from gateway.mirror import mirror_to_session
                 from gateway.session_context import get_session_env
                 source_label = get_session_env("HERMES_SESSION_PLATFORM", "cli")
-                user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
+                source_chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+                source_chat_name = get_session_env("HERMES_SESSION_CHAT_NAME", "")
+                source_user_id = get_session_env("HERMES_SESSION_USER_ID", "")
+                source_user_name = get_session_env("HERMES_SESSION_USER_NAME", "")
+                source_session_key = get_session_env("HERMES_SESSION_KEY", "")
+                user_id = source_user_id or None
                 if mirror_to_session(
                     platform_name,
                     chat_id,
@@ -296,6 +301,12 @@ def _handle_send(args):
                     source_label=source_label,
                     thread_id=thread_id,
                     user_id=user_id,
+                    source_platform=source_label,
+                    source_chat_id=source_chat_id,
+                    source_chat_name=source_chat_name,
+                    source_user_id=source_user_id,
+                    source_user_name=source_user_name,
+                    source_session_key=source_session_key,
                 ):
                     result["mirrored"] = True
             except Exception:

--- a/toolsets.py
+++ b/toolsets.py
@@ -53,7 +53,7 @@ _HERMES_CORE_TOOLS = [
     # Clarifying questions
     "clarify",
     # Code execution + delegation
-    "execute_code", "delegate_task",
+    "execute_code", "delegate_task", "spawn_background_agent",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -199,8 +199,8 @@ TOOLSETS = {
     },
     
     "delegation": {
-        "description": "Spawn subagents with isolated context for complex subtasks",
-        "tools": ["delegate_task"],
+        "description": "Spawn subagents or durable background agents for complex subtasks",
+        "tools": ["delegate_task", "spawn_background_agent"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary
- store cross-chat `send_message` mirrors as typed `delivery_mirror` records instead of plain assistant transcript turns
- preserve delivery/mirror metadata in SQLite and replay those events as labelled system context
- add `spawn_background_agent` for durable background Hermes workers
- guard `delegate_task` against durable/background/"mini you" requests that should use a real background worker
- register the new background-agent tool in tool discovery/toolsets and add regression coverage

## Test plan
- `python -m pytest tests/gateway/test_mirror.py tests/tools/test_send_message_tool.py tests/tools/test_background_agent_tool.py tests/test_toolsets.py tests/test_hermes_state.py tests/tools/test_delegate.py::TestDelegateRequirements tests/tools/test_delegate.py::TestDelegateTask tests/tools/test_delegate.py::TestBlockedTools tests/tools/test_registry.py::TestBuiltinDiscovery::test_matches_previous_manual_builtin_tool_set tests/tools/test_terminal_tool_requirements.py::TestTerminalRequirements -q --tb=short`
  - Result: `380 passed, 4 warnings in 71.18s`
- Full local suite completed with higher parallelism to avoid the local runner limit:
  - Command: `python -m pytest tests/ -q -o 'addopts=' -m 'not integration' -n 6 --tb=short --durations=50 -r fEs`
  - Result: `100 failed, 20033 passed, 67 skipped, 218 warnings in 535.28s`; wall time from `/usr/bin/time`: `8:58.85`, max RSS `697732KB`
  - Baseline `origin/main` under the same command also fails in this environment: `98 failed, 20028 passed, 67 skipped, 220 warnings in 508.90s`; wall time `8:30.54`
  - The new PR-specific registry failure was fixed; the remaining broad-suite failures are also present/flaky on baseline or environment-dependent. Targeted affected tests are green.

## Notes
- Direct force-push update of the earlier fork branch was not available from this environment, so this branch is rebased cleanly on current `origin/main` and supersedes the earlier PR branch.
