### PR TITLE
fix(kanban): avoid fragile failure-column renames

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -953,31 +953,29 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency "
             "ON tasks(idempotency_key)"
         )
-    # Legacy column rename: ``spawn_failures`` → ``consecutive_failures``
-    # and ``last_spawn_error`` → ``last_failure_error``. The counter was
-    # originally spawn-only; it's now unified across spawn/timeout/
-    # crash outcomes. Rename when only the legacy columns exist to
-    # preserve historical counter values across upgrades. Add fresh
-    # otherwise.
+    # Legacy column migration: ``spawn_failures`` → ``consecutive_failures``
+    # and ``last_spawn_error`` → ``last_failure_error``. Avoid
+    # ``ALTER TABLE ... RENAME COLUMN`` here: existing board DBs may have
+    # related schema objects from older Kanban builds, and SQLite reparses
+    # the whole schema during a rename. Adding/copying is more tolerant and
+    # still preserves the historical counter/error values.
     if "consecutive_failures" not in cols:
+        conn.execute(
+            "ALTER TABLE tasks ADD COLUMN consecutive_failures "
+            "INTEGER NOT NULL DEFAULT 0"
+        )
         if "spawn_failures" in cols:
             conn.execute(
-                "ALTER TABLE tasks RENAME COLUMN spawn_failures TO consecutive_failures"
-            )
-        else:
-            conn.execute(
-                "ALTER TABLE tasks ADD COLUMN consecutive_failures "
-                "INTEGER NOT NULL DEFAULT 0"
+                "UPDATE tasks SET consecutive_failures = COALESCE(spawn_failures, 0)"
             )
     if "worker_pid" not in cols:
         conn.execute("ALTER TABLE tasks ADD COLUMN worker_pid INTEGER")
     if "last_failure_error" not in cols:
+        conn.execute("ALTER TABLE tasks ADD COLUMN last_failure_error TEXT")
         if "last_spawn_error" in cols:
             conn.execute(
-                "ALTER TABLE tasks RENAME COLUMN last_spawn_error TO last_failure_error"
+                "UPDATE tasks SET last_failure_error = last_spawn_error"
             )
-        else:
-            conn.execute("ALTER TABLE tasks ADD COLUMN last_failure_error TEXT")
     if "max_runtime_seconds" not in cols:
         conn.execute("ALTER TABLE tasks ADD COLUMN max_runtime_seconds INTEGER")
     if "last_heartbeat_at" not in cols:

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2648,6 +2648,78 @@ def test_legacy_db_without_skills_column_migrates(tmp_path):
     conn.close()
 
 
