### PR TITLE
fix(cli): use display-width for CJK/emoji panel border alignment

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8943,26 +8943,68 @@ class HermesCLI:
         if not state:
             return []
 
+        try:
+            from prompt_toolkit.utils import get_cwidth as _get_cwidth
+        except Exception:
+            _get_cwidth = len
+
+        def _cwidth(text: str) -> int:
+            """Return the terminal display width of *text* (CJK/emoji aware)."""
+            return _get_cwidth(text or "")
+
+        def _pad_to_width(text: str, target_width: int) -> str:
+            """Right-pad *text* with spaces so it occupies *target_width* columns."""
+            current = _cwidth(text)
+            pad = max(0, target_width - current)
+            return text + " " * pad
+
+        def _wrap_by_width(text: str, width: int) -> list[str]:
+            """Split *text* into lines that fit within *width* terminal columns.
+
+            Falls back to textwrap.wrap when every character is single-width
+            (pure ASCII) so word boundaries are preserved.
+            """
+            if _cwidth(text) == len(text):
+                # Pure single-width text — textwrap handles word-wrap correctly.
+                wrapped = textwrap.wrap(
+                    text,
+                    width=max(8, width),
+                    replace_whitespace=False,
+                    drop_whitespace=False,
+                )
+                return wrapped or [""]
+            # Contains wide characters — wrap by display width.
+            result: list[str] = []
+            line: list[str] = []
+            line_w = 0
+            for ch in text:
+                ch_w = _get_cwidth(ch) if callable(_get_cwidth) else 1
+                if line_w + ch_w > width and line:
+                    result.append("".join(line))
+                    line = []
+                    line_w = 0
+                line.append(ch)
+                line_w += ch_w
+            if line:
+                result.append("".join(line))
+            return result or [""]
+
         def _panel_box_width(title_text: str, content_lines: list[str], min_width: int = 46, max_width: int = 76) -> int:
             term_cols = shutil.get_terminal_size((100, 20)).columns
-            longest = max([len(title_text)] + [len(line) for line in content_lines] + [min_width - 4])
+            longest = max([_cwidth(title_text)] + [_cwidth(line) for line in content_lines] + [min_width - 4])
             inner = min(max(longest + 4, min_width - 2), max_width - 2, max(24, term_cols - 6))
             return inner + 2
 
         def _wrap_panel_text(text: str, width: int, subsequent_indent: str = "") -> list[str]:
-            wrapped = textwrap.wrap(
-                text,
-                width=max(8, width),
-                replace_whitespace=False,
-                drop_whitespace=False,
-                subsequent_indent=subsequent_indent,
-            )
-            return wrapped or [""]
+            raw_lines = _wrap_by_width(text, max(8, width))
+            if subsequent_indent and len(raw_lines) > 1:
+                raw_lines[1:] = [subsequent_indent + l for l in raw_lines[1:]]
+            return raw_lines or [""]
 
         def _append_panel_line(lines, border_style: str, content_style: str, text: str, box_width: int) -> None:
             inner_width = max(0, box_width - 2)
             lines.append((border_style, "│ "))
