### PR TITLE
feat(gateway): Per-channel gateway restart notification flag

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -271,15 +271,23 @@ class PlatformConfig:
     # - "first": Only first chunk threads to user's message (default)
     # - "all": All chunks in multi-part replies thread to user's message
     reply_to_mode: str = "first"
-    
+
+    # Whether the gateway is allowed to send "♻️ Gateway online" /
+    # "♻ Gateway restarted" lifecycle notifications on this platform.
+    # Default True preserves prior behavior. Set False on platforms used
+    # by end users (e.g. Slack) where operator-flavored restart pings are
+    # noise; keep True for back-channels where the operator wants them.
+    gateway_restart_notification: bool = True
+
     # Platform-specific settings
     extra: Dict[str, Any] = field(default_factory=dict)
-    
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "enabled": self.enabled,
             "extra": self.extra,
             "reply_to_mode": self.reply_to_mode,
+            "gateway_restart_notification": self.gateway_restart_notification,
         }
         if self.token:
             result["token"] = self.token
@@ -288,19 +296,22 @@ class PlatformConfig:
         if self.home_channel:
             result["home_channel"] = self.home_channel.to_dict()
         return result
-    
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PlatformConfig":
         home_channel = None
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
-        
+
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
+            gateway_restart_notification=_coerce_bool(
+                data.get("gateway_restart_notification"), True
+            ),
             extra=data.get("extra", {}),
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11386,6 +11386,14 @@ class GatewayRunner:
                 )
                 return None
 
+            platform_cfg = self.config.platforms.get(platform)
+            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+                logger.info(
+                    "Restart notification suppressed: %s has gateway_restart_notification=false",
+                    platform_str,
+                )
+                return None
+
             metadata = {"thread_id": thread_id} if thread_id else None
             result = await adapter.send(
                 str(chat_id),
@@ -11435,6 +11443,14 @@ class GatewayRunner:
         for platform, adapter in self.adapters.items():
             home = self.config.get_home_channel(platform)
             if not home or not home.chat_id:
+                continue
+
+            platform_cfg = self.config.platforms.get(platform)
+            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+                logger.info(
+                    "Home-channel startup notification suppressed: %s has gateway_restart_notification=false",
+                    platform.value,
+                )
                 continue
 
             target = (platform.value, str(home.chat_id), str(home.thread_id) if home.thread_id else None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2458,6 +2458,14 @@ class GatewayRunner:
                 if not adapter:
                     continue
 
+                platform_cfg = self.config.platforms.get(platform)
+                if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+                    logger.info(
+                        "Shutdown notification suppressed for active session: %s has gateway_restart_notification=false",
+                        platform_str,
+                    )
+                    continue
+
                 # Include thread_id if present so the message lands in the
                 # correct forum topic / thread.
                 metadata = {"thread_id": thread_id} if thread_id else None
@@ -2486,6 +2494,14 @@ class GatewayRunner:
         for platform, adapter in self.adapters.items():
             home = self.config.get_home_channel(platform)
             if not home or not home.chat_id:
+                continue
+
+            platform_cfg = self.config.platforms.get(platform)
+            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+                logger.info(
+                    "Shutdown notification suppressed for home channel: %s has gateway_restart_notification=false",
+                    platform.value,
+                )
                 continue
 
             dedup_key = (platform.value, str(home.chat_id), str(home.thread_id) if home.thread_id else None)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -57,6 +57,19 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"enabled": "false"})
         assert restored.enabled is False
 
+    def test_gateway_restart_notification_defaults_true(self):
+        assert PlatformConfig().gateway_restart_notification is True
+        assert PlatformConfig.from_dict({}).gateway_restart_notification is True
+
+    def test_gateway_restart_notification_roundtrip_false(self):
+        pc = PlatformConfig(enabled=True, gateway_restart_notification=False)
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.gateway_restart_notification is False
+
+    def test_gateway_restart_notification_coerces_quoted_false(self):
+        restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
+        assert restored.gateway_restart_notification is False
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -258,6 +258,40 @@ async def test_shutdown_notification_send_failure_does_not_block():
 
 
 @pytest.mark.asyncio
