### PR TITLE
feat: add DCP context engine

### DIFF
--- a/DCP_CONTEXT_ENGINE_PR_SPEC.md
+++ b/DCP_CONTEXT_ENGINE_PR_SPEC.md
@@ -498,16 +498,181 @@ When `context.engine == "dcp"`:
 
 Gateway hygiene is still a safety net. It may need a DCP-aware branch eventually because hygiene compression mutates gateway session history. For first PR, document the interaction and avoid making gateway hygiene call DCP unless there is a clean state path.
 
-## Prompt caching
+## Appendix: Prompt caching internals and DCP interaction
 
-DCP must be careful with prompt caching.
+### What Hermes prompt caching is
 
-Rules:
+Prompt caching in Hermes is Anthropic-specific. It is not a generic cache across all providers. It exploits Anthropic's prefix caching API, where the provider caches the stable prefix of a prompt across turns and bills reused tokens at a reduced rate (~25% of full input price).
 
-- Run DCP transform before cache-control marker placement.
+Non-Anthropic providers (OpenAI, Gemini, local models) do not participate. The cache-control logic is a no-op for them.
+
+### Policy decision
+
+`_anthropic_prompt_cache_policy()` in `run_agent.py` decides at init time whether caching is enabled and which layout to use. Returns `(should_cache, use_native_layout)`.
+
+Enabled when:
+- native Anthropic (provider=anthropic, api_mode=anthropic_messages)
+- OpenRouter serving Claude models
+- third-party Anthropic-compatible gateways serving Claude models
+- MiniMax on its Anthropic-compatible endpoint
+- Qwen/Alibaba on OpenCode/DashScope (OpenAI-wire, but they honor cache_control markers)
+
+Two layouts:
+- `use_native_layout=True` -- cache_control markers on inner content blocks. Required by native Anthropic API.
+- `use_native_layout=False` -- markers on the message envelope. Expected by OpenRouter and OpenAI-wire proxies.
+
+All other providers/models: caching off.
+
+### The system_and_3 strategy
+
+`apply_anthropic_cache_control()` in `agent/prompt_caching.py` is a pure function. Deep-copies the entire api_messages list, then places up to 4 `cache_control: {"type": "ephemeral"}` breakpoints:
+- breakpoint 1: system prompt (index 0 if role=="system")
+- breakpoints 2-4: last 3 non-system messages
+
+Anthropic allows a max of 4 breakpoints. The system prompt is the most stable (rarely changes). The last 3 messages form a rolling window that shifts forward each turn.
+
+TTL is configurable: "5m" (default) or "1h" (2x write cost, better for long pauses between turns).
+
+### How Anthropic prefix caching works
+
+Anthropic caches everything from the start of the prompt up to and including the message with a cache_control breakpoint. The cache key is the exact byte content of that prefix.
+
+Example across 3 turns:
+
+```
+Turn 1: [system] [msg1] [msg2] [msg3]
+                       ^bp2   ^bp3   ^bp4
+         Cache miss. Full price. Cache stored for [system..msg3].
+
+Turn 2: [system] [msg1] [msg2] [msg3] [msg4]
+                                         ^bp4
+         [system..msg3] is cached. Only [msg4] is full price.
+         New cache stored for [system..msg4].
+
+Turn 3: [system] [msg1] [msg2] [msg3] [msg4] [msg5]
+                                                 ^bp4
+         [system..msg4] is cached. Only [msg5] is full price.
+```
+
+The invariant: the prefix must be byte-for-byte identical. Any change to any cached message invalidates the entire cached prefix from that point forward.
+
+### How Hermes protects cache stability
+
+Several deliberate design choices in run_agent.py prevent cache churn:
+
+1. Shallow copy per message, not deep copy. `api_msg = msg.copy()` at line 11097 creates a provider-bound copy. The canonical `messages` list is never mutated by anything downstream.
+
+2. Plugin context injected into user message, not system prompt. Lines 11147-11150: "system prompt modifications break the prompt cache prefix." Plugin context from pre_llm_call hooks goes into the current turn's user message instead.
+
+3. Ephemeral system prompt appended once. ephemeral_system_prompt changes the system message, but only at setup time, not per-turn.
+
+4. Whitespace normalization. Lines 11215-11217 strip content whitespace on the API copy. Prevents accidental cache misses from trailing whitespace.
+
+5. Deterministic JSON serialization for tool_calls. Lines 11218-11240 re-serialize tool_call arguments with `sort_keys=True` and compact separators `(",",":")`. Same logical tool call always produces same bytes.
+
+6. Cache control deep-copies. `apply_anthropic_cache_control()` deep-copies the message list before placing markers, so the pre-cache messages are not aliased.
+
+### The full API-call pipeline
+
+This is the actual sequence in `run_agent.py` for every API call, showing where DCP was inserted:
+
+```
+messages (canonical, never mutated)
+  |
+  v
+api_messages = shallow copy of messages              (line 11095-11138)
+  - ephemeral context injected into user message
+  - reasoning content handled
+  - internal fields stripped (finish_reason, _thinking_prefill, etc.)
+  |
+  v
+system prompt prepended                              (line 11151-11152)
+  |
+  v
+prefill messages injected                            (line 11156-11159)
+  |
+  v
+DCP transform_api_messages()                         (line 11166-11175)
+  |
+  v
+apply_anthropic_cache_control()                      (line 11187-11191)
+  - deep copies api_messages
+  - places cache_control breakpoints
+  |
+  v
+_sanitize_api_messages()                             (line 11197)
+  - orphaned tool result safety net
+  |
+  v
+_drop_thinking_only_and_merge_users()                (line 11207)
+  - removes thinking-only assistant turns
+  |
+  v
+whitespace normalization + deterministic JSON        (line 11215-11240)
+  - strip content whitespace
+  - sort_keys=True on tool_call arguments
+  |
+  v
+surrogate sanitization                               (line 11246)
+  |
+  v
+API call
+```
+
+### Why DCP runs before cache-control injection
+
+The ordering DCP -> cache_control is not arbitrary. It matters because:
+
+1. Cache-control deep-copies the already-transformed messages and places breakpoints on the DCP-transformed shape. The provider sees the final combined form.
+
+2. If cache-control ran before DCP, Hermes would mark one prefix as cacheable, then DCP would rewrite it afterward. The cache-control decision would be stale or wrong.
+
+3. By running DCP first, Hermes computes cache-control over the final provider-bound prompt shape.
+
+### The cache risk with DCP
+
+The system_and_3 strategy places breakpoints on the system prompt and the last 3 messages. DCP's transforms (refs, compression placeholders, nudges) primarily affect older messages in the middle of the transcript.
+
+If DCP rewrites message content in the cached prefix region between turns, the cache breaks. Specifically:
+
+- If DCP compresses messages 5-20 into a block placeholder while messages 21-25 are the last 3 (breakpoint targets), the cached prefix `[system, msg1..msg22]` from the previous turn is now invalid because messages 5-20 changed. Cache miss. But the new shape `[system, msg1-placeholder..msg22]` gets cached for the next turn.
+
+- If DCP does nothing (no compression triggered), messages are identical to the previous turn and the cache works normally.
+
+- The worst case is DCP making small changes every turn. That would defeat caching entirely.
+
+### DCP's mitigation for cache churn
+
+The implementation tries to reduce churn by:
+
+1. Only compressing when the model explicitly calls the `compress` tool or when automatic strategies find actual duplicates/errors. Between compression events, the prefix stays stable.
+
+2. Automatic strategies (dedup, purge-errors) are recalculated only when state changes (compress tool call, new turn), not randomly every request.
+
+3. Compression block application is deterministic. Same active blocks always produce the same placeholder text.
+
+4. Refs are stable across turns within a session. `m0001` always refers to the same canonical message.
+
+5. Never appending moving counters or timestamps into the cached prefix.
+
+### What is not yet solved
+
+This does not prove every possible prompt-cache churn case is solved. Known open concerns:
+
+1. When DCP compresses a range that overlaps the cached prefix, the entire prefix invalidates for one turn. The next turn re-caches with the new shape. This is a one-turn penalty per compression event, which is acceptable.
+
+2. Nudges are appended to the live tail (not the cached prefix), so they should not cause churn. But this has not been instrumented or tested against real Anthropic cache behavior.
+
+3. Non-Anthropic providers do not use this cache system. DCP transforms still run for them, but there is no prompt cache to worry about.
+
+4. `apply_anthropic_cache_control` does `copy.deepcopy(api_messages)` internally. DCP transforms the first copy, then cache_control deep-copies again. Two full message copies exist briefly during each API call. For a 100k-token transcript this is noticeable but not catastrophic.
+
+### Rules for future DCP changes
+
+- Run DCP transform before cache-control marker placement (current ordering).
 - Avoid changing old stable content every turn.
-- Compression block application should be deterministic.
-- Dedup and purge should avoid churn. Prefer recalculating after compress tool calls or when state changes, not randomly every request.
+- Compression block application must be deterministic.
+- Dedup and purge must avoid churn. Recalculate after compress tool calls or when state changes, not randomly every request.
 - Never append moving counters into the cached prefix unless unavoidable.
 
 ## Tests

