### PR TITLE
feat(delegation): add max_concurrent_children per-call override

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9466,6 +9466,7 @@ class AIAgent:
             max_iterations=function_args.get("max_iterations"),
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
+            max_concurrent_children=function_args.get("max_concurrent_children"),
             role=function_args.get("role"),
             parent_agent=self,
         )

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1841,6 +1841,7 @@ def delegate_task(
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
+    max_concurrent_children: Optional[int] = None,
     role: Optional[str] = None,
     parent_agent=None,
 ) -> str:
@@ -1917,6 +1918,10 @@ def delegate_task(
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
+    if max_concurrent_children is not None:
+        # Per-call override clamped to a sane window so a malformed model
+        # output cannot request unbounded concurrency.
+        max_children = max(1, min(int(max_concurrent_children), 10))
     if tasks and isinstance(tasks, list):
         if len(tasks) > max_children:
             return tool_error(
@@ -2533,6 +2538,18 @@ DELEGATE_TASK_SCHEMA = {
                     "Only used when acp_command is set. Example: ['--acp', '--stdio', '--model', 'claude-opus-4-6']"
                 ),
             },
+            "max_concurrent_children": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 10,
+                "description": (
+                    "Per-call override of delegation.max_concurrent_children. "
+                    "Clamped to 1..10 to prevent unbounded concurrency from "
+                    "a malformed request. Useful when a specific batch needs "
+                    "more parallelism than the global default without "
+                    "changing config."
+                ),
+            },
         },
         "required": [],
     },
@@ -2554,6 +2571,7 @@ registry.register(
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
+        max_concurrent_children=args.get("max_concurrent_children"),
         role=args.get("role"),
         parent_agent=kw.get("parent_agent"),
     ),


### PR DESCRIPTION
## Summary

Adds an optional `max_concurrent_children` kwarg to `delegate_task()` that overrides the config-level `delegation.max_concurrent_children` for a single batch. Clamped to `[1, 10]` so a malformed request cannot drive unbounded concurrency.

## Why

Today the only way to spawn more than `delegation.max_concurrent_children` (default 3) parallel children is to edit `config.yaml` and restart, or split a batch into sequential `delegate_task` calls. There's no way for the model to say "this particular batch needs more parallelism" — the cap is a global that's hard to right-size: low enough to bound runaway cost, high enough not to bottleneck legitimate fan-out (research, cross-model comparison, multi-file refactor).

A per-call override solves this:

```jsonc
delegate_task(
  tasks=[...5 tasks...],
  max_concurrent_children=5
)
```

## Implementation

The kwarg has to be threaded through four sites — missing any one of them turns the feature into silent dead code:

1. **`delegate_task` signature** — accept the kwarg (`Optional[int] = None`)
2. **The cap-check inside `delegate_task`** — when set, override `_get_max_concurrent_children()` with `max(1, min(int(max_concurrent_children), 10))` (the clamp)
3. **`DELEGATE_TASK_SCHEMA["properties"]`** — declare the field so the model knows it can request it. JSON-schema-level `minimum: 1, maximum: 10` mirrors the runtime clamp.
4. **`AIAgent._dispatch_delegate_task`** in `run_agent.py` — forward the kwarg from `function_args` to `delegate_task`.

(4) is load-bearing: `delegate_task` is in `model_tools._AGENT_LOOP_TOOLS` (line 495), which short-circuits `registry.dispatch()` at `model_tools.py:709`. So the actual dispatch path is `AIAgent._dispatch_delegate_task` — the registry handler lambda is unreachable from the agent loop. Without (4), the schema field is defined but silently dropped before reaching the function.

The registry handler lambda is also updated for callers that invoke via `registry.dispatch()` directly (none in-tree today, but keeps the two paths symmetric for any external embedder).

## Compatibility

Purely additive. `max_concurrent_children=None` is the default and yields existing behaviour (read from config). No call sites have to change.

## Test plan
- [x] Calling `delegate_task(tasks=[...5 tasks...], max_concurrent_children=5)` with config default of 3 succeeds (was previously rejected with "too many tasks")
- [x] Calling with `max_concurrent_children=15` clamps to 10
- [x] Calling with `max_concurrent_children=0` clamps to 1
- [x] Omitting the kwarg falls back to config (existing behaviour)
- [x] Model request via `function_args` reaches the function (verified via `_dispatch_delegate_task` forwarding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)