### PR TITLE
fix(credentials): prefer ~/.hermes/.env over stale os.environ on key rotation

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
-from hermes_cli.config import get_env_value, load_env
+from hermes_cli.config import get_env_value, get_env_value_prefer_dotenv, load_env
 import hermes_cli.auth as auth_mod
 from hermes_cli.auth import (
     CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
@@ -1401,14 +1401,8 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
     changed = False
     active_sources: Set[str] = set()
 
-    # Prefer ~/.hermes/.env over os.environ — the user's config file is the
-    # authoritative source for Hermes credentials. Stale env vars from parent
-    # processes (Codex CLI, test scripts, etc.) should not override deliberate
-    # changes to the .env file.
     def _get_env_prefer_dotenv(key: str) -> str:
-        env_file = load_env()
-        val = env_file.get(key) or os.environ.get(key) or ""
-        return val.strip()
+        return (get_env_value_prefer_dotenv(key) or "").strip()
 
     # Honour user suppression — `hermes auth remove <provider> <N>` for an
     # env-seeded credential marks the env:<VAR> source as suppressed so it

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -551,10 +551,12 @@ def _resolve_api_key_provider_secret(
             pass
         return "", ""
 
-    from hermes_cli.config import get_env_value
+    from hermes_cli.config import get_env_value_prefer_dotenv
     for env_var in pconfig.api_key_env_vars:
-        # Check both os.environ and ~/.hermes/.env file
-        val = (get_env_value(env_var) or "").strip()
+        # Prefer ~/.hermes/.env over os.environ so a deliberate key rotation
+        # in the user's .env file isn't shadowed by a stale shell export
+        # inherited from a parent process (Codex CLI, test runners, etc.).
+        val = (get_env_value_prefer_dotenv(env_var) or "").strip()
         if has_usable_secret(val):
             return val, env_var
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4589,10 +4589,26 @@ def get_env_value(key: str) -> Optional[str]:
     # Check environment first
     if key in os.environ:
         return os.environ[key]
-    
+
     # Then check .env file
     env_vars = load_env()
     return env_vars.get(key)
+
+
+def get_env_value_prefer_dotenv(key: str) -> Optional[str]:
+    """Resolve a credential env value, preferring ``~/.hermes/.env`` over ``os.environ``.
+
+    Used for Hermes-managed credentials where a deliberate edit to ``.env``
+    must take precedence over a stale value inherited from the parent shell
+    (Codex CLI, test scripts, login profile exports). Without this, rotating
+    a key in ``.env`` mid-session leaves callers serving the stale shell
+    value and produces persistent 401s.
+    """
+    env_vars = load_env()
+    val = env_vars.get(key)
+    if val:
+        return val
+    return os.environ.get(key)
 
 
 # =============================================================================

--- a/tests/tools/test_credential_pool_env_fallback.py
+++ b/tests/tools/test_credential_pool_env_fallback.py
@@ -1,10 +1,11 @@
 """Tests for credential_pool .env fallback and auth credential_pool lookup.
 
-Covers the fix from #15914 / PR #15920:
+Covers the fix from #15914 / PR #15920 and the rotation fix from #20591:
 - _seed_from_env reads API keys from ~/.hermes/.env when not in os.environ
 - _resolve_api_key_provider_secret falls back to credential_pool when env vars are empty
-- env vars take priority over .env file (handled by get_env_value itself)
-- env vars take priority over credential pool (fallback only kicks in when env is empty)
+- ~/.hermes/.env takes priority over os.environ for Hermes-managed credentials
+  (so a deliberate rotation in .env wins over a stale shell export)
+- env / dotenv values take priority over credential pool (pool fires only when both are empty)
 """
 
 import os
@@ -106,6 +107,23 @@ class TestCredentialPoolSeedsFromDotEnv:
         assert active_sources == set()
         assert entries == []
 
+    def test_dotenv_wins_over_stale_os_environ(self, isolated_hermes_home, monkeypatch):
+        """Regression for #20591: a fresh key rotated into ~/.hermes/.env must
+        win over a stale value inherited from os.environ (parent shell export
+        from Codex CLI, test runner, login profile, etc.). Without this, key
+        rotation produces persistent 401s.
+        """
+        _write_env_file(isolated_hermes_home, DEEPSEEK_API_KEY="sk-dotenv-fresh")
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-env-stale-xyz")
+
+        from agent.credential_pool import _seed_from_env
+        entries = []
+        changed, _ = _seed_from_env("deepseek", entries)
+
+        assert changed is True
+        seeded = [e for e in entries if e.source == "env:DEEPSEEK_API_KEY"]
+        assert len(seeded) == 1
+        assert seeded[0].access_token == "sk-dotenv-fresh"
 
 
 class TestAuthResolvesFromDotEnv:
@@ -122,6 +140,26 @@ class TestAuthResolvesFromDotEnv:
             pconfig=_make_pconfig(),
         )
         assert key == "sk-dotenv-resolve-789"
+        assert source == "DEEPSEEK_API_KEY"
+
+    def test_dotenv_wins_over_stale_os_environ_on_resolve(
+        self, isolated_hermes_home, monkeypatch
+    ):
+        """Regression for #20591: when both ~/.hermes/.env and os.environ define
+        the key, the .env value wins. Symmetric with the pool seeding rule —
+        without this, the pool gets re-seeded with the fresh .env key while the
+        live request path keeps returning the stale shell export, producing
+        persistent 401s after rotation.
+        """
+        _write_env_file(isolated_hermes_home, DEEPSEEK_API_KEY="sk-dotenv-fresh-rotate")
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-env-stale-shell")
+
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+        key, source = _resolve_api_key_provider_secret(
+            provider_id="deepseek",
+            pconfig=_make_pconfig(),
+        )
+        assert key == "sk-dotenv-fresh-rotate"
         assert source == "DEEPSEEK_API_KEY"
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a credential-pool / auth-resolve bug where a deliberate key rotation in `~/.hermes/.env` is shadowed by a stale shell export inherited from the parent process (Codex CLI, login profile, test runner). The result was persistent 401s after rotation: the user edits `.env`, but `os.environ` still wins and the live request path keeps using the dead key.

The issue's root-cause analysis pointed at `_seed_from_env` in `agent/credential_pool.py`, but the real divergence was on the **auth resolve path** — `_resolve_api_key_provider_secret` was calling `get_env_value`, which checks `os.environ` first. So even though the pool's inline `_get_env_prefer_dotenv` had the right intent, the live request resolution didn't share that policy. Symmetric fix on both sides.

## Related Issue

Fixes #20591

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py`: add `get_env_value_prefer_dotenv(key)` — checks `~/.hermes/.env` first, falls back to `os.environ`. Existing `get_env_value` is unchanged so generic env reads keep `os.environ`-first semantics.
- `hermes_cli/auth.py::_resolve_api_key_provider_secret`: route Hermes-managed credential lookup through the new helper so the resolve path matches the pool seeding policy.
- `agent/credential_pool.py::_seed_from_env`: collapse the inline `_get_env_prefer_dotenv` onto the shared helper (single source of truth).
- `tests/tools/test_credential_pool_env_fallback.py`:
  - flip `test_os_environ_still_wins_over_dotenv` → `test_dotenv_wins_over_stale_os_environ` (the prior expectation encoded the bug — it asserted stale shell export wins, which is exactly what users hit on rotation).
  - add `test_dotenv_wins_over_stale_os_environ_on_resolve` covering the auth resolve path so the pool/auth symmetry is locked in by tests.

## How to Test

1. `pytest tests/tools/test_credential_pool_env_fallback.py tests/agent/test_credential_pool.py -q` → 51 passed.
2. Reproduce the original bug manually:
   - `export OPENROUTER_API_KEY=sk-or-stale-from-shell`
   - edit `~/.hermes/.env` → `OPENROUTER_API_KEY=sk-or-fresh-rotated`
   - run `hermes` — pre-fix the request used the stale shell key (401), post-fix it uses the rotated `.env` value.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(credentials): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 14.2 (Darwin 23.2.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal helper, behavior preserved for `get_env_value`)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — yes, fix is pure Python over `os.environ` + dotenv parsing
- [x] I've updated tool descriptions/schemas — N/A