### PR TITLE
fix(gateway): make scoped-lock staleness detection work on macOS

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -109,13 +109,43 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
 
 
 def _get_process_start_time(pid: int) -> Optional[int]:
-    """Return the kernel start time for a process when available."""
+    """Return a stable per-PID start-time fingerprint when available.
+
+    On Linux this reads field 22 of /proc/<pid>/stat (start time in clock
+    ticks). On platforms without /proc (macOS, *BSD, Windows) we fall back
+    to ``ps -o lstart=`` which prints the process start timestamp; we
+    return its hash so the caller can compare equality across reads.
+
+    A stable value is critical for the scoped-lock staleness check: without
+    it, ``start_time`` is recorded as None and a recycled PID will appear
+    to still own the lock forever (silent platform lockout).
+    """
     stat_path = Path(f"/proc/{pid}/stat")
     try:
         # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
         return int(stat_path.read_text().split()[21])
     except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
-        return None
+        pass
+
+    # Fallback: ask `ps` for the process start timestamp. Works on macOS,
+    # *BSD, and Linux distributions that ship procps. We hash the string
+    # to a stable signed-int fingerprint so callers can equality-compare.
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "lstart=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        lstart = result.stdout.strip()
+        if result.returncode == 0 and lstart:
+            # Truncate sha256 to fit comfortably in a positive 63-bit int.
+            digest = hashlib.sha256(lstart.encode("utf-8")).hexdigest()[:15]
+            return int(digest, 16)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError, ValueError):
+        pass
+
+    return None
 
 
 def get_process_start_time(pid: int) -> Optional[int]:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -8,6 +8,50 @@ from types import SimpleNamespace
 from gateway import status
 
 
+class TestGetProcessStartTime:
+    """Verify the cross-platform start-time fingerprint behaviour.
+
+    On Linux this reads /proc; on macOS / *BSD it falls back to ``ps -o
+    lstart=``. The fallback path is critical: without it, the scoped-lock
+    staleness check stores ``start_time: None`` and a recycled PID will
+    appear to own the lock forever (silent platform lockout).
+    """
+
+    def test_returns_stable_value_for_self(self):
+        """Repeated calls for the same live process must return equal results."""
+        v1 = status._get_process_start_time(os.getpid())
+        v2 = status._get_process_start_time(os.getpid())
+        assert v1 is not None, (
+            "expected a non-None start time for the current process "
+            "(both /proc and `ps` fallback failed — staleness check is broken)"
+        )
+        assert v1 == v2
+
+    def test_returns_none_for_nonexistent_pid(self):
+        # Pick a PID extremely unlikely to exist.
+        assert status._get_process_start_time(99_999_999) is None
+
+    def test_ps_fallback_when_proc_missing(self, monkeypatch):
+        """Force the /proc read to fail and confirm the `ps` fallback fires.
+
+        This simulates the macOS / *BSD code path on any host (including
+        Linux CI runners) so the bug that caused the original incident
+        cannot silently regress.
+        """
+        from pathlib import Path as _Path
+
+        real_read_text = _Path.read_text
+
+        def fake_read_text(self, *a, **kw):
+            if str(self).startswith("/proc/"):
+                raise FileNotFoundError(str(self))
+            return real_read_text(self, *a, **kw)
+
+        monkeypatch.setattr(_Path, "read_text", fake_read_text)
+        v = status._get_process_start_time(os.getpid())
+        assert v is not None, "ps fallback failed to produce a fingerprint"
+
+
 class TestGatewayPidState:
     def test_write_pid_file_records_gateway_metadata(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary

`gateway/status.py::_get_process_start_time` only reads `/proc/<pid>/stat`, which doesn't exist on macOS / *BSD / Windows. On those platforms it always returns `None`, which silently disables the PID-recycling guard inside `acquire_scoped_lock`.

Concrete failure mode I just hit on macOS:
1. Gateway dies (crash, restart, system sleep).
2. macOS recycles the gateway's PID to an unrelated process — in my case Apple's `SetStoreUpdateService`.
3. `os.kill(stored_pid, 0)` succeeds against the squatter, and because `start_time` in the lock file is `null`, the equality check in the staleness path is short-circuited.
4. Lock is treated as live forever. `hermes gateway restart` succeeds, `hermes gateway status` reports healthy, but the affected platform (Telegram in my case; same code path covers Feishu) fails to bind with:

```
[Telegram] Telegram bot token already in use (PID <recycled>). Stop the other gateway first.
✗ telegram failed to connect
Gateway running with 1 platform(s)
```

The only fix today is to manually `rm ~/.local/state/hermes/gateway-locks/<scope>-*.lock`. Until then the platform is silently down.

## Fix

Add a `ps -o lstart=` fallback inside `_get_process_start_time` for hosts without `/proc`. The string is hashed to a stable int so the existing equality comparison in `acquire_scoped_lock` keeps working unchanged. Pure stdlib — no new dependency.

- Linux behaviour is preserved bit-for-bit (the `/proc` read still happens first and returns the same int).
- macOS / *BSD / WSL with `procps` installed all gain a real fingerprint.
- Hosts with neither still safely return `None` (current behaviour).

## Test Plan

Added `tests/gateway/test_status.py::TestGetProcessStartTime` with three cases:

- `test_returns_stable_value_for_self` — the function returns a non-None, repeat-stable value for the running test process. Would have caught the original bug on macOS.
- `test_returns_none_for_nonexistent_pid` — confirms None for a PID that can't exist.
- `test_ps_fallback_when_proc_missing` — monkeypatches `Path.read_text` to fail on `/proc/...`, forcing the `ps` branch. Exercises the fallback even on Linux CI.

I was not able to run the test suite locally (sandbox restriction on this machine); CI will be the source of truth.

## Notes for reviewers

- I deliberately avoided adding `psutil` even though `references/gateway-stale-platform-locks.md` suggests it. `ps` is everywhere, no new dep, and the existing call sites already only need a stable equality value.
- The hashing (sha256 truncated to 60 bits) is just so the return type stays `Optional[int]` and matches the `/proc` path; the actual value is opaque to callers.
- No behaviour change for already-working Linux deployments.
