### PR TITLE
fix(webhook): support Svix signatures

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -27,6 +27,8 @@ Security:
 """
 
 import asyncio
+import base64
+import binascii
 import hashlib
 import hmac
 import json
@@ -555,7 +557,11 @@ class WebhookAdapter(BasePlatformAdapter):
     def _validate_signature(
         self, request: "web.Request", body: bytes, secret: str
     ) -> bool:
-        """Validate webhook signature (GitHub, GitLab, generic HMAC-SHA256)."""
+        """Validate webhook signature.
+
+        Supports GitHub, GitLab, Svix-compatible providers, and a generic
+        HMAC-SHA256 header.
+        """
         # GitHub: X-Hub-Signature-256 = sha256=<hex>
         gh_sig = request.headers.get("X-Hub-Signature-256", "")
         if gh_sig:
@@ -568,6 +574,44 @@ class WebhookAdapter(BasePlatformAdapter):
         gl_token = request.headers.get("X-Gitlab-Token", "")
         if gl_token:
             return hmac.compare_digest(gl_token, secret)
+
+        # Svix: svix-signature = v1,<base64>; signed content is
+        # "{svix-id}.{svix-timestamp}.{raw_body}" and whsec_ secrets contain
+        # the base64-encoded HMAC key after the prefix.
+        svix_sig = request.headers.get("svix-signature", "")
+        svix_id = request.headers.get("svix-id", "")
+        svix_timestamp = request.headers.get("svix-timestamp", "")
+        if svix_sig or svix_id or svix_timestamp:
+            if not (svix_sig and svix_id and svix_timestamp):
+                return False
+            secret_value = (
+                secret[len("whsec_") :]
+                if secret.startswith("whsec_")
+                else secret
+            )
+            try:
+                key = base64.b64decode(secret_value, validate=True)
+            except (binascii.Error, ValueError):
+                logger.debug("[webhook] Invalid Svix signing secret format")
+                return False
+
+            signed_content = (
+                svix_id.encode("utf-8")
+                + b"."
+                + svix_timestamp.encode("utf-8")
+                + b"."
+                + body
+            )
+            expected = base64.b64encode(
+                hmac.new(key, signed_content, hashlib.sha256).digest()
+            ).decode("ascii")
+            for part in svix_sig.split():
+                if not part.startswith("v1,"):
+                    continue
+                candidate = part[3:]
+                if hmac.compare_digest(candidate, expected):
+                    return True
+            return False
 
         # Generic: X-Webhook-Signature = <hex HMAC-SHA256>
         generic_sig = request.headers.get("X-Webhook-Signature", "")

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -15,6 +15,7 @@ Covers:
 """
 
 import asyncio
+import base64
 import hashlib
 import hmac
 import json
@@ -100,6 +101,31 @@ def _generic_signature(body: bytes, secret: str) -> str:
     return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
+def _svix_secret(raw_secret: bytes = b"svix-secret-42") -> str:
+    """Build a Svix-style whsec_ signing secret for tests."""
+    return "whsec_" + base64.b64encode(raw_secret).decode("ascii")
+
+
+def _svix_signature(
+    body: bytes,
+    secret: str,
+    msg_id: str = "msg_test",
+    timestamp: str = "1700000000",
+) -> str:
+    """Compute Svix v1 signature for *body* using *secret*."""
+    secret_value = secret.removeprefix("whsec_")
+    key = base64.b64decode(secret_value)
+    signed_content = (
+        msg_id.encode("utf-8")
+        + b"."
+        + timestamp.encode("utf-8")
+        + b"."
+        + body
+    )
+    digest = hmac.new(key, signed_content, hashlib.sha256).digest()
+    return "v1," + base64.b64encode(digest).decode("ascii")
+
+
 # ===================================================================
 # Signature validation
 # ===================================================================
@@ -137,6 +163,67 @@ class TestValidateSignature:
         adapter = _make_adapter()
         req = _mock_request(headers={"X-Gitlab-Token": "wrong"})
         assert adapter._validate_signature(req, b"{}", "correct") is False
+
+    def test_validate_svix_signature_valid(self):
+        """Valid Svix v1 signature is accepted."""
+        adapter = _make_adapter()
+        body = b'{"type": "email.received"}'
+        secret = _svix_secret()
+        msg_id = "msg_2kYQ0V7q9Xc"
+        timestamp = "1700000000"
+        sig = _svix_signature(body, secret, msg_id, timestamp)
+        req = _mock_request(
+            headers={
+                "svix-id": msg_id,
+                "svix-timestamp": timestamp,
+                "svix-signature": sig,
+            }
+        )
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_svix_signature_accepts_matching_signature_from_list(self):
+        """Svix retries may include multiple signatures; accept any matching v1."""
+        adapter = _make_adapter()
+        body = b'{"type": "email.received"}'
+        secret = _svix_secret()
+        msg_id = "msg_2kYQ0V7q9Xc"
+        timestamp = "1700000000"
+        sig = _svix_signature(body, secret, msg_id, timestamp)
+        req = _mock_request(
+            headers={
+                "svix-id": msg_id,
+                "svix-timestamp": timestamp,
+                "svix-signature": "v1,invalid " + sig,
+            }
+        )
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_validate_svix_signature_invalid(self):
+        """Wrong Svix v1 signature is rejected."""
+        adapter = _make_adapter()
+        body = b'{"type": "email.received"}'
+        secret = _svix_secret()
+        req = _mock_request(
+            headers={
+                "svix-id": "msg_2kYQ0V7q9Xc",
+                "svix-timestamp": "1700000000",
+                "svix-signature": "v1,deadbeef",
+            }
+        )
+        assert adapter._validate_signature(req, body, secret) is False
+
+    def test_validate_svix_signature_missing_required_header_rejects(self):
+        """Partial Svix headers are not allowed to fall through."""
+        adapter = _make_adapter()
+        body = b'{"type": "email.received"}'
+        secret = _svix_secret()
+        req = _mock_request(
+            headers={
+                "svix-id": "msg_2kYQ0V7q9Xc",
+                "svix-signature": _svix_signature(body, secret),
+            }
+        )
+        assert adapter._validate_signature(req, body, secret) is False
 
     def test_validate_no_signature_with_secret_rejects(self):
         """Secret configured but no recognised signature header → reject."""


### PR DESCRIPTION
## Summary
- add Svix-compatible `svix-id` / `svix-timestamp` / `svix-signature` verification to the webhook adapter
- support `whsec_` signing secrets and multiple space-delimited `v1,<base64>` signatures
- cover valid, invalid, multi-signature, and partial-header rejection cases

Closes #20478

## Tests
- `scripts/run_tests.sh tests/gateway/test_webhook_adapter.py -k 'svix or ValidateSignature'`\n- `scripts/run_tests.sh tests/gateway/test_webhook_adapter.py`\n- `git diff --check`