### PR TITLE
Fixes #20558

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1273,7 +1273,9 @@ def resolve_provider(
     except Exception as e:
         logger.debug("Could not detect active auth provider: %s", e)
 
-    if has_usable_secret(os.getenv("OPENAI_API_KEY")) or has_usable_secret(os.getenv("OPENROUTER_API_KEY")):
+    from hermes_cli.config import get_env_value
+
+    if has_usable_secret(get_env_value("OPENAI_API_KEY")) or has_usable_secret(get_env_value("OPENROUTER_API_KEY")):
         return "openrouter"
 
     # Auto-detect API-key providers by checking their env vars
@@ -1289,7 +1291,7 @@ def resolve_provider(
         if pid in ("copilot", "lmstudio"):
             continue
         for env_var in pconfig.api_key_env_vars:
-            if has_usable_secret(os.getenv(env_var, "")):
+            if has_usable_secret(get_env_value(env_var) or ""):
                 return pid
 
     # AWS Bedrock — detect via boto3 credential chain (IAM roles, SSO, env vars).

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -845,6 +845,7 @@ def _build_child_agent(
     override_base_url: Optional[str] = None,
     override_api_key: Optional[str] = None,
     override_api_mode: Optional[str] = None,
+    override_reasoning_effort: Optional[str] = None,
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
@@ -984,6 +985,19 @@ def _build_child_agent(
     effective_base_url = override_base_url or parent_agent.base_url
     effective_api_key = override_api_key or parent_api_key
     effective_api_mode = override_api_mode or getattr(parent_agent, "api_mode", None)
+
+    # OpenCode-to-OpenCode loop protection: if the child model differs from the
+    # parent, we MUST re-derive the api_mode.  Blindly inheriting it causes
+    # 404s for the DeepSeek/MiniMax mix because they use different endpoints
+    # (one strips /v1, the other doesn't).
+    if effective_provider in ("opencode-zen", "opencode-go"):
+        if effective_model != getattr(parent_agent, "model", None) or override_provider:
+            from hermes_cli.models import opencode_model_api_mode
+
+            effective_api_mode = opencode_model_api_mode(
+                effective_provider, effective_model
+            )
+
     effective_acp_command = override_acp_command or getattr(
         parent_agent, "acp_command", None
     )
@@ -1007,11 +1021,15 @@ def _build_child_agent(
         effective_provider = "copilot-acp"
         effective_api_mode = "chat_completions"
 
-    # Resolve reasoning config: delegation override > parent inherit
+    # Resolve reasoning config: task override > delegation override > parent inherit
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning
     try:
-        delegation_effort = str(delegation_cfg.get("reasoning_effort") or "").strip()
+        delegation_effort = str(
+            override_reasoning_effort
+            or delegation_cfg.get("reasoning_effort")
+            or ""
+        ).strip()
         if delegation_effort:
             from hermes_constants import parse_reasoning_effort
 
@@ -1839,6 +1857,9 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
@@ -1848,8 +1869,8 @@ def delegate_task(
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, role)
-      - Batch:  provide tasks array [{goal, context, toolsets, role}, ...]
+      - Single: provide goal (+ optional context, toolsets, role, model, provider, reasoning_effort)
+      - Batch:  provide tasks array [{goal, context, toolsets, role, model, provider, reasoning_effort}, ...]
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
@@ -1929,7 +1950,15 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {
+                "goal": goal,
+                "context": context,
+                "toolsets": toolsets,
+                "role": top_role,
+                "model": model,
+                "provider": provider,
+                "reasoning_effort": reasoning_effort,
+            }
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -1966,26 +1995,60 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+
+            task_model = t.get("model")
+            task_provider = t.get("provider")
+            task_reasoning = t.get("reasoning_effort")
+
+            task_creds = creds
+            if task_model or task_provider:
+                # Resolve specific credentials for this task override
+                try:
+                    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+                    # Use delegation config as base, override with task-specifics
+                    requested_p = task_provider or cfg.get("provider")
+                    target_m = task_model or cfg.get("model")
+
+                    runtime = resolve_runtime_provider(
+                        requested=requested_p,
+                        target_model=target_m,
+                        explicit_api_key=cfg.get("api_key"),
+                        explicit_base_url=cfg.get("base_url"),
+                    )
+                    task_creds = {
+                        "model": target_m or runtime.get("model"),
+                        "provider": runtime.get("provider"),
+                        "base_url": runtime.get("base_url"),
+                        "api_key": runtime.get("api_key"),
+                        "api_mode": runtime.get("api_mode"),
+                        "command": runtime.get("command"),
+                        "args": runtime.get("args"),
+                    }
+                except Exception as exc:
+                    return tool_error(f"Task {i} credential resolution failed: {exc}")
+
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
+                override_reasoning_effort=task_reasoning,
                 override_acp_command=t.get("acp_command")
                 or acp_command
-                or creds.get("command"),
+                or task_creds.get("command"),
                 override_acp_args=(
                     task_acp_args
                     if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
+                    else (acp_args if acp_args is not None else task_creds.get("args"))
                 ),
                 role=effective_role,
             )
@@ -2323,7 +2386,12 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
-        runtime = resolve_runtime_provider(requested=configured_provider, target_model=configured_model)
+        runtime = resolve_runtime_provider(
+            requested=configured_provider,
+            target_model=configured_model,
+            explicit_api_key=configured_api_key,
+            explicit_base_url=configured_base_url,
+        )
     except Exception as exc:
         raise ValueError(
             f"Cannot resolve delegation provider '{configured_provider}': {exc}. "
@@ -2450,6 +2518,19 @@ DELEGATE_TASK_SCHEMA = {
                     "specific you are, the better the subagent performs."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": "Per-task model override (e.g. 'gpt-4o', 'claude-3-5-sonnet').",
+            },
+            "provider": {
+                "type": "string",
+                "description": "Per-task provider override (e.g. 'openrouter', 'nous', 'zai', 'opencode-go').",
+            },
+            "reasoning_effort": {
+                "type": "string",
+                "enum": ["low", "medium", "high", "none"],
+                "description": "Per-task reasoning effort override (for models that support it).",
+            },
             "toolsets": {
                 "type": "array",
                 "items": {"type": "string"},
@@ -2471,6 +2552,19 @@ DELEGATE_TASK_SCHEMA = {
                         "context": {
                             "type": "string",
                             "description": "Task-specific context",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": "Per-task model override (e.g. 'gpt-4o', 'claude-3-5-sonnet').",
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": "Per-task provider override (e.g. 'openrouter', 'nous', 'zai', 'opencode-go').",
+                        },
+                        "reasoning_effort": {
+                            "type": "string",
+                            "enum": ["low", "medium", "high", "none"],
+                            "description": "Per-task reasoning effort override (for models that support it).",
                         },
                         "toolsets": {
                             "type": "array",


### PR DESCRIPTION
  What does this PR do?
  This PR fixes a critical "double-bug" in the delegation system that causes subagents to fail credential resolution and hit HTTP 404 errors on providers with mixed
  API surfaces (like OpenCode Go). It also enhances the delegate_task tool to support per-task model, provider, and reasoning overrides, which were previously ignored
  or unsupported.

  The fix ensures that:
   1. Local .env variables are correctly detected during provider auto-discovery.
   2. Config overrides (api_key, base_url) in the delegation: section are actually honored.
   3. Subagents re-derive their API mode (OpenAI vs Anthropic) based on their specific model, preventing URL-stripping conflicts when switching between different model
      types on the same provider.

  Related Issue
  Fixes #20558

  Type of Change
   - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
   - [x] ✨ New feature (non-breaking change that adds functionality)

  Changes Made
   - hermes_cli/auth.py: Updated resolve_provider to use get_env_value() instead of os.getenv() for auto-detection, ensuring keys in local .env files are visible.
   - tools/delegate_tool.py:
       - Fixed _resolve_delegation_credentials to pass explicit_api_key and explicit_base_url to the runtime resolver.
       - Updated _build_child_agent to re-derive api_mode for OpenCode providers if the model differs from the parent.
       - Extended DELEGATE_TASK_SCHEMA and the task-building loop to support per-task model, provider, and reasoning_effort overrides.

  How to Test
   1. Credential Fix: Put an API key for a provider in a local .env file but NOT in the global ~/.hermes/.env. Attempt to delegate to that provider. Verify the
      subagent finds the key.
   2. OpenCode 404 Fix: Set the main agent to an Anthropic-style model on OpenCode (e.g., MiniMax) and delegate a task to an OpenAI-style model (e.g., DeepSeek).
      Verify the subagent correctly hits the /v1 endpoint instead of hitting a 404.
   3. Per-Task Overrides: Call delegate_task with a tasks array where one task specifies a different model or reasoning_effort. Verify (via logs or API monitoring)
      that the subagent is initialized with those specific settings.

  Checklist
   - [x] I've read the Contributing Guide
   - [x] My PR contains only changes related to this fix/feature
   - [x] I've tested on my platform: <!-- Insert your OS here, e.g., Ubuntu 24.04 or macOS -->
   - [x] I've updated tool descriptions/schemas as I changed tool behavior (updated DELEGATE_TASK_SCHEMA)

  Screenshots / Logs
  Before (404 Error):

   1 [subagent-0] ⚠️  API call failed (attempt 1/3): NotFoundError [HTTP 404]
   2 [subagent-0]    🔌 Provider: opencode-go  Model: deepseek-v4-pro
   3 [subagent-0]    🌐 Endpoint: https://opencode.ai/zen/go/v1
   4 [subagent-0]    📝 Error: HTTP 404 — Not Found | opencode
  (Caused by inheriting anthropic_messages mode and stripping /v1 from the URL)

  After (Success/Correct Routing):

   1 [subagent-0] ⚠️  API call failed (attempt 1/3): RateLimitError [HTTP 429]
   2 [subagent-0]    🔌 Provider: opencode-go  Model: deepseek-v4-flash
   3 [subagent-0]    🌐 Endpoint: https://opencode.ai/zen/go/v1
  (404 is gone; subagent is hitting the correct endpoint and receiving a valid [though rate-limited] response from the model)