### PR TITLE
feat: include token usage counters in session JSON log

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2358,6 +2358,15 @@ class AIAgent:
                 "system_prompt": redact_sensitive_text(self._cached_system_prompt or ""),
                 "tools": self.tools or [],
                 "message_count": len(cleaned),
+                "input_tokens": self.session_input_tokens,
+                "output_tokens": self.session_output_tokens,
+                "cache_read_tokens": self.session_cache_read_tokens,
+                "cache_write_tokens": self.session_cache_write_tokens,
+                "reasoning_tokens": self.session_reasoning_tokens,
+                "prompt_tokens": self.session_prompt_tokens,
+                "api_call_count": self.session_api_calls,
+                "estimated_cost_usd": self.session_estimated_cost_usd,
+                "cost_status": self.session_cost_status,
                 "messages": cleaned,
             }
 


### PR DESCRIPTION
## Summary

The session JSON file produced by `_save_session_log()` did not include token usage counters even though these values are tracked in-memory and persisted to the SQLite `state.db` via `update_token_counts()`. This made it impossible to see token usage from the raw session JSON without querying the database.

## Changes

Added the following fields to the JSON entry written by `_save_session_log()` in `run_agent.py`:

- `input_tokens` — total input tokens consumed
- `output_tokens` — total output tokens generated
- `cache_read_tokens` — tokens read from cache
- `cache_write_tokens` — tokens written to cache
- `reasoning_tokens` — tokens used for reasoning (if applicable)
- `prompt_tokens` — total prompt tokens
- `api_call_count` — number of API calls made in the session
- `estimated_cost_usd` — estimated cost in USD
- `cost_status` — cost tracking status

These are the same counter attributes already included in the conversation result dict returned by `run_conversation()`.

## Testing

- `python3 -m py_compile run_agent.py` — passes
- `pytest tests/run_agent/test_run_agent.py::TestSaveSessionLogAtomicWrite` — passes

Closes #20253
