### PR TITLE
fix: skip temp dir checkpoints

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -205,6 +205,19 @@ class TestTakeCheckpoint:
         r = mgr.ensure_checkpoint(str(Path.home()), "home")
         assert r is False
 
+    def test_skip_system_temp_dir(self, mgr, monkeypatch):
+        called = False
+
+        def _unexpected_take(*args, **kwargs):
+            nonlocal called
+            called = True
+            return True
+
+        monkeypatch.setattr(mgr, "_take", _unexpected_take)
+        r = mgr.ensure_checkpoint("/tmp", "temp")
+        assert r is False
+        assert called is False
+
 
 # =========================================================================
 # CheckpointManager — listing checkpoints

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -24,6 +24,7 @@ import os
 import re
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, List, Optional, Set
@@ -324,9 +325,10 @@ class CheckpointManager:
             return False
 
         abs_dir = str(_normalize_path(working_dir))
+        temp_dir = str(_normalize_path(tempfile.gettempdir()))
 
         # Skip root, home, and other overly broad directories
-        if abs_dir in ("/", str(Path.home())):
+        if abs_dir in ("/", str(Path.home()), temp_dir):
             logger.debug("Checkpoint skipped: directory too broad (%s)", abs_dir)
             return False
 


### PR DESCRIPTION
## Summary
- skip checkpoint creation when the resolved working directory is the system temp dir
- add a regression test covering `/tmp`-scoped checkpoint attempts
- prevent `git add -A` from traversing `systemd-private-*` directories under `/tmp`

## Testing
- uv run --python 3.12 --extra dev python -m pytest tests/tools/test_checkpoint_manager.py::TestTakeCheckpoint::test_skip_system_temp_dir -q
- uv run --python 3.12 --extra dev python -m pytest tests/tools/test_checkpoint_manager.py -q
- python -c "from tools.checkpoint_manager import CheckpointManager; print(CheckpointManager(enabled=True).ensure_checkpoint('/tmp', 'probe'))"

Closes EMT-70 in Paperclip.
