### PR TITLE
fix(cli): /branch copies full history from DB instead of compressed in-memory state

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5267,8 +5267,13 @@ class HermesCLI:
             _cprint(f"  Failed to create branch session: {e}")
             return
 
-        # Copy conversation history to the new session
-        for msg in self.conversation_history:
+        # Copy conversation history to the new session.
+        # Use the full history from the DB (including ancestors) rather than
+        # self.conversation_history which may have been compressed.
+        _source_messages = self._session_db.get_messages_as_conversation(
+            parent_session_id, include_ancestors=True
+        ) or self.conversation_history
+        for msg in _source_messages:
             try:
                 self._session_db.append_message(
                     session_id=new_session_id,


### PR DESCRIPTION
## Summary

`/branch` and `/fork` copied only `self.conversation_history`, which after auto-compression contains ~15 summarized messages instead of the full conversation.

## Root Cause

`cli.py:7652` replaces `self.conversation_history` with a compressed summary during auto-compression. When `/branch` is invoked later, it only has the compressed version to copy.

## Fix

Single surgical change in `_handle_branch_command()`: read the full history from `SessionDB.get_messages_as_conversation()` (which traverses ancestor sessions) instead of using the in-memory compressed state. Falls back to `self.conversation_history` if DB read fails.

## Testing

- Syntax verified with `py_compile`.

Closes #18870
