### PR TITLE
fix(gateway): clear typing indicator when cancel_session_processing gives up

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2396,6 +2396,7 @@ class BasePlatformAdapter(ABC):
         *,
         release_guard: bool = True,
         discard_pending: bool = True,
+        chat_id: str | None = None,
     ) -> None:
         """Cancel in-flight processing for a single session.
 
@@ -2408,8 +2409,15 @@ class BasePlatformAdapter(ABC):
         stall the calling dispatch coroutine — particularly under pytest-
         asyncio where the event loop's cancellation-propagation semantics
         differ subtly from a bare ``asyncio.run`` harness.
+
+        ``chat_id``, when provided, enables proactive typing-indicator cleanup
+        on the timeout path.  If the cancelled task is stuck in blocking I/O
+        (e.g. a hung tool call), its finally block may never run — calling
+        ``interrupt_session_activity`` signals the ``_keep_typing`` refresh
+        loop to exit and invokes ``stop_typing`` on the adapter.
         """
         task = self._session_tasks.pop(session_key, None)
+        _gave_up = False
         if task is not None and not task.done():
             logger.debug(
                 "[%s] Cancelling active processing for session %s",
@@ -2423,6 +2431,7 @@ class BasePlatformAdapter(ABC):
             except asyncio.CancelledError:
                 pass
             except asyncio.TimeoutError:
+                _gave_up = True
                 logger.warning(
                     "[%s] Cancelled task for %s did not exit within 5s; "
                     "unblocking dispatch and letting the task unwind in the background",
@@ -2435,6 +2444,17 @@ class BasePlatformAdapter(ABC):
                     session_key,
                     exc_info=True,
                 )
+        # When the task refuses to unwind, proactively signal the interrupt
+        # event (which the _keep_typing loop checks on each tick) and stop
+        # any persistent typing indicator so the user doesn't see an infinite
+        # "typing…" bubble.  interrupt_session_activity handles both — the
+        # interrupt event causes _keep_typing to exit its refresh loop, and
+        # stop_typing cleans up any platform-level indicator state.
+        if _gave_up and chat_id:
+            try:
+                await self.interrupt_session_activity(session_key, chat_id)
+            except Exception:
+                pass
         if discard_pending:
             self._pending_messages.pop(session_key, None)
         if release_guard:
@@ -2527,6 +2547,7 @@ class BasePlatformAdapter(ABC):
                 session_key,
                 release_guard=False,
                 discard_pending=False,
+                chat_id=event.source.chat_id,
             )
         except Exception:
             # On failure, restore the original guard if one still exists so


### PR DESCRIPTION
## Problem

When an agent processing task gets stuck in blocking I/O (e.g. a hung `web_extract` call lasting 961s), the inactivity watchdog fires, `cancel_session_processing` cancels the task, waits 5s, then unblocks dispatch — but the `_keep_typing` refresh loop keeps running. The user sees an infinite "typing…" indicator in Telegram with no way to stop it short of restarting the gateway.

Root cause: the cancelled task's finally block (which normally calls `_stop_typing_task`) may never run when the task is wedged in C-level blocking I/O. The `_keep_typing` asyncio task continues its 2-second refresh cycle forever.

## Fix

In `cancel_session_processing`, when the task refuses to unwind within the 5s window, proactively call `interrupt_session_activity(session_key, chat_id)`. This does two things:

1. **Sets the interrupt event** — `_keep_typing` checks `stop_event.is_set()` on each tick, so it exits within 2 seconds
2. **Calls `stop_typing`** on the adapter — platform-level cleanup (relevant for platforms with persistent typing loops like Discord/Slack)

Also passes `chat_id` through the existing call site in `_handle_slash_command` so command-initiated session cancels (`/new`, `/reset`, etc.) get this cleanup too.

## Changes

- `gateway/platforms/base.py` — `cancel_session_processing`: +21 lines
  - New optional `chat_id` parameter (backward compatible, defaults to `None`)
  - On 5s timeout, calls `interrupt_session_activity` if `chat_id` is provided
  - Existing call site in `_handle_slash_command` passes `event.source.chat_id`

## Testing

- [x] Tested locally on macOS with Telegram supergroup — typing indicator now clears within 2s of gateway inactivity timeout
- [x] Backward compatible — existing callers without `chat_id` behave identically
- [x] No new dependencies or config changes required