### PR TITLE
Transcribe TUI voice input when stopping recording

### DIFF
--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -470,6 +470,71 @@ def stop_continuous() -> None:
             pass
 
 
+def stop_continuous_and_transcribe() -> Optional[str]:
+    """Stop the active continuous loop and return the last captured transcript.
+
+    This mirrors the user-facing Ctrl+B *stop* behavior in the TUI: keep the
+    current utterance, transcribe it, and hand the text back to the caller.
+    If no speech was captured, returns ``None``.
+    """
+    global _continuous_active, _continuous_on_transcript
+    global _continuous_on_status, _continuous_on_silent_limit
+    global _continuous_recorder, _continuous_no_speech_count
+
+    with _continuous_lock:
+        if not _continuous_active:
+            return None
+        _continuous_active = False
+        rec = _continuous_recorder
+        on_status = _continuous_on_status
+        _continuous_on_transcript = None
+        _continuous_on_status = None
+        _continuous_on_silent_limit = None
+        _continuous_no_speech_count = 0
+
+    if on_status:
+        try:
+            on_status("transcribing")
+        except Exception:
+            pass
+
+    wav_path = None
+    transcript: Optional[str] = None
+    if rec is not None:
+        try:
+            wav_path = rec.stop()
+        except Exception as e:
+            logger.warning("failed to stop recorder for transcribe: %s", e)
+
+    # Audible "recording stopped" cue (CLI parity: same 660 Hz × 2 the
+    # silence-auto-stop path plays).
+    _play_beep(frequency=660, count=2)
+
+    if wav_path:
+        try:
+            result = transcribe_recording(wav_path)
+            success = bool(result.get("success"))
+            text = (result.get("transcript") or "").strip()
+            if success and text and not is_whisper_hallucination(text):
+                transcript = text
+        except Exception as e:
+            logger.warning("continuous stop transcription failed: %s", e)
+        finally:
+            try:
+                if os.path.isfile(wav_path):
+                    os.unlink(wav_path)
+            except Exception:
+                pass
+
+    if on_status:
+        try:
+            on_status("idle")
+        except Exception:
+            pass
+
+    return transcript
+
+
 def is_continuous_active() -> bool:
     """Whether a continuous voice loop is currently running."""
     with _continuous_lock:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5677,10 +5677,14 @@ def _(rid, params: dict) -> dict:
             return _ok(rid, {"status": "recording"})
 
         # action == "stop"
-        from hermes_cli.voice import stop_continuous
+        from hermes_cli.voice import stop_continuous_and_transcribe
 
-        stop_continuous()
-        return _ok(rid, {"status": "stopped"})
+        _voice_emit("voice.status", {"state": "transcribing"})
+        transcript = stop_continuous_and_transcribe()
+        if transcript:
+            _voice_emit("voice.transcript", {"text": transcript})
+        _voice_emit("voice.status", {"state": "idle"})
+        return _ok(rid, {"status": "stopped", "transcript": transcript or ""})
     except ImportError:
         return _err(
             rid, 5025, "voice module not available — install audio dependencies"

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -182,13 +182,15 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       voice.setRecording(true)
     } else {
       voice.setRecording(false)
-      voice.setProcessing(false)
+      voice.setProcessing(true)
     }
 
     gateway.rpc<VoiceRecordResponse>('voice.record', { action }).catch((e: Error) => {
       // Revert optimistic UI on failure.
       if (starting) {
         voice.setRecording(false)
+      } else {
+        voice.setProcessing(false)
       }
 
       actions.sys(`voice error: ${e.message}`)


### PR DESCRIPTION
## Summary

Make the TUI voice stop action preserve and transcribe the current utterance instead of only stopping the continuous recorder.

## Why

The TUI currently routes a manual voice stop to `stop_continuous()`, which tears down the continuous recording loop without returning the captured speech. That can discard the user's spoken input when they stop recording manually.

## Changes

- Add `stop_continuous_and_transcribe()` to stop the active recorder and return the final transcript.
- Use it from the TUI gateway `voice.record` stop path.
- Keep the TUI in a processing state while the stop/transcribe request completes.

## Validation

- `python3 -m py_compile hermes_cli/voice.py tui_gateway/server.py`
- `git diff --check`
