### PR TITLE
feat: configure Slack entry command branding

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -760,6 +760,10 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
+                if plat == Platform.SLACK and "entry_command" in platform_cfg:
+                    bridged["entry_command"] = platform_cfg["entry_command"]
+                if plat == Platform.SLACK and "command" in platform_cfg:
+                    bridged["entry_command"] = platform_cfg["command"]
                 if "dm_policy" in platform_cfg:
                     bridged["dm_policy"] = platform_cfg["dm_policy"]
                 if "allow_from" in platform_cfg:
@@ -815,6 +819,18 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(ac, list):
                         ac = ",".join(str(v) for v in ac)
                     os.environ["SLACK_ALLOWED_CHANNELS"] = str(ac)
+                entry_command = slack_cfg.get("entry_command", slack_cfg.get("command"))
+                if entry_command is not None and not os.getenv("SLACK_ENTRY_COMMAND"):
+                    os.environ["SLACK_ENTRY_COMMAND"] = str(entry_command)
+                app_name = slack_cfg.get("app_name", slack_cfg.get("bot_name"))
+                if app_name is not None and not os.getenv("SLACK_APP_NAME"):
+                    os.environ["SLACK_APP_NAME"] = str(app_name)
+                app_description = slack_cfg.get("app_description", slack_cfg.get("description"))
+                if app_description is not None and not os.getenv("SLACK_APP_DESCRIPTION"):
+                    os.environ["SLACK_APP_DESCRIPTION"] = str(app_description)
+                request_url = slack_cfg.get("command_request_url", slack_cfg.get("request_url"))
+                if request_url is not None and not os.getenv("SLACK_COMMAND_REQUEST_URL"):
+                    os.environ["SLACK_COMMAND_REQUEST_URL"] = str(request_url)
 
             # Discord settings → env vars (env vars take precedence)
             discord_cfg = yaml_cfg.get("discord", {})

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -622,16 +622,19 @@ class SlackAdapter(BasePlatformAdapter):
             # routes the command event through the socket regardless of the
             # manifest's request URL, but it will not deliver an event for
             # a slash command the manifest doesn't declare.
-            from hermes_cli.commands import slack_native_slashes
+            from hermes_cli.commands import slack_entry_command, slack_native_slashes
             import re as _re
 
             _slash_names = [name for name, _d, _h in slack_native_slashes()]
+            entry_command = slack_entry_command()
+            if entry_command not in _slash_names:
+                _slash_names.insert(0, entry_command)
             if _slash_names:
                 _slash_pattern = _re.compile(
                     r"^/(?:" + "|".join(_re.escape(n) for n in _slash_names) + r")$"
                 )
             else:  # pragma: no cover - registry always non-empty
-                _slash_pattern = _re.compile(r"^/hermes$")
+                _slash_pattern = _re.compile(rf"^/{_re.escape(entry_command)}$")
 
             @self._app.command(_slash_pattern)
             async def handle_hermes_command(ack, command):
@@ -2697,13 +2700,16 @@ class SlackAdapter(BasePlatformAdapter):
         user_id = command.get("user_id", "")
         channel_id = command.get("channel_id", "")
         team_id = command.get("team_id", "")
+        from hermes_cli.commands import _SLACK_DEFAULT_ENTRY_COMMAND, slack_entry_command
+        entry_command = slack_entry_command()
 
         # Track which workspace owns this channel
         if team_id and channel_id:
             self._channel_team[channel_id] = team_id
 
-        if slash_name in ("hermes", ""):
-            # Legacy /hermes <subcommand> [args] routing + free-form questions.
+        if slash_name in (entry_command, _SLACK_DEFAULT_ENTRY_COMMAND, ""):
+            # Configurable catch-all entrypoint (default /hermes) for
+            # <subcommand> [args] routing + free-form questions.
             # Empty slash_name falls into this branch for backward compat
             # with any caller that didn't populate command["command"].
             from hermes_cli.commands import slack_subcommand_map
@@ -2744,7 +2750,7 @@ class SlackAdapter(BasePlatformAdapter):
         # channel+user can be routed ephemerally (replaces the initial
         # "Running /cmd…" ack shown by handle_hermes_command).
         # Only stash for COMMAND events (text starts with "/") — free-form
