### PR TITLE
fix(docker): respect configured home mount

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -202,6 +202,43 @@ def test_auto_mount_replaces_persistent_workspace_bind(monkeypatch, tmp_path):
     assert "/sandboxes/docker/test-persistent-auto-mount/workspace:/workspace" not in run_args_str
 
 
+def test_persistent_home_mount_respects_docker_env_home(monkeypatch):
+    """Persistent Docker home should mount at docker_env.HOME when configured."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        persistent_filesystem=True,
+        task_id="test-persistent-home",
+        env={"HOME": "/home/custom"},
+    )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert "/sandboxes/docker/test-persistent-home/home:/home/custom" in run_args_str
+    assert "/sandboxes/docker/test-persistent-home/home:/root" not in run_args_str
+
+
+def test_persistent_home_mount_ignores_invalid_docker_env_home(monkeypatch, caplog):
+    """Invalid HOME values should not become Docker bind mount targets."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    with caplog.at_level(logging.WARNING):
+        _make_dummy_env(
+            persistent_filesystem=True,
+            task_id="test-invalid-home",
+            env={"HOME": "relative/path"},
+        )
+
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    run_args_str = " ".join(run_calls[0][0])
+    assert "/sandboxes/docker/test-invalid-home/home:/root" in run_args_str
+    assert any("Ignoring docker_env.HOME" in rec.getMessage() for rec in caplog.records)
+
+
 def test_non_persistent_cleanup_removes_container(monkeypatch):
     """When persistent=false, cleanup() must schedule docker stop + rm."""
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -31,6 +31,7 @@ _DOCKER_SEARCH_PATHS = [
 
 _docker_executable: Optional[str] = None  # resolved once, cached
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_CONTAINER_ABSOLUTE_PATH_RE = re.compile(r"^/[^\0:\n\r]*$")
 
 
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
@@ -86,6 +87,21 @@ def _normalize_env_dict(env: dict | None) -> dict[str, str]:
         normalized[key] = value
 
     return normalized
+
+
+def _resolve_home_mount_target(env: dict[str, str]) -> str:
+    """Return the container path for the persistent home bind mount."""
+    home = (env.get("HOME") or "").strip()
+    if not home:
+        return "/root"
+    if not _CONTAINER_ABSOLUTE_PATH_RE.match(home) or home == "/":
+        logger.warning(
+            "Ignoring docker_env.HOME=%r for persistent Docker home mount; "
+            "expected an absolute container path like /root or /home/hermes.",
+            home,
+        )
+        return "/root"
+    return home
 
 
 def _load_hermes_env_vars() -> dict[str, str]:
@@ -279,8 +295,8 @@ class DockerEnvironment(BaseEnvironment):
     boundary — the filesystem inside is writable so agents can install packages
     (pip, npm, apt) as needed. Writable workspace via tmpfs or bind mounts.
 
-    Persistence: when enabled, bind mounts preserve /workspace and /root
-    across container restarts.
+    Persistence: when enabled, bind mounts preserve /workspace and the
+    configured container home directory across container restarts.
     """
 
     def __init__(
@@ -374,8 +390,9 @@ class DockerEnvironment(BaseEnvironment):
             sandbox = get_sandbox_dir() / "docker" / task_id
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
+            home_mount_target = _resolve_home_mount_target(self._env)
             writable_args.extend([
-                "-v", f"{self._home_dir}:/root",
+                "-v", f"{self._home_dir}:{home_mount_target}",
             ])
             if not bind_host_cwd and not workspace_explicitly_mounted:
                 self._workspace_dir = str(sandbox / "workspace")


### PR DESCRIPTION
## Summary
- use `docker_env.HOME` as the persistent Docker home bind-mount target when it is a valid absolute container path
- keep `/root` as the fallback for unset or invalid HOME values
- add regression coverage for custom and invalid persistent home mount targets

Fixes #20538.

## Verification
- `scripts/run_tests.sh tests/tools/test_docker_environment.py -k 'persistent_home_mount or docker_env or auto_mount_replaces_persistent_workspace_bind'`\n- `git diff --check`