### PR TITLE
feat(gateway): atomic active-session marker for precise post-crash recovery

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3960,6 +3960,19 @@ class GatewayRunner:
             # Adapters are still connected here, so messages can be sent.
             await self._notify_active_sessions_of_shutdown()
 
+            # Persist which sessions had running agents so the next startup
+            # can mark exactly those as resume_pending (precise) instead of
+            # the time-based 120s sweep (broad).  See
+            # SessionStore.suspend_recently_active for the reader side.
+            if self._running_agents:
+                try:
+                    active_keys = set(self._running_agents.keys())
+                    self.session_store.save_active_sessions(active_keys)
+                except Exception as e:
+                    logger.warning(
+                        "save_active_sessions failed during gateway stop: %s", e
+                    )
+
             timeout = self._restart_drain_timeout
             active_agents, timed_out = await self._drain_active_agents(timeout)
             if timed_out:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1085,15 +1085,57 @@ class SessionStore:
             )
         return len(removed_keys)
 
+    def save_active_sessions(self, active_session_keys: set) -> None:
+        """Persist the set of session keys that had running agents at shutdown.
+
+        Writes a ``.active_sessions_at_shutdown`` JSON marker into
+        ``sessions_dir`` atomically (tmpfile + fsync + os.replace).  On the
+        next startup, :meth:`suspend_recently_active` consumes the marker
+        for precise targeting instead of the time-based sweep.
+
+        Called by the gateway from its shutdown path before draining active
+        agents (see ``GatewayRunner.stop``).
+        """
+        import json
+        import tempfile
+
+        marker_path = self.sessions_dir / ".active_sessions_at_shutdown"
+        self.sessions_dir.mkdir(parents=True, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(self.sessions_dir), suffix=".tmp", prefix=".active_"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(sorted(active_session_keys), f)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, str(marker_path))
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
     def suspend_recently_active(self, max_age_seconds: int = 120) -> int:
         """Mark recently-active sessions as resumable after an unexpected exit.
 
         Called on gateway startup after a crash or fast restart to preserve
         in-flight sessions instead of destroying their conversation history
-        (#7536).  Only marks sessions updated within *max_age_seconds* to
-        avoid touching long-idle sessions.  Sets ``resume_pending=True`` so
-        the next incoming message on the same session_key auto-resumes from
-        the existing transcript.
+        (#7536).  Sets ``resume_pending=True`` so the next incoming message
+        on the same session_key auto-resumes from the existing transcript.
+
+        Targeting:
+
+        * If a ``.active_sessions_at_shutdown`` marker exists (written by
+          :meth:`save_active_sessions` during a clean stop), only sessions
+          listed in the marker are marked resumable — precise, avoids
+          false-positives from idle-but-recently-touched sessions.
+        * Otherwise, falls back to the time-based sweep: mark anything
+          updated within *max_age_seconds*.
+
+        The marker is consumed (deleted) after read so a second startup
+        without an intervening shutdown reverts to the time-based path.
 
         Entries already flagged ``resume_pending=True`` are skipped.  Entries
         explicitly ``suspended=True`` (from /stop or stuck-loop escalation)
@@ -1103,7 +1145,21 @@ class SessionStore:
 
         Returns the number of sessions marked resumable.
         """
+        import json
         from datetime import timedelta
+
+        active_marker = self.sessions_dir / ".active_sessions_at_shutdown"
+        active_keys_from_marker: Optional[set] = None
+        if active_marker.exists():
+            try:
+                with open(active_marker, "r") as f:
+                    active_keys_from_marker = set(json.load(f))
+            except Exception:
+                active_keys_from_marker = None
+            try:
+                active_marker.unlink()
+            except Exception:
+                pass
 
         cutoff = _now() - timedelta(seconds=max_age_seconds)
         count = 0
@@ -1112,7 +1168,13 @@ class SessionStore:
             for entry in self._entries.values():
                 if entry.resume_pending:
                     continue
-                if not entry.suspended and entry.updated_at >= cutoff:
+                if entry.suspended:
+                    continue
+                if active_keys_from_marker is not None:
+                    should_mark = entry.session_key in active_keys_from_marker
+                else:
+                    should_mark = entry.updated_at >= cutoff
+                if should_mark:
                     entry.resume_pending = True
                     entry.resume_reason = "restart_interrupted"
                     entry.last_resume_marked_at = _now()


### PR DESCRIPTION
## Summary

Adds an optional active-session marker file so `suspend_recently_active()` can precisely target sessions that were mid-turn at shutdown, instead of broadly sweeping anything updated in the last 120 seconds. Resume semantics are unchanged — only the targeting is sharper.

## Why

`suspend_recently_active()` today uses a 120s time-based sweep (#7536). It catches the in-flight sessions correctly, but it also catches **false-positives**: sessions that received a message recently but had already finished processing it before the gateway stopped. Each false-positive forces an unnecessary auto-resume on the user's next message.

For clean stops / fast restarts (which account for the bulk of restarts in practice), the gateway already knows exactly which sessions had running agents at shutdown — `self._running_agents`. Persisting that set across the restart lets the next startup mark the precise set instead of guessing from timestamps.

For unclean exits (crash, OOM, power loss), the marker is absent and the existing time-based sweep runs unchanged.

## Implementation

Three pieces:

1. **`SessionStore.save_active_sessions(active_session_keys: set)`** — new method that writes a `.active_sessions_at_shutdown` JSON marker atomically (tmpfile + fsync + os.replace) into `sessions_dir`. Atomic write so a crash mid-write can't leave a half-written marker that the next startup misinterprets.

2. **Gateway shutdown call site** in `GatewayRunner.stop()` — right after `_notify_active_sessions_of_shutdown()` and before `_drain_active_agents()`, persist `set(self._running_agents.keys())`. Wrapped in `try/except`-with-warning-log so a marker-write failure can't block a shutdown that was already in progress.

3. **`SessionStore.suspend_recently_active()`** — check for the marker first. If present: mark only the sessions in the marker as `resume_pending`, then unlink the marker. If absent: existing time-based sweep runs unchanged.

## Why these specific design choices

- **Marker file vs. database column**: A file in `sessions_dir` requires no schema migration, no `from_dict`/`to_dict` changes, and is trivially inspectable / removable for debugging.
- **Atomic write**: A crash between `open()` and `write()` would otherwise leave a marker that says "no sessions were active" — worse than no marker, because the time-based fallback wouldn't run. tmpfile + os.replace eliminates that window.
- **Consume-on-read**: Deleting the marker after read means a second startup without an intervening shutdown reverts to the time-based path — protects against the marker becoming stale (e.g. if the second restart was caused by a crash that the first startup didn't see coming).
- **Resume semantics unchanged**: Existing users who rely on `resume_pending=True → auto-resume` get exactly that behaviour, just with fewer false-positives. No new fields on `SessionEntry`. No config option. Pure improvement on the existing contract.

## Compatibility

- No schema migration needed.
- Any installation that doesn't write the marker (e.g. an unclean exit, or an external embedder that calls `SessionStore` outside the gateway lifecycle) gets the existing time-based sweep — fully backward-compatible.
- The marker file is in `sessions_dir` and prefixed with `.` so it doesn't show up in normal listings; it never collides with a session JSON file.

## Test plan
- [x] Clean shutdown writes marker; next startup marks only marker-listed sessions as `resume_pending`
- [x] Marker is deleted after consumption
- [x] No marker (simulated crash) → time-based sweep runs as today
- [x] `resume_pending` and `suspended` entries skipped (existing behaviour preserved)
- [x] Atomic write — interrupting between tmp-write and os.replace doesn't corrupt the marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)