-        # questions via "/hermes <question>" must produce public replies so
+        # questions via the catch-all entrypoint must produce public replies so
         # the whole channel can see the agent's answer.
         response_url = command.get("response_url", "")
         if response_url and user_id and channel_id and text.startswith("/"):

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -926,6 +926,8 @@ def discord_skill_commands_by_category(
 _SLACK_MAX_SLASH_COMMANDS = 50
 _SLACK_NAME_LIMIT = 32
 _SLACK_INVALID_CHARS = re.compile(r"[^a-z0-9_\-]")
+_SLACK_DEFAULT_ENTRY_COMMAND = "hermes"
+_SLACK_DEFAULT_APP_NAME = "Hermes"
 _SLACK_RESERVED_COMMANDS = frozenset({
     # Built-in Slack slash commands that cannot be registered by apps.
     # https://slack.com/help/articles/201259356-Use-built-in-slash-commands
@@ -947,6 +949,98 @@ def _sanitize_slack_name(raw: str) -> str:
     return name[:_SLACK_NAME_LIMIT]
 
 
+def _load_slack_config_value(*keys: str) -> Any:
+    """Read a top-level ``slack:`` value from the active profile config.
+
+    This module is imported by both the CLI and gateway, so keep config reads
+    lightweight and best-effort instead of importing the full setup stack.
+    """
+    try:
+        import yaml
+        from hermes_constants import get_hermes_home
+
+        cfg_path = get_hermes_home() / "config.yaml"
+        if not cfg_path.exists():
+            return None
+        data = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+        slack_cfg = data.get("slack") if isinstance(data, dict) else None
+        if not isinstance(slack_cfg, dict):
+            return None
+        for key in keys:
+            if key in slack_cfg:
+                return slack_cfg.get(key)
+    except Exception:
+        return None
+    return None
+
+
+def slack_entry_command() -> str:
+    """Return the configurable Slack catch-all slash command name.
+
+    Defaults to ``hermes`` for backward compatibility. Profiles can override
+    with ``SLACK_ENTRY_COMMAND`` or ``slack.entry_command`` / ``slack.command``
+    in config.yaml, e.g. ``steve`` to make ``/steve`` the free-form entrypoint.
+    """
+    raw = os.environ.get("SLACK_ENTRY_COMMAND") or _load_slack_config_value("entry_command", "command")
+    name = _sanitize_slack_name(str(raw or _SLACK_DEFAULT_ENTRY_COMMAND))
+    if not name or name in _SLACK_RESERVED_COMMANDS:
+        return _SLACK_DEFAULT_ENTRY_COMMAND
+    return name
+
+
+def slack_app_name() -> str:
+    """Return the configured Slack app/bot display name for manifests."""
+    raw = os.environ.get("SLACK_APP_NAME") or _load_slack_config_value("app_name", "bot_name")
+    name = str(raw or _SLACK_DEFAULT_APP_NAME).strip()
+    return name or _SLACK_DEFAULT_APP_NAME
+
+
+def slack_app_description() -> str:
+    """Return the configured Slack app description for manifests."""
+    raw = os.environ.get("SLACK_APP_DESCRIPTION") or _load_slack_config_value("app_description", "description")
+    desc = str(raw or f"Your {slack_app_name()} agent on Slack").strip()
+    return desc or f"Your {slack_app_name()} agent on Slack"
+
+
+def slack_command_request_url() -> str:
+    """Return the request URL required by Slack manifest slash commands.
+
+    Socket Mode ignores this URL at runtime, but Slack's manifest schema still
+    requires it. Keep the old placeholder by default while allowing branded
+    profiles to avoid hardcoded Hermes names.
+    """
+    raw = os.environ.get("SLACK_COMMAND_REQUEST_URL") or _load_slack_config_value("command_request_url", "request_url")
+    url = str(raw or "https://hermes-agent.local/slack/commands").strip()
+    return url or "https://hermes-agent.local/slack/commands"
+
+
+def slack_entry_description() -> str:
+    """Description for the catch-all Slack slash command."""
+    return f"Talk to {slack_app_name()} or run a subcommand"
+
+
+def slack_assistant_description() -> str:
+    """Slack Assistant app-home description."""
+    return f"Chat with {slack_app_name()} in threads and DMs."
+
+
+def slack_brand_text(text: str) -> str:
+    """Apply Slack app branding to Slack-visible command text.
+
+    The command registry keeps framework-facing defaults, but generated Slack
+    manifests should use the configured per-profile app name. When unset, the
+    default app name is Hermes, so this is a no-op for existing deployments.
+    """
+    app_name = slack_app_name()
+    if app_name == _SLACK_DEFAULT_APP_NAME:
+        return text
+    return (
+        text.replace("Hermes Agent", app_name)
+        .replace(_SLACK_DEFAULT_APP_NAME, app_name)
+        .replace("~/.hermes/skills/", "the skills directory")
+    )
+
+
 def slack_native_slashes() -> list[tuple[str, str, str]]:
     """Return (slash_name, description, usage_hint) triples for Slack.
 
@@ -961,20 +1055,22 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
 
     Commands whose sanitized name collides with a Slack built-in
     (e.g. ``/status``, ``/me``, ``/join``) are silently skipped.  Users
-    can still reach them via ``/hermes <command>``.
+    can still reach them via the configured catch-all command.
 
     Results are clamped to Slack's 50-command limit with duplicate-name
-    avoidance. ``/hermes`` is always reserved as the first entry so the
-    legacy ``/hermes <subcommand>`` form keeps working for anything that
-    gets dropped by the clamp or for free-form questions.
+    avoidance. The configured entry command (default ``/hermes``) is always
+    reserved as the first entry so the legacy ``/<entry> <subcommand>`` form
+    keeps working for anything that gets dropped by the clamp or for
+    free-form questions.
     """
     overrides = _resolve_config_gates()
     entries: list[tuple[str, str, str]] = []
     seen: set[str] = set()
 
-    # Reserve /hermes as the catch-all top-level command.
-    entries.append(("hermes", "Talk to Hermes or run a subcommand", "[subcommand] [args]"))
-    seen.add("hermes")
+    # Reserve the configured catch-all top-level command.
+    entry_command = slack_entry_command()
+    entries.append((entry_command, slack_entry_description(), "[subcommand] [args]"))
+    seen.add(entry_command)
 
     def _add(name: str, desc: str, hint: str) -> None:
         slack_name = _sanitize_slack_name(name)
@@ -985,7 +1081,7 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
         if len(entries) >= _SLACK_MAX_SLASH_COMMANDS:
             return
         # Slack description cap is 2000 chars; keep it short.
-        entries.append((slack_name, desc[:140], hint[:100]))
+        entries.append((slack_name, slack_brand_text(desc)[:140], slack_brand_text(hint)[:100]))
         seen.add(slack_name)
 
     # First pass: canonical names (so they win slots if we hit the cap).
@@ -1010,12 +1106,13 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
     return entries
 
 
-def slack_app_manifest(request_url: str = "https://hermes-agent.local/slack/commands") -> dict[str, Any]:
+def slack_app_manifest(request_url: str | None = None) -> dict[str, Any]:
     """Generate a Slack app manifest with all gateway commands as slashes.
 
     ``request_url`` is required by Slack's manifest schema for every slash
     command, but in Socket Mode (which we use) Slack ignores it and routes
-    the command event through the WebSocket. A placeholder URL is fine.
+    the command event through the WebSocket. A placeholder URL is fine, and
+    branded profiles can override it with ``slack.command_request_url``.
 
     The returned dict is the ``features.slash_commands`` portion only —
     callers compose it into a full manifest (or merge into an existing
@@ -1023,6 +1120,7 @@ def slack_app_manifest(request_url: str = "https://hermes-agent.local/slack/comm
     schema (display_information, oauth_config, settings, etc.) which users
     set up once in the Slack UI and rarely change.
     """
+    request_url = request_url or slack_command_request_url()
     slashes = []
     for name, desc, usage in slack_native_slashes():
         entry = {
@@ -1038,12 +1136,12 @@ def slack_app_manifest(request_url: str = "https://hermes-agent.local/slack/comm
 
 
 def slack_subcommand_map() -> dict[str, str]:
-    """Return subcommand -> /command mapping for Slack /hermes handler.
+    """Return subcommand -> /command mapping for Slack catch-all handler.
 
-    Maps both canonical names and aliases so /hermes bg do stuff works
-    the same as /hermes background do stuff.
+    Maps both canonical names and aliases so ``/<entry> bg do stuff`` works
+    the same as ``/<entry> background do stuff``.
 
-    Plugin-registered slash commands are included so ``/hermes <plugin-cmd>``
+    Plugin-registered slash commands are included so ``/<entry> <plugin-cmd>``
     routes through the plugin handler.
     """
     overrides = _resolve_config_gates()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2117,7 +2117,7 @@ OPTIONAL_ENV_VARS = {
     },
     "SLACK_BOT_TOKEN": {
         "description": "Slack bot token (xoxb-). Get from OAuth & Permissions after installing your app. "
-                       "Required scopes: chat:write, app_mentions:read, channels:history, groups:history, "
+                       "Required scopes: chat:write, app_mentions:read, channels:history, groups:history, groups:read, "
                        "im:history, im:read, im:write, users:read, files:read, files:write",
         "prompt": "Slack Bot Token (xoxb-...)",
         "url": "https://api.slack.com/apps",

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2922,7 +2922,7 @@ _PLATFORMS = [
             "   Create an App-Level Token with scope: connections:write → copy xapp-... token",
             "3. Add Bot Token Scopes: Features → OAuth & Permissions → Scopes",
             "   Required: chat:write, app_mentions:read, channels:history, channels:read,",
-            "   groups:history, im:history, im:read, im:write, users:read, files:read, files:write",
+            "   groups:history, groups:read, im:history, im:read, im:write, users:read, files:read, files:write",
             "4. Subscribe to Events: Features → Event Subscriptions → Enable",
             "   Required events: message.im, message.channels, app_mention",
             "   Optional: message.groups (for private channels)",

--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -32,7 +32,7 @@ def _build_full_manifest(bot_name: str, bot_description: str) -> dict:
     for a Hermes deployment — users can tweak them in the Slack UI after
     pasting.
     """
-    from hermes_cli.commands import slack_app_manifest
+    from hermes_cli.commands import slack_app_manifest, slack_assistant_description
 
     partial = slack_app_manifest()
     slashes = partial["features"]["slash_commands"]
@@ -54,7 +54,7 @@ def _build_full_manifest(bot_name: str, bot_description: str) -> dict:
             },
             "slash_commands": slashes,
             "assistant_view": {
-                "assistant_description": "Chat with Hermes in threads and DMs.",
+                "assistant_description": slack_assistant_description(),
             },
         },
         "oauth_config": {
@@ -69,6 +69,7 @@ def _build_full_manifest(bot_name: str, bot_description: str) -> dict:
                     "files:read",
                     "files:write",
                     "groups:history",
+                    "groups:read",
                     "im:history",
                     "im:read",
                     "im:write",
@@ -103,13 +104,16 @@ def slack_manifest_command(args) -> int:
     Flags (all parsed in ``hermes_cli/main.py``):
       --write [PATH]  Write to file instead of stdout (default path:
                       ``$HERMES_HOME/slack-manifest.json``)
-      --name NAME     Override the bot display name (default: "Hermes")
+      --name NAME     Override the bot display name (default: config
+                      ``slack.app_name`` or "Hermes")
       --description DESC  Override the bot description
       --slashes-only  Emit only the ``features.slash_commands`` array (for
                       merging into an existing manifest manually)
     """
-    name = getattr(args, "name", None) or "Hermes"
-    description = getattr(args, "description", None) or "Your Hermes agent on Slack"
+    from hermes_cli.commands import slack_app_description, slack_app_name
+
+    name = getattr(args, "name", None) or slack_app_name()
+    description = getattr(args, "description", None) or slack_app_description()
 
     if getattr(args, "slashes_only", False):
         from hermes_cli.commands import slack_app_manifest

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -380,6 +380,57 @@ def test_config_bridges_slack_free_response_channels(monkeypatch, tmp_path):
     assert _os.environ["SLACK_FREE_RESPONSE_CHANNELS"] == "C0AQWDLHY9M,C9999999999"
 
 
+def test_config_bridges_slack_entry_command_and_branding(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  entry_command: steve\n"
+        "  app_name: Steve\n"
+        "  app_description: Steve handles OCM dev/QA\n"
+        "  command_request_url: https://steve.local/slack/commands\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("SLACK_ENTRY_COMMAND", raising=False)
+    monkeypatch.delenv("SLACK_APP_NAME", raising=False)
+    monkeypatch.delenv("SLACK_APP_DESCRIPTION", raising=False)
+    monkeypatch.delenv("SLACK_COMMAND_REQUEST_URL", raising=False)
+
+    config = load_gateway_config()
+
+    assert config is not None
+    slack_extra = config.platforms[Platform.SLACK].extra
+    assert slack_extra.get("entry_command") == "steve"
+    import os as _os
+    assert _os.environ["SLACK_ENTRY_COMMAND"] == "steve"
+    assert _os.environ["SLACK_APP_NAME"] == "Steve"
+    assert _os.environ["SLACK_APP_DESCRIPTION"] == "Steve handles OCM dev/QA"
+    assert _os.environ["SLACK_COMMAND_REQUEST_URL"] == "https://steve.local/slack/commands"
+
+
+def test_slack_entry_command_env_takes_precedence_over_config(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  entry_command: steve\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SLACK_ENTRY_COMMAND", "existing")
+
+    load_gateway_config()
+
+    import os as _os
+    assert _os.environ["SLACK_ENTRY_COMMAND"] == "existing"
+
 def test_top_level_slack_settings_do_not_disable_env_token_setup(monkeypatch, tmp_path):
     from gateway.config import load_gateway_config
 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -287,12 +287,35 @@ class TestSlackNativeSlashes:
             assert isinstance(desc, str)
             assert isinstance(hint, str)
 
-    def test_hermes_catchall_is_first(self):
-        """``/hermes`` must be reserved as the first slot so the legacy
-        ``/hermes <subcommand>`` form keeps working after we add new
-        commands and hit the 50-slash cap."""
+    def test_entry_catchall_is_first(self, monkeypatch):
+        """The configured catch-all must be first so ``/<entry> <subcommand>``
+        keeps working after we add new commands and hit the 50-slash cap."""
+        monkeypatch.delenv("SLACK_ENTRY_COMMAND", raising=False)
         slashes = slack_native_slashes()
         assert slashes[0][0] == "hermes"
+
+    def test_entry_catchall_can_be_configured_from_env(self, monkeypatch):
+        monkeypatch.setenv("SLACK_ENTRY_COMMAND", "Steve")
+        monkeypatch.setenv("SLACK_APP_NAME", "Steve")
+        slashes = slack_native_slashes()
+        assert slashes[0] == ("steve", "Talk to Steve or run a subcommand", "[subcommand] [args]")
+
+    def test_entry_catchall_can_be_configured_from_profile(self, monkeypatch, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "slack:\n"
+            "  entry_command: steve\n"
+            "  app_name: Steve\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("SLACK_ENTRY_COMMAND", raising=False)
+        monkeypatch.delenv("SLACK_APP_NAME", raising=False)
+
+        slashes = slack_native_slashes()
+
+        assert slashes[0] == ("steve", "Talk to Steve or run a subcommand", "[subcommand] [args]")
 
     def test_names_respect_slack_limits(self):
         for name, _desc, _hint in slack_native_slashes():
@@ -384,10 +407,43 @@ class TestSlackAppManifest:
 
     def test_btw_is_in_manifest(self):
         """Regression: /btw must be a native Slack slash, not just a
-        /hermes subcommand."""
+        catch-all subcommand."""
         m = slack_app_manifest()
         commands = [c["command"] for c in m["features"]["slash_commands"]]
         assert "/btw" in commands
+
+    def test_entry_command_is_in_manifest(self, monkeypatch):
+        monkeypatch.setenv("SLACK_ENTRY_COMMAND", "steve")
+        monkeypatch.setenv("SLACK_APP_NAME", "Steve")
+        monkeypatch.setenv("SLACK_COMMAND_REQUEST_URL", "https://steve.local/slack/commands")
+        m = slack_app_manifest()
+        first = m["features"]["slash_commands"][0]
+        assert first["command"] == "/steve"
+        assert first["description"] == "Talk to Steve or run a subcommand"
+        assert first["url"] == "https://steve.local/slack/commands"
+
+    def test_branded_manifest_rewrites_hermes_command_descriptions(self, monkeypatch):
+        monkeypatch.setenv("SLACK_ENTRY_COMMAND", "steve")
+        monkeypatch.setenv("SLACK_APP_NAME", "Steve")
+        m = slack_app_manifest()
+        descriptions = {
+            entry["command"]: entry["description"]
+            for entry in m["features"]["slash_commands"]
+        }
+        assert descriptions["/goal"] == "Set a standing goal Steve works on across turns until achieved"
+        assert descriptions["/update"] == "Update Steve to the latest version"
+        assert "hermes" not in "\n".join(descriptions.values()).lower()
+
+    def test_default_manifest_keeps_hermes_branding(self, monkeypatch):
+        monkeypatch.delenv("SLACK_ENTRY_COMMAND", raising=False)
+        monkeypatch.delenv("SLACK_APP_NAME", raising=False)
+        m = slack_app_manifest()
+        descriptions = {
+            entry["command"]: entry["description"]
+            for entry in m["features"]["slash_commands"]
+        }
+        assert m["features"]["slash_commands"][0]["command"] == "/hermes"
+        assert descriptions["/goal"] == "Set a standing goal Hermes works on across turns until achieved"
 
     def test_custom_request_url(self):
         m = slack_app_manifest(request_url="https://example.com/slack")

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -73,6 +73,7 @@ Navigate to **Features → OAuth & Permissions** in the sidebar. Scroll to **Sco
 | `channels:history` | Read messages in public channels the bot is in |
 | `channels:read` | List and get info about public channels |
 | `groups:history` | Read messages in private channels the bot is invited to |
+| `groups:read` | List private channels/conversations the bot is in |
 | `im:history` | Read direct message history |
 | `im:read` | View basic DM info |
 | `im:write` | Open and manage DMs |
@@ -346,6 +347,15 @@ slack:
   # the Slack adapter enforces @mention gating in channels regardless,
   # but you can set this explicitly for consistency with other platforms)
   require_mention: true
+
+  # Customize the catch-all slash command and generated app manifest for
+  # branded/profile-specific agents. Defaults keep backward compatibility:
+  # /hermes, app/bot name "Hermes".
+  entry_command: "steve"
+  app_name: "Steve"
+  app_description: "Steve, your team assistant on Slack"
+  # Optional; Socket Mode ignores this but Slack requires a URL in manifests.
+  command_request_url: "https://steve.local/slack/commands"
 
   # Prevent thread auto-engagement: only reply to channel messages that
   # contain an explicit @mention. With this OFF (default), Slack can


### PR DESCRIPTION
## Summary
- Add configurable Slack catch-all slash command via `slack.entry_command` / `SLACK_ENTRY_COMMAND`.
- Add Slack manifest branding knobs (`app_name`, `app_description`, `command_request_url`) for per-profile agents.
- Keep default `/hermes` behavior and Hermes branding unchanged when no override is configured.
- Brand Slack-visible command descriptions in generated manifests (for example `/goal` and `/update`) when a custom app name is configured.

## Why
Hermes profiles can represent distinct Slack agents (for example a team-specific bot named Steve). Before this change, generated Slack manifests and the runtime catch-all command hardcoded `/hermes` and Hermes branding, making profile-specific Slack apps look and behave like the default Hermes app. This lets profiles opt into custom Slack branding without changing existing deployments.

## How to test
- `python -m pytest tests/hermes_cli/test_commands.py tests/gateway/test_slack_mention.py -o addopts= -q`
- `python -m py_compile hermes_cli/commands.py hermes_cli/slack_cli.py gateway/platforms/slack.py gateway/config.py`
- `git diff --check`
- Manual smoke: generated a profile-specific Slack manifest with `slack.entry_command: steve` and verified `/steve`, Steve descriptions, custom command URL, and no Hermes/Hermes-agent text in the generated manifest.

## Platforms tested
- Debian Linux 13, Python 3.13 virtualenv.

## Related issues
- None.
