### PR TITLE
fix(agent): reset fallback chain index when activation fails in interactive sessions

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7840,6 +7840,14 @@ class AIAgent:
         ``gateway/run.py``), so this restoration IS needed there too.
         """
         if not self._fallback_activated:
+            # Reset the chain index even when no fallback was activated this
+            # turn.  Without this, a turn where _try_activate_fallback() was
+            # called but returned False (chain exhausted or provider not
+            # configured) leaves _fallback_index >= len(_fallback_chain) while
+            # _fallback_activated stays False.  The next turn skips this block
+            # entirely, stranding the index and silently blocking all future
+            # fallback attempts for the session.  Fixes #20465.
+            self._fallback_index = 0
             return False
 
         if getattr(self, "_rate_limited_until", 0) > time.monotonic():

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -123,6 +123,26 @@ class TestRestorePrimaryRuntime:
         assert agent._fallback_activated is False
         assert agent._restore_primary_runtime() is False
 
+    def test_resets_index_when_fallback_not_activated(self):
+        """Regression for #20465: failed activation leaves _fallback_index advanced
+        with _fallback_activated=False; the next turn's restore must reset the index."""
+        fbs = [{"provider": "custom", "model": "gpt-oss:20b",
+                "base_url": "http://host.docker.internal:11434/v1", "api_key": "ollama"}]
+        agent = _make_agent(fallback_model=fbs)
+
+        # resolve_provider_client returns None → _try_activate_fallback returns False
+        # but _fallback_index has already been incremented to 1
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)):
+            assert agent._try_activate_fallback() is False
+
+        assert agent._fallback_activated is False
+        assert agent._fallback_index == 1  # advanced past the only entry
+
+        # _restore_primary_runtime must reset the index so the next turn can retry
+        result = agent._restore_primary_runtime()
+        assert result is False  # still no-op (primary was never left)
+        assert agent._fallback_index == 0  # chain available again
+
     def test_restores_model_and_provider(self):
         agent = _make_agent(
             fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},


### PR DESCRIPTION
## What changed and why

In long-lived interactive CLI sessions (and gateway agent-cache hits), a single `AIAgent` instance is reused across multiple turns. `_try_activate_fallback()` increments `_fallback_index` **before** resolving the fallback provider's client. When client resolution fails (provider not configured, auth missing, etc.) the function returns `False` without ever setting `_fallback_activated = True`.

`_restore_primary_runtime()` was guarded by `if not self._fallback_activated: return False`, so it skipped its reset block entirely. `_fallback_index` was left at `>= len(_fallback_chain)` across turns. On the next Codex 429, the eager-fallback check

```python
if is_rate_limited and self._fallback_index < len(self._fallback_chain):
```

fails silently — no status message, no fallback attempt, just three retries and a hard failure every time.

Cron jobs spawn a fresh `AIAgent` per run (index always 0), which is exactly why the same chain works reliably for cron while interactive sessions fail.

**Fix**: add an unconditional `self._fallback_index = 0` reset in the `not _fallback_activated` early-return branch of `_restore_primary_runtime()`. Every new turn now starts with the full chain available, regardless of what happened in the prior turn.

Per the reporter's follow-up on 2026-05-06 confirming that sessions with `msgs=2` (effectively single-shot shape) also fail without fallback, and that the one session where fallback fired at 14:51:34 was likely the first turn after a fresh agent start.

Fixes #20465

## How to test

1. Configure `model.provider: openai-codex` and a `fallback_providers` list with a reachable local provider (e.g. Ollama).
2. In a single interactive `hermes` session, exhaust the Codex 5-hour quota.
3. Send a second message: confirm the fallback activates (log line `Fallback activated: gpt-5.5 → <model> (custom)`) instead of `API call failed after 3 retries`.
4. Unit test path: `pytest tests/run_agent/test_primary_runtime_restore.py tests/run_agent/test_provider_fallback.py -q` — all 51 tests pass.

Alternatively, reproduce with the unit test added in this PR:
```
pytest tests/run_agent/test_primary_runtime_restore.py::TestRestorePrimaryRuntime::test_resets_index_when_fallback_not_activated -v
```

## What platforms tested on

- macOS (Darwin 24.6.0) — unit tests
- WSL2 Ubuntu 24.04 — reporter confirmed reproduction environment

<!-- autocontrib:worker-id=issue-followup-d6a04b83 kind=pr-open -->