### PR TITLE
feat(i18n): add Korean (ko) locale

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -25,7 +25,7 @@ Language resolution order:
     3. ``display.language`` from config.yaml
     4. ``"en"`` (baseline)
 
-Supported languages: en, zh, ja, de, es, fr, tr, uk.  Unknown values fall back to en.
+Supported languages: en, zh, ja, de, es, fr, tr, uk, ko.  Unknown values fall back to en.
 """
 
 from __future__ import annotations
@@ -39,7 +39,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "ja", "de", "es", "fr", "tr", "uk")
+SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "ja", "de", "es", "fr", "tr", "uk", "ko")
 DEFAULT_LANGUAGE = "en"
 
 # Accept a few natural aliases so users who type "chinese" / "zh-CN" / "jp"
@@ -53,6 +53,7 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "french": "fr", "français": "fr", "france": "fr", "fr-fr": "fr", "fr-be": "fr", "fr-ca": "fr", "fr-ch": "fr",
     "ukrainian": "uk", "ukrainisch": "uk", "українська": "uk", "uk-ua": "uk", "ua": "uk",
     "turkish": "tr", "türkçe": "tr", "tr-tr": "tr",
+    "korean": "ko", "한국어": "ko", "ko-kr": "ko", "kr": "ko",
 }
 
 _catalog_cache: dict[str, dict[str, str]] = {}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -784,7 +784,7 @@ DEFAULT_CONFIG = {
         # UI language for static user-facing messages (approval prompts, a
         # handful of gateway slash-command replies).  Does NOT affect agent
         # responses, log lines, tool outputs, or slash-command descriptions.
-        # Supported: en, zh, ja, de, es, fr, tr, uk.  Unknown values fall back to en.
+        # Supported: en, zh, ja, de, es, fr, tr, uk, ko.  Unknown values fall back to en.
         "language": "en",
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -7,7 +7,7 @@
 #
 # Keys are dotted paths; nesting below is purely for readability.  Values may
 # contain {placeholder} tokens for str.format substitution.  When adding a
-# new key, add it to EVERY locale file (en/zh/ja/de/es/fr/tr/uk) in the same commit --
+# new key, add it to EVERY locale file (en/zh/ja/de/es/fr/tr/uk/ko) in the same commit --
 # tests/agent/test_i18n.py asserts catalog parity.
 
 approval:

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -1,0 +1,24 @@
+# Hermes 정적 메시지 카탈로그 -- 한국어
+# See locales/en.yaml for the source of truth; keep keys in sync.
+
+approval:
+  dangerous_header: "⚠️  위험한 명령: {description}"
+  choose_long:     "      [o]한 번  |  [s]세션  |  [a]항상  |  [d]거부"
+  choose_short:    "      [o]한 번  |  [s]세션  |  [d]거부"
+  prompt_long:     "      선택 [o/s/a/D]: "
+  prompt_short:    "      선택 [o/s/D]: "
+  timeout:         "      ⏱ 시간 초과 — 명령이 거부됨"
+  allowed_once:    "      ✓ 한 번 허용됨"
+  allowed_session: "      ✓ 이 세션 동안 허용됨"
+  allowed_always:  "      ✓ 영구 허용 목록에 추가됨"
+  denied:          "      ✗ 거부됨"
+  cancelled:       "      ✗ 취소됨"
+  blocklist_message: "이 명령은 무조건적인 차단 목록에 있어 승인할 수 없습니다."
+
+gateway:
+  approval_expired: "⚠️ 승인이 만료되었습니다(에이전트가 더 이상 대기 중이지 않습니다). 에이전트에게 다시 시도하도록 요청하세요."
+  draining:         "⏳ 재시작 전에 활성 에이전트 {count}개를 종료하는 중..."
+  goal_cleared:     "✓ 목표가 지워졌습니다."
+  no_active_goal:   "활성 목표가 없습니다."
+  config_read_failed: "⚠️ config.yaml을 읽을 수 없습니다: {error}"
+  config_save_failed: "⚠️ 설정을 저장할 수 없습니다: {error}"

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -95,6 +95,10 @@ def test_normalize_lang_accepts_aliases():
     assert i18n._normalize_lang("Turkish") == "tr"
     assert i18n._normalize_lang("tr-TR") == "tr"
     assert i18n._normalize_lang("türkçe") == "tr"
+    assert i18n._normalize_lang("Korean") == "ko"
+    assert i18n._normalize_lang("ko-KR") == "ko"
+    assert i18n._normalize_lang("한국어") == "ko"
+    assert i18n._normalize_lang("kr") == "ko"
 
 
 def test_normalize_lang_unknown_falls_back():
@@ -134,6 +138,7 @@ def test_t_explicit_lang():
     assert i18n.t("approval.denied", lang="zh").endswith("已拒绝")
     assert i18n.t("approval.denied", lang="uk").endswith("Відхилено")
     assert i18n.t("approval.denied", lang="tr").endswith("Reddedildi")
+    assert i18n.t("approval.denied", lang="ko").endswith("거부됨")
 
 
 def test_t_formats_placeholders():

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1167,14 +1167,14 @@ display:
   show_cost: false        # Show estimated $ cost in the CLI status bar
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
   runtime_metadata_footer: false  # Gateway: append a runtime-context footer to final replies
-  language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | ja | de | es | fr | tr | uk
+  language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | ja | de | es | fr | tr | uk | ko
 ```
 
 ### UI language for static messages
 
 The `display.language` setting translates a small set of static user-facing messages — the CLI approval prompt, a handful of gateway slash-command replies (e.g. restart-drain notices, "approval expired", "goal cleared"). It does **not** translate agent responses, log lines, tool output, error tracebacks, or slash-command descriptions — those stay in English. If you want the agent itself to reply in another language, just tell it in your prompt or system message.
 
-Supported values: `en` (default), `zh` (Simplified Chinese), `ja` (Japanese), `de` (German), `es` (Spanish), `fr` (French), `tr` (Turkish), `uk` (Ukrainian). Unknown values fall back to English.
+Supported values: `en` (default), `zh` (Simplified Chinese), `ja` (Japanese), `de` (German), `es` (Spanish), `fr` (French), `tr` (Turkish), `uk` (Ukrainian), `ko` (Korean). Unknown values fall back to English.
 
 You can also set this per-session with the `HERMES_LANGUAGE` env var, which overrides the config value.
 


### PR DESCRIPTION
## Summary

Adds **Korean (`ko`)** as the 9th supported UI locale, following the exact pattern of `feat(i18n): add Turkish (tr) locale` (#20474) and `feat(i18n): add Ukrainian locale` (#20467).

Translates the small set of static user-facing messages — CLI approval prompts and a handful of gateway slash-command replies. Agent-generated output, log lines, error tracebacks, and tool outputs continue to stay in English by design.

## Changes

- `locales/ko.yaml` — 18-key catalog (Korean translations of every key in `locales/en.yaml`)
- `agent/i18n.py` — `"ko"` added to `SUPPORTED_LANGUAGES`; aliases `korean`, `한국어`, `ko-kr`, `kr` added to `_LANGUAGE_ALIASES`
- `hermes_cli/config.py` — supported-language comment updated
- `locales/en.yaml` — header note updated to list `ko`
- `website/docs/user-guide/configuration.md` — both docs lines updated
- `tests/agent/test_i18n.py` — alias assertions + a `t("approval.denied", lang="ko")` round-trip assertion

## Community signal

Closes the UI-locale half of two long-standing open issues requesting Korean support: #18126 and #18124. The issues focus on docs translation (larger scope); a UI locale catalog is the surgical first step.

## Test plan

- [x] `pytest tests/agent/test_i18n.py` — all 29 tests pass locally
- [x] Catalog parity test (`test_catalog_keys_match_english`) automatically covers `ko` via parametrize over `SUPPORTED_LANGUAGES`
- [x] Placeholder parity test (`test_catalog_placeholders_match_english`) confirms `{description}`, `{count}`, `{error}` tokens preserved
- [x] Manual: `HERMES_LANGUAGE=ko hermes` shows the Korean approval prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)