### PR TITLE
fix: use stringWidth() for Markdown table column widths to support CJ…

### DIFF
--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -1,4 +1,4 @@
-import { Box, Link, Text } from '@hermes/ink'
+import { Box, Link, Text, stringWidth } from '@hermes/ink'
 import { Fragment, memo, type ReactNode, useMemo } from 'react'
 
 import { ensureEmojiPresentation } from '../lib/emoji.js'
@@ -170,16 +170,15 @@ export const stripInlineMarkup = (v: string) =>
     .replace(/\\\(([^\n]+?)\\\)/g, '$1')
 
 const renderTable = (k: number, rows: string[][], t: Theme) => {
-  const widths = rows[0]!.map((_, ci) => Math.max(...rows.map(r => stripInlineMarkup(r[ci] ?? '').length)))
+  const widths = rows[0]!.map((_, ci) => Math.max(...rows.map(r => stringWidth(stripInlineMarkup(r[ci] ?? '')))))
 
   // Thin divider under the header.  Without it tables look like prose
   // with extra spacing because the header is just accent-coloured text
-  // (#15534).  We avoid full borders on purpose — column widths come
-  // from `stripInlineMarkup(...).length` (UTF-16 code units, not
-  // display width), so a real outline often misaligns on emoji and
-  // East-Asian wide characters; one dim solid rule (`─`) under row 0
-  // plus tab-style column gaps reads cleanly on every terminal we
-  // tested.
+  // (#15534).  We avoid full borders on purpose — one dim solid rule
+  // (`─`) under row 0 plus tab-style column gaps reads cleanly on every
+  // terminal we tested.  Column widths use `stringWidth` (grapheme-aware
+  // display width from `get-east-asian-width`) so CJK and emoji align
+  // correctly.
   const sep = widths.map(w => '─'.repeat(Math.max(1, w))).join('  ')
 
   return (
@@ -190,7 +189,7 @@ const renderTable = (k: number, rows: string[][], t: Theme) => {
             {widths.map((w, ci) => (
               <Text bold={ri === 0} color={ri === 0 ? t.color.accent : undefined} key={ci}>
                 <MdInline t={t} text={row[ci] ?? ''} />
-                {' '.repeat(Math.max(0, w - stripInlineMarkup(row[ci] ?? '').length))}
+                {' '.repeat(Math.max(0, w - stringWidth(stripInlineMarkup(row[ci] ?? ''))))}
                 {ci < widths.length - 1 ? '  ' : ''}
               </Text>
             ))}


### PR DESCRIPTION
What does this PR do?

Replace .length (UTF-16 code units) with stringWidth() (terminal display width) in renderTable() column width and padding calculations. CJK characters are 2 terminal cells wide; .length miscounts them, causing table misalignment. stringWidth() from @hermes/ink uses get-east-asian-width for correct widths.

Related Issue

Fixes #20621

Type of Change

☑ 🐛 Bug fix

Changes Made

• ui-tui/src/components/markdown.tsx:
  • Added stringWidth to @hermes/ink imports
  • Replaced .length with stringWidth() in column width calculation (line 173)
  • Replaced .length with stringWidth() in padding calculation (line 193)
  • Updated inline comment to reflect the fix

How to Test

1. Start Hermes TUI: hermes --tui
2. Ask the agent to output a Markdown table with CJK characters, e.g.: "用中英文混合表格列出 git 工作流步骤"
3. Verify table columns align correctly (no misalignment or ragged edges)
4. Verify ASCII-only tables still render correctly (no regression)

Checklist

Code

☑ Commit messages follow Conventional Commits
☑ Searched for existing PRs — no duplicate
☑ PR contains only related changes (1 file)
☐ Tests — N/A (pure display fix, no new logic to unit-test)
☑ Tested on: macOS

Documentation & Housekeeping

☑ Documentation — N/A
☑ cli-config.yaml.example — N/A
☑ CONTRIBUTING.md / AGENTS.md — N/A
☑ Cross-platform — stringWidth works on macOS/Linux/Windows identically
☑ Tool descriptions — N/A