### PR TITLE
feat(cli): optionally share gh cli auth config

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -389,6 +389,12 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    "profiles": {
+        # When true, new profiles symlink their per-profile gh CLI config to
+        # the default user's ~/.config/gh so specialist workers can create PRs
+        # without re-running gh auth login in every isolated profile HOME.
+        "share_gh_config": False,
+    },
     "agent": {
         "max_turns": 90,
         # Inactivity timeout for gateway agent execution (seconds).

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -359,6 +359,56 @@ def _check_gateway_running(profile_dir: Path) -> bool:
         return False
 
 
+def _share_gh_config_enabled() -> bool:
+    """Return whether new profiles should share the default gh CLI config."""
+    env_value = os.environ.get("HERMES_PROFILE_SHARE_GH_CONFIG")
+    if env_value is not None:
+        return env_value.strip().lower() in {"1", "true", "yes", "on"}
+
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        profiles_cfg = cfg.get("profiles") or {}
+        return bool(profiles_cfg.get("share_gh_config"))
+    except Exception:
+        return False
+
+
+def _link_shared_gh_config(profile_dir: Path) -> None:
+    """Best-effort symlink of default gh CLI auth into a new profile.
+
+    Profile subprocesses use ``{profile_dir}/home`` as HOME, so gh looks under
+    ``home/.config/gh``.  Some profile-aware subprocesses may instead set
+    XDG_CONFIG_HOME to ``{profile_dir}/.config``; link both locations to keep
+    GitHub auth available without copying tokens into each profile.
+    """
+    if not _share_gh_config_enabled():
+        return
+
+    source = Path.home() / ".config" / "gh"
+    if not source.is_dir():
+        return
+
+    for config_root in (profile_dir / "home" / ".config", profile_dir / ".config"):
+        target = config_root / "gh"
+        try:
+            config_root.mkdir(parents=True, exist_ok=True)
+            if target.is_symlink():
+                if target.resolve() == source.resolve():
+                    continue
+                target.unlink()
+            elif target.exists():
+                # Do not overwrite profile-local gh auth/config.  Users may
+                # intentionally want a different GitHub account in this profile.
+                continue
+            target.symlink_to(source, target_is_directory=True)
+        except OSError:
+            # Profile creation must not fail just because external tool config
+            # sharing is unavailable on this filesystem/platform.
+            continue
+
+
 def _count_skills(profile_dir: Path) -> int:
     """Count installed skills in a profile."""
     skills_dir = profile_dir / "skills"
@@ -526,6 +576,11 @@ def create_profile(
             soul_path.write_text(DEFAULT_SOUL_MD, encoding="utf-8")
         except Exception:
             pass  # best-effort — don't fail profile creation over this
+
+    # Seed shared external tool auth/config after the profile's per-profile
+    # HOME exists.  This is opt-in because profiles are otherwise isolated by
+    # design.
+    _link_shared_gh_config(profile_dir)
 
     return profile_dir
 

--- a/tests/test_subprocess_home_isolation.py
+++ b/tests/test_subprocess_home_isolation.py
@@ -170,6 +170,50 @@ class TestProfileBootstrap:
         profile_dir = create_profile("testbot", no_alias=True)
         assert (profile_dir / "home").is_dir()
 
+    def test_create_profile_links_shared_gh_config_when_enabled(self, tmp_path, monkeypatch):
+        """New profiles can opt into sharing the default gh CLI auth config."""
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        default_gh = tmp_path / ".config" / "gh"
+        default_gh.mkdir(parents=True)
+        (default_gh / "hosts.yml").write_text("github.com: {}\n")
+        (home / "config.yaml").write_text("profiles:\n  share_gh_config: true\n")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        from hermes_cli.profiles import create_profile
+        profile_dir = create_profile("testbot", no_alias=True)
+
+        assert (profile_dir / "home" / ".config" / "gh").resolve() == default_gh.resolve()
+        assert (profile_dir / ".config" / "gh").resolve() == default_gh.resolve()
+
+    def test_create_profile_does_not_overwrite_profile_local_gh_config(
+        self, tmp_path, monkeypatch
+    ):
+        """Existing profile-local gh config wins over shared config."""
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        default_gh = tmp_path / ".config" / "gh"
+        default_gh.mkdir(parents=True)
+        (home / "config.yaml").write_text("profiles:\n  share_gh_config: true\n")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        from hermes_cli.profiles import create_profile
+
+        profile_dir = create_profile("source", no_alias=True)
+        local_gh = profile_dir / "home" / ".config" / "gh"
+        local_gh.unlink()
+        local_gh.mkdir()
+        (local_gh / "hosts.yml").write_text("github.com:\n  user: profile-local\n")
+
+        from hermes_cli.profiles import _link_shared_gh_config
+        _link_shared_gh_config(profile_dir)
+
+        assert local_gh.is_dir()
+        assert not local_gh.is_symlink()
+        assert "profile-local" in (local_gh / "hosts.yml").read_text()
+
 
 # ---------------------------------------------------------------------------
 # Python process HOME unchanged


### PR DESCRIPTION
## Summary
- add opt-in `profiles.share_gh_config` config for sharing default GitHub CLI auth with new Hermes profiles
- symlink shared `gh` config into both `{profile}/home/.config/gh` and `{profile}/.config/gh`
- preserve profile-local `gh` config if a profile already has one
- add coverage for profile bootstrap symlink behavior

## Why
Hermes profiles isolate subprocess `HOME`, which means specialist/worker profiles do not see the user's existing `gh` login under `~/.config/gh`. That makes profile-based workers fail on `gh pr create` even when the default profile is authenticated. This keeps isolation by default while giving users an explicit opt-in for shared GitHub CLI auth.

## Test Plan
- [x] `./venv/bin/python -m pytest tests/test_subprocess_home_isolation.py -q`
- [x] `./venv/bin/python -m pytest tests/hermes_cli/test_profiles.py tests/test_hermes_home_profile_warning.py tests/test_subprocess_home_isolation.py -q`
- [x] manual smoke: `HERMES_HOME=<temp> ./venv/bin/hermes profile create gh-share-smoke --no-alias` with `profiles.share_gh_config: true`, then verified both symlinks point to `/home/walter/.config/gh`
- [x] attempted full `./venv/bin/python -m pytest tests/ -v`; run timed out/was terminated before completion in this environment. A transient pair of Discord attachment tests failed during the broad parallel run but passed when rerun directly:
  - `tests/gateway/test_send_image_file.py::TestDiscordSendImageFile::test_send_document_uploads_file_attachment`
  - `tests/gateway/test_send_image_file.py::TestDiscordSendImageFile::test_send_video_uploads_file_attachment`

## Platforms tested
- Linux x86_64
- Python 3.11.15
- git-lfs 3.7.1
- Node v22.22.2 / npm 10.9.7
