### PR TITLE
fix: preserve update cache correctness for source installs

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -175,6 +175,24 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     return None
 
 
+def _git_full_hash(repo_dir: Path, rev: str = "HEAD") -> Optional[str]:
+    """Resolve a git revision to its full hash for cache invalidation."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", rev],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=str(repo_dir),
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    value = (result.stdout or "").strip()
+    return value or None
+
+
 def check_for_updates() -> Optional[int]:
     """Check whether a Hermes update is available.
 
@@ -189,32 +207,42 @@ def check_for_updates() -> Optional[int]:
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
+    repo_dir: Optional[Path] = None
+    repo_head: Optional[str] = None
 
-    # Read cache — invalidate if the embedded rev has changed since last check
+    if not embedded_rev:
+        repo_dir = _resolve_repo_dir()
+        if repo_dir is None:
+            return None
+        repo_head = _git_full_hash(repo_dir, "HEAD")
+
+    # Read cache — invalidate if the embedded rev or local HEAD has changed.
     now = time.time()
     try:
         if cache_file.exists():
             cached = json.loads(cache_file.read_text())
-            if (
-                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
-                and cached.get("rev") == embedded_rev
-            ):
-                return cached.get("behind")
+            if now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS:
+                if embedded_rev and cached.get("rev") == embedded_rev:
+                    return cached.get("behind")
+                if not embedded_rev and repo_head and cached.get("repo_head") == repo_head:
+                    return cached.get("behind")
     except Exception:
         pass
 
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
     else:
-        repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
-            repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            return None
         behind = _check_via_local_git(repo_dir)
 
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": embedded_rev}))
+        cache_file.write_text(
+            json.dumps({
+                "ts": now,
+                "behind": behind,
+                "rev": embedded_rev,
+                "repo_head": repo_head,
+            })
+        )
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -1,5 +1,7 @@
 """Tests for banner toolset name normalization and skin color usage."""
 
+import json
+import time
 from unittest.mock import patch
 
 from rich.console import Console
@@ -133,3 +135,52 @@ def test_build_welcome_banner_title_falls_back_when_no_tag():
     raw = buf.getvalue()
     assert "Hermes Agent v" in raw, "Version label missing from title"
     assert "\x1b]8;" not in raw, "OSC-8 hyperlink should not be emitted without a tag"
+
+
+def test_check_for_updates_reuses_cache_when_local_head_matches(tmp_path):
+    cache_path = tmp_path / ".update_check"
+    cache_path.write_text(
+        json.dumps({
+            "ts": time.time(),
+            "behind": 7,
+            "rev": None,
+            "repo_head": "abc123",
+        })
+    )
+
+    with (
+        patch.object(banner, "get_hermes_home", return_value=tmp_path),
+        patch.object(banner, "_resolve_repo_dir", return_value=tmp_path),
+        patch.object(banner, "_git_full_hash", return_value="abc123"),
+        patch.object(banner, "_check_via_local_git") as local_git,
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        assert banner.check_for_updates() == 7
+
+    local_git.assert_not_called()
+
+
+def test_check_for_updates_invalidates_cache_when_local_head_changes(tmp_path):
+    cache_path = tmp_path / ".update_check"
+    cache_path.write_text(
+        json.dumps({
+            "ts": time.time(),
+            "behind": 406,
+            "rev": None,
+            "repo_head": "old-head",
+        })
+    )
+
+    with (
+        patch.object(banner, "get_hermes_home", return_value=tmp_path),
+        patch.object(banner, "_resolve_repo_dir", return_value=tmp_path),
+        patch.object(banner, "_git_full_hash", return_value="new-head"),
+        patch.object(banner, "_check_via_local_git", return_value=0) as local_git,
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        assert banner.check_for_updates() == 0
+
+    local_git.assert_called_once_with(tmp_path)
+    cached = json.loads(cache_path.read_text())
+    assert cached["behind"] == 0
+    assert cached["repo_head"] == "new-head"


### PR DESCRIPTION
## Summary
- invalidate source-install update cache when local git HEAD changes
- store repo_head alongside the cached behind count
- add regression tests covering cache reuse and invalidation for local HEAD changes

## Problem
On source installs, Hermes could reuse a stale update-check cache entry after a local pull because the cache only keyed off the embedded revision/timestamp. That could leave `hermes version` showing an old commits-behind warning even after the repo had advanced locally.

## Test Plan
- [x]   cd /home/bfoster/hermes-agent && venv/bin/python -m pytest tests/hermes_cli/test_banner.py
- [x] verified `hermes --version` recomputes accurately after update/cache refresh on this install
