### PR TITLE
fix(hermes-tui): handle non-UTF-8 npm output + use esbuild Node.js API

### DIFF
--- a/ui-tui/packages/hermes-ink/package.json
+++ b/ui-tui/packages/hermes-ink/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "esbuild src/entry-exports.ts --bundle --platform=node --format=esm --packages=external --outdir=dist"
+    "build": "node scripts/build.js"
   },
   "sideEffects": true,
   "main": "./index.js",

--- a/ui-tui/packages/hermes-ink/scripts/build.js
+++ b/ui-tui/packages/hermes-ink/scripts/build.js
@@ -1,0 +1,21 @@
+import { buildSync } from '../node_modules/esbuild/lib/main.js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const result = buildSync({
+  entryPoints: [path.join(__dirname, '../src/entry-exports.ts')],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  packages: 'external',
+  outdir: path.join(__dirname, '../dist'),
+});
+
+if (result.errors.length > 0) {
+  console.error('Build failed:', result.errors);
+  process.exit(1);
+}
+
+console.log('Build complete.');

--- a/ui-tui/packages/hermes-ink/scripts/build.js
+++ b/ui-tui/packages/hermes-ink/scripts/build.js
@@ -1,4 +1,4 @@
-import { buildSync } from '../node_modules/esbuild/lib/main.js';
+import { buildSync } from 'esbuild';
 import path from 'path';
 import { fileURLToPath } from 'url';
 


### PR DESCRIPTION
## Description

Fixes two TUI build failures on Android/Termux:

### Fix 1: UnicodeDecodeError (Python 3.13)

Added `encoding="utf-8", errors="replace"` to all three `subprocess.run` calls in `_make_tui_argv()` in `hermes_cli/main.py`:
- `npm install`
- `npm run build --prefix packages/hermes-ink` (dev mode)
- `npm run build` (production mode)

Without explicit encoding, Python 3.13 tries to decode subprocess output as UTF-8 and crashes when npm emits non-UTF-8 bytes.

### Fix 2: esbuild CLI binary on Android/ARM64

The `@esbuild/android-arm64` CLI binary produces linker "bad shdr" warnings and fails to process input files. The `scripts/build.js` file uses esbuild's Node.js API (`buildSync`) instead of CLI, which works correctly in Termux.

Closes #20645
