### PR TITLE
fix: harden gateway SMS opt-out and Gemini doctor probe

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1290,8 +1290,18 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # SMS (Twilio)
+    # Historically, TWILIO_ACCOUNT_SID alone auto-enabled the SMS gateway adapter.
+    # That is convenient for simple personal setups but noisy/unsafe on systems
+    # that keep Twilio credentials in ~/.hermes/.env for other services while
+    # routing customer SMS through a separate approval bridge. SMS_GATEWAY_ENABLED
+    # provides an explicit gateway-level opt-out without removing credentials.
+    sms_gateway_enabled = os.getenv("SMS_GATEWAY_ENABLED", "").strip().lower()
+    sms_gateway_disabled = sms_gateway_enabled in ("false", "0", "no", "off")
     twilio_sid = os.getenv("TWILIO_ACCOUNT_SID")
-    if twilio_sid:
+    if sms_gateway_disabled:
+        if Platform.SMS in config.platforms:
+            config.platforms[Platform.SMS].enabled = False
+    elif twilio_sid:
         if Platform.SMS not in config.platforms:
             config.platforms[Platform.SMS] = PlatformConfig()
         config.platforms[Platform.SMS].enabled = True

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -415,6 +415,8 @@ def write_runtime_status(
 
     if gateway_state is not _UNSET:
         payload["gateway_state"] = gateway_state
+        if gateway_state == "starting" and platform is _UNSET:
+            payload["platforms"] = {}
     if exit_reason is not _UNSET:
         payload["exit_reason"] = exit_reason
     if restart_requested is not _UNSET:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1220,6 +1220,13 @@ def run_doctor(args):
                 }
                 if base_url_host_matches(_base, "api.kimi.com"):
                     _headers["User-Agent"] = "claude-code/0.1.0"
+                # Google AI Studio's native Gemini API does not accept OpenAI-style
+                # Authorization: Bearer auth on /models; the API key must be sent
+                # as key=... or x-goog-api-key. Without this special case doctor
+                # reports valid GOOGLE_API_KEY/GEMINI_API_KEY values as invalid.
+                if base_url_host_matches(_url, "generativelanguage.googleapis.com"):
+                    _headers.pop("Authorization", None)
+                    _headers["x-goog-api-key"] = _key
                 _resp = httpx.get(
                     _url,
                     headers=_headers,

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -301,6 +301,8 @@ class TestLoadGatewayConfig:
         )
 
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("API_SERVER_ENABLED", raising=False)
+        monkeypatch.delenv("API_SERVER_KEY", raising=False)
 
         config = load_gateway_config()
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -530,6 +530,42 @@ class TestLoadGatewayConfig:
         assert os.environ.get("TELEGRAM_PROXY") == "socks5://from-env:1080"
 
 
+class TestSmsEnvOverrides:
+    def test_sms_gateway_enabled_false_prevents_twilio_auto_enable(self):
+        config = GatewayConfig()
+
+        with patch.dict(
+            os.environ,
+            {
+                "TWILIO_ACCOUNT_SID": "AC123",
+                "TWILIO_AUTH_TOKEN": "twilio_token",
+                "SMS_GATEWAY_ENABLED": "false",
+            },
+            clear=True,
+        ):
+            _apply_env_overrides(config)
+
+        assert Platform.SMS not in config.platforms
+
+    def test_sms_gateway_enabled_false_disables_existing_sms_config(self):
+        config = GatewayConfig(
+            platforms={Platform.SMS: PlatformConfig(enabled=True, api_key="twilio_token")}
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "TWILIO_ACCOUNT_SID": "AC123",
+                "TWILIO_AUTH_TOKEN": "twilio_token",
+                "SMS_GATEWAY_ENABLED": "0",
+            },
+            clear=True,
+        ):
+            _apply_env_overrides(config)
+
+        assert config.platforms[Platform.SMS].enabled is False
+
+
 class TestHomeChannelEnvOverrides:
     """Home channel env vars should apply even when the platform was already
     configured via config.yaml (not just when credential env vars create it)."""

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -334,6 +334,24 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["discord"]["error_code"] is None
         assert payload["platforms"]["discord"]["error_message"] is None
 
+    def test_write_runtime_status_starting_clears_stale_platform_failures(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        status.write_runtime_status(
+            gateway_state="startup_failed",
+            exit_reason="stale error",
+            platform="sms",
+            platform_state="retrying",
+            error_code=None,
+            error_message="stale SMS error",
+        )
+        status.write_runtime_status(gateway_state="starting", exit_reason=None)
+
+        payload = status.read_runtime_status()
+        assert payload["gateway_state"] == "starting"
+        assert payload["exit_reason"] is None
+        assert payload["platforms"] == {}
+
 
 class TestTerminatePid:
     def test_force_uses_taskkill_on_windows(self, monkeypatch):

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -652,6 +652,68 @@ def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, 
     assert any(url == "https://api.moonshot.cn/v1/models" for url, _, _ in calls)
 
 
+def test_run_doctor_gemini_models_probe_uses_x_goog_api_key(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+    monkeypatch.setattr(
+        doctor_mod,
+        "_APIKEY_PROVIDERS_CACHE",
+        [
+            (
+                "gemini",
+                ("GEMINI_API_KEY",),
+                "https://generativelanguage.googleapis.com/v1beta/models",
+                None,
+                True,
+            )
+        ],
+    )
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers or {}, timeout))
+        return types.SimpleNamespace(status_code=200)
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+
+    gemini_calls = [
+        (url, headers)
+        for url, headers, _ in calls
+        if "generativelanguage.googleapis.com" in url
+    ]
+    assert gemini_calls
+    _, headers = gemini_calls[-1]
+    assert headers["x-goog-api-key"] == "gemini-test-key"
+    assert "Authorization" not in headers
+
+
 @pytest.mark.parametrize("base_url", [None, "https://opencode.ai/zen/go/v1"])
 def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path, base_url):
     home = tmp_path / ".hermes"


### PR DESCRIPTION
## Summary
- Add `SMS_GATEWAY_ENABLED=false` opt-out so Twilio credentials can exist without auto-starting the direct SMS gateway adapter.
- Fix Hermes doctor Gemini API-key validation to use `x-goog-api-key` for native Google AI Studio `/models` probes instead of OpenAI-style Bearer auth.
- Add regression coverage for the Gemini header behavior and make the gateway API-server config regression hermetic against inherited env vars.

## Test Plan
- `python -m pytest tests/hermes_cli/test_doctor.py tests/gateway/test_config.py tests/gateway/test_status.py -q -o 'addopts='`

Result: `123 passed, 2 warnings`.
