### PR TITLE
Add H2/H3 project context boundaries for durable writes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5087,6 +5087,15 @@ class GatewayRunner:
                     return await self._handle_goal_command(event)
                 return "Agent is running — use /goal status / pause / clear mid-run, or /stop before setting a new goal."
 
+            # /project is a session control-plane command.  Inspection and
+            # clearing are safe mid-run; setting/replacing project context waits
+            # until the current turn finishes to avoid racing durable-write gates.
+            if _cmd_def_inner and _cmd_def_inner.name == "project":
+                _project_arg = (event.get_command_args() or "").strip().lower()
+                if not _project_arg or _project_arg in ("status", "clear"):
+                    return await self._handle_project_command(event)
+                return "Agent is running — use /project status or /project clear mid-run, or /stop before setting a new project."
+
             # Session-level toggles that are safe to run mid-agent —
             # /yolo can unblock a pending approval prompt, /verbose cycles
             # the tool-progress display mode for the ongoing stream.
@@ -5432,6 +5441,9 @@ class GatewayRunner:
 
         if canonical == "goal":
             return await self._handle_goal_command(event)
+
+        if canonical == "project":
+            return await self._handle_project_command(event)
 
         if canonical == "voice":
             return await self._handle_voice_command(event)
@@ -8090,6 +8102,86 @@ class GatewayRunner:
         except Exception:
             max_turns = 20
         return GoalManager(session_id=sid, default_max_turns=max_turns), session_entry
