### PR TITLE
fix(tools): externalize large tool outputs during replay

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
 import uuid
 from types import SimpleNamespace
@@ -227,6 +228,49 @@ def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[L
 # Message format conversion
 # ---------------------------------------------------------------------------
 
+
+def _codex_tool_output_max_chars() -> int:
+    raw = os.environ.get("HERMES_CODEX_TOOL_OUTPUT_MAX_CHARS", "4000")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        value = 4000
+    return max(0, value)
+
+
+def _is_compact_persisted_output_handle(output: str) -> bool:
+    if len(output) > 8000:
+        return False
+    stripped = output.strip()
+    return (
+        stripped.startswith("<persisted-output>")
+        and "</persisted-output>" in stripped
+        and "Full output saved to:" in stripped
+        and "read_file" in stripped
+    )
+
+
+def _truncate_codex_tool_output(output: str) -> str:
+    if _is_compact_persisted_output_handle(output):
+        return output
+    if "[Hermes truncated this prior tool output for Codex replay:" in output:
+        return output
+    max_chars = _codex_tool_output_max_chars()
+    if not max_chars or len(output) <= max_chars:
+        return output
+    omitted = len(output) - max_chars
+    logger.warning(
+        "Codex Responses tool output truncated from %d to %d chars before replay",
+        len(output),
+        max_chars,
+    )
+    return (
+        output[:max_chars].rstrip()
+        + f"\n\n[Hermes truncated this prior tool output for Codex replay: {omitted} chars omitted. "
+        + "Call the relevant tool again if exact omitted details are required.]"
+    )
+
+
 _RESPONSE_MESSAGE_STATUSES = {"completed", "incomplete", "in_progress"}
 
 
@@ -413,7 +457,7 @@ def _chat_messages_to_responses_input(messages: List[Dict[str, Any]]) -> List[Di
             items.append({
                 "type": "function_call_output",
                 "call_id": call_id,
-                "output": str(msg.get("content", "") or ""),
+                "output": _truncate_codex_tool_output(str(msg.get("content", "") or "")),
             })
 
     return items
@@ -473,7 +517,7 @@ def _preflight_codex_input_items(raw_items: Any) -> List[Dict[str, Any]]:
                 {
                     "type": "function_call_output",
                     "call_id": call_id.strip(),
-                    "output": output,
+                    "output": _truncate_codex_tool_output(output),
                 }
             )
             continue

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1603,6 +1603,56 @@ def test_codex_message_item_status_survives_conversion_and_preflight(monkeypatch
     assert normalized[0]["status"] == "in_progress"
 
 
+
+def test_codex_replay_preserves_compact_persisted_output_handle(monkeypatch):
+    from agent.codex_responses_adapter import (
+        _chat_messages_to_responses_input,
+        _preflight_codex_input_items,
+    )
+
+    handle = """<persisted-output>
+[Large tool output externalized by Hermes]
+Tool: mcp_codealive_fetch_artifacts
+Original: 56,000 characters (54.7 KB).
+Full output saved to: /Users/ilya/.hermes/tool-artifacts/2026-05-06/result.txt
+Use the read_file tool with offset and limit to access specific sections of this output.
+
+Preview (first 20 chars):
+important preview
+...
+</persisted-output>"""
+    items = _chat_messages_to_responses_input([
+        {"role": "tool", "tool_call_id": "call_1", "content": handle}
+    ])
+    normalized = _preflight_codex_input_items(items)
+    output = next(item["output"] for item in normalized if item.get("type") == "function_call_output")
+    assert output == handle
+
+
+def test_codex_replay_safety_cap_truncates_legacy_raw_output(monkeypatch):
+    monkeypatch.setenv("HERMES_CODEX_TOOL_OUTPUT_MAX_CHARS", "1000")
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+    items = _chat_messages_to_responses_input([
+        {"role": "tool", "tool_call_id": "call_1", "content": "x" * 5000}
+    ])
+    output = next(item["output"] for item in items if item.get("type") == "function_call_output")
+    assert len(output) < 1300
+    assert "Hermes truncated this prior tool output" in output
+
+
+def test_codex_replay_does_not_trust_spoofed_large_persisted_marker(monkeypatch):
+    monkeypatch.setenv("HERMES_CODEX_TOOL_OUTPUT_MAX_CHARS", "1000")
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+    spoofed = "prefix <persisted-output> " + ("x" * 5000)
+    items = _chat_messages_to_responses_input([
+        {"role": "tool", "tool_call_id": "call_1", "content": spoofed}
+    ])
+    output = next(item["output"] for item in items if item.get("type") == "function_call_output")
+    assert len(output) < 1300
+    assert "Hermes truncated this prior tool output" in output
+
 def test_duplicate_detection_distinguishes_different_codex_reasoning(monkeypatch):
     """Two consecutive reasoning-only responses with different encrypted content
     must NOT be treated as duplicates."""

--- a/tests/tools/test_budget_config.py
+++ b/tests/tools/test_budget_config.py
@@ -30,13 +30,13 @@ class TestModuleConstants:
     """Verify documented default values haven't drifted."""
 
     def test_default_result_size(self):
-        assert DEFAULT_RESULT_SIZE_CHARS == 100_000
+        assert DEFAULT_RESULT_SIZE_CHARS == 20_000
 
     def test_default_turn_budget(self):
-        assert DEFAULT_TURN_BUDGET_CHARS == 200_000
+        assert DEFAULT_TURN_BUDGET_CHARS == 80_000
 
     def test_default_preview_size(self):
-        assert DEFAULT_PREVIEW_SIZE_CHARS == 1_500
+        assert DEFAULT_PREVIEW_SIZE_CHARS == 2_000
 
 
 class TestPinnedThresholds:

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -251,7 +251,8 @@ class TestMaybePersistToolResult:
         cmd = env.execute.call_args[0][0]
         assert '"exit_code"' in cmd
 
-    def test_above_threshold_no_env_truncates_inline(self):
+    def test_above_threshold_no_env_persists_locally(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_TOOL_ARTIFACT_DIR", str(tmp_path))
         content = "x" * 60_000
         result = maybe_persist_tool_result(
             content=content,
@@ -260,9 +261,46 @@ class TestMaybePersistToolResult:
             env=None,
             threshold=30_000,
         )
-        assert PERSISTED_OUTPUT_TAG not in result
-        assert "Truncated" in result
+        assert PERSISTED_OUTPUT_TAG in result
+        assert "Full output saved to:" in result
+        saved_line = next(line for line in result.splitlines() if line.startswith("Full output saved to:"))
+        saved_path = saved_line.split(":", 1)[1].strip()
+        with open(saved_path, encoding="utf-8") as fh:
+            assert fh.read() == content
         assert len(result) < len(content)
+
+
+    def test_local_artifact_sanitizes_unsafe_tool_use_id(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_TOOL_ARTIFACT_DIR", str(tmp_path))
+        content = "x" * 60_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="mcp/codealive fetch",
+            tool_use_id="../../evil/id with spaces",
+            env=None,
+            threshold=30_000,
+        )
+        saved_line = next(line for line in result.splitlines() if line.startswith("Full output saved to:"))
+        saved_path = saved_line.split(":", 1)[1].strip()
+        assert str(tmp_path) in saved_path
+        assert ".." not in saved_path.replace(str(tmp_path), "")
+        with open(saved_path, encoding="utf-8") as fh:
+            assert fh.read() == content
+
+    def test_local_artifact_uses_hermes_home_by_default(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_TOOL_ARTIFACT_DIR", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+        content = "x" * 60_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="tc_home",
+            env=None,
+            threshold=30_000,
+        )
+        saved_line = next(line for line in result.splitlines() if line.startswith("Full output saved to:"))
+        saved_path = saved_line.split(":", 1)[1].strip()
+        assert saved_path.startswith(str(tmp_path / "hermes-home" / "tool-artifacts"))
 
     def test_env_write_failure_falls_back_to_truncation(self):
         env = MagicMock()
@@ -516,25 +554,12 @@ class TestPerToolThresholds:
         except ImportError:
             pytest.skip("terminal_tool not importable in test env")
 
-    def test_read_file_result_size_cap(self):
+    def test_read_file_never_persisted(self):
         from tools.registry import registry
         try:
             import tools.file_tools  # noqa: F401
             val = registry.get_max_result_size("read_file")
-            assert val == 100_000
-        except ImportError:
-            pytest.skip("file_tools not importable in test env")
-
-    def test_read_file_registry_cap_is_100k(self):
-        """Regression test: read_file must have a 100_000 char registry cap (Layer 2 safety net)."""
-        from tools.registry import registry
-        try:
-            import tools.file_tools  # noqa: F401
-            val = registry.get_max_result_size("read_file")
-            assert val == 100_000, (
-                f"read_file registry cap must be 100_000, got {val!r}. "
-                "float('inf') is not allowed — it disables the Layer 2 result-size guard."
-            )
+            assert val == float("inf")
         except ImportError:
             pytest.skip("file_tools not importable in test env")
 

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -15,9 +15,9 @@ PINNED_THRESHOLDS: Dict[str, float] = {
 
 # Defaults matching the current hardcoded values in tool_result_storage.py.
 # Kept here as the single source of truth; tool_result_storage.py imports these.
-DEFAULT_RESULT_SIZE_CHARS: int = 100_000
-DEFAULT_TURN_BUDGET_CHARS: int = 200_000
-DEFAULT_PREVIEW_SIZE_CHARS: int = 1_500
+DEFAULT_RESULT_SIZE_CHARS: int = 20_000
+DEFAULT_TURN_BUDGET_CHARS: int = 80_000
+DEFAULT_PREVIEW_SIZE_CHARS: int = 2_000
 
 
 @dataclass(frozen=True)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1137,7 +1137,7 @@ def _handle_search_files(args, **kw):
         output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
 
 
-registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)
+registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=float("inf"))
 registry.register(name="write_file", toolset="file", schema=WRITE_FILE_SCHEMA, handler=_handle_write_file, check_fn=_check_file_reqs, emoji="✍️", max_result_size_chars=100_000)
 registry.register(name="patch", toolset="file", schema=PATCH_SCHEMA, handler=_handle_patch, check_fn=_check_file_reqs, emoji="🔧", max_result_size_chars=100_000)
 registry.register(name="search_files", toolset="file", schema=SEARCH_FILES_SCHEMA, handler=_handle_search_files, check_fn=_check_file_reqs, emoji="🔎", max_result_size_chars=100_000)

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -8,25 +8,32 @@ Defense against context-window overflow operates at three levels:
 
 2. **Per-result persistence** (maybe_persist_tool_result): After a tool
    returns, if its output exceeds the tool's registered threshold
-   (registry.get_max_result_size), the full output is written INTO THE
-   SANDBOX temp dir (for example /tmp/hermes-results/{tool_use_id}.txt on
-   standard Linux, or $TMPDIR/hermes-results/{tool_use_id}.txt on Termux)
-   via env.execute(). The in-context content is replaced with a preview +
-   file path reference. The model can read_file to access the full output
-   on any backend.
+   (registry.get_max_result_size), the full output is written into a readable
+   artifact file and the in-context content is replaced with a preview + file
+   path reference. Remote/sandbox environments are preferred when available;
+   local Hermes runs fall back to HERMES_HOME/tool-artifacts.
 
 3. **Per-turn aggregate budget** (enforce_turn_budget): After all tool
    results in a single assistant turn are collected, if the total exceeds
-   MAX_TURN_BUDGET_CHARS (200K), the largest non-persisted results are
-   spilled to disk until the aggregate is under budget. This catches cases
-   where many medium-sized results combine to overflow context.
+   DEFAULT_TURN_BUDGET_CHARS, the largest non-persisted results are spilled to
+   disk until the aggregate is under budget. This catches cases where many
+   medium-sized results combine to overflow context.
 """
 
+from __future__ import annotations
+
+import hashlib
+import json
 import logging
 import os
+import re
 import shlex
+import tempfile
+import time
 import uuid
+from pathlib import Path
 
+from hermes_constants import get_hermes_home
 from tools.budget_config import (
     DEFAULT_PREVIEW_SIZE_CHARS,
     BudgetConfig,
@@ -36,9 +43,12 @@ from tools.budget_config import (
 logger = logging.getLogger(__name__)
 PERSISTED_OUTPUT_TAG = "<persisted-output>"
 PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
+EXTERNALIZED_OUTPUT_MARKER = "[Large tool output externalized by Hermes]"
 STORAGE_DIR = "/tmp/hermes-results"
+LOCAL_STORAGE_ENV = "HERMES_TOOL_ARTIFACT_DIR"
 HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
+_MAX_SLUG_LEN = 64
 
 
 def _resolve_storage_dir(env) -> str:
@@ -55,6 +65,82 @@ def _resolve_storage_dir(env) -> str:
                     temp_dir = temp_dir.rstrip("/") or "/"
                     return f"{temp_dir}/hermes-results"
     return STORAGE_DIR
+
+
+def _resolve_local_storage_dir() -> Path:
+    """Return the host-local artifact directory, honoring HERMES_HOME profiles."""
+    override = os.environ.get(LOCAL_STORAGE_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
+    return get_hermes_home() / "tool-artifacts"
+
+
+def _safe_slug(value: str, *, default: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value or "")).strip("._-")
+    if not slug:
+        slug = default
+    return slug[:_MAX_SLUG_LEN]
+
+
+def _local_artifact_paths(content: str, tool_name: str, tool_use_id: str) -> tuple[Path, Path, str]:
+    digest = hashlib.sha256(content.encode("utf-8", errors="replace")).hexdigest()
+    day = time.strftime("%Y-%m-%d", time.gmtime())
+    tool_slug = _safe_slug(tool_name, default="tool")
+    call_slug = _safe_slug(tool_use_id, default="call")
+    base = _resolve_local_storage_dir() / day / f"{tool_slug}_{call_slug}_{digest[:12]}"
+    return base.with_suffix(".txt"), base.with_suffix(".json"), digest
+
+
+def _write_atomic_text(path: Path, content: str, *, mode: int = 0o600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        os.chmod(path.parent, 0o700)
+    except OSError:
+        pass
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        os.chmod(tmp_path, mode)
+        os.replace(tmp_path, path)
+        try:
+            os.chmod(path, mode)
+        except OSError:
+            pass
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def _write_to_local_artifact(content: str, tool_name: str, tool_use_id: str) -> tuple[str, str] | None:
+    """Write exact raw output to a local artifact plus metadata sidecar."""
+    try:
+        artifact_path, meta_path, digest = _local_artifact_paths(content, tool_name, tool_use_id)
+        _write_atomic_text(artifact_path, content)
+        metadata = {
+            "tool": tool_name,
+            "tool_call_id": tool_use_id,
+            "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "original_chars": len(content),
+            "sha256": digest,
+            "artifact_path": str(artifact_path),
+        }
+        _write_atomic_text(meta_path, json.dumps(metadata, ensure_ascii=False, indent=2) + "\n")
+        logger.info(
+            "Persisted large tool result locally: %s (%s, %d chars -> %s)",
+            tool_name,
+            tool_use_id,
+            len(content),
+            artifact_path,
+        )
+        return str(artifact_path), digest
+    except Exception as exc:
+        logger.warning("Local artifact write failed for %s: %s", tool_use_id, exc)
+        return None
 
 
 def generate_preview(content: str, max_chars: int = DEFAULT_PREVIEW_SIZE_CHARS) -> tuple[str, bool]:
@@ -93,6 +179,9 @@ def _build_persisted_message(
     has_more: bool,
     original_size: int,
     file_path: str,
+    *,
+    tool_name: str | None = None,
+    sha256: str | None = None,
 ) -> str:
     """Build the <persisted-output> replacement block."""
     size_kb = original_size / 1024
@@ -102,8 +191,13 @@ def _build_persisted_message(
         size_str = f"{size_kb:.1f} KB"
 
     msg = f"{PERSISTED_OUTPUT_TAG}\n"
-    msg += f"This tool result was too large ({original_size:,} characters, {size_str}).\n"
+    msg += f"{EXTERNALIZED_OUTPUT_MARKER}\n"
+    if tool_name:
+        msg += f"Tool: {tool_name}\n"
+    msg += f"Original: {original_size:,} characters ({size_str}).\n"
     msg += f"Full output saved to: {file_path}\n"
+    if sha256:
+        msg += f"SHA256: {sha256}\n"
     msg += "Use the read_file tool with offset and limit to access specific sections of this output.\n\n"
     msg += f"Preview (first {len(preview)} chars):\n"
     msg += preview
@@ -121,22 +215,11 @@ def maybe_persist_tool_result(
     config: BudgetConfig = DEFAULT_BUDGET,
     threshold: int | float | None = None,
 ) -> str:
-    """Layer 2: persist oversized result into the sandbox, return preview + path.
+    """Layer 2: persist oversized result, return preview + path.
 
-    Writes via env.execute() so the file is accessible from any backend
-    (local, Docker, SSH, Modal, Daytona). Falls back to inline truncation
-    if write fails or no env is available.
-
-    Args:
-        content: Raw tool result string.
-        tool_name: Name of the tool (used for threshold lookup).
-        tool_use_id: Unique ID for this tool call (used as filename).
-        env: The active BaseEnvironment instance, or None.
-        config: BudgetConfig controlling thresholds and preview size.
-        threshold: Explicit override; takes precedence over config resolution.
-
-    Returns:
-        Original content if small, or <persisted-output> replacement.
+    Remote/sandbox writes are preferred when an env is available. When no env
+    is available (normal local CLI/gateway path), full raw output is written to
+    HERMES_HOME/tool-artifacts and can be recovered with read_file.
     """
     effective_threshold = threshold if threshold is not None else config.resolve_threshold(tool_name)
 
@@ -147,7 +230,8 @@ def maybe_persist_tool_result(
         return content
 
     storage_dir = _resolve_storage_dir(env)
-    remote_path = f"{storage_dir}/{tool_use_id}.txt"
+    safe_call_id = _safe_slug(tool_use_id, default="tool_result")
+    remote_path = f"{storage_dir}/{safe_call_id}.txt"
     preview, has_more = generate_preview(content, max_chars=config.preview_size)
 
     if env is not None:
@@ -157,18 +241,40 @@ def maybe_persist_tool_result(
                     "Persisted large tool result: %s (%s, %d chars -> %s)",
                     tool_name, tool_use_id, len(content), remote_path,
                 )
-                return _build_persisted_message(preview, has_more, len(content), remote_path)
+                digest = hashlib.sha256(content.encode("utf-8", errors="replace")).hexdigest()
+                return _build_persisted_message(
+                    preview,
+                    has_more,
+                    len(content),
+                    remote_path,
+                    tool_name=tool_name,
+                    sha256=digest,
+                )
         except Exception as exc:
             logger.warning("Sandbox write failed for %s: %s", tool_use_id, exc)
+        # Do not return host-local paths for remote env failures. File tools for
+        # that task may read inside the remote env, making host paths broken.
+    else:
+        local_result = _write_to_local_artifact(content, tool_name, tool_use_id)
+        if local_result is not None:
+            local_path, digest = local_result
+            return _build_persisted_message(
+                preview,
+                has_more,
+                len(content),
+                local_path,
+                tool_name=tool_name,
+                sha256=digest,
+            )
 
     logger.info(
-        "Inline-truncating large tool result: %s (%d chars, no sandbox write)",
+        "Inline-truncating large tool result: %s (%d chars, no readable artifact write)",
         tool_name, len(content),
     )
     return (
         f"{preview}\n\n"
         f"[Truncated: tool response was {len(content):,} chars. "
-        f"Full output could not be saved to sandbox.]"
+        f"Full output could not be saved to a readable artifact.]"
     )
 
 
@@ -177,14 +283,7 @@ def enforce_turn_budget(
     env=None,
     config: BudgetConfig = DEFAULT_BUDGET,
 ) -> list[dict]:
-    """Layer 3: enforce aggregate budget across all tool results in a turn.
-
-    If total chars exceed budget, persist the largest non-persisted results
-    first (via sandbox write) until under budget. Already-persisted results
-    are skipped.
-
-    Mutates the list in-place and returns it.
-    """
+    """Layer 3: enforce aggregate budget across all tool results in a turn."""
     candidates = []
     total_size = 0
     for i, msg in enumerate(tool_messages):


### PR DESCRIPTION
# PR draft

Title: fix(tools): externalize large tool outputs during replay

## Summary

Large MCP/tool outputs can substantially inflate later Codex Responses replay because each `function_call_output` may be resent inline. This PR routes oversized persisted tool results through readable local artifacts and replays only a compact handle with metadata and a preview.

The motivating incident involved replayed MCP outputs in the 50k-65k character range after normal chat-history compaction. This change protects future oversized tool outputs; legacy sessions that already contain raw inline outputs still rely on the raw replay safety cap.

## Changes

- `tools/tool_result_storage.py`
  - Persist oversized local tool outputs under `HERMES_HOME/tool-artifacts/YYYY-MM-DD/` or `HERMES_TOOL_ARTIFACT_DIR`.
  - Store exact raw output in a `.txt` artifact with a `.json` metadata sidecar.
  - Return a compact `<persisted-output>` handle with tool name, original size, path, SHA256, `read_file` guidance, and preview.
  - Sanitize artifact path components and write artifacts atomically with restrictive local permissions.
  - Prefer sandbox artifacts when a sandbox env is active, and avoid returning unreadable host-local paths for remote/task-scoped environments.

- `tools/budget_config.py`, `tools/file_tools.py`
  - Lower default externalization thresholds so medium-large MCP results are externalized earlier:
    - per-result default: `100_000` -> `20_000`
    - per-turn budget: `200_000` -> `80_000`
    - preview: `1_500` -> `2_000`
  - Keep `read_file` unbounded in the persistence layer so reading an artifact does not re-externalize into another artifact.

- `agent/codex_responses_adapter.py`
  - Preserve compact persisted-output handles during Codex Responses replay.
  - Keep a bounded raw-output replay fallback for legacy sessions, spoofed markers, or artifact write failures.

## Validation/Test plan

- `python3 -m py_compile tools/tool_result_storage.py tools/budget_config.py agent/codex_responses_adapter.py tests/tools/test_tool_result_storage.py tests/run_agent/test_run_agent_codex_responses.py`
- `scripts/run_tests.sh tests/tools/test_tool_result_storage.py tests/tools/test_budget_config.py tests/run_agent/test_run_agent_codex_responses.py -q` — 132 passed

Supplemental manual check using a local incident request dump, not included in the repo:

| Check | Result |
|---|---|
| Legacy failed request body with replay safety cap | `575262` chars -> `369932` chars |
| Legacy max raw function output after safety cap | `4150` chars |
| Synthetic oversized tool output | `60024` chars |
| Persisted replay handle | `2513` chars |
| Artifact exactness | artifact exists and matches original output |
| Unsafe tool id | sanitized; no path traversal |
| Codex replay of persisted handle | preserved unchanged |

## Caveats / Out of scope

- This does not retroactively artifactize historical sessions that already stored raw inline tool outputs.
- Artifact cleanup / TTL is intentionally left for a follow-up.
- The raw replay cap remains as a liveness fallback for legacy sessions and persistence failures.
