### PR TITLE
fix(toolsets): use typing.Any instead of builtin any in get_distribution

### DIFF
--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -19,7 +19,7 @@ Usage:
     all_dists = list_distributions()
 """
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 import random
 from toolsets import validate_toolset
 
@@ -220,7 +220,7 @@ DISTRIBUTIONS = {
 }
 
 
-def get_distribution(name: str) -> Optional[Dict[str, any]]:
+def get_distribution(name: str) -> Optional[Dict[str, Any]]:
     """
     Get a toolset distribution by name.
     


### PR DESCRIPTION
Closes #2139

In `toolset_distributions.py`, the `get_distribution()` return type annotation used lowercase `any` (Python's builtin `any()` function) instead of `typing.Any`. This was a simple typo.

**Changes:**
- Add `Any` to the `typing` import
- Change `any` to `Any` in the return type annotation