### PR TITLE
fix(feishu): avoid threading regular replies

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2760,7 +2760,7 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        thread_id = getattr(message, "thread_id", None) or None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4495,6 +4495,64 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         )
         adapter._dispatch_inbound_event.assert_not_called()
 
+    def test_regular_reply_root_id_does_not_become_thread_id(self):
+        adapter = self._build_adapter()
+        adapter._fetch_message_text = AsyncMock(return_value="parent text")
+        message = SimpleNamespace(
+            content=json.dumps({"text": "regular reply"}),
+            message_type="text",
+            message_id="m6",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            root_id="om_root",
+            thread_id=None,
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="m6",
+            )
+        )
+
+        adapter.build_source.assert_called_once()
+        self.assertIsNone(adapter.build_source.call_args.kwargs["thread_id"])
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.reply_to_message_id, "om_root")
+        self.assertEqual(event.reply_to_text, "parent text")
+
+    def test_explicit_thread_id_is_preserved(self):
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content=json.dumps({"text": "thread reply"}),
+            message_type="text",
+            message_id="m7",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            root_id="om_root",
+            thread_id="omt_thread",
+        )
+
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message,
+                message=message,
+                sender_id=None,
+                chat_type="group",
+                message_id="m7",
+            )
+        )
+
+        adapter.build_source.assert_called_once()
+        self.assertEqual(adapter.build_source.call_args.kwargs["thread_id"], "omt_thread")
+
 
 class TestFeishuFetchMessageText(unittest.TestCase):
     def _build_adapter(self):


### PR DESCRIPTION
## Summary
- stop using Feishu `root_id` as a fallback `thread_id` for inbound messages
- keep `root_id` available as reply context via `reply_to_message_id`
- add regressions for regular replies and explicit thread replies

Fixes #20548

## Verification
- `scripts/run_tests.sh tests/gateway/test_feishu.py -k 'ProcessInboundMessage or reply_to_text or thread_metadata'`\n- `scripts/run_tests.sh tests/gateway/test_feishu.py`\n- `python -m py_compile gateway/platforms/feishu.py`\n- `git diff --check`