### PR TITLE
fix(auth): expand dotenv refs before credential pool seeding

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -77,6 +77,23 @@ EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
 # Custom endpoints all share provider='custom' but are keyed by their
 # custom_providers name: 'custom:<normalized_name>'.
 CUSTOM_POOL_PREFIX = "custom:"
+_DOTENV_REF_RE = re.compile(r"\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))")
+
+
+def _expand_dotenv_env_refs(value: str, env_file: Dict[str, str]) -> str:
+    """Expand simple $VAR/${VAR} references from .env before pool persistence."""
+    expanded = value
+    for _ in range(10):
+        next_value = _DOTENV_REF_RE.sub(
+            lambda match: env_file.get(match.group(1) or match.group(2))
+            or os.environ.get(match.group(1) or match.group(2), "")
+            or match.group(0),
+            expanded,
+        )
+        if next_value == expanded:
+            break
+        expanded = next_value
+    return expanded
 
 
 # Fields that are only round-tripped through JSON — never used for logic as attributes.
@@ -1381,14 +1398,20 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
 def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
     changed = False
     active_sources: Set[str] = set()
+    env_file = load_env()
 
     # Prefer ~/.hermes/.env over os.environ — the user's config file is the
     # authoritative source for Hermes credentials. Stale env vars from parent
     # processes (Codex CLI, test scripts, etc.) should not override deliberate
     # changes to the .env file.
     def _get_env_prefer_dotenv(key: str) -> str:
-        env_file = load_env()
-        val = env_file.get(key) or os.environ.get(key) or ""
+        raw_value = env_file.get(key)
+        if raw_value:
+            val = _expand_dotenv_env_refs(raw_value, env_file)
+            if _DOTENV_REF_RE.search(val):
+                val = os.environ.get(key, "")
+        else:
+            val = os.environ.get(key, "")
         return val.strip()
 
     # Honour user suppression — `hermes auth remove <provider> <N>` for an

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -382,6 +382,78 @@ def test_load_pool_prefers_dotenv_over_stale_os_environ(tmp_path, monkeypatch):
     )
 
 
+def test_load_pool_expands_dotenv_reference_before_seeding(tmp_path, monkeypatch):
+    """Regression for #20310: do not persist raw ${VAR} tokens to auth.json."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-ant-api03-expanded-from-env")
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    (hermes_home / ".env").write_text("ANTHROPIC_API_KEY=${OPENAI_API_KEY}\n")
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.source == "env:ANTHROPIC_API_KEY"
+    assert entry.access_token == "sk-ant-api03-expanded-from-env"
+
+    auth_payload = json.loads((hermes_home / "auth.json").read_text())
+    persisted = auth_payload["credential_pool"]["anthropic"][0]
+    assert persisted["access_token"] == "sk-ant-api03-expanded-from-env"
+
+
+def test_load_pool_expands_dotenv_reference_from_same_file(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-ant-api03-stale-from-shell")
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    (hermes_home / ".env").write_text(
+        "OPENAI_API_KEY=sk-ant-api03-fresh-from-dotenv\n"
+        "ANTHROPIC_API_KEY=${OPENAI_API_KEY}\n"
+    )
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.access_token == "sk-ant-api03-fresh-from-dotenv"
+
+
+def test_load_pool_skips_unresolved_dotenv_reference(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("MISSING_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    (hermes_home / ".env").write_text("ANTHROPIC_API_KEY=${MISSING_API_KEY}\n")
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+
+    assert pool.select() is None
+    auth_payload = json.loads((hermes_home / "auth.json").read_text())
+    assert auth_payload.get("credential_pool", {}).get("anthropic", []) == []
+
+
 def test_load_pool_falls_back_to_os_environ_when_dotenv_empty(tmp_path, monkeypatch):
     """When ~/.hermes/.env does not define OPENROUTER_API_KEY (typical Docker /
     K8s / systemd deployment), seeding must still pick up the key from


### PR DESCRIPTION
## Summary
- expand `$VAR` / `${VAR}` references from `~/.hermes/.env` before seeding env credentials into the credential pool
- preserve existing `.env`-over-shell precedence, including references to other values in the same `.env`
- skip unresolved references instead of persisting raw `${VAR}` strings to `auth.json`

Fixes #20310.

## Verification
- `scripts/run_tests.sh tests/agent/test_credential_pool.py -k "dotenv_reference or prefers_dotenv_over_stale_os_environ or falls_back_to_os_environ"` -> 5 passed
- `scripts/run_tests.sh tests/agent/test_credential_pool.py` -> 44 passed
- `git diff --check`

## Non-goals
- Does not change the general `load_env()` parser contract outside credential-pool seeding.
