### PR TITLE
feat: add realtime activity ledger

### DIFF
--- a/docs/plans/realtime-activity-ledger-requirements.md
+++ b/docs/plans/realtime-activity-ledger-requirements.md
@@ -1,0 +1,272 @@
+# Realtime Activity Ledger Requirements
+
+> **For Hermes / Codex:** Evaluate the design first, then implement the smallest production-quality MVP that satisfies the acceptance criteria. Keep it lightweight and do not create a second memory system.
+
+**Goal:** Add a lightweight, realtime, append-only activity ledger for Hermes turns and important events so daily reports and audits can use structured facts instead of relying primarily on keyword-based `session_search`.
+
+**Architecture:** The ledger is a sidecar factual index, not a memory provider and not a replacement for the existing session DB/transcripts. It should write small JSONL records at conversation time via existing gateway lifecycle hooks where possible. Daily report jobs may consume it later, but the ledger itself must not require a daily backfill cron.
+
+**Tech Stack:** Python, existing Hermes gateway hooks, existing `get_hermes_home()` path helpers, JSONL files, pytest.
+
+---
+
+## Background
+
+Hermes already has several persistence layers:
+
+- persistent memory / user profile: small durable facts that are injected into future sessions;
+- session DB and legacy transcripts: full conversation history;
+- logs: operational debugging;
+- domain-specific event logs such as PR auto-review events.
+
+The missing piece is not another memory store. The missing piece is a small factual ledger for questions like:
+
+- What meaningful work happened today?
+- Which turns used tools and produced artifacts?
+- Which decisions, configuration changes, skill updates, PR reviews, cron edits, or integration work should be considered by the daily report?
+- Where should the daily report look before falling back to brittle keyword search?
+
+Recent daily-report gaps showed that keyword recall is unreliable. Important work can exist in sessions but still be missed because queries are too narrow, because PR events dominate the report, or because a content/design outcome is compressed into a technical PR status.
+
+## Non-Goals
+
+This feature must **not**:
+
+1. Replace or compete with Hermes persistent memory.
+2. Automatically inject ledger records into the system prompt or memory context.
+3. Store full transcripts, secrets, raw tool outputs, credentials, tokens, cookies, OAuth payloads, or connection strings.
+4. Add a daily cron job that scans all sessions after the fact as the primary collection mechanism.
+5. Build topic clustering, daily summarization, semantic search, or a second session index in the MVP.
+6. Require users to configure a database service.
+7. Break prompt caching by mutating tools/system prompt mid-conversation.
+
+## Core Design Principles
+
+### 1. Sidecar, not memory
+
+The activity ledger is only a structured factual index for reporting/audit. It should not be loaded into normal conversations unless explicitly read by a user/tool/report job.
+
+### 2. Realtime append
+
+Collection should happen at turn time, preferably on existing events such as:
+
+- `session:start`
+- `agent:start`
+- `agent:step`
+- `agent:end`
+- `command:*`
+
+The MVP should avoid any design that depends on a nightly collector to discover what happened.
+
+### 3. Small and boring JSONL
+
+Prefer date-partitioned JSONL over SQLite or a new service for the MVP:
+
+```text
+$HERMES_HOME/activity-ledger/YYYY-MM-DD/turns.jsonl
+$HERMES_HOME/activity-ledger/YYYY-MM-DD/events.jsonl
+```
+
+The date should be derived from local time in a predictable way. If the project already has a timezone helper/config convention, use it. Otherwise use system local time and keep the implementation simple.
+
+### 4. Redacted previews, not full content
+
+Turn records may store short previews of user message and assistant response, but must not store raw full message bodies by default.
+
+### 5. Explicit events beat inference
+
+The MVP may start with turn skeletons from hooks. Future work can add explicit event logging from tools such as skill management, cron management, PR review, config edits, and a possible `activity_log` tool. Do not overbuild this in the first pass unless it is clearly cheap and well-contained.
+
+## Required MVP Behavior
+
+### A. Realtime turn ledger
+
+On each completed gateway agent turn, append one record to:
+
+```text
+$HERMES_HOME/activity-ledger/YYYY-MM-DD/turns.jsonl
+```
+
+Suggested schema:
+
+```json
+{
+  "schema_version": 1,
+  "id": "turn_20260506T160112Z_<short-random-or-stable-suffix>",
+  "time": "2026-05-07T00:01:12+08:00",
+  "date": "2026-05-07",
+  "type": "turn",
+  "session_id": "20260506_...",
+  "platform": "discord",
+  "user_id": "<stable platform id if already available; omit or hash if privacy config requires it>",
+  "chat_id": "<if already available and safe under existing gateway privacy rules>",
+  "thread_id": "<if already available>",
+  "message_preview": "short redacted preview, max 500 chars",
+  "response_preview": "short redacted preview, max 500 chars",
+  "tool_names": ["read_file", "terminal"],
+  "reportable": "unknown",
+  "visibility": "private"
+}
+```
+
+Implementation notes:
+
+- Existing `agent:start` hook context includes platform/user/session/message preview.
+- Existing `agent:step` hook context includes tool names.
+- Existing `agent:end` hook context includes response preview.
+- If hook contexts do not share state directly, implement a small process-local accumulator keyed by `session_id` and/or another safe turn key.
+- Hook failures must never block the user turn.
+
+### B. Optional explicit event helper, if cheap
+
+Evaluate whether it is low-risk to add a small internal helper such as:
+
+```python
+record_activity_event(type, title, summary, session_id=None, artifacts=None, visibility="private", reportable=True, metadata=None)
+```
+
+If implemented, append records to:
+
+```text
+$HERMES_HOME/activity-ledger/YYYY-MM-DD/events.jsonl
+```
+
+Suggested schema:
+
+```json
+{
+  "schema_version": 1,
+  "id": "evt_20260506T160112Z_<suffix>",
+  "time": "2026-05-07T00:01:12+08:00",
+  "date": "2026-05-07",
+  "type": "design_decision",
+  "source": "agent_or_tool_or_hook",
+  "session_id": "20260506_...",
+  "title": "Daily report should consume realtime ledger before session_search",
+  "summary": "Ledger is a sidecar factual index and must not be injected as memory.",
+  "artifacts": [],
+  "visibility": "private",
+  "reportable": true,
+  "metadata": {}
+}
+```
+
+Do not add broad automatic LLM summarization for event extraction in the MVP.
+
+### C. Configuration
+
+Add a small config surface if needed. Suggested defaults:
+
+```yaml
+activity_ledger:
+  enabled: false
+  capture_turns: true
+  capture_commands: true
+  max_preview_chars: 500
+```
+
+Default can be `false` if maintainers prefer opt-in, or `true` if the implementation is clearly safe and privacy-preserving. Codex should evaluate current project conventions and choose the safer default.
+
+If config is added, document it briefly and add tests for defaults.
+
+### D. Redaction / privacy
+
+The ledger must apply conservative local redaction before writing previews. At minimum redact common secret-looking fields and values:
+
+- `api_key`
+- `token`
+- `secret`
+- `password`
+- `private key`
+- `client_secret`
+- `cookie`
+- bearer tokens
+- GitHub PAT-looking values
+- connection strings where obvious
+
+Use existing redaction utilities if the codebase has them. If not, implement a small helper near the ledger module and keep it deliberately conservative.
+
+Respect existing privacy settings where applicable. If gateway privacy config hashes or redacts user IDs before model context, do not bypass that policy in ledger writes.
+
+### E. Atomic-ish append and robustness
+
+- Ensure parent directories are created.
+- Append one JSON object per line.
+- Use UTF-8.
+- Avoid throwing exceptions to the gateway main path.
+- If a write fails, log debug/warning but do not fail the turn.
+- Keep files profile-aware by using `get_hermes_home()` or the current canonical helper.
+
+## Suggested Implementation Shape
+
+Codex should evaluate the repository and choose exact paths. A likely approach:
+
+1. Add a small module, for example:
+   - `gateway/activity_ledger.py` or `agent/activity_ledger.py`
+2. Register a built-in gateway hook or wire into existing hook emission in a minimal way.
+3. Keep state small and process-local:
+   - on `agent:start`, remember message preview and metadata;
+   - on `agent:step`, accumulate tool names;
+   - on `agent:end`, write one turn record and clear the accumulator.
+4. Add tests under `tests/gateway/` or another existing suitable test area.
+5. Add short documentation if config/user-facing behavior is introduced.
+
+If the existing user hook system can solve this without code changes, Codex should still consider whether a built-in implementation is preferable for tests, config, and daily report integration. Avoid dumping this into a user-specific hook under `~/.hermes/hooks` as the final repo implementation unless there is a clear reason.
+
+## Daily Report Integration Contract
+
+This task does not need to rewrite the daily report job. It should provide a reliable file contract that a future report job can consume:
+
+```text
+$HERMES_HOME/activity-ledger/<date>/turns.jsonl
+$HERMES_HOME/activity-ledger/<date>/events.jsonl
+```
+
+A daily report job should be able to read those files and treat `session_search` as fallback, not primary source.
+
+## Acceptance Criteria
+
+1. A completed gateway turn writes exactly one turn record when the ledger is enabled.
+2. The record is date-partitioned under `$HERMES_HOME/activity-ledger/YYYY-MM-DD/turns.jsonl`.
+3. The record includes session id, platform, timestamp/date, redacted message preview, redacted response preview, and accumulated tool names when available.
+4. Hook/ledger write failures do not break the user turn.
+5. The implementation is profile-aware and does not hardcode `/data00/home/huangbaixi` or `~/.hermes`.
+6. It does not write full transcripts or raw tool outputs.
+7. It does not modify or depend on Hermes persistent memory.
+8. It does not add a daily collection cron as the main mechanism.
+9. Tests cover successful write, disabled config behavior, redaction, and failure isolation.
+10. Any config/docs changes are minimal and clearly describe that the ledger is not memory.
+
+## Evaluation Questions for Codex
+
+Before implementing, answer these briefly in the final response and/or commit notes:
+
+1. Should the MVP be implemented as a built-in gateway hook, direct gateway integration, or a general module called from hook events?
+2. Should default `activity_ledger.enabled` be true or false, given project privacy conventions?
+3. Is an explicit `record_activity_event` helper cheap enough for this PR, or should it be deferred?
+4. Which existing redaction/privacy utilities should be reused?
+5. Which tests give the best confidence without running the entire huge suite?
+
+## Verification Commands
+
+Codex should run the narrowest relevant tests first, then a broader sanity check if feasible. Examples, adjust to actual files:
+
+```bash
+python -m pytest tests/gateway/test_activity_ledger.py -q -o 'addopts='
+python -m pytest tests/gateway/test_hooks.py -q -o 'addopts='
+python -m pytest tests/gateway -q -o 'addopts='  # if runtime is acceptable
+```
+
+Also run:
+
+```bash
+git diff --check
+```
+
+## Commit / PR Expectations
+
+- Work on branch: `feat/realtime-activity-ledger`.
+- Keep changes scoped to this feature.
+- Commit the requirements document first, then implementation commits.
+- Push the branch when complete.
+- Do not include user-specific files, secrets, local sessions, logs, or generated caches.

