### PR TITLE
feat(feishu): Add interactive card model picker (send_model_picker)

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1401,6 +1401,9 @@ class FeishuAdapter(BasePlatformAdapter):
         # Exec approval button state (approval_id → {session_key, message_id, chat_id})
         self._approval_state: Dict[int, Dict[str, str]] = {}
         self._approval_counter = itertools.count(1)
+        # Model picker state (chat_id → picker state dict)
+        self._model_picker_state: Dict[str, dict] = {}
+        self._MODEL_PAGE_SIZE = 6
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
@@ -1852,6 +1855,390 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.warning("[Feishu] send_exec_approval failed: %s", exc)
             return SendResult(success=False, error=str(exc))
+
+    # =========================================================================
+    # Model Picker — interactive card-based model selector
+    # =========================================================================
+
+    async def send_model_picker(
+        self,
+        chat_id: str,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        session_key: str,
+        on_model_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive Feishu card for model selection.
+
+        Two-layer drill-down: provider buttons → model buttons.
+        Card is updated in-place as the user navigates via card action
+        callbacks.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        card = self._build_model_picker_provider_card(
+            providers, current_model, current_provider
+        )
+        payload = json.dumps(card, ensure_ascii=False)
+
+        response = await self._feishu_send_with_retry(
+            chat_id=chat_id,
+            msg_type="interactive",
+            payload=payload,
+            reply_to=None,
+            metadata=metadata,
+        )
+        result = self._finalize_send_result(response, "send_model_picker failed")
+
+        if result.success:
+            self._model_picker_state[str(chat_id)] = {
+                "msg_id": result.message_id or "",
+                "providers": providers,
+                "session_key": session_key,
+                "on_model_selected": on_model_selected,
+                "current_model": current_model,
+                "current_provider": current_provider,
+            }
+        return result
+
+    # ── Card builders ──────────────────────────────────────────────────
+
+    def _build_model_picker_provider_card(
+        self, providers: list, current_model: str, current_provider: str
+    ) -> Dict[str, Any]:
+        """Build the top-level provider selection card."""
+        try:
+            from hermes_cli.providers import get_label
+        except ImportError:
+            def get_label(_):
+                return ""
+
+        provider_label = get_label(current_provider) or current_provider
+        elements: list = [
+            {
+                "tag": "markdown",
+                "content": (
+                    f"**目前模型：** `{current_model or 'unknown'}`\n"
+                    f"**Provider：** {provider_label}\n\n"
+                    "請選擇 Provider："
+                ),
+            },
+        ]
+
+        # Feishu limits 4 buttons per action element
+        actions: list = []
+        for p in providers:
+            count = p.get("total_models", len(p.get("models", [])))
+            label = p.get("name", p.get("slug", "?"))
+            if p.get("is_current"):
+                label = f"✓ {label}"
+            label = f"{label} ({count})"
+            actions.append({
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": label},
+                "type": "primary" if p.get("is_current") else "default",
+                "value": {"hermes_action": f"mp:{p['slug']}"},
+            })
+
+        # Split into groups of 4
+        for i in range(0, len(actions), 4):
+            elements.append({"tag": "action", "actions": actions[i:i + 4]})
+
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "⚙️ 模型設定", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": elements,
+        }
+
+    def _build_model_picker_model_card(
+        self, provider_name: str, models: list, page: int
+    ) -> Dict[str, Any]:
+        """Build the model selection card for a given page."""
+        page_size = self._MODEL_PAGE_SIZE
+        total = len(models)
+        total_pages = max(1, (total + page_size - 1) // page_size)
+        page = max(0, min(page, total_pages - 1))
+
+        start = page * page_size
+        end = min(start + page_size, total)
+        page_models = models[start:end]
+
+        elements: list = [
+            {
+                "tag": "markdown",
+                "content": (
+                    f"**Provider：** {provider_name}\n"
+                    f"（{start + 1}–{end} / {total}）\n\n"
+                    "請選擇模型："
+                ),
+            },
+        ]
+
+        # Model buttons
+        actions: list = []
+        for i, model_id in enumerate(page_models):
+            display = model_id.split("/")[-1] if "/" in model_id else model_id
+            if len(display) > 30:
+                display = display[:27] + "..."
+            actions.append({
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": display},
+                "type": "default",
+                "value": {"hermes_action": f"mm:{start + i}"},
+            })
+
+        for i in range(0, len(actions), 4):
+            elements.append({"tag": "action", "actions": actions[i:i + 4]})
+
+        # Navigation row
+        nav_actions: list = []
+        if page > 0:
+            nav_actions.append({
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": "◀ 上一頁"},
+                "type": "default",
+                "value": {"hermes_action": f"mg:{page - 1}"},
+            })
+        nav_actions.append({
+            "tag": "button",
+            "text": {"tag": "plain_text", "content": f"{page + 1}/{total_pages}"},
+            "type": "default",
+            "value": {"hermes_action": "mx:noop"},
+        })
+        if page < total_pages - 1:
+            nav_actions.append({
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": "下一頁 ▶"},
+                "type": "default",
+                "value": {"hermes_action": f"mg:{page + 1}"},
+            })
+
+        # Back + Cancel
+        bottom_actions: list = [
+            {
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": "◀ 返回"},
+                "type": "default",
+                "value": {"hermes_action": "mb"},
+            },
+            {
+                "tag": "button",
+                "text": {"tag": "plain_text", "content": "✗ 取消"},
+                "type": "danger",
+                "value": {"hermes_action": "mx"},
+            },
+        ]
+
+        elements.append({"tag": "action", "actions": nav_actions})
+        elements.append({"tag": "action", "actions": bottom_actions})
+
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "⚙️ 模型設定", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": elements,
+        }
+
+    # ── Card action handler (synchronous — updates card inline) ────────
+
+    def _handle_model_picker_card_action(
+        self, *, event, action_value, hermes_action: str, loop
+    ) -> Any:
+        """Handle model picker navigation actions synchronously.
+
+        Returns P2CardActionTriggerResponse with updated card for
+        navigation, or schedules async selection work and returns a
+        placeholder card.
+        """
+        chat_id = str(getattr(getattr(event, "context", None), "open_chat_id", "") or "")
+        state = self._model_picker_state.get(chat_id)
+
+        if not state:
+            return self._picker_expired_response()
+
+        # ── Provider selected ──
+        if hermes_action.startswith("mp:"):
+            slug = hermes_action[3:]
+            provider = next((p for p in state["providers"] if p["slug"] == slug), None)
+            if not provider:
+                return self._picker_error_response("Provider 不存在")
+
+            models = provider.get("models", [])
+            state["selected_provider"] = slug
+            state["selected_provider_name"] = provider.get("name", slug)
+            state["model_list"] = models
+            state["model_page"] = 0
+
+            card = self._build_model_picker_model_card(
+                provider.get("name", slug), models, 0
+            )
+            return self._update_card(card)
+
+        # ── Page navigation ──
+        if hermes_action.startswith("mg:"):
+            try:
+                page = int(hermes_action[3:])
+            except ValueError:
+                return self._picker_error_response("無效的頁碼")
+
+            models = state.get("model_list", [])
+            state["model_page"] = page
+
+            card = self._build_model_picker_model_card(
+                state.get("selected_provider_name", ""), models, page
+            )
+            return self._update_card(card)
+
+        # ── Back to provider list ──
+        if hermes_action == "mb":
+            card = self._build_model_picker_provider_card(
+                state["providers"],
+                state.get("current_model", ""),
+                state.get("current_provider", ""),
+            )
+            return self._update_card(card)
+
+        # ── Model selected ──
+        if hermes_action.startswith("mm:"):
+            try:
+                idx = int(hermes_action[3:])
+            except ValueError:
+                return self._picker_error_response("無效的選擇")
+
+            # Show "processing" card immediately, schedule real work
+            processing_card = {
+                "config": {"wide_screen_mode": True},
+                "header": {
+                    "title": {"content": "⚙️ 模型設定", "tag": "plain_text"},
+                    "template": "blue",
+                },
+                "elements": [
+                    {"tag": "markdown", "content": "⏳ 正在切換模型..."},
+                ],
+            }
+            self._submit_on_loop(loop, self._handle_model_picker_selection(chat_id, idx))
+            return self._update_card(processing_card)
+
+        # ── Cancel ──
+        if hermes_action == "mx":
+            cancel_card = {
+                "config": {"wide_screen_mode": True},
+                "header": {
+                    "title": {"content": "⚙️ 模型設定", "tag": "plain_text"},
+                    "template": "blue",
+                },
+                "elements": [
+                    {"tag": "markdown", "content": "已取消模型選擇。"},
+                ],
+            }
+            self._submit_on_loop(loop, self._cleanup_picker_state(chat_id))
+            return self._update_card(cancel_card)
+
+        # ── No-op placeholder (e.g. page counter button) ──
+        return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+    # ── Async selection handler ────────────────────────────────────────
+
+    async def _handle_model_picker_selection(self, chat_id: str, idx: int) -> None:
+        """Perform the actual model switch and update the card."""
+        state = self._model_picker_state.get(chat_id)
+        if not state:
+            return
+
+        model_list = state.get("model_list", [])
+        if idx < 0 or idx >= len(model_list):
+            await self.edit_message(
+                chat_id, state.get("msg_id", ""),
+                "❌ 無效的模型選擇。請重新 `/model`。"
+            )
+            return
+
+        model_id = model_list[idx]
+        provider_slug = state.get("selected_provider", "")
+        callback = state.get("on_model_selected")
+
+        if not callback:
+            await self.edit_message(
+                chat_id, state.get("msg_id", ""),
+                "❌ Picker 已過期。請重新 `/model`。"
+            )
+            self._model_picker_state.pop(chat_id, None)
+            return
+
+        try:
+            result_text = await callback(chat_id, model_id, provider_slug)
+        except Exception as exc:
+            logger.error("[Feishu] Model picker switch failed: %s", exc, exc_info=True)
+            result_text = "Error switching model."
+
+        try:
+            await self.edit_message(chat_id, state.get("msg_id", ""), result_text)
+        except Exception:
+            pass
+
+        self._model_picker_state.pop(chat_id, None)
+
+    # ── Helpers ────────────────────────────────────────────────────────
+
+    async def _cleanup_picker_state(self, chat_id: str) -> None:
+        """Remove stale picker state.
+
+        The brief sleep ensures Feishu has propagated the card update
+        (P2CardActionTriggerResponse) before we discard the state dict.
+        Without it, a racing card-action callback can see a missing state
+        and return the ``picker expired`` card to the user.
+        """
+        await asyncio.sleep(0.5)
+        self._model_picker_state.pop(chat_id, None)
+
+    @staticmethod
+    def _update_card(card: Dict[str, Any]) -> Any:
+        """Build a P2CardActionTriggerResponse with a replacement card."""
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            cc = CallBackCard()
+            cc.type = "raw"
+            cc.data = card
+            response.card = cc
+        return response
+
+    @staticmethod
+    def _picker_expired_response() -> Any:
+        card = {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "⚙️ 模型設定", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": [
+                {"tag": "markdown", "content": "Picker 已過期。請重新 `/model`。"},
+            ],
+        }
+        return FeishuAdapter._update_card(card)
+
+    @staticmethod
+    def _picker_error_response(msg: str) -> Any:
+        card = {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "⚙️ 模型設定", "tag": "plain_text"},
+                "template": "blue",
+            },
+            "elements": [
+                {"tag": "markdown", "content": f"❌ {msg}"},
+            ],
+        }
+        return FeishuAdapter._update_card(card)
 
     @staticmethod
     def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
