### PR TITLE
fix(cli,auth): resolve base_url_env_var from ~/.hermes/.env

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3682,7 +3682,11 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+        from hermes_cli.config import get_env_value
+        env_url = (
+            get_env_value(pconfig.base_url_env_var)
+            or os.getenv(pconfig.base_url_env_var, "")
+        ).strip()
 
     if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -3786,7 +3790,11 @@ def resolve_api_key_provider_credentials(provider_id: str) -> Dict[str, Any]:
 
     env_url = ""
     if pconfig.base_url_env_var:
-        env_url = os.getenv(pconfig.base_url_env_var, "").strip()
+        from hermes_cli.config import get_env_value
+        env_url = (
+            get_env_value(pconfig.base_url_env_var)
+            or os.getenv(pconfig.base_url_env_var, "")
+        ).strip()
 
     if provider_id in ("kimi-coding", "kimi-coding-cn"):
         base_url = _resolve_kimi_base_url(api_key, pconfig.inference_base_url, env_url)
@@ -3815,7 +3823,14 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             code="invalid_provider",
         )
 
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
+    if pconfig.base_url_env_var:
+        from hermes_cli.config import get_env_value
+        base_url = (
+            get_env_value(pconfig.base_url_env_var)
+            or os.getenv(pconfig.base_url_env_var, "")
+        ).strip()
+    else:
+        base_url = ""
     if not base_url:
         base_url = pconfig.inference_base_url
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -844,7 +844,11 @@ def _resolve_explicit_runtime(
     if pconfig and pconfig.auth_type == "api_key":
         env_url = ""
         if pconfig.base_url_env_var:
-            env_url = os.getenv(pconfig.base_url_env_var, "").strip().rstrip("/")
+            from hermes_cli.config import get_env_value
+            env_url = (
+                get_env_value(pconfig.base_url_env_var)
+                or os.getenv(pconfig.base_url_env_var, "")
+            ).strip().rstrip("/")
 
         base_url = explicit_base_url
         if not base_url:

--- a/tests/hermes_cli/test_provider_base_url_dotenv.py
+++ b/tests/hermes_cli/test_provider_base_url_dotenv.py
@@ -1,0 +1,100 @@
+"""Regression tests for #18757.
+
+Provider base URLs declared via ``base_url_env_var`` must resolve from
+``~/.hermes/.env`` (via :func:`hermes_cli.config.get_env_value`) — not only
+from the process environment (``os.getenv``). API keys already used the
+``.env``-aware lookup; base URLs were previously inconsistent.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    get_api_key_provider_status,
+    resolve_api_key_provider_credentials,
+)
+
+
+# Use Arcee as a representative API-key provider with a base_url_env_var.
+# The fix is provider-agnostic — we just need any provider whose registry
+# entry has base_url_env_var set.
+_PROVIDER = "arcee"
+_BASE_URL_ENV = "ARCEE_BASE_URL"
+_API_KEY_ENV = "ARCEEAI_API_KEY"
+_DOTENV_BASE_URL = "https://custom-arcee.example.com/v1"
+_API_KEY_VALUE = "arc-test-from-dotenv"
+
+
+def _stub_get_env_value(values):
+    """Build a get_env_value replacement that reads from ``values`` only."""
+    def _impl(key, default=""):
+        return values.get(key, default)
+    return _impl
+
+
+@pytest.fixture(autouse=True)
+def _registry_has_base_url_env_var():
+    """Sanity-guard: the test only makes sense if the provider declares a
+    base_url_env_var. If the registry changes, fail loudly."""
+    assert PROVIDER_REGISTRY[_PROVIDER].base_url_env_var == _BASE_URL_ENV
+
+
+class TestResolveApiKeyProviderCredentialsReadsDotenvBaseUrl:
+    """``resolve_api_key_provider_credentials()`` must consult ``.env`` for
+    the base URL — not only the shell environment."""
+
+    def test_dotenv_base_url_used_when_shell_env_unset(self, monkeypatch):
+        # Clear the shell env so ``os.getenv`` returns nothing for the base URL.
+        monkeypatch.delenv(_BASE_URL_ENV, raising=False)
+
+        env_values = {
+            _BASE_URL_ENV: _DOTENV_BASE_URL,
+            _API_KEY_ENV: _API_KEY_VALUE,
+        }
+        with patch(
+            "hermes_cli.config.get_env_value",
+            side_effect=_stub_get_env_value(env_values),
+        ):
+            result = resolve_api_key_provider_credentials(_PROVIDER)
+
+        # Pre-fix this would be the registry default ("https://api.arcee.ai/api/v1")
+        # because os.getenv could not see the .env value.
+        assert result["base_url"] == _DOTENV_BASE_URL.rstrip("/")
+
+    def test_shell_env_still_works_when_dotenv_empty(self, monkeypatch):
+        # Confirm we did not regress the shell-env path.
+        monkeypatch.setenv(_BASE_URL_ENV, _DOTENV_BASE_URL)
+
+        env_values = {_API_KEY_ENV: _API_KEY_VALUE}  # no BASE_URL in .env
+        with patch(
+            "hermes_cli.config.get_env_value",
+            side_effect=_stub_get_env_value(env_values),
+        ):
+            result = resolve_api_key_provider_credentials(_PROVIDER)
+
+        assert result["base_url"] == _DOTENV_BASE_URL.rstrip("/")
+
+
+class TestApiKeyProviderStatusReadsDotenvBaseUrl:
+    """``get_api_key_provider_status()`` (used by ``hermes doctor``) must also
+    surface the .env base URL — otherwise users get inconsistent reporting:
+    runtime works but ``doctor`` shows the wrong endpoint."""
+
+    def test_doctor_status_reflects_dotenv_base_url(self, monkeypatch):
+        monkeypatch.delenv(_BASE_URL_ENV, raising=False)
+
+        env_values = {
+            _BASE_URL_ENV: _DOTENV_BASE_URL,
+            _API_KEY_ENV: _API_KEY_VALUE,
+        }
+        with patch(
+            "hermes_cli.config.get_env_value",
+            side_effect=_stub_get_env_value(env_values),
+        ):
+            status = get_api_key_provider_status(_PROVIDER)
+
+        # The status should reflect the .env base URL — pre-fix it returned
+        # the registry default.
+        assert status.get("base_url") == _DOTENV_BASE_URL or status.get("base_url", "").rstrip("/") == _DOTENV_BASE_URL.rstrip("/")


### PR DESCRIPTION
## Issue

Closes #18757

## Root cause

Provider base URLs declared via `base_url_env_var` (e.g. `XIAOMI_BASE_URL`, `ARCEE_BASE_URL`) resolved only through `os.getenv` — they didn't see `~/.hermes/.env`. API keys already used `get_env_value` (which reads `.env`), so the function had two halves with inconsistent semantics: API key found, base URL silently fell back to the registry default.

The original report describes Xiaomi's `token-plan-cn-cn.xiaomimimo.com` endpoint silently regressing to the public `api.xiaomimimo.com` default → 401s on auxiliary tasks. The same inconsistency affected every API-key provider with a `base_url_env_var` (Arcee, GLM, Kimi, GMI, MiniMax, Stepfun, GMI, AI Gateway, OpenCode, Kilocode, HF, TokenHub, Ollama, Bedrock, Azure Foundry, etc.).

## Fix

Four call sites needed the same `.env`-aware lookup. The bug report named the first one; the rest were grep'd from the same access pattern:

| File | Function | Used by |
|---|---|---|
| `hermes_cli/auth.py` | `resolve_api_key_provider_credentials` | runtime auxiliary client (the original bug) |
| `hermes_cli/auth.py` | `get_api_key_provider_status` | `hermes doctor` status output |
| `hermes_cli/auth.py` | `resolve_external_process_provider_credentials` | Copilot ACP runtime |
| `hermes_cli/runtime_provider.py` | `_build_runtime_for_api_key_provider` (around the existing `pconfig.base_url_env_var` block) | main agent runtime selection |

All four now use the same fallback pattern that API-key resolution already uses elsewhere in the file:

```python
get_env_value(pconfig.base_url_env_var) or os.getenv(pconfig.base_url_env_var, "")
```

Behavior when the value is set in the shell environment is unchanged.

## Tests

`tests/hermes_cli/test_provider_base_url_dotenv.py` (new) covers:

- A `.env`-only base URL is now picked up by `resolve_api_key_provider_credentials`
- The same value is reflected by `get_api_key_provider_status` (so `hermes doctor` no longer lies when a `.env` base URL is set)
- The shell-env path still works (regression guard for the other direction)

Existing `test_arcee_provider.py` and `test_runtime_provider_resolution.py` also pass unchanged (139 tests in this scope, all green).