### PR TITLE
fix(cron): emit load-time warning for non-dict origin in jobs.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Changes
+
+- **fix(cron): emit load-time warning for non-dict `origin` in jobs.json (#20725)**
+  The scheduler's `_resolve_origin` already treats non-dict `origin` values
+  (strings, ints, lists from hand-edits or migration scripts) as missing rather
+  than crashing with `AttributeError: 'str' object has no attribute 'get'`.
+  However, operators had no way to discover the bad field until it appeared in
+  the run-time error log after the job fired.
+
+  `cron/jobs.py` now calls `_warn_non_dict_origins()` inside `load_jobs()` and
+  emits a `logger.warning` for every job whose `origin` is non-null and
+  non-dict.  This surfaces the problem at load time (gateway startup, daemon
+  tick) before any job runs.  Null and valid dict `origin` values are
+  unaffected.

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -338,16 +338,41 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
 # Job CRUD Operations
 # =============================================================================
 
+def _warn_non_dict_origins(jobs: List[Dict[str, Any]]) -> None:
+    """Emit a warning for any job whose ``origin`` field is a non-null, non-dict value.
+
+    Such values are silently treated as "no origin" by ``_resolve_origin`` in
+    the scheduler (see cron/scheduler.py), but they are almost always the result
+    of a hand-edit or migration script that wrote a free-form string (e.g. a
+    phase tag like ``"phase-a.5"``) instead of an origin dict.  Emitting the
+    warning at load time surfaces the problem before the first tick rather than
+    leaving the operator to discover it from a run-time error log (#20725).
+    """
+    for job in jobs:
+        origin = job.get("origin")
+        if origin is not None and not isinstance(origin, dict):
+            logger.warning(
+                "Job '%s' (id=%s) has a non-dict 'origin' field (%r); "
+                "it will be treated as missing.  Update the job's origin to a "
+                "dict with 'platform' and 'chat_id' keys, or set it to null.",
+                job.get("name", "?"),
+                job.get("id", "?"),
+                origin,
+            )
+
+
 def load_jobs() -> List[Dict[str, Any]]:
     """Load all jobs from storage."""
     ensure_dirs()
     if not JOBS_FILE.exists():
         return []
-    
+
     try:
         with open(JOBS_FILE, 'r', encoding='utf-8') as f:
             data = json.load(f)
-            return data.get("jobs", [])
+            jobs = data.get("jobs", [])
+            _warn_non_dict_origins(jobs)
+            return jobs
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         try:
@@ -358,6 +383,7 @@ def load_jobs() -> List[Dict[str, Any]]:
                     # Auto-repair: rewrite with proper escaping
                     save_jobs(jobs)
                     logger.warning("Auto-repaired jobs.json (had invalid control characters)")
+                _warn_non_dict_origins(jobs)
                 return jobs
         except Exception as e:
             logger.error("Failed to auto-repair jobs.json: %s", e)

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -751,3 +751,106 @@ class TestSaveJobOutput:
         assert output_file.exists()
         assert output_file.read_text() == "# Results\nEverything ok."
         assert "test123" in str(output_file)
+
+
+class TestLoadJobsNonDictOriginWarning:
+    """Regression guard for #20725.
+
+    ``load_jobs()`` must emit a logger.warning for every job whose ``origin``
+    field is a non-null, non-dict value (e.g. a provenance string written by a
+    migration script).  The warning lets operators discover the bad field before
+    the scheduler tick instead of finding it only in the run-time error log.
+
+    The scheduler's ``_resolve_origin`` already silently treats non-dict values
+    as missing (no crash), so no data is lost — the warning is purely
+    informational.
+    """
+
+    def _write_jobs(self, path, jobs):
+        import json as _json
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(_json.dumps({"jobs": jobs}), encoding="utf-8")
+
+    def test_string_origin_emits_warning(self, tmp_cron_dir, caplog):
+        import logging
+        jobs_file = tmp_cron_dir / "cron" / "jobs.json"
+        self._write_jobs(jobs_file, [
+            {
+                "id": "abc123",
+                "name": "Phase job",
+                "origin": "phase-a.5",
+                "prompt": "...",
+                "enabled": True,
+                "schedule": {"kind": "interval", "interval_minutes": 60},
+                "deliver": "local",
+            }
+        ])
+        with caplog.at_level(logging.WARNING, logger="cron.jobs"):
+            load_jobs()
+        assert any(
+            "non-dict" in r.message and "phase-a.5" in r.message
+            for r in caplog.records
+        ), f"Expected non-dict origin warning, got: {[r.message for r in caplog.records]}"
+
+    @pytest.mark.parametrize("bad_origin", [
+        "some-tag-string",
+        123,
+        ["telegram", "12345"],
+        42.0,
+    ])
+    def test_various_non_dict_origins_emit_warning(self, tmp_cron_dir, caplog, bad_origin):
+        import logging
+        jobs_file = tmp_cron_dir / "cron" / "jobs.json"
+        self._write_jobs(jobs_file, [
+            {
+                "id": "xyz999",
+                "name": "Bad origin job",
+                "origin": bad_origin,
+                "prompt": "...",
+                "enabled": True,
+                "schedule": {"kind": "interval", "interval_minutes": 30},
+                "deliver": "local",
+            }
+        ])
+        with caplog.at_level(logging.WARNING, logger="cron.jobs"):
+            load_jobs()
+        assert any("non-dict" in r.message for r in caplog.records), (
+            f"Expected non-dict origin warning for origin={bad_origin!r}, "
+            f"got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_null_origin_does_not_warn(self, tmp_cron_dir, caplog):
+        import logging
+        jobs_file = tmp_cron_dir / "cron" / "jobs.json"
+        self._write_jobs(jobs_file, [
+            {
+                "id": "ok001",
+                "name": "No origin job",
+                "origin": None,
+                "prompt": "...",
+                "enabled": True,
+                "schedule": {"kind": "interval", "interval_minutes": 60},
+                "deliver": "local",
+            }
+        ])
+        with caplog.at_level(logging.WARNING, logger="cron.jobs"):
+            load_jobs()
+        assert not any("non-dict" in r.message for r in caplog.records)
+
+    def test_dict_origin_does_not_warn(self, tmp_cron_dir, caplog):
+        import logging
+        jobs_file = tmp_cron_dir / "cron" / "jobs.json"
+        self._write_jobs(jobs_file, [
+            {
+                "id": "ok002",
+                "name": "Good origin job",
+                "origin": {"platform": "telegram", "chat_id": "12345"},
+                "prompt": "...",
+                "enabled": True,
+                "schedule": {"kind": "interval", "interval_minutes": 60},
+                "deliver": "origin",
+            }
+        ])
+        with caplog.at_level(logging.WARNING, logger="cron.jobs"):
+            load_jobs()
+        assert not any("non-dict" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Relates to #20725.

The scheduler's `_resolve_origin` already silently treats non-dict `origin` values (strings, ints, lists written by migration scripts or hand-edits of `jobs.json`) as missing — no crash occurs on tick. However, operators had no visibility into the bad field until it appeared in the run-time error log **after** the first failed fire.

### What this adds

A new `_warn_non_dict_origins()` helper in `cron/jobs.py` is called inside `load_jobs()` for both the normal JSON parse path and the `strict=False` auto-repair path. It emits a `logger.warning` for every job whose `origin` is non-null and non-dict, naming the job, its id, and the offending value. Null `origin` and well-formed dict `origin` are unaffected.

This surfaces the problem at load time (gateway startup, daemon tick) rather than waiting for the job to fire.

### Relationship to prior fix

The `isinstance(origin, dict)` guard in `cron/scheduler.py`'s `_resolve_origin` (added for #18722) prevents the crash. This PR adds the operator-facing early warning that lets users discover and repair bad `origin` values without needing to wait for a run-time error.

### Example warning output

```
WARNING cron.jobs: Job 'Phase job' (id=abc123) has a non-dict 'origin' field ('phase-a.5');
it will be treated as missing.  Update the job's origin to a dict with 'platform' and
'chat_id' keys, or set it to null.
```

### Tests added (`tests/cron/test_jobs.py`)

- `test_string_origin_emits_warning` — string origin triggers warning
- `test_various_non_dict_origins_emit_warning` — parametrised: str / int / list / float
- `test_null_origin_does_not_warn` — null origin is silent
- `test_dict_origin_does_not_warn` — valid dict origin is silent

## Test plan

- [ ] `python3 -m py_compile cron/jobs.py` passes
- [ ] `python3 -m py_compile tests/cron/test_jobs.py` passes
- [ ] New `TestLoadJobsNonDictOriginWarning` tests pass (`pytest tests/cron/test_jobs.py -k NonDictOrigin -v`)
- [ ] Existing cron/jobs tests unaffected
- [ ] Manual: set `origin: "phase-tag"` on a job in `jobs.json`, restart gateway — confirm warning appears in logs before any job fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)