### PR TITLE
fix(slack): enable writable App Home DMs in manifest

### DIFF
--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -48,6 +48,11 @@ def _build_full_manifest(bot_name: str, bot_description: str) -> dict:
             "background_color": "#1a1a2e",
         },
         "features": {
+            "app_home": {
+                "home_tab_enabled": False,
+                "messages_tab_enabled": True,
+                "messages_tab_read_only_enabled": False,
+            },
             "bot_user": {
                 "display_name": bot_name[:80],
                 "always_online": True,
@@ -69,6 +74,7 @@ def _build_full_manifest(bot_name: str, bot_description: str) -> dict:
                     "files:read",
                     "files:write",
                     "groups:history",
+                    "groups:read",
                     "im:history",
                     "im:read",
                     "im:write",

--- a/tests/hermes_cli/test_slack_cli.py
+++ b/tests/hermes_cli/test_slack_cli.py
@@ -1,0 +1,30 @@
+"""Tests for Slack CLI helpers."""
+
+from hermes_cli.slack_cli import _build_full_manifest
+
+
+class TestSlackFullManifest:
+    """Generated full Slack app manifest used by `hermes slack manifest`."""
+
+    def test_app_home_messages_are_writable(self):
+        manifest = _build_full_manifest("Hermes", "Your Hermes agent on Slack")
+
+        assert manifest["features"]["app_home"] == {
+            "home_tab_enabled": False,
+            "messages_tab_enabled": True,
+            "messages_tab_read_only_enabled": False,
+        }
+
+    def test_private_channel_directory_scope_is_included(self):
+        manifest = _build_full_manifest("Hermes", "Your Hermes agent on Slack")
+
+        bot_scopes = manifest["oauth_config"]["scopes"]["bot"]
+        assert "groups:read" in bot_scopes
+
+    def test_assistant_features_remain_enabled(self):
+        manifest = _build_full_manifest("Hermes", "Your Hermes agent on Slack")
+
+        assert "assistant_view" in manifest["features"]
+        assert "assistant:write" in manifest["oauth_config"]["scopes"]["bot"]
+        bot_events = manifest["settings"]["event_subscriptions"]["bot_events"]
+        assert "assistant_thread_started" in bot_events


### PR DESCRIPTION
## Summary

- Add `features.app_home` to the generated full Slack app manifest so App Home DMs are enabled and writable by default.
- Add `groups:read` to the generated bot scopes so private-channel directory enumeration has the scope it already expects.
- Add regression tests for the full `hermes slack manifest` output while preserving the existing Slack Assistant manifest fields.

## Context

The Slack setup docs already call out that the Messages Tab must be enabled, otherwise users see "Sending messages to this app has been turned off" when trying to DM the bot. That documentation landed in #3590, but `hermes slack manifest --write` did not encode the same App Home setting, so users following the recommended manifest path could still create an app with blocked DMs.

This keeps the existing assistant UX (`assistant_view`, `assistant:write`, and assistant thread events) intact; it only makes the generated manifest match the documented DM setup requirement.

Related to #17054.

## Tests

- `uv run --extra dev pytest tests/hermes_cli/test_slack_cli.py tests/hermes_cli/test_commands.py::TestSlackAppManifest -q`
- `uv run --extra dev ruff check hermes_cli/slack_cli.py tests/hermes_cli/test_slack_cli.py`
