### PR TITLE
fix: live model discovery for custom providers in /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1605,6 +1605,7 @@ def list_authenticated_providers(
                     "slug": slug,
                     "name": display_name,
                     "api_url": api_url,
+                    "api_key": api_key,
                     "models": [],
                 }
 
@@ -1666,6 +1667,29 @@ def list_authenticated_providers(
             _grp_url_norm = _pair_key[1]
             if _grp_url_norm and _grp_url_norm in _builtin_endpoints:
                 continue
+
+            # Live model discovery for custom provider endpoints.
+            # If the endpoint exposes OpenAI-compatible /v1/models, fetch the
+            # live model list so the picker shows all available models instead
+            # of just the single model: field from config. Falls back to the
+            # static model list from config if the endpoint is unreachable.
+            api_url = grp["api_url"]
+            api_key = grp.get("api_key") or ""
+            if api_url and api_key:
+                try:
+                    from hermes_cli.models import fetch_api_models
+                    live_models = fetch_api_models(api_key, api_url)
+                    if live_models:
+                        # Merge live models with any statically configured
+                        # models (preserve config order, append new ones)
+                        existing = set(grp["models"])
+                        for m in live_models:
+                            if m not in existing:
+                                grp["models"].append(m)
+                                existing.add(m)
+                except Exception:
+                    pass
+
             results.append({
                 "slug": slug,
                 "name": grp["name"],


### PR DESCRIPTION
## Problem

Custom providers with 600+ models on their `/v1/models` endpoint only show 1 model in the `/model` picker because Section 4 of `list_authenticated_providers()` only reads the static `model:` and `models:` fields from config.

Section 3 (`providers:` / user-defined endpoints) already fetches the live model list via `fetch_api_models()` — this PR adds the same behavior to Section 4 (`custom_providers:`).

## Changes

- Store `api_key` in the group dict (needed for the fetch call)
- Add live `/v1/models` discovery for custom provider endpoints that have an `api_key` configured
- Merge live model list with any statically configured models
- Graceful fallback if the endpoint is unreachable (keeps static config models)

## Fix for

Closes #20582

## Provider-agnostic

Works for any OpenAI-compatible endpoint that exposes `/v1/models`. No provider-specific code.