### PR TITLE
feat(gateway): respect reply_to_mode in base adapter

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1265,6 +1265,28 @@ class BasePlatformAdapter(ABC):
         # _keep_typing skips send_typing when the chat_id is in this set.
         self._typing_paused: set = set()
 
+    def _resolve_reply_to(self, event: "MessageEvent") -> Optional[str]:
+        """Return the message ID to reply to, or None if reply threading is off.
+
+        Respects ``reply_to_mode`` from the platform config:
+          - ``"off"``   → never reply-thread (return None)
+          - ``"first"`` → reply to the triggering message (default)
+          - ``"all"``   → reply to the triggering message
+
+        For Feishu threads, uses ``reply_to_message_id`` when available
+        (preserves upstream behaviour for that platform).
+        """
+        if getattr(self.config, "reply_to_mode", "first") == "off":
+            return None
+        # Feishu threads use reply_to_message_id when in a thread context
+        if (
+            event.source.platform == Platform.FEISHU
+            and event.source.thread_id
+            and event.reply_to_message_id
+        ):
+            return event.reply_to_message_id
+        return event.message_id
+
     @property
     def has_fatal_error(self) -> bool:
         return self._fatal_error_message is not None
@@ -2506,13 +2528,7 @@ class BasePlatformAdapter(ABC):
                 _r = await self._send_with_retry(
                     chat_id=event.source.chat_id,
                     content=_text,
-                    reply_to=(
-                        event.reply_to_message_id
-                        if event.source.platform == Platform.FEISHU
-                        and event.source.thread_id
-                        and event.reply_to_message_id
-                        else event.message_id
-                    ),
+                    reply_to=self._resolve_reply_to(event),
                     metadata=thread_meta,
                 )
                 if _eph_ttl > 0 and _r.success and _r.message_id:
@@ -2612,13 +2628,7 @@ class BasePlatformAdapter(ABC):
                         _r = await self._send_with_retry(
                             chat_id=event.source.chat_id,
                             content=_text,
-                            reply_to=(
-                                event.reply_to_message_id
-                                if event.source.platform == Platform.FEISHU
-                                and event.source.thread_id
-                                and event.reply_to_message_id
-                                else event.message_id
-                            ),
+                            reply_to=self._resolve_reply_to(event),
                             metadata=_thread_meta,
                         )
                         if _eph_ttl > 0 and _r.success and _r.message_id:
@@ -2830,15 +2840,10 @@ class BasePlatformAdapter(ABC):
                 # Send the text portion
                 if text_content:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
-                    _reply_anchor = (
-                        event.reply_to_message_id
-                        if event.source.platform == Platform.FEISHU and event.source.thread_id and event.reply_to_message_id
-                        else event.message_id
-                    )
                     result = await self._send_with_retry(
                         chat_id=event.source.chat_id,
                         content=text_content,
-                        reply_to=_reply_anchor,
+                        reply_to=self._resolve_reply_to(event),
                         metadata=_thread_metadata,
                     )
                     _record_delivery(result)

