### PR TITLE
feat(models): add deepseek/deepseek-v4-pro to OpenRouter + Nous Portal curated lists

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -67,6 +67,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("arcee-ai/trinity-large-thinking",  ""),
     ("openai/gpt-5.5-pro",              ""),
     ("openai/gpt-5.4-nano",             ""),
+    ("deepseek/deepseek-v4-pro",        ""),
 ]
 
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None
@@ -185,6 +186,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "arcee-ai/trinity-large-thinking",
         "openai/gpt-5.5-pro",
         "openai/gpt-5.4-nano",
+        "deepseek/deepseek-v4-pro",
     ],
     # Native OpenAI Chat Completions (api.openai.com). Used by /model counts and
     # provider_model_ids fallback when /v1/models is unavailable.

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-05-04T09:41:25Z",
+  "updated_at": "2026-05-06T00:37:26Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -42,6 +42,10 @@
         },
         {
           "id": "openrouter/elephant-alpha",
+          "description": "free"
+        },
+        {
+          "id": "openrouter/owl-alpha",
           "description": "free"
         },
         {
@@ -147,6 +151,10 @@
         {
           "id": "openai/gpt-5.4-nano",
           "description": ""
+        },
+        {
+          "id": "deepseek/deepseek-v4-pro",
+          "description": ""
         }
       ]
     },
@@ -232,7 +240,7 @@
           "id": "z-ai/glm-5-turbo"
         },
         {
-          "id": "x-ai/grok-4.20"
+          "id": "x-ai/grok-4.20-beta"
         },
         {
           "id": "nvidia/nemotron-3-super-120b-a12b"
@@ -245,6 +253,9 @@
         },
         {
           "id": "openai/gpt-5.4-nano"
+        },
+        {
+          "id": "deepseek/deepseek-v4-pro"
         }
       ]
     }


### PR DESCRIPTION
## Summary
Re-adds `deepseek/deepseek-v4-pro` to the OpenRouter curated recommendations and the Nous Portal curated list. Also regenerates the online model catalog JSON that users pull from.

## Endpoint validation (OpenRouter)
Before reintroducing: tested `deepseek/deepseek-v4-pro` via `https://openrouter.ai/api/v1` over 6 real conversational turns with tool calls plus an 8-request burst.

|   | Turns | API calls | Tool calls | Failures | Rate limits | Avg latency |
|---|---|---|---|---|---|---|
| Multi-turn | 6 | 9 | 3 | 0 | 0 | ~3.1s/turn |
| Burst      | 8 | 8 | 0 | 0 | 0 | ~2.1s/call |

All `finish_reason` values were `stop` or `tool_calls` as expected. Tool-call arguments decoded as valid JSON on every call. The historical rate-limit issues that caused the original removal are gone.

## Changes
- `hermes_cli/models.py`: append `deepseek/deepseek-v4-pro` to `OPENROUTER_MODELS` and `_PROVIDER_MODELS['nous']`.
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py` (openrouter 35→36, nous 30→31).

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_models.py` — 58 passed
- `scripts/run_tests.sh tests/hermes_cli/test_model_normalize.py tests/agent/test_model_metadata.py` — 170 passed