### PR TITLE
fix(docker/tui): chown ui-tui to hermes + actionable build error (#20500)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,26 @@ RUN npm install --prefer-offline --no-audit && \
 COPY --chown=hermes:hermes . .
 
 # Build browser dashboard and terminal UI assets.
+#
+# NOTE: this RUN executes as root (no preceding USER directive), so the
+# build artifacts that npm/esbuild emit into ui-tui/dist/ and
+# ui-tui/packages/hermes-ink/dist/ end up root-owned.  At runtime the
+# entrypoint drops privileges to the unprivileged ``hermes`` user, and
+# the dashboard's Chat tab launches the TUI which probes
+# ``_tui_build_needed`` — a fresh image where ``dist/`` is current
+# already runnable, but if the launcher decides to rebuild (e.g.
+# manifest drift, or the user rebuilt one workspace and not the other),
+# esbuild fails with EACCES on the root-owned dist dirs and the Chat
+# tab surfaces the unhelpful "Chat unavailable: 1" banner (#20500).
+#
+# Reset ownership of the entire ui-tui tree to ``hermes:hermes`` here
+# so any subsequent in-container rebuild succeeds.  This is cheap (one
+# chown on a tree we've just written) and survives image rebuilds, so
+# users no longer have to chown manually after each ``docker compose
+# pull``.
 RUN cd web && npm run build && \
-    cd ../ui-tui && npm run build
+    cd ../ui-tui && npm run build && \
+    chown -R hermes:hermes /opt/hermes/ui-tui
 
 # ---------- Permissions ----------
 # Make install dir world-readable so any HERMES_UID can read it at runtime.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -50,6 +50,18 @@ if [ "$(id -u)" = "0" ]; then
         chmod 640 "$HERMES_HOME/config.yaml" 2>/dev/null || true
     fi
 
+    # Defensive chown of $INSTALL_DIR/ui-tui so the dashboard's Chat tab can
+    # rebuild the TUI bundle if its launcher's _tui_build_needed() trips.
+    # The Dockerfile already chowns this tree at build time (#20500), but a
+    # remapped HERMES_UID changes the runtime hermes UID — without this the
+    # tree appears uid=10000-owned to a process running as the remapped UID,
+    # esbuild fails with EACCES, and pty_ws surfaces "Chat unavailable: 1".
+    # The chown is no-op on already-correctly-owned trees and silently
+    # tolerates rootless containers where chown isn't permitted.
+    if [ -d "$INSTALL_DIR/ui-tui" ]; then
+        chown -R hermes:hermes "$INSTALL_DIR/ui-tui" 2>/dev/null || true
+    fi
+
     echo "Dropping root privileges"
     exec gosu hermes "$0" "$@"
 fi

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1126,12 +1126,29 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             print("TUI build failed.")
             if preview:
                 print(preview)
-            sys.exit(1)
+            # Surface a short reason on the SystemExit code so callers that
+            # render ``Chat unavailable: {exc}`` (notably ``pty_ws`` in the
+            # dashboard's WebSocket handler) get an actionable hint instead
+            # of a bare ``Chat unavailable: 1`` (#20500).  Detect the
+            # common in-container EACCES on the dist directories so users
+            # know why and can chown.  The numeric exit code is preserved
+            # by SystemExit's str(arg) → arg conversion when arg is non-int,
+            # so launchers that key on returncode still see a non-zero exit.
+            _eacces_signal = (
+                "permission denied" in combined.lower()
+                or "eacces" in combined.lower()
+            )
+            if _eacces_signal:
+                raise SystemExit(
+                    "TUI build failed (permission denied writing to dist/). "
+                    "If running in Docker, ensure /opt/hermes/ui-tui is "
+                    "owned by the hermes user; see issue #20500."
+                )
+            raise SystemExit("TUI build failed; see container logs for details.")
 
     root = _find_bundled_tui(tui_dir)
     if not root:
-        print("TUI build did not produce dist/entry.js")
-        sys.exit(1)
+        raise SystemExit("TUI build did not produce dist/entry.js")
 
     node = _node_bin("node")
     return [node, str(root / "dist" / "entry.js")], root

--- a/tests/hermes_cli/test_tui_build_failure_message.py
+++ b/tests/hermes_cli/test_tui_build_failure_message.py
@@ -1,0 +1,110 @@
+"""Surfaced error messages when ``_make_tui_argv`` aborts on a build failure.
+
+Regression for #20500: in Docker images where ``/opt/hermes/ui-tui`` is
+root-owned but the dashboard runs as the unprivileged ``hermes`` user,
+``npm run build`` inside ``ui-tui`` fails with EACCES on the ``dist/``
+write step, ``_make_tui_argv`` previously called ``sys.exit(1)`` (no
+arg), and ``hermes_cli.web_server.pty_ws`` rendered the unhelpful
+``Chat unavailable: 1`` banner over the WebSocket.
+
+The new behavior raises ``SystemExit`` with an actionable string so
+``pty_ws`` surfaces ``Chat unavailable: TUI build failed (permission
+denied writing to dist/). ...`` instead.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def main_mod():
+    import hermes_cli.main as m
+
+    return m
+
+
+def _stub_tui_dir(tmp_path: Path) -> Path:
+    """Build a tui_dir that lets ``_make_tui_argv`` reach the build step."""
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    # node_modules must exist so _tui_need_npm_install short-circuits to False
+    # for the lockfile branch.  Touch the @hermes/ink sentinel.
+    ink = tui_dir / "node_modules" / "@hermes" / "ink" / "package.json"
+    ink.parent.mkdir(parents=True, exist_ok=True)
+    ink.write_text("{}")
+    # No package-lock.json → _tui_need_npm_install returns False (no lock file).
+    return tui_dir
+
+
+def test_eacces_failure_yields_actionable_systemexit(
+    monkeypatch, tmp_path, main_mod
+):
+    """An esbuild EACCES on dist/ → SystemExit message mentions permission +
+    points to issue #20500 + the chown remedy."""
+    tui_dir = _stub_tui_dir(tmp_path)
+
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _p: False)
+    monkeypatch.setattr(main_mod, "_tui_build_needed", lambda _p: True)
+    # Provide a deterministic node/npm binary discovery shim so we don't
+    # depend on the host environment.
+    monkeypatch.setattr(main_mod.shutil, "which", lambda _bin: "/usr/bin/" + _bin)
+
+    def _fake_run(*_args, **_kwargs):
+        return SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr=(
+                "> hermes-tui@0.0.1 build\n"
+                "✘ [ERROR] Failed to write to output file:\n"
+                "   open /opt/hermes/ui-tui/packages/hermes-ink/dist/"
+                "entry-exports.js: permission denied\n"
+            ),
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    with pytest.raises(SystemExit) as excinfo:
+        main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    msg = str(excinfo.value)
+    assert "permission denied" in msg.lower()
+    assert "20500" in msg
+    # Must NOT collapse to the bare ``1`` integer that produced the
+    # unhelpful ``Chat unavailable: 1`` banner.
+    assert msg != "1"
+    assert excinfo.value.code != 1  # str arg → code is the str, not 1
+
+
+def test_generic_build_failure_yields_descriptive_systemexit(
+    monkeypatch, tmp_path, main_mod
+):
+    """Non-permission build failures still get a descriptive SystemExit so
+    ``Chat unavailable:`` is followed by a hint, not a stray ``1``."""
+    tui_dir = _stub_tui_dir(tmp_path)
+
+    monkeypatch.setattr(main_mod, "_ensure_tui_node", lambda: None)
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _p: False)
+    monkeypatch.setattr(main_mod, "_tui_build_needed", lambda _p: True)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda _bin: "/usr/bin/" + _bin)
+
+    def _fake_run(*_args, **_kwargs):
+        return SimpleNamespace(
+            returncode=2,
+            stdout="",
+            stderr="✘ [ERROR] Could not resolve 'react'\n",
+        )
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    with pytest.raises(SystemExit) as excinfo:
+        main_mod._make_tui_argv(tui_dir, tui_dev=False)
+
+    msg = str(excinfo.value)
+    assert "TUI build failed" in msg
+    assert msg != "1"