--- a/tests/gateway/test_base_adapter_reply_to_mode.py
+++ b/tests/gateway/test_base_adapter_reply_to_mode.py
@@ -1,0 +1,141 @@
+"""Tests for BasePlatformAdapter._resolve_reply_to — gateway-level reply threading.
+
+Covers the reply_to_mode config honouring at the base adapter layer,
+which orchestrates gateway response sends for ALL platforms (not just
+Discord, which has its own adapter-level implementation).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete subclass — BasePlatformAdapter is ABC
+# ---------------------------------------------------------------------------
+
+class _StubAdapter(BasePlatformAdapter):
+    """Trivially instantiable subclass for testing base-class helpers."""
+
+    def __init__(self, config=None, platform=Platform.DISCORD):
+        cfg = config or PlatformConfig(enabled=True, token="t")
+        super().__init__(config=cfg, platform=platform)
+
+    # Satisfy remaining abstract methods (not exercised in these tests)
+    async def connect(self):
+        pass
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, text, **kw):
+        pass
+
+    async def _send_with_retry(self, *, chat_id, content, reply_to=None, metadata=None):
+        return MagicMock(success=True, message_id="fake")
+
+    async def get_chat_info(self, chat_id: str):
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_event(*, platform=Platform.DISCORD, message_id="123", thread_id=None,
+                reply_to_message_id=None):
+    """Build a minimal MessageEvent for _resolve_reply_to tests."""
+    source = SimpleNamespace(platform=platform, chat_id="C1", thread_id=thread_id)
+    return MessageEvent(
+        source=source,
+        text="hello",
+        message_id=message_id,
+        reply_to_message_id=reply_to_message_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestResolveReplyTo:
+    """Tests for _resolve_reply_to respecting reply_to_mode."""
+
+    def test_off_mode_returns_none(self):
+        adapter = _StubAdapter(PlatformConfig(enabled=True, token="t", reply_to_mode="off"))
+        event = _make_event(message_id="100")
+        assert adapter._resolve_reply_to(event) is None
+
+    def test_off_mode_ignores_feishu_thread_reply(self):
+        """Even in a Feishu thread with reply_to_message_id, 'off' wins."""
+        adapter = _StubAdapter(PlatformConfig(enabled=True, token="t", reply_to_mode="off"))
+        event = _make_event(
+            platform=Platform.FEISHU, message_id="100",
+            thread_id="T1", reply_to_message_id="99",
+        )
+        assert adapter._resolve_reply_to(event) is None
+
+    def test_first_mode_returns_message_id(self):
+        adapter = _StubAdapter(PlatformConfig(enabled=True, token="t", reply_to_mode="first"))
+        event = _make_event(message_id="100")
+        assert adapter._resolve_reply_to(event) == "100"
+
+    def test_all_mode_returns_message_id(self):
+        adapter = _StubAdapter(PlatformConfig(enabled=True, token="t", reply_to_mode="all"))
+        event = _make_event(message_id="100")
+        assert adapter._resolve_reply_to(event) == "100"
+
+    def test_default_mode_is_first(self):
+        """No reply_to_mode set → defaults to 'first' → returns message_id."""
+        adapter = _StubAdapter(PlatformConfig(enabled=True, token="t"))
+        event = _make_event(message_id="100")
+        assert adapter._resolve_reply_to(event) == "100"
+
+    def test_feishu_thread_returns_reply_to_message_id(self):
+        """Feishu threads should use reply_to_message_id when available."""
+        adapter = _StubAdapter(PlatformConfig(enabled=True, token="t", reply_to_mode="first"))
+        event = _make_event(
+            platform=Platform.FEISHU, message_id="100",
+            thread_id="T1", reply_to_message_id="99",
+        )
+        assert adapter._resolve_reply_to(event) == "99"
+
+    def test_feishu_non_thread_returns_message_id(self):
+        """Feishu without thread_id falls through to message_id."""
+        adapter = _StubAdapter(PlatformConfig(enabled=True, token="t", reply_to_mode="first"))
+        event = _make_event(
+            platform=Platform.FEISHU, message_id="100",
+            thread_id=None, reply_to_message_id="99",
+        )
+        assert adapter._resolve_reply_to(event) == "100"
+
+    def test_feishu_thread_no_reply_to_returns_message_id(self):
+        """Feishu thread without reply_to_message_id falls back to message_id."""
+        adapter = _StubAdapter(PlatformConfig(enabled=True, token="t", reply_to_mode="first"))
+        event = _make_event(
+            platform=Platform.FEISHU, message_id="100",
+            thread_id="T1", reply_to_message_id=None,
+        )
+        assert adapter._resolve_reply_to(event) == "100"
+
+    def test_discord_ignores_reply_to_message_id(self):
+        """Non-Feishu platforms always return message_id, ignoring reply_to_message_id."""
+        adapter = _StubAdapter(PlatformConfig(enabled=True, token="t", reply_to_mode="first"))
+        event = _make_event(
+            platform=Platform.DISCORD, message_id="100",
+            reply_to_message_id="99",
+        )
+        assert adapter._resolve_reply_to(event) == "100"
+
+    def test_telegram_ignores_reply_to_message_id(self):
+        """Telegram (non-Feishu) returns message_id."""
+        adapter = _StubAdapter(PlatformConfig(enabled=True, token="t", reply_to_mode="first"))
+        event = _make_event(
+            platform=Platform.TELEGRAM, message_id="100",
+            reply_to_message_id="99",
+        )
+        assert adapter._resolve_reply_to(event) == "100"


### PR DESCRIPTION
## What does this PR do?

The `BasePlatformAdapter` (which orchestrates the gateway-level response flow for **all** platforms) was ignoring `reply_to_mode` from `PlatformConfig` and always passing `reply_to=event.message_id` to `_send_with_retry`. This meant setting `reply_to_mode: off` in `config.yaml` (or the `DISCORD_REPLY_TO_MODE=off` / `TELEGRAM_REPLY_TO_MODE=off` env vars) had **no effect** at the gateway orchestration layer — every response was threaded to the triggering message regardless.

The Discord adapter's own `send()` method already respected `reply_to_mode` ("off" skips message references, "first" replies on first chunk, "all" replies on all chunks), but the base adapter was bypassing that entirely by hardcoding `reply_to` at the three `_send_with_retry` call sites in the response delivery path.

## Related Issue

No open issue — discovered during fleet deployment configuration.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: Add `_resolve_reply_to(event)` helper to `BasePlatformAdapter` that checks `self.config.reply_to_mode` and returns `None` when `"off"`
- Replace 3 hardcoded `reply_to` ternary expressions with calls to the helper
- Preserve Feishu-specific `reply_to_message_id` behavior for threads (existing upstream logic)
- `tests/gateway/test_base_adapter_reply_to_mode.py` (NEW): 10 tests covering all `reply_to_mode` values + Feishu thread behavior + non-Feishu fallback

## How to Test

1. Set `reply_to_mode: off` in the Discord (or any platform) config section
2. Send a message in a channel — the bot response should **not** be threaded to the triggering message
3. Set `reply_to_mode: first` (default) — response threads to the triggering message (no change from current behavior)
4. Run tests: `pytest tests/gateway/test_base_adapter_reply_to_mode.py -v` (10/10 pass)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(gateway):`, `test(gateway):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] N/A — no new config keys, no architecture changes, no tool behavior changes