### PR TITLE
feat(kanban): add bounded Kanban MCP bridge

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -405,6 +405,21 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_archive = sub.add_parser("archive", help="Archive one or more tasks")
     p_archive.add_argument("task_ids", nargs="+")
 
+    # --- mcp ---
+    p_mcp = sub.add_parser(
+        "mcp",
+        help="Run a bounded Kanban MCP server for external LLM clients",
+        description=(
+            "Expose a board-scoped Kanban MCP facade over stdio. This is separate "
+            "from dispatcher-only kanban_* worker tools and never exposes raw SQLite."
+        ),
+    )
+    mcp_sub = p_mcp.add_subparsers(dest="kanban_mcp_action")
+    p_mcp_serve = mcp_sub.add_parser("serve", help="Serve Kanban MCP tools over stdio")
+    p_mcp_serve.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable verbose logging on stderr"
+    )
+
     # --- tail ---
     p_tail = sub.add_parser("tail", help="Follow a task's event stream")
     p_tail.add_argument("task_id")
@@ -637,6 +652,7 @@ def kanban_command(args: argparse.Namespace) -> int:
         "block":    _cmd_block,
         "unblock":  _cmd_unblock,
         "archive":  _cmd_archive,
+        "mcp":      _cmd_mcp,
         "tail":     _cmd_tail,
         "dispatch": _cmd_dispatch,
         "daemon":   _cmd_daemon,
@@ -1354,6 +1370,17 @@ def _cmd_archive(args: argparse.Namespace) -> int:
             else:
                 print(f"Archived {tid}")
     return 0 if not failed else 1
