### PR TITLE
feat(model-picker): add display.model_picker_providers allowlist

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1723,8 +1723,31 @@ def list_picker_providers(
         current_model=current_model,
     )
 
+    # Optional explicit allowlist: display.model_picker_providers in config.yaml.
+    # When set, the picker shows ONLY these provider slugs (plus the current
+    # provider, always). Empty/missing -> no filtering (legacy behavior).
+    allowlist: set[str] = set()
+    try:
+        from hermes_cli.config import load_config
+
+        _cfg = load_config() or {}
+        _disp = _cfg.get("display", {}) if isinstance(_cfg, dict) else {}
+        _raw = _disp.get("model_picker_providers") if isinstance(_disp, dict) else None
+        if isinstance(_raw, str):
+            allowlist = {s.strip().lower() for s in _raw.split(",") if s.strip()}
+        elif isinstance(_raw, (list, tuple)):
+            allowlist = {str(s).strip().lower() for s in _raw if str(s).strip()}
+    except Exception:
+        allowlist = set()
+    if allowlist and current_provider:
+        allowlist.add(str(current_provider).strip().lower())
+
     filtered: List[dict] = []
     for p in providers:
+        if allowlist:
+            slug_check = str(p.get("slug", "")).lower()
+            if slug_check not in allowlist:
+                continue
         slug = str(p.get("slug", "")).lower()
         if slug == "openrouter":
             try:

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -259,3 +259,94 @@ def test_current_custom_endpoint_passthrough_marks_current_row(monkeypatch):
     assert row["slug"] == "custom:ollama"
     assert row["is_current"] is True
     assert row["models"] == ["glm-5.1", "qwen3"]
