### PR TITLE
fix(acp): persist empty history updates

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -1002,7 +1002,7 @@ class HermesACPAgent(acp.Agent):
                 state.current_prompt_text = ""
             return PromptResponse(stop_reason="end_turn")
 
-        if result.get("messages"):
+        if "messages" in result:
             state.history = result["messages"]
             # Persist updated history so sessions survive process restarts.
             self.session_manager.save_session(session_id)

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -656,6 +656,34 @@ class TestPrompt:
         assert state.history == expected_history
 
     @pytest.mark.asyncio
+    async def test_prompt_clears_history_for_empty_messages(self, agent):
+        """An explicit empty messages list should replace and persist prior history."""
+        new_resp = await agent.new_session(cwd=".")
+        state = agent.session_manager.get_session(new_resp.session_id)
+        state.history = [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+        ]
+        state.agent.run_conversation = MagicMock(return_value={
+            "final_response": "history cleared",
+            "messages": [],
+        })
+        agent.session_manager.save_session = MagicMock(
+            wraps=agent.session_manager.save_session
+        )
+
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        prompt = [TextContentBlock(type="text", text="reset this history")]
+        await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
+
+        assert state.history == []
+        agent.session_manager.save_session.assert_called_once_with(new_resp.session_id)
+
+
+    @pytest.mark.asyncio
     async def test_prompt_sends_final_message_update(self, agent):
         """The final response should be sent as an AgentMessageChunk."""
         new_resp = await agent.new_session(cwd=".")


### PR DESCRIPTION
## What does this PR do?

Fixes ACP prompt history persistence when `run_conversation()` returns an explicit empty `messages` list.

Before this change, ACP only saved history when `result.get("messages")` was truthy. That meant `messages=[]` was treated the same as a missing field, so stale prior `state.history` could remain in memory and avoid persistence even though the agent returned an explicit empty history.

This PR treats key presence as the update signal, so an empty list clears history and is persisted.

## Related Issue

No issue found. This is a focused runtime correctness fix from current-main inspection.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `acp_adapter/server.py`: save history when `messages` is present in the result, including `[]`.
- `tests/acp/test_server.py`: add a regression test that starts with non-empty history, returns `messages=[]`, and verifies history is cleared and `save_session()` is called.

## How to Test

1. Run:
   ```bash
   uv run --extra acp --extra dev pytest -o addopts= tests/acp/test_server.py::TestPrompt::test_prompt_clears_history_for_empty_messages tests/acp/test_server.py::TestPrompt::test_prompt_updates_history tests/acp/test_server.py::TestPrompt::test_prompt_sends_final_message_update -q
   ```
2. Confirm the focused ACP prompt tests pass.

Result: `3 passed` locally.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS local checkout

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update N/A
- [x] Cross-platform impact considered: pure Python ACP session state handling
- [x] Tool descriptions/schemas update N/A
