### PR TITLE
fix(gateway): treat weixin ret=-2 with empty errmsg as stale context_token

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -96,12 +96,25 @@ MESSAGE_DEDUP_TTL_SECONDS = 300
 def _is_stale_session_ret(
     ret: "Optional[int]", errcode: "Optional[int]", errmsg: "Optional[str]",
 ) -> bool:
-    """True when iLink returns ret=-2 / errcode=-2 with 'unknown error',
-    which is a stale-session signal (same as errcode=-14) rather than
-    a genuine rate limit."""
+    """True when iLink returns ret=-2 / errcode=-2 that is likely a stale
+    context_token rather than a genuine rate limit.
+
+    Empirically iLink distinguishes these two scenarios weakly:
+    - stale session:  ret=-2, errmsg="unknown error" OR errmsg is empty/None
+    - genuine rate limit: ret=-2 with a populated errmsg such as "frequency
+      limit" / "too frequently" etc.
+
+    We treat "unknown error" and empty/None errmsg as stale-session signals
+    so the caller can attempt a tokenless retry once (Issue #17228, option B).
+    A true rate limit will still be handled correctly: if the tokenless
+    retry also fails, the normal rate-limit backoff path kicks in.
+    """
     if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
         return False
-    return (errmsg or "").lower() == "unknown error"
+    msg = (errmsg or "").strip().lower()
+    if not msg:
+        return True
+    return msg == "unknown error"
 
 
 MEDIA_IMAGE = 1

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -761,7 +761,7 @@ class TestWeixinVoiceSending:
 
 
 class TestIsStaleSessionRet:
-    """Regression test for #17228: distinguish stale-session ret=-2 from rate-limit ret=-2."""
+    """Regression tests for #17228 and #18100: distinguish stale-session ret=-2 from rate-limit ret=-2."""
 
     def test_ret_minus_2_with_unknown_error_is_stale(self):
         assert weixin._is_stale_session_ret(-2, None, "unknown error") is True
@@ -776,9 +776,15 @@ class TestIsStaleSessionRet:
         # Genuine rate limit — must NOT be treated as stale session.
         assert weixin._is_stale_session_ret(-2, None, "freq limit") is False
 
-    def test_ret_minus_2_with_no_errmsg_is_not_stale(self):
-        assert weixin._is_stale_session_ret(-2, None, None) is False
-        assert weixin._is_stale_session_ret(-2, None, "") is False
+    def test_ret_minus_2_with_empty_errmsg_is_stale(self):
+        # Regression for #18100: iLink returns ret=-2 with errmsg=None/empty
+        # as a stale context_token signal, not a genuine rate limit.
+        assert weixin._is_stale_session_ret(-2, None, None) is True
+        assert weixin._is_stale_session_ret(-2, None, "") is True
+
+    def test_errcode_minus_2_with_empty_errmsg_is_stale(self):
+        # Same via errcode path.
+        assert weixin._is_stale_session_ret(None, -2, None) is True
 
     def test_errcode_minus_14_is_not_matched_here(self):
         # -14 is handled by the separate SESSION_EXPIRED_ERRCODE path; the


### PR DESCRIPTION
## What does this PR do?

`_is_stale_session_ret` in `gateway/platforms/weixin.py` only recognized `ret=-2` as a stale `context_token` when `errmsg == "unknown error"`. In the wild, iLink also returns `ret=-2` with `errmsg=None` (empty) for the same stale-session condition. The previous check missed this variant, causing the adapter to fall through to the rate-limit branch and burn all retries against a dead token.

This PR extends the check: if `errmsg` is empty/`None`, we return `True` (stale session). Genuine iLink rate limits always carry a populated `errmsg` such as `"frequency limit"` or `"too frequently"`, so the distinction remains reliable.

## Related Issue

Fixes #18100. Follow-up to #17228.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/weixin.py`: extend `_is_stale_session_ret` to return `True` when `errmsg` is empty/`None` (in addition to the existing `"unknown error"` match)
- `tests/gateway/test_weixin.py`: update `TestIsStaleSessionRet` — replace the old `test_ret_minus_2_with_no_errmsg_is_not_stale` (which asserted the now-fixed wrong behavior) with two new regression tests covering `None` and `""` errmsg via both `ret` and `errcode` paths

## How to Test

1. Run the unit tests: `pytest tests/gateway/test_weixin.py::TestIsStaleSessionRet -v`
2. All 7 cases should pass, including the two new `_empty_errmsg_is_stale` tests.
3. To verify end-to-end: trigger a WeChat session expiry (let the iLink token go stale), observe `gateway.log` — previously you'd see `rate limited ... ret=-2 errcode=None errmsg=None` repeated until failure; with this fix the adapter correctly detects the stale token and attempts a tokenless retry.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (2 files: `weixin.py` + its test)
- [x] I've added tests for my changes (updated `TestIsStaleSessionRet` in `test_weixin.py`)
- [x] I've tested on my platform: Ubuntu 22.04 (WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal helper, no user-facing config change)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (WeChat/iLink gateway only)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Real-world `gateway.log` showing the bug (before fix):

```
WARNING  gateway.platforms.weixin: [Weixin] rate limited for o9cq80_r; backing off 3.0s before retry
WARNING  gateway.platforms.weixin: [Weixin] rate limited for o9cq80_r; backing off 3.0s before retry
WARNING  gateway.platforms.weixin: [Weixin] rate limited for o9cq80_r; backing off 3.0s before retry
ERROR    gateway.platforms.weixin: [Weixin] send failed to=o9cq80_r: iLink sendmessage rate limited: ret=-2 errcode=None errmsg=None
```

After a user-initiated inbound message refreshed the session, the next send went through immediately — confirming this is a stale-session signal, not a genuine frequency cap.
