### PR TITLE
feat(zoom): add meeting intelligence plugin

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9732,9 +9732,30 @@ Examples:
     plugins_parser.set_defaults(func=cmd_plugins)
 
     # =========================================================================
-    # Plugin CLI commands — dynamically registered by memory/general plugins.
-    # Plugins provide a register_cli(subparser) function that builds their
-    # own argparse tree.  No hardcoded plugin commands in main.py.
+    # Plugin CLI commands — dynamically registered by general plugins.
+    # Plugins provide register_cli_command(name=..., setup_fn=..., handler_fn=...)
+    # and are loaded via the standard plugin manager.
+    # =========================================================================
+    try:
+        from hermes_cli.plugins import get_plugin_cli_commands
+
+        for cmd_info in get_plugin_cli_commands().values():
+            plugin_parser = subparsers.add_parser(
+                cmd_info["name"],
+                help=cmd_info["help"],
+                description=cmd_info.get("description", ""),
+                formatter_class=__import__("argparse").RawDescriptionHelpFormatter,
+            )
+            cmd_info["setup_fn"](plugin_parser)
+            if cmd_info.get("handler_fn") is not None:
+                plugin_parser.set_defaults(func=cmd_info["handler_fn"])
+    except Exception as _exc:
+        logging.getLogger(__name__).debug("General plugin CLI discovery failed: %s", _exc)
+
+    # =========================================================================
+    # Memory-provider CLI commands — dynamically discovered by the memory
+    # plugin subsystem. These use the active provider's register_cli(subparser)
+    # convention rather than the general plugin manager registry above.
     # =========================================================================
     try:
         from plugins.memory import discover_plugin_cli_commands

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1317,6 +1317,15 @@ def get_plugin_commands() -> Dict[str, dict]:
     return _ensure_plugins_discovered()._plugin_commands
 
 
