### PR TITLE
feat(api-server): add local websocket bridge for agent clients

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1510,10 +1510,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     api_server_cors_origins = os.getenv("API_SERVER_CORS_ORIGINS", "")
     api_server_port = os.getenv("API_SERVER_PORT")
     api_server_host = os.getenv("API_SERVER_HOST")
-    if api_server_enabled or api_server_key:
+    api_server_ws_enabled = os.getenv("API_SERVER_WS_ENABLED", "").lower() in ("true", "1", "yes")
+    if api_server_enabled or api_server_key or api_server_ws_enabled:
         if Platform.API_SERVER not in config.platforms:
             config.platforms[Platform.API_SERVER] = PlatformConfig()
         config.platforms[Platform.API_SERVER].enabled = True
+        if api_server_ws_enabled:
+            config.platforms[Platform.API_SERVER].extra["ws_enabled"] = True
         if api_server_key:
             config.platforms[Platform.API_SERVER].extra["key"] = api_server_key
         if api_server_cors_origins:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -17,8 +17,9 @@ Exposes an HTTP server with endpoints:
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
 - GET  /v1/runs/{run_id}           — retrieve current run status
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
-- POST /v1/runs/{run_id}/approval — resolve a pending run approval
+- POST /v1/runs/{run_id}/approval  — resolve a pending run approval
 - POST /v1/runs/{run_id}/stop       — interrupt a running agent
+- GET  /v1/ws                      — optional JSON-frame WebSocket bridge
 - GET  /health                     — health check
 - GET  /health/detailed            — rich status for cross-container dashboard probing
 
@@ -46,10 +47,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 try:
-    from aiohttp import web
+    from aiohttp import WSMsgType, web
     AIOHTTP_AVAILABLE = True
 except ImportError:
     AIOHTTP_AVAILABLE = False
+    WSMsgType = None  # type: ignore[assignment]
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
@@ -105,6 +107,27 @@ def _coerce_request_bool(value: Any, default: bool = False) -> bool:
         return default
     if isinstance(value, (int, float)):
         return bool(value)