--- a/gateway/activity_ledger.py
+++ b/gateway/activity_ledger.py
@@ -1,0 +1,313 @@
+"""Realtime gateway activity ledger.
+
+This module records small, redacted turn facts from gateway lifecycle hooks.
+It is intentionally a sidecar JSONL writer: records are not memory, are not
+loaded into prompts, and do not contain transcripts or raw tool output.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import secrets
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from agent.redact import redact_sensitive_text
+from hermes_constants import get_hermes_home
+from hermes_time import now as hermes_now
+from hermes_cli.config import cfg_get, read_raw_config
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+DEFAULT_MAX_PREVIEW_CHARS = 500
+MAX_PREVIEW_CHARS_CAP = 500
+
+_SENSITIVE_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b"
+    r"(?P<key>api[_-]?key|token|secret|password|private[_ -]?key|client[_-]?secret|cookie)"
+    r"\b\s*(?P<sep>[:=])\s*(?P<quote>['\"]?)"
+    r"(?P<value>[^\s,'\"&;]+)(?P=quote)"
+)
+_BARE_BEARER_RE = re.compile(
+    r"(?i)\b(bearer)\s+([A-Za-z0-9._~+/=-]{12,})"
+)
+
+
+@dataclass(frozen=True)
+class ActivityLedgerSettings:
+    enabled: bool = False
+    capture_turns: bool = True
+    max_preview_chars: int = DEFAULT_MAX_PREVIEW_CHARS
+
+
+@dataclass
+class _TurnAccumulator:
+    session_id: str
+    platform: str = ""
+    message_preview: str = ""
+    tool_names: list[str] = field(default_factory=list)
+
+
+_turns: Dict[str, _TurnAccumulator] = {}
+_lock = threading.Lock()
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+        return default
+    return bool(value)
+
+
+def _coerce_preview_chars(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = DEFAULT_MAX_PREVIEW_CHARS
+    if parsed < 0:
+        return DEFAULT_MAX_PREVIEW_CHARS
+    return min(parsed, MAX_PREVIEW_CHARS_CAP)
+
+
+def load_settings(config: Optional[Dict[str, Any]] = None) -> ActivityLedgerSettings:
+    """Return activity ledger settings from raw config.yaml values."""
+    cfg = read_raw_config() if config is None else config
+    section = cfg_get(cfg, "activity_ledger", default={})
+    if not isinstance(section, dict):
+        section = {}
+    return ActivityLedgerSettings(
+        enabled=_coerce_bool(section.get("enabled"), False),
+        capture_turns=_coerce_bool(section.get("capture_turns"), True),
+        max_preview_chars=_coerce_preview_chars(
+            section.get("max_preview_chars", DEFAULT_MAX_PREVIEW_CHARS)
+        ),
+    )
+
+
+def redact_activity_text(text: Any) -> str:
+    """Apply forced secret redaction plus ledger-local conservative patterns."""
+    if text is None:
+        return ""
+    if not isinstance(text, str):
+        text = str(text)
+    if not text:
+        return ""
+
+    redacted = redact_sensitive_text(text, force=True)
+
+    def _assignment_sub(match: re.Match[str]) -> str:
+        quote = match.group("quote") or ""
+        return (
+            f"{match.group('key')}{match.group('sep')}"
+            f"{quote}***{quote}"
+        )
+
+    redacted = _SENSITIVE_ASSIGNMENT_RE.sub(_assignment_sub, redacted)
+    redacted = _BARE_BEARER_RE.sub(lambda m: f"{m.group(1)} ***", redacted)
+    return redacted
+
+
+def make_preview(text: Any, max_chars: int = DEFAULT_MAX_PREVIEW_CHARS) -> str:
+    """Return a single-line redacted preview capped at 500 chars."""
+    limit = _coerce_preview_chars(max_chars)
+    preview = redact_activity_text(text)
+    preview = re.sub(r"\s+", " ", preview).strip()
+    if limit == 0:
+        return ""
+    if len(preview) <= limit:
+        return preview
+    if limit <= 3:
+        return preview[:limit]
+    return preview[: limit - 3].rstrip() + "..."
+
+
+def _turn_key(context: Dict[str, Any]) -> str:
+    session_id = str(context.get("session_id") or "").strip()
+    if session_id:
+        return session_id
+    platform = str(context.get("platform") or "").strip()
+    user_id = str(context.get("user_id") or "").strip()
+    return f"{platform}:{user_id}" if platform or user_id else ""
+
+
+def _tool_names_from_context(context: Dict[str, Any]) -> list[str]:
+    names: list[str] = []
+
+    raw_names = context.get("tool_names")
+    if isinstance(raw_names, (list, tuple, set)):
+        for item in raw_names:
+            name = str(item or "").strip()
+            if name:
+                names.append(name)
+
+    raw_tools = context.get("tools")
+    if isinstance(raw_tools, (list, tuple)):
+        for item in raw_tools:
+            name = ""
+            if isinstance(item, dict):
+                name = str(item.get("name") or item.get("tool_name") or "").strip()
+            elif item is not None:
+                name = str(item).strip()
+            if name:
+                names.append(name)
+
+    return names
+
+
+def _extend_tool_names(acc: _TurnAccumulator, names: Iterable[str]) -> None:
+    seen = set(acc.tool_names)
+    for name in names:
+        clean = str(name or "").strip()
+        if clean and clean not in seen:
+            acc.tool_names.append(clean)
+            seen.add(clean)
+
+
+def _ledger_file(kind: str, when: datetime) -> Path:
+    return get_hermes_home() / "activity-ledger" / when.date().isoformat() / f"{kind}.jsonl"
+
+
+def _append_jsonl(path: Path, record: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False, sort_keys=True))
+        fh.write("\n")
+
+
+def _record_id(prefix: str) -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{prefix}_{stamp}_{secrets.token_hex(4)}"
+
+
+def _build_turn_record(
+    acc: _TurnAccumulator,
+    *,
+    response_preview: str,
+    when: datetime,
+) -> Dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "id": _record_id("turn"),
+        "time": when.isoformat(),
+        "date": when.date().isoformat(),
+        "type": "turn",
+        "session_id": acc.session_id,
+        "platform": acc.platform,
+        "message_preview": acc.message_preview,
+        "response_preview": response_preview,
+        "tool_names": list(acc.tool_names),
+        "reportable": "unknown",
+        "visibility": "private",
+    }
+
+
+def _handle_agent_start(context: Dict[str, Any], settings: ActivityLedgerSettings) -> None:
+    key = _turn_key(context)
+    session_id = str(context.get("session_id") or "").strip()
+    if not key or not session_id:
+        return
+
+    acc = _TurnAccumulator(
+        session_id=session_id,
+        platform=str(context.get("platform") or "").strip(),
+        message_preview=make_preview(context.get("message"), settings.max_preview_chars),
+    )
+    with _lock:
+        _turns[key] = acc
+
+
+def _handle_agent_step(context: Dict[str, Any]) -> None:
+    key = _turn_key(context)
+    if not key:
+        return
+    session_id = str(context.get("session_id") or "").strip()
+    with _lock:
+        acc = _turns.get(key)
+        if acc is None and session_id:
+            acc = _TurnAccumulator(
+                session_id=session_id,
+                platform=str(context.get("platform") or "").strip(),
+            )
+            _turns[key] = acc
+        if acc is not None:
+            _extend_tool_names(acc, _tool_names_from_context(context))
+
+
+def _handle_agent_end(context: Dict[str, Any], settings: ActivityLedgerSettings) -> None:
+    key = _turn_key(context)
+    session_id = str(context.get("session_id") or "").strip()
+    if not key or not session_id:
+        return
+
+    with _lock:
+        acc = _turns.pop(key, None)
+    if acc is None:
+        acc = _TurnAccumulator(
+            session_id=session_id,
+            platform=str(context.get("platform") or "").strip(),
+            message_preview=make_preview(context.get("message"), settings.max_preview_chars),
+        )
+
+    if not acc.platform:
+        acc.platform = str(context.get("platform") or "").strip()
+    if not acc.message_preview:
+        acc.message_preview = make_preview(context.get("message"), settings.max_preview_chars)
+    _extend_tool_names(acc, _tool_names_from_context(context))
+
+    when = hermes_now()
+    record = _build_turn_record(
+        acc,
+        response_preview=make_preview(context.get("response"), settings.max_preview_chars),
+        when=when,
+    )
+    _append_jsonl(_ledger_file("turns", when), record)
+
+
+def _discard_turn(context: Dict[str, Any]) -> None:
+    key = _turn_key(context)
+    if key:
+        with _lock:
+            _turns.pop(key, None)
+
+
+def handle_gateway_hook(event_type: str, context: Optional[Dict[str, Any]]) -> None:
+    """Built-in gateway hook entry point.
+
+    All exceptions are swallowed so activity-ledger failures never affect the
+    user-visible turn.
+    """
+    try:
+        ctx = context if isinstance(context, dict) else {}
+        settings = load_settings()
+        if not settings.enabled or not settings.capture_turns:
+            if event_type in {"agent:start", "agent:end"}:
+                _discard_turn(ctx)
+            return
+
+        if event_type == "agent:start":
+            _handle_agent_start(ctx, settings)
+        elif event_type == "agent:step":
+            _handle_agent_step(ctx)
+        elif event_type == "agent:end":
+            _handle_agent_end(ctx, settings)
+    except Exception:
+        logger.warning("activity ledger hook failed for %s", event_type, exc_info=True)
+
+
+def _clear_state_for_tests() -> None:
+    with _lock:
+        _turns.clear()

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -54,6 +54,10 @@ class HookRegistry:
         """Return metadata about all loaded hooks."""
         return list(self._loaded_hooks)
 
+    def has_handlers(self, event_type: str) -> bool:
+        """Return True when any user or built-in handler would fire."""
+        return bool(self._resolve_handlers(event_type))
+
     def _register_builtin_hooks(self) -> None:
         """Register built-in hooks that are always active.
 

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -45,7 +45,9 @@ class HookRegistry:
     def __init__(self):
         # event_type -> [handler_fn, ...]
         self._handlers: Dict[str, List[Callable]] = {}
