### PR TITLE
feat(memory): add noldomem provider

### DIFF
--- a/plugins/memory/noldomem/README.md
+++ b/plugins/memory/noldomem/README.md
@@ -1,0 +1,51 @@
+# NoldoMem Memory Provider
+
+NoldoMem is a long-term memory backend for agent memory retrieval. This
+provider connects Hermes to a running NoldoMem HTTP API through the native
+Hermes `MemoryProvider` interface.
+
+NoldoMem handles storage, embeddings, hybrid search, decay, and reranking.
+Hermes only sends recall/store/pin requests and degrades gracefully when the
+service is unavailable.
+
+## Setup
+
+Configure the provider:
+
+```bash
+hermes memory setup
+```
+
+Or set values directly:
+
+```bash
+hermes config set memory.provider noldomem
+export NOLDOMEM_API_URL=http://127.0.0.1:8787
+export NOLDOMEM_API_KEY=YOUR_KEY
+```
+
+Optional environment variables:
+
+```bash
+export NOLDOMEM_AGENT=hermes
+export NOLDOMEM_NAMESPACE=default
+export NOLDOMEM_API_TIMEOUT=2
+export NOLDOMEM_MAX_RECALL_RESULTS=5
+export NOLDOMEM_MAX_CONTEXT_CHARS=4000
+```
+
+## Tools
+
+The provider exposes:
+
+- `noldomem_recall`
+- `noldomem_store`
+- `noldomem_pin`
+
+## Safety
+
+- API keys are read from environment variables or Hermes secret storage.
+- Recall output is bounded by result count and character budget.
+- Completed-turn storage runs in a background thread.
+- Cron, subagent, and flush contexts skip automatic writes by default.
+- Request failures return empty recall context instead of blocking replies.

