### PR TITLE
fix(gateway): offload /model catalog work

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7662,13 +7662,15 @@ class GatewayRunner:
 
             if has_picker:
                 try:
-                    providers = list_picker_providers(
-                        current_provider=current_provider,
-                        current_base_url=current_base_url,
-                        current_model=current_model,
-                        user_providers=user_provs,
-                        custom_providers=custom_provs,
-                        max_models=50,
+                    providers = await self._run_in_executor_with_context(
+                        lambda: list_picker_providers(
+                            current_provider=current_provider,
+                            current_base_url=current_base_url,
+                            current_model=current_model,
+                            user_providers=user_provs,
+                            custom_providers=custom_provs,
+                            max_models=50,
+                        )
                     )
                 except Exception:
                     providers = []
@@ -7687,16 +7689,18 @@ class GatewayRunner:
                         _chat_id: str, model_id: str, provider_slug: str
                     ) -> str:
                         """Perform the model switch and return confirmation text."""
-                        result = _switch_model(
-                            raw_input=model_id,
-                            current_provider=_cur_provider,
-                            current_model=_cur_model,
-                            current_base_url=_cur_base_url,
-                            current_api_key=_cur_api_key,
-                            is_global=False,
-                            explicit_provider=provider_slug,
-                            user_providers=user_provs,
-                            custom_providers=custom_provs,
+                        result = await _self._run_in_executor_with_context(
+                            lambda: _switch_model(
+                                raw_input=model_id,
+                                current_provider=_cur_provider,
+                                current_model=_cur_model,
+                                current_base_url=_cur_base_url,
+                                current_api_key=_cur_api_key,
+                                is_global=False,
+                                explicit_provider=provider_slug,
+                                user_providers=user_provs,
+                                custom_providers=custom_provs,
+                            )
                         )
                         if not result.success:
                             return f"Error: {result.error_message}"
@@ -7795,13 +7799,15 @@ class GatewayRunner:
             lines = [f"Current: `{current_model or 'unknown'}` on {provider_label}", ""]
 
             try:
-                providers = list_authenticated_providers(
-                    current_provider=current_provider,
-                    current_base_url=current_base_url,
-                    current_model=current_model,
-                    user_providers=user_provs,
-                    custom_providers=custom_provs,
-                    max_models=5,
+                providers = await self._run_in_executor_with_context(
+                    lambda: list_authenticated_providers(
+                        current_provider=current_provider,
+                        current_base_url=current_base_url,
+                        current_model=current_model,
+                        user_providers=user_provs,
+                        custom_providers=custom_provs,
+                        max_models=5,
+                    )
                 )
                 for p in providers:
                     tag = " (current)" if p["is_current"] else ""
@@ -7822,16 +7828,18 @@ class GatewayRunner:
             return "\n".join(lines)
 
         # Perform the switch
-        result = _switch_model(
-            raw_input=model_input,
-            current_provider=current_provider,
-            current_model=current_model,
-            current_base_url=current_base_url,
-            current_api_key=current_api_key,
-            is_global=persist_global,
-            explicit_provider=explicit_provider,
-            user_providers=user_provs,
-            custom_providers=custom_provs,
+        result = await self._run_in_executor_with_context(
+            lambda: _switch_model(
+                raw_input=model_input,
+                current_provider=current_provider,
+                current_model=current_model,
+                current_base_url=current_base_url,
+                current_api_key=current_api_key,
+                is_global=persist_global,
+                explicit_provider=explicit_provider,
+                user_providers=user_provs,
+                custom_providers=custom_provs,
+            )
         )
 
         if not result.success:

--- a/tests/gateway/test_model_command_custom_providers.py
+++ b/tests/gateway/test_model_command_custom_providers.py
@@ -1,5 +1,7 @@
 """Regression tests for gateway /model support of config.yaml custom_providers."""
 
+from types import SimpleNamespace
+
 import yaml
 import pytest
 
@@ -61,3 +63,181 @@ async def test_handle_model_command_lists_saved_custom_provider(tmp_path, monkey
     assert "Local (127.0.0.1:4141)" in result
     assert "custom:local-(127.0.0.1:4141)" in result
     assert "rotator-openrouter-coding" in result
+
+
+@pytest.mark.asyncio
+async def test_model_text_list_uses_gateway_executor(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"model": {"default": "gpt-5.4", "provider": "openai"}}),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+    import hermes_cli.model_switch as model_switch
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(
+        model_switch,
+        "list_authenticated_providers",
+        lambda **_kwargs: [
+            {
+                "name": "OpenAI",
+                "slug": "openai",
+                "models": ["gpt-5.4"],
+                "total_models": 1,
+                "is_current": True,
+            }
+        ],
+    )
+
+    runner = _make_runner()
+    calls = []
+
+    async def fake_executor(func, *args):
+        calls.append(func)
+        return func(*args)
+
+    runner._run_in_executor_with_context = fake_executor
+
+    result = await runner._handle_model_command(_make_event("/model"))
+
+    assert calls
+    assert result is not None
+    assert "**OpenAI**" in result
+
+
+@pytest.mark.asyncio
+async def test_model_switch_uses_gateway_executor(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"model": {"default": "old-model", "provider": "openai"}}),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+    import hermes_cli.model_switch as model_switch
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(
+        model_switch,
+        "switch_model",
+        lambda **_kwargs: SimpleNamespace(
+            success=True,
+            new_model="gpt-5.4",
+            target_provider="openai",
+            api_key="",
+            base_url="",
+            api_mode="chat_completions",
+            provider_label="OpenAI",
+            model_info=None,
+            warning_message=None,
+        ),
+    )
+    monkeypatch.setattr(
+        model_switch,
+        "resolve_display_context_length",
+        lambda *args, **kwargs: None,
+    )
+
+    runner = _make_runner()
+    calls = []
+
+    async def fake_executor(func, *args):
+        calls.append(func)
+        return func(*args)
+
+    runner._run_in_executor_with_context = fake_executor
+
+    result = await runner._handle_model_command(_make_event("/model gpt-5.4 --provider openai"))
+
+    assert calls
+    assert result is not None
+    assert "Model switched to `gpt-5.4`" in result
+
+
+class _PickerAdapter:
+    def __init__(self):
+        self.callback_response = None
+
+    async def send_model_picker(
+        self,
+        *,
+        chat_id,
+        providers,
+        current_model,
+        current_provider,
+        session_key,
+        on_model_selected,
+        metadata=None,
+    ):
+        self.callback_response = await on_model_selected(chat_id, "gpt-5.4", "openai")
+        return SimpleNamespace(success=True)
+
+
+@pytest.mark.asyncio
+async def test_interactive_model_picker_switch_uses_gateway_executor(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"model": {"default": "old-model", "provider": "openai"}}),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+    import hermes_cli.model_switch as model_switch
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(
+        model_switch,
+        "list_picker_providers",
+        lambda **_kwargs: [
+            {
+                "name": "OpenAI",
+                "slug": "openai",
+                "models": ["gpt-5.4"],
+                "total_models": 1,
+                "is_current": True,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        model_switch,
+        "switch_model",
+        lambda **_kwargs: SimpleNamespace(
+            success=True,
+            new_model="gpt-5.4",
+            target_provider="openai",
+            api_key="",
+            base_url="",
+            api_mode="chat_completions",
+            provider_label="OpenAI",
+            model_info=None,
+            warning_message=None,
+        ),
+    )
+    monkeypatch.setattr(
+        model_switch,
+        "resolve_display_context_length",
+        lambda *args, **kwargs: None,
+    )
+
+    runner = _make_runner()
+    adapter = _PickerAdapter()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    calls = []
+
+    async def fake_executor(func, *args):
+        calls.append(func)
+        return func(*args)
+
+    runner._run_in_executor_with_context = fake_executor
+
+    result = await runner._handle_model_command(_make_event("/model"))
+
+    assert result is None
+    assert len(calls) == 2
+    assert adapter.callback_response is not None
+    assert "Model switched to `gpt-5.4`" in adapter.callback_response


### PR DESCRIPTION
Fixes #20525

## Summary
- run gateway `/model` provider listing through the existing context-preserving executor
- run both picker callback model switches and text `/model ...` switches through the same executor
- add regression coverage for text listing, text switching, and interactive picker switching

## Why
`list_authenticated_providers`, `list_picker_providers`, and `switch_model` can touch synchronous model catalog/auth paths such as models.dev. Calling them directly inside the async gateway command handler can block Telegram/Discord event-loop progress during provider/model switching.

## Verification
- `scripts/run_tests.sh tests/gateway/test_model_command_custom_providers.py` -> 4 passed
- `scripts/run_tests.sh tests/gateway/test_model_command_custom_providers.py tests/gateway/test_session_env.py tests/gateway/test_model_switch_persistence.py` -> 25 passed, 2 existing deprecation warnings from `tests/conftest.py:492`
- `git diff --check`

## Non-goals
- no changes to model catalog semantics
- no timeout tuning in `agent/models_dev.py`
- no platform-specific picker behavior changes