### PR TITLE
fix(kanban): reset code element background inside board

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -9,6 +9,15 @@
   width: 100%;
 }
 
+/* Override the Nous DS global `code { background: var(--midground) }` rule
+   which paints an opaque cream/yellow fill on every <code> inside the board,
+   hiding the text underneath. Kanban uses <code> for event payloads, run-meta,
+   and log panes — those need transparent backgrounds. */
+.hermes-kanban code {
+  background: transparent;
+  color: inherit;
+}
+
 /* ---- Columns layout -------------------------------------------------- */
 
 .hermes-kanban-columns {


### PR DESCRIPTION
## Problem

The Nous DS `globals.css` applies a global rule:

```css
*::selection,
code {
  background: var(--selection-bg, var(--midground));
  @apply text-background;
}
```

This paints an opaque cream/yellow fill on **every** `<code>` element. The kanban dashboard drawer uses `<code>` tags to render:
- Event payloads (`.hermes-kanban-event-payload`)
- Run metadata (`.hermes-kanban-run-meta`)
- Worker log panes (`.hermes-kanban-pre`)

As a result, these sections display solid colored blocks that completely obscure the text content underneath.

## Before

Event payloads and run history sections show opaque yellow/cream rectangles covering all text — completely unreadable:

![before](https://github.com/user-attachments/assets/placeholder-before)

## After

Text is clearly visible with proper contrast against the dark background:

![after](https://github.com/user-attachments/assets/placeholder-after)

*(Screenshots omitted from this PR — the fix is straightforward to verify locally.)*

## Fix

Add a scoped reset at the top of the kanban plugin stylesheet:

```css
.hermes-kanban code {
  background: transparent;
  color: inherit;
}
```

This ensures `<code>` elements inside the kanban board inherit their parent's color and stay transparent, without affecting the DS selection/code styling elsewhere.

## Testing

- Opened the kanban dashboard drawer on a task with events and run history
- Verified event payload text, run-meta, and worker log are all readable
- Confirmed no visual regression on other dashboard pages