+
+    async def _handle_project_command(self, event: "MessageEvent") -> str:
+        """Handle /project for gateway platforms.
+
+        Subcommands: ``/project`` / ``/project status`` / ``/project clear`` /
+        ``/project set <id> <name> [capsule_path]``.  The project context is
+        stored in SessionDB.state_meta and is loaded into the dynamic session
+        context on subsequent turns.
+        """
+        args = (event.get_command_args() or "").strip()
+        lower = args.lower()
+
+        try:
+            session_entry = self.session_store.get_or_create_session(event.source)
+            sid = getattr(session_entry, "session_id", "") or ""
+        except Exception as exc:
+            logger.debug("project command: session lookup failed: %s", exc)
+            sid = ""
+        if not sid:
+            return "Project context unavailable on this session."
+
+        try:
+            from hermes_cli.project_context import (
+                ActiveProjectContext,
+                clear_project_context,
+                load_project_context,
+                save_project_context,
+            )
+        except Exception as exc:
+            logger.debug("project command: project_context import failed: %s", exc)
+            return "Project context support is unavailable."
+
+        if not args or lower == "status":
+            ctx = load_project_context(sid)
+            if ctx is None:
+                return "No active project context set for this session."
+            lines = [
+                f"Active project: {ctx.project_id} — {ctx.project_name}",
+            ]
+            if ctx.capsule_path:
+                lines.append(f"Capsule: {ctx.capsule_path}")
+            if ctx.metadata:
+                safe = []
+                for key in sorted(ctx.metadata):
+                    value = ctx.metadata[key]
+                    if isinstance(value, (str, int, float, bool)) and str(value).strip():
+                        safe.append(f"{key}={value}")
+                if safe:
+                    lines.append(f"Metadata: {', '.join(safe[:8])}")
+            lines.append("Controls: /project clear · /project set <id> <name> [capsule_path]")
+            return "\n".join(lines)
+
+        if lower == "clear":
+            return "Project context cleared." if clear_project_context(sid) else "Project context clear failed."
+
+        if lower.startswith("set "):
+            import shlex
+            try:
+                parts = shlex.split(args)
+            except ValueError as exc:
+                return f"Invalid /project set syntax: {exc}"
+            if len(parts) < 3:
+                return "Usage: /project set <id> <name> [capsule_path]"
+            _, project_id, project_name, *rest = parts
+            capsule_path = rest[0] if rest else ""
+            ctx = ActiveProjectContext(
+                project_id=project_id,
+                project_name=project_name,
+                capsule_path=capsule_path,
+            )
+            err = save_project_context(sid, ctx)
+            if err:
+                return f"Project context not set: {err}"
+            return (
+                f"Project context set: {ctx.project_id} — {ctx.project_name}\n"
+                + (f"Capsule: {ctx.capsule_path}\n" if ctx.capsule_path else "")
+                + "Durable memory/skill writes now require explicit scope and source_reference."
+            )
+
+        return "Usage: /project [status | clear | set <id> <name> [capsule_path]]"
 
     async def _handle_goal_command(self, event: "MessageEvent") -> str:
         """Handle /goal for gateway platforms.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -293,6 +293,18 @@ def build_session_context_prompt(
     if context.source.chat_topic:
         lines.append(f"**Channel Topic:** {context.source.chat_topic}")
 
+    # Project context (if available) is loaded from SessionDB state_meta and
+    # appended to this dynamic context section.  It does not mutate the static
+    # base system prompt, preserving prompt-cache behavior across turns.
+    if context.session_id:
+        try:
+            from hermes_cli.project_context import load_project_context
+            active_project = load_project_context(context.session_id)
+            if active_project is not None:
+                lines.extend(active_project.prompt_lines())
+        except Exception:
+            logger.debug("failed to load active project context", exc_info=True)
+
     # User identity.
     # In shared multi-user sessions (shared threads OR shared non-thread groups
     # when group_sessions_per_user=False), multiple users contribute to the same

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -102,6 +102,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="<prompt>"),
     CommandDef("goal", "Set a standing goal Hermes works on across turns until achieved", "Session",
                args_hint="[text | pause | resume | clear | status]"),
+    CommandDef("project", "Set or inspect the active project context for this session", "Session",
+               args_hint="[status | clear | set <id> <name> [capsule_path]]"),
     CommandDef("status", "Show session info", "Session"),
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",

--- a/hermes_cli/project_context.py
+++ b/hermes_cli/project_context.py
@@ -1,0 +1,253 @@
+"""Project-boundary primitives for long-running session work.
+
+H2/H3 minimal implementation:
+- ActiveProjectContext: per-session metadata stored outside the prompt prefix.
+- DurableWriteIntent: explicit metadata required for writes to global stores.
+- validation helpers for memory/skill durable writes.
+
+The active project context is persisted in SessionDB.state_meta under
+``project:<session_id>``.  It is intentionally loaded when building dynamic
+session context, not injected by mutating the static system prompt mid-session.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+PROJECT_SCOPES = frozenset({"global", "user", "project", "local", "none"})
+PROJECT_DERIVED_SCOPES = frozenset({"project", "local"})
+_MUTATING_SKILL_ACTIONS = frozenset({"create", "edit", "patch", "delete", "write_file", "remove_file"})
+_MUTATING_MEMORY_ACTIONS = frozenset({"add", "replace", "remove"})
+
+
+@dataclass
+class ActiveProjectContext:
+    """Project metadata attached to a session.
+
+    This is deliberately small and declarative so it can be shown in the
+    dynamic session context and used by write gates without importing project
+    facts into global memory.
+    """
+
+    project_id: str
+    project_name: str
+    capsule_path: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+
+    def normalized(self) -> "ActiveProjectContext":
+        self.project_id = (self.project_id or "").strip()
+        self.project_name = (self.project_name or "").strip()
+        self.capsule_path = (self.capsule_path or "").strip()
+        if not isinstance(self.metadata, dict):
+            self.metadata = {}
+        return self
+
+    def validate(self) -> Optional[str]:
+        self.normalized()
+        if not self.project_id:
+            return "project_id is required."
+        if not self.project_name:
+            return "project_name is required."
+        return None
+
+    def to_json(self) -> str:
+        self.updated_at = time.time()
+        return json.dumps(asdict(self), ensure_ascii=False, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, raw: str) -> "ActiveProjectContext":
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise ValueError("stored project context is not an object")
+        return cls(
+            project_id=str(data.get("project_id") or ""),
+            project_name=str(data.get("project_name") or ""),
+            capsule_path=str(data.get("capsule_path") or ""),
+            metadata=data.get("metadata") if isinstance(data.get("metadata"), dict) else {},
+            created_at=float(data.get("created_at") or time.time()),
+            updated_at=float(data.get("updated_at") or time.time()),
+        ).normalized()
+
+    def prompt_lines(self) -> list[str]:
+        lines = ["", "## Current Project Context", ""]
+        lines.append(f"**Project:** {self.project_id} — {self.project_name}")
+        if self.capsule_path:
+            lines.append(f"**Capsule path:** `{self.capsule_path}`")
+        if self.metadata:
+            safe_items = []
+            for key in sorted(self.metadata):
+                value = self.metadata[key]
+                if isinstance(value, (str, int, float, bool)) and str(value).strip():
+                    safe_items.append(f"{key}={value}")
+            if safe_items:
+                lines.append(f"**Metadata:** {', '.join(safe_items[:8])}")
+        lines.append(
+            "**Durable write boundary:** Project facts, design choices, source evidence, "
+            "and task progress are project-local by default. Global memory/skill writes "
+            "must declare `scope`, `source_reference`, and set `approved_global=true` "
+            "when derived from this project."
+        )
+        return lines
+
+
+@dataclass
+class DurableWriteIntent:
+    """Explicit durable-write metadata supplied by the tool caller."""
+
+    tool_name: str
+    action: str
+    destination: str
+    scope: str = ""
+    source_reference: str = ""
+    project_id: str = ""
+    approved_global: bool = False
+
+    def normalized_scope(self) -> str:
+        return (self.scope or "").strip().lower()
+
+    def is_mutating(self) -> bool:
+        if self.tool_name == "memory":
+            return self.action in _MUTATING_MEMORY_ACTIONS
+        if self.tool_name == "skill_manage":
+            return self.action in _MUTATING_SKILL_ACTIONS
+        return True
+
+    def project_derived(self, active_project: Optional[ActiveProjectContext]) -> bool:
+        scope = self.normalized_scope()
+        if scope in PROJECT_DERIVED_SCOPES:
+            return True
+        pid = (self.project_id or "").strip()
+        return bool(active_project and pid and pid == active_project.project_id)
+
+
+_DB_CACHE: Dict[str, Any] = {}
+
+
+def _meta_key(session_id: str) -> str:
+    return f"project:{session_id}"
+
+
+def _get_session_db() -> Optional[Any]:
+    try:
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        home = str(get_hermes_home())
+    except Exception as exc:  # pragma: no cover
+        logger.debug("project context: SessionDB bootstrap failed (%s)", exc)
+        return None
+
+    cached = _DB_CACHE.get(home)
+    if cached is not None:
+        return cached
+    try:
+        db = SessionDB()
+    except Exception as exc:  # pragma: no cover
+        logger.debug("project context: SessionDB() raised (%s)", exc)
+        return None
+    _DB_CACHE[home] = db
+    return db
+
+
+def load_project_context(session_id: str) -> Optional[ActiveProjectContext]:
+    if not session_id:
+        return None
+    db = _get_session_db()
+    if db is None:
+        return None
+    try:
+        raw = db.get_meta(_meta_key(session_id))
+    except Exception as exc:
+        logger.debug("project context: get_meta failed: %s", exc)
+        return None
+    if not raw:
+        return None
+    try:
+        ctx = ActiveProjectContext.from_json(raw)
+    except Exception as exc:
+        logger.warning("project context: could not parse stored project for %s: %s", session_id, exc)
+        return None
+    return ctx if ctx.validate() is None else None
+
+
+def save_project_context(session_id: str, context: ActiveProjectContext) -> Optional[str]:
+    if not session_id:
+        return "session_id is required."
+    err = context.validate()
+    if err:
+        return err
+    db = _get_session_db()
+    if db is None:
+        return "Session database is unavailable."
+    try:
+        db.set_meta(_meta_key(session_id), context.to_json())
+    except Exception as exc:
+        logger.debug("project context: set_meta failed: %s", exc)
+        return f"Failed to persist project context: {exc}"
+    return None
+
+
+def clear_project_context(session_id: str) -> bool:
+    """Clear by storing an empty JSON marker.
+
+    SessionDB currently has get/set only for state_meta.  Storing an empty value
+    keeps the operation non-invasive and makes load_project_context return None.
+    """
+    if not session_id:
+        return False
+    db = _get_session_db()
+    if db is None:
+        return False
+    try:
+        db.set_meta(_meta_key(session_id), "")
+        return True
+    except Exception as exc:
+        logger.debug("project context: clear failed: %s", exc)
+        return False
+
+
+def validate_durable_write_intent(
+    *,
+    session_id: str = "",
+    intent: DurableWriteIntent,
+    active_project: Optional[ActiveProjectContext] = None,
+) -> Optional[str]:
+    """Return a rejection message, or None if the durable write may proceed."""
+    if not intent.is_mutating():
+        return None
+    active_project = active_project or load_project_context(session_id)
+    if active_project is None:
+        return None
+
+    scope = intent.normalized_scope()
+    if not scope:
+        return (
+            "Durable write rejected: this session has an active project context "
+            f"({active_project.project_id}). Provide an explicit `scope` "
+            "('global', 'user', or 'project') and `source_reference`."
+        )
+    if scope not in PROJECT_SCOPES:
+        return (
+            f"Durable write rejected: unknown scope '{intent.scope}'. Use one of: "
+            f"{', '.join(sorted(PROJECT_SCOPES))}."
+        )
+    if not (intent.source_reference or "").strip():
+        return (
+            "Durable write rejected: active project sessions require a "
+            "`source_reference` (capsule path, note path, issue, or explicit user instruction)."
+        )
+    if (scope == "global" or intent.project_derived(active_project)) and not intent.approved_global:
+        return (
+            "Durable write rejected: project-session content cannot be written to "
+            f"global {intent.tool_name} storage without `approved_global=true`. "
+            f"Keep it in the project capsule instead: {active_project.capsule_path or active_project.project_id}."
+        )
+    return None

