### PR TITLE
fix: gate durable writes by active project context

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -293,6 +293,18 @@ def build_session_context_prompt(
     if context.source.chat_topic:
         lines.append(f"**Channel Topic:** {context.source.chat_topic}")
 
+    # Project context (if available) is loaded from SessionDB state_meta and
+    # appended to this dynamic context section.  It does not mutate the static
+    # base system prompt, preserving prompt-cache behavior across turns.
+    if context.session_id:
+        try:
+            from hermes_cli.project_context import load_project_context
+            active_project = load_project_context(context.session_id)
+            if active_project is not None:
+                lines.extend(active_project.prompt_lines())
+        except Exception:
+            logger.debug("failed to load active project context", exc_info=True)
+
     # User identity.
     # In shared multi-user sessions (shared threads OR shared non-thread groups
     # when group_sessions_per_user=False), multiple users contribute to the same

--- a/hermes_cli/project_context.py
+++ b/hermes_cli/project_context.py
@@ -1,0 +1,253 @@
+"""Project-boundary primitives for long-running session work.
+
+H2/H3 minimal implementation:
+- ActiveProjectContext: per-session metadata stored outside the prompt prefix.
+- DurableWriteIntent: explicit metadata required for writes to global stores.
+- validation helpers for memory/skill durable writes.
+
+The active project context is persisted in SessionDB.state_meta under
+``project:<session_id>``.  It is intentionally loaded when building dynamic
+session context, not injected by mutating the static system prompt mid-session.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+PROJECT_SCOPES = frozenset({"global", "user", "project", "local", "none"})
+PROJECT_DERIVED_SCOPES = frozenset({"project", "local"})
+_MUTATING_SKILL_ACTIONS = frozenset({"create", "edit", "patch", "delete", "write_file", "remove_file"})
+_MUTATING_MEMORY_ACTIONS = frozenset({"add", "replace", "remove"})
+
+
+@dataclass
+class ActiveProjectContext:
+    """Project metadata attached to a session.
+
+    This is deliberately small and declarative so it can be shown in the
+    dynamic session context and used by write gates without importing project
+    facts into global memory.
+    """
+
+    project_id: str
+    project_name: str
+    capsule_path: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+
+    def normalized(self) -> "ActiveProjectContext":
+        self.project_id = (self.project_id or "").strip()
+        self.project_name = (self.project_name or "").strip()
+        self.capsule_path = (self.capsule_path or "").strip()
+        if not isinstance(self.metadata, dict):
+            self.metadata = {}
+        return self
+
+    def validate(self) -> Optional[str]:
+        self.normalized()
+        if not self.project_id:
+            return "project_id is required."
+        if not self.project_name:
+            return "project_name is required."
+        return None
+
+    def to_json(self) -> str:
+        self.updated_at = time.time()
+        return json.dumps(asdict(self), ensure_ascii=False, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, raw: str) -> "ActiveProjectContext":
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise ValueError("stored project context is not an object")
+        return cls(
+            project_id=str(data.get("project_id") or ""),
+            project_name=str(data.get("project_name") or ""),
+            capsule_path=str(data.get("capsule_path") or ""),
+            metadata=data.get("metadata") if isinstance(data.get("metadata"), dict) else {},
+            created_at=float(data.get("created_at") or time.time()),
+            updated_at=float(data.get("updated_at") or time.time()),
+        ).normalized()
+
+    def prompt_lines(self) -> list[str]:
+        lines = ["", "## Current Project Context", ""]
+        lines.append(f"**Project:** {self.project_id} — {self.project_name}")
+        if self.capsule_path:
+            lines.append(f"**Capsule path:** `{self.capsule_path}`")
+        if self.metadata:
+            safe_items = []
+            for key in sorted(self.metadata):
+                value = self.metadata[key]
+                if isinstance(value, (str, int, float, bool)) and str(value).strip():
+                    safe_items.append(f"{key}={value}")
+            if safe_items:
+                lines.append(f"**Metadata:** {', '.join(safe_items[:8])}")
+        lines.append(
+            "**Durable write boundary:** Project facts, design choices, source evidence, "
+            "and task progress are project-local by default. Global memory/skill writes "
+            "must declare `scope`, `source_reference`, and set `approved_global=true` "
+            "when derived from this project."
+        )
+        return lines
+
+
+@dataclass
+class DurableWriteIntent:
+    """Explicit durable-write metadata supplied by the tool caller."""
+
+    tool_name: str
+    action: str
+    destination: str
+    scope: str = ""
+    source_reference: str = ""
+    project_id: str = ""
+    approved_global: bool = False
+
+    def normalized_scope(self) -> str:
+        return (self.scope or "").strip().lower()
+
+    def is_mutating(self) -> bool:
+        if self.tool_name == "memory":
+            return self.action in _MUTATING_MEMORY_ACTIONS
+        if self.tool_name == "skill_manage":
+            return self.action in _MUTATING_SKILL_ACTIONS
+        return True
+
+    def project_derived(self, active_project: Optional[ActiveProjectContext]) -> bool:
+        scope = self.normalized_scope()
+        if scope in PROJECT_DERIVED_SCOPES:
+            return True
+        pid = (self.project_id or "").strip()
+        return bool(active_project and pid and pid == active_project.project_id)
+
+
+_DB_CACHE: Dict[str, Any] = {}
+
+
+def _meta_key(session_id: str) -> str:
+    return f"project:{session_id}"
+
+
+def _get_session_db() -> Optional[Any]:
+    try:
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        home = str(get_hermes_home())
+    except Exception as exc:  # pragma: no cover
+        logger.debug("project context: SessionDB bootstrap failed (%s)", exc)
+        return None
+
+    cached = _DB_CACHE.get(home)
+    if cached is not None:
+        return cached
+    try:
+        db = SessionDB()
+    except Exception as exc:  # pragma: no cover
+        logger.debug("project context: SessionDB() raised (%s)", exc)
+        return None
+    _DB_CACHE[home] = db
+    return db
+
+
+def load_project_context(session_id: str) -> Optional[ActiveProjectContext]:
+    if not session_id:
+        return None
+    db = _get_session_db()
+    if db is None:
+        return None
+    try:
+        raw = db.get_meta(_meta_key(session_id))
+    except Exception as exc:
+        logger.debug("project context: get_meta failed: %s", exc)
+        return None
+    if not raw:
+        return None
+    try:
+        ctx = ActiveProjectContext.from_json(raw)
+    except Exception as exc:
+        logger.warning("project context: could not parse stored project for %s: %s", session_id, exc)
+        return None
+    return ctx if ctx.validate() is None else None
+
+
+def save_project_context(session_id: str, context: ActiveProjectContext) -> Optional[str]:
+    if not session_id:
+        return "session_id is required."
+    err = context.validate()
+    if err:
+        return err
+    db = _get_session_db()
+    if db is None:
+        return "Session database is unavailable."
+    try:
+        db.set_meta(_meta_key(session_id), context.to_json())
+    except Exception as exc:
+        logger.debug("project context: set_meta failed: %s", exc)
+        return f"Failed to persist project context: {exc}"
+    return None
+
+
+def clear_project_context(session_id: str) -> bool:
+    """Clear by storing an empty JSON marker.
+
+    SessionDB currently has get/set only for state_meta.  Storing an empty value
+    keeps the operation non-invasive and makes load_project_context return None.
+    """
+    if not session_id:
+        return False
+    db = _get_session_db()
+    if db is None:
+        return False
+    try:
+        db.set_meta(_meta_key(session_id), "")
+        return True
+    except Exception as exc:
+        logger.debug("project context: clear failed: %s", exc)
+        return False
+
+
+def validate_durable_write_intent(
+    *,
+    session_id: str = "",
+    intent: DurableWriteIntent,
+    active_project: Optional[ActiveProjectContext] = None,
+) -> Optional[str]:
+    """Return a rejection message, or None if the durable write may proceed."""
+    if not intent.is_mutating():
+        return None
+    active_project = active_project or load_project_context(session_id)
+    if active_project is None:
+        return None
+
+    scope = intent.normalized_scope()
+    if not scope:
+        return (
+            "Durable write rejected: this session has an active project context "
+            f"({active_project.project_id}). Provide an explicit `scope` "
+            "('global', 'user', or 'project') and `source_reference`."
+        )
+    if scope not in PROJECT_SCOPES:
+        return (
+            f"Durable write rejected: unknown scope '{intent.scope}'. Use one of: "
+            f"{', '.join(sorted(PROJECT_SCOPES))}."
+        )
+    if not (intent.source_reference or "").strip():
+        return (
+            "Durable write rejected: active project sessions require a "
+            "`source_reference` (capsule path, note path, issue, or explicit user instruction)."
+        )
+    if intent.project_derived(active_project) and not intent.approved_global:
+        return (
+            "Durable write rejected: project-derived content cannot be written to "
+            f"global {intent.tool_name} storage without `approved_global=true`. "
+            f"Keep it in the project capsule instead: {active_project.capsule_path or active_project.project_id}."
+        )
+    return None

--- a/model_tools.py
+++ b/model_tools.py
@@ -767,6 +767,7 @@ def handle_function_call(
                 function_name, function_args,
                 task_id=task_id,
                 user_task=user_task,
+                session_id=session_id or "",
             )
         duration_ms = int((time.monotonic() - _dispatch_start) * 1000)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -9515,6 +9515,11 @@ class AIAgent:
                 content=function_args.get("content"),
                 old_text=function_args.get("old_text"),
                 store=self._memory_store,
+                session_id=self.session_id or "",
+                scope=function_args.get("scope", ""),
+                source_reference=function_args.get("source_reference", ""),
+                project_id=function_args.get("project_id", ""),
+                approved_global=function_args.get("approved_global", False),
             )
             # Bridge: notify external memory provider of built-in memory writes
             if self._memory_manager and function_args.get("action") in ("add", "replace"):

--- a/tests/hermes_cli/test_project_context.py
+++ b/tests/hermes_cli/test_project_context.py
@@ -1,0 +1,91 @@
+from hermes_cli import project_context as pc
+
+
+class FakeSessionDB:
+    def __init__(self):
+        self.meta = {}
+
+    def get_meta(self, key):
+        return self.meta.get(key)
+
+    def set_meta(self, key, value):
+        self.meta[key] = value
+
+
+def test_project_context_round_trips_through_state_meta(monkeypatch):
+    db = FakeSessionDB()
+    monkeypatch.setattr(pc, "_get_session_db", lambda: db)
+
+    ctx = pc.ActiveProjectContext(
+        project_id="pci-010",
+        project_name="AI optimization",
+        capsule_path="/capsules/010",
+        metadata={"track": 10, "empty": "", "nested": {"skip": True}},
+    )
+
+    assert pc.save_project_context("session-1", ctx) is None
+    loaded = pc.load_project_context("session-1")
+
+    assert loaded is not None
+    assert loaded.project_id == "pci-010"
+    assert loaded.project_name == "AI optimization"
+    assert loaded.capsule_path == "/capsules/010"
+    prompt = "\n".join(loaded.prompt_lines())
+    assert "Current Project Context" in prompt
+    assert "track=10" in prompt
+    assert "nested" not in prompt
+
+
+def test_durable_write_intent_requires_scope_and_source_for_active_project():
+    active = pc.ActiveProjectContext(project_id="pci-010", project_name="AI optimization")
+
+    rejection = pc.validate_durable_write_intent(
+        intent=pc.DurableWriteIntent(tool_name="memory", action="add", destination="memory"),
+        active_project=active,
+    )
+
+    assert rejection is not None
+    assert "Provide an explicit `scope`" in rejection
+
+
+def test_project_derived_global_write_requires_explicit_approval():
+    active = pc.ActiveProjectContext(project_id="pci-010", project_name="AI optimization")
+
+    rejection = pc.validate_durable_write_intent(
+        intent=pc.DurableWriteIntent(
+            tool_name="skill_manage",
+            action="create",
+            destination="workflow",
+            scope="project",
+            source_reference="/capsules/010/source.md",
+            project_id="pci-010",
+        ),
+        active_project=active,
+    )
+
+    assert rejection is not None
+    assert "without `approved_global=true`" in rejection
+
+    allowed = pc.validate_durable_write_intent(
+        intent=pc.DurableWriteIntent(
+            tool_name="skill_manage",
+            action="create",
+            destination="workflow",
+            scope="project",
+            source_reference="/capsules/010/source.md",
+            project_id="pci-010",
+            approved_global=True,
+        ),
+        active_project=active,
+    )
+    assert allowed is None
+
+
+def test_clear_project_context_stores_empty_marker(monkeypatch):
+    db = FakeSessionDB()
+    monkeypatch.setattr(pc, "_get_session_db", lambda: db)
+    assert pc.save_project_context("session-1", pc.ActiveProjectContext("p", "Project")) is None
+
+    assert pc.clear_project_context("session-1") is True
+    assert db.meta["project:session-1"] == ""
+    assert pc.load_project_context("session-1") is None

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -248,6 +248,43 @@ class TestMemoryToolDispatcher:
         result = json.loads(memory_tool(action="add", target="memory", content="via tool", store=store))
         assert result["success"] is True
 
+    def test_active_project_rejects_memory_write_without_scope(self, store, monkeypatch):
+        from hermes_cli import project_context as pc
+
+        active = pc.ActiveProjectContext(project_id="pci-010", project_name="AI optimization")
+        monkeypatch.setattr(pc, "load_project_context", lambda session_id: active)
+
+        result = json.loads(memory_tool(
+            action="add",
+            target="memory",
+            content="project fact",
+            store=store,
+            session_id="session-1",
+        ))
+
+        assert result["success"] is False
+        assert "active project context" in result["error"]
+
+    def test_active_project_allows_approved_memory_write(self, store, monkeypatch):
+        from hermes_cli import project_context as pc
+
+        active = pc.ActiveProjectContext(project_id="pci-010", project_name="AI optimization")
+        monkeypatch.setattr(pc, "load_project_context", lambda session_id: active)
+
+        result = json.loads(memory_tool(
+            action="add",
+            target="memory",
+            content="project fact",
+            store=store,
+            session_id="session-1",
+            scope="project",
+            source_reference="/capsules/010/source.md",
+            project_id="pci-010",
+            approved_global=True,
+        ))
+
+        assert result["success"] is True
+
     def test_replace_requires_old_text(self, store):
         result = json.loads(memory_tool(action="replace", content="new", store=store))
         assert result["success"] is False

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -524,6 +524,45 @@ class TestSkillManageDispatcher:
         assert result["success"] is False
         assert "content" in result["error"].lower()
 
+    def test_active_project_rejects_skill_write_without_scope(self, tmp_path, monkeypatch):
+        from hermes_cli import project_context as pc
+
+        active = pc.ActiveProjectContext(project_id="pci-010", project_name="AI optimization")
+        monkeypatch.setattr(pc, "load_project_context", lambda session_id: active)
+
+        with _skill_dir(tmp_path):
+            raw = skill_manage(
+                action="create",
+                name="test-skill",
+                content=VALID_SKILL_CONTENT,
+                session_id="session-1",
+            )
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "active project context" in result["error"]
+
+    def test_active_project_allows_approved_skill_write(self, tmp_path, monkeypatch):
+        from hermes_cli import project_context as pc
+
+        active = pc.ActiveProjectContext(project_id="pci-010", project_name="AI optimization")
+        monkeypatch.setattr(pc, "load_project_context", lambda session_id: active)
+
+        with _skill_dir(tmp_path):
+            raw = skill_manage(
+                action="create",
+                name="test-skill",
+                content=VALID_SKILL_CONTENT,
+                session_id="session-1",
+                scope="project",
+                source_reference="/capsules/010/source.md",
+                project_id="pci-010",
+                approved_global=True,
+            )
+
+        result = json.loads(raw)
+        assert result["success"] is True
+
     def test_patch_without_old_string(self, tmp_path):
         with _skill_dir(tmp_path):
             raw = skill_manage(action="patch", name="test")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -468,6 +468,11 @@ def memory_tool(
     content: str = None,
     old_text: str = None,
     store: Optional[MemoryStore] = None,
+    session_id: str = "",
+    scope: str = "",
+    source_reference: str = "",
+    project_id: str = "",
+    approved_global: bool = False,
 ) -> str:
     """
     Single entry point for the memory tool. Dispatches to MemoryStore methods.
@@ -479,6 +484,25 @@ def memory_tool(
 
     if target not in ("memory", "user"):
         return tool_error(f"Invalid target '{target}'. Use 'memory' or 'user'.", success=False)
+
+    try:
+        from hermes_cli.project_context import DurableWriteIntent, validate_durable_write_intent
+        rejection = validate_durable_write_intent(
+            session_id=session_id or "",
+            intent=DurableWriteIntent(
+                tool_name="memory",
+                action=action or "",
+                destination=target,
+                scope=scope or "",
+                source_reference=source_reference or "",
+                project_id=project_id or "",
+                approved_global=bool(approved_global),
+            ),
+        )
+        if rejection:
+            return tool_error(rejection, success=False)
+    except Exception:
+        logger.debug("memory durable write boundary check failed open", exc_info=True)
 
     if action == "add":
         if not content:
@@ -558,6 +582,23 @@ MEMORY_SCHEMA = {
                 "type": "string",
                 "description": "Short unique substring identifying the entry to replace or remove."
             },
+            "scope": {
+                "type": "string",
+                "enum": ["global", "user", "project", "local", "none"],
+                "description": "Durable-write scope. Required when a project context is active."
+            },
+            "source_reference": {
+                "type": "string",
+                "description": "Capsule path, source note, issue, or explicit user instruction justifying this durable write. Required when a project context is active."
+            },
+            "project_id": {
+                "type": "string",
+                "description": "Active project id when the write is derived from project-local context."
+            },
+            "approved_global": {
+                "type": "boolean",
+                "description": "Set true only after explicit approval to promote project-derived content into global memory."
+            },
         },
         "required": ["action", "target"],
     },
