### PR TITLE
feat(tui): collapsible sections in startup banner (skills, system prompt, MCP)

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1414,6 +1414,10 @@ def _session_info(agent) -> dict:
     except Exception:
         info["mcp_servers"] = []
     try:
+        info["system_prompt"] = getattr(agent, "_cached_system_prompt", "") or ""
+    except Exception:
+        pass
+    try:
         from hermes_cli.banner import get_update_result
         from hermes_cli.config import recommended_update_command
 

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -58,6 +58,44 @@ export function Banner({ t }: { t: Theme }) {
   )
 }
 
+// ── Collapsible helpers ──────────────────────────────────────────────
+
+function CollapseToggle({
+  count,
+  open,
+  suffix,
+  t,
+  title,
+  onToggle
+}: {
+  count?: number
+  open: boolean
+  suffix?: string
+  t: Theme
+  title: string
+  onToggle: () => void
+}) {
+  return (
+    <Box onClick={onToggle}>
+      <Text color={t.color.accent}>{open ? '▾ ' : '▸ '}</Text>
+      <Text bold color={t.color.accent}>
+        {title}
+      </Text>
+      {typeof count === 'number' ? (
+        <Text color={t.color.muted}> ({count})</Text>
+      ) : null}
+      {suffix ? (
+        <Text color={t.color.muted}> {suffix}</Text>
+      ) : null}
+    </Box>
+  )
+}
+
+// ── SessionPanel ─────────────────────────────────────────────────────
+
+const SKILLS_MAX = 8
+const TOOLSETS_MAX = 8
+
 export function SessionPanel({ info, sid, t }: SessionPanelProps) {
   const cols = useStdout().stdout?.columns ?? 100
   const heroLines = caduceus(t.color, t.bannerHero || undefined)
@@ -66,6 +104,12 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
   const w = Math.max(20, wide ? cols - leftW - 14 : cols - 12)
   const lineBudget = Math.max(12, w - 2)
   const strip = (s: string) => (s.endsWith('_tools') ? s.slice(0, -6) : s)
+
+  // ── Local collapse state for each section ──
+  const [toolsOpen, setToolsOpen] = useState(true)
+  const [skillsOpen, setSkillsOpen] = useState(false)
+  const [systemOpen, setSystemOpen] = useState(false)
+  const [mcpOpen, setMcpOpen] = useState(false)
 
   const truncLine = (pfx: string, items: string[]) => {
     let line = ''
@@ -85,35 +129,89 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
     return line
   }
 
-  const section = (title: string, data: Record<string, string[]>, max = 8, overflowLabel = 'more…') => {
-    const entries = Object.entries(data).sort()
-    const shown = entries.slice(0, max)
-    const overflow = entries.length - max
-    const skeleton = info.lazy && entries.length === 0
+  // ── Collapsible skills section ──
+  const skillEntries = Object.entries(info.skills).sort()
+  const skillsTotal = flat(info.skills).length
+  const skillsCatCount = skillEntries.length
+
+  const skillsBody = () => {
+    if (info.lazy && skillEntries.length === 0) {
+      return <InlineLoader label="scanning skills" t={t} />
+    }
+
+    const shown = skillEntries.slice(0, SKILLS_MAX)
+    const overflow = skillEntries.length - SKILLS_MAX
 
     return (
-      <Box flexDirection="column" marginTop={1}>
-        <Text bold color={t.color.accent}>
-          Available {title}
-        </Text>
-
-        {skeleton ? (
-          <InlineLoader label={title === 'Tools' ? 'discovering tools' : 'scanning skills'} t={t} />
-        ) : (
-          shown.map(([k, vs]) => (
-            <Text key={k} wrap="truncate">
-              <Text color={t.color.muted}>{strip(k)}: </Text>
-              <Text color={t.color.text}>{truncLine(strip(k) + ': ', vs)}</Text>
-            </Text>
-          ))
-        )}
-
-        {overflow > 0 && (
-          <Text color={t.color.muted}>
-            (and {overflow} {overflowLabel})
+      <>
+        {shown.map(([k, vs]) => (
+          <Text key={k} wrap="truncate">
+            <Text color={t.color.muted}>{strip(k)}: </Text>
+            <Text color={t.color.text}>{truncLine(strip(k) + ': ', vs)}</Text>
           </Text>
+        ))}
+        {overflow > 0 && (
+          <Text color={t.color.muted}>(and {overflow} more categories…)</Text>
         )}
-      </Box>
+      </>
+    )
+  }
+
+  // ── Collapsible tools section ──
+  const toolEntries = Object.entries(info.tools).sort()
+  const toolsTotal = flat(info.tools).length
+
+  const toolsBody = () => {
+    const shown = toolEntries.slice(0, TOOLSETS_MAX)
+    const overflow = toolEntries.length - TOOLSETS_MAX
+
+    return (
+      <>
+        {shown.map(([k, vs]) => (
+          <Text key={k} wrap="truncate">
+            <Text color={t.color.muted}>{strip(k)}: </Text>
+            <Text color={t.color.text}>{truncLine(strip(k) + ': ', vs)}</Text>
+          </Text>
+        ))}
+        {overflow > 0 && (
+          <Text color={t.color.muted}>(and {overflow} more toolsets…)</Text>
+        )}
+      </>
+    )
+  }
+
+  // ── Collapsible MCP section ──
+  const mcpBody = () => (
+    <>
+      {(info.mcp_servers ?? []).map(s => (
+        <Text key={s.name} wrap="truncate">
+          <Text color={t.color.muted}>{`  ${s.name} `}</Text>
+          <Text color={t.color.muted}>{`[${s.transport}]`}</Text>
+          <Text color={t.color.muted}>: </Text>
+          {s.connected ? (
+            <Text color={t.color.text}>
+              {s.tools} tool{s.tools === 1 ? '' : 's'}
+            </Text>
+          ) : (
+            <Text color={t.color.error}>failed</Text>
+          )}
+        </Text>
+      ))}
+    </>
+  )
+
+  // ── System prompt body ──
+  const sysPromptLen = (info.system_prompt ?? '').length
+
+  const systemBody = () => {
+    if (sysPromptLen === 0) {
+      return <Text color={t.color.muted}>No system prompt loaded.</Text>
+    }
+
+    return (
+      <Text color={t.color.muted}>
+        {info.system_prompt}
+      </Text>
     )
   }
 
@@ -151,37 +249,64 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
           </Text>
         </Box>
 
-        {section('Tools', info.tools, 8, 'more toolsets…')}
-        {section('Skills', info.skills)}
+        {/* ── Tools (expanded by default) ── */}
+        <Box flexDirection="column" marginTop={1}>
+          <CollapseToggle
+            onToggle={() => setToolsOpen(v => !v)}
+            open={toolsOpen}
+            t={t}
+            title="Available Tools"
+          />
+          {toolsOpen && toolsBody()}
+        </Box>
 
+        {/* ── Skills (collapsed by default) ── */}
+        <Box flexDirection="column" marginTop={1}>
+          <CollapseToggle
+            count={skillsTotal}
+            onToggle={() => setSkillsOpen(v => !v)}
+            open={skillsOpen}
+            suffix={skillsCatCount > 0 ? `in ${skillsCatCount} categor${skillsCatCount === 1 ? 'y' : 'ies'}` : undefined}
+            t={t}
+            title="Available Skills"
+          />
+          {skillsOpen && skillsBody()}
+        </Box>
+
+        {/* ── System Prompt (collapsed by default) ── */}
+        {sysPromptLen > 0 && (
+          <Box flexDirection="column" marginTop={1}>
+            <CollapseToggle
+              onToggle={() => setSystemOpen(v => !v)}
+              open={systemOpen}
+              suffix={`— ${sysPromptLen.toLocaleString()} chars`}
+              t={t}
+              title="System Prompt"
+            />
+            {systemOpen && systemBody()}
+          </Box>
+        )}
+
+        {/* ── MCP Servers (collapsed by default) ── */}
         {info.mcp_servers && info.mcp_servers.length > 0 && (
           <Box flexDirection="column" marginTop={1}>
-            <Text bold color={t.color.accent}>
-              MCP Servers
-            </Text>
-
-            {info.mcp_servers.map(s => (
-              <Text key={s.name} wrap="truncate">
-                <Text color={t.color.muted}>{`  ${s.name} `}</Text>
-                <Text color={t.color.muted}>{`[${s.transport}]`}</Text>
-                <Text color={t.color.muted}>: </Text>
-                {s.connected ? (
-                  <Text color={t.color.text}>
-                    {s.tools} tool{s.tools === 1 ? '' : 's'}
-                  </Text>
-                ) : (
-                  <Text color={t.color.error}>failed</Text>
-                )}
-              </Text>
-            ))}
+            <CollapseToggle
+              count={info.mcp_servers.length}
+              onToggle={() => setMcpOpen(v => !v)}
+              open={mcpOpen}
+              suffix="connected"
+              t={t}
+              title="MCP Servers"
+            />
+            {mcpOpen && mcpBody()}
           </Box>
         )}
 
         <Text />
 
         <Text color={t.color.text}>
-          {flat(info.tools).length} tools{' · '}
-          {flat(info.skills).length} skills
+          {toolsTotal} tools{' · '}
+          {skillsTotal} skills
           {info.mcp_servers?.length ? ` · ${info.mcp_servers.length} MCP` : ''}
           {' · '}
           <Text color={t.color.muted}>/help for commands</Text>

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -1,5 +1,5 @@
 import { Ansi, Box, NoSelect, Text } from '@hermes/ink'
-import { memo } from 'react'
+import { memo, useState } from 'react'
 
 import { LONG_MSG } from '../config/limits.js'
 import { sectionMode } from '../domain/details.js'
@@ -21,6 +21,9 @@ import { Md } from './markdown.js'
 import { StreamingMd } from './streamingMarkdown.js'
 import { ToolTrail } from './thinking.js'
 import { TodoPanel } from './todoPanel.js'
+
+// Collapse threshold for long system messages (system prompt etc.)
+const SYSTEM_COLLAPSE_CHARS = 400
 
 export const MessageLine = memo(function MessageLine({
   cols,
@@ -45,6 +48,10 @@ export const MessageLine = memo(function MessageLine({
   const toolsMode = sectionMode('tools', detailsMode, sections, detailsModeCommandOverride)
   const activityMode = sectionMode('activity', detailsMode, sections, detailsModeCommandOverride)
   const thinking = msg.thinking?.trim() ?? ''
+
+  // Collapse toggle for long system messages
+  const systemIsLong = msg.role === 'system' && msg.text.length > SYSTEM_COLLAPSE_CHARS
+  const [systemOpen, setSystemOpen] = useState(false)
 
   if (msg.kind === 'trail' && msg.todos?.length) {
     return (
@@ -104,6 +111,27 @@ export const MessageLine = memo(function MessageLine({
   const content = (() => {
     if (msg.kind === 'slash') {
       return <Text color={t.color.muted}>{msg.text}</Text>
+    }
+
+    // ── Collapsible long system message (system prompt, AGENTS.md, etc.) ──
+    // MUST come before the hasAnsi check — system messages from the backend
+    // contain Rich markup escape codes that would otherwise hit <Ansi> full render.
+    if (systemIsLong) {
+      const firstLine = (msg.text.split('\n')[0] ?? '').trim().slice(0, 120) || '(system message)'
+
+      return (
+        <Box flexDirection="column">
+          <Box onClick={() => setSystemOpen(v => !v)}>
+            <Text color={t.color.accent}>{systemOpen ? '▾ ' : '▸ '}</Text>
+            <Text color={t.color.muted}>{firstLine}</Text>
+            <Text color={t.color.muted} dimColor>
+              {' — '}
+              {msg.text.length.toLocaleString()} chars
+            </Text>
+          </Box>
+          {systemOpen && <Ansi>{msg.text}</Ansi>}
+        </Box>
+      )
     }
 
     if (msg.role !== 'user' && hasAnsi(msg.text)) {

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -150,6 +150,7 @@ export interface SessionInfo {
   release_date?: string
   service_tier?: string
   skills: Record<string, string[]>
+  system_prompt?: string
   tools: Record<string, string[]>
   update_behind?: number | null
   update_command?: string


### PR DESCRIPTION
## Summary

The TUI now uses collapsible **▸/▾** toggles for verbose content in two places, matching the existing Chevron convention used for runtime agent details (thinking, tools, subagents).

### 1. Startup banner (SessionPanel)

Sections that were previously always expanded are now collapsible:

| Section | Default | Collapsed shows |
|---------|---------|-----------------|
| Tools | **Expanded** | — |
| Skills | Collapsed | `▸ Available Skills (52) in 12 categories` |
| System Prompt | Collapsed | `▸ System Prompt — 18,247 chars` |
| MCP Servers | Collapsed | `▸ MCP Servers (3) connected` |

### 2. Long system messages in transcript (system prompt, AGENTS.md, etc.)

System messages over 400 chars now render as a collapsed one-liner instead of dumping 18k+ chars into the transcript. Shows the first line + char count; clicking expands to full content.

**Before:** `· You are Hermes Agent, an AI assistant...(18,247 chars of system prompt inline)`

**After:** `▸ You are Hermes Agent, an AI assistant — 18,247 chars`

This fixes the problem where resuming a session with a large system prompt (personality, skills index, memory, project context) floods the entire transcript.

## Changes

- **`tui_gateway/server.py`** (+4 lines): `_session_info()` pipes `agent._cached_system_prompt` to the TUI
- **`ui-tui/src/types.ts`** (+1 field): `system_prompt?: string` in `SessionInfo`
- **`ui-tui/src/components/branding.tsx`** (+175/−45): rewrote SessionPanel with CollapseToggle + per-section useState
- **`ui-tui/src/components/messageLine.tsx`** (+27/−1): long system messages (>400 chars) collapse with ▸/▾ toggle

## Testing

- **TypeScript:** `tsc --noEmit` passes, full `npm run build` succeeds
- **TUI unit tests:** 613/616 pass, 0 regressions (3 skipped unrelated)
- **Python server tests:** 172/173 pass (1 pre-existing Chrome-not-found failure, unrelated)
- **E2E data contract:** JSON-RPC round-trip verified