+
+
+def _cmd_mcp(args: argparse.Namespace) -> int:
+    action = getattr(args, "kanban_mcp_action", None) or "serve"
+    if action != "serve":
+        print(f"kanban mcp: unknown action {action!r}", file=sys.stderr)
+        return 2
+    from hermes_cli.kanban_mcp import run_mcp_server
+
+    run_mcp_server(verbose=bool(getattr(args, "verbose", False)))
+    return 0
 
 
 def _cmd_tail(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_mcp.py
+++ b/hermes_cli/kanban_mcp.py
@@ -1,0 +1,687 @@
+"""Bounded MCP facade for Hermes Kanban.
+
+This module intentionally does *not* expose the dispatcher-only ``kanban_*``
+worker tools. External MCP clients get a separate, board-scoped facade that
+routes every write through ``hermes_cli.kanban_db`` APIs and never touches raw
+SQLite directly.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import sys
+import threading
+from typing import Any, Callable, Optional
+
+from hermes_cli import kanban_db as kb
+
+logger = logging.getLogger("hermes.kanban_mcp")
+
+WRITE_MODE_READONLY = "readonly"
+WRITE_MODE_SAFE = "safe"
+WRITE_MODE_OPERATOR = "operator"
+_ALLOWED_WRITE_MODES = {WRITE_MODE_READONLY, WRITE_MODE_SAFE, WRITE_MODE_OPERATOR}
+
+_MCP_SERVER_AVAILABLE = False
+_BOARD_ENV_LOCK = threading.RLock()
+try:
+    from mcp.server.fastmcp import FastMCP
+
+    _MCP_SERVER_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised by runtime error path
+    FastMCP = None  # type: ignore[assignment,misc]
+
+
+def _write_mode() -> str:
+    raw = os.environ.get("HERMES_KANBAN_MCP_WRITE_MODE", WRITE_MODE_SAFE)
+    mode = str(raw or "").strip().lower() or WRITE_MODE_SAFE
+    if mode not in _ALLOWED_WRITE_MODES:
+        return WRITE_MODE_READONLY
+    return mode
+
+
+def _task_to_dict(t: kb.Task) -> dict[str, Any]:
+    return {
+        "id": t.id,
+        "title": t.title,
+        "body": t.body,
+        "assignee": t.assignee,
+        "status": t.status,
+        "priority": t.priority,
+        "tenant": t.tenant,
+        "workspace_kind": t.workspace_kind,
+        "workspace_path": t.workspace_path,
+        "claim_lock": t.claim_lock,
+        "claim_expires": t.claim_expires,
+        "created_by": t.created_by,
+        "created_at": t.created_at,
+        "started_at": t.started_at,
+        "completed_at": t.completed_at,
+        "result": t.result,
+        "idempotency_key": t.idempotency_key,
+        "spawn_failures": t.spawn_failures,
+        "worker_pid": t.worker_pid,
+        "last_spawn_error": t.last_spawn_error,
+        "max_runtime_seconds": t.max_runtime_seconds,
+        "last_heartbeat_at": t.last_heartbeat_at,
+        "current_run_id": t.current_run_id,
+        "workflow_template_id": t.workflow_template_id,
+        "current_step_key": t.current_step_key,
+        "skills": list(t.skills) if t.skills else [],
+    }
+
+
+def _comment_to_dict(c: kb.Comment) -> dict[str, Any]:
+    return {
+        "id": c.id,
+        "task_id": c.task_id,
+        "author": c.author,
+        "body": c.body,
+        "created_at": c.created_at,
+    }
+
+
+def _event_to_dict(e: kb.Event) -> dict[str, Any]:
+    return {
+        "id": e.id,
+        "task_id": e.task_id,
+        "kind": e.kind,
+        "payload": e.payload,
+        "created_at": e.created_at,
+        "run_id": e.run_id,
+    }
+
+
+def _run_to_dict(r: kb.Run) -> dict[str, Any]:
+    return {
+        "id": r.id,
+        "task_id": r.task_id,
+        "profile": r.profile,
+        "step_key": r.step_key,
+        "status": r.status,
+        "claim_lock": r.claim_lock,
+        "claim_expires": r.claim_expires,
+        "worker_pid": r.worker_pid,
+        "max_runtime_seconds": r.max_runtime_seconds,
+        "last_heartbeat_at": r.last_heartbeat_at,
+        "started_at": r.started_at,
+        "ended_at": r.ended_at,
+        "outcome": r.outcome,
+        "summary": r.summary,
+        "metadata": r.metadata,
+        "error": r.error,
+    }
+
+
+def _dispatch_to_dict(result: kb.DispatchResult, *, dry_run: bool) -> dict[str, Any]:
+    return {
+        "dry_run": dry_run,
+        "reclaimed": result.reclaimed,
+        "promoted": result.promoted,
+        "spawned": [
+            {"task_id": tid, "assignee": assignee, "workspace_path": workspace}
+            for tid, assignee, workspace in result.spawned
+        ],
+        "skipped_unassigned": list(result.skipped_unassigned),
+        "skipped_nonspawnable": list(result.skipped_nonspawnable),
+        "crashed": list(result.crashed),
+        "auto_blocked": list(result.auto_blocked),
+        "timed_out": list(result.timed_out),
+    }
+
+
+@contextlib.contextmanager
+def _board_env(board: str):
+    """Pin kanban_db to ``board`` and neutralise legacy DB/path overrides.
+
+    ``kanban_db_path(board=...)`` intentionally honours ``HERMES_KANBAN_DB``
+    for dispatcher/worker handoff compatibility. MCP board scope must be a hard
+    boundary, so the facade clears those legacy env pins while operating.
+    """
+
+    keys = (
+        "HERMES_KANBAN_BOARD",
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+    )
+    with _BOARD_ENV_LOCK:
+        previous = {k: os.environ.get(k) for k in keys}
+        os.environ.pop("HERMES_KANBAN_DB", None)
+        os.environ.pop("HERMES_KANBAN_WORKSPACES_ROOT", None)
+        os.environ["HERMES_KANBAN_BOARD"] = board
+        try:
+            yield
+        finally:
+            for key, value in previous.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+
+class KanbanMCPFacade:
+    """Board-scoped Kanban API exposed through MCP tools."""
+
+    def _normalise_board(self, board: str) -> tuple[Optional[str], Optional[dict[str, Any]]]:
+        if not board or not str(board).strip():
+            raise ValueError("board is required")
+        try:
+            slug = kb._normalize_board_slug(board)
+        except ValueError as exc:
+            return None, {"error": "invalid_board", "board": board, "message": str(exc)}
+        if not slug:
+            raise ValueError("board is required")
+        with _board_env(slug):
+            if not kb.board_exists(slug):
+                return None, {"error": "board_not_found", "board": slug}
+        return slug, None
+
+    def _safe_write_denied(self) -> Optional[dict[str, Any]]:
+        mode = _write_mode()
+        if mode == WRITE_MODE_READONLY:
+            return {
+                "error": "write_disabled",
+                "write_mode": mode,
+                "message": "Set HERMES_KANBAN_MCP_WRITE_MODE=safe or operator to enable Kanban MCP writes.",
+            }
+        return None
+
+    def _operator_denied(self) -> Optional[dict[str, Any]]:
+        mode = _write_mode()
+        if mode != WRITE_MODE_OPERATOR:
+            return {
+                "error": "operator_mode_required",
+                "write_mode": mode,
+                "message": "Set HERMES_KANBAN_MCP_WRITE_MODE=operator to enable dangerous Kanban MCP operations.",
+            }
+        return None
+
+    def boards_list(self, include_archived: bool = False) -> dict[str, Any]:
+        boards = kb.list_boards(include_archived=include_archived)
+        for board in boards:
+            slug = board.get("slug")
+            if not slug:
+                continue
+            try:
+                with _board_env(slug):
+                    if kb.kanban_db_path(board=slug).exists():
+                        with kb.connect(board=slug) as conn:
+                            board["counts"] = _board_counts(conn)
+                    else:
+                        board["counts"] = {}
+            except Exception:
+                board["counts"] = {}
+            board["total"] = sum(board.get("counts", {}).values())
+        return {"count": len(boards), "boards": boards}
+
+    def tasks_list(
+        self,
+        *,
+        board: str,
+        status: Optional[str] = None,
+        assignee: Optional[str] = None,
+        tenant: Optional[str] = None,
+        include_archived: bool = False,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        slug, err = self._normalise_board(board)
+        if err:
+            return err
+        assert slug is not None
+        limit = max(1, min(int(limit or 100), 500))
+        with _board_env(slug), kb.connect(board=slug) as conn:
+            tasks = kb.list_tasks(
+                conn,
+                assignee=assignee,
+                status=status,
+                tenant=tenant,
+                include_archived=include_archived,
+            )[:limit]
+        return {"board": slug, "count": len(tasks), "tasks": [_task_to_dict(t) for t in tasks]}
+
+    def task_show(self, *, board: str, task_id: str) -> dict[str, Any]:
+        slug, err = self._normalise_board(board)
+        if err:
+            return err
+        assert slug is not None
+        with _board_env(slug), kb.connect(board=slug) as conn:
+            task = kb.get_task(conn, task_id)
+            if not task:
+                return {"error": "task_not_found", "board": slug, "task_id": task_id}
+            comments = kb.list_comments(conn, task_id)
+            events = kb.list_events(conn, task_id)
+            parents = kb.parent_ids(conn, task_id)
+            children = kb.child_ids(conn, task_id)
+            runs = kb.list_runs(conn, task_id)
+        return {
+            "board": slug,
+            "task": _task_to_dict(task),
+            "parents": parents,
+            "children": children,
+            "comments": [_comment_to_dict(c) for c in comments],
+            "events": [_event_to_dict(e) for e in events],
+            "runs": [_run_to_dict(r) for r in runs],
+        }
+
+    def task_create(
+        self,
+        *,
+        board: str,
+        title: str,
+        body: Optional[str] = None,
+        assignee: Optional[str] = None,
+        created_by: str = "kanban-mcp",
+        parents: Optional[list[str]] = None,
+        tenant: Optional[str] = None,
+        priority: int = 0,
+        workspace_kind: str = "scratch",
+        workspace_path: Optional[str] = None,
+        triage: bool = False,
+        idempotency_key: Optional[str] = None,
+        max_runtime_seconds: Optional[int] = None,
+        skills: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        denied = self._safe_write_denied()
+        if denied:
+            return denied
+        slug, err = self._normalise_board(board)
+        if err:
+            return err
+        assert slug is not None
+        try:
+            with _board_env(slug), kb.connect(board=slug) as conn:
+                task_id = kb.create_task(
+                    conn,
+                    title=title,
+                    body=body,
+                    assignee=assignee,
+                    created_by=created_by or "kanban-mcp",
+                    workspace_kind=workspace_kind,
+                    workspace_path=workspace_path,
+                    tenant=tenant,
+                    priority=int(priority or 0),
+                    parents=tuple(parents or ()),
+                    triage=bool(triage),
+                    idempotency_key=idempotency_key,
+                    max_runtime_seconds=max_runtime_seconds,
+                    skills=skills,
+                )
+                task = kb.get_task(conn, task_id)
+        except Exception as exc:
+            return {"error": "create_failed", "board": slug, "message": str(exc)}
+        return {"ok": True, "board": slug, "task": _task_to_dict(task)}
+
+    def task_comment(
+        self,
+        *,
+        board: str,
+        task_id: str,
+        body: str,
+        author: str = "kanban-mcp",
+    ) -> dict[str, Any]:
+        denied = self._safe_write_denied()
+        if denied:
+            return denied
+        slug, err = self._normalise_board(board)
+        if err:
+            return err
+        assert slug is not None
+        try:
+            with _board_env(slug), kb.connect(board=slug) as conn:
+                comment_id = kb.add_comment(conn, task_id, author or "kanban-mcp", body)
+        except Exception as exc:
+            return {"error": "comment_failed", "board": slug, "task_id": task_id, "message": str(exc)}
+        return {"ok": True, "board": slug, "task_id": task_id, "comment_id": comment_id}
+
+    def task_assign(self, *, board: str, task_id: str, assignee: Optional[str]) -> dict[str, Any]:
+        denied = self._safe_write_denied()
+        if denied:
+            return denied
+        slug, err = self._normalise_board(board)
+        if err:
+            return err
+        assert slug is not None
+        try:
+            with _board_env(slug), kb.connect(board=slug) as conn:
+                ok = kb.assign_task(conn, task_id, assignee)
+                task = kb.get_task(conn, task_id) if ok else None
+        except Exception as exc:
+            return {"error": "assign_failed", "board": slug, "task_id": task_id, "message": str(exc)}
+        if not ok or not task:
+            return {"error": "task_not_found", "board": slug, "task_id": task_id}
+        return {"ok": True, "board": slug, "task": _task_to_dict(task)}
+
+    def task_link(self, *, board: str, parent_id: str, child_id: str) -> dict[str, Any]:
+        denied = self._safe_write_denied()
+        if denied:
+            return denied
+        slug, err = self._normalise_board(board)
+        if err:
+            return err
+        assert slug is not None
+        try:
+            with _board_env(slug), kb.connect(board=slug) as conn:
+                kb.link_tasks(conn, parent_id, child_id)
+        except Exception as exc:
+            return {"error": "link_failed", "board": slug, "message": str(exc)}
+        return {"ok": True, "board": slug, "parent_id": parent_id, "child_id": child_id}
+
+    def task_unlink(self, *, board: str, parent_id: str, child_id: str) -> dict[str, Any]:
+        denied = self._safe_write_denied()
+        if denied:
+            return denied
+        slug, err = self._normalise_board(board)
+        if err:
+            return err
+        assert slug is not None
+        with _board_env(slug), kb.connect(board=slug) as conn:
+            ok = kb.unlink_tasks(conn, parent_id, child_id)
+        return {"ok": bool(ok), "board": slug, "parent_id": parent_id, "child_id": child_id}
+
+    def stats(self, *, board: str) -> dict[str, Any]:
+        slug, err = self._normalise_board(board)
+        if err:
+            return err
+        assert slug is not None
+        with _board_env(slug), kb.connect(board=slug) as conn:
+            stats = kb.board_stats(conn)
+        return {"board": slug, "stats": stats}
+
+    def dispatch_dry_run(self, *, board: str, max_spawn: Optional[int] = None) -> dict[str, Any]:
+        slug, err = self._normalise_board(board)
+        if err:
+            return err
+        assert slug is not None
+        with _board_env(slug), kb.connect(board=slug) as conn:
+            result = kb.dispatch_once(conn, dry_run=True, max_spawn=max_spawn, board=slug)
+        out = _dispatch_to_dict(result, dry_run=True)
+        out["board"] = slug
+        return out
+
+    def task_complete(
+        self,
+        *,
+        board: str,
+        task_id: str,
+        result: Optional[str] = None,
+        summary: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        denied = self._operator_denied()
+        if denied:
+            return denied
+        slug, err = self._normalise_board(board)
+        if err:
+            return err
+        assert slug is not None
+        try:
+            with _board_env(slug), kb.connect(board=slug) as conn:
+                ok = kb.complete_task(conn, task_id, result=result, summary=summary, metadata=metadata)
+                task = kb.get_task(conn, task_id) if ok else None
+        except Exception as exc:
+            return {"error": "complete_failed", "board": slug, "task_id": task_id, "message": str(exc)}
+        if not ok or not task:
+            return {"error": "task_not_found", "board": slug, "task_id": task_id}
+        return {"ok": True, "board": slug, "task": _task_to_dict(task)}
+
+    def task_block(self, *, board: str, task_id: str, reason: str) -> dict[str, Any]:
+        denied = self._operator_denied()
+        if denied:
+            return denied
+        slug, err = self._normalise_board(board)
+        if err:
+            return err
+        assert slug is not None
+        try:
+            with _board_env(slug), kb.connect(board=slug) as conn:
+                ok = kb.block_task(conn, task_id, reason=reason)
+                task = kb.get_task(conn, task_id) if ok else None
+        except Exception as exc:
+            return {"error": "block_failed", "board": slug, "task_id": task_id, "message": str(exc)}
+        if not ok or not task:
+            return {"error": "task_not_found", "board": slug, "task_id": task_id}
+        return {"ok": True, "board": slug, "task": _task_to_dict(task)}
+
+    def task_unblock(self, *, board: str, task_id: str) -> dict[str, Any]:
+        denied = self._operator_denied()
+        if denied:
+            return denied
+        slug, err = self._normalise_board(board)
+        if err:
+            return err
+        assert slug is not None
+        with _board_env(slug), kb.connect(board=slug) as conn:
+            ok = kb.unblock_task(conn, task_id)
+            task = kb.get_task(conn, task_id) if ok else None
+        if not ok or not task:
+            return {"error": "task_not_found_or_not_blocked", "board": slug, "task_id": task_id}
+        return {"ok": True, "board": slug, "task": _task_to_dict(task)}
+
+    def task_archive(self, *, board: str, task_id: str) -> dict[str, Any]:
+        denied = self._operator_denied()
+        if denied:
+            return denied
+        slug, err = self._normalise_board(board)
+        if err:
+            return err
+        assert slug is not None
+        with _board_env(slug), kb.connect(board=slug) as conn:
+            ok = kb.archive_task(conn, task_id)
+            task = kb.get_task(conn, task_id) if ok else None
+        if not ok or not task:
+            return {"error": "task_not_found", "board": slug, "task_id": task_id}
+        return {"ok": True, "board": slug, "task": _task_to_dict(task)}
+
+    def dispatch(
+        self,
+        *,
+        board: str,
+        max_spawn: Optional[int] = None,
+        _spawn_fn: Optional[Callable[..., Optional[int]]] = None,
+    ) -> dict[str, Any]:
+        denied = self._operator_denied()
+        if denied:
+            return denied
+        slug, err = self._normalise_board(board)
+        if err:
+            return err
+        assert slug is not None
+        with _board_env(slug), kb.connect(board=slug) as conn:
+            result = kb.dispatch_once(
+                conn,
+                spawn_fn=_spawn_fn,
+                dry_run=False,
+                max_spawn=max_spawn,
+                board=slug,
+            )
+        out = _dispatch_to_dict(result, dry_run=False)
+        out["board"] = slug
+        return out
+
+
+def _board_counts(conn) -> dict[str, int]:
+    rows = conn.execute("SELECT status, COUNT(*) AS n FROM tasks GROUP BY status").fetchall()
+    return {r["status"]: int(r["n"]) for r in rows}
+
+
+def _json_result(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2, ensure_ascii=False)
+
+
+def create_mcp_server() -> "FastMCP":
+    """Create a stdio MCP server exposing the bounded Kanban facade."""
+    if not _MCP_SERVER_AVAILABLE:
+        raise ImportError(
+            "Kanban MCP server requires the 'mcp' package. "
+            f"Install with: {sys.executable} -m pip install 'mcp'"
+        )
+
+    facade = KanbanMCPFacade()
+    mcp = FastMCP(
+        "hermes-kanban",
+        instructions=(
+            "Bounded Hermes Kanban bridge. Every task operation requires an explicit board slug. "
+            "Safe writes are allowed unless HERMES_KANBAN_MCP_WRITE_MODE=readonly; dangerous "
+            "operations require HERMES_KANBAN_MCP_WRITE_MODE=operator."
+        ),
+    )
+
+    @mcp.tool()
+    def boards_list(include_archived: bool = False) -> str:
+        """List Hermes Kanban boards with per-status counts."""
+        return _json_result(facade.boards_list(include_archived=include_archived))
+
+    @mcp.tool()
+    def tasks_list(
+        board: str,
+        status: Optional[str] = None,
+        assignee: Optional[str] = None,
+        tenant: Optional[str] = None,
+        include_archived: bool = False,
+        limit: int = 100,
+    ) -> str:
+        """List tasks on one explicit board, optionally filtered by status/assignee/tenant."""
+        return _json_result(
+            facade.tasks_list(
+                board=board,
+                status=status,
+                assignee=assignee,
+                tenant=tenant,
+                include_archived=include_archived,
+                limit=limit,
+            )
+        )
+
+    @mcp.tool()
+    def task_show(board: str, task_id: str) -> str:
+        """Show one task including comments, events, parents, children, and runs."""
+        return _json_result(facade.task_show(board=board, task_id=task_id))
+
+    @mcp.tool()
+    def task_create(
+        board: str,
+        title: str,
+        body: Optional[str] = None,
+        assignee: Optional[str] = None,
+        created_by: str = "kanban-mcp",
+        parents: Optional[list[str]] = None,
+        tenant: Optional[str] = None,
+        priority: int = 0,
+        workspace_kind: str = "scratch",
+        workspace_path: Optional[str] = None,
+        triage: bool = False,
+        idempotency_key: Optional[str] = None,
+        max_runtime_seconds: Optional[int] = None,
+        skills: Optional[list[str]] = None,
+    ) -> str:
+        """Create a task on an explicit board through the Kanban DB API."""
+        return _json_result(
+            facade.task_create(
+                board=board,
+                title=title,
+                body=body,
+                assignee=assignee,
+                created_by=created_by,
+                parents=parents,
+                tenant=tenant,
+                priority=priority,
+                workspace_kind=workspace_kind,
+                workspace_path=workspace_path,
+                triage=triage,
+                idempotency_key=idempotency_key,
+                max_runtime_seconds=max_runtime_seconds,
+                skills=skills,
+            )
+        )
+
+    @mcp.tool()
+    def task_comment(board: str, task_id: str, body: str, author: str = "kanban-mcp") -> str:
+        """Append an audited comment to a task."""
+        return _json_result(facade.task_comment(board=board, task_id=task_id, body=body, author=author))
+
+    @mcp.tool()
+    def task_assign(board: str, task_id: str, assignee: Optional[str]) -> str:
+        """Assign or unassign a task. Pass null/empty assignee to unassign."""
+        return _json_result(facade.task_assign(board=board, task_id=task_id, assignee=assignee))
+
+    @mcp.tool()
+    def task_link(board: str, parent_id: str, child_id: str) -> str:
+        """Add a parent -> child task dependency on one board."""
+        return _json_result(facade.task_link(board=board, parent_id=parent_id, child_id=child_id))
+
+    @mcp.tool()
+    def task_unlink(board: str, parent_id: str, child_id: str) -> str:
+        """Remove a parent -> child task dependency on one board."""
+        return _json_result(facade.task_unlink(board=board, parent_id=parent_id, child_id=child_id))
+
+    @mcp.tool()
+    def stats(board: str) -> str:
+        """Return board stats for one explicit board."""
+        return _json_result(facade.stats(board=board))
+
+    @mcp.tool()
+    def dispatch_dry_run(board: str, max_spawn: Optional[int] = None) -> str:
+        """Run a non-spawning dispatcher preview for one board."""
+        return _json_result(facade.dispatch_dry_run(board=board, max_spawn=max_spawn))
+
+    @mcp.tool()
+    def task_complete(
+        board: str,
+        task_id: str,
+        result: Optional[str] = None,
+        summary: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> str:
+        """Dangerous: mark a task done. Requires HERMES_KANBAN_MCP_WRITE_MODE=operator."""
+        return _json_result(
+            facade.task_complete(board=board, task_id=task_id, result=result, summary=summary, metadata=metadata)
+        )
+
+    @mcp.tool()
+    def task_block(board: str, task_id: str, reason: str) -> str:
+        """Dangerous: block a task. Requires HERMES_KANBAN_MCP_WRITE_MODE=operator."""
+        return _json_result(facade.task_block(board=board, task_id=task_id, reason=reason))
+
+    @mcp.tool()
+    def task_unblock(board: str, task_id: str) -> str:
+        """Dangerous: unblock a task. Requires HERMES_KANBAN_MCP_WRITE_MODE=operator."""
+        return _json_result(facade.task_unblock(board=board, task_id=task_id))
+
+    @mcp.tool()
+    def task_archive(board: str, task_id: str) -> str:
+        """Dangerous: archive a task. Requires HERMES_KANBAN_MCP_WRITE_MODE=operator."""
+        return _json_result(facade.task_archive(board=board, task_id=task_id))
+
+    @mcp.tool()
+    def dispatch(board: str, max_spawn: Optional[int] = None) -> str:
+        """Dangerous: actually dispatch workers. Requires HERMES_KANBAN_MCP_WRITE_MODE=operator."""
+        return _json_result(facade.dispatch(board=board, max_spawn=max_spawn))
+
+    return mcp
+
+
+def run_mcp_server(verbose: bool = False) -> None:
+    """Start the bounded Kanban MCP server on stdio."""
+    if not _MCP_SERVER_AVAILABLE:
+        print(
+            "Error: Kanban MCP server requires the 'mcp' package.\n"
+            f"Install with: {sys.executable} -m pip install 'mcp'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    logging.basicConfig(level=logging.DEBUG if verbose else logging.WARNING, stream=sys.stderr)
+    server = create_mcp_server()
+    import asyncio
+
+    try:
+        asyncio.run(server.run_stdio_async())
+    except KeyboardInterrupt:
+        return
+
+
+def main() -> None:
+    verbose = "--verbose" in sys.argv or "-v" in sys.argv
+    run_mcp_server(verbose=verbose)

--- a/hermes_cli/kanban_mcp.py
+++ b/hermes_cli/kanban_mcp.py
@@ -43,6 +43,31 @@ def _write_mode() -> str:
     return mode
 
 
+def _allowed_boards() -> Optional[set[str]]:
+    """Return the optional MCP board allowlist from the environment.
+
+    ``HERMES_KANBAN_MCP_ALLOWED_BOARDS`` is the specific knob for this facade;
+    ``HERMES_KANBAN_ALLOWED_BOARDS`` is accepted for compatibility with early
+    design notes and external config snippets.
+    """
+
+    raw = os.environ.get("HERMES_KANBAN_MCP_ALLOWED_BOARDS")
+    if raw is None:
+        raw = os.environ.get("HERMES_KANBAN_ALLOWED_BOARDS")
+    if raw is None or not str(raw).strip():
+        return None
+    allowed: set[str] = set()
+    for part in str(raw).split(","):
+        name = part.strip()
+        if not name:
+            continue
+        try:
+            allowed.add(kb._normalize_board_slug(name))
+        except ValueError:
+            logger.warning("Ignoring invalid Kanban MCP allowed board slug %r", name)
+    return allowed
+
+
 def _task_to_dict(t: kb.Task) -> dict[str, Any]:
     return {
         "id": t.id,
@@ -174,6 +199,13 @@ class KanbanMCPFacade:
             return None, {"error": "invalid_board", "board": board, "message": str(exc)}
         if not slug:
             raise ValueError("board is required")
+        allowed = _allowed_boards()
+        if allowed is not None and slug not in allowed:
+            return None, {
+                "error": "board_not_allowed",
+                "board": slug,
+                "allowed_boards": sorted(allowed),
+            }
         with _board_env(slug):
             if not kb.board_exists(slug):
                 return None, {"error": "board_not_found", "board": slug}
@@ -200,7 +232,12 @@ class KanbanMCPFacade:
         return None
 
     def boards_list(self, include_archived: bool = False) -> dict[str, Any]:
-        boards = kb.list_boards(include_archived=include_archived)
+        allowed = _allowed_boards()
+        boards = [
+            board
+            for board in kb.list_boards(include_archived=include_archived)
+            if allowed is None or board.get("slug") in allowed
+        ]
         for board in boards:
             slug = board.get("slug")
             if not slug:
@@ -685,3 +722,7 @@ def run_mcp_server(verbose: bool = False) -> None:
 def main() -> None:
     verbose = "--verbose" in sys.argv or "-v" in sys.argv
     run_mcp_server(verbose=verbose)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ all = [
 hermes = "hermes_cli.main:main"
 hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
+hermes-kanban-mcp = "hermes_cli.kanban_mcp:main"
 
 [tool.setuptools]
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "rl_cli", "utils"]

--- a/tests/hermes_cli/test_kanban_mcp.py
+++ b/tests/hermes_cli/test_kanban_mcp.py
@@ -1,0 +1,134 @@
+"""Tests for the bounded Kanban MCP facade."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_mcp import KanbanMCPFacade
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_WORKSPACES_ROOT", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_MCP_WRITE_MODE", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def test_boards_list_reports_existing_boards(kanban_home):
+    kb.create_board("alpha", name="Alpha Board")
+
+    result = KanbanMCPFacade().boards_list()
+
+    assert result["count"] == 2
+    assert [b["slug"] for b in result["boards"]] == ["default", "alpha"]
+    assert result["boards"][1]["name"] == "Alpha Board"
+
+
+def test_create_comment_link_and_assign_preserve_audit_events(kanban_home):
+    facade = KanbanMCPFacade()
+    parent = facade.task_create(
+        board="default",
+        title="parent",
+        assignee="builder",
+        created_by="mcp-test",
+    )["task"]["id"]
+    child = facade.task_create(
+        board="default",
+        title="child",
+        assignee="researcher",
+        created_by="mcp-test",
+    )["task"]["id"]
+
+    assert facade.task_comment(
+        board="default", task_id=parent, body="visible note", author="external-llm"
+    )["ok"] is True
+    assert facade.task_link(board="default", parent_id=parent, child_id=child)["ok"] is True
+    assert facade.task_assign(board="default", task_id=child, assignee="reviewer")["ok"] is True
+
+    shown = facade.task_show(board="default", task_id=child)
+    assert shown["task"]["assignee"] == "reviewer"
+    assert shown["parents"] == [parent]
+    assert any(e["kind"] == "linked" for e in shown["events"])
+    parent_shown = facade.task_show(board="default", task_id=parent)
+    assert parent_shown["comments"][0]["body"] == "visible note"
+    assert any(e["kind"] == "commented" for e in parent_shown["events"])
+
+
+def test_board_isolation_requires_explicit_board_and_does_not_cross_read(kanban_home):
+    kb.create_board("alpha")
+    with kb.connect(board="default") as conn:
+        default_tid = kb.create_task(conn, title="default task", tenant="tenant-a")
+    with kb.connect(board="alpha") as conn:
+        alpha_tid = kb.create_task(conn, title="alpha task", tenant="tenant-a")
+
+    facade = KanbanMCPFacade()
+
+    assert [t["id"] for t in facade.tasks_list(board="default")["tasks"]] == [default_tid]
+    assert [t["id"] for t in facade.tasks_list(board="alpha")["tasks"]] == [alpha_tid]
+    assert facade.task_show(board="default", task_id=alpha_tid)["error"] == "task_not_found"
+
+    with pytest.raises(ValueError, match="board is required"):
+        facade.tasks_list(board="")
+
+
+def test_invalid_board_returns_structured_error(kanban_home):
+    result = KanbanMCPFacade().tasks_list(board="missing-board")
+
+    assert result["error"] == "board_not_found"
+    assert result["board"] == "missing-board"
+
+
+def test_readonly_mode_denies_safe_mutations(kanban_home, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_MCP_WRITE_MODE", "readonly")
+    result = KanbanMCPFacade().task_create(board="default", title="nope")
+
+    assert result["error"] == "write_disabled"
+    assert result["write_mode"] == "readonly"
+    with kb.connect() as conn:
+        assert kb.list_tasks(conn) == []
+
+
+def test_dangerous_operations_are_gated_until_operator_mode(kanban_home, monkeypatch):
+    facade = KanbanMCPFacade()
+    task_id = facade.task_create(board="default", title="finish me")["task"]["id"]
+
+    denied = facade.task_complete(board="default", task_id=task_id, result="done")
+    assert denied["error"] == "operator_mode_required"
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id).status == "ready"
+
+    monkeypatch.setenv("HERMES_KANBAN_MCP_WRITE_MODE", "operator")
+    allowed = facade.task_complete(board="default", task_id=task_id, result="done")
+    assert allowed["ok"] is True
+    assert facade.task_show(board="default", task_id=task_id)["task"]["status"] == "done"
+
+
+def test_dispatch_dry_run_is_safe_but_real_dispatch_requires_operator(kanban_home, monkeypatch):
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda name: True)
+    facade = KanbanMCPFacade()
+    task_id = facade.task_create(board="default", title="spawnable", assignee="builder")["task"]["id"]
+
+    dry = facade.dispatch_dry_run(board="default")
+    assert dry["dry_run"] is True
+    assert dry["spawned"][0]["task_id"] == task_id
+
+    real = facade.dispatch(board="default")
+    assert real["error"] == "operator_mode_required"
+
+    monkeypatch.setenv("HERMES_KANBAN_MCP_WRITE_MODE", "operator")
+    # Use a stubbed spawn function so the test never launches Hermes workers.
+    real = facade.dispatch(board="default", _spawn_fn=lambda task, workspace, **kw: 12345)
+    assert real["dry_run"] is False
+    assert real["spawned"][0]["task_id"] == task_id

