### PR TITLE
fix(send-message): accept WhatsApp JID targets

### DIFF
--- a/tests/gateway/test_send_message_whatsapp_targets.py
+++ b/tests/gateway/test_send_message_whatsapp_targets.py
@@ -1,0 +1,33 @@
+from tools.send_message_tool import _parse_target_ref
+
+
+def test_parse_target_ref_accepts_whatsapp_lid_jid():
+    assert _parse_target_ref("whatsapp", "15551234567@lid") == (
+        "15551234567@lid",
+        None,
+        True,
+    )
+
+
+def test_parse_target_ref_accepts_whatsapp_phone_jid():
+    assert _parse_target_ref("whatsapp", "15551234567@s.whatsapp.net") == (
+        "15551234567@s.whatsapp.net",
+        None,
+        True,
+    )
+
+
+def test_parse_target_ref_accepts_whatsapp_group_jid():
+    assert _parse_target_ref("whatsapp", "120363001234567890@g.us") == (
+        "120363001234567890@g.us",
+        None,
+        True,
+    )
+
+
+def test_parse_target_ref_accepts_legacy_e164_whatsapp_target():
+    assert _parse_target_ref("whatsapp", "+15551234567") == (
+        "+15551234567",
+        None,
+        True,
+    )

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -30,6 +30,10 @@ _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::(
 _SLACK_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,})\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
+# WhatsApp Baileys chat IDs can be phone JIDs, LIDs, or group JIDs.
+# These are explicit targets; otherwise directory-resolved WhatsApp DMs like
+# "15551234567@lid" are treated as unresolved names and fall back to home.
+_WHATSAPP_JID_TARGET_RE = re.compile(r"^\s*([A-Za-z0-9._:-]+@(?:s\.whatsapp\.net|lid|g\.us))\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # Platforms that address recipients by phone number and accept E.164 format
@@ -337,6 +341,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if target_ref.strip().isdigit():
             return f"group:{target_ref.strip()}", None, True
         return None, None, False
+    if platform_name == "whatsapp":
+        match = _WHATSAPP_JID_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
     if platform_name in _PHONE_PLATFORMS:
         match = _E164_TARGET_RE.fullmatch(target_ref)
         if match:


### PR DESCRIPTION
## Summary
- Accept WhatsApp Baileys JIDs (`@lid`, `@s.whatsapp.net`, `@g.us`) as explicit `send_message` targets.
- Prevent directory-resolved WhatsApp DMs/groups from falling through to home-channel delivery.
- Add regression coverage for WhatsApp LID, phone JID, group JID, and legacy E.164 targets.

## Problem
`send_message(target="whatsapp:<contact name>", ...)` can resolve a contact name to a WhatsApp Baileys JID such as `15551234567@lid`, but `_parse_target_ref()` did not recognize those JID formats as explicit WhatsApp targets.

When the resolved target was not parsed as explicit, `chat_id` remained unset and `send_message` fell back to the configured WhatsApp home channel. That can route messages intended for a named WhatsApp contact/group to the wrong recipient.

## Test plan
- `python -m pytest -o addopts='' tests/gateway/test_send_message_whatsapp_targets.py tests/cron/test_scheduler.py::TestResolveDeliveryTarget::test_raw_id_not_mangled_when_directory_returns_none -q`