+    return default
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    """Parse common env/config boolean spellings.
+
+    Used for env/config flags such as ``API_SERVER_WS_ENABLED`` that gate the
+    optional WebSocket bridge.
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
     return default
 
 
@@ -725,6 +748,10 @@ class APIServerAdapter(BasePlatformAdapter):
         self._model_name: str = self._resolve_model_name(
             extra.get("model_name", os.getenv("API_SERVER_MODEL_NAME", "")),
         )
+        self._ws_enabled: bool = _coerce_bool(
+            extra.get("ws_enabled", os.getenv("API_SERVER_WS_ENABLED")),
+            default=False,
+        )
         self._app: Optional["web.Application"] = None
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
@@ -1102,6 +1129,32 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
+        endpoints = {
+            "health": {"method": "GET", "path": "/health"},
+            "health_detailed": {"method": "GET", "path": "/health/detailed"},
+            "models": {"method": "GET", "path": "/v1/models"},
+            "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
+            "responses": {"method": "POST", "path": "/v1/responses"},
+            "runs": {"method": "POST", "path": "/v1/runs"},
+            "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
+            "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
+            "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
+            "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
+            "skills": {"method": "GET", "path": "/v1/skills"},
+            "toolsets": {"method": "GET", "path": "/v1/toolsets"},
+            "sessions": {"method": "GET", "path": "/api/sessions"},
+            "session_create": {"method": "POST", "path": "/api/sessions"},
+            "session": {"method": "GET", "path": "/api/sessions/{session_id}"},
+            "session_update": {"method": "PATCH", "path": "/api/sessions/{session_id}"},
+            "session_delete": {"method": "DELETE", "path": "/api/sessions/{session_id}"},
+            "session_messages": {"method": "GET", "path": "/api/sessions/{session_id}/messages"},
+            "session_fork": {"method": "POST", "path": "/api/sessions/{session_id}/fork"},
+            "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat"},
+            "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
+        }
+        if self._ws_enabled:
+            endpoints["websocket_bridge"] = {"method": "GET", "path": "/v1/ws"}
+
         return web.json_response({
             "object": "hermes.api_server.capabilities",
             "platform": "hermes-agent",
@@ -1142,33 +1195,12 @@ class APIServerAdapter(BasePlatformAdapter):
                 "skills_api": True,
                 "audio_api": False,
                 "realtime_voice": False,
+                "websocket_bridge": self._ws_enabled,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
                 "cors": bool(self._cors_origins),
             },
-            "endpoints": {
-                "health": {"method": "GET", "path": "/health"},
-                "health_detailed": {"method": "GET", "path": "/health/detailed"},
-                "models": {"method": "GET", "path": "/v1/models"},
-                "chat_completions": {"method": "POST", "path": "/v1/chat/completions"},
-                "responses": {"method": "POST", "path": "/v1/responses"},
-                "runs": {"method": "POST", "path": "/v1/runs"},
-                "run_status": {"method": "GET", "path": "/v1/runs/{run_id}"},
-                "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
-                "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
-                "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
-                "skills": {"method": "GET", "path": "/v1/skills"},
-                "toolsets": {"method": "GET", "path": "/v1/toolsets"},
-                "sessions": {"method": "GET", "path": "/api/sessions"},
-                "session_create": {"method": "POST", "path": "/api/sessions"},
-                "session": {"method": "GET", "path": "/api/sessions/{session_id}"},
-                "session_update": {"method": "PATCH", "path": "/api/sessions/{session_id}"},
-                "session_delete": {"method": "DELETE", "path": "/api/sessions/{session_id}"},
-                "session_messages": {"method": "GET", "path": "/api/sessions/{session_id}/messages"},
-                "session_fork": {"method": "POST", "path": "/api/sessions/{session_id}/fork"},
-                "session_chat": {"method": "POST", "path": "/api/sessions/{session_id}/chat"},
-                "session_chat_stream": {"method": "POST", "path": "/api/sessions/{session_id}/chat/stream"},
-            },
+            "endpoints": endpoints,
         })
 
     async def _handle_skills(self, request: "web.Request") -> "web.Response":
@@ -1692,6 +1724,280 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("[api_server] session SSE stream error: %s", exc)
         return response
+
+    @staticmethod
+    def _ws_error(frame_id: Any, code: str, message: str) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "type": "agent.message.error",
+            "code": code,
+            "message": message,
+        }
+        if frame_id is not None:
+            payload["id"] = frame_id
+        return payload
+
+    @staticmethod
+    def _ws_frame_id(frame: Any) -> Any:
+        return frame.get("id") if isinstance(frame, dict) else None
+
+    async def _ws_send_error(self, ws: "web.WebSocketResponse", frame_id: Any, code: str, message: str) -> None:
+        await ws.send_json(self._ws_error(frame_id, code, message))
+
+    async def _handle_ws_status(self, ws: "web.WebSocketResponse", frame: Dict[str, Any]) -> None:
+        await ws.send_json({
+            "id": frame.get("id"),
+            "type": "status.result",
+            "status": "ok",
+            "platform": "hermes-agent",
+            "model": self._model_name,
+            "auth_required": bool(self._api_key),
+            "websocket_bridge": True,
+        })
+
+    async def _handle_ws_session_list(self, ws: "web.WebSocketResponse", frame: Dict[str, Any]) -> None:
+        db = self._ensure_session_db()
+        if db is None:
+            await self._ws_send_error(ws, frame.get("id"), "session_db_unavailable", "Session database unavailable")
+            return
+
+        try:
+            limit = max(1, min(100, int(frame.get("limit", 20))))
+            offset = max(0, int(frame.get("offset", 0)))
+        except (TypeError, ValueError):
+            await self._ws_send_error(ws, frame.get("id"), "invalid_request", "limit and offset must be integers")
+            return
+
+        sessions = db.list_sessions_rich(limit=limit, offset=offset)
+        await ws.send_json({
+            "id": frame.get("id"),
+            "type": "session.list.result",
+            "sessions": sessions,
+        })
+
+    async def _handle_ws_session_get(self, ws: "web.WebSocketResponse", frame: Dict[str, Any]) -> None:
+        session_id = str(frame.get("session_id") or "").strip()
+        if not session_id:
+            await self._ws_send_error(ws, frame.get("id"), "invalid_request", "session_id is required")
+            return
+
+        db = self._ensure_session_db()
+        if db is None:
+            await self._ws_send_error(ws, frame.get("id"), "session_db_unavailable", "Session database unavailable")
+            return
+
+        session = db.get_session(session_id)
+        if not session:
+            await self._ws_send_error(ws, frame.get("id"), "session_not_found", "Session not found")
+            return
+
+        await ws.send_json({
+            "id": frame.get("id"),
+            "type": "session.get.result",
+            "session": session,
+            "messages": db.get_messages(session_id),
+        })
+
+    async def _handle_ws_session_reset(self, ws: "web.WebSocketResponse", frame: Dict[str, Any]) -> None:
+        session_id = str(frame.get("session_id") or "").strip()
+        if not session_id:
+            await self._ws_send_error(ws, frame.get("id"), "invalid_request", "session_id is required")
+            return
+
+        db = self._ensure_session_db()
+        if db is None:
+            await self._ws_send_error(ws, frame.get("id"), "session_db_unavailable", "Session database unavailable")
+            return
+
+        if not db.get_session(session_id):
+            await self._ws_send_error(ws, frame.get("id"), "session_not_found", "Session not found")
+            return
+
+        db.clear_messages(session_id)
+        await ws.send_json({
+            "id": frame.get("id"),
+            "type": "session.reset.result",
+            "session_id": session_id,
+            "ok": True,
+        })
+
+    async def _run_ws_agent_message(
+        self,
+        ws: "web.WebSocketResponse",
+        frame: Dict[str, Any],
+        active_agents: Dict[str, Any],
+    ) -> None:
+        frame_id = frame.get("id")
+        text = frame.get("text")
+        if not isinstance(text, str) or not text.strip():
+            await self._ws_send_error(ws, frame_id, "invalid_request", "text is required")
+            return
+
+        session_id = str(frame.get("session_id") or "").strip() or f"ws_{uuid.uuid4().hex}"
+        raw_history = frame.get("conversation_history") or []
+        if not isinstance(raw_history, list):
+            await self._ws_send_error(ws, frame_id, "invalid_request", "conversation_history must be an array")
+            return
+
+        conversation_history: List[Dict[str, str]] = []
+        for i, entry in enumerate(raw_history):
+            if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
+                await self._ws_send_error(
+                    ws,
+                    frame_id,
+                    "invalid_request",
+                    f"conversation_history[{i}] must have role and content",
+                )
+                return
+            conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+
+        loop = asyncio.get_running_loop()
+        delta_q: "asyncio.Queue[Optional[Dict[str, Any]]]" = asyncio.Queue()
+
+        def _text_cb(delta: Optional[str]) -> None:
+            if delta is None:
+                return
+            try:
+                loop.call_soon_threadsafe(delta_q.put_nowait, {
+                    "id": frame_id,
+                    "type": "agent.message.delta",
+                    "session_id": session_id,
+                    "delta": delta,
+                })
+            except Exception:
+                pass
+
+        async def _drain_deltas() -> None:
+            while True:
+                item = await delta_q.get()
+                if item is None:
+                    return
+                if not ws.closed:
+                    await ws.send_json(item)
+
+        drain_task = asyncio.create_task(_drain_deltas())
+        agent_key = str(frame_id or session_id)
+
+        try:
+            agent_ref = [None]
+            active_agents[agent_key] = agent_ref
+            result, usage = await self._run_agent(
+                user_message=text,
+                conversation_history=conversation_history,
+                ephemeral_system_prompt=frame.get("instructions") or None,
+                session_id=session_id,
+                stream_delta_callback=_text_cb,
+                agent_ref=agent_ref,
+                gateway_session_key=frame.get("session_key") or None,
+            )
+            await delta_q.put(None)
+            await drain_task
+
+            if isinstance(result, dict) and result.get("failed"):
+                await self._ws_send_error(
+                    ws,
+                    frame_id,
+                    "agent_run_failed",
+                    str(result.get("error") or "agent run failed"),
+                )
+                return
+
+            output = result.get("final_response", "") if isinstance(result, dict) else ""
+            await ws.send_json({
+                "id": frame_id,
+                "type": "agent.message.done",
+                "session_id": session_id,
+                "output": output,
+                "usage": usage,
+            })
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.exception("[api_server] WebSocket agent message failed")
+            if not ws.closed:
+                await self._ws_send_error(ws, frame_id, "agent_run_failed", str(exc))
+        finally:
+            active_agents.pop(agent_key, None)
+            try:
+                delta_q.put_nowait(None)
+            except Exception:
+                pass
+            if not drain_task.done():
+                drain_task.cancel()
+                try:
+                    await drain_task
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+    async def _handle_ws(self, request: "web.Request") -> "web.StreamResponse":
+        """GET /v1/ws — JSON-frame WebSocket bridge for local/mobile clients."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        origin = request.headers.get("Origin", "")
+        if not self._origin_allowed(origin):
+            return web.json_response(
+                {"error": {"message": "Origin not allowed", "type": "invalid_request_error"}},
+                status=403,
+            )
+
+        ws = web.WebSocketResponse(heartbeat=30.0)
+        await ws.prepare(request)
+
+        active_tasks: set[asyncio.Task] = set()
+        active_agents: Dict[str, Any] = {}
+
+        try:
+            async for msg in ws:
+                if msg.type == WSMsgType.TEXT:
+                    try:
+                        frame = json.loads(msg.data)
+                    except json.JSONDecodeError:
+                        await self._ws_send_error(ws, None, "invalid_json", "Invalid JSON frame")
+                        continue
+
+                    if not isinstance(frame, dict):
+                        await self._ws_send_error(ws, None, "invalid_frame", "Frame must be a JSON object")
+                        continue
+
+                    frame_type = frame.get("type")
+                    if frame_type == "status.get":
+                        await self._handle_ws_status(ws, frame)
+                    elif frame_type == "session.list":
+                        await self._handle_ws_session_list(ws, frame)
+                    elif frame_type == "session.get":
+                        await self._handle_ws_session_get(ws, frame)
+                    elif frame_type == "session.reset":
+                        await self._handle_ws_session_reset(ws, frame)
+                    elif frame_type == "agent.message.send":
+                        task = asyncio.create_task(self._run_ws_agent_message(ws, frame, active_agents))
+                        active_tasks.add(task)
+                        task.add_done_callback(active_tasks.discard)
+                    else:
+                        await self._ws_send_error(
+                            ws,
+                            self._ws_frame_id(frame),
+                            "unknown_type",
+                            f"Unknown frame type: {frame_type}",
+                        )
+                elif msg.type == WSMsgType.ERROR:
+                    logger.debug("[api_server] WebSocket closed with exception: %s", ws.exception())
+        finally:
+            for agent_ref in list(active_agents.values()):
+                try:
+                    agent = agent_ref[0] if isinstance(agent_ref, list) else agent_ref
+                    if agent is None:
+                        continue
+                    agent.interrupt("WebSocket client disconnected")
+                except Exception:
+                    pass
+            for task in list(active_tasks):
+                if not task.done():
+                    task.cancel()
+            if active_tasks:
+                await asyncio.gather(*active_tasks, return_exceptions=True)
+
+        return ws
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
@@ -4158,6 +4464,9 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)
             self._app.router.add_post("/v1/runs/{run_id}/approval", self._handle_run_approval)
             self._app.router.add_post("/v1/runs/{run_id}/stop", self._handle_stop_run)
