### PR TITLE
fix(agent): rewrite /anthropic base URL for OpenAI fallback in custom endpoint

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1786,8 +1786,14 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
     logger.debug("Auxiliary client: custom endpoint (%s, api_mode=%s)", model, custom_mode or "chat_completions")
     _clean_base, _dq = _extract_url_query_params(custom_base)
     _extra = {"default_query": _dq} if _dq else {}
+    # OpenAI-wire base URL: if custom_base ends in /anthropic (MiniMax,
+    # Zhipu GLM, LiteLLM Anthropic proxies, etc.), rewrite to the
+    # provider's /v1 surface so any OpenAI SDK fallback path doesn't 404
+    # on /anthropic/chat/completions.  AnthropicAuxiliaryClient ignores
+    # this and uses the raw custom_base via the Anthropic SDK.
+    _openai_clean_base = _to_openai_base_url(_clean_base)
     if custom_mode == "codex_responses":
-        real_client = OpenAI(api_key=custom_key, base_url=_clean_base, **_extra)
+        real_client = OpenAI(api_key=custom_key, base_url=_openai_clean_base, **_extra)
         return CodexAuxiliaryClient(real_client, model), model
     if custom_mode == "anthropic_messages":
         # Third-party Anthropic-compatible gateway (MiniMax, Zhipu GLM,
@@ -1801,14 +1807,14 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
                 "Custom endpoint declares api_mode=anthropic_messages but the "
                 "anthropic SDK is not installed — falling back to OpenAI-wire."
             )
-            return OpenAI(api_key=custom_key, base_url=_clean_base, **_extra), model
+            return OpenAI(api_key=custom_key, base_url=_openai_clean_base, **_extra), model
         return (
             AnthropicAuxiliaryClient(real_client, model, custom_key, custom_base, is_oauth=False),
             model,
         )
     # URL-based anthropic detection for custom endpoints that didn't set
     # api_mode explicitly (e.g. kimi.com/coding reached via custom config).
-    _fallback_client = OpenAI(api_key=custom_key, base_url=_clean_base, **_extra)
+    _fallback_client = OpenAI(api_key=custom_key, base_url=_openai_clean_base, **_extra)
     _fallback_client = _maybe_wrap_anthropic(
         _fallback_client, model, custom_key, custom_base, custom_mode,
     )

--- a/tests/agent/test_auxiliary_client_anthropic_custom.py
+++ b/tests/agent/test_auxiliary_client_anthropic_custom.py
@@ -87,6 +87,59 @@ def test_custom_endpoint_anthropic_messages_falls_back_when_sdk_missing():
     # OpenAI client, not AnthropicAuxiliaryClient.
     from agent.auxiliary_client import AnthropicAuxiliaryClient
     assert not isinstance(client, AnthropicAuxiliaryClient)
+    # The fallback OpenAI client must point at the /v1 surface — without the
+    # rewrite, requests would hit /anthropic/chat/completions and 404.
+    assert "/anthropic" not in str(client.base_url)
+    assert str(client.base_url).rstrip("/").endswith("/v1")
+
+
+def test_custom_endpoint_no_api_mode_rewrites_anthropic_url_for_openai_fallback():
+    """No api_mode + /anthropic URL: when wrap fails, OpenAI client must use /v1.
+
+    Reproduces #20514 — `auxiliary.*.provider: auto` with main_provider=minimax-cn
+    fell through to the custom endpoint path, where the OpenAI client was built
+    with the raw /anthropic base URL and 404'd on /anthropic/chat/completions.
+    """
+    from agent.auxiliary_client import _try_custom_endpoint, AnthropicAuxiliaryClient
+
+    with patch(
+        "agent.auxiliary_client._resolve_custom_runtime",
+        return_value=("https://api.minimaxi.com/anthropic", "minimax-cn-key", None),
+    ), patch(
+        "agent.auxiliary_client._read_main_model",
+        return_value="MiniMax-M2.7",
+    ), patch(
+        "agent.auxiliary_client._maybe_wrap_anthropic",
+        side_effect=lambda client_obj, *_args, **_kwargs: client_obj,
+    ):
+        client, model = _try_custom_endpoint()
+
+    assert client is not None
+    assert model == "MiniMax-M2.7"
+    assert not isinstance(client, AnthropicAuxiliaryClient)
+    # The OpenAI client must be pointed at /v1, not /anthropic.
+    assert "/anthropic" not in str(client.base_url)
+    assert str(client.base_url).rstrip("/").endswith("/v1")
+
+
+def test_custom_endpoint_codex_responses_rewrites_anthropic_url():
+    """codex_responses + /anthropic URL: underlying OpenAI client uses /v1."""
+    from agent.auxiliary_client import _try_custom_endpoint, CodexAuxiliaryClient
+
+    with patch(
+        "agent.auxiliary_client._resolve_custom_runtime",
+        return_value=("https://api.minimaxi.com/anthropic", "k", "codex_responses"),
+    ), patch(
+        "agent.auxiliary_client._read_main_model",
+        return_value="gpt-5-codex",
+    ):
+        client, model = _try_custom_endpoint()
+
+    assert isinstance(client, CodexAuxiliaryClient)
+    assert model == "gpt-5-codex"
+    inner_base = str(client.base_url)
+    assert "/anthropic" not in inner_base
+    assert inner_base.rstrip("/").endswith("/v1")
 
 
 def test_custom_endpoint_chat_completions_still_uses_openai_wire():


### PR DESCRIPTION
Pre-apply `_to_openai_base_url()` to the OpenAI client constructed in `_try_custom_endpoint()` so /anthropic-suffixed endpoints don't 404 when the Anthropic SDK wrap doesn't take.

## What changed and why
- `agent/auxiliary_client.py`: in `_try_custom_endpoint()`, build the OpenAI client with `_to_openai_base_url(_clean_base)` instead of the raw `_clean_base`. For URLs like `https://api.minimaxi.com/anthropic` this yields `https://api.minimaxi.com/v1`. `AnthropicAuxiliaryClient` still receives the original `custom_base` and routes through the Anthropic SDK against `/anthropic`, so the wrapped happy path is unchanged. The fix prevents auxiliary tasks (title generation, vision auto, compression, etc.) from hitting `/anthropic/chat/completions` and 404ing whenever `_maybe_wrap_anthropic()` returns the unwrapped OpenAI client (e.g. anthropic SDK import failed, `build_anthropic_client` raised, or URL-based detection didn't fire).
- `tests/agent/test_auxiliary_client_anthropic_custom.py`: extended the SDK-missing fallback test to assert the OpenAI client base URL ends in `/v1` (not `/anthropic`); added two new tests covering the no-api-mode `/anthropic` URL path and the `codex_responses` mode rewrite.

## How to test
- `pytest tests/agent/test_auxiliary_client_anthropic_custom.py -v` — 5 tests pass, including 3 new assertions on the rewritten base URL.
- `pytest tests/agent/test_auxiliary_client.py tests/agent/test_minimax_provider.py tests/agent/test_minimax_auxiliary_url.py tests/agent/test_auxiliary_client_anthropic_custom.py -q` — 190 tests pass.
- `pytest tests/run_agent/test_provider_parity.py -k 'minimax or anthropic or custom' -q` — 5 tests pass.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #20514

<!-- autocontrib:worker-id=issue-new-bb8c2c56 kind=pr-open -->