### PR TITLE
fix: use atomic writes for persistent state files to prevent corruption

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -9,6 +9,8 @@ Routes messages to the appropriate destination based on:
 """
 
 import logging
+import os
+import tempfile
 from pathlib import Path
 from datetime import datetime
 from dataclasses import dataclass
@@ -17,6 +19,28 @@ from typing import Dict, List, Optional, Any
 from hermes_cli.config import get_hermes_home
 
 logger = logging.getLogger(__name__)
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Write text to a file atomically using temp file + os.replace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.stem}_",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 MAX_PLATFORM_OUTPUT = 4000
 TRUNCATED_VISIBLE = 3800
@@ -207,7 +231,7 @@ class DeliveryRouter:
         lines.append("")
         lines.append(content)
         
-        output_path.write_text("\n".join(lines))
+        _atomic_write_text(output_path, "\n".join(lines))
         
         return {
             "path": str(output_path),
@@ -220,7 +244,7 @@ class DeliveryRouter:
         out_dir = get_hermes_home() / "cron" / "output"
         out_dir.mkdir(parents=True, exist_ok=True)
         path = out_dir / f"{job_id}_{timestamp}.txt"
-        path.write_text(content)
+        _atomic_write_text(path, content)
         return path
 
     async def _deliver_to_platform(

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -18,6 +18,8 @@ import time
 import uuid
 from abc import ABC, abstractmethod
 from pathlib import Path
+
+from utils import atomic_json_write
 from typing import IO, Callable, Protocol
 
 from hermes_constants import get_hermes_home
@@ -144,9 +146,8 @@ def _load_json_store(path: Path) -> dict:
 
 
 def _save_json_store(path: Path, data: dict) -> None:
-    """Write *data* as pretty-printed JSON to *path*."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2))
+    """Write *data* as pretty-printed JSON to *path* atomically."""
+    atomic_json_write(path, data, indent=2)
 
 
 def _file_mtime_key(host_path: str) -> tuple[float, int] | None:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -36,6 +36,8 @@ from tools.skills_guard import (
     ScanResult, content_hash, TRUSTED_REPOS,
 )
 
+from utils import atomic_json_write
+
 logger = logging.getLogger(__name__)
 
 
@@ -2561,8 +2563,7 @@ class HubLockFile:
             return {"version": 1, "installed": {}}
 
     def save(self, data: dict) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+        atomic_json_write(self.path, data, indent=2)
 
     def record_install(
         self,
@@ -2628,8 +2629,7 @@ class TapsManager:
             return []
 
     def save(self, taps: List[dict]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps({"taps": taps}, indent=2) + "\n")
+        atomic_json_write(self.path, {"taps": taps}, indent=2)
 
     def add(self, repo: str, path: str = "skills/") -> bool:
         """Add a tap. Returns False if already exists."""
@@ -2915,8 +2915,7 @@ def _load_hermes_index() -> Optional[dict]:
 
     # Cache locally
     try:
-        HERMES_INDEX_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
-        HERMES_INDEX_CACHE_FILE.write_text(json.dumps(data))
+        atomic_json_write(HERMES_INDEX_CACHE_FILE, data)
     except OSError:
         pass
 


### PR DESCRIPTION
## Problem

Non-atomic `write_text()` calls can leave files in a partially-written state if the process is killed mid-write (OOM kill, power loss, SIGKILL). This causes:

- **JSON stores**: `json.loads()` raises `JSONDecodeError` on next read, breaking all functionality that depends on the store
- **Text files**: Truncated output, incomplete delivery records

The codebase already uses atomic writes in several places (`run_agent.py` via `atomic_json_write()`, `gateway/run.py` via tmp+replace, `tools/mcp_oauth.py` via tmp+rename). This PR brings the remaining persistent state writes to parity.

## Fix

Replace `write_text()` with atomic write patterns for 6 locations across 3 files.

### Files changed:

| File | Function | What it writes | Risk |
|------|----------|----------------|------|
| `tools/environments/base.py` | `_save_json_store()` | Execution environment state | HIGH — JSONDecodeError breaks all subsequent reads |
| `tools/skills_hub.py` | `InstalledSkillsRegistry.save()` | Installed skills metadata | HIGH — loses all installed-skill tracking |
| `tools/skills_hub.py` | `TapsRegistry.save()` | Taps data | MEDIUM — loses skill source repos |
| `tools/skills_hub.py` | index cache write | Skills hub index cache | LOW — regeneratable from network |
| `gateway/delivery.py` | `_save_summary_output()` | Cron delivery output | MEDIUM — truncated delivery record |
| `gateway/delivery.py` | `_save_full_output()` | Full cron output | MEDIUM — truncated output |

### Implementation:

- **JSON writes**: Reuse existing `atomic_json_write()` from `utils.py` (handles temp file + fsync + `os.replace` + symlink resolution)
- **Text writes** (delivery.py): Added local `_atomic_write_text()` helper with the same pattern (tempfile + fsync + `os.replace`)

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Process killed mid-write | File left partially written, next read crashes | Previous version intact, no data loss |
| Normal write | Works | Works (atomic replace is transparent) |
| Disk full during write | Partial file + no error handling | Temp file creation fails, original preserved |

## Tests

The fix is defensive-only — it cannot break existing behavior since atomic writes produce identical output to non-atomic writes under normal operation. The difference only matters under abnormal termination, which is difficult to test in unit tests.

## References

- `utils.py:85` — `atomic_json_write()` implementation
- `run_agent.py:4377` — existing atomic write usage for session logs
- `gateway/run.py:4788` — existing tmp+replace pattern for response files
- `tools/mcp_oauth.py:165` — existing tmp+rename pattern for OAuth tokens