### PR TITLE
fix: refresh Telegram DM topic binding after session split (#20470)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13830,6 +13830,17 @@ class GatewayRunner:
                 if entry:
                     entry.session_id = agent.session_id
                     self.session_store._save()
+                    # Refresh the Telegram DM topic binding so the next
+                    # inbound message resolves to the post-split child
+                    # session instead of the stale pre-compression root.
+                    # Without this, every message re-triggers preflight
+                    # compression in an infinite loop.  (#20470)
+                    try:
+                        self._record_telegram_topic_binding(source, entry)
+                    except Exception:
+                        logger.exception(
+                            "Failed to refresh telegram topic binding after session split"
+                        )
 
             effective_session_id = getattr(agent, 'session_id', session_id) if agent else session_id
 


### PR DESCRIPTION
## Fixes #20470

## Problem

When a session bound to a Telegram DM topic splits during mid-turn context compression, the gateway updates `session_store._entries` with the new session ID but does **not** update the corresponding row in `telegram_dm_topic_bindings`. On the next inbound message in that topic, the gateway reads the stale binding, calls `switch_session()` back to the pre-compression root session, reloads its full transcript, fires preflight compression, splits again — repeat forever.

**Symptom:** every message in a Telegram DM topic prints `📦 Preflight compression: ~N tokens >= threshold` even after the conversation has been compressed multiple times. Each turn pays the full compression latency before any real work begins.

## Fix

After `session_store._save()` updates the in-memory entry and persists it, call `_record_telegram_topic_binding(source, entry)` to also refresh the SQLite topic-binding row. The call is wrapped in `try/except` to guard against edge cases where `bind_telegram_topic` might raise (e.g. if the new session ID is already linked to a different topic).

`_record_telegram_topic_binding` already early-returns when `source.thread_id` is falsy, so this is safe across all platform surfaces — only Telegram DM topic bindings are affected.

## Before vs After

| | Before | After |
|---|---|---|
| Topic binding after split | Points to pre-compression root session | Points to post-split child session |
| Preflight compression on next message | Triggers every time (infinite loop) | Skipped (child session is small) |
| Compression latency per turn | Full compression cost | Zero (no re-compression needed) |