+            # Optional WebSocket bridge for local/mobile clients (gated by API_SERVER_WS_ENABLED)
+            if self._ws_enabled:
+                self._app.router.add_get("/v1/ws", self._handle_ws)
             # Store the adapter after native routes are registered. Local Hermes-Relay
             # bootstrap shims use this key as a feature-detection hook; registering
             # native routes first lets those shims no-op instead of shadowing the

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -71,6 +71,7 @@ MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversation
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+WS_CONVERSATION_HISTORY_ROLES = frozenset({"user", "assistant", "system"})
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -1760,13 +1761,17 @@ class APIServerAdapter(BasePlatformAdapter):
             await self._ws_send_error(ws, frame.get("id"), "session_db_unavailable", "Session database unavailable")
             return
 
-        try:
-            limit = max(1, min(100, int(frame.get("limit", 20))))
-            offset = max(0, int(frame.get("offset", 0)))
-        except (TypeError, ValueError):
-            await self._ws_send_error(ws, frame.get("id"), "invalid_request", "limit and offset must be integers")
+        limit_value = frame.get("limit", 20)
+        offset_value = frame.get("offset", 0)
+        if not isinstance(limit_value, int):
+            await self._ws_send_error(ws, frame.get("id"), "invalid_request", "limit must be an integer")
+            return
+        if not isinstance(offset_value, int):
+            await self._ws_send_error(ws, frame.get("id"), "invalid_request", "offset must be an integer")
             return
 
