### PR TITLE
feat(tools): add think tool for structured reasoning

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7658,6 +7658,36 @@ class HermesCLI:
                 " — all commands auto-approved. Use with caution."
             )
 
+    def _cycle_approval_mode(self):
+        """Cycle through approval modes: auto -> smart -> ask -> auto.
+        
+        Similar to Claude Code's Shift+Tab permission mode cycling.
+        """
+        from hermes_cli.colors import Colors as _Colors
+        
+        current_mode = self.config.get("approvals", {}).get("mode", "smart")
+        
+        # Cycle: auto -> smart -> ask -> auto
+        mode_cycle = ["auto", "smart", "ask"]
+        try:
+            current_idx = mode_cycle.index(current_mode)
+        except ValueError:
+            current_idx = 1  # Default to smart if unknown mode
+        
+        next_idx = (current_idx + 1) % len(mode_cycle)
+        next_mode = mode_cycle[next_idx]
+        
+        # Update config
+        if save_config_value("approvals.mode", next_mode):
+            mode_labels = {
+                "auto": f"{_Colors.BOLD}{_Colors.GREEN}AUTO{_Colors.RESET} — all commands auto-approved",
+                "smart": f"{_Colors.BOLD}{_Colors.YELLOW}SMART{_Colors.RESET} — low-risk auto-approved, destructive asks",
+                "ask": f"{_Colors.BOLD}{_Colors.RED}ASK{_Colors.RESET} — all commands require approval",
+            }
+            _cprint(f"  ⚡ Approval mode: {mode_labels.get(next_mode, next_mode)}")
+        else:
+            _cprint(f"  ⚠ Failed to save approval mode")
+
     def _handle_reasoning_command(self, cmd: str):
         """Handle /reasoning — manage effort level and display toggle.
 
@@ -11098,6 +11128,15 @@ class HermesCLI:
             else:
                 # No image found — show a hint
                 pass  # silent when no image (avoid noise on accidental press)
+
+        @kb.add('s-tab')  # Shift+Tab — cycle approval modes
+        def handle_shift_tab(event):
+            """Cycle through approval modes: auto -> smart -> ask -> auto.
+            
+            Similar to Claude Code's Shift+Tab permission mode cycling.
+            """
+            self._cycle_approval_mode()
+            event.app.invalidate()
 
         # Dynamic prompt: shows Hermes symbol when agent is working,
         # or answer prompt when clarify freetext mode is active.

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -485,7 +485,7 @@ _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during de
 # time to finish; child_timeout_seconds (default 600s) is still the hard cap.
 _HEARTBEAT_STALE_CYCLES_IDLE = 15  # 15 * 30s = 450s idle between turns → stale
 _HEARTBEAT_STALE_CYCLES_IN_TOOL = 40  # 40 * 30s = 1200s stuck on same tool → stale
-DEFAULT_TOOLSETS = ["terminal", "file", "web"]
+DEFAULT_TOOLSETS = ["terminal", "file", "web", "think"]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/think_tool.py
+++ b/tools/think_tool.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Think Tool Module - Structured Reasoning for Complex Tasks
+
+Allows the agent to pause and think through complex reasoning without making
+external changes. The thought is logged but doesn't obtain new information or
+change any state.
+
+Based on Anthropic's research showing 54% performance improvement on complex
+tasks when agents use explicit reasoning steps.
+
+Use cases:
+- Analyzing tool output before acting on it
+- Planning multi-step approaches
+- Evaluating tradeoffs between alternatives
+- Checking policy compliance before actions
+- Debugging why a previous action failed
+"""
+
+import json
+from typing import Optional
+from datetime import datetime
+
+
+def think_tool(
+    thought: str,
+    reasoning_type: Optional[str] = None,
+    confidence: Optional[float] = None,
+) -> str:
+    """
+    Think about something. Use this tool to reason through complex problems,
+    analyze information, or plan approaches without making external changes.
+
+    The thought is appended to the conversation log but does not obtain new
+    information or change the database/filesystem.
+
+    Args:
+        thought: The reasoning or analysis to record. Be thorough and explicit.
+        reasoning_type: Optional category: "analysis", "planning", "evaluation",
+                       "debugging", or "policy_check"
+        confidence: Optional confidence level (0.0-1.0) in the reasoning
+
+    Returns:
+        JSON string confirming the thought was recorded.
+    """
+    if not thought or not thought.strip():
+        return json.dumps({
+            "error": "Thought text is required.",
+            "hint": "Provide a detailed reasoning about what you're analyzing or planning."
+        }, ensure_ascii=False)
+
+    thought = thought.strip()
+    
+    # Build the response
+    result = {
+        "status": "thought_recorded",
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "thought": thought,
+    }
+    
+    if reasoning_type:
+        result["reasoning_type"] = reasoning_type
+    
+    if confidence is not None:
+        # Clamp to 0-1 range
+        result["confidence"] = max(0.0, min(1.0, float(confidence)))
+    
+    # Word count for tracking thinking depth
+    word_count = len(thought.split())
+    result["word_count"] = word_count
+    
+    return json.dumps(result, ensure_ascii=False, indent=2)
+
+
+def check_think_requirements() -> bool:
+    """Think tool is available unless agent.think_tool.enabled is explicitly false.
+
+    Default: True (tool stays available when YAML key is absent). Fail-open
+    on config-read errors so a corrupt config doesn't strip the tool.
+    """
+    try:
+        from hermes_cli.config import cfg_get, load_config
+        return bool(cfg_get(load_config(), "agent", "think_tool", "enabled", default=True))
+    except Exception:
+        return True
+
+
+# =============================================================================
+# OpenAI Function-Calling Schema
+# =============================================================================
+
+THINK_SCHEMA = {
+    "name": "think",
+    "description": (
+        "Use this tool to think about something. It will not obtain new information "
+        "or change the database, but just append the thought to the log. "
+        "Use it when complex reasoning or some cache memory is needed.\n\n"
+        "**When to use:**\n"
+        "- Analyzing complex tool output before acting on it\n"
+        "- Planning multi-step approaches to problems\n"
+        "- Evaluating tradeoffs between different alternatives\n"
+        "- Checking policy compliance before taking actions\n"
+        "- Debugging why a previous action failed\n"
+        "- Exploring the repo and brainstorming bug fixes\n"
+        "- Reviewing test results and planning fixes\n\n"
+        "**When NOT to use:**\n"
+        "- Simple tasks that don't require reasoning\n"
+        "- When you already know exactly what to do\n"
+        "- For obtaining new information (use other tools)\n\n"
+        "**Tips for effective use:**\n"
+        "- Be explicit and thorough in your reasoning\n"
+        "- Consider multiple approaches before deciding\n"
+        "- Check your assumptions\n"
+        "- Use confidence score when uncertain"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "thought": {
+                "type": "string",
+                "description": (
+                    "A detailed thought to think about. Write your reasoning explicitly "
+                    "and thoroughly. This is your scratchpad for complex analysis."
+                ),
+            },
+            "reasoning_type": {
+                "type": "string",
+                "enum": ["analysis", "planning", "evaluation", "debugging", "policy_check"],
+                "description": (
+                    "Optional: categorize the type of reasoning. "
+                    "analysis=understanding data, planning=deciding steps, "
+                    "evaluation=judging options, debugging=finding errors, "
+                    "policy_check=verifying compliance"
+                ),
+            },
+            "confidence": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0,
+                "description": (
+                    "Optional: confidence level in this reasoning (0.0-1.0). "
+                    "Use lower values when uncertain or when exploring alternatives."
+                ),
+            },
+        },
+        "required": ["thought"],
+    },
+}
+
+
+# --- Registry ---
+from tools.registry import registry
+
+registry.register(
+    name="think",
+    toolset="think",  # Dedicated toolset for reasoning tools
+    schema=THINK_SCHEMA,
+    handler=lambda args, **kw: think_tool(
+        thought=args.get("thought", ""),
+        reasoning_type=args.get("reasoning_type"),
+        confidence=args.get("confidence")),
+    check_fn=check_think_requirements,
+    emoji="🧠",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -52,6 +52,8 @@ _HERMES_CORE_TOOLS = [
     "session_search",
     # Clarifying questions
     "clarify",
+    # Structured reasoning (Anthropic research - 54% improvement on complex tasks)
+    "think",
     # Code execution + delegation
     "execute_code", "delegate_task",
     # Cronjob management
@@ -72,6 +74,19 @@ _HERMES_CORE_TOOLS = [
 # These can include individual tools or reference other toolsets
 TOOLSETS = {
     # Basic toolsets - individual tool categories
+    "core": {
+        "description": "Core reasoning and interaction tools",
+        "tools": ["clarify", "think"],
+        "includes": []
+    },
+    
+    # Extended thinking (pre-response reasoning for coding/math tasks)
+    "think": {
+        "description": "Structured reasoning tool for complex analysis and planning",
+        "tools": ["think"],
+        "includes": []
+    },
+    
     "web": {
         "description": "Web research and content extraction tools",
         "tools": ["web_search", "web_extract"],
@@ -197,7 +212,7 @@ TOOLSETS = {
         "tools": ["execute_code"],
         "includes": []
     },
-    
+
     "delegation": {
         "description": "Spawn subagents with isolated context for complex subtasks",
         "tools": ["delegate_task"],


### PR DESCRIPTION
## Summary

- Adds a self-registering `think` tool that records a reasoning step with optional `reasoning_type` and `confidence`. No side effects — purely a scratchpad.
- Wires it into `_HERMES_CORE_TOOLS` and adds two toolsets: `core` (clarify + think) and `think` (think only). Spawned subagents get it via `DEFAULT_TOOLSETS` in `delegate_tool`.
- Adds Shift+Tab in the CLI to cycle approval mode (auto → smart → ask), matching Claude Code's permission-mode hotkey.

## Why

Anthropic's [research on tool use](https://www.anthropic.com/engineering/claude-think-tool) reports ~54% improvement on complex agentic tasks when an agent has an explicit \"think\" scratchpad to use between tool calls. Hermes had no equivalent — agents either reasoned silently in their next assistant turn (lost on context compaction) or burned a delegated subagent.

Fail-open on `agent.think_tool.enabled` so a missing/corrupt config doesn't strip the tool.

## Notes

- Did **not** inline `think` into `terminal` / `code_execution` / `delegation` toolsets. Doing so breaks the subset inference in `_get_platform_tools` (which reverse-maps composite toolsets to configurable toolsets) — verified via `tests/hermes_cli/test_tools_config.py::test_get_platform_tools_recovers_non_configurable_toolsets_from_composite`.
- `think` is in `_HERMES_CORE_TOOLS`, so it's automatically part of every composite that includes core tools (e.g. `hermes-cli`).

## Test plan

- [x] `tests/hermes_cli/test_tools_config.py` — 61/61 pass
- [x] Manual: `discover_builtin_tools()` picks up `tools/think_tool.py`; `resolve_toolset('hermes-cli')` includes `think`; handler returns valid JSON with `status`, `timestamp`, `thought`, `word_count`
- [ ] Reviewer: smoke-test in CLI — invoke `think` from a `hermes-cli` session
- [ ] Reviewer: smoke-test Shift+Tab approval-mode cycling in CLI