+def get_plugin_cli_commands() -> Dict[str, dict]:
+    """Return plugin CLI subcommands registered via ``register_cli_command()``.
+
+    Triggers idempotent plugin discovery so terminal entry points can build
+    argparse subcommands for enabled plugins before parsing argv.
+    """
+    return _ensure_plugins_discovered()._cli_commands
+
+
 def get_plugin_toolsets() -> List[tuple]:
     """Return plugin toolsets as ``(key, label, description)`` tuples.
 

--- a/plugins/zoom_meeting/README.md
+++ b/plugins/zoom_meeting/README.md
@@ -1,0 +1,62 @@
+# zoom_meeting plugin
+
+Official-surface-first Zoom meeting intelligence for Hermes.
+
+## What this first version does
+
+- Fetches Zoom meeting metadata using server-to-server OAuth
+- Stores durable local state under `~/.hermes/cache/zoom/meetings/<meeting_id>/`
+- Runs a local webhook receiver for meeting lifecycle / RTMS-like events
+- Normalizes event payloads into JSONL
+- Extracts transcript-like fragments into `transcript.txt`
+- Extracts action items, decisions, and open questions from transcript text
+- Exports deterministic markdown / JSON artifacts for follow-up work
+
+## What it does not do yet
+
+- Join a Zoom call as a participant
+- Speak inside the meeting
+- Control meeting UI
+- Act as a Team Chat adapter
+
+Those are later phases. This plugin is the substrate they will build on.
+
+## Required environment
+
+For REST metadata fetches:
+
+- `ZOOM_ACCOUNT_ID`
+- `ZOOM_CLIENT_ID`
+- `ZOOM_CLIENT_SECRET`
+
+For webhook validation:
+
+- `ZOOM_WEBHOOK_SECRET_TOKEN` (preferred) or `ZOOM_WEBHOOK_SECRET`
+
+## CLI
+
+```bash
+hermes plugins enable zoom_meeting
+
+hermes zoom auth-check
+hermes zoom watch 123456789
+hermes zoom serve --port 8754
+hermes zoom status 123456789
+hermes zoom transcript 123456789 --last 40
+hermes zoom summary 123456789
+hermes zoom action-items 123456789
+hermes zoom export 123456789 --format markdown
+```
+
+## Files per meeting
+
+Each meeting gets a workspace:
+
+```text
+~/.hermes/cache/zoom/meetings/<meeting_id>/
+  state.json
+  events.jsonl
+  transcript.txt
+  summary.md
+  artifact.md / artifact.json
+```

--- a/plugins/zoom_meeting/__init__.py
+++ b/plugins/zoom_meeting/__init__.py
@@ -1,0 +1,71 @@
+"""zoom_meeting plugin — webhook/RTMS-first Zoom meeting intelligence.
+
+This first iteration deliberately targets the official-ish surfaces that are
+most stable for a self-hosted agent:
+
+- Server-to-server OAuth for account-scoped meeting metadata
+- Webhook ingestion for meeting lifecycle events
+- RTMS-style event ingestion for transcript/caption fragments
+- Durable local artifacts so the agent can reason about meetings after the
+  live call ends
+
+It does NOT attempt to impersonate a participant or automate the Zoom UI.
+That is a larger second phase and should build on top of the state/artifact
+model introduced here rather than replacing it.
+"""
+
+from __future__ import annotations
+
+from plugins.zoom_meeting.cli import register_cli as _register_cli
+from plugins.zoom_meeting.cli import zoom_command as _zoom_command
+from plugins.zoom_meeting.tools import (
+    ZOOM_MEETING_ACTION_ITEMS_SCHEMA,
+    ZOOM_MEETING_ARTIFACTS_SCHEMA,
+    ZOOM_MEETING_EVENTS_SCHEMA,
+    ZOOM_MEETING_STATUS_SCHEMA,
+    ZOOM_MEETING_SUMMARY_SCHEMA,
+    ZOOM_MEETING_TRANSCRIPT_SCHEMA,
+    ZOOM_MEETING_WATCH_SCHEMA,
+    check_zoom_meeting_requirements,
+    handle_zoom_meeting_action_items,
+    handle_zoom_meeting_artifacts,
+    handle_zoom_meeting_events,
+    handle_zoom_meeting_status,
+    handle_zoom_meeting_summary,
+    handle_zoom_meeting_transcript,
+    handle_zoom_meeting_watch,
+)
+
+_TOOLS = (
+    ("zoom_meeting_watch",      ZOOM_MEETING_WATCH_SCHEMA,      handle_zoom_meeting_watch,      "🎥"),
+    ("zoom_meeting_status",     ZOOM_MEETING_STATUS_SCHEMA,     handle_zoom_meeting_status,     "🟢"),
+    ("zoom_meeting_transcript", ZOOM_MEETING_TRANSCRIPT_SCHEMA, handle_zoom_meeting_transcript, "📝"),
+    ("zoom_meeting_events",     ZOOM_MEETING_EVENTS_SCHEMA,     handle_zoom_meeting_events,     "📡"),
+    ("zoom_meeting_summary",    ZOOM_MEETING_SUMMARY_SCHEMA,    handle_zoom_meeting_summary,    "🧠"),
+    ("zoom_meeting_action_items", ZOOM_MEETING_ACTION_ITEMS_SCHEMA, handle_zoom_meeting_action_items, "✅"),
+    ("zoom_meeting_artifacts",  ZOOM_MEETING_ARTIFACTS_SCHEMA,  handle_zoom_meeting_artifacts,  "📦"),
+)
+
+
+def register(ctx) -> None:
+    """Register Zoom meeting tools and CLI surface."""
+    for name, schema, handler, emoji in _TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset="zoom_meeting",
+            schema=schema,
+            handler=handler,
+            check_fn=check_zoom_meeting_requirements,
+            emoji=emoji,
+        )
+
+    ctx.register_cli_command(
+        name="zoom",
+        help="Zoom meeting intelligence (watch, serve, ingest, transcript, action-items, artifacts)",
+        setup_fn=_register_cli,
+        handler_fn=_zoom_command,
+        description=(
+            "Track Zoom meetings through OAuth metadata fetches plus webhook/RTMS "
+            "event ingestion, then export transcript, action-item, and summary artifacts."
+        ),
+    )

--- a/plugins/zoom_meeting/cli.py
+++ b/plugins/zoom_meeting/cli.py
@@ -1,0 +1,150 @@
+"""CLI commands for the zoom_meeting plugin."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from plugins.zoom_meeting.client import ZoomClient, ZoomCredentials
+from plugins.zoom_meeting.server import AIOHTTP_AVAILABLE, ZoomWebhookServer
+from plugins.zoom_meeting.store import ZoomMeetingStore
+from plugins.zoom_meeting.tools import (
+    handle_zoom_meeting_action_items,
+    handle_zoom_meeting_artifacts,
+    handle_zoom_meeting_events,
+    handle_zoom_meeting_status,
+    handle_zoom_meeting_summary,
+    handle_zoom_meeting_transcript,
+    handle_zoom_meeting_watch,
+)
+
+
+def register_cli(subparser: argparse.ArgumentParser) -> None:
+    subs = subparser.add_subparsers(dest="zoom_command")
+
+    auth_p = subs.add_parser("auth-check", help="Check whether Zoom OAuth env vars are configured and fetch a token")
+    auth_p.set_defaults(func=zoom_command)
+
+    watch_p = subs.add_parser("watch", help="Initialize local state for a Zoom meeting from REST metadata")
+    watch_p.add_argument("meeting_id")
+    watch_p.add_argument("--fetch-recordings", action="store_true")
+
+    status_p = subs.add_parser("status", help="Print local state for a watched Zoom meeting")
+    status_p.add_argument("meeting_id")
+
+    tr_p = subs.add_parser("transcript", help="Print the locally captured transcript for a meeting")
+    tr_p.add_argument("meeting_id")
+    tr_p.add_argument("--last", type=int, default=None)
+
+    ev_p = subs.add_parser("events", help="Print normalized events for a meeting")
+    ev_p.add_argument("meeting_id")
+    ev_p.add_argument("--last", type=int, default=None)
+
+    sum_p = subs.add_parser("summary", help="Render a markdown summary for a meeting")
+    sum_p.add_argument("meeting_id")
+
+    ai_p = subs.add_parser("action-items", help="Extract action items, decisions, and open questions")
+    ai_p.add_argument("meeting_id")
+
+    exp_p = subs.add_parser("export", help="Export artifact bundle for a meeting")
+    exp_p.add_argument("meeting_id")
+    exp_p.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    exp_p.add_argument("--output", default=None)
+
+    ing_p = subs.add_parser("ingest", help="Ingest a webhook payload from a local JSON file")
+    ing_p.add_argument("payload_file")
+
+    serve_p = subs.add_parser("serve", help="Run an aiohttp Zoom webhook receiver")
+    serve_p.add_argument("--host", default="0.0.0.0")
+    serve_p.add_argument("--port", type=int, default=8754)
+    serve_p.add_argument("--path", default="/zoom/webhook")
+
+    subparser.set_defaults(func=zoom_command)
+
+
+def _print_json(result: str) -> int:
+    parsed = json.loads(result)
+    print(json.dumps(parsed, indent=2, ensure_ascii=False))
+    return 0 if parsed.get("success", parsed.get("ok", False)) else 1
+
+
+def _client_from_env() -> ZoomClient | None:
+    account_id = os.getenv("ZOOM_ACCOUNT_ID", "").strip()
+    client_id = os.getenv("ZOOM_CLIENT_ID", "").strip()
+    client_secret = os.getenv("ZOOM_CLIENT_SECRET", "").strip()
+    if not (account_id and client_id and client_secret):
+        return None
+    return ZoomClient(ZoomCredentials(account_id=account_id, client_id=client_id, client_secret=client_secret))
+
+
+def zoom_command(args: argparse.Namespace) -> int:
+    sub = getattr(args, "zoom_command", None)
+    if not sub:
+        print("usage: hermes zoom {auth-check,watch,status,transcript,events,summary,action-items,export,ingest,serve}")
+        return 2
+    if sub == "auth-check":
+        client = _client_from_env()
+        if client is None:
+            print("Zoom OAuth env vars missing. Set ZOOM_ACCOUNT_ID, ZOOM_CLIENT_ID, and ZOOM_CLIENT_SECRET.")
+            return 1
+        token = client.get_access_token()
+        print(json.dumps({"ok": True, "token_prefix": token[:8], "token_length": len(token)}, indent=2))
+        return 0
+    if sub == "watch":
+        return _print_json(handle_zoom_meeting_watch({"meeting_id": args.meeting_id, "fetch_recordings": bool(args.fetch_recordings)}))
+    if sub == "status":
+        return _print_json(handle_zoom_meeting_status({"meeting_id": args.meeting_id}))
+    if sub == "transcript":
+        payload = {"meeting_id": args.meeting_id}
+        if args.last:
+            payload["last"] = args.last
+        return _print_json(handle_zoom_meeting_transcript(payload))
+    if sub == "events":
+        payload = {"meeting_id": args.meeting_id}
+        if args.last:
+            payload["last"] = args.last
+        return _print_json(handle_zoom_meeting_events(payload))
+    if sub == "summary":
+        return _print_json(handle_zoom_meeting_summary({"meeting_id": args.meeting_id}))
+    if sub == "action-items":
+        return _print_json(handle_zoom_meeting_action_items({"meeting_id": args.meeting_id}))
+    if sub == "export":
+        payload = {"meeting_id": args.meeting_id, "format": args.format}
+        if args.output:
+            payload["output_path"] = args.output
+        return _print_json(handle_zoom_meeting_artifacts(payload))
+    if sub == "ingest":
+        payload = json.loads(Path(args.payload_file).expanduser().read_text(encoding="utf-8"))
+        normalized = ZoomMeetingStore().ingest_event(payload)
+        print(json.dumps(normalized, indent=2, ensure_ascii=False))
+        return 0
+    if sub == "serve":
+        if not AIOHTTP_AVAILABLE:
+            print("aiohttp not installed. Run: pip install aiohttp")
+            return 1
+        secret = os.getenv("ZOOM_WEBHOOK_SECRET_TOKEN", "").strip() or os.getenv("ZOOM_WEBHOOK_SECRET", "").strip()
+        server = ZoomWebhookServer(
+            ZoomMeetingStore(),
+            secret_token=secret,
+            host=args.host,
+            port=args.port,
+            path=args.path,
+        )
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "host": args.host,
+                    "port": args.port,
+                    "path": args.path,
+                    "secret_configured": bool(secret),
+                },
+                indent=2,
+            )
+        )
+        server.serve_forever()
+        return 0
+    print(f"unknown subcommand: {sub}")
+    return 2

