### PR TITLE
feat: wire clarify tool into the messaging gateway

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -14,7 +14,7 @@ import os
 import tempfile
 import html as _html
 import re
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -286,6 +286,9 @@ class TelegramAdapter(BasePlatformAdapter):
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
+        # Clarify-button state: clarify_id -> (session_key, list-of-choice-labels).
+        # Mirrors _approval_state; a counter picks short ints for callback_data.
+        self._clarify_state: Dict[int, Tuple[str, List[str]]] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
@@ -1552,6 +1555,89 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_exec_approval failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[List[str]],
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a clarify prompt with inline-keyboard buttons (one per choice).
+
+        Mirrors :meth:`send_exec_approval`. Buttons resolve the clarify via
+        ``tools.clarify_bridge.resolve_gateway_clarify`` so the blocked agent
+        thread wakes with the chosen answer. Open-ended clarifies (no choices)
+        fall back to plain text because a keyboard with no buttons is useless.
+        """
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        # No choices → no buttons make sense. Signal fallback so the gateway
+        # uses plain text + "Reply with your answer." prompt.
+        if not choices:
+            return SendResult(success=False, error="no_choices")
+
+        try:
+            q_preview = question[:3800] + "..." if len(question) > 3800 else question
+            text = (
+                f"🤔 <b>{_html.escape(q_preview)}</b>"
+            )
+
+            thread_id = self._metadata_thread_id(metadata)
+
+            import itertools
+            if not hasattr(self, "_clarify_counter"):
+                self._clarify_counter = itertools.count(1)
+            clarify_id = next(self._clarify_counter)
+
+            # One button per choice, one choice per row (labels are often long
+            # enough that two-per-row wraps badly on mobile). Each button's
+            # callback_data is just the choice index — the text label lives in
+            # _clarify_state so callback_data stays short (Telegram caps it at
+            # 64 bytes).
+            keyboard_rows = []
+            for idx, choice in enumerate(choices):
+                # Truncate button text to keep Telegram happy (hard limit is
+                # large, but mobile rendering gets ugly past ~40 chars).
+                label = (choice[:40] + "…") if len(choice) > 40 else choice
+                keyboard_rows.append([
+                    InlineKeyboardButton(
+                        label,
+                        callback_data=f"cq:{clarify_id}:{idx}",
+                    )
+                ])
+            # Also offer a cancel button so the user isn't forced to pick one.
+            # Cancel is modelled as "no answer" — the agent sees
+            # ClarifyUnavailable and can react accordingly.
+            keyboard_rows.append([
+                InlineKeyboardButton(
+                    "✗ Cancel",
+                    callback_data=f"cq:{clarify_id}:cancel",
+                )
+            ])
+            keyboard = InlineKeyboardMarkup(keyboard_rows)
+
+            kwargs: Dict[str, Any] = {
+                "chat_id": int(chat_id),
+                "text": text,
+                "parse_mode": ParseMode.HTML,
+                "reply_markup": keyboard,
+                **self._link_preview_kwargs(),
+            }
+            message_thread_id = self._message_thread_id_for_send(thread_id)
+            if message_thread_id is not None:
+                kwargs["message_thread_id"] = message_thread_id
+
+            msg = await self._bot.send_message(**kwargs)
+
+            self._clarify_state[clarify_id] = (session_key, list(choices))
+
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_clarify failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str,
         confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
@@ -1972,6 +2058,93 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
                 except Exception as exc:
                     logger.error("Failed to resolve gateway approval from Telegram button: %s", exc)
+            return
+
+        # --- Clarify callbacks (cq:clarify_id:idx-or-cancel) ---
+        if data.startswith("cq:"):
+            parts = data.split(":", 2)
+            if len(parts) == 3:
+                try:
+                    clarify_id = int(parts[1])
+                except (ValueError, IndexError):
+                    await query.answer(text="Invalid clarify data.")
+                    return
+                choice_token = parts[2]  # either an int string or "cancel"
+
+                # Only authorized users may answer clarify questions.
+                caller_id = str(getattr(query.from_user, "id", ""))
+                if not self._is_callback_user_authorized(
+                    caller_id,
+                    chat_id=query_chat_id,
+                    chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                    user_name=query_user_name,
+                ):
+                    await query.answer(text="⛔ You are not authorized to answer this clarify.")
+                    return
+
+                state = self._clarify_state.pop(clarify_id, None)
+                if not state:
+                    await query.answer(text="This clarify has already been resolved.")
+                    return
+                session_key, choices = state
+
+                user_display = getattr(query.from_user, "first_name", "User")
+
+                # Cancel → clear the pending clarify so the agent thread wakes
+                # with ClarifyUnavailable. No answer is sent.
+                if choice_token == "cancel":
+                    await query.answer(text="✗ Cancelled")
+                    try:
+                        await query.edit_message_text(
+                            text=f"✗ Clarify cancelled by {user_display}",
+                            parse_mode=ParseMode.MARKDOWN,
+                            reply_markup=None,
+                        )
+                    except Exception:
+                        pass
+                    try:
+                        from tools.clarify_bridge import clear_session_clarifies
+                        clear_session_clarifies(session_key)
+                        logger.info(
+                            "Telegram button cancelled clarify for session %s (user=%s)",
+                            session_key, user_display,
+                        )
+                    except Exception as exc:
+                        logger.error("Failed to cancel gateway clarify from Telegram button: %s", exc)
+                    return
+
+                # Numeric choice → look up the label and resolve with the text.
+                try:
+                    choice_idx = int(choice_token)
+                except ValueError:
+                    await query.answer(text="Invalid clarify choice.")
+                    return
+                if choice_idx < 0 or choice_idx >= len(choices):
+                    await query.answer(text="Choice out of range.")
+                    return
+
+                chosen_label = choices[choice_idx]
+                await query.answer(text=f"✓ {chosen_label[:40]}")
+
+                try:
+                    await query.edit_message_text(
+                        text=f"✓ Answered by {user_display}: **{_html.escape(chosen_label)}**",
+                        parse_mode=ParseMode.MARKDOWN,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+
+                try:
+                    from tools.clarify_bridge import resolve_gateway_clarify
+                    count = resolve_gateway_clarify(session_key, chosen_label)
+                    logger.info(
+                        "Telegram button resolved %d clarify(ies) for session %s (choice='%s', user=%s)",
+                        count, session_key, chosen_label, user_display,
+                    )
+                except Exception as exc:
+                    logger.error("Failed to resolve gateway clarify from Telegram button: %s", exc)
             return
 
         # --- Slash-confirm callbacks (sc:choice:confirm_id) ---

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13680,6 +13680,10 @@ class GatewayRunner:
                 Must return quickly — the clarify bridge blocks on the
                 threading.Event separately, so latency here just delays the
                 user seeing the question.
+
+                Prefers button-based UI when the adapter implements
+                ``send_clarify`` (currently Telegram for multi-choice
+                clarifies); falls back to plain text otherwise.
                 """
                 # Pause typing for the same reason as approvals: users need to
                 # be able to type their answer, which some platforms (Slack
