### PR TITLE
fix(anthropic): preserve betas when fast mode is unsupported

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import platform
+import re
 import subprocess
 from pathlib import Path
 
@@ -228,7 +229,13 @@ def _supports_fast_mode(model: str) -> bool:
     returns HTTP 400. This guard prevents silently 400'ing when stale config
     or older callers leave fast mode enabled across a model upgrade.
     """
-    return any(v in model for v in _FAST_MODE_SUPPORTED_SUBSTRINGS)
+    normalized = model.lower()
+    return bool(
+        re.search(
+            r"(^|[/_.:-])claude-opus-4[-.]6($|[/_.:-])",
+            normalized,
+        )
+    )
 
 
 # Beta headers for enhanced features (sent with ALL auth types).
@@ -1943,17 +1950,12 @@ def build_anthropic_kwargs(
             kwargs.pop(_sampling_key, None)
 
     # ── Fast mode (Opus 4.6 only) ────────────────────────────────────
-    # Adds extra_body.speed="fast" + the fast-mode beta header for ~2.5x
-    # output speed. Per Anthropic docs, fast mode is only supported on
-    # Opus 4.6 — Opus 4.7 and other models 400 on the speed parameter.
-    # Only for native Anthropic endpoints — third-party providers would
-    # reject the unknown beta header and speed parameter.
-    if (
-        fast_mode
-        and not _is_third_party_anthropic_endpoint(base_url)
-        and _supports_fast_mode(model)
-    ):
-        kwargs.setdefault("extra_body", {})["speed"] = "fast"
+    # Fast-mode calls need per-request extra_headers because the Anthropic SDK
+    # merges them over client-level default_headers. Keep common betas on the
+    # request even when speed=fast is rejected for this model, so Bedrock/Azure
+    # 1M-context support does not disappear when stale config leaves fast_mode
+    # enabled after an Opus 4.6 -> 4.7 migration.
+    if fast_mode and not _is_third_party_anthropic_endpoint(base_url):
         # Build extra_headers with ALL applicable betas (the per-request
         # extra_headers override the client-level anthropic-beta header).
         betas = list(_common_betas_for_base_url(
@@ -1962,9 +1964,10 @@ def build_anthropic_kwargs(
         ))
         if is_oauth:
             betas.extend(_OAUTH_ONLY_BETAS)
-        betas.append(_FAST_MODE_BETA)
+        if _supports_fast_mode(model):
+            kwargs.setdefault("extra_body", {})["speed"] = "fast"
+            betas.append(_FAST_MODE_BETA)
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
 
     return kwargs
-
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1118,7 +1118,9 @@ class TestBuildAnthropicKwargs:
         from agent.anthropic_adapter import _supports_fast_mode
         assert _supports_fast_mode("claude-opus-4-6") is True
         assert _supports_fast_mode("anthropic/claude-opus-4-6") is True
+        assert _supports_fast_mode("Claude-Opus-4.6") is True
         assert _supports_fast_mode("claude-opus-4-7") is False
+        assert _supports_fast_mode("claude-opus-4-60") is False
         assert _supports_fast_mode("claude-sonnet-4-6") is False
         assert _supports_fast_mode("claude-haiku-4-5") is False
         assert _supports_fast_mode("") is False


### PR DESCRIPTION
## Summary
- tighten Anthropic fast-mode support detection to Opus 4.6 model IDs only
- keep common Anthropic beta headers on native `fast_mode` requests even when `speed=fast` is omitted for unsupported models
- add predicate coverage for dotted/cased Opus 4.6 names and non-4.6 lookalikes

## Why This Matters
Issue [#20360](https://github.com/NousResearch/hermes-agent/issues/20360) reports that the Anthropic fast-mode predicate was matching non-4.6 models. This PR narrows the predicate to the intended Opus 4.6 IDs while preserving the shared beta headers Hermes still needs on native Anthropic requests. The change stays focused on the predicate/header boundary rather than broad adapter behavior.

## Verification
- `scripts/run_tests.sh tests/agent/test_anthropic_adapter.py::TestBuildAnthropicKwargs::test_supports_fast_mode_predicate tests/agent/test_anthropic_adapter.py::TestBuildAnthropicKwargs::test_fast_mode_omitted_for_unsupported_model tests/agent/test_anthropic_adapter.py::TestBuildAnthropicKwargs::test_fast_mode_still_applied_on_opus_46 tests/agent/test_bedrock_1m_context.py::TestBedrockContext1MBeta::test_build_anthropic_kwargs_includes_1m_for_bedrock_fastmode`
- `git diff --check -- agent/anthropic_adapter.py tests/agent/test_anthropic_adapter.py`

## Note
- I also ran `scripts/run_tests.sh tests/agent/test_anthropic_adapter.py tests/agent/test_bedrock_1m_context.py`. The affected fast-mode/Bedrock coverage passed, but three existing macOS OAuth setup-token tests in `test_anthropic_adapter.py` failed because the keychain subprocess mock returns a `MagicMock` stdout; that is outside this predicate/header change.

Closes NousResearch/hermes-agent#20360
