### PR TITLE
feat(i18n): add zh-hant locale

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -25,7 +25,7 @@ Language resolution order:
     3. ``display.language`` from config.yaml
     4. ``"en"`` (baseline)
 
-Supported languages: en, zh, ja, de, es, fr, tr, uk.  Unknown values fall back to en.
+Supported languages: en, zh, zh-hant, ja, de, es, fr, tr, uk.  Unknown values fall back to en.
 """
 
 from __future__ import annotations
@@ -39,14 +39,15 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "ja", "de", "es", "fr", "tr", "uk")
+SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "zh-hant", "ja", "de", "es", "fr", "tr", "uk")
 DEFAULT_LANGUAGE = "en"
 
 # Accept a few natural aliases so users who type "chinese" / "zh-CN" / "jp"
 # get the right catalog instead of silently falling back to English.
 _LANGUAGE_ALIASES: dict[str, str] = {
     "english": "en", "en-us": "en", "en-gb": "en",
-    "chinese": "zh", "mandarin": "zh", "zh-cn": "zh", "zh-tw": "zh", "zh-hans": "zh", "zh-hant": "zh",
+    "chinese": "zh", "mandarin": "zh", "zh-cn": "zh", "zh-hans": "zh",
+    "zh-tw": "zh-hant",
     "japanese": "ja", "jp": "ja", "ja-jp": "ja",
     "german": "de", "deutsch": "de", "de-de": "de",
     "spanish": "es", "español": "es", "espanol": "es", "es-es": "es", "es-mx": "es",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -784,7 +784,7 @@ DEFAULT_CONFIG = {
         # UI language for static user-facing messages (approval prompts, a
         # handful of gateway slash-command replies).  Does NOT affect agent
         # responses, log lines, tool outputs, or slash-command descriptions.
-        # Supported: en, zh, ja, de, es, fr, tr, uk.  Unknown values fall back to en.
+        # Supported: en, zh, zh-hant, ja, de, es, fr, tr, uk.  Unknown values fall back to en.
         "language": "en",
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -7,7 +7,7 @@
 #
 # Keys are dotted paths; nesting below is purely for readability.  Values may
 # contain {placeholder} tokens for str.format substitution.  When adding a
-# new key, add it to EVERY locale file (en/zh/ja/de/es/fr/tr/uk) in the same commit --
+# new key, add it to EVERY locale file (en/zh/zh-hant/ja/de/es/fr/tr/uk) in the same commit --
 # tests/agent/test_i18n.py asserts catalog parity.
 
 approval:

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -1,0 +1,24 @@
+# Hermes 靜態訊息目錄 -- 中文（繁體）
+# See locales/en.yaml for the source of truth; keep keys in sync.
+
+approval:
+  dangerous_header: "⚠️  危險指令： {description}"
+  choose_long:     "      [o]僅此一次  |  [s]本次工作階段  |  [a]永久允許  |  [d]拒絕"
+  choose_short:    "      [o]僅此一次  |  [s]本次工作階段  |  [d]拒絕"
+  prompt_long:     "      選擇 [o/s/a/D]: "
+  prompt_short:    "      選擇 [o/s/D]: "
+  timeout:         "      ⏱ 逾時 — 已拒絕指令"
+  allowed_once:    "      ✓ 本次允許"
+  allowed_session: "      ✓ 本次工作階段內允許"
+  allowed_always:  "      ✓ 已加入永久允許清單"
+  denied:          "      ✗ 已拒絕"
+  cancelled:       "      ✗ 已取消"
+  blocklist_message: "此指令位於無條件封鎖清單中，無法核准。"
+
+gateway:
+  approval_expired: "⚠️ 核准已逾時（Agent 已不再等待）。請讓 Agent 重試。"
+  draining:         "⏳ 正在等待 {count} 個 Agent 完成後重啟..."
+  goal_cleared:     "✓ 目標已清除。"
+  no_active_goal:   "目前沒有執行中的目標。"
+  config_read_failed: "⚠️ 無法讀取 config.yaml：{error}"
+  config_save_failed: "⚠️ 無法儲存設定：{error}"

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -86,6 +86,7 @@ def test_normalize_lang_accepts_supported():
 def test_normalize_lang_accepts_aliases():
     assert i18n._normalize_lang("chinese") == "zh"
     assert i18n._normalize_lang("zh-CN") == "zh"
+    assert i18n._normalize_lang("zh-TW") == "zh-hant"
     assert i18n._normalize_lang("Deutsch") == "de"
     assert i18n._normalize_lang("español") == "es"
     assert i18n._normalize_lang("jp") == "ja"
@@ -132,6 +133,7 @@ def test_default_when_nothing_set(monkeypatch):
 def test_t_explicit_lang():
     assert i18n.t("approval.denied", lang="en").endswith("Denied")
     assert i18n.t("approval.denied", lang="zh").endswith("已拒绝")
+    assert i18n.t("approval.denied", lang="zh-hant").endswith("已拒絕") 
     assert i18n.t("approval.denied", lang="uk").endswith("Відхилено")
     assert i18n.t("approval.denied", lang="tr").endswith("Reddedildi")
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1167,20 +1167,20 @@ display:
   show_cost: false        # Show estimated $ cost in the CLI status bar
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
   runtime_metadata_footer: false  # Gateway: append a runtime-context footer to final replies
-  language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | ja | de | es | fr | tr | uk
+  language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | zh-hant | ja | de | es | fr | tr | uk
 ```
 
 ### UI language for static messages
 
 The `display.language` setting translates a small set of static user-facing messages — the CLI approval prompt, a handful of gateway slash-command replies (e.g. restart-drain notices, "approval expired", "goal cleared"). It does **not** translate agent responses, log lines, tool output, error tracebacks, or slash-command descriptions — those stay in English. If you want the agent itself to reply in another language, just tell it in your prompt or system message.
 
-Supported values: `en` (default), `zh` (Simplified Chinese), `ja` (Japanese), `de` (German), `es` (Spanish), `fr` (French), `tr` (Turkish), `uk` (Ukrainian). Unknown values fall back to English.
+Supported values: `en` (default), `zh` (Simplified Chinese), `zh-hant` (Traditional Chinese), `ja` (Japanese), `de` (German), `es` (Spanish), `fr` (French), `tr` (Turkish), `uk` (Ukrainian). Unknown values fall back to English.
 
 You can also set this per-session with the `HERMES_LANGUAGE` env var, which overrides the config value.
 
 ```yaml
 display:
-  language: zh   # CLI approval prompts appear in Chinese
+  language: zh   # CLI approval prompts appear in Simplified Chinese
 ```
 
 | Mode | What you see |


### PR DESCRIPTION
## What does this PR do?
- Add zh-hant file: `locales/zh-hant.yaml`
- Add "zh-hant" to SUPPORTED_LANGUAGES in agent/i18n.py
- Amended language alias, isolated `zh-tw` from `zh` to `zh-hant`.

## Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made
- locales/zh-hant.yaml
- agent/i18n.py - alias zh-tw to zh-hant
- user-guide/configuration.md

## How to Test
1. python -m pytest tests/agent/test_i18n.py -v

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1<!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping
<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->
All N/A
