### PR TITLE
fix(security): guard bundled and hub skills from skill_manage writes

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -12,6 +12,7 @@ from tools.skill_manager_tool import (
     _validate_category,
     _validate_frontmatter,
     _validate_file_path,
+    _bundled_hub_guard,
     _find_skill,
     _resolve_skill_dir,
     _create_skill,
@@ -56,6 +57,19 @@ description: Updated description.
 # Test Skill v2
 
 Step 1: Do the new thing.
+"""
+
+
+def skill_content(name: str, body: str = "Step 1: Do the thing.") -> str:
+    return f"""\
+---
+name: {name}
+description: A test skill for unit testing.
+---
+
+# {name}
+
+{body}
 """
 
 
@@ -182,6 +196,59 @@ class TestValidateFilePath:
         err = _validate_file_path("malicious.py")
         assert "File must be under one of:" in err
         assert "'malicious.py'" in err
+
+
+# ---------------------------------------------------------------------------
+# Bundled / hub protection
+# ---------------------------------------------------------------------------
+
+
+class TestBundledHubGuard:
+    def test_bundled_manifest_blocks_all_mutation_actions(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        (skills_root / ".bundled_manifest").write_text("guarded:abc123\n", encoding="utf-8")
+
+        with _skill_dir(skills_root):
+            _create_skill("guarded", skill_content("guarded"))
+            (skills_root / "guarded" / "references").mkdir()
+            (skills_root / "guarded" / "references" / "api.md").write_text("original", encoding="utf-8")
+
+            edit = _edit_skill("guarded", skill_content("guarded", "Updated."))
+            patch_result = _patch_skill("guarded", "Do the thing.", "Do the unsafe thing.")
+            write = _write_file("guarded", "references/new.md", "new")
+            remove = _remove_file("guarded", "references/api.md")
+            delete = _delete_skill("guarded")
+
+        for result in (edit, patch_result, write, remove, delete):
+            assert result["success"] is False
+            assert "bundled or hub-installed" in result["error"]
+        assert (skills_root / "guarded" / "SKILL.md").exists()
+        assert "Do the unsafe thing" not in (skills_root / "guarded" / "SKILL.md").read_text()
+        assert not (skills_root / "guarded" / "references" / "new.md").exists()
+        assert (skills_root / "guarded" / "references" / "api.md").read_text() == "original"
+
+    def test_hub_lock_blocks_mutation_for_nested_install_path(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+        hub_dir = skills_root / ".hub"
+        hub_dir.mkdir(parents=True)
+        (hub_dir / "lock.json").write_text(
+            json.dumps({"installed": {"hub-skill": {"install_path": "community/hub-skill"}}}),
+            encoding="utf-8",
+        )
+
+        with _skill_dir(skills_root):
+            _create_skill("hub-skill", skill_content("hub-skill"), category="community")
+            guard = _bundled_hub_guard("hub-skill")
+            result = _patch_skill("hub-skill", "Do the thing.", "Do the unsafe thing.")
+
+        assert guard is not None
+        assert "bundled or hub-installed" in guard
+        assert result["success"] is False
+        assert "bundled or hub-installed" in result["error"]
+        assert "Do the unsafe thing" not in (skills_root / "community" / "hub-skill" / "SKILL.md").read_text()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -4,8 +4,8 @@ Skill Manager Tool -- Agent-Managed Skill Creation & Editing
 
 Allows the agent to create, update, and delete skills, turning successful
 approaches into reusable procedural knowledge. New skills are created in
-~/.hermes/skills/. Existing skills (bundled, hub-installed, or user-created)
-can be modified or deleted wherever they live.
+~/.hermes/skills/. Agent-created and user-created skills can be modified;
+bundled and hub-installed skills are protected from agent writes.
 
 Skills are the agent's procedural memory: they capture *how to do a specific
 type of task* based on proven experience. General memory (MEMORY.md, USER.md) is
@@ -158,6 +158,31 @@ def _pinned_guard(name: str) -> Optional[str]:
             )
     except Exception:
         logger.debug("pinned-guard lookup failed for %s", name, exc_info=True)
+    return None
+
+
+def _bundled_hub_guard(name: str) -> Optional[str]:
+    """Return a refusal message if *name* is bundled or hub-installed.
+
+    Bundled skills ship with Hermes and hub-installed skills are managed by
+    their upstream source. They must be protected at the tool boundary rather
+    than relying only on curator/background-review prompt instructions: a
+    poisoned skill can otherwise prompt-inject an autonomous review pass into
+    making persistent edits to a trusted skill.
+
+    Best-effort: if provenance lookup fails, fall open rather than blocking
+    writes to user-created skills because of a corrupt sidecar/lock file.
+    """
+    try:
+        from tools import skill_usage
+        if not skill_usage.is_agent_created(name):
+            return (
+                f"Skill '{name}' is bundled or hub-installed and cannot be "
+                f"modified by skill_manage. To customize it, copy the skill "
+                f"to a new local skill name first."
+            )
+    except Exception:
+        logger.debug("bundled/hub guard lookup failed for %s", name, exc_info=True)
     return None
 
 
@@ -439,6 +464,10 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     if not existing:
         return {"success": False, "error": f"Skill '{name}' not found. Use skills_list() to see available skills."}
 
+    bundled_err = _bundled_hub_guard(name)
+    if bundled_err:
+        return {"success": False, "error": bundled_err}
+
     skill_md = existing["path"] / "SKILL.md"
     # Back up original content for rollback
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
@@ -478,6 +507,10 @@ def _patch_skill(
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": f"Skill '{name}' not found."}
+
+    bundled_err = _bundled_hub_guard(name)
+    if bundled_err:
+        return {"success": False, "error": bundled_err}
 
     skill_dir = existing["path"]
 
@@ -568,6 +601,10 @@ def _delete_skill(name: str, absorbed_into: Optional[str] = None) -> Dict[str, A
     if not existing:
         return {"success": False, "error": f"Skill '{name}' not found."}
 
+    bundled_err = _bundled_hub_guard(name)
+    if bundled_err:
+        return {"success": False, "error": bundled_err}
+
     pinned_err = _pinned_guard(name)
     if pinned_err:
         return {"success": False, "error": pinned_err}
@@ -637,6 +674,10 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     if not existing:
         return {"success": False, "error": f"Skill '{name}' not found. Create it first with action='create'."}
 
+    bundled_err = _bundled_hub_guard(name)
+    if bundled_err:
+        return {"success": False, "error": bundled_err}
+
     target, err = _resolve_skill_target(existing["path"], file_path)
     if err:
         return {"success": False, "error": err}
@@ -670,6 +711,10 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": f"Skill '{name}' not found."}
+
+    bundled_err = _bundled_hub_guard(name)
+    if bundled_err:
+        return {"success": False, "error": bundled_err}
 
     skill_dir = existing["path"]
 
@@ -797,7 +842,8 @@ SKILL_MANAGE_SCHEMA = {
     "description": (
         "Manage skills (create, update, delete). Skills are your procedural "
         "memory — reusable approaches for recurring task types. "
-        f"New skills go to {display_hermes_home()}/skills/; existing skills can be modified wherever they live.\n\n"
+        f"New skills go to {display_hermes_home()}/skills/; existing user/agent-created skills can be modified; "
+        "bundled and hub-installed skills are protected from write operations.\n\n"
         "Actions: create (full SKILL.md + optional category), "
         "patch (old_string/new_string — preferred for fixes), "
         "edit (full SKILL.md rewrite — major overhauls only), "


### PR DESCRIPTION
## Summary

- Add a tool-level provenance guard that refuses `skill_manage` mutations for bundled and hub-installed skills.
- Apply the guard to `edit`, `patch`, `delete`, `write_file`, and `remove_file` before any filesystem mutation.
- Use the existing `tools.skill_usage.is_agent_created()` provenance path instead of inventing a new marker, so bundled `.bundled_manifest` and hub `.hub/lock.json` state remain the source of truth.
- Add regression tests for bundled manifest protection and nested hub lock install paths.

Fixes #20273.

## Why this approach

The current boundary is prompt-level only: autonomous review/curator prompts may say not to touch bundled or hub-installed skills, but `skill_manage` itself still accepts writes. That makes prompt injection against autonomous skill review a persistent code/content mutation path.

This PR enforces the boundary in the mutation tool itself. If legitimate customization is desired, the safe path is to copy/fork the skill into a new local skill name first.

This also supersedes the open #19379 approach in one important way: this PR uses the existing provenance machinery (`is_agent_created()`, backed by bundled manifest and hub lock metadata) rather than a `.hub-source` marker.

## Verification

Clean worktree created from current `origin/main`, then cherry-picked only this security fix.

```text
scripts/run_tests.sh tests/tools/test_skill_manager_tool.py
88 passed

python -m py_compile tools/skill_manager_tool.py tests/tools/test_skill_manager_tool.py
passed

git diff --check origin/main...HEAD
clean
```

I also checked focused ruff on these files:

```text
ruff check tools/skill_manager_tool.py tests/tools/test_skill_manager_tool.py
```

That command still reports the same pre-existing baseline lint issues on current `origin/main` for these files (unused imports / E702 semicolons in existing tests, E402 imports in the tool module). This PR does not introduce those baseline lint findings.
