### PR TITLE
fix(model-picker): require real credentials in section 1 (api_key path)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1217,13 +1217,19 @@ def list_authenticated_providers(
         # Check if any env var is set
         has_creds = any(os.environ.get(ev) for ev in env_vars)
         if not has_creds:
+            # Check the credential pool for real credentials. Mirrors the
+            # pattern used in section 2 (overlays). The previous test —
+            # ``hermes_id in store.get("credential_pool", {})`` — gave false
+            # positives for entries with empty list values, surfacing
+            # providers (e.g. huggingface, opencode-go, minimax(-cn), zai)
+            # in the /model picker that the user never authenticated to.
             try:
-                from hermes_cli.auth import _load_auth_store
-                store = _load_auth_store()
-                if store and hermes_id in store.get("credential_pool", {}):
+                from agent.credential_pool import load_pool
+                pool = load_pool(hermes_id)
+                if pool.has_credentials():
                     has_creds = True
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("Credential pool check failed for %s: %s", hermes_id, exc)
         if not has_creds:
             continue
 

--- a/tests/hermes_cli/test_overlay_slug_resolution.py
+++ b/tests/hermes_cli/test_overlay_slug_resolution.py
@@ -85,18 +85,26 @@ def test_kilo_overlay_uses_hermes_slug():
 
 
 def test_mapped_provider_credential_pool_visibility(monkeypatch):
-    """Mapped providers should appear when credentials live only in auth-store credential_pool."""
+    """Mapped providers should appear when the credential pool reports real creds.
+
+    Updated for the section-1 fix that requires real credentials (via
+    ``load_pool(...).has_credentials()``) rather than bare key-presence in
+    the auth store's ``credential_pool`` dict.  Empty values used to leak
+    through; they no longer do.
+    """
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {"google-ai-studio": {"env": ["GEMINI_API_KEY"]}})
     monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {"gemini": "google-ai-studio"})
-    monkeypatch.setattr(
-        "hermes_cli.auth._load_auth_store",
-        lambda: {"providers": {}, "credential_pool": {"gemini": {"token": "fake"}}},
-    )
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    class _StubPool:
+        def has_credentials(self):
+            return True
+
+    monkeypatch.setattr("agent.credential_pool.load_pool", lambda slug, *a, **kw: _StubPool())
 
     providers = list_authenticated_providers(current_provider="gemini")
 
     gemini = next((p for p in providers if p["slug"] == "gemini"), None)
-    assert gemini is not None, "gemini should appear when auth-store credential_pool has creds"
+    assert gemini is not None, "gemini should appear when credential pool has real creds"
     assert gemini["is_current"] is True
     assert gemini["total_models"] > 0

