### PR TITLE
fix(cli): probe /v1/models for custom providers in model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1482,6 +1482,10 @@ def list_authenticated_providers(
             if not raw_name or not api_url:
                 continue
             api_key = (entry.get("api_key") or "").strip()
+            if not api_key:
+                key_env = str(entry.get("key_env", "") or entry.get("api_key_env", "") or "").strip()
+                if key_env:
+                    api_key = os.environ.get(key_env, "").strip()
 
             group_key = (api_url, api_key)
             if group_key not in groups:
@@ -1540,7 +1544,7 @@ def list_authenticated_providers(
                         groups[group_key]["models"].append(m)
 
         _section4_emitted_slugs: set = set()
-        for grp in groups.values():
+        for (grp_url, grp_api_key), grp in groups.items():
             slug = grp["slug"]
             # If the slug is already claimed by a built-in / overlay /
             # user-provider row (sections 1-3), skip this custom group
@@ -1578,6 +1582,20 @@ def list_authenticated_providers(
             _grp_url_norm = _pair_key[1]
             if _grp_url_norm and _grp_url_norm in _builtin_endpoints:
                 continue
+            # Probe the live /v1/models endpoint when credentials are
+            # available — keeps the picker in sync with the server catalog
+            # without requiring every model to be mirrored in config.yaml.
+            # (Mirrors section-3 behavior for user_providers.)
+            if grp["api_url"] and grp_api_key:
+                try:
+                    from hermes_cli.models import fetch_api_models
+                    live_models = fetch_api_models(grp_api_key, grp["api_url"])
+                    if live_models:
+                        for m in live_models:
+                            if m and m not in grp["models"]:
+                                grp["models"].append(m)
+                except Exception:
+                    pass
             results.append({
                 "slug": slug,
                 "name": grp["name"],

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -506,3 +506,165 @@ def test_lmstudio_picker_skips_probe_when_not_configured(monkeypatch):
     )
 
     assert "base_url" not in captured
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section 4: live model probe for custom_providers entries
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_custom_provider_probes_live_models_endpoint(monkeypatch):
+    """Custom providers should probe /v1/models and merge live results."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda api_key, base_url, **kw: ["live-model-1", "live-model-2", "live-model-3"],
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="openai",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "My vLLM Server",
+                "base_url": "http://localhost:8000/v1",
+                "api_key": "test-key",
+                "model": "config-model-1",
+            }
+        ],
+        max_models=50,
+    )
+
+    custom = [p for p in providers if "vllm" in p["name"].lower() or "vllm" in p["slug"].lower()]
+    assert len(custom) == 1
+    row = custom[0]
+    # Config model preserved
+    assert "config-model-1" in row["models"]
+    # Live models merged in
+    assert "live-model-1" in row["models"]
+    assert "live-model-2" in row["models"]
+    assert "live-model-3" in row["models"]
+    assert row["total_models"] == 4
+
+
+def test_custom_provider_live_probe_does_not_duplicate_existing(monkeypatch):
+    """Live probe should not duplicate models already present from config."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda api_key, base_url, **kw: ["model-a", "model-b"],
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="openai",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "My Server",
+                "base_url": "http://localhost:8000/v1",
+                "api_key": "test-key",
+                "model": "model-a",
+            }
+        ],
+        max_models=50,
+    )
+
+    custom = [p for p in providers if p["source"] == "user-config" and "my server" in p["name"].lower()]
+    assert len(custom) == 1
+    assert custom[0]["models"].count("model-a") == 1
+    assert "model-b" in custom[0]["models"]
+    assert custom[0]["total_models"] == 2
+
+
+def test_custom_provider_live_probe_skipped_without_api_key(monkeypatch):
+    """Without api_key, live probe is skipped — only config models shown."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    probe_called = []
+
+    def mock_fetch(api_key, base_url, **kw):
+        probe_called.append(True)
+        return ["should-not-appear"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", mock_fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="openai",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "No Key Server",
+                "base_url": "http://localhost:8000/v1",
+                "model": "only-this-model",
+            }
+        ],
+        max_models=50,
+    )
+
+    custom = [p for p in providers if p["source"] == "user-config" and "no key" in p["name"].lower()]
+    assert len(custom) == 1
+    assert custom[0]["models"] == ["only-this-model"]
+    assert not probe_called
+
+
+def test_custom_provider_live_probe_failure_falls_back_to_config(monkeypatch):
+    """If live probe fails, fall back gracefully to config models."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    def mock_fetch_fail(api_key, base_url, **kw):
+        raise ConnectionError("Server unreachable")
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", mock_fetch_fail)
+
+    providers = list_authenticated_providers(
+        current_provider="openai",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Offline Server",
+                "base_url": "http://localhost:8000/v1",
+                "api_key": "test-key",
+                "model": "fallback-model",
+            }
+        ],
+        max_models=50,
+    )
+
+    custom = [p for p in providers if p["source"] == "user-config" and "offline" in p["name"].lower()]
+    assert len(custom) == 1
+    assert custom[0]["models"] == ["fallback-model"]
+    assert custom[0]["total_models"] == 1
+
+
+def test_custom_provider_resolves_key_env_for_live_probe(monkeypatch):
+    """Custom providers using key_env should still probe /v1/models."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setenv("MY_VLLM_KEY", "resolved-secret")
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_api_models",
+        lambda api_key, base_url, **kw: ["env-model-1", "env-model-2"],
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="openai",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Env Key Server",
+                "base_url": "http://localhost:8000/v1",
+                "key_env": "MY_VLLM_KEY",
+                "model": "config-only",
+            }
+        ],
+        max_models=50,
+    )
+
+    custom = [p for p in providers if p["source"] == "user-config" and "env key" in p["name"].lower()]
+    assert len(custom) == 1
+    assert "config-only" in custom[0]["models"]
+    assert "env-model-1" in custom[0]["models"]
+    assert "env-model-2" in custom[0]["models"]


### PR DESCRIPTION
## Summary

- Custom providers now probe the live `/v1/models` endpoint and merge results into the model picker, matching existing behavior for user-defined providers (Section 3)
- Resolves `key_env`/`api_key_env` from environment variables so env-backed credentials also trigger the probe
- Config models are preserved as fallback; live models are appended (no duplicates)

## Root cause

`list_authenticated_providers()` Section 4 (custom_providers) only read the static `model:` field and `models:` dict from config. Unlike Section 3 (user_providers), it never called `fetch_api_models()` to discover all available models from the server.

## Changes

| File | What |
|------|------|
| `hermes_cli/model_switch.py` | +20 lines: resolve key_env in grouping loop, unpack group key, add live probe block |
| `tests/hermes_cli/test_model_switch_custom_providers.py` | +5 tests: live probe, dedup, no-key skip, error fallback, key_env resolution |

## Test plan

- [x] 22/22 custom provider tests pass (17 existing + 5 new)
- [x] Codex review passed — caught the key_env gap, now fixed
- [ ] Manual test with local vLLM/Ollama server returning multiple models

Closes #20582