### PR TITLE
fix(gateway): route image documents through vision pipeline in Telegram

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3266,7 +3266,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     image_bytes = await file_obj.download_as_bytearray()
                     cached_path = cache_image_from_bytes(bytes(image_bytes), ext=ext)
                     event.media_urls = [cached_path]
-                    event.media_types = [f"image/{ext.lstrip('.')}"]
+                    event.media_types = [doc.mime_type]
                     event.message_type = MessageType.IMAGE
                     logger.info("[Telegram] Cached image document (%s) at %s", ext, cached_path)
                     await self.handle_message(event)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3250,6 +3250,28 @@ class TelegramAdapter(BasePlatformAdapter):
                     video_mime_to_ext = {v: k for k, v in SUPPORTED_VIDEO_TYPES.items()}
                     ext = video_mime_to_ext.get(doc.mime_type, "")
 
+                # Also resolve image MIME types (#20128)
+                if not ext and doc.mime_type:
+                    IMAGE_MIME_TO_EXT = {
+                        "image/jpeg": ".jpg", "image/png": ".png",
+                        "image/webp": ".webp", "image/gif": ".gif",
+                    }
+                    ext = IMAGE_MIME_TO_EXT.get(doc.mime_type, "")
+
+                # Image documents (.webp, .jpg, .png, .gif) should be routed
+                # through the image/vision pipeline, not rejected as unsupported. (#20128)
+                IMAGE_DOCUMENT_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
+                if ext in IMAGE_DOCUMENT_EXTS:
+                    file_obj = await doc.get_file()
+                    image_bytes = await file_obj.download_as_bytearray()
+                    cached_path = cache_image_from_bytes(bytes(image_bytes), ext=ext)
+                    event.media_urls = [cached_path]
+                    event.media_types = [f"image/{ext.lstrip('.')}"]
+                    event.message_type = MessageType.IMAGE
+                    logger.info("[Telegram] Cached image document (%s) at %s", ext, cached_path)
+                    await self.handle_message(event)
+                    return
+
                 if ext in SUPPORTED_VIDEO_TYPES:
                     file_obj = await doc.get_file()
                     video_bytes = await file_obj.download_as_bytearray()


### PR DESCRIPTION
## Summary

When users send images as **documents** (not as photos) in Telegram, the bot treated them as generic files — the vision pipeline was never invoked, so no OCR or image understanding.

## Changes

- Added `IMAGE_DOCUMENT_EXTS` set before the video/document checks.
- If the file extension matches an image type, downloads, caches via `cache_image_from_bytes()`, sets `event.message_type = MessageType.IMAGE`, and calls `handle_message()` early.
- Added `IMAGE_MIME_TO_EXT` for MIME type reverse lookup.

## Testing

- Syntax verified with `py_compile`.

Closes #20128