### PR TITLE
fix(cli): suppress OSError EINVAL on macOS kqueue stdin registration

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11934,8 +11934,8 @@ class HermesCLI:
         except (KeyError, OSError) as _stdin_err:
             # Catch selector registration failures from broken stdin (#6393)
             # and I/O errors from broken stdout during interrupt (#13710).
-            if isinstance(_stdin_err, OSError) and getattr(_stdin_err, "errno", None) == errno.EIO:
-                pass  # suppress broken-stdout I/O errors on interrupt (#13710)
+            if isinstance(_stdin_err, OSError) and getattr(_stdin_err, "errno", None) in (errno.EIO, errno.EINVAL):
+                pass  # suppress broken-stdout/kqueue EINVAL errors on macOS uv-python (#13710)
             elif "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err):
                 print(
                     f"\nError: stdin is not usable ({_stdin_err}).\n"


### PR DESCRIPTION
## Problem

On macOS with uv-managed Python (`cpython-3.11.11-macos-aarch64`), Hermes crashes with a full traceback on exit:

```
Traceback (most recent call last):
  ...
  File "prompt_toolkit/input/vt100.py", line 165, in _attached_input
    loop.add_reader(fd, callback_wrapper)
  ...
OSError: [Errno 22] Invalid argument
```

**Root cause**: kqueue cannot register stdin (`fd 0`) for `EVENT_READ` and raises `OSError` with `errno.EINVAL` (22). The existing handler at `cli.py:11937` only suppressed `errno.EIO` (5), so `EINVAL` fell through to `else: raise`.

## Fix

Add `errno.EINVAL` to the suppressed errno set — same silent-pass treatment as `EIO` — since the root cause is the same uv/kqueue incompatibility already documented in the surrounding comment.

```python
# Before
if isinstance(_stdin_err, OSError) and getattr(_stdin_err, "errno", None) == errno.EIO:

# After
if isinstance(_stdin_err, OSError) and getattr(_stdin_err, "errno", None) in (errno.EIO, errno.EINVAL):
```

## Test plan

- [ ] Run `hermes` on macOS with uv-managed Python (`cpython-3.11.11-macos-aarch64`)
- [ ] Verify no traceback printed on normal exit
- [ ] Verify existing behavior unchanged on Linux / Homebrew Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)