### PR TITLE
fix(tui): omit system_prompt key from session info when empty

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2426,6 +2426,33 @@ def test_session_info_includes_mcp_servers(monkeypatch):
     assert info["mcp_servers"] == fake_status
 
 
+def test_session_info_omit_system_prompt_when_empty():
+    """system_prompt key should be omitted when _cached_system_prompt is empty/None."""
+    # Case 1: empty string
+    agent = types.SimpleNamespace(tools=[], model="", _cached_system_prompt="")
+    info = server._session_info(agent)
+    assert "system_prompt" not in info
+
+    # Case 2: None
+    agent = types.SimpleNamespace(tools=[], model="", _cached_system_prompt=None)
+    info = server._session_info(agent)
+    assert "system_prompt" not in info
+
+    # Case 3: attribute missing entirely
+    agent = types.SimpleNamespace(tools=[], model="")
+    info = server._session_info(agent)
+    assert "system_prompt" not in info
+
+
+def test_session_info_includes_system_prompt_when_present():
+    """system_prompt key should be present when _cached_system_prompt has content."""
+    agent = types.SimpleNamespace(
+        tools=[], model="", _cached_system_prompt="You are a helpful assistant."
+    )
+    info = server._session_info(agent)
+    assert info["system_prompt"] == "You are a helpful assistant."
+
+
 # ---------------------------------------------------------------------------
 # History-mutating commands must reject while session.running is True.
 # Without these guards, prompt.submit's post-run history write either

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1414,7 +1414,9 @@ def _session_info(agent) -> dict:
     except Exception:
         info["mcp_servers"] = []
     try:
-        info["system_prompt"] = getattr(agent, "_cached_system_prompt", "") or ""
+        _prompt = getattr(agent, "_cached_system_prompt", "") or ""
+        if _prompt:
+            info["system_prompt"] = _prompt
     except Exception:
         pass
     try:


### PR DESCRIPTION
## Summary

Omits the `system_prompt` key from `_session_info()` when `_cached_system_prompt` is empty or None.

### Problem
The Python side always set `info['system_prompt']` to at least an empty string (`""`), even when `_cached_system_prompt` was empty or None. The TypeScript type `system_prompt?: string` implies it can be `undefined`, but it never was — making the optional typing misleading.

### Fix
Changed the assignment in `_session_info()` from:
```python
info["system_prompt"] = getattr(agent, "_cached_system_prompt", "") or ""
```
to:
```python
_prompt = getattr(agent, "_cached_system_prompt", "") or ""
if _prompt:
    info["system_prompt"] = _prompt
```

The TypeScript side already handles `undefined` correctly via `info.system_prompt ?? ''` in `branding.tsx`.

### Tests Added
- `test_session_info_omit_system_prompt_when_empty`: verifies key is absent for empty string, None, and missing attribute
- `test_session_info_includes_system_prompt_when_present`: verifies key is present with correct value when prompt has content

### Verification
```bash
python3 -m py_compile tui_gateway/server.py  # Syntax: OK
python3 -m pytest tests/test_tui_gateway_server.py -q  # 170 passed, 0 failed
```

Fixes #20669
