### PR TITLE
fix(agent): halt on non-retryable tool billing blockers

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from dataclasses import dataclass, field
 from typing import Any, Mapping
 
@@ -56,6 +57,34 @@ MUTATING_TOOL_NAMES = frozenset(
         "delegate_task",
         "process",
     }
+)
+
+_NON_RETRYABLE_BILLING_HINTS = (
+    "payment required",
+    "insufficient credits",
+    "insufficient quota",
+    "insufficient balance",
+    "credits have been exhausted",
+    "credit balance",
+    "billing hard limit",
+    "billing_not_active",
+    "top up your credits",
+    "top up your account",
+    "add more credits",
+    "out of credits",
+    "can only afford",
+)
+
+_TRANSIENT_QUOTA_HINTS = (
+    "try again",
+    "retry",
+    "daily quota",
+    "weekly quota",
+    "monthly quota",
+    "quota reset",
+    "resets at",
+    "cooldown",
+    "rate limit",
 )
 
 
@@ -218,6 +247,45 @@ def classify_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str
     return False, ""
 
 
+def _extract_tool_error_text(result: str | None) -> str:
+    if not result:
+        return ""
+
+    parsed = safe_json_loads(result)
+    if isinstance(parsed, dict):
+        for key in ("error", "message", "detail"):
+            value = parsed.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+
+    if isinstance(result, str):
+        return result.strip()
+    return ""
+
+
+def detect_non_retryable_tool_blocker(tool_name: str, result: str | None) -> str:
+    """Return a concise blocker reason when a tool hit a non-retryable billing wall.
+
+    These failures are qualitatively different from a generic tool error: retrying the
+    same tool path will burn iterations and tokens without producing progress, while the
+    correct next step is to surface the blocker to the user immediately.
+    """
+    error_text = _extract_tool_error_text(result)
+    if not error_text:
+        return ""
+
+    normalized = " ".join(error_text.lower().split())
+    if not any(hint in normalized for hint in _NON_RETRYABLE_BILLING_HINTS):
+        return ""
+    if any(hint in normalized for hint in _TRANSIENT_QUOTA_HINTS):
+        return ""
+
+    trimmed = re.sub(r"\s+", " ", error_text).strip()
+    if len(trimmed) > 220:
+        trimmed = trimmed[:217].rstrip() + "..."
+    return trimmed
+
+
 class ToolCallGuardrailController:
     """Per-turn controller for repeated failed/non-progressing tool calls."""
 
@@ -293,6 +361,22 @@ class ToolCallGuardrailController:
             failed, _ = classify_tool_failure(tool_name, result)
 
         if failed:
