### PR TITLE
feat(zoom): add team chat platform adapter

### DIFF
--- a/plugins/platforms/zoom/README.md
+++ b/plugins/platforms/zoom/README.md
@@ -1,0 +1,57 @@
+# zoom platform plugin
+
+Webhook-first Zoom Team Chat adapter for the Hermes gateway.
+
+## What it does
+
+- receives Zoom webhook events over `aiohttp`
+- validates Zoom webhook signatures and URL-validation challenges
+- normalizes Team Chat messages into Hermes `MessageEvent`s
+- sends bot replies back through Zoom using server-to-server OAuth
+
+## Required environment
+
+- `ZOOM_ACCOUNT_ID`
+- `ZOOM_CLIENT_ID`
+- `ZOOM_CLIENT_SECRET`
+- `ZOOM_CHAT_BOT_JID`
+- `ZOOM_WEBHOOK_SECRET_TOKEN`
+
+Optional:
+
+- `ZOOM_ALLOWED_USERS`
+- `ZOOM_ALLOW_ALL_USERS`
+
+## Gateway config
+
+```yaml
+gateway:
+  platforms:
+    zoom:
+      enabled: true
+      extra:
+        host: 0.0.0.0
+        port: 8762
+        path: /zoom/chat/webhook
+        webhook_secret: ${ZOOM_WEBHOOK_SECRET_TOKEN}
+        account_id: ${ZOOM_ACCOUNT_ID}
+        client_id: ${ZOOM_CLIENT_ID}
+        client_secret: ${ZOOM_CLIENT_SECRET}
+        bot_jid: ${ZOOM_CHAT_BOT_JID}
+```
+
+## API drift note
+
+Zoom Team Chat app payloads and send endpoints can vary by app type. This adapter
+keeps two escape hatches configurable through `extra`:
+
+- `base_url`
+- `send_path`
+
+Defaults:
+
+- `base_url`: `https://api.zoom.us`
+- `send_path`: `/v2/im/chat/messages`
+
+If your Zoom app expects a different chat-send endpoint or payload rollout, adjust
+those values first before changing adapter code.

--- a/plugins/platforms/zoom/__init__.py
+++ b/plugins/platforms/zoom/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/zoom/adapter.py
+++ b/plugins/platforms/zoom/adapter.py
@@ -297,6 +297,16 @@ class ZoomTeamChatAdapter(BasePlatformAdapter):
         actual = signature.split("=", 1)[-1]
         return hmac.compare_digest(expected.encode("utf-8"), actual.encode("utf-8"))
 
+    def _is_self_event(self, normalized: Dict[str, Any]) -> bool:
+        user_id = _coerce_text(normalized.get("user_id"))
+        if user_id and self._bot_jid and user_id == self._bot_jid:
+            return True
+
+        raw = normalized.get("raw") or {}
+        obj = _deep_get(raw, "payload", "object") or raw.get("object") or {}
+        sender_jid = _coerce_text(_find_first(obj, ("sender_jid", "user_jid", "robot_jid", "bot_jid")))
+        return bool(sender_jid and self._bot_jid and sender_jid == self._bot_jid)
+
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         return web.json_response({"ok": True, "platform": "zoom"})
 
@@ -330,6 +340,8 @@ class ZoomTeamChatAdapter(BasePlatformAdapter):
             )
 
         normalized = normalize_zoom_chat_event(payload)
