### PR TITLE
fix(kanban): reset <code> background inside dashboard board

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -9,6 +9,15 @@
   width: 100%;
 }
 
+/* Override the Nous DS global `code { background: var(--midground) }` rule
+   which paints an opaque cream/yellow fill on every <code> inside the board,
+   hiding the text underneath. Kanban uses <code> for event payloads, run-meta,
+   and log panes — those need transparent backgrounds. */
+.hermes-kanban code {
+  background: transparent;
+  color: inherit;
+}
+
 /* ---- Columns layout -------------------------------------------------- */
 
 .hermes-kanban-columns {

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -50,6 +50,7 @@ AUTHOR_MAP = {
     "159539633+MottledShadow@users.noreply.github.com": "MottledShadow",
     "aludwin+gh@gmail.com": "adamludwin",
     "ngusev@astralinux.ru": "NikolayGusev-astra",
+    "liuguangyong201@hellobike.com": "liuguangyong93",
     "2093036+exiao@users.noreply.github.com": "exiao",
     "rylen.anil@gmail.com": "rylena",
     "godnanijatin@gmail.com": "jatingodnani",


### PR DESCRIPTION
## Summary
Event payloads, run metadata, and markdown code blocks inside the kanban board are no longer hidden by the Nous DS global `code { background: var(--midground) }` fill.

## Root cause
Nous DS ships a global rule that paints an opaque cream/yellow background on every `<code>` element. The kanban dashboard uses `<code>` for `hermes-kanban-event-payload`, `hermes-kanban-run-meta`, and markdown code. The DS rule won on specificity — cards rendered as unreadable chips.

## Fix
Add a single scoped override at `.hermes-kanban code { background: transparent; color: inherit; }`. Higher specificity than bare `code`, cascades to all three sites — no per-selector patching needed.

## Changes
- `plugins/kanban/dashboard/dist/style.css`: +9 lines (one rule block)
- `scripts/release.py`: AUTHOR_MAP entry for @liuguangyong93

## Alternatives considered
3 competing PRs (#20461, #19319, #18424) patched individual selectors downstream or added chip styling. All close as superseded by this root-cause fix.

## Validation
- tests/plugins/test_kanban_dashboard_plugin.py: 67/67 passing

Cherry-picked from PR #20648 by @liuguangyong93, authorship preserved.