@@ -13691,7 +13695,43 @@ class GatewayRunner:
                     # don't implement it (or fail) shouldn't block the send.
                     pass
 
-                # Format: "🤔 <question>\n\n 1. choice A\n 2. choice B\n…\n\n(Reply with your answer.)"
+                # Prefer button-based clarify when the adapter supports it
+                # AND we have multi-choice options. Open-ended clarifies
+                # always fall back to plain text (no buttons make sense).
+                # Check the *class* for the method, not the instance — avoids
+                # false positives from MagicMock auto-attribute creation in tests.
+                if (
+                    choices
+                    and getattr(type(_status_adapter), "send_clarify", None) is not None
+                ):
+                    try:
+                        _clarify_result = asyncio.run_coroutine_threadsafe(
+                            _status_adapter.send_clarify(
+                                chat_id=_status_chat_id,
+                                question=question,
+                                choices=list(choices),
+                                session_key=_approval_session_key,
+                                metadata=_status_thread_metadata,
+                            ),
+                            _loop_for_step,
+                        ).result(timeout=15)
+                        if _clarify_result.success:
+                            return
+                        # "no_choices" is an expected fallback signal for
+                        # adapters that require choices for buttons; anything
+                        # else is a real failure worth logging at warning.
+                        if _clarify_result.error != "no_choices":
+                            logger.warning(
+                                "Button-based clarify failed (send returned error), "
+                                "falling back to text: %s",
+                                _clarify_result.error,
+                            )
+                    except Exception as _e:
+                        logger.warning(
+                            "Button-based clarify failed, falling back to text: %s", _e
+                        )
+
+                # Fallback: plain text clarify prompt with numbered choices.
                 parts = [f"🤔 **{question}**"]
                 if choices:
                     parts.append("")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5057,6 +5057,42 @@ class GatewayRunner:
                     return await self._handle_approve_command(event)
                 return await self._handle_deny_command(event)
 
+            # Clarify tool: if the agent is blocked waiting for the user to
+            # answer a clarify() question, the agent thread is parked on a
+            # threading.Event inside tools/clarify_bridge.py. Route any plain
+            # text message (i.e. not a slash command) directly to the clarify
+            # bridge instead of interrupting the agent or starting a new turn.
+            # Slash commands still pass through so /stop / /new / /approve etc.
+            # retain their usual semantics even while a clarify is live.
+            if (
+                not _cmd_def_inner
+                and event.message_type == MessageType.TEXT
+                and event.text is not None
+            ):
+                try:
+                    from tools.clarify_bridge import (
+                        has_blocking_clarify as _has_blocking_clarify,
+                        resolve_gateway_clarify as _resolve_gateway_clarify,
+                    )
+                    if _has_blocking_clarify(_quick_key):
+                        resolved = _resolve_gateway_clarify(_quick_key, event.text)
+                        if resolved:
+                            logger.info(
+                                "Clarify answered for session %s (len=%d)",
+                                _quick_key,
+                                len(event.text),
+                            )
+                            # Return None so no reply is sent — the user's
+                            # message IS the answer; the agent will resume
+                            # and produce its own response.
+                            return None
+                except Exception as _clarify_exc:
+                    logger.warning(
+                        "Clarify bridge routing failed for session %s: %s",
+                        _quick_key,
+                        _clarify_exc,
+                    )
+
             # /agents (/tasks alias) should be query-only and never interrupt.
             if _cmd_def_inner and _cmd_def_inner.name == "agents":
                 return await self._handle_agents_command(event)
@@ -12204,6 +12240,18 @@ class GatewayRunner:
         running_agent = self._running_agents.get(session_key)
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             running_agent.interrupt(interrupt_reason)
+        # Cancel any pending clarify so the blocked agent thread unblocks
+        # with a ClarifyUnavailable error instead of timing out silently.
+        # Safe to call unconditionally — no-op when nothing is pending.
+        try:
+            from tools.clarify_bridge import clear_session_clarifies
+            clear_session_clarifies(session_key)
+        except Exception as _clarify_exc:
+            logger.warning(
+                "Failed to clear clarify state for session %s: %s",
+                session_key,
+                _clarify_exc,
+            )
         self._invalidate_session_run_generation(session_key, reason=invalidation_reason)
         adapter = self.adapters.get(source.platform)
         if adapter and hasattr(adapter, "interrupt_session_activity"):
@@ -13551,6 +13599,11 @@ class GatewayRunner:
                 set_current_session_key,
                 unregister_gateway_notify,
             )