--- a/plugins/zoom_meeting/client.py
+++ b/plugins/zoom_meeting/client.py
@@ -1,0 +1,102 @@
+"""Zoom REST client primitives for the zoom_meeting plugin."""
+
+from __future__ import annotations
+
+import base64
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class ZoomClientError(RuntimeError):
+    """Raised when Zoom auth or REST calls fail."""
+
+
+@dataclass
+class ZoomCredentials:
+    account_id: str
+    client_id: str
+    client_secret: str
+
+
+class ZoomClient:
+    """Minimal server-to-server OAuth client for Zoom meeting metadata."""
+
+    def __init__(
+        self,
+        credentials: ZoomCredentials,
+        *,
+        api_base_url: str = "https://api.zoom.us/v2",
+        oauth_base_url: str = "https://zoom.us",
+        timeout: int = 20,
+        session: Optional[requests.Session] = None,
+    ):
+        self.credentials = credentials
+        self.api_base_url = api_base_url.rstrip("/")
+        self.oauth_base_url = oauth_base_url.rstrip("/")
+        self.timeout = timeout
+        self.session = session or requests.Session()
+        self._access_token = ""
+        self._expires_at = 0.0
+
+    def _basic_auth_header(self) -> str:
+        raw = f"{self.credentials.client_id}:{self.credentials.client_secret}".encode("utf-8")
+        return "Basic " + base64.b64encode(raw).decode("ascii")
+
+    def get_access_token(self, *, force_refresh: bool = False) -> str:
+        if not force_refresh and self._access_token and time.time() < self._expires_at - 60:
+            return self._access_token
+
+        params = {
+            "grant_type": "account_credentials",
+            "account_id": self.credentials.account_id,
+        }
+        try:
+            resp = self.session.post(
+                f"{self.oauth_base_url}/oauth/token",
+                params=params,
+                headers={"Authorization": self._basic_auth_header()},
+                timeout=self.timeout,
+            )
+            resp.raise_for_status()
+            data = resp.json() or {}
+        except Exception as exc:  # pragma: no cover - network failure branch
+            raise ZoomClientError(f"Zoom OAuth token request failed: {exc}") from exc
+
+        token = str(data.get("access_token") or "")
+        if not token:
+            raise ZoomClientError(f"Zoom OAuth response missing access_token: {data}")
+        expires_in = int(data.get("expires_in") or 3600)
+        self._access_token = token
+        self._expires_at = time.time() + max(60, expires_in)
+        return token
+
+    def request(self, method: str, path: str, **kwargs) -> Dict[str, Any]:
+        token = self.get_access_token()
+        headers = dict(kwargs.pop("headers", {}) or {})
+        headers.setdefault("Authorization", f"Bearer {token}")
+        headers.setdefault("Content-Type", "application/json")
+        try:
+            resp = self.session.request(
+                method.upper(),
+                f"{self.api_base_url}/{path.lstrip('/')}",
+                headers=headers,
+                timeout=kwargs.pop("timeout", self.timeout),
+                **kwargs,
+            )
+            resp.raise_for_status()
+        except Exception as exc:  # pragma: no cover - network failure branch
+            raise ZoomClientError(f"Zoom API {method.upper()} {path} failed: {exc}") from exc
+
+        if not resp.content:
+            return {}
+        return resp.json() or {}
+
+    def fetch_meeting(self, meeting_id: str) -> Dict[str, Any]:
+        return self.request("GET", f"meetings/{meeting_id}")
+
+    def fetch_meeting_recordings(self, meeting_id: str) -> Dict[str, Any]:
+        return self.request("GET", f"meetings/{meeting_id}/recordings")
+

--- a/plugins/zoom_meeting/plugin.yaml
+++ b/plugins/zoom_meeting/plugin.yaml
@@ -1,0 +1,17 @@
+name: zoom_meeting
+version: 0.1.0
+description: "Zoom meeting intelligence plugin built around official-style OAuth, REST, and webhook/RTMS ingestion. Tracks meeting state, captures transcript-like events, and exports durable artifacts for follow-up work."
+author: NousResearch
+kind: standalone
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - zoom_meeting_watch
+  - zoom_meeting_status
+  - zoom_meeting_transcript
+  - zoom_meeting_events
+  - zoom_meeting_summary
+  - zoom_meeting_action_items
+  - zoom_meeting_artifacts