--- a/model_tools.py
+++ b/model_tools.py
@@ -767,6 +767,7 @@ def handle_function_call(
                 function_name, function_args,
                 task_id=task_id,
                 user_task=user_task,
+                session_id=session_id or "",
             )
         duration_ms = int((time.monotonic() - _dispatch_start) * 1000)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3765,6 +3765,24 @@ class AIAgent:
             metadata["tool_call_id"] = tool_call_id
         return {k: v for k, v in metadata.items() if v not in (None, "")}
 
+    @staticmethod
+    def _tool_result_succeeded(result: Any) -> bool:
+        """Return True only when a tool result explicitly did not fail."""
+        if isinstance(result, str):
+            try:
+                parsed = json.loads(result)
+            except Exception:
+                return False
+        elif isinstance(result, dict):
+            parsed = result
+        else:
+            return False
+        if not isinstance(parsed, dict):
+            return False
+        if parsed.get("success") is False or parsed.get("error"):
+            return False
+        return True
+
     def _apply_persist_user_message_override(self, messages: List[Dict]) -> None:
         """Rewrite the current-turn user message before persistence/return.
 
@@ -9515,9 +9533,18 @@ class AIAgent:
                 content=function_args.get("content"),
                 old_text=function_args.get("old_text"),
                 store=self._memory_store,
+                session_id=self.session_id or "",
+                scope=function_args.get("scope", ""),
+                source_reference=function_args.get("source_reference", ""),
+                project_id=function_args.get("project_id", ""),
+                approved_global=function_args.get("approved_global", False),
             )
-            # Bridge: notify external memory provider of built-in memory writes
-            if self._memory_manager and function_args.get("action") in ("add", "replace"):
+            # Bridge: notify external memory provider only after accepted built-in memory writes.
+            if (
+                self._memory_manager
+                and function_args.get("action") in ("add", "replace")
+                and self._tool_result_succeeded(result)
+            ):
                 try:
                     self._memory_manager.on_memory_write(
                         function_args.get("action", ""),
@@ -10122,9 +10149,18 @@ class AIAgent:
                     content=function_args.get("content"),
                     old_text=function_args.get("old_text"),
                     store=self._memory_store,
+                    session_id=self.session_id or "",
+                    scope=function_args.get("scope", ""),
+                    source_reference=function_args.get("source_reference", ""),
+                    project_id=function_args.get("project_id", ""),
+                    approved_global=function_args.get("approved_global", False),
                 )
-                # Bridge: notify external memory provider of built-in memory writes
-                if self._memory_manager and function_args.get("action") in ("add", "replace"):
+                # Bridge: notify external memory provider only after accepted built-in memory writes.
+                if (
+                    self._memory_manager
+                    and function_args.get("action") in ("add", "replace")
+                    and self._tool_result_succeeded(function_result)
+                ):
                     try:
                         self._memory_manager.on_memory_write(
                             function_args.get("action", ""),

--- a/tests/tools/test_project_context_boundaries.py
+++ b/tests/tools/test_project_context_boundaries.py
@@ -1,0 +1,258 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.project_context import (
+    ActiveProjectContext,
+    DurableWriteIntent,
+    clear_project_context,
+    load_project_context,
+    save_project_context,
+    validate_durable_write_intent,
+)
+from run_agent import AIAgent
+from tools.memory_tool import MemoryStore, memory_tool
+from tools.skill_manager_tool import skill_manage
+
+
+ACTIVE_PROJECT = ActiveProjectContext(
+    project_id="W080-H",
+    project_name="Project Boundary Hardening",
+    capsule_path="Projects/080/PROJECT_IDENTITY.md",
+)
+
+
+class FakeSessionDB:
+    def __init__(self):
+        self.meta = {}
+
+    def get_meta(self, key):
+        return self.meta.get(key)
+
+    def set_meta(self, key, value):
+        self.meta[key] = value
+
+
+def _decode(result):
+    return json.loads(result)
+
+
+def test_project_context_save_load_clear(monkeypatch):
+    import hermes_cli.project_context as project_context
+
+    db = FakeSessionDB()
+    monkeypatch.setattr(project_context, "_get_session_db", lambda: db)
+
+    assert save_project_context("s1", ACTIVE_PROJECT) is None
+    loaded = load_project_context("s1")
+    assert loaded is not None
+    assert loaded.project_id == "W080-H"
+    assert loaded.project_name == "Project Boundary Hardening"
+    assert loaded.capsule_path == "Projects/080/PROJECT_IDENTITY.md"
+
+    assert clear_project_context("s1") is True
+    assert load_project_context("s1") is None
+
+
+def test_memory_write_without_active_project_allows_legacy_path(tmp_path, monkeypatch):
+    import hermes_cli.project_context as project_context
+    import tools.memory_tool as memory_module
+
+    monkeypatch.setattr(project_context, "load_project_context", lambda session_id: None)
+    monkeypatch.setattr(memory_module, "get_memory_dir", lambda: tmp_path)
+
+    store = MemoryStore()
+    result = _decode(memory_tool(action="add", target="memory", content="Durable non-project fact.", store=store, session_id="s1"))
+
+    assert result["success"] is True
+
+
+def test_active_project_requires_scope(monkeypatch):
+    import hermes_cli.project_context as project_context
+
+    monkeypatch.setattr(project_context, "load_project_context", lambda session_id: ACTIVE_PROJECT)
+    result = _decode(memory_tool(action="add", target="memory", content="Project fact", store=MemoryStore(), session_id="s1"))
+
+    assert result["success"] is False
+    assert "Provide an explicit `scope`" in result["error"]
+
+
+def test_active_project_rejects_invalid_scope(monkeypatch):
+    import hermes_cli.project_context as project_context
+
+    monkeypatch.setattr(project_context, "load_project_context", lambda session_id: ACTIVE_PROJECT)
+    result = _decode(
+        memory_tool(
+            action="add",
+            target="memory",
+            content="Project fact",
+            store=MemoryStore(),
+            session_id="s1",
+            scope="planetary",
+            source_reference="Projects/080/source.md",
+        )
+    )
+
+    assert result["success"] is False
+    assert "unknown scope" in result["error"]
+
+
+def test_active_project_requires_source_reference(monkeypatch):
+    import hermes_cli.project_context as project_context
+
+    monkeypatch.setattr(project_context, "load_project_context", lambda session_id: ACTIVE_PROJECT)
+    result = _decode(
+        memory_tool(
+            action="add",
+            target="memory",
+            content="Project fact",
+            store=MemoryStore(),
+            session_id="s1",
+            scope="project",
+        )
+    )
+
+    assert result["success"] is False
+    assert "`source_reference`" in result["error"]
+
+
+def test_project_scope_requires_global_approval(monkeypatch):
+    import hermes_cli.project_context as project_context
+
+    monkeypatch.setattr(project_context, "load_project_context", lambda session_id: ACTIVE_PROJECT)
+    result = _decode(
+        memory_tool(
+            action="add",
+            target="memory",
+            content="Project fact",
+            store=MemoryStore(),
+            session_id="s1",
+            scope="project",
+            source_reference="Projects/080/source.md",
+        )
+    )
+
+    assert result["success"] is False
+    assert "approved_global=true" in result["error"]
+
+
+def test_global_scope_requires_approval_in_active_project():
+    rejection = validate_durable_write_intent(
+        intent=DurableWriteIntent(
+            tool_name="memory",
+            action="add",
+            destination="memory",
+            scope="global",
+            source_reference="Projects/080/source.md",
+            approved_global=False,
+        ),
+        active_project=ACTIVE_PROJECT,
+    )
+
+    assert rejection is not None
+    assert "approved_global=true" in rejection
+
+
+def test_approved_global_memory_write_passes(tmp_path, monkeypatch):
+    import hermes_cli.project_context as project_context
+    import tools.memory_tool as memory_module
+
+    monkeypatch.setattr(project_context, "load_project_context", lambda session_id: ACTIVE_PROJECT)
+    monkeypatch.setattr(memory_module, "get_memory_dir", lambda: tmp_path)
+
+    store = MemoryStore()
+    result = _decode(
+        memory_tool(
+            action="add",
+            target="memory",
+            content="Approved reusable workflow fact.",
+            store=store,
+            session_id="s1",
+            scope="global",
+            source_reference="Projects/080/source.md",
+            project_id="W080-H",
+            approved_global=True,
+        )
+    )
+
+    assert result["success"] is True
+
+
+def test_skill_create_requires_scope(monkeypatch):
+    import hermes_cli.project_context as project_context
+
+    monkeypatch.setattr(project_context, "load_project_context", lambda session_id: ACTIVE_PROJECT)
+    result = _decode(skill_manage(action="create", name="w080-test", content="---\nname: w080-test\ndescription: test\n---\n# Test", session_id="s1"))
+
+    assert result["success"] is False
+    assert "Provide an explicit `scope`" in result["error"]
+
+
+def test_skill_create_approved_global_passes(monkeypatch):
+    import hermes_cli.project_context as project_context
+    import tools.skill_manager_tool as skill_module
+
+    monkeypatch.setattr(project_context, "load_project_context", lambda session_id: ACTIVE_PROJECT)
+    monkeypatch.setattr(skill_module, "_create_skill", lambda name, content, category=None: {"success": True, "message": "created"})
+
+    result = _decode(
+        skill_manage(
+            action="create",
+            name="w080-test",
+            content="---\nname: w080-test\ndescription: test\n---\n# Test",
+            session_id="s1",
+            scope="global",
+            source_reference="Projects/080/source.md",
+            project_id="W080-H",
+            approved_global=True,
+        )
+    )
+
+    assert result["success"] is True
+
+
+def test_non_mutating_intents_skip_project_boundary():
+    assert validate_durable_write_intent(
+        intent=DurableWriteIntent(tool_name="memory", action="read", destination="memory"),
+        active_project=ACTIVE_PROJECT,
+    ) is None
+
+
+def _bare_agent_with_memory_manager():
+    agent = object.__new__(AIAgent)
+    agent._memory_store = MagicMock()
+    agent._memory_manager = MagicMock()
+    agent.session_id = "s1"
+    agent._parent_session_id = ""
+    agent.platform = "test"
+    return agent
+
+
+def test_rejected_memory_write_does_not_reach_external_provider():
+    agent = _bare_agent_with_memory_manager()
+    rejected = json.dumps({"success": False, "error": "Durable write rejected"})
+
+    with patch("tools.memory_tool.memory_tool", return_value=rejected):
+        result = agent._invoke_tool(
+            "memory",
+            {"action": "add", "target": "memory", "content": "Project fact"},
+            effective_task_id="task1",
+        )
+
+    assert _decode(result)["success"] is False
+    agent._memory_manager.on_memory_write.assert_not_called()
+
+
+def test_successful_memory_write_reaches_external_provider():
+    agent = _bare_agent_with_memory_manager()
+    accepted = json.dumps({"success": True, "message": "Entry added."})
+
+    with patch("tools.memory_tool.memory_tool", return_value=accepted):
+        result = agent._invoke_tool(
+            "memory",
+            {"action": "add", "target": "memory", "content": "Approved fact"},
+            effective_task_id="task1",
+            tool_call_id="call1",
+        )
+
+    assert _decode(result)["success"] is True
+    agent._memory_manager.on_memory_write.assert_called_once()

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -468,6 +468,11 @@ def memory_tool(
     content: str = None,
     old_text: str = None,
     store: Optional[MemoryStore] = None,
+    session_id: str = "",
+    scope: str = "",
+    source_reference: str = "",
+    project_id: str = "",
+    approved_global: bool = False,
 ) -> str:
     """
     Single entry point for the memory tool. Dispatches to MemoryStore methods.