+        self._builtin_handlers: Dict[str, List[Callable]] = {}
         self._loaded_hooks: List[dict] = []  # metadata for listing
+        self._builtins_registered = False
 
     @property
     def loaded_hooks(self) -> List[dict]:
@@ -55,11 +57,21 @@ class HookRegistry:
     def _register_builtin_hooks(self) -> None:
         """Register built-in hooks that are always active.
 
-        Currently empty — no shipped built-in hooks. Kept as the extension
-        point for future always-on gateway hooks so they drop in without
-        re-plumbing discover_and_load().
+        Built-ins are process-local observers and must not block the main
+        gateway pipeline. They are intentionally not included in
+        ``loaded_hooks`` because that list represents user-installed hook
+        packages from HERMES_HOME.
         """
-        return
+        if self._builtins_registered:
+            return
+        try:
+            from gateway.activity_ledger import handle_gateway_hook
+
+            for event in ("agent:start", "agent:step", "agent:end"):
+                self._builtin_handlers.setdefault(event, []).append(handle_gateway_hook)
+            self._builtins_registered = True
+        except Exception as e:
+            print(f"[hooks] Error loading built-in activity ledger hook: {e}", flush=True)
 
     def discover_and_load(self) -> None:
         """
@@ -71,9 +83,8 @@ class HookRegistry:
           - HOOK.yaml with at least 'name' and 'events' keys
           - handler.py with a top-level 'handle' function (sync or async)
         """
