### PR TITLE
fix: forward reasoning_config to custom providers (vLLM, Ollama, etc.)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -341,7 +341,16 @@ class ChatCompletionsTransport(ProviderTransport):
                 if gh_reasoning is not None:
                     extra_body["reasoning"] = gh_reasoning
             else:
-                extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
+                # Use the user-configured effort level when available,
+                # falling back to "medium" for known providers.  Custom
+                # providers (vLLM etc.) carry the user's reasoning_config
+                # effort so thinking_token_budget is respected.  See #20576.
+                _effort = "medium"
+                if reasoning_config and isinstance(reasoning_config, dict):
+                    _e = (reasoning_config.get("effort") or "").strip().lower()
+                    if _e in ("low", "medium", "high"):
+                        _effort = _e
+                extra_body["reasoning"] = {"enabled": True, "effort": _effort}
 
         if provider_name == "gemini":
             raw_thinking_config = _build_gemini_thinking_config(model, reasoning_config)

--- a/run_agent.py
+++ b/run_agent.py
@@ -8662,6 +8662,14 @@ class AIAgent:
             opts = self._lmstudio_reasoning_options_cached()
             # "off-only" (or absent) means no real reasoning capability.
             return any(opt and opt != "off" for opt in opts)
+        # Custom provider (e.g. vLLM, Ollama, etc.): honor explicit
+        # reasoning_config from the user.  vLLM supports reasoning_effort
+        # and thinking_token_budget for thinking models; without this gate
+        # those parameters are silently dropped.  See #20576.
+        if (self.provider or "").strip().lower() == "custom":
+            if self.reasoning_config and isinstance(self.reasoning_config, dict):
+                return self.reasoning_config.get("enabled") is not False
+            return False
         if "openrouter" not in self._base_url_lower:
             return False
         if "api.mistral.ai" in self._base_url_lower:


### PR DESCRIPTION
## Problem

When using `provider: custom` with a vLLM-served thinking model (e.g. MiniMax-M2.7, DeepSeek-R1, GLM-4.x), the agent silently sends no thinking-budget control on the wire request. This causes:

1. **Runaway reasoning**: The model spends the entire `max_tokens` budget inside `<think>` blocks, producing empty `content` with `finish_reason: "length"` — no recovery path for the user.
2. **No effort control**: Even when the user explicitly configures `reasoning_config.effort`, it's ignored for custom providers.

**Root cause**: `_supports_reasoning_extra_body()` in `run_agent.py` returns `False` for any `base_url` not in its hardcoded allowlist (OpenRouter, Nous, GitHub, LM Studio). Custom/vLLM providers are excluded, so `extra_body.reasoning` is never emitted — even when the user explicitly opted in via `reasoning_config`.

Additionally, when reasoning *is* supported, the effort level was hardcoded to `"medium"` instead of respecting the user's `reasoning_config.effort`.

## Fix

**`run_agent.py`**: Added a `"custom"` provider check in `_supports_reasoning_extra_body()` that honors the user's explicit `reasoning_config`. Returns `True` when `enabled` is not explicitly set to `False`.

**`agent/transports/chat_completions.py`**: Changed the reasoning extra_body assembly to use the user's configured effort level from `reasoning_config` instead of hardcoding `"medium"`. Consistent with how Kimi and TokenHub handle effort levels.

## Before vs After

| Scenario | Before | After |
|---|---|---|
| `provider: custom` + `reasoning_config: {effort: high}` | `extra_body.reasoning` NOT sent | `extra_body.reasoning = {enabled: true, effort: "high"}` |
| `provider: custom` + no reasoning_config | No reasoning sent | No reasoning sent (unchanged) |
| `provider: custom` + `reasoning_config: {enabled: false}` | No reasoning sent | No reasoning sent (unchanged) |
| OpenRouter + `reasoning_config: {effort: low}` | Hardcoded `"medium"` | `"low"` from user config |

## Related

Fixes #20576
