### PR TITLE
feat: read context_length from providers.<name>.context_length (Step 0c)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1281,6 +1281,38 @@ def get_model_context_length(
         except Exception:
             pass  # fall through to probing
 
+    # 0c. Provider-level explicit context_length from providers.<name>.context_length.
+    # Custom endpoints (e.g. llama-server) rarely expose context_length via
+    # /models probing, leading to artificially low fallback values (e.g. 32K).
+    # This reads the per-provider override from config.yaml independently of
+    # the custom_providers list (which requires base_url matching — unavailable
+    # for cron jobs whose base_url is resolved later).
+    # Also handles the 'custom' provider alias — when the full provider name
+    # (e.g. 'custom:qwj-local') gets normalized to bare 'custom' during
+    # AIAgent init, we match by prefix against providers.custom:* keys.
+    if provider and not config_context_length:
+        try:
+            _cfg_path = Path.home() / ".hermes" / "config.yaml"
+            if _cfg_path.exists():
+                with open(_cfg_path) as _f:
+                    _cfg = yaml.safe_load(_f)
+                _providers = _cfg.get("providers", {}) if isinstance(_cfg, dict) else {}
+                if isinstance(_providers, dict):
+                    _p_cfg = _providers.get(provider)
+                    if not _p_cfg and provider == "custom":
+                        for _key, _val in _providers.items():
+                            if _key.startswith("custom:") and isinstance(_val, dict) and _val.get("context_length"):
+                                _p_cfg = _val
+                                break
+                    if isinstance(_p_cfg, dict):
+                        _raw = _p_cfg.get("context_length")
+                        if _raw is not None:
+                            _ctx_int = int(_raw)
+                            if _ctx_int > 0:
+                                return _ctx_int
+        except Exception:
+            pass  # fall through to probing
+
     # Normalise provider-prefixed model names (e.g. "local:model-name" →
     # "model-name") so cache lookups and server queries use the bare ID that
     # local servers actually know about.  Ollama "model:tag" colons are preserved.


### PR DESCRIPTION
## Summary

Add Step 0c to `get_model_context_length()` that reads per-provider `context_length` overrides from `providers.<name>.context_length` in config.yaml.

## Problem

Custom endpoints (e.g. llama-server) rarely expose `context_length` via `/models` probing, causing Hermes to fall back to artificially low values (e.g. 32K). This blocks cron jobs and any scenario where the model's true context window (e.g. 64K) can't be auto-detected.

The existing Step 0b (`custom_providers` per-model override) requires `base_url` matching, which is unavailable for cron jobs — their `base_url` is resolved later in the AIAgent init sequence.

## Solution

Step 0c reads `providers.<name>.context_length` directly from config.yaml, independently of the `custom_providers` list. It also handles the `custom` provider alias — when the full provider name (e.g. `custom:qwj-local`) gets normalized to bare `custom` during AIAgent init, it falls back to prefix-matching `providers.custom:*` keys.

## Test Plan

- [x] Direct function test: `get_model_context_length()` with provider=`custom:qwj-local` and config_context_length=None returns 65536 (from `providers.custom:qwj-local.context_length: 65536`)
- [x] Cron job test: previously failing with 32K error, now runs successfully with Qwen 27B (64K context)
- [x] Non-custom providers unaffected: DeepSeek continues to auto-detect 1M context
- [x] Fallback intact: if no provider-level config, falls through to existing probing chain

## Configuration Example

```yaml
providers:
  custom:qwj-local:
    base_url: http://192.168.0.68:18081/v1
    api_key: dummy
    context_length: 65536
```