### PR TITLE
fix(file_operations): correct total_lines for files without trailing newline

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -692,6 +692,16 @@ class ShellFileOperations(FileOperations):
             total_lines = int(wc_output.strip())
         except ValueError:
             total_lines = 0
+
+        # wc -l counts newline characters, not lines. A file without a trailing
+        # newline has one more line of content than wc -l reports. Detect this
+        # by checking if the last byte of the file is 0a (\n).
+        if file_size > 0:
+            tail_cmd = f"tail -c 1 {self._escape_shell_arg(path)} | od -An -tx1 | tr -d ' '"
+            tail_result = self._exec(tail_cmd)
+            last_byte = tail_result.stdout.strip()
+            if last_byte and last_byte != "0a":
+                total_lines += 1
         
         # Check if truncated
         truncated = total_lines > end_line


### PR DESCRIPTION
Closes #3907

The `read_file()` tool was undercounting `total_lines` by 1 when reading files that do not end with a trailing newline character.

**Root cause:** `wc -l` counts newline characters, not lines. A file like:
```
line1\n
line2\n
line3
```
has only 2 newlines (between line1-line2 and line2-line3), so `wc -l` reports 2 instead of 3.

**Fix:** After getting the `wc -l` count, check if the file's last byte is `0a` (\n). If not, add 1 to the reported count.