### PR TITLE
fix(update): drop pip --quiet so slow installs don't look hung

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6450,10 +6450,21 @@ def _install_python_dependencies_with_optional_fallback(
     *,
     env: dict[str, str] | None = None,
 ) -> None:
-    """Install base deps plus as many optional extras as the environment supports."""
+    """Install base deps plus as many optional extras as the environment supports.
+
+    We intentionally do NOT pass ``--quiet`` to pip. On platforms without
+    prebuilt wheels for some extras (Termux/Android aarch64, older musl
+    distros, fresh Raspberry Pi) pip has to compile C/Rust extensions from
+    source, which can take several minutes with zero network activity.
+    Without progress output the call looks like a hang and users Ctrl+C it.
+    Pip's default output is proportional to actual work (one line per
+    Collecting/Building/Installing step), so keeping it visible costs
+    nothing on fast hardware and prevents the "hermes update hangs" reports
+    on slow hardware.
+    """
     try:
         subprocess.run(
-            install_cmd_prefix + ["install", "-e", ".[all]", "--quiet"],
+            install_cmd_prefix + ["install", "-e", ".[all]"],
             cwd=PROJECT_ROOT,
             check=True,
             env=env,
@@ -6465,7 +6476,7 @@ def _install_python_dependencies_with_optional_fallback(
         )
 
     subprocess.run(
-        install_cmd_prefix + ["install", "-e", ".", "--quiet"],
+        install_cmd_prefix + ["install", "-e", "."],
         cwd=PROJECT_ROOT,
         check=True,
         env=env,
@@ -6476,7 +6487,7 @@ def _install_python_dependencies_with_optional_fallback(
     for extra in _load_installable_optional_extras():
         try:
             subprocess.run(
-                install_cmd_prefix + ["install", "-e", f".[{extra}]", "--quiet"],
+                install_cmd_prefix + ["install", "-e", f".[{extra}]"],
                 cwd=PROJECT_ROOT,
                 check=True,
                 env=env,


### PR DESCRIPTION
## Summary
`hermes update` no longer looks hung during the pip step on slow hardware. Dropping `pip install --quiet` restores the Collecting/Building/Installing progress lines pip emits by default.

## Root cause
On Termux/Android aarch64 (and other platforms missing prebuilt wheels for some optional extras), `pip install -e .[all] --quiet` can run for several minutes compiling C/Rust from source with zero stdout. Users see "→ Updating Python dependencies…", phone heats up, nothing prints for 5+ min, they Ctrl+C. Re-running says "up to date" because `git pull` already succeeded in the previous run.

## Changes
- `hermes_cli/main.py`: remove `--quiet` from the 3 `pip install` invocations inside `_install_python_dependencies_with_optional_fallback()` (covers both `uv pip` and `python -m pip` paths, and all three fallback branches — `.[all]`, base, individual extras).
- Docstring documents why we don't want `--quiet` here.

## Validation
| | Before | After |
|---|---|---|
| Fast hardware, wheels cached | 1 line, near-instant | A few `Requirement already satisfied` lines, same speed |
| Termux, compiling from source | Silent for 5+ min, user Ctrl+Cs | Per-step progress, user knows to wait |

Supersedes #20466, which misdiagnosed the hang as `PYTHONPATH` shadowing. `install.sh` isn't invoked by `hermes update`, and `terminal()` doesn't inherit `PYTHONPATH` (only `execute_code` sandbox subprocesses do, per `tools/code_execution_tool.py:1063`).

Reported via Discord by LikiusInik on Termux/Android. Debug dump: https://paste.rs/Rzn5c