### PR TITLE
feat(skills): co-load frontmatter for declarative skill dependencies

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -403,6 +403,77 @@ def resolve_skill_command_key(command: str) -> Optional[str]:
     return cmd_key if cmd_key in get_skill_commands() else None
 
 
+def _resolve_co_loads(
+    loaded_skill: dict[str, Any],
+    primary_name: str,
+    task_id: str | None = None,
+    seen: set[str] | None = None,
+) -> list[str]:
+    """Resolve skills declared in the primary skill's ``co-load:`` frontmatter.
+
+    A skill can opt into automatic loading of dependent skills by adding a
+    ``co-load:`` field to its frontmatter::
+
+        ---
+        name: my-orchestrator
+        co-load: [shared-helpers, telemetry]
+        ---
+
+    Resolution is non-transitive (depth-1) — co-loaded skills are NOT
+    themselves expanded — and de-duplicated against ``seen`` so a future
+    transitive resolver cannot loop. Missing dependencies log a warning and
+    are skipped; they do not abort the primary skill's invocation.
+
+    Returns a list of formatted skill-message strings ready to be appended
+    to the primary skill's message body.
+    """
+    try:
+        from agent.skill_utils import parse_frontmatter
+    except Exception:
+        return []
+
+    raw_content = str(loaded_skill.get("raw_content") or loaded_skill.get("content") or "")
+    if not raw_content:
+        return []
+
+    frontmatter, _ = parse_frontmatter(raw_content)
+    co_load_names = frontmatter.get("co-load") or []
+    if isinstance(co_load_names, str):
+        co_load_names = [co_load_names]
+    if not co_load_names:
+        return []
+
+    if seen is None:
+        seen = set()
+    seen.add(primary_name.lower())
+
+    parts: list[str] = []
+    for co_name in co_load_names:
+        co_name_lower = (co_name or "").strip().lower()
+        if not co_name_lower or co_name_lower in seen:
+            continue
+        seen.add(co_name_lower)
+
+        loaded = _load_skill_payload(co_name, task_id=task_id)
+        if not loaded:
+            logger.warning(
+                "Co-load skill '%s' (required by '%s') not found",
+                co_name, primary_name,
+            )
+            continue
+
+        co_loaded_skill, co_skill_dir, co_display_name = loaded
+        activation_note = (
+            f'[SYSTEM: Co-loaded "{co_display_name}" '
+            f'(required by "{primary_name}")]'
+        )
+        msg = _build_skill_message(co_loaded_skill, co_skill_dir, activation_note)
+        if msg:
+            parts.append(msg)
+
+    return parts
+
+
 def build_skill_invocation_message(
     cmd_key: str,
     user_instruction: str = "",
@@ -440,7 +511,7 @@ def build_skill_invocation_message(
         f'[IMPORTANT: The user has invoked the "{skill_name}" skill, indicating they want '
         "you to follow its instructions. The full skill content is loaded below.]"
     )
-    return _build_skill_message(
+    msg = _build_skill_message(
         loaded_skill,
         skill_dir,
         activation_note,
@@ -448,6 +519,11 @@ def build_skill_invocation_message(
         runtime_note=runtime_note,
         session_id=task_id,
     )
+
+    co_loaded_parts = _resolve_co_loads(loaded_skill, skill_name, task_id=task_id)
+    if co_loaded_parts:
+        return msg + "\n\n" + "\n\n".join(co_loaded_parts)
+    return msg
 
 
 def build_preloaded_skills_prompt(


### PR DESCRIPTION
## Summary

Adds support for a `co-load:` field in a skill's frontmatter. When the skill is invoked, its declared dependencies are auto-loaded into the same turn:

```yaml
---
name: my-orchestrator
co-load: [shared-helpers, telemetry]
---
# Body of my-orchestrator
```

Invoking `/my-orchestrator` builds a message that contains the orchestrator's body + the bodies of `shared-helpers` and `telemetry`, so the model gets the full context in a single turn instead of needing the orchestrator to manually invoke each dependency.

## Why

Today there are two ways to compose multi-skill workflows:

1. **Inline duplication** — copy shared scaffolding (logging, error handling, terminal-style norms) into every skill body. Drift-prone, hard to keep consistent.
2. **Manual invocation** — the orchestrator skill instructs the model to call dependencies via the slash registry. Costs an extra turn per dependency, and depends on the model actually following the instruction reliably.

`co-load:` is a third option: declare the dependency in metadata, get a single message containing everything. It sits well alongside the existing skill model — no new runtime concepts, just a frontmatter field.

## Implementation

- New helper `_resolve_co_loads(loaded_skill, primary_name, task_id, seen)` reads the `co-load:` field via the existing `agent.skill_utils.parse_frontmatter`. Accepts list-of-names or a single string.
- Resolution is **depth-1** (non-transitive). The `seen` set is already wired so a future transitive variant can cycle-detect without API changes.
- Missing dependencies log a warning and are skipped — they do not abort the primary skill's invocation. (A typo'd dependency name shouldn't break a working skill.)
- `build_skill_invocation_message` calls the resolver after building its own body and appends the resulting message blocks separated by blank lines. The dependent-skill activation note (`[SYSTEM: Co-loaded "X" (required by "Y")]`) makes the provenance explicit so the model knows context.

## Compatibility

- Skills without a `co-load:` field behave identically to today — `_resolve_co_loads` short-circuits when the frontmatter key is absent.
- `co-load:` value is treated as opaque list of skill names. No path resolution happens here; the existing `_load_skill_payload` handles directory traversal protection (skills outside `~/.hermes/skills/` are rejected by the existing `_outside_skills_dir` guard).

## Test plan
- [x] Skill with `co-load: [foo]` produces a message containing both the primary body and `foo`'s body, with the `[SYSTEM: Co-loaded "foo"...]` marker present
- [x] Skill with `co-load: [missing]` returns the primary message + warning log; primary still works
- [x] Skill with `co-load:` referencing itself does not infinite-loop (seen-set prevents)
- [x] Skill without `co-load:` produces the same message as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)