### PR TITLE
feat: add transform_llm_output plugin hook

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -80,6 +80,10 @@ VALID_HOOKS: Set[str] = {
     "post_tool_call",
     "transform_terminal_output",
     "transform_tool_result",
+    # Transform LLM output before it's returned to the user.
+    # Plugins return a string to replace the response text, or None/empty to leave unchanged.
+    # First non-None string wins. Useful for vocabulary/personality transformation.
+    "transform_llm_output",
     "pre_llm_call",
     "post_llm_call",
     "pre_api_request",

--- a/run_agent.py
+++ b/run_agent.py
@@ -14035,6 +14035,27 @@ class AIAgent:
         else:
             logger.info(_diag_msg, *_diag_args)
 
+        # Plugin hook: transform_llm_output
+        # Fired once per turn after the tool-calling loop completes.
+        # Plugins can transform the LLM's output text before it's returned.
+        # First hook to return a string wins; None/empty return leaves text unchanged.
+        if final_response and not interrupted:
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                _transform_results = _invoke_hook(
+                    "transform_llm_output",
+                    response_text=final_response,
+                    session_id=self.session_id or "",
+                    model=self.model,
+                    platform=getattr(self, "platform", None) or "",
+                )
+                for _hook_result in _transform_results:
+                    if isinstance(_hook_result, str) and _hook_result:
+                        final_response = _hook_result
+                        break  # First non-empty string wins
+            except Exception as exc:
+                logger.warning("transform_llm_output hook failed: %s", exc)
+
         # Plugin hook: post_llm_call
         # Fired once per turn after the tool-calling loop completes.
         # Plugins can use this to persist conversation data (e.g. sync


### PR DESCRIPTION
# Summary

Adds a new plugin hook `transform_llm_output` that allows plugins to transform the LLM's output text before it's returned to the user.

## Motivation

Personalized vocabulary transformation previously required either lots of personality flavor text in the SOUL, a skill that burned inference tokens on every response, or similar systems which burn tokens unnecessarily. A native plugin hook allows zero-cost vocabulary/personality transformation using more "classical" programming methods.

This follows the pattern of existing transform hooks (`transform_terminal_output`, `transform_tool_result`):
- Fired once per turn after the tool-calling loop completes
- First non-empty string result wins
- Fail-open: exceptions logged as warnings, don't break agent execution

## Changes

```
hermes_cli/plugins.py  | 4 ++++
run_agent.py           | 21 +++++++++++++++++++++
```

### `hermes_cli/plugins.py`
Added `transform_llm_output` to `VALID_HOOKS` set.

### `run_agent.py`
Added hook invocation after `final_response` is set, before `post_llm_call`.

## Hook Signature

```python
def transform_llm_output(response_text: str, session_id: str, model: str, platform: str) -> str | None
```

- **Return:** Non-empty string to transform, `None` or empty string to pass through
- **Priority:** First non-empty string result wins (same as `transform_tool_result`)
- **Error handling:** Fail-open, exceptions logged as warnings

## Use Case

```python
# ~/.hermes/plugins/spongebob-vocab/handler.py
import os

def transform_llm_output(response_text: str, session_id: str, model: str, platform: str) -> str | None:
    if os.environ.get("SPONGEBOB_MODE") != "on":
        return None  # Pass through unchanged
    
    # Transform exclamations in conversational parts
    # (Preserves code blocks, URLs, paths, commands)
    ...
```

## Testing

Unit test verified:
```bash
SPONGEBOB_MODE=on python3 -c "
from hermes_cli.plugins import get_plugin_manager
pm = get_plugin_manager()
pm.discover_and_load()
results = pm.invoke_hook('transform_llm_output', 'Wow!! Amazing!', '', '', '')
print(results[0])  # Output: Tartar sauce!! Holy Krabby Patties!
"
```

## Documentation

This hook will be documented in the plugin hooks reference alongside `transform_terminal_output` and `transform_tool_result`.