@@ -2371,6 +2758,14 @@ class FeishuAdapter(BasePlatformAdapter):
         hermes_action = action_value.get("hermes_action") if isinstance(action_value, dict) else None
 
         if hermes_action:
+            # Model picker actions take priority — they use the same
+            # hermes_action key but with specific prefixes.
+            _mp_prefixes = ("mp:", "mm:", "mg:")
+            if hermes_action.startswith(_mp_prefixes) or hermes_action in ("mb", "mx", "mx:noop"):
+                return self._handle_model_picker_card_action(
+                    event=event, action_value=action_value,
+                    hermes_action=hermes_action, loop=loop,
+                )
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
 
         self._submit_on_loop(loop, self._handle_card_action_event(data))

--- a/tests/gateway/test_feishu_model_picker.py
+++ b/tests/gateway/test_feishu_model_picker.py
@@ -1,0 +1,291 @@
+"""Tests for the Feishu /model interactive card picker.
+
+Covers card builders and the synchronous _handle_model_picker_card_action
+dispatch that drives the two-layer provider→model drill-down.
+"""
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from gateway.platforms.feishu import FeishuAdapter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _dummy_providers():
+    return [
+        {
+            "slug": "openrouter",
+            "name": "OpenRouter",
+            "models": ["openai/gpt-5.4", "anthropic/claude-sonnet-4",
+                       "google/gemini-2.5-pro", "meta-llama/llama-4",
+                       "deepseek/deepseek-chat", "qwen/qwen3-235b"],
+            "total_models": 6,
+            "is_current": True,
+        },
+        {
+            "slug": "copilot",
+            "name": "GitHub Copilot",
+            "models": ["gpt-5.4"],
+            "total_models": 1,
+            "is_current": False,
+        },
+    ]
+
+
+def _skeleton_adapter(**kw) -> FeishuAdapter:
+    """Return a bare FeishuAdapter with the attrs our picker needs."""
+    adapter = object.__new__(FeishuAdapter)
+    adapter._client = object()  # truthy so send_model_picker passes guard
+    adapter._model_picker_state = {}
+    adapter._MODEL_PAGE_SIZE = 6
+    # minimal attrs for _feishu_send_with_retry / _finalize_send_result
+    adapter._loop = Mock()
+    adapter._loop_accepts_callbacks = Mock(return_value=True)
+    adapter._submit_on_loop = Mock()
+    adapter._card_action_tokens = {}
+    adapter._app_id = "test-app"
+    adapter.edit_message = AsyncMock()
+    for k, v in kw.items():
+        setattr(adapter, k, v)
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Card-builder tests
+# ---------------------------------------------------------------------------
+
+class TestProviderCard:
+    def test_provider_card_structure(self):
+        adapter = _skeleton_adapter()
+        card = adapter._build_model_picker_provider_card(
+            _dummy_providers(), "openai/gpt-5.4", "openrouter"
+        )
+        assert card["config"]["wide_screen_mode"] is True
+        assert card["header"]["title"]["content"] == "⚙️ 模型設定"
+
+        # At least one markdown + one action element
+        tags = [e["tag"] for e in card["elements"]]
+        assert "markdown" in tags
+        assert "action" in tags
+
+        # All buttons carry mp:<slug>
+        for el in card["elements"]:
+            if el["tag"] != "action":
+                continue
+            for btn in el["actions"]:
+                val = btn["value"]["hermes_action"]
+                assert val.startswith("mp:"), f"unexpected action {val}"
+
+    def test_provider_card_marks_current(self):
+        adapter = _skeleton_adapter()
+        card = adapter._build_model_picker_provider_card(
+            _dummy_providers(), "openai/gpt-5.4", "openrouter"
+        )
+        all_btn_texts = []
+        for el in card["elements"]:
+            if el["tag"] == "action":
+                for btn in el["actions"]:
+                    all_btn_texts.append(btn["text"]["content"])
+        current_labels = [t for t in all_btn_texts if t.startswith("✓")]
+        assert len(current_labels) == 1  # only openrouter
+
+
+class TestModelCard:
+    def test_model_card_structure(self):
+        adapter = _skeleton_adapter()
+        models = ["openai/gpt-5.4", "anthropic/claude-sonnet-4",
+                  "google/gemini-2.5-pro", "meta-llama/llama-4"]
+        card = adapter._build_model_picker_model_card("OpenRouter", models, 0)
+        assert card["header"]["title"]["content"] == "⚙️ 模型設定"
+
+        # Model buttons carry mm:<idx>
+        mm_actions = []
+        for el in card["elements"]:
+            if el["tag"] != "action":
+                continue
+            for btn in el["actions"]:
+                val = btn["value"]["hermes_action"]
+                if val.startswith("mm:"):
+                    mm_actions.append(val)
+        assert len(mm_actions) == len(models)
+
+    def test_model_card_no_pagination_when_few_models(self):
+        adapter = _skeleton_adapter()
+        models = ["a", "b"]
+        card = adapter._build_model_picker_model_card("X", models, 0)
+        nav_buttons = []
+        for el in card["elements"]:
+            if el["tag"] == "action":
+                for btn in el["actions"]:
+                    v = btn["value"]["hermes_action"]
+                    if v.startswith("mg:") or v == "mx:noop":
+                        nav_buttons.append(v)
+        # 2 models fit on one page → no prev/next, only page counter + back + cancel
+        page_counters = [v for v in nav_buttons if v == "mx:noop"]
+        assert len(page_counters) == 1
+
+    def test_model_card_has_back_and_cancel(self):
+        adapter = _skeleton_adapter()
+        card = adapter._build_model_picker_model_card("X", ["m1", "m2"], 0)
+        bottom_actions = []
+        for el in card["elements"]:
+            if el["tag"] == "action":
+                for btn in el["actions"]:
+                    v = btn["value"]["hermes_action"]
+                    if v in ("mb", "mx"):
+                        bottom_actions.append(v)
+        assert "mb" in bottom_actions
+        assert "mx" in bottom_actions
+
+    def test_model_card_pagination(self):
+        """With 7 models and page_size=2, page 0 should show prev disabled, next enabled."""
+        adapter = _skeleton_adapter()
+        adapter._MODEL_PAGE_SIZE = 2
+        models = [f"model-{i}" for i in range(7)]
+        card = adapter._build_model_picker_model_card("P", models, 0)
+        nav = []
+        for el in card["elements"]:
+            if el["tag"] == "action":
+                for btn in el["actions"]:
+                    v = btn["value"]["hermes_action"]
+                    if v.startswith("mg:") or v == "mx:noop":
+                        nav.append(v)
+        # page 0 / 4 → no prev button, has next
+        assert not any(v.startswith("mg:0") for v in nav if v != "mx:noop")
+        has_next = any("mg:1" in v for v in nav)
+        assert has_next
+
+
+# ---------------------------------------------------------------------------
+# Card-action dispatch tests
+# ---------------------------------------------------------------------------
+
+def _make_event(chat_id="oc_test", hermes_action="mp:openrouter"):
+    return SimpleNamespace(
+        context=SimpleNamespace(open_chat_id=chat_id),
+        action=SimpleNamespace(
+            tag="button",
+            value={"hermes_action": hermes_action},
+        ),
+    )
+
+
+class TestCardActionDispatch:
+    """Synchronous dispatch (_handle_model_picker_card_action)."""
+
+    def test_provider_selection_switches_to_model_list(self):
+        adapter = _skeleton_adapter()
+        adapter._model_picker_state["oc_test"] = {
+            "providers": _dummy_providers(),
+            "current_model": "a", "current_provider": "p",
+            "msg_id": "m1",
+        }
+        event = _make_event(hermes_action="mp:openrouter")
+        resp = adapter._handle_model_picker_card_action(
+            event=event, action_value={"hermes_action": "mp:openrouter"},
+            hermes_action="mp:openrouter", loop=Mock(),
+        )
+        assert resp is not None
+        card = resp.card.data
+        assert "OpenRouter" in card["elements"][0]["content"]
+        # state updated
+        st = adapter._model_picker_state["oc_test"]
+        assert st["selected_provider"] == "openrouter"
+        assert st["model_page"] == 0
+
+    def test_page_navigation(self):
+        adapter = _skeleton_adapter()
+        adapter._MODEL_PAGE_SIZE = 2
+        models = [f"m{i}" for i in range(5)]
+        adapter._model_picker_state["oc_test"] = {
+            "providers": _dummy_providers(),
+            "model_list": models,
+            "model_page": 0,
+            "selected_provider": "x",
+            "selected_provider_name": "X",
+            "current_model": "a", "current_provider": "p",
+        }
+        event = _make_event(hermes_action="mg:1")
+        resp = adapter._handle_model_picker_card_action(
+            event=event, action_value={}, hermes_action="mg:1", loop=Mock(),
+        )
+        assert resp is not None
+        card = resp.card.data
+        # should show page 1/3
+        md = card["elements"][0]["content"]
+        assert "3–4" in md or "3–4" in md  # items 3-4 of 5
+        assert adapter._model_picker_state["oc_test"]["model_page"] == 1
+
+    def test_back_to_provider_list(self):
+        adapter = _skeleton_adapter()
+        adapter._model_picker_state["oc_test"] = {
+            "providers": _dummy_providers(),
+            "model_list": ["m1"],
+            "model_page": 0,
+            "selected_provider": "x",
+            "current_model": "a", "current_provider": "p",
+        }
+        event = _make_event(hermes_action="mb")
+        resp = adapter._handle_model_picker_card_action(
+            event=event, action_value={}, hermes_action="mb", loop=Mock(),
+        )
+        assert resp is not None
+        card = resp.card.data
+        md = card["elements"][0]["content"]
+        assert "Provider" in md
+
+    def test_model_selected_schedules_async_and_returns_processing_card(self):
+        adapter = _skeleton_adapter()
+        adapter._submit_on_loop = Mock()
+        adapter._model_picker_state["oc_test"] = {
+            "providers": _dummy_providers(),
+            "model_list": ["openai/gpt-5.4"],
+            "model_page": 0,
+            "selected_provider": "openrouter",
+            "selected_provider_name": "OpenRouter",
+            "current_model": "a", "current_provider": "p",
+            "msg_id": "m1",
+        }
+        event = _make_event(hermes_action="mm:0")
+        resp = adapter._handle_model_picker_card_action(
+            event=event, action_value={}, hermes_action="mm:0", loop=Mock(),
+        )
+        assert resp is not None
+        card = resp.card.data
+        assert "正在切換" in card["elements"][0]["content"]
+        # Verify async work was scheduled
+        adapter._submit_on_loop.assert_called_once()
+
+    def test_cancel_schedules_cleanup_and_returns_cancel_card(self):
+        adapter = _skeleton_adapter()
+        adapter._submit_on_loop = Mock()
+        adapter._model_picker_state["oc_test"] = {
+            "providers": _dummy_providers(),
+            "current_model": "a", "current_provider": "p",
+        }
+        event = _make_event(hermes_action="mx")
+        resp = adapter._handle_model_picker_card_action(
+            event=event, action_value={}, hermes_action="mx", loop=Mock(),
+        )
+        assert resp is not None
+        card = resp.card.data
+        assert "已取消" in card["elements"][0]["content"]
+        adapter._submit_on_loop.assert_called_once()
+
+    def test_expired_state_returns_expired_card(self):
+        adapter = _skeleton_adapter()
+        # no state for this chat_id
+        event = _make_event(hermes_action="mp:openrouter")
+        resp = adapter._handle_model_picker_card_action(
+            event=event, action_value={}, hermes_action="mp:openrouter", loop=Mock(),
+        )
+        assert resp is not None
+        card = resp.card.data
+        assert "過期" in card["elements"][0]["content"]


