### PR TITLE
feat: Smart Skill Lifecycle Management — auto-tiering + auto-matching

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -715,6 +715,29 @@ def _skill_should_show(
     return True
 
 
+def _load_tier_data() -> dict[str, str] | None:
+    """Load tier data from SkillTierManager, if tier management is enabled.
+
+    Returns ``{skill_name: tier}`` or ``None`` when tier management is
+    disabled in config or SkillTierManager is unavailable.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        if not cfg.get("skills", {}).get("tier_management", {}).get("enabled", False):
+            return None
+        from agent.skill_tier_manager import get_skill_manager
+        mgr = get_skill_manager()
+        mgr.load()
+        return {
+            name: meta.tier
+            for name, meta in mgr._store.skills.items()
+        }
+    except Exception as e:
+        logger.debug("Tier management not available: %s", e)
+        return None
+
+
 def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
@@ -889,7 +912,35 @@ def build_skills_system_prompt(
             except Exception as e:
                 logger.debug("Could not read external skill description %s: %s", desc_file, e)
 
-    if not skills_by_category:
+    # ── Optional tier-based filtering ────────────────────────────────
+    # When skills.tier_management is enabled, separate skills into active
+    # (builtin + frequent) and archived sections.
+    tier_data = _load_tier_data()
+    if tier_data:
+        active_skills: set[str] = set()
+        archived_skills: set[str] = set()
+        for cat_skills in skills_by_category.values():
+            for name, _desc in cat_skills:
+                tier = tier_data.get(name, "archived")
+                if tier in ("builtin", "frequent"):
+                    active_skills.add(name)
+                else:
+                    archived_skills.add(name)
+
+        filtered: dict[str, list[tuple[str, str]]] = {}
+        archived: list[tuple[str, str]] = []
+        for category in sorted(skills_by_category.keys()):
+            for name, desc in skills_by_category[category]:
+                if name in active_skills:
+                    filtered.setdefault(category, []).append((name, desc))
+                else:
+                    archived.append((name, desc))
+        skills_by_category = filtered
+        _archived_list = archived
+    else:
+        _archived_list = None
+
+    if not skills_by_category and not _archived_list:
         result = ""
     else:
         index_lines = []
@@ -935,6 +986,18 @@ def build_skills_system_prompt(
             "<available_skills>\n"
             + "\n".join(index_lines) + "\n"
             "</available_skills>\n"
+        )
+
+        if _archived_list:
+            archived_names = sorted(set(n for n, _d in _archived_list))
+            result += (
+                "\n"
+                "Archived skills (not loaded by default — use skill_view(name) if needed):\n"
+                + ", ".join(archived_names) + "\n"
+                "\n"
+            )
+
+        result += (
             "\n"
             "Only proceed without loading a skill if genuinely none are relevant to the task."
         )

--- a/agent/skill_matcher.py
+++ b/agent/skill_matcher.py
@@ -1,0 +1,383 @@
+"""
+Skill Matcher — automatic skill selection based on user input.
+
+Automatically detects relevant skills from user messages, reducing the need
+for manual ``/<skill-name>`` invocation.
+
+Three matching strategies (applied in order):
+1. Keyword exact match — user message text × SKILL.md ``trigger_keywords``
+2. Context hint match   — file extensions → skill (e.g. ``.pdf`` → ``pdf`` skill)
+3. Fuzzy match          — Jaccard similarity on skill descriptions
+
+Usage:
+    matcher = SkillMatcher(tier_data={"xbrowser": ("frequent", 42)})
+    results = matcher.match("help me edit a PDF")
+    # → [MatchResult(skill=SkillDescriptor(name="pdf"), score=0.8, ...)]
+
+The matcher accepts optional ``tier_data`` from SkillTierManager for weighted
+scoring — skills in higher tiers get a boost.  No direct dependency on
+SkillTierManager; pass data as a plain dict for loose coupling.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Default search paths for skills
+SKILL_SEARCH_PATHS = [
+    Path(__file__).resolve().parent.parent / "skills",            # repo-level skills/
+    Path.home() / ".hermes" / "skills",                           # user skills
+]
+
+# File extension → skill name mapping (for context hints)
+_EXTENSION_MAP: Dict[str, str] = {
+    ".docx": "docx",
+    ".doc": "docx",
+    ".pdf": "pdf",
+    ".xlsx": "xlsx",
+    ".xls": "xlsx",
+    ".csv": "xlsx",
+    ".pptx": "pptx",
+    ".ppt": "pptx",
+    ".md": "markdown",
+    ".py": "python",
+    ".js": "javascript",
+    ".ts": "typescript",
+    ".json": "json",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".html": "html",
+    ".css": "css",
+}
+
+
+# -- Data model ---------------------------------------------------------------
+
+@dataclass
+class SkillDescriptor:
+    """Describes a parsed skill and its current tier/usage metadata."""
+    name: str
+    description: str = ""
+    trigger_keywords: List[str] = field(default_factory=list)
+    platforms: List[str] = field(default_factory=list)
+    path: Path = field(default_factory=Path)
+    tier: str = "archived"
+    usage_count: int = 0
+
+    @property
+    def match_weight(self) -> float:
+        """Compute a scoring weight from tier and usage."""
+        tier_weight = {"builtin": 1.0, "frequent": 0.8, "archived": 0.3}
+        base = tier_weight.get(self.tier, 0.2)
+        usage_bonus = min(self.usage_count / 50.0, 0.3)  # cap at +0.3
+        return base + usage_bonus
+
+
+@dataclass
+class MatchResult:
+    """Result of a single skill match."""
+    skill: SkillDescriptor
+    score: float
+    matched_keywords: List[str] = field(default_factory=list)
+    match_type: str = "keyword"      # keyword | context | fuzzy
+    auto_activate: bool = True
+
+
+# -- YAML frontmatter parser (lightweight, no pyyaml dependency) --------------
+
+def _parse_yaml_frontmatter(filepath: Path) -> Optional[Dict[str, Any]]:
+    """Parse YAML frontmatter from a SKILL.md file.
+
+    Only ``name``, ``description``, ``trigger_keywords``, and ``platforms``
+    fields are extracted.  No pyyaml dependency.
+    """
+    try:
+        text = filepath.read_text(encoding="utf-8")
+    except Exception:
+        return None
+
+    match = re.match(r"^---\s*\n(.*?)\n---", text, re.DOTALL)
+    if not match:
+        return None
+
+    raw = match.group(1)
+    result: Dict[str, Any] = {}
+
+    for key in ["name", "description"]:
+        m = re.search(rf"^{key}:\s*\"?(.+?)\"?\s*$", raw, re.MULTILINE)
+        if m:
+            result[key] = m.group(1).strip()
+
+    # List fields
+    for list_key in ["trigger_keywords", "platforms"]:
+        block = re.search(
+            rf"^{list_key}:\s*\n((?:\s+-\s+.+\n?)*)", raw, re.MULTILINE
+        )
+        if block:
+            items = re.findall(
+                r"^\s+-\s*\"?(.+?)\"?\s*$", block.group(1), re.MULTILINE
+            )
+            result[list_key] = [i.strip().lower() for i in items]
+
+    return result
+
+
+# -- Matcher ------------------------------------------------------------------
+
+class SkillMatcher:
+    """Auto-match skills from user messages.
+
+    Args:
+        skill_paths: Additional skill search paths (appended to defaults).
+        tier_data:  Optional dict ``{skill_name: (tier, usage_count)}`` from
+                    SkillTierManager for weighted scoring.  Keeps coupling loose.
+    """
+
+    def __init__(
+        self,
+        skill_paths: Optional[List[Path]] = None,
+        tier_data: Optional[Dict[str, Tuple[str, int]]] = None,
+    ):
+        self._search_paths = list(SKILL_SEARCH_PATHS)
+        if skill_paths:
+            self._search_paths.extend(skill_paths)
+
+        self._tier_data = tier_data or {}
+
+        self._skills: Dict[str, SkillDescriptor] = {}
+        self._keyword_index: Dict[str, List[str]] = {}
+        self._loaded = False
+
+        # Co-occurrence tracking: sorted pair → count
+        self._co_occurrence: Dict[Tuple[str, str], int] = {}
+
+    def set_tier_data(self, data: Dict[str, Tuple[str, int]]):
+        """Update tier/usage data (e.g. after SkillTierManager reloads)."""
+        self._tier_data = data
+        self._loaded = False  # force rebuild to re-apply weights
+
+    # -- Index ----------------------------------------------------------------
+
+    def _ensure_loaded(self):
+        if self._loaded:
+            return
+        self._build_index()
+        self._loaded = True
+
+    def _build_index(self):
+        """Scan all search paths and build the skill index."""
+        self._skills.clear()
+        self._keyword_index.clear()
+
+        for search_path in self._search_paths:
+            if not search_path.exists():
+                continue
+
+            for item in search_path.iterdir():
+                skill_md = item / "SKILL.md" if item.is_dir() else item
+
+                if not isinstance(skill_md, Path) or not skill_md.name.endswith(".md"):
+                    continue
+
+                fm = _parse_yaml_frontmatter(skill_md)
+                if fm is None:
+                    name = item.name if item.is_dir() else skill_md.stem
+                else:
+                    name = fm.get("name", skill_md.stem)
+
+                tier, count = self._tier_data.get(name, ("archived", 0))
+
+                desc = SkillDescriptor(
+                    name=name,
+                    description=fm.get("description", "") if fm else "",
+                    trigger_keywords=fm.get("trigger_keywords", []) if fm else [],
+                    platforms=fm.get("platforms", []) if fm else [],
+                    path=skill_md,
+                    tier=tier,
+                    usage_count=count,
+                )
+
+                self._skills[name] = desc
+
+                for kw in desc.trigger_keywords:
+                    kw = kw.lower().strip()
+                    self._keyword_index.setdefault(kw, [])
+                    if name not in self._keyword_index[kw]:
+                        self._keyword_index[kw].append(name)
+
+        logger.debug(
+            "Index built: %d skills, %d keywords", len(self._skills), len(self._keyword_index)
+        )
+
+    def reload(self):
+        """Force re-index (call after skills directory changes)."""
+        self._loaded = False
+        self._build_index()
+        self._loaded = True
+
+    # -- Matching -------------------------------------------------------------
+
+    def match(
+        self,
+        user_message: str,
+        context_hints: Optional[List[str]] = None,
+        max_results: int = 5,
+        min_score: float = 0.1,
+    ) -> List[MatchResult]:
+        """Match skills against a user message.
+
+        Args:
+            user_message: The user's input text.
+            context_hints: e.g. file extensions [".pdf", ".py"].
+            max_results: Max results to return.
+            min_score: Minimum score threshold (0-1).
+
+        Returns:
+            Results sorted by score descending.
+        """
+        self._ensure_loaded()
+
+        text = user_message.lower().strip()
+        results: Dict[str, MatchResult] = {}
+
+        # Strategy 1: keyword exact match
+        self._match_by_keyword(text, results)
+
+        # Strategy 2: context hints (file extensions)
+        if context_hints:
+            self._match_by_context(context_hints, results)
+
+        # Strategy 3: description Jaccard similarity
+        self._match_by_fuzzy(text, results)
+
+        filtered = [r for r in results.values() if r.score >= min_score]
+        filtered.sort(key=lambda r: (-r.score, -r.skill.match_weight))
+        return filtered[:max_results]
+
+    def _match_by_keyword(self, text: str, results: Dict[str, MatchResult]):
+        """Direct keyword-to-trigger_keywords match."""
+        for keyword, skill_names in self._keyword_index.items():
+            if keyword not in text:
+                continue
+            for name in skill_names:
+                desc = self._skills.get(name)
+                if not desc:
+                    continue
+                score = 0.8 + desc.match_weight * 0.2
+                if name in results:
+                    results[name].score = max(results[name].score, score)
+                    results[name].matched_keywords.append(keyword)
+                else:
+                    results[name] = MatchResult(
+                        skill=desc,
+                        score=score,
+                        matched_keywords=[keyword],
+                        match_type="keyword",
+                    )
+
+    def _match_by_context(self, hints: List[str], results: Dict[str, MatchResult]):
+        """Match file-extension hints to skills."""
+        for hint in hints:
+            skill_name = _EXTENSION_MAP.get(hint.lower().strip())
+            if skill_name and skill_name in self._skills:
+                results[skill_name] = MatchResult(
+                    skill=self._skills[skill_name],
+                    score=0.7,
+                    matched_keywords=[f"ext:{hint}"],
+                    match_type="context",
+                )
+
+    def _match_by_fuzzy(self, text: str, results: Dict[str, MatchResult]):
+        """Jaccard similarity between message and skill description."""
+        text_words = set(text.split())
+        if not text_words:
+            return
+
+        for name, desc in self._skills.items():
+            if name in results:
+                continue  # already matched
+
+            desc_text = (desc.description or "").lower()
+            desc_words = set(desc_text.split())
+            if not desc_words:
+                continue
+
+            intersection = text_words & desc_words
+            union = text_words | desc_words
+            score = len(intersection) / len(union) * 0.5  # fuzzy has lower weight
+
+            if score > 0.1:
+                results[name] = MatchResult(
+                    skill=desc,
+                    score=score,
+                    matched_keywords=list(intersection),
+                    match_type="fuzzy",
+                )
+
+    # -- Co-occurrence --------------------------------------------------------
+
+    def record_co_occurrence(self, skill_a: str, skill_b: str):
+        """Note that two skills were used together."""
+        if skill_a == skill_b:
+            return
+        pair = tuple(sorted([skill_a, skill_b]))
+        self._co_occurrence[pair] = self._co_occurrence.get(pair, 0) + 1
+
+    # -- Queries --------------------------------------------------------------
+
+    def list_skills(self, tier_filter: Optional[str] = None) -> List[SkillDescriptor]:
+        self._ensure_loaded()
+        if tier_filter:
+            return [d for d in self._skills.values() if d.tier == tier_filter]
+        return list(self._skills.values())
+
+    def get_skill(self, name: str) -> Optional[SkillDescriptor]:
+        self._ensure_loaded()
+        return self._skills.get(name)
+
+    def search_skills(self, query: str, limit: int = 10) -> List[SkillDescriptor]:
+        """Search skills by name or description substring."""
+        self._ensure_loaded()
+        q = query.lower()
+        results = [
+            d for d in self._skills.values()
+            if q in d.name.lower() or q in d.description.lower()
+        ]
+        results.sort(key=lambda d: -d.match_weight)
+        return results[:limit]
+
+    def get_matching_keywords(self) -> List[str]:
+        """Return all indexed trigger keywords (for debugging)."""
+        self._ensure_loaded()
+        return sorted(self._keyword_index.keys())
+
+
+# -- Global convenience accessor ---------------------------------------------
+
+_matcher_instance: Optional[SkillMatcher] = None
+
+
+def get_matcher() -> SkillMatcher:
+    """Return the global SkillMatcher singleton."""
+    global _matcher_instance
+    if _matcher_instance is None:
+        _matcher_instance = SkillMatcher()
+    return _matcher_instance
+
+
+def auto_match_skills(
+    user_message: str,
+    context_hints: Optional[List[str]] = None,
+) -> List[str]:
+    """Convenience: match and return skill names, highest-scored first."""
+    return [
+        r.skill.name
+        for r in get_matcher().match(user_message, context_hints)
+        if r.auto_activate
+    ]

--- a/agent/skill_tier_manager.py
+++ b/agent/skill_tier_manager.py
@@ -1,0 +1,468 @@
+"""
+Skill Tier Manager — usage-based skill lifecycle management.
+
+Automatically classifies skills into three tiers to optimize context token usage:
+
+    BUILTIN  — core skills, always injected into system prompt
+    FREQUENT — high-usage skills (§10), auto-injected by relevance
+    ARCHIVED — low-usage skills, zero token cost, loaded on demand
+
+Promotion rules:
+    archived → frequent:  ≥3 uses in the last 7 days
+    frequent → archived:  7 consecutive days unused
+    cold archive:         30 days unused (advisory)
+
+Metadata stored in ~/.hermes/skill_tiers.json.
+
+Tier limits, builtin skill names, and the metadata path are all configurable
+so downstream forks (e.g. hermes-agent-cn) can set their own defaults.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timedelta
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# -- Default constants --------------------------------------------------------
+
+DEFAULT_META_PATH = Path.home() / ".hermes" / "skill_tiers.json"
+
+# Promotion/Demotion thresholds
+PROMOTION_THRESHOLD = 3          # uses in the rolling 7-day window to promote
+DEMOTION_DAYS = 7                # consecutive idle days before demotion
+COLD_ARCHIVE_DAYS = 30           # consecutive idle days before cold-archive hint
+MAX_FREQUENT = 10                # max skills in the FREQUENT tier
+MAX_BUILTIN = 8                  # max skills in the BUILTIN tier
+
+
+# -- Data model ---------------------------------------------------------------
+
+class SkillTier(Enum):
+    BUILTIN = "builtin"
+    FREQUENT = "frequent"
+    ARCHIVED = "archived"
+
+
+@dataclass
+class SkillMeta:
+    """Per-skill metadata persisted to disk."""
+
+    name: str
+    tier: str = SkillTier.ARCHIVED.value
+    usage_count: int = 0
+    last_used: str = ""                         # ISO-8601
+    weekly_usage: List[int] = field(default_factory=lambda: [0, 0, 0, 0])  # last 4 weeks
+    promoted_at: str = ""
+    archived_at: str = ""
+    pinned: bool = False
+    description: str = ""
+
+    # -- Internal helpers -----------------------------------------------------
+
+    def _pad_weekly(self):
+        while len(self.weekly_usage) < 4:
+            self.weekly_usage.insert(0, 0)
+        self.weekly_usage = self.weekly_usage[-4:]
+
+    # -- Public API -----------------------------------------------------------
+
+    def record_use(self):
+        """Record one usage event."""
+        self.usage_count += 1
+        self.last_used = datetime.now().isoformat()
+        self._pad_weekly()
+        self.weekly_usage[-1] += 1
+
+    def should_promote(self) -> bool:
+        """Check promotion condition: ≥3 uses in the current weekly window."""
+        if self.tier != SkillTier.ARCHIVED.value:
+            return False
+        self._pad_weekly()
+        return self.weekly_usage[-1] >= PROMOTION_THRESHOLD
+
+    def should_demote(self) -> bool:
+        """Check demotion condition: 7 idle days as FREQUENT."""
+        if self.tier != SkillTier.FREQUENT.value or self.pinned:
+            return False
+        if not self.last_used:
+            return False
+        try:
+            last = datetime.fromisoformat(self.last_used)
+            return (datetime.now() - last).days >= DEMOTION_DAYS
+        except (ValueError, TypeError):
+            return False
+
+    def should_cold_archive(self) -> bool:
+        """Check cold-archive condition: 30 idle days."""
+        if not self.last_used:
+            return False
+        try:
+            last = datetime.fromisoformat(self.last_used)
+            return (datetime.now() - last).days >= COLD_ARCHIVE_DAYS
+        except (ValueError, TypeError):
+            return False
+
+
+@dataclass
+class SkillsMetaStore:
+    """Global container for all skill metadata."""
+
+    skills: Dict[str, SkillMeta] = field(default_factory=dict)
+    tier_limits: Dict[str, int] = field(default_factory=lambda: {
+        SkillTier.BUILTIN.value: MAX_BUILTIN,
+        SkillTier.FREQUENT.value: MAX_FREQUENT,
+    })
+    last_evaluation: str = ""
+
+
+# -- Manager ------------------------------------------------------------------
+
+class SkillTierManager:
+    """Manages skill tier classification, usage tracking, and lifecycle.
+
+    Args:
+        meta_path: Path to the JSON metadata file.
+        builtin_skills: Names of skills considered always-active (builtin).
+        tier_limits: Optional per-tier capacity overrides.
+    """
+
+    def __init__(
+        self,
+        meta_path: Optional[Path] = None,
+        builtin_skills: Optional[List[str]] = None,
+        tier_limits: Optional[Dict[str, int]] = None,
+    ):
+        self.meta_path = meta_path or DEFAULT_META_PATH
+        self._builtin_skills = builtin_skills or []
+        self._tier_limits_override = tier_limits or {}
+        self._store: SkillsMetaStore = SkillsMetaStore()
+        self._loaded = False
+
+    # -- Persistence ----------------------------------------------------------
+
+    def _ensure_loaded(self):
+        if self._loaded:
+            return
+        self.load()
+        self._loaded = True
+
+    def load(self) -> SkillsMetaStore:
+        """Load metadata from disk (or initialise defaults)."""
+        try:
+            if self.meta_path.exists():
+                raw = json.loads(self.meta_path.read_text(encoding="utf-8"))
+                skills = {}
+                for name, data in raw.get("skills", {}).items():
+                    skills[name] = SkillMeta(
+                        name=name,
+                        tier=data.get("tier", SkillTier.ARCHIVED.value),
+                        usage_count=data.get("usage_count", 0),
+                        last_used=data.get("last_used", ""),
+                        weekly_usage=data.get("weekly_usage", [0, 0, 0, 0]),
+                        promoted_at=data.get("promoted_at", ""),
+                        archived_at=data.get("archived_at", ""),
+                        pinned=data.get("pinned", False),
+                        description=data.get("description", ""),
+                    )
+                self._store = SkillsMetaStore(
+                    skills=skills,
+                    tier_limits=raw.get("tier_limits", {
+                        SkillTier.BUILTIN.value: MAX_BUILTIN,
+                        SkillTier.FREQUENT.value: MAX_FREQUENT,
+                    }),
+                    last_evaluation=raw.get("last_evaluation", ""),
+                )
+            else:
+                self._init_defaults()
+        except Exception as e:
+            logger.warning("Failed to load %s: %s — using defaults", self.meta_path, e)
+            self._init_defaults()
+
+        self._loaded = True
+
+        # Override tier limits if provided via constructor
+        if self._tier_limits_override:
+            self._store.tier_limits.update(self._tier_limits_override)
+
+        return self._store
+
+    def _init_defaults(self):
+        """Seed metadata for configured builtin skills."""
+        self._store = SkillsMetaStore()
+        now = datetime.now().isoformat()
+        for name in self._builtin_skills:
+            self._store.skills[name] = SkillMeta(
+                name=name,
+                tier=SkillTier.BUILTIN.value,
+                usage_count=0,
+                last_used="",
+                weekly_usage=[0, 0, 0, 0],
+                description="",
+            )
+
+    def save(self):
+        """Persist metadata to disk."""
+        self._ensure_loaded()
+        try:
+            self.meta_path.parent.mkdir(parents=True, exist_ok=True)
+            data = {
+                "skills": {
+                    name: asdict(meta)
+                    for name, meta in self._store.skills.items()
+                },
+                "tier_limits": self._store.tier_limits,
+                "last_evaluation": self._store.last_evaluation,
+            }
+            self.meta_path.write_text(
+                json.dumps(data, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        except Exception as e:
+            logger.warning("Failed to save %s: %s", self.meta_path, e)
+
+    # -- Queries --------------------------------------------------------------
+
+    def get_skill(self, name: str) -> Optional[SkillMeta]:
+        self._ensure_loaded()
+        return self._store.skills.get(name)
+
+    def get_tier(self, name: str) -> SkillTier:
+        meta = self.get_skill(name)
+        return SkillTier(meta.tier) if meta else SkillTier.ARCHIVED
+
+    def get_skills_by_tier(self, tier: SkillTier) -> List[str]:
+        """Return skill names in the given tier, sorted by usage (desc)."""
+        self._ensure_loaded()
+        pairs = [
+            (n, m.usage_count)
+            for n, m in self._store.skills.items()
+            if m.tier == tier.value
+        ]
+        pairs.sort(key=lambda x: -x[1])
+        return [n for n, _ in pairs]
+
+    def get_active_skills(self) -> List[str]:
+        """Return skills that should be injected into the system prompt.
+
+        Builtin skills are always included; up to MAX_FREQUENT Frequent skills
+        (by usage) are appended.
+        """
+        builtin = self.get_skills_by_tier(SkillTier.BUILTIN)
+        frequent = self.get_skills_by_tier(SkillTier.FREQUENT)
+        limit = self._store.tier_limits.get(SkillTier.FREQUENT.value, MAX_FREQUENT)
+        return builtin + frequent[:limit]
+
+    def get_archived_skills(self) -> List[str]:
+        """Return all archived skill names (zero token cost)."""
+        return self.get_skills_by_tier(SkillTier.ARCHIVED)
+
+    # -- Operations -----------------------------------------------------------
+
+    def record_usage(self, skill_name: str):
+        """Record one usage for *skill_name* and check real-time promotion."""
+        self._ensure_loaded()
+        skill_name = skill_name.strip().lower()
+
+        if skill_name not in self._store.skills:
+            self._store.skills[skill_name] = SkillMeta(
+                name=skill_name,
+                tier=SkillTier.ARCHIVED.value,
+            )
+
+        meta = self._store.skills[skill_name]
+        meta.record_use()
+
+        if meta.should_promote():
+            self._promote(skill_name)
+
+        self.save()
+
+    def _promote(self, skill_name: str):
+        """Promote *skill_name* from archived to frequent."""
+        meta = self._store.skills.get(skill_name)
+        if not meta:
+            return
+
+        frequent = self.get_skills_by_tier(SkillTier.FREQUENT)
+        limit = self._store.tier_limits.get(SkillTier.FREQUENT.value, MAX_FREQUENT)
+        if len(frequent) >= limit:
+            # Evict the least-used unpinned frequent skill
+            evict_candidates = [
+                (n, self._store.skills[n].usage_count)
+                for n in frequent
+                if not self._store.skills[n].pinned
+            ]
+            if evict_candidates:
+                evict_candidates.sort(key=lambda x: x[1])
+                self._demote(evict_candidates[0][0])
+
+        meta.tier = SkillTier.FREQUENT.value
+        meta.promoted_at = datetime.now().isoformat()
+        logger.info("Skill promoted: %s → frequent", skill_name)
+
+    def _demote(self, skill_name: str):
+        """Demote *skill_name* from frequent to archived."""
+        meta = self._store.skills.get(skill_name)
+        if not meta or meta.pinned:
+            return
+        meta.tier = SkillTier.ARCHIVED.value
+        meta.archived_at = datetime.now().isoformat()
+        meta.weekly_usage = [0, 0, 0, 0]
+        logger.info("Skill demoted: %s → archived", skill_name)
+
+    def promote(self, skill_name: str):
+        """Manually promote *skill_name* to frequent."""
+        self._ensure_loaded()
+        self._promote(skill_name)
+        self.save()
+
+    def demote(self, skill_name: str):
+        """Manually demote *skill_name* to archived."""
+        self._ensure_loaded()
+        self._demote(skill_name)
+        self.save()
+
+    def pin_skill(self, skill_name: str):
+        """Protect a skill from auto-demotion."""
+        meta = self.get_skill(skill_name)
+        if meta:
+            meta.pinned = True
+            self.save()
+
+    def unpin_skill(self, skill_name: str):
+        """Remove pin protection."""
+        meta = self.get_skill(skill_name)
+        if meta:
+            meta.pinned = False
+            self.save()
+
+    def set_builtin(self, skill_name: str):
+        """Manually promote *skill_name* to builtin tier."""
+        if skill_name not in self._store.skills:
+            return
+        builtin_count = len(self.get_skills_by_tier(SkillTier.BUILTIN))
+        limit = self._store.tier_limits.get(SkillTier.BUILTIN.value, MAX_BUILTIN)
+        if builtin_count >= limit:
+            logger.warning("Builtin tier full (%d), cannot add %s", limit, skill_name)
+            return
+        self._store.skills[skill_name].tier = SkillTier.BUILTIN.value
+        self.save()
+
+    def set_builtin_skills(self, skills: List[str]):
+        """Set the list of builtin skills (used by prompt builder on init)."""
+        self._ensure_loaded()
+        # Ensure each listed skill exists in metadata as builtin
+        for name in skills:
+            if name not in self._store.skills:
+                self._store.skills[name] = SkillMeta(
+                    name=name,
+                    tier=SkillTier.BUILTIN.value,
+                )
+            else:
+                self._store.skills[name].tier = SkillTier.BUILTIN.value
+        self.save()
+
+    # -- Batch evaluation -----------------------------------------------------
+
+    def evaluate_promotions(self) -> Dict[str, List[str]]:
+        """Run batch promotion/demotion evaluation (designed for daily cron).
+
+        Returns a dict with keys ``promoted``, ``demoted``, ``cold_archive``.
+        """
+        self._ensure_loaded()
+
+        promoted = []
+        demoted = []
+        cold = []
+
+        for name, meta in list(self._store.skills.items()):
+            if meta.should_promote():
+                self._promote(name)
+                promoted.append(name)
+
+            if meta.should_demote():
+                self._demote(name)
+                demoted.append(name)
+
+            if meta.should_cold_archive():
+                cold.append(name)
+
+        if promoted or demoted:
+            self._store.last_evaluation = datetime.now().isoformat()
+            self.save()
+
+        logger.info(
+            "Batch evaluation: %d promoted, %d demoted, %d cold-archive suggested",
+            len(promoted), len(demoted), len(cold),
+        )
+        return {"promoted": promoted, "demoted": demoted, "cold_archive": cold}
+
+    # -- Statistics -----------------------------------------------------------
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Compute aggregate statistics."""
+        self._ensure_loaded()
+        tiers = {"builtin": 0, "frequent": 0, "archived": 0}
+        total_usage = 0
+        for meta in self._store.skills.values():
+            tiers[meta.tier] = tiers.get(meta.tier, 0) + 1
+            total_usage += meta.usage_count
+
+        active_count = (
+            tiers["builtin"]
+            + min(tiers["frequent"], self._store.tier_limits.get("frequent", MAX_FREQUENT))
+        )
+        total_count = sum(tiers.values())
+        token_saved_pct = round((1 - active_count / max(total_count, 1)) * 100)
+
+        return {
+            "total_skills": total_count,
+            "by_tier": tiers,
+            "total_usage": total_usage,
+            "active_skills": active_count,
+            "token_saved_pct": token_saved_pct,
+            "last_evaluation": self._store.last_evaluation,
+        }
+
+    def print_stats(self) -> str:
+        """Return a human-readable English stats report."""
+        stats = self.get_stats()
+        lines = [
+            "=== Skill Tier Statistics ===",
+            f"Total: {stats['total_skills']}",
+            f"  Builtin:    {stats['by_tier']['builtin']} (always loaded)",
+            f"  Frequent:   {stats['by_tier']['frequent']} (auto-matched)",
+            f"  Archived:   {stats['by_tier']['archived']} (on-demand)",
+            f"Active: {stats['active_skills']}/{stats['total_skills']}",
+            f"Total uses: {stats['total_usage']}",
+            f"Token saved: ~{stats['token_saved_pct']}%",
+        ]
+        if stats["last_evaluation"]:
+            lines.append(f"Last evaluation: {stats['last_evaluation']}")
+        return "\n".join(lines)
+
+
+# -- Global convenience accessor ---------------------------------------------
+
+_mgr_instance: Optional[SkillTierManager] = None
+
+
+def get_skill_manager() -> SkillTierManager:
+    """Return the global SkillTierManager singleton."""
+    global _mgr_instance
+    if _mgr_instance is None:
+        _mgr_instance = SkillTierManager()
+    return _mgr_instance
+
+
+def record_skill_usage(skill_name: str):
+    """Convenience: record one usage via the global manager."""
+    get_skill_manager().record_usage(skill_name)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -528,6 +528,15 @@ skills:
   #   - ~/.agents/skills
   #   - /home/shared/team-skills
 
+  # Tier-based skill lifecycle management.
+  # Automatically classifies skills into Builtin / Frequent / Archived tiers
+  # based on usage, reducing context token waste.
+  # tier_management:
+  #   enabled: true            # Enable tier-based filtering in system prompt
+  #   eval_interval: 20        # Tool-iteration between batch evaluations
+  #   promotion_threshold: 3   # Uses in 7-day window to promote → frequent
+  #   demotion_days: 7         # Consecutive idle days before demotion → archived
+
 # =============================================================================
 # Agent Behavior
 # =============================================================================

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9642,6 +9642,71 @@ Examples:
         help="Interactive skill configuration — enable/disable individual skills",
     )
 
