### PR TITLE
fix(agent): handle vendor-prefixed model IDs in models.dev lookup

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -254,37 +254,18 @@ def lookup_models_dev_context(provider: str, model: str) -> Optional[int]:
     """Look up context_length for a provider+model combo in models.dev.
 
     Returns the context window in tokens, or None if not found.
-    Handles case-insensitive matching and filters out context=0 entries.
+    Delegates lookup to ``_find_model_entry`` so vendor-prefix-stripping
+    and case-insensitive matching apply uniformly with capability lookups.
+    Filters out context=0 entries.
     """
-    mdev_provider_id = PROVIDER_TO_MODELS_DEV.get(provider)
-    if not mdev_provider_id:
+    models = _get_provider_models(provider)
+    if models is None:
         return None
 
-    data = fetch_models_dev()
-    provider_data = data.get(mdev_provider_id)
-    if not isinstance(provider_data, dict):
+    entry = _find_model_entry(models, model)
+    if entry is None:
         return None
-
-    models = provider_data.get("models", {})
-    if not isinstance(models, dict):
-        return None
-
-    # Exact match
-    entry = models.get(model)
-    if entry:
-        ctx = _extract_context(entry)
-        if ctx:
-            return ctx
-
-    # Case-insensitive match
-    model_lower = model.lower()
-    for mid, mdata in models.items():
-        if mid.lower() == model_lower:
-            ctx = _extract_context(mdata)
-            if ctx:
-                return ctx
-
-    return None
+    return _extract_context(entry)
 
 
 def _extract_context(entry: Dict[str, Any]) -> Optional[int]:
@@ -342,16 +323,28 @@ def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
 
 
 def _find_model_entry(models: Dict[str, Any], model: str) -> Optional[Dict[str, Any]]:
-    """Find a model entry by exact match, then case-insensitive fallback."""
-    # Exact match
-    entry = models.get(model)
-    if isinstance(entry, dict):
-        return entry
+    """Find a model entry by exact match, vendor-prefix strip, or
+    case-insensitive fallback.
 
-    # Case-insensitive match
-    model_lower = model.lower()
+    The prefix-strip fallback accepts inputs like ``xiaomi/mimo-v2.5``
+    against a direct provider whose cache is keyed by bare names
+    (``mimo-v2.5``). Aggregator caches are keyed by full ``vendor/model``
+    slugs and matched by the exact path. Callers pre-constrain the search
+    to one provider's catalog, so a non-matching prefix simply falls
+    through to None.
+    """
+    candidates = [model]
+    if "/" in model:
+        candidates.append(model.split("/", 1)[1])
+
+    for candidate in candidates:
+        entry = models.get(candidate)
+        if isinstance(entry, dict):
+            return entry
+
+    candidates_lower = {c.lower() for c in candidates}
     for mid, mdata in models.items():
-        if mid.lower() == model_lower and isinstance(mdata, dict):
+        if mid.lower() in candidates_lower and isinstance(mdata, dict):
             return mdata
 
     return None

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -156,6 +156,26 @@ class TestLookupModelsDevContext:
         mock_fetch.return_value = {}
         assert lookup_models_dev_context("anthropic", "claude-opus-4-6") is None
 
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_vendor_prefix_stripped_for_direct_provider(self, mock_fetch):
+        """Users sometimes copy aggregator-style ``vendor/model`` slugs into
+        a direct provider's config (e.g. ``xiaomi/mimo-v2.5`` against the
+        ``xiaomi`` provider whose cache is keyed by bare names). The lookup
+        must strip a leading ``vendor/`` prefix on miss so context-length
+        auto-detection still works."""
+        mock_fetch.return_value = SAMPLE_REGISTRY
+        # Anthropic cache is keyed by "claude-opus-4-6" (bare); user-supplied
+        # "anthropic/claude-opus-4-6" should still resolve.
+        assert lookup_models_dev_context("anthropic", "anthropic/claude-opus-4-6") == 1000000
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_aggregator_slug_match_unchanged(self, mock_fetch):
+        """Aggregator caches (e.g. kilocode→kilo) are keyed by the full
+        ``vendor/model`` slug. Exact match must still win — prefix-strip
+        is only a fallback."""
+        mock_fetch.return_value = SAMPLE_REGISTRY
+        assert lookup_models_dev_context("kilocode", "anthropic/claude-sonnet-4.6") == 1000000
+
 
 class TestFetchModelsDev:
     @patch("agent.models_dev.requests.get")
@@ -284,4 +304,27 @@ class TestGetModelCapabilities:
         """Unknown model should return None."""
         with patch("agent.models_dev.fetch_models_dev", return_value=CAPS_REGISTRY):
             caps = get_model_capabilities("anthropic", "nonexistent-model")
