### PR TITLE
fix(cli,gateway): guard quick_commands non-dict entries before .get()

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6676,8 +6676,18 @@ class HermesCLI:
             # Check for user-defined quick commands (bypass agent loop, no LLM call)
             base_cmd = cmd_lower.split()[0]
             quick_commands = self.config.get("quick_commands", {})
-            if base_cmd.lstrip("/") in quick_commands:
-                qcmd = quick_commands[base_cmd.lstrip("/")]
+            if not isinstance(quick_commands, dict):
+                quick_commands = {}
+            qcmd_raw = quick_commands.get(base_cmd.lstrip("/"))
+            if qcmd_raw is not None and not isinstance(qcmd_raw, dict):
+                logger.warning(
+                    "quick_commands entry for %s is not a dict (got %s); skipping and falling through to plugin/skill commands",
+                    base_cmd,
+                    type(qcmd_raw).__name__,
+                )
+                qcmd_raw = None
+            if isinstance(qcmd_raw, dict):
+                qcmd = qcmd_raw
                 if qcmd.get("type") == "exec":
                     import subprocess
                     exec_cmd = qcmd.get("command", "")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5245,7 +5245,13 @@ class GatewayRunner:
                 quick_commands = getattr(self.config, "quick_commands", {}) or {}
             if isinstance(quick_commands, dict) and command in quick_commands:
                 qcmd = quick_commands[command]
-                if qcmd.get("type") == "alias":
+                if not isinstance(qcmd, dict):
+                    logger.warning(
+                        "quick_commands entry for /%s is not a dict (got %s); skipping early alias resolution",
+                        command,
+                        type(qcmd).__name__,
+                    )
+                elif qcmd.get("type") == "alias":
                     target = qcmd.get("target", "").strip()
                     if target:
                         target = target if target.startswith("/") else f"/{target}"
@@ -5447,8 +5453,15 @@ class GatewayRunner:
                 quick_commands = getattr(self.config, "quick_commands", {}) or {}
             if not isinstance(quick_commands, dict):
                 quick_commands = {}
-            if command in quick_commands:
-                qcmd = quick_commands[command]
+            qcmd = quick_commands.get(command)
+            if qcmd is not None and not isinstance(qcmd, dict):
+                logger.warning(
+                    "quick_commands entry for /%s is not a dict (got %s); skipping and falling through to plugin/skill commands",
+                    command,
+                    type(qcmd).__name__,
+                )
+                qcmd = None
+            if isinstance(qcmd, dict):
                 if qcmd.get("type") == "exec":
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -127,6 +127,43 @@ class TestCLIQuickCommands:
         args = cli.console.print.call_args[0][0]
         assert "timed out" in args.lower()
 
+    def test_string_value_does_not_crash(self, caplog):
+        """A non-dict quick_commands entry must not crash the dispatcher.
+
+        Regression test for #18816 — `qcmd.get('type')` raised AttributeError
+        when the entry was a string.
+        """
+        import logging
+        cli = self._make_cli({"foo": ""})
+        with caplog.at_level(logging.WARNING):
+            with patch("cli._cprint"):
+                cli.process_command("/foo")
+        assert any(
+            "not a dict" in record.getMessage()
+            for record in caplog.records
+        ), f"expected warning about non-dict entry, got: {[r.getMessage() for r in caplog.records]}"
+
+    def test_string_value_does_not_block_skill_command_with_same_name(self, caplog):
+        """When a quick_commands entry overlaps a skill command name but is
+        malformed (e.g., a string), the skill command must still be dispatched —
+        the broken quick_commands entry must not poison skill dispatch.
+
+        Regression test for #18816.
+        """
+        import logging
+        cli = self._make_cli({"mygif": "broken"})
+        cli._pending_input = MagicMock()
+        with caplog.at_level(logging.WARNING):
+            with patch("cli._skill_commands", {"/mygif": {"name": "gif-search"}}):
+                with patch("cli.build_skill_invocation_message", return_value="msg") as build_msg:
+                    cli.process_command("/mygif")
+        build_msg.assert_called_once()
+        cli._pending_input.put.assert_called_once_with("msg")
+        assert any(
+            "not a dict" in record.getMessage()
+            for record in caplog.records
+        )
+
 
 # ── Gateway tests ──────────────────────────────────────────────────────────
 
@@ -205,3 +242,35 @@ class TestGatewayQuickCommands:
         event = self._make_event("limits")
         result = await runner._handle_message(event)
         assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_string_value_does_not_crash_gateway(self, caplog):
+        """A non-dict quick_commands entry must not crash the gateway dispatcher.
+
+        Regression test for #18816 — same crash pattern as cli.py existed in
+        gateway/run.py.
+        """
+        import logging
+        from gateway.run import GatewayRunner
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = {"quick_commands": {"foo": "broken-string"}}
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+
+        event = self._make_event("foo")
+        with caplog.at_level(logging.WARNING):
+            with patch("hermes_cli.plugins.get_plugin_command_handler", return_value=None):
+                # Should not raise AttributeError; falls through to plugin/skill dispatch.
+                # Whatever final return value comes from downstream is not asserted —
+                # this test covers the crash regression only.
+                try:
+                    await runner._handle_message(event)
+                except AttributeError as e:
+                    if "'str' object has no attribute 'get'" in str(e):
+                        pytest.fail(f"regression: gateway crashed on string quick_commands value: {e}")
+                    raise
+        assert any(
+            "not a dict" in record.getMessage()
+            for record in caplog.records
+        ), f"expected warning about non-dict entry, got: {[r.getMessage() for r in caplog.records]}"


### PR DESCRIPTION
## Issue

Closes #18816

## Root cause

A `quick_commands` entry that is not a dict (e.g. `foo: ''` in `config.yaml`) crashed slash-command dispatch with `AttributeError: 'str' object has no attribute 'get'`. Worse, since quick_commands dispatch runs before plugin/skill commands, a single malformed entry poisoned every command sharing that key — a valid `/mygif` skill could not load if `quick_commands.mygif` was a string.

The same crash pattern existed in three places — the bug report flagged one, but I found two more in `gateway/run.py` while writing the regression test:

1. `cli.py:6580` — the interactive CLI's main slash-command dispatcher
2. `gateway/run.py:5247` — the gateway's **early alias resolution block** (runs before built-in dispatch so aliases like `/model openai/...` reach the `/model` handler)
3. `gateway/run.py:5446` — the gateway's **main quick_commands dispatch**

## Fix

All three sites now guard `isinstance(qcmd, dict)` before calling `.get()`. When a malformed entry is encountered, we log a warning and fall through to the next dispatch tier (plugin commands → skill commands → built-in commands). Behavior for valid dict entries is unchanged.

The cli.py change also defensively re-validates that `quick_commands` itself is a dict (matching the pattern already used in `gateway/run.py:5214`).

## Tests

Added three regression tests in `tests/cli/test_quick_commands.py`:

- `test_string_value_does_not_crash` — `quick_commands={'foo': ''}`, `/foo` no longer raises `AttributeError`; warning is logged.
- `test_string_value_does_not_block_skill_command_with_same_name` — confirms the skill-poisoning scenario from the bug report: a string `quick_commands.mygif` no longer blocks a same-named skill command from loading.
- `test_string_value_does_not_crash_gateway` — gateway equivalent; would have failed twice without both gateway fixes.

All 19 tests in `tests/cli/test_quick_commands.py` pass:

```
$ pytest tests/cli/test_quick_commands.py
19 passed in 1.06s
```