--- a/plugins/memory/noldomem/__init__.py
+++ b/plugins/memory/noldomem/__init__.py
@@ -1,0 +1,425 @@
+"""NoldoMem memory plugin using the MemoryProvider interface.
+
+NoldoMem is an external long-term memory service with semantic recall,
+structured memory types, decay, and optional reranking. Hermes talks to it
+through the public HTTP API and keeps storage, embeddings, and reranking in
+NoldoMem instead of duplicating that logic locally.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List
+
+from agent.memory_provider import MemoryProvider
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_API_URL = "http://127.0.0.1:8787"
+_DEFAULT_AGENT = "hermes"
+_DEFAULT_NAMESPACE = "default"
+_DEFAULT_TIMEOUT = 2.0
+_DEFAULT_MAX_RECALL_RESULTS = 5
+_DEFAULT_MAX_CONTEXT_CHARS = 4000
+_VALID_MEMORY_TYPES = ("fact", "preference", "rule", "conversation", "lesson", "other")
+_SKIP_WRITE_CONTEXTS = {"cron", "subagent", "flush"}
+_CONTEXT_TAG_RE = re.compile(r"</?\s*memory-context\s*>", re.IGNORECASE)
+
+
+def _as_int(value: Any, default: int, *, minimum: int, maximum: int) -> int:
+    try:
+        return max(minimum, min(maximum, int(value)))
+    except Exception:
+        return default
+
+
+def _as_float(value: Any, default: float, *, minimum: float, maximum: float) -> float:
+    try:
+        return max(minimum, min(maximum, float(value)))
+    except Exception:
+        return default
+
+
+def _clean_text(text: str) -> str:
+    return _CONTEXT_TAG_RE.sub("", str(text or "")).strip()
+
+
+def _load_config(hermes_home: str | None = None) -> dict:
+    """Load env defaults plus optional profile-local config.
+
+    ``hermes memory setup`` stores non-secret values in ``noldomem.json`` and
+    secrets in ``.env``. Runtime availability therefore needs to merge both.
+    """
+    config = {
+        "api_url": os.environ.get("NOLDOMEM_API_URL", ""),
+        "api_key": os.environ.get("NOLDOMEM_API_KEY", ""),
+        "agent": os.environ.get("NOLDOMEM_AGENT", ""),
+        "namespace": os.environ.get("NOLDOMEM_NAMESPACE", ""),
+        "api_timeout": os.environ.get("NOLDOMEM_API_TIMEOUT", ""),
+        "max_recall_results": os.environ.get("NOLDOMEM_MAX_RECALL_RESULTS", ""),
+        "max_context_chars": os.environ.get("NOLDOMEM_MAX_CONTEXT_CHARS", ""),
+    }
+
+    config_home = hermes_home
+    if not config_home:
+        try:
+            from hermes_constants import get_hermes_home
+
+            config_home = str(get_hermes_home())
+        except Exception:
+            config_home = ""
+
+    if config_home:
+        config_path = Path(config_home) / "noldomem.json"
+        if config_path.exists():
+            try:
+                raw = json.loads(config_path.read_text(encoding="utf-8"))
+                if isinstance(raw, dict):
+                    config.update({k: v for k, v in raw.items() if v not in (None, "")})
+            except Exception:
+                logger.debug("Failed to parse NoldoMem config", exc_info=True)
+
+    return config
+
+
+def _normalize_memory_type(value: Any) -> str:
+    memory_type = str(value or "").strip().lower()
+    return memory_type if memory_type in _VALID_MEMORY_TYPES else "other"
+
+
+def _unwrap_results(response: Any) -> list[dict[str, Any]]:
+    if isinstance(response, dict):
+        results = response.get("results", [])
+    elif isinstance(response, list):
+        results = response
+    else:
+        results = []
+    return [item for item in results if isinstance(item, dict)]
+
+
+def _result_text(item: dict[str, Any]) -> str:
+    for key in ("text", "memory", "content", "document"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return _clean_text(value)
+    return ""
+
+
+def _format_recall_results(results: list[dict[str, Any]], *, max_chars: int) -> str:
+    lines = []
+    for item in results:
+        text = _result_text(item)
+        if not text:
+            continue
+        memory_type = item.get("memory_type") or item.get("category") or "other"
+        score_parts = []
+        if item.get("semantic_score") is not None:
+            score_parts.append(f"semantic={item['semantic_score']}")
+        if item.get("rerank_score") is not None:
+            score_parts.append(f"rerank={item['rerank_score']}")
+        score_suffix = f" ({', '.join(score_parts)})" if score_parts else ""
+        lines.append(f"- [{memory_type}] {text}{score_suffix}")
+
+    if not lines:
+        return ""
+
+    rendered = "## NoldoMem recalled context\n" + "\n".join(lines)
+    if len(rendered) <= max_chars:
+        return rendered
+    return rendered[: max_chars - 3].rstrip() + "..."
+
+
+RECALL_SCHEMA = {
+    "name": "noldomem_recall",
+    "description": (
+        "Search NoldoMem long-term memory by meaning. Use for prior facts, "
+        "preferences, rules, lessons, and operational context."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "What to search for."},
+            "limit": {"type": "integer", "description": "Maximum results, default 5."},
+            "memory_type": {
+                "type": "string",
+                "enum": list(_VALID_MEMORY_TYPES),
+                "description": "Optional memory type filter.",
+            },
+            "namespace": {"type": "string", "description": "Optional namespace override."},
+        },
+        "required": ["query"],
+    },
+}
+
+STORE_SCHEMA = {
+    "name": "noldomem_store",
+    "description": "Store an important memory in NoldoMem.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "text": {"type": "string", "description": "Memory text to store."},
+            "memory_type": {
+                "type": "string",
+                "enum": list(_VALID_MEMORY_TYPES),
+                "description": "Memory type, default other.",
+            },
+            "namespace": {"type": "string", "description": "Optional namespace override."},
+        },
+        "required": ["text"],
+    },
+}
+
+PIN_SCHEMA = {
+    "name": "noldomem_pin",
+    "description": "Pin a NoldoMem memory so decay and cleanup do not remove it.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "memory_id": {"type": "string", "description": "Memory ID to pin."},
+            "namespace": {"type": "string", "description": "Optional namespace override."},
+        },
+        "required": ["memory_id"],
+    },
+}
+
+
+class NoldoMemMemoryProvider(MemoryProvider):
+    """Hermes memory provider backed by a NoldoMem HTTP service."""
+
+    def __init__(self) -> None:
+        self._api_url = ""
+        self._api_key = ""
+        self._agent = _DEFAULT_AGENT
+        self._namespace = _DEFAULT_NAMESPACE
+        self._api_timeout = _DEFAULT_TIMEOUT
+        self._max_recall_results = _DEFAULT_MAX_RECALL_RESULTS
+        self._max_context_chars = _DEFAULT_MAX_CONTEXT_CHARS
+        self._agent_context = "primary"
+        self._prefetch_result = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread: threading.Thread | None = None
+        self._sync_thread: threading.Thread | None = None
+
+    @property
+    def name(self) -> str:
+        return "noldomem"
+
+    def is_available(self) -> bool:
+        config = _load_config()
+        return bool(config.get("api_url") and config.get("api_key"))
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        config_path = Path(hermes_home) / "noldomem.json"
+        existing: dict[str, Any] = {}
+        if config_path.exists():
+            try:
+                raw = json.loads(config_path.read_text(encoding="utf-8"))
+                if isinstance(raw, dict):
+                    existing = raw
+            except Exception:
+                existing = {}
+        sanitized = {k: v for k, v in values.items() if k != "api_key"}
+        existing.update(sanitized)
+        config_path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "api_url",
+                "description": "NoldoMem API URL",
+                "required": True,
+                "default": _DEFAULT_API_URL,
+            },
+            {
+                "key": "api_key",
+                "description": "NoldoMem API key",
+                "secret": True,
+                "required": True,
+                "env_var": "NOLDOMEM_API_KEY",
+            },
+            {"key": "agent", "description": "NoldoMem agent scope", "default": _DEFAULT_AGENT},
+            {"key": "namespace", "description": "NoldoMem namespace", "default": _DEFAULT_NAMESPACE},
+            {"key": "max_recall_results", "description": "Maximum auto-recall results", "default": "5"},
+        ]
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        hermes_home = str(kwargs.get("hermes_home") or "")
+        config = _load_config(hermes_home)
+        self._api_url = str(config.get("api_url") or _DEFAULT_API_URL).rstrip("/")
+        self._api_key = str(config.get("api_key") or "")
+        self._agent = str(
+            config.get("agent")
+            or kwargs.get("agent_identity")
+            or kwargs.get("user_id")
+            or _DEFAULT_AGENT
+        )
+        self._namespace = str(
+            config.get("namespace")
+            or kwargs.get("agent_workspace")
+            or _DEFAULT_NAMESPACE
+        )
+        self._api_timeout = _as_float(
+            config.get("api_timeout"), _DEFAULT_TIMEOUT, minimum=0.2, maximum=30.0
+        )
+        self._max_recall_results = _as_int(
+            config.get("max_recall_results"),
+            _DEFAULT_MAX_RECALL_RESULTS,
+            minimum=1,
+            maximum=20,
+        )
+        self._max_context_chars = _as_int(
+            config.get("max_context_chars"),
+            _DEFAULT_MAX_CONTEXT_CHARS,
+            minimum=500,
+            maximum=20000,
+        )
+        self._agent_context = str(kwargs.get("agent_context") or "primary")
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# NoldoMem Memory\n"
+            "Active. Use noldomem_recall for long-term memory search, "
+            "noldomem_store for important facts/preferences/rules/lessons, "
+            "and noldomem_pin for critical memory IDs."
+        )
+
+    def _request_json(self, path: str, body: dict[str, Any]) -> dict[str, Any]:
+        if not self._api_url or not self._api_key:
+            return {}
+        payload = json.dumps(body).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self._api_url}{path}",
+            data=payload,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "X-API-Key": self._api_key,
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self._api_timeout) as response:
+                raw = response.read().decode("utf-8")
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            logger.debug("NoldoMem request failed for %s: %s", path, exc)
+            return {}
+        try:
+            parsed = json.loads(raw) if raw else {}
+            return parsed if isinstance(parsed, dict) else {}
+        except json.JSONDecodeError:
+            logger.debug("NoldoMem returned invalid JSON for %s", path)
+            return {}
+
+    def _recall(self, query: str, *, namespace: str | None = None, limit: int | None = None) -> str:
+        query = _clean_text(query)
+        if not query:
+            return ""
+        body = {
+            "query": query,
+            "agent": self._agent,
+            "namespace": namespace or self._namespace,
+            "limit": limit or self._max_recall_results,
+        }
+        response = self._request_json("/v1/recall", body)
+        results = _unwrap_results(response)[: body["limit"]]
+        return _format_recall_results(results, max_chars=self._max_context_chars)
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=self._api_timeout)
+        with self._prefetch_lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        return result
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        query = _clean_text(query)
+        if not query or not self._api_key:
+            return
+
+        def worker() -> None:
+            result = self._recall(query)
+            with self._prefetch_lock:
+                self._prefetch_result = result
+
+        self._prefetch_thread = threading.Thread(target=worker, daemon=True)
+        self._prefetch_thread.start()
+
+    def _store(self, text: str, memory_type: str = "conversation", *, namespace: str | None = None) -> dict[str, Any]:
+        text = _clean_text(text)
+        if not text:
+            return {}
+        body = {
+            "text": text,
+            "agent": self._agent,
+            "namespace": namespace or self._namespace,
+            "memory_type": _normalize_memory_type(memory_type),
+        }
+        return self._request_json("/v1/store", body)
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if self._agent_context in _SKIP_WRITE_CONTEXTS:
+            return
+        user = _clean_text(user_content)
+        assistant = _clean_text(assistant_content)
+        if not user and not assistant:
+            return
+        text = f"[role: user]\n{user}\n[user:end]\n[role: assistant]\n{assistant}\n[assistant:end]"
+
+        def worker() -> None:
+            self._store(text, "conversation")
+
+        self._sync_thread = threading.Thread(target=worker, daemon=True)
+        self._sync_thread.start()
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [RECALL_SCHEMA, STORE_SCHEMA, PIN_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        if tool_name == "noldomem_recall":
+            query = _clean_text(str(args.get("query") or ""))
+            limit = _as_int(args.get("limit"), self._max_recall_results, minimum=1, maximum=20)
+            namespace = str(args.get("namespace") or self._namespace)
+            body = {"query": query, "agent": self._agent, "namespace": namespace, "limit": limit}
+            memory_type = args.get("memory_type")
+            if memory_type:
+                body["memory_type"] = _normalize_memory_type(memory_type)
+            response = self._request_json("/v1/recall", body)
+            results = _unwrap_results(response)
+            return json.dumps(
+                {
+                    "count": len(results),
+                    "result": _format_recall_results(results[:limit], max_chars=self._max_context_chars),
+                    "results": results,
+                }
+            )
+
+        if tool_name == "noldomem_store":
+            text = _clean_text(str(args.get("text") or ""))
+            namespace = str(args.get("namespace") or self._namespace)
+            response = self._store(text, args.get("memory_type") or "other", namespace=namespace)
+            return json.dumps(response)
+
+        if tool_name == "noldomem_pin":
+            memory_id = _clean_text(str(args.get("memory_id") or args.get("id") or ""))
+            namespace = str(args.get("namespace") or self._namespace)
+            body = {"id": memory_id, "agent": self._agent, "namespace": namespace}
+            response = self._request_json("/v1/pin", body)
+            return json.dumps(response)
+
+        return json.dumps({"error": f"NoldoMem does not handle tool '{tool_name}'"})
+
+    def shutdown(self) -> None:
+        for thread in (self._prefetch_thread, self._sync_thread):
+            if thread and thread.is_alive():
+                thread.join(timeout=self._api_timeout)
+
+
+def register(ctx) -> None:
+    ctx.register_memory_provider(NoldoMemMemoryProvider())

--- a/plugins/memory/noldomem/plugin.yaml
+++ b/plugins/memory/noldomem/plugin.yaml
@@ -1,0 +1,3 @@
+name: noldomem
+version: 1.0.0
+description: "NoldoMem long-term memory provider with semantic recall, explicit store, and pin tools."

--- a/tests/plugins/memory/test_noldomem_provider.py
+++ b/tests/plugins/memory/test_noldomem_provider.py
@@ -1,0 +1,181 @@
+import json
+import urllib.error
+
+from plugins.memory.noldomem import NoldoMemMemoryProvider
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def test_provider_unavailable_without_endpoint_or_key(monkeypatch):
+    monkeypatch.delenv("NOLDOMEM_API_URL", raising=False)
+    monkeypatch.delenv("NOLDOMEM_API_KEY", raising=False)
+
+    provider = NoldoMemMemoryProvider()
+
+    assert provider.is_available() is False
+
+
+def test_provider_available_with_endpoint_and_key(monkeypatch):
+    monkeypatch.setenv("NOLDOMEM_API_URL", "http://127.0.0.1:8787")
+    monkeypatch.setenv("NOLDOMEM_API_KEY", "test-key")
+
+    provider = NoldoMemMemoryProvider()
+
+    assert provider.is_available() is True
+
+
+def test_provider_available_with_saved_endpoint_and_env_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("NOLDOMEM_API_URL", raising=False)
+    monkeypatch.setenv("NOLDOMEM_API_KEY", "test-key")
+    (tmp_path / "noldomem.json").write_text(
+        json.dumps({"api_url": "http://memory.test"}) + "\n",
+        encoding="utf-8",
+    )
+
+    provider = NoldoMemMemoryProvider()
+
+    assert provider.is_available() is True
+
+
+def test_provider_setup_schema_mentions_endpoint_and_key():
+    provider = NoldoMemMemoryProvider()
+
+    fields = {field["key"]: field for field in provider.get_config_schema()}
+
+    assert {"api_url", "api_key"}.issubset(fields)
+    assert fields["api_key"]["secret"] is True
+    assert fields["api_key"]["env_var"] == "NOLDOMEM_API_KEY"
+
+
+def test_recall_uses_api_key_and_formats_bounded_results(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["headers"] = dict(request.header_items())
+        captured["body"] = json.loads(request.data.decode("utf-8"))
+        captured["timeout"] = timeout
+        return FakeResponse(
+            {
+                "results": [
+                    {
+                        "text": "Embedding server used Qwen3 0.6B with 1024 dimensions.",
+                        "memory_type": "fact",
+                        "semantic_score": 0.91,
+                        "rerank_score": 0.88,
+                    },
+                    {
+                        "text": "This second memory should be clipped by max_recall_results.",
+                        "memory_type": "lesson",
+                    },
+                ]
+            }
+        )
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setenv("NOLDOMEM_API_URL", "http://memory.test")
+    monkeypatch.setenv("NOLDOMEM_API_KEY", "test-key")
+    provider = NoldoMemMemoryProvider()
+    provider.initialize(
+        "session-1",
+        hermes_home=str(tmp_path),
+        agent_identity="coder",
+        agent_workspace="workspace-a",
+    )
+    provider._max_recall_results = 1
+
+    result = provider._recall("embedding dimensions")
+
+    assert captured["url"] == "http://memory.test/v1/recall"
+    assert captured["headers"]["X-api-key"] == "test-key"
+    assert captured["body"] == {
+        "query": "embedding dimensions",
+        "agent": "coder",
+        "namespace": "workspace-a",
+        "limit": 1,
+    }
+    assert captured["timeout"] == provider._api_timeout
+    assert "NoldoMem recalled context" in result
+    assert "Qwen3 0.6B" in result
+    assert "second memory" not in result
+
+
+def test_prefetch_returns_cached_background_recall(monkeypatch, tmp_path):
+    monkeypatch.setenv("NOLDOMEM_API_URL", "http://memory.test")
+    monkeypatch.setenv("NOLDOMEM_API_KEY", "test-key")
+    provider = NoldoMemMemoryProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path))
+    monkeypatch.setattr(provider, "_recall", lambda query: f"remembered: {query}")
+
+    provider.queue_prefetch("previous query")
+    provider._prefetch_thread.join(timeout=1)
+
+    assert provider.prefetch("current query") == "remembered: previous query"
+    assert provider.prefetch("current query") == ""
+
+
+def test_sync_turn_skips_non_primary_context(monkeypatch, tmp_path):
+    monkeypatch.setenv("NOLDOMEM_API_URL", "http://memory.test")
+    monkeypatch.setenv("NOLDOMEM_API_KEY", "test-key")
+    provider = NoldoMemMemoryProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), agent_context="cron")
+    monkeypatch.setattr(provider, "_store", lambda text, memory_type="conversation": (_ for _ in ()).throw(AssertionError("should not store")))
+
+    provider.sync_turn("user", "assistant", session_id="session-1")
+
+    assert provider._sync_thread is None
+
+
+def test_tool_calls_map_to_noldomem_endpoints(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_request(path, body):
+        calls.append((path, body))
+        if path == "/v1/recall":
+            return {"results": [{"text": "Stored test memory", "memory_type": "fact"}]}
+        return {"ok": True, "id": 123}
+
+    monkeypatch.setenv("NOLDOMEM_API_URL", "http://memory.test")
+    monkeypatch.setenv("NOLDOMEM_API_KEY", "test-key")
+    provider = NoldoMemMemoryProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path), agent_identity="coder")
+    monkeypatch.setattr(provider, "_request_json", fake_request)
+
+    recall = json.loads(provider.handle_tool_call("noldomem_recall", {"query": "test", "limit": 3}))
+    store = json.loads(provider.handle_tool_call("noldomem_store", {"text": "remember this", "memory_type": "lesson"}))
+    pin = json.loads(provider.handle_tool_call("noldomem_pin", {"memory_id": "mem-123"}))
+
+    assert recall["count"] == 1
+    assert store["ok"] is True
+    assert pin["ok"] is True
+    assert calls == [
+        ("/v1/recall", {"query": "test", "agent": "coder", "namespace": "default", "limit": 3}),
+        ("/v1/store", {"text": "remember this", "agent": "coder", "namespace": "default", "memory_type": "lesson"}),
+        ("/v1/pin", {"id": "mem-123", "agent": "coder", "namespace": "default"}),
+    ]
+
+
+def test_http_errors_degrade_to_empty_recall(monkeypatch, tmp_path):
+    def fake_urlopen(request, timeout):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    monkeypatch.setenv("NOLDOMEM_API_URL", "http://memory.test")
+    monkeypatch.setenv("NOLDOMEM_API_KEY", "test-key")
+    provider = NoldoMemMemoryProvider()
+    provider.initialize("session-1", hermes_home=str(tmp_path))
+
+    assert provider._recall("anything") == ""

--- a/website/docs/guides/cron-script-only.md
+++ b/website/docs/guides/cron-script-only.md
@@ -10,6 +10,7 @@ Sometimes you already know exactly what message you want to send. You don't need
 
 Hermes calls this **no-agent mode**. It's the cron system minus the LLM.
 
+<!-- ascii-guard-ignore -->
 ```
    ┌──────────────────┐          ┌──────────────────┐
    │ scheduler tick   │  every   │ run script       │
@@ -23,6 +24,7 @@ Hermes calls this **no-agent mode**. It's the cron system minus the LLM.
                                  │ (telegram/disc…) │
                                  └──────────────────┘
 ```
+<!-- ascii-guard-ignore-end -->
 
 - **No LLM call.** Zero tokens, zero agent loop, zero model spend.
 - **Script is the job.** The script decides whether to alert. Emit output → message gets sent. Emit nothing → silent tick.

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -53,6 +53,8 @@ hermes skills uninstall <skill-name>
 |-------|-------------|
 | [**blender-mcp**](/docs/user-guide/skills/optional/creative/creative-blender-mcp) | Control Blender directly from Hermes via socket connection to the blender-mcp addon. Create 3D objects, materials, animations, and run arbitrary Blender Python (bpy) code. Use when user wants to create or modify anything in Blender. |
 | [**concept-diagrams**](/docs/user-guide/skills/optional/creative/creative-concept-diagrams) | Generate flat, minimal light/dark-aware SVG diagrams as standalone HTML files, using a unified educational visual language with 9 semantic color ramps, sentence-case typography, and automatic dark mode. Best suited for educational and no... |
+| [**hyperframes**](/docs/user-guide/skills/optional/creative/creative-hyperframes) | Create HTML-based video compositions, animated title cards, social overlays, captioned talking-head videos, audio-reactive visuals, and shader transitions using HyperFrames. HTML is the source of truth for video. Use when the user wants... |
+| [**kanban-video-orchestrator**](/docs/user-guide/skills/optional/creative/creative-kanban-video-orchestrator) | Plan, set up, and monitor a multi-agent video production pipeline backed by Hermes Kanban. Use when the user wants to make ANY video — narrative film, product/marketing, music video, explainer, ASCII/terminal art, abstract/generative loo... |
 | [**meme-generation**](/docs/user-guide/skills/optional/creative/creative-meme-generation) | Generate real meme images by picking a template and overlaying text with Pillow. Produces actual .png meme files. |
 
 ## devops

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -447,6 +447,7 @@ Visually the target is the familiar Linear / Fusion layout: dark theme, column h
 
 The GUI is strictly a **read-through-the-DB + write-through-kanban_db** layer with no domain logic of its own:
 
+<!-- ascii-guard-ignore -->
 ```
 ┌────────────────────────┐      WebSocket (tails task_events)
 │   React SPA (plugin)   │ ◀──────────────────────────────────┐
@@ -466,6 +467,7 @@ The GUI is strictly a **read-through-the-DB + write-through-kanban_db** layer wi
 │  (WAL, shared)         │
 └────────────────────────┘
 ```
+<!-- ascii-guard-ignore-end -->
 
 ### REST surface
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory, NoldoMem"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -22,7 +22,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
+  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory, noldomem
 ```
 
 ## How It Works
@@ -522,6 +522,57 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 
 ---
 
+### NoldoMem
+
+Self-hosted long-term memory service with semantic recall, explicit memory
+types, decay, and optional reranking. Hermes connects to a running NoldoMem
+HTTP API through the native MemoryProvider interface.
+
+| | |
+|---|---|
+| **Best for** | Developers who already run NoldoMem or want a self-hosted memory API |
+| **Requires** | Running NoldoMem service + API key |
+| **Data storage** | Self-hosted NoldoMem database |
+| **Cost** | Free/self-hosted, plus any configured embedding or reranker costs |
+
+**Tools:** `noldomem_recall` (semantic memory search), `noldomem_store`
+(explicit memory write), `noldomem_pin` (pin critical memory IDs)
+
+**Setup:**
+```bash
+hermes memory setup    # select "noldomem"
+# Or manually:
+hermes config set memory.provider noldomem
+echo "NOLDOMEM_API_URL=http://127.0.0.1:8787" >> ~/.hermes/.env
+echo "NOLDOMEM_API_KEY=your-key" >> ~/.hermes/.env
+```
+
+**Config:** `$HERMES_HOME/noldomem.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `api_url` | `http://127.0.0.1:8787` | NoldoMem API URL |
+| `agent` | `hermes` | NoldoMem agent scope |
+| `namespace` | `default` | NoldoMem namespace |
+| `api_timeout` | `2.0` | Request timeout in seconds |
+| `max_recall_results` | `5` | Max recalled items formatted into context |
+| `max_context_chars` | `4000` | Character budget for auto-recall context |
+
+**Environment variables:** `NOLDOMEM_API_KEY` (required),
+`NOLDOMEM_API_URL`, `NOLDOMEM_AGENT`, `NOLDOMEM_NAMESPACE`,
+`NOLDOMEM_API_TIMEOUT`, `NOLDOMEM_MAX_RECALL_RESULTS`,
+`NOLDOMEM_MAX_CONTEXT_CHARS`.
+
+**Key features:**
+- Uses NoldoMem for storage, embeddings, search, and reranking instead of
+  duplicating that logic in Hermes
+- Auto-recall is bounded by result count and character budget
+- Completed-turn storage runs in the background
+- Cron, subagent, and flush contexts skip automatic writes by default
+- Request failures degrade to empty recall context instead of blocking replies
+
+---
+
 ## Provider Comparison
 
 | Provider | Storage | Cost | Tools | Dependencies | Unique Feature |
@@ -534,6 +585,7 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 | **RetainDB** | Cloud | $20/mo | 5 | `requests` | Delta compression |
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
 | **Supermemory** | Cloud | Paid | 4 | `supermemory` | Context fencing + session graph ingest + multi-container |
+| **NoldoMem** | Self-hosted | Free/self-hosted | 3 | Running NoldoMem API | Semantic recall + explicit memory types + optional reranking |
 
 ## Profile Isolation
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -302,7 +302,7 @@ Command-type providers run whatever shell command you configure, with your user'
 Voice messages sent on Telegram, Discord, WhatsApp, Slack, or Signal are automatically transcribed and injected as text into the conversation. The agent sees the transcript as normal text.
 
 | Provider | Quality | Cost | API Key |
-|----------|---------|------|---------| 
+|----------|---------|------|---------|
 | **Local Whisper** (default) | Good | Free | None needed |
 | **Groq Whisper API** | Good–Best | Free tier | `GROQ_API_KEY` |
 | **OpenAI Whisper API** | Good–Best | Paid | `VOICE_TOOLS_OPENAI_KEY` or `OPENAI_API_KEY` |

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -16,7 +16,7 @@ Configure, extend, or contribute to Hermes Agent.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/autonomous-ai-agents/hermes-agent` |
-| Version | `2.0.0` |
+| Version | `2.1.0` |
 | Author | Hermes Agent + Teknium |
 | License | MIT |
 | Tags | `hermes`, `setup`, `configuration`, `multi-agent`, `spawning`, `cli`, `gateway`, `development` |
@@ -165,7 +165,7 @@ hermes gateway status       Check status
 hermes gateway setup        Configure platforms
 ```
 
-Supported platforms: Telegram, Discord, Slack, WhatsApp, Signal, Email, SMS, Matrix, Mattermost, Home Assistant, DingTalk, Feishu, WeCom, BlueBubbles (iMessage), Weixin (WeChat), Microsoft Teams, API Server, Webhooks. Open WebUI connects via the API Server adapter.
+Supported platforms: Telegram, Discord, Slack, WhatsApp, Signal, Email, SMS, Matrix, Mattermost, Home Assistant, DingTalk, Feishu, WeCom, BlueBubbles (iMessage), Weixin (WeChat), API Server, Webhooks. Open WebUI connects via the API Server adapter.
 
 Platform docs: https://hermes-agent.nousresearch.com/docs/user-guide/messaging/
 
@@ -244,7 +244,11 @@ hermes uninstall            Uninstall Hermes
 
 ## Slash Commands (In-Session)
 
-Type these during an interactive chat session.
+Type these during an interactive chat session. New commands land fairly
+often; if something below looks stale, run `/help` in-session for the
+authoritative list or see the [live slash commands reference](https://hermes-agent.nousresearch.com/docs/reference/slash-commands).
+The registry of record is `hermes_cli/commands.py` — every consumer
+(autocomplete, Telegram menu, Slack mapping, `/help`) derives from it.
 
 ### Session Control
 ```
@@ -256,9 +260,15 @@ Type these during an interactive chat session.
 /compress            Manually compress context
 /stop                Kill background processes
 /rollback [N]        Restore filesystem checkpoint
+/snapshot [sub]      Create or restore state snapshots of Hermes config/state (CLI)
 /background <prompt> Run prompt in background
 /queue <prompt>      Queue for next turn
+/steer <prompt>      Inject a message after the next tool call without interrupting
+/agents (/tasks)     Show active agents and running tasks
 /resume [name]       Resume a named session
+/goal [text|sub]     Set a standing goal Hermes works on across turns until achieved
+                     (subcommands: status, pause, resume, clear)
+/redraw              Force a full UI repaint (CLI)
 ```
 
 ### Configuration
@@ -270,6 +280,11 @@ Type these during an interactive chat session.
 /verbose             Cycle: off → new → all → verbose
 /voice [on|off|tts]  Voice mode
 /yolo                Toggle approval bypass
+/busy [sub]          Control what Enter does while Hermes is working (CLI)
+                     (subcommands: queue, steer, interrupt, status)
+/indicator [style]   Pick the TUI busy-indicator style (CLI)
+                     (styles: kaomoji, emoji, unicode, ascii)
+/footer [on|off]     Toggle gateway runtime-metadata footer on final replies
 /skin [name]         Change theme (CLI)
 /statusbar           Toggle status bar (CLI)
 ```
@@ -280,8 +295,12 @@ Type these during an interactive chat session.
 /toolsets            List toolsets (CLI)
 /skills              Search/install skills (CLI)
 /skill <name>        Load a skill into session
-/cron                Manage cron jobs (CLI)
+/reload-skills       Re-scan ~/.hermes/skills/ for added/removed skills
+/reload              Reload .env variables into the running session (CLI)
 /reload-mcp          Reload MCP servers
+/cron                Manage cron jobs (CLI)
+/curator [sub]       Background skill maintenance (status, run, pin, archive, …)
+/kanban [sub]        Multi-profile collaboration board (tasks, links, comments)
 /plugins             List plugins (CLI)
 ```
 
@@ -292,6 +311,7 @@ Type these during an interactive chat session.
 /restart             Restart gateway (gateway)
 /sethome             Set current chat as home channel (gateway)
 /update              Update Hermes to latest (gateway)
+/topic [sub]         Enable or inspect Telegram DM topic sessions (gateway)
 /platforms (/gateway) Show platform connection status (gateway)
 ```
 
@@ -302,6 +322,7 @@ Type these during an interactive chat session.
 /browser             Open CDP browser connection
 /history             Show conversation history (CLI)
 /save                Save conversation to file (CLI)
+/copy [N]            Copy the last assistant response to clipboard (CLI)
 /paste               Attach clipboard image (CLI)
 /image               Attach local image file (CLI)
 ```
@@ -312,8 +333,10 @@ Type these during an interactive chat session.
 /commands [page]     Browse all commands (gateway)
 /usage               Token usage
 /insights [days]     Usage analytics
+/gquota              Show Google Gemini Code Assist quota usage (CLI)
 /status              Session info (gateway)
 /profile             Active profile info
+/debug               Upload debug report (system info + logs) and get shareable links
 ```
 
 ### Exit
@@ -395,12 +418,14 @@ Enable/disable via `hermes tools` (interactive) or `hermes tools enable/disable 
 | Toolset | What it provides |
 |---------|-----------------|
 | `web` | Web search and content extraction |
+| `search` | Web search only (subset of `web`) |
 | `browser` | Browser automation (Browserbase, Camofox, or local Chromium) |
 | `terminal` | Shell commands and process management |
 | `file` | File read/write/search/patch |
 | `code_execution` | Sandboxed Python execution |
 | `vision` | Image analysis |
 | `image_gen` | AI image generation |
+| `video` | Video analysis and generation |
 | `tts` | Text-to-speech |
 | `skills` | Skill browsing and management |
 | `memory` | Persistent cross-session memory |
@@ -409,11 +434,21 @@ Enable/disable via `hermes tools` (interactive) or `hermes tools enable/disable 
 | `cronjob` | Scheduled task management |
 | `clarify` | Ask user clarifying questions |
 | `messaging` | Cross-platform message sending |
-| `search` | Web search only (subset of `web`) |
 | `todo` | In-session task planning and tracking |
+| `kanban` | Multi-agent work-queue tools (gated to workers) |
+| `debugging` | Extra introspection/debug tools (off by default) |
+| `safe` | Minimal, low-risk toolset for locked-down sessions |
+| `spotify` | Spotify playback and playlist control |
+| `homeassistant` | Smart home control (off by default) |
+| `discord` | Discord integration tools |
+| `discord_admin` | Discord admin/moderation tools |
+| `feishu_doc` | Feishu (Lark) document tools |
+| `feishu_drive` | Feishu (Lark) drive tools |
+| `yuanbao` | Yuanbao integration tools |
 | `rl` | Reinforcement learning tools (off by default) |
 | `moa` | Mixture of Agents (off by default) |
-| `homeassistant` | Smart home control (off by default) |
+
+Full enumeration lives in `toolsets.py` as the `TOOLSETS` dict; `_HERMES_CORE_TOOLS` is the default bundle most platforms inherit from.
 
 Tool changes take effect on `/reset` (new session). They do NOT apply mid-conversation to preserve prompt caching.
 
@@ -590,6 +625,95 @@ terminal(command="tmux new-session -d -s resumed 'hermes --resume 20260225_14305
 - **Use `hermes chat -q` for fire-and-forget** — no PTY needed
 - **Use tmux for interactive sessions** — raw PTY mode has `\r` vs `\n` issues with prompt_toolkit
 - **For scheduled tasks**, use the `cronjob` tool instead of spawning — handles delivery and retry
+
+---
+
+## Durable & Background Systems
+
+Four systems run alongside the main conversation loop. Quick reference
+here; full developer notes live in `AGENTS.md`, user-facing docs under
+`website/docs/user-guide/features/`.
+
+### Delegation (`delegate_task`)
+
+Synchronous subagent spawn — the parent waits for the child's summary
+before continuing its own loop. Isolated context + terminal session.
+
+- **Single:** `delegate_task(goal, context, toolsets)`.
+- **Batch:** `delegate_task(tasks=[{goal, ...}, ...])` runs children in
+  parallel, capped by `delegation.max_concurrent_children` (default 3).
+- **Roles:** `leaf` (default; cannot re-delegate) vs `orchestrator`
+  (can spawn its own workers, bounded by `delegation.max_spawn_depth`).
+- **Not durable.** If the parent is interrupted, the child is
+  cancelled. For work that must outlive the turn, use `cronjob` or
+  `terminal(background=True, notify_on_complete=True)`.
+
+Config: `delegation.*` in `config.yaml`.
+
+### Cron (scheduled jobs)
+
+Durable scheduler — `cron/jobs.py` + `cron/scheduler.py`. Drive it via
+the `cronjob` tool, the `hermes cron` CLI (`list`, `add`, `edit`,
+`pause`, `resume`, `run`, `remove`), or the `/cron` slash command.
+
+- **Schedules:** duration (`"30m"`, `"2h"`), "every" phrase
+  (`"every monday 9am"`), 5-field cron (`"0 9 * * *"`), or ISO timestamp.
+- **Per-job knobs:** `skills`, `model`/`provider` override, `script`
+  (pre-run data collection; `no_agent=True` makes the script the whole
+  job), `context_from` (chain job A's output into job B), `workdir`
+  (run in a specific dir with its `AGENTS.md` / `CLAUDE.md` loaded),
+  multi-platform delivery.
+- **Invariants:** 3-minute hard interrupt per run, `.tick.lock` file
+  prevents duplicate ticks across processes, cron sessions pass
+  `skip_memory=True` by default, and cron deliveries are framed with a
+  header/footer instead of being mirrored into the target gateway
+  session (keeps role alternation intact).
+
+User docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/cron
+
+### Curator (skill lifecycle)
+
+Background maintenance for agent-created skills. Tracks usage, marks
+idle skills stale, archives stale ones, keeps a pre-run tar.gz backup
+so nothing is lost.
+
+- **CLI:** `hermes curator <verb>` — `status`, `run`, `pause`, `resume`,
+  `pin`, `unpin`, `archive`, `restore`, `prune`, `backup`, `rollback`.
+- **Slash:** `/curator <subcommand>` mirrors the CLI.
+- **Scope:** only touches skills with `created_by: "agent"` provenance.
+  Bundled + hub-installed skills are off-limits. **Never deletes** —
+  max destructive action is archive. Pinned skills are exempt from
+  every auto-transition and every LLM review pass.
+- **Telemetry:** sidecar at `~/.hermes/skills/.usage.json` holds
+  per-skill `use_count`, `view_count`, `patch_count`,
+  `last_activity_at`, `state`, `pinned`.
+
+Config: `curator.*` (`enabled`, `interval_hours`, `min_idle_hours`,
+`stale_after_days`, `archive_after_days`, `backup.*`).
+User docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/curator
+
+### Kanban (multi-agent work queue)
+
+Durable SQLite board for multi-profile / multi-worker collaboration.
+Users drive it via `hermes kanban <verb>`; dispatcher-spawned workers
+see a focused `kanban_*` toolset gated by `HERMES_KANBAN_TASK` so the
+schema footprint is zero outside worker processes.
+
+- **CLI verbs (common):** `init`, `create`, `list` (alias `ls`),
+  `show`, `assign`, `link`, `unlink`, `comment`, `complete`, `block`,
+  `unblock`, `archive`, `tail`. Less common: `watch`, `stats`, `runs`,
+  `log`, `dispatch`, `daemon`, `gc`.
+- **Worker toolset:** `kanban_show`, `kanban_complete`, `kanban_block`,
+  `kanban_heartbeat`, `kanban_comment`, `kanban_create`, `kanban_link`.
+- **Dispatcher** runs inside the gateway by default
+  (`kanban.dispatch_in_gateway: true`) — reclaims stale claims,
+  promotes ready tasks, atomically claims, spawns assigned profiles.
+  Auto-blocks a task after ~5 consecutive spawn failures.
+- **Isolation:** board is the hard boundary (workers get
+  `HERMES_KANBAN_BOARD` pinned in env); tenant is a soft namespace
+  within a board for workspace-path + memory-key isolation.
+
+User docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/kanban
 
 ---
 

--- a/website/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator.md
@@ -168,3 +168,13 @@ Tell them what you created in plain prose:
 **Don't pre-create the whole graph if the shape depends on intermediate findings.** If T3's structure depends on what T1 and T2 find, let T3 exist as a "synthesize findings" task whose own first step is to read parent handoffs and plan the rest. Orchestrators can spawn orchestrators.
 
 **Tenant inheritance.** If `HERMES_TENANT` is set in your env, pass `tenant=os.environ.get("HERMES_TENANT")` on every `kanban_create` call so child tasks stay in the same namespace.
+
+## Recovering stuck workers
+
+When a worker profile keeps crashing, hallucinating, or getting blocked by its own mistakes (usually: wrong model, missing skill, broken credential), the kanban dashboard flags the task with a ⚠ badge and opens a **Recovery** section in the drawer. Three primary actions:
+
+1. **Reclaim** (or `hermes kanban reclaim <task_id>`) — abort the running worker immediately and reset the task to `ready`. The existing claim TTL is ~15 min; this is the fast path out.
+2. **Reassign** (or `hermes kanban reassign <task_id> <new-profile> --reclaim`) — switch the task to a different profile and let the dispatcher pick it up with a fresh worker.
+3. **Change profile model** — the dashboard prints a copy-paste hint for `hermes -p <profile> model` since profile config lives on disk; edit it in a terminal, then Reclaim to retry with the new model.
+
+Hallucination warnings appear on tasks where a worker's `kanban_complete(created_cards=[...])` claim included card ids that don't exist or weren't created by the worker's profile (the gate blocks the completion), or where the free-form summary references `t_<hex>` ids that don't resolve (advisory prose scan, non-blocking). Both produce audit events that persist even after recovery actions — the trail stays for debugging.

--- a/website/docs/user-guide/skills/bundled/devops/devops-kanban-worker.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-kanban-worker.md
@@ -93,6 +93,32 @@ kanban_complete(
 
 Shape `metadata` so downstream parsers (reviewers, aggregators, schedulers) can use it without re-reading your prose.
 
+## Claiming cards you actually created
+
+If your run produced new kanban tasks (via `kanban_create`), pass the ids in `created_cards` on `kanban_complete`. The kernel verifies each id exists and was created by your profile; any phantom id blocks the completion with an error listing what went wrong, and the rejected attempt is permanently recorded on the task's event log. **Only list ids you captured from a successful `kanban_create` return value — never invent ids from prose, never paste ids from earlier runs, never claim cards another worker created.**
+
+```python
+# GOOD — capture return values, then claim them.
+c1 = kanban_create(title="remediate SQL injection", assignee="security-worker")
+c2 = kanban_create(title="fix CSRF middleware", assignee="web-worker")
+
+kanban_complete(
+    summary="Review done; spawned remediations for both findings.",
+    metadata={"pr_number": 123, "approved": False},
+    created_cards=[c1["task_id"], c2["task_id"]],
+)
+```
+
+```python
+# BAD — claiming ids you don't have captured return values for.
+kanban_complete(
+    summary="Created remediation cards t_a1b2c3d4, t_deadbeef",  # hallucinated
+    created_cards=["t_a1b2c3d4", "t_deadbeef"],                   # → gate rejects
+)
+```
+
+If a `kanban_create` call fails (exception, tool_error), the card was NOT created — do not include a phantom id for it. Retry the create, or omit the id and mention the failure in your summary. The prose-scan pass also catches `t_<hex>` references in your free-form summary that don't resolve; these don't block the completion but show up as advisory warnings on the task in the dashboard.
+
 ## Block reasons that get answered fast
 
 Bad: `"stuck"` — the human has no context.

--- a/website/docs/user-guide/skills/bundled/email/email-himalaya.md
+++ b/website/docs/user-guide/skills/bundled/email/email-himalaya.md
@@ -16,7 +16,7 @@ Himalaya CLI: IMAP/SMTP email from terminal.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/email/himalaya` |
-| Version | `1.0.0` |
+| Version | `1.1.0` |
 | Author | community |
 | License | MIT |
 | Tags | `Email`, `IMAP`, `SMTP`, `CLI`, `Communication` |
@@ -86,7 +86,27 @@ message.send.backend.encryption.type = "start-tls"
 message.send.backend.login = "you@example.com"
 message.send.backend.auth.type = "password"
 message.send.backend.auth.cmd = "pass show email/smtp"
+
+# Folder aliases (himalaya v1.2.0+ syntax). Required whenever the
+# server's folder names don't match himalaya's canonical names
+# (inbox/sent/drafts/trash). Gmail is the common case — see
+# `references/configuration.md` for the `[Gmail]/Sent Mail` mapping.
+folder.aliases.inbox = "INBOX"
+folder.aliases.sent = "Sent"
+folder.aliases.drafts = "Drafts"
+folder.aliases.trash = "Trash"
 ```
+
+> **Heads up on the alias syntax.** Pre-v1.2.0 docs used a
+> `[accounts.NAME.folder.alias]` sub-section (singular `alias`).
+> v1.2.0 silently ignores that form — TOML parses fine, but the
+> alias resolver never reads it, so every lookup falls through to
+> the canonical name. On Gmail this means save-to-Sent fails *after*
+> SMTP delivery succeeds, and `himalaya message send` exits non-zero.
+> Any caller (agent, script, user) that retries on that exit code
+> will re-run the entire send — including SMTP — producing duplicate
+> emails to recipients. Always use `folder.aliases.X` (plural, dotted
+> keys, directly under `[accounts.NAME]`).
 
 ## Hermes Integration Notes
 

--- a/website/docs/user-guide/skills/bundled/productivity/productivity-google-workspace.md
+++ b/website/docs/user-guide/skills/bundled/productivity/productivity-google-workspace.md
@@ -16,7 +16,7 @@ Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python.
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/productivity/google-workspace` |
-| Version | `1.0.0` |
+| Version | `1.0.1` |
 | Author | Nous Research |
 | License | MIT |
 | Tags | `Google`, `Gmail`, `Calendar`, `Drive`, `Sheets`, `Docs`, `Contacts`, `Email`, `OAuth` |

--- a/website/docs/user-guide/skills/optional/creative/creative-hyperframes.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-hyperframes.md
@@ -1,0 +1,204 @@
+---
+title: "Hyperframes"
+sidebar_label: "Hyperframes"
+description: "Create HTML-based video compositions, animated title cards, social overlays, captioned talking-head videos, audio-reactive visuals, and shader transitions us..."
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Hyperframes
+
+Create HTML-based video compositions, animated title cards, social overlays, captioned talking-head videos, audio-reactive visuals, and shader transitions using HyperFrames. HTML is the source of truth for video. Use when the user wants a rendered MP4/WebM from an HTML composition, wants to animate text/logos/charts over media, needs captions synced to audio, wants TTS narration, or wants to convert a website into a video.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/creative/hyperframes` |
+| Path | `optional-skills/creative/hyperframes` |
+| Version | `1.0.0` |
+| Author | heygen-com |
+| License | Apache-2.0 |
+| Tags | `creative`, `video`, `animation`, `html`, `gsap`, `motion-graphics` |
+| Related skills | [`manim-video`](/docs/user-guide/skills/bundled/creative/creative-manim-video), [`meme-generation`](/docs/user-guide/skills/optional/creative/creative-meme-generation) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# HyperFrames
+
+HTML is the source of truth for video. A composition is an HTML file with `data-*` attributes for timing, a GSAP timeline for animation, and CSS for appearance. The HyperFrames engine captures the page frame-by-frame and encodes to MP4/WebM with FFmpeg.
+
+**Complement to `manim-video`:** Use `manim-video` for mathematical/geometric explainers (equations, 3B1B-style). Use `hyperframes` for motion-graphics, talking-head with captions, product tours, social overlays, shader transitions, and anything driven by real video/audio media.
+
+## When to Use
+
+- User asks for a rendered video from text, a script, or a website
+- Animated title cards, lower thirds, or typographic intros
+- Captioned narration video (TTS + captions synced to waveform)
+- Audio-reactive visuals (beat sync, spectrum bars, pulsing glow)
+- Scene-to-scene transitions (crossfade, wipe, shader warp, flash-through-white)
+- Social overlays (Instagram/TikTok/YouTube style)
+- Website-to-video pipeline (capture a URL, produce a promo)
+- Any HTML/CSS/JS animation that must render deterministically to a video file
+
+Do **not** use this skill for:
+- Pure math/equation animation (→ `manim-video`)
+- Image generation or memes (→ `meme-generation`, image models)
+- Live video conferencing or streaming
+
+## Quick Reference
+
+```bash
+npx hyperframes init my-video               # scaffold a project
+cd my-video
+npx hyperframes lint                        # validate before preview/render
+npx hyperframes preview                     # live-reload browser preview (port 3002)
+npx hyperframes render --output final.mp4   # render to MP4
+npx hyperframes doctor                      # diagnose environment issues
+```
+
+Render flags: `--quality draft|standard|high` · `--fps 24|30|60` · `--format mp4|webm` · `--docker` (reproducible) · `--strict`.
+
+Full CLI reference: [references/cli.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/hyperframes/references/cli.md).
+
+## Setup (one-time)
+
+```bash
+bash "$(dirname "$(find ~/.hermes/skills -path '*/hyperframes/SKILL.md' 2>/dev/null | head -1)")/scripts/setup.sh"
+```
+
+The script:
+1. Verifies Node.js >= 22 and FFmpeg are installed (prints fix instructions if not).
+2. Installs the `hyperframes` CLI globally (`npm install -g hyperframes@>=0.4.2`).
+3. Pre-caches `chrome-headless-shell` via Puppeteer — **required** for best-quality rendering via Chrome's `HeadlessExperimental.beginFrame` capture path.
+4. Runs `npx hyperframes doctor` and reports the result.
+
+See [references/troubleshooting.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/hyperframes/references/troubleshooting.md) if setup fails.
+
+## Procedure
+
+### 1. Plan before writing HTML
+
+Before touching code, articulate at a high level:
+- **What** — narrative arc, key moments, emotional beats
+- **Structure** — compositions, tracks (video/audio/overlays), durations
+- **Visual identity** — colors, fonts, motion character (explosive / cinematic / fluid / technical)
+- **Hero frame** — for each scene, the moment when the most elements are simultaneously visible. This is the static layout you'll build first.
+
+**Visual Identity Gate (HARD-GATE).** Before writing ANY composition HTML, a visual identity must be defined. Do NOT write compositions with default or generic colors (`#333`, `#3b82f6`, `Roboto` are tells that this step was skipped). Check in order:
+
+1. **`DESIGN.md` at project root?** → Use its exact colors, fonts, motion rules, and "What NOT to Do" constraints.
+2. **User named a style** (e.g. "Swiss Pulse", "dark and techy", "luxury brand")? → Generate a minimal `DESIGN.md` with `## Style Prompt`, `## Colors` (3-5 hex with roles), `## Typography` (1-2 families), `## What NOT to Do` (3-5 anti-patterns).
+3. **None of the above?** → Ask 3 questions before writing any HTML:
+   - Mood? (explosive / cinematic / fluid / technical / chaotic / warm)
+   - Light or dark canvas?
+   - Any brand colors, fonts, or visual references?
+
+   Then generate a `DESIGN.md` from the answers. Every composition must trace its palette and typography back to `DESIGN.md` or explicit user direction.
+
+### 2. Scaffold
+
+```bash
+npx hyperframes init my-video --non-interactive
+```
+
+Templates: `blank`, `warm-grain`, `play-mode`, `swiss-grid`, `vignelli`, `decision-tree`, `kinetic-type`, `product-promo`, `nyt-graph`. Pass `--example <name>` to pick one, `--video clip.mp4` or `--audio track.mp3` to seed with media.
+
+### 3. Layout before animation
+
+Write the static HTML+CSS for the **hero frame first** — no GSAP yet. The `.scene-content` container must fill the scene (`width:100%; height:100%; padding:Npx`) with `display:flex` + `gap`. Use padding to push content inward — never `position: absolute; top: Npx` on a content container (content overflows when taller than the remaining space).
+
+Only after the hero frame looks right, add `gsap.from()` entrances (animate **to** the CSS position) and `gsap.to()` exits (animate **from** it).
+
+See [references/composition.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/hyperframes/references/composition.md) for the full data-attribute schema and composition rules.
+
+### 4. Animate with GSAP
+
+Every composition must:
+- Register its timeline: `window.__timelines["<composition-id>"] = tl`
+- Start paused: `gsap.timeline({ paused: true })` — the player controls playback
+- Use finite `repeat` values (no `repeat: -1` — breaks the capture engine). Calculate: `repeat: Math.ceil(duration / cycleDuration) - 1`.
+- Be deterministic — no `Math.random()`, `Date.now()`, or wall-clock logic. Use a seeded PRNG if you need pseudo-randomness.
+- Build synchronously — no `async`/`await`, `setTimeout`, or Promises around timeline construction.
+
+See [references/gsap.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/hyperframes/references/gsap.md) for the core GSAP API (tweens, eases, stagger, timelines).
+
+### 5. Transitions between scenes
+
+Multi-scene compositions require transitions. Rules:
+1. **Always use a transition between scenes** — no jump cuts.
+2. **Always use entrance animations** on every scene element (`gsap.from(...)`).
+3. **Never use exit animations** except on the final scene — the transition IS the exit.
+4. The final scene may fade out.
+
+Use `npx hyperframes add <transition-name>` to install shader transitions (`flash-through-white`, `liquid-wipe`, etc.). Full list: `npx hyperframes add --list`.
+
+### 6. Audio, captions, TTS, audio-reactive, highlighting
+
+- **Audio:** always a separate `<audio>` element (video is `muted playsinline`).
+- **TTS:** `npx hyperframes tts "Script text" --voice af_nova --output narration.wav`. List voices with `--list`. Voice ID first letter encodes language (`a`/`b`=English, `e`=Spanish, `f`=French, `j`=Japanese, `z`=Mandarin, etc.) — the CLI auto-infers the phonemizer locale; pass `--lang` only to override. Non-English phonemization requires `espeak-ng` installed system-wide.
+- **Captions:** `npx hyperframes transcribe narration.wav` → word-level transcript. Pick style from the transcript tone (hype / corporate / tutorial / storytelling / social — see the table in `references/features.md`). **Language rule:** never use `.en` whisper models unless the audio is confirmed English — `.en` translates non-English audio instead of transcribing it. Every caption group MUST have a hard `tl.set(el, { opacity: 0, visibility: "hidden" }, group.end)` kill after its exit tween — otherwise groups leak visible into later ones.
+- **Audio-reactive visuals:** pre-extract audio bands (bass / mid / treble) and sample per-frame inside the timeline with a `for` loop of `tl.call(draw, [], f / fps)` — a single long tween does NOT react to audio. Map bass → `scale` (pulse), treble → `textShadow`/`boxShadow` (glow), overall amplitude → `opacity`/`y`/`backgroundColor`. Avoid equalizer-bar clichés — let content guide the visual, audio drive its behavior.
+- **Marker-style highlighting:** highlight, circle, burst, scribble, sketchout effects for text emphasis are deterministic CSS+GSAP — see `references/features.md#marker-highlighting`. Fully seekable, no animated SVG filters.
+- **Scene transitions:** every multi-scene composition MUST use transitions (no jump cuts). Pick from CSS primitives (push slide, blur crossfade, zoom through, staggered blocks) or shader transitions (`flash-through-white`, `liquid-wipe`, `cross-warp-morph`, `chromatic-split`, etc.) via `npx hyperframes add`. Mood and energy tables live in `references/features.md#transitions`. Do not mix CSS and shader transitions in the same composition.
+
+### 7. Lint, validate, inspect, preview, render
+
+```bash
+npx hyperframes lint              # catches missing data-composition-id, overlapping tracks, unregistered timelines
+npx hyperframes validate          # WCAG contrast audit at 5 timestamps
+npx hyperframes inspect           # visual layout audit — overflow, off-frame elements, occluded text
+npx hyperframes preview           # live browser preview
+npx hyperframes render --quality draft --output draft.mp4    # fast iteration
+npx hyperframes render --quality high --output final.mp4     # final delivery
+```
+
+`hyperframes validate` samples background pixels behind every text element and warns on contrast ratios below 4.5:1 (or 3:1 for large text). `hyperframes inspect` is the layout-side companion — runs the page at multiple timestamps and flags issues that a static lint can't see (a caption that wraps past the safe area only at 4.5s, a card that overflows when its title is the longest variant, an element that ends up behind a transition shader). Run `inspect` especially on compositions with speech bubbles, cards, captions, or tight typography.
+
+### 8. Website-to-video (if the user gives a URL)
+
+Use the 7-step capture-to-video workflow in [references/website-to-video.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/hyperframes/references/website-to-video.md): capture → DESIGN.md → SCRIPT.md → storyboard → composition → render → deliver.
+
+## Pitfalls
+
+- **`HeadlessExperimental.beginFrame' wasn't found`** — Chromium 147+ removed this protocol. Ensure you're on `hyperframes@>=0.4.2` (auto-detects and falls back to screenshot mode). Escape hatch: `export PRODUCER_FORCE_SCREENSHOT=true`. See [hyperframes#294](https://github.com/heygen-com/hyperframes/issues/294) and [references/troubleshooting.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/hyperframes/references/troubleshooting.md).
+- **System Chrome (not `chrome-headless-shell`)** — renders hang for 120s then timeout. Run `npx puppeteer browsers install chrome-headless-shell` (setup.sh does this). `hyperframes doctor` reports which binary will be used.
+- **`repeat: -1` anywhere** — breaks the capture engine. Always compute a finite repeat count.
+- **`gsap.set()` on clip elements that enter later** — the element doesn't exist at page load. Use `tl.set(selector, vars, timePosition)` inside the timeline instead, at or after the clip's `data-start`.
+- **`<br>` inside content text** — forced breaks don't know the rendered font width, so natural wrap + `<br>` double-breaks. Use `max-width` to let text wrap. Exception: short display titles where each word is deliberately on its own line.
+- **Animating `visibility` or `display`** — GSAP can't tween these. Use `autoAlpha` (handles both visibility and opacity).
+- **Calling `video.play()` or `audio.play()`** — the framework owns playback. Never call these yourself.
+- **Building timelines async** — the capture engine reads `window.__timelines` synchronously after page load. Never wrap timeline construction in `async`, `setTimeout`, or a Promise.
+- **Standalone `index.html` wrapped in `<template>`** — hides all content from the browser. Only **sub-compositions** loaded via `data-composition-src` use `<template>`.
+- **Using video for audio** — always muted `<video>` + separate `<audio>`.
+
+## Verification
+
+Before and after rendering:
+
+1. **Lint + validate + inspect pass:** `npx hyperframes lint --strict && npx hyperframes validate && npx hyperframes inspect` (lint catches structural issues, validate catches contrast, inspect catches visual layout / overflow issues — see troubleshooting.md if warnings appear).
+2. **Animation choreography** — for new compositions or significant animation changes, run the animation map. `npx hyperframes init` copies the skill scripts into the project, so the path is project-local:
+   ```bash
+   node skills/hyperframes/scripts/animation-map.mjs <composition-dir> \
+     --out <composition-dir>/.hyperframes/anim-map
+   ```
+   Outputs a single `animation-map.json` with per-tween summaries, ASCII Gantt timeline, stagger detection, dead zones (>1s with no animation), element lifecycles, and flags (`offscreen`, `collision`, `invisible`, `paced-fast` &lt;0.2s, `paced-slow` >2s). Scan summaries and flags — fix or justify each. Skip on small edits.
+3. **File exists + non-zero:** `ls -lh final.mp4`.
+4. **Duration matches `data-duration`:** `ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 final.mp4`.
+5. **Visual check:** extract a mid-composition frame: `ffmpeg -i final.mp4 -ss 00:00:05 -vframes 1 preview.png`.
+6. **Audio present if expected:** `ffprobe -v error -show_streams -select_streams a -of default=nw=1:nk=1 final.mp4 | head -1`.
+
+If `hyperframes render` fails, run `npx hyperframes doctor` and attach its output when reporting.
+
+## References
+
+- [composition.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/hyperframes/references/composition.md) — data attributes, timeline contract, non-negotiable rules, typography/asset rules
+- [cli.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/hyperframes/references/cli.md) — every CLI command (init, capture, lint, validate, inspect, preview, render, transcribe, tts, doctor, browser, info, upgrade, benchmark)
+- [gsap.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/hyperframes/references/gsap.md) — GSAP core API for HyperFrames (tweens, eases, stagger, timelines, matchMedia)
+- [features.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/hyperframes/references/features.md) — captions, TTS, audio-reactive, marker highlighting, transitions (load on demand)
+- [website-to-video.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/hyperframes/references/website-to-video.md) — 7-step capture-to-video workflow
+- [troubleshooting.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/hyperframes/references/troubleshooting.md) — OpenClaw fix, env vars, common render errors

--- a/website/docs/user-guide/skills/optional/creative/creative-kanban-video-orchestrator.md
+++ b/website/docs/user-guide/skills/optional/creative/creative-kanban-video-orchestrator.md
@@ -1,0 +1,218 @@
+---
+title: "Kanban Video Orchestrator — Plan, set up, and monitor a multi-agent video production pipeline backed by Hermes Kanban"
+sidebar_label: "Kanban Video Orchestrator"
+description: "Plan, set up, and monitor a multi-agent video production pipeline backed by Hermes Kanban"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Kanban Video Orchestrator
+
+Plan, set up, and monitor a multi-agent video production pipeline backed by Hermes Kanban. Use when the user wants to make ANY video — narrative film, product/marketing, music video, explainer, ASCII/terminal art, abstract/generative loop, comic, 3D, real-time/installation — and the work warrants decomposition into specialized profiles (writer, designer, animator, renderer, voice, editor, etc.) coordinated through a kanban board. Performs adaptive discovery to scope the brief, designs an appropriate team for the requested style, generates the setup script that creates Hermes profiles + initial kanban task, then helps monitor execution and intervene when tasks stall or fail. Routes scenes to whichever Hermes rendering / audio / design skill fits each beat (`ascii-video`, `manim-video`, `p5js`, `comfyui`, `touchdesigner-mcp`, `blender-mcp`, `pixel-art`, `baoyu-comic`, `claude-design`, `excalidraw`, `songsee`, `heartmula`, …) plus external APIs for TTS, image-gen, and image-to-video as needed.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/creative/kanban-video-orchestrator` |
+| Path | `optional-skills/creative/kanban-video-orchestrator` |
+| Version | `1.0.0` |
+| Author | ['SHL0MS', 'alt-glitch'] |
+| License | MIT |
+| Tags | `video`, `kanban`, `multi-agent`, `orchestration`, `production-pipeline` |
+| Related skills | [`kanban-orchestrator`](/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator), [`kanban-worker`](/docs/user-guide/skills/bundled/devops/devops-kanban-worker), [`ascii-video`](/docs/user-guide/skills/bundled/creative/creative-ascii-video), [`manim-video`](/docs/user-guide/skills/bundled/creative/creative-manim-video), [`p5js`](/docs/user-guide/skills/bundled/creative/creative-p5js), [`comfyui`](/docs/user-guide/skills/bundled/creative/creative-comfyui), [`touchdesigner-mcp`](/docs/user-guide/skills/bundled/creative/creative-touchdesigner-mcp), [`blender-mcp`](/docs/user-guide/skills/optional/creative/creative-blender-mcp), [`pixel-art`](/docs/user-guide/skills/bundled/creative/creative-pixel-art), [`ascii-art`](/docs/user-guide/skills/bundled/creative/creative-ascii-art), [`songwriting-and-ai-music`](/docs/user-guide/skills/bundled/creative/creative-songwriting-and-ai-music), [`heartmula`](/docs/user-guide/skills/bundled/media/media-heartmula), [`songsee`](/docs/user-guide/skills/bundled/media/media-songsee), [`spotify`](/docs/user-guide/skills/bundled/media/media-spotify), [`youtube-content`](/docs/user-guide/skills/bundled/media/media-youtube-content), [`claude-design`](/docs/user-guide/skills/bundled/creative/creative-claude-design), [`excalidraw`](/docs/user-guide/skills/bundled/creative/creative-excalidraw), [`architecture-diagram`](/docs/user-guide/skills/bundled/creative/creative-architecture-diagram), [`concept-diagrams`](/docs/user-guide/skills/optional/creative/creative-concept-diagrams), [`baoyu-comic`](/docs/user-guide/skills/bundled/creative/creative-baoyu-comic), [`baoyu-infographic`](/docs/user-guide/skills/bundled/creative/creative-baoyu-infographic), [`humanizer`](/docs/user-guide/skills/bundled/creative/creative-humanizer), [`gif-search`](/docs/user-guide/skills/bundled/media/media-gif-search), [`meme-generation`](/docs/user-guide/skills/optional/creative/creative-meme-generation) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Kanban Video Orchestrator
+
+Wrap any video request — from a 15-second product teaser to a 5-minute narrative
+short to a music video to an ASCII loop — in a Hermes Kanban pipeline that
+decomposes the work to specialized agent profiles.
+
+This skill does **not** render anything itself. It is a meta-pipeline that:
+
+1. **Scopes** the request through targeted discovery
+2. **Designs** an appropriate team (which roles, which tools per role) based on the style
+3. **Generates** a setup script that creates Hermes profiles, project workspace, and the initial kanban task
+4. **Hands off** to the director profile, which decomposes via the kanban
+5. **Monitors** execution, helps intervene when tasks stall or fail
+
+The actual rendering happens inside the kanban once it's running, via whichever
+existing skills + tools fit the scenes — `ascii-video`, `manim-video`, `p5js`,
+`comfyui`, `touchdesigner-mcp`, `blender-mcp`, `songwriting-and-ai-music`,
+`heartmula`, external APIs, or plain Python with PIL + ffmpeg.
+
+## When NOT to use this skill
+
+- The video is one continuous procedural project that needs no specialists. Just write the code directly.
+- The user wants a quick one-shot conversion (e.g. "convert this mp4 to a GIF") — use ffmpeg directly.
+- The output is a static image, GIF, or audio-only artifact — use the matching specific skill (`ascii-art`, `gifs`, `meme-generation`, `songwriting-and-ai-music`).
+- The work fits a single existing skill cleanly (e.g. a pure ASCII video — just use `ascii-video`).
+
+## Workflow
+
+```
+DISCOVER  →  BRIEF  →  TEAM DESIGN  →  SETUP  →  EXECUTE  →  MONITOR
+```
+
+### Step 1 — Discover (ask the right questions)
+
+The discovery process is **adaptive**: ask only what is actually needed. Always
+start with three questions to identify the broad shape:
+
+- **What is the video?** (one-sentence brief)
+- **How long?** (5-30s teaser / 30-90s short / 90s-3min explainer / 3-10min film / longer)
+- **What aspect ratio + target platform?** (1:1 / 9:16 / 16:9; X, IG, YouTube, internal, etc.)
+
+From the answer, classify the style category. The style determines which
+follow-up questions to ask. **Do not ask all questions at once.** Ask 2-4 at a
+time, listen, then proceed. Make reasonable assumptions whenever the user
+implies an answer.
+
+For complete intake patterns and per-style question banks, see
+**[references/intake.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/kanban-video-orchestrator/references/intake.md)**.
+
+### Step 2 — Brief
+
+Once enough is known, produce a structured `brief.md` using the template in
+`assets/brief.md.tmpl`. Stages:
+
+1. **Concept** — the one-sentence pitch + emotional north star
+2. **Scope** — duration, aspect, platform, deadline
+3. **Style** — visual references, brand constraints, tone
+4. **Scenes** — beat-by-beat breakdown (durations, content, target tool)
+5. **Audio** — narration / music / SFX / silent (per scene if needed)
+6. **Deliverables** — file format, resolution, optional alternates (vertical cut, GIF, etc.)
+
+Show the brief to the user for confirmation before designing the team. **The
+brief is the contract** — every downstream task references it.
+
+### Step 3 — Team design
+
+Pick role archetypes from the library that fit this video. **Compose, don't
+clone.** Most videos need 4-7 profiles. The director is always present; the
+rest are picked by what the brief actually requires.
+
+For the role library and per-style team compositions, see
+**[references/role-archetypes.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/kanban-video-orchestrator/references/role-archetypes.md)**.
+
+For mapping role → which Hermes skills + toolsets it loads, see
+**[references/tool-matrix.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/kanban-video-orchestrator/references/tool-matrix.md)**.
+
+### Step 4 — Setup
+
+Generate a setup script (`setup.sh`) and run it. The script:
+
+1. Creates the project workspace (`~/projects/video-pipeline/<slug>/`)
+2. Copies any provided assets into `taste/`, `audio/`, `assets/`
+3. Creates each Hermes profile via `hermes profile create --clone`
+4. Writes per-profile `SOUL.md` (personality + role definition)
+5. Configures profile YAML (toolsets, always_load skills, cwd)
+6. Writes `brief.md`, `TEAM.md`, and `taste/` content
+7. Fires the initial `hermes kanban create` task assigned to the director
+
+Use `scripts/bootstrap_pipeline.py` to generate setup.sh from a brief +
+team-design JSON. See **[references/kanban-setup.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/kanban-video-orchestrator/references/kanban-setup.md)**
+for the setup script structure, profile config patterns, and the critical
+"shared workspace" rule.
+
+### Step 5 — Execute
+
+Run `setup.sh`. Then provide the user with monitoring commands:
+
+```bash
+hermes kanban watch --tenant <project-tenant>     # live events
+hermes kanban list  --tenant <project-tenant>     # board snapshot
+hermes dashboard                                   # visual board UI
+```
+
+The director profile takes over from here, decomposing the work and routing
+tasks to specialist profiles via the kanban toolset.
+
+### Step 6 — Monitor and intervene
+
+Stay engaged — the kanban runs autonomously but a stuck task or bad output
+needs human (or AI) judgment.
+
+Monitoring patterns: poll `kanban list` periodically, inspect any RUNNING task
+that exceeds its expected duration with `kanban show <id>`, and check
+heartbeats. When a worker's output fails review, the standard interventions are:
+
+1. Comment on the worker's task with specific feedback (`kanban_comment`)
+2. Create a re-run task with the original as parent
+3. Adjust the brief's scope and let the director re-decompose
+
+For diagnostic patterns, intervention recipes, and the "task is stuck"
+playbook, see **[references/monitoring.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/kanban-video-orchestrator/references/monitoring.md)**.
+
+## Reference: worked examples
+
+Six concrete pipelines covering very different video styles — narrative film,
+product/marketing, music video, math/algorithm explainer, ASCII video, real-time
+installation — showing how the same workflow yields very different teams and
+task graphs. See **[references/examples.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/creative/kanban-video-orchestrator/references/examples.md)**.
+
+## Critical rules
+
+1. **Discovery before action.** Never start generating a brief or team without
+   asking at least the three baseline questions. A bad brief cascades through
+   the entire pipeline.
+
+2. **Match the team to the video.** Don't reuse the same 4-profile setup for
+   every job. A music video that doesn't have a beat-analysis profile will
+   misfire. A narrative film that doesn't have a writer profile will produce
+   incoherent scenes. See `references/role-archetypes.md`.
+
+3. **One workspace per project.** All profiles for a given video share the same
+   `dir:` workspace. Tasks pass artifacts via shared filesystem and structured
+   handoffs. **Every** `kanban_create` call passes
+   `workspace_kind="dir"` + `workspace_path="<absolute project path>"`.
+
+4. **Tenant every project.** Use a project-specific tenant
+   (`--tenant <project-slug>`). Keeps the dashboard scoped and prevents
+   cross-pollination with other ongoing kanbans.
+
+5. **Respect existing skills.** When a scene fits an existing skill, the
+   relevant renderer should load that skill via `--skill <name>` on its task
+   or `always_load` in its profile. Do not re-derive what a skill already
+   provides.
+
+6. **The director never executes.** Even with the full `kanban + terminal +
+   file` toolset, the director's `SOUL.md` rules forbid it from executing
+   work itself. It decomposes and routes only — every concrete task becomes
+   a `hermes kanban create` call to a specialist profile. The
+   `kanban-orchestrator` skill spells this out further.
+
+7. **Don't over-decompose.** A 30-second product video does NOT need 20 tasks.
+   Aim for the smallest task graph that still parallelizes well and exposes the
+   right human-review gates.
+
+8. **Verify API keys BEFORE firing.** External APIs (TTS, image-gen,
+   image-to-video) need keys in `~/.hermes/.env` or the user's secret store.
+   A worker that hits a missing-key error wastes a task slot. The setup
+   script's `check_key` helper aborts cleanly if a required key is missing.
+
+## File map
+
+```
+SKILL.md                            ← this file (workflow + rules)
+references/
+  intake.md                         ← discovery question banks per style
+  role-archetypes.md                ← role library (writer, designer, animator, …)
+  tool-matrix.md                    ← skill + toolset mapping per role
+  kanban-setup.md                   ← setup script structure & profile config
+  monitoring.md                     ← watch + intervene patterns
+  examples.md                       ← six worked pipelines
+assets/
+  brief.md.tmpl                     ← brief skeleton
+  setup.sh.tmpl                     ← setup script skeleton
+  soul.md.tmpl                      ← profile personality skeleton
+scripts/
+  bootstrap_pipeline.py             ← generate setup.sh from brief + team JSON
+  monitor.py                        ← polling + intervention helpers
+```

--- a/website/docs/user-guide/skills/optional/mlops/mlops-flash-attention.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-flash-attention.md
@@ -362,10 +362,6 @@ Flash Attention uses float16/bfloat16 for speed. Float32 not supported.
 
 **Performance benchmarks**: See [references/benchmarks.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/mlops/flash-attention/references/benchmarks.md) for detailed speed and memory comparisons across GPUs and sequence lengths.
 
-**Algorithm details**: See [references/algorithm.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/mlops/flash-attention/references/algorithm.md) for tiling strategy, recomputation, and IO complexity analysis.
-
-**Advanced features**: See [references/advanced-features.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/mlops/flash-attention/references/advanced-features.md) for rotary embeddings, ALiBi, paged KV cache, and custom attention masks.
-
 ## Hardware requirements
 
 - **GPU**: NVIDIA Ampere+ (A100, A10, A30) or AMD MI200+


### PR DESCRIPTION
## What does this PR do?

Adds a NoldoMem memory provider plugin for Hermes. It lets Hermes use a running NoldoMem HTTP API for long-term memory recall, explicit memory writes, and memory pinning.

The provider uses the existing `MemoryProvider` interface and only depends on the Python standard library.

## Related Issue

No issue yet.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Security fix
- [x] Documentation update
- [x] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- Added `plugins/memory/noldomem` with recall, store, and pin tools.
- Added bounded recall formatting and background completed-turn storage.
- Added setup docs in the memory providers guide.
- Added focused tests for config loading, API headers, endpoint mapping, bounded recall, and failure behavior.

## How to Test

1. `python3 -m pytest -o addopts='' tests/plugins/memory/test_noldomem_provider.py tests/hermes_cli/test_plugin_cli_registration.py tests/agent/test_memory_provider.py -q`
2. `.venv/bin/ruff check plugins/memory/noldomem tests/plugins/memory/test_noldomem_provider.py`
3. `git diff --check`

## Real-world validation

I tested the provider behavior with mocked NoldoMem API calls in the focused test suite. The implementation uses the public NoldoMem API shape: `/v1/recall`, `/v1/store`, and `/v1/pin`, with the `X-API-Key` header.

I also tried `pytest tests/ -q` locally. It did not reach this change because the local environment is missing optional test dependencies: `acp`, `fastapi`, and `numpy`.

## Checklist

### Code

- [x] I read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I ran `pytest tests/ -q` and all tests pass, local optional deps are missing
- [x] I added tests for my changes
- [x] I tested on my platform: macOS

### Documentation & Housekeeping

- [x] I updated relevant documentation
- [x] `cli-config.yaml.example` is N/A
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A
- [x] I considered cross-platform impact
- [x] I added tool schemas for the new provider tools
