### PR TITLE
fix(docker): make terminal cleanup remove containers reliably

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4264,17 +4264,22 @@ class HermesCLI:
         from /stop (clean up background processes). See openai/codex#14602.
         """
         from tools.process_registry import process_registry
+        from tools.terminal_tool import cleanup_all_environments
 
         processes = process_registry.list_sessions()
         running = [p for p in processes if p.get("status") == "running"]
 
-        if not running:
-            print("  No running background processes.")
-            return
+        if running:
+            print(f"  Stopping {len(running)} background process(es)...")
+            killed = process_registry.kill_all()
+            print(f"  ✅ Stopped {killed} process(es).")
 
-        print(f"  Stopping {len(running)} background process(es)...")
-        killed = process_registry.kill_all()
-        print(f"  ✅ Stopped {killed} process(es).")
+        cleaned = cleanup_all_environments()
+        if cleaned:
+            print(f"  Cleaned up {cleaned} terminal environment(s).")
+
+        if not running and not cleaned:
+            print("  No running background processes.")
 
     def _handle_agents_command(self):
         """Handle /agents — show background processes and agent status."""

--- a/tests/cli/test_stop_command_cleanup.py
+++ b/tests/cli/test_stop_command_cleanup.py
@@ -24,4 +24,3 @@ def test_stop_command_cleans_terminal_environments_without_background_processes(
     output = capsys.readouterr().out
     assert "Cleaned up 2 terminal environment(s)." in output
     assert "No running background processes." not in output
-

--- a/tests/cli/test_stop_command_cleanup.py
+++ b/tests/cli/test_stop_command_cleanup.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_stop_command_cleans_terminal_environments_without_background_processes(
+    monkeypatch, capsys
+):
+    import cli
+    import tools.terminal_tool as terminal_tool
+    from tools.process_registry import process_registry
+
+    monkeypatch.setattr(process_registry, "list_sessions", lambda: [])
+    monkeypatch.setattr(
+        process_registry,
+        "kill_all",
+        lambda: pytest.fail("kill_all should not run without active processes"),
+    )
+    monkeypatch.setattr(terminal_tool, "cleanup_all_environments", lambda: 2)
+
+    instance = cli.HermesCLI.__new__(cli.HermesCLI)
+    instance._handle_stop_command()
+
+    output = capsys.readouterr().out
+    assert "Cleaned up 2 terminal environment(s)." in output
+    assert "No running background processes." not in output
+

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1,8 +1,6 @@
 import logging
 from io import StringIO
 import subprocess
-import sys
-import types
 
 import pytest
 
@@ -203,25 +201,46 @@ def test_auto_mount_replaces_persistent_workspace_bind(monkeypatch, tmp_path):
 
 
 def test_non_persistent_cleanup_removes_container(monkeypatch):
-    """When persistent=false, cleanup() must schedule docker stop + rm."""
+    """When persistent=false, cleanup() must stop and remove the container."""
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
     calls = _mock_subprocess_run(monkeypatch)
-
-    popen_cmds = []
-    monkeypatch.setattr(
-        docker_env.subprocess, "Popen",
-        lambda cmd, **kw: (popen_cmds.append(cmd), type("P", (), {"poll": lambda s: 0, "wait": lambda s, **k: None, "returncode": 0, "stdout": iter([]), "stdin": None})())[1],
-    )
 
     env = _make_dummy_env(persistent_filesystem=False, task_id="ephemeral-task")
     assert env._container_id
     container_id = env._container_id
 
-    env.cleanup()
+    assert env.cleanup() is True
+    assert env._container_id is None
 
-    # Should have stop and rm calls via Popen
-    stop_cmds = [c for c in popen_cmds if container_id in str(c) and "stop" in str(c)]
-    assert len(stop_cmds) >= 1, f"cleanup() should schedule docker stop for {container_id}"
+    stop_cmds = [c for c, _ in calls if c[:3] == ["/usr/bin/docker", "stop", "-t"] and container_id in c]
+    rm_cmds = [c for c, _ in calls if c[:3] == ["/usr/bin/docker", "rm", "-f"] and container_id in c]
+    assert stop_cmds, f"cleanup() should stop {container_id}"
+    assert rm_cmds, f"cleanup() should remove {container_id}"
+
+
+def test_cleanup_reports_failure_and_keeps_container_id(monkeypatch):
+    """A failed docker rm must be visible to callers instead of losing tracking."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+
+    def _run(cmd, **kwargs):
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            if cmd[1] == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+            if cmd[1] == "run":
+                return subprocess.CompletedProcess(cmd, 0, stdout="fake-container-id\n", stderr="")
+            if cmd[1] == "stop":
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if cmd[1] == "rm":
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="daemon busy")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+
+    env = _make_dummy_env(persistent_filesystem=False, task_id="failed-cleanup-task")
+    container_id = env._container_id
+
+    assert env.cleanup() is False
+    assert env._container_id == container_id
 
 
 class _FakePopen:

--- a/tests/tools/test_terminal_environment_cleanup.py
+++ b/tests/tools/test_terminal_environment_cleanup.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from tools import terminal_tool
+
+
+class _FailingEnvironment:
+    def cleanup(self):
+        return False
+
+
+def test_cleanup_vm_retracks_environment_when_cleanup_fails():
+    """Failed cleanup should not make Hermes forget a live container."""
+    task_id = "cleanup-failed-task"
+    env = _FailingEnvironment()
+
+    with terminal_tool._env_lock:
+        terminal_tool._active_environments[task_id] = env
+        terminal_tool._last_activity[task_id] = 1.0
+
+    try:
+        assert terminal_tool.cleanup_vm(task_id) is False
+        with terminal_tool._env_lock:
+            assert terminal_tool._active_environments[task_id] is env
+            assert task_id in terminal_tool._last_activity
+    finally:
+        with terminal_tool._env_lock:
+            terminal_tool._active_environments.pop(task_id, None)
+            terminal_tool._last_activity.pop(task_id, None)

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -618,28 +618,48 @@ class DockerEnvironment(BaseEnvironment):
     def cleanup(self):
         """Stop and remove the container. Bind-mount dirs persist if persistent=True."""
         if self._container_id:
