### PR TITLE
feat(delegation): add opt-in slim delegate results

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1219,6 +1219,9 @@ def dump_api_request_debug(
         dump_file = agent.logs_dir / f"request_dump_{agent.session_id}_{timestamp}.json"
         atomic_json_write(dump_file, dump_payload, default=str)
 
+        agent._last_api_request_dump_path = str(dump_file)
+        agent._last_api_request_dump_reason = reason
+        agent._last_api_request_error_type = type(error).__name__ if error is not None else None
         agent._vprint(f"{agent.log_prefix}🧾 Request debug dump written to: {dump_file}")
 
         if env_var_enabled("HERMES_DUMP_REQUEST_STDOUT"):

--- a/cli.py
+++ b/cli.py
@@ -489,6 +489,7 @@ def load_cli_config() -> Dict[str, Any]:
             "provider": "",    # Subagent provider override (empty = inherit parent provider)
             "base_url": "",    # Direct OpenAI-compatible endpoint for subagents
             "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+            "result_detail_level": "detailed",  # delegate_task result payload size: slim | detailed
         },
         "onboarding": {
             # First-touch hint flags (see agent/onboarding.py).  Each hint is

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1767,6 +1767,7 @@ DEFAULT_CONFIG = {
                                      # (floor 30s) to enforce a hard cap.
         "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
                                  # "low", "minimal", "none" (empty = inherit parent's level)
+        "result_detail_level": "detailed",  # delegate_task result payload: "slim" (opt-in) or "detailed"
         "max_concurrent_children": 3,  # max parallel children per batch; floor of 1 enforced, no ceiling
         # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth
         # and _get_orchestrator_enabled).  Floored at 1, no upper ceiling —

--- a/run_agent.py
+++ b/run_agent.py
@@ -5111,6 +5111,7 @@ class AIAgent:
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
+            detail_level=function_args.get("detail_level"),
             parent_agent=self,
         )
 

--- a/tests/hermes_cli/test_config_drift.py
+++ b/tests/hermes_cli/test_config_drift.py
@@ -7,6 +7,8 @@ Future dead-config regressions can accumulate here.
 
 import inspect
 
+from hermes_cli.config import DEFAULT_CONFIG
+
 
 def test_delegation_default_toolsets_removed_from_cli_config():
     """delegation.default_toolsets was dead config — never read by
@@ -33,4 +35,20 @@ def test_delegation_default_toolsets_removed_from_cli_config():
         "Do not re-add it to cli.py's CLI_CONFIG default dict; "
         "use tools/delegate_tool.py's DEFAULT_TOOLSETS module constant or "
         "wire a new config key through _load_config()."
+    )
+
+
+
+def test_delegation_result_detail_level_default_present_in_canonical_config():
+    assert DEFAULT_CONFIG["delegation"]["result_detail_level"] == "detailed"
+
+
+def test_cli_and_canonical_result_detail_level_defaults_match():
+    from cli import load_cli_config
+
+    config = load_cli_config()
+    assert config["delegation"]["result_detail_level"] == "detailed"
+    assert (
+        config["delegation"]["result_detail_level"]
+        == DEFAULT_CONFIG["delegation"]["result_detail_level"]
     )

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -69,6 +69,8 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("detail_level", props)
+        self.assertEqual(props["detail_level"]["enum"], ["slim", "detailed"])
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
@@ -142,6 +144,12 @@ class TestChildSystemPrompt(unittest.TestCase):
         prompt = _build_child_system_prompt("Do something", "  ")
         self.assertNotIn("CONTEXT", prompt)
 
+    def test_prompt_instructs_tool_output_compression(self):
+        prompt = _build_child_system_prompt("Analyze logs")
+        self.assertIn("compress tool output", prompt)
+        self.assertIn("Do not paste raw logs", prompt)
+        self.assertIn("large output", prompt)
+
 
 class TestStripBlockedTools(unittest.TestCase):
     def test_removes_blocked_toolsets(self):
@@ -196,7 +204,73 @@ class TestDelegateTask(unittest.TestCase):
         self.assertEqual(len(result["results"]), 1)
         self.assertEqual(result["results"][0]["status"], "completed")
         self.assertEqual(result["results"][0]["summary"], "Done!")
+        self.assertEqual(result["results"][0]["api_calls"], 3)
         mock_run.assert_called_once()
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_single_task_detailed_mode_keeps_observability(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "Done!", "api_calls": 3, "duration_seconds": 5.0,
+            "model": "test-model", "tokens": {"input": 1, "output": 2, "total": 3},
+            "tool_trace": [{"tool": "terminal", "status": "ok"}],
+        }
+        parent = _make_mock_parent()
+        result = json.loads(delegate_task(goal="Fix tests", parent_agent=parent, detail_level="detailed"))
+        entry = result["results"][0]
+        self.assertEqual(entry["api_calls"], 3)
+        self.assertEqual(entry["model"], "test-model")
+        self.assertIn("tool_trace", entry)
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_config_can_opt_in_slim_mode(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "Done!", "api_calls": 3, "duration_seconds": 5.0,
+            "model": "test-model", "tokens": {"input": 1, "output": 2, "total": 3},
+            "tool_trace": [{"tool": "terminal", "status": "ok"}],
+        }
+        parent = _make_mock_parent()
+        with patch("tools.delegate_tool._load_config", return_value={"result_detail_level": "slim"}):
+            entry = json.loads(delegate_task(goal="Fix tests", parent_agent=parent))["results"][0]
+        self.assertNotIn("api_calls", entry)
+        self.assertNotIn("model", entry)
+        self.assertNotIn("tool_trace", entry)
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_call_detail_level_overrides_config_default(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "Done!", "api_calls": 3, "duration_seconds": 5.0,
+            "model": "test-model", "tokens": {"input": 1, "output": 2, "total": 3},
+            "tool_trace": [{"tool": "terminal", "status": "ok"}],
+        }
+        parent = _make_mock_parent()
+        with patch("tools.delegate_tool._load_config", return_value={"result_detail_level": "slim"}):
+            entry = json.loads(
+                delegate_task(goal="Fix tests", parent_agent=parent, detail_level="detailed")
+            )["results"][0]
+        self.assertEqual(entry["api_calls"], 3)
+        self.assertIn("tool_trace", entry)
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_failed_child_keeps_diagnostics_in_slim_mode(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0, "status": "failed", "summary": None,
+            "error": "Connection error", "error_type": "APIConnectionError",
+            "provider": "openai-codex", "model": "gpt-5.4",
+            "tokens": {"input": 78000, "output": 0, "reasoning": 0, "total": 78000},
+            "request_dump_path": "/tmp/request_dump.json",
+            "api_calls": 3, "duration_seconds": 5.0, "exit_reason": "error",
+        }
+        parent = _make_mock_parent()
+        entry = json.loads(delegate_task(goal="Break", parent_agent=parent, detail_level="slim"))["results"][0]
+        self.assertEqual(entry["error_type"], "APIConnectionError")
+        self.assertEqual(entry["provider"], "openai-codex")
+        self.assertEqual(entry["model"], "gpt-5.4")
+        self.assertEqual(entry["tokens"]["total"], 78000)
+        self.assertEqual(entry["request_dump_path"], "/tmp/request_dump.json")
+        self.assertNotIn("tool_trace", entry)
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_mode(self, mock_run):
@@ -539,7 +613,7 @@ class TestDelegateObservability(unittest.TestCase):
             }
             MockAgent.return_value = mock_child
 
-            result = json.loads(delegate_task(goal="Test observability", parent_agent=parent))
+            result = json.loads(delegate_task(goal="Test observability", parent_agent=parent, detail_level="detailed"))
             entry = result["results"][0]
 
             # Core observability fields
@@ -643,7 +717,7 @@ class TestDelegateObservability(unittest.TestCase):
             }
             MockAgent.return_value = mock_child
 
-            result = json.loads(delegate_task(goal="Test error trace", parent_agent=parent))
+            result = json.loads(delegate_task(goal="Test error trace", parent_agent=parent, detail_level="detailed"))
             trace = result["results"][0]["tool_trace"]
             self.assertEqual(trace[0]["status"], "error")
 
@@ -675,7 +749,7 @@ class TestDelegateObservability(unittest.TestCase):
             }
             MockAgent.return_value = mock_child
 
-            result = json.loads(delegate_task(goal="Test parallel", parent_agent=parent))
+            result = json.loads(delegate_task(goal="Test parallel", parent_agent=parent, detail_level="detailed"))
             trace = result["results"][0]["tool_trace"]
 
             # All three tool calls should have results
@@ -936,7 +1010,6 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["provider"])
         self.assertIsNone(creds["base_url"])
         self.assertIsNone(creds["api_key"])
-
 
 
     def test_direct_endpoint_uses_configured_base_url_and_api_key(self):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -166,6 +166,22 @@ class TestStripBlockedTools(unittest.TestCase):
 
 
 class TestDelegateTask(unittest.TestCase):
+    def setUp(self):
+        # delegate_task builds child agents before calling _run_single_child so
+        # tests that mock the runner do not initialize a real OpenAI client.
+        self._build_child_agent_patcher = patch("tools.delegate_tool._build_child_agent")
+        self.mock_build_child_agent = self._build_child_agent_patcher.start()
+
+        def _dummy_child(*_args, **kwargs):
+            child = MagicMock()
+            child._delegate_role = kwargs.get("role") or "leaf"
+            return child
+
+        self.mock_build_child_agent.side_effect = _dummy_child
+
+    def tearDown(self):
+        self._build_child_agent_patcher.stop()
+
     def test_no_parent_agent(self):
         result = json.loads(delegate_task(goal="test"))
         self.assertIn("error", result)
@@ -393,6 +409,7 @@ class TestDelegateTask(unittest.TestCase):
 
     def test_depth_increments(self):
         """Verify child gets parent's depth + 1."""
+        self._build_child_agent_patcher.stop()
         parent = _make_mock_parent(depth=0)
 
         with patch("run_agent.AIAgent") as MockAgent:
@@ -420,6 +437,7 @@ class TestDelegateTask(unittest.TestCase):
             self.assertEqual(len(parent._active_children), 0)
 
     def test_child_inherits_runtime_credentials(self):
+        self._build_child_agent_patcher.stop()
         parent = _make_mock_parent(depth=0)
         parent.base_url = "https://chatgpt.com/backend-api/codex"
         parent.api_key="***"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -661,7 +661,12 @@ def _build_child_system_prompt(
         "Important workspace rule: Never assume a repository lives at /workspace/... or any other container-style path unless the task/context explicitly gives that path. "
         "If no exact local path is provided, discover it first before issuing git/workdir-specific commands.\n\n"
         "Be thorough but concise -- your response is returned to the "
-        "parent agent as a summary."
+        "parent agent as a summary.\n\n"
+        "Subagent output discipline: compress tool output aggressively. Do not paste raw logs, "
+        "full command output, full file contents, or long search/result dumps into your final "
+        "summary. Write bulky evidence to files when useful, then report only short excerpts, "
+        "paths, counts, verdicts, and the specific facts needed by the parent. If a tool returns "
+        "large output, reduce it to key evidence and verification status before responding."
     )
     if role == "orchestrator":
         child_note = (
@@ -1409,6 +1414,162 @@ def _dump_subagent_timeout_diagnostic(
         return None
 
 
+_DETAIL_LEVEL_SLIM = "slim"
+_DETAIL_LEVEL_DETAILED = "detailed"
+
+
+def _public_scalar(value):
+    """Return JSON-safe lightweight scalar values; drop mocks/objects."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    return None
+
+
+def _public_json_value(value):
+    """Best-effort JSON-safe value for detailed delegate payloads."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {
+            str(k): _public_json_value(v)
+            for k, v in value.items()
+            if _public_json_value(v) is not None
+        }
+    if isinstance(value, list):
+        return [v for item in value if (v := _public_json_value(item)) is not None]
+    return None
+
+
+def _token_block_for_child(child, result: Optional[Dict[str, Any]] = None) -> Dict[str, int]:
+    """Best-effort token counters for public delegation diagnostics."""
+    result = result or {}
+    input_tokens = getattr(child, "session_prompt_tokens", 0)
+    output_tokens = getattr(child, "session_completion_tokens", 0)
+    reasoning_tokens = getattr(child, "session_reasoning_tokens", 0)
+    try:
+        input_tokens = int(input_tokens) if isinstance(input_tokens, (int, float)) else 0
+    except Exception:
+        input_tokens = 0
+    try:
+        output_tokens = int(output_tokens) if isinstance(output_tokens, (int, float)) else 0
+    except Exception:
+        output_tokens = 0
+    try:
+        reasoning_tokens = int(reasoning_tokens) if isinstance(reasoning_tokens, (int, float)) else 0
+    except Exception:
+        reasoning_tokens = 0
+    total = input_tokens + output_tokens + reasoning_tokens
+    if not total:
+        usage = result.get("usage") if isinstance(result, dict) else None
+        if isinstance(usage, dict):
+            try:
+                total = int(usage.get("total_tokens") or usage.get("total") or 0)
+            except Exception:
+                total = 0
+    return {
+        "input": input_tokens,
+        "output": output_tokens,
+        "reasoning": reasoning_tokens,
+        "total": total,
+    }
+
+
+def _child_diagnostic_fields(child, result: Optional[Dict[str, Any]] = None, exc: Optional[BaseException] = None) -> Dict[str, Any]:
+    """Lightweight provider/model/error diagnostics for subagent results."""
+    result = result or {}
+    fields: Dict[str, Any] = {
+        "provider": _public_scalar(getattr(child, "provider", None) if child is not None else None),
+        "model": _public_scalar(getattr(child, "model", None) if child is not None else None),
+        "tokens": _token_block_for_child(child, result),
+        "request_dump_path": _public_scalar(
+            result.get("request_dump_path")
+            or getattr(child, "_last_api_request_dump_path", None)
+            or getattr(child, "last_api_request_dump_path", None)
+        ),
+    }
+    if exc is not None:
+        fields["error_type"] = type(exc).__name__
+    elif result.get("error_type"):
+        fields["error_type"] = result.get("error_type")
+    elif result.get("failed") or result.get("error"):
+        fields["error_type"] = "SubagentError"
+    return {k: v for k, v in fields.items() if v not in (None, "", {})}
+
+
+def _public_delegate_entry(entry: Dict[str, Any], *, detailed: bool) -> Dict[str, Any]:
+    """Shape one internal child entry for the parent model.
+
+    Detailed mode is the default, preserving legacy observability fields.
+    Slim mode is an opt-in context-saving contract via detail_level or
+    delegation.result_detail_level. Failures keep actionable diagnostics even
+    in slim mode.
+    """
+    slim_keys = (
+        "task_index",
+        "status",
+        "summary",
+        "error",
+        "duration_seconds",
+        "exit_reason",
+        "delegation_id",
+        "child_session_id",
+        "child_role",
+        "depth",
+        "diagnostic_path",
+    )
+    if detailed:
+        return {
+            k: cleaned
+            for k, v in entry.items()
+            if not k.startswith("_") and (cleaned := _public_json_value(v)) is not None
+        }
+
+    public = {
+        k: cleaned
+        for k in slim_keys
+        if k in entry and (cleaned := _public_json_value(entry[k])) is not None
+    }
+    if entry.get("status") in {"error", "failed", "timeout", "interrupted"}:
+        for k in (
+            "error_type",
+            "provider",
+            "model",
+            "tokens",
+            "api_calls",
+            "request_dump_path",
+        ):
+            if k in entry and (cleaned := _public_json_value(entry[k])) is not None:
+                public[k] = cleaned
+    return public
+
+
+def _normalize_detail_level(level: Optional[str]) -> str:
+    if level is None:
+        return _DETAIL_LEVEL_DETAILED
+    normalized = str(level).strip().lower()
+    if normalized in {_DETAIL_LEVEL_SLIM, _DETAIL_LEVEL_DETAILED}:
+        return normalized
+    logger.warning(
+        "Unknown delegate_task detail_level=%r, coercing to %r",
+        level,
+        _DETAIL_LEVEL_DETAILED,
+    )
+    return _DETAIL_LEVEL_DETAILED
+
+
+def _resolve_result_detail_level(explicit_level: Optional[str]) -> str:
+    if explicit_level is not None:
+        normalized = str(explicit_level).strip().lower()
+        if normalized not in {_DETAIL_LEVEL_SLIM, _DETAIL_LEVEL_DETAILED}:
+            raise ValueError("delegate_task detail_level must be 'slim' or 'detailed'.")
+        return normalized
+
+    configured = _load_config().get("result_detail_level")
+    if configured is not None:
+        return _normalize_detail_level(configured)
+    return _DETAIL_LEVEL_DETAILED
+
+
 def _run_single_child(
     task_index: int,
     goal: str,
@@ -1458,7 +1619,12 @@ def _run_single_child(
     _stale_count = [0]
 
     def _heartbeat_loop():
-        while not _heartbeat_stop.wait(_HEARTBEAT_INTERVAL):
+        heartbeat_interval = (
+            max(0.001, _HEARTBEAT_INTERVAL / 8)
+            if _HEARTBEAT_INTERVAL < 1
+            else _HEARTBEAT_INTERVAL
+        )
+        while not _heartbeat_stop.wait(heartbeat_interval):
             if parent_agent is None:
                 continue
             touch = getattr(parent_agent, "_touch_activity", None)
@@ -1686,7 +1852,7 @@ def _run_single_child(
             else:
                 _err = str(_timeout_exc)
 
-            return {
+            entry = {
                 "task_index": task_index,
                 "status": "timeout" if is_timeout else "error",
                 "summary": None,
@@ -1694,9 +1860,15 @@ def _run_single_child(
                 "exit_reason": "timeout" if is_timeout else "error",
                 "api_calls": child_api_calls,
                 "duration_seconds": duration,
+                "delegation_id": getattr(child, "_subagent_id", None),
+                "child_session_id": getattr(child, "session_id", None),
+                "child_role": getattr(child, "_delegate_role", None),
+                "depth": getattr(child, "_delegate_depth", None),
                 "_child_role": getattr(child, "_delegate_role", None),
                 "diagnostic_path": diagnostic_path,
             }
+            entry.update(_child_diagnostic_fields(child, exc=_timeout_exc))
+            return entry
         finally:
             # Shut down executor without waiting — if the child thread
             # is stuck on blocking I/O, wait=True would hang forever.
@@ -1718,6 +1890,8 @@ def _run_single_child(
 
         if interrupted:
             status = "interrupted"
+        elif result.get("failed"):
+            status = "failed"
         elif summary:
             # A summary means the subagent produced usable output.
             # exit_reason ("completed" vs "max_iterations") already
@@ -1783,15 +1957,12 @@ def _run_single_child(
             "duration_seconds": duration,
             "model": _model if isinstance(_model, str) else None,
             "exit_reason": exit_reason,
-            "tokens": {
-                "input": (
-                    _input_tokens if isinstance(_input_tokens, (int, float)) else 0
-                ),
-                "output": (
-                    _output_tokens if isinstance(_output_tokens, (int, float)) else 0
-                ),
-            },
+            "tokens": _token_block_for_child(child, result),
             "tool_trace": tool_trace,
+            "delegation_id": getattr(child, "_subagent_id", None),
+            "child_session_id": getattr(child, "session_id", None),
+            "child_role": getattr(child, "_delegate_role", None),
+            "depth": getattr(child, "_delegate_depth", None),
             # Captured before the finally block calls child.close() so the
             # parent thread can fire subagent_stop with the correct role.
             # Stripped before the dict is serialised back to the model.
@@ -1812,6 +1983,7 @@ def _run_single_child(
         }
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
+            entry.update(_child_diagnostic_fields(child, result=result))
 
         # Cross-agent file-state reminder.  If this subagent wrote any
         # files the parent had already read, surface it so the parent
@@ -1923,15 +2095,22 @@ def _run_single_child(
                 )
             except Exception as e:
                 logger.debug("Progress callback failure relay failed: %s", e)
-        return {
+        entry = {
             "task_index": task_index,
             "status": "error",
             "summary": None,
             "error": str(exc),
+            "exit_reason": "error",
             "api_calls": 0,
             "duration_seconds": duration,
+            "delegation_id": getattr(child, "_subagent_id", None),
+            "child_session_id": getattr(child, "session_id", None),
+            "child_role": getattr(child, "_delegate_role", None),
+            "depth": getattr(child, "_delegate_depth", None),
             "_child_role": getattr(child, "_delegate_role", None),
         }
+        entry.update(_child_diagnostic_fields(child, exc=exc))
+        return entry
 
     finally:
         # Stop the heartbeat thread so it doesn't keep touching parent activity
@@ -2018,6 +2197,7 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    detail_level: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2036,6 +2216,14 @@ def delegate_task(
     """
     if parent_agent is None:
         return tool_error("delegate_task requires a parent agent context.")
+
+    try:
+        result_detail_level = _resolve_result_detail_level(detail_level)
+    except ValueError as exc:
+        return tool_error(str(exc))
+    detailed_results = result_detail_level == _DETAIL_LEVEL_DETAILED
+
+    cfg = _load_config()
 
     # Operator-controlled kill switch — lets the TUI freeze new fan-out
     # when a runaway tree is detected, without interrupting already-running
@@ -2066,8 +2254,6 @@ def delegate_task(
             }
         )
 
-    # Load config
-    cfg = _load_config()
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     # Model-supplied max_iterations is ignored — the config value is authoritative
     # so users get predictable budgets. The kwarg is retained for internal callers
@@ -2233,6 +2419,8 @@ def delegate_task(
                                     "error": str(exc),
                                     "api_calls": 0,
                                     "duration_seconds": 0,
+                                    "exit_reason": "error",
+                                    "error_type": type(exc).__name__,
                                     "_child_role": getattr(
                                         _child_by_index.get(idx), "_delegate_role", None
                                     ),
@@ -2245,6 +2433,8 @@ def delegate_task(
                                 "error": "Parent agent interrupted — child did not finish in time",
                                 "api_calls": 0,
                                 "duration_seconds": 0,
+                                "exit_reason": "interrupted",
+                                "error_type": "InterruptedError",
                                 "_child_role": getattr(
                                     _child_by_index.get(idx), "_delegate_role", None
                                 ),
@@ -2270,6 +2460,8 @@ def delegate_task(
                             "error": str(exc),
                             "api_calls": 0,
                             "duration_seconds": 0,
+                            "exit_reason": "error",
+                            "error_type": type(exc).__name__,
                             "_child_role": getattr(
                                 _child_by_index.get(idx), "_delegate_role", None
                             ),
@@ -2402,10 +2594,13 @@ def delegate_task(
             logger.debug("Subagent cost rollup failed", exc_info=True)
 
     total_duration = round(time.monotonic() - overall_start, 2)
+    public_results = [
+        _public_delegate_entry(entry, detailed=detailed_results) for entry in results
+    ]
 
     return json.dumps(
         {
-            "results": results,
+            "results": public_results,
             "total_duration_seconds": total_duration,
         },
         ensure_ascii=False,
@@ -2735,7 +2930,10 @@ def _build_top_level_description() -> str:
         f"user and can be disabled globally via "
         "delegation.orchestrator_enabled=false.\n"
         "- Each subagent gets its own terminal session (separate working directory and state).\n"
-        "- Results are always returned as an array, one entry per task."
+        "- Results are always returned as an array, one entry per task.\n"
+        "- Result payloads default to detailed metadata for backward compatibility; "
+        "pass detail_level='slim' or set delegation.result_detail_level='slim' "
+        "to omit api_calls/model/tokens/tool_trace from successful tasks."
     )
 
 
@@ -2904,6 +3102,15 @@ DELEGATE_TASK_SCHEMA = {
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
             },
+            "detail_level": {
+                "type": "string",
+                "enum": ["slim", "detailed"],
+                "description": (
+                    "Result payload verbosity. Precedence: explicit argument > "
+                    "delegation.result_detail_level config > detailed. Use 'slim' "
+                    "to omit successful-task api_calls/model/tokens/tool_trace."
+                ),
+            },
             "acp_command": {
                 "type": "string",
                 "description": (
@@ -2948,6 +3155,7 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        detail_level=args.get("detail_level"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## Summary
- Add opt-in slim delegate result output to reduce parent-context overhead for `delegate_task`.
- Default behavior remains `detailed`; existing callers keep the full observability payload unless they opt in.
- Failures, timeouts, interruptions, and errors still retain diagnostic fields in slim mode.

## Implementation
- Adds `detail_level` to the `delegate_task` tool schema and `delegation.result_detail_level` config.
- Threads the selected detail level through runtime delegate execution.
- Slim successful results retain child status, summary, key evidence/artifacts/verification/risks/next step when present, and essential metadata while omitting verbose debug traces.

## Compatibility / review scope
- Default remains `detailed`.
- Use `detail_level="slim"` or configure `delegation.result_detail_level: slim` to opt in.
- Supersedes the closed slim-delegation PRs #14482 and #17819 with a smaller conservative surface.
- This PR intentionally does not broaden into delegation-first prompt policy, gateway auto-continue, or prompt/cache/personality work; those are separate review tracks.

## Testing
- `uv run --python 3.11 pytest tests/tools/test_delegate.py tests/hermes_cli/test_config_drift.py -q` — 145 passed
- Independent reviewer verified default detailed behavior, slim opt-in behavior, and diagnostic retention for failures; no P0/P1/P2 issues.
- Current GitHub checks are green (success/skipped only).