--- a/DCP_CONTEXT_ENGINE_PR_SPEC.md
+++ b/DCP_CONTEXT_ENGINE_PR_SPEC.md
@@ -1,0 +1,630 @@
+# Temporary PR Spec: DCP Context Engine
+
+Status: temporary agent-facing implementation spec.
+
+Cleanup rule: before merge, either delete this file or fold the durable parts into:
+
+- `website/docs/developer-guide/context-compression-and-caching.md`
+- `website/docs/developer-guide/context-engine-plugin.md`
+- `website/docs/developer-guide/prompt-assembly.md`
+- `website/docs/developer-guide/agent-loop.md`
+- `website/docs/developer-guide/architecture.md` if the file layout changes
+- `website/docs/reference/cli-commands.md` if `/dcp` commands land
+
+This file is for coordination during the PR. It is not intended to become permanent product documentation.
+
+## Goal
+
+Add a DCP-style context engine to Hermes Agent, based on the design pattern from `Opencode-DCP/opencode-dynamic-context-pruning`:
+
+- model-callable `compress` tool
+- stable message and compression block references
+- outbound API-call-time context transform
+- DCP-compatible config surface under `context.dcp`
+- automatic strategies for duplicate tool output and old error cleanup
+- nudges that teach the model when to call `compress`
+- canonical transcript preservation
+
+The target is not just “make the existing compressor more proactive.” The target is a separate `context.engine: dcp` mode whose primary compaction mechanism is model-guided compression over referenced message ranges or individual messages.
+
+## Non-goals
+
+- Do not copy DCP source or prompt text verbatim. DCP is AGPL-3.0-or-later. Reimplement behavior in Hermes-native Python with original prompts.
+- Do not replace the existing `ContextCompressor` default.
+- Do not mutate canonical conversation history during normal DCP operation.
+- Do not run both the existing reactive compressor and DCP as primary compression systems in the same session.
+- Do not implement the full `/dcp decompress` and `/dcp recompress` command surface in the first PR unless the core engine is already stable.
+
+## Current Hermes architecture facts
+
+Primary files:
+
+- `agent/context_engine.py`: context engine ABC.
+- `agent/context_compressor.py`: built-in default lossy compressor.
+- `run_agent.py`: AIAgent loop, context engine loading, tool registration, API message assembly.
+- `agent/prompt_caching.py`: Anthropic prompt caching.
+- `hermes_cli/config.py`: `DEFAULT_CONFIG` and config migration.
+- `hermes_cli/commands.py`, `cli.py`, `gateway/run.py`: slash command registry and dispatch.
+
+Existing context engine behavior:
+
+- One context engine is active per agent.
+- `context.engine: "compressor"` selects the built-in default.
+- Plugin/context engines can expose tools via `get_tool_schemas()`.
+- Context engine tools are routed to `handle_tool_call()` by `run_agent.py`.
+- Existing `compress()` returns a new valid OpenAI-format message list and can mutate the session history when invoked by the current compression loop.
+
+DCP needs one new context engine capability:
+
+- transform the API-call copy of messages before provider conversion/caching/request, without mutating canonical messages.
+
+## Design decision
+
+Implement DCP as a first-class context engine named `dcp`.
+
+Recommended file layout for first PR:
+
+```text
+agent/dcp_config.py
+agent/dcp_context_engine.py
+agent/dcp_state.py
+agent/dcp_ids.py
+agent/dcp_prompts.py
+agent/dcp_transform.py
+agent/dcp_strategies.py
+agent/dcp_compress.py
+```
+
+If this feels too many modules during implementation, start with fewer files but preserve the responsibility boundaries:
+
+- config parsing
+- state model
+- ID assignment
+- outbound transform
+- strategies
+- compress tool handling
+- prompt/nudge generation
+
+## Required context engine interface change
+
+Add an optional method to `ContextEngine`:
+
+```python
+def transform_api_messages(
+    self,
+    api_messages: list[dict],
+    *,
+    canonical_messages: list[dict],
+    system_prompt: str,
+    tools: list[dict] | None,
+    api_call_count: int,
+    model: str,
+    provider: str | None,
+    session_id: str | None,
+) -> list[dict]:
+    return api_messages
+```
+
+Contract:
+
+- Receives the API-call copy, not authoritative history.
+- Must not mutate `canonical_messages`.
+- Should avoid mutating `api_messages` in place unless documented and tested.
+- Must preserve valid OpenAI message ordering.
+- Must not separate an assistant `tool_calls` message from its required tool results.
+- Must return messages that still pass Hermes provider sanitization.
+- Should run before prompt-cache marker placement so caching logic sees the actual outgoing request.
+
+Wire this into `run_agent.py` after API messages are assembled and before provider-specific cache-control/sanitization/request conversion.
+
+## DCP engine behavior
+
+### Canonical history invariant
+
+DCP mode must preserve this invariant:
+
+> The saved session transcript remains the full conversation. DCP only replaces or annotates content in the outbound API request copy.
+
+The `compress` tool updates DCP state. It does not rewrite `messages` directly.
+
+### Message references
+
+The engine assigns stable refs that the model can use in `compress` calls.
+
+Use:
+
+- `m0001`, `m0002`, ... for canonical messages
+- `b1`, `b2`, ... for compression blocks
+
+Refs should be stable across turns within a session. If message IDs are not available in the canonical message dict, assign by append order and persist the mapping in DCP state.
+
+The transform must expose refs to the model. Two implementation modes are acceptable:
+
+1. Inline refs, closer to DCP
+   - append or prefix a compact marker to user/assistant/tool content
+   - examples: `<dcp-ref id="m0042" />`, `<dcp-ref id="m0043" tool="terminal" />`
+   - risk: can disturb tool result adjacency or provider formatting if done carelessly
+
+2. Index refs, safer first pass
+   - inject a compact `<dcp-context-index>` block into the latest user-facing context
+   - maps refs to role/tool/topic one-liners
+   - less DCP-like, but lower provider risk
+
+Recommendation for first PR:
+
+- implement inline refs only for messages whose content can be safely represented as text
+- keep a fallback index for messages that cannot be safely annotated
+- add tests proving canonical messages are unchanged
+
+### Compression blocks
+
+A compression block is an active replacement over either:
+
+- a contiguous range of message refs, range mode
+- one or more individual message refs, message mode
+
+Minimal state model:
+
+```python
+@dataclass
+class CompressionBlock:
+    block_id: int
+    run_id: int
+    mode: Literal["range", "message"]
+    topic: str
+    summary: str
+    active: bool
+    start_ref: str | None
+    end_ref: str | None
+    message_refs: list[str]
+    included_block_ids: list[int]
+    consumed_block_ids: list[int]
+    created_at: float
+    deactivated_at: float | None = None
+    deactivated_by_block_id: int | None = None
+```
+
+Session state should also track:
+
+```python
+@dataclass
+class DCPSessionState:
+    session_id: str | None
+    next_message_ref: int
+    next_block_id: int
+    next_run_id: int
+    ref_by_message_key: dict[str, str]
+    message_key_by_ref: dict[str, str]
+    blocks_by_id: dict[int, CompressionBlock]
+    active_block_ids: set[int]
+    last_prompt_tokens: int
+    last_user_turn_index: int
+    turns_since_last_compress: int
+    stats: dict[str, Any]
+    manual_mode: bool | Literal["compress-pending"]
+    pending_manual_focus: str | None
+```
+
+Persistence:
+
+- First PR may keep state in memory for CLI and gateway agent lifetime.
+- Prefer lightweight JSON persistence under Hermes home if session IDs are stable enough.
+- Do not entangle DCP state with canonical `SessionDB` schema in first PR unless necessary.
+
+### Compress tool
+
+Tool name: `compress`.
+
+Expose only when:
+
+- `context.engine == "dcp"`
+- `context.dcp.compress.permission != "deny"`
+- `context.dcp.commands.enabled` does not disable tool exposure, if we choose to mirror DCP semantics there
+
+Range mode schema:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "topic": {
+      "type": "string",
+      "description": "Short 3-5 word label for the compression batch"
+    },
+    "content": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "startId": {"type": "string"},
+          "endId": {"type": "string"},
+          "summary": {"type": "string"}
+        },
+        "required": ["startId", "endId", "summary"]
+      }
+    }
+  },
+  "required": ["topic", "content"]
+}
+```
+
+Message mode schema:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "topic": {"type": "string"},
+    "content": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "messageId": {"type": "string"},
+          "topic": {"type": "string"},
+          "summary": {"type": "string"}
+        },
+        "required": ["messageId", "topic", "summary"]
+      }
+    }
+  },
+  "required": ["topic", "content"]
+}
+```
+
+Tool result should be JSON text:
+
+```json
+{
+  "ok": true,
+  "mode": "range",
+  "created_blocks": [1, 2],
+  "deactivated_blocks": [0],
+  "estimated_tokens_removed": 42000,
+  "estimated_summary_tokens": 1800,
+  "message": "Compressed 2 ranges into b1 and b2."
+}
+```
+
+Validation failures must be explicit and non-silent:
+
+```json
+{
+  "ok": false,
+  "error": "Unknown message ref: m0042",
+  "hint": "Use refs visible in the current context."
+}
+```
+
+### Applying blocks in outbound transform
+
+When transforming API messages:
+
+- detect active compression blocks
+- replace covered content with a compact summary placeholder
+- keep enough structural messages to satisfy provider format rules
+- do not orphan tool results
+- do not remove current active tail
+
+Placeholder format should be concise and model-readable:
+
+```text
+<dcp-compressed-block id="b3" topic="Dependency investigation">
+Summary: ...
+Covers: m0018-m0036
+</dcp-compressed-block>
+```
+
+For messages fully covered by a block but not chosen as the block anchor, replace with a very short placeholder or remove only if tool adjacency remains valid:
+
+```text
+[DCP: content moved into compressed block b3]
+```
+
+Do not delete assistant tool-call messages unless their paired tool results are also handled safely. It is safer in first PR to stub content than to physically remove messages.
+
+### Nudges
+
+DCP should teach the model to call `compress`.
+
+Inject a DCP system extension or ephemeral message containing:
+
+- `compress` tool exists
+- refs are available as `mNNNN` and `bN`
+- use range mode for closed contiguous spans
+- use message mode for isolated large messages if configured
+- do not compress the active task or very recent messages
+- preserve concrete details in summaries
+
+Nudge types:
+
+- context limit nudge when prompt tokens exceed max limit
+- turn nudge when prompt tokens exceed min limit and new user turns happen
+- iteration nudge when many assistant/tool messages happen since last user turn
+- manual nudge when `/dcp compress [focus]` is used
+
+`nudgeForce`:
+
+- `soft`: suggestion wording
+- `strong`: direct instruction to compress before continuing if safe
+
+### Automatic strategies
+
+Deduplication:
+
+- enabled by `context.dcp.strategies.deduplication.enabled`
+- signature is `tool_name + "::" + stable_json(args)`
+- keep latest matching output
+- replace older repeated tool outputs with placeholder
+- respect protected tools
+
+Purge errors:
+
+- enabled by `context.dcp.strategies.purgeErrors.enabled`
+- after N turns, remove or summarize old failed tool inputs/large outputs
+- preserve the actual error message
+- respect protected tools
+
+Turn protection:
+
+- if `context.dcp.turnProtection.enabled`, never prune messages in the last N user turns
+
+Protected tools:
+
+Recommended Hermes defaults:
+
+- `delegate_task`
+- `todo`
+- `memory`
+- `skill_view`
+- `skill_manage`
+- `write_file`
+- `patch`
+- `clarify`
+- `cronjob`
+- `compress`
+
+Also consider protecting MCP tools with mutating prefixes:
+
+- create
+- update
+- delete
+- remove
+- write
+- patch
+
+Do not blindly protect all `terminal` calls. Terminal output is often the largest waste source. Instead, protect commands only if later evidence shows this is needed.
+
+## Config surface
+
+Add defaults under `context.dcp` in `hermes_cli/config.py`:
+
+```yaml
+context:
+  engine: compressor
+  dcp:
+    enabled: true
+    debug: false
+    pruneNotification: detailed
+    pruneNotificationType: chat
+    commands:
+      enabled: true
+      protectedTools: []
+    manualMode:
+      enabled: false
+      automaticStrategies: true
+    turnProtection:
+      enabled: false
+      turns: 4
+    experimental:
+      allowSubAgents: false
+      customPrompts: false
+    protectedFilePatterns: []
+    compress:
+      mode: range
+      permission: allow
+      showCompression: false
+      summaryBuffer: true
+      maxContextLimit: 100000
+      minContextLimit: 50000
+      modelMaxLimits: {}
+      modelMinLimits: {}
+      nudgeFrequency: 5
+      iterationNudgeThreshold: 15
+      nudgeForce: soft
+      protectedTools: []
+      protectUserMessages: false
+    strategies:
+      deduplication:
+        enabled: true
+        protectedTools: []
+      purgeErrors:
+        enabled: true
+        turns: 4
+        protectedTools: []
+```
+
+Support numeric limits and percentage strings:
+
+- `100000`
+- `"50%"`
+
+Model-specific limit maps should support Hermes provider/model naming. Use exact strings first and document the caveat:
+
+```yaml
+modelMaxLimits:
+  openai/gpt-5.5: "80%"
+  openrouter/anthropic/claude-sonnet-4.6: 120000
+```
+
+## Permission behavior
+
+DCP supports `allow`, `ask`, and `deny`.
+
+First PR recommendation:
+
+- `allow`: expose and execute `compress`
+- `deny`: do not expose `compress`
+- `ask`: expose but route through Hermes approval if feasible; otherwise treat as `allow` with a warning in logs and status
+
+Do not fake interactive approval if Hermes does not have the plumbing at the context-engine tool layer yet.
+
+## Slash commands
+
+First PR can defer slash commands, but if included, add only:
+
+- `/dcp`
+- `/dcp context`
+- `/dcp stats`
+- `/dcp manual [on|off]`
+- `/dcp compress [focus]`
+
+Later PR:
+
+- `/dcp sweep [n]`
+- `/dcp decompress <block>`
+- `/dcp recompress <block>`
+
+Commands should dispatch to the active context engine if `engine.name == "dcp"` and return a clear message otherwise.
+
+## Interaction with existing compression
+
+When `context.engine == "dcp"`:
+
+- DCP should not routinely call the existing `ContextCompressor`.
+- `DCPContextEngine.should_compress()` should return `False` by default.
+- DCP uses nudges and the `compress` tool as its primary mechanism.
+- Existing compressor may be used only as emergency fallback if the API request would exceed the hard provider limit or a context-length error is returned.
+
+Gateway hygiene is still a safety net. It may need a DCP-aware branch eventually because hygiene compression mutates gateway session history. For first PR, document the interaction and avoid making gateway hygiene call DCP unless there is a clean state path.
+
+## Prompt caching
+
+DCP must be careful with prompt caching.
+
+Rules:
+
+- Run DCP transform before cache-control marker placement.
+- Avoid changing old stable content every turn.
+- Compression block application should be deterministic.
+- Dedup and purge should avoid churn. Prefer recalculating after compress tool calls or when state changes, not randomly every request.
+- Never append moving counters into the cached prefix unless unavoidable.
+
+## Tests
+
+Use `scripts/run_tests.sh`, not direct pytest.
+
+Add tests:
+
+```text
+tests/agent/test_dcp_config.py
+tests/agent/test_dcp_context_engine.py
+tests/agent/test_dcp_transform.py
+tests/agent/test_dcp_compress_tool.py
+tests/agent/test_dcp_strategies.py
+```
+
+If slash commands are implemented:
+
+```text
+tests/cli/test_dcp_command.py
+```
+
+Required coverage:
+
+- config defaults and mode parsing
+- percentage limit resolution
+- `deny` permission hides tool
+- range schema shape
+- message schema shape
+- canonical messages are not mutated by transform
+- refs are stable across calls
+- range compression creates active block
+- overlapping range compression consumes/nests prior block or returns clear error
+- invalid refs return clear error
+- active blocks replace outbound content
+- tool adjacency is preserved
+- dedup keeps latest duplicate and prunes earlier duplicate
+- protected tools are not deduped
+- purgeErrors keeps error text but prunes old bulky input/output
+- turn protection prevents pruning recent messages
+- prompt-cache marker logic still receives valid messages
+
+Run focused tests first:
+
+```bash
+scripts/run_tests.sh tests/agent/test_dcp_config.py tests/agent/test_dcp_context_engine.py tests/agent/test_dcp_transform.py tests/agent/test_dcp_compress_tool.py tests/agent/test_dcp_strategies.py
+```
+
+Then full suite before PR readiness:
+
+```bash
+scripts/run_tests.sh
+```
+
+## Documentation updates before merge
+
+Permanent docs to update:
+
+1. `website/docs/developer-guide/context-compression-and-caching.md`
+   - describe `context.engine: dcp`
+   - explain DCP vs built-in compressor
+   - describe canonical transcript preservation
+   - explain fallback and gateway hygiene interaction
+
+2. `website/docs/developer-guide/context-engine-plugin.md`
+   - add `transform_api_messages()` optional method
+   - document API-call-time transform contract
+
+3. `website/docs/developer-guide/prompt-assembly.md`
+   - add context-engine API-call-time transforms
+   - explain refs/nudges are ephemeral model-facing context
+
+4. `website/docs/developer-guide/agent-loop.md`
+   - add transform step to loop lifecycle
+   - mention context-engine tools like DCP `compress`
+
+5. `website/docs/developer-guide/architecture.md`
+   - update file layout if new DCP modules are under `agent/`
+
+6. `website/docs/reference/cli-commands.md`
+   - only if `/dcp` commands are implemented
+
+## Implementation order
+
+1. Add DCP config parser and tests.
+2. Add DCP state and ID assignment tests.
+3. Add `transform_api_messages()` optional hook to `ContextEngine` and no-op default tests.
+4. Wire the hook in `run_agent.py` using API-message copy only.
+5. Add `DCPContextEngine` with status and tool schema only.
+6. Add range-mode `compress` handling and block application.
+7. Add message-mode handling.
+8. Add nudges and system extension.
+9. Add deduplication strategy.
+10. Add purgeErrors strategy.
+11. Add optional slash commands if scope allows.
+12. Update permanent docs.
+13. Delete or fold this temporary spec.
+
+## Open questions
+
+- Should DCP state be persisted in JSON under Hermes home in the first PR, or kept in memory until behavior stabilizes?
+- Should inline refs or an index block be the default for provider compatibility?
+- Should `ask` permission be implemented via existing approval callbacks in the first PR or deferred?
+- How should gateway hygiene behave when `context.engine == "dcp"` and a session is already too large before the agent starts?
+- Which MCP mutating tools should be protected by default?
+- Should `terminal` be partially protected based on command classification, or left unprotected for token savings?
+
+## Review checklist
+
+Before marking the PR ready:
+
+- No DCP AGPL source or prompt text copied.
+- Canonical transcript preservation is tested.
+- Provider-valid message ordering is tested.
+- Existing compressor behavior still passes tests.
+- DCP config is ignored unless `context.engine == "dcp"`.
+- Prompt caching behavior is intentionally placed and documented.
+- `/compress` existing Hermes command still works with the built-in compressor.
+- `compress` tool only appears in DCP mode.
+- Docs are updated or this temporary spec remains clearly marked as temporary if the PR is still draft.

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -105,6 +105,26 @@ class ContextEngine(ABC):
         """
         return False
 
+    def transform_api_messages(
+        self,
+        api_messages: List[Dict[str, Any]],
+        *,
+        canonical_messages: List[Dict[str, Any]],
+        system_prompt: str,
+        tools: List[Dict[str, Any]] | None,
+        api_call_count: int,
+        model: str,
+        provider: str | None,
+        session_id: str | None,
+    ) -> List[Dict[str, Any]]:
+        """Transform the provider-bound API-call copy of the transcript.
+
+        Default returns ``api_messages`` unchanged. Engines may override this
+        to add ephemeral refs, compression placeholders, or other context
+        layers without mutating ``canonical_messages``.
+        """
+        return api_messages
+
     # -- Optional: manual /compress preflight ------------------------------
 
     def has_content_to_compress(self, messages: List[Dict[str, Any]]) -> bool:

--- a/agent/dcp_config.py
+++ b/agent/dcp_config.py
@@ -1,0 +1,256 @@
+"""Configuration helpers for the DCP context engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+DCP_DEFAULT_PROTECTED_TOOLS = {
+    "delegate_task",
+    "todo",
+    "memory",
+    "skill_view",
+    "skill_manage",
+    "write_file",
+    "patch",
+    "clarify",
+    "cronjob",
+    "compress",
+}
+
+
+@dataclass(slots=True)
+class DCPStrategyConfig:
+    enabled: bool = True
+    protected_tools: set[str] = field(default_factory=set)
+
+
+@dataclass(slots=True)
+class DCPPurgeErrorsConfig(DCPStrategyConfig):
+    turns: int = 4
+
+
+@dataclass(slots=True)
+class DCPCompressConfig:
+    mode: Literal["range", "message"] = "range"
+    permission: Literal["allow", "ask", "deny"] = "allow"
+    show_compression: bool = False
+    summary_buffer: bool = True
+    max_context_limit: int | str = 100000
+    min_context_limit: int | str = 50000
+    model_max_limits: dict[str, int | str] = field(default_factory=dict)
+    model_min_limits: dict[str, int | str] = field(default_factory=dict)
+    nudge_frequency: int = 5
+    iteration_nudge_threshold: int = 15
+    nudge_force: Literal["soft", "strong"] = "soft"
+    protected_tools: set[str] = field(default_factory=set)
+    protect_user_messages: bool = False
+
+
+@dataclass(slots=True)
+class DCPTurnProtectionConfig:
+    enabled: bool = False
+    turns: int = 4
+
+
+@dataclass(slots=True)
+class DCPManualModeConfig:
+    enabled: bool = False
+    automatic_strategies: bool = True
+
+
+@dataclass(slots=True)
+class DCPCommandsConfig:
+    enabled: bool = True
+    protected_tools: set[str] = field(default_factory=set)
+
+
+@dataclass(slots=True)
+class DCPExperimentalConfig:
+    allow_subagents: bool = False
+    custom_prompts: bool = False
+
+
+@dataclass(slots=True)
+class DCPConfig:
+    enabled: bool = True
+    debug: bool = False
+    prune_notification: Literal["off", "minimal", "detailed"] = "detailed"
+    prune_notification_type: Literal["chat", "toast"] = "chat"
+    commands: DCPCommandsConfig = field(default_factory=DCPCommandsConfig)
+    manual_mode: DCPManualModeConfig = field(default_factory=DCPManualModeConfig)
+    turn_protection: DCPTurnProtectionConfig = field(default_factory=DCPTurnProtectionConfig)
+    experimental: DCPExperimentalConfig = field(default_factory=DCPExperimentalConfig)
+    protected_file_patterns: list[str] = field(default_factory=list)
+    compress: DCPCompressConfig = field(default_factory=DCPCompressConfig)
+    deduplication: DCPStrategyConfig = field(default_factory=DCPStrategyConfig)
+    purge_errors: DCPPurgeErrorsConfig = field(default_factory=DCPPurgeErrorsConfig)
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    return default
+
+
+def _as_int(value: Any, default: int, *, minimum: int | None = None) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    if minimum is not None:
+        parsed = max(minimum, parsed)
+    return parsed
+
+
+def _as_choice(value: Any, choices: set[str], default: str) -> str:
+    if isinstance(value, str) and value in choices:
+        return value
+    return default
+
+
+def _as_limit(value: Any, default: int | str) -> int | str:
+    if isinstance(value, int) and value > 0:
+        return value
+    if isinstance(value, str):
+        raw = value.strip()
+        if raw.endswith("%"):
+            try:
+                pct = float(raw[:-1])
+            except ValueError:
+                return default
+            if pct > 0:
+                return raw
+        else:
+            try:
+                parsed = int(raw)
+            except ValueError:
+                return default
+            if parsed > 0:
+                return parsed
+    return default
+
+
+def _as_limit_map(value: Any) -> dict[str, int | str]:
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, int | str] = {}
+    for key, limit in value.items():
+        if not isinstance(key, str):
+            continue
+        parsed = _as_limit(limit, 0)
+        if parsed:
+            out[key] = parsed
+    return out
+
+
+def _tool_set(value: Any) -> set[str]:
+    if not isinstance(value, list):
+        return set()
+    return {item for item in value if isinstance(item, str) and item.strip()}
+
+
+def _str_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def parse_dcp_config(config: dict[str, Any] | None) -> DCPConfig:
+    """Parse ``context.dcp`` config into typed defaults."""
+    raw = config if isinstance(config, dict) else {}
+
+    commands_raw = raw.get("commands", {}) if isinstance(raw.get("commands", {}), dict) else {}
+    manual_raw = raw.get("manualMode", {}) if isinstance(raw.get("manualMode", {}), dict) else {}
+    turn_raw = raw.get("turnProtection", {}) if isinstance(raw.get("turnProtection", {}), dict) else {}
+    exp_raw = raw.get("experimental", {}) if isinstance(raw.get("experimental", {}), dict) else {}
+    compress_raw = raw.get("compress", {}) if isinstance(raw.get("compress", {}), dict) else {}
+    strategies_raw = raw.get("strategies", {}) if isinstance(raw.get("strategies", {}), dict) else {}
+    dedup_raw = strategies_raw.get("deduplication", {}) if isinstance(strategies_raw.get("deduplication", {}), dict) else {}
+    purge_raw = strategies_raw.get("purgeErrors", {}) if isinstance(strategies_raw.get("purgeErrors", {}), dict) else {}
+
+    return DCPConfig(
+        enabled=_as_bool(raw.get("enabled"), True),
+        debug=_as_bool(raw.get("debug"), False),
+        prune_notification=_as_choice(raw.get("pruneNotification"), {"off", "minimal", "detailed"}, "detailed"),  # type: ignore[arg-type]
+        prune_notification_type=_as_choice(raw.get("pruneNotificationType"), {"chat", "toast"}, "chat"),  # type: ignore[arg-type]
+        commands=DCPCommandsConfig(
+            enabled=_as_bool(commands_raw.get("enabled"), True),
+            protected_tools=_tool_set(commands_raw.get("protectedTools")),
+        ),
+        manual_mode=DCPManualModeConfig(
+            enabled=_as_bool(manual_raw.get("enabled"), False),
+            automatic_strategies=_as_bool(manual_raw.get("automaticStrategies"), True),
+        ),
+        turn_protection=DCPTurnProtectionConfig(
+            enabled=_as_bool(turn_raw.get("enabled"), False),
+            turns=_as_int(turn_raw.get("turns"), 4, minimum=0),
+        ),
+        experimental=DCPExperimentalConfig(
+            allow_subagents=_as_bool(exp_raw.get("allowSubAgents"), False),
+            custom_prompts=_as_bool(exp_raw.get("customPrompts"), False),
+        ),
+        protected_file_patterns=_str_list(raw.get("protectedFilePatterns")),
+        compress=DCPCompressConfig(
+            mode=_as_choice(compress_raw.get("mode"), {"range", "message"}, "range"),  # type: ignore[arg-type]
+            permission=_as_choice(compress_raw.get("permission"), {"allow", "ask", "deny"}, "allow"),  # type: ignore[arg-type]
+            show_compression=_as_bool(compress_raw.get("showCompression"), False),
+            summary_buffer=_as_bool(compress_raw.get("summaryBuffer"), True),
+            max_context_limit=_as_limit(compress_raw.get("maxContextLimit"), 100000),
+            min_context_limit=_as_limit(compress_raw.get("minContextLimit"), 50000),
+            model_max_limits=_as_limit_map(compress_raw.get("modelMaxLimits")),
+            model_min_limits=_as_limit_map(compress_raw.get("modelMinLimits")),
+            nudge_frequency=_as_int(compress_raw.get("nudgeFrequency"), 5, minimum=1),
+            iteration_nudge_threshold=_as_int(compress_raw.get("iterationNudgeThreshold"), 15, minimum=1),
+            nudge_force=_as_choice(compress_raw.get("nudgeForce"), {"soft", "strong"}, "soft"),  # type: ignore[arg-type]
+            protected_tools=_tool_set(compress_raw.get("protectedTools")),
+            protect_user_messages=_as_bool(compress_raw.get("protectUserMessages"), False),
+        ),
+        deduplication=DCPStrategyConfig(
+            enabled=_as_bool(dedup_raw.get("enabled"), True),
+            protected_tools=_tool_set(dedup_raw.get("protectedTools")),
+        ),
+        purge_errors=DCPPurgeErrorsConfig(
+            enabled=_as_bool(purge_raw.get("enabled"), True),
+            protected_tools=_tool_set(purge_raw.get("protectedTools")),
+            turns=_as_int(purge_raw.get("turns"), 4, minimum=0),
+        ),
+    )
+
+
+def resolve_limit(limit: int | str, context_length: int) -> int:
+    """Resolve an absolute token limit or percentage string."""
+    if isinstance(limit, int):
+        return limit
+    raw = limit.strip()
+    if raw.endswith("%"):
+        try:
+            pct = float(raw[:-1]) / 100.0
+        except ValueError:
+            return 0
+        return int(context_length * pct)
+    try:
+        return int(raw)
+    except ValueError:
+        return 0
+
+
+def resolve_model_limit(
+    limits: dict[str, int | str],
+    *,
+    provider: str | None,
+    model: str | None,
+    context_length: int,
+    fallback: int | str,
+) -> int:
+    """Resolve DCP per-model limits with a simple provider/model key."""
+    keys = []
+    if provider and model:
+        keys.append(f"{provider}/{model}")
+    if model:
+        keys.append(model)
+    for key in keys:
+        if key in limits:
+            return resolve_limit(limits[key], context_length)
+    return resolve_limit(fallback, context_length)

