### PR TITLE
fix(cli): hermes debug now sees credential_pool OAuth tokens

### DIFF
--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -360,41 +360,74 @@ def run_dump(args):
     # API keys
     lines.append("")
     lines.append("api_keys:")
+    # Each entry: (env_var, label, pool_key_or_None).  ``pool_key`` is the
+    # provider id under ``auth.json::credential_pool`` whose entries should
+    # be consulted when the env var is unset — this lets OAuth-backed
+    # providers (Nous Portal, Anthropic via claude_code, etc.) report as
+    # set even when no API-key env var is configured.  ``None`` means the
+    # provider has no OAuth flow that lands in the credential pool.
     api_keys = [
-        ("OPENROUTER_API_KEY", "openrouter"),
-        ("OPENAI_API_KEY", "openai"),
-        ("ANTHROPIC_API_KEY", "anthropic"),
-        ("ANTHROPIC_TOKEN", "anthropic_token"),
-        ("NOUS_API_KEY", "nous"),
-        ("GOOGLE_API_KEY", "google/gemini"),
-        ("GEMINI_API_KEY", "gemini"),
-        ("GLM_API_KEY", "glm/zai"),
-        ("ZAI_API_KEY", "zai"),
-        ("KIMI_API_KEY", "kimi"),
-        ("MINIMAX_API_KEY", "minimax"),
-        ("DEEPSEEK_API_KEY", "deepseek"),
-        ("DASHSCOPE_API_KEY", "dashscope"),
-        ("HF_TOKEN", "huggingface"),
-        ("NVIDIA_API_KEY", "nvidia"),
-        ("OPENCODE_ZEN_API_KEY", "opencode_zen"),
-        ("OPENCODE_GO_API_KEY", "opencode_go"),
-        ("KILOCODE_API_KEY", "kilocode"),
-        ("FIRECRAWL_API_KEY", "firecrawl"),
-        ("TAVILY_API_KEY", "tavily"),
-        ("BROWSERBASE_API_KEY", "browserbase"),
-        ("FAL_KEY", "fal"),
-        ("ELEVENLABS_API_KEY", "elevenlabs"),
-        ("GITHUB_TOKEN", "github"),
+        ("OPENROUTER_API_KEY", "openrouter", "openrouter"),
+        ("OPENAI_API_KEY", "openai", None),
+        ("ANTHROPIC_API_KEY", "anthropic", "anthropic"),
+        ("ANTHROPIC_TOKEN", "anthropic_token", "anthropic"),
+        ("NOUS_API_KEY", "nous", "nous"),
+        ("GOOGLE_API_KEY", "google/gemini", "gemini"),
+        ("GEMINI_API_KEY", "gemini", "gemini"),
+        ("GLM_API_KEY", "glm/zai", "zai"),
+        ("ZAI_API_KEY", "zai", "zai"),
+        ("KIMI_API_KEY", "kimi", "kimi-coding"),
+        ("MINIMAX_API_KEY", "minimax", "minimax"),
+        ("DEEPSEEK_API_KEY", "deepseek", "deepseek"),
+        ("DASHSCOPE_API_KEY", "dashscope", "alibaba"),
+        ("HF_TOKEN", "huggingface", None),
+        ("NVIDIA_API_KEY", "nvidia", "nvidia"),
+        ("OPENCODE_ZEN_API_KEY", "opencode_zen", "opencode-zen"),
+        ("OPENCODE_GO_API_KEY", "opencode_go", "opencode-go"),
+        ("KILOCODE_API_KEY", "kilocode", None),
+        ("FIRECRAWL_API_KEY", "firecrawl", None),
+        ("TAVILY_API_KEY", "tavily", None),
+        ("BROWSERBASE_API_KEY", "browserbase", None),
+        ("FAL_KEY", "fal", None),
+        ("ELEVENLABS_API_KEY", "elevenlabs", None),
+        ("GITHUB_TOKEN", "github", "copilot"),
     ]
 
     dotenv_keys = _dotenv_key_names()
 
