### PR TITLE
feat(gateway): support chat-type display overrides

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -4,10 +4,12 @@ Provides ``resolve_display_setting()`` — the single entry-point for reading
 display settings with platform-specific overrides and sensible defaults.
 
 Resolution order (first non-None wins):
-    1. ``display.platforms.<platform>.<key>``  — explicit per-platform user override
-    2. ``display.<key>``                       — global user setting
-    3. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
-    4. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
+    1. ``display.platforms.<platform>.chat_types.<chat_type>.<key>``
+       — explicit per-chat-type user override
+    2. ``display.platforms.<platform>.<key>``  — explicit per-platform user override
+    3. ``display.<key>``                       — global user setting
+    4. ``_PLATFORM_DEFAULTS[<platform>][<key>]``  — built-in sensible default
+    5. ``_GLOBAL_DEFAULTS[<key>]``              — built-in global default
 
 Exception: ``display.streaming`` is CLI-only.  Gateway streaming follows the
 top-level ``streaming`` config unless ``display.platforms.<platform>.streaming``
@@ -112,6 +114,8 @@ def resolve_display_setting(
     platform_key: str,
     setting: str,
     fallback: Any = None,
+    *,
+    chat_type: str | None = None,
 ) -> Any:
     """Resolve a display setting with per-platform override support.
 
@@ -126,6 +130,10 @@ def resolve_display_setting(
         Display setting name (e.g. ``"tool_progress"``, ``"show_reasoning"``).
     fallback : Any
         Fallback value when the setting isn't found anywhere.
+    chat_type : str | None
+        Optional source chat type (e.g. ``"dm"``, ``"group"``,
+        ``"channel"``, ``"thread"``).  When provided, chat-type overrides
+        under ``display.platforms.<platform>.chat_types`` take precedence.
 
     Returns
     -------
@@ -133,15 +141,26 @@ def resolve_display_setting(
     """
     display_cfg = user_config.get("display") or {}
 
-    # 1. Explicit per-platform override (display.platforms.<platform>.<key>)
+    # 1. Explicit per-chat-type override
+    # (display.platforms.<platform>.chat_types.<chat_type>.<key>)
     platforms = display_cfg.get("platforms") or {}
     plat_overrides = platforms.get(platform_key)
     if isinstance(plat_overrides, dict):
+        chat_type_key = _normalise_chat_type(chat_type)
+        chat_types = plat_overrides.get("chat_types")
+        if chat_type_key and isinstance(chat_types, dict):
+            chat_overrides = chat_types.get(chat_type_key)
+            if isinstance(chat_overrides, dict):
+                val = chat_overrides.get(setting)
+                if val is not None:
+                    return _normalise(setting, val)
+
+        # 2. Explicit per-platform override (display.platforms.<platform>.<key>)
         val = plat_overrides.get(setting)
         if val is not None:
             return _normalise(setting, val)
 
-    # 1b. Backward compat: display.tool_progress_overrides.<platform>
+    # 2b. Backward compat: display.tool_progress_overrides.<platform>
     if setting == "tool_progress":
         legacy = display_cfg.get("tool_progress_overrides")
         if isinstance(legacy, dict):