@@ -479,6 +484,25 @@ def memory_tool(
 
     if target not in ("memory", "user"):
         return tool_error(f"Invalid target '{target}'. Use 'memory' or 'user'.", success=False)
+
+    try:
+        from hermes_cli.project_context import DurableWriteIntent, validate_durable_write_intent
+        rejection = validate_durable_write_intent(
+            session_id=session_id or "",
+            intent=DurableWriteIntent(
+                tool_name="memory",
+                action=action or "",
+                destination=target,
+                scope=scope or "",
+                source_reference=source_reference or "",
+                project_id=project_id or "",
+                approved_global=bool(approved_global),
+            ),
+        )
+        if rejection:
+            return tool_error(rejection, success=False)
+    except Exception:
+        logger.debug("memory durable write boundary check failed open", exc_info=True)
 
     if action == "add":
         if not content:
@@ -558,6 +582,23 @@ MEMORY_SCHEMA = {
                 "type": "string",
                 "description": "Short unique substring identifying the entry to replace or remove."
             },
+            "scope": {
+                "type": "string",
+                "enum": ["global", "user", "project", "local", "none"],
+                "description": "Durable-write scope. Required when a project context is active."
+            },
+            "source_reference": {
+                "type": "string",
+                "description": "Capsule path, source note, issue, or explicit user instruction justifying this durable write. Required when a project context is active."
+            },
+            "project_id": {
+                "type": "string",
+                "description": "Active project id when the write is derived from project-local context."
+            },
+            "approved_global": {
+                "type": "boolean",
+                "description": "Set true only after explicit approval to promote project-derived content into global memory."
+            },
         },
         "required": ["action", "target"],
     },
