### PR TITLE
fix(checkpoints): reject cross-project checkpoint hashes

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -400,6 +400,45 @@ class TestRestore:
         assert restore_result["success"] is True
         assert file_path.read_text() == "original\n"
 
+    def test_diff_rejects_checkpoint_from_other_project(self, mgr, tmp_path):
+        project_a = tmp_path / "project-a"
+        project_a.mkdir()
+        (project_a / "secret_logic.py").write_text("project A private logic\n")
+        project_b = tmp_path / "project-b"
+        project_b.mkdir()
+        (project_b / "app.py").write_text("project B app\n")
+
+        assert mgr.ensure_checkpoint(str(project_a), "project A") is True
+        mgr.new_turn()
+        assert mgr.ensure_checkpoint(str(project_b), "project B") is True
+        project_a_hash = mgr.list_checkpoints(str(project_a))[0]["hash"]
+
+        result = mgr.diff(str(project_b), project_a_hash)
+
+        assert result["success"] is False
+        assert "does not belong to this directory" in result["error"]
+
+    def test_restore_rejects_checkpoint_from_other_project(self, mgr, tmp_path):
+        project_a = tmp_path / "project-a"
+        project_a.mkdir()
+        (project_a / "secret_logic.py").write_text("project A private logic\n")
+        project_b = tmp_path / "project-b"
+        project_b.mkdir()
+        app_file = project_b / "app.py"
+        app_file.write_text("project B app\n")
+
+        assert mgr.ensure_checkpoint(str(project_a), "project A") is True
+        mgr.new_turn()
+        assert mgr.ensure_checkpoint(str(project_b), "project B") is True
+        project_a_hash = mgr.list_checkpoints(str(project_a))[0]["hash"]
+
+        result = mgr.restore(str(project_b), project_a_hash)
+
+        assert result["success"] is False
+        assert "does not belong to this directory" in result["error"]
+        assert app_file.read_text() == "project B app\n"
+        assert not (project_b / "secret_logic.py").exists()
+
 
 # =========================================================================
 # CheckpointManager — working dir resolution

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -225,6 +225,29 @@ def _ref_name(dir_hash: str) -> str:
     return f"{_REFS_PREFIX}/{dir_hash}"
 
 
+def _validate_project_checkpoint(
+    store: Path, working_dir: str, commit_hash: str,
+) -> Optional[str]:
+    """Return an error if ``commit_hash`` is not in this project's ref history."""
+    ref = _ref_name(_project_hash(working_dir))
+    ok_ref, _, _ = _run_git(
+        ["rev-parse", "--verify", ref + "^{commit}"],
+        store, working_dir,
+        allowed_returncodes={128},
+    )
+    if not ok_ref:
+        return "No checkpoints exist for this directory"
+
+    ok_member, _, _ = _run_git(
+        ["merge-base", "--is-ancestor", commit_hash, ref],
+        store, working_dir,
+        allowed_returncodes={1, 128},
+    )
+    if not ok_member:
+        return f"Checkpoint '{commit_hash}' does not belong to this directory"
+    return None
+
+
 def _project_meta_path(store: Path, dir_hash: str) -> Path:
     return store / _PROJECTS_DIRNAME / f"{dir_hash}.json"
 
@@ -724,6 +747,10 @@ class CheckpointManager:
         if not ok:
             return {"success": False, "error": f"Checkpoint '{commit_hash}' not found"}
 
+        project_err = _validate_project_checkpoint(store, abs_dir, commit_hash)
+        if project_err:
+            return {"success": False, "error": project_err}
+
         dir_hash = _project_hash(abs_dir)
         index_file = _index_path(store, dir_hash)
 
@@ -780,6 +807,10 @@ class CheckpointManager:
         if not ok:
             return {"success": False, "error": f"Checkpoint '{commit_hash}' not found",
                     "debug": err or None}
+
+        project_err = _validate_project_checkpoint(store, abs_dir, commit_hash)
+        if project_err:
+            return {"success": False, "error": project_err}
 
         # Take a pre-rollback snapshot so you can undo the undo.
         self._take(abs_dir, f"pre-rollback snapshot (restoring to {commit_hash[:8]})")


### PR DESCRIPTION
## Summary
- validate rollback/diff hashes against the current directory's checkpoint ref
- reject checkpoint hashes from other projects before diff or restore side effects
- add regression coverage for cross-project diff and restore isolation

## Root cause
Checkpoint v2 uses one shared git store for all projects, but diff and restore only checked that a commit hash existed in that store. A raw hash from project A could therefore be used while operating in project B.

## Validation
- pytest tests/tools/test_checkpoint_manager.py