### PR TITLE
fix(run_agent): pass reasoning_config to background review fork (#18871)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3658,6 +3658,14 @@ class AIAgent:
                         api_mode=_parent_runtime.get("api_mode") or None,
                         base_url=_parent_runtime.get("base_url") or None,
                         api_key=_parent_runtime.get("api_key") or None,
+                        # Inherit reasoning_config so the review fork honors the
+                        # parent's configured reasoning effort instead of
+                        # falling back to the Codex Responses default of
+                        # ``{"effort": "medium", "summary": "auto"}``. Mirrors
+                        # the api_mode / base_url / api_key inheritance above
+                        # (see #16006, #15884, #13076 for prior runtime-field
+                        # plumbing) — addresses #18871.
+                        reasoning_config=self.reasoning_config,
                         credential_pool=getattr(self, "_credential_pool", None),
                         parent_session_id=self.session_id,
                         enabled_toolsets=["memory", "skills"],

--- a/tests/run_agent/test_background_review_reasoning_config.py
+++ b/tests/run_agent/test_background_review_reasoning_config.py
@@ -1,0 +1,102 @@
+"""Regression test for #18871.
+
+When the parent ``AIAgent`` has a configured ``reasoning_config`` (e.g. an
+``xhigh`` reasoning effort), spawning a background memory/skill review must
+pass that config into the forked review agent — otherwise the review
+inherits the transport's default ``{"effort": "medium", "summary": "auto"}``
+and silently downgrades the user's configured effort.
+
+This pins the same runtime-inheritance contract that #16006/#15884/#13076
+already established for ``base_url``, ``api_key``, ``api_mode``.
+"""
+
+from unittest.mock import patch
+
+
+def _make_agent_stub(agent_cls, reasoning_config):
+    """Minimal AIAgent-like stub with just enough state for
+    ``_spawn_background_review`` to reach the ``AIAgent(...)`` call site."""
+    agent = object.__new__(agent_cls)
+    agent.model = "test-model"
+    agent.platform = "test"
+    agent.provider = "openai"
+    agent.session_id = "sess-123"
+    agent.quiet_mode = True
+    agent._memory_store = None
+    agent._memory_enabled = True
+    agent._user_profile_enabled = False
+    agent._memory_nudge_interval = 5
+    agent._skill_nudge_interval = 5
+    agent.background_review_callback = None
+    agent.status_callback = None
+    agent.reasoning_config = reasoning_config
+    agent._credential_pool = None
+    agent._MEMORY_REVIEW_PROMPT = "review memory"
+    agent._SKILL_REVIEW_PROMPT = "review skills"
+    agent._COMBINED_REVIEW_PROMPT = "review both"
+    return agent
+
+
+class _SyncThread:
+    """Drop-in replacement for ``threading.Thread`` that runs the target inline,
+    so the patched ``AIAgent.__init__`` capture happens before the test exits."""
+
+    def __init__(self, *, target=None, daemon=None, name=None):
+        self._target = target
+
+    def start(self):
+        if self._target:
+            self._target()
+
+
+def _spawn_and_capture(reasoning_config):
+    """Run ``_spawn_background_review`` and capture the kwargs the review fork
+    would have been initialized with."""
+    import run_agent
+
+    agent = _make_agent_stub(run_agent.AIAgent, reasoning_config)
+    captured: dict = {}
+
+    def _capture_init(self, *args, **kwargs):
+        captured.update(kwargs)
+        raise RuntimeError("stop after capturing init args")
+
+    # ``_current_main_runtime`` is called inside the spawn to forward live
+    # provider/auth state. Stub it to a benign empty mapping.
+    with patch.object(run_agent.AIAgent, "__init__", _capture_init), \
+         patch("threading.Thread", _SyncThread), \
+         patch.object(
+             run_agent.AIAgent,
+             "_current_main_runtime",
+             lambda self: {},
+             create=False,
+         ):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    return captured
+
+
+def test_background_review_agent_inherits_reasoning_config():
+    """A configured reasoning_config on the parent must reach the review
+    agent's constructor — otherwise the fork falls back to medium effort."""
+    parent_reasoning = {"effort": "xhigh", "summary": "detailed"}
+    captured = _spawn_and_capture(parent_reasoning)
+
+    assert "reasoning_config" in captured, (
+        "AIAgent.__init__ was called but reasoning_config was not passed — "
+        "regression of #18871 (review fork drops parent reasoning config)"
+    )
+    assert captured["reasoning_config"] == parent_reasoning
+
+
+def test_background_review_agent_inherits_none_reasoning_config():
+    """When the parent has no reasoning_config (None), the review agent must
+    receive None too — not be silently bound to a default. Pre-fix the kwarg
+    was missing entirely; post-fix it is present and equal to None."""
+    captured = _spawn_and_capture(None)
+    assert "reasoning_config" in captured
+    assert captured["reasoning_config"] is None

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -24,6 +24,8 @@ def _make_agent_stub(agent_cls):
     agent._skill_nudge_interval = 5
     agent.background_review_callback = None
     agent.status_callback = None
+    agent.reasoning_config = None
+    agent._credential_pool = None
     agent._MEMORY_REVIEW_PROMPT = "review memory"
     agent._SKILL_REVIEW_PROMPT = "review skills"
     agent._COMBINED_REVIEW_PROMPT = "review both"


### PR DESCRIPTION
## Issue

Closes #18871

## Root cause

`_spawn_background_review()` constructs a forked `AIAgent` with explicit inheritance of the parent's live runtime — `model`, `provider`, `api_mode`, `base_url`, `api_key`, `credential_pool`. The same call site was missing `reasoning_config`.

On Codex Responses transports the review fork therefore fell back to the transport default `{"effort": "medium", "summary": "auto"}`, even when the parent session was configured for `xhigh` reasoning. The user's configured effort was silently downgraded on every background memory/skill review pass — same class of bug as #16006 / #15884 / #13076 (other runtime fields that also had to be plumbed explicitly into the fork).

## Fix

Add `reasoning_config=self.reasoning_config` to the existing kwarg list on the `AIAgent(...)` call inside `_spawn_background_review`. Single-line code change next to the existing inheritance kwargs, with an inline comment pointing at #18871 and the prior-art issues for context.

## Tests

`tests/run_agent/test_background_review_reasoning_config.py` (new):

- `test_background_review_agent_inherits_reasoning_config` — pins the configured-effort case. A parent with `{"effort": "xhigh", "summary": "detailed"}` must propagate that exact dict to the review fork.
- `test_background_review_agent_inherits_none_reasoning_config` — pins the unconfigured case. None must be forwarded explicitly, not silently swapped for a transport default.

`tests/run_agent/test_background_review_toolset_restriction.py` (existing) — stub gains `reasoning_config = None` + `_credential_pool = None` so the spawn site can read the new attribute without an `AttributeError`. No behavior change to the existing test's assertions.

```
$ pytest tests/run_agent/test_background_review_*
12 passed in 0.55s
```