### PR TITLE
fix(gateway): delete tool-progress bubble after response lands, with opt-out

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12752,6 +12752,10 @@ class GatewayRunner:
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform
         tool_progress_enabled = progress_mode != "off" and source.platform != Platform.WEBHOOK
+        delete_progress_messages = is_truthy_value(
+            resolve_display_setting(user_config, platform_key, "delete_progress_messages"),
+            default=True,
+        )
         # Natural assistant status messages are intentionally independent from
         # tool progress and token streaming. Users can keep tool_progress quiet
         # in chat platforms while opting into concise mid-turn updates.
@@ -12930,6 +12934,13 @@ class GatewayRunner:
                                 progress_queue.get_nowait()
                             except Exception:
                                 break
+                        if delete_progress_messages and progress_msg_id and can_edit:
+                            try:
+                                _del = getattr(adapter, "delete_message", None)
+                                if _del is not None:
+                                    await _del(source.chat_id, progress_msg_id)
+                            except Exception:
+                                pass
                         return
 
                     raw = progress_queue.get_nowait()
@@ -12957,14 +12968,16 @@ class GatewayRunner:
                             progress_lines[-1] = f"{base_msg} (×{count + 1})"
                         msg = progress_lines[-1] if progress_lines else base_msg
                     elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
-                        # Content bubble just landed on the platform — close off
-                        # the current tool-progress bubble so the next tool
-                        # starts a fresh bubble below the content. Without this,
-                        # tool lines keep editing the ORIGINAL progress message
-                        # above the new content, making the chat appear out of
-                        # order. Mirrors GatewayStreamConsumer.on_segment_break
-                        # on the content side. (Issue: tool + content
-                        # linearization regression after PR #7885.)
+                        # Content bubble just landed on the platform — delete
+                        # the tool-progress bubble so it doesn't linger above
+                        # the response, then start fresh below the content.
+                        if delete_progress_messages and can_edit and progress_msg_id:
+                            try:
+                                _del = getattr(adapter, "delete_message", None)
+                                if _del is not None:
+                                    await _del(source.chat_id, progress_msg_id)
+                            except Exception:
+                                pass
                         progress_msg_id = None
                         progress_lines = []
                         last_progress_msg[0] = None
@@ -12988,6 +13001,13 @@ class GatewayRunner:
                         continue
 
                     if not _run_still_current():
+                        if delete_progress_messages and progress_msg_id and can_edit:
+                            try:
+                                _del = getattr(adapter, "delete_message", None)
+                                if _del is not None:
+                                    await _del(source.chat_id, progress_msg_id)
+                            except Exception:
+                                pass
                         return
 
                     if can_edit and progress_msg_id is not None:
@@ -13029,7 +13049,17 @@ class GatewayRunner:
                         await adapter.send_typing(source.chat_id, metadata=_progress_metadata)
 
                 except queue.Empty:
-                    await asyncio.sleep(0.3)
+                    try:
+                        await asyncio.sleep(0.3)
+                    except asyncio.CancelledError:
+                        if delete_progress_messages and progress_msg_id and can_edit:
+                            try:
+                                _del = getattr(adapter, "delete_message", None)
+                                if _del is not None:
+                                    await _del(source.chat_id, progress_msg_id)
+                            except Exception:
+                                pass
+                        return
                 except asyncio.CancelledError:
                     # Drain remaining queued messages
                     while not progress_queue.empty():
@@ -13040,17 +13070,13 @@ class GatewayRunner:
                                 if progress_lines:
                                     progress_lines[-1] = f"{base_msg} (×{count + 1})"
                             elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
-                                # Content-bubble marker during drain: close off
-                                # the current progress bubble and start a fresh
-                                # one for any tool lines that arrived after.
-                                if can_edit and progress_lines and progress_msg_id:
-                                    _pending_text = "\n".join(progress_lines)
+                                # Content-bubble marker during drain: delete the
+                                # progress bubble (content already delivered).
+                                if delete_progress_messages and can_edit and progress_msg_id:
                                     try:
-                                        await adapter.edit_message(
-                                            chat_id=source.chat_id,
-                                            message_id=progress_msg_id,
-                                            content=_pending_text,
-                                        )
+                                        _del = getattr(adapter, "delete_message", None)
+                                        if _del is not None:
+                                            await _del(source.chat_id, progress_msg_id)
                                     except Exception:
                                         pass
                                 progress_msg_id = None
@@ -13070,6 +13096,15 @@ class GatewayRunner:
                                 message_id=progress_msg_id,
                                 content=full_text,
                             )
+                        except Exception:
+                            pass
+                    # Delete the progress message so it doesn't persist as an
+                    # artifact in the chat after the run completes.
+                    if delete_progress_messages and progress_msg_id and can_edit:
+                        try:
+                            delete_fn = getattr(adapter, "delete_message", None)
+                            if delete_fn is not None:
+                                await delete_fn(source.chat_id, progress_msg_id)
                         except Exception:
                             pass
                     return

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1157,6 +1157,7 @@ display:
   platforms: {}           # Per-platform display overrides (see below)
   tool_progress_overrides: {}  # DEPRECATED — use display.platforms instead
   interim_assistant_messages: true  # Gateway: send natural mid-turn assistant updates as separate messages
+  delete_progress_messages: true   # Gateway: delete tool-progress bubbles after the response lands
   skin: default           # Built-in or custom CLI skin (see user-guide/features/skins)
   personality: "kawaii"  # Legacy cosmetic field still surfaced in some summaries
   compact: false          # Compact output mode (less whitespace)
@@ -1214,6 +1215,22 @@ display:
 Platforms without an override fall back to the global `tool_progress` value. Valid platform keys: `telegram`, `discord`, `slack`, `signal`, `whatsapp`, `matrix`, `mattermost`, `email`, `sms`, `homeassistant`, `dingtalk`, `feishu`, `wecom`, `weixin`, `bluebubbles`, `qqbot`. The legacy `display.tool_progress_overrides` key still loads for backward compatibility but is deprecated and migrated into `display.platforms` on first load.
 
 `interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
+
+`delete_progress_messages` is gateway-only. When enabled (the default), the tool-progress bubble is deleted once the final response has been delivered — keeping the chat clean with only the assistant reply visible. Set to `false` to preserve the progress bubble above the response:
+
+```yaml
+display:
+  delete_progress_messages: false
+```
+
+Can also be scoped per-platform:
+
+```yaml
+display:
+  platforms:
+    telegram:
+      delete_progress_messages: false   # keep progress visible on Telegram
+```
 
 ## Privacy
 


### PR DESCRIPTION
## Summary

- Replaces the close-off / final-edit pattern on `__reset__` with an explicit `delete_message` call so the tool-progress bubble disappears once the assistant reply is delivered
- Adds `display.delete_progress_messages` config key (default `true`) so users can opt out and keep the bubble visible
- Documents the new option in the configuration reference

## Behavior

**Before:** the progress bubble was left in the chat above the response (or finalized with a last edit), creating visual noise.

**After:** the progress bubble is deleted once the response lands. To preserve the old behavior:

```yaml
display:
  delete_progress_messages: false
```

Supports per-platform overrides:

```yaml
display:
  platforms:
    telegram:
      delete_progress_messages: false
```

## Test plan

- [ ] Send a message that triggers tool use — confirm the progress bubble disappears after the response arrives
- [ ] Set `delete_progress_messages: false` — confirm the progress bubble persists above the response
- [ ] Test per-platform override (e.g. disable only on Telegram)
- [ ] Verify interrupted runs still clean up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)