--- a/plugins/zoom_meeting/server.py
+++ b/plugins/zoom_meeting/server.py
@@ -1,0 +1,121 @@
+"""A small aiohttp webhook receiver for Zoom meeting events."""
+
+from __future__ import annotations
+
+import asyncio
+import hmac
+import json
+import logging
+from typing import Optional
+
+try:
+    from aiohttp import web
+
+    AIOHTTP_AVAILABLE = True
+except ImportError:  # pragma: no cover - import guard
+    web = None  # type: ignore[assignment]
+    AIOHTTP_AVAILABLE = False
+
+from plugins.zoom_meeting.store import ZoomMeetingStore, compute_webhook_validation_token
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_equal(a: str, b: str) -> bool:
+    return hmac.compare_digest(a.encode("utf-8"), b.encode("utf-8"))
+
+
+class ZoomWebhookServer:
+    def __init__(
+        self,
+        store: ZoomMeetingStore,
+        *,
+        secret_token: str = "",
+        host: str = "0.0.0.0",
+        port: int = 8754,
+        path: str = "/zoom/webhook",
+    ):
+        self.store = store
+        self.secret_token = secret_token
+        self.host = host
+        self.port = port
+        self.path = path
+        self._runner: Optional["web.AppRunner"] = None
+
+    def _verify_signature(self, timestamp: str, signature: str, body: bytes) -> bool:
+        if not self.secret_token:
+            return True
+        if not timestamp or not signature:
+            return False
+        expected = compute_webhook_validation_token(self.secret_token, f"v0:{timestamp}:{body.decode('utf-8')}")
+        actual = signature.split("=", 1)[-1]
+        return _safe_equal(expected, actual)
+
+    async def _handle_health(self, request: "web.Request") -> "web.Response":
+        return web.json_response({"status": "ok"})
+
+    async def _handle_webhook(self, request: "web.Request") -> "web.Response":
+        raw_body = await request.read()
+        try:
+            payload = json.loads(raw_body.decode("utf-8") or "{}")
+        except Exception:
+            return web.json_response({"ok": False, "error": "invalid JSON"}, status=400)
+
+        timestamp = request.headers.get("x-zm-request-timestamp", "")
+        signature = request.headers.get("x-zm-signature", "")
+        if self.secret_token and not self._verify_signature(timestamp, signature, raw_body):
+            return web.json_response({"ok": False, "error": "invalid signature"}, status=401)
+
+        event_name = str(payload.get("event") or payload.get("event_type") or payload.get("type") or "")
+        if event_name == "endpoint.url_validation":
+            plain_token = (
+                payload.get("payload", {}).get("plainToken")
+                or payload.get("payload", {}).get("plain_token")
+                or payload.get("plainToken")
+                or ""
+            )
+            if not plain_token:
+                return web.json_response({"ok": False, "error": "missing plainToken"}, status=400)
+            return web.json_response(
+                {
+                    "plainToken": plain_token,
+                    "encryptedToken": compute_webhook_validation_token(self.secret_token, plain_token),
+                }
+            )
+
+        normalized = self.store.ingest_event(payload)
+        return web.json_response(
+            {
+                "ok": True,
+                "meeting_id": normalized.get("meeting_id"),
+                "event": normalized.get("event"),
+                "transcript_entries": len(normalized.get("transcript_entries") or []),
+            }
+        )
+
+    async def start(self) -> None:
+        if not AIOHTTP_AVAILABLE:
+            raise RuntimeError("aiohttp not installed. Run: pip install aiohttp")
+        app = web.Application()
+        app.router.add_get("/health", self._handle_health)
+        app.router.add_post(self.path, self._handle_webhook)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.host, self.port)
+        await site.start()
+        logger.info("[zoom_meeting] webhook server listening on %s:%d%s", self.host, self.port, self.path)
+
+    async def stop(self) -> None:
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+
+    def serve_forever(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(self.start())
+        try:
+            loop.run_forever()
+        finally:  # pragma: no cover - shutdown path
+            loop.run_until_complete(self.stop())
+            loop.close()

--- a/plugins/zoom_meeting/store.py
+++ b/plugins/zoom_meeting/store.py
@@ -1,0 +1,462 @@
+"""Persistent state, event normalization, and artifact export for Zoom meetings."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from hermes_constants import get_hermes_home
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _slugify(value: str) -> str:
+    value = re.sub(r"[^A-Za-z0-9._-]+", "-", value.strip())
+    return value.strip("-") or "unknown"
+
+
+def _coerce_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _parse_transcript_line(line: str) -> Dict[str, str]:
+    text = line.strip()
+    if not text:
+        return {"speaker": "", "text": ""}
+
+    if text.startswith("[") and "] " in text:
+        text = text.split("] ", 1)[1].strip()
+
+    if ": " in text:
+        speaker, message = text.split(": ", 1)
+        return {"speaker": speaker.strip(), "text": message.strip()}
+
+    return {"speaker": "", "text": text}
+
+
+def _deep_get(obj: Any, *keys: str) -> Any:
+    current = obj
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def compute_webhook_validation_token(secret: str, plain_token: str) -> str:
+    return hmac.new(secret.encode("utf-8"), plain_token.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _find_first(obj: Any, candidate_keys: Iterable[str]) -> Any:
+    stack = [obj]
+    keyset = {k.lower() for k in candidate_keys}
+    while stack:
+        current = stack.pop()
+        if isinstance(current, dict):
+            for key, value in current.items():
+                if key.lower() in keyset and value not in (None, ""):
+                    return value
+                stack.append(value)
+        elif isinstance(current, list):
+            stack.extend(reversed(current))
+    return None
+
+
+def extract_meeting_identity(payload: Dict[str, Any]) -> Dict[str, str]:
+    obj = _deep_get(payload, "payload", "object") or payload.get("object") or payload
+    meeting_id = _find_first(obj, ("id", "meeting_id", "meetingId", "meetingNumber"))
+    meeting_uuid = _find_first(obj, ("uuid", "meeting_uuid", "meetingUUID"))
+    topic = _find_first(obj, ("topic", "meeting_topic", "title"))
+    return {
+        "meeting_id": str(meeting_id or meeting_uuid or "unknown"),
+        "meeting_uuid": str(meeting_uuid or meeting_id or ""),
+        "topic": str(topic or ""),
+    }
+
+
+def _extract_transcript_entries(payload: Dict[str, Any]) -> List[Dict[str, str]]:
+    event_name = _coerce_text(payload.get("event") or payload.get("event_type") or payload.get("type")).lower()
+    want_loose_match = any(token in event_name for token in ("transcript", "caption", "rtms", "utterance"))
+    results: List[Dict[str, str]] = []
+
+    def visit(node: Any, path: tuple[str, ...]) -> None:
+        if isinstance(node, dict):
+            lowered = {str(k).lower(): v for k, v in node.items()}
+            path_joined = ".".join(path).lower()
+            text = ""
+            key_used = ""
+            for key in ("transcript", "caption", "utterance", "content", "text", "message"):
+                value = lowered.get(key)
+                value_text = _coerce_text(value)
+                if value_text:
+                    text = value_text
+                    key_used = key
+                    break
+
+            speaker = ""
+            for key in ("speaker", "speaker_name", "participant_name", "display_name", "user_name", "name"):
+                value_text = _coerce_text(lowered.get(key))
+                if value_text:
+                    speaker = value_text
+                    break
+
+            ts = ""
+            for key in ("timestamp", "time", "start_time", "ts"):
+                value_text = _coerce_text(lowered.get(key))
+                if value_text:
+                    ts = value_text
+                    break
+
+            if text:
+                relevant_path = any(token in path_joined for token in ("transcript", "caption", "utterance", "chat"))
+                transcriptish_key = key_used in {"transcript", "caption", "utterance"}
+                if transcriptish_key or relevant_path or want_loose_match:
+                    results.append({"speaker": speaker, "text": text, "timestamp": ts})
+
+            for key, value in node.items():
+                visit(value, path + (str(key),))
+        elif isinstance(node, list):
+            for idx, value in enumerate(node):
+                visit(value, path + (str(idx),))
+
+    visit(payload, ())
+
+    deduped: List[Dict[str, str]] = []
+    seen = set()
+    for item in results:
+        key = (item["speaker"], item["text"], item["timestamp"])
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(item)
+    return deduped
+
+
+def normalize_event(payload: Dict[str, Any]) -> Dict[str, Any]:
+    identity = extract_meeting_identity(payload)
+    event_name = _coerce_text(payload.get("event") or payload.get("event_type") or payload.get("type")) or "unknown"
+    transcript_entries = _extract_transcript_entries(payload)
+    lifecycle = "lifecycle" if any(token in event_name.lower() for token in ("meeting.", "recording.", "participant.")) else "data"
+    return {
+        "received_at": _utcnow_iso(),
+        "event": event_name,
+        "kind": "transcript" if transcript_entries else lifecycle,
+        "meeting_id": identity["meeting_id"],
+        "meeting_uuid": identity["meeting_uuid"],
+        "topic": identity["topic"],
+        "transcript_entries": transcript_entries,
+        "payload": payload,
+    }
+
+
+class ZoomMeetingStore:
+    def __init__(self, root: Optional[Path] = None):
+        base = root or (Path(get_hermes_home()) / "cache" / "zoom" / "meetings")
+        self.root = Path(base)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def meeting_dir(self, meeting_id: str) -> Path:
+        path = self.root / _slugify(meeting_id)
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def _state_path(self, meeting_id: str) -> Path:
+        return self.meeting_dir(meeting_id) / "state.json"
+
+    def _events_path(self, meeting_id: str) -> Path:
+        return self.meeting_dir(meeting_id) / "events.jsonl"
+
+    def _transcript_path(self, meeting_id: str) -> Path:
+        return self.meeting_dir(meeting_id) / "transcript.txt"
+
+    def _summary_path(self, meeting_id: str) -> Path:
+        return self.meeting_dir(meeting_id) / "summary.md"
+
+    def load_state(self, meeting_id: str) -> Dict[str, Any]:
+        path = self._state_path(meeting_id)
+        if not path.is_file():
+            return {}
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+
+    def save_state(self, meeting_id: str, state: Dict[str, Any]) -> Dict[str, Any]:
+        path = self._state_path(meeting_id)
+        path.write_text(json.dumps(state, indent=2, ensure_ascii=False), encoding="utf-8")
+        return state
+
+    def ensure_meeting(self, meeting_id: str, metadata: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        state = self.load_state(meeting_id)
+        if not state:
+            state = {
+                "meeting_id": meeting_id,
+                "meeting_uuid": "",
+                "topic": "",
+                "status": "initialized",
+                "created_at": _utcnow_iso(),
+                "updated_at": _utcnow_iso(),
+                "transcript_lines": 0,
+                "event_count": 0,
+                "participants": [],
+            }
+        if metadata:
+            for key in ("uuid", "id", "topic", "join_url", "start_time", "duration", "timezone", "host_id", "agenda"):
+                value = metadata.get(key)
+                if value not in (None, ""):
+                    state_key = "meeting_uuid" if key == "uuid" else ("meeting_id" if key == "id" else key)
+                    state[state_key] = value
+            state["status"] = state.get("status") or "watched"
+        state["updated_at"] = _utcnow_iso()
+        return self.save_state(meeting_id, state)
+
+    def ingest_event(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        normalized = normalize_event(payload)
+        meeting_id = str(normalized["meeting_id"] or "unknown")
+        state = self.ensure_meeting(meeting_id, metadata={"id": meeting_id, "uuid": normalized.get("meeting_uuid"), "topic": normalized.get("topic")})
+
+        with self._events_path(meeting_id).open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(normalized, ensure_ascii=False) + "\n")
+
+        transcript_entries = normalized["transcript_entries"]
+        if transcript_entries:
+            with self._transcript_path(meeting_id).open("a", encoding="utf-8") as fh:
+                for entry in transcript_entries:
+                    speaker = entry["speaker"] or "Unknown"
+                    text = entry["text"]
+                    ts = f"[{entry['timestamp']}] " if entry["timestamp"] else ""
+                    fh.write(f"{ts}{speaker}: {text}\n")
+
+        participants = set(state.get("participants") or [])
+        payload_obj = _deep_get(payload, "payload", "object") or payload.get("object") or {}
+        candidate_name = _find_first(payload_obj, ("participant_name", "display_name", "user_name", "name"))
+        if isinstance(candidate_name, str) and candidate_name.strip():
+            participants.add(candidate_name.strip())
+
+        state["updated_at"] = _utcnow_iso()
+        state["last_event"] = normalized["event"]
+        state["last_event_at"] = normalized["received_at"]
+        state["event_count"] = int(state.get("event_count") or 0) + 1
+        state["transcript_lines"] = int(state.get("transcript_lines") or 0) + len(transcript_entries)
+        state["participants"] = sorted(participants)
+
+        event_lower = normalized["event"].lower()
+        if "meeting.started" in event_lower:
+            state["status"] = "started"
+        elif "meeting.ended" in event_lower:
+            state["status"] = "ended"
+            state["ended_at"] = normalized["received_at"]
+        elif transcript_entries and state.get("status") in ("initialized", "watched"):
+            state["status"] = "active"
+
+        self.save_state(meeting_id, state)
+        return normalized
+
+    def read_transcript(self, meeting_id: str, last: Optional[int] = None) -> str:
+        path = self._transcript_path(meeting_id)
+        if not path.is_file():
+            return ""
+        lines = path.read_text(encoding="utf-8").splitlines()
+        if isinstance(last, int) and last > 0:
+            lines = lines[-last:]
+        return "\n".join(lines)
+
+    def read_events(self, meeting_id: str, last: Optional[int] = None) -> List[Dict[str, Any]]:
+        path = self._events_path(meeting_id)
+        if not path.is_file():
+            return []
+        lines = path.read_text(encoding="utf-8").splitlines()
+        if isinstance(last, int) and last > 0:
+            lines = lines[-last:]
+        result: List[Dict[str, Any]] = []
+        for line in lines:
+            try:
+                result.append(json.loads(line))
+            except Exception:
+                continue
+        return result
+
+    def analyze_meeting(self, meeting_id: str) -> Dict[str, Any]:
+        transcript = self.read_transcript(meeting_id)
+        action_items: List[Dict[str, str]] = []
+        decisions: List[Dict[str, str]] = []
+        questions: List[Dict[str, str]] = []
+        seen_actions = set()
+        seen_decisions = set()
+        seen_questions = set()
+
+        action_tokens = (
+            "action item",
+            "todo",
+            "follow up",
+            "follow-up",
+            "next step",
+            "need to",
+            "needs to",
+            "should ",
+            "please ",
+            "will ",
+        )
+        decision_tokens = (
+            "decided",
+            "decision",
+            "agreed",
+            "approved",
+            "chosen",
+            "we'll go with",
+            "we will go with",
+        )
+        question_tokens = ("who ", "what ", "when ", "where ", "why ", "how ", "can ", "should ", "do we ", "does ")
+
+        for raw_line in transcript.splitlines():
+            parsed = _parse_transcript_line(raw_line)
+            speaker = parsed["speaker"]
+            text = parsed["text"]
+            lowered = text.lower()
+            if not text:
+                continue
+
+            if any(token in lowered for token in action_tokens):
+                key = (speaker, text)
+                if key not in seen_actions:
+                    seen_actions.add(key)
+                    action_items.append(
+                        {
+                            "owner": speaker,
+                            "text": text,
+                            "source": raw_line,
+                        }
+                    )
+
+            if any(token in lowered for token in decision_tokens):
+                key = (speaker, text)
+                if key not in seen_decisions:
+                    seen_decisions.add(key)
+                    decisions.append(
+                        {
+                            "speaker": speaker,
+                            "text": text,
+                            "source": raw_line,
+                        }
+                    )
+
+            if text.endswith("?") or lowered.startswith(question_tokens):
+                key = (speaker, text)
+                if key not in seen_questions:
+                    seen_questions.add(key)
+                    questions.append(
+                        {
+                            "speaker": speaker,
+                            "text": text,
+                            "source": raw_line,
+                        }
+                    )
+
+        return {
+            "action_items": action_items[:12],
+            "decisions": decisions[:12],
+            "questions": questions[:12],
+        }
+
+    def render_markdown_summary(self, meeting_id: str) -> str:
+        state = self.load_state(meeting_id)
+        transcript = self.read_transcript(meeting_id)
+        events = self.read_events(meeting_id, last=10)
+        analysis = self.analyze_meeting(meeting_id)
+        lines = transcript.splitlines()
+        excerpt = lines[:8]
+        tail = lines[-8:] if len(lines) > 8 else []
+        if tail and excerpt != tail:
+            excerpt = excerpt + ["...", *tail]
+
+        md = [
+            f"# Zoom Meeting Summary — {state.get('topic') or meeting_id}",
+            "",
+            f"- Meeting ID: `{state.get('meeting_id') or meeting_id}`",
+            f"- UUID: `{state.get('meeting_uuid') or ''}`",
+            f"- Status: `{state.get('status') or 'unknown'}`",
+            f"- Transcript lines: `{state.get('transcript_lines') or 0}`",
+            f"- Event count: `{state.get('event_count') or 0}`",
+        ]
+        if state.get("participants"):
+            md.append(f"- Participants seen: {', '.join(state['participants'])}")
+        if state.get("start_time"):
+            md.append(f"- Scheduled start: `{state['start_time']}`")
+        if state.get("ended_at"):
+            md.append(f"- Ended at: `{state['ended_at']}`")
+        md.extend(["", "## Recent Event Feed", ""])
+        if events:
+            for event in events:
+                md.append(f"- `{event.get('received_at')}` `{event.get('event')}` ({event.get('kind')})")
+        else:
+            md.append("- No events captured yet.")
+
+        md.extend(["", "## Action Items", ""])
+        if analysis["action_items"]:
+            for item in analysis["action_items"]:
+                owner = item["owner"] or "Unassigned"
+                md.append(f"- **{owner}**: {item['text']}")
+        else:
+            md.append("- No action-item signals detected yet.")
+
+        md.extend(["", "## Decisions", ""])
+        if analysis["decisions"]:
+            for item in analysis["decisions"]:
+                speaker = item["speaker"] or "Unknown"
+                md.append(f"- **{speaker}**: {item['text']}")
+        else:
+            md.append("- No decision signals detected yet.")
+
+        md.extend(["", "## Open Questions", ""])
+        if analysis["questions"]:
+            for item in analysis["questions"]:
+                speaker = item["speaker"] or "Unknown"
+                md.append(f"- **{speaker}**: {item['text']}")
+        else:
+            md.append("- No question signals detected yet.")
+
+        md.extend(["", "## Transcript Excerpt", ""])
+        if excerpt:
+            md.append("```text")
+            md.extend(excerpt)
+            md.append("```")
+        else:
+            md.append("No transcript captured yet.")
+        return "\n".join(md) + "\n"
+
+    def write_summary(self, meeting_id: str) -> Path:
+        summary = self.render_markdown_summary(meeting_id)
+        path = self._summary_path(meeting_id)
+        path.write_text(summary, encoding="utf-8")
+        return path
+
+    def export_artifacts(self, meeting_id: str, *, fmt: str = "markdown", output_path: Optional[str] = None) -> Path:
+        fmt = (fmt or "markdown").strip().lower()
+        state = self.load_state(meeting_id)
+        transcript = self.read_transcript(meeting_id)
+        events = self.read_events(meeting_id)
+        if output_path:
+            path = Path(output_path).expanduser()
+        else:
+            suffix = "md" if fmt == "markdown" else "json"
+            path = self.meeting_dir(meeting_id) / f"artifact.{suffix}"
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        if fmt == "json":
+            payload = {
+                "state": state,
+                "transcript": transcript,
+                "events": events,
+                "analysis": self.analyze_meeting(meeting_id),
+            }
+            path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+        else:
+            path.write_text(self.render_markdown_summary(meeting_id), encoding="utf-8")
+        return path

--- a/plugins/zoom_meeting/tools.py
+++ b/plugins/zoom_meeting/tools.py
@@ -1,0 +1,263 @@
+"""Agent-facing tools for the zoom_meeting plugin."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+from plugins.zoom_meeting.client import ZoomClient, ZoomClientError, ZoomCredentials
+from plugins.zoom_meeting.store import ZoomMeetingStore
+
+
+def _json(obj: Any) -> str:
+    return json.dumps(obj, ensure_ascii=False)
+
+
+def _ok(**payload: Any) -> str:
+    return _json({"success": True, **payload})
+
+
+def _err(message: str, **payload: Any) -> str:
+    return _json({"success": False, "error": message, **payload})
+
+
+def check_zoom_meeting_requirements() -> bool:
+    try:
+        import requests  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _store() -> ZoomMeetingStore:
+    return ZoomMeetingStore()
+
+
+def _client_from_env() -> Optional[ZoomClient]:
+    account_id = os.getenv("ZOOM_ACCOUNT_ID", "").strip()
+    client_id = os.getenv("ZOOM_CLIENT_ID", "").strip()
+    client_secret = os.getenv("ZOOM_CLIENT_SECRET", "").strip()
+    if not (account_id and client_id and client_secret):
+        return None
+    return ZoomClient(ZoomCredentials(account_id=account_id, client_id=client_id, client_secret=client_secret))
+
+
+ZOOM_MEETING_WATCH_SCHEMA: Dict[str, Any] = {
+    "name": "zoom_meeting_watch",
+    "description": (
+        "Initialize or refresh local state for a Zoom meeting using account-scoped REST metadata. "
+        "This creates a durable meeting workspace under ~/.hermes/cache/zoom/meetings/<meeting_id>/ "
+        "so later webhook/RTMS events can accumulate transcript and status data there."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "meeting_id": {"type": "string", "description": "Zoom meeting ID."},
+            "fetch_recordings": {
+                "type": "boolean",
+                "description": "Also fetch recording metadata for past meetings if the account can access it.",
+            },
+        },
+        "required": ["meeting_id"],
+        "additionalProperties": False,
+    },
+}
+
+ZOOM_MEETING_STATUS_SCHEMA: Dict[str, Any] = {
+    "name": "zoom_meeting_status",
+    "description": "Return local state for a watched Zoom meeting, including transcript and event counts.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "meeting_id": {"type": "string"},
+        },
+        "required": ["meeting_id"],
+        "additionalProperties": False,
+    },
+}
+
+ZOOM_MEETING_TRANSCRIPT_SCHEMA: Dict[str, Any] = {
+    "name": "zoom_meeting_transcript",
+    "description": "Read the locally accumulated transcript for a Zoom meeting.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "meeting_id": {"type": "string"},
+            "last": {"type": "integer", "minimum": 1},
+        },
+        "required": ["meeting_id"],
+        "additionalProperties": False,
+    },
+}
+
+ZOOM_MEETING_EVENTS_SCHEMA: Dict[str, Any] = {
+    "name": "zoom_meeting_events",
+    "description": "Read normalized Zoom meeting events captured by the webhook server.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "meeting_id": {"type": "string"},
+            "last": {"type": "integer", "minimum": 1},
+        },
+        "required": ["meeting_id"],
+        "additionalProperties": False,
+    },
+}
+
+ZOOM_MEETING_SUMMARY_SCHEMA: Dict[str, Any] = {
+    "name": "zoom_meeting_summary",
+    "description": (
+        "Render a deterministic markdown summary from the locally captured Zoom meeting state, "
+        "events, and transcript excerpt."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "meeting_id": {"type": "string"},
+        },
+        "required": ["meeting_id"],
+        "additionalProperties": False,
+    },
+}
+
+ZOOM_MEETING_ACTION_ITEMS_SCHEMA: Dict[str, Any] = {
+    "name": "zoom_meeting_action_items",
+    "description": (
+        "Extract deterministic action items, decisions, and open questions from the locally captured "
+        "Zoom meeting transcript."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "meeting_id": {"type": "string"},
+        },
+        "required": ["meeting_id"],
+        "additionalProperties": False,
+    },
+}
+
+ZOOM_MEETING_ARTIFACTS_SCHEMA: Dict[str, Any] = {
+    "name": "zoom_meeting_artifacts",
+    "description": (
+        "Export a local artifact bundle for a watched Zoom meeting. "
+        "Formats: markdown (human-friendly report) or json (state + transcript + events)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "meeting_id": {"type": "string"},
+            "format": {"type": "string", "enum": ["markdown", "json"]},
+            "output_path": {"type": "string"},
+        },
+        "required": ["meeting_id"],
+        "additionalProperties": False,
+    },
+}
+
+
+def handle_zoom_meeting_watch(args: Dict[str, Any], **_kw) -> str:
+    meeting_id = str(args.get("meeting_id") or "").strip()
+    if not meeting_id:
+        return _err("meeting_id is required")
+
+    store = _store()
+    client = _client_from_env()
+    metadata: Dict[str, Any] = {}
+    recordings: Dict[str, Any] | None = None
+    if client is None:
+        state = store.ensure_meeting(meeting_id)
+        return _ok(
+            meeting_id=meeting_id,
+            state=state,
+            warning=(
+                "Zoom OAuth env vars are not configured. Created the local workspace only; "
+                "set ZOOM_ACCOUNT_ID, ZOOM_CLIENT_ID, and ZOOM_CLIENT_SECRET to fetch live metadata."
+            ),
+        )
+
+    try:
+        metadata = client.fetch_meeting(meeting_id)
+        if bool(args.get("fetch_recordings", False)):
+            try:
+                recordings = client.fetch_meeting_recordings(meeting_id)
+            except ZoomClientError as exc:
+                recordings = {"error": str(exc)}
+    except ZoomClientError as exc:
+        state = store.ensure_meeting(meeting_id)
+        return _err(str(exc), meeting_id=meeting_id, state=state)
+
+    state = store.ensure_meeting(meeting_id, metadata=metadata)
+    if recordings:
+        state["recordings"] = recordings
+        store.save_state(meeting_id, state)
+    return _ok(meeting_id=meeting_id, state=state)
+
+
+def handle_zoom_meeting_status(args: Dict[str, Any], **_kw) -> str:
+    meeting_id = str(args.get("meeting_id") or "").strip()
+    if not meeting_id:
+        return _err("meeting_id is required")
+    state = _store().load_state(meeting_id)
+    if not state:
+        return _err(f"no local Zoom meeting state found for {meeting_id!r}")
+    return _ok(meeting_id=meeting_id, state=state)
+
+
+def handle_zoom_meeting_transcript(args: Dict[str, Any], **_kw) -> str:
+    meeting_id = str(args.get("meeting_id") or "").strip()
+    if not meeting_id:
+        return _err("meeting_id is required")
+    last = args.get("last")
+    transcript = _store().read_transcript(meeting_id, last=last if isinstance(last, int) else None)
+    if not transcript:
+        return _err(f"no transcript captured yet for {meeting_id!r}", meeting_id=meeting_id)
+    return _ok(meeting_id=meeting_id, transcript=transcript)
+
+
+def handle_zoom_meeting_events(args: Dict[str, Any], **_kw) -> str:
+    meeting_id = str(args.get("meeting_id") or "").strip()
+    if not meeting_id:
+        return _err("meeting_id is required")
+    last = args.get("last")
+    events = _store().read_events(meeting_id, last=last if isinstance(last, int) else None)
+    return _ok(meeting_id=meeting_id, events=events, count=len(events))
+
+
+def handle_zoom_meeting_summary(args: Dict[str, Any], **_kw) -> str:
+    meeting_id = str(args.get("meeting_id") or "").strip()
+    if not meeting_id:
+        return _err("meeting_id is required")
+    store = _store()
+    state = store.load_state(meeting_id)
+    if not state:
+        return _err(f"no local Zoom meeting state found for {meeting_id!r}")
+    summary = store.render_markdown_summary(meeting_id)
+    path = store.write_summary(meeting_id)
+    return _ok(meeting_id=meeting_id, summary=summary, path=str(path))
+
+
+def handle_zoom_meeting_action_items(args: Dict[str, Any], **_kw) -> str:
+    meeting_id = str(args.get("meeting_id") or "").strip()
+    if not meeting_id:
+        return _err("meeting_id is required")
+    store = _store()
+    state = store.load_state(meeting_id)
+    if not state:
+        return _err(f"no local Zoom meeting state found for {meeting_id!r}")
+    analysis = store.analyze_meeting(meeting_id)
+    return _ok(meeting_id=meeting_id, **analysis)
+
+
+def handle_zoom_meeting_artifacts(args: Dict[str, Any], **_kw) -> str:
+    meeting_id = str(args.get("meeting_id") or "").strip()
+    if not meeting_id:
+        return _err("meeting_id is required")
+    store = _store()
+    state = store.load_state(meeting_id)
+    if not state:
+        return _err(f"no local Zoom meeting state found for {meeting_id!r}")
+    fmt = str(args.get("format") or "markdown")
+    output_path = args.get("output_path")
+    path = store.export_artifacts(meeting_id, fmt=fmt, output_path=output_path if isinstance(output_path, str) else None)
+    return _ok(meeting_id=meeting_id, format=fmt, path=str(path))

