### PR TITLE
Avoid clobbering symlinked hermes launcher during install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1291,17 +1291,21 @@ setup_path() {
     # We intentionally clear PYTHONPATH/PYTHONHOME here so inherited env vars
     # can't make this launcher import modules from another checkout.
     mkdir -p "$command_link_dir"
-    # Older installs created this path as a symlink to $HERMES_BIN. Without
-    # the rm, `cat >` follows the symlink and overwrites the venv pip entry
-    # point with this shim — making `exec "$HERMES_BIN"` self-recurse. (#21454)
+    # Older installs may leave ~/.local/bin/hermes as a symlink (#21454) or
+    # point back into the venv entry point. Removing any existing path
+    # before writing avoids self-recursing shims; writing via mktemp+mv
+    # avoids redirect-following overwriting the symlink target on some shells.
     rm -f "$command_link_dir/hermes"
-    cat > "$command_link_dir/hermes" <<EOF
+    local launcher_tmp
+    launcher_tmp="$(mktemp "$command_link_dir/.hermes-launcher.XXXXXX")"
+    cat > "$launcher_tmp" <<EOF
 #!/usr/bin/env bash
 unset PYTHONPATH
 unset PYTHONHOME
 exec "$HERMES_BIN" "\$@"
 EOF
-    chmod +x "$command_link_dir/hermes"
+    chmod +x "$launcher_tmp"
+    mv -f "$launcher_tmp" "$command_link_dir/hermes"
     log_success "Installed hermes launcher → $command_link_display_dir/hermes"
 
     if [ "$DISTRO" = "termux" ]; then

--- a/tests/test_install_sh_pythonpath_sanitization.py
+++ b/tests/test_install_sh_pythonpath_sanitization.py
@@ -46,8 +46,8 @@ def test_setup_path_does_not_clobber_symlinked_venv_entrypoint(tmp_path) -> None
     runs — no systemd or gateway mutation.
     """
     install_source = INSTALL_SH.read_text(encoding="utf-8")
-    install_prelude, _, _ = install_source.rpartition("\nmain\n")
-    assert install_prelude, "expected trailing `main` call in scripts/install.sh"
+    install_prelude, _, _ = install_source.rpartition('\nif [ -n "$ENSURE_DEPS" ]')
+    assert install_prelude, "expected install.sh entry dispatch block"
 
     install_dir = tmp_path / "install"
     home = tmp_path / "home"

--- a/tests/test_install_sh_pythonpath_sanitization.py
+++ b/tests/test_install_sh_pythonpath_sanitization.py
@@ -5,6 +5,9 @@ PYTHONPATH/PYTHONHOME can shadow the freshly installed checkout. The installer
 must sanitize those vars both during installation and at runtime launch.
 """
 
+import os
+import stat
+import subprocess
 from pathlib import Path
 
 
@@ -24,7 +27,63 @@ def test_hermes_launcher_wrapper_clears_python_env_before_exec() -> None:
     text = INSTALL_SH.read_text()
 
     # Wrapper should clear env and forward args untouched to the venv entrypoint.
-    assert 'cat > "$command_link_dir/hermes" <<EOF' in text
+    assert 'launcher_tmp="$(mktemp "$command_link_dir/.hermes-launcher.XXXXXX")"' in text
+    assert 'cat > "$launcher_tmp" <<EOF' in text
     assert 'unset PYTHONPATH' in text
     assert 'unset PYTHONHOME' in text
     assert 'exec "$HERMES_BIN" "\\$@"' in text
+    assert 'mv -f "$launcher_tmp" "$command_link_dir/hermes"' in text
+
+
+def test_setup_path_does_not_clobber_symlinked_venv_entrypoint(tmp_path) -> None:
+    """setup_path() must replace the launcher symlink, not overwrite its target."""
+    install_source = INSTALL_SH.read_text(encoding="utf-8")
+    install_prelude, _, _ = install_source.rpartition("\nmain\n")
+    assert install_prelude, "expected trailing `main` call in scripts/install.sh"
+
+    install_dir = tmp_path / "install"
+    home = tmp_path / "home"
+    venv_bin = install_dir / "venv" / "bin"
+    launcher_dir = home / ".local" / "bin"
+    hermes_bin = venv_bin / "hermes"
+    launcher = launcher_dir / "hermes"
+
+    venv_bin.mkdir(parents=True)
+    launcher_dir.mkdir(parents=True)
+    hermes_bin.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    hermes_bin.chmod(hermes_bin.stat().st_mode | stat.S_IXUSR)
+    launcher.symlink_to(hermes_bin)
+
+    subprocess.run(
+        [
+            "bash",
+            "-lc",
+            f"""
+            set -euo pipefail
+            {install_prelude}
+            log_info() {{ :; }}
+            log_success() {{ :; }}
+            log_warn() {{ :; }}
+            USE_VENV=true
+            INSTALL_DIR="$TEST_INSTALL_DIR"
+            HOME="$TEST_HOME"
+            DISTRO=linux
+            ROOT_FHS_LAYOUT=false
+            setup_path
+            """,
+        ],
+        check=True,
+        env={
+            **os.environ,
+            "TEST_INSTALL_DIR": str(install_dir),
+            "TEST_HOME": str(home),
+        },
+        text=True,
+    )
+
+    assert hermes_bin.read_text(encoding="utf-8") == "#!/bin/sh\nexit 0\n"
+    assert not launcher.is_symlink()
+    launcher_text = launcher.read_text(encoding="utf-8")
+    assert 'unset PYTHONPATH' in launcher_text
+    assert 'unset PYTHONHOME' in launcher_text
+    assert f'exec "{hermes_bin}" "$@"' in launcher_text

--- a/tests/test_install_sh_pythonpath_sanitization.py
+++ b/tests/test_install_sh_pythonpath_sanitization.py
@@ -10,6 +10,8 @@ import stat
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
@@ -35,8 +37,14 @@ def test_hermes_launcher_wrapper_clears_python_env_before_exec() -> None:
     assert 'mv -f "$launcher_tmp" "$command_link_dir/hermes"' in text
 
 
+@pytest.mark.live_system_guard_bypass
 def test_setup_path_does_not_clobber_symlinked_venv_entrypoint(tmp_path) -> None:
-    """setup_path() must replace the launcher symlink, not overwrite its target."""
+    """setup_path() must replace the launcher symlink, not overwrite its target.
+
+    The bash -lc script embeds scripts/install.sh; the live-system subprocess
+    guard matches ``systemctl`` substrings inside that text. Only ``setup_path``
+    runs — no systemd or gateway mutation.
+    """
     install_source = INSTALL_SH.read_text(encoding="utf-8")
     install_prelude, _, _ = install_source.rpartition("\nmain\n")
     assert install_prelude, "expected trailing `main` call in scripts/install.sh"

--- a/tests/test_install_sh_symlink_stomp.py
+++ b/tests/test_install_sh_symlink_stomp.py
@@ -31,7 +31,8 @@ def _extract_setup_path_shim_block() -> str:
     """Return the install.sh shim-write block used by setup_path()."""
     text = INSTALL_SH.read_text()
     match = re.search(
-        r"(?P<block>mkdir -p \"\$command_link_dir\".*?chmod \+x \"\$command_link_dir/hermes\")",
+        r"(?P<block>mkdir -p \"\$command_link_dir\".*?"
+        r"mv -f \"\$launcher_tmp\" \"\$command_link_dir/hermes\")",
         text,
         re.DOTALL,
     )
@@ -45,16 +46,16 @@ def test_setup_path_shim_block_removes_old_link_before_writing() -> None:
     """Static guard: the rm must precede the cat heredoc, not follow it."""
     block = _extract_setup_path_shim_block()
     rm_idx = block.find('rm -f "$command_link_dir/hermes"')
-    cat_idx = block.find('cat > "$command_link_dir/hermes" <<EOF')
+    cat_idx = block.find('cat > "$launcher_tmp" <<EOF')
     assert rm_idx != -1, (
         "setup_path() must `rm -f` $command_link_dir/hermes before the "
         "`cat >` heredoc, otherwise an existing symlink (left by older "
         "installs) will be followed and the pip entry point overwritten. "
         "See #21454."
     )
-    assert cat_idx != -1, "expected `cat >` heredoc still present"
+    assert cat_idx != -1, "expected mktemp+heredoc launcher write still present"
     assert rm_idx < cat_idx, (
-        "`rm -f` must come *before* the `cat >` heredoc, not after."
+        "`rm -f` must come *before* the launcher heredoc, not after."
     )
 
 
@@ -90,8 +91,15 @@ def test_re_running_setup_path_block_preserves_pip_entry_point(tmp_path: Path) -
     assert shim_path.is_symlink()
 
     block = _extract_setup_path_shim_block()
-    # Drive the block with the real env vars setup_path() sets.
-    script = f'set -e\nHERMES_BIN={pip_entry!s}\ncommand_link_dir={command_link_dir!s}\n{block}\n'
+    # Drive the block inside a function so `local` declarations are valid.
+    script = f"""set -e
+HERMES_BIN={pip_entry!s}
+command_link_dir={command_link_dir!s}
+run_setup_path_block() {{
+{block}
+}}
+run_setup_path_block
+"""
     result = subprocess.run(
         ["bash", "-c", script],
         capture_output=True,


### PR DESCRIPTION
## Summary
Prevent `scripts/install.sh` from overwriting the real `venv/bin/hermes` entrypoint when the user-facing launcher path is a symlink back into the venv.

## Changes
- write the launcher shim to a temporary file before moving it into `hermes`
- keep the existing `PYTHONPATH` / `PYTHONHOME` sanitization behavior intact
- add a regression test that reproduces the symlinked-launcher layout and verifies the venv entrypoint is preserved

## Tests
- [x] `scripts/run_tests.sh tests/test_install_sh_pythonpath_sanitization.py`