### PR TITLE
fix(qqbot): preserve original filename when caching file attachments

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1213,7 +1213,7 @@ class QQAdapter(BasePlatformAdapter):
             elif ct.startswith("image/"):
                 # Image: download and cache locally.
                 try:
-                    cached_path = await self._download_and_cache(url, ct)
+                    cached_path = await self._download_and_cache(url, ct, filename)
                     if cached_path and os.path.isfile(cached_path):
                         image_urls.append(cached_path)
                         image_media_types.append(ct or "image/jpeg")
@@ -1228,7 +1228,7 @@ class QQAdapter(BasePlatformAdapter):
             else:
                 # Other attachments (video, file, etc.): record as text.
                 try:
-                    cached_path = await self._download_and_cache(url, ct)
+                    cached_path = await self._download_and_cache(url, ct, filename)
                     if cached_path:
                         other_attachments.append(f"[Attachment: {filename or ct}]")
                 except Exception as exc:
@@ -1242,8 +1242,17 @@ class QQAdapter(BasePlatformAdapter):
             "attachment_info": attachment_info,
         }
 
-    async def _download_and_cache(self, url: str, content_type: str) -> Optional[str]:
-        """Download a URL and cache it locally."""
+    async def _download_and_cache(
+        self, url: str, content_type: str, filename: str = ""
+    ) -> Optional[str]:
+        """Download a URL and cache it locally.
+
+        Args:
+            url: The URL to download.
+            content_type: MIME type hint for the content.
+            filename: Original filename from the QQ message attachment metadata
+                (preserved in cache when provided).
+        """
         from tools.url_safety import is_safe_url
 
         if not is_safe_url(url):
@@ -1274,8 +1283,10 @@ class QQAdapter(BasePlatformAdapter):
             # Convert to .wav using ffmpeg so STT engines can process it.
             return await self._convert_audio_to_wav(data, url)
         else:
-            filename = Path(urlparse(url).path).name or "qq_attachment"
-            return cache_document_from_bytes(data, filename)
+            # Prefer the original filename from QQ attachment metadata;
+            # fall back to URL basename for safety.
+            cache_name = filename or Path(urlparse(url).path).name or "qq_attachment"
+            return cache_document_from_bytes(data, cache_name)
 
     @staticmethod
     def _is_voice_content_type(content_type: str, filename: str) -> bool:


### PR DESCRIPTION
## Summary

When receiving file attachments via QQ Bot, the adapter correctly extracts
`filename` from the QQ message attachment metadata (visible in logs as
`filename=Untitled-2.js`), but `_download_and_cache()` ignores it and extracts
the filename from the URL path instead (`qqdownloadftnv5`), causing the
original filename to be lost in the local cache.

## Root Cause

In `gateway/platforms/qqbot/adapter.py`, `_download_and_cache()` uses:

```python
filename = Path(urlparse(url).path).name or "qq_attachment"
```

The `filename` variable declared at line 1170 — carrying the original
attachment name from `att.get("filename")` — is never passed to this
function, so every file lands on disk as `qqdownloadftnv5` regardless of
its true name.

## Fix

1. Add `filename` as an optional parameter to `_download_and_cache()`.
2. Pass `filename` from both call sites (image branch and other branch).
3. Prefer the original filename when saving; fall back to the URL basename.

## Files Changed

- `gateway/platforms/qqbot/adapter.py`