### PR TITLE
Add SMS to shared platform registry

### DIFF
--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -37,6 +37,7 @@ PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("weixin",         PlatformInfo(label="💬 Weixin",          default_toolset="hermes-weixin")),
     ("qqbot",          PlatformInfo(label="💬 QQBot",           default_toolset="hermes-qqbot")),
     ("yuanbao",        PlatformInfo(label="🤖 Yuanbao",         default_toolset="hermes-yuanbao")),
+    ("sms",            PlatformInfo(label="📱 SMS (Twilio)",     default_toolset="hermes-sms")),
     ("webhook",        PlatformInfo(label="🔗 Webhook",         default_toolset="hermes-webhook")),
     ("api_server",     PlatformInfo(label="🌐 API Server",      default_toolset="hermes-api-server")),
     ("cron",           PlatformInfo(label="⏰ Cron",            default_toolset="hermes-cron")),


### PR DESCRIPTION
## Summary

Adds the built-in Twilio SMS platform to the shared `hermes_cli.platforms.PLATFORMS` registry.

## Why

SMS is already a core gateway platform:

- `gateway.config.Platform.SMS` exists
- `gateway.run` creates `SmsAdapter`
- `gateway/platforms/sms.py` implements the adapter

However, the shared platform registry used by toolset and skills configuration omitted `sms`, which can make registry lookups inconsistent for SMS sessions and platform-specific defaults.

## Validation

- `python3 -m py_compile hermes_cli/platforms.py`
- `git diff --check`