+            blocker_reason = detect_non_retryable_tool_blocker(tool_name, result)
+            if blocker_reason:
+                decision = ToolGuardrailDecision(
+                    action="halt",
+                    code="non_retryable_tool_blocker",
+                    message=(
+                        f"Stopped {tool_name}: it hit a non-retryable billing or credits blocker. "
+                        f"Surface the blocker to the user instead of retrying. Last error: {blocker_reason}"
+                    ),
+                    tool_name=tool_name,
+                    count=1,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
+
             exact_count = self._exact_failure_counts.get(signature, 0) + 1
             self._exact_failure_counts[signature] = exact_count
             self._no_progress.pop(signature, None)

--- a/run_agent.py
+++ b/run_agent.py
@@ -9214,6 +9214,12 @@ class AIAgent:
 
     def _toolguard_controlled_halt_response(self, decision: ToolGuardrailDecision) -> str:
         tool = decision.tool_name or "a tool"
+        if decision.code == "non_retryable_tool_blocker":
+            return (
+                f"I stopped after {tool} hit a non-retryable billing or credits blocker. "
+                "The tool backend needs attention before I can continue, so retrying would only "
+                "waste iterations. The last tool result contains the exact error."
+            )
         return (
             f"I stopped retrying {tool} because it hit the tool-call guardrail "
             f"({decision.code}) after {decision.count} repeated non-progressing "

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -7,6 +7,7 @@ from agent.tool_guardrails import (
     ToolCallGuardrailController,
     ToolCallSignature,
     canonical_tool_args,
+    detect_non_retryable_tool_blocker,
 )
 
 
@@ -89,6 +90,22 @@ def test_default_repeated_identical_failed_call_warns_without_blocking():
     assert {d.code for d in decisions[1:]} == {"repeated_exact_failure_warning"}
     assert controller.before_call("web_search", args).action == "allow"
     assert controller.halt_decision is None
+
+
+def test_non_retryable_billing_tool_error_halts_immediately_without_config_hard_stop():
+    controller = ToolCallGuardrailController()
+    args = {"query": "latest news"}
+    result = json.dumps({"error": "Error searching web: Payment Required / Insufficient credits"})
+
+    assert controller.before_call("web_search", args).action == "allow"
+    decision = controller.after_call("web_search", args, result, failed=True)
+
+    assert detect_non_retryable_tool_blocker("web_search", result)
+    assert decision.action == "halt"
+    assert decision.code == "non_retryable_tool_blocker"
+    assert decision.tool_name == "web_search"
+    assert "Insufficient credits" in decision.message
+    assert controller.halt_decision == decision
 
 
 def test_hard_stop_enabled_blocks_repeated_exact_failure_before_next_execution():

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -237,6 +237,43 @@ def test_default_run_conversation_warns_without_guardrail_halt():
     assert any("repeated_exact_failure_warning" in content for content in tool_contents)
 
 
+def test_non_retryable_tool_blocker_halts_conversation_after_first_failed_tool_call():
+    agent = _make_agent("web_search", max_iterations=10)
+    args = {"query": "latest market news"}
+    responses = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("web_search", json.dumps(args), "c-billing")],
+        ),
+        _mock_response(content="SHOULD_NOT_BE_USED", finish_reason="stop", tool_calls=None),
+    ]
+    agent.client.chat.completions.create.side_effect = responses
+
+    with (
+        patch(
+            "run_agent.handle_function_call",
+            return_value=json.dumps({"error": "Error searching web: Payment Required / Insufficient credits"}),
+        ) as mock_hfc,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("search for the latest news")
+
+    mock_hfc.assert_called_once()
+    assert result["api_calls"] == 1
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert result["completed"] is True
+    assert "billing or credits blocker" in result["final_response"]
+    assert result["guardrail"]["code"] == "non_retryable_tool_blocker"
+    assert result["guardrail"]["tool_name"] == "web_search"
+    tool_contents = [m["content"] for m in result["messages"] if m.get("role") == "tool"]
+    assert len(tool_contents) == 1
+    assert "Payment Required / Insufficient credits" in tool_contents[0]
+    assert "Tool loop hard stop" in tool_contents[0]
+
+
 def test_config_enabled_hard_stop_run_conversation_returns_controlled_guardrail_halt_without_top_level_error():
     agent = _make_agent("web_search", max_iterations=10, config=_hard_stop_config())
     same_args = {"query": "same"}


### PR DESCRIPTION
 ## Summary

  When a tool returns a clear non-retryable billing/credits failure like:

  - `Payment Required`
  - `Insufficient credits`
  - `Insufficient quota`
  - similar exhausted-balance blockers

  Hermes currently feeds that tool result back to the model and keeps iterating. In practice this can burn extra iterations/tokens, retry the same dead path, and delay a clear user-visible explanation of the blocker.

  This PR changes that behavior:

  - detect non-retryable billing/credits blockers in failed tool results
  - escalate them to a controlled guardrail halt on the first failed tool call
  - return a direct assistant message explaining that Hermes stopped because retrying would only waste iterations
  - preserve the original tool result in history so the exact upstream error remains visible

  ## Why

  This is aimed at cases like `web_search` returning `Payment Required / Insufficient credits`, where continuing the same strategy is non-productive and the correct action is to surface the blocker
  immediately.

  Before this PR:
  - tool error was appended to history
  - model had to interpret it correctly
  - Hermes could continue iterating and spend more tokens before clearly reporting the blocker

  After this PR:
  - Hermes stops on the first clearly non-retryable billing blocker
  - the user gets a direct explanation immediately
  - the exact tool error is still preserved in the tool result

  ## Implementation

  - added non-retryable billing blocker detection in `agent/tool_guardrails.py`
  - wired those failures into the existing controlled-halt flow
  - added a specific halt response for billing/credits blockers in `run_agent.py`
  - added unit and runtime coverage for first-failure halt behavior

  ## Tests

  Ran:

  - `pytest tests/agent/test_tool_guardrails.py -q`
  - `pytest tests/run_agent/test_tool_call_guardrail_runtime.py -q`

  ## Related

  Related but not duplicate:

  - #8993
  - #10849
  - #5220

  Historical context:
  - #1732 introduced post-call tool guardrails
  - #10057 improved 402 handling on the gateway side
