### PR TITLE
feat: add claude-memory-layer prefetch provider

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8948,6 +8948,7 @@ class GatewayRunner:
                     chat_name=source.chat_name,
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
+                    chat_topic=source.chat_topic,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
                 )
@@ -13358,6 +13359,7 @@ class GatewayRunner:
                     chat_name=source.chat_name,
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
+                    chat_topic=source.chat_topic,
                     gateway_session_key=session_key,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,

--- a/plugins/memory/claude_memory_layer/README.md
+++ b/plugins/memory/claude_memory_layer/README.md
@@ -15,7 +15,9 @@ memory:
   provider: claude_memory_layer
   claude_memory_layer:
     context_tool: mcp_claude_memory_layer_mem_context_pack
-    # Optional; defaults to TERMINAL_CWD in gateway sessions, else cwd.
+    # Optional override. If empty, Hermes uses an explicit per-session cwd/project_path,
+    # then infers an existing local path from gateway thread title/channel topic,
+    # then falls back to TERMINAL_CWD/cwd.
     project_path: ""
     top_k: 5
     recent_limit: 30

--- a/plugins/memory/claude_memory_layer/README.md
+++ b/plugins/memory/claude_memory_layer/README.md
@@ -1,0 +1,45 @@
+# Claude Memory Layer Memory Provider
+
+Read-only Hermes memory provider that automatically calls the project-aware
+`mem-context-pack` MCP tool before each model turn and injects the returned
+compact context through Hermes' existing `<memory-context>` prefetch path.
+
+## Enable
+
+1. Configure the claude-memory-layer MCP server so Hermes has the tool
+   `mcp_claude_memory_layer_mem_context_pack`.
+2. Set the memory provider:
+
+```yaml
+memory:
+  provider: claude_memory_layer
+  claude_memory_layer:
+    context_tool: mcp_claude_memory_layer_mem_context_pack
+    # Optional; defaults to TERMINAL_CWD in gateway sessions, else cwd.
+    project_path: ""
+    top_k: 5
+    recent_limit: 30
+    session_limit: 5
+    max_chars: 6000
+    # Optional claude-memory-layer source-session filter; empty by default.
+    session_id: ""
+```
+
+Environment overrides are also supported:
+
+- `CLAUDE_MEMORY_LAYER_CONTEXT_TOOL`
+- `CLAUDE_MEMORY_LAYER_PROJECT_PATH`
+- `CLAUDE_MEMORY_LAYER_TOP_K`
+- `CLAUDE_MEMORY_LAYER_RECENT_LIMIT`
+- `CLAUDE_MEMORY_LAYER_SESSION_LIMIT`
+- `CLAUDE_MEMORY_LAYER_MAX_CHARS`
+- `CLAUDE_MEMORY_LAYER_SESSION_ID`
+
+## Privacy notes
+
+- This provider does not write memories or mirror Hermes turns.
+- It delegates retrieval to `mem-context-pack`, which should use the
+  claude-memory-layer read-only `recordTrace: false` path.
+- It does not pass the live Hermes `session_id` as a claude-memory-layer
+  `sessionId` filter unless explicitly configured, because those identifiers
+  live in different namespaces and default filtering would hide project context.

--- a/plugins/memory/claude_memory_layer/__init__.py
+++ b/plugins/memory/claude_memory_layer/__init__.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 from agent.memory_provider import MemoryProvider
 from tools.registry import registry
@@ -23,6 +24,15 @@ _DEFAULT_TOP_K = 5
 _DEFAULT_RECENT_LIMIT = 30
 _DEFAULT_SESSION_LIMIT = 5
 _DEFAULT_MAX_CHARS = 6000
