### PR TITLE
fix(agent): add platform_hint parameter to AIAgent.__init__ for custom platform descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Changes
+
+- **fix(agent): add `platform_hint` parameter to `AIAgent.__init__` for custom platform descriptions** — External clients such as hermes-webui can now pass `platform_hint: str` to `AIAgent.__init__`. When provided, it takes priority over the static `PLATFORM_HINTS` dict lookup and the plugin registry fallback, allowing clients with unregistered platform keys (e.g. `"webui"`) to supply accurate channel context to the agent. Existing callers are unaffected — `platform_hint` defaults to `None`. (Fixes [#20637](https://github.com/NousResearch/hermes-agent/issues/20637))

--- a/run_agent.py
+++ b/run_agent.py
@@ -938,6 +938,7 @@ class AIAgent:
         request_overrides: Dict[str, Any] = None,
         prefill_messages: List[Dict[str, Any]] = None,
         platform: str = None,
+        platform_hint: str = None,
         user_id: str = None,
         user_name: str = None,
         chat_id: str = None,
@@ -995,6 +996,10 @@ class AIAgent:
                 output_config.format instead of a trailing-assistant prefill.
             platform (str): The interface platform the user is on (e.g. "cli", "telegram", "discord", "whatsapp").
                 Used to inject platform-specific formatting hints into the system prompt.
+            platform_hint (str): Custom platform description injected into the system prompt verbatim.
+                Takes priority over the static PLATFORM_HINTS dict and the plugin registry when set.
+                Useful for clients (e.g. hermes-webui) whose platform key is not in PLATFORM_HINTS.
+                Example: "You are on the Hermes WebUI in a browser. Markdown is fully supported."
             skip_context_files (bool): If True, skip auto-injection of SOUL.md, AGENTS.md, and .cursorrules
                 into the system prompt. Use this for batch processing and data generation to avoid
                 polluting trajectories with user-specific persona or project instructions.
@@ -1015,6 +1020,7 @@ class AIAgent:
         self.quiet_mode = quiet_mode
         self.ephemeral_system_prompt = ephemeral_system_prompt
         self.platform = platform  # "cli", "telegram", "discord", "whatsapp", etc.
+        self.platform_hint = platform_hint  # Custom hint; takes priority over PLATFORM_HINTS. (#20637)
         self._user_id = user_id  # Platform user identifier (gateway sessions)
         self._user_name = user_name
         self._chat_id = chat_id
@@ -5038,8 +5044,16 @@ class AIAgent:
         if _env_hints:
             prompt_parts.append(_env_hints)
 
+        # Platform hint resolution order (first match wins):
+        #   1. Caller-supplied platform_hint — lets external clients (e.g. hermes-webui)
+        #      inject a custom description even when their platform key is not in
+        #      PLATFORM_HINTS. (#20637)
+        #   2. Static PLATFORM_HINTS dict lookup by platform key.
+        #   3. Plugin registry fallback.
         platform_key = (self.platform or "").lower().strip()
-        if platform_key in PLATFORM_HINTS:
+        if self.platform_hint:
+            prompt_parts.append(self.platform_hint)
+        elif platform_key in PLATFORM_HINTS:
             prompt_parts.append(PLATFORM_HINTS[platform_key])
         elif platform_key:
             # Check plugin registry for platform-specific LLM guidance

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1070,6 +1070,7 @@ class TestToolUseEnforcementConfig:
             assert TOOL_USE_ENFORCEMENT_GUIDANCE not in prompt
 
 
+
 class TestInvalidateSystemPrompt:
     def test_clears_cache(self, agent):
         agent._cached_system_prompt = "cached value"
@@ -1082,6 +1083,71 @@ class TestInvalidateSystemPrompt:
         agent._cached_system_prompt = "cached"
         agent._invalidate_system_prompt()
         mock_store.load_from_disk.assert_called_once()
+
+
+class TestPlatformHint:
+    """Regression tests for AIAgent.platform_hint parameter (issue #20637).
+
+    External clients such as hermes-webui can pass a custom platform description
+    that takes priority over the static PLATFORM_HINTS dict lookup.
+    """
+
+    def _make_agent_with_platform(self, platform=None, platform_hint=None):
+        """Helper: build a minimal AIAgent with a given platform / platform_hint."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                platform=platform,
+                platform_hint=platform_hint,
+            )
+            a.client = MagicMock()
+            return a
+
+    def test_platform_hint_appears_in_system_prompt(self):
+        """A custom platform_hint is injected verbatim into the system prompt."""
+        custom = "You are on the Hermes WebUI. Markdown is fully supported."
+        agent = self._make_agent_with_platform(platform="webui", platform_hint=custom)
+        prompt = agent._build_system_prompt()
+        assert custom in prompt
+
+    def test_platform_hint_takes_priority_over_static_platform_hints(self):
+        """platform_hint overrides the PLATFORM_HINTS dict even for known keys like 'cli'."""
+        from agent.prompt_builder import PLATFORM_HINTS
+        custom = "CUSTOM HINT — overrides static dict"
+        agent = self._make_agent_with_platform(platform="cli", platform_hint=custom)
+        prompt = agent._build_system_prompt()
+        assert custom in prompt
+        # The static CLI hint must NOT appear when platform_hint is provided.
+        cli_hint = PLATFORM_HINTS.get("cli", "")
+        if cli_hint and cli_hint != custom:
+            assert cli_hint not in prompt
+
+    def test_no_platform_hint_falls_back_to_static_dict(self):
+        """Without platform_hint, the existing PLATFORM_HINTS lookup still works."""
+        from agent.prompt_builder import PLATFORM_HINTS
+        agent = self._make_agent_with_platform(platform="telegram")
+        prompt = agent._build_system_prompt()
+        if "telegram" in PLATFORM_HINTS:
+            assert PLATFORM_HINTS["telegram"] in prompt
+
+    def test_unknown_platform_without_hint_does_not_crash(self):
+        """An unrecognised platform key with no platform_hint does not crash."""
+        agent = self._make_agent_with_platform(platform="webui")
+        # Should not raise; unknown key + no hint = no extra block appended.
+        prompt = agent._build_system_prompt()
+        assert prompt  # at minimum the identity is present
+
+    def test_platform_hint_none_by_default(self, agent):
+        """AIAgent instances created without platform_hint default to None."""
+        assert agent.platform_hint is None
 
 
 class TestBuildApiKwargs:


### PR DESCRIPTION
## Bug Description

Fixes #20637.

`AIAgent` has a static `PLATFORM_HINTS` dict with 18 entries (telegram, discord, cli, signal, …) but no `"webui"` key, and no way for external clients to supply a custom platform description. Hermes WebUI passes `platform="webui"` correctly, but the resolver falls through all three checks (`PLATFORM_HINTS` dict → plugin registry → nothing) and the agent receives zero context about the channel it's on.

Concrete failure: ask the agent _"What channel am I on? How do you know?"_ from the WebUI — it has no answer because nothing was appended to the system prompt.

## Fix Description

Added an optional `platform_hint: str = None` parameter to `AIAgent.__init__`. When non-empty it is injected into the system prompt with priority over the static dict and the plugin registry:

```python
agent = AIAgent(
    platform="webui",
    platform_hint=(
        "You are communicating via the Hermes WebUI in a browser. "
        "Markdown formatting is fully supported — use it freely. "
        "You can send media files natively via MEDIA:... in your response."
    ),
)
```

The resolution order in `_build_system_prompt()` is now:

```
1. self.platform_hint          ← new; caller-supplied (highest priority)
2. PLATFORM_HINTS[platform_key] ← existing static dict
3. platform_registry.get(...)   ← existing plugin fallback
```

**Backward compatibility**: `platform_hint` defaults to `None`. All existing callers behave identically.

## Test Output

```
tests/run_agent/test_run_agent.py::TestPlatformHint::test_platform_hint_appears_in_system_prompt PASSED
tests/run_agent/test_run_agent.py::TestPlatformHint::test_platform_hint_takes_priority_over_static_platform_hints PASSED
tests/run_agent/test_run_agent.py::TestPlatformHint::test_no_platform_hint_falls_back_to_static_dict PASSED
tests/run_agent/test_run_agent.py::TestPlatformHint::test_unknown_platform_without_hint_does_not_crash PASSED
tests/run_agent/test_run_agent.py::TestPlatformHint::test_platform_hint_none_by_default PASSED

======================== 5 passed in 3.93s =========================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)