### PR TITLE
feat(delegation): per-task model/provider overrides in batch dispatch

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1966,26 +1966,29 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Per-task model/provider override (falls back to batch creds
+            # when neither is set on the task).
+            task_creds = _resolve_task_credentials(t, creds)
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
                 override_acp_command=t.get("acp_command")
                 or acp_command
-                or creds.get("command"),
+                or task_creds.get("command"),
                 override_acp_args=(
                     task_acp_args
                     if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
+                    else (acp_args if acp_args is not None else task_creds.get("args"))
                 ),
                 role=effective_role,
             )
@@ -2350,6 +2353,62 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     }
 
 
+def _resolve_task_credentials(task: dict, delegation_creds: dict) -> dict:
+    """Resolve credentials for a single task, applying any per-task override.
+
+    A task entry may include ``model`` and/or ``provider`` to run on a
+    different provider than the batch default::
+
+        delegate_task(tasks=[
+            {"goal": "...", "provider": "anthropic", "model": "claude-opus-4-7"},
+            {"goal": "...", "provider": "openai", "model": "gpt-5"},
+        ])
+
+    Resolution priority: task-level provider/model > delegation-level creds.
+
+    Returns a creds dict in the same shape as
+    :func:`_resolve_delegation_credentials` so it drops into the existing
+    ``_build_child_agent`` override kwargs without further plumbing.
+
+    On resolution failure (e.g. a misconfigured provider name), logs a
+    warning and returns ``delegation_creds`` unchanged so the batch keeps
+    running on the default provider — preferable to failing every task in
+    the batch over one bad entry.
+    """
+    task_provider = task.get("provider")
+    task_model = task.get("model")
+
+    if not task_provider and not task_model:
+        return delegation_creds
+
+    if task_model and not task_provider:
+        # Model-only override: keep the delegation provider, swap the model.
+        creds = dict(delegation_creds)
+        creds["model"] = task_model
+        return creds
+
+    # Provider override: re-run runtime resolution for the named provider.
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        runtime = resolve_runtime_provider(requested=task_provider)
+    except Exception as exc:
+        logger.warning(
+            "Per-task provider %r failed to resolve (%s); using batch default",
+            task_provider, exc,
+        )
+        return delegation_creds
+
+    return {
+        "model": task_model or runtime.get("model") or delegation_creds.get("model"),
+        "provider": runtime.get("provider") or runtime.get("requested_provider"),
+        "base_url": runtime.get("base_url"),
+        "api_key": runtime.get("api_key"),
+        "api_mode": runtime.get("api_mode"),
+        "command": runtime.get("command"),
+        "args": list(runtime.get("args") or []),
+    }
+
+
 def _load_config() -> dict:
     """Load delegation config from CLI_CONFIG or persistent config.
 
@@ -2490,6 +2549,27 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "string",
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override. When set, this task runs on "
+                                "the specified model instead of the batch default. "
+                                "Combine with 'provider' to route to a different "
+                                "provider, or use alone to keep the delegation "
+                                "provider but swap the model."
+                            ),
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": (
+                                "Per-task provider override (e.g. 'anthropic', "
+                                "'openai', 'openrouter'). Re-runs the runtime "
+                                "provider resolution so this task can target a "
+                                "different provider:model than the batch default. "
+                                "If resolution fails the task falls back to the "
+                                "batch default and logs a warning."
+                            ),
                         },
                     },
                     "required": ["goal"],


### PR DESCRIPTION
## Summary

Lets each task in a `delegate_task` batch target a different model/provider:

```python
delegate_task(tasks=[
    {"goal": "Review for security",  "provider": "anthropic", "model": "claude-opus-4-7"},
    {"goal": "Review for performance", "provider": "openai",   "model": "gpt-5"},
    {"goal": "Review for clarity",     "provider": "openrouter", "model": "..."},
])
```

All three children spawn in parallel under the existing concurrency cap, each on its specified provider. Tasks without `model`/`provider` use the batch default (existing behaviour preserved).

## Why

The current contract supports a single `delegation.provider` for the whole batch — every child runs on the same provider:model pair. That's the right default for fan-out research where the model choice is uniform, but it blocks several patterns where the value comes from diversity:

- **Cross-model evaluation**: same prompt to N different models, compare outputs.
- **Adversarial review**: each reviewer is a different model so blind spots don't compound.
- **Cost-tiered routing**: high-stakes task on a frontier model, secondary tasks on cheaper models.

Today users have to either:
- Run sequential `delegate_task` calls (loses parallelism), or
- Build their own thread pool calling the agent directly (loses delegation infrastructure: progress callbacks, approval forwarding, role propagation, interrupt handling).

## Implementation

Three changes, all in `tools/delegate_tool.py`:

### 1. `_resolve_task_credentials(task, delegation_creds) -> dict`

New helper that resolves per-task creds. Returns the same shape as `_resolve_delegation_credentials` so the result drops into the existing `_build_child_agent` `override_*` kwargs without new plumbing.

Resolution priority: `task.provider/model` > `delegation_creds`.

Failure handling: if a task's `provider` doesn't resolve (typo, missing runtime config), log a warning and return `delegation_creds` unchanged. **Why**: failing the whole batch over one bad entry is worse UX than running that task on the default provider — the user can see the warning, fix the config, and the rest of the batch already produced useful output.

### 2. Per-task loop in `delegate_task`

One additional line per task before the `_build_child_agent` call:

```python
task_creds = _resolve_task_credentials(t, creds)
```

Then `_build_child_agent` receives `task_creds["..."]` instead of `creds["..."]`. No structural changes to the loop.

### 3. Schema additions

Per-task entries can now declare `model` and `provider` fields. Top-level `tasks[].properties.model` and `tasks[].properties.provider` were missing — adding them lets the model legitimately request the override.

## Compatibility

- Tasks without `model`/`provider` are unaffected: `_resolve_task_credentials` short-circuits and returns the batch creds.
- Top-level single-task mode (`delegate_task(goal=...)`) is unchanged — only the per-task loop is touched.
- `_resolve_delegation_credentials` is unchanged; `_resolve_task_credentials` reuses the same `resolve_runtime_provider` machinery.
- No new config keys.

## Test plan
- [x] Batch with all tasks defaulted: each child runs on `delegation.provider`
- [x] Batch with one task specifying `provider="anthropic"`: that task runs on Anthropic, others on default
- [x] Batch with model-only override: provider stays, model swaps
- [x] Batch with bad provider name: warning logged, task runs on batch default, other tasks unaffected
- [x] Top-level single task mode unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)