### PR TITLE
fix(gateway/config): merge top-level platform keys into extra (#20501)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -289,19 +289,48 @@ class PlatformConfig:
             result["home_channel"] = self.home_channel.to_dict()
         return result
     
+    # Top-level keys consumed directly by PlatformConfig itself; everything
+    # else found at the top level is treated as platform-specific and merged
+    # into ``extra`` so users can write the natural YAML structure
+    # (``platforms.api_server.port: 8643``) instead of having to nest under
+    # ``extra``.  Without this merge, top-level platform settings written by
+    # ``hermes config set platforms.<plat>.<key> <value>`` are silently
+    # ignored at gateway startup (issue #20501).
+    _RESERVED_TOP_LEVEL_KEYS = frozenset({
+        "enabled",
+        "token",
+        "api_key",
+        "home_channel",
+        "reply_to_mode",
+        "extra",
+    })
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PlatformConfig":
         home_channel = None
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
-        
+
+        # Merge top-level platform-specific keys into ``extra``.  Anything
+        # explicitly nested under ``extra`` wins so existing configs and the
+        # to_dict→from_dict roundtrip remain stable.
+        explicit_extra = data.get("extra") or {}
+        if not isinstance(explicit_extra, dict):
+            explicit_extra = {}
+        merged_extra: Dict[str, Any] = {}
+        for key, value in data.items():
+            if key in cls._RESERVED_TOP_LEVEL_KEYS:
+                continue
+            merged_extra[key] = value
+        merged_extra.update(explicit_extra)
+
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
-            extra=data.get("extra", {}),
+            extra=merged_extra,
         )
 
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -57,6 +57,54 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"enabled": "false"})
         assert restored.enabled is False
 
+    def test_from_dict_merges_top_level_platform_keys_into_extra(self):
+        # Regression for #20501: ``hermes config set platforms.api_server.port
+        # 8643`` writes ``port`` at the top of the platform block, not nested
+        # under ``extra``.  Top-level platform-specific keys must be merged
+        # into ``extra`` so adapters that read ``config.extra.get("port")``
+        # see the configured value instead of silently using the default.
+        restored = PlatformConfig.from_dict({
+            "enabled": True,
+            "port": 8643,
+            "host": "127.0.0.1",
+            "key": "secret",
+            "cors_origins": ["*"],
+        })
+        assert restored.enabled is True
+        assert restored.extra["port"] == 8643
+        assert restored.extra["host"] == "127.0.0.1"
+        assert restored.extra["key"] == "secret"
+        assert restored.extra["cors_origins"] == ["*"]
+
+    def test_from_dict_explicit_extra_takes_precedence_over_top_level(self):
+        # Roundtrip stability: when both a top-level key and an explicit
+        # ``extra`` mapping are present, the nested ``extra`` value wins so
+        # configs produced by ``to_dict`` survive a from_dict round-trip
+        # unchanged even if a stale top-level key is also present.
+        restored = PlatformConfig.from_dict({
+            "enabled": True,
+            "port": 1111,
+            "extra": {"port": 2222, "other": "x"},
+        })
+        assert restored.extra["port"] == 2222
+        assert restored.extra["other"] == "x"
+
+    def test_from_dict_ignores_reserved_top_level_keys(self):
+        # ``token``, ``api_key``, ``home_channel``, ``reply_to_mode`` and
+        # ``enabled`` continue to be consumed as dedicated fields and must
+        # not pollute ``extra``.
+        restored = PlatformConfig.from_dict({
+            "enabled": True,
+            "token": "tok",
+            "api_key": "key",
+            "reply_to_mode": "all",
+            "port": 9000,
+        })
+        assert restored.token == "tok"
+        assert restored.api_key == "key"
+        assert restored.reply_to_mode == "all"
+        assert restored.extra == {"port": 9000}
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):


### PR DESCRIPTION
## Summary

Fixes #20501 — `platforms.api_server` config values (`port`, `host`, `key`, `cors_origins`) are silently ignored when written at the natural top level instead of nested under `extra`.

## Root cause

`PlatformConfig.from_dict()` in `gateway/config.py` only read platform-specific values from `data.get("extra", {})`. But `hermes config set platforms.api_server.port 8643` writes the value at `platforms.api_server.port` (top level of the platform block, which is the natural and documented YAML shape and matches the error message in `api_server.py:3112`). The result: gateway falls back to default 8642 with no warning, no error, no log line — extremely hard to debug.

## Fix

In `PlatformConfig.from_dict()`, merge any top-level keys that aren't dedicated PlatformConfig fields (`enabled`, `token`, `api_key`, `home_channel`, `reply_to_mode`, `extra`) into the `extra` dict. Explicit `extra` entries still win on key collision so the `to_dict` → `from_dict` roundtrip remains stable for existing configs.

This is a minimal, additive change — existing nested-under-`extra` configs keep working unchanged; the new behavior only kicks in for top-level keys that were previously dropped on the floor.

## Test plan

- [x] New regression test: top-level `port`/`host`/`key`/`cors_origins` now reach `extra`
- [x] New regression test: explicit `extra` wins over a stale top-level key (roundtrip stability)
- [x] New regression test: reserved keys (`token`, `api_key`, `reply_to_mode`) still consumed as fields, not pushed into `extra`
- [x] All 43 tests in `tests/gateway/test_config.py` pass

## Affected adapters

Any platform whose adapter reads `config.extra.get(...)` benefits. The reported issue is `api_server` (port/host/key/cors_origins/model_name) but the same pattern is used across other platform adapters, so they all become more forgiving of natural top-level config layout.