+        if self._is_self_event(normalized):
+            return web.json_response({"ok": True, "ignored": True, "reason": "self_message"})
         if not normalized["text"] or not normalized["chat_id"]:
             return web.json_response(
                 {"ok": True, "ignored": True, "reason": "no text/chat_id"},

--- a/plugins/platforms/zoom/adapter.py
+++ b/plugins/platforms/zoom/adapter.py
@@ -449,7 +449,7 @@ class ZoomTeamChatAdapter(BasePlatformAdapter):
 
 def interactive_setup() -> None:
     from hermes_cli.config import get_env_value, save_env_value
-    from hermes_cli.ui import print_info, print_success, print_warning, prompt
+    from hermes_cli.cli_output import print_info, print_success, print_warning, prompt
 
     print_info("Zoom Team Chat setup")
     account_id = prompt("Account ID", default=get_env_value("ZOOM_ACCOUNT_ID") or "")

--- a/plugins/platforms/zoom/adapter.py
+++ b/plugins/platforms/zoom/adapter.py
@@ -1,0 +1,491 @@
+"""Zoom Team Chat platform adapter for Hermes.
+
+This adapter is intentionally webhook-first and API-driven:
+
+- inbound Team Chat events come in through an aiohttp webhook server
+- Zoom webhook URL validation and request signature checks are supported
+- outbound messages use server-to-server OAuth plus a bot JID
+
+The exact Team Chat event payloads vary across Zoom app types, so the
+normalizer is deliberately defensive and accepts several likely field shapes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+try:
+    from aiohttp import web
+
+    AIOHTTP_AVAILABLE = True
+except ImportError:
+    AIOHTTP_AVAILABLE = False
+    web = None  # type: ignore[assignment]
+
+try:
+    import requests
+
+    REQUESTS_AVAILABLE = True
+except ImportError:
+    REQUESTS_AVAILABLE = False
+    requests = None  # type: ignore[assignment]
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.platforms.helpers import MessageDeduplicator
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PORT = 8762
+_DEFAULT_PATH = "/zoom/chat/webhook"
+_DEFAULT_BASE_URL = "https://api.zoom.us"
+_DEFAULT_SEND_PATH = "/v2/im/chat/messages"
+
+
+def _hmac_sha256(secret: str, payload: str) -> str:
+    return hmac.new(
+        secret.encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def compute_zoom_webhook_response_token(secret: str, plain_token: str) -> str:
+    return _hmac_sha256(secret, plain_token)
+
+
+def compute_zoom_request_signature(secret: str, timestamp: str, body: bytes) -> str:
+    return _hmac_sha256(secret, f"v0:{timestamp}:{body.decode('utf-8')}")
+
+
+def _coerce_text(value: Any) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _deep_get(node: Any, *keys: str) -> Any:
+    current = node
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _find_first(node: Any, candidate_keys: tuple[str, ...]) -> Any:
+    stack = [node]
+    wanted = {item.lower() for item in candidate_keys}
+    while stack:
+        current = stack.pop()
+        if isinstance(current, dict):
+            for key, value in current.items():
+                if str(key).lower() in wanted and value not in (None, ""):
+                    return value
+                stack.append(value)
+        elif isinstance(current, list):
+            stack.extend(reversed(current))
+    return None
+
+
+def normalize_zoom_chat_event(payload: Dict[str, Any]) -> Dict[str, Any]:
+    event_name = _coerce_text(payload.get("event") or payload.get("event_type") or payload.get("type")) or "unknown"
+    obj = _deep_get(payload, "payload", "object") or payload.get("object") or payload
+    body = _deep_get(obj, "message") or obj
+
+    message_text = ""
+    for key in ("text", "message", "content", "body", "cmd"):
+        message_text = _coerce_text(_find_first(body, (key,)))
+        if message_text:
+            break
+
+    user_name = _coerce_text(
+        _find_first(obj, ("user_name", "sender_name", "display_name", "name", "user"))
+    )
+    user_id = _coerce_text(
+        _find_first(obj, ("user_id", "sender_id", "account_id", "email", "sender"))
+    )
+    chat_id = _coerce_text(
+        _find_first(obj, ("to_jid", "chat_id", "channel_id", "session_id", "conversation_id"))
+    )
+    thread_id = _coerce_text(_find_first(obj, ("thread_id", "message_thread_id", "parent_id")))
+    message_id = _coerce_text(_find_first(obj, ("message_id", "id")))
+    chat_topic = _coerce_text(_find_first(obj, ("channel_name", "topic", "session_name", "chat_name")))
+    chat_type = "channel" if _find_first(obj, ("channel_id", "channel_name")) else "dm"
+
+    return {
+        "event": event_name,
+        "text": message_text,
+        "chat_id": chat_id,
+        "chat_topic": chat_topic,
+        "chat_type": chat_type,
+        "thread_id": thread_id or None,
+        "message_id": message_id or None,
+        "user_id": user_id or None,
+        "user_name": user_name or None,
+        "raw": payload,
+    }
+
+
+@dataclass
+class ZoomChatCredentials:
+    account_id: str
+    client_id: str
+    client_secret: str
+    bot_jid: str
+    base_url: str = _DEFAULT_BASE_URL
+    send_path: str = _DEFAULT_SEND_PATH
+
+
+class ZoomChatClient:
+    def __init__(self, credentials: ZoomChatCredentials):
+        self.credentials = credentials
+        self._access_token: str | None = None
+        self._expires_at: float = 0.0
+
+    def _oauth_token_url(self) -> str:
+        return "https://zoom.us/oauth/token"
+
+    def get_access_token(self) -> str:
+        now = time.time()
+        if self._access_token and now < (self._expires_at - 60):
+            return self._access_token
+        if not REQUESTS_AVAILABLE:
+            raise RuntimeError("requests is not installed")
+
+        response = requests.post(
+            self._oauth_token_url(),
+            params={
+                "grant_type": "account_credentials",
+                "account_id": self.credentials.account_id,
+            },
+            auth=(self.credentials.client_id, self.credentials.client_secret),
+            timeout=20,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        token = str(payload.get("access_token") or "").strip()
+        if not token:
+            raise RuntimeError("Zoom OAuth token response missing access_token")
+        expires_in = int(payload.get("expires_in") or 3600)
+        self._access_token = token
+        self._expires_at = now + expires_in
+        return token
+
+    def _send_url(self) -> str:
+        return f"{self.credentials.base_url.rstrip('/')}{self.credentials.send_path}"
+
+    def build_send_payload(
+        self,
+        *,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {
+            "robot_jid": self.credentials.bot_jid,
+            "to_jid": chat_id,
+            "account_id": self.credentials.account_id,
+            "content": {
+                "head": {"text": "Hermes"},
+                "body": [
+                    {
+                        "type": "message",
+                        "text": content,
+                    }
+                ],
+            },
+        }
+        if reply_to:
+            body["reply_main_message_id"] = reply_to
+        return body
+
+    def send_message(self, *, chat_id: str, content: str, reply_to: Optional[str] = None) -> Dict[str, Any]:
+        if not REQUESTS_AVAILABLE:
+            raise RuntimeError("requests is not installed")
+        response = requests.post(
+            self._send_url(),
+            headers={
+                "Authorization": f"Bearer {self.get_access_token()}",
+                "Content-Type": "application/json",
+            },
+            json=self.build_send_payload(chat_id=chat_id, content=content, reply_to=reply_to),
+            timeout=20,
+        )
+        response.raise_for_status()
+        try:
+            return response.json()
+        except Exception:
+            return {"status_code": response.status_code, "text": response.text}
+
+
+def check_requirements() -> bool:
+    return AIOHTTP_AVAILABLE and REQUESTS_AVAILABLE
+
+
+def validate_config(config: PlatformConfig) -> bool:
+    extra = config.extra or {}
+    account_id = os.getenv("ZOOM_ACCOUNT_ID") or extra.get("account_id", "")
+    client_id = os.getenv("ZOOM_CLIENT_ID") or extra.get("client_id", "")
+    client_secret = os.getenv("ZOOM_CLIENT_SECRET") or extra.get("client_secret", "")
+    bot_jid = os.getenv("ZOOM_CHAT_BOT_JID") or extra.get("bot_jid", "")
+    secret = (
+        os.getenv("ZOOM_WEBHOOK_SECRET_TOKEN")
+        or os.getenv("ZOOM_WEBHOOK_SECRET")
+        or extra.get("webhook_secret", "")
+    )
+    return bool(account_id and client_id and client_secret and bot_jid and secret)
+
+
+def is_connected(config: PlatformConfig) -> bool:
+    return validate_config(config)
+
+
+class ZoomTeamChatAdapter(BasePlatformAdapter):
+    MAX_MESSAGE_LENGTH = 4000
+
+    def __init__(self, config: PlatformConfig):
+        platform = Platform("zoom")
+        super().__init__(config=config, platform=platform)
+        extra = config.extra or {}
+        self._account_id = os.getenv("ZOOM_ACCOUNT_ID") or extra.get("account_id", "")
+        self._client_id = os.getenv("ZOOM_CLIENT_ID") or extra.get("client_id", "")
+        self._client_secret = os.getenv("ZOOM_CLIENT_SECRET") or extra.get("client_secret", "")
+        self._bot_jid = os.getenv("ZOOM_CHAT_BOT_JID") or extra.get("bot_jid", "")
+        self._webhook_secret = (
+            os.getenv("ZOOM_WEBHOOK_SECRET_TOKEN")
+            or os.getenv("ZOOM_WEBHOOK_SECRET")
+            or extra.get("webhook_secret", "")
+        )
+        self._base_url = extra.get("base_url", _DEFAULT_BASE_URL)
+        self._send_path = extra.get("send_path", _DEFAULT_SEND_PATH)
+        self._host = str(extra.get("host") or "0.0.0.0")
+        self._port = int(extra.get("port") or _DEFAULT_PORT)
+        self._path = str(extra.get("path") or _DEFAULT_PATH)
+        self._runner: Optional["web.AppRunner"] = None
+        self._dedup = MessageDeduplicator(max_size=1000)
+        self._chat_cache: Dict[str, Dict[str, Any]] = {}
+
+    @property
+    def name(self) -> str:
+        return "Zoom Team Chat"
+
+    def _client(self) -> ZoomChatClient:
+        return ZoomChatClient(
+            ZoomChatCredentials(
+                account_id=self._account_id,
+                client_id=self._client_id,
+                client_secret=self._client_secret,
+                bot_jid=self._bot_jid,
+                base_url=self._base_url,
+                send_path=self._send_path,
+            )
+        )
+
+    def _verify_signature(self, timestamp: str, signature: str, body: bytes) -> bool:
+        if not self._webhook_secret:
+            return True
+        if not timestamp or not signature:
+            return False
+        expected = compute_zoom_request_signature(self._webhook_secret, timestamp, body)
+        actual = signature.split("=", 1)[-1]
+        return hmac.compare_digest(expected.encode("utf-8"), actual.encode("utf-8"))
+
+    async def _handle_health(self, request: "web.Request") -> "web.Response":
+        return web.json_response({"ok": True, "platform": "zoom"})
+
+    async def _handle_webhook(self, request: "web.Request") -> "web.Response":
+        raw_body = await request.read()
+        try:
+            payload = json.loads(raw_body.decode("utf-8") or "{}")
+        except Exception:
+            return web.json_response({"ok": False, "error": "invalid JSON"}, status=400)
+
+        timestamp = request.headers.get("x-zm-request-timestamp", "")
+        signature = request.headers.get("x-zm-signature", "")
+        if self._webhook_secret and not self._verify_signature(timestamp, signature, raw_body):
+            return web.json_response({"ok": False, "error": "invalid signature"}, status=401)
+
+        event_name = _coerce_text(payload.get("event") or payload.get("event_type") or payload.get("type"))
+        if event_name == "endpoint.url_validation":
+            plain_token = (
+                _deep_get(payload, "payload", "plainToken")
+                or _deep_get(payload, "payload", "plain_token")
+                or payload.get("plainToken")
+                or ""
+            )
+            if not plain_token:
+                return web.json_response({"ok": False, "error": "missing plainToken"}, status=400)
+            return web.json_response(
+                {
+                    "plainToken": plain_token,
+                    "encryptedToken": compute_zoom_webhook_response_token(self._webhook_secret, plain_token),
+                }
+            )
+
+        normalized = normalize_zoom_chat_event(payload)
+        if not normalized["text"] or not normalized["chat_id"]:
+            return web.json_response(
+                {"ok": True, "ignored": True, "reason": "no text/chat_id"},
+                status=202,
+            )
+
+        message_id = normalized["message_id"]
+        if message_id and self._dedup.is_duplicate(message_id):
+            return web.json_response({"ok": True, "duplicate": True})
+
+        source = self.build_source(
+            chat_id=normalized["chat_id"],
+            chat_name=normalized["chat_topic"] or normalized["chat_id"],
+            chat_type=normalized["chat_type"],
+            user_id=normalized["user_id"],
+            user_name=normalized["user_name"],
+            thread_id=normalized["thread_id"],
+            message_id=message_id,
+        )
+        self._chat_cache[normalized["chat_id"]] = {
+            "name": normalized["chat_topic"] or normalized["chat_id"],
+            "type": normalized["chat_type"],
+            "thread_id": normalized["thread_id"],
+        }
+        event = MessageEvent(
+            text=normalized["text"],
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message={
+                "zoom_event": normalized["event"],
+                "zoom_raw": normalized["raw"],
+            },
+            message_id=message_id,
+        )
+        await self.handle_message(event)
+        return web.json_response({"ok": True, "chat_id": normalized["chat_id"], "event": normalized["event"]})
+
+    async def connect(self) -> bool:
+        if not AIOHTTP_AVAILABLE:
+            self._set_fatal_error("MISSING_SDK", "aiohttp not installed. Run: pip install aiohttp", retryable=False)
+            return False
+        if not REQUESTS_AVAILABLE:
+            self._set_fatal_error("MISSING_SDK", "requests not installed. Run: pip install requests", retryable=False)
+            return False
+        if not validate_config(self.config):
+            self._set_fatal_error(
+                "MISSING_CREDENTIALS",
+                "Zoom Team Chat requires ZOOM_ACCOUNT_ID, ZOOM_CLIENT_ID, ZOOM_CLIENT_SECRET, ZOOM_CHAT_BOT_JID, and ZOOM_WEBHOOK_SECRET_TOKEN",
+                retryable=False,
+            )
+            return False
+
+        try:
+            app = web.Application()
+            app.router.add_get("/health", self._handle_health)
+            app.router.add_post(self._path, self._handle_webhook)
+            self._runner = web.AppRunner(app)
+            await self._runner.setup()
+            site = web.TCPSite(self._runner, self._host, self._port)
+            await site.start()
+            self._running = True
+            self._mark_connected()
+            logger.info("[zoom] Team Chat webhook listening on %s:%d%s", self._host, self._port, self._path)
+            return True
+        except Exception as exc:
+            self._set_fatal_error("CONNECT_FAILED", f"Zoom Team Chat connection failed: {exc}", retryable=True)
+            logger.error("[zoom] connect failed: %s", exc)
+            return False
+
+    async def disconnect(self) -> None:
+        self._running = False
+        if self._runner is not None:
+            await self._runner.cleanup()
+            self._runner = None
+        self._mark_disconnected()
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        try:
+            payload = await asyncio.to_thread(
+                self._client().send_message,
+                chat_id=chat_id,
+                content=content,
+                reply_to=reply_to,
+            )
+            message_id = _coerce_text(_find_first(payload, ("message_id", "id")))
+            return SendResult(success=True, message_id=message_id or None, raw_response=payload)
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc), retryable=True)
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        cached = self._chat_cache.get(chat_id)
+        if cached:
+            return {"name": cached.get("name", chat_id), "type": cached.get("type", "dm"), "chat_id": chat_id}
+        return {"name": chat_id, "type": "dm", "chat_id": chat_id}
+
+
+def interactive_setup() -> None:
+    from hermes_cli.config import get_env_value, save_env_value
+    from hermes_cli.ui import print_info, print_success, print_warning, prompt
+
+    print_info("Zoom Team Chat setup")
+    account_id = prompt("Account ID", default=get_env_value("ZOOM_ACCOUNT_ID") or "")
+    client_id = prompt("Client ID", default=get_env_value("ZOOM_CLIENT_ID") or "")
+    client_secret = prompt("Client Secret", default=get_env_value("ZOOM_CLIENT_SECRET") or "", password=True)
+    bot_jid = prompt("Chat bot JID", default=get_env_value("ZOOM_CHAT_BOT_JID") or "")
+    secret = prompt(
+        "Webhook secret token",
+        default=(get_env_value("ZOOM_WEBHOOK_SECRET_TOKEN") or get_env_value("ZOOM_WEBHOOK_SECRET") or ""),
+        password=True,
+    )
+
+    if not all([account_id, client_id, client_secret, bot_jid, secret]):
+        print_warning("Zoom Team Chat setup skipped — all fields are required")
+        return
+
+    save_env_value("ZOOM_ACCOUNT_ID", account_id.strip())
+    save_env_value("ZOOM_CLIENT_ID", client_id.strip())
+    save_env_value("ZOOM_CLIENT_SECRET", client_secret.strip())
+    save_env_value("ZOOM_CHAT_BOT_JID", bot_jid.strip())
+    save_env_value("ZOOM_WEBHOOK_SECRET_TOKEN", secret.strip())
+    print_success("Zoom Team Chat configuration saved to ~/.hermes/.env")
+
+
+def register(ctx) -> None:
+    ctx.register_platform(
+        name="zoom",
+        label="Zoom Team Chat",
+        adapter_factory=lambda cfg: ZoomTeamChatAdapter(cfg),
+        check_fn=check_requirements,
+        validate_config=validate_config,
+        is_connected=is_connected,
+        required_env=[
+            "ZOOM_ACCOUNT_ID",
+            "ZOOM_CLIENT_ID",
+            "ZOOM_CLIENT_SECRET",
+            "ZOOM_CHAT_BOT_JID",
+            "ZOOM_WEBHOOK_SECRET_TOKEN",
+        ],
+        install_hint="pip install aiohttp requests",
+        setup_fn=interactive_setup,
+        allowed_users_env="ZOOM_ALLOWED_USERS",
+        allow_all_env="ZOOM_ALLOW_ALL_USERS",
+        max_message_length=4000,
+        emoji="🎥",
+        allow_update_command=True,
+        platform_hint=(
+            "You are chatting via Zoom Team Chat. Keep formatting simple and readable. "
+            "Prefer short paragraphs and bullets over complex markdown."
+        ),
+    )

--- a/plugins/platforms/zoom/plugin.yaml
+++ b/plugins/platforms/zoom/plugin.yaml
@@ -1,0 +1,15 @@
+name: zoom-platform
+kind: platform
+version: 0.1.0
+description: >
+  Zoom Team Chat gateway adapter for Hermes Agent.
+  Receives Zoom webhook events, validates signatures, normalizes Team Chat
+  messages into Hermes MessageEvents, and can send bot replies back through
+  Zoom's chat APIs.
+author: NousResearch
+requires_env:
+  - ZOOM_ACCOUNT_ID
+  - ZOOM_CLIENT_ID
+  - ZOOM_CLIENT_SECRET
+  - ZOOM_CHAT_BOT_JID
+  - ZOOM_WEBHOOK_SECRET_TOKEN

--- a/tests/hermes_cli/test_setup_zoom.py
+++ b/tests/hermes_cli/test_setup_zoom.py
@@ -1,0 +1,152 @@
+"""Tests for Zoom Team Chat gateway setup integration."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+from gateway.platform_registry import PlatformEntry, platform_registry
+
+
+def _register_zoom_platform(**overrides):
+    defaults = dict(
+        name="zoom",
+        label="Zoom Team Chat",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: bool(os.getenv("ZOOM_ACCOUNT_ID", "") and os.getenv("ZOOM_CHAT_BOT_JID", "")),
+        validate_config=lambda cfg: True,
+        required_env=[
+            "ZOOM_ACCOUNT_ID",
+            "ZOOM_CLIENT_ID",
+            "ZOOM_CLIENT_SECRET",
+            "ZOOM_CHAT_BOT_JID",
+            "ZOOM_WEBHOOK_SECRET_TOKEN",
+        ],
+        install_hint="pip install aiohttp requests",
+        setup_fn=lambda: None,
+        source="plugin",
+        plugin_name="zoom-platform",
+        allowed_users_env="ZOOM_ALLOWED_USERS",
+        allow_all_env="ZOOM_ALLOW_ALL_USERS",
+        max_message_length=4000,
+        pii_safe=False,
+        emoji="🎥",
+        allow_update_command=True,
+        platform_hint="You are chatting via Zoom Team Chat.",
+    )
+    defaults.update(overrides)
+    entry = PlatformEntry(**defaults)
+    platform_registry.register(entry)
+    return {
+        "key": entry.name,
+        "label": entry.label,
+        "emoji": entry.emoji,
+        "token_var": entry.required_env[0] if entry.required_env else "",
+        "install_hint": entry.install_hint,
+        "_registry_entry": entry,
+    }
+
+
+def _unregister_zoom_platform():
+    platform_registry.unregister("zoom")
+
+
+class TestZoomFreshInstallDiscovery:
+    def test_zoom_appears_in_all_platforms(self, monkeypatch):
+        import hermes_cli.gateway as gateway_mod
+
+        _register_zoom_platform()
+        try:
+            for key in (
+                "ZOOM_ACCOUNT_ID",
+                "ZOOM_CLIENT_ID",
+                "ZOOM_CLIENT_SECRET",
+                "ZOOM_CHAT_BOT_JID",
+                "ZOOM_WEBHOOK_SECRET_TOKEN",
+            ):
+                monkeypatch.delenv(key, raising=False)
+
+            platforms = gateway_mod._all_platforms()
+            keys = {p["key"] for p in platforms}
+            assert "zoom" in keys
+
+            zoom_plat = next(p for p in platforms if p["key"] == "zoom")
+            assert zoom_plat["label"] == "Zoom Team Chat"
+            assert zoom_plat["emoji"] == "🎥"
+        finally:
+            _unregister_zoom_platform()
+
+    def test_zoom_status_not_configured_when_fresh(self, monkeypatch):
+        import hermes_cli.gateway as gateway_mod
+
+        plat = _register_zoom_platform()
+        try:
+            for key in (
+                "ZOOM_ACCOUNT_ID",
+                "ZOOM_CLIENT_ID",
+                "ZOOM_CLIENT_SECRET",
+                "ZOOM_CHAT_BOT_JID",
+                "ZOOM_WEBHOOK_SECRET_TOKEN",
+            ):
+                monkeypatch.delenv(key, raising=False)
+            status = gateway_mod._platform_status(plat)
+            assert status == "not configured"
+        finally:
+            _unregister_zoom_platform()
+
+    def test_zoom_status_configured_when_env_set(self, monkeypatch):
+        import hermes_cli.gateway as gateway_mod
+
+        plat = _register_zoom_platform()
+        try:
+            monkeypatch.setenv("ZOOM_ACCOUNT_ID", "acct")
+            monkeypatch.setenv("ZOOM_CLIENT_ID", "cid")
+            monkeypatch.setenv("ZOOM_CLIENT_SECRET", "sec")
+            monkeypatch.setenv("ZOOM_CHAT_BOT_JID", "bot-jid")
+            monkeypatch.setenv("ZOOM_WEBHOOK_SECRET_TOKEN", "whsec")
+            status = gateway_mod._platform_status(plat)
+            assert status == "configured"
+        finally:
+            _unregister_zoom_platform()
+
+
+class TestZoomInteractiveSetup:
+    def test_configure_platform_dispatches_to_zoom_setup_fn(self, capsys):
+        import hermes_cli.gateway as gateway_mod
+
+        calls = []
+
+        def fake_setup():
+            calls.append("setup_called")
+            print("Zoom setup complete!")
+
+        plat = _register_zoom_platform(setup_fn=fake_setup)
+        try:
+            gateway_mod._configure_platform(plat)
+        finally:
+            _unregister_zoom_platform()
+
+        assert "setup_called" in calls
+        assert "Zoom setup complete!" in capsys.readouterr().out
+
+    def test_interactive_setup_persists_credentials(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        import hermes_cli.cli_output as cli_output_mod
+        import plugins.platforms.zoom.adapter as zoom_mod
+
+        answers = iter(["acct", "cid", "sec", "bot-jid", "whsec"])
+        monkeypatch.setattr(cli_output_mod, "prompt", lambda *_a, **_kw: next(answers))
+        monkeypatch.setattr(cli_output_mod, "print_info", lambda *_a, **_kw: None)
+        monkeypatch.setattr(cli_output_mod, "print_success", lambda *_a, **_kw: None)
+        monkeypatch.setattr(cli_output_mod, "print_warning", lambda *_a, **_kw: None)
+
+        zoom_mod.interactive_setup()
+
+        env_text = (hermes_home / ".env").read_text(encoding="utf-8")
+        assert "ZOOM_ACCOUNT_ID=acct" in env_text
+        assert "ZOOM_CLIENT_ID=cid" in env_text
+        assert "ZOOM_CLIENT_SECRET=sec" in env_text
+        assert "ZOOM_CHAT_BOT_JID=bot-jid" in env_text
+        assert "ZOOM_WEBHOOK_SECRET_TOKEN=whsec" in env_text

--- a/tests/plugins/test_zoom_platform_plugin.py
+++ b/tests/plugins/test_zoom_platform_plugin.py
@@ -80,6 +80,71 @@ def test_register_adds_zoom_platform_entry():
     assert callable(calls["adapter_factory"])
 
 
+def test_send_uses_client_and_preserves_reply_to(monkeypatch):
+    adapter = ZoomTeamChatAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "account_id": "acct",
+                "client_id": "cid",
+                "client_secret": "sec",
+                "bot_jid": "bot-jid",
+                "webhook_secret": "zoom-secret",
+            },
+        )
+    )
+
+    captured = {}
+
+    class _FakeClient:
+        def send_message(self, *, chat_id: str, content: str, reply_to: str | None = None):
+            captured["chat_id"] = chat_id
+            captured["content"] = content
+            captured["reply_to"] = reply_to
+            return {"message_id": "out-1"}
+
+    monkeypatch.setattr(adapter, "_client", lambda: _FakeClient())
+
+    import asyncio
+
+    result = asyncio.run(adapter.send("chat-1", "hello zoom", reply_to="root-9"))
+    assert result.success is True
+    assert result.message_id == "out-1"
+    assert captured == {
+        "chat_id": "chat-1",
+        "content": "hello zoom",
+        "reply_to": "root-9",
+    }
+
+
+def test_send_returns_retryable_error_on_client_failure(monkeypatch):
+    adapter = ZoomTeamChatAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "account_id": "acct",
+                "client_id": "cid",
+                "client_secret": "sec",
+                "bot_jid": "bot-jid",
+                "webhook_secret": "zoom-secret",
+            },
+        )
+    )
+
+    class _FailingClient:
+        def send_message(self, *, chat_id: str, content: str, reply_to: str | None = None):
+            raise RuntimeError("send failed")
+
+    monkeypatch.setattr(adapter, "_client", lambda: _FailingClient())
+
+    import asyncio
+
+    result = asyncio.run(adapter.send("chat-1", "hello zoom"))
+    assert result.success is False
+    assert result.retryable is True
+    assert "send failed" in result.error
+
+
 def test_webhook_handler_validates_and_dispatches(monkeypatch):
     adapter = ZoomTeamChatAdapter(
         PlatformConfig(
@@ -161,3 +226,63 @@ def test_webhook_handler_validates_and_dispatches(monkeypatch):
     asyncio.run(_run())
     assert captured["event"].text == "zoom adapter smoke"
     assert captured["event"].source.chat_id == "chat-123"
+
+
+def test_webhook_handler_ignores_self_messages(monkeypatch):
+    adapter = ZoomTeamChatAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "account_id": "acct",
+                "client_id": "cid",
+                "client_secret": "sec",
+                "bot_jid": "bot-jid",
+                "webhook_secret": "zoom-secret",
+            },
+        )
+    )
+
+    called = {"count": 0}
+
+    async def _fake_handle_message(event):
+        called["count"] += 1
+
+    monkeypatch.setattr(adapter, "handle_message", _fake_handle_message)
+
+    class _Request:
+        def __init__(self, payload: dict, headers: dict[str, str]):
+            self._body = json.dumps(payload).encode("utf-8")
+            self.headers = headers
+
+        async def read(self) -> bytes:
+            return self._body
+
+    async def _run():
+        payload = {
+            "event": "chat.message.sent",
+            "payload": {
+                "object": {
+                    "to_jid": "chat-123",
+                    "message_id": "m-self",
+                    "sender_jid": "bot-jid",
+                    "sender_name": "Hermes",
+                    "message": {"text": "ignore me"},
+                }
+            },
+        }
+        timestamp = "1700000000"
+        sig = compute_zoom_request_signature(
+            "zoom-secret",
+            timestamp,
+            json.dumps(payload).encode("utf-8"),
+        )
+        req = _Request(payload, {"x-zm-request-timestamp": timestamp, "x-zm-signature": f"v0={sig}"})
+        response = await adapter._handle_webhook(req)
+        body = json.loads(response.text)
+        assert body["ignored"] is True
+        assert body["reason"] == "self_message"
+
+    import asyncio
+
+    asyncio.run(_run())
+    assert called["count"] == 0