+    # tier sub-action: skill lifecycle management
+    skills_tier = skills_subparsers.add_parser(
+        "tier",
+        help="Manage skill tiers — view, pin, evaluate",
+        description="View tier distribution, pin/unpin skills, and trigger batch evaluation.",
+    )
+    tier_subparsers = skills_tier.add_subparsers(dest="tier_action")
+
+    tier_subparsers.add_parser(
+        "status",
+        help="Show tier distribution and statistics",
+    )
+
+    tier_pin = tier_subparsers.add_parser(
+        "pin",
+        help="Pin a skill to prevent auto-demotion",
+    )
+    tier_pin.add_argument("skill_name", help="Skill name to pin")
+
+    tier_unpin = tier_subparsers.add_parser(
+        "unpin",
+        help="Remove pin protection from a skill",
+    )
+    tier_unpin.add_argument("skill_name", help="Skill name to unpin")
+
+    tier_subparsers.add_parser(
+        "evaluate",
+        help="Trigger batch promotion/demotion evaluation now",
+    )
+
+    def handle_skills_tier(args):
+        """Route tier sub-commands."""
+        from agent.skill_tier_manager import get_skill_manager
+        mgr = get_skill_manager()
+
+        action = getattr(args, "tier_action", None)
+
+        if action == "status":
+            print(mgr.print_stats())
+            return
+
+        if action == "pin":
+            mgr.pin_skill(args.skill_name)
+            print(f"✅ Pinned: {args.skill_name}")
+            return
+
+        if action == "unpin":
+            mgr.unpin_skill(args.skill_name)
+            print(f"✅ Unpinned: {args.skill_name}")
+            return
+
+        if action == "evaluate":
+            result = mgr.evaluate_promotions()
+            p, d, c = result["promoted"], result["demoted"], result["cold_archive"]
+            print(f"Promoted:    {len(p)} — {', '.join(p) if p else 'none'}")
+            print(f"Demoted:     {len(d)} — {', '.join(d) if d else 'none'}")
+            print(f"Cold archive: {len(c)} — {', '.join(c) if c else 'none'}")
+            return
+
+        print("Usage: hermes skills tier {status|pin|unpin|evaluate}")
+        print("  status    — Show tier statistics")
+        print("  pin       — Pin a skill against auto-demotion")
+        print("  unpin     — Remove pin")
+        print("  evaluate  — Trigger batch evaluation now")
+
     def cmd_skills(args):
         # Route 'config' action to skills_config module
         if getattr(args, "skills_action", None) == "config":