+        limit = max(1, min(100, limit_value))
+        offset = max(0, offset_value)
         sessions = db.list_sessions_rich(limit=limit, offset=offset)
         await ws.send_json({
             "id": frame.get("id"),
@@ -1848,7 +1853,16 @@ class APIServerAdapter(BasePlatformAdapter):
                     f"conversation_history[{i}] must have role and content",
                 )
                 return
-            conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+            role = str(entry["role"])
+            if role not in WS_CONVERSATION_HISTORY_ROLES:
+                await self._ws_send_error(
+                    ws,
+                    frame_id,
+                    "invalid_request",
+                    f"conversation_history[{i}] role must be one of {sorted(WS_CONVERSATION_HISTORY_ROLES)}",
+                )
+                return
+            conversation_history.append({"role": role, "content": str(entry["content"])})
 
         loop = asyncio.get_running_loop()
         delta_q: "asyncio.Queue[Optional[Dict[str, Any]]]" = asyncio.Queue()
@@ -1982,6 +1996,16 @@ class APIServerAdapter(BasePlatformAdapter):
                         )
                 elif msg.type == WSMsgType.ERROR:
                     logger.debug("[api_server] WebSocket closed with exception: %s", ws.exception())
+                    if not ws.closed:
+                        try:
+                            await self._ws_send_error(
+                                ws,
+                                None,
+                                "connection_error",
+                                str(ws.exception() or "WebSocket connection error"),
+                            )
+                        except Exception:
+                            pass
         finally:
             for agent_ref in list(active_agents.values()):
                 try:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -262,6 +262,7 @@ class TestAdapterInit:
         assert adapter._host == "127.0.0.1"
         assert adapter._port == 8642
         assert adapter._api_key == ""
+        assert adapter._ws_enabled is False
         assert adapter.platform == Platform.API_SERVER
 
     def test_custom_config_from_extra(self):
@@ -272,6 +273,7 @@ class TestAdapterInit:
                 "port": 9999,
                 "key": "sk-test",
                 "cors_origins": ["http://localhost:3000"],
+                "ws_enabled": True,
             },
         )
         adapter = APIServerAdapter(config)
@@ -279,12 +281,14 @@ class TestAdapterInit:
         assert adapter._port == 9999
         assert adapter._api_key == "sk-test"
         assert adapter._cors_origins == ("http://localhost:3000",)
