### PR TITLE
fix(tui): cap expanded system-prompt rendering

### DIFF
--- a/ui-tui/src/__tests__/text.test.ts
+++ b/ui-tui/src/__tests__/text.test.ts
@@ -4,6 +4,7 @@ import {
   boundedLiveRenderText,
   buildToolTrailLine,
   buildVerboseToolTrailLine,
+  cappedSystemPromptText,
   edgePreview,
   estimateRows,
   estimateTokensRough,
@@ -213,6 +214,47 @@ describe('boundedLiveRenderText', () => {
     expect(out).toContain('c\nd')
     expect(out).toContain('omitted 2 lines')
     expect(out).not.toContain('a\nb')
+  })
+})
+
+describe('cappedSystemPromptText', () => {
+  it('passes through short prompts untouched', () => {
+    const out = cappedSystemPromptText('one\ntwo', { maxChars: 100, maxLines: 10 })
+    expect(out.truncated).toBe(false)
+    expect(out.text).toBe('one\ntwo')
+    expect(out.omittedChars).toBe(0)
+    expect(out.omittedLines).toBe(0)
+  })
+
+  it('caps the head by character budget', () => {
+    const out = cappedSystemPromptText('abcdefghij', { maxChars: 4, maxLines: 10 })
+    expect(out.truncated).toBe(true)
+    expect(out.text).toBe('abcd')
+    expect(out.omittedChars).toBe(6)
+  })
+
+  it('caps the head by line budget and reports omitted lines', () => {
+    const text = ['a', 'b', 'c', 'd', 'e'].join('\n')
+    const out = cappedSystemPromptText(text, { maxChars: 100, maxLines: 2 })
+    expect(out.truncated).toBe(true)
+    expect(out.text).toBe('a\nb')
+    expect(out.omittedLines).toBe(2)
+    expect(out.omittedChars).toBe(text.length - out.text.length - 1)
+  })
+
+  it('preserves an exact line-limit trailing newline', () => {
+    const text = 'a\n'.repeat(80)
+    const out = cappedSystemPromptText(text, { maxChars: 1000, maxLines: 80 })
+
+    expect(out).toEqual({ omittedChars: 0, omittedLines: 0, text, truncated: false })
+  })
+
+  it('does not flood when the prompt is 18k+ chars (issue #20668)', () => {
+    const huge = 'a'.repeat(18_000)
+    const out = cappedSystemPromptText(huge)
+    expect(out.truncated).toBe(true)
+    expect(out.text.length).toBeLessThanOrEqual(4000)
+    expect(out.omittedChars).toBeGreaterThan(13_000)
   })
 })
 

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -4,7 +4,7 @@ import unicodeSpinners from 'unicode-animations'
 
 import { artWidth, caduceus, CADUCEUS_WIDTH, logo, LOGO_WIDTH } from '../banner.js'
 import { mix } from '../lib/color.js'
-import { flat } from '../lib/text.js'
+import { cappedSystemPromptText, flat, fmtK } from '../lib/text.js'
 import type { Theme } from '../theme.js'
 import type { PanelSection, SessionInfo } from '../types.js'
 
@@ -340,7 +340,19 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
       return <Text color={t.color.muted}>No system prompt loaded.</Text>
     }
 