### PR DESCRIPTION
## Summary

Implements `send_model_picker` for the Feishu/Lark platform adapter, enabling an interactive card-based model selector — matching the UX that Telegram and Discord already have.

Closes #20520

## What Changed

### `gateway/platforms/feishu.py`
- Added `_model_picker_state` dict to track per-chat picker state
- Added `send_model_picker()` — sends an interactive provider selection card, matching the contract in `gateway/run.py`
- Added `_build_model_picker_provider_card()` — builds the top-level provider selection card (4 buttons per action group, Feishu limit)
- Added `_build_model_picker_model_card()` — builds the paginated model selection card with navigation
- Added `_handle_model_picker_card_action()` — synchronous dispatch handler for all picker button clicks:
  - `mp:<slug>` → switch to model list for selected provider
  - `mg:<page>` → paginate model list
  - `mm:<idx>` → show "processing..." card + schedule async switch
  - `mb` → back to provider list
  - `mx` → cancel
- Added `_handle_model_picker_selection()` — async callback that performs the actual model switch via `on_model_selected`
- Added helper methods: `_cleanup_picker_state`, `_update_card`, `_picker_expired_response`, `_picker_error_response`
- Modified `_on_card_action_trigger` to intercept model picker actions before approval handling

### `tests/gateway/test_feishu_model_picker.py` (new)
- 12 unit tests covering:
  - Provider card structure and current-provider marking
  - Model card structure, pagination, back/cancel buttons
  - Synchronous dispatch: provider→model, page nav, back, cancel, expired state
  - Model selection schedules async work and returns processing card

All tests pass ✅

## Design Decisions

- **Navigation is synchronous** — `P2CardActionTriggerResponse` replaces the card immediately on provider/page/back actions (fast, no loading state needed)
- **Model switch is async** — the actual `on_model_selected` callback may involve API calls; we show "⏳ processing..." card first, then update via `edit_message` when done
- **Reuses existing infrastructure** — `_submit_on_loop`, `_feishu_send_with_retry`, `_finalize_send_result`, `P2CardActionTriggerResponse`/`CallBackCard` patterns
- **Feishu card constraints honored** — 4 buttons per action group, wide screen mode enabled

## Testing

```bash
pytest tests/gateway/test_feishu_model_picker.py -v
# 12 passed ✅
```

## Before/After

**Before:** `/model` on Feishu → plain text list:
```
Current: deepseek-v4-pro on ollama-cloud

OpenRouter:
  openai/gpt-5.4, anthropic/claude-sonnet-4, ...
```

**After:** `/model` on Feishu → interactive card with buttons for provider selection, then paginated model list with navigation.