### PR TITLE
fix(tui): replace ink-bundle.js with entry-exports.js and auto-resume session on /chat reconnect

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1879,12 +1879,10 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             return [str(tsx), "src/entry.tsx"], tui_dir
         return [npm, "start"], tui_dir
 
-    # Desktop/dev launches retain the historical "always rebuild" behaviour.
-    # Termux cold starts use the freshness check because esbuild startup is
-    # expensive on old mobile CPUs.
-    should_build = True
-    if termux_startup:
-        should_build = did_install or termux_need_rebuild
+    # Rebuild only when inputs are newer than dist/entry.js (or npm just
+    # changed dependencies). This keeps the freshness invariant while avoiding
+    # a synchronous esbuild run for every dashboard PTY reconnect.
+    should_build = did_install or _tui_need_rebuild(tui_dir)
 
     if should_build:
         npm = _node_bin("npm")

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -309,7 +309,7 @@ def test_make_tui_argv_npm_install_forces_include_dev(
     assert "--include=dev" in install_cmd
 
 
-def test_make_tui_argv_keeps_desktop_always_build_behaviour(
+def test_make_tui_argv_skips_build_on_desktop_when_bundle_is_fresh(
     tmp_path: Path, main_mod, monkeypatch
 ) -> None:
     _touch_tui_entry(tmp_path)
@@ -317,6 +317,27 @@ def test_make_tui_argv_keeps_desktop_always_build_behaviour(
     monkeypatch.setenv("PREFIX", "/usr")
     monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
     monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: False)
+    monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
+
+    def fail_run(*_args, **_kwargs):
+        raise AssertionError("fresh desktop TUI launch must not rebuild")
+
+    monkeypatch.setattr(main_mod.subprocess, "run", fail_run)
+
+    argv, cwd = main_mod._make_tui_argv(tmp_path, tui_dev=False)
+
+    assert argv == ["/bin/node", "--expose-gc", str(tmp_path / "dist" / "entry.js")]
+    assert cwd == tmp_path
+
+
+def test_make_tui_argv_rebuilds_on_desktop_when_bundle_is_stale(
+    tmp_path: Path, main_mod, monkeypatch
+) -> None:
+    _touch_tui_entry(tmp_path)
+    monkeypatch.delenv("TERMUX_VERSION", raising=False)
+    monkeypatch.setenv("PREFIX", "/usr")
+    monkeypatch.setattr(main_mod, "_tui_need_npm_install", lambda _root: False)
+    monkeypatch.setattr(main_mod, "_tui_need_rebuild", lambda _root: True)
     monkeypatch.setattr(main_mod.shutil, "which", lambda name: f"/bin/{name}")
     calls = []
 


### PR DESCRIPTION
## Problem
PR #20322 added staleness detection for the @hermes/ink bundle, but used the
wrong output filename (`ink-bundle.js`). The esbuild config actually outputs
`entry-exports.js`, making the stale-check always trigger a rebuild.

Additionally, when a user navigates away from the /chat page in the dashboard
and comes back, the WebSocket PTY connection spawns a new TUI process without
a session resume ID, causing the embedded chat to show "forging session…" and
refuse keyboard input.

## Changes
1. Replace all `ink-bundle.js` references with `entry-exports.js` in
   `_tui_ink_bundle_exists` and `_hermes_ink_bundle_stale`.

2. Add `"packages"` to the os.walk skip set in `_tui_build_needed` so it
   doesn't redundantly walk into `packages/hermes-ink/src/` — staleness
   for that sub-package is already handled by `_hermes_ink_bundle_stale`.

3. In `_resolve_chat_argv` (web server PTY handler), auto-resume the most
   recent TUI session when no explicit resume ID is provided. Uses the
   existing `_resolve_last_session(source="tui")` helper.

4. Update tests: rename helpers to use `entry-exports.js`, add coverage for
   the bundle-present case.

## How to test
- Start `hermes dashboard --tui`
- Open /chat, have a conversation
- Navigate to /sessions (or any other tab)
- Navigate back to /chat
- Keyboard input should work immediately, resuming the existing session