### PR TITLE
docs(providers): add 7 missing providers to quick-reference table

### DIFF
--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -19,7 +19,9 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **GitHub Copilot** | `hermes model` (OAuth device code flow, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`) |
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
 | **Anthropic** | `hermes model` (Claude Max + extra usage credits via OAuth; also supports Anthropic API key or manual setup-token — see note below) |
+| **AWS Bedrock** | AWS SDK credential chain (`~/.aws/credentials` or `AWS_PROFILE` + `AWS_REGION`; no API key needed) (provider: `bedrock`) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
+| **xAI (Grok)** | `XAI_API_KEY` in `~/.hermes/.env` (provider: `xai`) |
 | **AI Gateway** | `AI_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `ai-gateway`) |
 | **z.ai / GLM** | `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`) |
 | **Kimi / Moonshot** | `KIMI_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding`) |
@@ -28,14 +30,19 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **GMI Cloud** | `GMI_API_KEY` in `~/.hermes/.env` (provider: `gmi`; aliases: `gmi-cloud`, `gmicloud`) |
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
+| **MiniMax (OAuth)** | `hermes model` → "MiniMax (OAuth)" (provider: `minimax-oauth`, browser PKCE login) |
 | **Alibaba Cloud** | `DASHSCOPE_API_KEY` in `~/.hermes/.env` (provider: `alibaba`) |
 | **Alibaba Coding Plan** | `DASHSCOPE_API_KEY` (provider: `alibaba-coding-plan`, alias: `alibaba_coding`) — separate billing SKU, different endpoint |
+| **Qwen Portal (OAuth)** | `hermes model` → "Qwen OAuth (Portal)" (provider: `qwen-oauth`, browser PKCE login via Alibaba account) |
 | **Kilo Code** | `KILOCODE_API_KEY` in `~/.hermes/.env` (provider: `kilocode`) |
 | **Xiaomi MiMo** | `XIAOMI_API_KEY` in `~/.hermes/.env` (provider: `xiaomi`, aliases: `mimo`, `xiaomi-mimo`) |
 | **Tencent TokenHub** | `TOKENHUB_API_KEY` in `~/.hermes/.env` (provider: `tencent-tokenhub`, aliases: `tencent`, `tokenhub`, `tencentmaas`) |
 | **OpenCode Zen** | `OPENCODE_ZEN_API_KEY` in `~/.hermes/.env` (provider: `opencode-zen`) |
 | **OpenCode Go** | `OPENCODE_GO_API_KEY` in `~/.hermes/.env` (provider: `opencode-go`) |
 | **DeepSeek** | `DEEPSEEK_API_KEY` in `~/.hermes/.env` (provider: `deepseek`) |
+| **NVIDIA NIM** | `NVIDIA_API_KEY` in `~/.hermes/.env` (provider: `nvidia`) — free tier via [build.nvidia.com](https://build.nvidia.com), or local NIM endpoint |
+| **Ollama Cloud** | `OLLAMA_API_KEY` in `~/.hermes/.env` (provider: `ollama-cloud`) — managed Ollama models, key from [ollama.com/settings/keys](https://ollama.com/settings/keys) |
+| **StepFun** | `STEPFUN_API_KEY` in `~/.hermes/.env` (provider: `stepfun`) |
 | **Hugging Face** | `HF_TOKEN` in `~/.hermes/.env` (provider: `huggingface`, aliases: `hf`) |
 | **Google / Gemini** | `GOOGLE_API_KEY` (or `GEMINI_API_KEY`) in `~/.hermes/.env` (provider: `gemini`) |
 | **Google Gemini (OAuth)** | `hermes model` → "Google Gemini (OAuth)" (provider: `google-gemini-cli`, free tier supported, browser PKCE login) |


### PR DESCRIPTION
## Summary

The "Inference Providers" quick-reference table at the top of `website/docs/integrations/providers.md` was missing 7 providers that have full dedicated sections later in the same file (and are explicitly listed in the line-1389 `Supported providers` enumeration).

A user skimming the top-of-page table to find a provider's env-var name would not learn that these providers exist, even though Hermes supports them as first-class.

Added rows (in alphabetical / contextual position within the existing grouping):

| Provider | Setup |
|---|---|
| AWS Bedrock | AWS SDK credential chain (`bedrock`) |
| xAI (Grok) | `XAI_API_KEY` (`xai`) |
| MiniMax (OAuth) | `hermes model` browser PKCE login (`minimax-oauth`) |
| Qwen Portal (OAuth) | `hermes model` browser PKCE login (`qwen-oauth`) |
| NVIDIA NIM | `NVIDIA_API_KEY` (`nvidia`) |
| Ollama Cloud | `OLLAMA_API_KEY` (`ollama-cloud`) |
| StepFun | `STEPFUN_API_KEY` (`stepfun`) |

Each row mirrors the setup detail in that provider's existing dedicated section (xAI at L325, Ollama Cloud at L335, AWS Bedrock at L359, Qwen at L391, MiniMax OAuth at L435, NVIDIA at L461, StepFun at L504).

## Changes

- `website/docs/integrations/providers.md` — 7 new table rows; no other content changed.

## Test plan

- [x] `grep -E "^### (xAI|NVIDIA|Ollama Cloud|AWS Bedrock|Qwen|MiniMax|StepFun)"` confirms each new row corresponds to an existing dedicated section
- [x] Provider IDs match those in `Supported providers:` line at L1389+
- [x] No code paths affected — pure docs change

🤖 Generated with [Claude Code](https://claude.com/claude-code)