@@ -576,7 +617,12 @@ registry.register(
         target=args.get("target", "memory"),
         content=args.get("content"),
         old_text=args.get("old_text"),
-        store=kw.get("store")),
+        store=kw.get("store"),
+        session_id=kw.get("session_id") or args.get("session_id", ""),
+        scope=args.get("scope", ""),
+        source_reference=args.get("source_reference", ""),
+        project_id=args.get("project_id", ""),
+        approved_global=args.get("approved_global", False)),
     check_fn=check_memory_requirements,
     emoji="🧠",
 )

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -719,12 +719,36 @@ def skill_manage(
     new_string: str = None,
     replace_all: bool = False,
     absorbed_into: str = None,
+    session_id: str = "",
+    scope: str = "",
+    source_reference: str = "",
+    project_id: str = "",
+    approved_global: bool = False,
 ) -> str:
     """
     Manage user-created skills. Dispatches to the appropriate action handler.
 
     Returns JSON string with results.
     """
+    try:
+        from hermes_cli.project_context import DurableWriteIntent, validate_durable_write_intent
+        rejection = validate_durable_write_intent(
+            session_id=session_id or "",
+            intent=DurableWriteIntent(
+                tool_name="skill_manage",
+                action=action or "",
+                destination=name or "",
+                scope=scope or "",
+                source_reference=source_reference or "",
+                project_id=project_id or "",
+                approved_global=bool(approved_global),
+            ),
+        )
+        if rejection:
+            return tool_error(rejection, success=False)
+    except Exception:
+        logger.debug("skill_manage durable write boundary check failed open", exc_info=True)
+
     if action == "create":
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
@@ -901,6 +925,23 @@ SKILL_MANAGE_SCHEMA = {
                     "rewriting) will have to guess at intent."
                 )
             },