--- a/tests/hermes_cli/test_plugin_cli_registration.py
+++ b/tests/hermes_cli/test_plugin_cli_registration.py
@@ -20,6 +20,7 @@ from hermes_cli.plugins import (
     PluginContext,
     PluginManager,
     PluginManifest,
+    get_plugin_cli_commands,
 )
 
 
@@ -61,6 +62,25 @@ class TestRegisterCliCommand:
         ctx, mgr = self._make_ctx()
         ctx.register_cli_command("nocb", "test", MagicMock())
         assert mgr._cli_commands["nocb"]["handler_fn"] is None
+
+    def test_get_plugin_cli_commands_discovers_enabled_bundled_plugin(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir(parents=True)
+        (hermes_home / "config.yaml").write_text(
+            "plugins:\n  enabled:\n    - zoom_meeting\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        import hermes_cli.plugins as plugins_mod
+
+        plugins_mod._plugin_manager = PluginManager()
+        cmds = get_plugin_cli_commands()
+
+        assert "zoom" in cmds
+        assert cmds["zoom"]["plugin"] == "zoom_meeting"
+        assert callable(cmds["zoom"]["setup_fn"])
+        assert callable(cmds["zoom"]["handler_fn"])
 
 
 # ── Memory plugin CLI discovery ───────────────────────────────────────────

--- a/tests/hermes_cli/test_zoom_meeting_cli_smoke.py
+++ b/tests/hermes_cli/test_zoom_meeting_cli_smoke.py
@@ -1,0 +1,32 @@
+"""Smoke test for the zoom_meeting plugin CLI wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_zoom_subcommand_is_reachable_from_main_cli(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text(
+        "plugins:\n  enabled:\n    - zoom_meeting\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("ZOOM_ACCOUNT_ID", raising=False)
+    monkeypatch.delenv("ZOOM_CLIENT_ID", raising=False)
+    monkeypatch.delenv("ZOOM_CLIENT_SECRET", raising=False)
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hermes", "zoom", "auth-check"],
+    )
+
+    import hermes_cli.plugins as plugins_mod
+    from hermes_cli.main import main
+
+    plugins_mod._plugin_manager = plugins_mod.PluginManager()
+    main()
+
+    out = capsys.readouterr().out
+    assert "Zoom OAuth env vars missing" in out
+    assert "ZOOM_ACCOUNT_ID" in out

--- a/tests/plugins/test_zoom_meeting_plugin.py
+++ b/tests/plugins/test_zoom_meeting_plugin.py
@@ -1,0 +1,225 @@
+"""Tests for the zoom_meeting plugin primitives."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import plugins.zoom_meeting as plugin
+from plugins.zoom_meeting.server import AIOHTTP_AVAILABLE, ZoomWebhookServer
+from plugins.zoom_meeting.store import (
+    ZoomMeetingStore,
+    compute_webhook_validation_token,
+    extract_meeting_identity,
+    normalize_event,
+)
+from plugins.zoom_meeting.tools import (
+    handle_zoom_meeting_action_items,
+    handle_zoom_meeting_artifacts,
+    handle_zoom_meeting_status,
+    handle_zoom_meeting_summary,
+    handle_zoom_meeting_transcript,
+    handle_zoom_meeting_watch,
+)
+
+import pytest
+
+
+def test_compute_webhook_validation_token_is_stable():
+    token = compute_webhook_validation_token("secret", "plain-token")
+    assert len(token) == 64
+    assert token == compute_webhook_validation_token("secret", "plain-token")
+
+
+def test_normalize_event_extracts_identity_and_transcript_entries():
+    payload = {
+        "event": "meeting.rtms_transcript",
+        "payload": {
+            "object": {
+                "id": "12345",
+                "uuid": "uuid-1",
+                "topic": "Quarterly Review",
+                "segments": [
+                    {"speaker_name": "Dilek", "transcript": "Welcome everyone", "timestamp": "2026-05-06T10:00:00Z"},
+                    {"speaker_name": "Alex", "transcript": "Status update follows", "timestamp": "2026-05-06T10:00:04Z"},
+                ],
+            }
+        },
+    }
+    identity = extract_meeting_identity(payload)
+    assert identity["meeting_id"] == "12345"
+    assert identity["meeting_uuid"] == "uuid-1"
+    assert identity["topic"] == "Quarterly Review"
+
+    normalized = normalize_event(payload)
+    assert normalized["kind"] == "transcript"
+    assert len(normalized["transcript_entries"]) == 2
+    assert normalized["transcript_entries"][0]["speaker"] == "Dilek"
+
+
+def test_store_ingest_event_updates_state_and_transcript(tmp_path):
+    store = ZoomMeetingStore(root=tmp_path / "zoom")
+    payload = {
+        "event": "meeting.started",
+        "payload": {
+            "object": {
+                "id": "2468",
+                "topic": "Infra Sync",
+                "speaker_name": "Dilek",
+                "transcript": "Kickoff and agenda review",
+            }
+        },
+    }
+    normalized = store.ingest_event(payload)
+    assert normalized["meeting_id"] == "2468"
+
+    state = store.load_state("2468")
+    assert state["status"] in ("started", "active")
+    assert state["event_count"] == 1
+    assert state["transcript_lines"] == 1
+
+    transcript = store.read_transcript("2468")
+    assert "Kickoff and agenda review" in transcript
+
+
+def test_tool_handlers_use_local_store_and_export_artifacts(tmp_path, monkeypatch):
+    monkeypatch.setattr("plugins.zoom_meeting.tools._store", lambda: ZoomMeetingStore(root=tmp_path / "zoom"))
+    monkeypatch.setattr(
+        "plugins.zoom_meeting.tools._client_from_env",
+        lambda: None,
+    )
+
+    watch = json.loads(handle_zoom_meeting_watch({"meeting_id": "777"}))
+    assert watch["success"] is True
+    assert "warning" in watch
+
+    store = ZoomMeetingStore(root=tmp_path / "zoom")
+    store.ingest_event(
+        {
+            "event": "meeting.rtms_transcript",
+            "payload": {
+                "object": {
+                    "id": "777",
+                    "topic": "Strategy",
+                    "caption": "We should expand in Q3",
+                    "speaker": "Dilek",
+                }
+            },
+        }
+    )
+
+    status = json.loads(handle_zoom_meeting_status({"meeting_id": "777"}))
+    assert status["success"] is True
+    assert status["state"]["event_count"] >= 1
+
+    transcript = json.loads(handle_zoom_meeting_transcript({"meeting_id": "777"}))
+    assert transcript["success"] is True
+    assert "expand in Q3" in transcript["transcript"]
+
+    summary = json.loads(handle_zoom_meeting_summary({"meeting_id": "777"}))
+    assert summary["success"] is True
+    assert "# Zoom Meeting Summary" in summary["summary"]
+    assert "## Action Items" in summary["summary"]
+    assert Path(summary["path"]).is_file()
+
+    action_items = json.loads(handle_zoom_meeting_action_items({"meeting_id": "777"}))
+    assert action_items["success"] is True
+    assert action_items["action_items"]
+
+    artifact = json.loads(handle_zoom_meeting_artifacts({"meeting_id": "777", "format": "json"}))
+    assert artifact["success"] is True
+    exported = json.loads(Path(artifact["path"]).read_text(encoding="utf-8"))
+    assert exported["state"]["meeting_id"] == "777"
+    assert exported["analysis"]["action_items"]
+
+
+def test_register_wires_tools_and_cli():
+    calls = {"tools": [], "cli": []}
+
+    class _Ctx:
+        def register_tool(self, **kw):
+            calls["tools"].append(kw["name"])
+
+        def register_cli_command(self, **kw):
+            calls["cli"].append(kw["name"])
+
+    plugin.register(_Ctx())
+
+    assert set(calls["tools"]) == {
+        "zoom_meeting_watch",
+        "zoom_meeting_status",
+        "zoom_meeting_transcript",
+        "zoom_meeting_events",
+        "zoom_meeting_summary",
+        "zoom_meeting_action_items",
+        "zoom_meeting_artifacts",
+    }
+    assert calls["cli"] == ["zoom"]
+
+
+@pytest.mark.skipif(not AIOHTTP_AVAILABLE, reason="aiohttp not installed")
+def test_webhook_server_validates_endpoint_and_ingests_events(tmp_path):
+    class _Request:
+        def __init__(self, payload: dict, *, headers: dict[str, str]):
+            self._body = json.dumps(payload).encode("utf-8")
+            self.headers = headers
+
+        async def read(self) -> bytes:
+            return self._body
+
+    async def _run() -> None:
+        store = ZoomMeetingStore(root=tmp_path / "zoom")
+        server = ZoomWebhookServer(store, secret_token="zoom-secret")
+
+        validation_payload = {"event": "endpoint.url_validation", "payload": {"plainToken": "abc123"}}
+        timestamp = "1700000000"
+        validation_sig = compute_webhook_validation_token(
+            "zoom-secret",
+            f"v0:{timestamp}:{json.dumps(validation_payload)}",
+        )
+        validation_request = _Request(
+            validation_payload,
+            headers={
+                "x-zm-request-timestamp": timestamp,
+                "x-zm-signature": f"v0={validation_sig}",
+            },
+        )
+        response = await server._handle_webhook(validation_request)
+        assert response.status == 200
+        body = json.loads(response.text)
+        assert body["plainToken"] == "abc123"
+        assert body["encryptedToken"] == compute_webhook_validation_token("zoom-secret", "abc123")
+
+        event_payload = {
+            "event": "meeting.rtms_transcript",
+            "payload": {
+                "object": {
+                    "id": "4242",
+                    "topic": "Roadmap",
+                    "speaker_name": "Dilek",
+                    "transcript": "We should prepare the launch brief",
+                }
+            },
+        }
+        event_sig = compute_webhook_validation_token(
+            "zoom-secret",
+            f"v0:{timestamp}:{json.dumps(event_payload)}",
+        )
+        event_request = _Request(
+            event_payload,
+            headers={
+                "x-zm-request-timestamp": timestamp,
+                "x-zm-signature": f"v0={event_sig}",
+            },
+        )
+        response = await server._handle_webhook(event_request)
+        assert response.status == 200
+        body = json.loads(response.text)
+        assert body["ok"] is True
+        assert body["meeting_id"] == "4242"
+
+        transcript = store.read_transcript("4242")
+        assert "launch brief" in transcript
+
+    asyncio.run(_run())


### PR DESCRIPTION
 ## Summary

  This PR adds a new bundled `zoom_meeting` plugin that gives Hermes a Zoom meeting intelligence surface built around OAuth metadata fetches, webhook ingestion, durable local state, and deterministic post-meeting artifacts.

  It introduces:

  - a new `plugins/zoom_meeting/` plugin
  - server-to-server OAuth support for Zoom meeting metadata
  - local meeting workspaces under `~/.hermes/cache/zoom/meetings/<meeting_id>/`
  - webhook ingestion for lifecycle and transcript-like events
  - transcript/event normalization and persistence
  - deterministic markdown / JSON exports
  - transcript-derived action items, decisions, and open questions
  -  a new `hermes zoom` CLI with commands for auth checks, meeting setup, webhook serving, transcript access, summaries, and artifact export

  ## What this adds

  ### Tools

  The plugin registers these tools:

  - `zoom_meeting_watch`
  - `zoom_meeting_status`
  - `zoom_meeting_transcript`
  - `zoom_meeting_events`
  - `zoom_meeting_summary`
  - `zoom_meeting_action_items`
  - `zoom_meeting_artifacts`

  ### CLI

  The plugin also adds a `hermes zoom` command with:

  - `auth-check`
  - `watch`
  - `status`
  - `transcript`
  - `events`
  - `summary`
  - `action-items`
  - `export`
  - `ingest`
  - `serve`

  ## Design

  This implementation is intentionally official-surface-first. It focuses on the parts that are stable and composable for a self-hosted agent:

  - Zoom server-to-server OAuth
  - meeting metadata fetches
  - webhook ingestion
  - durable local artifacts for later reasoning and follow-up work

  ## Files

  Main additions:

  - `plugins/zoom_meeting/plugin.yaml`
  - `plugins/zoom_meeting/__init__.py`
  - `plugins/zoom_meeting/client.py`
  - `plugins/zoom_meeting/store.py`
  - `plugins/zoom_meeting/server.py`
  - `plugins/zoom_meeting/tools.py`
  - `plugins/zoom_meeting/cli.py`
  - `plugins/zoom_meeting/README.md`

  Tests:

  - `tests/plugins/test_zoom_meeting_plugin.py`

  ## Tests

  Ran:

  - `pytest -q tests/plugins/test_zoom_meeting_plugin.py`
  - `pytest -q tests/hermes_cli/test_plugin_cli_registration.py tests/hermes_cli/test_zoom_meeting_cli_smoke.py`

  ## Related

  Follow-up work is being developed separately for the Zoom Team Chat gateway adapter.