-        self._register_builtin_hooks()
-
         if not HOOKS_DIR.exists():
+            self._register_builtin_hooks()
             return
 
         for hook_dir in sorted(HOOKS_DIR.iterdir()):
@@ -142,6 +153,8 @@ class HookRegistry:
             except Exception as e:
                 print(f"[hooks] Error loading hook {hook_dir.name}: {e}", flush=True)
 
+        self._register_builtin_hooks()
+
     def _resolve_handlers(self, event_type: str) -> List[Callable]:
         """Return all handlers that should fire for ``event_type``.
 
@@ -149,10 +162,12 @@ class HookRegistry:
         ``command:*`` matches ``command:reset``).
         """
         handlers = list(self._handlers.get(event_type, []))
+        handlers.extend(self._builtin_handlers.get(event_type, []))
         if ":" in event_type:
             base = event_type.split(":")[0]
             wildcard_key = f"{base}:*"
             handlers.extend(self._handlers.get(wildcard_key, []))
+            handlers.extend(self._builtin_handlers.get(wildcard_key, []))
         return handlers
 
     async def emit(self, event_type: str, context: Optional[Dict[str, Any]] = None) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13428,7 +13428,9 @@ class GatewayRunner:
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
-            agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
+            agent.step_callback = (
+                _step_callback_sync if _hooks_ref.has_handlers("agent:step") else None
+            )
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
             agent.status_callback = _status_callback_sync

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6550,10 +6550,28 @@ class GatewayRunner:
             if _footer_line and response and not agent_result.get("already_sent"):
                 response = f"{response}\n\n{_footer_line}"
 