@@ -576,7 +617,12 @@ registry.register(
         target=args.get("target", "memory"),
         content=args.get("content"),
         old_text=args.get("old_text"),
-        store=kw.get("store")),
+        store=kw.get("store"),
+        session_id=kw.get("session_id") or args.get("session_id", ""),
+        scope=args.get("scope", ""),
+        source_reference=args.get("source_reference", ""),
+        project_id=args.get("project_id", ""),
+        approved_global=args.get("approved_global", False)),
     check_fn=check_memory_requirements,
     emoji="🧠",
 )

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -719,12 +719,36 @@ def skill_manage(
     new_string: str = None,
     replace_all: bool = False,
     absorbed_into: str = None,
+    session_id: str = "",
+    scope: str = "",
+    source_reference: str = "",
+    project_id: str = "",
+    approved_global: bool = False,
 ) -> str:
     """
     Manage user-created skills. Dispatches to the appropriate action handler.
 
     Returns JSON string with results.
     """
+    try:
+        from hermes_cli.project_context import DurableWriteIntent, validate_durable_write_intent
+        rejection = validate_durable_write_intent(
+            session_id=session_id or "",
+            intent=DurableWriteIntent(
+                tool_name="skill_manage",
+                action=action or "",
+                destination=name or "",
+                scope=scope or "",
+                source_reference=source_reference or "",
+                project_id=project_id or "",
+                approved_global=bool(approved_global),
+            ),
+        )
+        if rejection:
+            return tool_error(rejection, success=False)
+    except Exception:
+        logger.debug("skill durable write boundary check failed open", exc_info=True)
+
     if action == "create":
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
@@ -901,6 +925,23 @@ SKILL_MANAGE_SCHEMA = {
                     "rewriting) will have to guess at intent."
                 )
             },
