### PR TITLE
fix(agent): implement constraints_path config loading in system prompt

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5021,6 +5021,22 @@ class AIAgent:
             if context_files_prompt:
                 prompt_parts.append(context_files_prompt)
 
+        # Load constraints file if configured
+        if not self.skip_context_files:
+            try:
+                from hermes_cli.config import load_config
+                _cfg = load_config()
+                _cpath = _cfg.get("constraints_path") if isinstance(_cfg, dict) else None
+                if _cpath:
+                    _cpath = os.path.expanduser(str(_cpath).strip())
+                    if os.path.isfile(_cpath):
+                        with open(_cpath, "r", encoding="utf-8") as _f:
+                            _constraints = _f.read().strip()
+                        if _constraints:
+                            prompt_parts.append(f"<constraints>\n{_constraints}\n</constraints>")
+            except Exception:
+                pass
+
         from hermes_time import now as _hermes_now
         now = _hermes_now()
         timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"


### PR DESCRIPTION
## Summary

`constraints_path` in `config.yaml` was a dead config — no code ever read the file. Users who set it had their constraints silently ignored.

## Changes

Single surgical addition in `AIAgent._build_system_prompt()`:

After loading context files (AGENTS.md, .cursorrules), read `constraints_path` from config, expand `~`, and inject the file contents as a `<constraints>` block into the system prompt.

- Only activates when `skip_context_files` is False (same gate as other context files)
- Silently ignored if the file doesn't exist or is empty
- No new `__init__` parameters — reads config directly
- Wrapped in try/except to never break prompt assembly

## Testing

- Syntax verified with `py_compile`

Closes #18744
