### PR TITLE
fix(slack): scope sessions and routing by workspace

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5547,6 +5547,7 @@ class BasePlatformAdapter(ABC):
                         user_id_alt=user_id_alt,
                         chat_id_alt=chat_id_alt,
                         is_bot=is_bot,
+                        scope_id=str(scope_id) if scope_id else None,
                         guild_id=str(guild_id) if guild_id else None,
                         parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
                         message_id=str(message_id) if message_id else None,

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -17,7 +17,7 @@ import threading
 import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
@@ -906,12 +906,16 @@ def build_session_key(
     multiplexing gateway passes a non-default profile.
 
     DM rules:
+      - Slack ``scope_id`` identifies the workspace before chat/user ids. Other
+        platforms retain their existing key format; in particular, Discord
+        guild scope is intentionally not added here as a compatibility change.
       - DMs include chat_id when present, so each private conversation is isolated.
       - thread_id further differentiates threaded DMs within the same DM chat.
       - Without chat_id, thread_id is used as a best-effort fallback.
       - Without thread_id or chat_id, DMs share a single session.
 
     Group/channel rules:
+      - Slack ``scope_id`` identifies the workspace before chat/thread ids.
       - chat_id identifies the parent group/channel.
       - user_id/user_id_alt isolates participants within that parent chat when available when
         ``group_sessions_per_user`` is enabled.
@@ -926,15 +930,24 @@ def build_session_key(
     """
     ns = _session_key_namespace(profile)
     platform = source.platform.value
+    slack_scope_id = (
+        str(source.scope_id)
+        if source.platform == Platform.SLACK and source.scope_id
+        else None
+    )
     if source.chat_type == "dm":
         dm_chat_id = source.chat_id
         if source.platform == Platform.WHATSAPP:
             dm_chat_id = canonical_whatsapp_identifier(source.chat_id)
 
+        dm_parts = [ns, platform, "dm"]
+        if slack_scope_id:
+            dm_parts.append(slack_scope_id)
         if dm_chat_id:
+            dm_parts.append(dm_chat_id)
             if source.thread_id:
-                return f"{ns}:{platform}:dm:{dm_chat_id}:{source.thread_id}"
-            return f"{ns}:{platform}:dm:{dm_chat_id}"
+                dm_parts.append(source.thread_id)
+            return ":".join(str(part) for part in dm_parts)
         # No chat_id — fall back to the sender's own identifier before the
         # bare per-platform sink.  Without this, every DM from every user that
         # arrives without a chat_id (non-standard adapters / synthetic sources)
@@ -948,12 +961,13 @@ def build_session_key(
                 or dm_participant_id
             )
         if dm_participant_id:
+            dm_parts.append(str(dm_participant_id))
             if source.thread_id:
-                return f"{ns}:{platform}:dm:{dm_participant_id}:{source.thread_id}"
-            return f"{ns}:{platform}:dm:{dm_participant_id}"
+                dm_parts.append(source.thread_id)
+            return ":".join(str(part) for part in dm_parts)
         if source.thread_id:
-            return f"{ns}:{platform}:dm:{source.thread_id}"
-        return f"{ns}:{platform}:dm"
+            dm_parts.append(source.thread_id)
+        return ":".join(str(part) for part in dm_parts)
 
     participant_id = source.user_id_alt or source.user_id
     if participant_id and source.platform == Platform.WHATSAPP:
@@ -963,6 +977,8 @@ def build_session_key(
         participant_id = canonical_whatsapp_identifier(str(participant_id)) or participant_id
     key_parts = [ns, platform, source.chat_type]
 
+    if slack_scope_id:
+        key_parts.append(slack_scope_id)
     if source.chat_id:
         key_parts.append(source.chat_id)
     if source.thread_id:
@@ -978,7 +994,7 @@ def build_session_key(
     if isolate_user and participant_id:
         key_parts.append(str(participant_id))
 
-    return ":".join(key_parts)
+    return ":".join(str(part) for part in key_parts)
 
 
 class _SessionFlight:
@@ -1028,6 +1044,11 @@ class SessionStore:
         self._persisted_routing_generation = 0
         self._inflight_lock = threading.Lock()
         self._inflight_sessions: Dict[str, _SessionFlight] = {}
+        # An unscoped pre-migration Slack key can represent at most one
+        # workspace. Claim it once per process so simultaneous first messages
+        # from two workspaces cannot both revive the same legacy session.
+        self._legacy_slack_claim_lock = threading.Lock()
+        self._claimed_legacy_slack_keys: set[str] = set()
         self._has_active_processes_fn = has_active_processes_fn
         # Whether to keep writing the legacy sessions.json mirror alongside
         # the primary gateway_routing table in state.db. Default True for
@@ -1386,6 +1407,46 @@ class SessionStore:
             profile=self._resolve_profile_for_key(source),
         )
 
+    def _legacy_slack_session_key(self, source: SessionSource) -> Optional[str]:
+        """Return the pre-workspace Slack key for an explicitly scoped source.
+
+        The compatibility path is deliberately Slack-only. Discord and every
+        other platform keep byte-identical keys, and an unscoped Slack session
+        may be claimed by only one workspace because its old key contains no
+        information that could safely distinguish multiple teams.
+        """
+        if source.platform != Platform.SLACK or not source.scope_id:
+            return None
+        legacy_source = replace(source, scope_id=None, guild_id=None)
+        return build_session_key(
+            legacy_source,
+            group_sessions_per_user=getattr(
+                self.config, "group_sessions_per_user", True
+            ),
+            thread_sessions_per_user=getattr(
+                self.config, "thread_sessions_per_user", False
+            ),
+            profile=self._resolve_profile_for_key(source),
+        )
+
+    def _claim_legacy_slack_key(self, legacy_key: Optional[str]) -> bool:
+        """Atomically reserve one ambiguous legacy Slack key for migration."""
+        if not legacy_key:
+            return False
+        claim_lock = getattr(self, "_legacy_slack_claim_lock", None)
+        if claim_lock is None:
+            claim_lock = threading.Lock()
+            self._legacy_slack_claim_lock = claim_lock
+        with claim_lock:
+            claimed = getattr(self, "_claimed_legacy_slack_keys", None)
+            if claimed is None:
+                claimed = set()
+                self._claimed_legacy_slack_keys = claimed
+            if legacy_key in claimed:
+                return False
+            claimed.add(legacy_key)
+            return True
+
     def _create_entry_from_recovered_row(
         self,
         *,
@@ -1410,6 +1471,42 @@ class SessionStore:
             chat_type=source.chat_type,
         )
 
+    def _find_gateway_session_row(
+        self,
+        *,
+        session_key: str,
+        source: SessionSource,
+        allow_peer_fallback: bool,
+    ) -> Optional[Dict[str, Any]]:
+        """Query one durable gateway session row.
+
+        Scoped Slack lookups disable SessionDB's platform/chat/user fallback:
+        that tuple does not contain a workspace id and could therefore revive
+        another team's session. The caller performs one explicit exact lookup
+        of the old unscoped key instead.
+        """
+        if not self._db:
+            return None
+        finder = getattr(self._db, "find_latest_gateway_session_for_peer", None)
+        if not callable(finder):
+            return None
+        try:
+            return finder(
+                source=source.platform.value,
+                user_id=source.user_id,
+                session_key=session_key,
+                chat_id=source.chat_id if allow_peer_fallback else None,
+                chat_type=source.chat_type if allow_peer_fallback else None,
+                thread_id=source.thread_id,
+            )
+        except Exception as exc:
+            logger.debug(
+                "Gateway session DB recovery failed for %s: %s",
+                session_key,
+                exc,
+            )
+            return None
+
     def _recover_session_from_db(
         self,
         *,
@@ -1418,23 +1515,24 @@ class SessionStore:
         now: datetime,
     ) -> Optional[SessionEntry]:
         """Rebuild a missing session-key mapping from durable state.db data."""
-        if not self._db:
-            return None
-        finder = getattr(self._db, "find_latest_gateway_session_for_peer", None)
-        if not callable(finder):
-            return None
-        try:
-            recovered = finder(
-                source=source.platform.value,
-                user_id=source.user_id,
-                session_key=session_key,
-                chat_id=source.chat_id,
-                chat_type=source.chat_type,
-                thread_id=source.thread_id,
+        legacy_key = self._legacy_slack_session_key(source)
+        recovered = self._find_gateway_session_row(
+            session_key=session_key,
+            source=source,
+            allow_peer_fallback=legacy_key is None,
+        )
+        migrated_legacy = False
+        if (
+            not recovered
+            and legacy_key
+            and self._claim_legacy_slack_key(legacy_key)
+        ):
+            recovered = self._find_gateway_session_row(
+                session_key=legacy_key,
+                source=source,
+                allow_peer_fallback=False,
             )
-        except Exception as exc:
-            logger.debug("Gateway session DB recovery failed for %s: %s", session_key, exc)
-            return None
+            migrated_legacy = bool(recovered)
         if not recovered:
             return None
         if not self._recovered_row_allowed_for_active_profile(
@@ -1453,36 +1551,44 @@ class SessionStore:
             self._db.reopen_session(str(recovered["id"]))
         except Exception as exc:
             logger.debug("Gateway session DB reopen failed for %s: %s", session_key, exc)
-        return self._create_entry_from_recovered_row(
+        entry = self._create_entry_from_recovered_row(
             row=recovered,
             session_key=session_key,
             source=source,
             now=now,
         )
+        if migrated_legacy:
+            self._record_gateway_session_peer(
+                entry.session_id,
+                session_key,
+                source,
+                display_name=entry.display_name,
+            )
+        return entry
 
     def _query_recoverable_session(self, *, session_key, source, now):
         """DB-only half of _recover_session_from_db (no lock needed).
 
         Returns a SessionEntry or None.  Caller assigns _entries[key] under lock.
         """
-        if not self._db:
-            return None
-        finder = getattr(self._db, "find_latest_gateway_session_for_peer", None)
-        if not callable(finder):
-            return None
-        try:
-            recovered = finder(
-                source=source.platform.value,
-                user_id=source.user_id,
-                session_key=session_key,
-                chat_id=source.chat_id,
-                chat_type=source.chat_type,
-                thread_id=source.thread_id,
+        legacy_key = self._legacy_slack_session_key(source)
+        recovered = self._find_gateway_session_row(
+            session_key=session_key,
+            source=source,
+            allow_peer_fallback=legacy_key is None,
+        )
+        migrated_legacy = False
+        if (
+            not recovered
+            and legacy_key
+            and self._claim_legacy_slack_key(legacy_key)
+        ):
+            recovered = self._find_gateway_session_row(
+                session_key=legacy_key,
+                source=source,
+                allow_peer_fallback=False,
             )
-        except Exception as exc:
-            logger.debug("Gateway session DB recovery failed for %s: %s",
-                         session_key, exc)
-            return None
+            migrated_legacy = bool(recovered)
         if not isinstance(recovered, dict):
             return None
         if not self._recovered_row_allowed_for_active_profile(
@@ -1502,9 +1608,17 @@ class SessionStore:
         except Exception as exc:
             logger.debug("Gateway session DB reopen failed for %s: %s",
                          session_key, exc)
-        return self._create_entry_from_recovered_row(
+        entry = self._create_entry_from_recovered_row(
             row=recovered, session_key=session_key, source=source, now=now,
         )
+        if migrated_legacy:
+            self._record_gateway_session_peer(
+                entry.session_id,
+                session_key,
+                source,
+                display_name=entry.display_name,
+            )
+        return entry
     def _record_gateway_session_peer(
         self,
         session_id: str,
@@ -1853,6 +1967,35 @@ class SessionStore:
         """
         session_key = self._generate_session_key(source)
         now = _now()
+
+        # One-time routing-index migration for Slack sessions created before
+        # workspace scope was part of the key. Move (rather than copy) the
+        # legacy entry so a second workspace with identical Slack ids cannot
+        # attach to the same transcript.
+        migrated_legacy_entry: Optional[SessionEntry] = None
+        legacy_key = self._legacy_slack_session_key(source)
+        if legacy_key and not force_new:
+            with self._lock:
+                self._ensure_loaded_locked()
+                if (
+                    session_key not in self._entries
+                    and legacy_key in self._entries
+                    and self._claim_legacy_slack_key(legacy_key)
+                ):
+                    migrated_legacy_entry = self._entries.pop(legacy_key)
+                    migrated_legacy_entry.session_key = session_key
+                    migrated_legacy_entry.origin = source
+                    migrated_legacy_entry.platform = source.platform
+                    migrated_legacy_entry.chat_type = source.chat_type
+                    self._entries[session_key] = migrated_legacy_entry
+            if migrated_legacy_entry is not None:
+                self._save_entries()
+                self._record_gateway_session_peer(
+                    migrated_legacy_entry.session_id,
+                    session_key,
+                    source,
+                    display_name=migrated_legacy_entry.display_name,
+                )
 
         db_end_session_id = None
         db_create_kwargs = None

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -448,13 +448,17 @@ class SlackAdapter(BasePlatformAdapter):
         # Multi-workspace support
         self._team_clients: Dict[str, Any] = {}  # team_id → WebClient
         self._team_bot_user_ids: Dict[str, str] = {}  # team_id → bot_user_id
-        self._channel_team: Dict[str, str] = {}  # channel_id → team_id
+        # Compatibility fallback for callers that have only a channel id.
+        # Entries exist only while a channel id maps to exactly one workspace;
+        # explicit outbound metadata remains the authoritative route.
+        self._channel_team: Dict[str, str] = {}  # unambiguous channel_id → team_id
+        self._channel_teams: Dict[str, set[str]] = {}
         # Dedup cache: prevents duplicate bot responses when Socket Mode
         # reconnects redeliver events.
         self._dedup = MessageDeduplicator()
         # Track pending approval message_ts → resolved flag to prevent
         # double-clicks on approval buttons.
-        self._approval_resolved: Dict[str, bool] = {}
+        self._approval_resolved: Dict[Any, bool] = {}
         # Track timestamps of messages sent by the bot so we can respond
         # to thread replies even without an explicit @mention.
         self._bot_message_ts: set = set()
@@ -488,9 +492,11 @@ class SlackAdapter(BasePlatformAdapter):
         self._TITLED_ASSISTANT_THREADS_MAX = 5000
         # Slash-command contexts: stash response_url + user_id so send()
         # can route the first reply ephemerally.  Keyed by
-        # (channel_id, user_id) to avoid cross-user collisions.
+        # (team_id, channel_id, user_id) to avoid cross-workspace and
+        # cross-user collisions. The two-part form remains readable only for
+        # commands that arrived without a workspace id.
         # Each value: {"response_url": str, "ts": float}
-        self._slash_command_contexts: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        self._slash_command_contexts: Dict[Tuple[str, ...], Dict[str, Any]] = {}
         # Socket Mode resilience: track runtime connection state so we can
         # self-heal when Slack silently drops the websocket.
         self._app_token: Optional[str] = None
@@ -765,17 +771,17 @@ class SlackAdapter(BasePlatformAdapter):
     def _pop_slash_context(
         self,
         chat_id: str,
+        team_id: str = "",
     ) -> Optional[Dict[str, Any]]:
         """Return and remove the slash-command context for *chat_id*, if fresh.
 
         Contexts older than ``_SLASH_CTX_TTL`` seconds are silently discarded.
 
         Uses the ``_slash_user_id`` ContextVar (set in ``_handle_slash_command``)
-        to match the exact ``(channel_id, user_id)`` key.  This prevents a
-        concurrent slash command from a different user on the same channel from
-        stealing another user's ephemeral context.  Falls back to a
-        channel-only scan when the ContextVar is unset (e.g. send() called
-        from a non-slash code path — should not match anything).
+        to match the exact ``(team_id, channel_id, user_id)`` key. This prevents
+        a concurrent slash command from another user or workspace with the same
+        Slack-local ids from stealing the ephemeral context. The legacy
+        two-part form is used only when no team id was supplied.
         """
         now = time.monotonic()
         # Clean up stale entries on every lookup — dict is small.
@@ -787,16 +793,22 @@ class SlackAdapter(BasePlatformAdapter):
         for k in stale_keys:
             self._slash_command_contexts.pop(k, None)
 
-        # Precise match: (channel_id, user_id) from ContextVar.
+        team_id = str(team_id or "")
+
+        # Precise match from ContextVar.
         uid = _slash_user_id.get()
         if uid:
-            return self._slash_command_contexts.pop((chat_id, uid), None)
+            key = (team_id, chat_id, uid) if team_id else (chat_id, uid)
+            return self._slash_command_contexts.pop(key, None)
 
         # Fallback: channel-only scan (only reachable when ContextVar is
         # unset, i.e. send() called outside a slash-command async context).
         match_key = None
         for key in list(self._slash_command_contexts):
-            if key[0] == chat_id:
+            if team_id and len(key) == 3 and key[:2] == (team_id, chat_id):
+                match_key = key
+                break
+            if not team_id and len(key) == 2 and key[0] == chat_id:
                 match_key = key
                 break
         if match_key is None:
@@ -1369,12 +1381,53 @@ class SlackAdapter(BasePlatformAdapter):
         """Return Slack workspace id from generic or Slack-specific metadata."""
         if not metadata:
             return ""
-        return str(
-            metadata.get("team_id")
-            or metadata.get("team")
-            or metadata.get("slack_team_id")
-            or ""
-        )
+        for key in (
+            "scope_id",
+            "slack_team_id",
+            "team_id",
+            "team",
+            "guild_id",
+            "workspace_id",
+        ):
+            value = metadata.get(key)
+            if value:
+                return str(value)
+        source = metadata.get("source")
+        if isinstance(source, dict):
+            for key in ("scope_id", "slack_team_id", "team_id", "guild_id"):
+                value = source.get(key)
+                if value:
+                    return str(value)
+        elif source is not None:
+            value = getattr(source, "scope_id", None) or getattr(
+                source, "guild_id", None
+            )
+            if value:
+                return str(value)
+        return ""
+
+    @staticmethod
+    def _workspace_event_id(team_id: str, event_id: str) -> str:
+        """Scope Slack's workspace-local event/message ids for deduplication."""
+        return f"{team_id}:{event_id}" if team_id else str(event_id)
+
+    @staticmethod
+    def _workspace_message_marker(team_id: str, message_id: str) -> Any:
+        """Return an in-memory routing marker without changing legacy no-team tests."""
+        return (str(team_id), str(message_id)) if team_id else str(message_id)
+
+    def _remember_channel_team(self, channel_id: str, team_id: str) -> None:
+        """Cache a channel fallback only while its workspace is unambiguous."""
+        if not channel_id or not team_id:
+            return
+        channel_id = str(channel_id)
+        team_id = str(team_id)
+        teams = self._channel_teams.setdefault(channel_id, set())
+        teams.add(team_id)
+        if len(teams) == 1:
+            self._channel_team[channel_id] = team_id
+        else:
+            self._channel_team.pop(channel_id, None)
 
     def _get_client(self, chat_id: str, team_id: Optional[str] = None) -> Any:
         """Return the workspace-specific WebClient for a channel."""
@@ -1398,12 +1451,13 @@ class SlackAdapter(BasePlatformAdapter):
 
         thread_ts = None
         try:
+            team_id = self._metadata_team_id(metadata)
             # Check for a pending slash-command context.  When the user ran a
             # native slash command (e.g. /q, /stop, /model), the initial ack
             # already showed an ephemeral "Running /cmd…" message.  If we have
             # a stashed response_url for this channel, replace that ack with
             # the actual command reply ephemerally instead of posting publicly.
-            slash_ctx = self._pop_slash_context(chat_id)
+            slash_ctx = self._pop_slash_context(chat_id, team_id)
             if slash_ctx:
                 return await self._send_slash_ephemeral(
                     slash_ctx,
@@ -1445,7 +1499,7 @@ class SlackAdapter(BasePlatformAdapter):
                         kwargs["reply_broadcast"] = True
 
                 last_result = await self._get_client(
-                    chat_id, team_id=self._metadata_team_id(metadata)
+                    chat_id, team_id=team_id
                 ).chat_postMessage(**kwargs)
 
             # Clear Slack Assistant status as soon as the final message is posted.
@@ -1456,10 +1510,14 @@ class SlackAdapter(BasePlatformAdapter):
             # replies without requiring @mention.
             sent_ts = last_result.get("ts") if last_result else None
             if sent_ts:
-                self._bot_message_ts.add(sent_ts)
+                self._bot_message_ts.add(
+                    self._workspace_message_marker(team_id, sent_ts)
+                )
                 # Also register the thread root so replies-to-my-replies work
                 if thread_ts:
-                    self._bot_message_ts.add(thread_ts)
+                    self._bot_message_ts.add(
+                        self._workspace_message_marker(team_id, thread_ts)
+                    )
                 if len(self._bot_message_ts) > self._BOT_TS_MAX:
                     excess = len(self._bot_message_ts) - self._BOT_TS_MAX // 2
                     for old_ts in list(self._bot_message_ts)[:excess]:
@@ -1809,7 +1867,7 @@ class SlackAdapter(BasePlatformAdapter):
                     initial_comment=caption or "",
                     thread_ts=thread_ts,
                 )
-                self._record_uploaded_file_thread(chat_id, thread_ts)
+                self._record_uploaded_file_thread(chat_id, thread_ts, metadata)
                 return SendResult(success=True, raw_response=result)
             except Exception as exc:
                 last_exc = exc
@@ -1937,7 +1995,7 @@ class SlackAdapter(BasePlatformAdapter):
                     initial_comment=initial_comment,
                     thread_ts=thread_ts,
                 )
-                self._record_uploaded_file_thread(chat_id, thread_ts)
+                self._record_uploaded_file_thread(chat_id, thread_ts, metadata)
                 _ = result
             except Exception as e:
                 logger.warning(
@@ -1952,12 +2010,18 @@ class SlackAdapter(BasePlatformAdapter):
                 )
 
     def _record_uploaded_file_thread(
-        self, chat_id: str, thread_ts: Optional[str]
+        self,
+        chat_id: str,
+        thread_ts: Optional[str],
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Treat successful file uploads as bot participation in a thread."""
         if not thread_ts:
             return
-        self._bot_message_ts.add(thread_ts)
+        team_id = self._metadata_team_id(metadata)
+        self._bot_message_ts.add(
+            self._workspace_message_marker(team_id, thread_ts)
+        )
         if len(self._bot_message_ts) > self._BOT_TS_MAX:
             excess = len(self._bot_message_ts) - self._BOT_TS_MAX // 2
             for old_ts in list(self._bot_message_ts)[:excess]:
@@ -2215,13 +2279,13 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._reactions_enabled():
             return
         ts = getattr(event, "message_id", None)
-        if not ts or ts not in self._reacting_message_ids:
+        team_id = str(getattr(event.source, "scope_id", "") or "")
+        marker = self._workspace_message_marker(team_id, ts) if ts else None
+        if not ts or marker not in self._reacting_message_ids:
             return
         channel_id = getattr(event.source, "chat_id", None)
         if channel_id:
-            await self._add_reaction(
-                channel_id, ts, "eyes", str(getattr(event.source, "scope_id", "") or "")
-            )
+            await self._add_reaction(channel_id, ts, "eyes", team_id)
 
     async def on_processing_complete(
         self, event: MessageEvent, outcome: ProcessingOutcome
@@ -2230,13 +2294,14 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._reactions_enabled():
             return
         ts = getattr(event, "message_id", None)
-        if not ts or ts not in self._reacting_message_ids:
+        team_id = str(getattr(event.source, "scope_id", "") or "")
+        marker = self._workspace_message_marker(team_id, ts) if ts else None
+        if not ts or marker not in self._reacting_message_ids:
             return
-        self._reacting_message_ids.discard(ts)
+        self._reacting_message_ids.discard(marker)
         channel_id = getattr(event.source, "chat_id", None)
         if not channel_id:
             return
-        team_id = str(getattr(event.source, "scope_id", "") or "")
         await self._remove_reaction(channel_id, ts, "eyes", team_id)
         if outcome == ProcessingOutcome.SUCCESS:
             await self._add_reaction(channel_id, ts, "white_check_mark", team_id)
@@ -2364,7 +2429,7 @@ class SlackAdapter(BasePlatformAdapter):
                 initial_comment=caption or "",
                 thread_ts=thread_ts,
             )
-            self._record_uploaded_file_thread(chat_id, thread_ts)
+            self._record_uploaded_file_thread(chat_id, thread_ts, metadata)
 
             return SendResult(success=True, raw_response=result)
 
@@ -2442,7 +2507,7 @@ class SlackAdapter(BasePlatformAdapter):
                         initial_comment=caption or "",
                         thread_ts=thread_ts,
                     )
-                    self._record_uploaded_file_thread(chat_id, thread_ts)
+                    self._record_uploaded_file_thread(chat_id, thread_ts, metadata)
                     return SendResult(success=True, raw_response=result)
                 except Exception as exc:
                     last_exc = exc
@@ -2504,7 +2569,7 @@ class SlackAdapter(BasePlatformAdapter):
                         initial_comment=caption or "",
                         thread_ts=thread_ts,
                     )
-                    self._record_uploaded_file_thread(chat_id, thread_ts)
+                    self._record_uploaded_file_thread(chat_id, thread_ts, metadata)
                     return SendResult(success=True, raw_response=result)
                 except Exception as exc:
                     last_exc = exc
@@ -2726,8 +2791,7 @@ class SlackAdapter(BasePlatformAdapter):
             for old_key in list(self._assistant_threads)[:excess]:
                 del self._assistant_threads[old_key]
 
-        if team_id and channel_id:
-            self._channel_team[channel_id] = team_id
+        self._remember_channel_team(channel_id, team_id)
 
     def _lookup_assistant_thread_metadata(
         self,
@@ -2990,8 +3054,7 @@ class SlackAdapter(BasePlatformAdapter):
         team_id = self._event_team_id(event, body)
         context_channel_id = self._context_channel_id(context)
 
-        if team_id and channel_id:
-            self._channel_team[str(channel_id)] = str(team_id)
+        self._remember_channel_team(channel_id, team_id)
 
         metadata = {
             "channel_id": str(channel_id) if channel_id else "",
@@ -3068,7 +3131,9 @@ class SlackAdapter(BasePlatformAdapter):
         # If it does, _handle_slack_message records the same share ts and this
         # fallback skips instead of duplicating the user turn.
         await asyncio.sleep(0.75)
-        if ts and self._dedup.is_duplicate(ts):
+        if ts and self._dedup.is_duplicate(
+            self._workspace_event_id(team_id, ts)
+        ):
             return
 
         fallback_event = {
@@ -3092,7 +3157,10 @@ class SlackAdapter(BasePlatformAdapter):
         """Handle an incoming Slack message event."""
         # Dedup: Slack Socket Mode can redeliver events after reconnects (#4777)
         event_ts = event.get("ts", "")
-        if event_ts and self._dedup.is_duplicate(event_ts):
+        dedup_team_id = self._event_team_id(event, payload)
+        if event_ts and self._dedup.is_duplicate(
+            self._workspace_event_id(dedup_team_id, event_ts)
+        ):
             return
 
         # Bot message filtering (SLACK_ALLOW_BOTS / config allow_bots):
@@ -3257,8 +3325,7 @@ class SlackAdapter(BasePlatformAdapter):
         )
 
         # Track which workspace owns this channel
-        if team_id and channel_id:
-            self._channel_team[channel_id] = team_id
+        self._remember_channel_team(channel_id, team_id)
 
         # Determine if this is a DM or channel message
         channel_type = event.get("channel_type", "")
@@ -3352,12 +3419,15 @@ class SlackAdapter(BasePlatformAdapter):
             elif self._slack_strict_mention() and not is_mentioned:
                 return  # Strict mode: ignore until @-mentioned again
             elif not is_mentioned:
+                thread_marker = self._workspace_message_marker(
+                    team_id, event_thread_ts
+                )
                 reply_to_bot_thread = (
-                    is_thread_reply and event_thread_ts in self._bot_message_ts
+                    is_thread_reply and thread_marker in self._bot_message_ts
                 )
                 in_mentioned_thread = (
                     event_thread_ts is not None
-                    and event_thread_ts in self._mentioned_threads
+                    and thread_marker in self._mentioned_threads
                 )
                 has_session = is_thread_reply and self._has_active_session_for_thread(
                     channel_id=channel_id,
@@ -3380,7 +3450,9 @@ class SlackAdapter(BasePlatformAdapter):
             # re-mentioned every turn, so remembering the thread would
             # defeat the feature (and re-enable agent-to-agent ack loops).
             if event_thread_ts and not self._slack_strict_mention():
-                self._mentioned_threads.add(event_thread_ts)
+                self._mentioned_threads.add(
+                    self._workspace_message_marker(team_id, event_thread_ts)
+                )
                 if len(self._mentioned_threads) > self._MENTIONED_THREADS_MAX:
                     to_remove = list(self._mentioned_threads)[
                         : self._MENTIONED_THREADS_MAX // 2
@@ -3756,7 +3828,9 @@ class SlackAdapter(BasePlatformAdapter):
         # be @mentioned to earn a reaction — same as any channel.
         _should_react = (is_one_to_one_dm or is_mentioned) and self._reactions_enabled()
         if _should_react:
-            self._reacting_message_ids.add(ts)
+            self._reacting_message_ids.add(
+                self._workspace_message_marker(team_id, ts)
+            )
 
         # App-context is per-turn, user-controlled Slack UI state. Surface it
         # with the inbound user message rather than storing it on SessionSource:
@@ -3863,7 +3937,10 @@ class SlackAdapter(BasePlatformAdapter):
             ).chat_postMessage(**kwargs)
             msg_ts = result.get("ts", "")
             if msg_ts:
-                self._approval_resolved[msg_ts] = False
+                team_id = self._metadata_team_id(metadata)
+                self._approval_resolved[
+                    self._workspace_message_marker(team_id, msg_ts)
+                ] = False
 
             return SendResult(success=True, message_id=msg_ts, raw_response=result)
         except Exception as e:
@@ -4186,7 +4263,8 @@ class SlackAdapter(BasePlatformAdapter):
         choice = choice_map.get(action_id, "deny")
 
         # Prevent double-clicks — atomic pop; first caller gets False, others get True (default)
-        if self._approval_resolved.pop(msg_ts, True):
+        approval_key = self._workspace_message_marker(team_id, msg_ts)
+        if self._approval_resolved.pop(approval_key, True):
             return
 
         # Update the message to show the decision and remove buttons
@@ -4487,9 +4565,8 @@ class SlackAdapter(BasePlatformAdapter):
         channel_id = command.get("channel_id", "")
         team_id = command.get("team_id", "")
 
-        # Track which workspace owns this channel
-        if team_id and channel_id:
-            self._channel_team[channel_id] = team_id
+        # Keep the channel-only fallback only while this id is unambiguous.
+        self._remember_channel_team(channel_id, team_id)
 
         if slash_name in {"hermes", ""}:
             # Legacy /hermes <subcommand> [args] routing + free-form questions.
@@ -4548,7 +4625,12 @@ class SlackAdapter(BasePlatformAdapter):
         # the whole channel can see the agent's answer.
         response_url = command.get("response_url", "")
         if response_url and user_id and channel_id and text.startswith("/"):
-            self._slash_command_contexts[(channel_id, user_id)] = {
+            context_key = (
+                (str(team_id), str(channel_id), str(user_id))
+                if team_id
+                else (str(channel_id), str(user_id))
+            )
+            self._slash_command_contexts[context_key] = {
                 "response_url": response_url,
                 "ts": time.monotonic(),
             }

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1,6 +1,7 @@
 """Tests for gateway session management."""
 import json
 import pytest
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 from gateway.config import Platform, HomeChannel, GatewayConfig, PlatformConfig
@@ -806,6 +807,130 @@ class TestSessionStoreLookupBySessionId:
         assert store.lookup_by_session_id(entry.session_id) is entry
         assert store.lookup_by_session_id("missing") is None
         assert store.lookup_by_session_id("") is None
+
+
+class TestSlackWorkspaceSessionIsolation:
+    @pytest.fixture()
+    def store(self, tmp_path):
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            session_store = SessionStore(sessions_dir=tmp_path, config=config)
+        session_store._db = None
+        session_store._loaded = True
+        return session_store
+
+    def test_dm_keys_include_only_slack_workspace_scope(self):
+        first = SessionSource(
+            platform=Platform.SLACK,
+            scope_id="T111",
+            chat_id="D123",
+            chat_type="dm",
+        )
+        second = SessionSource(
+            platform=Platform.SLACK,
+            scope_id="T222",
+            chat_id="D123",
+            chat_type="dm",
+        )
+
+        assert build_session_key(first) == "agent:main:slack:dm:T111:D123"
+        assert build_session_key(second) == "agent:main:slack:dm:T222:D123"
+        assert build_session_key(first) != build_session_key(second)
+
+        discord = SessionSource(
+            platform=Platform.DISCORD,
+            scope_id="G111",
+            chat_id="D123",
+            chat_type="dm",
+        )
+        assert build_session_key(discord) == "agent:main:discord:dm:D123"
+
+    def test_channel_keys_include_workspace_scope(self):
+        first = SessionSource(
+            platform=Platform.SLACK,
+            scope_id="T111",
+            chat_id="C123",
+            chat_type="group",
+            user_id="U1",
+            thread_id="1700000000.000100",
+        )
+        second = SessionSource(
+            platform=Platform.SLACK,
+            scope_id="T222",
+            chat_id="C123",
+            chat_type="group",
+            user_id="U1",
+            thread_id="1700000000.000100",
+        )
+
+        expected_suffix = "C123:1700000000.000100"
+        assert build_session_key(first) == f"agent:main:slack:group:T111:{expected_suffix}"
+        assert build_session_key(second) == f"agent:main:slack:group:T222:{expected_suffix}"
+        assert build_session_key(first) != build_session_key(second)
+
+    def test_legacy_routing_entry_moves_to_first_workspace_only(self, store):
+        legacy_source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="D_SHARED",
+            chat_type="dm",
+            user_id="U_SHARED",
+        )
+        legacy_entry = store.get_or_create_session(legacy_source)
+        legacy_key = legacy_entry.session_key
+
+        team_one_source = SessionSource(
+            platform=Platform.SLACK,
+            scope_id="T_ONE",
+            chat_id="D_SHARED",
+            chat_type="dm",
+            user_id="U_SHARED",
+        )
+        team_one_entry = store.get_or_create_session(team_one_source)
+
+        assert team_one_entry.session_id == legacy_entry.session_id
+        assert team_one_entry.session_key == "agent:main:slack:dm:T_ONE:D_SHARED"
+        assert legacy_key not in store._entries
+
+        team_two_source = replace(team_one_source, scope_id="T_TWO", guild_id="T_TWO")
+        team_two_entry = store.get_or_create_session(team_two_source)
+        assert team_two_entry.session_id != team_one_entry.session_id
+        assert team_two_entry.session_key == "agent:main:slack:dm:T_TWO:D_SHARED"
+
+    def test_legacy_db_fallback_is_exact_and_rewrites_peer_key(self, store):
+        source = SessionSource(
+            platform=Platform.SLACK,
+            scope_id="T_ONE",
+            chat_id="D_SHARED",
+            chat_type="dm",
+            user_id="U_SHARED",
+        )
+        scoped_key = build_session_key(source)
+        legacy_key = build_session_key(replace(source, scope_id=None, guild_id=None))
+        store._db = MagicMock()
+        store._db.find_latest_gateway_session_for_peer.side_effect = [
+            None,
+            {
+                "id": "legacy-session",
+                "session_key": legacy_key,
+                "started_at": 1.0,
+            },
+        ]
+
+        entry = store.get_or_create_session(source)
+
+        assert entry.session_id == "legacy-session"
+        assert entry.session_key == scoped_key
+        calls = store._db.find_latest_gateway_session_for_peer.call_args_list
+        assert [call.kwargs["session_key"] for call in calls] == [
+            scoped_key,
+            legacy_key,
+        ]
+        assert all(call.kwargs["chat_id"] is None for call in calls)
+        assert all(call.kwargs["chat_type"] is None for call in calls)
+        assert (
+            store._db.record_gateway_session_peer.call_args.kwargs["session_key"]
+            == scoped_key
+        )
 
 
 class TestWhatsAppSessionKeyConsistency:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -170,6 +170,87 @@ class TestSlashCommandSessionIsolation:
         assert event.source.scope_id == "T123"
 
 
+class TestSlackWorkspaceCollisionIsolation:
+    @pytest.mark.asyncio
+    async def test_same_ids_in_two_workspaces_are_both_delivered(self, adapter):
+        from gateway.session import build_session_key
+
+        team_one, team_two = AsyncMock(), AsyncMock()
+        team_one.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Alice"}}}
+        )
+        team_two.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Bob"}}}
+        )
+        adapter._team_clients.update({"T_ONE": team_one, "T_TWO": team_two})
+
+        event = {
+            "text": "same Slack-local ids",
+            "user": "U_SHARED",
+            "channel": "D_SHARED",
+            "channel_type": "im",
+            "ts": "171.000",
+        }
+        await adapter._handle_slack_message(event, {"team_id": "T_ONE"})
+        await adapter._handle_slack_message(event, {"team_id": "T_TWO"})
+
+        assert adapter.handle_message.await_count == 2
+        first = adapter.handle_message.await_args_list[0].args[0]
+        second = adapter.handle_message.await_args_list[1].args[0]
+        assert first.source.scope_id == "T_ONE"
+        assert second.source.scope_id == "T_TWO"
+        assert build_session_key(first.source) != build_session_key(second.source)
+        assert adapter._channel_teams["D_SHARED"] == {"T_ONE", "T_TWO"}
+        assert "D_SHARED" not in adapter._channel_team
+
+    @pytest.mark.asyncio
+    async def test_same_ids_route_outbound_through_each_workspace_client(self, adapter):
+        one, two = AsyncMock(), AsyncMock()
+        one.chat_postMessage = AsyncMock(return_value={"ts": "171.000"})
+        two.chat_postMessage = AsyncMock(return_value={"ts": "171.000"})
+        adapter._team_clients.update({"T_ONE": one, "T_TWO": two})
+
+        await adapter.send(
+            "D_SHARED", "one", metadata={"scope_id": "T_ONE"}
+        )
+        await adapter.send(
+            "D_SHARED", "two", metadata={"slack_team_id": "T_TWO"}
+        )
+
+        one.chat_postMessage.assert_awaited_once_with(
+            channel="D_SHARED", text="one", mrkdwn=True
+        )
+        two.chat_postMessage.assert_awaited_once_with(
+            channel="D_SHARED", text="two", mrkdwn=True
+        )
+        assert ("T_ONE", "171.000") in adapter._bot_message_ts
+        assert ("T_TWO", "171.000") in adapter._bot_message_ts
+
+    @pytest.mark.asyncio
+    async def test_same_ids_keep_slash_contexts_workspace_scoped(self, adapter):
+        import time
+        from plugins.platforms.slack.adapter import _slash_user_id
+
+        for team_id in ("T_ONE", "T_TWO"):
+            adapter._slash_command_contexts[
+                (team_id, "C_SHARED", "U_SHARED")
+            ] = {
+                "response_url": f"https://hooks.slack.com/{team_id}",
+                "ts": time.monotonic(),
+            }
+
+        token = _slash_user_id.set("U_SHARED")
+        try:
+            first = adapter._pop_slash_context("C_SHARED", "T_ONE")
+            second = adapter._pop_slash_context("C_SHARED", "T_TWO")
+        finally:
+            _slash_user_id.reset(token)
+
+        assert first["response_url"].endswith("T_ONE")
+        assert second["response_url"].endswith("T_TWO")
+        assert adapter._slash_command_contexts == {}
+
+
 # ---------------------------------------------------------------------------
 # TestAppMentionHandler
 # ---------------------------------------------------------------------------
@@ -3090,7 +3171,7 @@ class TestThreadReplyHandling:
     ):
         """Thread replies without mention should be processed if there's an active session."""
         # Simulate an active session for this thread
-        session_key = "agent:main:slack:group:C123:123.000:U_USER"
+        session_key = "agent:main:slack:group:T_TEAM:C123:123.000:U_USER"
         mock_session_store._entries = {session_key: MagicMock()}
 
         event = {
@@ -3115,7 +3196,7 @@ class TestThreadReplyHandling:
     ):
         """Thread replies with @mention should still strip the bot ID."""
         # Even with a session, mentions should be stripped
-        session_key = "agent:main:slack:group:C123:123.000:U_USER"
+        session_key = "agent:main:slack:group:T_TEAM:C123:123.000:U_USER"
         mock_session_store._entries = {session_key: MagicMock()}
 
         event = {


### PR DESCRIPTION
## Summary
- include Slack team/workspace scope in gateway session keys
- key slash response contexts, assistant-thread metadata, active status, and bot thread markers by workspace
- keep legacy fallback lookups so existing sessions and cached metadata continue to work

## Why
Slack channel, DM, user, and thread IDs can collide across connected workspaces. Without team_id in these keys, multi-workspace gateways can route responses or session state across workspace boundaries.

## Tests
- uv run pytest tests/gateway/test_session.py tests/gateway/test_slack.py tests/gateway/test_slack_approval_buttons.py -q

Fixes part of #10099.