### PR TITLE
fix(gateway): ignore pending sentinels during drain

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1743,7 +1743,7 @@ class GatewayRunner:
         self._shutdown_event.set()
 
     def _running_agent_count(self) -> int:
-        return len(self._running_agents)
+        return len(self._snapshot_running_agents())
 
     def _status_action_label(self) -> str:
         return "restart" if self._restart_requested else "shutdown"
@@ -2380,10 +2380,10 @@ class GatewayRunner:
             return snapshot, True
 
         deadline = asyncio.get_running_loop().time() + timeout
-        while self._running_agents and asyncio.get_running_loop().time() < deadline:
+        while self._running_agent_count() and asyncio.get_running_loop().time() < deadline:
             _maybe_update_status()
             await asyncio.sleep(0.1)
-        timed_out = bool(self._running_agents)
+        timed_out = bool(self._running_agent_count())
         _maybe_update_status(force=True)
         return snapshot, timed_out
 

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -910,6 +910,28 @@ async def test_drain_timeout_skips_pending_sentinel_sessions():
     assert marked == {session_key_real}
 
 
+@pytest.mark.asyncio
+async def test_drain_ignores_only_pending_sentinel_sessions():
+    """A construction sentinel is not an active agent for shutdown drain.
+
+    M43's fake/local seam proved that active-run snapshots must be shape-only
+    and exclude not-yet-started sentinels.  If the live drain loop treats a
+    lone sentinel as active work, shutdown burns the whole drain budget and
+    reports a timeout even though no AIAgent exists to interrupt or resume.
+    """
+    from gateway.run import _AGENT_PENDING_SENTINEL
+
+    runner, _adapter = make_restart_runner()
+    runner._running_agents = {"agent:main:telegram:dm:pending": _AGENT_PENDING_SENTINEL}
+
+    with patch("gateway.status.write_runtime_status"):
+        snapshot, timed_out = await runner._drain_active_agents(timeout=0.01)
+
+    assert snapshot == {}
+    assert timed_out is False
+    assert runner._running_agent_count() == 0
+
+
 # ---------------------------------------------------------------------------
 # Shutdown banner wording
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes gateway drain accounting so pending agent-construction sentinel entries are not treated as active running agents during shutdown/restart drain.

`GatewayRunner._running_agents` can temporarily contain `_AGENT_PENDING_SENTINEL` while an agent is being constructed. That sentinel is not an interruptible/runnable `AIAgent`, so drain logic should not count it as active work or wait on it as if it were a real running session.

This patch updates drain active-agent counting to use the existing filtered running-agent snapshot instead of raw `_running_agents`, and adds regression coverage for pending-sentinel-only drain cases.

## Test plan

- `python -m py_compile gateway/run.py`
- `python -m pytest -q -o 'addopts=' tests/gateway/test_restart_resume_pending.py::test_drain_timeout_marks_resume_pending tests/gateway/test_restart_resume_pending.py::test_drain_timeout_only_marks_still_running_sessions tests/gateway/test_restart_resume_pending.py::test_drain_timeout_skips_pending_sentinel_sessions tests/gateway/test_restart_resume_pending.py::test_drain_ignores_only_pending_sentinel_sessions`
- `python -m pytest -q -o 'addopts=' tests/gateway/test_restart_resume_pending.py`

