### PR TITLE
fix(telegram): route cron dismiss feedback

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1191,6 +1191,15 @@ class TelegramAdapter(BasePlatformAdapter):
             
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
+            reply_markup = None
+            cron_apply = (metadata or {}).get("cron_apply") if isinstance(metadata, dict) else None
+            if cron_apply:
+                job_id = str(cron_apply.get("job_id", "")).strip()
+                if job_id:
+                    reply_markup = InlineKeyboardMarkup([[
+                        InlineKeyboardButton("✅ Apply", callback_data=f"ca:{job_id[:48]}"),
+                        InlineKeyboardButton("❌ Don’t apply", callback_data=f"cd:{job_id[:48]}"),
+                    ]])
             
             try:
                 from telegram.error import NetworkError as _NetErr
@@ -1223,6 +1232,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
                                 message_thread_id=effective_thread_id,
+                                reply_markup=reply_markup if i == 0 else None,
                                 **self._link_preview_kwargs(),
                             )
                         except Exception as md_error:
@@ -1236,6 +1246,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
                                     message_thread_id=effective_thread_id,
+                                    reply_markup=reply_markup if i == 0 else None,
                                     **self._link_preview_kwargs(),
                                 )
                             else:
@@ -1884,6 +1895,125 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_id = str(query.message.chat_id) if query.message else None
             if chat_id:
                 await self._handle_model_picker_callback(query, data, chat_id)
+            return
+
+        # --- Cron apply callbacks (ca:job_id) ---
+        if data.startswith("ca:"):
+            job_id = data.split(":", 1)[1].strip()
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to apply this.")
+                return
+
+            await query.answer(text="Applying…")
+            try:
+                await query.edit_message_reply_markup(reply_markup=None)
+            except Exception:
+                pass
+
+            if not query.message:
+                return
+
+            from gateway.session import SessionSource
+
+            chat_type = str(query_chat_type or "dm").lower()
+            if chat_type == "private":
+                chat_type = "dm"
+            elif chat_type == "supergroup":
+                chat_type = "group"
+
+            source = SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id=str(query.message.chat_id),
+                chat_name=getattr(query_chat, "title", None) or getattr(query_chat, "full_name", None),
+                chat_type=chat_type,
+                user_id=caller_id,
+                user_name=query_user_name,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                message_id=str(getattr(query.message, "message_id", "")),
+            )
+            message_text = getattr(query.message, "text", None) or getattr(query.message, "caption", None) or ""
+            event = MessageEvent(
+                text=(
+                    f"Apply the actionable proposal from cron job {job_id}. "
+                    "Use the clicked Telegram message as the source of truth. "
+                    "Do not apply anything outside that message without asking."
+                ),
+                message_type=MessageType.TEXT,
+                source=source,
+                raw_message=query.message,
+                message_id=str(getattr(query.message, "message_id", "")),
+                reply_to_message_id=str(getattr(query.message, "message_id", "")),
+                reply_to_text=message_text,
+                internal=True,
+            )
+            await self.handle_message(event)
+            return
+
+        # --- Cron don't-apply callbacks (cd:job_id) ---
+        if data.startswith("cd:"):
+            job_id = data.split(":", 1)[1].strip()
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to dismiss this.")
+                return
+            await query.answer(text="Not applied. I’ll down-rank similar Mneme suggestions.")
+            try:
+                await query.edit_message_reply_markup(reply_markup=None)
+            except Exception:
+                pass
+
+            if not query.message:
+                return
+
+            from gateway.session import SessionSource
+
+            chat_type = str(query_chat_type or "dm").lower()
+            if chat_type == "private":
+                chat_type = "dm"
+            elif chat_type == "supergroup":
+                chat_type = "group"
+
+            source = SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id=str(query.message.chat_id),
+                chat_name=getattr(query_chat, "title", None) or getattr(query_chat, "full_name", None),
+                chat_type=chat_type,
+                user_id=caller_id,
+                user_name=query_user_name,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                message_id=str(getattr(query.message, "message_id", "")),
+            )
+            message_text = getattr(query.message, "text", None) or getattr(query.message, "caption", None) or ""
+            event = MessageEvent(
+                text=(
+                    f"The user clicked Don’t apply for cron job {job_id}. "
+                    "Do not apply the proposal. Treat the clicked message as negative memory-graph feedback: "
+                    "identify the surfaced Mneme leaf/synapse or closest source candidate from the message, "
+                    "then reduce the strength of that synapse rather than reinforcing or killing it unless the message proves it is false. "
+                    "Use mneme_private.py weaken-synapse when a synapse id is available; otherwise record concise negative feedback for this surfaced item."
+                ),
+                message_type=MessageType.TEXT,
+                source=source,
+                raw_message=query.message,
+                message_id=str(getattr(query.message, "message_id", "")),
+                reply_to_message_id=str(getattr(query.message, "message_id", "")),
+                reply_to_text=message_text,
+                internal=True,
+            )
+            await self.handle_message(event)
             return
 
         # --- Exec approval callbacks (ea:choice:id) ---

