### PR TITLE
docs(config): add xai and deepseek to provider list in cli-config.yaml.example

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -19,6 +19,8 @@ model:
   #   "openai-codex" - OpenAI Codex (requires: hermes auth)
   #   "copilot"      - GitHub Copilot / GitHub Models (requires: GITHUB_TOKEN)
   #   "gemini"      - Use Google AI Studio direct (requires: GOOGLE_API_KEY or GEMINI_API_KEY)
+  #   "xai"          - xAI direct API / Grok models (requires: XAI_API_KEY)
+  #   "deepseek"     - DeepSeek direct API (requires: DEEPSEEK_API_KEY)
   #   "zai"         - Use z.ai / ZhipuAI GLM models (requires: GLM_API_KEY)
   #   "kimi-coding"  - Kimi / Moonshot AI (requires: KIMI_API_KEY)
   #   "minimax"      - MiniMax global (requires: MINIMAX_API_KEY)


### PR DESCRIPTION
## Summary

The provider selection comment in `cli-config.yaml.example` (`model.provider:` block) lists ~21 supported providers, but **`xai`** and **`deepseek`** were missing. Both are first-class providers with dedicated `ProviderEntry` definitions in `hermes_cli/models.py` and active model additions in the last 48 hours:

- `xai` → grok-4.3 added in #20497
- `deepseek` → deepseek-v4-pro added in #20495

Both are listed in `website/docs/integrations/providers.md` line 1389 (`Supported providers: ..., deepseek, ..., xai, ...`) but were absent from the example config users actually copy when setting up. A user who already has `XAI_API_KEY` or `DEEPSEEK_API_KEY` in their `.env` and then opens the example config to switch providers won't find the right string to use.

## Changes

- `cli-config.yaml.example` — added 2 lines to the provider comment block:
  ```yaml
  #   "xai"          - xAI direct API / Grok models (requires: XAI_API_KEY)
  #   "deepseek"     - DeepSeek direct API (requires: DEEPSEEK_API_KEY)
  ```

## Test plan

- [x] `grep -E '"(xai|deepseek)"' hermes_cli/models.py` confirms both providers are first-class
- [x] No code paths affected — pure docs/example-config change

🤖 Generated with [Claude Code](https://claude.com/claude-code)