### PR TITLE
fix(xai): omit tool_choice when no tools are available

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -711,6 +711,13 @@ def _preflight_codex_api_kwargs(
         if val is not None:
             normalized[passthrough_key] = val
 
+    # Strip tool_choice/parallel_tool_calls when no tools are present to
+    # avoid provider 400 errors (e.g. xAI/Grok rejects tool_choice without
+    # any tools in the tools array — issue #20590).
+    if normalized.get("tool_choice") is not None and not normalized.get("tools"):
+        normalized.pop("tool_choice", None)
+        normalized.pop("parallel_tool_calls", None)
+
     extra_headers = api_kwargs.get("extra_headers")
     if extra_headers is not None:
         if not isinstance(extra_headers, dict):

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -89,15 +89,17 @@ class ResponsesApiTransport(ProviderTransport):
         _effort_clamp = {"minimal": "low"}
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
 
-        kwargs = {
+        _resolved_tools = _responses_tools(tools)
+        kwargs: Dict[str, Any] = {
             "model": model,
             "instructions": instructions,
             "input": _chat_messages_to_responses_input(payload_messages),
-            "tools": _responses_tools(tools),
-            "tool_choice": "auto",
-            "parallel_tool_calls": True,
             "store": False,
         }
+        if _resolved_tools:
+            kwargs["tools"] = _resolved_tools
+            kwargs["tool_choice"] = "auto"
+            kwargs["parallel_tool_calls"] = True
 
         session_id = params.get("session_id")
         if not is_github_responses and session_id:


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where xAI/Grok providers reject requests with HTTP 400
`"tool_choice was set but no tools were specified"` when no local function
tools are available (e.g. the `web_search` toolset is filtered out by
`check_web_api_key`).

**Root cause:** The `ResponsesApiTransport.build_kwargs()` unconditionally
sets `tool_choice: "auto"` and `parallel_tool_calls: true` in every request,
regardless of whether any function tools were resolved. When
`_responses_tools(tools)` returns `None` (empty input list), the outgoing
body contains `tool_choice` and `parallel_tool_calls` but no `tools` array
— which xAI's Responses API rejects.

## Related Issue

Fixes #20590 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

### `agent/transports/codex.py`
- Moved `tool_choice`/`parallel_tool_calls` out of the static kwargs dict
  into a conditional block that only executes when `_responses_tools()`
  returns a non-empty list
- When no function tools are available, these fields are omitted entirely

### `agent/codex_responses_adapter.py`
- Added defense-in-depth in `_preflight_codex_api_kwargs()`: after the
  `tool_choice`/`parallel_tool_calls` passthrough, strip both fields when
  the normalized `tools` array is empty or absent

## How to Test

1. Configure xAI/Grok as provider
2. Remove/disable all function tools (e.g. remove API keys for web_search)
3. Run a query — the outgoing request should have no `tool_choice` field
   when `tools` is empty
4. The request should no longer receive HTTP 400 from xAI