### PR TITLE
fix(security): protect plugin API routes with session-token auth

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -225,7 +225,7 @@ async def host_header_middleware(request: Request, call_next):
 async def auth_middleware(request: Request, call_next):
     """Require the session token on all /api/ routes except the public list."""
     path = request.url.path
-    if path.startswith("/api/") and path not in _PUBLIC_API_PATHS and not path.startswith("/api/plugins/"):
+    if path.startswith("/api/") and path not in _PUBLIC_API_PATHS:
         if not _has_valid_session_token(request):
             return JSONResponse(
                 status_code=401,


### PR DESCRIPTION
## Problem

The `auth_middleware` in `hermes_cli/web_server.py` explicitly excludes `/api/plugins/*` from session-token checks:

```python
if path.startswith("/api/") and path not in _PUBLIC_API_PATHS and not path.startswith("/api/plugins/"):
```

This leaves **all plugin endpoints** (read, write, delete, export) completely unprotected. Anyone who can reach the dashboard port can read, modify, or delete all plugin data without any credentials.

## Why this matters

- **Docker deployments** expose the dashboard port (`-p 9119:9119`)
- **VPS hosting** (e.g., Hostinger one-click deploy) makes the port internet-accessible
- **`--insecure` mode** binds to `0.0.0.0`
- Plugins like Prompt Vault store reusable prompts — some may contain API keys, credential templates, or structured business logic
- The `/export` endpoint dumps everything in one call

## Fix

Remove the `/api/plugins/` exclusion from the auth middleware condition. One line:

```python
# BEFORE
if path.startswith("/api/") and path not in _PUBLIC_API_PATHS and not path.startswith("/api/plugins/"):

# AFTER
if path.startswith("/api/") and path not in _PUBLIC_API_PATHS:
```

## Why this is safe

1. **Frontend already sends the token** — `fetchJSON()` in `web/src/lib/api.ts` injects `X-Hermes-Session-Token` on ALL requests. Dashboard UI works unchanged.
2. **External callers** (curl, scripts, Postman) now need the token — same as every other `/api/` route.
3. **No plugin changes needed** — the fix is entirely in the framework.

## Testing

Verified locally:
- All plugin endpoints return `401` without token
- All plugin endpoints return `200` with valid token
- Dashboard UI loads and functions normally

## Context

The original exclusion was an intentional localhost-only design choice (commit `01214a7f7`). With Hermes now deployed on VPSes, Docker containers, and shared networks, plugin routes need the same auth protection as every other API endpoint.

Fixes [LeventeNagy/hermes-prompt-vault#8](https://github.com/LeventeNagy/hermes-prompt-vault/issues/8)