### PR TITLE
fix(profile): detect service-managed gateway status

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -354,7 +354,25 @@ def _check_gateway_running(profile_dir: Path) -> bool:
     """Check if a gateway is running for a given profile directory."""
     try:
         from gateway.status import get_running_pid
-        return get_running_pid(profile_dir / "gateway.pid", cleanup_stale=False) is not None
+        if (
+            get_running_pid(profile_dir / "gateway.pid", cleanup_stale=False)
+            is not None
+        ):
+            return True
+    except Exception:
+        pass
+    try:
+        from hermes_cli.gateway import get_gateway_runtime_snapshot
+        previous_home = os.environ.get("HERMES_HOME")
+        os.environ["HERMES_HOME"] = str(profile_dir)
+        try:
+            snapshot = get_gateway_runtime_snapshot()
+            return bool(getattr(snapshot, "service_running", False))
+        finally:
+            if previous_home is None:
+                os.environ.pop("HERMES_HOME", None)
+            else:
+                os.environ["HERMES_HOME"] = previous_home
     except Exception:
         return False
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -958,7 +958,9 @@ class TestEdgeCases:
         assert result == expected
 
     def test_list_profiles_default_info_fields(self, profile_env):
-        profiles = list_profiles()
+        with patch("hermes_cli.gateway.get_gateway_runtime_snapshot") as mock_snapshot:
+            mock_snapshot.return_value.service_running = False
+            profiles = list_profiles()
         default = [p for p in profiles if p.name == "default"][0]
         assert default.is_default is True
         assert default.gateway_running is False
@@ -983,12 +985,49 @@ class TestEdgeCases:
         tmp_path = profile_env
         default_home = tmp_path / ".hermes"
 
-        with patch("gateway.status.get_running_pid", return_value=None) as mock_get_running_pid:
+        with (
+            patch(
+                "gateway.status.get_running_pid",
+                return_value=None,
+            ) as mock_get_running_pid,
+            patch("hermes_cli.gateway.get_gateway_runtime_snapshot") as mock_snapshot,
+        ):
+            mock_snapshot.return_value.service_running = False
             assert _check_gateway_running(default_home) is False
         mock_get_running_pid.assert_called_once_with(
             default_home / "gateway.pid",
             cleanup_stale=False,
         )
+        mock_snapshot.assert_called_once_with()
+
+    def test_gateway_running_check_uses_runtime_snapshot_fallback(
+        self, profile_env, monkeypatch
+    ):
+        """Profile status should detect service-managed gateways without a pid file."""
+        from hermes_cli.profiles import _check_gateway_running
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        previous_home = str(tmp_path / ".hermes" / "profiles" / "coder")
+        monkeypatch.setenv("HERMES_HOME", previous_home)
+        captured_home = {}
+
+        def _snapshot():
+            captured_home["value"] = os.environ.get("HERMES_HOME")
+            snap = MagicMock()
+            snap.service_running = True
+            return snap
+
+        with (
+            patch("gateway.status.get_running_pid", return_value=None),
+            patch(
+                "hermes_cli.gateway.get_gateway_runtime_snapshot",
+                side_effect=_snapshot,
+            ),
+        ):
+            assert _check_gateway_running(default_home) is True
+
+        assert captured_home["value"] == str(default_home)
+        assert os.environ["HERMES_HOME"] == previous_home
 
     def test_profile_name_boundary_single_char(self):
         """Single alphanumeric character is valid."""


### PR DESCRIPTION
## Summary
- keep the existing profile-scoped gateway.pid check as the fast path
- fall back to the shared gateway runtime snapshot with HERMES_HOME temporarily scoped to the profile being displayed
- use service-manager state for the fallback so profile list/show can detect systemd/launchd gateways without attributing unrelated gateway PIDs to the wrong profile
- add regression coverage for the service-managed no-pid-file path

Closes #20254

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_profiles.py -k gateway_running_check`
- `scripts/run_tests.sh tests/hermes_cli/test_profiles.py`

## Non-goals
- does not change gateway start/stop/install behavior
- does not attempt to infer profile ownership for arbitrary manual gateway processes without a pid file