### PR TITLE
fix(telegram): refresh topic binding after session split

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1552,6 +1552,29 @@ class GatewayRunner:
             session_id=session_entry.session_id,
         )
 
+    def _sync_session_split_entry(
+        self,
+        source: SessionSource,
+        session_key: Optional[str],
+        new_session_id: str,
+    ) -> None:
+        """Persist a compression-created session id rollover for the active lane."""
+        if not session_key:
+            return
+        entry = self.session_store._entries.get(session_key)
+        if not entry:
+            return
+        entry.session_id = new_session_id
+        self.session_store._save()
+        if not self._is_telegram_topic_lane(source):
+            return
+        try:
+            self._record_telegram_topic_binding(source, entry)
+        except Exception:
+            logger.exception(
+                "Failed to refresh Telegram topic binding after session split"
+            )
+
     def _resolve_session_agent_runtime(
         self,
         *,
@@ -13826,10 +13849,7 @@ class GatewayRunner:
                     "Session split detected: %s → %s (compression)",
                     session_id, agent.session_id,
                 )
-                entry = self.session_store._entries.get(session_key)
-                if entry:
-                    entry.session_id = agent.session_id
-                    self.session_store._save()
+                self._sync_session_split_entry(source, session_key, agent.session_id)
 
             effective_session_id = getattr(agent, 'session_id', session_id) if agent else session_id
 

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -443,6 +443,58 @@ async def test_new_inside_telegram_topic_rewrites_binding_to_new_session(tmp_pat
     assert binding["session_id"] == "new-topic-session"
 
 
+def test_compression_session_split_rewrites_topic_binding(tmp_path):
+    """Compression session splits must keep Telegram topic bindings current."""
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    session_db.create_session(
+        session_id="old-topic-session",
+        source="telegram",
+        user_id="208214988",
+    )
+    session_db.create_session(
+        session_id="compressed-topic-session",
+        source="telegram",
+        user_id="208214988",
+    )
+    topic_source = _make_source(thread_id="17585")
+    topic_key = build_session_key(topic_source)
+    session_db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="17585",
+        user_id="208214988",
+        session_key=topic_key,
+        session_id="old-topic-session",
+    )
+
+    runner = _make_runner(session_db=session_db)
+    entry = SessionEntry(
+        session_key=topic_key,
+        session_id="old-topic-session",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        origin=topic_source,
+    )
+    runner.session_store._entries = {topic_key: entry}
+    runner.session_store._save = MagicMock()
+
+    runner._sync_session_split_entry(
+        topic_source,
+        topic_key,
+        "compressed-topic-session",
+    )
+
+    binding = session_db.get_telegram_topic_binding(
+        chat_id="208214988", thread_id="17585",
+    )
+    assert binding is not None
+    assert binding["session_id"] == "compressed-topic-session"
+    assert entry.session_id == "compressed-topic-session"
+    runner.session_store._save.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_topic_root_command_explicitly_migrates_and_enables_topic_mode(tmp_path, monkeypatch):
     import gateway.run as gateway_run


### PR DESCRIPTION
## Summary
- refresh Telegram DM topic bindings when context compression rotates a gateway session id
- keep the existing SessionStore rollover behavior for all platforms
- add a regression test for topic bindings after compression-created session splits

Closes #20470

## Verification
- `scripts/run_tests.sh tests/gateway/test_telegram_topic_mode.py`

## Non-goals
- does not change Telegram topic creation, /new handling, or existing session switching semantics
- does not attempt to repair historical stale bindings automatically