### PR TITLE
fix(telegram): expose kanban blocked notifier helper

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1340,6 +1340,47 @@ class TelegramAdapter(BasePlatformAdapter):
             is_timeout = (_to and isinstance(e, _to)) or "timed out" in err_str
             return SendResult(success=False, error=str(e), retryable=not is_timeout)
 
+    async def send_kanban_blocked(
+        self,
+        chat_id: str,
+        task_id: Any,
+        reason: Optional[str] = None,
+        *,
+        assignee: Optional[str] = None,
+        title: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> SendResult:
+        """Send a kanban blocked notification through the standard Telegram sender."""
+        task = task_id if isinstance(task_id, dict) else {}
+        resolved_task_id = (
+            task.get("task_id")
+            or task.get("id")
+            or kwargs.get("task_id")
+            or kwargs.get("id")
+            or task_id
+        )
+        resolved_reason = (
+            reason
+            or task.get("blocked_reason")
+            or task.get("block_reason")
+            or task.get("reason")
+            or kwargs.get("blocked_reason")
+            or kwargs.get("block_reason")
+            or kwargs.get("reason")
+            or ""
+        )
+        resolved_assignee = assignee or task.get("assignee") or kwargs.get("assignee") or ""
+        resolved_title = title or task.get("title") or kwargs.get("title") or ""
+
+        tag = f"@{resolved_assignee} " if resolved_assignee else ""
+        reason_suffix = f": {str(resolved_reason)[:160]}" if resolved_reason else ""
+        title_suffix = f" - {str(resolved_title)[:120]}" if resolved_title else ""
+        message = f"⏸ {tag}Kanban {resolved_task_id} blocked{reason_suffix}{title_suffix}"
+
+        return await self.send(chat_id, message, reply_to=reply_to, metadata=metadata)
+
     async def edit_message(
         self,
         chat_id: str,

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -13,6 +13,7 @@ WITHOUT message_thread_id so the message still reaches the chat.
 import sys
 import types
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -271,6 +272,55 @@ async def test_send_without_thread_id_unaffected():
     assert result.success is True
     assert len(call_log) == 1
     assert call_log[0]["message_thread_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_send_kanban_blocked_delegates_to_send_with_metadata():
+    """The blocked-notifier compatibility API should use the normal sender."""
+    adapter = _make_adapter()
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="kanban-msg"))
+
+    result = await adapter.send_kanban_blocked(
+        "123",
+        "KAN-7",
+        "waiting for owner",
+        assignee="ada",
+        metadata={"thread_id": "42"},
+    )
+
+    assert result.success is True
+    assert result.message_id == "kanban-msg"
+    adapter.send.assert_awaited_once_with(
+        "123",
+        "⏸ @ada Kanban KAN-7 blocked: waiting for owner",
+        reply_to=None,
+        metadata={"thread_id": "42"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_kanban_blocked_accepts_task_mapping():
+    """Downstream guardrails may pass task payloads instead of separate fields."""
+    adapter = _make_adapter()
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="kanban-msg"))
+
+    result = await adapter.send_kanban_blocked(
+        "123",
+        {
+            "task_id": "KAN-8",
+            "blocked_reason": "needs maintainer answer",
+            "assignee": "leon",
+            "title": "Clarify gateway hook contract",
+        },
+    )
+
+    assert result.success is True
+    adapter.send.assert_awaited_once_with(
+        "123",
+        "⏸ @leon Kanban KAN-8 blocked: needs maintainer answer - Clarify gateway hook contract",
+        reply_to=None,
+        metadata=None,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `TelegramAdapter.send_kanban_blocked(...)` as a stable compatibility API for kanban guardrail/notifier integrations.
- Delegate through the existing Telegram `send(...)` path so formatting, thread metadata, reply handling, and retry behavior stay centralized.
- Cover separate-field and task-payload call shapes in the Telegram gateway tests.

Fixes #20263

## Tests
- `scripts/run_tests.sh tests/gateway/test_telegram_thread_fallback.py`
- `git diff --check`
