### PR TITLE
feat(skills): add firecrawl, tavily, exa-search research skills

### DIFF
--- a/skills/research/exa-search/SKILL.md
+++ b/skills/research/exa-search/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: exa-search
+description: "Use when you need semantic/neural web search that finds documents by meaning not just keywords, with highlighted query-relevant excerpts and date/domain filtering. Requires exa-py and EXA_API_KEY. Free tier: 1000 searches/mo."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [web, search, semantic, neural, highlights, research]
+    related_skills: [firecrawl, tavily]
+---
+
+# Exa Search
+
+Website: https://exa.ai | Docs: https://docs.exa.ai
+
+## When to Use
+
+* Searching for documents/pages by meaning rather than keyword matching
+* Research tasks needing highlighted excerpts showing matched content in context
+* Date-filtered news search (e.g. "after March 2026")
+* Finding similar pages to a known URL (semantic "more like this")
+* Structured output via `outputSchema` for data extraction pipelines
+
+**Trigger examples:**
+- "Find articles about AI model releases this month"
+- "Search for news on X with highlights"
+- "Find pages similar to this URL"
+- "Deep research on [topic] with citations"
+
+Exa's neural search understands intent and context, outperforming keyword search for nuanced queries. Its `highlights` feature is especially useful for citation-based work — each result comes back with query-relevant excerpts ready to reference.
+
+## Setup
+
+```bash
+pip install exa-py
+```
+
+Add to `~/.hermes/.env`:
+```
+EXA_API_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+```
+
+Free tier: 1000 searches/month. Dashboard: https://dashboard.exa.ai
+
+## Core Usage
+
+### Basic Search with Highlights
+
+```python
+import os
+from exa_py import Exa
+
+exa = Exa(api_key=os.environ.get('EXA_API_KEY'))
+
+results = exa.search(
+    'AI model releases March 2026',
+    num_results=10,
+    highlights=True
+)
+for r in results.results:
+    print(r.url, r.title)
+    if r.highlights:
+        print(f"  Highlight: {r.highlights[0][:200]}")
+```
+
+### News Search with Date Filter
+
+```python
+results = exa.search(
+    'OpenAI announcements',
+    type='auto',
+    category='news',
+    start_published_date='2026-03-01',   # use start_published_date (not start_date!)
+    num_results=10,
+    contents={'highlights': True}
+)
+```
+
+### Domain Filtering
+
+```python
+results = exa.search(
+    'Kimi K2.6 release',
+    domains=['huggingface.co', 'techcrunch.com', 'venturebeat.com'],
+    num_results=10,
+    highlights=True
+)
+```
+
+### Find Similar Pages
+
+```python
+results = exa.find_similar('https://example.com/article', num_results=5)
+for r in results.results:
+    print(r.url, r.title, r.score)
+```
+
+### Structured Output (outputSchema)
+
+```python
+results = exa.search(
+    'AI company funding rounds',
+    type='auto',
+    num_results=10,
+    outputSchema={
+        'type': 'object',
+        'properties': {
+            'companies': {
+                'type': 'array',
+                'items': {
+                    'type': 'object',
+                    'properties': {
+                        'name': {'type': 'string'},
+                        'amount': {'type': 'string'}
+                    }
+                }
+            }
+        }
+    },
+    contents={'highlights': True}
+)
+# Structured result is in: results.results[0].text (or parsed)
+```
+
+## Search Type Reference
+
+| Type | Latency | Best For |
+|------|---------|----------|
+| `auto` | ~1s | Most queries — balanced (default) |
+| `fast` | ~450ms | Latency-sensitive queries |
+| `instant` | ~250ms | Chat/autocomplete |
+| `deep-lite` | ~4s | Cheap synthesis |
+| `deep` | ~4-15s | Research, thorough results |
+| `deep-reasoning` | ~12-40s | Complex multi-step reasoning |
+
+## Common Pitfalls
+
+1. **Wrong date filter parameter name.** Use `start_published_date` — the parameter `start_date` does NOT exist and will silently be ignored.
+
+2. **Using `domains` vs `includeDomains`.** Exa uses `domains` (list) in the Python SDK, not `includeDomains` (that's the REST API field). In Python: `exa.search(query, domains=[...])`.
+
+3. **`highlights` not showing up.** Highlights must be requested — pass `highlights=True` or `contents={'highlights': True}` in the search call.
+
+4. **Free tier limits.** 1000 searches/mo resets monthly. Set up caching if running recurring research tasks.
+
+5. **Slow response on `deep` types.** Deep search runs multiple query variations. Use `auto` for speed unless you specifically need synthesis quality.
+
+## Verification Checklist
+
+- [ ] `pip install exa-py` completes without error
+- [ ] `EXA_API_KEY` set in `~/.hermes/.env`
+- [ ] `python -c "from exa_py import Exa; print('OK')"` runs cleanly
+- [ ] `exa.search('test', num_results=1, highlights=True)` returns results with highlights

--- a/skills/research/firecrawl/SKILL.md
+++ b/skills/research/firecrawl/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: firecrawl
+description: "Use when you need to scrape a specific URL into clean markdown, discover all pages via sitemap, or crawl a site with subpage discovery. Requires firecrawl-py and FIRECRAWL_API_KEY. Free tier: 500 credits/mo at firecrawl.dev."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [web, scraping, crawl, sitemap, markdown, firecrawl]
+    related_skills: [tavily, exa-search]
+---
+
+# Firecrawl
+
+Website: https://firecrawl.dev | API: https://api.firecrawl.dev
+
+## When to Use
+
+* Scrape a single URL into clean markdown (better than raw curl)
+* Discover all pages on a site via sitemap mapping
+* Crawl an entire site with configurable depth and subpage following
+* Bypass paywalls or JavaScript-rendered content that curl cannot handle
+
+**Trigger examples:**
+- "Get the content of this URL"
+- "Scrape this article"
+- "Find all pages on this website"
+- "Crawl this site"
+
+## Setup
+
+```bash
+pip install firecrawl-py
+```
+
+Add to `~/.hermes/.env`:
+```
+FIRECRAWL_API_KEY=fc-xxxxxxxxxxxxxxxx
+```
+
+Dashboard: https://firecrawl.dev/dashboard
+
+## Core Usage
+
+### Scrape a URL (most common)
+
+```python
+import os
+from firecrawl import V1FirecrawlApp
+
+fc = V1FirecrawlApp(api_key=os.environ.get('FIRECRAWL_API_KEY'))
+
+r = fc.scrape_url('https://example.com/article')
+print(r.markdown)                          # clean markdown content
+print(r.metadata.get('title'))             # page title
+print(r.metadata.get('description'))      # meta description
+print(r.metadata.get('statusCode'))       # 200 = success
+```
+
+### Map a site (discover all pages via sitemap)
+
+```python
+map_result = fc.map_url('https://example.com/blog')
+print(map_result.links)                   # list of discovered URLs
+```
+
+### Crawl a site with subpage discovery
+
+```python
+result = fc.crawl_url('https://example.com', params={
+    'crawlSubpages': True,
+    'maxDepth': 2,
+})
+for page in result.data:
+    print(page['metadata']['title'], page['metadata']['sourceURL'])
+```
+
+## Common Pitfalls
+
+1. **Using `Firecrawl()` (v2) instead of `V1FirecrawlApp()` (v1).** The v2 class has a known URL parsing bug in the current pip package version. Always use `V1FirecrawlApp` for reliable results.
+
+2. **Missing metadata fields.** Always check `statusCode` in metadata — a 403 or 404 means the page is inaccessible and `markdown` may be empty.
+
+3. **Rate limits.** Free tier has 500 credits/mo. A typical scrape costs ~3-10 credits depending on page size. Monitor at https://firecrawl.dev/dashboard.
+
+4. **JavaScript-heavy pages.** Firecrawl handles basic JS rendering but is not a full browser. For complex SPAs, use `browser_navigate` + `browser_snapshot` instead.
+
+## Verification Checklist
+
+- [ ] `pip install firecrawl-py` completes without error
+- [ ] `FIRECRAWL_API_KEY` set in `~/.hermes/.env`
+- [ ] `python -c "from firecrawl import V1FirecrawlApp; print('OK')"` runs cleanly
+- [ ] `fc.scrape_url('https://example.com')` returns markdown content

--- a/skills/research/tavily/SKILL.md
+++ b/skills/research/tavily/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: tavily
+description: "Use when you need web search with built-in citations, direct Q&A answers, or deep extraction from multiple URLs. Requires tavily-python and TAVILY_API_KEY. Free tier: 1000 searches/mo."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [web, search, Q&A, citations, RAG, research]
+    related_skills: [firecrawl, exa-search]
+---
+
+# Tavily
+
+Website: https://tavily.com | Docs: https://docs.tavily.com
+
+## When to Use
+
+* General web search that needs source citations automatically
+* Asking a question and wanting a direct answer with attribution
+* Research across multiple URLs simultaneously
+* RAG pipelines where content needs to be pre-structured for LLM consumption
+
+**Trigger examples:**
+- "Search for recent AI model releases"
+- "Answer: what is the latest news on X?"
+- "Extract content from these URLs"
+- "What are the top results for ..."
+
+Tavily is specifically designed for AI workflows. Output is clean, pre-structured, and citation-aware. Compared to raw curl or even Firecrawl, Tavily adds relevance scoring and semantic understanding.
+
+## Setup
+
+```bash
+pip install tavily-python
+```
+
+Add to `~/.hermes/.env`:
+```
+TAVILY_API_KEY=tvly-xxxxxxxxxxxxxxxx
+```
+
+Free tier: 1000 searches/month. Pro: unlimited.
+
+## Core Usage
+
+### Basic Search
+
+```python
+from tavily import TavilyClient
+tc = TavilyClient()
+
+results = tc.search('your query', max_results=10)
+for r in results['results']:
+    print(r['url'], r['title'])
+    print(r['content'][:200])
+    print(f"  Score: {r['score']}")
+    print()
+```
+
+### Q&A (direct answers with source citations)
+
+```python
+answer = tc.qna_search('your question', max_results=5)
+print(answer['answer'])
+for src in answer.get('sources', []):
+    print(f"  Source: {src['url']}")
+```
+
+### Extract (deep content from multiple URLs)
+
+```python
+content = tc.extract(['https://url1.com', 'https://url2.com'])
+for item in content['results']:
+    print(item['url'])
+    print(item['raw_content'][:300])
+    print()
+```
+
+## Method Reference
+
+| Method | Best For | Output |
+|--------|----------|--------|
+| `search(query, max_results)` | Broad discovery | List of ranked results with url, title, content, score |
+| `qna_search(question, max_results)` | Direct answers | Answer string + source list |
+| `extract(urls)` | Content extraction | Full raw_content per URL |
+
+## Common Pitfalls
+
+1. **No API key.** Tavily requires a key even on free tier. Sign up at tavily.com. Free tier is generous at 1000 searches/mo.
+
+2. **`qna_search` returning empty answers.** This happens when Tavily cannot find a confident answer. Fall back to `search()` and summarize from results.
+
+3. **`max_results` too high.** Each result adds latency and token cost. For quick lookups use `max_results=3`. For research use `max_results=10`.
+
+4. **Rate limits on free tier.** At 1000/mo, be strategic. Cache results if the same query might run again.
+
+## Verification Checklist
+
+- [ ] `pip install tavily-python` completes without error
+- [ ] `TAVILY_API_KEY` set in `~/.hermes/.env`
+- [ ] `python -c "from tavily import TavilyClient; print('OK')"` runs cleanly
+- [ ] `tc.search('test', max_results=1)` returns results with url and content


### PR DESCRIPTION
## Summary
Adds three new search and web scraping skills to the `research` category:

### firecrawl
- Website scraping via firecrawl.dev V1 API (`V1FirecrawlApp`)
- Clean markdown extraction, sitemap mapping, site crawling
- Free tier: 500 credits/mo

### tavily
- AI-optimized search with built-in citations and Q&A
- Designed for RAG and research workflows
- Free tier: 1000 searches/mo

### exa-search
- Semantic/neural web search (finds by meaning not keywords)
- Highlighted query-relevant excerpts, date/domain filtering
- Structured output via outputSchema
- Free tier: 1000 searches/mo

All three replace raw curl for content discovery tasks and have been tested against live APIs with real credentials.

## Changes
- `skills/research/firecrawl/SKILL.md`
- `skills/research/tavily/SKILL.md`
- `skills/research/exa-search/SKILL.md`

## Testing
All three skills verified with live API calls:
- Firecrawl: ✓ scrape_url returns markdown
- Tavily: ✓ search returns results with scores
- Exa: ✓ search with highlights returns results