--- a/agent/dcp_context_engine.py
+++ b/agent/dcp_context_engine.py
@@ -1,0 +1,624 @@
+"""DCP-style model-guided context engine for Hermes Agent."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+import time
+from collections import defaultdict, deque
+from typing import Any
+
+from agent.context_engine import ContextEngine
+from agent.dcp_config import (
+    DCP_DEFAULT_PROTECTED_TOOLS,
+    DCPConfig,
+    parse_dcp_config,
+    resolve_model_limit,
+)
+from agent.dcp_state import CompressionBlock, DCPSessionState
+from agent.model_metadata import estimate_messages_tokens_rough
+
+_ERROR_RE = re.compile(r"\b(error|exception|traceback|failed|failure|timed out|timeout)\b", re.I)
+
+
+class DCPContextEngine(ContextEngine):
+    """Model-guided context engine inspired by Dynamic Context Pruning.
+
+    The engine keeps canonical history intact. ``compress`` creates DCP state;
+    ``transform_api_messages`` applies that state to the provider-bound copy.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: dict[str, Any] | DCPConfig | None = None,
+        context_length: int = 0,
+        model: str = "",
+        provider: str = "",
+        quiet_mode: bool = False,
+    ) -> None:
+        self.config = config if isinstance(config, DCPConfig) else parse_dcp_config(config)
+        self.context_length = context_length or 0
+        self.model = model or ""
+        self.provider = provider or ""
+        self.quiet_mode = quiet_mode
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+        self.last_total_tokens = 0
+        self.compression_count = 0
+        self.threshold_tokens = self._min_limit()
+        self.state = DCPSessionState()
+
+    @property
+    def name(self) -> str:
+        return "dcp"
+
+    def update_from_response(self, usage: dict[str, Any]) -> None:
+        self.last_prompt_tokens = int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+        self.last_completion_tokens = int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+        self.last_total_tokens = int(usage.get("total_tokens") or (self.last_prompt_tokens + self.last_completion_tokens))
+        self.state.last_prompt_tokens = self.last_prompt_tokens
+
+    def should_compress(self, prompt_tokens: int = None) -> bool:
+        # DCP is normally model-guided through the compress tool, not host-driven.
+        return False
+
+    def should_compress_preflight(self, messages: list[dict[str, Any]]) -> bool:
+        return False
+
+    def has_content_to_compress(self, messages: list[dict[str, Any]]) -> bool:
+        self._ensure_refs(messages)
+        return len(self.state.index_by_ref) > 4
+
+    def compress(
+        self,
+        messages: list[dict[str, Any]],
+        current_tokens: int = None,
+        focus_topic: str = None,
+    ) -> list[dict[str, Any]]:
+        # Manual /compress fallback: record a pending nudge and leave transcript intact.
+        if focus_topic:
+            self.state.manual_mode = "compress-pending"
+            self.state.pending_manual_focus = focus_topic
+        return messages
+
+    def on_session_start(self, session_id: str, **kwargs: Any) -> None:
+        self.state.session_id = session_id
+        model = kwargs.get("model")
+        context_length = kwargs.get("context_length")
+        if isinstance(model, str) and model:
+            self.model = model
+        if isinstance(context_length, int) and context_length > 0:
+            self.context_length = context_length
+            self.threshold_tokens = self._min_limit()
+
+    def on_session_reset(self) -> None:
+        super().on_session_reset()
+        self.state = DCPSessionState(session_id=self.state.session_id)
+
+    def update_model(
+        self,
+        model: str,
+        context_length: int,
+        base_url: str = "",
+        api_key: str = "",
+        provider: str = "",
+    ) -> None:
+        self.model = model or self.model
+        self.provider = provider or self.provider
+        self.context_length = context_length
+        self.threshold_tokens = self._min_limit()
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        if not self.config.enabled or self.config.compress.permission == "deny":
+            return []
+        if self.config.compress.mode == "message":
+            return [self._message_tool_schema()]
+        return [self._range_tool_schema()]
+
+    def handle_tool_call(self, name: str, args: dict[str, Any], **kwargs: Any) -> str:
+        if name != "compress":
+            return json.dumps({"ok": False, "error": f"Unknown context engine tool: {name}"})
+        messages = kwargs.get("messages")
+        if not isinstance(messages, list):
+            return json.dumps({"ok": False, "error": "compress requires current messages"})
+        try:
+            if self.config.compress.mode == "message":
+                result = self._handle_message_compress(args, messages)
+            else:
+                result = self._handle_range_compress(args, messages)
+        except Exception as exc:  # fail loudly to the model, not to the agent loop
+            return json.dumps({"ok": False, "error": str(exc)})
+        return json.dumps(result)
+
+    def transform_api_messages(
+        self,
+        api_messages: list[dict[str, Any]],
+        *,
+        canonical_messages: list[dict[str, Any]],
+        system_prompt: str,
+        tools: list[dict[str, Any]] | None,
+        api_call_count: int,
+        model: str,
+        provider: str | None,
+        session_id: str | None,
+    ) -> list[dict[str, Any]]:
+        if not self.config.enabled:
+            return api_messages
+
+        self.model = model or self.model
+        self.provider = provider or self.provider
+        self.state.session_id = session_id or self.state.session_id
+        self._ensure_refs(canonical_messages)
+
+        transformed = copy.deepcopy(api_messages)
+        ref_by_api_index = self._match_api_messages_to_refs(transformed, canonical_messages)
+        self._annotate_refs(transformed, ref_by_api_index)
+        self._apply_blocks(transformed, ref_by_api_index)
+
+        if self._automatic_strategies_enabled():
+            if self.config.deduplication.enabled:
+                self._apply_deduplication(transformed)
+            if self.config.purge_errors.enabled:
+                self._apply_purge_errors(transformed)
+
+        self._inject_system_extension(transformed)
+        self._inject_nudge(transformed, api_call_count=api_call_count)
+        return transformed
+
+    def get_status(self) -> dict[str, Any]:
+        active_blocks = self.state.active_blocks()
+        return {
+            **super().get_status(),
+            "engine": "dcp",
+            "active_blocks": len(active_blocks),
+            "message_refs": len(self.state.ref_by_message_key),
+            "min_context_limit": self._min_limit(),
+            "max_context_limit": self._max_limit(),
+            "compress_mode": self.config.compress.mode,
+            "compress_permission": self.config.compress.permission,
+        }
+
+    # -- Tool schemas -----------------------------------------------------
+
+    def _range_tool_schema(self) -> dict[str, Any]:
+        return {
+            "name": "compress",
+            "description": (
+                "Compress completed, stale context ranges by message/block ref. "
+                "Use this when prior work is closed and a concise technical summary "
+                "will preserve the useful state. Do not compress the active task."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "topic": {"type": "string", "description": "Short 3-5 word label for this compression batch."},
+                    "content": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "startId": {"type": "string", "description": "Starting message or block ref, e.g. m0004 or b2."},
+                                "endId": {"type": "string", "description": "Ending message or block ref, e.g. m0018 or b3."},
+                                "summary": {"type": "string", "description": "Complete technical summary replacing the range."},
+                            },
+                            "required": ["startId", "endId", "summary"],
+                        },
+                    },
+                },
+                "required": ["topic", "content"],
+            },
+        }
+
+    def _message_tool_schema(self) -> dict[str, Any]:
+        return {
+            "name": "compress",
+            "description": (
+                "Compress individual high-volume messages by ref. Preserve concrete "
+                "technical facts, file paths, commands, decisions, errors, and open questions."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "topic": {"type": "string", "description": "Short label for this compression batch."},
+                    "content": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "messageId": {"type": "string", "description": "Message ref, e.g. m0042."},
+                                "topic": {"type": "string", "description": "Short label for this message."},
+                                "summary": {"type": "string", "description": "Complete technical summary replacing this message."},
+                            },
+                            "required": ["messageId", "topic", "summary"],
+                        },
+                    },
+                },
+                "required": ["topic", "content"],
+            },
+        }
+
+    # -- Tool handling ----------------------------------------------------
+
+    def _handle_range_compress(self, args: dict[str, Any], messages: list[dict[str, Any]]) -> dict[str, Any]:
+        self._ensure_refs(messages)
+        topic = self._require_str(args, "topic")
+        content = args.get("content")
+        if not isinstance(content, list) or not content:
+            raise ValueError("compress.content must be a non-empty array")
+
+        created: list[int] = []
+        deactivated: list[int] = []
+        run_id = self.state.new_run_id()
+        for item in content:
+            if not isinstance(item, dict):
+                raise ValueError("Each compression range must be an object")
+            start_ref = self._require_str(item, "startId")
+            end_ref = self._require_str(item, "endId")
+            summary = self._require_str(item, "summary")
+            message_refs, included_blocks = self._resolve_range(start_ref, end_ref)
+            if not message_refs:
+                raise ValueError(f"Range {start_ref}-{end_ref} does not cover any messages")
+            block_id = self.state.new_block_id()
+            consumed_blocks: list[int] = []
+            for included in included_blocks:
+                block = self.state.blocks_by_id.get(included)
+                if block and block.active:
+                    block.active = False
+                    block.deactivated_at = time.time()
+                    block.deactivated_by_block_id = block_id
+                    self.state.active_block_ids.discard(included)
+                    consumed_blocks.append(included)
+                    deactivated.append(included)
+            block = CompressionBlock(
+                block_id=block_id,
+                run_id=run_id,
+                mode="range",
+                topic=topic,
+                summary=self._augment_summary(summary, message_refs),
+                start_ref=start_ref,
+                end_ref=end_ref,
+                message_refs=message_refs,
+                included_block_ids=included_blocks,
+                consumed_block_ids=consumed_blocks,
+                created_at=time.time(),
+            )
+            self.state.blocks_by_id[block_id] = block
+            self.state.active_block_ids.add(block_id)
+            created.append(block_id)
+
+        self.compression_count += len(created)
+        self.state.turns_since_last_compress = 0
+        return {
+            "ok": True,
+            "mode": "range",
+            "created_blocks": created,
+            "deactivated_blocks": deactivated,
+            "active_blocks": sorted(self.state.active_block_ids),
+            "message": f"Compressed {len(created)} range(s) into {', '.join(f'b{i}' for i in created)}.",
+        }
+
+    def _handle_message_compress(self, args: dict[str, Any], messages: list[dict[str, Any]]) -> dict[str, Any]:
+        self._ensure_refs(messages)
+        batch_topic = self._require_str(args, "topic")
+        content = args.get("content")
+        if not isinstance(content, list) or not content:
+            raise ValueError("compress.content must be a non-empty array")
+        created: list[int] = []
+        run_id = self.state.new_run_id()
+        for item in content:
+            if not isinstance(item, dict):
+                raise ValueError("Each compressed message must be an object")
+            ref = self._require_str(item, "messageId")
+            if ref not in self.state.index_by_ref:
+                raise ValueError(f"Unknown message ref: {ref}")
+            topic = item.get("topic") if isinstance(item.get("topic"), str) else batch_topic
+            summary = self._require_str(item, "summary")
+            block_id = self.state.new_block_id()
+            block = CompressionBlock(
+                block_id=block_id,
+                run_id=run_id,
+                mode="message",
+                topic=topic,
+                summary=self._augment_summary(summary, [ref]),
+                message_refs=[ref],
+                created_at=time.time(),
+            )
+            self.state.blocks_by_id[block_id] = block
+            self.state.active_block_ids.add(block_id)
+            created.append(block_id)
+        self.compression_count += len(created)
+        self.state.turns_since_last_compress = 0
+        return {
+            "ok": True,
+            "mode": "message",
+            "created_blocks": created,
+            "active_blocks": sorted(self.state.active_block_ids),
+            "message": f"Compressed {len(created)} message(s) into {', '.join(f'b{i}' for i in created)}.",
+        }
+
+    # -- Transforms -------------------------------------------------------
+
+    def _ensure_refs(self, messages: list[dict[str, Any]]) -> None:
+        self.state.index_by_ref.clear()
+        for idx, msg in enumerate(messages):
+            key = self._message_key(msg, idx)
+            ref = self.state.ref_by_message_key.get(key)
+            if ref is None:
+                ref = self.state.new_message_ref()
+                self.state.ref_by_message_key[key] = ref
+                self.state.message_key_by_ref[ref] = key
+            self.state.index_by_ref[ref] = idx
+        user_indices = [idx for idx, msg in enumerate(messages) if msg.get("role") == "user"]
+        if user_indices:
+            last_user = user_indices[-1]
+            if last_user != self.state.last_user_turn_index:
+                self.state.turns_since_last_compress += 1
+            self.state.last_user_turn_index = last_user
+            self.state.messages_since_last_user = len(messages) - last_user - 1
+
+    def _match_api_messages_to_refs(
+        self,
+        api_messages: list[dict[str, Any]],
+        canonical_messages: list[dict[str, Any]],
+    ) -> dict[int, str]:
+        self._ensure_refs(canonical_messages)
+        refs_by_key: dict[str, deque[str]] = defaultdict(deque)
+        for idx, msg in enumerate(canonical_messages):
+            key = self._message_key(msg, idx)
+            ref = self.state.ref_by_message_key.get(key)
+            if ref:
+                refs_by_key[self._message_signature(msg)].append(ref)
+
+        out: dict[int, str] = {}
+        for api_idx, msg in enumerate(api_messages):
+            if msg.get("role") == "system":
+                continue
+            sig = self._message_signature(msg)
+            queue = refs_by_key.get(sig)
+            if queue:
+                out[api_idx] = queue.popleft()
+        return out
+
+    def _annotate_refs(self, messages: list[dict[str, Any]], ref_by_api_index: dict[int, str]) -> None:
+        for idx, ref in ref_by_api_index.items():
+            msg = messages[idx]
+            content = msg.get("content")
+            marker = f'<dcp-ref id="{ref}" />'
+            if isinstance(content, str):
+                if marker not in content:
+                    msg["content"] = f"{content}\n\n{marker}" if content else marker
+            elif isinstance(content, list):
+                msg["content"] = content + [{"type": "text", "text": marker}]
+
+    def _apply_blocks(self, messages: list[dict[str, Any]], ref_by_api_index: dict[int, str]) -> None:
+        ref_to_api_index = {ref: idx for idx, ref in ref_by_api_index.items()}
+        for block in self.state.active_blocks():
+            covered = [ref for ref in block.message_refs if ref in ref_to_api_index]
+            if not covered:
+                continue
+            anchor_ref = covered[0]
+            anchor_idx = ref_to_api_index[anchor_ref]
+            anchor = messages[anchor_idx]
+            anchor["content"] = self._block_summary_text(block)
+            for ref in covered[1:]:
+                idx = ref_to_api_index[ref]
+                msg = messages[idx]
+                msg["content"] = f"[DCP: content moved into compressed block {block.ref}.]"
+
+    def _apply_deduplication(self, messages: list[dict[str, Any]]) -> None:
+        protected = DCP_DEFAULT_PROTECTED_TOOLS | self.config.deduplication.protected_tools
+        latest_by_sig: dict[str, int] = {}
+        result_by_call_id: dict[str, int] = {}
+        calls: list[tuple[int, str, str]] = []
+        for idx, msg in enumerate(messages):
+            if msg.get("role") == "assistant":
+                for tc in msg.get("tool_calls") or []:
+                    name = self._tool_name(tc)
+                    if not name or name in protected:
+                        continue
+                    call_id = tc.get("id") if isinstance(tc, dict) else None
+                    if not isinstance(call_id, str):
+                        continue
+                    sig = self._tool_signature(tc)
+                    calls.append((idx, call_id, sig))
+                    latest_by_sig[sig] = idx
+            elif msg.get("role") == "tool":
+                call_id = msg.get("tool_call_id")
+                if isinstance(call_id, str):
+                    result_by_call_id[call_id] = idx
+        protected_indices = self._turn_protected_indices(messages)
+        for call_idx, call_id, sig in calls:
+            if latest_by_sig.get(sig) == call_idx:
+                continue
+            result_idx = result_by_call_id.get(call_id)
+            if result_idx is not None and result_idx not in protected_indices:
+                messages[result_idx]["content"] = "[DCP: duplicate tool output removed. Same tool and arguments were called again later.]"
+
+    def _apply_purge_errors(self, messages: list[dict[str, Any]]) -> None:
+        protected = DCP_DEFAULT_PROTECTED_TOOLS | self.config.purge_errors.protected_tools
+        keep_tail = max(0, self.config.purge_errors.turns * 2)
+        cutoff = max(0, len(messages) - keep_tail)
+        call_name_by_id: dict[str, str] = {}
+        for msg in messages:
+            if msg.get("role") != "assistant":
+                continue
+            for tc in msg.get("tool_calls") or []:
+                call_id = tc.get("id") if isinstance(tc, dict) else None
+                name = self._tool_name(tc)
+                if isinstance(call_id, str) and name:
+                    call_name_by_id[call_id] = name
+        protected_indices = self._turn_protected_indices(messages)
+        for idx, msg in enumerate(messages[:cutoff]):
+            if idx in protected_indices or msg.get("role") != "tool":
+                continue
+            call_id = msg.get("tool_call_id")
+            name = call_name_by_id.get(call_id) if isinstance(call_id, str) else None
+            if name in protected:
+                continue
+            content = msg.get("content")
+            if isinstance(content, str) and len(content) > 240 and _ERROR_RE.search(content):
+                first_line = content.strip().splitlines()[0][:240]
+                msg["content"] = f"[DCP: old failed tool output pruned after {self.config.purge_errors.turns} turns. Error preserved: {first_line}]"
+
+    def _inject_system_extension(self, messages: list[dict[str, Any]]) -> None:
+        if self.config.compress.permission == "deny":
+            return
+        extension = (
+            "DCP context management is active. Message refs look like m0001; "
+            "compressed blocks look like b1. Use the compress tool when older work "
+            "is complete or stale. Preserve concrete file paths, commands, errors, "
+            "test results, decisions, constraints, and open questions. Do not compress "
+            "the active task or very recent user turns."
+        )
+        if messages and messages[0].get("role") == "system" and isinstance(messages[0].get("content"), str):
+            if "DCP context management is active" not in messages[0]["content"]:
+                messages[0]["content"] = f"{messages[0]['content']}\n\n{extension}"
+
+    def _inject_nudge(self, messages: list[dict[str, Any]], *, api_call_count: int) -> None:
+        prompt_tokens = estimate_messages_tokens_rough(messages)
+        max_limit = self._max_limit()
+        min_limit = self._min_limit()
+        nudge: str | None = None
+        if max_limit and prompt_tokens >= max_limit:
+            force = "Before continuing, call compress on any completed range if safe." if self.config.compress.nudge_force == "strong" else "Consider calling compress on completed older ranges before continuing."
+            nudge = f"DCP context pressure is high (~{prompt_tokens:,} tokens). {force}"
+        elif min_limit and prompt_tokens >= min_limit and self.state.turns_since_last_compress >= self.config.compress.nudge_frequency:
+            nudge = "DCP: context is growing. If an older topic is complete, use compress with the visible refs."
+        elif self.state.messages_since_last_user >= self.config.compress.iteration_nudge_threshold:
+            nudge = "DCP: many assistant/tool messages have accumulated since the last user turn. Compress closed context if safe."
+        elif self.state.manual_mode == "compress-pending":
+            focus = f" Focus: {self.state.pending_manual_focus}." if self.state.pending_manual_focus else ""
+            nudge = f"DCP manual compression requested.{focus} Call compress before continuing if there is safe completed context."
+            self.state.manual_mode = False
+            self.state.pending_manual_focus = None
+
+        if not nudge:
+            return
+        for msg in reversed(messages):
+            if msg.get("role") == "user" and isinstance(msg.get("content"), str):
+                msg["content"] = f"{msg['content']}\n\n<dcp-nudge>{nudge}</dcp-nudge>"
+                return
+        if messages and isinstance(messages[-1].get("content"), str):
+            messages[-1]["content"] = f"{messages[-1]['content']}\n\n<dcp-nudge>{nudge}</dcp-nudge>"
+
+    # -- Helpers ----------------------------------------------------------
+
+    def _message_key(self, msg: dict[str, Any], idx: int) -> str:
+        return f"{idx}:{self._message_signature(msg)}"
+
+    def _message_signature(self, msg: dict[str, Any]) -> str:
+        clean = {
+            "role": msg.get("role"),
+            "content": msg.get("content"),
+            "tool_call_id": msg.get("tool_call_id"),
+            "tool_calls": msg.get("tool_calls"),
+        }
+        raw = json.dumps(clean, sort_keys=True, default=str, separators=(",", ":"))
+        return hashlib.sha1(raw.encode("utf-8", "ignore")).hexdigest()
+
+    def _require_str(self, args: dict[str, Any], key: str) -> str:
+        value = args.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"compress.{key} must be a non-empty string")
+        return value.strip()
+
+    def _resolve_range(self, start_ref: str, end_ref: str) -> tuple[list[str], list[int]]:
+        start_idx = self._resolve_ref_to_index(start_ref)
+        end_idx = self._resolve_ref_to_index(end_ref)
+        if start_idx is None:
+            raise ValueError(f"Unknown startId: {start_ref}")
+        if end_idx is None:
+            raise ValueError(f"Unknown endId: {end_ref}")
+        if end_idx < start_idx:
+            start_idx, end_idx = end_idx, start_idx
+        refs = [ref for ref, idx in self.state.index_by_ref.items() if start_idx <= idx <= end_idx]
+        refs.sort(key=lambda ref: self.state.index_by_ref[ref])
+        included_blocks = [
+            block.block_id
+            for block in self.state.active_blocks()
+            if any(ref in refs for ref in block.message_refs)
+        ]
+        return refs, included_blocks
+
+    def _resolve_ref_to_index(self, ref: str) -> int | None:
+        if ref.startswith("m"):
+            return self.state.index_by_ref.get(ref)
+        if ref.startswith("b"):
+            try:
+                block_id = int(ref[1:])
+            except ValueError:
+                return None
+            block = self.state.blocks_by_id.get(block_id)
+            if not block or not block.message_refs:
+                return None
+            return self.state.index_by_ref.get(block.message_refs[0])
+        return None
+
+    def _augment_summary(self, summary: str, message_refs: list[str]) -> str:
+        parts = [summary.strip()]
+        if self.config.compress.protect_user_messages:
+            parts.append(f"Covered refs: {', '.join(message_refs)}")
+        return "\n\n".join(part for part in parts if part)
+
+    def _block_summary_text(self, block: CompressionBlock) -> str:
+        covers = f"{block.start_ref}-{block.end_ref}" if block.start_ref and block.end_ref else ", ".join(block.message_refs)
+        return (
+            f'<dcp-compressed-block id="{block.ref}" topic="{block.topic}">\n'
+            f"Summary: {block.summary}\n"
+            f"Covers: {covers}\n"
+            "</dcp-compressed-block>"
+        )
+
+    def _tool_name(self, tool_call: Any) -> str | None:
+        if not isinstance(tool_call, dict):
+            return None
+        function = tool_call.get("function")
+        if isinstance(function, dict) and isinstance(function.get("name"), str):
+            return function["name"]
+        return None
+
+    def _tool_signature(self, tool_call: dict[str, Any]) -> str:
+        function = tool_call.get("function") if isinstance(tool_call.get("function"), dict) else {}
+        name = function.get("name", "")
+        args = function.get("arguments", "")
+        try:
+            args_obj = json.loads(args) if isinstance(args, str) else args
+            args_norm = json.dumps(args_obj, sort_keys=True, separators=(",", ":"), default=str)
+        except Exception:
+            args_norm = str(args)
+        return f"{name}::{args_norm}"
+
+    def _automatic_strategies_enabled(self) -> bool:
+        if self.config.manual_mode.enabled and not self.config.manual_mode.automatic_strategies:
+            return False
+        return True
+
+    def _turn_protected_indices(self, messages: list[dict[str, Any]]) -> set[int]:
+        if not self.config.turn_protection.enabled or self.config.turn_protection.turns <= 0:
+            return set()
+        user_indices = [idx for idx, msg in enumerate(messages) if msg.get("role") == "user"]
+        if not user_indices:
+            return set()
+        start = user_indices[-self.config.turn_protection.turns] if len(user_indices) >= self.config.turn_protection.turns else user_indices[0]
+        return set(range(start, len(messages)))
+
+    def _min_limit(self) -> int:
+        return resolve_model_limit(
+            self.config.compress.model_min_limits,
+            provider=self.provider,
+            model=self.model,
+            context_length=self.context_length,
+            fallback=self.config.compress.min_context_limit,
+        )
+
+    def _max_limit(self) -> int:
+        return resolve_model_limit(
+            self.config.compress.model_max_limits,
+            provider=self.provider,
+            model=self.model,
+            context_length=self.context_length,
+            fallback=self.config.compress.max_context_limit,
+        )

