### PR TITLE
fix(dashboard): preserve browser zoom and pan gestures

### DIFF
--- a/tests/hermes_cli/test_dashboard_zoom_scroll_contract.py
+++ b/tests/hermes_cli/test_dashboard_zoom_scroll_contract.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _css_rule(source: str, selector: str) -> str:
+    match = re.search(rf"{re.escape(selector)}\s*\{{(?P<body>.*?)\}}", source, re.DOTALL)
+    assert match is not None, f"missing CSS rule for {selector}"
+    return match.group("body")
+
+
+def _chat_page_source() -> str:
+    return (ROOT / "web" / "src" / "pages" / "ChatPage.tsx").read_text(
+        encoding="utf-8"
+    )
+
+
+def test_dashboard_document_can_grow_beyond_viewport_for_browser_zoom_pan() -> None:
+    css = (ROOT / "web" / "src" / "index.css").read_text(encoding="utf-8")
+
+    html_rule = _css_rule(css, "html")
+    body_rule = _css_rule(css, "body")
+    root_rule = _css_rule(css, "#root")
+
+    assert not re.search(r"(?m)^\s*height:\s*100dvh\s*;", html_rule)
+    assert "max-height:" not in html_rule
+    assert not re.search(r"(?m)^\s*height:\s*100%\s*;", body_rule)
+    assert "max-height:" not in root_rule
+
+    assert "min-height:" in html_rule
+    assert "min-height:" in body_rule
+    assert "min-height:" in root_rule
+    assert "overflow: auto" in html_rule
+    assert "overflow: auto" in body_rule
+    assert "overflow: visible" in root_rule
+
+
+def test_scaled_vertical_wheel_stays_with_tui_transcript_scroll() -> None:
+    chat_page = _chat_page_source()
+
+    assert "function isHorizontalPan(ev: WheelEvent): boolean" in chat_page
+    assert "ev.ctrlKey || ev.metaKey || isVisualViewportScaled()" not in chat_page
+    assert re.search(
+        r"if\s*\(\s*isVisualViewportScaled\(\)\s*\)\s*\{\s*"
+        r"return\s+isHorizontalPan\(ev\);\s*\}",
+        chat_page,
+    )
+    assert "if (shouldLetBrowserHandleWheel(ev))" in chat_page
+    assert "const delta = ev.deltaY" in chat_page
+    assert "wsRef.current.send(seq)" in chat_page
+
+
+def test_scaled_horizontal_pan_inside_terminal_host_reaches_browser() -> None:
+    chat_page = _chat_page_source()
+
+    assert "function isHorizontalPan(ev: WheelEvent): boolean" in chat_page
+    assert "function documentCanPanHorizontally(): boolean" in chat_page
+    assert re.search(
+        r"return\s+documentCanPanHorizontally\(\)\s*&&\s*isHorizontalPan\(ev\)",
+        chat_page,
+    )
+    assert "host.addEventListener(\"wheel\", keepBrowserViewportWheelOutOfTerminal" in chat_page
+    assert "capture: true" in chat_page
+    assert "passive: true" in chat_page

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -399,7 +399,7 @@ export default function App() {
   return (
     <div
       data-layout-variant={layoutVariant}
-      className="font-mondwest flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-black uppercase text-midground antialiased"
+      className="font-mondwest flex min-h-dvh flex-col overflow-visible bg-black uppercase text-midground antialiased"
     >
       <SelectionSwitcher />
       <Backdrop />
@@ -452,7 +452,7 @@ export default function App() {
 
       <PluginSlot name="header-banner" />
 
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden pt-12 lg:pt-0">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-visible pt-12 lg:pt-0">
         <div className="flex min-h-0 min-w-0 flex-1">
           <aside
             id="app-sidebar"

--- a/web/src/contexts/PageHeaderProvider.tsx
+++ b/web/src/contexts/PageHeaderProvider.tsx
@@ -47,7 +47,7 @@ export function PageHeaderProvider({
 
   return (
     <PageHeaderContext.Provider value={value}>
-      <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
+      <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-visible">
         <header
           className={cn(
             "z-1 w-full shrink-0",
@@ -94,8 +94,8 @@ export function PageHeaderProvider({
           className={cn(
             "min-h-0 w-full min-w-0 flex-1 flex flex-col",
             isChatRoute
-              ? "overflow-hidden"
-              : "overflow-y-auto overflow-x-hidden [scrollbar-gutter:stable]",
+              ? "overflow-visible"
+              : "overflow-y-auto overflow-x-auto [scrollbar-gutter:stable]",
           )}
         >
           {children}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -85,17 +85,15 @@ html {
   font-size: var(--theme-base-size);
   line-height: var(--theme-line-height);
   letter-spacing: var(--theme-letter-spacing);
-  height: 100dvh;
-  max-height: 100dvh;
-  overflow: hidden;
+  min-height: 100dvh;
+  overflow: auto;
 }
 
 body {
   font-family: var(--theme-font-sans);
-  min-height: 0;
-  height: 100%;
+  min-height: 100%;
   margin: 0;
-  overflow: hidden;
+  overflow: auto;
 }
 
 code, kbd, pre, samp, .font-mono, .font-mono-ui {
@@ -111,10 +109,8 @@ code, kbd, pre, samp, .font-mono, .font-mono-ui {
 }
 
 #root {
-  min-height: 0;
-  height: 100%;
-  max-height: 100%;
-  overflow: hidden;
+  min-height: 100%;
+  overflow: visible;
 }
 
 /* Nousnet's hermes-agent layout bumps `small` and `code` to readable

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -103,6 +103,36 @@ function terminalLineHeightForWidth(layoutWidthPx: number): number {
   return layoutWidthPx < 1024 ? 1.02 : 1.15;
 }
 
+function isVisualViewportScaled(): boolean {
+  return (window.visualViewport?.scale ?? 1) > 1.01;
+}
+
+function isHorizontalPan(ev: WheelEvent): boolean {
+  return Math.abs(ev.deltaX) > Math.abs(ev.deltaY);
+}
+
+function documentCanPanHorizontally(): boolean {
+  const scrollingElement =
+    document.scrollingElement ?? document.documentElement;
+  return scrollingElement.scrollWidth > scrollingElement.clientWidth + 1;
+}
+
+function shouldLetBrowserHandleWheel(ev: WheelEvent): boolean {
+  if (ev.ctrlKey || ev.metaKey) return true;
+
+  if (isVisualViewportScaled()) {
+    return isHorizontalPan(ev);
+  }
+
+  return documentCanPanHorizontally() && isHorizontalPan(ev);
+}
+
+function keepBrowserViewportWheelOutOfTerminal(ev: WheelEvent): void {
+  if (shouldLetBrowserHandleWheel(ev)) {
+    ev.stopPropagation();
+  }
+}
+
 export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -333,7 +363,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           // original keydown event's activation. Log to aid debugging.
           console.warn("[dashboard clipboard] OSC 52 write failed:", err.message);
         });
-      } catch (e) {
+      } catch {
         console.warn("[dashboard clipboard] malformed OSC 52 payload");
       }
       return true;
@@ -402,6 +432,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // correctly (`Shift+Up` / `Shift+Down`, `PageUp` / `PageDown`), so we
     // translate browser wheel gestures into those known-good key sequences.
     term.attachCustomWheelEventHandler((ev) => {
+      if (shouldLetBrowserHandleWheel(ev)) {
+        return false;
+      }
+
       if (wsRef.current?.readyState !== WebSocket.OPEN) {
         return false;
       }
@@ -424,6 +458,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       ev.preventDefault();
       ev.stopPropagation();
       return false;
+    });
+    host.addEventListener("wheel", keepBrowserViewportWheelOutOfTerminal, {
+      capture: true,
+      passive: true,
     });
 
     const unicode11 = new Unicode11Addon();
@@ -643,6 +681,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         "resize",
         scheduleSyncTerminalMetrics,
       );
+      host.removeEventListener("wheel", keepBrowserViewportWheelOutOfTerminal, {
+        capture: true,
+      });
       ro.disconnect();
       if (hostSyncRaf) cancelAnimationFrame(hostSyncRaf);
       if (settleRaf1) cancelAnimationFrame(settleRaf1);


### PR DESCRIPTION
## What does this PR do?

Fixes a Dashboard interaction issue where browser viewport zoom and pan gestures can be trapped by the app shell or the embedded xterm chat pane.

This change lets the browser handle browser-level viewport gestures while preserving normal terminal wheel scrolling.

## Related Issue

N/A - no issue filed.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Allow the Dashboard root document and app shell to participate in browser scrolling instead of globally clipping overflow.
- Allow routed page content to expose scrollable overflow instead of forcing hidden horizontal overflow.
- Use xterm's custom wheel handler so browser-reserved wheel gestures are left to the browser.
- Add a capture-phase wheel listener around the terminal host so viewport zoom and horizontal page pan gestures are not consumed by the terminal.
- Add a Dashboard zoom/scroll contract test covering browser zoom passthrough, horizontal viewport pan passthrough, and vertical terminal scrolling.

## How to Test

Automated and build checks run for the current commit:

- `scripts/run_tests.sh tests/hermes_cli/test_dashboard_zoom_scroll_contract.py -q` — `3 passed`
- `git diff --check` — passed
- Touched-file ESLint — `0 errors`, with `1` existing warning still present
- `cd web && npm run build` — passed

Manual acceptance was also completed in Chrome on macOS with a Magic Trackpad:

1. Open the Dashboard chat page in Chrome on macOS.
2. Use Magic Trackpad pinch gestures to zoom the browser viewport in and out.
3. While zoomed, pan the page horizontally and vertically over the Dashboard/chat area.
4. Confirm browser viewport zoom and horizontal page pan are preserved, and normal vertical terminal/chat scrolling still works.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass - not run; targeted Dashboard contract test passed with `3 passed`
- [x] I've added tests for my changes - added `tests/hermes_cli/test_dashboard_zoom_scroll_contract.py`
- [x] I've tested on my platform: macOS, Chrome, Magic Trackpad

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted contract test:

```text
scripts/run_tests.sh tests/hermes_cli/test_dashboard_zoom_scroll_contract.py -q
3 passed
```

Validation summary:

- `git diff --check` passed.
- Touched-file ESLint completed with `0 errors` and `1` existing warning.
- `cd web && npm run build` passed.
- Manual verification completed on macOS Chrome with a Magic Trackpad: browser zoom works, horizontal viewport pan works while zoomed, and normal vertical terminal/chat scrolling is preserved.