@@ -149,7 +168,7 @@ def resolve_display_setting(
             if val is not None:
                 return _normalise(setting, val)
 
-    # 2. Global user setting (display.<key>).  Skip display.streaming because
+    # 3. Global user setting (display.<key>).  Skip display.streaming because
     # that key controls only CLI terminal streaming; gateway token streaming is
     # governed by the top-level streaming config plus per-platform overrides.
     if setting != "streaming":
@@ -157,14 +176,14 @@ def resolve_display_setting(
         if val is not None:
             return _normalise(setting, val)
 
-    # 3. Built-in platform default
+    # 4. Built-in platform default
     plat_defaults = _PLATFORM_DEFAULTS.get(platform_key)
     if plat_defaults:
         val = plat_defaults.get(setting)
         if val is not None:
             return val
 
-    # 4. Built-in global default
+    # 5. Built-in global default
     val = _GLOBAL_DEFAULTS.get(setting)
     if val is not None:
         return val
@@ -194,3 +213,16 @@ def _normalise(setting: str, value: Any) -> Any:
         except (TypeError, ValueError):
             return 0
     return value
+
+
+def _normalise_chat_type(value: str | None) -> str | None:
+    if value is None:
+        return None
+    key = str(value).strip().lower()
+    if not key:
+        return None
+    aliases = {
+        "direct": "dm",
+        "private": "dm",
+    }
+    return aliases.get(key, key)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6509,6 +6509,7 @@ class GatewayRunner:
                     _platform_config_key(source.platform),
                     "show_reasoning",
                     getattr(self, "_show_reasoning", False),
+                    chat_type=getattr(source, "chat_type", None),
                 )
             except Exception:
                 _show_reasoning_effective = getattr(self, "_show_reasoning", False)
@@ -12496,7 +12497,10 @@ class GatewayRunner:
         user_config = _load_gateway_config()
         from gateway.display_config import resolve_display_setting
         _plat_streaming = resolve_display_setting(
-            user_config, platform_key, "streaming"
+            user_config,
+            platform_key,
+            "streaming",
+            chat_type=getattr(source, "chat_type", None),
         )
         _streaming_enabled = (
             _scfg.enabled and _scfg.transport != "off"
@@ -12751,17 +12755,39 @@ class GatewayRunner:
         # Apply tool preview length config (0 = no limit)
         try:
             from agent.display import set_tool_preview_max_len
-            _tpl = resolve_display_setting(user_config, platform_key, "tool_preview_length", 0)
+            _tpl = resolve_display_setting(
+                user_config,
+                platform_key,
+                "tool_preview_length",
+                0,
+                chat_type=getattr(source, "chat_type", None),
+            )
             set_tool_preview_max_len(int(_tpl) if _tpl else 0)
         except Exception:
             pass
 
         # Tool progress mode — resolved per-platform with env var fallback
-        _resolved_tp = resolve_display_setting(user_config, platform_key, "tool_progress")
+        _source_chat_type = getattr(source, "chat_type", None)
+        _resolved_tp = resolve_display_setting(
+            user_config,
+            platform_key,
+            "tool_progress",
+            chat_type=_source_chat_type,
+        )
         _env_tp = os.getenv("HERMES_TOOL_PROGRESS_MODE")
         _display_cfg = display_config if isinstance(display_config, dict) else {}
         _platforms_cfg = _display_cfg.get("platforms") or {}
         _platform_cfg = _platforms_cfg.get(platform_key) or {}
+        _chat_type_cfg = {}
+        if isinstance(_platform_cfg, dict):
+            _chat_types_cfg = _platform_cfg.get("chat_types") or {}
+            if isinstance(_chat_types_cfg, dict):
+                _source_chat_key = str(_source_chat_type or "").strip().lower()
+                if _source_chat_key in {"direct", "private"}:
+                    _source_chat_key = "dm"
+                _maybe_chat_type_cfg = _chat_types_cfg.get(_source_chat_key)
+                if isinstance(_maybe_chat_type_cfg, dict):
+                    _chat_type_cfg = _maybe_chat_type_cfg
         _legacy_tp_overrides = _display_cfg.get("tool_progress_overrides") or {}
         _tool_progress_configured = (
             "tool_progress" in _display_cfg
@@ -12769,6 +12795,7 @@ class GatewayRunner:
                 isinstance(_platform_cfg, dict)
                 and "tool_progress" in _platform_cfg
             )
+            or "tool_progress" in _chat_type_cfg
             or (
                 isinstance(_legacy_tp_overrides, dict)
                 and platform_key in _legacy_tp_overrides
@@ -13240,7 +13267,10 @@ class GatewayRunner:
             # can disable streaming for specific platforms even when the global
             # streaming config is enabled.
             _plat_streaming = resolve_display_setting(
-                user_config, platform_key, "streaming"
+                user_config,
+                platform_key,
+                "streaming",
+                chat_type=getattr(source, "chat_type", None),
             )
             # None = no per-platform override → follow global config
             _streaming_enabled = (

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -79,6 +79,109 @@ class TestResolveDisplaySetting:
         assert resolve_display_setting(config, "telegram", "tool_progress") == "all"
 
 
+class TestChatTypeOverrides:
+    """Per-chat-type display overrides refine platform settings."""
+
+    def test_chat_type_override_wins_over_platform_and_global(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "tool_progress": "all",
+                "platforms": {
+                    "telegram": {
+                        "tool_progress": "new",
+                        "chat_types": {
+                            "dm": {"tool_progress": "verbose"},
+                            "group": {"tool_progress": "off"},
+                        },
+                    },
+                },
+            }
+        }
+
+        assert (
+            resolve_display_setting(
+                config,
+                "telegram",
+                "tool_progress",
+                chat_type="dm",
+            )
+            == "verbose"
+        )
+        assert (
+            resolve_display_setting(
+                config,
+                "telegram",
+                "tool_progress",
+                chat_type="group",
+            )
+            == "off"
+        )
+
+    def test_missing_chat_type_override_falls_back_to_platform(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "tool_progress": "new",
+                        "chat_types": {"dm": {"tool_progress": "verbose"}},
+                    },
+                },
+            }
+        }
+
+        assert (
+            resolve_display_setting(
+                config,
+                "telegram",
+                "tool_progress",
+                chat_type="group",
+            )
+            == "new"
+        )
+        assert resolve_display_setting(config, "telegram", "tool_progress") == "new"
+
+    def test_chat_type_overrides_are_normalised(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "telegram": {
+                        "chat_types": {
+                            "dm": {
+                                "show_reasoning": "true",
+                                "tool_preview_length": "120",
+                            },
+                        },
+                    },
+                },
+            }
+        }
+
+        assert (
+            resolve_display_setting(
+                config,
+                "telegram",
+                "show_reasoning",
+                chat_type="private",
+            )
+            is True
+        )
+        assert (
+            resolve_display_setting(
+                config,
+                "telegram",
+                "tool_preview_length",
+                chat_type="Direct",
+            )
+            == 120
+        )
+
+
 # ---------------------------------------------------------------------------
 # Backward compatibility: tool_progress_overrides
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `display.platforms.<platform>.chat_types.<chat_type>` resolution for gateway display settings
- apply chat-type-aware display settings to reasoning visibility, streaming, tool preview length, and tool progress
- preserve platform/global fallback order and legacy `tool_progress_overrides` behavior

Fixes #20533

## Verification
- `scripts/run_tests.sh tests/gateway/test_display_config.py`
- `scripts/run_tests.sh tests/gateway/test_display_config.py tests/gateway/test_run_progress_topics.py`
- `python -m py_compile gateway/display_config.py gateway/run.py`
- `git diff --check`