-    for env_var, label in api_keys:
+    # OAuth-backed providers with no env var in the table above.  Their
+    # tokens live in ``credential_pool`` only, so the user previously had
+    # no way to tell from ``hermes debug`` whether they were logged in.
+    oauth_only_providers = [
+        ("openai-codex", "openai_codex"),
+        ("qwen-oauth", "qwen_oauth"),
+        ("minimax-oauth", "minimax_oauth"),
+        ("google-gemini-cli", "google_gemini_cli"),
+    ]
+
+    try:
+        from hermes_cli.auth import read_credential_pool
+        pool_data = read_credential_pool(None)
+    except Exception:
+        pool_data = {}
+
+    def _pool_has_token(pool_key: str) -> bool:
+        entries = pool_data.get(pool_key)
+        if not isinstance(entries, list):
+            return False
+        return any(
+            isinstance(e, dict) and str(e.get("access_token") or "").strip()
+            for e in entries
+        )
+
+    for env_var, label, pool_key in api_keys:
         val = os.getenv(env_var, "")
-        if show_keys and val:
-            display = _redact(val)
+        if val:
+            display = _redact(val) if show_keys else "set (env)"
+        elif pool_key and _pool_has_token(pool_key):
+            display = "set (oauth)"
         else:
-            display = "set" if val else "not set"
+            display = "not set"
         # Set in this (shell) process but absent from ~/.hermes/.env: a managed
         # backend (launchd/systemd/desktop `serve`) loads .env, not the login
         # shell, so it likely can't see this key — even though the dump reads
@@ -405,7 +438,7 @@ def run_dump(args):
         # A credential added via `hermes auth add openrouter` lives in the
         # credential pool, not as an env var — surface it so the dump doesn't
         # misleadingly read "not set" while `hermes auth list` shows it (#42130).
-        if not val and label == "openrouter":
+        if display == "not set" and label == "openrouter":
             try:
                 from agent.credential_pool import load_pool as _load_pool
 
@@ -413,6 +446,10 @@ def run_dump(args):
                     display = "set (auth pool)"
             except Exception:
                 pass
+        lines.append(f"  {label:<20} {display}")
+
+    for pool_key, label in oauth_only_providers:
+        display = "set (oauth)" if _pool_has_token(pool_key) else "not set"
         lines.append(f"  {label:<20} {display}")
 
     # Features summary

