### PR TITLE
Rename Telegram topics from /title

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10071,6 +10071,12 @@ class GatewayRunner:
             # Set the title
             try:
                 if self._session_db.set_session_title(session_id, sanitized):
+                    if self._is_telegram_topic_lane(source):
+                        self._schedule_telegram_topic_title_rename(
+                            source,
+                            session_id,
+                            sanitized,
+                        )
                     return f"✏️ Session title set: **{sanitized}**"
                 else:
                     return "Session not found in database."

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -72,6 +72,28 @@ class TestHandleTitleCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_set_title_renames_telegram_topic_lane(self, tmp_path):
+        """Setting /title inside a Telegram topic also requests a topic rename."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+
+        runner = _make_runner(session_db=db)
+        runner._is_telegram_topic_lane = MagicMock(return_value=True)
+        runner._schedule_telegram_topic_title_rename = MagicMock()
+        event = _make_event(text="/title Topic Display Name")
+        result = await runner._handle_title_command(event)
+
+        assert "Topic Display Name" in result
+        assert db.get_session_title("test_session_123") == "Topic Display Name"
+        runner._schedule_telegram_topic_title_rename.assert_called_once_with(
+            event.source,
+            "test_session_123",
+            "Topic Display Name",
+        )
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_show_title_when_set(self, tmp_path):
         """Showing title when one is set returns the title."""
         from hermes_state import SessionDB


### PR DESCRIPTION
## Summary
- call the existing Telegram topic rename scheduler when `/title <name>` succeeds inside a Telegram topic lane
- keep non-topic and non-Telegram title behavior unchanged
- add regression coverage for the manual `/title` path

## Context
Related to #16255 and the existing broader Telegram topic title sync PRs (#14462, #16408, #9921). This PR is intentionally narrow: it only wires the already-existing manual `/title` command path to the existing Telegram topic rename helper on `main`.

## Testing
- `/Users/tleo/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_title_command.py -q`
- `/Users/tleo/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/run.py tests/gateway/test_title_command.py`
