### PR TITLE
fix(agent,tools): use extract_content_or_reasoning for reasoning-model safety

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -24,7 +24,7 @@ import re
 import time
 from typing import Any, Dict, List, Optional
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning
 from agent.context_engine import ContextEngine
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
@@ -882,10 +882,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model
             response = call_llm(**call_kwargs)
-            content = response.choices[0].message.content
-            # Handle cases where content is not a string (e.g., dict from llama.cpp)
-            if not isinstance(content, str):
-                content = str(content) if content else ""
+            content = extract_content_or_reasoning(response)
             # Redact the summary output as well — the summarizer LLM may
             # ignore prompt instructions and echo back secrets verbatim.
             summary = redact_sensitive_text(content.strip())

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -8,7 +8,7 @@ import logging
 import threading
 from typing import Callable, Optional
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,7 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
         )
-        title = (response.choices[0].message.content or "").strip()
+        title = extract_content_or_reasoning(response)
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
         title = title.strip('"\'')
         if title.lower().startswith("title:"):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -750,7 +750,7 @@ def _smart_approve(command: str, description: str) -> str:
     (openai/codex#13860).
     """
     try:
-        from agent.auxiliary_client import call_llm
+        from agent.auxiliary_client import call_llm, extract_content_or_reasoning
 
         prompt = f"""You are a security reviewer for an AI coding agent. A terminal command was flagged by pattern matching as potentially dangerous.
 
@@ -773,7 +773,7 @@ Respond with exactly one word: APPROVE, DENY, or ESCALATE"""
             max_tokens=16,
         )
 
-        answer = (response.choices[0].message.content or "").strip().upper()
+        answer = extract_content_or_reasoning(response).strip().upper()
 
         if "APPROVE" in answer:
             return "approve"

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -554,6 +554,19 @@ class TrajectoryCompressor:
         return "\n\n".join(parts)
 
     @staticmethod
+    @staticmethod
+    def _extract_content(response) -> str:
+        """Extract text from an LLM response, handling reasoning models."""
+        try:
+            from agent.auxiliary_client import extract_content_or_reasoning
+            return extract_content_or_reasoning(response)
+        except Exception:
+            content = response.choices[0].message.content
+            if not isinstance(content, str):
+                content = str(content) if content else ""
+            return content.strip()
+
+    @staticmethod
     def _coerce_summary_content(content: Any) -> str:
         """Normalize summary-model output to a safe string."""
         if not isinstance(content, str):
@@ -624,7 +637,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                         _create_kwargs["temperature"] = summary_temperature
                     response = self.client.chat.completions.create(**_create_kwargs)
                 
-                summary = self._coerce_summary_content(response.choices[0].message.content)
+                summary = self._coerce_summary_content(self._extract_content(response))
                 return self._ensure_summary_prefix(summary)
                 
             except Exception as e:
@@ -693,7 +706,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
                         _create_kwargs["temperature"] = summary_temperature
                     response = await self._get_async_client().chat.completions.create(**_create_kwargs)
                 
-                summary = self._coerce_summary_content(response.choices[0].message.content)
+                summary = self._coerce_summary_content(self._extract_content(response))
                 return self._ensure_summary_prefix(summary)
                 
             except Exception as e:

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -554,7 +554,6 @@ class TrajectoryCompressor:
         return "\n\n".join(parts)
 
     @staticmethod
-    @staticmethod
     def _extract_content(response) -> str:
         """Extract text from an LLM response, handling reasoning models."""
         try:


### PR DESCRIPTION
## Summary

Multiple call sites accessed `response.choices[0].message.content` directly, which returns `None` for reasoning models (e.g. DeepSeek-R1). This caused silent failures in title generation, context compression, trajectory compression, and the approval tool.

## Changes (one commit per file)

| Commit | File | Change |
|--------|------|--------|
| `d19bd3d` | `agent/title_generator.py` | Import and use `extract_content_or_reasoning` |
| `b880cc6` | `agent/context_compressor.py` | Replace direct `.content` access with safe helper |
| `d57d401` | `trajectory_compressor.py` | Add `_extract_content()` static method wrapping the helper |
| `268cc31` | `tools/approval.py` | Use `extract_content_or_reasoning` for approval parsing |

## Testing

- All 4 files verified with `py_compile`.

Refs #18529, #20305