+_PATH_RE = re.compile(r"(?:(?<=^)|(?<=[\s('`\"<\[]))(?:~|/)[^\s)'`\"<>\]]+")
+_INFER_CONTEXT_KEYS = (
+    "session_title",
+    "chat_name",
+    "chat_topic",
+    "thread_name",
+    "thread_title",
+    "source_context",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -88,6 +98,57 @@ def _str_setting(config: Dict[str, Any], key: str, env_name: str, default: str =
     return str(value).strip() if value is not None else default
 
 
+def _coerce_text_values(value: Any) -> Iterable[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple, set)):
+        items: list[str] = []
+        for item in value:
+            items.extend(_coerce_text_values(item))
+        return items
+    if isinstance(value, dict):
+        items = []
+        for item in value.values():
+            items.extend(_coerce_text_values(item))
+        return items
+    return [str(value)]
+
+
+def _normalize_inferred_path(candidate: str) -> str:
+    text = str(candidate or "").strip()
+    if not text:
+        return ""
+    text = text.rstrip(".,;:!?)>}]")
+    if text.startswith("~"):
+        text = os.path.expanduser(text)
+    path = Path(text)
+    if not path.is_absolute():
+        return ""
+    try:
+        resolved = path.resolve(strict=False)
+    except Exception:
+        resolved = path
+    # Only trust inferred paths that exist locally. This prevents arbitrary text
+    # like "see /docs" in a chat title from being treated as project metadata.
+    if not resolved.exists() or not resolved.is_dir():
+        return ""
+    if str(resolved) == resolved.anchor:
+        return ""
+    return str(resolved)
+
+
+def _infer_project_path_from_context(init_kwargs: Dict[str, Any]) -> str:
+    for key in _INFER_CONTEXT_KEYS:
+        for text in _coerce_text_values(init_kwargs.get(key)):
+            for match in _PATH_RE.finditer(text):
+                inferred = _normalize_inferred_path(match.group(0))
+                if inferred:
+                    return inferred
+    return ""
+
+
 def _resolve_project_path(config: Dict[str, Any], init_kwargs: Dict[str, Any]) -> str:
     configured = _str_setting(
         config,
@@ -98,15 +159,25 @@ def _resolve_project_path(config: Dict[str, Any], init_kwargs: Dict[str, Any]) -
     if configured:
         return configured
 
-    # Gateway sessions set TERMINAL_CWD to the user's actual project cwd; the
-    # gateway process itself often runs from the hermes-agent install dir.
+    # Gateway sessions may include the project path in thread titles or channel
+    # topics (e.g. a Discord thread named after ``/Users/me/workspace/repo``),
+    # while the gateway process cwd often remains the Hermes install dir. Prefer
+    # explicit init/env values, then infer from gateway metadata before falling
+    # back to process cwd.
     for candidate in (
         init_kwargs.get("project_path"),
         init_kwargs.get("cwd"),
-        os.environ.get("TERMINAL_CWD"),
     ):
         if candidate:
             return str(candidate)
+
+    inferred = _infer_project_path_from_context(init_kwargs)
+    if inferred:
+        return inferred
+
+    terminal_cwd = os.environ.get("TERMINAL_CWD")
+    if terminal_cwd:
+        return terminal_cwd
 
     try:
         return str(Path.cwd())
@@ -261,7 +332,7 @@ class ClaudeMemoryLayerProvider(MemoryProvider):
             },
             {
                 "key": "project_path",
-                "description": "Optional fixed project path; defaults to TERMINAL_CWD or current directory",
+                "description": "Optional fixed project path; if empty, uses explicit session cwd/project_path, then inferred existing local paths from gateway metadata, then TERMINAL_CWD/current directory",
                 "default": "",
             },
             {"key": "top_k", "description": "Relevant memory count", "default": str(_DEFAULT_TOP_K)},

--- a/plugins/memory/claude_memory_layer/__init__.py
+++ b/plugins/memory/claude_memory_layer/__init__.py
@@ -1,0 +1,280 @@
+"""Claude Memory Layer project-context prefetch provider.
+
+This memory provider is intentionally read-only. It calls the project-aware
+``mem-context-pack`` MCP tool before each turn and injects the returned compact
+context through Hermes' existing memory prefetch path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CONTEXT_TOOL = "mcp_claude_memory_layer_mem_context_pack"
+_DEFAULT_TOP_K = 5
+_DEFAULT_RECENT_LIMIT = 30
+_DEFAULT_SESSION_LIMIT = 5
+_DEFAULT_MAX_CHARS = 6000
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+def _load_hermes_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        return cfg if isinstance(cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+def _nested(mapping: Dict[str, Any], *keys: str, default: Any = None) -> Any:
+    current: Any = mapping
+    for key in keys:
+        if not isinstance(current, dict):
+            return default
+        current = current.get(key)
+        if current is None:
+            return default
+    return current
+
+
+def _setting(config: Dict[str, Any], key: str, env_name: str, default: Any) -> Any:
+    env_value = os.environ.get(env_name)
+    if env_value is not None and env_value != "":
+        return env_value
+
+    # Preferred colocated config:
+    # memory:
+    #   claude_memory_layer:
+    #     top_k: 5
+    memory_value = _nested(config, "memory", "claude_memory_layer", key)
+    if memory_value is not None:
+        return memory_value
+
+    # Backward/standalone config convenience:
+    # claude_memory_layer:
+    #   top_k: 5
+    root_value = _nested(config, "claude_memory_layer", key)
+    if root_value is not None:
+        return root_value
+
+    return default
+
+
+def _int_setting(config: Dict[str, Any], key: str, env_name: str, default: int) -> int:
+    value = _setting(config, key, env_name, default)
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid Claude Memory Layer setting %s=%r; using %s", key, value, default)
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _str_setting(config: Dict[str, Any], key: str, env_name: str, default: str = "") -> str:
+    value = _setting(config, key, env_name, default)
+    return str(value).strip() if value is not None else default
+
+
+def _resolve_project_path(config: Dict[str, Any], init_kwargs: Dict[str, Any]) -> str:
+    configured = _str_setting(
+        config,
+        "project_path",
+        "CLAUDE_MEMORY_LAYER_PROJECT_PATH",
+        "",
+    )
+    if configured:
+        return configured
+
+    # Gateway sessions set TERMINAL_CWD to the user's actual project cwd; the
+    # gateway process itself often runs from the hermes-agent install dir.
+    for candidate in (
+        init_kwargs.get("project_path"),
+        init_kwargs.get("cwd"),
+        os.environ.get("TERMINAL_CWD"),
+    ):
+        if candidate:
+            return str(candidate)
+
+    try:
+        return str(Path.cwd())
+    except Exception:
+        return ""
+
+
+def _extract_tool_text(raw: str) -> str:
+    """Extract model-facing text from a Hermes tool-dispatch JSON string."""
+    if not raw:
+        return ""
+    try:
+        payload = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return str(raw)
+
+    if not isinstance(payload, dict):
+        return str(payload)
+    if payload.get("error"):
+        return ""
+
+    result = payload.get("result", "")
+    if isinstance(result, str):
+        return result
+    if result is None:
+        return ""
+    try:
+        return json.dumps(result, ensure_ascii=False, indent=2)
+    except TypeError:
+        return str(result)
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    if max_chars <= 0 or len(text) <= max_chars:
+        return text
+    keep = max(0, max_chars - len("\n...[truncated]"))
+    return text[:keep].rstrip() + "\n...[truncated]"
+
+
+class ClaudeMemoryLayerProvider(MemoryProvider):
+    """Read-only provider that prefetches project context from claude-memory-layer."""
+
+    def __init__(self) -> None:
+        self._config = _load_hermes_config()
+        self._context_tool = _str_setting(
+            self._config,
+            "context_tool",
+            "CLAUDE_MEMORY_LAYER_CONTEXT_TOOL",
+            _DEFAULT_CONTEXT_TOOL,
+        )
+        self._top_k = _int_setting(
+            self._config,
+            "top_k",
+            "CLAUDE_MEMORY_LAYER_TOP_K",
+            _DEFAULT_TOP_K,
+        )
+        self._recent_limit = _int_setting(
+            self._config,
+            "recent_limit",
+            "CLAUDE_MEMORY_LAYER_RECENT_LIMIT",
+            _DEFAULT_RECENT_LIMIT,
+        )
+        self._session_limit = _int_setting(
+            self._config,
+            "session_limit",
+            "CLAUDE_MEMORY_LAYER_SESSION_LIMIT",
+            _DEFAULT_SESSION_LIMIT,
+        )
+        self._max_chars = _int_setting(
+            self._config,
+            "max_chars",
+            "CLAUDE_MEMORY_LAYER_MAX_CHARS",
+            _DEFAULT_MAX_CHARS,
+        )
+        # Optional claude-memory-layer source-session filter. Deliberately NOT
+        # defaulted to the live Hermes session_id; doing so would hide most
+        # project memories because CML session IDs and Hermes runtime session IDs
+        # are different namespaces.
+        self._source_session_id = _str_setting(
+            self._config,
+            "session_id",
+            "CLAUDE_MEMORY_LAYER_SESSION_ID",
+            "",
+        )
+        self._project_path = ""
+
+    @property
+    def name(self) -> str:
+        return "claude_memory_layer"
+
+    def is_available(self) -> bool:
+        return registry.get_entry(self._context_tool) is not None
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._project_path = _resolve_project_path(self._config, kwargs)
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# Claude Memory Layer\n"
+            "Active. A privacy-safe project context pack is prefetched before each turn "
+            "when the configured claude-memory-layer MCP tool is connected."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not self.is_available():
+            return ""
+
+        clean_query = query.strip() if isinstance(query, str) else ""
+        args: Dict[str, Any] = {
+            "query": clean_query or "recent project context",
+            "topK": self._top_k,
+            "recentLimit": self._recent_limit,
+            "sessionLimit": self._session_limit,
+        }
+        if self._project_path:
+            args["projectPath"] = self._project_path
+        if self._source_session_id:
+            args["sessionId"] = self._source_session_id
+
+        try:
+            raw = registry.dispatch(self._context_tool, args)
+        except Exception as exc:
+            logger.debug("Claude Memory Layer prefetch failed: %s", exc)
+            return ""
+
+        text = _extract_tool_text(raw).strip()
+        if not text:
+            return ""
+
+        text = _truncate(text, self._max_chars)
+        return "## Claude Memory Layer Project Context\n" + text
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        # Read-only provider: claude-memory-layer ingestion is handled by its
+        # own import/MCP paths. Do not mirror turns from Hermes here.
+        return None
+
+    def get_tool_schemas(self):
+        # The MCP server already exposes navigation tools; this provider only
+        # wires automatic pre-turn context injection.
+        return []
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        raise NotImplementedError("claude_memory_layer does not expose provider tools")
+
+    def get_config_schema(self):
+        return [
+            {
+                "key": "context_tool",
+                "description": "Hermes MCP tool name for claude-memory-layer mem-context-pack",
+                "default": _DEFAULT_CONTEXT_TOOL,
+            },
+            {
+                "key": "project_path",
+                "description": "Optional fixed project path; defaults to TERMINAL_CWD or current directory",
+                "default": "",
+            },
+            {"key": "top_k", "description": "Relevant memory count", "default": str(_DEFAULT_TOP_K)},
+            {"key": "recent_limit", "description": "Recent event scan limit", "default": str(_DEFAULT_RECENT_LIMIT)},
+            {"key": "session_limit", "description": "Recent session summary limit", "default": str(_DEFAULT_SESSION_LIMIT)},
+            {"key": "max_chars", "description": "Maximum injected context characters", "default": str(_DEFAULT_MAX_CHARS)},
+            {
+                "key": "session_id",
+                "description": "Optional claude-memory-layer source-session filter; empty means search across project sessions",
+                "default": "",
+            },
+        ]
+
+
+def register_memory_provider(ctx=None):
+    return ClaudeMemoryLayerProvider()

--- a/plugins/memory/claude_memory_layer/plugin.yaml
+++ b/plugins/memory/claude_memory_layer/plugin.yaml
@@ -1,0 +1,3 @@
+name: claude_memory_layer
+description: Privacy-safe project context prefetch from claude-memory-layer mem-context-pack MCP tool.
+version: 0.1.0

--- a/run_agent.py
+++ b/run_agent.py
@@ -946,6 +946,7 @@ class AIAgent:
         chat_name: str = None,
         chat_type: str = None,
         thread_id: str = None,
+        chat_topic: str = None,
         gateway_session_key: str = None,
         skip_context_files: bool = False,
         load_soul_identity: bool = False,
@@ -1023,6 +1024,7 @@ class AIAgent:
         self._chat_name = chat_name
         self._chat_type = chat_type
         self._thread_id = thread_id
+        self._chat_topic = chat_topic
         self._gateway_session_key = gateway_session_key  # Stable per-chat key (e.g. agent:main:telegram:dm:123)
         # Pluggable print function — CLI replaces this with _cprint so that
         # raw ANSI status lines are routed through prompt_toolkit's renderer
@@ -1772,6 +1774,8 @@ class AIAgent:
                             _init_kwargs["chat_type"] = self._chat_type
                         if self._thread_id:
                             _init_kwargs["thread_id"] = self._thread_id
+                        if self._chat_topic:
+                            _init_kwargs["chat_topic"] = self._chat_topic
                         # Thread gateway session key for stable per-chat Honcho session isolation
                         if self._gateway_session_key:
                             _init_kwargs["gateway_session_key"] = self._gateway_session_key

--- a/tests/plugins/test_claude_memory_layer_provider.py
+++ b/tests/plugins/test_claude_memory_layer_provider.py
@@ -1,0 +1,189 @@
+import json
+
+import pytest
+
+from tools.registry import registry
+
+
+@pytest.fixture(autouse=True)
+def isolated_claude_memory_layer_config(monkeypatch):
+    for env_name in [
+        "CLAUDE_MEMORY_LAYER_CONTEXT_TOOL",
+        "CLAUDE_MEMORY_LAYER_PROJECT_PATH",
+        "CLAUDE_MEMORY_LAYER_TOP_K",
+        "CLAUDE_MEMORY_LAYER_RECENT_LIMIT",
+        "CLAUDE_MEMORY_LAYER_SESSION_LIMIT",
+        "CLAUDE_MEMORY_LAYER_MAX_CHARS",
+        "CLAUDE_MEMORY_LAYER_SESSION_ID",
+        "TERMINAL_CWD",
+    ]:
+        monkeypatch.delenv(env_name, raising=False)
+
+    import plugins.memory.claude_memory_layer as cml
+
+    monkeypatch.setattr(cml, "_load_hermes_config", lambda: {})
+
+
+def _register_fake_tool(name, handler):
+    registry.deregister(name)
+    registry.register(
+        name=name,
+        toolset="mcp-claude-memory-layer-test",
+        schema={
+            "description": "fake claude-memory-layer mem-context-pack",
+            "parameters": {"type": "object", "properties": {}},
+        },
+        handler=handler,
+    )
+
+
+def test_prefetch_calls_project_context_pack_tool(monkeypatch):
+    from plugins.memory.claude_memory_layer import ClaudeMemoryLayerProvider
+
+    tool_name = "fake_cml_context_pack_prefetch"
+    calls = []
+
+    def handler(args, **kwargs):
+        calls.append((args, kwargs))
+        return json.dumps({"result": "Project Context Pack\n- relevant decision"})
+
+    _register_fake_tool(tool_name, handler)
+    monkeypatch.setenv("CLAUDE_MEMORY_LAYER_CONTEXT_TOOL", tool_name)
+    monkeypatch.setenv("CLAUDE_MEMORY_LAYER_TOP_K", "7")
+    monkeypatch.setenv("CLAUDE_MEMORY_LAYER_RECENT_LIMIT", "44")
+    monkeypatch.setenv("CLAUDE_MEMORY_LAYER_SESSION_LIMIT", "6")
+    monkeypatch.setenv("TERMINAL_CWD", "/tmp/example-project")
+
+    try:
+        provider = ClaudeMemoryLayerProvider()
+        assert provider.name == "claude_memory_layer"
+        assert provider.is_available()
+        provider.initialize("hermes-session")
+
+        context = provider.prefetch("continue the refactor", session_id="hermes-session")
+
+        assert "## Claude Memory Layer Project Context" in context
+        assert "relevant decision" in context
+        assert len(calls) == 1
+        args, kwargs = calls[0]
+        assert kwargs == {}
+        assert args == {
+            "query": "continue the refactor",
+            "projectPath": "/tmp/example-project",
+            "topK": 7,
+            "recentLimit": 44,
+            "sessionLimit": 6,
+        }
+        assert "sessionId" not in args
+    finally:
+        registry.deregister(tool_name)
+
+
+def test_prefetch_uses_configured_project_path_and_truncates(monkeypatch):
+    from plugins.memory.claude_memory_layer import ClaudeMemoryLayerProvider
+
+    tool_name = "fake_cml_context_pack_truncate"
+
+    def handler(args, **kwargs):
+        return json.dumps({"result": "0123456789" * 20})
+
+    _register_fake_tool(tool_name, handler)
+    monkeypatch.setenv("CLAUDE_MEMORY_LAYER_CONTEXT_TOOL", tool_name)
+    monkeypatch.setenv("CLAUDE_MEMORY_LAYER_PROJECT_PATH", "/workspace/override")
+    monkeypatch.setenv("CLAUDE_MEMORY_LAYER_MAX_CHARS", "40")
+
+    try:
+        provider = ClaudeMemoryLayerProvider()
+        provider.initialize("session")
+        context = provider.prefetch("task")
+
+        assert "/workspace/override" not in context  # path is an input, not echoed by provider
+        assert len(context) < 120
+        assert "[truncated]" in context
+    finally:
+        registry.deregister(tool_name)
+
+
+def test_prefetch_suppresses_mcp_errors(monkeypatch):
+    from plugins.memory.claude_memory_layer import ClaudeMemoryLayerProvider
+
+    tool_name = "fake_cml_context_pack_error"
+
+    def handler(args, **kwargs):
+        return json.dumps({"error": "server is unavailable"})
+
+    _register_fake_tool(tool_name, handler)
+    monkeypatch.setenv("CLAUDE_MEMORY_LAYER_CONTEXT_TOOL", tool_name)
+
+    try:
+        provider = ClaudeMemoryLayerProvider()
+        provider.initialize("session")
+
+        assert provider.prefetch("task") == ""
+    finally:
+        registry.deregister(tool_name)
+
+
+def test_explicit_source_session_filter_is_forwarded(monkeypatch):
+    from plugins.memory.claude_memory_layer import ClaudeMemoryLayerProvider
+
+    tool_name = "fake_cml_context_pack_session_filter"
+    calls = []
+
+    def handler(args, **kwargs):
+        calls.append(args)
+        return json.dumps({"result": "context"})
+
+    _register_fake_tool(tool_name, handler)
+    monkeypatch.setenv("CLAUDE_MEMORY_LAYER_CONTEXT_TOOL", tool_name)
+    monkeypatch.setenv("CLAUDE_MEMORY_LAYER_SESSION_ID", "cml-session-123")
+
+    try:
+        provider = ClaudeMemoryLayerProvider()
+        provider.initialize("live-hermes-session")
+        provider.prefetch("task", session_id="live-hermes-session")
+
+        assert calls[0]["sessionId"] == "cml-session-123"
+    finally:
+        registry.deregister(tool_name)
+
+
+def test_config_schema_documents_session_id(monkeypatch):
+    from plugins.memory.claude_memory_layer import ClaudeMemoryLayerProvider
+
+    keys = {item["key"] for item in ClaudeMemoryLayerProvider().get_config_schema()}
+
+    assert "session_id" in keys
+
+
+def test_is_available_requires_registered_context_tool(monkeypatch):
+    from plugins.memory.claude_memory_layer import ClaudeMemoryLayerProvider
+
+    tool_name = "fake_missing_cml_context_pack"
+    registry.deregister(tool_name)
+    monkeypatch.setenv("CLAUDE_MEMORY_LAYER_CONTEXT_TOOL", tool_name)
+
+    provider = ClaudeMemoryLayerProvider()
+
+    assert not provider.is_available()
+
+
+def test_provider_can_be_loaded_by_memory_plugin_discovery(monkeypatch):
+    from plugins.memory import load_memory_provider
+
+    tool_name = "fake_cml_context_pack_discovery"
+
+    def handler(args, **kwargs):
+        return json.dumps({"result": "context"})
+
+    _register_fake_tool(tool_name, handler)
+    monkeypatch.setenv("CLAUDE_MEMORY_LAYER_CONTEXT_TOOL", tool_name)
+
+    try:
+        provider = load_memory_provider("claude_memory_layer")
+
+        assert provider is not None
+        assert provider.name == "claude_memory_layer"
+        assert provider.is_available()
+    finally:
+        registry.deregister(tool_name)

--- a/tests/plugins/test_claude_memory_layer_provider.py
+++ b/tests/plugins/test_claude_memory_layer_provider.py
@@ -104,6 +104,92 @@ def test_prefetch_uses_configured_project_path_and_truncates(monkeypatch):
         registry.deregister(tool_name)
 
 
+def test_project_path_is_inferred_from_gateway_thread_title(monkeypatch, tmp_path):
+    from plugins.memory.claude_memory_layer import ClaudeMemoryLayerProvider
+
+    tool_name = "fake_cml_context_pack_thread_path"
+    calls = []
+    project_dir = tmp_path / "claude-memory-layer"
+    project_dir.mkdir()
+    hermes_install = tmp_path / "hermes-agent"
+    hermes_install.mkdir()
+
+    def handler(args, **kwargs):
+        calls.append(args)
+        return json.dumps({"result": "Project Context Pack\nRecent project events: 2"})
+
+    _register_fake_tool(tool_name, handler)
+    monkeypatch.setenv("CLAUDE_MEMORY_LAYER_CONTEXT_TOOL", tool_name)
+    monkeypatch.chdir(hermes_install)
+
+    try:
+        provider = ClaudeMemoryLayerProvider()
+        provider.initialize(
+            "session",
+            chat_name=f"server / #hermes / {project_dir} 이 프로젝트를 Codex 나 hermes 에서도 이어서",
+        )
+        context = provider.prefetch("continue")
+
+        assert "Recent project events: 2" in context
+        assert calls[0]["projectPath"] == str(project_dir)
+    finally:
+        registry.deregister(tool_name)
+
+
+def test_project_path_inference_scans_session_title_and_chat_topic(monkeypatch, tmp_path):
+    from plugins.memory.claude_memory_layer import ClaudeMemoryLayerProvider
+
+    tool_name = "fake_cml_context_pack_topic_path"
+    calls = []
+    project_dir = tmp_path / "topic-project"
+    project_dir.mkdir()
+
+    def handler(args, **kwargs):
+        calls.append(args)
+        return json.dumps({"result": "context"})
+
+    _register_fake_tool(tool_name, handler)
+    monkeypatch.setenv("CLAUDE_MEMORY_LAYER_CONTEXT_TOOL", tool_name)
+
+    try:
+        provider = ClaudeMemoryLayerProvider()
+        provider.initialize(
+            "session",
+            session_title="general discussion",
+            chat_topic=f"Active repo: {project_dir}",
+        )
+        provider.prefetch("status")
+
+        assert calls[0]["projectPath"] == str(project_dir)
+    finally:
+        registry.deregister(tool_name)
+
+
+def test_project_path_inference_scans_thread_title(monkeypatch, tmp_path):
+    from plugins.memory.claude_memory_layer import ClaudeMemoryLayerProvider
+
+    tool_name = "fake_cml_context_pack_thread_title_path"
+    calls = []
+    project_dir = tmp_path / "thread-title-project"
+    project_dir.mkdir()
+
+    def handler(args, **kwargs):
+        calls.append(args)
+        return json.dumps({"result": "context"})
+
+    _register_fake_tool(tool_name, handler)
+    monkeypatch.setenv("CLAUDE_MEMORY_LAYER_CONTEXT_TOOL", tool_name)
+
+    try:
+        provider = ClaudeMemoryLayerProvider()
+        provider.initialize("session", thread_title=f"Continue {project_dir}")
+        provider.prefetch("continue")
+
+        assert calls[0]["projectPath"] == str(project_dir)
+    finally:
+        registry.deregister(tool_name)
+
+
 def test_prefetch_suppresses_mcp_errors(monkeypatch):
     from plugins.memory.claude_memory_layer import ClaudeMemoryLayerProvider
 

--- a/tests/run_agent/test_memory_provider_init.py
+++ b/tests/run_agent/test_memory_provider_init.py
@@ -4,10 +4,26 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 
+class _FakeMemoryProvider:
+    name = "fake"
+
+    def __init__(self):
+        self.initialized_with = None
+
+    def is_available(self):
+        return True
+
+    def initialize(self, session_id, **kwargs):
+        self.initialized_with = {"session_id": session_id, **kwargs}
+
+    def get_tool_schemas(self):
+        return []
+
+
 def test_blank_memory_provider_does_not_auto_enable_honcho():
     """Blank memory.provider should remain opt-out even if Honcho fallback looks configured."""
     cfg = {"memory": {"provider": ""}, "agent": {}}
-    honcho_cfg = SimpleNamespace(enabled=True, api_key="stale-key", base_url=None)
+    honcho_cfg = SimpleNamespace(enabled=True, api_key="dummy", base_url=None)
 
     with (
         patch("hermes_cli.config.load_config", return_value=cfg),
@@ -25,7 +41,7 @@ def test_blank_memory_provider_does_not_auto_enable_honcho():
         from run_agent import AIAgent
 
         agent = AIAgent(
-            api_key="test-key-1234567890",
+            api_key="dummy",
             base_url="https://openrouter.ai/api/v1",
             quiet_mode=True,
             skip_context_files=True,
@@ -36,4 +52,37 @@ def test_blank_memory_provider_does_not_auto_enable_honcho():
     from_global_config.assert_not_called()
     load_memory_provider.assert_not_called()
     save_config.assert_not_called()
+
+
+def test_gateway_chat_topic_is_forwarded_to_memory_provider():
+    """Gateway channel topics can carry project paths for context-prefetch providers."""
+    cfg = {"memory": {"provider": "fake"}, "agent": {}}
+    provider = _FakeMemoryProvider()
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.memory.load_memory_provider", return_value=provider) as load_memory_provider,
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="dummy",
+            base_url="https://openrouter.ai/api/v1",
+            platform="discord",
+            chat_name="server / #hermes",
+            chat_topic="Project: /tmp/example-project",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=False,
+        )
+
+    load_memory_provider.assert_called_once_with("fake")
+    assert agent._memory_manager is not None
+    assert provider.initialized_with["platform"] == "discord"
+    assert provider.initialized_with["chat_name"] == "server / #hermes"
+    assert provider.initialized_with["chat_topic"] == "Project: /tmp/example-project"
 


### PR DESCRIPTION
## Summary
- Add a read-only `claude_memory_layer` MemoryProvider plugin for Hermes Agent
- Use the existing MemoryManager prefetch path to call the configured MCP context-pack tool before model turns
- Resolve project context from explicit config/init kwargs, `TERMINAL_CWD`, or current working directory
- Suppress MCP errors, avoid live session-id forwarding by default, and bound injected context size
- Document config/env overrides, including optional CML source-session filtering

## Validation
- `pytest -q tests/plugins/test_claude_memory_layer_provider.py`
- `python -m compileall -q plugins/memory/claude_memory_layer tests/plugins/test_claude_memory_layer_provider.py`
- `pytest -q tests/tools/test_registry.py tests/tools/test_mcp_structured_content.py tests/plugins/test_claude_memory_layer_provider.py`
- targeted `git diff --check`
- static security scan over intended files: no findings
- independent pre-commit review: no blockers

## Privacy notes
- Provider is read-only; it does not sync turns or write to claude-memory-layer.
- Hermes live `session_id` is not forwarded unless an explicit CML `session_id` source filter is configured.
- MCP exceptions/error payloads are suppressed from injected context.