### PR TITLE
feat: allow quick commands to append user args

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6679,9 +6679,13 @@ class HermesCLI:
             if base_cmd.lstrip("/") in quick_commands:
                 qcmd = quick_commands[base_cmd.lstrip("/")]
                 if qcmd.get("type") == "exec":
+                    import shlex
                     import subprocess
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
+                        user_args = cmd_original[len(base_cmd):].strip()
+                        if qcmd.get("append_args") and user_args:
+                            exec_cmd = f"{exec_cmd} {shlex.quote(user_args)}"
                         try:
                             result = subprocess.run(
                                 exec_cmd, shell=True, capture_output=True,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5445,8 +5445,12 @@ class GatewayRunner:
             if command in quick_commands:
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "exec":
+                    import shlex
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
+                        user_args = event.get_command_args().strip()
+                        if qcmd.get("append_args") and user_args:
+                            exec_cmd = f"{exec_cmd} {shlex.quote(user_args)}"
                         try:
                             proc = await asyncio.create_subprocess_shell(
                                 exec_cmd,

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -59,6 +59,28 @@ class TestCLIQuickCommands:
         # stderr fallback — should print something
         cli.console.print.assert_called_once()
 
+    def test_exec_command_appends_args_when_enabled(self):
+        cli = self._make_cli({"say": {"type": "exec", "command": "printf %s", "append_args": True}})
+        result = cli.process_command("/say hello tensor")
+        assert result is True
+        cli.console.print.assert_called_once()
+        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        assert printed == "hello tensor"
+
+    def test_exec_command_shell_quotes_appended_args(self):
+        cli = self._make_cli({"say": {"type": "exec", "command": "printf %s", "append_args": True}})
+        result = cli.process_command("/say hello; echo injected")
+        assert result is True
+        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        assert printed == "hello; echo injected"
+
+    def test_exec_command_does_not_append_args_by_default(self):
+        cli = self._make_cli({"say": {"type": "exec", "command": "printf fixed"}})
+        result = cli.process_command("/say ignored")
+        assert result is True
+        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        assert printed == "fixed"
+
     def test_exec_command_no_output_shows_fallback(self):
         cli = self._make_cli({"empty": {"type": "exec", "command": "true"}})
         cli.process_command("/empty")
@@ -158,6 +180,45 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_exec_command_appends_args_when_enabled(self):
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"say": {"type": "exec", "command": "printf %s", "append_args": True}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("say", "hello tensor")
+        result = await runner._handle_message(event)
+        assert result == "hello tensor"
+
+    @pytest.mark.asyncio
+    async def test_exec_command_shell_quotes_appended_args(self):
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"say": {"type": "exec", "command": "printf %s", "append_args": True}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("say", "hello; echo injected")
+        result = await runner._handle_message(event)
+        assert result == "hello; echo injected"
+
+    @pytest.mark.asyncio
+    async def test_exec_command_does_not_append_args_by_default(self):
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"say": {"type": "exec", "command": "printf fixed"}}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("say", "ignored")
+        result = await runner._handle_message(event)
+        assert result == "fixed"
 
     @pytest.mark.asyncio
     async def test_unsupported_type_returns_error(self):


### PR DESCRIPTION
## Summary
- Add optional `append_args: true` support for quick-command `exec` handlers in CLI and gateway flows.
- Shell-quote forwarded user arguments before appending them to the configured command.
- Add regression coverage for argument forwarding, default non-forwarding behavior, and shell-injection-like input.

## Why
This lets bounded quick commands such as `/tensor <prompt>` pass user text to a helper command without turning every quick command into an argument-forwarding shell wrapper.

## Safety
- Existing quick commands keep current behavior unless `append_args: true` is explicitly set.
- Forwarded arguments use `shlex.quote(...)` before shell execution.

## Validation
- `/home/sass/.hermes/hermes-agent/venv/bin/python -m pytest tests/cli/test_quick_commands.py -q -o 'addopts='`
  - `22 passed in 2.15s`
- `/home/sass/.hermes/hermes-agent/venv/bin/python -m py_compile cli.py gateway/run.py tests/cli/test_quick_commands.py`
  - `compile ok`
- Local smoke: `/tensor` quick-command path returned `quick-tensor-ok` through `HermesCLI.process_command`.

## Notes
- A pytest warning about an unawaited `Process.communicate` coroutine appears during the existing timeout mock path, but the focused suite passes.