+def test_legacy_spawn_failure_columns_are_copied_not_renamed(tmp_path):
+    """Legacy failure counters survive migration without fragile column renames."""
+    import sqlite3
+    db_path = tmp_path / "legacy-failures.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            body TEXT,
+            assignee TEXT,
+            status TEXT NOT NULL,
+            priority INTEGER DEFAULT 0,
+            created_by TEXT,
+            created_at INTEGER NOT NULL,
+            started_at INTEGER,
+            completed_at INTEGER,
+            workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+            workspace_path TEXT,
+            claim_lock TEXT,
+            claim_expires INTEGER,
+            tenant TEXT,
+            result TEXT,
+            idempotency_key TEXT,
+            spawn_failures INTEGER NOT NULL DEFAULT 0,
+            worker_pid INTEGER,
+            last_spawn_error TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE task_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            payload TEXT,
+            created_at INTEGER NOT NULL
+        )
+    """)
+    conn.execute(
+        "INSERT INTO tasks "
+        "(id, title, body, assignee, status, priority, created_by, created_at, "
+        "started_at, completed_at, workspace_kind, workspace_path, claim_lock, "
+        "claim_expires, tenant, result, idempotency_key, spawn_failures, "
+        "worker_pid, last_spawn_error) "
+        "VALUES ('legacy', 'old task', NULL, 'default', 'ready', 0, NULL, 1, "
+        "NULL, NULL, 'scratch', NULL, NULL, NULL, NULL, NULL, NULL, 4, NULL, "
+        "'missing profile')"
+    )
+    conn.commit()
+
+    kb._migrate_add_optional_columns(conn)
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(tasks)")}
+    assert "spawn_failures" in cols
+    assert "consecutive_failures" in cols
+    assert "last_spawn_error" in cols
+    assert "last_failure_error" in cols
+
+    row = conn.execute("SELECT * FROM tasks WHERE id = 'legacy'").fetchone()
+    assert row["consecutive_failures"] == 4
+    assert row["last_failure_error"] == "missing profile"
+    task = kb.Task.from_row(row)
+    assert task.consecutive_failures == 4
+    assert task.last_failure_error == "missing profile"
+
+    kb._migrate_add_optional_columns(conn)
+    row_again = conn.execute("SELECT * FROM tasks WHERE id = 'legacy'").fetchone()
+    assert row_again["consecutive_failures"] == 4
+    assert row_again["last_failure_error"] == "missing profile"
+    conn.close()
+
+
 
 # ---------------------------------------------------------------------------
 # Gateway-embedded dispatcher: config, CLI warnings, daemon deprecation stub


### PR DESCRIPTION
## What does this PR do?

Fixes the Kanban DB migration regression where the embedded dispatcher can fail on startup with `sqlite3.OperationalError: no such column: "spawn_failures"`.

This is a follow-up to #20410, not a duplicate of it. #20410 changed the Kanban failure counter schema from `spawn_failures` / `last_spawn_error` to `consecutive_failures` / `last_failure_error` and used `ALTER TABLE ... RENAME COLUMN` to migrate existing DBs. The reported failure happens when an existing Kanban DB is on an older or partial schema that does not actually have `spawn_failures`, so the rename path itself crashes before the dispatcher can start.

This PR makes that migration tolerant of those real-world DB shapes: add the new columns if missing, copy legacy values only when the legacy columns exist, and leave any old columns harmlessly in place. Installs with old counters keep their values; installs without the legacy columns no longer crash.

## Related Issue

Fixes #20842

Follow-up to #20410

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`
  - Replaces fragile legacy column renames with add-and-copy migration logic.
  - Copies `spawn_failures` into `consecutive_failures` only when the legacy column exists.
  - Copies `last_spawn_error` into `last_failure_error` only when the legacy column exists.
  - Preserves old columns harmlessly instead of forcing a SQLite table/schema rewrite.
- `tests/hermes_cli/test_kanban_core_functionality.py`
  - Adds a regression test proving legacy failure counters and last error text migrate without renaming columns.
  - Verifies the migration is idempotent.

## How to Test

1. Run `./.venv/bin/pytest tests/hermes_cli/test_kanban_core_functionality.py::test_legacy_db_without_skills_column_migrates tests/hermes_cli/test_kanban_core_functionality.py::test_legacy_spawn_failure_columns_are_copied_not_renamed -q`.
2. Run `./.venv/bin/pytest tests/hermes_cli/test_kanban_core_functionality.py -q`.
3. Update an install with an existing Kanban DB and confirm `hermes kanban init` / embedded gateway dispatcher startup no longer raises `no such column: "spawn_failures"`.

## Checklist

### Code

- [x] I’ve read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn’t a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I’ve run `pytest tests/ -q` and all tests pass
- [x] I’ve added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I’ve tested on my platform: Ubuntu/WSL2

### Documentation & Housekeeping

- [x] I’ve updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I’ve updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I’ve updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I’ve considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I’ve updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted migration checks pass:

```text
$ .venv/bin/pytest tests/hermes_cli/test_kanban_core_functionality.py::test_legacy_db_without_skills_column_migrates tests/hermes_cli/test_kanban_core_functionality.py::test_legacy_spawn_failure_columns_are_copied_not_renamed -q
2 passed in 4.51s
```

Full Kanban core test file passes:

```text
$ .venv/bin/pytest tests/hermes_cli/test_kanban_core_functionality.py -q
140 passed in 8.34s
```

Full suite was run and is not green on this checkout:

```text
$ scripts/run_tests.sh
47 failed, 20129 passed, 51 skipped, 232 warnings in 471.41s (0:07:51)
```

The full-suite failures are outside the touched Kanban migration path. They are in cron script prompting, gateway approval/config/DingTalk/API/restart tests, update command tests, model provider persistence/validation, concurrent interrupt tests, browser Chromium detection tests, delegation credentials/heartbeat, Dockerfile TUI dependency checks, skill provenance, credential-pool dotenv fallback, Tirith marker handling, and Daytona/Vercel environment command wrappers.