+            "scope": {
+                "type": "string",
+                "enum": ["global", "user", "project", "local", "none"],
+                "description": "Durable-write scope. Required when a project context is active."
+            },
+            "source_reference": {
+                "type": "string",
+                "description": "Capsule path, source note, issue, or explicit user instruction justifying this durable write. Required when a project context is active."
+            },
+            "project_id": {
+                "type": "string",
+                "description": "Active project id when the write is derived from project-local context."
+            },
+            "approved_global": {
+                "type": "boolean",
+                "description": "Set true only after explicit approval to promote project-derived content into global skills."
+            },
         },
         "required": ["action", "name"],
     },
@@ -924,6 +965,11 @@ registry.register(
         old_string=args.get("old_string"),
         new_string=args.get("new_string"),
         replace_all=args.get("replace_all", False),
-        absorbed_into=args.get("absorbed_into")),
+        absorbed_into=args.get("absorbed_into"),
+        session_id=kw.get("session_id") or args.get("session_id", ""),
+        scope=args.get("scope", ""),
+        source_reference=args.get("source_reference", ""),
+        project_id=args.get("project_id", ""),
+        approved_global=args.get("approved_global", False)),
     emoji="📝",
 )


### PR DESCRIPTION
## Summary
- Add per-session project context storage in `SessionDB.state_meta` and surface it in gateway dynamic session context without mutating the static prompt prefix.
- Gate project-active durable writes for both `memory` and `skill_manage` with explicit scope/source metadata and approval for project-derived global writes.
- Thread session id into registry-dispatched tool calls and add unit coverage for the project context helpers plus both durable-write gates.

## Tests
- `/Users/oc_runtime/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_project_context.py tests/tools/test_memory_tool.py tests/tools/test_skill_manager_tool.py`