--- a/tests/hermes_cli/test_kanban_mcp.py
+++ b/tests/hermes_cli/test_kanban_mcp.py
@@ -21,6 +21,8 @@ def kanban_home(tmp_path, monkeypatch):
     monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_WORKSPACES_ROOT", raising=False)
     monkeypatch.delenv("HERMES_KANBAN_MCP_WRITE_MODE", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_MCP_ALLOWED_BOARDS", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_ALLOWED_BOARDS", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     kb.init_db()
     return home
@@ -81,6 +83,25 @@ def test_board_isolation_requires_explicit_board_and_does_not_cross_read(kanban_
 
     with pytest.raises(ValueError, match="board is required"):
         facade.tasks_list(board="")
+
+
+def test_board_allowlist_filters_and_denies_unlisted_boards(kanban_home, monkeypatch):
+    kb.create_board("alpha")
+    kb.create_board("beta")
+    with kb.connect(board="alpha") as conn:
+        alpha_tid = kb.create_task(conn, title="alpha task")
+    with kb.connect(board="beta") as conn:
+        kb.create_task(conn, title="beta task")
+
+    monkeypatch.setenv("HERMES_KANBAN_MCP_ALLOWED_BOARDS", "alpha")
+    facade = KanbanMCPFacade()
+
+    listed = facade.boards_list()
+    assert [b["slug"] for b in listed["boards"]] == ["alpha"]
+    assert [t["id"] for t in facade.tasks_list(board="alpha")["tasks"]] == [alpha_tid]
+    denied = facade.tasks_list(board="beta")
+    assert denied["error"] == "board_not_allowed"
+    assert denied["allowed_boards"] == ["alpha"]
 
 
 def test_invalid_board_returns_structured_error(kanban_home):

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -19,6 +19,8 @@ The board has two front doors, both backed by the same `~/.hermes/kanban.db`:
 
 Both surfaces route through the same `kanban_db` layer, so reads see a consistent view and writes can't drift. The rest of this page shows CLI examples because they're easy to copy-paste, but every CLI verb has a tool-call equivalent the model uses.
 
+There is also a bounded MCP facade for **external MCP-capable LLM clients** that need board visibility without becoming Hermes workers: `hermes kanban mcp serve` (or the `hermes-kanban-mcp` console script). This is deliberately separate from the dispatcher-only `kanban_*` toolset: every task operation requires an explicit `board`, all writes go through `kanban_db`, and no raw SQLite path is exposed. See [External MCP clients](#external-mcp-clients) below.
+
 This is the shape that covers the workloads `delegate_task` can't:
 
 - **Research triage** — parallel researchers + analyst + writer, human-in-the-loop.
@@ -227,6 +229,102 @@ hermes kanban complete t_abc t_def t_hij --result "batch wrap"
 hermes kanban archive  t_abc t_def t_hij
 hermes kanban unblock  t_abc t_def
 hermes kanban block    t_abc "need input" --ids t_def t_hij
+```
+
+## External MCP clients
+
+External LLM clients that speak MCP can inspect and coordinate through Kanban without getting the dispatcher-only worker toolset. Run the bounded stdio server:
+
+```bash
+hermes kanban mcp serve
+# equivalent when installed from pyproject scripts:
+hermes-kanban-mcp
+```
+
+The MCP facade is intentionally stricter than the CLI:
+
+- Every task operation takes an explicit `board` argument. Board is the hard isolation boundary; `tenant` is only an optional filter within a board.
+- Reads: `boards_list`, `tasks_list`, `task_show`, `stats`, `dispatch_dry_run`.
+- Safe writes: `task_create`, `task_comment`, `task_assign`, `task_link`, `task_unlink`.
+- Dangerous writes: `task_complete`, `task_block`, `task_unblock`, `task_archive`, and real `dispatch` exist, but return `operator_mode_required` unless explicitly enabled.
+- The server never writes raw SQLite. It calls `hermes_cli.kanban_db` APIs, so comments/events/audit rows are preserved.
+- The existing `HERMES_KANBAN_TASK` worker-tool gate is unchanged; this MCP server is a separate facade, not global exposure of `kanban_*` tools.
+
+Write-mode control:
+
+```bash
+# default: safe writes enabled, dangerous writes denied
+HERMES_KANBAN_MCP_WRITE_MODE=safe hermes kanban mcp serve
+
+# read-only: deny create/comment/assign/link/unlink too
+HERMES_KANBAN_MCP_WRITE_MODE=readonly hermes kanban mcp serve
+
+# operator: enable complete/block/unblock/archive and real dispatch
+HERMES_KANBAN_MCP_WRITE_MODE=operator hermes kanban mcp serve
+```
+
+Client config examples:
+
+**Claude Desktop** (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "hermes-kanban": {
+      "command": "hermes",
+      "args": ["kanban", "mcp", "serve"],
+      "env": {
+        "HERMES_KANBAN_MCP_WRITE_MODE": "safe"
+      }
+    }
+  }
+}
+```
+
+**Claude Code** (`.mcp.json` in a repo):
+
+```json
+{
+  "mcpServers": {
+    "hermes-kanban": {
+      "command": "hermes",
+      "args": ["kanban", "mcp", "serve"]
+    }
+  }
+}
+```
+
+**Codex MCP** (`~/.codex/config.toml`):
+
+```toml
+[mcp_servers.hermes-kanban]
+command = "hermes"
+args = ["kanban", "mcp", "serve"]
+env = { HERMES_KANBAN_MCP_WRITE_MODE = "safe" }
+```
+
+**Hermes native MCP** (`~/.hermes/config.yaml`):
+
+```yaml
+mcp_servers:
+  kanban:
+    command: "hermes"
+    args: ["kanban", "mcp", "serve"]
+    env:
+      HERMES_KANBAN_MCP_WRITE_MODE: "safe"
+```
+
+Use `hermes-kanban-mcp` as the command if you prefer the standalone console script:
+
+```json
+{
+  "mcpServers": {
+    "hermes-kanban": {
+      "command": "hermes-kanban-mcp",
+      "args": []
+    }
+  }
+}
 ```
 
 ## How workers interact with the board

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -250,9 +250,13 @@ The MCP facade is intentionally stricter than the CLI:
 - The server never writes raw SQLite. It calls `hermes_cli.kanban_db` APIs, so comments/events/audit rows are preserved.
 - The existing `HERMES_KANBAN_TASK` worker-tool gate is unchanged; this MCP server is a separate facade, not global exposure of `kanban_*` tools.
 
-Write-mode control:
+Scope and write-mode control:
 
 ```bash
+# Optional hard allowlist. If set, every MCP call outside these boards is denied.
+HERMES_KANBAN_MCP_ALLOWED_BOARDS=the-forge,ingestion-pipeline,atlas-command \
+  hermes kanban mcp serve
+
 # default: safe writes enabled, dangerous writes denied
 HERMES_KANBAN_MCP_WRITE_MODE=safe hermes kanban mcp serve
 
@@ -274,6 +278,7 @@ Client config examples:
       "command": "hermes",
       "args": ["kanban", "mcp", "serve"],
       "env": {
+        "HERMES_KANBAN_MCP_ALLOWED_BOARDS": "the-forge,ingestion-pipeline,atlas-command",
         "HERMES_KANBAN_MCP_WRITE_MODE": "safe"
       }
     }
@@ -288,7 +293,11 @@ Client config examples:
   "mcpServers": {
     "hermes-kanban": {
       "command": "hermes",
-      "args": ["kanban", "mcp", "serve"]
+      "args": ["kanban", "mcp", "serve"],
+      "env": {
+        "HERMES_KANBAN_MCP_ALLOWED_BOARDS": "the-forge,ingestion-pipeline,atlas-command",
+        "HERMES_KANBAN_MCP_WRITE_MODE": "safe"
+      }
     }
   }
 }
@@ -300,7 +309,7 @@ Client config examples:
 [mcp_servers.hermes-kanban]
 command = "hermes"
 args = ["kanban", "mcp", "serve"]
-env = { HERMES_KANBAN_MCP_WRITE_MODE = "safe" }
+env = { HERMES_KANBAN_MCP_ALLOWED_BOARDS = "the-forge,ingestion-pipeline,atlas-command", HERMES_KANBAN_MCP_WRITE_MODE = "safe" }
 ```
 
 **Hermes native MCP** (`~/.hermes/config.yaml`):
@@ -311,6 +320,7 @@ mcp_servers:
     command: "hermes"
     args: ["kanban", "mcp", "serve"]
     env:
+      HERMES_KANBAN_MCP_ALLOWED_BOARDS: "the-forge,ingestion-pipeline,atlas-command"
       HERMES_KANBAN_MCP_WRITE_MODE: "safe"
 ```
 


### PR DESCRIPTION
## Summary
Adds a bounded Hermes Kanban MCP bridge so external MCP-capable LLMs can inspect and safely coordinate through Hermes Kanban without exposing raw SQLite or dispatcher-only worker tools.

## Key behavior
- New MCP surface for Kanban board/task visibility and safe coordination writes.
- Board allowlist via `HERMES_KANBAN_MCP_ALLOWED_BOARDS` / compatibility `HERMES_KANBAN_ALLOWED_BOARDS`.
- Safe/default/operator write modes.
- Preserves `HERMES_KANBAN_TASK` worker-tool gating.
- Adds `python -m hermes_cli.kanban_mcp` entrypoint.

## Kanban / memory anchors
- Board: the-forge
- Implementation task: t_74a1262c
- Consolidation task: t_933d2792
- GBrain: factory-swarm/hermes-kanban-mcp-client-setup

## Validation
- `python -m pytest tests/hermes_cli/test_kanban.py tests/hermes_cli/test_kanban_*.py -q -o addopts=` => 366 passed.
- Local stdio MCP smoke listed 15 tools, `boards_list` worked, and disallowed board returned `board_not_allowed`.