+        assert adapter._ws_enabled is True
 
     def test_config_from_env(self, monkeypatch):
         monkeypatch.setenv("API_SERVER_HOST", "10.0.0.1")
         monkeypatch.setenv("API_SERVER_PORT", "7777")
         monkeypatch.setenv("API_SERVER_KEY", "sk-env")
         monkeypatch.setenv("API_SERVER_CORS_ORIGINS", "http://localhost:3000, http://127.0.0.1:3000")
+        monkeypatch.setenv("API_SERVER_WS_ENABLED", "true")
         config = PlatformConfig(enabled=True)
         adapter = APIServerAdapter(config)
         assert adapter._host == "10.0.0.1"
@@ -294,6 +298,7 @@ class TestAdapterInit:
             "http://localhost:3000",
             "http://127.0.0.1:3000",
         )
+        assert adapter._ws_enabled is True
 
     def test_invalid_port_from_env_falls_back_to_default(self, monkeypatch):
         monkeypatch.setenv("API_SERVER_PORT", "not-a-port")
@@ -656,10 +661,22 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["websocket_bridge"] is False
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}
             assert data["endpoints"]["toolsets"] == {"method": "GET", "path": "/v1/toolsets"}
+
+    @pytest.mark.asyncio
+    async def test_capabilities_advertises_websocket_when_enabled(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True, extra={"ws_enabled": True}))
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["features"]["websocket_bridge"] is True
+            assert data["endpoints"]["websocket_bridge"] == {"method": "GET", "path": "/v1/ws"}
 
     @pytest.mark.asyncio
     async def test_capabilities_requires_auth_when_key_configured(self, auth_adapter):
@@ -2450,6 +2467,14 @@ class TestConfigIntegration:
             "http://localhost:3000",
             "http://127.0.0.1:3000",
         ]
+
+    def test_env_override_websocket_enabled(self, monkeypatch):
+        monkeypatch.setenv("API_SERVER_WS_ENABLED", "true")
+        from gateway.config import load_gateway_config
+        config = load_gateway_config()
+        assert Platform.API_SERVER in config.platforms
+        assert config.platforms[Platform.API_SERVER].enabled is True
+        assert config.platforms[Platform.API_SERVER].extra.get("ws_enabled") is True
 
     def test_api_server_in_connected_platforms(self):
         config = GatewayConfig()

