### PR TITLE
fix(tui): omit system_prompt key from session.info when empty

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2426,6 +2426,33 @@ def test_session_info_includes_mcp_servers(monkeypatch):
     assert info["mcp_servers"] == fake_status
 
 
+def test_session_info_omits_system_prompt_when_empty():
+    """system_prompt is typed `string | undefined` on the TS side; the gateway
+    must omit the key when no prompt is cached so the TS optional carries a
+    real signal (#20669)."""
+    info = server._session_info(
+        types.SimpleNamespace(tools=[], model="", _cached_system_prompt="")
+    )
+    assert "system_prompt" not in info
+
+    info_none = server._session_info(
+        types.SimpleNamespace(tools=[], model="", _cached_system_prompt=None)
+    )
+    assert "system_prompt" not in info_none
+
+    info_missing = server._session_info(types.SimpleNamespace(tools=[], model=""))
+    assert "system_prompt" not in info_missing
+
+
+def test_session_info_includes_system_prompt_when_set():
+    info = server._session_info(
+        types.SimpleNamespace(
+            tools=[], model="", _cached_system_prompt="You are helpful."
+        )
+    )
+    assert info["system_prompt"] == "You are helpful."
+
+
 # ---------------------------------------------------------------------------
 # History-mutating commands must reject while session.running is True.
 # Without these guards, prompt.submit's post-run history write either

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1414,7 +1414,9 @@ def _session_info(agent) -> dict:
     except Exception:
         info["mcp_servers"] = []
     try:
-        info["system_prompt"] = getattr(agent, "_cached_system_prompt", "") or ""
+        _sys_prompt = getattr(agent, "_cached_system_prompt", "") or ""
+        if _sys_prompt:
+            info["system_prompt"] = _sys_prompt
     except Exception:
         pass
     try:


### PR DESCRIPTION
Stop sending an always-empty `system_prompt` field from the TUI gateway so the optional TS type carries a real signal.

## What changed and why
- `tui_gateway/server.py` `_session_info` previously did `info['system_prompt'] = getattr(agent, '_cached_system_prompt', '') or ''`, so the key was always present (often as `""`). The TS type `SessionInfo.system_prompt?: string` implies the key can be `undefined`, but it never was — which made the optional typing misleading. Now we only set the key when a non-empty cached prompt exists.
- `ui-tui/src/components/branding.tsx` already coerces with `info.system_prompt ?? ''` and renders `No system prompt loaded.` when the length is 0, so the rendered empty-state UI is unaffected.
- Added two regression tests in `tests/test_tui_gateway_server.py`: one asserts the key is omitted when `_cached_system_prompt` is empty/`None`/missing, the other confirms it's present and correct when a prompt is cached.

## How to test
- `pytest tests/test_tui_gateway_server.py -q -k session_info`

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #20669

<!-- autocontrib:worker-id=issue-new-a8da7f67 kind=pr-open -->