### PR TITLE
fix(skills): steer skill writes to host tool

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -179,7 +179,12 @@ SKILLS_GUIDANCE = (
     "skill with skill_manage so you can reuse it next time.\n"
     "When using a skill and finding it outdated, incomplete, or wrong, "
     "patch it immediately with skill_manage(action='patch') — don't wait to be asked. "
-    "Skills that aren't maintained become liabilities."
+    "Skills that aren't maintained become liabilities.\n"
+    "Always create, patch, edit, and delete Hermes skills with skill_manage. "
+    "Do not write skill files with terminal, write_file, or patch: terminal and "
+    "project file tools may point at an SSH/container/backend filesystem, while "
+    "skill_manage runs in the Hermes host process and writes the host-side "
+    "skills directory."
 )
 
 KANBAN_GUIDANCE = (

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -26,6 +26,7 @@ from agent.prompt_builder import (
     OPENAI_MODEL_EXECUTION_GUIDANCE,
     MEMORY_GUIDANCE,
     SESSION_SEARCH_GUIDANCE,
+    SKILLS_GUIDANCE,
     PLATFORM_HINTS,
     WSL_ENVIRONMENT_HINT,
 )
@@ -48,6 +49,11 @@ class TestGuidanceConstants:
     def test_session_search_guidance_is_simple_cross_session_recall(self):
         assert "relevant cross-session context exists" in SESSION_SEARCH_GUIDANCE
         assert "recent turns of the current session" not in SESSION_SEARCH_GUIDANCE
+
+    def test_skills_guidance_routes_skill_files_to_host_tool(self):
+        assert "Always create, patch, edit, and delete Hermes skills with skill_manage" in SKILLS_GUIDANCE
+        assert "SSH/container/backend filesystem" in SKILLS_GUIDANCE
+        assert "host-side skills directory" in SKILLS_GUIDANCE
 
 
 # =========================================================================
@@ -1087,6 +1093,5 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 
 

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -21,6 +21,7 @@ from tools.skill_manager_tool import (
     _write_file,
     _remove_file,
     skill_manage,
+    SKILL_MANAGE_SCHEMA,
     VALID_NAME_RE,
     ALLOWED_SUBDIRS,
     MAX_NAME_LENGTH,
@@ -585,6 +586,14 @@ class TestSkillManageDispatcher:
         result = json.loads(raw)
         assert result["success"] is False
         assert "does not exist" in result["error"]
+
+
+class TestSkillManageSchemaGuidance:
+    def test_schema_explains_skill_writes_are_host_side(self):
+        description = SKILL_MANAGE_SCHEMA["description"]
+        assert "Hermes host process" in description
+        assert "do not use terminal, write_file, or patch for skill files" in description
+        assert "SSH, container, or project filesystem" in description
 
 
 class TestSecurityScanGate:

--- a/tests/tools/test_terminal_foreground_timeout_cap.py
+++ b/tests/tools/test_terminal_foreground_timeout_cap.py
@@ -232,3 +232,12 @@ class TestForegroundMaxTimeoutConstant:
         timeout_desc = TERMINAL_SCHEMA["parameters"]["properties"]["timeout"]["description"]
         assert str(FOREGROUND_MAX_TIMEOUT) in timeout_desc
         assert "background=true" in timeout_desc
+
+    def test_schema_defers_skill_files_to_skill_manage(self):
+        """Terminal guidance should not steer skill writes to remote backends."""
+        from tools.terminal_tool import TERMINAL_SCHEMA
+
+        description = TERMINAL_SCHEMA["description"]
+        assert "Do NOT create or edit Hermes skills with terminal" in description
+        assert "skill_manage" in description
+        assert "SSH/container backends" in description

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -797,7 +797,11 @@ SKILL_MANAGE_SCHEMA = {
     "description": (
         "Manage skills (create, update, delete). Skills are your procedural "
         "memory — reusable approaches for recurring task types. "
-        f"New skills go to {display_hermes_home()}/skills/; existing skills can be modified wherever they live.\n\n"
+        f"New skills go to {display_hermes_home()}/skills/; existing skills can be modified wherever they live. "
+        "This tool runs in the Hermes host process and is the only correct "
+        "way to create or modify Hermes skills; do not use terminal, write_file, "
+        "or patch for skill files because those tools may target an SSH, "
+        "container, or project filesystem instead of the host-side skills directory.\n\n"
         "Actions: create (full SKILL.md + optional category), "
         "patch (old_string/new_string — preferred for fixes), "
         "edit (full SKILL.md rewrite — major overhauls only), "

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -898,6 +898,8 @@ Do NOT use grep/rg/find to search — use search_files instead.
 Do NOT use ls to list directories — use search_files(target='files') instead.
 Do NOT use sed/awk to edit files — use patch instead.
 Do NOT use echo/cat heredoc to create files — use write_file instead.
+Do NOT create or edit Hermes skills with terminal — use skill_manage instead.
+Terminal may be connected to SSH/container backends, while skill_manage writes the host-side Hermes skills directory.
 Reserve terminal for: builds, installs, git, processes, scripts, network, package managers, and anything that needs a shell.
 
 Foreground (default): Commands return INSTANTLY when done, even if the timeout is high. Set timeout=300 for long builds/scripts — you'll still get the result in seconds if it's fast. Prefer foreground for short commands.


### PR DESCRIPTION
## Summary
- make skill-management guidance explicit that `skill_manage` writes in the Hermes host process
- warn terminal users not to create/edit Hermes skills through remote SSH/container terminal backends
- add prompt/schema regression coverage for the host-side skill-write contract

Fixes #20369.

## Verification
- `scripts/run_tests.sh tests/agent/test_prompt_builder.py::TestGuidanceConstants::test_skills_guidance_routes_skill_files_to_host_tool tests/tools/test_skill_manager_tool.py::TestSkillManageSchemaGuidance::test_schema_explains_skill_writes_are_host_side tests/tools/test_terminal_foreground_timeout_cap.py::TestForegroundMaxTimeoutConstant::test_schema_defers_skill_files_to_skill_manage`
- `scripts/run_tests.sh tests/agent/test_prompt_builder.py tests/tools/test_skill_manager_tool.py tests/tools/test_terminal_foreground_timeout_cap.py`
- `git diff --check -- agent/prompt_builder.py tools/skill_manager_tool.py tools/terminal_tool.py tests/agent/test_prompt_builder.py tests/tools/test_skill_manager_tool.py tests/tools/test_terminal_foreground_timeout_cap.py`