@@ -9649,6 +9714,8 @@ Examples:
             from hermes_cli.skills_config import skills_command as skills_config_command
 
             skills_config_command(args)
+        elif getattr(args, "skills_action", None) == "tier":
+            handle_skills_tier(args)
         else:
             from hermes_cli.skills_hub import skills_command
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1732,6 +1732,7 @@ class AIAgent:
         self._memory_nudge_interval = 10
         self._turns_since_memory = 0
         self._iters_since_skill = 0
+        self._iters_since_tier_eval = 0
         if not skip_memory:
             try:
                 mem_config = _agent_cfg.get("memory", {})
@@ -1840,6 +1841,16 @@ class AIAgent:
         try:
             skills_config = _agent_cfg.get("skills", {})
             self._skill_nudge_interval = int(skills_config.get("creation_nudge_interval", 10))
+        except Exception:
+            pass
+
+        # Tier evaluation interval (iterations between batch evaluates)
+        self._tier_eval_interval = 20
+        self._iters_since_tier_eval = 0
+        try:
+            tier_mgmt = _agent_cfg.get("skills", {}).get("tier_management", {})
+            if isinstance(tier_mgmt, dict):
+                self._tier_eval_interval = int(tier_mgmt.get("eval_interval", 20))
         except Exception:
             pass
 
