### PR TITLE
fix(ui+tui): stabilize spinner/ticker width to reduce status-line jitter

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2589,9 +2589,12 @@ class HermesCLI:
             elapsed = time.monotonic() - t0
             if elapsed >= 60:
                 _m, _s = int(elapsed // 60), int(elapsed % 60)
-                elapsed_str = f"{_m}m {_s}s"
+                # Fixed-width timer to avoid status-line wrap jitter while
+                # scrolling/repainting (e.g. 01m05s, 12m09s).
+                elapsed_str = f"{_m:02d}m{_s:02d}s"
             else:
-                elapsed_str = f"{elapsed:.1f}s"
+                # Keep width stable before the 60s rollover as well.
+                elapsed_str = f"{elapsed:5.1f}s"
             return f"  {txt}  ({elapsed_str})"
         return f"  {txt}"
 

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -243,6 +244,24 @@ class TestCLIStatusBar:
         cli_obj._tool_start_time = 0
 
         assert cli_obj._spinner_widget_height(width=64) == 2
+
+    def test_spinner_elapsed_format_is_fixed_width_to_reduce_wrap_jitter(self):
+        cli_obj = _make_cli()
+        cli_obj._spinner_text = "running tool"
+
+        # <60s path
+        cli_obj._tool_start_time = time.monotonic() - 9.2
+        short = cli_obj._render_spinner_text()
+
+        # >=60s path
+        cli_obj._tool_start_time = time.monotonic() - 65.2
+        long = cli_obj._render_spinner_text()
+
+        short_elapsed = short.split("(", 1)[1].rstrip(")")
+        long_elapsed = long.split("(", 1)[1].rstrip(")")
+
+        assert len(short_elapsed) == len(long_elapsed)
+        assert "m" in long_elapsed and "s" in long_elapsed
 
     def test_voice_status_bar_compacts_on_narrow_terminals(self):
         cli_obj = _make_cli()

--- a/ui-tui/src/__tests__/statusBarTicker.test.ts
+++ b/ui-tui/src/__tests__/statusBarTicker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { padVerb, VERB_PAD_LEN } from '../components/appChrome.js'
+import { DURATION_PAD_LEN, padTickerDuration, padVerb, VERB_PAD_LEN } from '../components/appChrome.js'
 import { VERBS } from '../content/verbs.js'
 
 describe('FaceTicker verb padding', () => {
@@ -14,5 +14,14 @@ describe('FaceTicker verb padding', () => {
     for (const verb of VERBS) {
       expect(padVerb(verb).startsWith(`${verb}…`)).toBe(true)
     }
+  })
+})
+
+describe('FaceTicker duration padding', () => {
+  it('keeps elapsed segment width stable across second/minute boundaries', () => {
+    const samples = [9000, 10000, 59000, 60000, 61000, 3599000]
+    const lens = samples.map(ms => padTickerDuration(ms).length)
+
+    expect(new Set(lens)).toEqual(new Set([DURATION_PAD_LEN]))
   })
 })

--- a/ui-tui/src/__tests__/statusBarTicker.test.ts
+++ b/ui-tui/src/__tests__/statusBarTicker.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { padVerb, VERB_PAD_LEN } from '../components/appChrome.js'
+import { VERBS } from '../content/verbs.js'
+
+describe('FaceTicker verb padding', () => {
+  it('pads every verb to the same width', () => {
+    for (const verb of VERBS) {
+      expect(padVerb(verb)).toHaveLength(VERB_PAD_LEN)
+    }
+  })
+
+  it('keeps trailing ellipsis attached', () => {
+    for (const verb of VERBS) {
+      expect(padVerb(verb).startsWith(`${verb}…`)).toBe(true)
+    }
+  })
+})

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -110,7 +110,11 @@ function FaceTicker({ color, startedAt }: { color: string; startedAt?: null | nu
   const { frame } = renderIndicator(style, tick)
   const verb = VERBS[verbTick % VERBS.length] ?? ''
   const verbSegment = showVerb ? ` ${padVerb(verb)}` : ''
-  const durationSegment = startedAt ? `· ${padTickerDuration(now - startedAt)}` : ''
+  // Leading space keeps a gap between the frame and the duration when the
+  // verb segment is hidden (e.g. `unicode` spinner style).  When the verb
+  // IS shown, its trailing padding already provides the gap, so the extra
+  // space is harmless.
+  const durationSegment = startedAt ? ` · ${padTickerDuration(now - startedAt)}` : ''
 
   return (
     <Text color={color}>

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -23,7 +23,9 @@ const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
 // Keep verb segment width stable so status-bar content to the right doesn't
 // jitter when the ticker rotates between short/long verbs.
 export const VERB_PAD_LEN = VERBS.reduce((max, v) => Math.max(max, v.length), 0) + 1 // + ellipsis
+export const DURATION_PAD_LEN = 7 // e.g. "  9s", "1m 05s", "59m 59s"
 export const padVerb = (verb: string) => `${verb}…`.padEnd(VERB_PAD_LEN, ' ')
+export const padTickerDuration = (ms: number) => fmtDuration(ms).padStart(DURATION_PAD_LEN, ' ')
 
 // Compact alternates for the `emoji` and `ascii` indicator styles.
 // Each entry is a fixed-width (display-width) glyph.
@@ -108,7 +110,7 @@ function FaceTicker({ color, startedAt }: { color: string; startedAt?: null | nu
   const { frame } = renderIndicator(style, tick)
   const verb = VERBS[verbTick % VERBS.length] ?? ''
   const verbSegment = showVerb ? ` ${padVerb(verb)}` : ''
-  const durationSegment = startedAt ? `· ${fmtDuration(now - startedAt)}` : ''
+  const durationSegment = startedAt ? `· ${padTickerDuration(now - startedAt)}` : ''
 
   return (
     <Text color={color}>

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -20,6 +20,11 @@ import type { Msg, Usage } from '../types.js'
 const FACE_TICK_MS = 2500
 const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
 
+// Keep verb segment width stable so status-bar content to the right doesn't
+// jitter when the ticker rotates between short/long verbs.
+export const VERB_PAD_LEN = VERBS.reduce((max, v) => Math.max(max, v.length), 0) + 1 // + ellipsis
+export const padVerb = (verb: string) => `${verb}…`.padEnd(VERB_PAD_LEN, ' ')
+
 // Compact alternates for the `emoji` and `ascii` indicator styles.
 // Each entry is a fixed-width (display-width) glyph.
 const EMOJI_FRAMES = ['⚕ ', '🌀', '🤔', '✨', '🍵', '🔮']
@@ -102,8 +107,8 @@ function FaceTicker({ color, startedAt }: { color: string; startedAt?: null | nu
 
   const { frame } = renderIndicator(style, tick)
   const verb = VERBS[verbTick % VERBS.length] ?? ''
-  const verbSegment = showVerb ? ` ${verb}…` : ''
-  const durationSegment = startedAt ? ` · ${fmtDuration(now - startedAt)}` : ''
+  const verbSegment = showVerb ? ` ${padVerb(verb)}` : ''
+  const durationSegment = startedAt ? `· ${fmtDuration(now - startedAt)}` : ''
 
   return (
     <Text color={color}>


### PR DESCRIPTION
Salvages the UI/TUI portions of #20466 onto current main. Original PR bundled these with an unrelated install.sh change under a misleading title; the install.sh half is in #20680, this is everything else.

## Summary
Make the spinner elapsed timer (classic CLI) and the FaceTicker verb + duration (TUI) fixed-width so the status line to the right doesn't shift every tick.

## Changes
- `cli.py`: elapsed timer formats as `  9.2s` / `01m05s` (both 6 chars) instead of `9.2s` → `1m 5s` (variable width).
- `ui-tui/src/components/appChrome.tsx`:
  - `padVerb` pads every verb in `VERBS` to the longest verb + ellipsis.
  - `padTickerDuration` right-pads `fmtDuration` output to 7 chars (covers up to 100+ hours).
  - `VERB_PAD_LEN` / `DURATION_PAD_LEN` exported for tests.
- Follow-up: put a space back in `durationSegment` (original author dropped it, but the unicode spinner style hides the verb segment entirely and would have lost the gap between frame and middot).
- Python + TS regression tests for width stability.

## Validation
- `scripts/run_tests.sh tests/cli/test_cli_status_bar.py` → 27/27 pass.
- TS assertions verified manually: `fmtDuration` max output is `59m 59s` = 7 chars; `100h 0m` edge case still 7 chars; `padTickerDuration` produces stable-length output across `[9s, 10s, 59s, 60s, 61s, 3599s]`.
- Didn't run vitest — worktree npm deps not installed. Tests are straightforward length assertions on pure functions.

## Notes
- This does NOT fix the prompt_toolkit input-bar-jumps-up bug on Termux that the Discord thread was originally about. That's a separate issue (the classic CLI input widget repositioning when the Android keyboard opens/closes) and is still open. These changes reduce a different, smaller class of jitter — status-bar width changes causing the line to wrap/unwrap during repaints.

Credits @adybag14-cyber — cherry-picked onto current main with authorship preserved.

Closes the UI portion of #20466.