### PR TITLE
fix(run_agent): use max_completion_tokens for newer OpenAI model families on any endpoint

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1481,3 +1481,29 @@ def estimate_request_tokens_rough(
     if tools:
         total_chars += len(str(tools))
     return (total_chars + 3) // 4
+
+
+def model_requires_max_completion_tokens(model: str) -> bool:
+    """Return True when a model requires max_completion_tokens instead of max_tokens.
+
+    OpenAI's newer model families (gpt-4o, gpt-4.1, gpt-5, o1/o3/o4) only accept
+    ``max_completion_tokens``.  This matters for custom OpenAI-compatible endpoints
+    (OpenRouter, self-hosted, proxies) that sit behind non-api.openai.com hosts —
+    the URL-based check alone is insufficient for those.
+
+    Provider-prefixed model names such as "openai/gpt-4o" or "anthropic/claude-3-5"
+    are handled by stripping the prefix before matching.
+    """
+    if not model:
+        return False
+    m = model.strip().lower()
+    if "/" in m:
+        m = m.rsplit("/", 1)[-1]
+    return (
+        m.startswith("gpt-4o")
+        or m.startswith("gpt-4.1")
+        or m.startswith("gpt-5")
+        or m.startswith("o1")
+        or m.startswith("o3")
+        or m.startswith("o4")
+    )

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1483,7 +1483,7 @@ def estimate_request_tokens_rough(
     return (total_chars + 3) // 4
 
 
-def model_requires_max_completion_tokens(model: str) -> bool:
+def model_requires_max_completion_tokens(model: str | None) -> bool:
     """Return True when a model requires max_completion_tokens instead of max_tokens.
 
     OpenAI's newer model families (gpt-4o, gpt-4.1, gpt-5, o1/o3/o4) only accept

--- a/run_agent.py
+++ b/run_agent.py
@@ -3043,10 +3043,10 @@ class AIAgent:
         """Return the correct max tokens kwarg for the current provider.
 
         OpenAI's newer models (gpt-4o, o-series, gpt-5+) require
-        'max_completion_tokens'. Azure OpenAI also requires
-        'max_completion_tokens' for gpt-5.x models served via the
-        OpenAI-compatible endpoint. OpenRouter, local models, and older
-        OpenAI models use 'max_tokens'.
+        'max_completion_tokens' on api.openai.com, Azure, and any
+        OpenAI-compatible endpoint (OpenRouter, self-hosted, proxies).
+        Older OpenAI models (gpt-4-turbo, gpt-3.5-turbo, etc.) use
+        'max_tokens' on all endpoints.
         """
         if (self._is_direct_openai_url()
                 or self._is_azure_openai_url()

--- a/run_agent.py
+++ b/run_agent.py
@@ -145,6 +145,7 @@ from agent.model_metadata import (
     parse_available_output_tokens_from_error,
     save_context_length, is_local_endpoint,
     query_ollama_num_ctx,
+    model_requires_max_completion_tokens,
 )
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
@@ -3047,7 +3048,9 @@ class AIAgent:
         OpenAI-compatible endpoint. OpenRouter, local models, and older
         OpenAI models use 'max_tokens'.
         """
-        if self._is_direct_openai_url() or self._is_azure_openai_url():
+        if (self._is_direct_openai_url()
+                or self._is_azure_openai_url()
+                or model_requires_max_completion_tokens(self.model)):
             return {"max_completion_tokens": value}
         return {"max_tokens": value}
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1022,3 +1022,69 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+
+class TestModelRequiresMaxCompletionTokens:
+    """Tests for model_requires_max_completion_tokens()."""
+
+    def test_gpt_4o_family(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("gpt-4o") is True
+        assert model_requires_max_completion_tokens("gpt-4o-mini") is True
+        assert model_requires_max_completion_tokens("gpt-4o-2024-08-06") is True
+
+    def test_gpt_4_1_family(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("gpt-4.1") is True
+        assert model_requires_max_completion_tokens("gpt-4.1-mini") is True
+        assert model_requires_max_completion_tokens("gpt-4.1-nano") is True
+
+    def test_gpt_5_family(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("gpt-5") is True
+        assert model_requires_max_completion_tokens("gpt-5.4") is True
+        assert model_requires_max_completion_tokens("gpt-5.4-mini") is True
+        assert model_requires_max_completion_tokens("gpt-5.4-nano") is True
+        assert model_requires_max_completion_tokens("gpt-5.1-chat") is True
+
+    def test_o_series(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("o1") is True
+        assert model_requires_max_completion_tokens("o1-mini") is True
+        assert model_requires_max_completion_tokens("o1-preview") is True
+        assert model_requires_max_completion_tokens("o3") is True
+        assert model_requires_max_completion_tokens("o3-mini") is True
+        assert model_requires_max_completion_tokens("o3-mini-high") is True
+        assert model_requires_max_completion_tokens("o4") is True
+        assert model_requires_max_completion_tokens("o4-mini") is True
+
+    def test_prefixed_model_names(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("openai/gpt-4o-mini") is True
+        assert model_requires_max_completion_tokens("openai/gpt-5.4") is True
+        assert model_requires_max_completion_tokens("anthropic/claude-sonnet-4") is False
+        assert model_requires_max_completion_tokens("openai/gpt-4o") is True
+
+    def test_older_models_use_max_tokens(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("gpt-4-turbo") is False
+        assert model_requires_max_completion_tokens("gpt-3.5-turbo") is False
+        assert model_requires_max_completion_tokens("claude-3-5-sonnet-20240620") is False
+        assert model_requires_max_completion_tokens("llama3.1-8b") is False
+        assert model_requires_max_completion_tokens("mixtral-8x7b") is False
+
+    def test_empty_and_none(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("") is False
+        assert model_requires_max_completion_tokens(None) is False
+
+    def test_whitespace_handling(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("  gpt-4o-mini  ") is True
+        assert model_requires_max_completion_tokens("gpt-5.4") is True
+
+    def test_case_insensitive(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("GPT-4O-MINI") is True
+        assert model_requires_max_completion_tokens("Gpt-5.4") is True
+        assert model_requires_max_completion_tokens("O3-MINI") is True


### PR DESCRIPTION
## Summary

Fixes a **P1 bug** where custom OpenAI-compatible endpoints (OpenRouter, self-hosted gateways, proxies) serving newer OpenAI models would fail 100% of requests with:

```
HTTP 400 unsupported_parameter: 'max_tokens' is not supported with this model.
Use 'max_completion_tokens' instead.
```

### Root Cause

`_max_tokens_param()` in `run_agent.py` only checked the URL host — `api.openai.com` and Azure got `max_completion_tokens`, but every other endpoint got `max_tokens`. Custom endpoints serving `gpt-4o`, `gpt-4.1`, `gpt-5`, `o1`, `o3`, `o4` models were broken.

### Fix

**New helper** `model_requires_max_completion_tokens(model: str) -> bool` in `agent/model_metadata.py`:
- Detects gpt-4o, gpt-4.1, gpt-5, o1, o3, o4 families by name
- Handles provider-prefixed names like `openai/gpt-4o-mini`
- Case-insensitive, strips whitespace

**Updated** `_max_tokens_param()` in `run_agent.py`:
```python
if (self._is_direct_openai_url()
        or self._is_azure_openai_url()
        or model_requires_max_completion_tokens(self.model)):
    return {"max_completion_tokens": value}
return {"max_tokens": value}
```

### Tests

9 new unit tests in `tests/agent/test_model_metadata.py`:
- gpt-4o, gpt-4.1, gpt-5, o-series families (should return True)
- Older models like gpt-4-turbo, gpt-3.5-turbo, claude-3-5-sonnet (should return False)
- Provider-prefixed names: `openai/gpt-4o-mini`, `openai/gpt-5.4` (should return True), `anthropic/claude-sonnet-4` (should return False)
- Edge cases: empty string, None, whitespace, uppercase

All 9 tests pass.

### Files Changed

| File | Change |
|------|--------|
| `agent/model_metadata.py` | Added `model_requires_max_completion_tokens()` |
| `run_agent.py` | Import + updated `_max_tokens_param()` |
| `tests/agent/test_model_metadata.py` | 9 unit tests |