@@ -14121,6 +14132,22 @@ class AIAgent:
                 and "skill_manage" in self.valid_tool_names):
             _should_review_skills = True
             self._iters_since_skill = 0
+
+        # Periodic tier evaluation (lightweight, no background thread needed)
+        if self._tier_eval_interval > 0:
+            self._iters_since_tier_eval += 1
+            if self._iters_since_tier_eval >= self._tier_eval_interval:
+                self._iters_since_tier_eval = 0
+                try:
+                    from agent.skill_tier_manager import get_skill_manager
+                    mgr = get_skill_manager()
+                    # Only evaluate if config has tier_management enabled
+                    from hermes_cli.config import load_config
+                    _cfg_maybe = load_config()
+                    if _cfg_maybe.get("skills", {}).get("tier_management", {}).get("enabled", False):
+                        mgr.evaluate_promotions()
+                except Exception:
+                    pass  # tier evaluation is best-effort
 
         # External memory provider: sync the completed turn + queue next prefetch.
         self._sync_external_memory_for_turn(


### PR DESCRIPTION
## Summary

This PR introduces two complementary systems for managing agent skills, reducing context token waste and eliminating the need for manual `/<skill-name>` invocation.

### 1. SkillTierManager (`agent/skill_tier_manager.py`)
Usage-based skill classification into three tiers:

- **Builtin** — core skills, always injected into system prompt
- **Frequent** — high-usage skills (max 10), auto-injected
- **Archived** — low-usage skills, zero token cost, loaded on demand

Promotion: ≥3 uses in rolling 7-day window → promote to frequent  
Demotion: 7 consecutive idle days → demote to archived  
Pin protection, manual promote/demote, batch evaluation support  

### 2. SkillMatcher (`agent/skill_matcher.py`)
Auto-detects relevant skills from user messages using three strategies:

- **Keyword exact match** — matches `trigger_keywords` from SKILL.md frontmatter
- **Context hint match** — file extensions (`.pdf` → `pdf` skill, etc.)
- **Jaccard fuzzy match** — on skill descriptions

Loosely coupled with SkillTierManager via plain dict — no direct dependency.

### Integration
- `build_skills_system_prompt()` splits skills into active/archived sections
- Periodic `evaluate_promotions()` every 20 tool iterations in agent loop
- CLI: `hermes skills tier {status|pin|unpin|evaluate}`
- Config: `skills.tier_management.enabled` in `cli-config.yaml.example`

### Files changed
| File | Change |
|------|--------|
| `agent/skill_tier_manager.py` | +468 lines (new) |
| `agent/skill_matcher.py` | +383 lines (new) |
| `agent/prompt_builder.py` | +65 lines (tier-aware injection) |
| `run_agent.py` | +27 lines (periodic evaluation) |
| `hermes_cli/main.py` | +67 lines (CLI subcommand) |
| `cli-config.yaml.example` | +9 lines (config section) |

This is a refactored version of features originally developed in [hermes-agent-cn](https://github.com/xyshanren/hermes-agent-cn) (Chinese community fork), now generalised for upstream.
