### PR TITLE
feat(gateway): plugin platforms can declare default home_channel + reset_policy

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1605,7 +1605,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Registry-driven enable for plugin platforms.  Built-ins have explicit
     # blocks above; plugins expose check_fn() which is the single source of
     # truth for "are my env vars set?".  When it returns True, ensure the
-    # platform is enabled so start() will create its adapter.
+    # platform is enabled so start() will create its adapter.  Also applies
+    # the plugin's declared default home_channel (read from env) and default
+    # reset policy — built-ins do these inline above; plugins declare them
+    # via PlatformEntry.home_channel_env / default_reset_policy.
     try:
         from hermes_cli.plugins import discover_plugins
         discover_plugins()  # idempotent
@@ -1621,5 +1624,27 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             if platform not in config.platforms:
                 config.platforms[platform] = PlatformConfig()
             config.platforms[platform].enabled = True
+
+            # Apply plugin-declared default home_channel (from env vars).
+            # Mirrors the <PLATFORM>_HOME_CHANNEL[_NAME|_THREAD_ID] convention
+            # used by built-ins, with the env var name supplied by the plugin
+            # so naming need not collide with PlatformEntry.name (e.g. a
+            # plugin named "irc" can declare "IRC_HOME_CHANNEL").
+            if entry.home_channel_env and config.platforms[platform].home_channel is None:
+                home_chat_id = os.getenv(entry.home_channel_env, "").strip()
+                if home_chat_id:
+                    config.platforms[platform].home_channel = HomeChannel(
+                        platform=platform,
+                        chat_id=home_chat_id,
+                        name=os.getenv(f"{entry.home_channel_env}_NAME", "Home"),
+                        thread_id=os.getenv(f"{entry.home_channel_env}_THREAD_ID") or None,
+                    )
+
+            # Apply plugin-declared default reset policy when the user has
+            # not set one in config.yaml.  Lets a plugin ship a sensible
+            # default (e.g. auto_resume_on_restart=True) without forcing
+            # users to write it into their config.
+            if entry.default_reset_policy is not None and platform not in config.reset_by_platform:
+                config.reset_by_platform[platform] = entry.default_reset_policy
     except Exception as e:
         logger.debug("Plugin platform enable pass failed: %s", e)

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -110,6 +110,23 @@ class PlatformEntry:
     # Do not use markdown.").  Empty string = no hint.
     platform_hint: str = ""
 
+    # ── Default home channel (for cron / notification delivery) ──
+    # Env var name to read for the default chat ID (e.g. "IRC_HOME_CHANNEL").
+    # When set and the env var is non-empty, the gateway populates
+    # ``config.platforms[<name>].home_channel`` automatically.  The optional
+    # ``<env>_NAME`` and ``<env>_THREAD_ID`` siblings are also read for the
+    # display name and thread/topic ID respectively.  Empty string disables
+    # the auto-bootstrap (config.yaml or programmatic setup must supply it).
+    home_channel_env: str = ""
+
+    # ── Default session reset policy ──
+    # Applied when ``config.reset_by_platform`` does not already define one
+    # for this platform.  Lets a plugin ship a sensible default
+    # (e.g. ``SessionResetPolicy(auto_resume_on_restart=True)``) without
+    # forcing users to write it into config.yaml.  ``None`` = use the
+    # gateway-wide default.
+    default_reset_policy: Optional[Any] = None
+
 
 class PlatformRegistry:
     """Central registry of platform adapters.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -487,10 +487,13 @@ class PluginContext:
         ``check_fn()`` before instantiation to verify dependencies.
 
         Extra keyword arguments are forwarded to ``PlatformEntry`` (e.g.
-        ``setup_fn``, ``emoji``, ``allowed_users_env``, ``platform_hint``).
-        Unknown keys raise TypeError from the dataclass constructor.
+        ``setup_fn``, ``emoji``, ``allowed_users_env``, ``platform_hint``,
+        ``home_channel_env``, ``default_reset_policy``).  Unknown keys raise
+        TypeError from the dataclass constructor.
 
         Example::
+
+            from gateway.config import SessionResetPolicy
 
             ctx.register_platform(
                 name="irc",
@@ -499,6 +502,11 @@ class PluginContext:
                 check_fn=lambda: True,
                 emoji="💬",
                 setup_fn=irc_interactive_setup,
+                # Auto-load `IRC_HOME_CHANNEL` (and _NAME / _THREAD_ID
+                # siblings) into config.platforms[Platform("irc")].home_channel.
+                home_channel_env="IRC_HOME_CHANNEL",
+                # Default to auto-resume sessions after gateway restart.
+                default_reset_policy=SessionResetPolicy(auto_resume_on_restart=True),
             )
         """
         from gateway.platform_registry import platform_registry, PlatformEntry