-            lines.append((content_style, text.ljust(inner_width)))
+            lines.append((content_style, _pad_to_width(text, inner_width)))
             lines.append((border_style, " │\n"))
 
         def _append_blank_panel_line(lines, border_style: str, box_width: int) -> None:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -484,6 +484,7 @@ AUTHOR_MAP = {
     "juan.ovalle@mistral.ai": "jjovalle99",
     "julien.talbot@ergonomia.re": "Julientalbot",
     "kagura.chen28@gmail.com": "kagura-agent",
+    "kagura.agent.ai@gmail.com": "kagura-agent",
     "1342088860@qq.com": "youngDoo",
     "kamil@gwozdz.me": "kamil-gwozdz",
     "skmishra1991@gmail.com": "bugkill3r",

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -421,3 +421,54 @@ class TestApprovalCallbackThreadLocalWiring:
         # would hold a stale reference to a disposed CLI instance.
         assert seen["approval_after"] is None
         assert seen["sudo_after"] is None
+
+
+class TestCliApprovalUiCJK:
+    """Verify CJK/emoji-aware panel rendering (issue #20621)."""
+
+    def test_cjk_command_panel_borders_aligned(self):
+        """CJK characters should not overflow the right border."""
+        cli = _make_cli_stub()
+        cjk_cmd = "rm -rf /危险/路径/删除全部内容"
+        cli._approval_state = {
+            "command": cjk_cmd,
+            "description": "⚠️ 危険なコマンド",
+            "choices": ["once", "deny"],
+            "selected": 0,
+            "show_full": False,
+            "response_queue": queue.Queue(),
+        }
+
+        fragments = cli._get_approval_display_fragments()
+        rendered = "".join(text for _style, text in fragments)
+        lines = rendered.split("\n")
+
+        # Every line with box borders should have equal rendered width
+        bordered_lines = [l for l in lines if l.startswith("│") or l.startswith("╭") or l.startswith("╰")]
+        assert len(bordered_lines) >= 3, "Should have top/content/bottom borders"
+
+        # The top and bottom borders define the box width
+        top = next(l for l in lines if l.startswith("╭"))
+        bottom = next(l for l in lines if l.startswith("╰"))
+        assert len(top) == len(bottom), "Top and bottom borders should match length"
+
+        # The CJK content should appear in the rendered output
+        assert "危険" in rendered or "危险" in rendered
+
+    def test_emoji_title_renders_without_overflow(self):
+        """Emoji in title should not cause border misalignment."""
+        cli = _make_cli_stub()
+        cli._approval_state = {
+            "command": "echo hello",
+            "description": "Safe command with emoji 🎉🔥",
+            "choices": ["once", "deny"],
+            "selected": 0,
+            "show_full": False,
+            "response_queue": queue.Queue(),
+        }
+
+        fragments = cli._get_approval_display_fragments()
+        rendered = "".join(text for _style, text in fragments)
+        # Should not crash and should contain the content
+        assert "echo hello" in rendered
+        assert "Safe command" in rendered


### PR DESCRIPTION
## What

Replace `len()`-based width calculations in the approval/clarify panel with `prompt_toolkit.utils.get_cwidth()`, which correctly accounts for CJK double-width characters and emoji.

## Why

CJK characters and emoji render as 2 terminal columns, but `len()` counts them as 1 code point. This causes:
1. Panel box (`╭───╮`) computed too narrow — content overflows past the right border
2. Right-padding (`text.ljust()`) leaves too few spaces — right border `│` misaligned
3. Text wrapping (`textwrap.wrap()`) wraps at wrong column position

Fixes #20621

## Changes

Three functions in `_get_approval_display_fragments()` updated:

| Function | Before | After |
|---|---|---|
| `_panel_box_width` | `len(title)`, `len(line)` | `_cwidth(title)`, `_cwidth(line)` |
| `_wrap_panel_text` | `textwrap.wrap()` | Display-width-aware wrapping (falls back to `textwrap` for pure ASCII to preserve word boundaries) |
| `_append_panel_line` | `text.ljust(inner_width)` | `_pad_to_width(text, inner_width)` — pads by display width |

Helper functions added (all scoped inside `_get_approval_display_fragments`):
- `_cwidth(text)` — terminal display width via `get_cwidth`
- `_pad_to_width(text, width)` — right-pad to exact column width
- `_wrap_by_width(text, width)` — character-level wrapping for wide text, `textwrap` for ASCII

Follows the same pattern as the existing `_status_bar_display_width()` which already uses `get_cwidth`.

## Testing

- All 11 existing approval UI tests pass
- Added 2 new tests:
  - `test_cjk_command_panel_borders_aligned` — verifies CJK content renders with matching top/bottom border widths
  - `test_emoji_title_renders_without_overflow` — verifies emoji content renders correctly

```
13 passed, 13 warnings in 6.25s
```