### PR TITLE
feat(dashboard): show Chat nav item as disabled hint when --tui is off

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -347,8 +347,16 @@ export default function App() {
   );
 
   const builtinNav = useMemo(
-    () =>
-      embeddedChat ? [CHAT_NAV_ITEM, ...BUILTIN_NAV_REST] : BUILTIN_NAV_REST,
+    () => [
+      embeddedChat
+        ? CHAT_NAV_ITEM
+        : {
+            ...CHAT_NAV_ITEM,
+            disabled: true,
+            disabledHint: "Run `hermes dashboard --tui` to enable",
+          },
+      ...BUILTIN_NAV_REST,
+    ],
     [embeddedChat],
   );
 
@@ -636,11 +644,33 @@ export default function App() {
 }
 
 function SidebarNavLink({ closeMobile, item, t }: SidebarNavLinkProps) {
-  const { path, label, labelKey, icon: Icon } = item;
+  const { path, label, labelKey, icon: Icon, disabled, disabledHint } = item;
 
   const navLabel = labelKey
     ? ((t.app.nav as Record<string, string>)[labelKey] ?? label)
     : label;
+
+  if (disabled) {
+    return (
+      <li>
+        <span
+          title={disabledHint}
+          aria-label={disabledHint ? `${navLabel} — ${disabledHint}` : navLabel}
+          aria-disabled="true"
+          className={cn(
+            "relative flex items-center gap-3",
+            "px-5 py-2.5",
+            "font-mondwest text-[0.8rem] tracking-[0.12em]",
+            "whitespace-nowrap opacity-30 cursor-not-allowed select-none",
+          )}
+          style={{ clipPath: "var(--component-tab-clip-path)" }}
+        >
+          <Icon className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">{navLabel}</span>
+        </span>
+      </li>
+    );
+  }
 
   return (
     <li>
@@ -802,6 +832,8 @@ interface NavItem {
   label: string;
   labelKey?: string;
   path: string;
+  disabled?: boolean;
+  disabledHint?: string;
 }
 
 interface SidebarNavLinkProps {


### PR DESCRIPTION
## Summary

- Chat nav item was previously hidden entirely when `hermes dashboard` is started without `--tui`, making the feature completely undiscoverable
- Now the Chat item is **always visible** in the sidebar but rendered as a non-interactive, grayed-out hint when `--tui` is not active
- Hovering the item shows a tooltip: `Run \`hermes dashboard --tui\` to enable`

## Changes

**`web/src/App.tsx`**
- Extended `NavItem` interface with optional `disabled?: boolean` and `disabledHint?: string` fields
- `builtinNav` memo now always includes the Chat nav item — enabled when `embeddedChat` is true, otherwise wrapped with `disabled: true` + hint text
- `SidebarNavLink` renders a `<span>` with `aria-disabled`, `opacity-30`, `cursor-not-allowed`, and `title` tooltip when `item.disabled` is set, instead of a navigable `<NavLink>`

## Before / After

| State | Before | After |
|---|---|---|
| `hermes dashboard` (no `--tui`) | Chat tab missing entirely | Chat tab visible, grayed out with tooltip |
| `hermes dashboard --tui` | Chat tab visible and functional | Chat tab visible and functional (unchanged) |

## Why this matters

Users running `hermes dashboard` for the first time have no indication that an embedded terminal/chat exists. This change makes the feature self-documenting — the sidebar communicates that Chat is available under a specific condition, without changing the default behavior or requiring `--tui` by default.

## Test

1. Run `hermes dashboard` (without `--tui`)
2. Sidebar now shows a dimmed "Chat" item — hover to see the enable hint
3. Run `hermes dashboard --tui`
4. Chat item is now active and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)