--- a/tests/gateway/test_plugin_home_channel_and_reset.py
+++ b/tests/gateway/test_plugin_home_channel_and_reset.py
@@ -1,0 +1,215 @@
+"""Tests for plugin-declared home_channel + default_reset_policy bootstrap.
+
+Built-in platforms hard-code their `<PLATFORM>_HOME_CHANNEL` env-var
+loading in ``_apply_env_overrides()``. Plugin platforms get the same
+treatment via two ``PlatformEntry`` fields:
+
+* ``home_channel_env`` — env var name to read for the default chat ID.
+  ``<env>_NAME`` and ``<env>_THREAD_ID`` siblings are also read.
+* ``default_reset_policy`` — applied to ``config.reset_by_platform`` when
+  the user has not configured one for this platform.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def isolated_registry(monkeypatch):
+    """Replace the module-level platform_registry with a fresh instance.
+
+    Prevents cross-test pollution and keeps real bundled platform plugins
+    (irc, teams) from interfering with these tests.
+    """
+    from gateway import platform_registry as pr_module
+
+    fresh = pr_module.PlatformRegistry()
+    monkeypatch.setattr(pr_module, "platform_registry", fresh)
+    return fresh
+
+
+def _register_test_platform(
+    registry,
+    *,
+    name: str,
+    home_channel_env: str = "",
+    default_reset_policy=None,
+    check_ok: bool = True,
+):
+    from gateway.platform_registry import PlatformEntry
+
+    registry.register(
+        PlatformEntry(
+            name=name,
+            label=name.title(),
+            adapter_factory=lambda cfg: object(),
+            check_fn=lambda: check_ok,
+            source="plugin",
+            home_channel_env=home_channel_env,
+            default_reset_policy=default_reset_policy,
+        )
+    )
+
+
+class TestPluginHomeChannelBootstrap:
+    def test_home_channel_loaded_from_env(self, monkeypatch, isolated_registry):
+        from gateway.config import (
+            GatewayConfig,
+            Platform,
+            _apply_env_overrides,
+        )
+
+        _register_test_platform(
+            isolated_registry,
+            name="acme",
+            home_channel_env="ACME_HOME_CHANNEL",
+        )
+        monkeypatch.setenv("ACME_HOME_CHANNEL", "room-42")
+        monkeypatch.setenv("ACME_HOME_CHANNEL_NAME", "ACME Lobby")
+        monkeypatch.setenv("ACME_HOME_CHANNEL_THREAD_ID", "thread-7")
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        platform = Platform("acme")
+        assert platform in config.platforms
+        hc = config.platforms[platform].home_channel
+        assert hc is not None
+        assert hc.chat_id == "room-42"
+        assert hc.name == "ACME Lobby"
+        assert hc.thread_id == "thread-7"
+
+    def test_no_home_channel_env_var_no_op(self, monkeypatch, isolated_registry):
+        """Plugin declares the env var but it isn't set — no home_channel."""
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
+        _register_test_platform(
+            isolated_registry,
+            name="bravo",
+            home_channel_env="BRAVO_HOME_CHANNEL",
+        )
+        monkeypatch.delenv("BRAVO_HOME_CHANNEL", raising=False)
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+        assert config.platforms[Platform("bravo")].home_channel is None
+
+    def test_no_env_field_skips_bootstrap(self, monkeypatch, isolated_registry):
+        """Plugin omits home_channel_env entirely — bootstrap is a no-op."""
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
+        _register_test_platform(isolated_registry, name="charlie")
+        monkeypatch.setenv("CHARLIE_HOME_CHANNEL", "would-be-loaded")
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+        # No env field declared, so the env var is ignored.
+        assert config.platforms[Platform("charlie")].home_channel is None
+
+    def test_user_set_home_channel_not_overwritten(
+        self, monkeypatch, isolated_registry
+    ):
+        """If config.yaml already populated home_channel, env doesn't clobber it."""
+        from gateway.config import (
+            GatewayConfig,
+            HomeChannel,
+            Platform,
+            PlatformConfig,
+            _apply_env_overrides,
+        )
+
+        _register_test_platform(
+            isolated_registry,
+            name="delta",
+            home_channel_env="DELTA_HOME_CHANNEL",
+        )
+        monkeypatch.setenv("DELTA_HOME_CHANNEL", "from-env")
+
+        config = GatewayConfig()
+        platform = Platform("delta")
+        config.platforms[platform] = PlatformConfig()
+        config.platforms[platform].home_channel = HomeChannel(
+            platform=platform, chat_id="from-yaml", name="user choice"
+        )
+        _apply_env_overrides(config)
+        assert config.platforms[platform].home_channel.chat_id == "from-yaml"
+
+
+class TestPluginResetPolicyBootstrap:
+    def test_default_reset_policy_applied(self, monkeypatch, isolated_registry):
+        from gateway.config import (
+            GatewayConfig,
+            Platform,
+            SessionResetPolicy,
+            _apply_env_overrides,
+        )
+
+        _register_test_platform(
+            isolated_registry,
+            name="echo",
+            default_reset_policy=SessionResetPolicy(mode="none"),
+        )
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+        platform = Platform("echo")
+        assert platform in config.reset_by_platform
+        assert config.reset_by_platform[platform].mode == "none"
+
+    def test_user_reset_policy_not_overwritten(
+        self, monkeypatch, isolated_registry
+    ):
+        """User-supplied config.yaml policy beats plugin default."""
+        from gateway.config import (
+            GatewayConfig,
+            Platform,
+            SessionResetPolicy,
+            _apply_env_overrides,
+        )
+
+        _register_test_platform(
+            isolated_registry,
+            name="foxtrot",
+            default_reset_policy=SessionResetPolicy(mode="none"),
+        )
+
+        config = GatewayConfig()
+        platform = Platform("foxtrot")
+        config.reset_by_platform[platform] = SessionResetPolicy(mode="daily")
+        _apply_env_overrides(config)
+        # User's explicit "daily" wins over plugin default "none".
+        assert config.reset_by_platform[platform].mode == "daily"
+
+    def test_no_default_no_entry(self, monkeypatch, isolated_registry):
+        """Plugin omits default_reset_policy — nothing added to reset_by_platform."""
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
+        _register_test_platform(isolated_registry, name="golf")
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+        assert Platform("golf") not in config.reset_by_platform
+
+
+class TestCheckFnGate:
+    def test_check_fn_false_skips_bootstrap(self, monkeypatch, isolated_registry):
+        """When check_fn returns False, neither home_channel nor reset are applied."""
+        from gateway.config import (
+            GatewayConfig,
+            Platform,
+            SessionResetPolicy,
+            _apply_env_overrides,
+        )
+
+        _register_test_platform(
+            isolated_registry,
+            name="hotel",
+            home_channel_env="HOTEL_HOME_CHANNEL",
+            default_reset_policy=SessionResetPolicy(mode="none"),
+            check_ok=False,
+        )
+        monkeypatch.setenv("HOTEL_HOME_CHANNEL", "should-not-load")
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+        platform = Platform("hotel")
+        assert platform not in config.platforms
+        assert platform not in config.reset_by_platform


