### PR TITLE
feat(gateway): emit stt:complete hook after voice transcription

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5705,10 +5705,23 @@ class GatewayRunner:
                     )
 
             if audio_paths:
+                _text_before_stt = message_text
                 message_text = await self._enrich_message_with_transcription(
                     message_text,
                     audio_paths,
                 )
+
+                # Emit stt:complete hook — lets plugin handle echo without core modifications
+                _is_transcription = message_text != _text_before_stt
+                await self.hooks.emit("stt:complete", {
+                    "platform": source.platform.value if source.platform else "",
+                    "chat_id": source.chat_id,
+                    "thread_id": source.thread_id,
+                    "user_id": source.user_id,
+                    "text": message_text,
+                    "is_transcription": _is_transcription,
+                })
+
                 _stt_fail_markers = (
                     "No STT provider",
                     "STT is disabled",


### PR DESCRIPTION
Emit a 'stt:complete' hook event after the gateway finishes processing a voice message and STT produces a transcript. This lets user-space plugins in ~/.hermes/hooks/ react to voice transcriptions without any core modifications.

Context provided to handlers:
- platform: telegram|discord|etc
- chat_id: destination chat
- thread_id: thread/topic if applicable
- user_id: sender
- text: the transcribed text
- is_transcription: true when STT actually ran

Hook plugin example at ~/.hermes/hooks/stt-echo/ — echoes voice transcripts back to the user via Telegram.