--- a/tests/gateway/test_api_server_websocket.py
+++ b/tests/gateway/test_api_server_websocket.py
@@ -1,0 +1,260 @@
+"""Tests for the API server WebSocket bridge."""
+
+import asyncio
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import WSServerHandshakeError, web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    cors_middleware,
+    security_headers_middleware,
+)
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {"ws_enabled": True}
+    if api_key:
+        extra["key"] = api_key
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_ws_app(adapter: APIServerAdapter) -> web.Application:
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/v1/ws", adapter._handle_ws)
+    return app
+
+
+async def _read_until_type(ws, frame_type: str, *, limit: int = 10):
+    for _ in range(limit):
+        frame = await ws.receive_json(timeout=3)
+        if frame.get("type") == frame_type:
+            return frame
+    raise AssertionError(f"Did not receive frame type {frame_type!r}")
+
+
+@pytest.fixture
+def adapter():
+    return _make_adapter()
+
+
+@pytest.fixture
+def auth_adapter():
+    return _make_adapter(api_key="sk-secret")
+
+
+class TestWebSocketAuth:
+    @pytest.mark.asyncio
+    async def test_websocket_requires_bearer_auth_when_key_configured(self, auth_adapter):
+        app = _create_ws_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with pytest.raises(WSServerHandshakeError) as exc:
+                await cli.ws_connect("/v1/ws")
+            assert exc.value.status == 401
+
+            ws = await cli.ws_connect(
+                "/v1/ws",
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            await ws.close()
+
+
+class TestWebSocketStatus:
+    @pytest.mark.asyncio
+    async def test_status_get_returns_bridge_status(self, adapter):
+        app = _create_ws_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            ws = await cli.ws_connect("/v1/ws")
+            await ws.send_json({"id": "status-1", "type": "status.get"})
+
+            frame = await ws.receive_json(timeout=3)
+            assert frame["id"] == "status-1"
+            assert frame["type"] == "status.result"
+            assert frame["status"] == "ok"
+            assert frame["model"] == "hermes-agent"
+            assert frame["auth_required"] is False
+            await ws.close()
+
+
+class TestWebSocketAgentMessage:
+    @pytest.mark.asyncio
+    async def test_message_send_streams_deltas_and_done(self, adapter):
+        app = _create_ws_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+
+                def _run_conversation(user_message=None, conversation_history=None, task_id=None):
+                    callback = mock_create.call_args.kwargs["stream_delta_callback"]
+                    callback("Hel")
+                    callback("lo")
+                    return {"final_response": "Hello"}
+
+                mock_agent.run_conversation.side_effect = _run_conversation
+                mock_agent.session_prompt_tokens = 3
+                mock_agent.session_completion_tokens = 2
+                mock_agent.session_total_tokens = 5
+                mock_create.return_value = mock_agent
+
+                ws = await cli.ws_connect("/v1/ws")
+                await ws.send_json({
+                    "id": "msg-1",
+                    "type": "agent.message.send",
+                    "text": "hello",
+                    "session_id": "mobile-session",
+                })
+
+                first_delta = await _read_until_type(ws, "agent.message.delta")
+                second_delta = await _read_until_type(ws, "agent.message.delta")
+                done = await _read_until_type(ws, "agent.message.done")
+
+                assert first_delta["id"] == "msg-1"
+                assert first_delta["delta"] == "Hel"
+                assert second_delta["delta"] == "lo"
+                assert done["id"] == "msg-1"
+                assert done["output"] == "Hello"
+                assert done["usage"] == {
+                    "input_tokens": 3,
+                    "output_tokens": 2,
+                    "total_tokens": 5,
+                }
+                mock_agent.run_conversation.assert_called_once_with(
+                    user_message="hello",
+                    conversation_history=[],
+                    task_id="mobile-session",
+                )
+                await ws.close()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_interrupts_running_agent(self, adapter):
+        app = _create_ws_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                ready = threading.Event()
+                interrupted = threading.Event()
+                mock_agent = MagicMock()
+
+                def _interrupt(message=None):
+                    interrupted.set()
+
+                def _run_conversation(user_message=None, conversation_history=None, task_id=None):
+                    ready.set()
+                    interrupted.wait(timeout=5)
+                    return {"final_response": "stopped"}
+
+                mock_agent.interrupt.side_effect = _interrupt
+                mock_agent.run_conversation.side_effect = _run_conversation
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                ws = await cli.ws_connect("/v1/ws")
+                await ws.send_json({"id": "msg-1", "type": "agent.message.send", "text": "hello"})
+                for _ in range(60):
+                    if ready.is_set():
+                        break
+                    await asyncio.sleep(0.05)
+                assert ready.is_set()
+
+                await ws.close()
+                for _ in range(20):
+                    if interrupted.is_set():
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert interrupted.is_set()
+                mock_agent.interrupt.assert_called_once_with("WebSocket client disconnected")
+
+
+class TestWebSocketSessions:
+    @pytest.mark.asyncio
+    async def test_session_list_and_get_use_session_db(self, adapter):
+        fake_db = MagicMock()
+        fake_db.list_sessions_rich.return_value = [
+            {"id": "session-1", "title": "Mobile", "message_count": 2}
+        ]
+        fake_db.get_session.return_value = {"id": "session-1", "source": "api_server"}
+        fake_db.get_messages.return_value = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        adapter._session_db = fake_db
+
+        app = _create_ws_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            ws = await cli.ws_connect("/v1/ws")
+
+            await ws.send_json({"id": "list-1", "type": "session.list", "limit": 5})
+            listed = await ws.receive_json(timeout=3)
+            assert listed == {
+                "id": "list-1",
+                "type": "session.list.result",
+                "sessions": [{"id": "session-1", "title": "Mobile", "message_count": 2}],
+            }
+            fake_db.list_sessions_rich.assert_called_once_with(limit=5, offset=0)
+
+            await ws.send_json({"id": "get-1", "type": "session.get", "session_id": "session-1"})
+            got = await ws.receive_json(timeout=3)
+            assert got["id"] == "get-1"
+            assert got["type"] == "session.get.result"
+            assert got["session"]["id"] == "session-1"
+            assert got["messages"] == [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+            ]
+            await ws.close()
+
+    @pytest.mark.asyncio
+    async def test_session_reset_clears_messages(self, adapter):
+        fake_db = MagicMock()
+        fake_db.get_session.return_value = {"id": "session-1", "source": "api_server"}
+        adapter._session_db = fake_db
+
+        app = _create_ws_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            ws = await cli.ws_connect("/v1/ws")
+            await ws.send_json({"id": "reset-1", "type": "session.reset", "session_id": "session-1"})
+
+            frame = await ws.receive_json(timeout=3)
+            assert frame == {
+                "id": "reset-1",
+                "type": "session.reset.result",
+                "session_id": "session-1",
+                "ok": True,
+            }
+            fake_db.clear_messages.assert_called_once_with("session-1")
+            await ws.close()
+
+
+class TestWebSocketErrors:
+    @pytest.mark.asyncio
+    async def test_malformed_json_returns_error_frame(self, adapter):
+        app = _create_ws_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            ws = await cli.ws_connect("/v1/ws")
+            await ws.send_str("{not-json")
+
+            frame = await ws.receive_json(timeout=3)
+            assert frame["type"] == "agent.message.error"
+            assert frame["code"] == "invalid_json"
+            await ws.close()
+
+    @pytest.mark.asyncio
+    async def test_unknown_type_returns_error_frame(self, adapter):
+        app = _create_ws_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            ws = await cli.ws_connect("/v1/ws")
+            await ws.send_json({"id": "bad-1", "type": "unknown.type"})
+
+            frame = await ws.receive_json(timeout=3)
+            assert frame["id"] == "bad-1"
+            assert frame["type"] == "agent.message.error"
+            assert frame["code"] == "unknown_type"
+            await ws.close()

--- a/tests/gateway/test_api_server_websocket.py
+++ b/tests/gateway/test_api_server_websocket.py
@@ -172,6 +172,27 @@ class TestWebSocketAgentMessage:
                 assert interrupted.is_set()
                 mock_agent.interrupt.assert_called_once_with("WebSocket client disconnected")
 
+    @pytest.mark.asyncio
+    async def test_message_send_rejects_unknown_history_role(self, adapter):
+        app = _create_ws_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                ws = await cli.ws_connect("/v1/ws")
+                await ws.send_json({
+                    "id": "msg-2",
+                    "type": "agent.message.send",
+                    "text": "hello",
+                    "conversation_history": [{"role": "tool", "content": "not allowed"}],
+                })
+
+                frame = await ws.receive_json(timeout=3)
+                assert frame["id"] == "msg-2"
+                assert frame["type"] == "agent.message.error"
+                assert frame["code"] == "invalid_request"
+                assert "conversation_history[0] role" in frame["message"]
+                mock_create.assert_not_called()
+                await ws.close()
+
 
 class TestWebSocketSessions:
     @pytest.mark.asyncio
@@ -209,6 +230,26 @@ class TestWebSocketSessions:
                 {"role": "user", "content": "hello"},
                 {"role": "assistant", "content": "hi"},
             ]