### PR DESCRIPTION
## Summary

Fixes #20500 — the dashboard's embedded Chat tab fails on first connect in the official Docker image with the unhelpful banner **\"Chat unavailable: 1\"**.

## Root cause (per the issue's reproduction)

Three compounding factors:

1. **Dockerfile** runs the TUI build as root: `COPY --chown=hermes:hermes . .` chowns the source tree, but the `RUN cd ui-tui && npm run build` step executes as root (no preceding `USER` directive). The artifacts written into `ui-tui/dist/` and `ui-tui/packages/hermes-ink/dist/` end up root-owned.
2. At runtime the entrypoint drops privileges via `gosu hermes`. When `_make_tui_argv` decides the bundle is stale and reruns `npm run build`, esbuild fails with EACCES on the root-owned dist dirs.
3. `_make_tui_argv` calls `sys.exit(1)`. `web_server.pty_ws` catches the resulting `SystemExit` and renders `Chat unavailable: {exc}` — `str(SystemExit(1))` is just `\"1\"`, hence the unhelpful banner.

## Fix

Three coordinated changes (each independent, but together close the bug for both new images and remapped-UID deployments):

1. **`Dockerfile`** — chown `/opt/hermes/ui-tui` to `hermes:hermes` immediately after `npm run build`. Survives image rebuilds, so users no longer have to chown manually after every `docker compose pull`. (Implements suggestion 1 in the issue.)
2. **`docker/entrypoint.sh`** — defensive recursive chown of `$INSTALL_DIR/ui-tui` while still running as root, before the gosu drop. Handles the `HERMES_UID` remap case where the Dockerfile's build-time chown is for UID 10000 but the runtime user has a different UID. Silent failure on rootless containers where chown isn't permitted. (Implements suggestion 2.)
3. **`hermes_cli/main.py`** — replace bare `sys.exit(1)` in `_make_tui_argv` with `raise SystemExit(\"<reason>\")` so `pty_ws` shows an actionable message. EACCES in the build output is detected and surfaced explicitly with the chown remedy and a pointer to issue #20500. (Implements the bonus surfacing improvement.)

## Test plan

- [x] New `tests/hermes_cli/test_tui_build_failure_message.py`:
  - EACCES in build output → `SystemExit` with message containing \"permission denied\" + \"#20500\"
  - Generic build failure → `SystemExit` with descriptive message (not bare `1`)
- [x] All 29 tests in `tests/hermes_cli/test_tui_npm_install.py` and `test_tui_resume_flow.py` still pass
- [ ] Manual verification (cannot run from this PR): rebuild image, start container with `HERMES_DASHBOARD=1`, open Chat tab — banner should not appear

## Compatibility

- Dockerfile chown adds ~1s to build time; cheap on the file count in `ui-tui/`.
- Entrypoint chown is no-op on already-correctly-owned trees.
- `SystemExit(\"<str>\")` returns a non-zero exit code (the str), so launchers that key on `returncode != 0` still see a non-zero exit.