### PR TITLE
fix(error_classifier): recognize "out of extra usage" as 1M-beta rejection variant

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -453,17 +453,24 @@ def classify_api_error(
         )
 
     # Anthropic OAuth subscription rejects the 1M-context beta header.
-    # Observed error body: "The long context beta is not yet available for
-    # this subscription." Returned as HTTP 400 from native Anthropic when
-    # the subscription doesn't include 1M context, even though the request
-    # carries ``anthropic-beta: context-1m-2025-08-07``. The recovery path
-    # in run_agent.py rebuilds the Anthropic client with the beta stripped
-    # and retries once. Pattern is narrow enough that it won't collide with
-    # the 429 tier-gate pattern above (different status, different phrase).
-    if (
-        status_code == 400
-        and "long context beta" in error_msg
-        and "not yet available" in error_msg
+    # Returned as HTTP 400 from native Anthropic when the subscription
+    # doesn't include 1M context, even though the request carries
+    # ``anthropic-beta: context-1m-2025-08-07``. Anthropic surfaces this as
+    # one of two error messages for the same root cause:
+    #   1. "The long context beta is not yet available for this subscription."
+    #   2. "You're out of extra usage. Add more at claude.ai/settings/usage..."
+    # Variant (2) is observed on Claude.ai OAuth tokens (gateway/cron jobs
+    # using ``hermes auth add anthropic --type oauth`` or inheriting from
+    # ``~/.claude/.credentials.json``); without this branch it falls into
+    # the generic billing classifier and the recovery path never fires.
+    # Both variants are recovered by the same code path: strip the beta
+    # header (``drop_context_1m_beta=True``) and retry once. The
+    # ``oauth_1m_beta_retry_attempted`` guard in run_agent.py ensures a
+    # genuine billing exhaustion (variant 2 that doesn't recover after the
+    # strip) surfaces naturally on the second attempt.
+    if status_code == 400 and (
+        ("long context beta" in error_msg and "not yet available" in error_msg)
+        or "out of extra usage" in error_msg
     ):
         return _result(
             FailoverReason.oauth_long_context_beta_forbidden,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -564,6 +564,22 @@ class TestClassifyApiError:
         result = classify_api_error(e, provider="anthropic")
         assert result.reason != FailoverReason.oauth_long_context_beta_forbidden
 
+    def test_anthropic_oauth_out_of_extra_usage_classified_as_1m_beta(self):
+        """400 + "You're out of extra usage..." is the second variant of the
+        same root cause (1M-context beta rejected by Claude.ai OAuth
+        subscription). Should classify as oauth_long_context_beta_forbidden
+        so the recovery path strips the beta and retries; the
+        ``oauth_1m_beta_retry_attempted`` guard in run_agent.py ensures a
+        single retry, after which a genuine billing exhaustion surfaces."""
+        e = MockAPIError(
+            "You're out of extra usage. Add more at claude.ai/settings/usage and keep going.",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="anthropic", model="claude-haiku-4.5")
+        assert result.reason == FailoverReason.oauth_long_context_beta_forbidden
+        assert result.retryable is True
+        assert result.should_compress is False
+
     # ── Transport errors ──
 
     def test_read_timeout(self):


### PR DESCRIPTION
## Summary

Anthropic surfaces the same root cause (Claude.ai OAuth subscription without 1M-context beta entitlement) under **two different error messages** on HTTP 400:

1. `"The long context beta is not yet available for this subscription."` — already classified as `oauth_long_context_beta_forbidden`, recovery works.
2. `"You're out of extra usage. Add more at claude.ai/settings/usage..."` — was falling through to generic billing classifier, recovery never fired.

This PR folds variant (2) into the same classifier branch so the existing recovery path (`drop_context_1m_beta=True` + retry) handles both.

## Reproduction

Telegram gateway running 24/7 on a Claude.ai MAX OAuth token. Every cron job and incoming message failed permanently after 3 retries with a misleading "out of extra usage" error. Replaying the dumped request body through the SDK directly:

```
drop_context_1m_beta=False → "The long context beta is not yet available for this subscription."
drop_context_1m_beta=True  → succeeds for the same payload
```

Confirms variant (2) is the same root cause — Anthropic just returns different diagnostic text in some cases.

## Why this is safe

- The existing `oauth_1m_beta_retry_attempted` guard in `run_agent.py` (lines 12232-12251) ensures **single-shot retry**.
- If variant (2) is genuine billing exhaustion (not 1M-beta related) and doesn't recover after the strip, the second failure surfaces naturally — no infinite retry.
- Pattern is narrow (status 400 + exact phrase `"out of extra usage"`), no collision with the existing 429 long-context-tier branch above.

## Test plan

- [x] Added `test_anthropic_oauth_out_of_extra_usage_classified_as_1m_beta` covering variant (2).
- [x] Existing `test_anthropic_oauth_1m_beta_forbidden` still passes (variant 1 unchanged).
- [x] Existing `test_anthropic_oauth_1m_beta_forbidden_does_not_collide_with_tier_gate` still passes (429 tier-gate branch unaffected).
- [x] `test_400_without_beta_phrase_is_not_1m_beta_forbidden` still passes (no false positives on generic 400).

```
$ venv/bin/python -m pytest tests/agent/test_error_classifier.py -k "1m_beta or out_of_extra or tier_gate" -v
4 passed in 2.40s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)