### PR TITLE
fix: pass extra_headers from custom provider config to OpenAI client

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2369,6 +2369,9 @@ def resolve_provider_client(
                     raw_base_for_wrap = custom_base
                 _clean_base2, _dq2 = _extract_url_query_params(openai_base)
                 _extra2 = {"default_query": _dq2} if _dq2 else {}
+                _entry_extra_headers = custom_entry.get("extra_headers")
+                if isinstance(_entry_extra_headers, dict) and _entry_extra_headers:
+                    _extra2["default_headers"] = dict(_entry_extra_headers)
                 logger.debug(
                     "resolve_provider_client: named custom provider %r (%s, api_mode=%s)",
                     provider, final_model, entry_api_mode or "chat_completions")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2560,6 +2560,7 @@ def _normalize_custom_provider_entry(
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
+        "extra_headers",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -2649,6 +2650,10 @@ def _normalize_custom_provider_entry(
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
+
+    extra_headers = entry.get("extra_headers")
+    if isinstance(extra_headers, dict) and extra_headers:
+        normalized["extra_headers"] = {str(k): str(v) for k, v in extra_headers.items()}
 
     return normalized
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1472,6 +1472,24 @@ class AIAgent:
                             client_kwargs["default_headers"] = dict(_ph.default_headers)
                     except Exception:
                         pass
+                    # Also read extra_headers from config for named custom providers
+                    # (e.g. x-claw-id for ai-service). Match by base_url because
+                    # the runtime resolves all custom providers to provider="custom".
+                    if "default_headers" not in client_kwargs:
+                        try:
+                            from hermes_cli.config import load_config as _lc
+                            _clean_base = base_url.rstrip("/")
+                            for _pentry in (_lc().get("providers") or {}).values():
+                                if not isinstance(_pentry, dict):
+                                    continue
+                                _pbase = (_pentry.get("base_url") or _pentry.get("api") or _pentry.get("url") or "").rstrip("/")
+                                if _pbase and _pbase == _clean_base:
+                                    _eh = _pentry.get("extra_headers")
+                                    if isinstance(_eh, dict) and _eh:
+                                        client_kwargs["default_headers"] = {str(k): str(v) for k, v in _eh.items()}
+                                    break
+                        except Exception:
+                            pass
             else:
                 # No explicit creds — use the centralized provider router
                 from agent.auxiliary_client import resolve_provider_client
@@ -6288,6 +6306,21 @@ class AIAgent:
                     _ph_headers = dict(_ph2.default_headers)
             except Exception:
                 pass
+            if not _ph_headers:
+                try:
+                    from hermes_cli.config import load_config as _lc2
+                    _clean_base2 = base_url.rstrip("/")
+                    for _pentry2 in (_lc2().get("providers") or {}).values():
+                        if not isinstance(_pentry2, dict):
+                            continue
+                        _pbase2 = (_pentry2.get("base_url") or _pentry2.get("api") or _pentry2.get("url") or "").rstrip("/")
+                        if _pbase2 and _pbase2 == _clean_base2:
+                            _eh2 = _pentry2.get("extra_headers")
+                            if isinstance(_eh2, dict) and _eh2:
+                                _ph_headers = {str(k): str(v) for k, v in _eh2.items()}
+                            break
+                except Exception:
+                    pass
             if _ph_headers:
                 self._client_kwargs["default_headers"] = _ph_headers
             else:


### PR DESCRIPTION
providers.extra_headers was silently dropped during normalization because _KNOWN_KEYS in _normalize_custom_provider_entry did not include it. Additionally, auxiliary_client.resolve_provider_client did not read the field when constructing the OpenAI client, so custom HTTP headers (e.g. x-claw-id required by some enterprise API gateways) were never sent, causing HTTP 403 errors.

Fixes:
- Add extra_headers to _KNOWN_KEYS to stop silent discard + warning
- Pass extra_headers through in normalized provider entry
- Read extra_headers in resolve_provider_client and pass as default_headers to the OpenAI client constructor

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