+
+
+# ---------------------------------------------------------------------------
+# display.model_picker_providers allowlist
+# ---------------------------------------------------------------------------
+
+
+def _patch_authed(monkeypatch, providers):
+    monkeypatch.setattr(
+        model_switch, "list_authenticated_providers", lambda **kw: list(providers)
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_openrouter_models", lambda *a, **kw: []
+    )
+
+
+def _patch_config(monkeypatch, value):
+    """Patch hermes_cli.config.load_config to return display.model_picker_providers=value."""
+    cfg = {"display": {"model_picker_providers": value}} if value is not None else {}
+    import hermes_cli.config as _config_mod
+
+    monkeypatch.setattr(_config_mod, "load_config", lambda: cfg)
+
+
+def test_allowlist_filters_to_listed_providers(monkeypatch):
+    """When display.model_picker_providers is set, only listed slugs survive."""
+    base = [
+        _make_provider("openai", models=["gpt-4o"]),
+        _make_provider("anthropic", models=["claude-3.5"]),
+        _make_provider("groq", models=["llama-3"]),
+    ]
+    _patch_authed(monkeypatch, base)
+    _patch_config(monkeypatch, ["openai", "anthropic"])
+
+    result = model_switch.list_picker_providers(max_models=50)
+    slugs = {p["slug"] for p in result}
+    assert slugs == {"openai", "anthropic"}
+
+
+def test_allowlist_always_includes_current_provider(monkeypatch):
+    """Current provider is implicitly added to the allowlist."""
+    base = [
+        _make_provider("openai", models=["gpt-4o"]),
+        _make_provider("groq", models=["llama-3"], is_current=True),
+    ]
+    _patch_authed(monkeypatch, base)
+    # Allowlist excludes groq, but groq is the current provider.
+    _patch_config(monkeypatch, ["openai"])
+
+    result = model_switch.list_picker_providers(
+        current_provider="groq", max_models=50
+    )
+    slugs = {p["slug"] for p in result}
+    assert "groq" in slugs
+    assert "openai" in slugs
+
+
+def test_empty_or_missing_allowlist_is_no_op(monkeypatch):
+    """No allowlist => legacy unfiltered behavior."""
+    base = [
+        _make_provider("openai", models=["gpt-4o"]),
+        _make_provider("anthropic", models=["claude-3.5"]),
+        _make_provider("groq", models=["llama-3"]),
+    ]
+    _patch_authed(monkeypatch, base)
+    _patch_config(monkeypatch, None)  # no display.model_picker_providers key
+
+    result = model_switch.list_picker_providers(max_models=50)
+    slugs = {p["slug"] for p in result}
+    assert slugs == {"openai", "anthropic", "groq"}
+
+    # Empty list also means "no filter"
+    _patch_config(monkeypatch, [])
+    result = model_switch.list_picker_providers(max_models=50)
+    slugs = {p["slug"] for p in result}
+    assert slugs == {"openai", "anthropic", "groq"}
+
+
+def test_allowlist_accepts_comma_string(monkeypatch):
+    """display.model_picker_providers may be a comma-separated string."""
+    base = [
+        _make_provider("openai", models=["gpt-4o"]),
+        _make_provider("anthropic", models=["claude-3.5"]),
+        _make_provider("groq", models=["llama-3"]),
+    ]
+    _patch_authed(monkeypatch, base)
+    _patch_config(monkeypatch, "openai, anthropic")
+
+    result = model_switch.list_picker_providers(max_models=50)
+    slugs = {p["slug"] for p in result}
+    assert slugs == {"openai", "anthropic"}

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1657,3 +1657,25 @@ Override the working directory:
 MESSAGING_CWD=/home/myuser/projects    # Gateway sessions
 TERMINAL_CWD=/workspace                # All terminal sessions
 ```
+
+## Model Picker Allowlist
+
+Limit which providers appear in the interactive `/model` picker (the inline keyboard surfaced by Telegram, Discord, and other gateway adapters) by setting `display.model_picker_providers` in `~/.hermes/config.yaml`.
+
+```yaml
+display:
+  # Only show these providers in the /model picker.
+  # Slugs are case-insensitive. The currently active provider is always
+  # included even if it is not in the list.
+  model_picker_providers:
+    - openai
+    - anthropic
+    - openrouter
+```
+
+Notes:
+
+- A comma-separated string is also accepted: `model_picker_providers: "openai, anthropic, openrouter"`.
+- Empty or missing → no filtering (legacy behavior — all authenticated providers are listed).
+- Only the picker is filtered. The typed `/model <name>` switch is unaffected.
+- Useful when many providers are authenticated but only a few are worth surfacing in a quick chat picker.


### PR DESCRIPTION
## Summary

Add an optional config key — `display.model_picker_providers` — that restricts the interactive `/model` picker (the inline keyboard surfaced by Telegram/Discord and other gateway adapters) to a user-chosen set of provider slugs.

When many providers are authenticated, the inline picker can balloon to dozens of rows. This lets the user scope the picker down to the handful they actually use from chat without affecting the typed `/model <name>` flow.

## Behavior

- **Set** (list or comma-separated string): only those provider slugs are shown in the picker.
- **Current provider always included** — the user never loses their currently-active row even if it isn't in the allowlist.
- **Empty / missing**: legacy unfiltered behavior is preserved.
- Slugs are matched case-insensitively.
- Only the interactive picker is filtered; typed `/model <name>` switches are unaffected.

## Config example

```yaml
display:
  model_picker_providers:
    - openai
    - anthropic
    - openrouter
```

A comma-separated string also works: `model_picker_providers: "openai, anthropic, openrouter"`.

## Tests

`tests/hermes_cli/test_list_picker_providers.py` (extended, all 14 tests green):

- allowlist filters to listed providers
- current provider is always included even when excluded by the allowlist
- empty/missing allowlist => no filter (legacy behavior preserved)
- comma-separated string form is accepted

```
$ pytest -q tests/hermes_cli/test_list_picker_providers.py
14 passed in 1.89s
```

## Docs

Adds a short "Model Picker Allowlist" section to `website/docs/user-guide/configuration.md`.

## Related

Closes the long-standing ask in #12655, #15267, #16608 — pluggable / configurable scope for the `/model` chat picker.