### PR TITLE
test(gateway): add webhook toolset regression coverage

### DIFF
--- a/tests/gateway/test_webhook_toolset.py
+++ b/tests/gateway/test_webhook_toolset.py
@@ -1,0 +1,29 @@
+"""Regression tests for webhook platform/toolset registration."""
+
+from hermes_cli.platforms import PLATFORMS as PLATFORM_REGISTRY
+from hermes_cli.tools_config import PLATFORMS as TOOLS_CONFIG_PLATFORMS
+from toolsets import _HERMES_CORE_TOOLS, get_toolset, resolve_toolset, validate_toolset
+
+
+class TestHermesWebhookToolset:
+    def test_toolset_exists(self):
+        assert get_toolset("hermes-webhook") is not None
+
+    def test_toolset_validates(self):
+        assert validate_toolset("hermes-webhook")
+
+    def test_toolset_resolves_to_shared_core_tools(self):
+        assert set(resolve_toolset("hermes-webhook")) == set(_HERMES_CORE_TOOLS)
+
+
+class TestWebhookPlatformRegistration:
+    def test_platform_registry_maps_webhook_to_hermes_webhook(self):
+        assert PLATFORM_REGISTRY["webhook"].default_toolset == "hermes-webhook"
+
+    def test_tools_config_exports_webhook_platform_mapping(self):
+        assert TOOLS_CONFIG_PLATFORMS["webhook"]["default_toolset"] == "hermes-webhook"
+
+    def test_gateway_toolset_includes_hermes_webhook(self):
+        gateway_tools = get_toolset("hermes-gateway")
+        assert gateway_tools is not None
+        assert "hermes-webhook" in gateway_tools["includes"]


### PR DESCRIPTION
 ## Summary

  Adds explicit regression coverage for the webhook platform/toolset wiring that previously caused `KeyError` failures on webhook-triggered agent runs.

  This PR verifies that:

  - `hermes-webhook` is defined and validates as a toolset
  - the `webhook` platform resolves to `default_toolset="hermes-webhook"`
  - `hermes_cli.tools_config.PLATFORMS` exports the same mapping
  - `hermes-gateway` still includes `hermes-webhook`

  ## Context

  This is a focused test-only follow-up to earlier webhook platform registration work.

  Related history:

  - #3775 originally proposed the runtime fix plus a dedicated regression test
  - during review on #3775, the runtime fix was noted as already having landed on `main`
  - that runtime wiring was merged via #4660
  - #4660 itself was a salvage/cherry-pick follow-up from #4363

  What landed on `main` from that chain was the runtime/config wiring:
  - webhook platform registration
  - `hermes-webhook` toolset registration
  - inclusion in `hermes-gateway`

  What did **not** land was the dedicated regression coverage from #3775.

  This PR adds that missing explicit test coverage only, without changing runtime behavior.

  ## Why this is still useful

  `main` already has broader platform/toolset consistency coverage, but this PR adds a webhook-specific regression test for the exact wiring that was previously missing and that motivated #3775.

  That makes the original failure mode easier to catch directly if webhook registration regresses again.