+        assert caps is None
+
+    def test_vendor_prefix_stripped_for_direct_provider(self):
+        """Capability lookup must accept ``vendor/model`` form against direct
+        providers whose cache is keyed by bare names. Without this fallback,
+        a user with ``model.default: anthropic/claude-sonnet-4`` in config
+        would silently lose vision/tools detection on the gateway and web
+        paths (which read config.yaml verbatim, bypassing the in-memory
+        normalization that AIAgent.__init__ applies)."""
+        with patch("agent.models_dev.fetch_models_dev", return_value=CAPS_REGISTRY):
+            caps = get_model_capabilities("anthropic", "anthropic/claude-sonnet-4")
+        assert caps is not None
+        assert caps.supports_vision is True
+        assert caps.supports_tools is True
+
+    def test_prefix_strip_does_not_cross_providers(self):
+        """The strip is harmless even when the prefix names another vendor —
+        because ``_get_provider_models`` has already scoped the search to a
+        single provider's catalog, a non-existent bare name still returns
+        None. The strip only succeeds when the bare name happens to exist
+        in the configured provider's catalog."""
+        with patch("agent.models_dev.fetch_models_dev", return_value=CAPS_REGISTRY):
+            caps = get_model_capabilities("anthropic", "openai/gpt-5")
         assert caps is None


### PR DESCRIPTION
## Problem

xiaomi's models.dev catalog is keyed by bare names (`mimo-v2.5`), but
nothing prevents users from writing `model.default: xiaomi/mimo-v2.5`
in config.yaml. `hermes doctor` flags this as user error
(`hermes_cli/doctor.py:499-512`), but doctor is a manual diagnostic
that's not auto-run — it's only surfaced when users hit other errors
that prompt them to run it. The silent capability degradation below
doesn't trigger such an error, so the warning rarely reaches affected
users.

At runtime the CLI auto-normalizes `self.model` at
`_ensure_runtime_credentials` time (`cli.py:3511` →
`run_agent.py:1102`), so the CLI's message-processing path ends up
calling capability lookups with the bare name. But two paths bypass
that normalization:

- The gateway runs `_decide_image_input_mode()` per message *before*
  the turn's AIAgent is instantiated (`gateway/run.py:5685`). It reads
  `model.default` directly via `_read_main_model()` and hands the raw
  slug to `decide_image_input_mode()` (`gateway/run.py:11515`).
- The web-server dashboard reads `model_cfg.get("default")` for
  capability display (`hermes_cli/web_server.py:889`).

Both lookup helpers (`get_model_capabilities`,
`lookup_models_dev_context`) do exact-match + case-insensitive only,
so they silently return `None` for vendor-prefixed input against
direct providers.

### User-visible impact

| Path | Impact |
|---|---|
| `get_model_capabilities` (vision/tools/reasoning detection) | **severe** — returns `None`. `decide_image_input_mode` falls back to `text` mode, routing user images through `vision_analyze` (lossy text summary) instead of native attachment, even when the model supports vision. |
| `lookup_models_dev_context` (context window — tier #7 in `get_model_context_length`) | **cushioned** — silently returns `None`, but tier #5 (OpenRouter live API metadata, indexed by `vendor/model` slugs) often catches the lookup. Models not in OpenRouter's catalog fall through to `DEFAULT_FALLBACK_CONTEXT = 256K`. |

### Reproduction

```python
from agent.models_dev import get_model_capabilities
from agent.image_routing import decide_image_input_mode

# config: provider=xiaomi, model=xiaomi/mimo-v2.5
get_model_capabilities("xiaomi", "xiaomi/mimo-v2.5")
# Before: None
# After:  ModelCapabilities(supports_vision=True, supports_tools=True, ctx=1048576)

decide_image_input_mode("xiaomi", "xiaomi/mimo-v2.5", cfg={})
# Before: "text"
# After:  "native"
```

## Fix

`_find_model_entry` accepts a `vendor/`-prefix-stripped candidate on
miss, and `lookup_models_dev_context` is consolidated to delegate
lookup through it so the same fix applies uniformly. The case-
insensitive loop in the old `lookup_models_dev_context` was effectively
dead (Python dicts cannot hold case-only-different keys), so the
consolidation is behavior-preserving.

The strip is harmless against mismatched prefixes (e.g. `openai/gpt-5`
against the xiaomi catalog) — `_get_provider_models` already scopes the
search to one provider's models dict, so a stripped name that doesn't
exist in that provider's catalog simply returns `None`.

This patch makes runtime capability/context lookups tolerant in the
same way the CLI's `_normalize_model_for_provider` already is for
`self.model`. The `hermes doctor` warning is unchanged — users who
run diagnostics still get the cue to clean up their config.

## Test plan

- 4 new unit tests in `tests/agent/test_models_dev.py` covering
  vendor-prefix-strip on both lookup paths and aggregator-slug
  regression
- `pytest tests/agent/test_models_dev.py tests/agent/test_image_routing.py tests/hermes_cli/test_model_normalize.py tests/hermes_cli/test_models_dev_preferred_merge.py` — 144 passed
- End-to-end measurement against the live `~/.hermes/models_dev_cache.json`: before patch, `get_model_capabilities("xiaomi", "xiaomi/mimo-v2.5")` returned `None` and `decide_image_input_mode` returned `"text"`; after patch, capabilities resolve to `vision=True, ctx=1,048,576` and routing returns `"native"`