### PR TITLE
Replace cumulative Hindsight transcript snapshots

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1029,13 +1029,16 @@ class HindsightMemoryProvider(MemoryProvider):
     def _resolve_retain_target(self, fallback_document_id: str) -> tuple[str, str | None]:
         """Pick (document_id, update_mode) based on live API capability.
 
-        On Hindsight ≥ 0.5.0 the API supports ``update_mode='append'``,
-        which lets us reuse a stable session-scoped ``document_id`` across
-        process lifecycles without overwriting prior turns. On older APIs
-        we fall back to *fallback_document_id* (the per-process unique
-        ``f"{session_id}-{start_ts}"`` minted at initialize / switch time)
-        and don't pass ``update_mode`` at all — that's the only way the
-        resume-overwrite fix (#6654) keeps working on legacy servers.
+        Hermes retains cumulative transcript snapshots from its in-process
+        session buffer. On Hindsight ≥ 0.5.0, use ``update_mode='replace'``
+        against the per-process document so each retain replaces the previous
+        cumulative snapshot instead of appending earlier turns again. Older
+        APIs fall back to the same per-process document without ``update_mode``.
+
+        Do not use the bare session_id with replace here: after a process
+        restart Hermes may only have newly observed turns in memory, so replacing
+        a session-scoped document could discard older turns retained by a prior
+        process lifecycle.
 
         Probe is cached at module level per API URL, so this is one HTTP
         round-trip per (process, api_url) pair regardless of how many
@@ -1044,7 +1047,7 @@ class HindsightMemoryProvider(MemoryProvider):
         if not self._session_id:
             return fallback_document_id, None
         if _check_api_supports_update_mode_append(self._probe_url(), self._api_key):
-            return self._session_id, "append"
+            return fallback_document_id, "replace"
         return fallback_document_id, None
 
     def initialize(self, session_id: str, **kwargs) -> None:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1101,21 +1101,21 @@ class TestUpdateModeAppendCapability:
         item = kw["items"][0]
         assert "update_mode" not in item
 
-    def test_modern_api_uses_stable_doc_id_with_append(self, provider, monkeypatch):
-        """API on >=0.5.0 — retain uses stable session_id and sets update_mode='append'."""
+    def test_modern_api_uses_per_process_doc_id_with_replace(self, provider, monkeypatch):
+        """API on >=0.5.0 — retain replaces the per-process cumulative snapshot."""
         self._clear_capability_cache()
         monkeypatch.setattr(
             "plugins.memory.hindsight._fetch_hindsight_api_version",
             lambda *a, **kw: "0.5.6",
         )
+        old_doc = provider._document_id
         provider.sync_turn("hello", "hi")
         provider._retain_queue.join()
 
         kw = provider._client.aretain_batch.call_args.kwargs
-        # Stable: just the session id, no per-process timestamp suffix.
-        assert kw["document_id"] == "test-session"
+        assert kw["document_id"] == old_doc
         item = kw["items"][0]
-        assert item["update_mode"] == "append"
+        assert item["update_mode"] == "replace"
 
     def test_capability_cached_per_url(self, provider, monkeypatch):
         """The /version probe must run at most once per (process, api_url)."""
@@ -1154,26 +1154,26 @@ class TestUpdateModeAppendCapability:
         # Cache hit on the second call → no second warn.
         assert len(warns) == 1
 
-    def test_session_switch_flush_picks_capability_against_old_session(
+    def test_session_switch_flush_picks_capability_against_old_document(
         self, provider_with_config, monkeypatch
     ):
-        """When the API supports append, the flush on /reset must land
-        in the OLD session's stable document, not a per-process id."""
+        """When the API supports replace, the flush on /reset must replace
+        the OLD session's per-process document, not append to a session doc."""
         self._clear_capability_cache()
         monkeypatch.setattr(
             "plugins.memory.hindsight._fetch_hindsight_api_version",
             lambda *a, **kw: "0.5.6",
         )
         p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        old_doc = p._document_id
         p.sync_turn("turn1-user", "turn1-asst")
         p.sync_turn("turn2-user", "turn2-asst")
         p.on_session_switch("new-sid", parent_session_id="test-session", reset=True)
         p._retain_queue.join()
 
         kw = p._client.aretain_batch.call_args.kwargs
-        # Flush goes to the OLD session's stable doc, not new-sid's.
-        assert kw["document_id"] == "test-session"
-        assert kw["items"][0]["update_mode"] == "append"
+        assert kw["document_id"] == old_doc
+        assert kw["items"][0]["update_mode"] == "replace"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- switch modern Hindsight retain batches from `update_mode=append` on the session document to `update_mode=replace` on the per-process document
- avoid repeatedly appending cumulative transcript snapshots, which duplicated earlier turns and grew documents indefinitely
- keep legacy API behavior unchanged by omitting `update_mode` when unsupported

## Rationale
Hermes builds each auto-retain payload from the full in-process session buffer. Appending those cumulative snapshots duplicates earlier turns on every retain. Replacing the per-process snapshot preserves the current process lifecycle transcript without risking a restart overwriting a prior process lifecycle.

## Testing
- `/Users/tleo/.hermes/hermes-agent/venv/bin/python -m pytest tests/plugins/memory/test_hindsight_provider.py -q`
- `/Users/tleo/.hermes/hermes-agent/venv/bin/python -m py_compile plugins/memory/hindsight/__init__.py run_agent.py gateway/run.py tests/plugins/memory/test_hindsight_provider.py`