+            "scope": {
+                "type": "string",
+                "enum": ["global", "user", "project", "local", "none"],
+                "description": "Durable-write scope. Required when a project context is active."
+            },
+            "source_reference": {
+                "type": "string",
+                "description": "Capsule path, source note, issue, or explicit user instruction justifying this durable skill write. Required when a project context is active."
+            },
+            "project_id": {
+                "type": "string",
+                "description": "Active project id when the skill write is derived from project-local context."
+            },
+            "approved_global": {
+                "type": "boolean",
+                "description": "Set true only after explicit approval to promote project-derived procedures into global skills."
+            },
         },
         "required": ["action", "name"],
     },
@@ -924,6 +965,11 @@ registry.register(
         old_string=args.get("old_string"),
         new_string=args.get("new_string"),
         replace_all=args.get("replace_all", False),
-        absorbed_into=args.get("absorbed_into")),
+        absorbed_into=args.get("absorbed_into"),
+        session_id=kw.get("session_id") or args.get("session_id", ""),
+        scope=args.get("scope", ""),
+        source_reference=args.get("source_reference", ""),
+        project_id=args.get("project_id", ""),
+        approved_global=args.get("approved_global", False)),
     emoji="📝",
 )


### PR DESCRIPTION
## Summary

Adds H2/H3 project-boundary primitives for long-running Hermes sessions:

