### PR TITLE
fix: inject Discord thread starter context

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3611,6 +3611,116 @@ class DiscordAdapter(BasePlatformAdapter):
             return f"{parent_name} / {thread_name}"
         return thread_name
 
+    def _discord_thread_context_messages(self) -> int:
+        """Number of prior thread messages to inject for Discord thread context."""
+        raw = os.getenv("DISCORD_THREAD_CONTEXT_MESSAGES", "5").strip()
+        try:
+            value = int(raw)
+        except ValueError:
+            value = 5
+        return max(0, min(value, 20))
+
+    def _discord_thread_context_max_chars(self) -> int:
+        """Maximum size of injected Discord thread context."""
+        raw = os.getenv("DISCORD_THREAD_CONTEXT_MAX_CHARS", "4000").strip()
+        try:
+            value = int(raw)
+        except ValueError:
+            value = 4000
+        return max(500, min(value, 20000))
+
+    @staticmethod
+    def _discord_message_author_name(message: Any) -> str:
+        author = getattr(message, "author", None)
+        return (
+            getattr(author, "display_name", None)
+            or getattr(author, "name", None)
+            or getattr(author, "id", None)
+            or "unknown"
+        )
+
+    @staticmethod
+    def _discord_message_text(message: Any) -> str:
+        text = (getattr(message, "content", None) or "").strip()
+        if text:
+            return text
+        attachments = getattr(message, "attachments", None) or []
+        if attachments:
+            names = [getattr(att, "filename", None) for att in attachments]
+            names = [name for name in names if name]
+            return f"[attachments: {', '.join(names)}]" if names else "[attachments]"
+        return ""
+
+    async def _build_thread_context_injection(self, thread: Any, current_message: Any) -> Optional[str]:
+        """Fetch a small, bounded snapshot of the thread body for agent context.
+
+        Discord only delivers the new message event to the gateway; it does not
+        automatically include the thread starter/body.  In threads, fetch a few
+        earlier messages so short follow-ups like "can this be implemented?"
+        carry the actual thread body into the agent turn.
+        """
+        context_message_limit = self._discord_thread_context_messages()
+        if context_message_limit <= 0:
+            return None
+
+        current_id = str(getattr(current_message, "id", ""))
+        seen_ids = {current_id} if current_id else set()
+        entries: list[tuple[str, str, str]] = []
+
+        def add(label: str, msg: Any) -> None:
+            msg_id = str(getattr(msg, "id", ""))
+            if msg_id and msg_id in seen_ids:
+                return
+            if msg_id:
+                seen_ids.add(msg_id)
+            text = self._discord_message_text(msg)
+            if not text:
+                return
+            author = str(self._discord_message_author_name(msg))
+            entries.append((label, author, text))
+
+        starter = getattr(thread, "starter_message", None)
+        if starter:
+            add("starter", starter)
+        else:
+            parent = getattr(thread, "parent", None)
+            fetch_message = getattr(parent, "fetch_message", None)
+            thread_id = getattr(thread, "id", None)
+            if callable(fetch_message) and thread_id is not None:
+                try:
+                    add("starter", await fetch_message(thread_id))
+                except Exception as e:
+                    logger.debug("[%s] Could not fetch Discord thread starter: %s", self.name, e)
+
+        history = getattr(thread, "history", None)
+        if callable(history):
+            try:
+                message_entries = 0
+                async for msg in history(limit=context_message_limit + 1, oldest_first=True):
+                    before_count = len(entries)
+                    add("message", msg)
+                    if len(entries) > before_count and entries[-1][0] == "message":
+                        message_entries += 1
+                    if message_entries >= context_message_limit:
+                        break
+            except Exception as e:
+                logger.debug("[%s] Could not fetch Discord thread history: %s", self.name, e)
+
+        if not entries:
+            return None
+
+        title = getattr(thread, "name", None) or getattr(thread, "id", "thread")
+        lines = ["[Discord thread context]", f"Thread: {title}"]
+        for label, author, text in entries:
+            prefix = "Starter" if label == "starter" else "Message"
+            lines.append(f"{prefix} from {author}: {text}")
+
+        injected = "\n".join(lines)
+        max_chars = self._discord_thread_context_max_chars()
+        if len(injected) > max_chars:
+            injected = injected[: max_chars - 20].rstrip() + "\n[truncated]"
+        return injected
+
     # ------------------------------------------------------------------
     # Attachment download helpers
     #