--- a/tests/hermes_cli/test_dump_credentials.py
+++ b/tests/hermes_cli/test_dump_credentials.py
@@ -1,0 +1,236 @@
+"""Tests for ``hermes dump`` API-keys section, focused on OAuth detection.
+
+Regression coverage for the bug where providers authenticated via OAuth
+(Nous Portal, OpenAI Codex, Anthropic via claude_code) reported as
+"not set" in the debug dump even when their tokens were live in
+``auth.json::credential_pool``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+def _run_dump(show_keys: bool = False) -> str:
+    """Invoke ``run_dump`` and capture its stdout."""
+    from hermes_cli.dump import run_dump
+
+    args = SimpleNamespace(show_keys=show_keys)
+    captured = io.StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = captured
+    try:
+        run_dump(args)
+    finally:
+        sys.stdout = old_stdout
+    return captured.getvalue()
+
+
+def _write_credential_pool(hermes_home, pool: dict) -> None:
+    """Persist a credential_pool payload into ``auth.json`` under HERMES_HOME."""
+    auth_path = hermes_home / "auth.json"
+    auth_path.write_text(
+        json.dumps({
+            "version": 1,
+            "providers": {},
+            "credential_pool": pool,
+        })
+    )
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME for dump tests."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+class TestDumpApiKeysOAuthDetection:
+    """``hermes dump`` should report OAuth-backed providers as set."""
+
+    def test_nous_oauth_token_reports_set_oauth(self, hermes_home):
+        """Nous logged in via OAuth → reported as ``set (oauth)``."""
+        _write_credential_pool(
+            hermes_home,
+            {
+                "nous": [
+                    {
+                        "id": "abc123",
+                        "source": "device_code",
+                        "auth_type": "oauth",
+                        "access_token": "eyJhbGciOiJSUzI1NiJ9.fake.token",
+                    }
+                ],
+            },
+        )
+
+        out = _run_dump()
+
+        # Find the nous row and assert it shows oauth, not "not set".
+        nous_lines = [l for l in out.splitlines() if l.strip().startswith("nous ")]
+        assert nous_lines, f"no nous row in dump output:\n{out}"
+        assert "set (oauth)" in nous_lines[0], (
+            f"nous OAuth login should show 'set (oauth)', got: {nous_lines[0]}"
+        )
+
+    def test_anthropic_oauth_via_claude_code_reports_set_oauth(self, hermes_home):
+        """Anthropic claude_code OAuth seed → ``anthropic`` shows ``set (oauth)``."""
+        _write_credential_pool(
+            hermes_home,
+            {
+                "anthropic": [
+                    {
+                        "id": "cc1",
+                        "source": "claude_code",
+                        "auth_type": "oauth",
+                        "access_token": "sk-ant-oat01-fake-claude-code-token",
+                    }
+                ],
+            },
+        )
+
+        out = _run_dump()
+        anthropic_lines = [
+            l
+            for l in out.splitlines()
+            if l.strip().startswith("anthropic ")
+            or l.strip().startswith("anthropic_token ")
+        ]
+        assert any("set (oauth)" in l for l in anthropic_lines), (
+            f"anthropic should show 'set (oauth)' when claude_code is in pool, "
+            f"got: {anthropic_lines}"
+        )
+
+    def test_codex_oauth_only_provider_appears(self, hermes_home):
+        """OpenAI Codex (OAuth-only, no env var) shows up when logged in."""
+        _write_credential_pool(
+            hermes_home,
+            {
+                "openai-codex": [
+                    {
+                        "id": "cdx1",
+                        "source": "device_code",
+                        "auth_type": "oauth",
+                        "access_token": "ChatGPT-token",
+                    }
+                ],
+            },
+        )
+
+        out = _run_dump()
+        codex_lines = [
+            l for l in out.splitlines() if l.strip().startswith("openai_codex ")
+        ]
+        assert codex_lines, f"openai_codex row missing from dump:\n{out}"
+        assert "set (oauth)" in codex_lines[0]
+
+    def test_codex_not_logged_in_shows_not_set(self, hermes_home):
+        """OAuth-only providers without a pool entry render as ``not set``."""
+        _write_credential_pool(hermes_home, {})
+
+        out = _run_dump()
+        codex_lines = [
+            l for l in out.splitlines() if l.strip().startswith("openai_codex ")
+        ]
+        assert codex_lines
+        assert "not set" in codex_lines[0]
+
+    def test_env_set_takes_precedence_over_pool(self, hermes_home, monkeypatch):
+        """Env var present → ``set (env)``, even if pool also has an entry."""
+        monkeypatch.setenv("NOUS_API_KEY", "manual-api-key")
+        _write_credential_pool(
+            hermes_home,
+            {
+                "nous": [
+                    {
+                        "id": "abc",
+                        "source": "device_code",
+                        "auth_type": "oauth",
+                        "access_token": "oauth-token",
+                    }
+                ],
+            },
+        )
+
+        out = _run_dump()
+        nous_lines = [l for l in out.splitlines() if l.strip().startswith("nous ")]
+        assert nous_lines
+        assert "set (env)" in nous_lines[0], f"env var should win, got: {nous_lines[0]}"
+
+    def test_empty_pool_entry_does_not_falsely_report_set(self, hermes_home):
+        """Pool entries with empty ``access_token`` must not count as set."""
+        _write_credential_pool(
+            hermes_home,
+            {
+                "nous": [
+                    {
+                        "id": "abc",
+                        "source": "device_code",
+                        "auth_type": "oauth",
+                        "access_token": "",
+                    }
+                ],
+            },
+        )
+
+        out = _run_dump()
+        nous_lines = [l for l in out.splitlines() if l.strip().startswith("nous ")]
+        assert nous_lines
+        assert "not set" in nous_lines[0]
+
+    def test_no_auth_file_falls_back_to_not_set(self, tmp_path, monkeypatch):
+        """Missing auth.json → providers report ``not set`` cleanly (no crash)."""
+        home = tmp_path / ".hermes-empty"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        out = _run_dump()
+        # Spot-check: nous should still appear, marked as not set.
+        nous_lines = [l for l in out.splitlines() if l.strip().startswith("nous ")]
+        assert nous_lines
+        assert "not set" in nous_lines[0]
+
+    def test_show_keys_redacts_env_value(self, hermes_home, monkeypatch):
+        """``--show-keys`` continues to render redacted env values."""
+        monkeypatch.setenv("NOUS_API_KEY", "abcd-very-long-secret-1234")
+
+        out = _run_dump(show_keys=True)
+        nous_lines = [l for l in out.splitlines() if l.strip().startswith("nous ")]
+        assert nous_lines
+        # Redaction shows first/last chars but not the full string.
+        assert "abcd-very-long-secret-1234" not in nous_lines[0]
+        # And it does NOT show "set (env)" because show_keys path emits the
+        # redacted value instead.
+        assert "set (env)" not in nous_lines[0]
+
+    def test_oauth_only_label_unchanged_when_show_keys(self, hermes_home):
+        """``--show-keys`` does not leak OAuth tokens — still emits ``set (oauth)``."""
+        _write_credential_pool(
+            hermes_home,
+            {
+                "openai-codex": [
+                    {
+                        "id": "cdx",
+                        "source": "device_code",
+                        "auth_type": "oauth",
+                        "access_token": "very-secret-codex-token",
+                    }
+                ],
+            },
+        )
+
+        out = _run_dump(show_keys=True)
+        codex_lines = [
+            l for l in out.splitlines() if l.strip().startswith("openai_codex ")
+        ]
+        assert codex_lines
+        assert "set (oauth)" in codex_lines[0]
+        assert "very-secret-codex-token" not in codex_lines[0]


### PR DESCRIPTION
hermes debug previously listed OAuth-authenticated providers (Nous Portal, OpenAI Codex, Anthropic via claude_code) as "not set" because the api_keys section only consulted env vars and `~/.hermes/.env` — not the live OAuth tokens in `auth.json::credential_pool`. The misleading report repeatedly sent triage workflows down false "auth misconfigured" paths.

## What changed and why
- `hermes_cli/dump.py`: each api_keys row now carries a `pool_key`. When the env var is unset, the dumper falls back to checking `auth.json::credential_pool[pool_key][*].access_token` and emits `set (oauth)` if any non-empty token is present. Status is now one of `set (env)` / `set (oauth)` / `not set`, matching the agent's actual runtime credential resolution.
- New section listing OAuth-only providers (`openai_codex`, `qwen_oauth`, `minimax_oauth`, `google_gemini_cli`) that previously had no row in the dump at all, so users could never tell from `hermes debug` whether they were logged in.
- `tests/hermes_cli/test_dump_credentials.py`: 9 new tests covering the OAuth detection path, env-var precedence over OAuth, empty/missing pool entries, missing `auth.json`, and `--show-keys` redaction safety for OAuth tokens.

## How to test
- `pytest tests/hermes_cli/test_dump_credentials.py -q` — 9 new tests pass
- `pytest tests/hermes_cli/test_debug.py -q` — existing 66 tests still pass
- Manual: log in to Nous Portal via OAuth, then `hermes debug` — `nous` should now show `set (oauth)` instead of `not set`.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #20675

<!-- autocontrib:worker-id=issue-new-de93a87c kind=pr-open -->