-    return <Text color={t.color.muted}>{info.system_prompt}</Text>
+    const capped = cappedSystemPromptText(info.system_prompt ?? '')
+
+    return (
+      <>
+        <Text color={t.color.muted}>{capped.text}</Text>
+        {capped.truncated && (
+          <Text color={t.color.muted} dimColor>
+            … {fmtK(capped.omittedChars)} more chars
+            {capped.omittedLines > 0 ? ` / ${fmtK(capped.omittedLines)} lines` : ''} hidden
+          </Text>
+        )}
+      </>
+    )
   }
 
   // The wide layout is a real two-column grid: a fixed-width hero track and a

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -10,7 +10,9 @@ import { ROLE } from '../domain/roles.js'
 import { transcriptBodyWidth, transcriptGutterWidth } from '../lib/inputMetrics.js'
 import {
   boundedLiveRenderText,
+  cappedSystemPromptText,
   compactPreview,
+  fmtK,
   hasAnsi,
   isPasteBackedText,
   sanitizeAnsiForRender,
@@ -139,6 +141,7 @@ export const MessageLine = memo(function MessageLine({
     // contain Rich markup escape codes that would otherwise hit <Ansi> full render.
     if (systemIsLong) {
       const firstLine = (msg.text.split('\n')[0] ?? '').trim().slice(0, 120) || '(system message)'
+      const capped = systemOpen ? cappedSystemPromptText(msg.text) : null
 
       return (
         <Box flexDirection="column">
@@ -150,7 +153,13 @@ export const MessageLine = memo(function MessageLine({
               {msg.text.length.toLocaleString()} chars
             </Text>
           </Box>
-          {systemOpen && <Ansi>{sanitizeAnsiForRender(msg.text)}</Ansi>}
+          {capped && <Ansi>{sanitizeAnsiForRender(capped.text)}</Ansi>}
+          {capped?.truncated && (
+            <Text color={t.color.muted} dimColor>
+              … {fmtK(capped.omittedChars)} more chars
+              {capped.omittedLines > 0 ? ` / ${fmtK(capped.omittedLines)} lines` : ''} hidden
+            </Text>
+          )}
         </Box>
       )
     }

--- a/ui-tui/src/config/limits.ts
+++ b/ui-tui/src/config/limits.ts
@@ -20,6 +20,12 @@ export const LONG_MSG = 300
 export const MAX_HISTORY = 800
 export const THINKING_COT_MAX = 160
 
+// Cap for expanded system-prompt rendering (SessionPanel + transcript).
+// An 18k+ char system prompt as a single Text/Ansi node otherwise floods the
+// viewport faster than the user can hit the (top-only) collapse toggle.
+export const SYSTEM_PROMPT_RENDER_MAX_CHARS = 4000
+export const SYSTEM_PROMPT_RENDER_MAX_LINES = 80
+
 // Rows per wheel event (pre-accel). 1 keeps Ink's DECSTBM fast path live
 // (each scroll < viewport-1) and produces smooth motion. wheelAccel.ts
 // ramps this on sustained scrolls.

--- a/ui-tui/src/lib/text.ts
+++ b/ui-tui/src/lib/text.ts
@@ -1,6 +1,8 @@
 import {
   LIVE_RENDER_MAX_CHARS,
   LIVE_RENDER_MAX_LINES,
+  SYSTEM_PROMPT_RENDER_MAX_CHARS,
+  SYSTEM_PROMPT_RENDER_MAX_LINES,
   THINKING_COT_MAX,
   VERBOSE_TRAIL_MAX_CHARS,
   VERBOSE_TRAIL_MAX_LINES
@@ -172,6 +174,44 @@ const boundedRenderText = (
       : `[${labelPrefix}; omitted ${fmtK(omittedChars)} chars]\n`
 
   return `${label}${tail}`
+}
+
+export interface CappedText {
+  omittedChars: number
+  omittedLines: number
+  text: string
+  truncated: boolean
+}
+
+export const cappedSystemPromptText = (
+  text: string,
+  { maxChars = SYSTEM_PROMPT_RENDER_MAX_CHARS, maxLines = SYSTEM_PROMPT_RENDER_MAX_LINES } = {}
+): CappedText => {
+  if (text.length <= maxChars && text.split('\n', maxLines + 1).length <= maxLines) {
+    return { omittedChars: 0, omittedLines: 0, text, truncated: false }
+  }
+
+  let end = 0
+  let lines = 0
+
+  while (lines < maxLines && end < text.length && end < maxChars) {
+    const next = text.indexOf('\n', end)
+
+    if (next < 0 || next >= maxChars) {
+      end = Math.min(text.length, maxChars)
+
+      break
+    }
+
+    end = next + 1
+    lines++
+  }
+
+  const head = end === text.length ? text : text.slice(0, end).replace(/\n+$/, '')
+  const omittedChars = text.length - end
+  const omittedLines = countNewlines(text, text.length) - countNewlines(text, end)
+
+  return { omittedChars, omittedLines, text: head, truncated: omittedChars > 0 }
 }
 
 const countNewlines = (text: string, end: number) => {


### PR DESCRIPTION
Cap expanded system-prompt rendering so an 18k+ char prompt no longer floods the terminal past the (top-only) collapse toggle.

## What changed and why
- Added `cappedSystemPromptText` in `ui-tui/src/lib/text.ts` that head-caps text to `SYSTEM_PROMPT_RENDER_MAX_CHARS` (4000) / `SYSTEM_PROMPT_RENDER_MAX_LINES` (80) and reports omitted chars/lines.
- `SessionPanel.systemBody` (`branding.tsx`) and the long-system-message branch in `messageLine.tsx` now render `capped.text` and append a `… N more chars hidden` line when truncated, instead of dumping the full string into a single `Text`/`Ansi` node.
- Added 4 unit tests covering the short-prompt passthrough, char cap, line cap, and the 18k-char regression path.

## How to test
- `cd ui-tui && npm install && npm run build --prefix packages/hermes-ink && npx vitest run` — all 622 tests pass.
- `cd ui-tui && npm run type-check` — passes.
- Manual: open the TUI with a long system prompt, expand the **System Prompt** section in the SessionPanel banner and the long-system message line in the transcript; the body shows at most ~80 lines / ~4000 chars followed by `… N more chars hidden`. Re-collapse at the top still works without scrolling.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #20668

<!-- autocontrib:worker-id=issue-new-edc5faad kind=pr-open -->