### PR TITLE
fix(cli): CJK/emoji panel border alignment

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2272,6 +2272,54 @@ def save_config_value(key_path: str, value: any) -> bool:
 
 
 # ============================================================================
+# Display-width helpers (CJK / emoji aware)
+# ============================================================================
+
+def _display_width(text: str) -> int:
+    """Return terminal display width (columns) accounting for CJK and emoji."""
+    try:
+        from prompt_toolkit.utils import get_cwidth
+        return get_cwidth(text or "")
+    except Exception:
+        return len(text or "")
+
+
+def _display_ljust(text: str, width: int) -> str:
+    """Left-justify *text* to *width* terminal columns."""
+    pad = max(0, width - _display_width(text))
+    return text + " " * pad
+
+
+def _display_wrap(text: str, width: int, subsequent_indent: str = "") -> list[str]:
+    """Word-wrap *text* to *width* terminal columns (CJK-aware)."""
+    if not text:
+        return [""]
+    width = max(8, width)
+    lines: list[str] = []
+    current = ""
+    current_width = 0
+    indent = ""
+
+    for word in text.split():
+        word_w = _display_width(word)
+        sep = " " if current else indent
+        sep_w = _display_width(sep)
+
+        if current and current_width + sep_w + word_w > width:
+            lines.append(current)
+            indent = subsequent_indent
+            current = indent + word
+            current_width = _display_width(indent) + word_w
+        else:
+            current += sep + word
+            current_width += sep_w + word_w
+
+    if current:
+        lines.append(current)
+    return lines or [""]
+
+
+# ============================================================================
 # HermesCLI Class
 # ============================================================================
 
@@ -10002,24 +10050,17 @@ class HermesCLI:
 
         def _panel_box_width(title_text: str, content_lines: list[str], min_width: int = 46, max_width: int = 76) -> int:
             term_cols = shutil.get_terminal_size((100, 20)).columns
-            longest = max([len(title_text)] + [len(line) for line in content_lines] + [min_width - 4])
+            longest = max([_display_width(title_text)] + [_display_width(line) for line in content_lines] + [min_width - 4])
             inner = min(max(longest + 4, min_width - 2), max_width - 2, max(24, term_cols - 6))
             return inner + 2
 
         def _wrap_panel_text(text: str, width: int, subsequent_indent: str = "") -> list[str]:
-            wrapped = textwrap.wrap(
-                text,
-                width=max(8, width),
-                replace_whitespace=False,
-                drop_whitespace=False,
-                subsequent_indent=subsequent_indent,
-            )
-            return wrapped or [""]
+            return _display_wrap(text, width, subsequent_indent)
 
         def _append_panel_line(lines, border_style: str, content_style: str, text: str, box_width: int) -> None:
             inner_width = max(0, box_width - 2)
             lines.append((border_style, "│ "))
-            lines.append((content_style, text.ljust(inner_width)))
+            lines.append((content_style, _display_ljust(text, inner_width)))
             lines.append((border_style, " │\n"))
 
         def _append_blank_panel_line(lines, border_style: str, box_width: int) -> None:
@@ -10032,7 +10073,7 @@ class HermesCLI:
         show_full = state.get("show_full", False)
 
         title = "⚠️  Dangerous Command"
