### PR TITLE
feat: add OPENROUTER_TRANSCRIPTION_MODELS section with openai/whisper-1

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -69,6 +69,12 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("openai/gpt-5.4-nano",             ""),
 ]
 
+# OpenRouter transcription models (audio-to-text). These are NOT chat/completion
+# models — they are passed to the audio transcription endpoint, not /chat/completions.
+OPENROUTER_TRANSCRIPTION_MODELS: list[tuple[str, str]] = [
+    ("openai/whisper-1", "transcription"),
+]
+
 _openrouter_catalog_cache: list[tuple[str, str]] | None = None
 
 


### PR DESCRIPTION
Adds a new `OPENROUTER_TRANSCRIPTION_MODELS` list in `hermes_cli/models.py`, separate from the chat/completion `OPENROUTER_MODELS` list. The comment clearly indicates these models are for audio-to-text transcription (passed to the transcription endpoint, not `/chat/completions`).\n\n- Adds `openai/whisper-1` as the first entry tagged `"transcription"`