--- a/tests/plugins/test_zoom_platform_plugin.py
+++ b/tests/plugins/test_zoom_platform_plugin.py
@@ -1,0 +1,163 @@
+"""Tests for the Zoom Team Chat platform plugin."""
+
+from __future__ import annotations
+
+import json
+
+from gateway.config import PlatformConfig
+from plugins.platforms.zoom.adapter import (
+    ZoomChatClient,
+    ZoomChatCredentials,
+    ZoomTeamChatAdapter,
+    compute_zoom_request_signature,
+    compute_zoom_webhook_response_token,
+    normalize_zoom_chat_event,
+    register,
+)
+
+
+def test_zoom_signature_helpers_are_stable():
+    body = b'{"hello":"world"}'
+    sig = compute_zoom_request_signature("secret", "1700000000", body)
+    assert sig == compute_zoom_request_signature("secret", "1700000000", body)
+    assert len(sig) == 64
+
+    token = compute_zoom_webhook_response_token("secret", "plain-token")
+    assert token == compute_zoom_webhook_response_token("secret", "plain-token")
+    assert len(token) == 64
+
+
+def test_normalize_zoom_chat_event_handles_nested_payload():
+    payload = {
+        "event": "chat.message.sent",
+        "payload": {
+            "object": {
+                "to_jid": "chat-123",
+                "channel_name": "Hermes Ops",
+                "message_id": "m-1",
+                "sender_name": "Dilek",
+                "sender_id": "user-9",
+                "message": {
+                    "text": "please prepare the rollout notes",
+                },
+            }
+        },
+    }
+    normalized = normalize_zoom_chat_event(payload)
+    assert normalized["chat_id"] == "chat-123"
+    assert normalized["chat_topic"] == "Hermes Ops"
+    assert normalized["message_id"] == "m-1"
+    assert normalized["user_name"] == "Dilek"
+    assert normalized["text"] == "please prepare the rollout notes"
+
+
+def test_zoom_chat_client_builds_structured_send_payload():
+    client = ZoomChatClient(
+        ZoomChatCredentials(
+            account_id="acct",
+            client_id="cid",
+            client_secret="sec",
+            bot_jid="bot-jid",
+        )
+    )
+    payload = client.build_send_payload(chat_id="chat-1", content="Hello Zoom", reply_to="root-1")
+    assert payload["robot_jid"] == "bot-jid"
+    assert payload["to_jid"] == "chat-1"
+    assert payload["reply_main_message_id"] == "root-1"
+    assert payload["content"]["body"][0]["text"] == "Hello Zoom"
+
+
+def test_register_adds_zoom_platform_entry():
+    calls = {}
+
+    class _Ctx:
+        def register_platform(self, **kw):
+            calls.update(kw)
+
+    register(_Ctx())
+    assert calls["name"] == "zoom"
+    assert calls["label"] == "Zoom Team Chat"
+    assert callable(calls["adapter_factory"])
+
+
+def test_webhook_handler_validates_and_dispatches(monkeypatch):
+    adapter = ZoomTeamChatAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "account_id": "acct",
+                "client_id": "cid",
+                "client_secret": "sec",
+                "bot_jid": "bot-jid",
+                "webhook_secret": "zoom-secret",
+            },
+        )
+    )
+
+    captured = {}
+
+    async def _fake_handle_message(event):
+        captured["event"] = event
+
+    monkeypatch.setattr(adapter, "handle_message", _fake_handle_message)
+
+    class _Request:
+        def __init__(self, payload: dict, headers: dict[str, str]):
+            self._body = json.dumps(payload).encode("utf-8")
+            self.headers = headers
+
+        async def read(self) -> bytes:
+            return self._body
+
+    async def _run():
+        validation_payload = {"event": "endpoint.url_validation", "payload": {"plainToken": "abc123"}}
+        timestamp = "1700000000"
+        validation_sig = compute_zoom_request_signature(
+            "zoom-secret",
+            timestamp,
+            json.dumps(validation_payload).encode("utf-8"),
+        )
+        validation_req = _Request(
+            validation_payload,
+            {
+                "x-zm-request-timestamp": timestamp,
+                "x-zm-signature": f"v0={validation_sig}",
+            },
+        )
+        validation_resp = await adapter._handle_webhook(validation_req)
+        validation_body = json.loads(validation_resp.text)
+        assert validation_body["plainToken"] == "abc123"
+
+        message_payload = {
+            "event": "chat.message.sent",
+            "payload": {
+                "object": {
+                    "to_jid": "chat-123",
+                    "message_id": "m-1",
+                    "sender_name": "Dilek",
+                    "sender_id": "user-9",
+                    "message": {"text": "zoom adapter smoke"},
+                }
+            },
+        }
+        message_sig = compute_zoom_request_signature(
+            "zoom-secret",
+            timestamp,
+            json.dumps(message_payload).encode("utf-8"),
+        )
+        message_req = _Request(
+            message_payload,
+            {
+                "x-zm-request-timestamp": timestamp,
+                "x-zm-signature": f"v0={message_sig}",
+            },
+        )
+        message_resp = await adapter._handle_webhook(message_req)
+        body = json.loads(message_resp.text)
+        assert body["ok"] is True
+
+    import asyncio
+
+    asyncio.run(_run())
+    assert captured["event"].text == "zoom adapter smoke"
+    assert captured["event"].source.chat_id == "chat-123"

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -59,6 +59,8 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `observability/langfuse` | hooks | Trace turns / LLM calls / tools to [Langfuse](https://langfuse.com) |
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
+| `zoom_meeting` | standalone | Zoom meeting intelligence: metadata fetch, webhook transcript capture, summaries, artifacts |
+| `platforms/zoom` | platform | Zoom Team Chat gateway adapter: webhook ingress, auth, outbound bot replies |
 | `image_gen/openai` | image backend | OpenAI `gpt-image-2` image generation backend (alternative to FAL) |
 | `image_gen/openai-codex` | image backend | OpenAI image generation via Codex OAuth |
 | `image_gen/xai` | image backend | xAI `grok-2-image` backend |
@@ -208,6 +210,49 @@ The agent kicks off the meeting join, streams the transcription back into its co
 **When to use it:** recurring standups where you want a bot to transcribe + summarize for async attendees; deposition-style interviews where you want structured notes; any case where you'd otherwise need Fireflies / Otter / Grain. When you'd rather not have an AI listening in — don't enable it.
 
 **Disabling:** `hermes plugins disable google_meet`. Any cached transcripts and recordings stay in `~/.hermes/cache/google_meet/` until you remove them.
+
+### zoom_meeting
+
+Adds a **Zoom meeting intelligence** surface without trying to impersonate a meeting participant yet. The plugin is built around Zoom's official-ish server-side surfaces: server-to-server OAuth, REST meeting metadata, webhook event ingestion, and transcript-like event capture.
+
+**What it adds:**
+
+- `hermes zoom watch <meeting_id>` — initialize a local meeting workspace
+- webhook receiver for lifecycle and transcript-like events
+- durable state under `~/.hermes/cache/zoom/meetings/<meeting_id>/`
+- deterministic markdown and JSON artifacts
+- transcript-derived action items, decisions, and open questions
+
+**Typical use:** seed a meeting workspace with a known meeting ID, point Zoom webhooks or RTMS-like transcript events at Hermes, then let the agent summarize and follow up after the call.
+
+**CLI examples:**
+
+```bash
+hermes plugins enable zoom_meeting
+hermes zoom auth-check
+hermes zoom watch 123456789
+hermes zoom transcript 123456789 --last 40
+hermes zoom summary 123456789
+hermes zoom action-items 123456789
+```
+
+**Current scope:** this plugin does not yet join a Zoom call as a live participant or speak into it. It is the substrate for those later phases.
+
+### platforms/zoom
+
+Adds a **Zoom Team Chat** gateway adapter so Hermes can receive and send Team Chat messages through Zoom.
+
+**What it adds:**
+
+- webhook server for Zoom Team Chat events
+- Zoom webhook URL-validation and signature verification
+- message normalization into Hermes gateway `MessageEvent`s
+- outbound bot replies using server-to-server OAuth + bot JID
+- gateway setup/discovery integration
+
+**Use it when:** you want Hermes accessible from Zoom Team Chat the way Hermes can already be exposed on Teams, IRC, Telegram, Slack, and similar messaging surfaces.
+
+See [Zoom Team Chat](/docs/user-guide/features/zoom-team-chat) for the full runbook and live verification checklist.
 
 ### hermes-achievements
 

--- a/website/docs/user-guide/features/zoom-team-chat.md
+++ b/website/docs/user-guide/features/zoom-team-chat.md
@@ -1,0 +1,132 @@
+---
+sidebar_position: 34
+sidebar_label: "Zoom Team Chat"
+title: "Zoom Team Chat"
+description: "Run Hermes inside Zoom Team Chat via the bundled Zoom gateway platform adapter"
+---
+
+# Zoom Team Chat
+
+Hermes ships a bundled **Zoom Team Chat** gateway adapter at `plugins/platforms/zoom/`. It is a webhook-first integration:
+
+- inbound Zoom Team Chat events arrive through an `aiohttp` webhook server
+- Zoom webhook URL-validation and request signatures are verified
+- Hermes normalizes incoming messages into gateway `MessageEvent`s
+- outbound replies use Zoom server-to-server OAuth plus a bot JID
+
+This is the Zoom analogue of the existing Teams and IRC platform adapters.
+
+## What you need
+
+Environment variables:
+
+- `ZOOM_ACCOUNT_ID`
+- `ZOOM_CLIENT_ID`
+- `ZOOM_CLIENT_SECRET`
+- `ZOOM_CHAT_BOT_JID`
+- `ZOOM_WEBHOOK_SECRET_TOKEN`
+
+Optional auth controls:
+
+- `ZOOM_ALLOWED_USERS`
+- `ZOOM_ALLOW_ALL_USERS`
+
+Python dependencies:
+
+```bash
+pip install aiohttp requests
+```
+
+## Gateway config
+
+Add the Zoom platform in `~/.hermes/config.yaml`:
+
+```yaml
+gateway:
+  platforms:
+    zoom:
+      enabled: true
+      extra:
+        host: 0.0.0.0
+        port: 8762
+        path: /zoom/chat/webhook
+        webhook_secret: ${ZOOM_WEBHOOK_SECRET_TOKEN}
+        account_id: ${ZOOM_ACCOUNT_ID}
+        client_id: ${ZOOM_CLIENT_ID}
+        client_secret: ${ZOOM_CLIENT_SECRET}
+        bot_jid: ${ZOOM_CHAT_BOT_JID}
+```
+
+Then start the gateway:
+
+```bash
+hermes gateway run
+```
+
+## What the adapter does today
+
+- verifies `endpoint.url_validation`
+- verifies `x-zm-signature` / `x-zm-request-timestamp`
+- ignores duplicate message IDs
+- ignores self-messages from the configured bot JID
+- turns Team Chat messages into Hermes gateway events
+- sends text replies back through Zoom's chat API
+
+## Current limitations
+
+- exact Zoom Team Chat payload shapes can vary by app type
+- exact send endpoint shape can vary across Zoom app surfaces
+- rich interactive cards / typing indicators are not implemented yet
+- thread/reply semantics are basic and should be verified in a live tenant
+
+For that reason the adapter exposes these escape hatches via `extra`:
+
+- `base_url`
+- `send_path`
+
+Defaults:
+
+- `base_url`: `https://api.zoom.us`
+- `send_path`: `/v2/im/chat/messages`
+
+## Live verification checklist
+
+Before treating the adapter as production-ready in your tenant, verify these in a real Zoom app:
+
+1. Webhook challenge
+   Set the Zoom webhook target to `http(s)://<host>:8762/zoom/chat/webhook` and confirm Zoom accepts the `plainToken` / `encryptedToken` response.
+
+2. Signature enforcement
+   Send one real webhook event and confirm Hermes only accepts requests with the correct `x-zm-signature`.
+
+3. Inbound message shape
+   Send a Team Chat DM and a channel message, then confirm Hermes sees:
+   - correct `chat_id`
+   - correct sender identity
+   - stable `message_id`
+   - text body in the expected field
+
+4. Self-echo suppression
+   Send a reply from Hermes and confirm that Zoom's own webhook echo does not trigger a second Hermes turn.
+
+5. Outbound send endpoint
+   Confirm the default `POST /v2/im/chat/messages` shape is valid for your app type. If not, override `base_url` / `send_path` first.
+
+6. Reply semantics
+   Verify whether `reply_main_message_id` actually threads replies in your Zoom chat surface the way you expect.
+
+7. Authorization
+   If you do not want every Zoom user chatting with the bot, set `ZOOM_ALLOWED_USERS` and verify a denied user is blocked.
+
+## Operator checklist
+
+- Keep the webhook secret and OAuth credentials in `.env`, not inline in shared config.
+- Expose the webhook over HTTPS in real deployments.
+- If send requests fail but inbound webhooks work, test the Zoom app's bot scopes and the exact bot JID first.
+- If inbound webhooks never arrive, test URL-validation and signature headers before debugging Hermes.
+
+## Related pieces
+
+- `plugins/platforms/zoom/adapter.py` — gateway adapter
+- `plugins/platforms/zoom/README.md` — repo-local quick reference
+- `plugins/zoom_meeting/` — separate meeting-intelligence plugin for Zoom meetings


### PR DESCRIPTION
 ## Summary

  This PR adds a bundled Zoom Team Chat platform adapter for the Hermes gateway.

  It introduces a new plugin at `plugins/platforms/zoom/` that lets Hermes receive Zoom Team Chat webhook events, normalize them into gateway `MessageEvent`s, and send bot replies back through Zoom using server-to-server OAuth credentials.

  ## What this adds

  ### New platform plugin

  Adds a new bundled platform plugin:

  - `plugins/platforms/zoom/`

  with:

  - `plugin.yaml`
  - `__init__.py`
  - `adapter.py`
  - `README.md`

  ### Gateway capabilities

  The adapter adds:

  - Zoom Team Chat webhook ingestion over `aiohttp`
  - Zoom webhook URL-validation handling
  - Zoom request signature verification
  - Team Chat event normalization into Hermes gateway events
  - duplicate message suppression
  - self-message suppression for the configured bot JID
  - outbound bot replies using server-to-server OAuth
  - gateway setup/discovery integration through the plugin platform registry

  ### Configuration surface

  The adapter is configurable through the normal gateway platform path:

  ```yaml
  gateway:
    platforms:
      zoom:
        enabled: true
        extra:
          host: 0.0.0.0
          port: 8762
          path: /zoom/chat/webhook
          webhook_secret: ${ZOOM_WEBHOOK_SECRET_TOKEN}
          account_id: ${ZOOM_ACCOUNT_ID}
          client_id: ${ZOOM_CLIENT_ID}
          client_secret: ${ZOOM_CLIENT_SECRET}
          bot_jid: ${ZOOM_CHAT_BOT_JID}

  ```

  It also supports base_url and send_path overrides so Zoom chat-send routing can be adjusted without changing adapter code.

  ## Design

  This implementation is webhook-first and API-driven.

  Inbound messages come from Zoom webhook events, pass through signature validation and normalization, and are dispatched into the Hermes gateway just like other platform adapters. Outbound messages are sent through a dedicated Zoom client using account-scoped OAuth plus a configured bot JID.

  The adapter follows the existing plugin platform architecture used by bundled adapters like Teams and IRC, so it integrates with:

  - the platform registry
  - gateway setup/discovery
  - platform authorization env vars
  - platform-specific prompt hints
  - gateway message chunking limits

  ## Hardening included

  This PR also includes platform-level hardening and operator-facing guidance:

  - self-echo suppression to avoid bot reply loops
  - retryable failure handling for outbound sends
  - setup integration coverage
  - bundled docs/runbook for Zoom Team Chat configuration and operator workflow

  ## Docs

  Adds and updates:

  - plugins/platforms/zoom/README.md
  - website/docs/user-guide/features/zoom-team-chat.md
  - website/docs/user-guide/features/built-in-plugins.md

  ## Tests

  Ran:

  - pytest -q tests/plugins/test_zoom_platform_plugin.py
  - pytest -q tests/hermes_cli/test_setup_zoom.py

  ## Related

  This is the Team Chat / gateway side of the Zoom work.

  The separate meeting-intelligence plugin lives in:
  - feat(zoom): add meeting intelligence plugin
