### PR TITLE
fix(gateway): route Telegram image-MIME documents through the photo cache path

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3248,6 +3248,43 @@ class TelegramAdapter(BasePlatformAdapter):
                     video_mime_to_ext = {v: k for k, v in SUPPORTED_VIDEO_TYPES.items()}
                     ext = video_mime_to_ext.get(doc.mime_type, "")
 
+                # ── Image documents (sent as "file" without compression) ──
+                # Telegram clients let users send a PNG/JPG either as a photo
+                # (compressed) or as a document (uncompressed). The latter
+                # arrives here with mime_type='image/*'. Route those through
+                # the same cache-and-enqueue path as msg.photo so the vision
+                # pipeline (native attach + vision_analyze) can see the bytes.
+                # Without this, image-as-file messages fall into the
+                # "Unsupported document type" branch below and the model
+                # never receives the pixels.
+                _IMG_DOC_MIMES = {
+                    "image/jpeg": ".jpg", "image/jpg": ".jpg",
+                    "image/png": ".png", "image/webp": ".webp",
+                    "image/gif": ".gif", "image/heic": ".heic",
+                    "image/heif": ".heif", "image/bmp": ".bmp",
+                }
+                _IMG_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif", ".heic", ".heif", ".bmp"}
+                if (doc.mime_type in _IMG_DOC_MIMES) or (ext in _IMG_EXTS):
+                    if not ext:
+                        ext = _IMG_DOC_MIMES.get(doc.mime_type, ".jpg")
+                    file_obj = await doc.get_file()
+                    image_bytes = await file_obj.download_as_bytearray()
+                    cached_path = cache_image_from_bytes(bytes(image_bytes), ext=ext)
+                    event.media_urls = [cached_path]
+                    event.media_types = [doc.mime_type or f"image/{ext.lstrip('.')}"]
+                    event.message_type = MessageType.PHOTO
+                    logger.info(
+                        "[Telegram] Cached image-document at %s (mime=%s)",
+                        cached_path, doc.mime_type,
+                    )
+                    media_group_id = getattr(msg, "media_group_id", None)
+                    if media_group_id:
+                        await self._queue_media_group_event(str(media_group_id), event)
+                    else:
+                        batch_key = self._photo_batch_key(event, msg)
+                        self._enqueue_photo_event(batch_key, event)
+                    return
+
                 if ext in SUPPORTED_VIDEO_TYPES:
                     file_obj = await doc.get_file()
                     video_bytes = await file_obj.download_as_bytearray()


### PR DESCRIPTION
## What & Why

When a Telegram user sends an image with the **"Send as file"** option (or, on mobile, sends without ticking **"Compress images"**), python-telegram-bot delivers it as `msg.document` with an `image/*` MIME type — not as `msg.photo`.

The current document handler in `gateway/platforms/telegram.py` has no entry for image MIMEs in `SUPPORTED_DOCUMENT_TYPES`. So:

1. `ext` is set to `""` (no `image/png` → `.png` mapping)
2. `if ext not in SUPPORTED_DOCUMENT_TYPES:` fires
3. The user sees `"Unsupported document type 'unknown'"`
4. The vision pipeline (native attach / `vision_analyze`) never sees the bytes

This is surprising for users who do tick "Compress images" — they *do* see the image — but breaks the moment they uncompress.

**Fix**: add a small early branch in the existing `elif msg.document:` handler that detects `image/*` MIME types and routes them through the same `cache_image_from_bytes` + photo-batch enqueue path as `msg.photo`. ~30 lines, lives in the existing document branch (no new top-level handlers), and reuses the existing `_photo_batch_key` / `_enqueue_photo_event` plumbing. Photos and image-as-files behave identically end-to-end after this lands.

Recognized image MIMEs / extensions: `image/jpeg`, `image/jpg`, `image/png`, `image/webp`, `image/gif`, `image/heic`, `image/heif`, `image/bmp`.

## How to test

With `agent.image_input_mode: "native"` + a multimodal main model (Qwen-VL, etc.):

1. Photo via "Compress images" — works (existing behaviour)
2. **Same PNG via "Send as file" — model now describes it correctly** (was hallucinating before)
3. `.heic` / `.gif` / `.webp` document — same behaviour
4. `application/pdf` document — still hits the existing PDF handling path (no regression)
5. `video/mp4` document — still hits the existing video handling path (no regression)

## Tested on

- **End-to-end (production):** Linux x86_64 (Debian 13 / "trixie") in a Docker container, python-telegram-bot 21.x, vLLM serving a Qwen-VL multimodal model. Mobile Telegram (iOS) sending both compressed photos and "Send as file" PNG/JPG, plus PDF / MP4 documents to verify no regressions.
- **Unit tests (locally on macOS 15, Python 3.11, against this branch):**
  ```
  pytest tests/gateway/test_telegram_documents.py \
         tests/gateway/test_telegram_photo_interrupts.py \
         tests/gateway/test_telegram_caption_merge.py -v
  ============================== 53 passed in 5.17s ==============================
  ```