--- a/optional-skills/mcp/mcporter/SKILL.md
+++ b/optional-skills/mcp/mcporter/SKILL.md
@@ -120,3 +120,27 @@ mcporter emit-ts <server> --mode types
 - Use `--output json` for structured output that's easier to parse
 - Ad-hoc servers (HTTP URL or `--stdio` command) work without any config — useful for one-off calls
 - OAuth auth may require interactive browser flow — use `terminal(command="mcporter auth <server>", pty=true)` if needed
+
+## Typical Steps
+
+1. Confirm Node.js/npx is available: `node --version && npx --version`.
+2. Discover configured MCP servers: `npx mcporter list --output json`.
+3. Inspect the target server's tools and schemas: `npx mcporter list <server> --schema --output json`.
+4. Call the smallest safe read-only tool first with `--output json` to validate auth and argument shape.
+5. For state-changing tools, pass a complete JSON payload with `--args '{...}'` and record the returned ID/status for verification.
+
+## Pitfalls
+
+1. `mcporter` vs `npx mcporter`: many machines do not have a global `mcporter` binary. Prefer `npx mcporter ...` unless you have already verified the global install.
+2. Shell quoting breaks JSON easily. For complex arguments, write the payload in single quotes around valid JSON and escape only inner single quotes.
+3. OAuth flows may need a pseudo-terminal. Run auth with `pty=true` when using the terminal tool.
+4. Do not assume a configured server name. Always list servers first; MCP client configs differ across Claude Desktop, Cursor, Hermes, and project-local configs.
+5. Use `--output json` for automation. Human-formatted tables are harder to parse and can hide tool errors.
+
+## Verification Checklist
+
+- [ ] `npx mcporter list --output json` succeeds or the missing Node/npm prerequisite is explicit.
+- [ ] The target server appears in the list, or the ad-hoc `--http-url` / `--stdio` command was used deliberately.
+- [ ] Tool schema was inspected before calling a non-trivial tool.
+- [ ] Tool call output was captured in JSON and includes a success indicator, result object, or actionable error.
+- [ ] Any state-changing call was verified by reading back the created/updated resource.

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -441,3 +441,43 @@ class TestTelegramApprovalCallback:
         query.answer.assert_called_once()
         query.edit_message_text.assert_called_once()
         assert (tmp_path / ".update_response").read_text() == "n"
+
+    @pytest.mark.asyncio
+    async def test_cron_dont_apply_routes_internal_feedback_to_agent(self):
+        adapter = _make_adapter()
+        handled = []
+
+        async def fake_handle(event):
+            handled.append(event)
+
+        adapter.handle_message = fake_handle
+        query = AsyncMock()
+        query.data = "cd:test-job-id"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.chat.type = "private"
+        query.message.text = "**What I found:** Candidate leaf proposal"
+        query.message.caption = None
+        query.message.message_id = 88
+        query.message.message_thread_id = None
+        query.from_user = MagicMock()
+        query.from_user.id = 222
+        query.from_user.first_name = "User"
+        query.answer = AsyncMock()
+        query.edit_message_reply_markup = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        await adapter._handle_callback_query(update, context)
+
+        query.answer.assert_called_once()
+        assert "Not applied" in query.answer.call_args[1]["text"]
+        assert len(handled) == 1
+        event = handled[0]
+        assert event.internal is True
+        assert event.reply_to_text == "**What I found:** Candidate leaf proposal"
+        assert "do not apply" in event.text.lower()
+        assert "reduce the strength" in event.text.lower()
+        assert "test-job-id" in event.text


### PR DESCRIPTION
## Summary
- add Telegram inline callbacks for cron apply/don't-apply messages
- route don't-apply clicks back into the agent as negative memory-graph feedback
- add regression coverage for dismiss feedback routing

## Test plan
- venv/bin/python -m pytest -q tests/gateway/test_telegram_approval_buttons.py
- python3 -m py_compile gateway/platforms/telegram.py

## Privacy
- Public-generic only; no user names, addresses, IDs, credentials, or private data.