### PR TITLE
fix(tools): forward ImageContent blocks from MCP tool results

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2054,12 +2054,46 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     )
                 }, ensure_ascii=False)
 
-            # Collect text from content blocks
+            # Collect text + image content from MCP result blocks. MCP servers
+            # can return ImageContent (per the MCP spec); we cache them to the
+            # shared Hermes image cache and surface their paths in the text so
+            # the agent can follow up with vision_analyze. Without this,
+            # ImageContent was silently dropped — MCP tools that return
+            # rendered diagrams, screenshots, OCR previews, etc. were unusable.
             parts: List[str] = []
+            cached_image_paths: List[str] = []
             for block in (result.content or []):
-                if hasattr(block, "text"):
+                if hasattr(block, "text") and block.text is not None:
                     parts.append(block.text)
+                elif hasattr(block, "data") and hasattr(block, "mimeType") and block.data:
+                    try:
+                        import base64 as _b64
+                        import mimetypes as _mt
+                        from gateway.platforms.base import cache_image_from_bytes
+                        raw = _b64.b64decode(block.data)
+                        ext = _mt.guess_extension(block.mimeType) or ".png"
+                        path = cache_image_from_bytes(raw, ext=ext)
+                        cached_image_paths.append(path)
+                        logger.info(
+                            "[mcp] cached image from %s.%s -> %s (%d bytes, %s)",
+                            server_name, tool_name, path, len(raw), block.mimeType,
+                        )
+                    except Exception as _e:
+                        logger.warning(
+                            "[mcp] failed to cache image content from %s.%s: %s",
+                            server_name, tool_name, _e,
+                        )
             text_result = "\n".join(parts) if parts else ""
+            if cached_image_paths:
+                _img_note = "\n".join(
+                    f"- {p}" for p in cached_image_paths
+                )
+                _img_section = (
+                    f"\n\n[The tool returned {len(cached_image_paths)} image(s). "
+                    f"To inspect them, call vision_analyze with image_path set to "
+                    f"one of these local paths:\n{_img_note}\n]"
+                )
+                text_result = (text_result + _img_section) if text_result else _img_section.lstrip()
 
             # Combine content + structuredContent when both are present.
             # MCP spec: content is model-oriented (text), structuredContent


### PR DESCRIPTION
## What & Why

The MCP spec allows tools to return `ImageContent` blocks alongside `TextContent` (`data` = base64 bytes, `mimeType` = e.g. `image/png`). The result extractor in `tools/mcp_tool.py` only walks `block.text`:

```python
parts: List[str] = []
for block in (result.content or []):
    if hasattr(block, "text"):
        parts.append(block.text)
text_result = "\n".join(parts) if parts else ""
```

`ImageContent` has no `.text` attribute, so any image returned by an MCP tool is silently dropped. Tools that produce diagrams, screenshots, OCR previews, charts, or rendered pages are unusable — the agent has no way to inspect their visual output.

A workaround pattern in the wild is for an MCP tool to do its own LLM call inside the tool body and return text. That works but defeats the point of MCP — the agent should choose how to interpret the image.

**Fix**: cache `ImageContent` blocks via `cache_image_from_bytes` (same image cache the Telegram photo path uses) and surface the resulting local paths in the text result so the agent can `vision_analyze` them on a follow-up turn. Stays compatible with the OpenAI `role: "tool"` chat-completions contract (which requires string content) and reuses the existing image-cache infrastructure.

For a richer future where tool results carry image parts on a synthetic user turn, this provides the same caching primitive the `_pending_native_image_paths` plumbing in `run_agent.py` could later consume.

Net change: ~30 lines in the `_call()` helper, no API changes, no new dependencies (`base64` + `mimetypes` from stdlib, `cache_image_from_bytes` from `gateway.platforms.base`).

## How to test

- MCP tool that returns text only — unchanged behaviour
- MCP tool that returns one `ImageContent` block — image cached, path surfaced in tool result, `vision_analyze` describes it
- MCP tool that returns mixed text + image — text preserved, image path appended in a clearly-marked footer
- Image cache eviction still works (new entries land in the same per-day directory the Telegram path uses)

## Tested on

- **End-to-end (production):** Linux x86_64 (Debian 13 / "trixie") in a Docker container, custom MCP server returning `mcp.types.ImageContent` blocks via the Python MCP SDK, vLLM serving a Qwen-VL multimodal main model with `auxiliary.vision.provider: "main"` so `vision_analyze` lands on the same model.
- **Unit tests (locally on macOS 15, Python 3.11, against this branch):**
  ```
  pytest tests/tools/test_mcp_tool.py \
         tests/tools/test_mcp_tool_issue_948.py \
         tests/tools/test_mcp_tool_401_handling.py \
         tests/tools/test_mcp_tool_session_expired.py -v
  ============================= 210 passed in 9.60s ==============================
  ```