+            await ws.close()
+
+    @pytest.mark.asyncio
+    async def test_session_list_rejects_non_integer_limit(self, adapter):
+        fake_db = MagicMock()
+        adapter._session_db = fake_db
+
+        app = _create_ws_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            ws = await cli.ws_connect("/v1/ws")
+
+            await ws.send_json({"id": "list-2", "type": "session.list", "limit": "5"})
+            frame = await ws.receive_json(timeout=3)
+            assert frame == {
+                "id": "list-2",
+                "type": "agent.message.error",
+                "code": "invalid_request",
+                "message": "limit must be an integer",
+            }
+            fake_db.list_sessions_rich.assert_not_called()
             await ws.close()
 
     @pytest.mark.asyncio

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -417,6 +417,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `API_SERVER_PORT` | Port for the API server (default: `8642`) |
 | `API_SERVER_HOST` | Host/bind address for the API server (default: `127.0.0.1`). `API_SERVER_KEY` is still required on loopback; use a narrow `API_SERVER_CORS_ORIGINS` allowlist for browser access. |
 | `API_SERVER_MODEL_NAME` | Model name advertised on `/v1/models`. Defaults to the profile name (or `hermes-agent` for the default profile). Useful for multi-user setups where frontends like Open WebUI need distinct model names per connection. |
