### PR TITLE
fix(approval): validate approval mode against known values, warn on invalid

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -698,7 +698,11 @@ def _normalize_approval_mode(mode) -> str:
         return "off" if mode is False else "manual"
     if isinstance(mode, str):
         normalized = mode.strip().lower()
-        return normalized or "manual"
+        valid = ("manual", "smart", "off")
+        if normalized in valid:
+            return normalized
+        logger.warning("Invalid approval mode '%s' — defaulting to 'smart'", mode)
+        return "smart"
     return "manual"
 
 


### PR DESCRIPTION
Closes #4261

 accepted any string as valid, silently returning it. Invalid values like  were accepted without warning, causing unpredictable approval behavior.

**Fix:** Validate against  and default to  with a warning for unknown values.