- Adds an active project context model persisted per session in `SessionDB.state_meta`.
- Adds gateway `/project` session controls for status, clear, and set flows.
- Injects active project context into the dynamic session context instead of mutating the static base system prompt.
- Adds durable-write metadata validation for built-in memory and skill writes when an active project context is present.
- Propagates `session_id` through tool dispatch so memory/skill tools can evaluate session-local project boundaries.
- Prevents rejected built-in memory writes from being bridged to external memory providers.
- Adds focused boundary tests for project context persistence, write validation, and external memory bridge behavior.

This PR implements only the H2/H3 primitives. It does not add H4/H5 promotion queues or design-validator workflows.

## Tests

Passed:

- `scripts/run_tests.sh tests/tools/test_project_context_boundaries.py -q`
  - `13 passed in 0.95s`
- `scripts/run_tests.sh tests/tools/test_memory_tool.py tests/tools/test_skill_manager_tool.py tests/tools/test_project_context_boundaries.py -q`
  - `132 passed in 0.94s`
- `python3 -m py_compile hermes_cli/project_context.py run_agent.py tools/memory_tool.py tools/skill_manager_tool.py tests/tools/test_project_context_boundaries.py`
- `git diff --check`

Background full suite:

- `scripts/run_tests.sh tests -q`
- Hermes process id: `proc_83f4f8102222`
- Status at PR creation: still running; live output has shown existing full-suite failures/errors, so final status is pending and should not be treated as green.

## Risks / Caveats

- The branch was cut from local `origin/main` and is currently behind upstream main by a few commits; maintainers may want to update before merge.
- Gateway `/project set` is blocked while an agent run is active, except `/project status` and `/project clear`, to avoid racing durable-write gates.
- Durable-write validation is intentionally minimal and metadata-based; it does not attempt broader project fact classification or design validation.
- If project context support import/session DB access fails, the write-boundary checks currently fail open with debug logging.

## Reviewer notes

Main files to review:

- `hermes_cli/project_context.py`
- `gateway/run.py`
- `gateway/session.py`
- `tools/memory_tool.py`
- `tools/skill_manager_tool.py`
- `run_agent.py`
- `model_tools.py`
- `tests/tools/test_project_context_boundaries.py`

Please verify intended semantics for project-scoped durable writes:

- Active project sessions require explicit `scope` and `source_reference` for mutating memory/skill writes.
- Writes to global memory/skill storage require `approved_global=true` when an active project context is present.
