### PR TITLE
fix: preserve <think> blocks in content for vLLM/custom provider replay

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9044,6 +9044,19 @@ class AIAgent:
         # genuine reasoning content is not overwritten (#15812 regression in
         # PR #15478).
         if isinstance(normalized_reasoning, str) and normalized_reasoning:
+            # Custom/vLLM providers: vLLM's OpenAI-compat endpoint does NOT
+            # consume reasoning_content on incoming messages — it expects
+            # <think> blocks inline in content (MiniMax M2.7, DeepSeek-R1,
+            # GLM-4.x on vLLM).  Reconstruct the think blocks so the
+            # model's chain-of-thought is preserved across turns.  See #20577.
+            _provider = (getattr(self, "provider", None) or "").strip().lower()
+            if _provider == "custom":
+                _content = api_msg.get("content") or ""
+                if isinstance(_content, str) and normalized_reasoning not in _content:
+                    api_msg["content"] = (
+                        f"<think>\n{normalized_reasoning}\n</think>\n{_content}"
+                    )
+                return
             api_msg["reasoning_content"] = normalized_reasoning
             return
 


### PR DESCRIPTION
## Problem

When replaying multi-turn history to a vLLM-served thinking model (e.g. MiniMax-M2.7, DeepSeek-R1, GLM-4.x) over `provider: custom`, prior assistant turns have their `<think>` blocks **stripped from `content`** and routed to a separate `reasoning_content` field.

vLLM's OpenAI-compat chat endpoint does **not** consume `reasoning_content` on incoming messages — MiniMax's official documentation explicitly requires the prior `<think>` block to be re-embedded inline in `content`:

> "You must preserve the model's thinking content completely, i.e. `<think>reasoning_content</think>`. This is essential to ensure Interleaved Thinking works effectively."
> — [MiniMax M2.7 tool-calling guide](https://huggingface.co/MiniMaxAI/MiniMax-M2.7/blob/main/docs/tool_calling_guide.md)

**Net effect**: vLLM sees stripped content with no chain-of-thought from prior turns. MiniMax's interleaved-thinking docs claim up to ~40% regression on multi-step benchmarks when prior `<think>` is omitted.

## Fix

In `_copy_reasoning_content_for_api()`, when the provider is `"custom"`, reconstruct `<think>...</think>` blocks in the `content` field from the stored `reasoning` field instead of setting `reasoning_content`.

This is consistent with how the code already reconstructs think blocks for trajectory storage (line ~3953: `content = f"<think>\n{msg['reasoning']}\n</think>\n"`).

## Before vs After

| Scenario | Before | After |
|---|---|---|
| Custom provider + multi-turn history | `content` has no `<think>`, `reasoning_content` set (ignored by vLLM) | `content` has `<think>` blocks reconstructed from `reasoning` field |
| DeepSeek/Kimi provider | `reasoning_content` set (unchanged) | `reasoning_content` set (unchanged) |
| OpenRouter provider | `reasoning_content` set (unchanged) | `reasoning_content` set (unchanged) |

## Related

Fixes #20577
Companion PR: #20594 (reasoning_config forwarding to custom providers)
