### PR TITLE
Fix ACP approval allow_permanent callback

### DIFF
--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -28,9 +28,9 @@ def make_approval_callback(
     loop: asyncio.AbstractEventLoop,
     session_id: str,
     timeout: float = 60.0,
-) -> Callable[[str, str], str]:
+) -> Callable[..., str]:
     """
-    Return a hermes-compatible ``approval_callback(command, description) -> str``
+    Return a hermes-compatible ``approval_callback(command, description, *, allow_permanent=True) -> str``
     that bridges to the ACP client's ``request_permission`` call.
 
     Args:
@@ -40,12 +40,20 @@ def make_approval_callback(
         timeout: Seconds to wait for a response before auto-denying.
     """
 
-    def _callback(command: str, description: str) -> str:
+    def _callback(command: str, description: str, *, allow_permanent: bool = True) -> str:
         options = [
             PermissionOption(option_id="allow_once", kind="allow_once", name="Allow once"),
-            PermissionOption(option_id="allow_always", kind="allow_always", name="Allow always"),
             PermissionOption(option_id="deny", kind="reject_once", name="Deny"),
         ]
+        if allow_permanent:
+            options.insert(
+                1,
+                PermissionOption(
+                    option_id="allow_always",
+                    kind="allow_always",
+                    name="Allow always",
+                ),
+            )
         import acp as _acp
 
         tool_call = _acp.start_tool_call("perm-check", command, kind="execute")

--- a/tests/acp_adapter/test_permissions.py
+++ b/tests/acp_adapter/test_permissions.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import asyncio
+
+from acp.schema import AllowedOutcome
+
+from acp_adapter.permissions import make_approval_callback
+
+
+class _Response:
+    def __init__(self, option_id: str) -> None:
+        self.outcome = AllowedOutcome(optionId=option_id, outcome="selected")
+
+
+def test_approval_callback_accepts_allow_permanent_false(monkeypatch) -> None:
+    seen_options = []
+
+    class _Future:
+        def result(self, timeout):
+            return _Response("allow_once")
+
+    def request_permission_fn(**kwargs):
+        nonlocal seen_options
+        seen_options = kwargs["options"]
+        return object()
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", lambda coro, loop: _Future())
+
+    callback = make_approval_callback(request_permission_fn, object(), "session")
+
+    assert callback("terminal: rm file", "dangerous command", allow_permanent=False) == "once"
+    assert [option.option_id for option in seen_options] == ["allow_once", "deny"]


### PR DESCRIPTION
## Summary
- update the ACP approval callback to accept Hermes' allow_permanent keyword argument
- hide the permanent allow option when allow_permanent is false
- add regression coverage for the callback path

## Root cause
Hermes tools.approval passes allow_permanent as a keyword argument to the registered approval callback, but the ACP adapter callback only accepted command and description. The TypeError was caught by the approval path and failed closed as a denial before ACP could request user permission.

## Validation
- Confirmed latest origin/main still reproduces the TypeError after git fetch origin main
- /Library/Frameworks/Python.framework/Versions/3.13/bin/python3.13 -m pytest tests/acp_adapter