@@ -3976,6 +4086,11 @@ class DiscordAdapter(BasePlatformAdapter):
         event_text = normalized_content
         if pending_text_injection:
             event_text = f"{pending_text_injection}\n\n{event_text}" if event_text else pending_text_injection
+
+        if is_thread and msg_type != MessageType.COMMAND:
+            thread_context = await self._build_thread_context_injection(effective_channel, message)
+            if thread_context:
+                event_text = f"{thread_context}\n\n{event_text}" if event_text else thread_context
 
         # Defense-in-depth: prevent empty user messages from entering session
         # (can happen when user sends @mention-only with no other text)

--- a/tests/gateway/test_discord_thread_context.py
+++ b/tests/gateway/test_discord_thread_context.py
@@ -1,0 +1,189 @@
+"""Tests for Discord thread starter/body context injection."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+import sys
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_discord_mock():
+    """Install a mock discord module when discord.py isn't available."""
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, green=1, grey=2, blurple=2)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.MessageType = SimpleNamespace(reply="reply")
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+import gateway.platforms.discord as discord_platform  # noqa: E402
+from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+
+
+class FakeTextChannel:
+    def __init__(self, channel_id: int = 1, name: str = "general", guild_name: str = "Hermes Server", messages=None):
+        self.id = channel_id
+        self.name = name
+        self.guild = SimpleNamespace(id=10, name=guild_name)
+        self.topic = None
+        self._messages = {str(getattr(message, "id", "")): message for message in (messages or [])}
+
+    async def fetch_message(self, message_id):
+        return self._messages[str(message_id)]
+
+
+class FakeThread:
+    def __init__(self, channel_id: int = 2, name: str = "cli coding agents", parent=None, history_messages=None, starter_message=None):
+        self.id = channel_id
+        self.name = name
+        self.parent = parent
+        self.parent_id = getattr(parent, "id", None)
+        self.guild = getattr(parent, "guild", None) or SimpleNamespace(id=10, name="Hermes Server")
+        self.topic = None
+        self.starter_message = starter_message
+        self._history_messages = list(history_messages or [])
+
+    def history(self, *, limit=100, oldest_first=None):
+        async def gen():
+            messages = self._history_messages[:limit]
+            if oldest_first is False:
+                messages = list(reversed(messages))
+            for message in messages:
+                yield message
+
+        return gen()
+
+
+def fake_message(message_id: int, content: str, *, author_name: str = "probe", channel=None):
+    return SimpleNamespace(
+        id=message_id,
+        content=content,
+        mentions=[],
+        attachments=[],
+        reference=None,
+        created_at=datetime.now(timezone.utc),
+        channel=channel,
+        author=SimpleNamespace(id=message_id + 1000, display_name=author_name, name=author_name),
+        guild=getattr(channel, "guild", None),
+        type=None,
+    )
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    monkeypatch.setattr(discord_platform.discord, "DMChannel", type("FakeDMChannel", (), {}), raising=False)
+    monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_THREAD_CONTEXT_MESSAGES", "3")
+
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = DiscordAdapter(config)
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+    adapter._text_batch_delay_seconds = 0
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_thread_starter_and_history_are_injected(adapter):
+    parent = FakeTextChannel(channel_id=100, name="hermes-home")
+    starter = fake_message(1, "CLI coding agents should read the thread body", author_name="probe")
+    prior = fake_message(2, "Implementation should inspect Discord thread context", author_name="probe")
+    current = fake_message(3, "이거 구현 가능한지 검토해줘", author_name="probe")
+    thread = FakeThread(parent=parent, starter_message=starter, history_messages=[starter, prior, current])
+    current.channel = thread
+    current.guild = thread.guild
+
+    await adapter._handle_message(current)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+    assert event.source.thread_id == str(thread.id)
+    assert "[Discord thread context]" in event.text
+    assert "Thread: cli coding agents" in event.text
+    assert "Starter from probe: CLI coding agents should read the thread body" in event.text
+    assert "Message from probe: Implementation should inspect Discord thread context" in event.text
+    assert event.text.rstrip().endswith("이거 구현 가능한지 검토해줘")
+    assert "Message from probe: 이거 구현 가능한지 검토해줘" not in event.text
+
+
+@pytest.mark.asyncio
+async def test_thread_commands_keep_slash_prefix(adapter):
+    parent = FakeTextChannel(channel_id=100, name="hermes-home")
+    starter = fake_message(1, "Thread context should not break slash commands", author_name="probe")
+    current = fake_message(2, "/status", author_name="probe")
+    thread = FakeThread(parent=parent, starter_message=starter, history_messages=[starter, current])
+    current.channel = thread
+    current.guild = thread.guild
+
+    await adapter._handle_message(current)
+
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "/status"
+    assert event.get_command() == "status"
+
+
+@pytest.mark.asyncio
+async def test_parent_starter_message_is_fetched_when_thread_starter_is_not_cached(adapter):
+    starter = fake_message(200, "Parent message body that created this thread", author_name="probe")
+    parent = FakeTextChannel(channel_id=100, name="hermes-home", messages=[starter])
+    current = fake_message(201, "follow up", author_name="probe")
+    thread = FakeThread(channel_id=200, parent=parent, starter_message=None, history_messages=[current])
+    current.channel = thread
+    current.guild = thread.guild
+
+    await adapter._handle_message(current)
+
+    event = adapter.handle_message.await_args.args[0]
+    assert "Starter from probe: Parent message body that created this thread" in event.text
+    assert event.text.rstrip().endswith("follow up")
+
+
+@pytest.mark.asyncio
+async def test_thread_context_can_be_disabled(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_THREAD_CONTEXT_MESSAGES", "0")
+    parent = FakeTextChannel(channel_id=100, name="hermes-home")
+    starter = fake_message(1, "Hidden thread body", author_name="probe")
+    current = fake_message(2, "follow up", author_name="probe")
+    thread = FakeThread(parent=parent, starter_message=starter, history_messages=[starter])
+    current.channel = thread
+    current.guild = thread.guild
+
+    await adapter._handle_message(current)
+
+    event = adapter.handle_message.await_args.args[0]
+    assert "[Discord thread context]" not in event.text
+    assert event.text == "follow up"


### PR DESCRIPTION
## Summary
- Inject a bounded Discord thread context block into non-command thread messages so the agent can see the thread starter/body for short follow-ups.
- Fetch context from `Thread.starter_message`, fall back to the parent channel starter message when available, and include a small oldest-first history snapshot.
- Keep Discord thread slash commands untouched so `/status`, `/stop`, etc. still parse correctly.

## Verification
- `python3 -m pytest tests/gateway/test_discord_thread_context.py tests/gateway/test_discord_channel_controls.py tests/gateway/test_discord_thread_persistence.py -q -o 'addopts='`
- `python3 -m py_compile gateway/platforms/discord.py tests/gateway/test_discord_thread_context.py`
- `git diff --cached --check` before commit

## Risks / Follow-ups
- Thread context fetching uses a small default history limit (`DISCORD_THREAD_CONTEXT_MESSAGES=5`) and max character cap (`DISCORD_THREAD_CONTEXT_MAX_CHARS=4000`) to reduce token and rate-limit exposure.
- Text batching can still fetch context per incoming chunk before the batch flush; the default context block remains bounded, but a future refinement could attach thread context once at flush time.