### PR TITLE
fix(cli): correct WhatsApp platform detection and add Matrix support in tools menu

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -764,10 +764,17 @@ def _get_enabled_platforms() -> List[str]:
         enabled.append("discord")
     if get_env_value("SLACK_BOT_TOKEN"):
         enabled.append("slack")
-    if get_env_value("WHATSAPP_ENABLED"):
+    whatsapp_enabled = get_env_value("WHATSAPP_ENABLED", "").lower()
+    if whatsapp_enabled in ("true", "1", "yes"):
         enabled.append("whatsapp")
     if get_env_value("QQ_APP_ID"):
         enabled.append("qqbot")
+    # Matrix: check for homeserver URL (required) and either access token or password
+    matrix_homeserver = get_env_value("MATRIX_HOMESERVER")
+    matrix_token = get_env_value("MATRIX_ACCESS_TOKEN")
+    matrix_password = get_env_value("MATRIX_PASSWORD")
+    if matrix_homeserver and (matrix_token or matrix_password):
+        enabled.append("matrix")
     return enabled
 
 


### PR DESCRIPTION
## Problem

Two issues in `hermes_cli/tools_config.py` `_get_enabled_platforms()`:

1. **WhatsApp shown despite being disabled**: `WHATSAPP_ENABLED=false` was treated as truthy because `get_env_value()` returns the string `"false"`, which is truthy in Python. This caused WhatsApp to appear in `hermes tools` menus even when explicitly disabled.

2. **Matrix missing entirely**: The Matrix platform was not listed in `_get_enabled_platforms()`, so it never appeared in the tools menu even when fully configured.

## Changes

- WhatsApp: check for explicit truthy values (`true`, `1`, `yes`) instead of any non-empty string
- Matrix: add detection via `MATRIX_HOMESERVER` + (`MATRIX_ACCESS_TOKEN` or `MATRIX_PASSWORD`)

## Verification

Before:
```
$ hermes tools
→ (●) Configure 🖥️  CLI  (19/24 enabled)
   (○) Configure 📱 Telegram  (19/24 enabled)
   (○) Configure 📱 WhatsApp  (19/24 enabled)   ← shown despite WHATSAPP_ENABLED=false
   (○) Configure all platforms (global)
```

After (with this patch + WHATSAPP_ENABLED=false + Matrix configured):
```
$ hermes tools
→ (●) Configure 🖥️  CLI  (19/24 enabled)
   (○) Configure 📱 Telegram  (19/24 enabled)
   (○) Configure 💬 Matrix  (19/24 enabled)      ← now visible
   (○) Configure all platforms (global)
```

Fixes: platform shown in tools menu despite being disabled in .env