+            container_id = self._container_id
+            removed = False
             try:
-                # Stop in background so cleanup doesn't block
-                stop_cmd = (
-                    f"(timeout 60 {self._docker_exe} stop {self._container_id} || "
-                    f"{self._docker_exe} rm -f {self._container_id}) >/dev/null 2>&1 &"
+                subprocess.run(
+                    [self._docker_exe, "stop", "-t", "10", container_id],
+                    capture_output=True,
+                    text=True,
+                    timeout=20,
                 )
-                subprocess.Popen(stop_cmd, shell=True)
+            except subprocess.TimeoutExpired:
+                logger.warning("Timed out stopping Docker container %s", container_id)
             except Exception as e:
-                logger.warning("Failed to stop container %s: %s", self._container_id, e)
+                logger.warning("Failed to stop Docker container %s: %s", container_id, e)
 
-            if not self._persistent:
-                # Also schedule removal (stop only leaves it as stopped)
-                try:
-                    subprocess.Popen(
-                        f"sleep 3 && {self._docker_exe} rm -f {self._container_id} >/dev/null 2>&1 &",
-                        shell=True,
+            try:
+                result = subprocess.run(
+                    [self._docker_exe, "rm", "-f", container_id],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                stderr = (result.stderr or "").strip()
+                if result.returncode != 0 and "No such container" not in stderr:
+                    logger.warning(
+                        "Failed to remove Docker container %s: %s",
+                        container_id,
+                        stderr or result.returncode,
                     )
-                except Exception:
-                    pass
-            self._container_id = None
+                else:
+                    removed = True
+            except subprocess.TimeoutExpired:
+                logger.warning("Timed out removing Docker container %s", container_id)
+            except Exception as e:
+                logger.warning("Failed to remove Docker container %s: %s", container_id, e)
+
+            if removed:
+                self._container_id = None
+            else:
+                return False
 
         if not self._persistent:
             for d in (self._workspace_dir, self._home_dir):
                 if d:
                     shutil.rmtree(d, ignore_errors=True)
+        return True

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1292,12 +1292,15 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
             pass
 
         try:
+            cleanup_result = None
             if hasattr(env, 'cleanup'):
-                env.cleanup()
+                cleanup_result = env.cleanup()
             elif hasattr(env, 'stop'):
                 env.stop()
             elif hasattr(env, 'terminate'):
                 env.terminate()
+            if cleanup_result is False:
+                raise RuntimeError("environment cleanup reported failure")
 
             logger.info("Cleaned up inactive environment for task: %s", task_id)
 
@@ -1306,6 +1309,9 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
             if "404" in error_str or "not found" in error_str.lower():
                 logger.info("Environment for task %s already cleaned up", task_id)
             else:
+                with _env_lock:
+                    _active_environments.setdefault(task_id, env)
+                    _last_activity.setdefault(task_id, current_time)
                 logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
 
 
@@ -1379,8 +1385,8 @@ def cleanup_all_environments():
     
     for task_id in task_ids:
         try:
-            cleanup_vm(task_id)
-            cleaned += 1
+            if cleanup_vm(task_id):
+                cleaned += 1
         except Exception as e:
             logger.error("Error cleaning %s: %s", task_id, e, exc_info=True)
     
@@ -1421,24 +1427,32 @@ def cleanup_vm(task_id: str):
         pass
 
     if env is None:
-        return
+        return False
 
     try:
+        cleanup_result = None
         if hasattr(env, 'cleanup'):
-            env.cleanup()
+            cleanup_result = env.cleanup()
         elif hasattr(env, 'stop'):
             env.stop()
         elif hasattr(env, 'terminate'):
             env.terminate()
+        if cleanup_result is False:
+            raise RuntimeError("environment cleanup reported failure")
 
         logger.info("Manually cleaned up environment for task: %s", task_id)
+        return True
 
     except Exception as e:
         error_str = str(e)
         if "404" in error_str or "not found" in error_str.lower():
             logger.info("Environment for task %s already cleaned up", task_id)
         else:
+            with _env_lock:
+                _active_environments.setdefault(task_id, env)
+                _last_activity.setdefault(task_id, time.time())
             logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
+        return False
 
 
 def _atexit_cleanup():


### PR DESCRIPTION
## Summary
- make Docker environment cleanup stop and remove containers synchronously, with `docker rm -f` as the verified success point
- keep terminal environments tracked when cleanup reports failure so Hermes does not forget live containers and create duplicates
- have classic CLI `/stop` also clean active terminal environments, not only background process registry entries

Addresses #20561.

## Verification
- `scripts/run_tests.sh tests/tools/test_docker_environment.py tests/tools/test_terminal_environment_cleanup.py tests/cli/test_stop_command_cleanup.py` -> 26 passed, 4 existing warnings
- `python -m py_compile tools/environments/docker.py tools/terminal_tool.py cli.py tests/tools/test_terminal_environment_cleanup.py tests/cli/test_stop_command_cleanup.py`
- `git diff --check`

## Notes
- `ruff check` on the touched runtime files still reports pre-existing import-order findings in `cli.py` and `tools/terminal_tool.py`; no new lint-only cleanup is included here to keep the PR focused.