### PR TITLE
feat(delegation): surface child provider in delegate_task result entries

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1625,6 +1625,7 @@ def _run_single_child(
         _input_tokens = getattr(child, "session_prompt_tokens", 0)
         _output_tokens = getattr(child, "session_completion_tokens", 0)
         _model = getattr(child, "model", None)
+        _provider = getattr(child, "provider", None)
 
         entry: Dict[str, Any] = {
             "task_index": task_index,
@@ -1633,6 +1634,7 @@ def _run_single_child(
             "api_calls": api_calls,
             "duration_seconds": duration,
             "model": _model if isinstance(_model, str) else None,
+            "provider": _provider if isinstance(_provider, str) else None,
             "exit_reason": exit_reason,
             "tokens": {
                 "input": (
@@ -1763,6 +1765,7 @@ def _run_single_child(
     except Exception as exc:
         duration = round(time.monotonic() - child_start, 2)
         logging.exception(f"[subagent-{task_index}] failed")
+        _exc_provider = getattr(child, "provider", None)
         if child_progress_cb:
             try:
                 child_progress_cb(
@@ -1779,6 +1782,7 @@ def _run_single_child(
             "status": "error",
             "summary": None,
             "error": str(exc),
+            "provider": _exc_provider if isinstance(_exc_provider, str) else None,
             "api_calls": 0,
             "duration_seconds": duration,
             "_child_role": getattr(child, "_delegate_role", None),


### PR DESCRIPTION
## Summary

`_run_single_child` already records the child's `model` in its result/error dict, but not the `provider` that served the call. Adds `provider` alongside `model`.

## Why

Once `delegation.provider`, fallback chains, or OpenRouter routing are configured, identifying which provider actually answered is non-trivial. Knowing only the `model` (e.g. `claude-opus-4-7`) doesn't tell you whether it ran on Anthropic-direct, AWS Bedrock, OpenRouter, or another path. Today the answer requires log scraping.

This makes `provider` a peer of `model` in the structured result, so downstream consumers (debugging, cost attribution, A/B comparison) can read it directly.

## Implementation

Two ~one-line additions:
- Success entry (around line 1635): read `child.provider` once and surface in the dict alongside `model`.
- Error entry (around line 1782): same field on the error path so failed children also report which provider tried.

Same `getattr(child, ..., None)` + `isinstance(..., str) else None` pattern that `model` already uses, so mock-safety semantics match.

## Compatibility

Purely additive — adds a new field to a dict. Existing consumers that don't read `provider` are unaffected.

## Test plan
- [x] Subagent run on `delegation.provider="anthropic"` produces `result["provider"] == "anthropic"`
- [x] Subagent error path includes `provider` field
- [x] No regression in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)