### PR TITLE
Fix gateway model picker current context

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1687,9 +1687,11 @@ def list_authenticated_providers(
 
 def list_picker_providers(
     current_provider: str = "",
+    current_base_url: str = "",
     user_providers: dict = None,
     custom_providers: list | None = None,
     max_models: int = 8,
+    current_model: str = "",
 ) -> List[dict]:
     """Interactive-picker variant of :func:`list_authenticated_providers`.
 
@@ -1714,9 +1716,11 @@ def list_picker_providers(
 
     providers = list_authenticated_providers(
         current_provider=current_provider,
+        current_base_url=current_base_url,
         user_providers=user_providers,
         custom_providers=custom_providers,
         max_models=max_models,
+        current_model=current_model,
     )
 
     filtered: List[dict] = []

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -190,8 +190,11 @@ def test_max_models_caps_openrouter_live_output(monkeypatch):
 
 
 def test_passthrough_kwargs_to_base(monkeypatch):
-    """All kwargs (current_provider, user_providers, custom_providers, max_models)
-    must be forwarded to ``list_authenticated_providers`` unchanged.
+    """All kwargs must be forwarded to ``list_authenticated_providers`` unchanged.
+
+    The gateway /model picker passes ``current_base_url`` and ``current_model``
+    so custom endpoint grouping can mark the current row. Dropping those kwargs
+    regressed Telegram/Discord into the text-list fallback.
     """
     captured = {}
 
@@ -205,12 +208,54 @@ def test_passthrough_kwargs_to_base(monkeypatch):
 
     model_switch.list_picker_providers(
         current_provider="openrouter",
+        current_base_url="http://x",
+        current_model="openai/gpt-5.4",
         user_providers={"foo": {"api": "http://x"}},
         custom_providers=[{"name": "bar", "base_url": "http://y"}],
         max_models=12,
     )
 
     assert captured["current_provider"] == "openrouter"
+    assert captured["current_base_url"] == "http://x"
+    assert captured["current_model"] == "openai/gpt-5.4"
     assert captured["user_providers"] == {"foo": {"api": "http://x"}}
     assert captured["custom_providers"] == [{"name": "bar", "base_url": "http://y"}]
     assert captured["max_models"] == 12
+
+
+def test_current_custom_endpoint_passthrough_marks_current_row(monkeypatch):
+    """Interactive picker should preserve current custom endpoint semantics."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: [])
+
+    result = model_switch.list_picker_providers(
+        current_provider="custom:ollama",
+        current_base_url="http://localhost:11434/v1",
+        current_model="glm-5.1",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Ollama — GLM 5.1",
+                "base_url": "http://localhost:11434/v1",
+                "api_key": "ollama",
+                "model": "glm-5.1",
+            },
+            {
+                "name": "Ollama — Qwen3",
+                "base_url": "http://localhost:11434/v1",
+                "api_key": "ollama",
+                "model": "qwen3",
+            },
+        ],
+        max_models=50,
+    )
+
+    custom_rows = [p for p in result if p.get("is_user_defined")]
+    assert len(custom_rows) == 1
+    row = custom_rows[0]
+    assert row["slug"] == "custom:ollama"
+    assert row["is_current"] is True
+    assert row["models"] == ["glm-5.1", "qwen3"]


### PR DESCRIPTION
## What does this PR do?

Restores the Telegram/Discord interactive `/model` picker after the credential-filtered picker wrapper stopped accepting the current model context passed by the gateway.

Commit https://github.com/NousResearch/hermes-agent/commit/60235dba5e8d1a2a518131a53de63bba37f41830 switched the gateway no-arg `/model` path to `list_picker_providers(...)`. The gateway already passed `current_base_url` and `current_model`, but the new wrapper did not accept or forward those kwargs. That raised a `TypeError`, which the gateway caught and degraded into the non-interactive text list.

This keeps the intent of that commit: the picker still uses the credential-filtered provider list, live-filters OpenRouter, and drops empty non-custom rows. It only restores the passthrough state needed for custom endpoint grouping/current-row detection.

## Related Issue

No issue filed. Reported from Discord support after updating to a commit that included https://github.com/NousResearch/hermes-agent/commit/60235dba5e8d1a2a518131a53de63bba37f41830.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/model_switch.py`
  - Adds `current_base_url` and `current_model` parameters to `list_picker_providers(...)`.
  - Forwards both values to `list_authenticated_providers(...)` so existing custom-provider grouping and current-row logic still applies.
- `tests/hermes_cli/test_list_picker_providers.py`
  - Extends passthrough coverage to include `current_base_url` and `current_model`.
  - Adds a regression test for grouped current custom endpoints in the interactive picker path.

## How to Test

1. Run `./.venv/bin/pytest tests/hermes_cli/test_list_picker_providers.py`.
2. Run `./.venv/bin/pytest tests/gateway/test_discord_model_picker.py::test_model_picker_clears_controls_before_running_switch_callback tests/gateway/test_telegram_approval_buttons.py::TestTelegramApprovalCallback::test_model_picker_callback_not_affected`.
3. In a gateway with Discord or Telegram configured, run `/model` with no args and confirm the interactive picker opens instead of falling back to the text list.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted checks pass:

```text
$ .venv/bin/pytest tests/hermes_cli/test_list_picker_providers.py
10 passed

$ .venv/bin/pytest tests/gateway/test_discord_model_picker.py::test_model_picker_clears_controls_before_running_switch_callback tests/gateway/test_telegram_approval_buttons.py::TestTelegramApprovalCallback::test_model_picker_callback_not_affected
2 passed
```

Full suite was attempted with `scripts/run_tests.sh`, which runs pytest with 4 workers in the hermetic test env:

```text
45 failed, 20034 passed, 51 skipped, 229 warnings in 806.92s
```

The failures were outside the changed picker files and included existing/broader areas such as gateway approval E2E, auxiliary client provider selection, Bedrock beta headers, config boolean parsing, DingTalk cards, restart drain, update restart, delegation credential resolution, environment command wrappers, Tirith, and browser Chromium guards.