+            _end_tool_names = []
+            try:
+                _seen_tool_names = set()
+                for _msg in agent_messages:
+                    if not isinstance(_msg, dict):
+                        continue
+                    for _tc in (_msg.get("tool_calls") or []):
+                        if not isinstance(_tc, dict):
+                            continue
+                        _fn = _tc.get("function") or {}
+                        _name = str(_fn.get("name") or _tc.get("name") or "").strip()
+                        if _name and _name not in _seen_tool_names:
+                            _end_tool_names.append(_name)
+                            _seen_tool_names.add(_name)
+            except Exception:
+                _end_tool_names = []
+
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
                 **hook_ctx,
                 "response": (response or "")[:500],
+                "tool_names": _end_tool_names,
             })
             
             # Check for pending process watchers (check_interval on background processes)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -856,6 +856,15 @@ DEFAULT_CONFIG = {
     "privacy": {
         "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
     },
+
+    # Realtime activity ledger. Sidecar JSONL for reporting/audit only; not
+    # persistent memory and not injected into normal prompts. Disabled by
+    # default because it writes user/assistant previews to disk.
+    "activity_ledger": {
+        "enabled": False,
+        "capture_turns": True,
+        "max_preview_chars": 500,
+    },
     
     # Text-to-speech configuration
     # Each provider supports an optional `max_text_length:` override for the

