### PR TITLE
feat(agent): implement minimal conservative smart-2-tier model routing

### DIFF
--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -1,0 +1,86 @@
+"""Conservative smart-primary model routing decisions.
+
+This module is intentionally pure: no SDK imports, network calls, or config file
+reads. Runtime code passes a single turn and the smart_model_routing config in,
+and receives a small decision object.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    target: str  # "primary" or "cheap"
+    reason: str
+
+
+_CODE_OR_COMPLEX_PATTERNS = (
+    r"```",
+    r"\b(traceback|exception|stack trace|error|debug|bug|fix|failing|failed)\b",
+    r"\b(git|github|pr|issue|commit|branch|diff|patch|test|pytest|npm|pnpm|uv|pip)\b",
+    r"\b(docker|compose|deploy|server|service|systemd|nginx|caddy|kubernetes|k8s)\b",
+    r"\b(api|endpoint|database|sql|redis|mongodb|postgres|schema|migration)\b",
+    r"\b(refactor|implement|modify|edit|write code|run|execute|terminal|file)\b",
+    r"(修改|修复|调试|报错|错误|代码|运行|执行|部署|接口|数据库|提交|分支|测试|文件|项目)",
+)
+
+_MULTI_STEP_PATTERNS = (
+    r"\b(first|then|next|finally|step by step)\b",
+    r"(先.+再|然后|接着|最后|分步骤|一步步)",
+)
+
+
+def _word_count(text: str) -> int:
+    # Whitespace-delimited words for Latin text plus a rough CJK fallback.
+    latin_words = re.findall(r"[A-Za-z0-9_]+", text)
+    cjk_chars = re.findall(r"[\u4e00-\u9fff]", text)
+    return len(latin_words) + max(1, len(cjk_chars) // 2) if cjk_chars else len(latin_words)
+
+
+def _enabled(cfg: Mapping[str, Any]) -> bool:
+    return bool(isinstance(cfg, Mapping) and cfg.get("enabled") is True)
+
+
+def _cheap_model(cfg: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    cheap = cfg.get("cheap_model") if isinstance(cfg, Mapping) else None
+    if isinstance(cheap, Mapping) and cheap.get("provider") and cheap.get("model"):
+        return cheap
+    return None
+
+
+def decide_route(user_message: str, cfg: Mapping[str, Any] | None) -> RouteDecision:
+    """Return whether a turn should use the primary or configured cheap model.
+
+    The classifier is deliberately conservative: it only routes short,
+    standalone, plain-text turns to cheap_model. Anything tool-like, code-like,
+    long, multi-step, or context-heavy stays on primary.
+    """
+    if not isinstance(cfg, Mapping) or not _enabled(cfg):
+        return RouteDecision("primary", "disabled")
+    if _cheap_model(cfg) is None:
+        return RouteDecision("primary", "missing_cheap_model")
+    if not isinstance(user_message, str) or not user_message.strip():
+        return RouteDecision("primary", "empty")
+
+    text = user_message.strip()
+    max_chars = int(cfg.get("max_simple_chars") or 160)
+    max_words = int(cfg.get("max_simple_words") or 28)
+
+    if len(text) > max_chars:
+        return RouteDecision("primary", "too_long_chars")
+    if _word_count(text) > max_words:
+        return RouteDecision("primary", "too_long_words")
+
+    lowered = text.lower()
+    for pattern in _CODE_OR_COMPLEX_PATTERNS + _MULTI_STEP_PATTERNS:
+        if re.search(pattern, lowered, flags=re.IGNORECASE):
+            return RouteDecision("primary", "complex_marker")
+
+    if text.count("?") + text.count("？") > 1:
+        return RouteDecision("primary", "multi_question")
+
+    return RouteDecision("cheap", "short_plain_text")

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -387,6 +387,13 @@ DEFAULT_CONFIG = {
     "model": "",
     "providers": {},
     "fallback_providers": [],
+    "smart_model_routing": {
+        "enabled": False,
+        "mode": "smart-primary",
+        "max_simple_chars": 160,
+        "max_simple_words": 28,
+        "cheap_model": {},
+    },
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
     "agent": {
@@ -2792,7 +2799,7 @@ def check_config_version() -> Tuple[int, int]:
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
-    "fallback_providers", "credential_pool_strategies", "toolsets",
+    "fallback_providers", "smart_model_routing", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
     "sessions",

--- a/run_agent.py
+++ b/run_agent.py
@@ -952,6 +952,7 @@ class AIAgent:
         parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
         fallback_model: Dict[str, Any] = None,
+        smart_model_routing: Dict[str, Any] = None,
         credential_pool=None,
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 50,
@@ -1032,6 +1033,13 @@ class AIAgent:
         self.load_soul_identity = load_soul_identity
         self.pass_session_id = pass_session_id
         self._credential_pool = credential_pool
+        if smart_model_routing is None:
+            try:
+                from hermes_cli.config import load_config
+                smart_model_routing = (load_config() or {}).get("smart_model_routing") or {}
+            except Exception:
+                smart_model_routing = {}
+        self._smart_model_routing = dict(smart_model_routing or {})
         self.log_prefix_chars = log_prefix_chars
         self.log_prefix = f"{log_prefix} " if log_prefix else ""
         # Store effective base URL for feature detection (prompt caching, reasoning, etc.)
@@ -7486,6 +7494,174 @@ class AIAgent:
             raise result["error"]
         return result["response"]
 
+    # ── Smart model routing ────────────────────────────────────────────────
+
+    @staticmethod
+    def _resolve_model_target_api_key(target: Dict[str, Any]) -> str | None:
+        """Resolve api_key/key_env from a model target config."""
+        api_key = (target.get("api_key") or "").strip()
+        if api_key.startswith("${") and api_key.endswith("}"):
+            api_key = os.getenv(api_key[2:-1], "").strip()
+        if not api_key:
+            key_env = (target.get("key_env") or "").strip()
+            if key_env:
+                api_key = os.getenv(key_env, "").strip()
+        return api_key or None
+
+    def _apply_model_target_for_turn(self, target: Dict[str, Any], *, reason: str) -> bool:
+        """Temporarily swap runtime to a target model for the current turn.
+
+        Mirrors the provider/client bookkeeping used by fallback, but does not
+        advance the fallback chain. ``_fallback_activated`` is intentionally set
+        so the existing start-of-next-turn restoration path returns to primary.
+        """
+        target_provider = (target.get("provider") or "").strip().lower()
+        target_model = (target.get("model") or "").strip()
+        if not target_provider or not target_model:
+            return False
+
+        try:
+            from agent.auxiliary_client import resolve_provider_client
+            from hermes_cli.model_normalize import normalize_model_for_provider
+
+            target_base_url = (target.get("base_url") or "").strip() or None
+            target_api_key = self._resolve_model_target_api_key(target)
+            target_client, _resolved_model = resolve_provider_client(
+                target_provider,
+                model=target_model,
+                raw_codex=True,
+                explicit_base_url=target_base_url,
+                explicit_api_key=target_api_key,
+            )
+            if target_client is None:
+                logging.warning(
+                    "Smart model routing target unavailable: %s/%s",
+                    target_provider,
+                    target_model,
+                )
+                return False
+
+            target_model = normalize_model_for_provider(target_model, target_provider)
+            target_base_url = str(target_client.base_url)
+            target_api_mode = (target.get("api_mode") or "").strip()
+            if not target_api_mode:
+                target_api_mode = "chat_completions"
+                if target_provider == "openai-codex":
+                    target_api_mode = "codex_responses"
+                elif target_provider == "anthropic" or target_base_url.rstrip("/").lower().endswith("/anthropic"):
+                    target_api_mode = "anthropic_messages"
+                elif self._is_azure_openai_url(target_base_url):
+                    target_api_mode = "chat_completions"
+                elif self._is_direct_openai_url(target_base_url):
+                    target_api_mode = "codex_responses"
+                elif self._provider_model_requires_responses_api(
+                    target_model,
+                    provider=target_provider,
+                ):
+                    target_api_mode = "codex_responses"
+                elif target_provider == "bedrock" or (
+                    base_url_hostname(target_base_url).startswith("bedrock-runtime.")
+                    and base_url_host_matches(target_base_url, "amazonaws.com")
+                ):
+                    target_api_mode = "bedrock_converse"
+
+            old_model = self.model
+            self.model = target_model
+            self.provider = target_provider
+            self.base_url = target_base_url
+            self.api_mode = target_api_mode
+            if hasattr(self, "_transport_cache"):
+                self._transport_cache.clear()
+            self._fallback_activated = True
+
+            timeout = get_provider_request_timeout(target_provider, target_model)
+            if target_api_mode == "anthropic_messages":
+                from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token, _is_oauth_token
+                effective_key = (target_client.api_key or resolve_anthropic_token() or "") if target_provider == "anthropic" else (target_client.api_key or "")
+                self.api_key = effective_key
+                self._anthropic_api_key = effective_key
+                self._anthropic_base_url = target_base_url
+                self._anthropic_client = build_anthropic_client(
+                    effective_key,
+                    self._anthropic_base_url,
+                    timeout=timeout,
+                )
+                self._is_anthropic_oauth = _is_oauth_token(effective_key) if target_provider == "anthropic" else False
+                self.client = None
+                self._client_kwargs = {}
+            else:
+                self.api_key = target_client.api_key
+                self.client = target_client
+                headers = getattr(target_client, "_custom_headers", None) or getattr(target_client, "default_headers", None)
+                self._client_kwargs = {
+                    "api_key": target_client.api_key,
+                    "base_url": target_base_url,
+                    **({"default_headers": dict(headers)} if headers else {}),
+                }
+                if timeout is not None:
+                    self._client_kwargs["timeout"] = timeout
+                    self._replace_primary_openai_client(reason="smart_routing_timeout_apply")
+
+            self._use_prompt_caching, self._use_native_cache_layout = (
+                self._anthropic_prompt_cache_policy(
+                    provider=target_provider,
+                    base_url=target_base_url,
+                    api_mode=target_api_mode,
+                    model=target_model,
+                )
+            )
+
+            if hasattr(self, "context_compressor") and self.context_compressor:
+                from agent.model_metadata import get_model_context_length
+                context_length = get_model_context_length(
+                    self.model,
+                    base_url=self.base_url,
+                    api_key=self.api_key,
+                    provider=self.provider,
+                    config_context_length=getattr(self, "_config_context_length", None),
+                )
+                self.context_compressor.update_model(
+                    model=self.model,
+                    context_length=context_length,
+                    base_url=self.base_url,
+                    api_key=getattr(self, "api_key", ""),
+                    provider=self.provider,
+                )
+
+            logging.info(
+                "Smart model routing activated: %s -> %s (%s), reason=%s",
+                old_model,
+                target_model,
+                target_provider,
+                reason,
+            )
+            return True
+        except Exception as e:
+            logging.warning("Smart model routing failed for %s: %s", target_model, e)
+            return False
+
+    def _maybe_apply_smart_routing(self, user_message: str) -> bool:
+        """Route simple turns to cheap_model when smart_model_routing is enabled."""
+        cfg = getattr(self, "_smart_model_routing", {}) or {}
+        try:
+            from agent.smart_model_routing import decide_route
+
+            decision = decide_route(user_message, cfg)
+            logging.debug(
+                "Smart model routing decision: target=%s reason=%s",
+                decision.target,
+                decision.reason,
+            )
+            if decision.target != "cheap":
+                return False
+            cheap = cfg.get("cheap_model") if isinstance(cfg, dict) else None
+            if not isinstance(cheap, dict):
+                return False
+            return self._apply_model_target_for_turn(cheap, reason=decision.reason)
+        except Exception as e:
+            logging.debug("Smart model routing skipped: %s", e)
+            return False
+
     # ── Provider fallback ──────────────────────────────────────────────────
 
     def _try_activate_fallback(self, reason: "FailoverReason | None" = None) -> bool:
@@ -10430,6 +10606,8 @@ class AIAgent:
             user_message = _sanitize_surrogates(user_message)
         if isinstance(persist_user_message, str):
             persist_user_message = _sanitize_surrogates(persist_user_message)
+
+        self._maybe_apply_smart_routing(user_message)
 
         # Store stream callback for _interruptible_api_call to pick up
         self._stream_callback = stream_callback

--- a/tests/run_agent/test_smart_model_routing.py
+++ b/tests/run_agent/test_smart_model_routing.py
@@ -1,0 +1,109 @@
+"""Tests for conservative two-tier smart model routing."""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+from agent.smart_model_routing import decide_route
+
+
+def _make_agent(smart_model_routing=None):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            provider="openai-codex",
+            model="gpt-5.5",
+            api_key="primary-key",
+            base_url="https://chatgpt.com/backend-api/codex",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            smart_model_routing=smart_model_routing,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+def _mock_client(base_url="https://cheap.example/v1", api_key="cheap-key"):
+    mock = MagicMock()
+    mock.base_url = base_url
+    mock.api_key = api_key
+    return mock
+
+
+class TestSmartRoutingDecision:
+    def test_short_plain_text_routes_to_cheap_model(self):
+        cfg = {
+            "enabled": True,
+            "max_simple_chars": 160,
+            "max_simple_words": 28,
+            "cheap_model": {"provider": "custom", "model": "minimax-m2.5"},
+        }
+
+        decision = decide_route("你好，简单介绍一下你自己", cfg)
+
+        assert decision.target == "cheap"
+        assert decision.reason == "short_plain_text"
+
+    def test_code_and_tool_like_tasks_stay_primary(self):
+        cfg = {
+            "enabled": True,
+            "max_simple_chars": 400,
+            "max_simple_words": 80,
+            "cheap_model": {"provider": "custom", "model": "minimax-m2.5"},
+        }
+
+        assert decide_route("帮我修改 run_agent.py 并运行测试", cfg).target == "primary"
+        assert decide_route("```python\nprint('hi')\n```", cfg).target == "primary"
+
+
+class TestSmartRoutingRuntime:
+    def test_simple_turn_temporarily_switches_to_cheap_model(self):
+        cfg = {
+            "enabled": True,
+            "max_simple_chars": 160,
+            "max_simple_words": 28,
+            "cheap_model": {
+                "provider": "custom",
+                "model": "minimax-m2.5",
+                "base_url": "https://cheap.example/v1",
+                "api_key": "cheap-key",
+            },
+        }
+        agent = _make_agent(cfg)
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "minimax-m2.5"),
+        ) as mock_rpc:
+            assert agent._maybe_apply_smart_routing("你好") is True
+
+        assert mock_rpc.call_args.kwargs["explicit_base_url"] == "https://cheap.example/v1"
+        assert mock_rpc.call_args.kwargs["explicit_api_key"] == "cheap-key"
+        assert agent.model == "minimax-m2.5"
+        assert agent.provider == "custom"
+        assert agent._fallback_activated is True
+
+    def test_complex_turn_stays_on_primary(self):
+        cfg = {
+            "enabled": True,
+            "cheap_model": {"provider": "custom", "model": "minimax-m2.5"},
+        }
+        agent = _make_agent(cfg)
+
+        with patch("agent.auxiliary_client.resolve_provider_client") as mock_rpc:
+            assert agent._maybe_apply_smart_routing("帮我 debug 这个 traceback 并修改代码") is False
+
+        mock_rpc.assert_not_called()
+        assert agent.model == "gpt-5.5"
+        assert agent.provider == "openai-codex"
+
+    def test_disabled_config_does_nothing(self):
+        agent = _make_agent({"enabled": False})
+
+        with patch("agent.auxiliary_client.resolve_provider_client") as mock_rpc:
+            assert agent._maybe_apply_smart_routing("你好") is False
+
+        mock_rpc.assert_not_called()


### PR DESCRIPTION
## Summary

Implements a conservative two-tier smart model routing path that automatically routes simple text-only turns to a configured cheap model while keeping complex turns on the primary model.

Related issues: Fixes #16211, addresses #16525.

## Changes

- `agent/smart_model_routing.py` (new): conservative routing decision logic.
- `run_agent.py`: turn-level routing injection and temporary runtime model swap.
- `hermes_cli/config.py`: default config and root-key validation for `smart_model_routing`.
- `tests/run_agent/test_smart_model_routing.py` (new): unit tests for decisions and runtime switching.

## Behavior

- Simple tasks: short plain text under the configured thresholds routes to `cheap_model`.
- Complex tasks: code blocks, tool-like requests, debugging, file edits, installs, tests, and long text stay on the primary model.
- Per-turn isolation: cheap routing applies only to the current turn; the next turn restores the primary runtime.
- Graceful fallback: if the cheap model target is unavailable or incomplete, the turn continues on the primary model.

## Configuration

```yaml
smart_model_routing:
  enabled: true
  max_simple_chars: 160
  max_simple_words: 28
  cheap_model:
    provider: custom
    model: MiniMax-M2.5
    base_url: https://api.example.com/v1
    api_key: ${CHEAP_MODEL_API_KEY}
```

## Test Plan

- [x] `python -m pytest tests/run_agent/test_smart_model_routing.py`
- [x] `python -m pytest tests/run_agent/test_smart_model_routing.py tests/run_agent/test_provider_fallback.py tests/run_agent/test_fallback_model.py tests/hermes_cli/test_config.py tests/hermes_cli/test_config_validation.py -q` — 125 passed locally.
- [x] `python -m py_compile run_agent.py agent/smart_model_routing.py hermes_cli/config.py`
- [x] Local gateway smoke test confirmed routing activation and restoration:

```text
Smart model routing activated: gpt-5.5 -> MiniMax-M2.5 (custom), reason=short_plain_text
Primary runtime restored for new turn: gpt-5.5 (openai-codex)
```
