### PR TITLE
fix: pass sessions_dir to delete_session in web API endpoint (#20334)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2206,7 +2206,8 @@ async def delete_session_endpoint(session_id: str):
     from hermes_state import SessionDB
     db = SessionDB()
     try:
-        if not db.delete_session(session_id):
+        sessions_dir = get_hermes_home() / "sessions"
+        if not db.delete_session(session_id, sessions_dir=sessions_dir):
             raise HTTPException(status_code=404, detail="Session not found")
         return {"ok": True}
     finally:


### PR DESCRIPTION
## Summary

Fixes #20334

The `DELETE /api/sessions/{session_id}` endpoint in `hermes_cli/web_server.py` calls `db.delete_session(session_id)` **without** passing `sessions_dir`, so on-disk transcript files (`.jsonl`, `.json`, `request_dump_*`) are never cleaned up when sessions are deleted via the web dashboard API.

The CLI (`hermes_cli/main.py:9853`) and TUI gateway (`tui_gateway/server.py:2178`) both pass `sessions_dir` correctly — only the web API path was missing it.

## Fix

```python
# Before:
if not db.delete_session(session_id):

# After:
sessions_dir = get_hermes_home() / "sessions"
if not db.delete_session(session_id, sessions_dir=sessions_dir):
```

`get_hermes_home()` is already imported in `web_server.py` (line 41).

## Root Cause

`SessionDB.delete_session()` accepts an optional `sessions_dir` parameter. When `None` (the default), `_remove_session_files()` returns early without deleting anything. The CLI and TUI callers both resolve and pass the sessions directory, but the web API endpoint did not.

## Testing

- Verified that `get_hermes_home` is already imported in `web_server.py`
- Verified the fix matches the pattern used by CLI and TUI callers
- The change is minimal (1 file, +2/-1 lines) and low-risk