--- a/tests/gateway/test_activity_ledger.py
+++ b/tests/gateway/test_activity_ledger.py
@@ -177,3 +177,47 @@ def test_default_config_is_opt_in():
 
     assert DEFAULT_CONFIG["activity_ledger"]["enabled"] is False
     assert DEFAULT_CONFIG["activity_ledger"]["capture_turns"] is True
+
+
+def test_missing_or_malformed_config_is_disabled_by_default():
+    assert activity_ledger.load_settings({}).enabled is False
+    assert activity_ledger.load_settings({"activity_ledger": "invalid"}).enabled is False
+    settings = activity_ledger.load_settings(
+        {"activity_ledger": {"enabled": "yes", "capture_turns": "no", "max_preview_chars": "9999"}}
+    )
+    assert settings.enabled is True
+    assert settings.capture_turns is False
+    assert settings.max_preview_chars == activity_ledger.MAX_PREVIEW_CHARS_CAP
+
+
+@pytest.mark.asyncio
+async def test_agent_end_can_record_tool_names_without_step_event(monkeypatch):
+    fixed_now = datetime(2026, 5, 6, 12, 34, 56, tzinfo=timezone.utc)
+    monkeypatch.setattr(activity_ledger, "hermes_now", lambda: fixed_now)
+    _write_config(
+        "activity_ledger:\n"
+        "  enabled: true\n"
+        "  capture_turns: true\n"
+    )
+
+    registry = HookRegistry()
+    with patch("gateway.hooks.HOOKS_DIR", _hermes_home() / "missing-hooks"):
+        registry.discover_and_load()
+
+    await registry.emit(
+        "agent:start",
+        {"session_id": "sess-end-tools", "platform": "discord", "message": "hello"},
+    )
+    await registry.emit(
+        "agent:end",
+        {
+            "session_id": "sess-end-tools",
+            "platform": "discord",
+            "response": "done",
+            "tool_names": ["terminal", "read_file", "terminal"],
+        },
+    )
+
+    turns = _read_turns("2026-05-06")
+    assert len(turns) == 1
+    assert turns[0]["tool_names"] == ["terminal", "read_file"]

