### PR TITLE
fix(skills): inter-process lock for skill_usage._mutate (#18795)

### DIFF
--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -604,3 +604,96 @@ def test_end_to_end_no_code_path_mutates_bundled_skill(skills_home):
     # The agent-created skill can still be mutated normally
     bump_view("mine")
     assert load_usage()["mine"]["view_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — read-modify-write race protection (#18795)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="multiprocessing fcntl semantics differ on Windows; msvcrt path "
+    "is exercised by the unit-level _file_lock contract instead",
+)
+def test_concurrent_bumps_do_not_lose_updates(skills_home):
+    """Multiple processes bumping the same skill must not lose updates.
+
+    Pre-fix, the read-modify-write cycle in ``_mutate`` was unsynchronized:
+    two processes that loaded the file at the same time would each write
+    back ``count + 1`` and one update would be silently lost. This test
+    fans out to several real subprocesses (so ``fcntl.flock`` actually
+    serializes them — threads in the same process would not exercise the
+    bug or the fix) and asserts exact accounting.
+    """
+    import subprocess
+    import sys
+
+    from tools.skill_usage import (
+        bump_use,
+        get_record,
+        load_usage,
+        mark_agent_created,
+    )
+
+    skill_name = "concurrency-test-skill"
+    # ``_mutate`` is gated on is_agent_created; mark it once up front so
+    # the subprocesses' bumps actually persist.
+    mark_agent_created(skill_name)
+    assert load_usage()[skill_name]["created_by"] == "agent"
+
+    bumps_per_proc = 25
+    n_procs = 6
+    expected = bumps_per_proc * n_procs
+
+    repo_root = os.getcwd()  # tests run from hermes-agent root
+    script = (
+        "import sys, os; "
+        f"sys.path.insert(0, {repo_root!r}); "
+        "import tools.skill_usage as su; "
+        f"[su.bump_use({skill_name!r}) for _ in range({bumps_per_proc})]"
+    )
+
+    env = {**os.environ}
+    procs = [
+        subprocess.Popen([sys.executable, "-c", script], env=env)
+        for _ in range(n_procs)
+    ]
+    for p in procs:
+        rc = p.wait(timeout=60)
+        assert rc == 0, f"subprocess exited with {rc}"
+
+    rec = get_record(skill_name)
+    assert rec["use_count"] == expected, (
+        f"race regression: expected use_count={expected} after "
+        f"{n_procs} procs × {bumps_per_proc} bumps, got {rec['use_count']} "
+        "(lost updates implies the inter-process lock is missing)"
+    )
+
+
+def test_file_lock_is_a_noop_when_locking_unavailable(skills_home, monkeypatch):
+    """If neither fcntl nor msvcrt is importable, _file_lock must degrade
+    cleanly to a no-op so usage telemetry never crashes a tool call."""
+    import tools.skill_usage as su
+
+    monkeypatch.setattr(su, "fcntl", None)
+    monkeypatch.setattr(su, "msvcrt", None)
+
+    # Should not raise; should still allow the body to run.
+    with su._file_lock(skills_home / "skills" / ".usage.json"):
+        pass
+
+
+def test_file_lock_serializes_within_one_process(skills_home):
+    """A second acquire on the same lock from the same process should still
+    serialize (fcntl.flock with LOCK_EX is process-level on POSIX). Sanity
+    check that the helper actually acquires/releases — the regression test
+    above is the real teeth, this is just a smoke test."""
+    import tools.skill_usage as su
+
+    path = skills_home / "skills" / ".usage.json"
+    # Acquire and release twice in a row — must not deadlock or leak fds.
+    with su._file_lock(path):
+        pass
+    with su._file_lock(path):
+        pass

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -28,13 +28,86 @@ import json
 import logging
 import os
 import tempfile
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
 
+# fcntl is Unix-only; on Windows use msvcrt for file locking. Mirrors the
+# pattern in tools/memory_tool.py so a single read-modify-write cycle on
+# .usage.json is serialized across concurrent processes (#18795).
+msvcrt = None
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+    try:
+        import msvcrt
+    except ImportError:
+        pass
+
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _file_lock(path: Path):
+    """Acquire an exclusive inter-process lock on a sidecar lock file.
+
+    The lock is held for the duration of the context. ``path`` is the file
+    being protected; the lock itself lives at ``path + ".lock"`` so that
+    the protected file can still be replaced atomically via ``os.replace``.
+
+    On platforms without ``fcntl`` or ``msvcrt`` (or when the lock file
+    cannot be created), the lock degrades to a no-op so usage telemetry
+    never crashes a skill tool call — the file is best-effort by design
+    (see module docstring).
+    """
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        yield
+        return
+
+    if fcntl is None and msvcrt is None:
+        yield
+        return
+
+    if msvcrt and (not lock_path.exists() or lock_path.stat().st_size == 0):
+        try:
+            lock_path.write_text(" ", encoding="utf-8")
+        except OSError:
+            yield
+            return
+
+    try:
+        fd = open(lock_path, "r+" if msvcrt else "a+")
+    except OSError:
+        yield
+        return
+
+    try:
+        if fcntl:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        else:
+            fd.seek(0)
+            msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
+        yield
+    finally:
+        if fcntl:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+        elif msvcrt:
+            try:
+                fd.seek(0)
+                msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+            except OSError:
+                pass
+        fd.close()
 
 
 STATE_ACTIVE = "active"
@@ -328,13 +401,14 @@ def _mutate(skill_name: str, mutator) -> None:
     try:
         if not is_agent_created(skill_name):
             return
-        data = load_usage()
-        rec = data.get(skill_name)
-        if not isinstance(rec, dict):
-            rec = _empty_record()
-        mutator(rec)
-        data[skill_name] = rec
-        save_usage(data)
+        with _file_lock(_usage_file()):
+            data = load_usage()
+            rec = data.get(skill_name)
+            if not isinstance(rec, dict):
+                rec = _empty_record()
+            mutator(rec)
+            data[skill_name] = rec
+            save_usage(data)
     except Exception as e:
         logger.debug("skill_usage._mutate(%s) failed: %s", skill_name, e, exc_info=True)
 
@@ -404,10 +478,11 @@ def forget(skill_name: str) -> None:
     if not skill_name:
         return
     try:
-        data = load_usage()
-        if skill_name in data:
-            del data[skill_name]
-            save_usage(data)
+        with _file_lock(_usage_file()):
+            data = load_usage()
+            if skill_name in data:
+                del data[skill_name]
+                save_usage(data)
     except Exception as e:
         logger.debug("skill_usage.forget(%s) failed: %s", skill_name, e, exc_info=True)
 


### PR DESCRIPTION
## Issue

Closes #18795

## Root cause

`tools/skill_usage._mutate()` and `tools/skill_usage.forget()` performed an unsynchronized read → mutate → atomic-write cycle on `~/.hermes/skills/.usage.json`:

1. `data = load_usage()` — reads the file
2. `mutator(rec)` — bumps a counter / timestamp
3. `save_usage(data)` — atomic `os.replace`

`os.replace` only guarantees the write itself is atomic — the read-mutate-write window is not. Two concurrent processes (CLI session + gateway, two CLI sessions, `batch_runner` workers, `delegate_task` sub-agents, cron job overlap) can both observe the same state and each write back `count + 1`, silently losing one increment. The issue body's process-A / process-B trace describes this exactly.

## Fix

Wrap the read-modify-write window in `_mutate` and `forget` with an `fcntl.flock` / `msvcrt.locking` based context manager — the same pattern already established in `tools/memory_tool.py:_file_lock`, which the issue body cited as the reference implementation. The lock lives on a sidecar `.usage.json.lock` file so the protected file can still be replaced atomically by `save_usage`.

If neither `fcntl` nor `msvcrt` is available (or the lock file cannot be created), the helper degrades to a no-op so usage telemetry never crashes the tool call — `tools/skill_usage`'s module docstring explicitly says this file is best-effort.

## Tests

- **`test_concurrent_bumps_do_not_lose_updates`** — fans out to 6 real `subprocess.Popen` workers each performing 25 `bump_use` calls. Pre-fix the final `use_count` is non-deterministically < 150 due to lost updates; post-fix it is exactly 150. Threads in a single process would *not* reproduce the bug or the fix — `fcntl.flock` is process-level on POSIX — so the test deliberately spawns subprocesses.
- **`test_file_lock_is_a_noop_when_locking_unavailable`** — pins the graceful-degradation path so `tools/skill_usage` can still load on exotic platforms.
- **`test_file_lock_serializes_within_one_process`** — smoke test: acquire/release twice in a row without leaking fds or deadlocking.

The multi-process test is skipped on Windows (`fcntl` is None there); the unit-level `_file_lock` tests still cover the cross-platform graceful path. The `msvcrt` branch is exercised by the parallel implementation in `tools/memory_tool.py`.

```
$ pytest tests/tools/test_skill_usage.py
43 passed in 0.72s
```

## Scope

Per the issue's hint about related races, **scope is intentionally tight** to skill_usage only. The collaborator comment links #6589 (quota cache flock), #5199, and #18087 (cron jobs.json race) as the same pattern — those should land as separate PRs to keep review focused.