### PR TITLE
feat(github): add PR preflight receipt helper

### DIFF
--- a/scripts/github_pr_preflight.py
+++ b/scripts/github_pr_preflight.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""Preflight GitHub PR push/create strategy and emit a reviewable receipt.
+
+This script intentionally stays small and dependency-free. It answers the
+questions that should be known before an agent tries to push or open a PR:
+
+- Which GitHub repository does the current remote point to?
+- Is the working tree clean?
+- Is GitHub CLI authenticated?
+- Does the active account have write-level permission on upstream?
+- Should the branch push directly to origin or to a fork remote?
+- Is a fork PR blocked on maintainer workflow approval rather than CI failure?
+
+It prints JSON so callers can route, summarize, or write PR bodies without
+scraping terminal prose.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+WRITE_LEVEL_PERMISSIONS = {"ADMIN", "MAINTAIN", "WRITE"}
+FORK_LEVEL_PERMISSIONS = {"READ", "TRIAGE", "NONE"}
+REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+PR_NUMBER_RE = re.compile(r"^[1-9][0-9]*$")
+
+CommandRunner = Callable[[Sequence[str], Path], subprocess.CompletedProcess[str]]
+
+
+def parse_github_remote_url(url: str) -> str | None:
+    """Return owner/repo for common GitHub remote URL forms."""
+
+    cleaned = url.strip()
+    patterns = (
+        r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$",
+        r"^git@github\.com:(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?$",
+        r"^ssh://git@github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$",
+    )
+    for pattern in patterns:
+        match = re.match(pattern, cleaned)
+        if match:
+            candidate = f"{match.group('owner')}/{match.group('repo')}"
+            try:
+                return validate_repo_slug(candidate)
+            except ValueError:
+                return None
+    return None
+
+
+def validate_repo_slug(value: str) -> str:
+    """Validate OWNER/REPO before passing it to gh as a positional value."""
+
+    candidate = value.strip()
+    if not REPO_SLUG_RE.fullmatch(candidate):
+        raise ValueError("Repository must be in OWNER/REPO form.")
+    if any(part.startswith("-") for part in candidate.split("/")):
+        raise ValueError("Repository owner/name must not start with '-'.")
+    return candidate
+
+
+def parse_pr_identifier(value: str) -> str:
+    """Return a numeric PR id from a number or GitHub pull-request URL."""
+
+    candidate = value.strip()
+    if PR_NUMBER_RE.fullmatch(candidate):
+        return candidate
+    parsed = urlparse(candidate)
+    if parsed.scheme in {"http", "https"} and parsed.netloc.lower() == "github.com":
+        parts = [part for part in parsed.path.split("/") if part]
+        if len(parts) >= 4 and parts[-2] == "pull" and PR_NUMBER_RE.fullmatch(parts[-1]):
+            return parts[-1]
+    raise ValueError("PR must be a positive integer or a GitHub /pull/<number> URL.")
+
+
+def recommend_push_strategy(
+    *, viewer_permission: str | None, working_tree_clean: bool, gh_authenticated: bool
+) -> str:
+    """Return the safest push strategy for a GitHub PR workflow."""
+
+    if not gh_authenticated:
+        return "blocked_auth"
+    if not working_tree_clean:
+        return "blocked_dirty_tree"
+
+    normalized = (viewer_permission or "").upper()
+    if normalized in WRITE_LEVEL_PERMISSIONS:
+        return "direct_origin"
+    if normalized in FORK_LEVEL_PERMISSIONS:
+        return "fork_remote"
+    return "unknown_permission"
+
+
+def classify_ci_state(
+    *, checks: Sequence[dict[str, Any]] | None, workflow_runs: Sequence[dict[str, Any]] | None
+) -> dict[str, Any]:
+    """Classify PR checks/runs into a compact receipt state.
+
+    GitHub marks fork pull-request workflows as ``action_required`` before an
+    upstream maintainer approves them. That state is not a test failure and
+    should be surfaced as a waiting-for-maintainer gate.
+    """
+
+    checks = list(checks or [])
+    workflow_runs = list(workflow_runs or [])
+
+    failed_checks = [
+        check
+        for check in checks
+        if str(check.get("conclusion") or check.get("state") or "").lower()
+        in {"failure", "failed", "error", "cancelled", "timed_out"}
+    ]
+    failed_runs = [
+        run
+        for run in workflow_runs
+        if str(run.get("conclusion") or "").lower()
+        in {"failure", "failed", "error", "cancelled", "timed_out"}
+    ]
+    if failed_checks or failed_runs:
+        return {
+            "state": "failure",
+            "blocked_by": "ci_failure",
+            "is_failure": True,
+            "next_action": "Inspect failing checks or workflow logs and push a fix.",
+            "checks": failed_checks,
+            "runs": failed_runs,
+        }
+
+    action_required_runs = [
+        run
+        for run in workflow_runs
+        if str(run.get("conclusion") or "").lower() == "action_required"
+    ]
+    if action_required_runs:
+        return {
+            "state": "action_required",
+            "blocked_by": "maintainer_workflow_approval",
+            "is_failure": False,
+            "next_action": "Ask an upstream maintainer to approve fork workflow runs.",
+            "runs": action_required_runs,
+        }
+
+    pending_checks = [
+        check
+        for check in checks
+        if str(check.get("status") or check.get("state") or "").lower()
+        in {"queued", "pending", "in_progress", "requested", "waiting", "expected"}
+    ]
+    pending_runs = [
+        run
+        for run in workflow_runs
+        if str(run.get("status") or "").lower() in {"queued", "pending", "in_progress", "waiting"}
+    ]
+    if pending_checks or pending_runs:
+        return {
+            "state": "pending",
+            "blocked_by": "ci_pending",
+            "is_failure": False,
+            "next_action": "Wait for CI to finish.",
+            "checks": pending_checks,
+            "runs": pending_runs,
+        }
+
+    if checks or workflow_runs:
+        return {
+            "state": "success",
+            "blocked_by": None,
+            "is_failure": False,
+            "next_action": "Review or merge when ready.",
+            "checks": checks,
+            "runs": workflow_runs,
+        }
+
+    return {
+        "state": "no_checks",
+        "blocked_by": "checks_not_reported",
+        "is_failure": False,
+        "next_action": "Wait briefly, then inspect repository workflow configuration if checks remain absent.",
+        "checks": [],
+        "runs": [],
+    }
+
+
+def build_pr_receipt(
+    *,
+    preflight: dict[str, Any],
+    pr: dict[str, Any] | None,
+    ci: dict[str, Any] | None,
+    local_validation: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a stable JSON receipt for PR delivery/status updates."""
+
+    pr = pr or {}
+    ci = ci or classify_ci_state(checks=[], workflow_runs=[])
+    return {
+        "repo": preflight.get("repo"),
+        "branch": preflight.get("branch"),
+        "strategy": preflight.get("strategy"),
+        "viewer_permission": preflight.get("viewer_permission"),
+        "working_tree_clean": preflight.get("working_tree_clean"),
+        "pr_number": pr.get("number"),
+        "pr_url": pr.get("url"),
+        "pr_state": pr.get("state"),
+        "draft": pr.get("isDraft"),
+        "mergeable": pr.get("mergeable"),
+        "base": pr.get("baseRefName"),
+        "head": pr.get("headRefName"),
+        "ci_state": ci.get("state"),
+        "blocked_by": ci.get("blocked_by"),
+        "ci_failure": ci.get("is_failure"),
+        "next_action": ci.get("next_action"),
+        "local_validation": local_validation or {},
+    }
+
+
+def _default_runner(args: Sequence[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - args are static lists built by this script.
+        list(args),
+        cwd=str(cwd),
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _run_json(runner: CommandRunner, args: Sequence[str], cwd: Path) -> dict[str, Any] | None:
+    result = runner(args, cwd)
+    if result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout or "{}")
+    except json.JSONDecodeError:
+        return None
+
+
+def _run_json_list(runner: CommandRunner, args: Sequence[str], cwd: Path) -> list[dict[str, Any]]:
+    result = runner(args, cwd)
+    if result.returncode != 0:
+        return []
+    try:
+        data = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def _run_text(runner: CommandRunner, args: Sequence[str], cwd: Path) -> tuple[int, str, str]:
+    result = runner(args, cwd)
+    return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+
+def collect_preflight(
+    *, cwd: Path, remote: str = "origin", runner: CommandRunner = _default_runner
+) -> dict[str, Any]:
+    """Collect Git/GitHub preflight data for the current branch."""
+
+    code, branch, branch_err = _run_text(runner, ["git", "branch", "--show-current"], cwd)
+    if code != 0:
+        branch = ""
+
+    code, status, _ = _run_text(runner, ["git", "status", "--porcelain"], cwd)
+    working_tree_clean = code == 0 and status == ""
+
+    code, remote_url, remote_err = _run_text(runner, ["git", "remote", "get-url", remote], cwd)
+    repo = parse_github_remote_url(remote_url) if code == 0 else None
+
+    gh_status = runner(["gh", "auth", "status"], cwd)
+    gh_authenticated = gh_status.returncode == 0
+
+    repo_view = (
+        _run_json(
+            runner,
+            ["gh", "repo", "view", repo or "", "--json", "nameWithOwner,viewerPermission,defaultBranchRef"],
+            cwd,
+        )
+        if repo and gh_authenticated
+        else None
+    )
+    viewer_permission = (repo_view or {}).get("viewerPermission")
+    default_branch_ref = (repo_view or {}).get("defaultBranchRef") or {}
+    default_branch = default_branch_ref.get("name")
+
+    existing_prs = (
+        _run_json_list(
+            runner,
+            [
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--head",
+                branch,
+                "--json",
+                "number,url,state,title,isDraft",
+            ],
+            cwd,
+        )
+        if repo and branch and gh_authenticated
+        else []
+    )
+
+    strategy = recommend_push_strategy(
+        viewer_permission=viewer_permission,
+        working_tree_clean=working_tree_clean,
+        gh_authenticated=gh_authenticated,
+    )
+
+    return {
+        "repo": repo,
+        "remote": remote,
+        "remote_url": remote_url if code == 0 else None,
+        "branch": branch,
+        "default_branch": default_branch,
+        "viewer_permission": viewer_permission,
+        "strategy": strategy,
+        "working_tree_clean": working_tree_clean,
+        "gh_authenticated": gh_authenticated,
+        "existing_pr": existing_prs[0] if existing_prs else None,
+        "errors": [err for err in (branch_err, remote_err, gh_status.stderr.strip()) if err and not gh_authenticated],
+    }
+
+
+def collect_pr_status(
+    *,
+    repo: str,
+    pr_number: str,
+    branch: str | None = None,
+    cwd: Path,
+    runner: CommandRunner = _default_runner,
+) -> dict[str, Any]:
+    """Collect PR metadata and classify its check/workflow state."""
+
+    pr = _run_json(
+        runner,
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            repo,
+            "--json",
+            "number,url,title,state,isDraft,headRefName,headRefOid,baseRefName,mergeable,statusCheckRollup",
+        ],
+        cwd,
+    ) or {}
+    branch = branch or pr.get("headRefName") or ""
+    head_sha = pr.get("headRefOid")
+
+    run_args = [
+        "gh",
+        "run",
+        "list",
+        "--repo",
+        repo,
+    ]
+    if head_sha:
+        run_args.extend(["--commit", str(head_sha)])
+    else:
+        run_args.extend(["--branch", branch])
+    run_args.extend(
+        [
+            "--limit",
+            "20",
+            "--json",
+            "databaseId,name,status,conclusion,event,headBranch,headSha,displayTitle,url,createdAt,updatedAt",
+        ]
+    )
+
+    runs = _run_json_list(runner, run_args, cwd)
+    ci = classify_ci_state(checks=pr.get("statusCheckRollup") or [], workflow_runs=runs)
+    return {"pr": pr, "ci": ci, "runs": runs}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cwd", default=".", help="Repository working directory")
+    parser.add_argument("--remote", default="origin", help="Git remote to inspect")
+    parser.add_argument("--pr", help="PR number or URL to include status receipt")
+    parser.add_argument("--repo", help="Owner/repo override for PR status")
+    parser.add_argument("--local-validation-json", help="JSON object with local validation evidence")
+    args = parser.parse_args(argv)
+
+    cwd = Path(args.cwd).resolve()
+    preflight = collect_preflight(cwd=cwd, remote=args.remote)
+
+    local_validation: dict[str, Any] = {}
+    if args.local_validation_json:
+        try:
+            parsed = json.loads(args.local_validation_json)
+            if isinstance(parsed, dict):
+                local_validation = parsed
+        except json.JSONDecodeError as exc:
+            print(f"Invalid --local-validation-json: {exc}", file=sys.stderr)
+            return 2
+
+    output: dict[str, Any] = {"preflight": preflight}
+    if args.pr:
+        repo = args.repo or preflight.get("repo")
+        if not repo:
+            print("Cannot collect PR status without a GitHub repo.", file=sys.stderr)
+            return 2
+        try:
+            repo = validate_repo_slug(str(repo))
+            pr_number = parse_pr_identifier(args.pr)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
+        status = collect_pr_status(
+            repo=repo,
+            pr_number=pr_number,
+            # Let collect_pr_status use the PR head branch. The current local branch
+            # may be a separate follow-up branch while checking an existing PR.
+            branch=None,
+            cwd=cwd,
+        )
+        output["pr"] = status["pr"]
+        output["ci"] = status["ci"]
+        output["receipt"] = build_pr_receipt(
+            preflight=preflight,
+            pr=status["pr"],
+            ci=status["ci"],
+            local_validation=local_validation,
+        )
+
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/github/github-pr-workflow/SKILL.md
+++ b/skills/github/github-pr-workflow/SKILL.md
@@ -102,11 +102,95 @@ Types: `feat`, `fix`, `refactor`, `docs`, `test`, `ci`, `chore`, `perf`
 
 ## 3. Pushing and Creating a PR
 
-### Push the Branch (same either way)
+### Preflight before any external write
+
+Before pushing or creating a PR, run the reusable preflight helper. It emits
+machine-readable JSON instead of making the agent infer push permissions from a
+failed command:
+
+```bash
+python scripts/github_pr_preflight.py --cwd . --remote origin
+```
+
+Key fields:
+
+```json
+{
+  "preflight": {
+    "repo": "OWNER/REPO",
+    "branch": "feat/example",
+    "viewer_permission": "READ|TRIAGE|WRITE|MAINTAIN|ADMIN|null",
+    "strategy": "direct_origin|fork_remote|blocked_auth|blocked_dirty_tree|unknown_permission",
+    "working_tree_clean": true,
+    "existing_pr": null
+  }
+}
+```
+
+Decision rule:
+
+- `direct_origin` — push to `origin`.
+- `fork_remote` — push to a fork remote and open a PR against upstream.
+- `blocked_auth` — authenticate GitHub first.
+- `blocked_dirty_tree` — clean, commit, or intentionally stash unrelated local changes first.
+- `unknown_permission` — do not push yet; inspect `gh repo view` / auth output because the upstream permission could not be determined.
+
+### Push the Branch (direct-origin path)
 
 ```bash
 git push -u origin HEAD
 ```
+
+### Fork fallback when upstream push is denied or preflight says `fork_remote`
+
+If preflight reports `viewer_permission: READ` or a direct push returns a GitHub
+403 such as `Permission to OWNER/REPO.git denied`, create or reuse a fork, add it
+as a separate remote, and open the PR against upstream:
+
+```bash
+# Create fork when it does not exist. Note: when a repository argument is provided,
+# gh does NOT support `--remote=false`; use `--clone=false` instead.
+gh repo fork OWNER/REPO --clone=false
+
+# Add/update explicit fork remote instead of replacing upstream origin.
+git remote add fork https://github.com/YOUR_USER/REPO.git 2>/dev/null || \
+  git remote set-url fork https://github.com/YOUR_USER/REPO.git
+
+git push -u fork HEAD
+
+gh pr create \
+  --repo OWNER/REPO \
+  --base main \
+  --head YOUR_USER:$(git branch --show-current) \
+  --title "..." \
+  --body-file /tmp/pr-body.md \
+  --draft
+```
+
+After creating the PR, emit a receipt and classify CI/check state:
+
+```bash
+python scripts/github_pr_preflight.py \
+  --cwd . \
+  --repo OWNER/REPO \
+  --pr PR_NUMBER \
+  --local-validation-json '{"tests":"passed","ruff":"passed"}'
+```
+
+If the upstream repository gates fork workflows, the receipt may report:
+
+```json
+{
+  "receipt": {
+    "ci_state": "action_required",
+    "blocked_by": "maintainer_workflow_approval",
+    "next_action": "Ask an upstream maintainer to approve fork workflow runs."
+  }
+}
+```
+
+Treat that as maintainer approval pending, not as a CI failure, and document the
+local validation in the PR body.
 
 ### Create the PR
 

--- a/tests/test_github_pr_preflight.py
+++ b/tests/test_github_pr_preflight.py
@@ -1,0 +1,287 @@
+from pathlib import Path
+
+import pytest
+
+import scripts.github_pr_preflight as pr_preflight
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_module_path = Path(pr_preflight.__file__).resolve()
+assert _module_path.is_relative_to(_REPO_ROOT), (
+    f"{pr_preflight.__name__} resolved outside clean worktree: {_module_path}"
+)
+
+
+def test_parse_github_remote_url_supports_https_ssh_and_git_urls():
+    assert pr_preflight.parse_github_remote_url(
+        "https://github.com/NousResearch/hermes-agent.git"
+    ) == "NousResearch/hermes-agent"
+    assert pr_preflight.parse_github_remote_url(
+        "git@github.com:NousResearch/hermes-agent.git"
+    ) == "NousResearch/hermes-agent"
+    assert pr_preflight.parse_github_remote_url(
+        "ssh://git@github.com/NousResearch/hermes-agent.git"
+    ) == "NousResearch/hermes-agent"
+
+
+def test_parse_github_remote_url_rejects_flag_like_owner_or_repo():
+    assert pr_preflight.parse_github_remote_url("https://github.com/--repo=evil/repo.git") is None
+    assert pr_preflight.parse_github_remote_url("git@github.com:owner/--repo=evil.git") is None
+
+
+@pytest.mark.parametrize(
+    ("permission", "expected"),
+    [
+        ("ADMIN", "direct_origin"),
+        ("MAINTAIN", "direct_origin"),
+        ("WRITE", "direct_origin"),
+        ("TRIAGE", "fork_remote"),
+        ("READ", "fork_remote"),
+        ("NONE", "fork_remote"),
+    ],
+)
+def test_recommend_push_strategy_from_viewer_permission(permission, expected):
+    assert pr_preflight.recommend_push_strategy(
+        viewer_permission=permission,
+        working_tree_clean=True,
+        gh_authenticated=True,
+    ) == expected
+
+
+def test_missing_viewer_permission_is_unknown_not_fork_remote():
+    assert pr_preflight.recommend_push_strategy(
+        viewer_permission=None,
+        working_tree_clean=True,
+        gh_authenticated=True,
+    ) == "unknown_permission"
+    assert pr_preflight.recommend_push_strategy(
+        viewer_permission="",
+        working_tree_clean=True,
+        gh_authenticated=True,
+    ) == "unknown_permission"
+
+
+def test_preflight_blocks_dirty_tree_before_recommending_push_strategy():
+    assert pr_preflight.recommend_push_strategy(
+        viewer_permission="WRITE",
+        working_tree_clean=False,
+        gh_authenticated=True,
+    ) == "blocked_dirty_tree"
+
+
+def test_preflight_blocks_missing_github_auth_before_recommending_push_strategy():
+    assert pr_preflight.recommend_push_strategy(
+        viewer_permission="WRITE",
+        working_tree_clean=True,
+        gh_authenticated=False,
+    ) == "blocked_auth"
+
+
+def test_classify_ci_action_required_as_maintainer_approval_not_failure():
+    runs = [
+        {
+            "name": "Tests",
+            "status": "completed",
+            "conclusion": "action_required",
+            "databaseId": 123,
+            "url": "https://github.com/owner/repo/actions/runs/123",
+        }
+    ]
+
+    classification = pr_preflight.classify_ci_state(checks=[], workflow_runs=runs)
+
+    assert classification["state"] == "action_required"
+    assert classification["blocked_by"] == "maintainer_workflow_approval"
+    assert classification["is_failure"] is False
+    assert classification["next_action"] == "Ask an upstream maintainer to approve fork workflow runs."
+
+
+def test_classify_ci_failures_take_priority_over_action_required():
+    classification = pr_preflight.classify_ci_state(
+        checks=[{"name": "lint", "conclusion": "failure"}],
+        workflow_runs=[{"name": "Tests", "status": "completed", "conclusion": "action_required"}],
+    )
+
+    assert classification["state"] == "failure"
+    assert classification["blocked_by"] == "ci_failure"
+    assert classification["is_failure"] is True
+
+
+def test_classify_ci_expected_required_check_as_pending():
+    classification = pr_preflight.classify_ci_state(
+        checks=[{"name": "required", "state": "EXPECTED"}], workflow_runs=[]
+    )
+
+    assert classification["state"] == "pending"
+    assert classification["blocked_by"] == "ci_pending"
+    assert classification["is_failure"] is False
+
+
+def test_parse_pr_identifier_rejects_flags_and_non_pr_urls():
+    assert pr_preflight.parse_pr_identifier("20601") == "20601"
+    assert (
+        pr_preflight.parse_pr_identifier("https://github.com/NousResearch/hermes-agent/pull/20601")
+        == "20601"
+    )
+
+    with pytest.raises(ValueError):
+        pr_preflight.parse_pr_identifier("--web")
+    with pytest.raises(ValueError):
+        pr_preflight.parse_pr_identifier("https://github.com/NousResearch/hermes-agent/issues/20601")
+
+
+def test_validate_repo_slug_rejects_flags_and_malformed_repos():
+    assert pr_preflight.validate_repo_slug("NousResearch/hermes-agent") == "NousResearch/hermes-agent"
+
+    with pytest.raises(ValueError):
+        pr_preflight.validate_repo_slug("--repo")
+    with pytest.raises(ValueError):
+        pr_preflight.validate_repo_slug("NousResearch")
+
+
+class FakeRunner:
+    def __init__(self, responses):
+        self.responses = {tuple(key): value for key, value in responses.items()}
+        self.calls = []
+
+    def __call__(self, args, cwd):
+        self.calls.append((tuple(args), cwd))
+        return self.responses.get(
+            tuple(args),
+            pr_preflight.subprocess.CompletedProcess(args, 1, "", "unexpected command"),
+        )
+
+
+def completed(args, stdout="", stderr="", returncode=0):
+    return pr_preflight.subprocess.CompletedProcess(args, returncode, stdout, stderr)
+
+
+def test_collect_preflight_recommends_fork_and_detects_existing_pr(tmp_path):
+    runner = FakeRunner(
+        {
+            ("git", "branch", "--show-current"): completed((), "feat/example\n"),
+            ("git", "status", "--porcelain"): completed((), ""),
+            ("git", "remote", "get-url", "origin"): completed(
+                (), "https://github.com/NousResearch/hermes-agent.git\n"
+            ),
+            ("gh", "auth", "status"): completed((), "ok"),
+            (
+                "gh",
+                "repo",
+                "view",
+                "NousResearch/hermes-agent",
+                "--json",
+                "nameWithOwner,viewerPermission,defaultBranchRef",
+            ): completed(
+                (),
+                '{"nameWithOwner":"NousResearch/hermes-agent",'
+                '"viewerPermission":"READ",'
+                '"defaultBranchRef":{"name":"main"}}',
+            ),
+            (
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                "NousResearch/hermes-agent",
+                "--head",
+                "feat/example",
+                "--json",
+                "number,url,state,title,isDraft",
+            ): completed(
+                (),
+                '[{"number":42,"url":"https://github.com/NousResearch/hermes-agent/pull/42",'
+                '"state":"OPEN","title":"Example","isDraft":true}]',
+            ),
+        }
+    )
+
+    preflight = pr_preflight.collect_preflight(cwd=tmp_path, runner=runner)
+
+    assert preflight["repo"] == "NousResearch/hermes-agent"
+    assert preflight["branch"] == "feat/example"
+    assert preflight["viewer_permission"] == "READ"
+    assert preflight["strategy"] == "fork_remote"
+    assert preflight["existing_pr"]["number"] == 42
+
+
+def test_collect_pr_status_classifies_action_required_runs(tmp_path):
+    runner = FakeRunner(
+        {
+            (
+                "gh",
+                "pr",
+                "view",
+                "20601",
+                "--repo",
+                "NousResearch/hermes-agent",
+                "--json",
+                "number,url,title,state,isDraft,headRefName,headRefOid,baseRefName,mergeable,statusCheckRollup",
+            ): completed(
+                (),
+                '{"number":20601,"url":"https://github.com/NousResearch/hermes-agent/pull/20601",'
+                '"state":"OPEN","isDraft":true,"headRefName":"feat/example",'
+                '"headRefOid":"abc123","baseRefName":"main","mergeable":"MERGEABLE",'
+                '"statusCheckRollup":[]}',
+            ),
+            (
+                "gh",
+                "run",
+                "list",
+                "--repo",
+                "NousResearch/hermes-agent",
+                "--commit",
+                "abc123",
+                "--limit",
+                "20",
+                "--json",
+                "databaseId,name,status,conclusion,event,headBranch,headSha,displayTitle,url,createdAt,updatedAt",
+            ): completed(
+                (),
+                '[{"databaseId":123,"name":"Tests","status":"completed",'
+                '"conclusion":"action_required","url":"https://github.com/run/123"}]',
+            ),
+        }
+    )
+
+    status = pr_preflight.collect_pr_status(
+        repo="NousResearch/hermes-agent", pr_number="20601", cwd=tmp_path, runner=runner
+    )
+
+    assert status["pr"]["number"] == 20601
+    assert status["ci"]["state"] == "action_required"
+    assert status["ci"]["blocked_by"] == "maintainer_workflow_approval"
+
+
+def test_build_receipt_includes_pr_state_ci_state_and_next_action():
+    receipt = pr_preflight.build_pr_receipt(
+        preflight={
+            "repo": "NousResearch/hermes-agent",
+            "branch": "feat/example",
+            "viewer_permission": "READ",
+            "strategy": "fork_remote",
+            "working_tree_clean": True,
+        },
+        pr={
+            "number": 20601,
+            "url": "https://github.com/NousResearch/hermes-agent/pull/20601",
+            "state": "OPEN",
+            "isDraft": True,
+            "mergeable": "MERGEABLE",
+            "baseRefName": "main",
+            "headRefName": "feat/example",
+        },
+        ci={
+            "state": "action_required",
+            "blocked_by": "maintainer_workflow_approval",
+            "is_failure": False,
+            "next_action": "Ask an upstream maintainer to approve fork workflow runs.",
+        },
+        local_validation={"tests": "145 passed", "ruff": "passed"},
+    )
+
+    assert receipt["pr_url"] == "https://github.com/NousResearch/hermes-agent/pull/20601"
+    assert receipt["draft"] is True
+    assert receipt["ci_state"] == "action_required"
+    assert receipt["blocked_by"] == "maintainer_workflow_approval"
+    assert receipt["next_action"] == "Ask an upstream maintainer to approve fork workflow runs."
+    assert receipt["local_validation"]["tests"] == "145 passed"

--- a/website/docs/user-guide/skills/bundled/github/github-github-pr-workflow.md
+++ b/website/docs/user-guide/skills/bundled/github/github-github-pr-workflow.md
@@ -120,11 +120,95 @@ Types: `feat`, `fix`, `refactor`, `docs`, `test`, `ci`, `chore`, `perf`
 
 ## 3. Pushing and Creating a PR
 
-### Push the Branch (same either way)
+### Preflight before any external write
+
+Before pushing or creating a PR, run the reusable preflight helper. It emits
+machine-readable JSON instead of making the agent infer push permissions from a
+failed command:
+
+```bash
+python scripts/github_pr_preflight.py --cwd . --remote origin
+```
+
+Key fields:
+
+```json
+{
+  "preflight": {
+    "repo": "OWNER/REPO",
+    "branch": "feat/example",
+    "viewer_permission": "READ|TRIAGE|WRITE|MAINTAIN|ADMIN|null",
+    "strategy": "direct_origin|fork_remote|blocked_auth|blocked_dirty_tree|unknown_permission",
+    "working_tree_clean": true,
+    "existing_pr": null
+  }
+}
+```
+
+Decision rule:
+
+- `direct_origin` — push to `origin`.
+- `fork_remote` — push to a fork remote and open a PR against upstream.
+- `blocked_auth` — authenticate GitHub first.
+- `blocked_dirty_tree` — clean, commit, or intentionally stash unrelated local changes first.
+- `unknown_permission` — do not push yet; inspect `gh repo view` / auth output because the upstream permission could not be determined.
+
+### Push the Branch (direct-origin path)
 
 ```bash
 git push -u origin HEAD
 ```
+
+### Fork fallback when upstream push is denied or preflight says `fork_remote`
+
+If preflight reports `viewer_permission: READ` or a direct push returns a GitHub
+403 such as `Permission to OWNER/REPO.git denied`, create or reuse a fork, add it
+as a separate remote, and open the PR against upstream:
+
+```bash
+# Create fork when it does not exist. Note: when a repository argument is provided,
+# gh does NOT support `--remote=false`; use `--clone=false` instead.
+gh repo fork OWNER/REPO --clone=false
+
+# Add/update explicit fork remote instead of replacing upstream origin.
+git remote add fork https://github.com/YOUR_USER/REPO.git 2>/dev/null || \
+  git remote set-url fork https://github.com/YOUR_USER/REPO.git
+
+git push -u fork HEAD
+
+gh pr create \
+  --repo OWNER/REPO \
+  --base main \
+  --head YOUR_USER:$(git branch --show-current) \
+  --title "..." \
+  --body-file /tmp/pr-body.md \
+  --draft
+```
+
+After creating the PR, emit a receipt and classify CI/check state:
+
+```bash
+python scripts/github_pr_preflight.py \
+  --cwd . \
+  --repo OWNER/REPO \
+  --pr PR_NUMBER \
+  --local-validation-json '{"tests":"passed","ruff":"passed"}'
+```
+
+If the upstream repository gates fork workflows, the receipt may report:
+
+```json
+{
+  "receipt": {
+    "ci_state": "action_required",
+    "blocked_by": "maintainer_workflow_approval",
+    "next_action": "Ask an upstream maintainer to approve fork workflow runs."
+  }
+}
+```
+
+Treat that as maintainer approval pending, not as a CI failure, and document the
+local validation in the PR body.
 
 ### Create the PR
 


### PR DESCRIPTION
## Summary

Adds a small dependency-free GitHub PR preflight/receipt helper so Hermes repo workflows can decide push/PR strategy before attempting external writes.

Key changes:

- Adds `scripts/github_pr_preflight.py`.
- Detects current repo/branch, GitHub auth, upstream viewer permission, dirty tree state, and existing PRs.
- Classifies push strategy as `direct_origin`, `fork_remote`, `blocked_auth`, `blocked_dirty_tree`, or `unknown_permission`.
- Builds machine-readable PR receipts with PR URL/state, mergeability, CI state, blocker, next action, and local validation evidence.
- Classifies fork workflow `action_required` as maintainer approval pending, not test failure.
- Scopes workflow-run status lookup to PR head SHA via `gh run list --commit` to avoid stale branch runs.
- Validates repo and PR identifiers before passing them to `gh` positional args.
- Updates the bundled `github-pr-workflow` skill and generated website docs to use the helper.

## Validation

```text
python -m pytest tests/test_github_pr_preflight.py -q
# 19 passed, 19 warnings

ruff check scripts/github_pr_preflight.py tests/test_github_pr_preflight.py
# All checks passed

git diff --cached --check
# passed
```

Live receipt smoke test against PR #20601:

```text
LIVE_RECEIPT_OK https://github.com/NousResearch/hermes-agent/pull/20601 maintainer_workflow_approval
```

Security/static checks performed on the staged diff:

```text
no hardcoded secret pattern matches
no subprocess shell=True / os.system additions
no eval/exec additions
no pickle.loads additions
no SQL string-formatting additions
```

Independent review:

- First review found unsafe `--pr` argument handling and CI classification issues; fixed.
- Second review found remote-derived repo slug validation and stale branch run issues; fixed.
- Final independent review passed with no blocking security or logic issues.

## Notes

This PR is a follow-up mechanism improvement discovered while opening #20601. It is intentionally separate from the Scrapling/difficult_web_extract routing PR so review stays focused.