-        cmd_display = command if show_full or len(command) <= 70 else command[:70] + '...'
+        cmd_display = command if show_full or _display_width(command) <= 70 else command[:70] + '...'
         choice_labels = {
             "once": "Allow once",
             "session": "Allow for this session",
@@ -12342,24 +12383,17 @@ class HermesCLI:
         def _panel_box_width(title: str, content_lines: list[str], min_width: int = 46, max_width: int = 76) -> int:
             """Choose a stable panel width wide enough for the title and content."""
             term_cols = shutil.get_terminal_size((100, 20)).columns
-            longest = max([len(title)] + [len(line) for line in content_lines] + [min_width - 4])
+            longest = max([_display_width(title)] + [_display_width(line) for line in content_lines] + [min_width - 4])
             inner = min(max(longest + 4, min_width - 2), max_width - 2, max(24, term_cols - 6))
             return inner + 2  # account for the single leading/trailing spaces inside borders
 
         def _wrap_panel_text(text: str, width: int, subsequent_indent: str = "") -> list[str]:
-            wrapped = textwrap.wrap(
-                text,
-                width=max(8, width),
-                break_long_words=False,
-                break_on_hyphens=False,
-                subsequent_indent=subsequent_indent,
-            )
-            return wrapped or [""]
+            return _display_wrap(text, width, subsequent_indent)
 
         def _append_panel_line(lines, border_style: str, content_style: str, text: str, box_width: int) -> None:
             inner_width = max(0, box_width - 2)
             lines.append((border_style, "│ "))
-            lines.append((content_style, text.ljust(inner_width)))
+            lines.append((content_style, _display_ljust(text, inner_width)))
             lines.append((border_style, " │\n"))
 
         def _append_blank_panel_line(lines, border_style: str, box_width: int) -> None:
@@ -12484,7 +12518,7 @@ class HermesCLI:
             # Box top border
             lines.append(('class:clarify-border', '╭─ '))
             lines.append(('class:clarify-title', 'Hermes needs your input'))
-            lines.append(('class:clarify-border', ' ' + ('─' * max(0, box_width - len("Hermes needs your input") - 3)) + '╮\n'))
+            lines.append(('class:clarify-border', ' ' + ('─' * max(0, box_width - _display_width("Hermes needs your input") - 3)) + '╮\n'))
             if not use_compact_chrome:
                 _append_blank_panel_line(lines, 'class:clarify-border', box_width)
 
@@ -12551,7 +12585,7 @@ class HermesCLI:
             lines = []
             lines.append(('class:sudo-border', '╭─ '))
             lines.append(('class:sudo-title', title))
-            lines.append(('class:sudo-border', ' ' + ('─' * max(0, box_width - len(title) - 3)) + '╮\n'))
+            lines.append(('class:sudo-border', ' ' + ('─' * max(0, box_width - _display_width(title) - 3)) + '╮\n'))
             _append_blank_panel_line(lines, 'class:sudo-border', box_width)
             _append_panel_line(lines, 'class:sudo-border', 'class:sudo-text', body, box_width)
             _append_blank_panel_line(lines, 'class:sudo-border', box_width)
@@ -12583,7 +12617,7 @@ class HermesCLI:
             lines = []
             lines.append(('class:sudo-border', '╭─ '))
             lines.append(('class:sudo-title', title))
-            lines.append(('class:sudo-border', ' ' + ('─' * max(0, box_width - len(title) - 3)) + '╮\n'))
+            lines.append(('class:sudo-border', ' ' + ('─' * max(0, box_width - _display_width(title) - 3)) + '╮\n'))
             _append_blank_panel_line(lines, 'class:sudo-border', box_width)
             _append_panel_line(lines, 'class:sudo-border', 'class:sudo-text', prompt, box_width)
             if help_text:
@@ -12675,7 +12709,7 @@ class HermesCLI:
             lines = []
             lines.append(('class:clarify-border', '╭─ '))
             lines.append(('class:clarify-title', title))
-            lines.append(('class:clarify-border', ' ' + ('─' * max(0, box_width - len(title) - 3)) + '╮\n'))
+            lines.append(('class:clarify-border', ' ' + ('─' * max(0, box_width - _display_width(title) - 3)) + '╮\n'))
             _append_blank_panel_line(lines, 'class:clarify-border', box_width)
             _append_panel_line(lines, 'class:clarify-border', 'class:clarify-hint', hint, box_width)
             _append_blank_panel_line(lines, 'class:clarify-border', box_width)

--- a/tests/cli/test_display_width.py
+++ b/tests/cli/test_display_width.py
@@ -1,0 +1,83 @@
+import pytest
+
+from cli import _display_width, _display_ljust, _display_wrap
+
+
+class TestDisplayWidth:
+    def test_ascii_string(self):
+        assert _display_width("hello") == 5
+
+    def test_empty_string(self):
+        assert _display_width("") == 0
+
+    def test_none_input(self):
+        assert _display_width(None) == 0
+
+    def test_cjk_characters(self):
+        # Each CJK character occupies 2 terminal columns
+        assert _display_width("危险") == 4
+
+    def test_mixed_ascii_and_cjk(self):
+        # "hi" = 2 columns, "危险" = 4 columns
+        assert _display_width("hi危险") == 6
+
+    def test_emoji(self):
+        # Exact width depends on get_cwidth implementation; at minimum 1 column
+        assert _display_width("⚠️") >= 1
+
+    def test_wider_than_len(self):
+        s = "危险命令"
+        assert _display_width(s) >= len(s)
+
+
+class TestDisplayLjust:
+    def test_ascii_padding(self):
+        result = _display_ljust("hi", 10)
+        assert result.startswith("hi")
+        assert len(result) == 10
+
+    def test_cjk_padding(self):
+        # "危险" has display width 4; padding to 10 means 6 spaces appended
+        result = _display_ljust("危险", 10)
+        assert _display_width(result) == 10
+
+    def test_already_wide_enough(self):
+        result = _display_ljust("hello world", 5)
+        assert result == "hello world"
+
+    def test_exact_width(self):
+        result = _display_ljust("hello", 5)
+        assert result == "hello"
+
+
+class TestDisplayWrap:
+    def test_short_text_no_wrap(self):
+        assert _display_wrap("hello world", 20) == ["hello world"]
+
+    def test_wraps_at_width(self):
+        lines = _display_wrap("one two three four", 10)
+        assert len(lines) > 1
+        for line in lines:
+            assert _display_width(line) <= 10
+
+    def test_cjk_wraps_correctly(self):
+        # Each word ("危险", "命令", "执行") is 4 columns wide; two words = 9 cols
+        # which exceeds width=6, so each word should land on its own line
+        lines = _display_wrap("危险 命令 执行", 6)
+        for line in lines:
+            assert _display_width(line) <= 6
+
+    def test_subsequent_indent(self):
+        lines = _display_wrap("one two three", 8, subsequent_indent="  ")
+        assert len(lines) > 1
+        for line in lines[1:]:
+            assert line.startswith("  ")
+
+    def test_empty_string(self):
+        assert _display_wrap("", 20) == [""]
+
+    def test_minimum_width_clamp(self):
+        # Width of 2 is clamped to 8 internally; must not raise
+        lines = _display_wrap("hello world", 2)
+        assert isinstance(lines, list)
+        assert len(lines) >= 1


### PR DESCRIPTION
## Summary

- Adds display-width helpers using prompt_toolkit's get_cwidth() for terminal column-accurate width
- Replaces len() with _display_width() in 8 panel rendering locations (approval, clarify, sudo, secret, model picker)
- Replaces text.ljust() and textwrap.wrap() with CJK-aware equivalents
- No new dependencies

## Root cause

len() returns code-point count, but CJK/emoji occupy 2 terminal columns. Panels were computed too narrow.

## Test plan

- [x] 17 new tests for _display_width, _display_ljust, _display_wrap
- [x] No regressions in full test suite

Closes #20621