### PR DESCRIPTION
## Summary

Built-in platforms set their default home_channel from env vars (`<PLATFORM>_HOME_CHANNEL[_NAME|_THREAD_ID]`) and a default reset policy directly in `_apply_env_overrides()`. Plugin platforms had no equivalent mechanism — they could only register an adapter factory and a `check_fn`, leaving env-var → config wiring to user `config.yaml` or out-of-tree patches.

This adds two `PlatformEntry` fields so plugin platforms can ship sensible defaults that match the built-in convention, with no core code changes per platform.

## API additions

```python
@dataclass
class PlatformEntry:
    ...
    # Env var name to read for the default chat ID. `<env>_NAME` and
    # `<env>_THREAD_ID` siblings are also consumed when present.
    home_channel_env: str = ""

    # Applied to config.reset_by_platform[<platform>] when the user has
    # not configured one. Lets plugins ship a default without forcing
    # users to write it into config.yaml.
    default_reset_policy: Optional[Any] = None
```

Both default to `""` / `None` so existing plugins (irc, teams) are unaffected.

## Example usage

```python
from gateway.config import SessionResetPolicy

ctx.register_platform(
    name="irc",
    label="IRC",
    adapter_factory=lambda cfg: IRCAdapter(cfg),
    check_fn=lambda: True,
    home_channel_env="IRC_HOME_CHANNEL",
    default_reset_policy=SessionResetPolicy(mode="none"),
)
```

The gateway now reads `IRC_HOME_CHANNEL` (+ `_NAME` / `_THREAD_ID`) at startup and populates `config.platforms[Platform("irc")].home_channel` automatically — same shape as built-in platforms.

## Bootstrap precedence

User-supplied values win over plugin defaults:
- `config.platforms[<p>].home_channel` set by `config.yaml` → env var ignored
- `config.reset_by_platform[<p>]` set by `config.yaml` → plugin default ignored

## Test plan

- [x] New file `tests/gateway/test_plugin_home_channel_and_reset.py` (8 tests covering env loading, name/thread siblings, user-override precedence, missing env vars, omitted fields, and the `check_fn=False` gate)
- [x] All existing tests in `tests/gateway/test_platform_registry.py` and `tests/gateway/test_plugin_platform_interface.py` still pass

## Motivation

I'm maintaining a downstream Hi IM (RedCity) platform plugin and discovered I had to keep a 14-line bootstrap patch in `gateway/config.py` (touching `Platform("hi")`, `HomeChannel`, and `reset_by_platform`) just to load `HI_HOME_CHANNEL` from env and set `auto_resume_on_restart=True` as a platform default. With this PR, the plugin can declare both via `register_platform()` and the patch goes away — every future plugin author saves the same patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)