--- a/tests/hermes_cli/test_picker_empty_credential_pool.py
+++ b/tests/hermes_cli/test_picker_empty_credential_pool.py
@@ -1,0 +1,89 @@
+"""Regression test: section 1 of list_authenticated_providers must require
+real credentials, not a bare key in the auth store's ``credential_pool`` map.
+
+Background
+----------
+The auth store's ``credential_pool`` dict is keyed by provider id, and a key
+can exist with an *empty list* value (e.g. after credentials were rotated
+out, or after early seeding of an entry that was never populated).  The old
+section-1 check::
+
+    if store and hermes_id in store.get("credential_pool", {}):
+        has_creds = True
+
+returned True for empty entries, surfacing providers in the /model picker
+that the user never authenticated to (huggingface, opencode-go,
+minimax(-cn), zai, ...).  Selecting one routes every turn at a dead
+endpoint and 401s.
+
+A sister fix (commit 46072425f) plugged the same class of bug in sections
+2 and 2b but missed section 1 — this is the focused fix.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+class _StubPool:
+    """Minimal stand-in for ``agent.credential_pool.CredentialPool``."""
+
+    def __init__(self, has_creds: bool = False) -> None:
+        self._has_creds = has_creds
+
+    def has_credentials(self) -> bool:  # pragma: no cover - trivial
+        return self._has_creds
+
+
+def test_section1_skips_provider_with_empty_credential_pool_list(monkeypatch):
+    """huggingface entry with ``credential_pool['huggingface'] = []`` must NOT appear.
+
+    This is the exact pathological case observed in the wild — the auth
+    store contains the key but the value is an empty list, meaning no
+    credentials are actually available.  The picker must skip the row.
+    """
+    # Make sure no env-var path can let huggingface in via the front door.
+    for ev in ("HF_TOKEN", "HUGGINGFACE_API_KEY", "HUGGING_FACE_HUB_TOKEN"):
+        monkeypatch.delenv(ev, raising=False)
+
+    fake_store = {"credential_pool": {"huggingface": []}}
+
+    def _fake_load_pool(slug, *args, **kwargs):
+        # The bug-trigger: store key exists, but no real credentials behind it.
+        return _StubPool(has_creds=False)
+
+    with patch("hermes_cli.auth._load_auth_store", return_value=fake_store), \
+         patch("agent.credential_pool.load_pool", side_effect=_fake_load_pool):
+        providers = list_authenticated_providers(current_provider="")
+
+    slugs = [p["slug"] for p in providers]
+    assert "huggingface" not in slugs, (
+        "huggingface appeared in /model picker despite having no real "
+        f"credentials; pool-key-only check leaked through. Got: {slugs}"
+    )
+
+
+def test_section1_includes_provider_when_pool_has_real_credentials(monkeypatch):
+    """Sanity: when the credential pool reports real creds, the row appears."""
+    for ev in ("HF_TOKEN", "HUGGINGFACE_API_KEY", "HUGGING_FACE_HUB_TOKEN"):
+        monkeypatch.delenv(ev, raising=False)
+
+    fake_store = {"credential_pool": {"huggingface": []}}
+
+    def _fake_load_pool(slug, *args, **kwargs):
+        if slug == "huggingface":
+            return _StubPool(has_creds=True)
+        return _StubPool(has_creds=False)
+
+    with patch("hermes_cli.auth._load_auth_store", return_value=fake_store), \
+         patch("agent.credential_pool.load_pool", side_effect=_fake_load_pool):
+        providers = list_authenticated_providers(current_provider="")
+
+    slugs = [p["slug"] for p in providers]
+    assert "huggingface" in slugs, (
+        "huggingface should appear when the credential pool reports real "
+        f"credentials; got: {slugs}"
+    )


### PR DESCRIPTION
## Summary

Section 1 of `list_authenticated_providers` (the `api_key` auth path in `hermes_cli/model_switch.py`) was checking:

```python
if store and hermes_id in store.get("credential_pool", {}):
    has_creds = True
```

This gave **false positives for entries whose value is an empty list** — a state that occurs naturally after credential rotation or partial seeding. The picker therefore surfaced providers the user never authenticated to (huggingface, opencode-go, minimax / minimax-cn, zai, …). Selecting one of those routes every turn at a dead endpoint and 401s.

Sister fix `46072425f` closed the same class of bug in sections 2 and 2b but **missed section 1**. (PR #20703 tried to paper over the symptom with a config-side allowlist; that's been closed in favor of this focused fix.)

## Fix

Drop the key-presence test on the auth store and use the same pattern already used elsewhere in the function:

```python
from agent.credential_pool import load_pool
pool = load_pool(hermes_id)
if pool.has_credentials():
    has_creds = True
```

`load_pool().has_credentials()` checks that real credentials exist (env vars, singletons, and pool entries, with the usual seeding paths) — empty lists no longer leak through.

## Tests

- New: `tests/hermes_cli/test_picker_empty_credential_pool.py`
  - Empty `credential_pool['huggingface'] = []` ⇒ NOT in returned slugs.
  - Pool reports real creds ⇒ row appears.
- Updated `test_mapped_provider_credential_pool_visibility` (in `test_overlay_slug_resolution.py`) to validate via the new pool path instead of the leaky bandaid it previously asserted.
- Full target run: `tests/hermes_cli/ -k 'model_switch or picker or list_auth or overlay'` → **185 passed**.

## Scope

- No new public APIs.
- Single-function change inside `list_authenticated_providers`.
- Mirrors the approach already shipped in sections 2 / 2b.