### PR TITLE
fix(gateway): stop typing before sending response to prevent race condition

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2827,6 +2827,7 @@ class BasePlatformAdapter(ABC):
                         if event.source.platform == Platform.FEISHU and event.source.thread_id and event.reply_to_message_id
                         else event.message_id
                     )
+                    self.pause_typing_for_chat(event.source.chat_id)
                     result = await self._send_with_retry(
                         chat_id=event.source.chat_id,
                         content=text_content,


### PR DESCRIPTION
After sending a response on Telegram, the typing indicator can re-appear because _keep_typing may fire another typing before _stop_typing_task() cancels it in the finally block. Fix: pause typing via pause_typing_for_chat() right before _send_with_retry.