### PR TITLE
fix(run_agent): detect Kimi models on aggregator base URLs (#18742)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8505,10 +8505,23 @@ class AIAgent:
         )
         _is_nous = "nousresearch" in self._base_url_lower
         _is_nvidia = "integrate.api.nvidia.com" in self._base_url_lower
+        # Detect Kimi/Moonshot models routed through aggregators (synthetic.new,
+        # OpenRouter, Together, ...). Without the model-name branch, those
+        # routes miss the Kimi-specific max_tokens=32000 default and the
+        # reasoning_effort=medium hint, leaving the model with whatever tiny
+        # output budget the aggregator defaults to and free-running thinking
+        # mode that swallows the entire budget — visible response ends up
+        # empty (#18742). is_moonshot_model already recognizes the relevant
+        # slugs (hf:moonshotai/Kimi-K2.5, nous/moonshotai/kimi-k2.5, ...).
+        try:
+            from agent.moonshot_schema import is_moonshot_model as _is_moonshot
+        except Exception:  # pragma: no cover — optional helper
+            _is_moonshot = lambda _m: False  # noqa: E731
         _is_kimi = (
             base_url_host_matches(self.base_url, "api.kimi.com")
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
+            or _is_moonshot(self.model)
         )
         _is_tokenhub = base_url_host_matches(self._base_url_lower, "tokenhub.tencentmaas.com")
         _is_lmstudio = (self.provider or "").strip().lower() == "lmstudio"

--- a/tests/run_agent/test_kimi_aggregator_detection.py
+++ b/tests/run_agent/test_kimi_aggregator_detection.py
@@ -1,0 +1,54 @@
+"""Regression test for #18742.
+
+Kimi / Moonshot models routed through an aggregator base URL (synthetic.new,
+OpenRouter, Together, …) must still trigger the Kimi-specific output
+budget defaults — otherwise the agent emits empty responses on long agentic
+prompts because the aggregator's tiny default ``max_tokens`` is consumed
+entirely by Kimi's hidden reasoning before any visible token is produced.
+
+The fix wires ``is_moonshot_model`` (which already recognizes aggregator-
+prefixed slugs) into the ``_is_kimi`` runtime detection in
+``run_agent.AIAgent._build_api_kwargs`` so detection is no longer
+base-URL-only. This test pins that wiring.
+"""
+
+import inspect
+
+from agent.moonshot_schema import is_moonshot_model
+
+
+# is_moonshot_model has its own positive/negative tests in
+# tests/agent/test_moonshot_schema.py; the cases below are the *exact* slugs
+# the bug report calls out, asserted as a regression baseline so a future
+# change to is_moonshot_model that drops them will surface here too.
+def test_aggregator_prefixed_kimi_slugs_are_recognized_as_moonshot():
+    assert is_moonshot_model("hf:moonshotai/Kimi-K2.5") is True
+    assert is_moonshot_model("nous/moonshotai/kimi-k2.5") is True
+    assert is_moonshot_model("openrouter/moonshotai/kimi-k2.5") is True
+    # Bare slugs the existing flag path already covered should stay True.
+    assert is_moonshot_model("kimi-k2.5") is True
+    # Non-Moonshot model on an aggregator must still be False.
+    assert is_moonshot_model("openai/gpt-5") is False
+
+
+def test_build_api_kwargs_consults_is_moonshot_model_for_kimi_detection():
+    """The base-URL-only ``_is_kimi`` check missed every aggregator that
+    routes to Moonshot inference (#18742). The fix adds
+    ``is_moonshot_model(self.model)`` to the ``_is_kimi`` OR chain.
+
+    This is a source-level guard rather than a full integration test
+    because ``_build_api_kwargs`` is a 500+-line method whose other
+    branches require extensive agent state to exercise — the relevant
+    change is a single OR clause that we can verify is present.
+    """
+    import run_agent
+
+    src = inspect.getsource(run_agent.AIAgent._build_api_kwargs)
+    # Either the import alias or the imported name itself must appear inside
+    # the function body — we don't pin a single spelling.
+    assert "is_moonshot_model" in src or "_is_moonshot" in src, (
+        "regression #18742: _build_api_kwargs no longer references "
+        "is_moonshot_model — Kimi/Moonshot models routed through aggregator "
+        "base URLs will silently lose the max_tokens=32000 / "
+        "reasoning_effort=medium defaults and emit empty responses."
+    )


### PR DESCRIPTION
## Issue

Closes #18742

## Root cause

`_is_kimi` in `_build_api_kwargs` (run_agent.py:8516) was base-URL-only:

```python
_is_kimi = (
    base_url_host_matches(self.base_url, "api.kimi.com")
    or base_url_host_matches(self.base_url, "moonshot.ai")
    or base_url_host_matches(self.base_url, "moonshot.cn")
)
```

This missed every aggregator that routes to Moonshot inference (synthetic.new, OpenRouter, Together, …). The downstream Kimi defaults (`max_tokens=32000`, `reasoning_effort=medium`) therefore didn't apply on aggregator routes. Kimi K2.5's hidden reasoning mode then consumed the entire (tiny aggregator-default) output budget before producing any visible token, so the response came back empty with `finish_reason: length`. The retry path treated it as a truncated tool call → "refusing to execute incomplete tool arguments" → cron jobs reported `Agent completed but produced empty response`.

## Fix

`agent.moonshot_schema.is_moonshot_model` already recognizes the aggregator-prefixed slugs the bug report names (`hf:moonshotai/Kimi-K2.5`, `nous/moonshotai/kimi-k2.5`, `openrouter/moonshotai/...`) and is used elsewhere in the chat-completions transport to sanitize tool schemas. Wire it into the `_is_kimi` OR chain so detection is consistent.

The lazy import is wrapped in a `try/except` with a no-op fallback so a tree-shaken install missing the helper doesn't break agent startup. The new branch is purely additive — existing base-URL matches still succeed.

This is the exact `diff` shape the issue body proposed.

## Tests

- `test_aggregator_prefixed_kimi_slugs_are_recognized_as_moonshot` — pins the slug-recognition baseline (the bug report's exact slugs plus negative cases).
- `test_build_api_kwargs_consults_is_moonshot_model_for_kimi_detection` — source-level guard that flags any future regression that drops the model-name branch from `_build_api_kwargs`. (`_build_api_kwargs` is a ~500-line method whose other branches need extensive agent state to exercise; this guard is the lightest credible regression test for a one-line fix.)

```
$ pytest tests/run_agent/test_kimi_aggregator_detection.py tests/agent/test_moonshot_schema.py
36 passed in 0.66s
```