### PR TITLE
feat(kanban): add automatic routing rules

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1194,6 +1194,15 @@ DEFAULT_CONFIG = {
         # Seconds between dispatcher ticks (idle or not). Lower = snappier
         # pickup of newly-ready tasks; higher = less SQL pressure.
         "dispatch_interval_seconds": 60,
+        # Optional automatic routing rules evaluated by the dispatcher
+        # after todo->ready promotion and before worker spawn. This supports
+        # PM/specifier lanes: expensive planners can decompose work while
+        # concrete implementation/review is reassigned to cheaper or
+        # specialized profiles. Disabled by default for back-compat.
+        "routing": {
+            "enabled": False,
+            "rules": [],
+        },
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -82,6 +82,7 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Optional
+import fnmatch
 
 
 # ---------------------------------------------------------------------------
@@ -1722,6 +1723,148 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Automatic routing rules
+# ---------------------------------------------------------------------------
+
+def _load_config_routing_rules() -> list[dict[str, Any]]:
+    """Return enabled kanban routing rules from config.yaml.
+
+    The feature is intentionally config-gated so existing boards keep the
+    historical behaviour unless operators opt in. Rules are deliberately
+    simple: filters match task metadata/title/body, then perform one of:
+    ``promote`` (triage -> todo), ``reassign``, or ``promote_and_assign``.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+    except Exception:
+        return []
+    routing = (cfg.get("kanban") or {}).get("routing") or {}
+    if not routing.get("enabled", False):
+        return []
+    raw = routing.get("rules") or []
+    return [r for r in raw if isinstance(r, dict) and r.get("enabled", True)]
+
+
+def _as_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple, set)):
+        return [str(v) for v in value if v is not None and str(v)]
+    return [str(value)]
+
+
+def _merge_task_skills(existing_raw: Optional[str], new_skills: Iterable[str]) -> list[str]:
+    existing: list[str] = []
+    if existing_raw:
+        try:
+            parsed = json.loads(existing_raw)
+            if isinstance(parsed, list):
+                existing = [str(s) for s in parsed if s]
+        except Exception:
+            existing = []
+    seen = set(existing)
+    for skill in new_skills:
+        if skill and skill not in seen:
+            existing.append(str(skill))
+            seen.add(str(skill))
+    return existing
+
+
+def _routing_rule_matches(row: sqlite3.Row, rule: dict[str, Any]) -> bool:
+    created_by = rule.get("created_by")
+    if created_by is not None and row["created_by"] != created_by:
+        return False
+
+    assignee = rule.get("assignee") or rule.get("assignee_glob")
+    if assignee is not None and not fnmatch.fnmatch(row["assignee"] or "", str(assignee)):
+        return False
+
+    statuses = _as_list(rule.get("statuses"))
+    if statuses and row["status"] not in statuses:
+        return False
+
+    text = f"{row['title'] or ''}\n{row['body'] or ''}".lower()
+    keywords = [k.lower() for k in _as_list(rule.get("title_kw")) + _as_list(rule.get("body_kw"))]
+    if keywords and not any(k in text for k in keywords):
+        return False
+
+    return True
+
+
+def apply_routing_rules(
+    conn: sqlite3.Connection,
+    *,
+    rules: Optional[list[dict[str, Any]]] = None,
+) -> int:
+    """Apply configured automatic routing rules to inactive tasks.
+
+    This gives Kanban a native version of the common PM/specifier pattern:
+    a strong PM profile turns triage cards into concrete child cards, while
+    the dispatcher enforces that implementation and QA cards move to cheaper
+    or specialized profiles before workers are spawned.
+
+    Returns the number of task rows materially changed.
+    """
+    active_rules = rules if rules is not None else _load_config_routing_rules()
+    if not active_rules:
+        return 0
+    ordered = sorted(active_rules, key=lambda r: int(r.get("priority", 0)))
+    changed = 0
+    with write_txn(conn):
+        rows = conn.execute(
+            """
+            SELECT id, title, body, assignee, status, created_by, skills
+            FROM tasks
+            WHERE status NOT IN ('running', 'done', 'archived')
+            ORDER BY priority DESC, created_at ASC
+            """
+        ).fetchall()
+        for row in rows:
+            for rule in ordered:
+                if not _routing_rule_matches(row, rule):
+                    continue
+                task_id = row["id"]
+                action = str(rule.get("action") or "reassign")
+                assign_to = rule.get("assign_to")
+                ensure_skills = _as_list(rule.get("ensure_skills"))
+                updates: list[str] = []
+                params: list[Any] = []
+                payload: dict[str, Any] = {
+                    "source": "routing_rule",
+                    "rule": rule.get("name") or rule.get("id"),
+                    "action": action,
+                }
+
+                if action in {"promote", "promote_and_assign"} and row["status"] == "triage":
+                    updates.append("status = 'todo'")
+                    payload["status"] = "todo"
+
+                if action in {"reassign", "promote_and_assign"} and assign_to and assign_to != row["assignee"]:
+                    updates.append("assignee = ?")
+                    params.append(str(assign_to))
+                    payload["assignee"] = str(assign_to)
+                    payload["previous_assignee"] = row["assignee"]
+
+                if ensure_skills:
+                    merged = _merge_task_skills(row["skills"], ensure_skills)
+                    if json.dumps(merged, ensure_ascii=False) != (row["skills"] or ""):
+                        updates.append("skills = ?")
+                        params.append(json.dumps(merged, ensure_ascii=False))
+                        payload["skills"] = merged
+
+                if updates:
+                    params.append(task_id)
+                    conn.execute(f"UPDATE tasks SET {', '.join(updates)} WHERE id = ?", tuple(params))
+                    _append_event(conn, task_id, "routed", payload)
+                    changed += 1
+                break
+    return changed
+
+
+# ---------------------------------------------------------------------------
 # Claim / complete / block
 # ---------------------------------------------------------------------------
 
@@ -2553,6 +2696,7 @@ class DispatchResult:
 
     reclaimed: int = 0
     promoted: int = 0
+    routed: int = 0
     spawned: list[tuple[str, str, str]] = field(default_factory=list)
     """List of ``(task_id, assignee, workspace_path)`` triples."""
     skipped_unassigned: list[str] = field(default_factory=list)
@@ -3123,6 +3267,7 @@ def dispatch_once(
       1. Reclaim stale running tasks (TTL expired).
       2. Reclaim crashed running tasks (host-local PID no longer alive).
       3. Promote todo -> ready where all parents are done.
+      3b. Apply configured routing rules before spawning.
       4. For each ready task with an assignee, atomically claim and call
          ``spawn_fn(task, workspace_path, board) -> Optional[int]``. The
          return value (if any) is recorded as ``worker_pid`` so subsequent
@@ -3141,6 +3286,7 @@ def dispatch_once(
     result.crashed = detect_crashed_workers(conn)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn)
+    result.routed = apply_routing_rules(conn)
 
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3400,3 +3400,93 @@ def test_reclaim_task_clears_failure_counter(kanban_home):
         assert task.status == "ready"
     finally:
         conn.close()
+
+# ---------------------------------------------------------------------------
+# Automatic routing rules
+# ---------------------------------------------------------------------------
+
+def test_apply_routing_rules_promotes_pm_triage_and_adds_skill(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="Rough product idea", assignee="pm", triage=True)
+        changed = kb.apply_routing_rules(conn, rules=[{
+            "name": "pm-triage-promote",
+            "assignee": "pm",
+            "statuses": ["triage"],
+            "action": "promote",
+            "ensure_skills": ["kanban-orchestrator"],
+        }])
+        task = kb.get_task(conn, tid)
+        assert changed == 1
+        assert task.status == "todo"
+        assert task.assignee == "pm"
+        assert task.skills == ["kanban-orchestrator"]
+
+
+def test_apply_routing_rules_reassigns_pm_created_test_card_to_qa(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="Test: finance assistant E2E",
+            assignee="pm",
+            created_by="pm",
+        )
+        changed = kb.apply_routing_rules(conn, rules=[{
+            "name": "qa-from-pm",
+            "created_by": "pm",
+            "statuses": ["todo", "ready", "blocked"],
+            "title_kw": ["test", "qa", "review", "e2e"],
+            "assign_to": "qa",
+            "action": "reassign",
+        }])
+        task = kb.get_task(conn, tid)
+        assert changed == 1
+        assert task.assignee == "qa"
+
+
+def test_apply_routing_rules_uses_first_matching_priority_rule(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="Build import pipeline",
+            assignee="pm",
+            created_by="pm",
+        )
+        changed = kb.apply_routing_rules(conn, rules=[
+            {
+                "name": "routine-from-pm",
+                "priority": 10,
+                "created_by": "pm",
+                "statuses": ["todo", "ready"],
+                "title_kw": ["build"],
+                "assign_to": "routine",
+                "action": "reassign",
+            },
+            {
+                "name": "coding-from-pm",
+                "priority": 0,
+                "created_by": "pm",
+                "statuses": ["todo", "ready"],
+                "title_kw": ["build"],
+                "assign_to": "coding",
+                "action": "reassign",
+            },
+        ])
+        task = kb.get_task(conn, tid)
+        assert changed == 1
+        assert task.assignee == "coding"
+
+
+def test_dispatch_once_reports_routed_count(monkeypatch, kanban_home):
+    rules = [{
+        "name": "pm-triage-promote",
+        "assignee": "pm",
+        "statuses": ["triage"],
+        "action": "promote",
+    }]
+    monkeypatch.setattr(kb, "_load_config_routing_rules", lambda: rules)
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="Spec rough task", assignee="pm", triage=True)
+        result = kb.dispatch_once(conn, dry_run=True)
+        task = kb.get_task(conn, tid)
+        assert result.routed == 1
+        assert task.status == "todo"

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -192,6 +192,51 @@ kanban:
   dispatch_interval_seconds: 60    # default
 ```
 
+#### Automatic routing rules
+
+For durable role pipelines you can let a strong PM/specifier profile turn rough
+triage cards into concrete work, while the dispatcher enforces that the child
+cards move to cheaper or specialized profiles before they spawn. Routing is
+disabled by default and runs during each dispatcher tick after `todo → ready`
+promotion and before worker spawn.
+
+```yaml
+kanban:
+  routing:
+    enabled: true
+    rules:
+      # Specifier lane: rough cards assigned to pm leave triage automatically
+      # and force-load the orchestrator playbook.
+      - name: pm-triage-promote
+        assignee: pm
+        statuses: [triage]
+        action: promote
+        ensure_skills: [kanban-orchestrator]
+
+      # PM-created QA/review cards run on qa instead of spending PM tokens.
+      - name: qa-from-pm
+        priority: 0
+        created_by: pm
+        statuses: [todo, ready, blocked]
+        title_kw: [test, qa, review, validate, e2e]
+        action: reassign
+        assign_to: qa
+
+      # Simple build/script/report work can go to a cheaper routine profile.
+      - name: routine-from-pm
+        priority: 10
+        created_by: pm
+        statuses: [todo, ready, blocked]
+        title_kw: [build, script, import, report, schema, sqlite, csv, xlsx]
+        action: reassign
+        assign_to: routine
+```
+
+Supported rule filters: `created_by`, `assignee` / `assignee_glob`, `statuses`,
+`title_kw`, and `body_kw`. Keyword lists use OR semantics across title + body.
+Supported actions: `promote` (`triage → todo`), `reassign`, and
+`promote_and_assign`. `ensure_skills` appends per-task force-loaded skills.
+
 Override the config flag at runtime via `HERMES_KANBAN_DISPATCH_IN_GATEWAY=0`
 for debugging. Standard gateway supervision applies: run `hermes gateway
 start` directly, or wire the gateway up as a systemd user unit (see the


### PR DESCRIPTION
## Summary

Adds opt-in native Kanban routing rules evaluated by the dispatcher before worker spawn.

This supports a common durable multi-agent pattern:

1. A strong/expensive PM or specifier profile receives rough triage cards.
2. PM decomposes the work and creates concrete child cards.
3. The Kanban dispatcher enforces that child implementation/review cards are reassigned to cheaper or specialized profiles before they spawn.

The feature replaces local cron-style guardrails with native Kanban behavior while staying disabled by default for compatibility.

## Why

While dogfooding Kanban, we found a practical routing gap:

- `triage` is useful as a rough-input/spec lane, but it needs an automatic way to promote PM/specifier cards into the dispatcher flow.
- A PM/specifier profile should often use a stronger model because it shapes the task graph.
- But once PM has created the child cards, actual build/test/research work should be handled by cheaper or specialized worker profiles.
- Without an enforcement layer, PM can accidentally assign build/test child cards back to itself, spending the expensive planning lane on implementation.

We initially solved this locally with script-only cron jobs that:

- promoted `pm` triage cards to `todo`
- scanned PM-created child cards and reassigned them by title/body keywords

This PR moves that behavior into the Kanban dispatcher itself as an opt-in native feature.

## What changed

- Adds `kanban.routing.enabled` + `kanban.routing.rules` config shape.
- Adds `apply_routing_rules(...)` in `hermes_cli/kanban_db.py`.
- Adds `DispatchResult.routed`.
- Runs routing during each dispatcher tick after `todo -> ready` promotion and before spawn.
- Supports rule filters:
  - `created_by`
  - `assignee` / `assignee_glob`
  - `statuses`
  - `title_kw`
  - `body_kw`
- Supports actions:
  - `promote` — `triage -> todo`
  - `reassign`
  - `promote_and_assign`
- Supports `ensure_skills`, appending force-loaded per-task skills such as `kanban-orchestrator`.
- Documents a PM/specifier routing example in the Kanban docs.

## Example use case

```yaml
kanban:
  routing:
    enabled: true
    rules:
      - name: pm-triage-promote
        assignee: pm
        statuses: [triage]
        action: promote
        ensure_skills: [kanban-orchestrator]

      - name: qa-from-pm
        priority: 0
        created_by: pm
        statuses: [todo, ready, blocked]
        title_kw: [test, qa, review, validate, e2e]
        action: reassign
        assign_to: qa

      - name: routine-from-pm
        priority: 10
        created_by: pm
        statuses: [todo, ready, blocked]
        title_kw: [build, script, import, report, schema, sqlite, csv, xlsx]
        action: reassign
        assign_to: routine
```

This lets a high-quality PM profile do specification and decomposition while routine/coding/QA profiles do the actual work.

## Compatibility

- Disabled by default.
- No schema migration required.
- Existing Kanban behavior is unchanged unless `kanban.routing.enabled: true` is set.

## Test plan

```bash
python -m pytest tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_db.py -q -o 'addopts='
python -m py_compile hermes_cli/kanban_db.py hermes_cli/config.py
```

Result: `203 passed`.
