### PR TITLE
fix(browser): preserve Camofox sessions between turns

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3380,7 +3380,7 @@ class AIAgent:
             if self.verbose_logging:
                 logging.warning(f"Failed to cleanup VM for task {task_id}: {e}")
         try:
-            cleanup_browser(task_id)
+            cleanup_browser(task_id, preserve_camofox=True)
         except Exception as e:
             if self.verbose_logging:
                 logging.warning(f"Failed to cleanup browser for task {task_id}: {e}")

--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -121,6 +121,32 @@ class TestBrowserCleanup:
         mock_soft.assert_called_once_with("task-1")
         mock_close.assert_called_once_with("task-1")
 
+    def test_cleanup_camofox_preserve_keeps_session_open(self):
+        """Per-turn cleanup can preserve Camofox so the next turn can continue."""
+        browser_tool = self.browser_tool
+        browser_tool._active_sessions["task-1"] = {
+            "session_name": "sess-1",
+            "bb_session_id": None,
+        }
+        browser_tool._session_last_activity["task-1"] = 123.0
+
+        with (
+            patch("tools.browser_tool._is_camofox_mode", return_value=True),
+            patch("tools.browser_tool._maybe_stop_recording") as mock_stop,
+            patch(
+                "tools.browser_tool._run_browser_command",
+                return_value={"success": True},
+            ),
+            patch("tools.browser_tool.os.path.exists", return_value=False),
+            patch("tools.browser_camofox.camofox_soft_cleanup") as mock_soft,
+            patch("tools.browser_camofox.camofox_close") as mock_close,
+        ):
+            browser_tool.cleanup_browser("task-1", preserve_camofox=True)
+
+        mock_soft.assert_not_called()
+        mock_close.assert_not_called()
+        mock_stop.assert_called_once_with("task-1")
+
     def test_emergency_cleanup_clears_all_tracking_state(self):
         browser_tool = self.browser_tool
         browser_tool._cleanup_done = False

--- a/tests/tools/test_zombie_process_cleanup.py
+++ b/tests/tools/test_zombie_process_cleanup.py
@@ -120,6 +120,29 @@ class TestAgentCloseMethod:
                 mock_cleanup_vm.assert_called_once_with("test-close-cleanup")
                 mock_cleanup_browser.assert_called_once_with("test-close-cleanup")
 
+    def test_per_turn_cleanup_preserves_camofox_browser(self):
+        """Per-turn cleanup should not close Camofox between user turns."""
+        from unittest.mock import patch
+
+        with patch("run_agent.AIAgent.__init__", return_value=None):
+            from run_agent import AIAgent
+
+            agent = AIAgent.__new__(AIAgent)
+            agent.verbose_logging = False
+
+            with (
+                patch("run_agent.is_persistent_env", return_value=False),
+                patch("run_agent.cleanup_vm") as mock_cleanup_vm,
+                patch("run_agent.cleanup_browser") as mock_cleanup_browser,
+            ):
+                agent._cleanup_task_resources("test-turn-cleanup")
+
+            mock_cleanup_vm.assert_called_once_with("test-turn-cleanup")
+            mock_cleanup_browser.assert_called_once_with(
+                "test-turn-cleanup",
+                preserve_camofox=True,
+            )
+
     def test_close_is_idempotent(self):
         """close() can be called multiple times without error."""
         from unittest.mock import patch

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2599,7 +2599,11 @@ def _cleanup_old_recordings(max_age_hours=72):
 # Cleanup and Management Functions
 # ============================================================================
 
-def cleanup_browser(task_id: Optional[str] = None) -> None:
+def cleanup_browser(
+    task_id: Optional[str] = None,
+    *,
+    preserve_camofox: bool = False,
+) -> None:
     """
     Clean up browser session(s) for a task.
 
@@ -2614,6 +2618,10 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
 
     Args:
         task_id: Task identifier (or explicit session key)
+        preserve_camofox: When true, leave Camofox server-side sessions and
+            local Camofox tracking intact. Per-turn agent cleanup uses this so
+            browser state can continue across user turns; shutdown and idle
+            reaping use the default close behavior.
     """
     if task_id is None:
         task_id = "default"
@@ -2632,7 +2640,10 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
         bare_task_id = task_id
 
     for session_key in session_keys:
-        _cleanup_single_browser_session(session_key)
+        _cleanup_single_browser_session(
+            session_key,
+            preserve_camofox=preserve_camofox,
+        )
 
     # Drop the last-active pointer only when the bare task is being cleaned
     # (i.e. not when we're only reaping a sidecar mid-task).
@@ -2640,7 +2651,11 @@ def cleanup_browser(task_id: Optional[str] = None) -> None:
         _last_active_session_key.pop(bare_task_id, None)
 
 
-def _cleanup_single_browser_session(task_id: str) -> None:
+def _cleanup_single_browser_session(
+    task_id: str,
+    *,
+    preserve_camofox: bool = False,
+) -> None:
     """Internal: reap a single browser session by its exact session key."""
     # Stop the CDP supervisor for this task FIRST so we close our WebSocket
     # before the backend tears down the underlying CDP endpoint.
@@ -2651,12 +2666,15 @@ def _cleanup_single_browser_session(task_id: str) -> None:
     # profile (and its session cookies) must survive across agent tasks.
     # The inactivity reaper still frees idle resources.
     if _is_camofox_mode():
-        try:
-            from tools.browser_camofox import camofox_close, camofox_soft_cleanup
-            if not camofox_soft_cleanup(task_id):
-                camofox_close(task_id)
-        except Exception as e:
-            logger.debug("Camofox cleanup for task %s: %s", task_id, e)
+        if preserve_camofox:
+            logger.debug("Preserving Camofox session for task %s", task_id)
+        else:
+            try:
+                from tools.browser_camofox import camofox_close, camofox_soft_cleanup
+                if not camofox_soft_cleanup(task_id):
+                    camofox_close(task_id)
+            except Exception as e:
+                logger.debug("Camofox cleanup for task %s: %s", task_id, e)
 
     logger.debug("cleanup_browser called for task_id: %s", task_id)
     logger.debug("Active sessions: %s", list(_active_sessions.keys()))


### PR DESCRIPTION
## Summary
- Preserve Camofox browser sessions during per-turn `AIAgent` resource cleanup so follow-up browser operations can continue in the same visible session.
- Keep shutdown, inactivity reaping, and all-browser cleanup on the existing close path so idle/server-side sessions can still be reclaimed.
- Add regression coverage for both the browser cleanup helper and the per-turn `AIAgent._cleanup_task_resources` call.

Fixes #20507

## Tests
- `scripts/run_tests.sh tests/tools/test_browser_cleanup.py`
- `scripts/run_tests.sh tests/tools/test_browser_cleanup.py tests/tools/test_zombie_process_cleanup.py -k 'camofox or cleanup'`
- `git diff --check`