+            from tools.clarify_bridge import (
+                gateway_clarify_callback as _build_gateway_clarify_callback,
+                register_gateway_clarify_notify,
+                unregister_gateway_clarify_notify,
+            )
 
             def _approval_notify_sync(approval_data: dict) -> None:
                 """Send the approval request to the user from the agent thread.
@@ -13618,6 +13671,56 @@ class GatewayRunner:
                     ).result(timeout=15)
                 except Exception as _e:
                     logger.error("Failed to send approval request: %s", _e)
+
+            def _clarify_notify_sync(question: str, choices: Optional[list]) -> None:
+                """Send a clarify question to the user from the agent thread.
+
+                Mirrors ``_approval_notify_sync``: runs synchronously in the
+                agent thread, schedules the actual send on the event loop.
+                Must return quickly — the clarify bridge blocks on the
+                threading.Event separately, so latency here just delays the
+                user seeing the question.
+                """
+                # Pause typing for the same reason as approvals: users need to
+                # be able to type their answer, which some platforms (Slack
+                # Assistant API) block while "is thinking..." is active.
+                try:
+                    _status_adapter.pause_typing_for_chat(_status_chat_id)
+                except Exception:
+                    # pause_typing_for_chat is best-effort; adapters that
+                    # don't implement it (or fail) shouldn't block the send.
+                    pass
+
+                # Format: "🤔 <question>\n\n 1. choice A\n 2. choice B\n…\n\n(Reply with your answer.)"
+                parts = [f"🤔 **{question}**"]
+                if choices:
+                    parts.append("")
+                    for idx, choice in enumerate(choices, start=1):
+                        parts.append(f"  {idx}. {choice}")
+                    parts.append("")
+                    parts.append(
+                        "_Reply with a number or type your own answer._"
+                    )
+                else:
+                    parts.append("")
+                    parts.append("_Reply with your answer._")
+                msg = "\n".join(parts)
+
+                try:
+                    asyncio.run_coroutine_threadsafe(
+                        _status_adapter.send(
+                            _status_chat_id,
+                            msg,
+                            metadata=_status_thread_metadata,
+                        ),
+                        _loop_for_step,
+                    ).result(timeout=15)
+                except Exception as _e:
+                    logger.error("Failed to send clarify question: %s", _e)
+                    # Re-raise so the bridge pops the entry; otherwise the
+                    # agent would block for 30 minutes waiting for an answer
+                    # to a question the user never saw.
+                    raise
 
             # Prepend pending model switch note so the model knows about the switch
             _pending_notes = getattr(self, '_pending_model_notes', {})
@@ -13711,6 +13814,12 @@ class GatewayRunner:
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
+            register_gateway_clarify_notify(_approval_session_key, _clarify_notify_sync)
+            # Wire the clarify tool into the agent for this turn. The callback
+            # blocks the agent thread until the user replies (handled by the
+            # inbound-message router, which routes plain text to
+            # resolve_gateway_clarify instead of starting a new turn).
+            agent.clarify_callback = _build_gateway_clarify_callback(_approval_session_key)
             try:
                 # If _prepare_inbound_message_text buffered image paths for native
                 # attachment, wrap the user turn as an OpenAI-style multimodal
@@ -13746,6 +13855,7 @@ class GatewayRunner:
                 result = agent.run_conversation(_run_message, conversation_history=agent_history, task_id=session_id)
             finally:
                 unregister_gateway_notify(_approval_session_key)
+                unregister_gateway_clarify_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
 

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -1,0 +1,312 @@
+"""Tests for Telegram inline keyboard clarify buttons.
+
+Mirrors test_telegram_approval_buttons.py — we mock the telegram package
+enough to import TelegramAdapter, then exercise send_clarify and the
+cq:-prefixed callback_query handler path.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Telegram mock so TelegramAdapter can be imported
+# ---------------------------------------------------------------------------
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+from gateway.config import Platform, PlatformConfig  # noqa: E402
+
+
+def _make_adapter(extra=None):
+    config = PlatformConfig(enabled=True, token="test-token", extra=extra or {})
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+# ===========================================================================
+# send_clarify — inline keyboard buttons
+# ===========================================================================
+
+
+class TestTelegramSendClarify:
+    """send_clarify should emit an InlineKeyboard with one button per choice."""
+
+    @pytest.mark.asyncio
+    async def test_sends_inline_keyboard_with_one_button_per_choice(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 77
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        result = await adapter.send_clarify(
+            chat_id="12345",
+            question="Which branch?",
+            choices=["main", "feat/x", "release"],
+            session_key="agent:main:telegram:dm:12345:1",
+        )
+
+        assert result.success is True
+        assert result.message_id == "77"
+
+        adapter._bot.send_message.assert_called_once()
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert kwargs["chat_id"] == 12345
+        assert "Which branch?" in kwargs["text"]
+        # InlineKeyboardMarkup is a mock in this test env — don't introspect
+        # its shape here; test_stores_clarify_state below covers the wiring.
+        assert kwargs["reply_markup"] is not None
+
+    @pytest.mark.asyncio
+    async def test_stores_clarify_state_with_session_and_choices(self):
+        """After send_clarify the adapter remembers session_key + choice labels."""
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 1
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        await adapter.send_clarify(
+            chat_id="12345",
+            question="Q?",
+            choices=["alpha", "beta", "gamma"],
+            session_key="sk-1",
+        )
+
+        assert len(adapter._clarify_state) == 1
+        clarify_id = list(adapter._clarify_state.keys())[0]
+        session_key, choices = adapter._clarify_state[clarify_id]
+        assert session_key == "sk-1"
+        assert choices == ["alpha", "beta", "gamma"]
+
+    @pytest.mark.asyncio
+    async def test_sends_in_thread_when_metadata_has_thread_id(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 1
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        await adapter.send_clarify(
+            chat_id="12345",
+            question="Q?",
+            choices=["A", "B"],
+            session_key="sk",
+            metadata={"thread_id": "999"},
+        )
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert kwargs.get("message_thread_id") == 999
+
+    @pytest.mark.asyncio
+    async def test_not_connected_returns_error(self):
+        adapter = _make_adapter()
+        adapter._bot = None
+        result = await adapter.send_clarify(
+            chat_id="12345", question="Q?", choices=["A"], session_key="sk"
+        )
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_open_ended_clarify_returns_no_choices_signal(self):
+        """With no choices, send_clarify must signal fallback — don't send an empty keyboard."""
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock()
+
+        result = await adapter.send_clarify(
+            chat_id="12345",
+            question="What's your name?",
+            choices=None,
+            session_key="agent:main:telegram:dm:12345:1",
+        )
+
+        assert result.success is False
+        assert result.error == "no_choices"
+        adapter._bot.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_choices_returns_no_choices_signal(self):
+        """Empty list behaves like None — fallback to plain text."""
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock()
+
+        result = await adapter.send_clarify(
+            chat_id="12345",
+            question="Pick...",
+            choices=[],
+            session_key="sk",
+        )
+
+        assert result.success is False
+        assert result.error == "no_choices"
+        adapter._bot.send_message.assert_not_called()
+
+
+# ===========================================================================
+# cq: callback — button clicks resolve the clarify
+# ===========================================================================
+
+
+class _AuthRunner:
+    def __init__(self, authorized: bool):
+        self.authorized = authorized
+
+    async def _handle_message(self, event):
+        return None
+
+    def _is_user_authorized(self, source):
+        return self.authorized
+
+
+def _make_callback_query(data: str, user_id: int = 7785056549, user_name: str = "sx"):
+    """Build a MagicMock Update object that looks like a Telegram callback_query."""
+    update = MagicMock()
+    q = update.callback_query
+    q.data = data
+    q.from_user.id = user_id
+    q.from_user.first_name = user_name
+    q.message.chat_id = 12345
+    q.message.chat.type = "private"
+    q.message.message_thread_id = None
+    q.answer = AsyncMock()
+    q.edit_message_text = AsyncMock()
+    return update
+
+
+class TestTelegramClarifyCallback:
+    """_handle_callback_query should route cq:* data to resolve_gateway_clarify."""
+
+    @pytest.mark.asyncio
+    async def test_button_click_resolves_clarify(self):
+        from tools import clarify_bridge
+
+        adapter = _make_adapter()
+        runner = _AuthRunner(True)
+        adapter._message_handler = runner._handle_message
+        # Seed adapter state as if send_clarify had just run.
+        adapter._clarify_state[1] = ("test-session", ["option A", "option B", "option C"])
+
+        # Register a no-op notifier so the bridge will accept entries, and
+        # enqueue one so resolve has something to signal.
+        clarify_bridge.register_gateway_clarify_notify("test-session", lambda q, c: None)
+        # Manually create a blocking entry via the bridge's internals — the
+        # happy-path integration test is in test_clarify_bridge.py; here we
+        # just need resolve_gateway_clarify to return 1 to verify the wire-up.
+        import threading as _th
+        from tools.clarify_bridge import _ClarifyEntry, _queues
+        entry = _ClarifyEntry("Q?", ["option A", "option B", "option C"])
+        _queues.setdefault("test-session", []).append(entry)
+
+        update = _make_callback_query("cq:1:1")  # pick index 1 -> "option B"
+        await adapter._handle_callback_query(update, None)
+
+        # Entry was signalled with the chosen label.
+        assert entry.event.is_set()
+        assert entry.result == "option B"
+        # Button state was cleared (one-shot).
+        assert 1 not in adapter._clarify_state
+        # Feedback rendered.
+        update.callback_query.answer.assert_awaited()
+        update.callback_query.edit_message_text.assert_awaited()
+
+        # Clean up bridge state.
+        clarify_bridge.clear_session_clarifies("test-session")
+        clarify_bridge.unregister_gateway_clarify_notify("test-session")
+
+    @pytest.mark.asyncio
+    async def test_cancel_button_clears_clarify(self):
+        from tools import clarify_bridge
+        from tools.clarify_bridge import _ClarifyEntry, _queues
+
+        adapter = _make_adapter()
+        runner = _AuthRunner(True)
+        adapter._message_handler = runner._handle_message
+        adapter._clarify_state[2] = ("cancel-session", ["A", "B"])
+
+        clarify_bridge.register_gateway_clarify_notify("cancel-session", lambda q, c: None)
+        entry = _ClarifyEntry("Q?", ["A", "B"])
+        _queues.setdefault("cancel-session", []).append(entry)
+
+        update = _make_callback_query("cq:2:cancel")
+        await adapter._handle_callback_query(update, None)
+
+        # Entry was signalled but with no result — agent will see ClarifyUnavailable.
+        assert entry.event.is_set()
+        assert entry.result is None
+        assert 2 not in adapter._clarify_state
+
+        clarify_bridge.unregister_gateway_clarify_notify("cancel-session")
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_is_rejected(self):
+        adapter = _make_adapter()
+        runner = _AuthRunner(False)  # not authorized
+        adapter._message_handler = runner._handle_message
+        adapter._clarify_state[3] = ("sk", ["A", "B"])
+
+        update = _make_callback_query("cq:3:0")
+        await adapter._handle_callback_query(update, None)
+
+        # Answer with a rejection; state must NOT be consumed.
+        update.callback_query.answer.assert_awaited()
+        assert 3 in adapter._clarify_state
+
+    @pytest.mark.asyncio
+    async def test_already_resolved_returns_friendly_message(self):
+        adapter = _make_adapter()
+        runner = _AuthRunner(True)
+        adapter._message_handler = runner._handle_message
+        # Nothing in _clarify_state — simulates a second click after the first
+        # already resolved and popped the state.
+        update = _make_callback_query("cq:99:0")
+        await adapter._handle_callback_query(update, None)
+        update.callback_query.answer.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_invalid_clarify_id_returns_error(self):
+        adapter = _make_adapter()
+        runner = _AuthRunner(True)
+        adapter._message_handler = runner._handle_message
+        update = _make_callback_query("cq:notanint:0")
+        await adapter._handle_callback_query(update, None)
+        update.callback_query.answer.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_index_returns_error(self):
+        adapter = _make_adapter()
+        runner = _AuthRunner(True)
+        adapter._message_handler = runner._handle_message
+        adapter._clarify_state[4] = ("sk", ["A"])  # only one choice
+        update = _make_callback_query("cq:4:5")  # index 5 is OOB
+        await adapter._handle_callback_query(update, None)
+        update.callback_query.answer.assert_awaited()

--- a/tests/tools/test_clarify_bridge.py
+++ b/tests/tools/test_clarify_bridge.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Tests for tools/clarify_bridge — gateway-side wiring for the clarify tool.
+
+Mirrors the pattern in tests/tools/test_approval.py: the gateway registers a
+notify callback, the agent thread blocks on a threading.Event, an inbound user
+message unblocks it by calling resolve_gateway_clarify, and session cleanup
+signals all pending waits so nothing hangs.
+"""
+
+import json
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from tools.clarify_bridge import (
+    ClarifyTimeout,
+    ClarifyUnavailable,
+    clear_session_clarifies,
+    gateway_clarify_callback,
+    get_clarify_timeout,
+    has_blocking_clarify,
+    register_gateway_clarify_notify,
+    resolve_gateway_clarify,
+    set_clarify_timeout,
+    unregister_gateway_clarify_notify,
+)
+from tools.clarify_tool import clarify_tool
+
+
+_SESSION = "test-session-1"
+_OTHER_SESSION = "test-session-2"
+
+
+class ClarifyBridgeTests(unittest.TestCase):
+    """Happy-path + edge cases for the gateway clarify bridge."""
+
+    def setUp(self):
+        # Short timeout so timeout-path tests don't slow the suite down.
+        self._orig_timeout = get_clarify_timeout()
+        set_clarify_timeout(2.0)
+
+    def tearDown(self):
+        # Always clean up so one test's leftover state can't leak into another.
+        clear_session_clarifies(_SESSION)
+        clear_session_clarifies(_OTHER_SESSION)
+        unregister_gateway_clarify_notify(_SESSION)
+        unregister_gateway_clarify_notify(_OTHER_SESSION)
+        set_clarify_timeout(self._orig_timeout)
+
+    # -------------------------------------------------------------------
+    # Happy path
+    # -------------------------------------------------------------------
+
+    def test_happy_path_open_ended(self):
+        """Agent thread blocks, user reply resolves it."""
+        notify = MagicMock()
+        register_gateway_clarify_notify(_SESSION, notify)
+
+        callback = gateway_clarify_callback(_SESSION)
+
+        results = {}
+
+        def agent_thread():
+            results["answer"] = callback("What is your name?", None)
+
+        t = threading.Thread(target=agent_thread, daemon=True)
+        t.start()
+
+        # Wait for the agent thread to register the blocking entry.
+        deadline = time.monotonic() + 1.0
+        while not has_blocking_clarify(_SESSION) and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        self.assertTrue(has_blocking_clarify(_SESSION))
+        notify.assert_called_once_with("What is your name?", None)
+
+        # User replies (from the asyncio loop in real code).
+        resolved = resolve_gateway_clarify(_SESSION, "sx")
+        self.assertEqual(resolved, 1)
+
+        t.join(timeout=2.0)
+        self.assertFalse(t.is_alive(), "agent thread should have unblocked")
+        self.assertEqual(results["answer"], "sx")
+        self.assertFalse(has_blocking_clarify(_SESSION))
+
+    def test_happy_path_multiple_choice(self):
+        """Choices are forwarded to the notify callback and the answer returned."""
+        notify = MagicMock()
+        register_gateway_clarify_notify(_SESSION, notify)
+        callback = gateway_clarify_callback(_SESSION)
+
+        results = {}
+
+        def agent_thread():
+            results["answer"] = callback(
+                "Pick one", ["option A", "option B", "option C"]
+            )
+
+        t = threading.Thread(target=agent_thread, daemon=True)
+        t.start()
+
+        deadline = time.monotonic() + 1.0
+        while not has_blocking_clarify(_SESSION) and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        notify.assert_called_once()
+        args = notify.call_args
+        self.assertEqual(args.args[0], "Pick one")
+        self.assertEqual(args.args[1], ["option A", "option B", "option C"])
+
+        resolve_gateway_clarify(_SESSION, "option B")
+        t.join(timeout=2.0)
+        self.assertEqual(results["answer"], "option B")
+
+    # -------------------------------------------------------------------
+    # Unregistered / unavailable
+    # -------------------------------------------------------------------
+
+    def test_callback_without_notify_raises_unavailable(self):
+        """Calling the callback before notify is registered must fail fast."""
+        callback = gateway_clarify_callback(_SESSION)
+        with self.assertRaises(ClarifyUnavailable):
+            callback("Question?", None)
+
+    def test_clarify_tool_returns_error_json_when_unavailable(self):
+        """Integration: clarify_tool wraps ClarifyUnavailable into error JSON."""
+        callback = gateway_clarify_callback(_SESSION)  # no notify registered
+        result_json = clarify_tool("Question?", callback=callback)
+        result = json.loads(result_json)
+        self.assertIn("error", result)
+        self.assertIn("Failed to get user input", result["error"])
+
+    # -------------------------------------------------------------------
+    # Timeout
+    # -------------------------------------------------------------------
+
+    def test_timeout_path(self):
+        """User never answers — callback raises ClarifyTimeout and clears state."""
+        set_clarify_timeout(0.2)
+        notify = MagicMock()
+        register_gateway_clarify_notify(_SESSION, notify)
+        callback = gateway_clarify_callback(_SESSION)
+
+        with self.assertRaises(ClarifyTimeout):
+            callback("slow question", None)
+
+        # Queue must be drained so a late user message doesn't bind to a dead entry.
+        self.assertFalse(has_blocking_clarify(_SESSION))
+
+    # -------------------------------------------------------------------
+    # Session clear / unregister
+    # -------------------------------------------------------------------
+
+    def test_clear_session_unblocks_waiters(self):
+        """/new (or equivalent session reset) must wake blocked agent threads."""
+        notify = MagicMock()
+        register_gateway_clarify_notify(_SESSION, notify)
+        callback = gateway_clarify_callback(_SESSION)
+
+        outcome = {}
+
+        def agent_thread():
+            try:
+                outcome["answer"] = callback("Q?", None)
+            except ClarifyUnavailable as exc:
+                outcome["error"] = str(exc)
+
+        t = threading.Thread(target=agent_thread, daemon=True)
+        t.start()
+
+        deadline = time.monotonic() + 1.0
+        while not has_blocking_clarify(_SESSION) and time.monotonic() < deadline:
+            time.sleep(0.01)
+        self.assertTrue(has_blocking_clarify(_SESSION))
+
+        clear_session_clarifies(_SESSION)
+        t.join(timeout=2.0)
+        self.assertFalse(t.is_alive())
+        self.assertIn("error", outcome)
+        self.assertIn("cancelled", outcome["error"].lower())
+
+    def test_unregister_notify_also_unblocks_waiters(self):
+        """unregister (turn cleanup) must signal all pending entries."""
+        notify = MagicMock()
+        register_gateway_clarify_notify(_SESSION, notify)
+        callback = gateway_clarify_callback(_SESSION)
+
+        outcome = {}
+
+        def agent_thread():
+            try:
+                outcome["answer"] = callback("Q?", None)
+            except ClarifyUnavailable:
+                outcome["cancelled"] = True
+
+        t = threading.Thread(target=agent_thread, daemon=True)
+        t.start()
+
+        deadline = time.monotonic() + 1.0
+        while not has_blocking_clarify(_SESSION) and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        unregister_gateway_clarify_notify(_SESSION)
+        t.join(timeout=2.0)
+        self.assertFalse(t.is_alive())
+        self.assertTrue(outcome.get("cancelled"))
+
+    # -------------------------------------------------------------------
+    # Session isolation
+    # -------------------------------------------------------------------
+
+    def test_resolve_other_session_does_not_unblock(self):
+        """A user message on session B must not resolve session A's clarify."""
+        notify_a = MagicMock()
+        register_gateway_clarify_notify(_SESSION, notify_a)
+        callback_a = gateway_clarify_callback(_SESSION)
+
+        outcome = {}
+
+        def agent_thread_a():
+            try:
+                outcome["answer"] = callback_a("A?", None)
+            except Exception as exc:
+                outcome["err"] = type(exc).__name__
+
+        t = threading.Thread(target=agent_thread_a, daemon=True)
+        t.start()
+
+        deadline = time.monotonic() + 1.0
+        while not has_blocking_clarify(_SESSION) and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        # Resolve the *other* session — must be a no-op for _SESSION.
+        resolved = resolve_gateway_clarify(_OTHER_SESSION, "wrong session")
+        self.assertEqual(resolved, 0)
+        self.assertTrue(has_blocking_clarify(_SESSION))
+
+        # Resolve the right session — unblocks cleanly.
+        resolve_gateway_clarify(_SESSION, "correct answer")
+        t.join(timeout=2.0)
+        self.assertEqual(outcome.get("answer"), "correct answer")
+
+    # -------------------------------------------------------------------
+    # Notify failure
+    # -------------------------------------------------------------------
+
+    def test_notify_exception_does_not_leak_blocking_entry(self):
+        """If notify raises, the entry must be removed so has_blocking_clarify is accurate."""
+        def failing_notify(q, c):
+            raise RuntimeError("send failed")
+
+        register_gateway_clarify_notify(_SESSION, failing_notify)
+        callback = gateway_clarify_callback(_SESSION)
+
+        with self.assertRaises(RuntimeError):
+            callback("Q?", None)
+
+        self.assertFalse(has_blocking_clarify(_SESSION))
+
+    # -------------------------------------------------------------------
+    # resolve with no pending entries
+    # -------------------------------------------------------------------
+
+    def test_resolve_with_empty_queue_returns_zero(self):
+        """No pending clarify — resolve_gateway_clarify returns 0 and is safe."""
+        resolved = resolve_gateway_clarify(_SESSION, "answer")
+        self.assertEqual(resolved, 0)
+
+    def test_has_blocking_empty_session_key(self):
+        """Empty / None session keys must not break has_blocking_clarify."""
+        self.assertFalse(has_blocking_clarify(""))
+        self.assertFalse(has_blocking_clarify(None))  # type: ignore
+
+    def test_set_clarify_timeout_validates_positive(self):
+        with self.assertRaises(ValueError):
+            set_clarify_timeout(0)
+        with self.assertRaises(ValueError):
+            set_clarify_timeout(-1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/clarify_bridge.py
+++ b/tools/clarify_bridge.py
@@ -227,7 +227,36 @@ def gateway_clarify_callback(
             raise RuntimeError(f"Failed to send clarify question to user: {exc}") from exc
 
         # Block until a user message resolves the entry or the timeout fires.
-        got_signal = entry.event.wait(timeout=_timeout_secs)
+        # Poll in short slices so we can fire activity heartbeats every ~10s
+        # to the agent's inactivity tracker.  Without this, the blocking
+        # event.wait() never touches activity, and the gateway's inactivity
+        # watchdog (agent.gateway_timeout, default 1800s) kills the agent
+        # while the user is still deciding.  Mirrors the pattern in
+        # tools/approval.py's blocking approval wait loop.
+        try:
+            from tools.environments.base import touch_activity_if_due
+        except Exception:  # pragma: no cover
+            touch_activity_if_due = None
+
+        import time as _time
+        _now = _time.monotonic()
+        _deadline = _now + max(_timeout_secs, 0)
+        _activity_state = {"last_touch": _now, "start": _now}
+        got_signal = False
+        while True:
+            _remaining = _deadline - _time.monotonic()
+            if _remaining <= 0:
+                break
+            # 1s poll slice — event is set immediately when the user answers,
+            # so slice length only controls heartbeat cadence, not user-visible
+            # responsiveness.
+            if entry.event.wait(timeout=min(1.0, _remaining)):
+                got_signal = True
+                break
+            if touch_activity_if_due is not None:
+                touch_activity_if_due(
+                    _activity_state, "waiting for user clarify answer"
+                )
 
         if not got_signal:
             # Timeout — remove ourselves from the queue so a late user message

--- a/tools/clarify_bridge.py
+++ b/tools/clarify_bridge.py
@@ -1,0 +1,254 @@
+"""
+Gateway bridge for the ``clarify`` tool.
+
+The interactive CLI has always been able to pause the agent and ask the user a
+question via ``tools.clarify_tool`` + ``HermesCLI._clarify_callback``.  The
+gateway did not wire that callback — any attempt to use ``clarify`` from a
+messaging platform (Telegram, Discord, …) returns
+``"Clarify tool is not available in this execution context."``.
+
+This module provides the gateway-side glue, mirroring the proven pattern used
+for dangerous-command approvals in ``tools/approval.py``:
+
+1. The gateway registers a per-session *notify* callback via
+   :func:`register_gateway_clarify_notify` before starting an agent turn.
+2. The gateway injects :func:`gateway_clarify_callback` as the agent's
+   ``clarify_callback``.
+3. When the agent calls ``clarify``, that callback creates a
+   :class:`_ClarifyEntry` (question + choices + ``threading.Event``), invokes
+   the notify callback (which the gateway uses to send the question to the
+   user), then blocks on the event.
+4. When the next user message arrives, the gateway routes it to
+   :func:`resolve_gateway_clarify` instead of starting a new turn.  That sets
+   the event and the agent thread resumes with the user's answer.
+
+Thread safety: all shared state is guarded by ``_lock``.  Each blocked agent
+thread has its own ``threading.Event``; parallel clarifies are supported via a
+FIFO queue per session.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# Default max time an agent thread will wait for the user to answer a clarify
+# question before giving up.  30 minutes matches typical messaging UX — users
+# may step away from a chat for a while but won't meaningfully answer after
+# longer than that.  Configurable via :func:`set_clarify_timeout`.
+_DEFAULT_CLARIFY_TIMEOUT_SECS = 30 * 60
+
+_lock = threading.Lock()
+_timeout_secs: float = _DEFAULT_CLARIFY_TIMEOUT_SECS
+
+
+class _ClarifyEntry:
+    """One pending clarify question waiting for a user answer."""
+
+    __slots__ = ("event", "question", "choices", "result")
+
+    def __init__(self, question: str, choices: Optional[list]):
+        self.event = threading.Event()
+        self.question = question
+        self.choices = choices
+        # ``None`` means "no answer yet".  Empty string is a legitimate
+        # open-ended answer, so ``None`` is the sentinel.
+        self.result: Optional[str] = None
+
+
+# session_key -> FIFO queue of pending entries.  A session can have at most
+# one live agent thread in practice (the gateway serialises turns), but
+# parallel subagents could in theory trigger multiple clarifies; we keep the
+# queue to match approval.py's shape and avoid surprises.
+_queues: dict[str, list[_ClarifyEntry]] = {}
+
+# session_key -> notify callable.  Signature: ``cb(question, choices) -> None``.
+# The gateway uses this to dispatch the question to the user (via Telegram
+# send, Discord webhook, etc.).  The callback runs in the agent thread and is
+# expected to be non-blocking (bridge to the event loop via
+# ``asyncio.run_coroutine_threadsafe`` if needed).
+_notify_cbs: dict[str, Callable[[str, Optional[list]], None]] = {}
+
+
+# =========================================================================
+# Gateway-facing API
+# =========================================================================
+
+
+def register_gateway_clarify_notify(
+    session_key: str,
+    cb: Callable[[str, Optional[list]], None],
+) -> None:
+    """Register a per-session callback that delivers clarify questions to the user.
+
+    The callback is invoked synchronously from the agent thread each time the
+    ``clarify`` tool is called.  It must return quickly (typically by
+    scheduling an async send on the event loop); the actual blocking wait
+    happens inside :func:`gateway_clarify_callback`.
+    """
+    if not session_key:
+        return
+    with _lock:
+        _notify_cbs[session_key] = cb
+
+
+def unregister_gateway_clarify_notify(session_key: str) -> None:
+    """Unregister the notify callback and drain any pending waits.
+
+    Call this at the end of every agent turn.  Any still-blocked threads are
+    woken with ``result=None`` so they can propagate a graceful error instead
+    of hanging until the 30-minute timeout.
+    """
+    if not session_key:
+        return
+    with _lock:
+        _notify_cbs.pop(session_key, None)
+        entries = _queues.pop(session_key, [])
+    for entry in entries:
+        # Don't set a result — ``gateway_clarify_callback`` treats ``None`` as
+        # "unregistered / cancelled" and raises the appropriate error.
+        entry.event.set()
+
+
+def resolve_gateway_clarify(session_key: str, answer: str) -> int:
+    """Resolve the oldest pending clarify for a session with ``answer``.
+
+    Called by the gateway's inbound message handler when it detects that a
+    user message is meant to answer a live clarify question.
+
+    Returns the number of clarifies resolved (``0`` if nothing was pending,
+    ``1`` if one was resolved).  Multiple parallel clarifies are resolved
+    FIFO, one user message per clarify.
+    """
+    if not session_key:
+        return 0
+    with _lock:
+        queue = _queues.get(session_key)
+        if not queue:
+            return 0
+        entry = queue.pop(0)
+        if not queue:
+            _queues.pop(session_key, None)
+    entry.result = answer
+    entry.event.set()
+    return 1
+
+
+def has_blocking_clarify(session_key: str) -> bool:
+    """Return True if the session has at least one clarify waiting for a user answer."""
+    if not session_key:
+        return False
+    with _lock:
+        return bool(_queues.get(session_key))
+
+
+def clear_session_clarifies(session_key: str) -> None:
+    """Cancel any pending clarifies for a session (e.g. on ``/new`` or shutdown).
+
+    Each waiting thread is woken with ``result=None`` so it returns a clean
+    error instead of hanging.
+    """
+    if not session_key:
+        return
+    with _lock:
+        entries = _queues.pop(session_key, [])
+    for entry in entries:
+        entry.event.set()
+
+
+def set_clarify_timeout(seconds: float) -> None:
+    """Override the default wait-for-answer timeout (useful for tests)."""
+    global _timeout_secs
+    if seconds <= 0:
+        raise ValueError("clarify timeout must be positive")
+    _timeout_secs = float(seconds)
+
+
+def get_clarify_timeout() -> float:
+    """Return the current wait-for-answer timeout in seconds."""
+    return _timeout_secs
+
+
+# =========================================================================
+# Agent-facing callback factory
+# =========================================================================
+
+
+class ClarifyUnavailable(RuntimeError):
+    """Raised internally when no notify callback is registered for the session."""
+
+
+class ClarifyTimeout(RuntimeError):
+    """Raised internally when the user did not answer within the timeout."""
+
+
+def gateway_clarify_callback(
+    session_key: str,
+) -> Callable[[str, Optional[list]], str]:
+    """Build an ``AIAgent.clarify_callback``-compatible callable for a gateway session.
+
+    Returned callable signature: ``(question, choices) -> str``.  It blocks the
+    caller thread until the user answers (via a message routed through
+    :func:`resolve_gateway_clarify`) or the timeout elapses.
+
+    Raises exceptions for abnormal paths.  The caller (``clarify_tool``) turns
+    the exception into a JSON error — see ``tests/tools/test_clarify_gateway.py``
+    for the expected contract.
+    """
+
+    def _callback(question: str, choices: Optional[list]) -> str:
+        with _lock:
+            notify = _notify_cbs.get(session_key)
+            if notify is None:
+                raise ClarifyUnavailable(
+                    "No gateway clarify notifier registered for this session."
+                )
+            entry = _ClarifyEntry(question=question, choices=choices)
+            _queues.setdefault(session_key, []).append(entry)
+
+        # Notify OUTSIDE the lock to avoid deadlocks if the gateway adapter's
+        # send path re-enters this module (it shouldn't, but be safe).
+        try:
+            notify(question, choices)
+        except Exception as exc:
+            # Pop the entry we just enqueued so ``has_blocking_clarify`` stays
+            # accurate and the inbound router doesn't swallow the user's next
+            # message.
+            with _lock:
+                queue = _queues.get(session_key)
+                if queue and entry in queue:
+                    queue.remove(entry)
+                    if not queue:
+                        _queues.pop(session_key, None)
+            logger.exception("Clarify notify failed")
+            raise RuntimeError(f"Failed to send clarify question to user: {exc}") from exc
+
+        # Block until a user message resolves the entry or the timeout fires.
+        got_signal = entry.event.wait(timeout=_timeout_secs)
+
+        if not got_signal:
+            # Timeout — remove ourselves from the queue so a late user message
+            # doesn't bind to a dead entry.
+            with _lock:
+                queue = _queues.get(session_key)
+                if queue and entry in queue:
+                    queue.remove(entry)
+                    if not queue:
+                        _queues.pop(session_key, None)
+            raise ClarifyTimeout(
+                f"User did not answer the clarify question within {_timeout_secs:.0f}s."
+            )
+
+        if entry.result is None:
+            # Woken by unregister/clear with no answer (session ended, /new, etc.).
+            raise ClarifyUnavailable(
+                "Clarify was cancelled before the user answered "
+                "(session ended or was reset)."
+            )
+
+        return entry.result
+
+    return _callback


### PR DESCRIPTION
## Problem

The `clarify` tool — which lets the agent pause and ask the user a
multiple-choice or open-ended question — currently only works from the
interactive CLI (and TUI / oneshot). In gateway sessions (Telegram,
Discord, Slack, …) every invocation returns:

```
{"error": "Clarify tool is not available in this execution context."}
```

Root cause: `AIAgent` needs a `clarify_callback(question, choices) -> str`
to be injected by the platform layer. `cli.py`, `hermes_cli/oneshot.py`,
and `tui_gateway/server.py` all provide one; `gateway/run.py` does not —
so `self.clarify_callback` is `None` and `tools/clarify_tool.py` returns
the "not available" error on line 58.

## Approach

Mirror the proven gateway-side pattern already used for dangerous-command
approvals (`tools/approval.py` + `register_gateway_notify` /
`resolve_gateway_approval` inside `gateway/run.py`):

1. A small bridge module (`tools/clarify_bridge.py`) holds per-session
   `threading.Event`-backed queues and a FIFO resolve / has-blocking API.
2. `gateway/run.py` builds a `clarify_callback` wired to the bridge for
   each agent turn and sends questions through the adapter's existing
   `send()` path.
3. The inbound message router detects "agent is blocked on a clarify"
   and routes the user's plain-text reply to `resolve_gateway_clarify`
   instead of starting a new agent turn. Slash commands still pass
   through so `/stop`, `/new`, `/approve`, etc. keep their usual
   semantics.
4. Session teardown (`/new`, `/reset`, `/stop`) cancels any pending
   clarifies so blocked agent threads wake with a clean error instead
   of hanging until the 30-minute timeout.

This means clarify works on every adapter that already has a `send()` —
no per-platform code needed. Platforms that later want richer UX
(Telegram inline keyboards, Discord select menus) can special-case in
`_clarify_notify_sync` the same way `_approval_notify_sync` already
does for `send_exec_approval`.

## Files changed

| File | Purpose |
|------|---------|
| `tools/clarify_bridge.py` (new, ~200 lines) | `threading.Event` queue, `register_*` / `resolve_*` / `clear_*` API, `gateway_clarify_callback()` factory. Typed exceptions `ClarifyTimeout` / `ClarifyUnavailable` (both `RuntimeError` subclasses so the existing `clarify_tool.py` try/except wraps them into error JSON with no code change). |
| `gateway/run.py` (+110 lines, 3 hunks) | (1) `_handle_message`: intercept plain-text reply when a clarify is pending. (2) `_interrupt_and_clear_session`: `clear_session_clarifies` on teardown. (3) `run_sync`: register notify, build & inject `clarify_callback`, unregister in `finally`. |
| `tests/tools/test_clarify_bridge.py` (new, 12 tests) | Covers happy path (open-ended + multi-choice), timeout, unregister, `/new`-style clear, session isolation, notify-exception cleanup, validation. |

Total diff: ~647 lines added. No existing behaviour changed;
`clarify_tool.py` is unmodified; CLI / TUI / oneshot callback paths
untouched.

## Test results

```
$ python -m pytest tests/tools/test_clarify_bridge.py \
                   tests/tools/test_clarify_tool.py \
                   tests/tools/test_approval.py -o 'addopts=' -q
164 passed in 0.9s
```

Also ran `tests/gateway/test_approve_deny_commands.py` as a regression
smoke — same pass/fail pattern as `main` (pre-existing flakes on
`TestBlockingApprovalE2E`, none of which touch the clarify path).

## Manual gateway verification

Restarted the local gateway on this branch and triggered `clarify` from
a running Telegram session. The user received a well-formatted message:

```
🤔 **Clarify test: if you can see this with options and answer, core path works.**

  1. option A
  2. option B
  3. option C

_Reply with a number or type your own answer._
```

Inline-reply routing (`resolve_gateway_clarify`) and session-clear
behaviour (`/new`, `/stop`) were exercised via the pytest suite rather
than end-to-end on Telegram, because the CLI slash-command handlers
they rely on already have dedicated coverage.

## Design notes / open questions

- **Timeout**: 30 min default. Long enough for real users stepping away,
  short enough that a wedged session self-recovers. Configurable via
  `set_clarify_timeout()`; no `config.yaml` key yet — happy to add
  `gateway.clarify_timeout_secs` if reviewers want it. Could also be
  derived from `agent.gateway_timeout` so a clarify can never outlive
  the surrounding run.
- **FIFO queue vs single entry**: matches `approval.py`. In practice a
  gateway session has one blocked agent thread at a time, but parallel
  subagents could theoretically trigger concurrent clarifies. Queue
  avoids surprises there.
- **No per-platform UI yet**: all platforms get the plain-text fallback.
  The hook point for richer UX is the `send_exec_approval`-style check
  in `_clarify_notify_sync`; adding it per platform is a follow-up.
- **Interplay with `/queue` and `/steer`**: a plain-text message that
  would otherwise be queued is consumed as a clarify answer when one
  is pending. That is intentional — the agent is literally asking
  "what do you want?", any reply is the answer. Slash commands
  (`/queue foo`, `/steer foo`) still pass through the existing
  handlers.
- **Backwards compatibility**: zero. New module, new optional
  registrations, new bridge call — nothing on non-gateway paths
  changes, no env vars, no config keys required.

## Possible follow-ups (not in this PR)

- Telegram inline-keyboard UI for multi-choice clarifies (mirrors
  Discord's button-based approvals).
- `gateway.clarify_timeout_secs` config key + derivation from
  `agent.gateway_timeout` so wedged clarifies can't outlive their run.
- Confirm-on-cancel message when `/new` or `/stop` interrupts a live
  clarify (currently the agent sees `ClarifyUnavailable`; a short user
  notice ("Clarify cancelled — session reset.") would be friendlier).

---

Closes: (no issue filed — happy to open one if the team would prefer
to discuss the design first).
