### PR TITLE
fix(update): keep npm fallback out of update installs

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5622,15 +5622,16 @@ def _run_npm_install_deterministic(
     *,
     extra_args: tuple[str, ...] = (),
     capture_output: bool = True,
+    allow_install_fallback: bool = True,
 ) -> subprocess.CompletedProcess:
     """Run a deterministic npm install that does not mutate ``package-lock.json``.
 
-    Prefers ``npm ci`` (strict, lockfile-preserving) when a lockfile is present;
-    falls back to ``npm install`` only if ``npm ci`` fails (e.g. lockfile out of
-    sync on a WIP checkout).  Without this, ``npm install`` on npm ≥ 10 silently
-    rewrites committed lockfiles (stripping ``"peer": true`` etc.), which leaves
-    the working tree dirty and causes the next ``hermes update`` to stash the
-    lockfile — repeatedly.
+    Prefers ``npm ci`` (strict, lockfile-preserving) when a lockfile is present.
+    The optional ``npm install`` fallback is useful for WIP checkouts with stale
+    lockfiles, but update paths disable it because ``npm install`` on npm >= 10
+    can silently rewrite committed lockfiles (stripping ``"peer": true`` etc.),
+    leaving the working tree dirty and causing repeated ``[REDACTED_INTERNAL_IP] update``
+    stashes.
     """
     lockfile = cwd / "package-lock.json"
     if lockfile.exists():
@@ -5644,7 +5645,7 @@ def _run_npm_install_deterministic(
             errors="replace",
             check=False,
         )
-        if ci_result.returncode == 0:
+        if ci_result.returncode == 0 or not allow_install_fallback:
             return ci_result
         # Fall through to `npm install` — lockfile may be out of sync on a
         # WIP fork/branch, or `npm ci` may not be available on very old npm.
@@ -6992,6 +6993,7 @@ def _update_node_dependencies() -> None:
             npm,
             path,
             extra_args=("--silent", "--no-fund", "--no-audit", "--progress=false"),
+            allow_install_fallback=False,
         )
         if result.returncode == 0:
             print(f"  ✓ {label}")

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from hermes_cli.main import cmd_update, PROJECT_ROOT
+from hermes_cli.main import PROJECT_ROOT, cmd_update, _run_npm_install_deterministic
 
 
 def _make_run_side_effect(branch="main", verify_ok=True, commit_count="0"):
@@ -86,6 +86,59 @@ class TestCmdUpdateBranchFallback:
         pull_cmds = [c for c in commands if "pull" in c]
         assert len(pull_cmds) == 1
         assert "main" in pull_cmds[0]
+
+    @patch("subprocess.run")
+    def test_deterministic_npm_install_can_disable_install_fallback(
+        self, mock_run, tmp_path
+    ):
+        (tmp_path / "package-lock.json").write_text("{}")
+        ci_result = subprocess.CompletedProcess(
+            ["/usr/bin/npm", "ci"], 1, stdout="", stderr="lockfile mismatch"
+        )
+        mock_run.return_value = ci_result
+
+        result = _run_npm_install_deterministic(
+            "/usr/bin/npm",
+            tmp_path,
+            extra_args=("--silent",),
+            allow_install_fallback=False,
+        )
+
+        assert result is ci_result
+        mock_run.assert_called_once_with(
+            ["/usr/bin/npm", "ci", "--silent"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+
+    @patch("subprocess.run")
+    def test_deterministic_npm_install_keeps_fallback_for_wip_checkouts(
+        self, mock_run, tmp_path
+    ):
+        (tmp_path / "package-lock.json").write_text("{}")
+        ci_result = subprocess.CompletedProcess(
+            ["/usr/bin/npm", "ci"], 1, stdout="", stderr="lockfile mismatch"
+        )
+        install_result = subprocess.CompletedProcess(
+            ["/usr/bin/npm", "install"], 0, stdout="", stderr=""
+        )
+        mock_run.side_effect = [ci_result, install_result]
+
+        result = _run_npm_install_deterministic(
+            "/usr/bin/npm",
+            tmp_path,
+            extra_args=("--silent",),
+        )
+
+        assert result is install_result
+        assert [call.args[0] for call in mock_run.call_args_list] == [
+            ["/usr/bin/npm", "ci", "--silent"],
+            ["/usr/bin/npm", "install", "--silent"],
+        ]
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")


### PR DESCRIPTION
## Summary
- Adds an explicit `allow_install_fallback` switch to the deterministic npm install helper.
- Keeps the fallback available for WIP/manual installs.
- Disables fallback during `hermes update` node dependency refresh so update paths do not silently rewrite committed `package-lock.json` files.

## Why
`npm install` can rewrite committed lockfiles on newer npm versions even when dependency versions are unchanged. In update paths that leaves the checkout dirty immediately after update and can cause repeated stashing/dirty-tree behavior. `hermes update` should use `npm ci` when a lockfile exists and fail cleanly if the lockfile is invalid instead of mutating it.

Supersedes stale/conflicting #19355.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py -q` attempted, but local shared venv lacks pip and wrapper failed while trying to install pytest-split.
- Fallback focused verification: `/Users/acc001ak/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_cmd_update.py -q -n 4` -> 9 passed.
- `git diff --check` -> passed.
