### PR TITLE
fix(update): refuse destructive recovery after ff-only failure

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7653,26 +7653,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 text=True,
             )
             if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
+                print("✗ Fast-forward update failed; refusing destructive recovery.")
+                stderr = pull_result.stderr.strip()
+                if stderr:
+                    print(f"  {stderr.splitlines()[0]}")
+                print("  Your checkout was not reset or otherwise rewritten.")
                 print(
-                    "  ⚠ Fast-forward not possible (history diverged), resetting to match remote..."
+                    f"  Resolve manually, then retry: git fetch origin && git pull --ff-only origin {branch}"
                 )
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
-                    cwd=PROJECT_ROOT,
-                    capture_output=True,
-                    text=True,
-                )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
-                    print(
-                        "  Try manually: git fetch origin && git reset --hard origin/main"
-                    )
-                    sys.exit(1)
+                sys.exit(1)
             update_succeeded = True
         finally:
             if auto_stash_ref is not None:

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -106,6 +106,36 @@ class TestCmdUpdateBranchFallback:
         pull_cmds = [c for c in commands if "pull" in c]
         assert len(pull_cmds) == 0
 
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_update_pull_failure_does_not_hard_reset(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        def side_effect(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+            if "rev-parse" in joined and "--abbrev-ref" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+            if "rev-parse" in joined and "--verify" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if "rev-list" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="1\n", stderr="")
+            if "pull" in joined:
+                return subprocess.CompletedProcess(
+                    cmd, 1, stdout="", stderr="fatal: Not possible to fast-forward"
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        mock_run.side_effect = side_effect
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_update(mock_args)
+
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert "Fast-forward update failed; refusing destructive recovery" in captured.out
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+        assert not any("reset --hard" in c for c in commands)
+
     @patch("shutil.which")
     @patch("subprocess.run")
     def test_update_refreshes_repo_and_tui_node_dependencies(


### PR DESCRIPTION
## Summary
- Removes the `git reset --hard origin/main` fallback when `hermes update` cannot fast-forward.
- Fails cleanly with manual recovery guidance instead of rewriting the checkout.
- Adds a regression test proving pull failure does not invoke `reset --hard`.

## Why
A raw update command should not destructively rewrite a local checkout after fast-forward fails. Stashing uncommitted changes does not make `reset --hard` safe for local commits, diverged branches, or unexpected repository state. Failing cleanly preserves user work and makes recovery explicit.

Supersedes the stale/conflicting raw-update safety direction from #18145 with a smaller current-upstream patch.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_cmd_update.py -q` attempted, but local shared venv lacks pip and wrapper failed while trying to install pytest-split.
- Fallback focused verification: `/Users/acc001ak/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_cmd_update.py -q -n 4` -> 8 passed.
- `git diff --check` -> passed.
