### PR TITLE
fix(run_agent): pass custom_providers to compression feasibility check (#20608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Changes
+
+- run_agent/compression: Pass `custom_providers` to `get_model_context_length()` in `_check_compression_model_feasibility()` so per-model `context_length` overrides defined in `custom_providers` config are honoured for the compression model, preventing spurious "Auto-lowered threshold" warnings at startup (#20608)

--- a/run_agent.py
+++ b/run_agent.py
@@ -2694,6 +2694,19 @@ class AIAgent:
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
 
+            # Load custom_providers so per-model context_length overrides
+            # (step 0b in get_model_context_length) are honoured for the
+            # compression model. Without this, custom-provider models fall
+            # through to the 256K default, producing spurious
+            # "Auto-lowered threshold" warnings at startup.
+            _ccp_custom_providers = None
+            try:
+                from hermes_cli.config import load_config, get_compatible_custom_providers
+                _ccp_cfg = load_config()
+                _ccp_custom_providers = get_compatible_custom_providers(_ccp_cfg)
+            except Exception:
+                _ccp_custom_providers = None
+
             aux_context = get_model_context_length(
                 aux_model,
                 base_url=aux_base_url,
@@ -2703,6 +2716,7 @@ class AIAgent:
                 # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
                 # are invoked for the correct client, not inherited from the main model.
                 provider=(_aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(self, "provider", "")),
+                custom_providers=_ccp_custom_providers,
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -174,7 +174,9 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
     mock_get_client.return_value = (mock_client, "custom/big-model")
 
     agent._emit_status = lambda msg: None
-    agent._check_compression_model_feasibility()
+    with patch("hermes_cli.config.load_config", return_value={}), \
+         patch("hermes_cli.config.get_compatible_custom_providers", return_value=None):
+        agent._check_compression_model_feasibility()
 
     mock_ctx_len.assert_called_once_with(
         "custom/big-model",
@@ -182,6 +184,7 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="openrouter",
+        custom_providers=None,
     )
 
 
@@ -197,7 +200,9 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
     mock_get_client.return_value = (mock_client, "custom/model")
 
     agent._emit_status = lambda msg: None
-    agent._check_compression_model_feasibility()
+    with patch("hermes_cli.config.load_config", return_value={}), \
+         patch("hermes_cli.config.get_compatible_custom_providers", return_value=None):
+        agent._check_compression_model_feasibility()
 
     mock_ctx_len.assert_called_once_with(
         "custom/model",
@@ -205,6 +210,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
         api_key="sk-test",
         config_context_length=None,
         provider="openrouter",
+        custom_providers=None,
     )
 
 
@@ -258,6 +264,7 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="",
+        custom_providers=None,
     )
 
 
@@ -442,3 +449,58 @@ def test_run_conversation_clears_warning_after_replay(mock_get_client, mock_ctx_
         agent._compression_warning = None
 
     assert len(callback_events) == 0
+
+
+# ── custom_providers forwarding (fix #20608) ────────────────────────
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=1_000_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_feasibility_check_passes_custom_providers(mock_get_client, mock_ctx_len):
+    """_check_compression_model_feasibility must forward custom_providers to
+    get_model_context_length so per-model context_length overrides in
+    custom_providers config are respected for the compression model.
+
+    Regression: without this fix the call omitted custom_providers, causing
+    step 0b (custom_providers lookup) to be skipped and context to fall back
+    to the 256K default — producing spurious 'Auto-lowered threshold' warnings
+    even when the compression model has 1M context (#20608).
+    """
+    agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+    agent._aux_compression_context_length_config = None
+
+    mock_client = MagicMock()
+    mock_client.base_url = "https://api.360.cn/v1"
+    mock_client.api_key = "sk-custom"
+    mock_get_client.return_value = (mock_client, "deepseek/deepseek/deepseek-v4-flash")
+
+    custom_providers = [
+        {
+            "name": "zhinao",
+            "base_url": "https://api.360.cn/v1",
+            "models": {
+                "deepseek/deepseek/deepseek-v4-flash": {"context_length": 1_000_000}
+            },
+        }
+    ]
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+    with patch("hermes_cli.config.load_config", return_value={"custom_providers": custom_providers}), \
+         patch("hermes_cli.config.get_compatible_custom_providers", return_value=custom_providers):
+        agent._check_compression_model_feasibility()
+
+    # custom_providers must be forwarded so the 1M override is applied.
+    # _resolve_task_provider_model raises in tests (not mocked) → provider=""
+    # falls back to self.provider = "openrouter" from _make_agent().
+    mock_ctx_len.assert_called_once_with(
+        "deepseek/deepseek/deepseek-v4-flash",
+        base_url="https://api.360.cn/v1",
+        api_key="sk-custom",
+        config_context_length=None,
+        provider="openrouter",
+        custom_providers=custom_providers,
+    )
+
+    # 1M context >= 100K threshold → no spurious "Auto-lowered" warning
+    assert len(messages) == 0


### PR DESCRIPTION
## Bug

`_check_compression_model_feasibility()` calls `get_model_context_length()` **without** the `custom_providers` argument. The main model path in the same file (lines 2039, 2436) correctly passes `custom_providers`, but the compression check omits it.

`get_model_context_length` has step 0b that checks `custom_providers` for per-model `context_length` overrides — but only when `custom_providers` is passed. When omitted, step 0b is skipped and resolution falls through to the 256K default, causing a spurious startup warning:

```
⚠ Compression model deepseek/deepseek/deepseek-v4-flash (zhinao) context is 256,000 tokens,
but the main model deepseek/deepseek/deepseek-v4-pro (custom)'s compression threshold was
750,000 tokens. Auto-lowered this session's threshold to 256,000 tokens so compression can run.
```

This happens even when the custom provider defines `context_length: 1000000` for that model in `config.yaml`.

## Fix

Load `custom_providers` via `load_config()` / `get_compatible_custom_providers()` (mirroring the existing pattern at line ~2429) and forward it to `get_model_context_length()` inside `_check_compression_model_feasibility()`.

**Broken call (before):**
```python
aux_context = get_model_context_length(
    aux_model,
    base_url=aux_base_url,
    api_key=aux_api_key,
    config_context_length=...,
    provider=...,
    # custom_providers=... ← MISSING
)
```

**Fixed call (after):**
```python
_ccp_custom_providers = None
try:
    from hermes_cli.config import load_config, get_compatible_custom_providers
    _ccp_cfg = load_config()
    _ccp_custom_providers = get_compatible_custom_providers(_ccp_cfg)
except Exception:
    _ccp_custom_providers = None

aux_context = get_model_context_length(
    ...,
    custom_providers=_ccp_custom_providers,  # ← ADDED
)
```

## Tests

- Updated 3 existing tests that assert the exact call signature of `get_model_context_length` to include `custom_providers=None` (they now patch `load_config` + `get_compatible_custom_providers` to return `None`).
- Added `test_feasibility_check_passes_custom_providers` — regression test confirming `custom_providers` is forwarded when set, and that no spurious warning is emitted when the custom provider reports 1M context.

```
$ python3 -m pytest tests/run_agent/test_compression_feasibility.py -v 2>&1 | tail -25
PASSED ...test_auto_corrects_threshold_when_aux_context_below_threshold
PASSED ...test_rejects_aux_below_minimum_context
PASSED ...test_no_warning_when_aux_context_sufficient
PASSED ...test_feasibility_check_passes_live_main_runtime
PASSED ...test_feasibility_check_passes_config_context_length
PASSED ...test_feasibility_check_ignores_invalid_context_length
PASSED ...test_init_feasibility_check_uses_aux_context_override_from_config
PASSED ...test_warns_when_no_auxiliary_provider
PASSED ...test_skips_check_when_compression_disabled
PASSED ...test_exception_does_not_crash
PASSED ...test_exact_threshold_boundary_no_warning
PASSED ...test_just_below_threshold_auto_corrects
PASSED ...test_warning_stored_for_gateway_replay
PASSED ...test_no_replay_when_no_warning
PASSED ...test_replay_without_callback_is_noop
PASSED ...test_run_conversation_clears_warning_after_replay
PASSED ...test_feasibility_check_passes_custom_providers    ← new
17 passed
```

Closes #20608