--- a/agent/dcp_state.py
+++ b/agent/dcp_state.py
@@ -1,0 +1,70 @@
+"""State model for the DCP context engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+@dataclass(slots=True)
+class CompressionBlock:
+    block_id: int
+    run_id: int
+    mode: Literal["range", "message"]
+    topic: str
+    summary: str
+    active: bool = True
+    start_ref: str | None = None
+    end_ref: str | None = None
+    message_refs: list[str] = field(default_factory=list)
+    included_block_ids: list[int] = field(default_factory=list)
+    consumed_block_ids: list[int] = field(default_factory=list)
+    created_at: float = 0.0
+    deactivated_at: float | None = None
+    deactivated_by_block_id: int | None = None
+
+    @property
+    def ref(self) -> str:
+        return f"b{self.block_id}"
+
+
+@dataclass(slots=True)
+class DCPSessionState:
+    session_id: str | None = None
+    next_message_ref: int = 1
+    next_block_id: int = 1
+    next_run_id: int = 1
+    ref_by_message_key: dict[str, str] = field(default_factory=dict)
+    message_key_by_ref: dict[str, str] = field(default_factory=dict)
+    index_by_ref: dict[str, int] = field(default_factory=dict)
+    blocks_by_id: dict[int, CompressionBlock] = field(default_factory=dict)
+    active_block_ids: set[int] = field(default_factory=set)
+    last_prompt_tokens: int = 0
+    last_user_turn_index: int = 0
+    turns_since_last_compress: int = 0
+    messages_since_last_user: int = 0
+    manual_mode: bool | Literal["compress-pending"] = False
+    pending_manual_focus: str | None = None
+    stats: dict[str, Any] = field(default_factory=dict)
+
+    def new_message_ref(self) -> str:
+        ref = f"m{self.next_message_ref:04d}"
+        self.next_message_ref += 1
+        return ref
+
+    def new_block_id(self) -> int:
+        block_id = self.next_block_id
+        self.next_block_id += 1
+        return block_id
+
+    def new_run_id(self) -> int:
+        run_id = self.next_run_id
+        self.next_run_id += 1
+        return run_id
+
+    def active_blocks(self) -> list[CompressionBlock]:
+        return [
+            self.blocks_by_id[block_id]
+            for block_id in sorted(self.active_block_ids)
+            if block_id in self.blocks_by_id and self.blocks_by_id[block_id].active
+        ]

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -946,6 +946,55 @@ DEFAULT_CONFIG = {
     # a plugin in plugins/context_engine/<name>/ or ~/.hermes/plugins/.
     "context": {
         "engine": "compressor",
+        "dcp": {
+            "enabled": True,
+            "debug": False,
+            "pruneNotification": "detailed",
+            "pruneNotificationType": "chat",
+            "commands": {
+                "enabled": True,
+                "protectedTools": [],
+            },
+            "manualMode": {
+                "enabled": False,
+                "automaticStrategies": True,
+            },
+            "turnProtection": {
+                "enabled": False,
+                "turns": 4,
+            },
+            "experimental": {
+                "allowSubAgents": False,
+                "customPrompts": False,
+            },
+            "protectedFilePatterns": [],
+            "compress": {
+                "mode": "range",
+                "permission": "allow",
+                "showCompression": False,
+                "summaryBuffer": True,
+                "maxContextLimit": 100000,
+                "minContextLimit": 50000,
+                "modelMaxLimits": {},
+                "modelMinLimits": {},
+                "nudgeFrequency": 5,
+                "iterationNudgeThreshold": 15,
+                "nudgeForce": "soft",
+                "protectedTools": [],
+                "protectUserMessages": False,
+            },
+            "strategies": {
+                "deduplication": {
+                    "enabled": True,
+                    "protectedTools": [],
+                },
+                "purgeErrors": {
+                    "enabled": True,
+                    "turns": 4,
+                    "protectedTools": [],
+                },
+            },
+        },
     },
 
     # Persistent memory -- bounded curated memory injected into system prompt

--- a/run_agent.py
+++ b/run_agent.py
@@ -147,6 +147,7 @@ from agent.model_metadata import (
     query_ollama_num_ctx,
 )
 from agent.context_compressor import ContextCompressor
+from agent.dcp_context_engine import DCPContextEngine
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
@@ -2005,7 +2006,15 @@ class AIAgent:
         except Exception:
             pass
 
-        if _engine_name != "compressor":
+        if _engine_name == "dcp":
+            _selected_engine = DCPContextEngine(
+                config=_ctx_cfg.get("dcp", {}) if isinstance(_ctx_cfg, dict) else {},
+                model=self.model,
+                provider=self.provider,
+                quiet_mode=self.quiet_mode,
+            )
+
+        if _engine_name != "compressor" and _selected_engine is None:
             # Try loading from plugins/context_engine/<name>/
             try:
                 from plugins.context_engine import load_context_engine
@@ -11148,6 +11157,24 @@ class AIAgent:
                 sys_offset = 1 if effective_system else 0
                 for idx, pfm in enumerate(self.prefill_messages):
                     api_messages.insert(sys_offset + idx, pfm.copy())
+
+            # Let the active context engine transform the provider-bound copy.
+            # DCP uses this to add refs, compression block placeholders, and
+            # nudges without mutating the canonical `messages` transcript.
+            if self.context_compressor is not None:
+                try:
+                    api_messages = self.context_compressor.transform_api_messages(
+                        api_messages,
+                        canonical_messages=messages,
+                        system_prompt=effective_system,
+                        tools=self.tools,
+                        api_call_count=api_call_count,
+                        model=self.model,
+                        provider=self.provider,
+                        session_id=self.session_id,
+                    )
+                except Exception as _ctx_transform_err:
+                    logger.warning("Context engine API-message transform failed: %s", _ctx_transform_err)
 
             # Apply Anthropic prompt caching for Claude models on native
             # Anthropic, OpenRouter, and third-party Anthropic-compatible

--- a/tests/agent/test_dcp_config.py
+++ b/tests/agent/test_dcp_config.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from agent.dcp_config import parse_dcp_config, resolve_limit, resolve_model_limit
+
+
+def test_dcp_config_defaults_match_supported_surface():
+    cfg = parse_dcp_config({})
+
+    assert cfg.enabled is True
+    assert cfg.prune_notification == "detailed"
+    assert cfg.compress.mode == "range"
+    assert cfg.compress.permission == "allow"
+    assert cfg.compress.max_context_limit == 100000
+    assert cfg.compress.min_context_limit == 50000
+    assert cfg.deduplication.enabled is True
+    assert cfg.purge_errors.enabled is True
+    assert cfg.purge_errors.turns == 4
+
+
+def test_dcp_config_parses_percent_limits_and_model_overrides():
+    cfg = parse_dcp_config(
+        {
+            "compress": {
+                "maxContextLimit": "80%",
+                "minContextLimit": "40%",
+                "modelMaxLimits": {"openai/test-model": "90%"},
+                "modelMinLimits": {"test-model": 12345},
+            }
+        }
+    )
+
+    assert resolve_limit(cfg.compress.max_context_limit, 200000) == 160000
+    assert resolve_limit(cfg.compress.min_context_limit, 200000) == 80000
+    assert resolve_model_limit(
+        cfg.compress.model_max_limits,
+        provider="openai",
+        model="test-model",
+        context_length=200000,
+        fallback=cfg.compress.max_context_limit,
+    ) == 180000
+    assert resolve_model_limit(
+        cfg.compress.model_min_limits,
+        provider="openai",
+        model="test-model",
+        context_length=200000,
+        fallback=cfg.compress.min_context_limit,
+    ) == 12345
+
+
+def test_dcp_config_rejects_invalid_choices_to_defaults():
+    cfg = parse_dcp_config(
+        {
+            "compress": {
+                "mode": "bad",
+                "permission": "root",
+                "nudgeForce": "loud",
+            }
+        }
+    )
+
+    assert cfg.compress.mode == "range"
+    assert cfg.compress.permission == "allow"
+    assert cfg.compress.nudge_force == "soft"

--- a/tests/agent/test_dcp_context_engine.py
+++ b/tests/agent/test_dcp_context_engine.py
@@ -41,6 +41,26 @@ def test_deny_permission_hides_compress_tool():
     assert engine.get_tool_schemas() == []
 
 
+def test_disabled_engine_exposes_no_tool_and_returns_original_api_messages():
+    engine = DCPContextEngine(config={"enabled": False}, context_length=200000)
+    api_messages = [{"role": "user", "content": "hello"}]
+
+    transformed = engine.transform_api_messages(
+        api_messages,
+        canonical_messages=[{"role": "user", "content": "hello"}],
+        system_prompt="",
+        tools=[],
+        api_call_count=1,
+        model="test-model",
+        provider="openai",
+        session_id="s1",
+    )
+
+    assert engine.get_tool_schemas() == []
+    assert transformed is api_messages
+    assert api_messages == [{"role": "user", "content": "hello"}]
+
+
 def test_transform_does_not_mutate_canonical_messages_and_adds_refs():
     engine = DCPContextEngine(config={}, context_length=200000)
     canonical = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
@@ -99,6 +119,70 @@ def test_range_compress_creates_block_and_transform_applies_placeholder():
     assert '<dcp-compressed-block id="b1" topic="old work">' in transformed[0]["content"]
     assert "content moved into compressed block b1" in transformed[1]["content"]
     assert "new task" in transformed[2]["content"]
+
+
+def test_range_compress_consumes_overlapping_active_blocks():
+    engine = DCPContextEngine(config={}, context_length=200000)
+    canonical = [
+        {"role": "user", "content": "phase one"},
+        {"role": "assistant", "content": "phase one result"},
+        {"role": "user", "content": "phase two"},
+        {"role": "assistant", "content": "phase two result"},
+    ]
+    engine._ensure_refs(canonical)
+
+    first = json.loads(
+        engine.handle_tool_call(
+            "compress",
+            {"topic": "phase one", "content": [{"startId": "m0001", "endId": "m0002", "summary": "Phase one summary."}]},
+            messages=canonical,
+        )
+    )
+    second = json.loads(
+        engine.handle_tool_call(
+            "compress",
+            {"topic": "both phases", "content": [{"startId": "b1", "endId": "m0004", "summary": "Both phases summary."}]},
+            messages=canonical,
+        )
+    )
+
+    assert first["created_blocks"] == [1]
+    assert second["created_blocks"] == [2]
+    assert second["deactivated_blocks"] == [1]
+    assert engine.state.blocks_by_id[1].active is False
+    assert engine.state.blocks_by_id[1].deactivated_by_block_id == 2
+    assert engine.state.active_block_ids == {2}
+
+
+def test_multimodal_messages_get_text_ref_without_mutating_canonical_content():
+    engine = DCPContextEngine(config={}, context_length=200000)
+    canonical = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look at this"},
+                {"type": "image_url", "image_url": {"url": "https://example.invalid/image.png"}},
+            ],
+        }
+    ]
+    api_messages = [{"role": "system", "content": "sys"}] + [msg.copy() for msg in canonical]
+
+    transformed = engine.transform_api_messages(
+        api_messages,
+        canonical_messages=canonical,
+        system_prompt="sys",
+        tools=[],
+        api_call_count=1,
+        model="test-model",
+        provider="openai",
+        session_id="s1",
+    )
+
+    assert canonical[0]["content"] == [
+        {"type": "text", "text": "look at this"},
+        {"type": "image_url", "image_url": {"url": "https://example.invalid/image.png"}},
+    ]
+    assert transformed[1]["content"][-1] == {"type": "text", "text": '<dcp-ref id="m0001" />'}
 
 
 def test_message_compress_creates_message_block():
@@ -179,3 +263,69 @@ def test_turn_protection_prevents_dedup_pruning_recent_messages():
 
     assert messages[1]["content"] == ""
     assert messages[2]["content"] == "old output"
+
+
+def test_manual_mode_can_disable_automatic_strategies_in_transform():
+    engine = DCPContextEngine(
+        config={"manualMode": {"enabled": True, "automaticStrategies": False}},
+        context_length=200000,
+    )
+    canonical = [
+        {"role": "assistant", "content": "", "tool_calls": [_tool_call("a", "read_file", {"path": "x"})]},
+        {"role": "tool", "tool_call_id": "a", "content": "old output"},
+        {"role": "assistant", "content": "", "tool_calls": [_tool_call("b", "read_file", {"path": "x"})]},
+        {"role": "tool", "tool_call_id": "b", "content": "new output"},
+    ]
+
+    transformed = engine.transform_api_messages(
+        [msg.copy() for msg in canonical],
+        canonical_messages=canonical,
+        system_prompt="",
+        tools=[],
+        api_call_count=1,
+        model="test-model",
+        provider="openai",
+        session_id="s1",
+    )
+
+    assert transformed[1]["content"].startswith("old output")
+    assert transformed[3]["content"].startswith("new output")
+
+
+def test_manual_compress_request_injects_one_shot_nudge_without_mutating_history():
+    engine = DCPContextEngine(config={}, context_length=200000)
+    canonical = [
+        {"role": "user", "content": "please compact old work"},
+        {"role": "assistant", "content": "working"},
+    ]
+
+    returned = engine.compress(canonical, current_tokens=1234, focus_topic="old investigation")
+    first = engine.transform_api_messages(
+        [msg.copy() for msg in canonical],
+        canonical_messages=canonical,
+        system_prompt="",
+        tools=[],
+        api_call_count=1,
+        model="test-model",
+        provider="openai",
+        session_id="s1",
+    )
+    second = engine.transform_api_messages(
+        [msg.copy() for msg in canonical],
+        canonical_messages=canonical,
+        system_prompt="",
+        tools=[],
+        api_call_count=2,
+        model="test-model",
+        provider="openai",
+        session_id="s1",
+    )
+
+    assert returned is canonical
+    assert "DCP manual compression requested" in first[0]["content"]
+    assert "old investigation" in first[0]["content"]
+    assert "DCP manual compression requested" not in second[0]["content"]
+    assert canonical == [
+        {"role": "user", "content": "please compact old work"},
+        {"role": "assistant", "content": "working"},
+    ]

--- a/tests/agent/test_dcp_context_engine.py
+++ b/tests/agent/test_dcp_context_engine.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+
+from agent.dcp_context_engine import DCPContextEngine
+
+
+def _tool_call(call_id: str, name: str, args: dict) -> dict:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": json.dumps(args)},
+    }
+
+
+def test_range_tool_schema_is_exposed_by_default():
+    engine = DCPContextEngine(config={}, context_length=200000)
+
+    schemas = engine.get_tool_schemas()
+
+    assert len(schemas) == 1
+    schema = schemas[0]
+    assert schema["name"] == "compress"
+    assert schema["parameters"]["required"] == ["topic", "content"]
+    item = schema["parameters"]["properties"]["content"]["items"]
+    assert item["required"] == ["startId", "endId", "summary"]
+
+
+def test_message_tool_schema_when_configured():
+    engine = DCPContextEngine(config={"compress": {"mode": "message"}}, context_length=200000)
+
+    schema = engine.get_tool_schemas()[0]
+
+    item = schema["parameters"]["properties"]["content"]["items"]
+    assert item["required"] == ["messageId", "topic", "summary"]
+
+
+def test_deny_permission_hides_compress_tool():
+    engine = DCPContextEngine(config={"compress": {"permission": "deny"}}, context_length=200000)
+
+    assert engine.get_tool_schemas() == []
+
+
+def test_transform_does_not_mutate_canonical_messages_and_adds_refs():
+    engine = DCPContextEngine(config={}, context_length=200000)
+    canonical = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "world"}]
+    original = [msg.copy() for msg in canonical]
+    api_messages = [{"role": "system", "content": "sys"}] + [msg.copy() for msg in canonical]
+
+    transformed = engine.transform_api_messages(
+        api_messages,
+        canonical_messages=canonical,
+        system_prompt="sys",
+        tools=[],
+        api_call_count=1,
+        model="test-model",
+        provider="openai",
+        session_id="s1",
+    )
+
+    assert canonical == original
+    assert '<dcp-ref id="m0001" />' in transformed[1]["content"]
+    assert '<dcp-ref id="m0002" />' in transformed[2]["content"]
+    assert "DCP context management is active" in transformed[0]["content"]
+
+
+def test_range_compress_creates_block_and_transform_applies_placeholder():
+    engine = DCPContextEngine(config={}, context_length=200000)
+    canonical = [
+        {"role": "user", "content": "start"},
+        {"role": "assistant", "content": "old work"},
+        {"role": "user", "content": "new task"},
+    ]
+    engine._ensure_refs(canonical)
+
+    result = json.loads(
+        engine.handle_tool_call(
+            "compress",
+            {
+                "topic": "old work",
+                "content": [{"startId": "m0001", "endId": "m0002", "summary": "Old work summary."}],
+            },
+            messages=canonical,
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["created_blocks"] == [1]
+    transformed = engine.transform_api_messages(
+        [msg.copy() for msg in canonical],
+        canonical_messages=canonical,
+        system_prompt="",
+        tools=[],
+        api_call_count=1,
+        model="test-model",
+        provider="openai",
+        session_id="s1",
+    )
+    assert '<dcp-compressed-block id="b1" topic="old work">' in transformed[0]["content"]
+    assert "content moved into compressed block b1" in transformed[1]["content"]
+    assert "new task" in transformed[2]["content"]
+
+
+def test_message_compress_creates_message_block():
+    engine = DCPContextEngine(config={"compress": {"mode": "message"}}, context_length=200000)
+    canonical = [{"role": "user", "content": "huge pasted log"}]
+    engine._ensure_refs(canonical)
+
+    result = json.loads(
+        engine.handle_tool_call(
+            "compress",
+            {"topic": "logs", "content": [{"messageId": "m0001", "topic": "log", "summary": "Useful log facts."}]},
+            messages=canonical,
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["mode"] == "message"
+    assert result["created_blocks"] == [1]
+
+
+def test_deduplication_prunes_older_duplicate_tool_output():
+    engine = DCPContextEngine(config={}, context_length=200000)
+    messages = [
+        {"role": "assistant", "content": "", "tool_calls": [_tool_call("a", "read_file", {"path": "x"})]},
+        {"role": "tool", "tool_call_id": "a", "content": "old output"},
+        {"role": "assistant", "content": "", "tool_calls": [_tool_call("b", "read_file", {"path": "x"})]},
+        {"role": "tool", "tool_call_id": "b", "content": "new output"},
+    ]
+
+    engine._apply_deduplication(messages)
+
+    assert "duplicate tool output removed" in messages[1]["content"]
+    assert messages[3]["content"] == "new output"
+
+
+def test_deduplication_respects_protected_tools():
+    engine = DCPContextEngine(config={}, context_length=200000)
+    messages = [
+        {"role": "assistant", "content": "", "tool_calls": [_tool_call("a", "patch", {"path": "x"})]},
+        {"role": "tool", "tool_call_id": "a", "content": "old output"},
+        {"role": "assistant", "content": "", "tool_calls": [_tool_call("b", "patch", {"path": "x"})]},
+        {"role": "tool", "tool_call_id": "b", "content": "new output"},
+    ]
+
+    engine._apply_deduplication(messages)
+
+    assert messages[1]["content"] == "old output"
+
+
+def test_purge_errors_preserves_error_summary():
+    engine = DCPContextEngine(config={"strategies": {"purgeErrors": {"turns": 0}}}, context_length=200000)
+    messages = [
+        {"role": "assistant", "content": "", "tool_calls": [_tool_call("a", "terminal", {"command": "bad"})]},
+        {"role": "tool", "tool_call_id": "a", "content": "ERROR: failed\n" + "x" * 500},
+        {"role": "user", "content": "next"},
+    ]
+
+    engine._apply_purge_errors(messages)
+
+    assert "old failed tool output pruned" in messages[1]["content"]
+    assert "ERROR: failed" in messages[1]["content"]
+
+
+def test_turn_protection_prevents_dedup_pruning_recent_messages():
+    engine = DCPContextEngine(
+        config={"turnProtection": {"enabled": True, "turns": 1}},
+        context_length=200000,
+    )
+    messages = [
+        {"role": "user", "content": "latest turn"},
+        {"role": "assistant", "content": "", "tool_calls": [_tool_call("a", "read_file", {"path": "x"})]},
+        {"role": "tool", "tool_call_id": "a", "content": "old output"},
+        {"role": "assistant", "content": "", "tool_calls": [_tool_call("b", "read_file", {"path": "x"})]},
+        {"role": "tool", "tool_call_id": "b", "content": "new output"},
+    ]
+
+    engine._apply_deduplication(messages)
+
+    assert messages[1]["content"] == ""
+    assert messages[2]["content"] == "old output"

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -7,6 +7,7 @@ context_length, causing the CLI status bar to show 'ctx --'.
 from unittest.mock import MagicMock, patch
 
 from agent.context_engine import ContextEngine
+from agent.dcp_context_engine import DCPContextEngine
 
 
 class _StubEngine(ContextEngine):
@@ -88,4 +89,37 @@ def test_plugin_engine_update_model_args():
     assert "model" in kw
     assert "provider" in kw
     # Should NOT pass api_mode — the ABC doesn't accept it
-    assert "api_mode" not in kw
+    assert agent.context_compressor is engine
+
+
+def test_builtin_dcp_engine_selected_from_config():
+    cfg = {
+        "context": {
+            "engine": "dcp",
+            "dcp": {"compress": {"mode": "range", "permission": "allow"}},
+        },
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.model_metadata.get_model_context_length", return_value=204_800),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model="test/model",
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert isinstance(agent.context_compressor, DCPContextEngine)
+    assert agent.context_compressor.context_length == 204_800
+    assert "compress" in agent._context_engine_tool_names
+    assert any(tool.get("function", {}).get("name") == "compress" for tool in agent.tools)

--- a/website/docs/developer-guide/agent-loop.md
+++ b/website/docs/developer-guide/agent-loop.md
@@ -70,10 +70,13 @@ run_conversation()
      - chat_completions: OpenAI format as-is
      - codex_responses: convert to Responses API input items
      - anthropic_messages: convert via anthropic_adapter.py
-  6. Inject ephemeral prompt layers (budget warnings, context pressure)
-  7. Apply prompt caching markers if on Anthropic
-  8. Make interruptible API call (_interruptible_api_call)
-  9. Parse response:
+  6. Let the active context engine transform the API-call copy, if supported
+     - DCP-style engines can add refs, compression placeholders, and nudges
+     - canonical conversation history must remain unchanged
+  7. Inject ephemeral prompt layers (budget warnings, context pressure)
+  8. Apply prompt caching markers if on Anthropic
+  9. Make interruptible API call (_interruptible_api_call)
+  10. Parse response:
      - If tool_calls: execute them, append results, loop back to step 5
      - If text response: persist session, flush memory if needed, return
 ```
@@ -159,6 +162,19 @@ Some tools are intercepted by `run_agent.py` *before* reaching `handle_function_
 | `delegate_task` | Spawns subagent(s) with isolated context |
 
 These tools modify agent state directly and return synthetic tool results without going through the registry.
+
+
+### Context-engine tools
+
+The active context engine can expose tools via `get_tool_schemas()`. These tools
+are injected into the model-visible tool list and routed back to
+`handle_tool_call()` before normal registry dispatch.
+
+This is how DCP-style context management exposes a model-callable `compress`
+tool. The tool updates context-engine state, then the next API-call transform
+applies compression blocks to the outbound message copy. It should not mutate
+the canonical transcript unless the engine explicitly documents a
+transcript-mutating mode.
 
 ## Callback Surfaces
 

--- a/website/docs/developer-guide/architecture.md
+++ b/website/docs/developer-guide/architecture.md
@@ -30,7 +30,7 @@ This page is the top-level map of Hermes Agent internals. Use it to orient yours
 │  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘               │
 │         │                 │                 │                       │
 │  ┌──────┴───────┐  ┌──────┴───────┐  ┌──────┴───────┐               │
-│  │ Compression  │  │ 3 API Modes  │  │ Tool Registry│               │
+│  │ Context Mgmt │  │ 3 API Modes  │  │ Tool Registry│               │
 │  │ & Caching    │  │ chat_compl.  │  │ (registry.py)│               │
 │  │              │  │ codex_resp.  │  │ 61 tools     │               │
 │  │              │  │ anthropic    │  │ 52 toolsets  │               │
@@ -64,6 +64,7 @@ hermes-agent/
 │   ├── prompt_builder.py     # System prompt assembly
 │   ├── context_engine.py     # ContextEngine ABC (pluggable)
 │   ├── context_compressor.py # Default engine — lossy summarization
+│   ├── dcp_context_engine.py  # Optional DCP-style model-guided context engine
 │   ├── prompt_caching.py     # Anthropic prompt caching
 │   ├── auxiliary_client.py   # Auxiliary LLM for side tasks (vision, summarization)
 │   ├── model_metadata.py     # Model context lengths, token estimation
@@ -133,6 +134,15 @@ hermes-agent/
 ├── website/                  # Docusaurus documentation site
 └── tests/                    # Pytest suite (~3,000+ tests)
 ```
+
+
+### Context management
+
+Context management is handled through the `ContextEngine` interface. The default
+engine is `ContextCompressor`, which performs host-triggered summarization. Other
+engines can expose tools and transform the provider-bound API message copy. A
+DCP-style engine uses that path to keep the stored transcript complete while
+sending compressed blocks, refs, and nudges to the model.
 
 ## Data Flow
 

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -34,6 +34,88 @@ Configure via `hermes plugins` → Provider Plugins → Context Engine, or edit 
 
 For building a context engine plugin, see [Context Engine Plugins](/docs/developer-guide/context-engine-plugin).
 
+
+## DCP Context Engine
+
+Hermes can also run a DCP-style context engine with:
+
+```yaml
+context:
+  engine: "dcp"
+```
+
+DCP mode is different from the built-in `ContextCompressor`. The built-in
+compressor is host-driven: Hermes decides that the session is too large, calls
+an auxiliary summarization model, and replaces the stored message list with a
+compressed transcript. DCP mode is model-guided: Hermes exposes a `compress`
+tool, adds stable message and block references to the outbound request, and
+lets the active model compress completed ranges when it has enough semantic
+context to know what is safe to replace.
+
+The DCP invariant is:
+
+> The canonical session transcript remains complete. DCP transforms only the
+> API-call copy of the messages sent to the provider.
+
+A DCP engine owns separate compression state:
+
+- message refs such as `m0001`, `m0002`
+- compression block refs such as `b1`, `b2`
+- active block summaries
+- duplicate-tool and old-error pruning state
+- compression stats and nudge cadence
+
+### DCP `compress` tool
+
+When DCP mode is active, the context engine may expose a `compress` tool. The
+tool does not rewrite the stored transcript. Instead, it records compression
+blocks. The next API-call transform applies those blocks to the outbound copy.
+
+DCP supports two modes:
+
+- `range`: compress one or more contiguous spans using `{startId, endId, summary}`.
+- `message`: compress individual high-volume messages using `{messageId, topic, summary}`.
+
+Range mode is the default because it preserves chronology and usually gives
+the model enough context to summarize closed work accurately. Message mode is
+more surgical and should be treated as experimental until provider-format and
+cache behavior are well tested.
+
+### DCP nudges and automatic strategies
+
+DCP mode can inject ephemeral nudges when context pressure rises. Nudges tell
+the model to call `compress` before continuing if a completed topic is safe to
+compact. The engine may also run cheap automatic strategies over the outbound
+copy:
+
+- deduplicate repeated tool calls with the same tool name and arguments, keeping
+  the latest output
+- purge bulky old failed-tool inputs while preserving the error text
+- protect recent user turns and configured protected tools
+
+These strategies are DCP-state transformations, not transcript edits.
+
+### Interaction with existing compression
+
+When `context.engine: "dcp"`, the built-in `compression:` settings do not drive
+normal compaction. DCP should return `False` from `should_compress()` during
+normal operation and rely on nudges plus the `compress` tool. The built-in
+`ContextCompressor` may still be used as an emergency fallback for hard context
+limit failures, but it should not run as a parallel primary compressor.
+
+Gateway session hygiene remains a safety net. Because hygiene compression
+operates before the agent starts and may mutate gateway history, DCP-aware
+hygiene behavior must be handled deliberately rather than implicitly reusing
+the built-in compressor path.
+
+### Prompt caching
+
+DCP must run before provider cache-control markers are applied so prompt caching
+sees the actual outgoing request. The transform should be deterministic and
+should avoid modifying old stable content on every turn. Compression blocks and
+automatic pruning should change the cached prefix only when compression state
+changes, not as a side effect of moving counters or timestamps.
+
 ## Dual Compression System
 
 Hermes has two separate compression layers that operate independently:

--- a/website/docs/developer-guide/context-engine-plugin.md
+++ b/website/docs/developer-guide/context-engine-plugin.md
@@ -97,6 +97,46 @@ These have sensible defaults in the ABC. Override as needed:
 | `handle_tool_call(name, args, **kwargs)` | Returns error JSON | You implement tool handlers |
 | `should_compress_preflight(messages)` | Returns `False` | You can do a cheap pre-API-call estimate |
 | `get_status()` | Standard token/threshold dict | You have custom metrics to expose |
+| `transform_api_messages(api_messages, **kwargs)` | Returns `api_messages` unchanged | You need to alter the provider-bound copy without mutating stored history |
+
+
+## API-call-time transforms
+
+Context engines that need DCP-style behavior can override
+`transform_api_messages()` to transform the outbound API-call copy of the
+conversation:
+
+```python
+def transform_api_messages(
+    self,
+    api_messages: list[dict],
+    *,
+    canonical_messages: list[dict],
+    system_prompt: str,
+    tools: list[dict] | None,
+    api_call_count: int,
+    model: str,
+    provider: str | None,
+    session_id: str | None,
+) -> list[dict]:
+    return api_messages
+```
+
+This hook is for ephemeral, model-facing context changes such as message refs,
+compression block placeholders, and context-pressure nudges. It must not mutate
+`canonical_messages`, because those messages are the authoritative session
+transcript.
+
+Transform implementations must preserve provider-valid message order:
+
+- keep assistant `tool_calls` messages adjacent to their tool results
+- do not orphan tool results
+- do not create consecutive roles that the provider rejects
+- return OpenAI-format messages that still pass Hermes sanitization
+
+The hook should run before provider-specific cache-control placement. Engines
+should avoid churn in the stable prompt prefix because unnecessary changes lower
+prompt-cache hit rates.
 
 ## Engine tools
 

--- a/website/docs/developer-guide/prompt-assembly.md
+++ b/website/docs/developer-guide/prompt-assembly.md
@@ -116,6 +116,29 @@ You are a CLI AI Agent. Try not to use markdown but simple text
 renderable inside a terminal.
 ```
 
+
+## Context-engine API-call-time transforms
+
+After Hermes assembles the canonical conversation into provider-bound
+`api_messages`, the active context engine may transform that API-call copy. This
+keeps persisted session history separate from ephemeral model-facing context.
+
+DCP-style engines use this layer to add:
+
+- stable message refs such as `m0001`
+- compression block refs such as `b1`
+- compact placeholders for compressed ranges
+- context-pressure nudges that teach the model when to call a context tool
+- cheap outbound-only pruning such as duplicate tool output placeholders
+
+The transform must not rewrite the canonical transcript. If a session is saved,
+it should still contain the full original conversation unless a user explicitly
+invokes a separate transcript-mutating command.
+
+Because this layer changes what the provider sees, it should run before prompt
+cache-control markers are applied. Engines should keep the transformed stable
+prefix deterministic and avoid moving counters or timestamps in old context.
+
 ## How SOUL.md appears in the prompt
 
 `SOUL.md` lives at `~/.hermes/SOUL.md` and serves as the agent's identity — the very first section of the system prompt. The loading logic in `prompt_builder.py` works as follows:


### PR DESCRIPTION
## Summary

Adds a DCP-style context engine for Hermes behind `context.engine: dcp`.

Split into three commits:

1. temporary agent-facing PR spec at `DCP_CONTEXT_ENGINE_PR_SPEC.md`
2. permanent developer docs describing the DCP design and hook contract
3. implementation and tests

Core behavior:

- adds `DCPContextEngine` with typed `context.dcp` config parsing
- exposes a context-engine `compress` tool in range mode by default, with message mode available by config
- adds `ContextEngine.transform_api_messages(...)` for API-call-time outbound transforms
- wires that hook into `run_agent.py` before prompt caching and API message sanitization
- preserves canonical session history while adding refs, compressed block placeholders, and nudges to the provider-bound copy
- implements first-pass DCP-style automatic strategies
  - deduplicate older repeated tool outputs by tool-name plus stable argument signature
  - purge old failed tool outputs after a configurable turn window while preserving the first error line
- supports DCP-compatible config keys under `context.dcp`
- adds focused tests for config parsing, compression blocks, transforms, dedup, purge, protection, and built-in engine selection
- adds a prompt caching internals appendix to the spec documenting the full API-call pipeline and DCP's interaction with Anthropic prefix caching

## Notes and intentional scope limits

- The temporary root spec is intentionally committed because Jack requested it as a first commit. It should be deleted or folded into docs before final merge if maintainers do not want temporary coordination docs in tree.
- This is a Hermes-native reimplementation of the DCP ideas. It does not copy OpenCode DCP source.
- `context.dcp.compress.permission: ask` is currently accepted as config surface but behaves like `allow`; Hermes does not yet have a context-engine-specific approval path for this tool.
- Slash/operator commands such as `/dcp stats` and `/dcp compress` are out of this first implementation pass.
- `protectedFilePatterns`, `commands`, `experimental`, and some display options are parsed now so config is accepted, but only the engine-relevant portions are enforced in this PR.

## Validation

Fresh venv via `uv` in the worktree. Full CI-equivalent test run:

```bash
uv venv .venv --python 3.11 && uv pip install -e ".[all,dev]"
OPENROUTER_API_KEY="" OPENAI_API_KEY="" NOUS_API_KEY=""   python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e -n auto
```

Result: **20,096 passed, 47 failed, 70 skipped**. All 47 failures are pre-existing and unrelated to DCP (anthropic adapter, systemd service, WSL, Docker build, delegate credentials, etc.). Zero failures in DCP, context engine, compression, or prompt caching files.

Focused DCP + context engine suite:

```bash
python -m pytest   tests/agent/test_dcp_config.py   tests/agent/test_dcp_context_engine.py   tests/agent/test_context_engine.py   tests/run_agent/test_plugin_context_engine_init.py   tests/run_agent/test_compress_focus_plugin_fallback.py   tests/gateway/test_compress_plugin_engine.py   tests/test_get_tool_definitions_cache_isolation.py   -v
```

Result: **48 passed, 0 failed**.

Lint and compile:

```bash
python -m ruff check agent/dcp_config.py agent/dcp_state.py agent/dcp_context_engine.py   tests/agent/test_dcp_config.py tests/agent/test_dcp_context_engine.py   tests/run_agent/test_plugin_context_engine_init.py
# All checks passed!

python -m py_compile run_agent.py agent/context_engine.py agent/dcp_config.py   agent/dcp_state.py agent/dcp_context_engine.py hermes_cli/config.py   tests/agent/test_dcp_config.py tests/agent/test_dcp_context_engine.py   tests/run_agent/test_plugin_context_engine_init.py
# OK
```

CI workflows from fork PRs require maintainer approval to run. A maintainer can trigger them via the "Approve workflow runs" button on this PR.

Closes #20717
