### PR TITLE
perf(init): cache Copilot context lookups and avoid eager Feishu SDK imports

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -340,12 +340,31 @@ def _infer_provider_from_url(base_url: str) -> Optional[str]:
     normalized = _normalize_base_url(base_url)
     if not normalized:
         return None
+    if normalized.lower().startswith("acp://copilot"):
+        return "copilot-acp"
     parsed = urlparse(normalized if "://" in normalized else f"https://{normalized}")
     host = parsed.netloc.lower() or parsed.path.lower()
     for url_part, provider in _URL_TO_PROVIDER.items():
         if url_part in host:
             return provider
     return None
+
+
+def _is_copilot_provider(provider: Optional[str]) -> bool:
+    return provider in ("copilot", "copilot-acp", "github-copilot")
+
+
+def _is_copilot_context_source(provider: Optional[str], base_url: Optional[str]) -> bool:
+    """Return True when the lookup targets a Copilot-backed endpoint.
+
+    Copilot context windows are account-specific, so they must not use the
+    persistent context cache keyed only by ``model@base_url``.
+    """
+    if _is_copilot_provider(provider):
+        return True
+    if not base_url:
+        return False
+    return _infer_provider_from_url(base_url) in ("copilot", "copilot-acp", "github-copilot")
 
 
 def _is_known_provider_base_url(base_url: str) -> bool:
@@ -723,9 +742,14 @@ def _resolve_endpoint_context_length(
     model: str,
     base_url: str,
     api_key: str = "",
+    force_refresh: bool = False,
 ) -> Optional[int]:
     """Resolve context length from an endpoint's live ``/models`` metadata."""
-    endpoint_metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
+    endpoint_metadata = fetch_endpoint_model_metadata(
+        base_url,
+        api_key=api_key,
+        force_refresh=force_refresh,
+    )
     matched = endpoint_metadata.get(model)
     if not matched:
         if len(endpoint_metadata) == 1:
