### PR TITLE
feat(tui): add /sessions slash command for browsing and resuming previous sessions

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -110,6 +110,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[name]"),
 
     # Configuration
+    CommandDef("sessions", "Browse and resume previous sessions", "Session"),
+
+    # Configuration
     CommandDef("config", "Show current configuration", "Configuration",
                cli_only=True),
     CommandDef("model", "Switch model for this session", "Configuration",

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -93,6 +93,19 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
+    help: 'browse and resume previous sessions',
+    name: 'sessions',
+    run: (arg, ctx) => {
+      if (ctx.session.guardBusySessionSwitch('switch sessions')) {
+        return
+      }
+      if (!arg.trim()) {
+        return patchOverlayState({ picker: true })
+      }
+    }
+  },
+
+  {
     help: 'attach an image',
     name: 'image',
     run: (arg, ctx) => {


### PR DESCRIPTION
## What does this PR do?

Adds a `/sessions` slash command to the Hermes TUI (Terminal User Interface) that allows users to browse and resume previous sessions via an interactive picker. This provides a convenient way to switch between sessions without losing context.

## Related Issue

N/A

## Type of Change

- ✨ New feature

## Changes Made

- **ui-tui/src/app/slash/commands/session.ts**: Added the `/sessions` command definition that opens the existing `SessionPicker` overlay.
- **hermes_cli/commands.py**: Added `CommandDef("sessions", "Browse and resume previous sessions", "Session")` to the `COMMAND_REGISTRY` so the gateway recognizes the command and includes it in autocomplete.

## How to Test

1. Check out the branch: `git checkout austin-feat-sessions-skills-menu`
2. Run the TUI: `hermes htui`
3. Type `/se` in the command input — you should see `sessions` appear in the autocomplete dropdown.
4. Press Enter to open the SessionPicker:
   - Use up/down arrows to navigate
   - Press Enter or number keys (1-9) to resume a session
   - Press 'd' to delete a session (confirmation required)
   - Press Esc or 'q' to cancel
5. Verify that the picker shows a list of previous sessions (up to 200) and that selecting one resumes it correctly.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (no regressions)
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping
- [x] I've updated relevant documentation (this PR description explains the feature)
- [x] I've considered cross-platform impact (changes are UI-related, should work on all platforms)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior (N/A — no tool behavior change)

## For New Skills

N/A

## Screenshots / Logs

<img width="712" height="123" alt="image" src="https://github.com/user-attachments/assets/302f869a-6414-45db-b6ce-49f5676781c6" />
<img width="881" height="312" alt="image" src="https://github.com/user-attachments/assets/b822cdf3-a2d0-492d-aeae-1bbd58d2ae64" />