+async def test_shutdown_notification_suppressed_when_flag_disabled():
+    """Active-session ping is muted when gateway_restart_notification=False on the platform."""
+    from gateway.config import Platform
+
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+    session_key = "agent:main:telegram:dm:999"
+    runner._running_agents[session_key] = MagicMock()
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_home_channel_suppressed_when_flag_disabled():
+    """Home-channel ping during shutdown is muted when the flag is False."""
+    from gateway.config import HomeChannel, Platform
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
 async def test_shutdown_notification_uses_persisted_origin_for_colon_ids():
     """Shutdown notifications should route from persisted origin, not reparsed keys."""
     runner, adapter = make_restart_runner()

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -497,6 +497,82 @@ async def test_send_restart_notification_logs_warning_on_sendresult_failure(
 
 
 @pytest.mark.asyncio
+async def test_send_home_channel_startup_notification_skipped_when_flag_disabled(
+    tmp_path, monkeypatch
+):
+    """Per-platform opt-out: gateway_restart_notification=False mutes the home-channel ping."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+    adapter.send = AsyncMock()
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == set()
+    adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_home_channel_startup_notification_default_flag_true(
+    tmp_path, monkeypatch
+):
+    """Default behavior is unchanged: missing flag means notifications still fire."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    # Sanity-check the dataclass default — guards against future refactors
+    # silently flipping the default to False.
+    assert runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification is True
+
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {("telegram", "home-42", None)}
+    adapter.send.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_restart_notification_skipped_when_flag_disabled(
+    tmp_path, monkeypatch
+):
+    """The /restart originator's notification also honors the per-platform flag.
+
+    Slack used by end users → flag off → no "Gateway restarted" message even
+    when an end user accidentally triggers /restart. The marker file is still
+    cleaned up so the notification doesn't leak into the next boot.
+    """
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    notify_path = tmp_path / ".restart_notify.json"
+    notify_path.write_text(json.dumps({
+        "platform": "telegram",
+        "chat_id": "42",
+    }))
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+    adapter.send = AsyncMock()
+
+    delivered_target = await runner._send_restart_notification()
+
+    assert delivered_target is None
+    adapter.send.assert_not_called()
+    assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
 async def test_send_restart_notification_logs_info_on_sendresult_success(
     tmp_path, monkeypatch, caplog
 ):


### PR DESCRIPTION
## Summary

Adds a per-platform opt-out, `gateway_restart_notification` (default `true`), on `PlatformConfig`. The flag gates **all three** of the gateway's lifecycle pings:

1. **Pre-restart drain ping** — `⚠️ Gateway restarting — Your current task will be interrupted. Send any message after restart and I'll try to resume where you left off.` Sent to each active session's chat and to each platform's home channel just before drain (`_notify_active_sessions_of_shutdown`).
2. **Post-restart originator ping** — `♻ Gateway restarted successfully. Your session continues.` Sent back to the chat that issued `/restart` (`_send_restart_notification`).
3. **Post-restart home-channel ping** — `♻️ Gateway online — Hermes is back and ready.` Sent to each connected platform's home channel on startup (`_send_home_channel_startup_notifications`).

Default is `true`, so behavior is unchanged for everyone unless they explicitly opt a platform out.

```yaml
# ~/.hermes/config.yaml
platforms:
  telegram:
    gateway_restart_notification: true   # operator back-channel — keep the pings
  slack:
    gateway_restart_notification: false  # end-user surface — stay quiet
```

## Why this matters

Hermes increasingly sits on **two very different kinds of channels at the same time**:

1. **Operator back-channels.** A solo Telegram chat, a private Discord DM, a self-hosted Signal — surfaces where the *operator* lives. Here, "Gateway restarting" / "Gateway restarted" is a useful heartbeat: it confirms `/restart` actually came back, that systemd's exit-75 path drained cleanly, that the bot survived a config change. Operators *want* to see this.

2. **End-user surfaces.** A shared Slack workspace, a Discord server with customers, a WhatsApp group — surfaces where Hermes shows up as a teammate or product. Here, every lifecycle message is **infrastructure noise leaking into a user-facing channel**. Users see "⚠️ Gateway restarting — Your current task will be interrupted" as "the bot is broken again," it bumps unread counters, it pollutes search, and on Slack it pings everyone watching `#general` for something that's purely an ops concern.

Today it's all-or-nothing: either every connected platform gets pinged, or none do. The result is a forced trade-off — operators silence their own heartbeat to spare end users, or end users get spammed with restart confetti every time the operator pushes a config change. Neither is right.

This flag fixes the trade-off cleanly at the **per-platform** level, which matches how the home channel itself is already configured. Same data model, same surface area, just a new toggle.

### Why all three messages, not just the post-restart ones

The three lifecycle messages — pre-restart drain, post-restart originator, post-restart home channel — form a single conceptual unit: "the gateway is going down / is back." Gating only some of them would leave a partial opt-out: an operator who didn't want Slack pings would still see `⚠️ Gateway restarting…` leak into a `#general` channel mid-conversation. Treating the three as one toggle keeps the contract obvious: **"this platform receives gateway lifecycle messages — yes or no."**

The trade-off for end users on a muted platform: a request mid-restart fails silently rather than with a heads-up. The operator who chose `false` knew that — they'd rather have one quiet failure than every restart announce itself in a customer-facing channel.

### Why per-platform (and not finer-grained)

The home-channel concept is already per-platform — one home per platform — so per-platform is the natural granularity. Going finer (per-chat) would mean bolting per-chat config onto code paths that intentionally only know about the platform's home channel, the `/restart` originator, and a flat list of active-session origins. We can revisit if a real need emerges, but in practice the operator/end-user split *is* the platform split.

### Why not just delete the messages

They're load-bearing for operators — without them, `/restart` becomes a hope-it-came-back operation, especially under systemd where the parent process terminates. Removing them would degrade the operator experience to silence a surface where they aren't appropriate; this PR keeps them where they help and silences them where they hurt.

## Behavior

| # | Scenario | flag = `true` (default) | flag = `false` |
|---|---|---|---|
| 1 | Pre-restart drain — active session on this platform | `⚠️ Gateway restarting…` sent to the chat | Suppressed |
| 1 | Pre-restart drain — home channel on this platform | `⚠️ Gateway restarting…` sent to home channel | Suppressed |
| 2 | `/restart` originated from a chat on this platform | `♻ Gateway restarted` sent to the originator | Suppressed; `.restart_notify.json` still cleaned up so it doesn't leak into a future boot |
| 3 | Gateway startup with a configured home channel on this platform | `♻️ Gateway online` sent to the home channel | Suppressed |
| — | Suppression behavior | n/a | Logged at INFO with the platform name so operators can see why it's quiet |

The flag is **per-platform, not per-message**, on purpose: a deployment that wants the heartbeat wants all three messages; one that wants quiet wants none.

## Changes

- `gateway/config.py` — `PlatformConfig.gateway_restart_notification: bool = True`, with `to_dict`/`from_dict` round-tripping and `_coerce_bool` handling for quoted YAML values (`"false"`, `"no"`, etc.). YAML loading already merges arbitrary `platforms.<name>.<key>` pairs into the `PlatformConfig` constructor, so no loader changes are needed.
- `gateway/run.py` — three call sites consult the flag before sending and log an INFO line on suppression:
  - `_notify_active_sessions_of_shutdown` — both the active-session loop and the home-channel loop (message #1).
  - `_send_restart_notification` — the `/restart` originator path (message #2); marker file is still cleaned up.
  - `_send_home_channel_startup_notifications` — the startup path (message #3).
- `tests/gateway/test_config.py` — round-trip + default + quoted-coercion coverage for the new field.
- `tests/gateway/test_restart_notification.py` — three new async tests covering messages #2 and #3:
  - home-channel ping (#3) suppressed when flag is `false`,
  - default flag (unset) is `true` — guards against silent flips of the default,
  - `/restart` originator notification (#2) suppressed when flag is `false`, with marker-file cleanup verified.
- `tests/gateway/test_restart_drain.py` — two new async tests covering message #1: pre-restart suppression for active sessions and for home channels.

## Test plan

- [x] `pytest tests/gateway/test_config.py::TestPlatformConfigRoundtrip tests/gateway/test_restart_notification.py tests/gateway/test_restart_drain.py` — passes (46/46)
- [ ] Manual: set `platforms.slack.gateway_restart_notification: false`, run `/restart` from a Slack chat with an active task, confirm none of messages #1/#2/#3 are sent on Slack; confirm Telegram home channel still receives all three pings.
- [ ] Manual: leave config unchanged, confirm all three messages still fire (default = unchanged behavior).
- [ ] Verify INFO log lines (`Shutdown notification suppressed: …`, `Restart notification suppressed: …`, `Home-channel startup notification suppressed: …`) appear when suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)