### PR TITLE
feat(plugins): add transform_api_message hook

### DIFF
--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -134,6 +134,14 @@ _DEFAULT_PAYLOADS = {
         "model": "gpt-4",
         "platform": "cli",
     },
+    "transform_api_message": {
+        "msg": {"role": "tool", "content": "full local result"},
+        "api_msg": {"role": "tool", "content": "full local result"},
+        "idx": 2,
+        "session_id": "test-session",
+        "model": "gpt-4",
+        "platform": "cli",
+    },
     "post_llm_call": {
         "session_id": "test-session",
         "model": "gpt-4",

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -80,6 +80,7 @@ VALID_HOOKS: Set[str] = {
     "post_tool_call",
     "transform_terminal_output",
     "transform_tool_result",
+    "transform_api_message",
     "pre_llm_call",
     "post_llm_call",
     "pre_api_request",

--- a/run_agent.py
+++ b/run_agent.py
@@ -5194,6 +5194,28 @@ class AIAgent:
             )
         return messages
 
+    def _apply_transform_api_message_hooks(
+        self,
+        msg: Dict[str, Any],
+        api_msg: Dict[str, Any],
+        idx: int,
+    ) -> None:
+        """Let plugins mutate the per-request API message copy only."""
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+
+            _invoke_hook(
+                "transform_api_message",
+                msg=msg,
+                api_msg=api_msg,
+                idx=idx,
+                session_id=self.session_id or "",
+                model=self.model or "",
+                platform=self.platform or "",
+            )
+        except Exception as exc:
+            logger.warning("transform_api_message hook failed: %s", exc)
+
     @staticmethod
     def _is_thinking_only_assistant(msg: Dict[str, Any]) -> bool:
         """Return True if ``msg`` is an assistant turn whose only payload is reasoning.
@@ -10388,13 +10410,14 @@ class AIAgent:
             # (finish_reason, reasoning) that strict APIs like Mistral reject with 422
             _needs_sanitize = self._should_sanitize_tool_calls()
             api_messages = []
-            for msg in messages:
+            for idx, msg in enumerate(messages):
                 api_msg = msg.copy()
                 self._copy_reasoning_content_for_api(msg, api_msg)
                 for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
                     api_msg.pop(internal_field, None)
                 if _needs_sanitize:
                     self._sanitize_tool_calls_for_strict_api(api_msg)
+                self._apply_transform_api_message_hooks(msg, api_msg, idx)
                 api_messages.append(api_msg)
 
             effective_system = self._cached_system_prompt or ""
@@ -11122,6 +11145,7 @@ class AIAgent:
                     self._sanitize_tool_calls_for_strict_api(api_msg)
                 # Keep 'reasoning_details' - OpenRouter uses this for multi-turn reasoning context
                 # The signature field helps maintain reasoning continuity
+                self._apply_transform_api_message_hooks(msg, api_msg, idx)
                 api_messages.append(api_msg)
 
             # Build the final system message: cached prompt + ephemeral system prompt.

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -330,6 +330,7 @@ class TestPluginHooks:
         assert "post_api_request" in VALID_HOOKS
         assert "transform_terminal_output" in VALID_HOOKS
         assert "transform_tool_result" in VALID_HOOKS
+        assert "transform_api_message" in VALID_HOOKS
 
     def test_valid_hooks_include_pre_gateway_dispatch(self):
         assert "pre_gateway_dispatch" in VALID_HOOKS

--- a/tests/run_agent/test_transform_api_message_hook.py
+++ b/tests/run_agent/test_transform_api_message_hook.py
@@ -1,0 +1,55 @@
+"""Tests for the per-request transform_api_message plugin hook."""
+
+from run_agent import AIAgent
+
+
+def _agent() -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.session_id = "session-1"
+    agent.model = "gpt-test"
+    agent.platform = "cli"
+    return agent
+
+
+def test_transform_api_message_mutates_api_copy_only(monkeypatch):
+    calls = []
+
+    def fake_invoke_hook(hook_name, **kwargs):
+        calls.append((hook_name, kwargs))
+        kwargs["api_msg"]["content"] = "[redacted for api]"
+        kwargs["api_msg"]["ephemeral_only"] = True
+        return ["ignored"]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+
+    msg = {"role": "tool", "content": "full local result"}
+    api_msg = msg.copy()
+
+    _agent()._apply_transform_api_message_hooks(msg, api_msg, 3)
+
+    assert msg == {"role": "tool", "content": "full local result"}
+    assert api_msg == {
+        "role": "tool",
+        "content": "[redacted for api]",
+        "ephemeral_only": True,
+    }
+    assert calls[0][0] == "transform_api_message"
+    assert calls[0][1]["msg"] is msg
+    assert calls[0][1]["api_msg"] is api_msg
+    assert calls[0][1]["idx"] == 3
+    assert calls[0][1]["session_id"] == "session-1"
+    assert calls[0][1]["model"] == "gpt-test"
+    assert calls[0][1]["platform"] == "cli"
+
+
+def test_transform_api_message_hook_errors_leave_api_message_unchanged(monkeypatch, caplog):
+    def fake_invoke_hook(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+    api_msg = {"role": "user", "content": "hello"}
+
+    _agent()._apply_transform_api_message_hooks({"role": "user", "content": "hello"}, api_msg, 0)
+
+    assert api_msg == {"role": "user", "content": "hello"}
+    assert "transform_api_message hook failed" in caplog.text


### PR DESCRIPTION
## Summary

Fixes #20307.

Adds a `transform_api_message` plugin hook at the API-message copy boundary so plugins can make request-scoped message changes without mutating the canonical `messages` list that is persisted to session storage.

## Changes

- Registers `transform_api_message` as a valid plugin hook.
- Invokes it for each copied API message after Hermes' existing ephemeral mutations/internal-field stripping and before appending to `api_messages`.
- Adds synthetic payload coverage for `hermes hooks test`.
- Adds regression tests proving hook mutations affect only `api_msg`, not the original message, and hook failures leave the API message unchanged.

## Overlap Check

- Searched open PRs for `20307`, `transform_api_message`, and ephemeral API-message transformation.
- No open PR overlap found.

## Verification

- `scripts/run_tests.sh tests/run_agent/test_transform_api_message_hook.py tests/hermes_cli/test_plugins.py -k 'transform_api_message or valid_hooks_include_request_scoped_api_hooks'` -> 3 passed
- `scripts/run_tests.sh tests/hermes_cli/test_hooks_cli.py tests/run_agent/test_transform_api_message_hook.py tests/hermes_cli/test_plugins.py -k 'transform_api_message or valid_hooks_include_request_scoped_api_hooks or hooks'` -> 27 passed
- `git diff --check` -> clean