+| `API_SERVER_WS_ENABLED` | Enable the `/v1/ws` WebSocket bridge for local/mobile clients (`true`/`false`, default: `false`). Uses the same bearer auth as the API server. |
 | `GATEWAY_PROXY_URL` | URL of a remote Hermes API server to forward messages to ([proxy mode](/user-guide/messaging/matrix#proxy-mode-e2ee-on-macos)). When set, the gateway handles platform I/O only — all agent work is delegated to the remote server. Also configurable via `gateway.proxy_url` in `config.yaml`. |
 | `GATEWAY_PROXY_KEY` | Bearer token for authenticating with the remote API server in proxy mode. Must match `API_SERVER_KEY` on the remote host. |
 | `MESSAGING_CWD` | Deprecated compatibility fallback for gateway working directory. Prefer `terminal.cwd` in `config.yaml`. |

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -25,6 +25,8 @@ API_SERVER_ENABLED=true
 API_SERVER_KEY=change-me-local-dev
 # Optional: only if a browser must call Hermes directly
 # API_SERVER_CORS_ORIGINS=http://localhost:3000
+# Optional: bidirectional bridge for local/mobile clients
+# API_SERVER_WS_ENABLED=true
 ```
 
 ### 2. Start the gateway
@@ -214,7 +216,8 @@ Returns a machine-readable description of the API server's stable surface for ex
     "run_submission": true,
     "run_status": true,
     "run_events_sse": true,
-    "run_stop": true
+    "run_stop": true,
+    "websocket_bridge": false
   }
 }
 ```
@@ -275,6 +278,86 @@ Interrupt a running agent turn. The endpoint returns immediately with `{"status"
 ### POST /v1/runs/\{run_id\}/approval
 
 Resolve a pending approval for a run that is waiting on a human decision (for example, a tool call gated behind an approval policy). The body carries the approval decision; the run resumes once the decision is recorded. This endpoint is advertised in `/v1/capabilities` as the `run_approval` feature so external UIs can detect support before surfacing an approval prompt.
+
+## WebSocket Bridge
+
+The optional WebSocket bridge exposes a small bidirectional JSON-frame protocol for local/mobile clients that need one long-lived connection instead of separate HTTP and SSE requests. It reuses the same API server model, toolsets, session database, and bearer auth.
+
+Enable it with:
+
+```bash
+API_SERVER_ENABLED=true
+API_SERVER_KEY=change-me-local-dev
+API_SERVER_WS_ENABLED=true
+```
+
+Connect to:
+
+```text
+ws://127.0.0.1:8642/v1/ws
+```
+
+When `API_SERVER_KEY` is configured, clients must send the same bearer token used by the HTTP API:
+
+```http
+Authorization: Bearer change-me-local-dev
+```
+
+### Frames
+
+Every client frame is a JSON object with a `type` field and optional `id`. Hermes echoes `id` on response frames so clients can correlate requests.
+
+Check bridge readiness:
+
+```json
+{"id": "status-1", "type": "status.get"}
+```
+
+Response:
+
+```json
+{
+  "id": "status-1",
+  "type": "status.result",
+  "status": "ok",
+  "platform": "hermes-agent",
+  "model": "hermes-agent",
+  "auth_required": true,
+  "websocket_bridge": true
+}
+```
+
+Send an agent message:
+
+```json
+{
+  "id": "msg-1",
+  "type": "agent.message.send",
+  "text": "Summarize my current project",
+  "session_id": "mobile-client"
+}
+```
+
+Streaming responses arrive as zero or more delta frames followed by one done frame:
+
+```json
+{"id": "msg-1", "type": "agent.message.delta", "session_id": "mobile-client", "delta": "The project"}
+{"id": "msg-1", "type": "agent.message.done", "session_id": "mobile-client", "output": "The project...", "usage": {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30}}
+```
+
+Session operations:
+
+```json
+{"id": "sessions-1", "type": "session.list", "limit": 20, "offset": 0}
+{"id": "session-1", "type": "session.get", "session_id": "mobile-client"}
+{"id": "reset-1", "type": "session.reset", "session_id": "mobile-client"}
+```
+
+Errors use a common frame:
+
+```json
+{"id": "msg-1", "type": "agent.message.error", "code": "invalid_request", "message": "text is required"}
+```
 
 ## Jobs API (background scheduled work)
 
@@ -406,6 +489,7 @@ The API server gives full access to hermes-agent's toolset, **including terminal
 | `API_SERVER_KEY` | _(required)_ | Bearer token for auth |
 | `API_SERVER_CORS_ORIGINS` | _(none)_ | Comma-separated allowed browser origins |
 | `API_SERVER_MODEL_NAME` | _(profile name)_ | Model name on `/v1/models`. Defaults to profile name, or `hermes-agent` for default profile. |
+| `API_SERVER_WS_ENABLED` | `false` | Enable the `/v1/ws` WebSocket bridge |
 
 ### config.yaml
 


### PR DESCRIPTION
## Summary
- Adds an opt-in `/v1/ws` WebSocket bridge for local/mobile agent clients, enabled by `API_SERVER_WS_ENABLED=true`.
- Reuses the API server bearer auth, CORS origin checks, `_run_agent` execution path, session DB, model/toolset config, and streaming delta callback path.
- Advertises WebSocket support from `/v1/capabilities` and documents the v1 JSON-frame protocol.

Refs #11712.

## Protocol
Client frames:
- `status.get`
- `agent.message.send`
- `session.list`
- `session.get`
- `session.reset`

Server frames:
- `status.result`
- `agent.message.delta`
- `agent.message.done`
- `agent.message.error`
- session result frames for list/get/reset

This is intentionally generic for local/mobile clients and does not add CoClaw, OcuClaw, or device-specific code.

## Tests
- `UV_CACHE_DIR=/tmp/uv-cache-hermes-pr uv run pytest tests/gateway/test_api_server_websocket.py tests/gateway/test_api_server_runs.py tests/gateway/test_api_server.py tests/gateway/test_api_server_bind_guard.py tests/gateway/test_weak_credential_guard.py -q` (193 passed)
- `UV_CACHE_DIR=/tmp/uv-cache-hermes-pr uv run python -m py_compile gateway/platforms/api_server.py gateway/config.py tests/gateway/test_api_server_websocket.py`
- `git diff --check`
- `UV_CACHE_DIR=/tmp/uv-cache-hermes-pr uv run pytest tests/gateway -q` (17 failed, 4603 passed, 53 skipped; failing tests are outside the API server/WebSocket path: DingTalk SDK/mock setup, Feishu bot admission, QQ redirect guard, Discord free-channel threading, WeCom cache write under read-only home, and goal-verdict delivery tests in this local environment)