### PR TITLE
fix: harden Hermes edge cases from codebase review

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1936,7 +1936,7 @@ def build_anthropic_kwargs(
     # Adds extra_body.speed="fast" + the fast-mode beta header for ~2.5x
     # output speed. Only for native Anthropic endpoints — third-party
     # providers would reject the unknown beta header and speed parameter.
-    if fast_mode and not _is_third_party_anthropic_endpoint(base_url):
+    if fast_mode and _supports_fast_mode(model) and not _is_third_party_anthropic_endpoint(base_url):
         kwargs.setdefault("extra_body", {})["speed"] = "fast"
         # Build extra_headers with ALL applicable betas (the per-request
         # extra_headers override the client-level anthropic-beta header).

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -77,6 +77,10 @@ _ADAPTIVE_THINKING_SUBSTRINGS = ("4-6", "4.6", "4-7", "4.7")
 # This is the Opus 4.7 contract; future 4.x+ models are expected to follow it.
 _NO_SAMPLING_PARAMS_SUBSTRINGS = ("4-7", "4.7")
 
+# Models that support Anthropic Fast Mode (speed=fast). Per Anthropic docs,
+# fast mode is currently supported on Opus 4.6 only.
+_FAST_MODE_SUPPORTED_SUBSTRINGS = ("opus-4-6", "opus-4.6")
+
 # ── Max output token limits per Anthropic model ───────────────────────
 # Source: Anthropic docs + Cline model catalog.  Anthropic's API requires
 # max_tokens as a mandatory field.  Previously we hardcoded 16384, which
@@ -216,25 +220,30 @@ def _forbids_sampling_params(model: str) -> bool:
     return any(v in model for v in _NO_SAMPLING_PARAMS_SUBSTRINGS)
 
 
-# Beta headers for enhanced features (sent with ALL auth types).
-# As of Opus 4.7 (2026-04-16), the first two are GA on Claude 4.6+ — the
-# beta headers are still accepted (harmless no-op) but not required. Kept
-# here so older Claude (4.5, 4.1) + third-party Anthropic-compat endpoints
-# that still gate on the headers continue to get the enhanced features.
+def _supports_fast_mode(model: str) -> bool:
+    """Return True for models that support Anthropic Fast Mode (speed=fast).
+
+    Per Anthropic docs, fast mode is currently supported on Opus 4.6 only.
+    Sending ``speed: "fast"`` to any other Claude model (including Opus 4.7)
+    returns HTTP 400. This guard prevents silently 400'ing when stale config
+    or older callers leave fast mode enabled across a model upgrade.
+    """
+    return any(v in model for v in _FAST_MODE_SUPPORTED_SUBSTRINGS)
+
+
+# Beta headers for enhanced features (sent with Anthropic-compatible clients).
+# As of Opus 4.7 (2026-04-16), these are GA on Claude 4.6+ — the beta headers
+# are still accepted (harmless no-op) but not required. Kept here so older
+# Claude (4.5, 4.1) + third-party Anthropic-compat endpoints that still gate
+# on the headers continue to get the enhanced features.
 #
-# ``context-1m-2025-08-07`` unlocks the 1M context window on Claude Opus 4.6/4.7
-# and Sonnet 4.6 when served via AWS Bedrock or Azure AI Foundry. 1M is GA on
-# native Anthropic (api.anthropic.com) for Opus 4.6+, but Bedrock/Azure still
-# gate it behind this beta header as of 2026-04 — without it Bedrock caps Opus
-# at 200K even though model_metadata.py advertises 1M. The header is a harmless
-# no-op on endpoints where 1M is GA.
-#
-# Migration guide: remove these if you no longer support ≤4.5 models or once
-# Bedrock/Azure promote 1M to GA.
+# Do NOT include ``context-1m-2025-08-07`` in this generic/native list. Some
+# Anthropic subscriptions reject that long-context beta before the request body
+# is processed, which breaks short auxiliary tasks such as title generation.
+# Bedrock/Azure paths that still require the 1M gate opt in explicitly below.
 _COMMON_BETAS = [
     "interleaved-thinking-2025-05-14",
     "fine-grained-tool-streaming-2025-05-14",
-    "context-1m-2025-08-07",
 ]
 # MiniMax's Anthropic-compatible endpoints fail tool-use requests when
 # the fine-grained tool streaming beta is present.  Omit it so tool calls
@@ -244,6 +253,7 @@ _TOOL_STREAMING_BETA = "fine-grained-tool-streaming-2025-05-14"
 # Bearer-auth (MiniMax) endpoints since they host their own models and
 # unknown Anthropic beta headers risk request rejection.
 _CONTEXT_1M_BETA = "context-1m-2025-08-07"
+_BEDROCK_AZURE_BETAS = [*_COMMON_BETAS, _CONTEXT_1M_BETA]
 
 # Fast mode beta — enables the ``speed: "fast"`` request parameter for
 # significantly higher output token throughput on Opus 4.6 (~2.5x).
@@ -468,6 +478,10 @@ def _common_betas_for_base_url(
 ) -> list[str]:
     """Return the beta headers that are safe for the configured endpoint.
 
+    Native Anthropic endpoints omit the 1M-context beta by default because not
+    every subscription has that beta. Bedrock/Azure paths that still need the
+    1M gate opt in explicitly.
+
     MiniMax's Anthropic-compatible endpoints (Bearer-auth) reject requests
     that include Anthropic's ``fine-grained-tool-streaming`` beta — every
     tool-use message triggers a connection error.  Strip that beta for
@@ -485,9 +499,15 @@ def _common_betas_for_base_url(
     reactive recovery loop in ``run_agent.py`` and issue-comment history on
     PR #17680 for the full rationale.
     """
-    if _requires_bearer_auth(base_url):
+    normalized = _normalize_base_url_text(base_url)
+    if _requires_bearer_auth(normalized):
         _stripped = {_TOOL_STREAMING_BETA, _CONTEXT_1M_BETA}
         return [b for b in _COMMON_BETAS if b not in _stripped]
+    if normalized and "azure.com" in normalized.lower():
+        betas = _BEDROCK_AZURE_BETAS
+        if drop_context_1m_beta:
+            return [b for b in betas if b != _CONTEXT_1M_BETA]
+        return betas
     if drop_context_1m_beta:
         return [b for b in _COMMON_BETAS if b != _CONTEXT_1M_BETA]
     return _COMMON_BETAS
@@ -509,10 +529,9 @@ def build_anthropic_client(
     providers.
 
     ``drop_context_1m_beta=True`` strips ``context-1m-2025-08-07`` from the
-    client-level ``anthropic-beta`` header. Used by the reactive OAuth retry
-    path in ``run_agent.py`` when a subscription rejects the beta; leave at
-    its default on fresh clients so 1M-capable subscriptions keep the
-    capability.
+    client-level ``anthropic-beta`` header on endpoints that explicitly opt in
+    to it (Azure/Bedrock). Native Anthropic omits that beta by default so short
+    auxiliary calls do not fail on subscriptions without long-context access.
 
     Returns an anthropic.Anthropic instance.
     """
@@ -627,7 +646,7 @@ def build_anthropic_bedrock_client(region: str):
     return _anthropic_sdk.AnthropicBedrock(
         aws_region=region,
         timeout=Timeout(timeout=900.0, connect=10.0),
-        default_headers={"anthropic-beta": ",".join(_COMMON_BETAS)},
+        default_headers={"anthropic-beta": ",".join(_BEDROCK_AZURE_BETAS)},
     )
 
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -440,13 +440,25 @@ def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
 def iter_skill_index_files(skills_dir: Path, filename: str):
     """Walk skills_dir yielding sorted paths matching *filename*.
 
-    Excludes ``.git``, ``.github``, ``.hub``, ``.archive`` directories.
+    Excludes ``.git``, ``.github``, ``.hub``, ``.archive`` directories and
+    skips symlink escapes so index generation never reads files outside the
+    trusted skills root.
     """
     matches = []
-    for root, dirs, files in os.walk(skills_dir, followlinks=True):
+    try:
+        skills_root = skills_dir.resolve()
+    except OSError:
+        return
+    for root, dirs, files in os.walk(skills_dir, followlinks=False):
         dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS]
-        if filename in files:
-            matches.append(Path(root) / filename)
+        if filename not in files:
+            continue
+        candidate = Path(root) / filename
+        try:
+            candidate.resolve().relative_to(skills_root)
+        except (OSError, ValueError):
+            continue
+        matches.append(candidate)
     for path in sorted(matches, key=lambda p: str(p.relative_to(skills_dir))):
         yield path
 

--- a/cli.py
+++ b/cli.py
@@ -6279,6 +6279,10 @@ class HermesCLI:
         cmd_lower = command.lower().strip()
         cmd_original = command.strip()
 
+        if not cmd_lower or cmd_lower == "/":
+            self._console_print("[dim]Type /help for commands[/]")
+            return True
+
         # Resolve aliases via central registry so adding an alias is a one-line
         # change in hermes_cli/commands.py instead of touching every dispatch site.
         from hermes_cli.commands import resolve_command as _resolve_cmd

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -183,6 +183,22 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         platform_name, rest = deliver_value.split(":", 1)
         platform_key = platform_name.lower()
 
+        if platform_key not in _KNOWN_DELIVERY_PLATFORMS:
+            try:
+                from hermes_cli.plugins import discover_plugins
+
+                discover_plugins()
+            except Exception:
+                pass
+            try:
+                from gateway.platform_registry import platform_registry
+
+                platform_entry = platform_registry.get(platform_key)
+            except Exception:
+                platform_entry = None
+            if platform_entry is None:
+                return None
+
         from tools.send_message_tool import _parse_target_ref
 
         parsed_chat_id, parsed_thread_id, is_explicit = _parse_target_ref(platform_key, rest)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -576,10 +576,23 @@ class PluginContext:
             )
         if not path.exists():
             raise FileNotFoundError(f"SKILL.md not found at {path}")
+        skill_path = path.resolve()
+        manifest_path = Path(self.manifest.path or ".").resolve()
+        # Directory-discovered plugins store manifest.path as the plugin directory;
+        # tests and older callers may provide the manifest file path instead.
+        plugin_root = manifest_path.parent if manifest_path.is_file() else manifest_path
+        try:
+            skill_path.relative_to(plugin_root)
+        except ValueError as exc:
+            raise ValueError(
+                f"Plugin skill path must stay inside plugin directory: {path}"
+            ) from exc
+        if not skill_path.is_file():
+            raise FileNotFoundError(f"Plugin skill path is not a file: {path}")
 
         qualified = f"{self.manifest.name}:{name}"
         self._manager._plugin_skills[qualified] = {
-            "path": path,
+            "path": skill_path,
             "plugin": self.manifest.name,
             "bare_name": name,
             "description": description,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -870,6 +870,9 @@ class SessionDB:
             )
             numbered = cursor.fetchall()
 
+        lineage_re = re.compile(rf"^{re.escape(title)} #\d+$")
+        numbered = [row for row in numbered if lineage_re.match(row["title"])]
+
         if numbered:
             # Return the most recent numbered variant
             return numbered[0]["id"]
@@ -900,15 +903,19 @@ class SessionDB:
             )
             existing = [row["title"] for row in cursor.fetchall()]
 
-        if not existing:
-            return base  # No conflict, use the base name as-is
-
-        # Find the highest number
+        lineage_re = re.compile(rf"^{re.escape(base)} #(\d+)$")
+        has_exact_base = False
         max_num = 1  # The unnumbered original counts as #1
         for t in existing:
-            m = re.match(r'^.* #(\d+)$', t)
+            if t == base:
+                has_exact_base = True
+                continue
+            m = lineage_re.match(t)
             if m:
                 max_num = max(max_num, int(m.group(1)))
+
+        if not has_exact_base and max_num == 1:
+            return base  # No exact or numeric conflict; use the base name as-is
 
         return f"{base} #{max_num + 1}"
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1021,6 +1021,20 @@ class TestBuildAnthropicKwargs:
         assert "claude-code-20250219" in betas
         assert "interleaved-thinking-2025-05-14" in betas
 
+    def test_fast_mode_omitted_for_unsupported_native_models(self):
+        """Do not send speed=fast to models Anthropic documents as unsupported."""
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-7",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+            fast_mode=True,
+        )
+
+        assert "extra_body" not in kwargs or kwargs["extra_body"].get("speed") != "fast"
+        assert "fast-mode-2026-02-01" not in kwargs.get("extra_headers", {}).get("anthropic-beta", "")
+
     def test_reasoning_config_maps_to_manual_thinking_for_pre_4_6_models(self):
         kwargs = build_anthropic_kwargs(
             model="claude-sonnet-4-20250514",

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -66,11 +66,9 @@ class TestBuildAnthropicClient:
             assert "claude-code-20250219" in betas
             assert "interleaved-thinking-2025-05-14" in betas
             assert "fine-grained-tool-streaming-2025-05-14" in betas
-            # Default: 1M-context beta stays IN for OAuth so 1M-capable
-            # subscriptions keep full context. The reactive recovery path
-            # in run_agent.py flips it off only after a subscription
-            # actually rejects the beta.
-            assert "context-1m-2025-08-07" in betas
+            # Native OAuth must not opt into the long-context beta by default:
+            # subscriptions without that beta reject even tiny auxiliary calls.
+            assert "context-1m-2025-08-07" not in betas
             assert "api_key" not in kwargs
 
     def test_oauth_drop_context_1m_beta_strips_only_1m(self):
@@ -96,10 +94,11 @@ class TestBuildAnthropicClient:
             kwargs = mock_sdk.Anthropic.call_args[1]
             assert kwargs["api_key"] == "sk-ant-api03-something"
             assert "auth_token" not in kwargs
-            # API key auth should still get common betas
+            # API key auth should still get common betas, but native Anthropic
+            # must not opt into the long-context beta by default.
             betas = kwargs["default_headers"]["anthropic-beta"]
             assert "interleaved-thinking-2025-05-14" in betas
-            assert "context-1m-2025-08-07" in betas
+            assert "context-1m-2025-08-07" not in betas
             assert "oauth-2025-04-20" not in betas  # OAuth-only beta NOT present
             assert "claude-code-20250219" not in betas  # OAuth-only beta NOT present
 
@@ -109,7 +108,7 @@ class TestBuildAnthropicClient:
             kwargs = mock_sdk.Anthropic.call_args[1]
             assert kwargs["base_url"] == "https://custom.api.com"
             assert kwargs["default_headers"] == {
-                "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14,context-1m-2025-08-07"
+                "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
             }
 
     def test_minimax_anthropic_endpoint_uses_bearer_auth_for_regular_api_keys(self):
@@ -986,8 +985,8 @@ class TestBuildAnthropicKwargs:
         )
         assert kwargs["model"] == "claude-sonnet-4-20250514"
 
-    def test_fast_mode_oauth_default_keeps_context_1m_beta(self):
-        """Default OAuth fast-mode requests still carry context-1m-2025-08-07."""
+    def test_fast_mode_oauth_default_omits_context_1m_beta(self):
+        """Default OAuth fast-mode requests omit gated context-1m beta."""
         kwargs = build_anthropic_kwargs(
             model="claude-opus-4-6",
             messages=[{"role": "user", "content": "Hi"}],
@@ -1000,7 +999,7 @@ class TestBuildAnthropicKwargs:
         betas = kwargs["extra_headers"]["anthropic-beta"]
         assert "fast-mode-2026-02-01" in betas
         assert "oauth-2025-04-20" in betas
-        assert "context-1m-2025-08-07" in betas
+        assert "context-1m-2025-08-07" not in betas
 
     def test_fast_mode_oauth_drop_context_1m_beta_strips_only_1m(self):
         """drop_context_1m_beta=True strips context-1m from fast-mode

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
@@ -23,6 +24,7 @@ from agent.auxiliary_client import (
     _normalize_aux_provider,
     _try_payment_fallback,
     _resolve_auto,
+    shutdown_cached_clients,
 )
 
 
@@ -65,6 +67,45 @@ class TestNormalizeAuxProvider:
     def test_maps_github_copilot_acp_aliases(self):
         assert _normalize_aux_provider("github-copilot-acp") == "copilot-acp"
         assert _normalize_aux_provider("copilot-acp-agent") == "copilot-acp"
+
+
+class TestCompressionAnthropicAuxiliary:
+    def test_compression_task_uses_native_anthropic_without_1m_beta(self, monkeypatch):
+        """Regression: compression is an auxiliary Anthropic call too.
+
+        Subscriptions without Anthropic's long-context beta rejected context
+        compression with HTTP 400 when the native client globally advertised
+        ``context-1m-2025-08-07``.  Title generation covered one auxiliary
+        path; this exercises the compression task specifically.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+        shutdown_cached_clients()
+
+        fake_response = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="compact summary ok")],
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=5, output_tokens=3),
+        )
+        fake_client = MagicMock(name="anthropic_client")
+        fake_client.messages.create.return_value = fake_response
+        fake_sdk = SimpleNamespace(Anthropic=MagicMock(return_value=fake_client))
+
+        with patch("agent.anthropic_adapter._anthropic_sdk", fake_sdk):
+            response = call_llm(
+                task="compression",
+                provider="anthropic",
+                model="claude-haiku-4-5-20251001",
+                messages=[{"role": "user", "content": "summarize"}],
+                max_tokens=64,
+            )
+
+        kwargs = fake_sdk.Anthropic.call_args.kwargs
+        betas = kwargs["default_headers"]["anthropic-beta"]
+        assert "context-1m-2025-08-07" not in betas
+        assert "interleaved-thinking-2025-05-14" in betas
+        assert response.choices[0].message.content == "compact summary ok"
+
+        shutdown_cached_clients()
 
 
 class TestReadCodexAccessToken:

--- a/tests/agent/test_bedrock_1m_context.py
+++ b/tests/agent/test_bedrock_1m_context.py
@@ -15,23 +15,34 @@ from unittest.mock import MagicMock, patch
 class TestBedrockContext1MBeta:
     """``context-1m-2025-08-07`` must reach Bedrock Claude requests."""
 
-    def test_common_betas_includes_1m(self):
+    def test_common_betas_omit_1m(self):
         from agent.anthropic_adapter import _COMMON_BETAS, _CONTEXT_1M_BETA
 
         assert _CONTEXT_1M_BETA == "context-1m-2025-08-07"
-        assert _CONTEXT_1M_BETA in _COMMON_BETAS
+        assert _CONTEXT_1M_BETA not in _COMMON_BETAS
 
-    def test_common_betas_for_native_anthropic_includes_1m(self):
-        """Native Anthropic endpoints (and Bedrock with empty base_url) get 1M."""
+    def test_common_betas_for_native_anthropic_omit_1m(self):
+        """Native Anthropic omits the gated 1M beta by default."""
         from agent.anthropic_adapter import (
             _common_betas_for_base_url,
             _CONTEXT_1M_BETA,
         )
 
-        assert _CONTEXT_1M_BETA in _common_betas_for_base_url(None)
-        assert _CONTEXT_1M_BETA in _common_betas_for_base_url("")
-        assert _CONTEXT_1M_BETA in _common_betas_for_base_url(
+        assert _CONTEXT_1M_BETA not in _common_betas_for_base_url(None)
+        assert _CONTEXT_1M_BETA not in _common_betas_for_base_url("")
+        assert _CONTEXT_1M_BETA not in _common_betas_for_base_url(
             "https://api.anthropic.com"
+        )
+
+    def test_common_betas_for_azure_include_1m(self):
+        """Azure AI Foundry still gates 1M context behind the beta header."""
+        from agent.anthropic_adapter import (
+            _common_betas_for_base_url,
+            _CONTEXT_1M_BETA,
+        )
+
+        assert _CONTEXT_1M_BETA in _common_betas_for_base_url(
+            "https://example.services.ai.azure.com/models/anthropic"
         )
 
     def test_common_betas_strips_1m_for_minimax(self):
@@ -79,27 +90,22 @@ class TestBedrockContext1MBeta:
         assert "interleaved-thinking-2025-05-14" in beta_header
         assert "fine-grained-tool-streaming-2025-05-14" in beta_header
 
-    def test_build_anthropic_kwargs_includes_1m_for_bedrock_fastmode(self):
-        """Fast-mode requests (per-request extra_headers) still include 1M beta.
+    def test_build_anthropic_client_includes_1m_for_azure(self):
+        """Azure AI Foundry clients must still opt into the 1M beta."""
+        import agent.anthropic_adapter as adapter
 
-        Per-request extra_headers override client-level default_headers, so
-        the fast-mode path must re-include everything in _COMMON_BETAS.
-        """
-        from agent.anthropic_adapter import build_anthropic_kwargs
+        fake_sdk = MagicMock()
+        fake_sdk.Anthropic = MagicMock()
 
-        kwargs = build_anthropic_kwargs(
-            model="claude-opus-4-7",
-            messages=[{"role": "user", "content": "hi"}],
-            tools=None,
-            max_tokens=1024,
-            reasoning_config=None,
-            is_oauth=False,
-            # Empty base_url mirrors AnthropicBedrock (no HTTP base URL)
-            base_url=None,
-            fast_mode=True,
-        )
-        beta_header = kwargs.get("extra_headers", {}).get("anthropic-beta", "")
+        with patch.object(adapter, "_anthropic_sdk", fake_sdk):
+            adapter.build_anthropic_client(
+                api_key="azure-key",
+                base_url="https://example.services.ai.azure.com/models/anthropic",
+            )
+
+        kwargs = fake_sdk.Anthropic.call_args.kwargs
+        beta_header = kwargs.get("default_headers", {}).get("anthropic-beta", "")
         assert "context-1m-2025-08-07" in beta_header, (
-            "fast-mode extra_headers must carry the 1M beta or it overrides "
-            "client-level default_headers and Bedrock drops back to 200K"
+            "Azure client must send context-1m-2025-08-07 or 1M context "
+            "can be capped behind the provider-side beta gate"
         )

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -4,6 +4,8 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
     build_preloaded_skills_prompt,
@@ -111,7 +113,7 @@ class TestScanSkillCommands:
         assert "/enabled-skill" in result
         assert "/disabled-skill" not in result
 
-    def test_finds_skills_in_symlinked_category_dir(self, tmp_path):
+    def test_skips_skills_in_symlinked_category_dir(self, tmp_path):
         external_root = tmp_path / "repo"
         skills_root = tmp_path / "skills"
         skills_root.mkdir()
@@ -122,8 +124,7 @@ class TestScanSkillCommands:
         with patch("tools.skills_tool.SKILLS_DIR", skills_root):
             result = scan_skill_commands()
 
-        assert "/knowledge-brain" in result
-        assert result["/knowledge-brain"]["name"] == "knowledge-brain"
+        assert "/knowledge-brain" not in result
 
     def test_get_skill_commands_rescans_when_platform_scope_changes(self, tmp_path):
         """Platform-specific disabled-skill caches must not leak across platforms.

--- a/tests/cli/test_cli_prefix_matching.py
+++ b/tests/cli/test_cli_prefix_matching.py
@@ -158,3 +158,12 @@ class TestSlashCommandPrefixMatching:
         mock_help.assert_called_once()
         printed = " ".join(str(c) for c in cli_obj.console.print.call_args_list)
         assert "Ambiguous" not in printed
+
+
+def test_bare_slash_does_not_crash():
+    cli_obj = _make_cli()
+    printed = []
+    cli_obj._console_print = lambda msg: printed.append(msg)
+
+    assert cli_obj.process_command("/") is True
+    assert "Type /help" in printed[0]

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -555,3 +555,38 @@ class TestRunJobEnvVarCleanup:
         assert os.environ.get("HERMES_SESSION_PLATFORM") is None
         assert os.environ.get("HERMES_SESSION_CHAT_ID") is None
         assert os.environ.get("HERMES_SESSION_CHAT_NAME") is None
+
+
+def test_explicit_delivery_target_rejects_unknown_platform():
+    from cron.scheduler import _resolve_delivery_targets
+
+    assert _resolve_delivery_targets({"deliver": "notaplatform:chat"}) == []
+
+
+def test_explicit_delivery_target_discovers_plugin_platform(monkeypatch):
+    from cron.scheduler import _resolve_delivery_targets
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    calls = []
+
+    def fake_discover_plugins():
+        calls.append(True)
+        platform_registry.register(
+            PlatformEntry(
+                name="plugcron",
+                label="PlugCron",
+                adapter_factory=lambda cfg: object(),
+                check_fn=lambda: True,
+            )
+        )
+
+    platform_registry.unregister("plugcron")
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", fake_discover_plugins)
+
+    try:
+        assert _resolve_delivery_targets({"deliver": "plugcron:chat"}) == [
+            {"platform": "plugcron", "chat_id": "chat", "thread_id": None}
+        ]
+        assert calls
+    finally:
+        platform_registry.unregister("plugcron")

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1746,6 +1746,22 @@ class TestTitleLineage:
 class TestTitleSqlWildcards:
     """Titles containing SQL LIKE wildcards (%, _) must not cause false matches."""
 
+    def test_resolve_ignores_non_numeric_hash_suffix(self, db):
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "my project")
+        time.sleep(0.01)
+        db.create_session("s2", "cli")
+        db.set_session_title("s2", "my project #notes")
+
+        assert db.resolve_session_by_title("my project") == "s1"
+
+    def test_next_title_ignores_non_numeric_hash_suffix(self, db):
+        db.create_session("s1", "cli")
+        db.set_session_title("s1", "my project #notes")
+
+        assert db.get_next_title_in_lineage("my project") == "my project"
+
+
     def test_resolve_title_with_underscore(self, db):
         """A title like 'test_project' should not match 'testXproject #2'."""
         db.create_session("s1", "cli")

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -127,21 +127,54 @@ class TestPluginContextRegisterSkill:
 
         pm = PluginManager()
         monkeypatch.setattr(plugins_mod, "_plugin_manager", pm)
+        plugin_dir = tmp_path / "plugins" / "testplugin"
+        plugin_dir.mkdir(parents=True)
+        manifest_file = plugin_dir / "plugin.yaml"
+        manifest_file.write_text("name: testplugin\n")
         manifest = PluginManifest(
             name="testplugin",
             version="1.0.0",
             description="test",
             source="user",
+            path=str(manifest_file),
         )
         return PluginContext(manifest, pm)
 
     def test_happy_path(self, ctx, tmp_path):
-        skill_md = tmp_path / "skills" / "my-skill" / "SKILL.md"
+        skill_md = tmp_path / "plugins" / "testplugin" / "skills" / "my-skill" / "SKILL.md"
         skill_md.parent.mkdir(parents=True)
         skill_md.write_text("---\nname: my-skill\n---\nContent.\n")
 
         ctx.register_skill("my-skill", skill_md, "A test skill")
-        assert ctx._manager.find_plugin_skill("testplugin:my-skill") == skill_md
+        assert ctx._manager.find_plugin_skill("testplugin:my-skill") == skill_md.resolve()
+
+    def test_rejects_skill_path_outside_plugin_dir(self, ctx, tmp_path):
+        md = tmp_path / "outside" / "SKILL.md"
+        md.parent.mkdir()
+        md.write_text("test")
+        with pytest.raises(ValueError, match="inside plugin directory"):
+            ctx.register_skill("leak", md)
+
+    def test_directory_manifest_path_rejects_sibling_plugin_skill(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins as plugins_mod
+        from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+        pm = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", pm)
+        plugins_root = tmp_path / "plugins"
+        plugin_a = plugins_root / "a"
+        plugin_b = plugins_root / "b"
+        plugin_a.mkdir(parents=True)
+        md = plugin_b / "skills" / "leak" / "SKILL.md"
+        md.parent.mkdir(parents=True)
+        md.write_text("test")
+        ctx = PluginContext(
+            PluginManifest(name="a", source="user", path=str(plugin_a)),
+            pm,
+        )
+
+        with pytest.raises(ValueError, match="inside plugin directory"):
+            ctx.register_skill("leak", md)
 
     def test_rejects_colon_in_name(self, ctx, tmp_path):
         md = tmp_path / "SKILL.md"

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1576,3 +1576,44 @@ class TestDownloadDirectoryRecursive:
 
         assert "SKILL.md" in files
         assert "scripts/run.py" not in files  # lost due to rate limit
+
+
+def test_optional_source_rejects_sibling_prefix_traversal(tmp_path):
+    from tools.skills_hub import OptionalSkillSource
+
+    optional_dir = tmp_path / "optional-skills"
+    optional_dir.mkdir()
+    evil = tmp_path / "optional-skills-evil" / "evil"
+    evil.mkdir(parents=True)
+    (evil / "SKILL.md").write_text("---\nname: evil\n---\nsecret")
+
+    from unittest.mock import patch
+
+    with patch("hermes_constants.get_optional_skills_dir", return_value=optional_dir):
+        src = OptionalSkillSource()
+    assert src.fetch("official/../optional-skills-evil/evil") is None
+
+
+def test_optional_source_skips_symlinked_files_outside_skill_dir(tmp_path):
+    from tools.skills_hub import OptionalSkillSource
+
+    optional_dir = tmp_path / "optional-skills"
+    skill = optional_dir / "safe"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: safe\n---\nbody")
+    secret = tmp_path / "secret.txt"
+    secret.write_text("SECRET OUTSIDE")
+    try:
+        (skill / "references.md").symlink_to(secret)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+    from unittest.mock import patch
+
+    with patch("hermes_constants.get_optional_skills_dir", return_value=optional_dir):
+        src = OptionalSkillSource()
+    bundle = src.fetch("official/safe")
+
+    assert bundle is not None
+    assert "SKILL.md" in bundle.files
+    assert "references.md" not in bundle.files

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -267,7 +267,7 @@ class TestFindAllSkills:
         assert len(skills) == 1
         assert skills[0]["name"] == "real-skill"
 
-    def test_finds_skills_in_symlinked_category_dir(self, tmp_path):
+    def test_does_not_follow_symlinked_category_dir(self, tmp_path):
         external_root = tmp_path / "repo"
         skills_root = tmp_path / "skills"
         skills_root.mkdir()
@@ -278,8 +278,24 @@ class TestFindAllSkills:
         with patch("tools.skills_tool.SKILLS_DIR", skills_root):
             skills = _find_all_skills()
 
-        assert [s["name"] for s in skills] == ["knowledge-brain"]
-        assert skills[0]["category"] == "linked"
+        assert skills == []
+
+    def test_skips_symlinked_skill_md_outside_skills_root(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        skill_dir = skills_root / "safe"
+        skill_dir.mkdir()
+        secret = tmp_path / "secret.md"
+        secret.write_text("---\nname: safe\ndescription: leaked\n---\nSECRET")
+        try:
+            (skill_dir / "SKILL.md").symlink_to(secret)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_root):
+            skills = _find_all_skills()
+
+        assert skills == []
 
 
 # ---------------------------------------------------------------------------
@@ -314,7 +330,7 @@ class TestSkillsList:
         assert result["count"] == 1
         assert result["skills"][0]["name"] == "skill-a"
 
-    def test_category_filter_finds_symlinked_category(self, tmp_path):
+    def test_category_filter_skips_symlinked_category(self, tmp_path):
         external_root = tmp_path / "repo"
         skills_root = tmp_path / "skills"
         skills_root.mkdir()
@@ -327,9 +343,8 @@ class TestSkillsList:
 
         result = json.loads(raw)
         assert result["success"] is True
-        assert result["count"] == 1
-        assert result["categories"] == ["linked"]
-        assert result["skills"][0]["name"] == "knowledge-brain"
+        assert result.get("count", 0) == 0
+        assert result.get("skills", []) == []
 
 
 # ---------------------------------------------------------------------------
@@ -346,6 +361,57 @@ class TestSkillView:
         assert result["success"] is True
         assert result["name"] == "my-skill"
         assert "Step 1" in result["content"]
+
+    def test_rejects_traversal_name(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        secret = tmp_path / "secret"
+        _make_skill(secret.parent, "secret")
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_root):
+            raw = skill_view("../secret")
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "traversal" in result["error"]
+
+    def test_rejects_symlinked_skill_md_outside_skills_root(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        skill_dir = skills_root / "safe"
+        skill_dir.mkdir()
+        secret = tmp_path / "secret.md"
+        secret.write_text("---\nname: safe\n---\nSECRET OUTSIDE")
+        try:
+            (skill_dir / "SKILL.md").symlink_to(secret)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_root):
+            raw = skill_view("safe")
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "outside the trusted skills directories" in result["error"]
+
+    def test_rejects_legacy_md_symlink_outside_skills_root(self, tmp_path):
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        category = skills_root / "legacy"
+        category.mkdir()
+        secret = tmp_path / "flat-secret.md"
+        secret.write_text("---\nname: flat\n---\nSECRET OUTSIDE")
+        try:
+            (category / "flat.md").symlink_to(secret)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_root):
+            raw = skill_view("flat")
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "outside the trusted skills directories" in result["error"]
 
     def test_skill_view_applies_template_vars(self, tmp_path):
         with (
@@ -496,7 +562,7 @@ class TestSkillView:
         result = json.loads(raw)
         assert result["success"] is True
 
-    def test_view_finds_skill_in_symlinked_category_dir(self, tmp_path):
+    def test_view_skips_skill_in_symlinked_category_dir(self, tmp_path):
         external_root = tmp_path / "repo"
         skills_root = tmp_path / "skills"
         skills_root.mkdir()
@@ -508,8 +574,8 @@ class TestSkillView:
             raw = skill_view("knowledge-brain")
 
         result = json.loads(raw)
-        assert result["success"] is True
-        assert result["name"] == "knowledge-brain"
+        assert result["success"] is False
+        assert "not found" in result["error"]
 
     def test_not_found_hint_uses_same_order_as_skills_list(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2369,7 +2369,9 @@ class OptionalSkillSource(SkillSource):
         # Guard against path traversal (e.g. "official/../../etc")
         try:
             resolved = skill_dir.resolve()
-            if not str(resolved).startswith(str(self._optional_dir.resolve())):
+            optional_root = self._optional_dir.resolve()
+            resolved.relative_to(optional_root)
+            if optional_root == resolved:
                 return None
         except (OSError, ValueError):
             return None
@@ -2383,6 +2385,12 @@ class OptionalSkillSource(SkillSource):
         else:
             skill_dir = resolved
 
+        try:
+            skill_root = skill_dir.resolve()
+            skill_root.relative_to(optional_root)
+        except (OSError, ValueError):
+            return None
+
         files: Dict[str, Union[str, bytes]] = {}
         for f in skill_dir.rglob("*"):
             if (
@@ -2391,10 +2399,13 @@ class OptionalSkillSource(SkillSource):
                 and "__pycache__" not in f.parts
                 and f.suffix != ".pyc"
             ):
-                rel_path = str(f.relative_to(skill_dir))
                 try:
-                    files[rel_path] = f.read_bytes()
-                except OSError:
+                    resolved_file = f.resolve()
+                    resolved_file.relative_to(skill_root)
+                    resolved_file.relative_to(optional_root)
+                    rel_path = str(f.relative_to(skill_dir))
+                    files[rel_path] = resolved_file.read_bytes()
+                except (OSError, ValueError):
                     continue
 
         if not files:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -951,16 +951,56 @@ def skill_view(
         skill_dir = None
         skill_md = None
 
+        requested_path = Path(name)
+        if requested_path.is_absolute() or ".." in requested_path.parts:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"Invalid skill name '{name}': path traversal is not allowed.",
+                },
+                ensure_ascii=False,
+            )
+
+        trusted_roots = []
+        for search_dir in all_dirs:
+            try:
+                trusted_roots.append(search_dir.resolve())
+            except OSError:
+                continue
+
+        def _is_within_trusted_root(candidate: Path) -> bool:
+            try:
+                resolved = candidate.resolve()
+            except OSError:
+                return False
+            for root in trusted_roots:
+                try:
+                    resolved.relative_to(root)
+                    return True
+                except ValueError:
+                    continue
+            return False
+
         # Search all dirs: local first, then external (first match wins)
         for search_dir in all_dirs:
             # Try direct path first (e.g., "mlops/axolotl")
             direct_path = search_dir / name
-            if direct_path.is_dir() and (direct_path / "SKILL.md").exists():
-                skill_dir = direct_path
-                skill_md = direct_path / "SKILL.md"
+            try:
+                direct_resolved = direct_path.resolve()
+                direct_resolved.relative_to(search_dir.resolve())
+            except (OSError, ValueError):
+                continue
+            if direct_resolved.is_dir() and (direct_resolved / "SKILL.md").exists():
+                skill_dir = direct_resolved
+                skill_md = direct_resolved / "SKILL.md"
                 break
-            elif direct_path.with_suffix(".md").exists():
-                skill_md = direct_path.with_suffix(".md")
+            direct_md = direct_resolved.with_suffix(".md")
+            try:
+                direct_md.relative_to(search_dir.resolve())
+            except ValueError:
+                continue
+            if direct_md.exists():
+                skill_md = direct_md
                 break
 
         # Search by directory name across all dirs
@@ -997,6 +1037,28 @@ def skill_view(
                 },
                 ensure_ascii=False,
             )
+
+        try:
+            resolved_skill_md = skill_md.resolve()
+        except OSError as e:
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"Failed to resolve skill '{name}': {e}",
+                },
+                ensure_ascii=False,
+            )
+        if not _is_within_trusted_root(resolved_skill_md):
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"Skill '{name}' resolves outside the trusted skills directories.",
+                },
+                ensure_ascii=False,
+            )
+        skill_md = resolved_skill_md
+        if skill_dir:
+            skill_dir = skill_dir.resolve()
 
         # Read the file once — reused for platform check and main content below
         try:


### PR DESCRIPTION
## Summary
- gate Anthropic fast mode to supported native models
- harden skill discovery/view/install paths against traversal, symlink escapes, and sibling-prefix confusion
- constrain plugin-provided skill paths to the owning plugin directory
- reject unknown cron delivery platforms while allowing discovered plugin platforms
- fix title lineage false matches for non-numeric # suffixes and handle bare slash CLI input

## Validation
- venv/bin/python -m pytest tests/tools/test_skills_tool.py tests/test_plugin_skills.py tests/agent/test_anthropic_adapter.py tests/test_hermes_state.py tests/cron/test_cron_script.py tests/tools/test_skills_hub.py tests/cli/test_cli_prefix_matching.py tests/agent/test_skill_commands.py -q -o 'addopts=' — 658 passed
- venv/bin/python -m compileall -q agent tools cron hermes_cli cli.py hermes_state.py
- git diff --check
- independent reviewer subagent: OK to commit

## Full-suite note
- venv/bin/python -m pytest tests -q -o 'addopts=' --maxfail=10 -ra still has unrelated/environmental failures outside this diff (ACP command list expectation, delegation provider credentials, gateway cache timeout/no auxiliary provider, Discord mock allowed mentions). The changed/affected suites above pass.