@@ -1290,7 +1314,10 @@ def get_model_context_length(
     # LM Studio is excluded — its loaded context length is transient (the
     # user can reload the model with a different context_length at any time
     # via /api/v1/models/load), so a stale cached value would mask reloads.
-    if base_url and provider != "lmstudio":
+    # Copilot endpoints are also excluded because the limit is tied to the
+    # account/token rather than the base URL alone.
+    skip_persistent_cache = _is_copilot_context_source(provider, base_url)
+    if base_url and provider != "lmstudio" and not skip_persistent_cache:
         cached = get_cached_context_length(model, base_url)
         if cached is not None:
             # Invalidate stale Codex OAuth cache entries: pre-PR #14935 builds
@@ -1329,13 +1356,28 @@ def get_model_context_length(
         except ImportError:
             pass  # boto3 not installed — fall through to generic resolution
 
+    # Provider-aware lookups need to know whether a custom endpoint is
+    # Copilot-backed before the /models probe runs, so infer it here.
+    effective_provider = provider
+    if not effective_provider or effective_provider in ("openrouter", "custom"):
+        if base_url:
+            inferred = _infer_provider_from_url(base_url)
+            if inferred:
+                effective_provider = inferred
+
     # 2. Active endpoint metadata for truly custom/unknown endpoints.
     # Known providers (Copilot, OpenAI, Anthropic, etc.) skip this — their
     # /models endpoint may report a provider-imposed limit (e.g. Copilot
     # returns 128k) instead of the model's full context (400k).  models.dev
     # has the correct per-provider values and is checked at step 5+.
     if _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url):
-        context_length = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
+        refresh_endpoint_probe = effective_provider in {"copilot", "copilot-acp", "github-copilot"}
+        context_length = _resolve_endpoint_context_length(
+            model,
+            base_url,
+            api_key=api_key,
+            force_refresh=refresh_endpoint_probe,
+        )
         if context_length is not None:
             return context_length
         if not _is_known_provider_base_url(base_url):
@@ -1343,7 +1385,7 @@ def get_model_context_length(
             if is_local_endpoint(base_url):
                 local_ctx = _query_local_context_length(model, base_url, api_key=api_key)
                 if local_ctx and local_ctx > 0:
-                    if provider != "lmstudio":
+                    if provider != "lmstudio" and not skip_persistent_cache:
                         save_context_length(model, base_url, local_ctx)
                     return local_ctx
             logger.info(
@@ -1412,6 +1454,8 @@ def get_model_context_length(
         from agent.models_dev import lookup_models_dev_context
         ctx = lookup_models_dev_context(effective_provider, model)
         if ctx:
+            if base_url and provider != "lmstudio" and not skip_persistent_cache:
+                save_context_length(model, base_url, ctx)
             return ctx
 
     # 6. OpenRouter live API metadata (provider-unaware fallback)
@@ -1434,7 +1478,7 @@ def get_model_context_length(
     if base_url and is_local_endpoint(base_url):
         local_ctx = _query_local_context_length(model, base_url, api_key=api_key)
         if local_ctx and local_ctx > 0:
-            if provider != "lmstudio":
+            if provider != "lmstudio" and not skip_persistent_cache:
                 save_context_length(model, base_url, local_ctx)
             return local_ctx
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -7,6 +7,7 @@ Add, remove, or reorder entries here — both `hermes setup` and
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import urllib.request
@@ -17,6 +18,7 @@ from pathlib import Path
 from typing import Any, NamedTuple, Optional
 
 from hermes_cli import __version__ as _HERMES_VERSION
+from hermes_cli.copilot_auth import COPILOT_ENV_VARS
 
 # Identify ourselves so endpoints fronted by Cloudflare's Browser Integrity
 # Check (error 1010) don't reject the default ``Python-urllib/*`` signature.
@@ -1810,64 +1812,6 @@ def resolve_fast_mode_overrides(model_id: Optional[str]) -> dict[str, Any] | Non
     return {"service_tier": "priority"}
 
 
-def _resolve_copilot_catalog_api_key() -> str:
-    """Best-effort GitHub token for fetching the Copilot model catalog.
-
-    Resolution order:
-      1. ``resolve_api_key_provider_credentials("copilot")`` — env vars
-         (``COPILOT_GITHUB_TOKEN`` / ``GH_TOKEN`` / ``GITHUB_TOKEN``) plus
-         the ``gh auth token`` CLI fallback.
-      2. ``read_credential_pool("copilot")`` — a token (typically a
-         ``gho_*`` from device-code login, or a fine-grained PAT) stored in
-         ``auth.json`` under ``credential_pool.copilot[]``. The pool is
-         populated by ``hermes auth add copilot`` and by ``_seed_from_env``
-         when the env var is set in ``~/.hermes/.env``.
-
-    Without (2), users whose only Copilot credential is in the pool see
-    the ``/model`` picker fall back to a stale hardcoded list because the
-    live catalog fetch silently 401s. To avoid wedging on a malformed pool
-    entry, each candidate is exchanged via ``exchange_copilot_token`` —
-    only entries that actually exchange successfully are returned, so a
-    later valid entry is reachable when an earlier one is unsupported.
-    """
-    try:
-        from hermes_cli.auth import resolve_api_key_provider_credentials
-
-        creds = resolve_api_key_provider_credentials("copilot")
-        api_key = str(creds.get("api_key") or "").strip()
-        if api_key:
-            return api_key
-    except Exception:
-        pass
-
-    try:
-        from hermes_cli.auth import read_credential_pool
-        from hermes_cli.copilot_auth import (
-            exchange_copilot_token,
-            validate_copilot_token,
-        )
-
-        for entry in read_credential_pool("copilot"):
-            if not isinstance(entry, dict):
-                continue
-            raw = str(entry.get("access_token") or "").strip()
-            if not raw:
-                continue
-            valid, _ = validate_copilot_token(raw)
-            if not valid:
-                continue
-            try:
-                api_token, _expires_at = exchange_copilot_token(raw)
-            except Exception:
-                continue
-            if api_token:
-                return api_token
-    except Exception:
-        pass
-
-    return ""
-
-
 # Providers where models.dev is treated as authoritative: curated static
 # lists are kept only as an offline fallback and to capture custom additions
 # the registry doesn't publish yet. Adding a provider here causes its
@@ -2223,7 +2167,9 @@ def _copilot_catalog_item_is_text_model(item: dict[str, Any]) -> bool:
 
 
 def fetch_github_model_catalog(
-    api_key: Optional[str] = None, timeout: float = 5.0
+    api_key: Optional[str] = None,
+    timeout: float = 5.0,
+    retry_without_auth: bool = True,
 ) -> Optional[list[dict[str, Any]]]:
     """Fetch the live GitHub Copilot model catalog for this account."""
     attempts: list[dict[str, str]] = []
@@ -2232,7 +2178,8 @@ def fetch_github_model_catalog(
             **copilot_default_headers(),
             "Authorization": f"Bearer {api_key}",
         })
-    attempts.append(copilot_default_headers())
+    if not api_key or retry_without_auth:
+        attempts.append(copilot_default_headers())
 
     for headers in attempts:
         req = urllib.request.Request(COPILOT_MODELS_URL, headers=headers)
@@ -2259,10 +2206,103 @@ def fetch_github_model_catalog(
 
 # ─── Copilot catalog context-window helpers ─────────────────────────────────
 
-# Module-level cache: {model_id: max_prompt_tokens}
-_copilot_context_cache: dict[str, int] = {}
-_copilot_context_cache_time: float = 0.0
+# Module-level cache: {token_fingerprint: {model_id: max_prompt_tokens}}
+_copilot_context_cache: dict[str, dict[str, int]] = {}
+_copilot_context_cache_time: dict[str, float] = {}
+_copilot_catalog_api_key_cache: dict[str, tuple[str, float]] = {}
 _COPILOT_CONTEXT_CACHE_TTL = 3600  # 1 hour
+_COPILOT_CATALOG_TOKEN_REFRESH_MARGIN_SECONDS = 120
+
+
+def _copilot_cache_identity(api_key: Optional[str]) -> str:
+    """Return a stable, non-secret namespace for a Copilot token."""
+    return hashlib.sha256((api_key or "").encode("utf-8")).hexdigest()
+
+
+def _copilot_auth_state_fingerprint() -> str:
+    """Return a cheap fingerprint for the current Copilot auth state.
+
+    This is used to memoize the resolved Copilot catalog API key so repeated
+    lookups do not keep walking env vars, auth.json, credential pools, and gh.
+    The fingerprint changes when the common auth inputs change.
+    """
+    from hermes_cli.config import get_hermes_home
+
+    def _gh_hosts_yml_path() -> Path:
+        gh_config_dir = os.getenv("GH_CONFIG_DIR", "").strip()
+        if gh_config_dir:
+            return Path(gh_config_dir) / "hosts.yml"
+        xdg_config_home = os.getenv("XDG_CONFIG_HOME", "").strip()
+        if xdg_config_home:
+            return Path(xdg_config_home) / "gh" / "hosts.yml"
+        return Path.home() / ".config" / "gh" / "hosts.yml"
+
+    def _fingerprint_path(path: Path) -> str:
+        try:
+            stat = path.stat()
+        except OSError:
+            return f"{path}:missing"
+        return f"{path}:{stat.st_mtime_ns}:{stat.st_size}"
+
+    parts = [
+        f"{env_var}={os.getenv(env_var, '').strip()}"
+        for env_var in COPILOT_ENV_VARS
+    ]
+    parts.append(f"COPILOT_GH_HOST={os.getenv('COPILOT_GH_HOST', '').strip()}")
+    parts.append(_fingerprint_path(_gh_hosts_yml_path()))
+    parts.append(_fingerprint_path(get_hermes_home() / "auth.json"))
+    return hashlib.sha256("\n".join(parts).encode("utf-8")).hexdigest()
+
+
+def _resolve_copilot_catalog_api_key_details() -> tuple[str, float]:
+    """Return ``(api_key, expires_at_epoch)`` for the Copilot catalog API.
+
+    The expiry is only known for exchanged tokens. Env / gh-auth tokens are
+    treated as effectively non-expiring and are revalidated by the auth-state
+    fingerprint when the underlying inputs change.
+    """
+    try:
+        from hermes_cli.auth import resolve_api_key_provider_credentials
+
+        creds = resolve_api_key_provider_credentials("copilot")
+        api_key = str(creds.get("api_key") or "").strip()
+        if api_key:
+            return api_key, float("inf")
+    except Exception:
+        pass
+
+    try:
+        from hermes_cli.auth import read_credential_pool
+        from hermes_cli.copilot_auth import (
+            exchange_copilot_token,
+            validate_copilot_token,
+        )
+
+        for entry in read_credential_pool("copilot"):
+            if not isinstance(entry, dict):
+                continue
+            raw = str(entry.get("access_token") or "").strip()
+            if not raw:
+                continue
+            valid, _ = validate_copilot_token(raw)
+            if not valid:
+                continue
+            try:
+                api_token, expires_at = exchange_copilot_token(raw)
+            except Exception:
+                continue
+            if api_token:
+                return api_token, float(expires_at)
+    except Exception:
+        pass
+
+    return "", 0.0
+
+
+def _resolve_copilot_catalog_api_key() -> str:
+    """Best-effort GitHub token for fetching the Copilot model catalog."""
+    api_key, _expires_at = _resolve_copilot_catalog_api_key_details()
+    return api_key
 
 
 def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> Optional[int]:
@@ -2271,17 +2311,60 @@ def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> O
     Results are cached in-process for 1 hour to avoid repeated API calls.
     Returns the token limit or None if not found.
     """
-    global _copilot_context_cache, _copilot_context_cache_time
+    global _copilot_context_cache, _copilot_context_cache_time, _copilot_catalog_api_key_cache
 
-    # Serve from cache if fresh
-    if _copilot_context_cache and (time.time() - _copilot_context_cache_time < _COPILOT_CONTEXT_CACHE_TTL):
-        if model_id in _copilot_context_cache:
-            return _copilot_context_cache[model_id]
-        # Cache is fresh but model not in it — don't re-fetch
-        return None
+    cached_key = ""
+    cached_expires_at = 0.0
+    if not api_key:
+        state_key = _copilot_auth_state_fingerprint()
+        anonymous_cache_key = f"anon:{state_key}"
+        anonymous_cache = _copilot_context_cache.get(anonymous_cache_key)
+        anonymous_cached_at = _copilot_context_cache_time.get(anonymous_cache_key, 0.0)
+        cached = _copilot_catalog_api_key_cache.get(state_key)
+        if (
+            not cached
+            and anonymous_cache
+            and (time.time() - anonymous_cached_at < _COPILOT_CONTEXT_CACHE_TTL)
+        ):
+            if model_id in anonymous_cache:
+                return anonymous_cache[model_id]
+        now = time.time()
+        if cached:
+            cached_key, cached_expires_at = cached
+            if cached_key:
+                cache_identity = _copilot_cache_identity(cached_key)
+                cached_catalog = _copilot_context_cache.get(cache_identity)
+                cached_at = _copilot_context_cache_time.get(cache_identity, 0.0)
+                if cached_catalog and (now - cached_at < _COPILOT_CONTEXT_CACHE_TTL):
+                    if model_id in cached_catalog:
+                        return cached_catalog[model_id]
+            if cached_key and (
+                cached_expires_at == float("inf")
+                or now < (cached_expires_at - _COPILOT_CATALOG_TOKEN_REFRESH_MARGIN_SECONDS)
+            ):
+                api_key = cached_key
+        if not api_key:
+            resolved_key, expires_at = _resolve_copilot_catalog_api_key_details()
+            if resolved_key:
+                api_key = resolved_key
+                _copilot_catalog_api_key_cache[state_key] = (resolved_key, expires_at)
+
+    cache_identity = _copilot_cache_identity(api_key) if api_key else f"anon:{_copilot_auth_state_fingerprint()}"
+
+    # Serve from the per-token cache if fresh.
+    cached_catalog = _copilot_context_cache.get(cache_identity)
+    cached_at = _copilot_context_cache_time.get(cache_identity, 0.0)
+    if cached_catalog and (time.time() - cached_at < _COPILOT_CONTEXT_CACHE_TTL):
+        if model_id in cached_catalog:
+            return cached_catalog[model_id]
+        # Cache is fresh but model not in it — re-probe in case the catalog
+        # changed or the prior fetch was incomplete.
 
     # Fetch and populate cache
-    catalog = fetch_github_model_catalog(api_key=api_key)
+    catalog = fetch_github_model_catalog(
+        api_key=api_key,
+        retry_without_auth=not bool(api_key),
+    )
     if not catalog:
         return None
 
@@ -2296,8 +2379,8 @@ def get_copilot_model_context(model_id: str, api_key: Optional[str] = None) -> O
         if isinstance(max_prompt, int) and max_prompt > 0:
             cache[mid] = max_prompt
 
-    _copilot_context_cache = cache
-    _copilot_context_cache_time = time.time()
+    _copilot_context_cache[cache_identity] = cache
+    _copilot_context_cache_time[cache_identity] = time.time()
 
     return cache.get(model_id)
 
@@ -2533,7 +2616,11 @@ def lmstudio_model_reasoning_options(
 
 
 def _fetch_github_models(api_key: Optional[str] = None, timeout: float = 5.0) -> Optional[list[str]]:
-    catalog = fetch_github_model_catalog(api_key=api_key, timeout=timeout)
+    catalog = fetch_github_model_catalog(
+        api_key=api_key,
+        timeout=timeout,
+        retry_without_auth=not bool(api_key),
+    )
     if not catalog:
         return None
     return [item.get("id", "") for item in catalog if item.get("id")]
@@ -2583,7 +2670,7 @@ def _copilot_catalog_ids(
     api_key: Optional[str] = None,
 ) -> set[str]:
     if catalog is None and api_key:
-        catalog = fetch_github_model_catalog(api_key=api_key)
+        catalog = fetch_github_model_catalog(api_key=api_key, retry_without_auth=False)
     if not catalog:
         return set()
     return {
@@ -2676,7 +2763,7 @@ def copilot_model_api_mode(
     # Fetch the catalog once so normalize + endpoint check share it
     # (avoids two redundant network calls for non-GPT-5 models).
     if catalog is None and api_key:
-        catalog = fetch_github_model_catalog(api_key=api_key)
+        catalog = fetch_github_model_catalog(api_key=api_key, retry_without_auth=False)
 
     normalized = normalize_copilot_model_id(model_id, catalog=catalog, api_key=api_key)
     if not normalized:
@@ -2810,7 +2897,7 @@ def github_model_reasoning_efforts(
     if catalog is not None:
         catalog_entry = next((item for item in catalog if item.get("id") == normalized), None)
     elif api_key:
-        fetched_catalog = fetch_github_model_catalog(api_key=api_key)
+        fetched_catalog = fetch_github_model_catalog(api_key=api_key, retry_without_auth=False)
         if fetched_catalog:
             catalog_entry = next((item for item in fetched_catalog if item.get("id") == normalized), None)
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -138,6 +138,7 @@ AUTHOR_MAP = {
     "formulahendry@gmail.com": "formulahendry",
     "93757150+bogerman1@users.noreply.github.com": "bogerman1",
     "132852777+rob-maron@users.noreply.github.com": "rob-maron",
+    "mjc@kernel.org": "mjc",
     # Matrix parity salvage batch (April 2026)
     "sr@samirusani": "samrusani",
     "angelclaw@AngelMacBook.local": "angel12",

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -543,6 +543,61 @@ class TestGetModelContextLength:
             assert result == CONTEXT_PROBE_TIERS[0]
 
     @patch("agent.model_metadata.fetch_model_metadata")
+    def test_provider_aware_lookup_for_copilot_is_not_saved_to_cache(self, mock_fetch):
+        mock_fetch.return_value = {}
+
+        with patch("agent.model_metadata.get_cached_context_length") as mock_cache, \
+             patch("hermes_cli.models.get_copilot_model_context", return_value=None), \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=272000) as mock_lookup, \
+             patch("agent.model_metadata.save_context_length") as mock_save:
+            result = get_model_context_length(
+                "gpt-5.4",
+                base_url="acp://copilot",
+                provider="copilot-acp",
+            )
+
+        assert result == 272000
+        mock_cache.assert_not_called()
+        mock_lookup.assert_called_once_with("copilot-acp", "gpt-5.4")
+        mock_save.assert_not_called()
+
+    @patch("agent.model_metadata.fetch_model_metadata")
+    def test_custom_provider_acp_marker_is_treated_as_copilot(self, mock_fetch):
+        mock_fetch.return_value = {}
+
+        with patch("agent.model_metadata.get_cached_context_length") as mock_cache, \
+             patch("hermes_cli.models.get_copilot_model_context", return_value=200000) as mock_copilot_ctx, \
+             patch("agent.model_metadata.save_context_length") as mock_save:
+            result = get_model_context_length(
+                "claude-sonnet-4",
+                base_url="acp://copilot",
+                provider="custom",
+            )
+
+        assert result == 200000
+        mock_cache.assert_not_called()
+        mock_copilot_ctx.assert_called_once_with("claude-sonnet-4", api_key="")
+        mock_save.assert_not_called()
+
+    @patch("agent.model_metadata.fetch_model_metadata")
+    def test_provider_aware_lookup_for_non_copilot_is_saved_to_cache(self, mock_fetch):
+        mock_fetch.return_value = {}
+
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata._is_custom_endpoint", return_value=False), \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=272000) as mock_lookup, \
+             patch("agent.model_metadata.save_context_length") as mock_save:
+            result = get_model_context_length(
+                "gpt-5.4",
+                base_url="http://local",
+                provider="openrouter",
+            )
+
+        assert result == 272000
+        mock_lookup.assert_called_once_with("openrouter", "gpt-5.4")
+        mock_save.assert_called_once_with("gpt-5.4", "http://local", 272000)
+
+    @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
     def test_custom_endpoint_metadata_beats_fuzzy_default(self, mock_endpoint_fetch, mock_fetch):
         mock_fetch.return_value = {}
@@ -557,6 +612,55 @@ class TestGetModelContextLength:
         )
 
         assert result == 65536
+
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_copilot_proxy_bypasses_endpoint_metadata_cache(self, mock_endpoint_fetch, mock_fetch):
+        mock_fetch.return_value = {}
+        mock_endpoint_fetch.return_value = {
+            "claude-sonnet-4": {"context_length": 200000}
+        }
+
+        result = get_model_context_length(
+            "claude-sonnet-4",
+            base_url="https://proxy.example.com/v1",
+            provider="copilot-acp",
+        )
+
+        assert result == 200000
+        mock_endpoint_fetch.assert_called_once_with(
+            "https://proxy.example.com/v1",
+            api_key="",
+            force_refresh=True,
+        )
+
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata._resolve_endpoint_context_length", return_value=None)
+    @patch("agent.model_metadata._query_local_context_length", return_value=65536)
+    def test_copilot_proxy_skips_local_persistent_cache(self, mock_local_ctx, mock_endpoint_ctx, mock_fetch):
+        mock_fetch.return_value = {}
+
+        with patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata.save_context_length") as mock_save:
+            result = get_model_context_length(
+                "claude-sonnet-4",
+                base_url="http://proxy.local/v1",
+                provider="copilot-acp",
+            )
+
+        assert result == 65536
+        mock_endpoint_ctx.assert_called_once_with(
+            "claude-sonnet-4",
+            "http://proxy.local/v1",
+            api_key="",
+            force_refresh=True,
+        )
+        mock_local_ctx.assert_called_once_with(
+            "claude-sonnet-4",
+            "http://proxy.local/v1",
+            api_key="",
+        )
+        mock_save.assert_not_called()
 
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")

--- a/tests/hermes_cli/test_copilot_context.py
+++ b/tests/hermes_cli/test_copilot_context.py
@@ -53,10 +53,12 @@ def _clear_cache():
     import hermes_cli.models as mod
 
     mod._copilot_context_cache = {}
-    mod._copilot_context_cache_time = 0.0
+    mod._copilot_context_cache_time = {}
+    mod._copilot_catalog_api_key_cache = {}
     yield
     mod._copilot_context_cache = {}
-    mod._copilot_context_cache_time = 0.0
+    mod._copilot_context_cache_time = {}
+    mod._copilot_catalog_api_key_cache = {}
 
 
 class TestGetCopilotModelContext:
@@ -87,6 +89,111 @@ class TestGetCopilotModelContext:
         assert mock_fetch.call_count == 1
 
     @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
+    def test_cache_is_scoped_to_api_key(self, mock_fetch):
+        assert get_copilot_model_context("gpt-4.1", api_key="token-a") == 128_000
+        assert get_copilot_model_context("gpt-4.1", api_key="token-b") == 128_000
+        assert get_copilot_model_context("gpt-4.1", api_key="token-a") == 128_000
+        assert mock_fetch.call_count == 2
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
+    @patch("hermes_cli.models._resolve_copilot_catalog_api_key_details", return_value=("gh-token", float("inf")))
+    def test_resolves_catalog_api_key_when_not_provided(self, mock_resolve, mock_fetch):
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+        mock_resolve.assert_called_once_with()
+        mock_fetch.assert_called_once_with(api_key="gh-token", retry_without_auth=False)
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
+    @patch("hermes_cli.models._resolve_copilot_catalog_api_key_details", return_value=("gh-token", float("inf")))
+    def test_no_key_cache_hit_skips_token_refresh(self, mock_resolve, mock_fetch):
+        import hermes_cli.models as mod
+
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+        state_key = next(iter(mod._copilot_catalog_api_key_cache))
+        assert mod._copilot_catalog_api_key_cache[state_key][0] == "gh-token"
+
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+        assert mock_resolve.call_count == 1
+        assert mock_fetch.call_count == 1
+        mock_fetch.assert_called_once_with(api_key="gh-token", retry_without_auth=False)
+
+    @patch(
+        "hermes_cli.models.fetch_github_model_catalog",
+        side_effect=[_SAMPLE_CATALOG, _SAMPLE_CATALOG],
+    )
+    @patch(
+        "hermes_cli.models._resolve_copilot_catalog_api_key_details",
+        side_effect=[("", 0.0), ("gh-token", float("inf"))],
+    )
+    def test_anonymous_cache_invalidates_on_auth_change(self, mock_resolve, mock_fetch, monkeypatch):
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "fresh-token")
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+        assert mock_resolve.call_count == 2
+        assert mock_fetch.call_count == 2
+        assert mock_fetch.call_args_list[0].kwargs.get("retry_without_auth") is True
+        assert mock_fetch.call_args_list[1].kwargs.get("retry_without_auth") is False
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
+    @patch("hermes_cli.models._resolve_copilot_catalog_api_key_details", return_value=("gh-token-a", 1.0))
+    def test_fresh_cached_context_skips_token_refresh(self, mock_resolve, mock_fetch):
+        import hermes_cli.models as mod
+
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+        state_key = next(iter(mod._copilot_catalog_api_key_cache))
+        mod._copilot_catalog_api_key_cache[state_key] = ("gh-token-a", 0.0)
+
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+        assert mock_resolve.call_count == 1
+        assert mock_fetch.call_count == 1
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
+    @patch(
+        "hermes_cli.models._resolve_copilot_catalog_api_key_details",
+        side_effect=[("gh-token-a", float("inf")), ("gh-token-b", float("inf"))],
+    )
+    def test_catalog_api_key_cache_respects_gh_host(self, mock_resolve, mock_fetch, monkeypatch):
+        monkeypatch.setenv("COPILOT_GH_HOST", "github.com")
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+        monkeypatch.setenv("COPILOT_GH_HOST", "github.example.com")
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+        assert mock_resolve.call_count == 2
+        assert mock_fetch.call_count == 2
+
+    @patch(
+        "hermes_cli.models.fetch_github_model_catalog",
+        side_effect=[_SAMPLE_CATALOG, _SAMPLE_CATALOG, _SAMPLE_CATALOG],
+    )
+    @patch(
+        "hermes_cli.models._resolve_copilot_catalog_api_key_details",
+        side_effect=[("gh-token-a", 1.0), ("", 0.0), ("gh-token-b", float("inf"))],
+    )
+    def test_expired_cached_catalog_token_refreshes_without_memoizing_empty(self, mock_resolve, mock_fetch):
+        import hermes_cli.models as mod
+
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+        state_key = next(iter(mod._copilot_catalog_api_key_cache))
+        token, expires_at = mod._copilot_catalog_api_key_cache[state_key]
+        assert token == "gh-token-a"
+        mod._copilot_catalog_api_key_cache[state_key] = (token, 0.0)
+        cache_id = next(iter(mod._copilot_context_cache))
+        mod._copilot_context_cache_time[cache_id] = time.time() - 7200
+
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+        assert mod._copilot_catalog_api_key_cache[state_key] == ("gh-token-a", 0.0)
+        assert mock_fetch.call_args_list[1].kwargs.get("api_key") is None
+        assert mock_fetch.call_args_list[1].kwargs.get("retry_without_auth") is True
+
+        mod._copilot_catalog_api_key_cache[state_key] = ("gh-token-a", 0.0)
+        mod._copilot_context_cache_time[cache_id] = time.time() - 7200
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+        assert mod._copilot_catalog_api_key_cache[state_key][0] == "gh-token-b"
+        assert mock_fetch.call_args_list[2].kwargs.get("api_key") == "gh-token-b"
+        assert mock_fetch.call_args_list[2].kwargs.get("retry_without_auth") is False
+        assert mock_resolve.call_count == 3
+        assert mock_fetch.call_count == 3
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
     def test_cache_expires(self, mock_fetch):
         import hermes_cli.models as mod
 
@@ -94,7 +201,8 @@ class TestGetCopilotModelContext:
         assert mock_fetch.call_count == 1
 
         # Expire the cache
-        mod._copilot_context_cache_time = time.time() - 7200
+        cache_id = next(iter(mod._copilot_context_cache))
+        mod._copilot_context_cache_time[cache_id] = time.time() - 7200
         get_copilot_model_context("gpt-4.1")
         assert mock_fetch.call_count == 2
 
@@ -105,6 +213,81 @@ class TestGetCopilotModelContext:
     @patch("hermes_cli.models.fetch_github_model_catalog", return_value=[])
     def test_returns_none_for_empty_catalog(self, mock_fetch):
         assert get_copilot_model_context("gpt-4.1") is None
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
+    @patch("hermes_cli.models._resolve_copilot_catalog_api_key_details", return_value=("", 0.0))
+    def test_unauthenticated_fallback_still_fetches_catalog(self, mock_resolve, mock_fetch):
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+        mock_resolve.assert_called_once_with()
+        mock_fetch.assert_called_once_with(api_key=None, retry_without_auth=True)
+
+    @patch(
+        "hermes_cli.models.fetch_github_model_catalog",
+        side_effect=[[
+            {
+                "id": "claude-opus-4.6-1m",
+                "capabilities": {"type": "chat", "limits": {"max_prompt_tokens": 1_000_000}},
+            }
+        ], _SAMPLE_CATALOG],
+    )
+    def test_fresh_cache_miss_refetches_catalog(self, mock_fetch):
+        import hermes_cli.models as mod
+
+        assert get_copilot_model_context("gpt-4.1", api_key="token-a") is None
+        assert get_copilot_model_context("gpt-4.1", api_key="token-a") == 128_000
+        assert mock_fetch.call_count == 2
+        cache_id = mod._copilot_cache_identity("token-a")
+        assert "gpt-4.1" in mod._copilot_context_cache[cache_id]
+
+    @patch(
+        "hermes_cli.models.fetch_github_model_catalog",
+        side_effect=[[
+            {
+                "id": "claude-opus-4.6-1m",
+                "capabilities": {"type": "chat", "limits": {"max_prompt_tokens": 1_000_000}},
+            }
+        ], _SAMPLE_CATALOG],
+    )
+    @patch("hermes_cli.models._resolve_copilot_catalog_api_key_details", return_value=("gh-token", float("inf")))
+    def test_no_key_fresh_cache_miss_refetches_catalog(self, mock_resolve, mock_fetch):
+        assert get_copilot_model_context("gpt-4.1") is None
+        assert get_copilot_model_context("gpt-4.1") == 128_000
+        assert mock_resolve.call_count == 1
+        assert mock_fetch.call_count == 2
+
+
+class TestCopilotAuthStateFingerprint:
+    def test_uses_gh_config_dir_when_set(self, monkeypatch):
+        import hermes_cli.models as mod
+
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "")
+        monkeypatch.setenv("GH_TOKEN", "")
+        monkeypatch.setenv("GITHUB_TOKEN", "")
+        monkeypatch.setenv("COPILOT_GH_HOST", "")
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        monkeypatch.setenv("GH_CONFIG_DIR", "/tmp/gh-config-a")
+        fingerprint_a = mod._copilot_auth_state_fingerprint()
+        monkeypatch.setenv("GH_CONFIG_DIR", "/tmp/gh-config-b")
+        fingerprint_b = mod._copilot_auth_state_fingerprint()
+
+        assert fingerprint_a != fingerprint_b
+
+    def test_uses_xdg_config_home_when_gh_config_dir_missing(self, monkeypatch):
+        import hermes_cli.models as mod
+
+        monkeypatch.setenv("COPILOT_GITHUB_TOKEN", "")
+        monkeypatch.setenv("GH_TOKEN", "")
+        monkeypatch.setenv("GITHUB_TOKEN", "")
+        monkeypatch.setenv("COPILOT_GH_HOST", "")
+        monkeypatch.delenv("GH_CONFIG_DIR", raising=False)
+
+        monkeypatch.setenv("XDG_CONFIG_HOME", "/tmp/xdg-config-a")
+        fingerprint_a = mod._copilot_auth_state_fingerprint()
+        monkeypatch.setenv("XDG_CONFIG_HOME", "/tmp/xdg-config-b")
+        fingerprint_b = mod._copilot_auth_state_fingerprint()
+
+        assert fingerprint_a != fingerprint_b
 
 
 class TestModelMetadataCopilotIntegration:
@@ -123,6 +306,25 @@ class TestModelMetadataCopilotIntegration:
 
         ctx = get_model_context_length("claude-sonnet-4", provider="copilot-acp")
         assert ctx == 200_000
+
+    @patch("hermes_cli.models.fetch_github_model_catalog", return_value=_SAMPLE_CATALOG)
+    @patch("hermes_cli.models._resolve_copilot_catalog_api_key_details", return_value=("gh-token", float("inf")))
+    def test_copilot_live_context_skips_provider_cache(self, mock_resolve, mock_fetch):
+        from agent.model_metadata import get_model_context_length
+
+        with patch("agent.model_metadata.get_cached_context_length") as mock_cache, \
+             patch("agent.model_metadata.save_context_length") as mock_save:
+            ctx = get_model_context_length(
+                "claude-sonnet-4",
+                provider="copilot-acp",
+                base_url="acp://copilot",
+            )
+
+        assert ctx == 200_000
+        mock_resolve.assert_called_once_with()
+        mock_fetch.assert_called_once_with(api_key="gh-token", retry_without_auth=False)
+        mock_cache.assert_not_called()
+        mock_save.assert_not_called()
 
     @patch("hermes_cli.models.fetch_github_model_catalog", return_value=None)
     def test_falls_through_when_catalog_unavailable(self, mock_fetch):

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -321,6 +321,48 @@ class TestFetchApiModels:
         assert catalog is not None
         assert [item["id"] for item in catalog] == ["gpt-5.4"]
 
+    def test_fetch_github_model_catalog_retries_without_auth_on_failure(self):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"data": [{"id": "gpt-5.4", "model_picker_enabled": true, "supported_endpoints": ["/responses"], "capabilities": {"type": "chat", "supports": {"reasoning_effort": ["low", "medium", "high"]}}}]}'
+
+        calls = []
+
+        def _fake_urlopen(req, timeout=5.0):
+            calls.append(req)
+            if req.get_header("Authorization"):
+                raise Exception("auth failed")
+            return _Resp()
+
+        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=_fake_urlopen):
+            catalog = fetch_github_model_catalog("gh-token")
+
+        assert catalog is not None
+        assert [item["id"] for item in catalog] == ["gpt-5.4"]
+        assert len(calls) == 2
+        assert calls[0].get_header("Authorization") == "Bearer gh-token"
+        assert calls[1].get_header("Authorization") is None
+
+    def test_fetch_github_model_catalog_can_skip_anonymous_retry_for_tokened_calls(self):
+        calls = []
+
+        def _fake_urlopen(req, timeout=5.0):
+            calls.append(req)
+            raise Exception("auth failed")
+
+        with patch("hermes_cli.models.urllib.request.urlopen", side_effect=_fake_urlopen):
+            catalog = fetch_github_model_catalog("gh-token", retry_without_auth=False)
+
+        assert catalog is None
+        assert len(calls) == 1
+        assert calls[0].get_header("Authorization") == "Bearer gh-token"
+
 
 class TestGithubReasoningEfforts:
     def test_gpt5_supports_minimal_to_high(self):

--- a/tests/tools/test_feishu_tools.py
+++ b/tests/tools/test_feishu_tools.py
@@ -2,6 +2,7 @@
 
 import importlib
 import unittest
+from unittest.mock import patch
 
 from tools.registry import registry
 
@@ -56,6 +57,23 @@ class TestFeishuToolRegistration(unittest.TestCase):
             props = entry.schema["parameters"].get("properties", {})
             self.assertIn("file_token", props, f"{tool_name} missing file_token param")
             self.assertIn("file_type", props, f"{tool_name} missing file_type param")
+
+    def test_feishu_checks_use_spec_probe(self):
+        doc_entry = registry.get_entry("feishu_doc_read")
+        drive_entry = registry.get_entry("feishu_drive_list_comments")
+
+        with patch("importlib.util.find_spec", return_value=object()) as mock_find_spec:
+            self.assertTrue(doc_entry.check_fn())
+            self.assertTrue(drive_entry.check_fn())
+
+        self.assertGreaterEqual(mock_find_spec.call_count, 2)
+        self.assertTrue(any(call.args[0] == "lark_oapi" for call in mock_find_spec.mock_calls))
+
+    def test_feishu_checks_disable_missing_spec(self):
+        doc_entry = registry.get_entry("feishu_doc_read")
+
+        with patch("importlib.util.find_spec", return_value=None):
+            self.assertFalse(doc_entry.check_fn())
 
 
 if __name__ == "__main__":

--- a/tools/feishu_doc_tool.py
+++ b/tools/feishu_doc_tool.py
@@ -6,6 +6,7 @@ Uses the same lazy-import + BaseRequest pattern as feishu_comment.py.
 
 import json
 import logging
+import importlib.util
 import threading
 
 from tools.registry import registry, tool_error, tool_result
@@ -62,7 +63,7 @@ def _check_feishu():
     import importlib.util
     try:
         return importlib.util.find_spec("lark_oapi") is not None
-    except (ImportError, ValueError):
+    except Exception:
         return False
 
 

--- a/tools/feishu_drive_tool.py
+++ b/tools/feishu_drive_tool.py
@@ -7,6 +7,7 @@ The lark client is injected per-thread by the comment event handler.
 
 import json
 import logging
+import importlib.util
 import threading
 
 from tools.registry import registry, tool_error, tool_result
@@ -33,7 +34,7 @@ def _check_feishu():
     import importlib.util
     try:
         return importlib.util.find_spec("lark_oapi") is not None
-    except (ImportError, ValueError):
+    except Exception:
         return False
 
 


### PR DESCRIPTION
## What does this PR do?

This PR removes two startup-time costs and makes provider-aware context resolution stickier across repeated lookups. Copilot model-context lookups now resolve the GitHub catalog API key automatically when one is not passed, and provider-aware Copilot/models.dev context results are written back to the persistent cache when a base URL is available. Feishu document/drive availability checks now use `importlib.util.find_spec("lark_oapi")` instead of importing the SDK just to probe whether it is installed.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py`: resolve the Copilot catalog API key lazily when `get_copilot_model_context()` is called without one.
- `agent/model_metadata.py`: persist provider-aware Copilot / models.dev context results into the base-URL cache when a base URL is present.
- `tools/feishu_doc_tool.py`, `tools/feishu_drive_tool.py`: replace `lark_oapi` import probes with a cheap spec lookup.
- `tests/hermes_cli/test_copilot_context.py`, `tests/agent/test_model_metadata.py`, `tests/tools/test_feishu_tools.py`: cover the new lookup and cache behavior.

## How to Test

1. `./scripts/run_tests.sh tests/agent/test_model_metadata.py tests/hermes_cli/test_copilot_context.py tests/tools/test_feishu_tools.py`
2. Confirm the suite passes and the new tests cover the API-key fallback, cache write-through, and Feishu spec-probe behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation: `113 passed, 4 warnings in 5.23s`