--- a/tests/gateway/test_activity_ledger.py
+++ b/tests/gateway/test_activity_ledger.py
@@ -1,0 +1,179 @@
+"""Tests for the realtime gateway activity ledger."""
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gateway.hooks import HookRegistry
+import gateway.activity_ledger as activity_ledger
+
+
+def _hermes_home() -> Path:
+    return Path(os.environ["HERMES_HOME"])
+
+
+def _write_config(body: str) -> None:
+    (_hermes_home() / "config.yaml").write_text(body, encoding="utf-8")
+
+
+def _read_turns(date: str) -> list[dict]:
+    path = _hermes_home() / "activity-ledger" / date / "turns.jsonl"
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _clear_ledger_state():
+    activity_ledger._clear_state_for_tests()
+    yield
+    activity_ledger._clear_state_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_enabled_gateway_turn_writes_one_redacted_record(monkeypatch):
+    fixed_now = datetime(2026, 5, 6, 12, 34, 56, tzinfo=timezone.utc)
+    monkeypatch.setattr(activity_ledger, "hermes_now", lambda: fixed_now)
+    _write_config(
+        "activity_ledger:\n"
+        "  enabled: true\n"
+        "  capture_turns: true\n"
+        "  max_preview_chars: 500\n"
+    )
+
+    registry = HookRegistry()
+    with patch("gateway.hooks.HOOKS_DIR", _hermes_home() / "missing-hooks"):
+        registry.discover_and_load()
+
+    await registry.emit(
+        "agent:start",
+        {
+            "session_id": "sess-1",
+            "platform": "discord",
+            "message": "deploy with api_key=plain-secret " + ("x" * 700),
+        },
+    )
+    await registry.emit(
+        "agent:step",
+        {
+            "session_id": "sess-1",
+            "platform": "discord",
+            "tool_names": ["read_file"],
+            "tools": [
+                {
+                    "name": "terminal",
+                    "result": "RAW TOOL OUTPUT sk-proj-abcdefghijklmnop123456",
+                }
+            ],
+        },
+    )
+    await registry.emit(
+        "agent:end",
+        {
+            "session_id": "sess-1",
+            "platform": "discord",
+            "response": "done token=response-secret",
+            "tool_names": ["write_file"],
+        },
+    )
+
+    turns = _read_turns("2026-05-06")
+    assert len(turns) == 1
+
+    record = turns[0]
+    assert record["schema_version"] == 1
+    assert record["type"] == "turn"
+    assert record["session_id"] == "sess-1"
+    assert record["platform"] == "discord"
+    assert record["date"] == "2026-05-06"
+    assert record["time"] == "2026-05-06T12:34:56+00:00"
+    assert record["tool_names"] == ["read_file", "terminal", "write_file"]
+    assert len(record["message_preview"]) <= 500
+    assert len(record["response_preview"]) <= 500
+    assert "plain-secret" not in record["message_preview"]
+    assert "response-secret" not in record["response_preview"]
+    assert "RAW TOOL OUTPUT" not in json.dumps(record)
+
+
+@pytest.mark.asyncio
+async def test_disabled_ledger_does_not_write_turn_record(monkeypatch):
+    fixed_now = datetime(2026, 5, 6, 12, 34, 56, tzinfo=timezone.utc)
+    monkeypatch.setattr(activity_ledger, "hermes_now", lambda: fixed_now)
+    _write_config(
+        "activity_ledger:\n"
+        "  enabled: false\n"
+        "  capture_turns: true\n"
+    )
+
+    registry = HookRegistry()
+    with patch("gateway.hooks.HOOKS_DIR", _hermes_home() / "missing-hooks"):
+        registry.discover_and_load()
+
+    await registry.emit(
+        "agent:start",
+        {"session_id": "sess-disabled", "platform": "telegram", "message": "hello"},
+    )
+    await registry.emit(
+        "agent:end",
+        {"session_id": "sess-disabled", "platform": "telegram", "response": "hi"},
+    )
+
+    assert not (_hermes_home() / "activity-ledger").exists()
+
+
+def test_redaction_covers_common_secret_shapes():
+    github_pat = "github_pat_" + ("a" * 32)
+    preview = activity_ledger.make_preview(
+        "api_key=plain-secret "
+        "client_secret: client-secret-value "
+        "Cookie: sessionid=abc123 "
+        "Bearer bearer-token-1234567890 "
+        "postgres://user:db-password@example.com/app "
+        f"{github_pat}",
+        500,
+    )
+
+    assert "plain-secret" not in preview
+    assert "client-secret-value" not in preview
+    assert "sessionid=abc123" not in preview
+    assert "bearer-token-1234567890" not in preview
+    assert "db-password" not in preview
+    assert github_pat not in preview
+    assert "***" in preview
+
+
+def test_ledger_write_failure_is_isolated(monkeypatch):
+    _write_config(
+        "activity_ledger:\n"
+        "  enabled: true\n"
+        "  capture_turns: true\n"
+    )
+
+    def _raise(*_args, **_kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(activity_ledger, "_append_jsonl", _raise)
+
+    activity_ledger.handle_gateway_hook(
+        "agent:start",
+        {"session_id": "sess-fail", "platform": "slack", "message": "hello"},
+    )
+    activity_ledger.handle_gateway_hook(
+        "agent:end",
+        {"session_id": "sess-fail", "platform": "slack", "response": "hi"},
+    )
+
+    assert not (_hermes_home() / "activity-ledger").exists()
+
+
+def test_default_config_is_opt_in():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["activity_ledger"]["enabled"] is False
+    assert DEFAULT_CONFIG["activity_ledger"]["capture_turns"] is True

--- a/tests/gateway/test_hooks.py
+++ b/tests/gateway/test_hooks.py
@@ -100,6 +100,18 @@ class TestDiscoverAndLoad:
 
         assert len(reg.loaded_hooks) == 0
 
+    def test_has_handlers_includes_user_and_builtin_handlers(self, tmp_path):
+        _create_hook(tmp_path, "my-hook", '["command:*"]',
+                      "def handle(e, c): pass\n")
+
+        reg = HookRegistry()
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path):
+            reg.discover_and_load()
+
+        assert reg.has_handlers("agent:step") is True
+        assert reg.has_handlers("command:reset") is True
+        assert reg.has_handlers("unknown:event") is False
+
     def test_multiple_hooks(self, tmp_path):
         _create_hook(tmp_path, "hook-a", '["agent:start"]',
                       "def handle(e, c): pass\n")


### PR DESCRIPTION
## Summary
- Add a lightweight realtime activity ledger for gateway turns using built-in gateway hook observers.
- Write redacted, date-partitioned turn records to `$HERMES_HOME/activity-ledger/YYYY-MM-DD/turns.jsonl` when explicitly enabled.
- Keep the ledger opt-in and separate from persistent memory / prompt injection.
- Add focused tests for enabled writes, disabled behavior, redaction, failure isolation, and hook compatibility.

## Design Notes
- Implemented as a built-in gateway hook backed by `gateway/activity_ledger.py`, rather than a user-specific `~/.hermes/hooks` package.
- Default `activity_ledger.enabled` is `false` because the feature writes message/response previews to disk.
- Explicit `record_activity_event` is deferred; this PR focuses on turn skeletons and a stable file contract.
- Reuses `agent.redact.redact_sensitive_text(force=True)` plus ledger-local conservative redaction patterns.

## Test Plan
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_activity_ledger.py tests/gateway/test_hooks.py -q -o 'addopts='`
- `git diff --check`

## Safety / Privacy
- Does not store full transcripts or raw tool outputs.
- Does not modify or depend on persistent memory.
- Does not add a daily/backfill cron collector.
- Uses profile-aware `$HERMES_HOME` paths.
