### PR TITLE
fix(gateway): guard queued follow-up send result

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14390,11 +14390,16 @@ class GatewayRunner:
                                 "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",
                                 session_key or "?",
                             )
-                            await adapter.send(
+                            send_result = await adapter.send(
                                 source.chat_id,
                                 first_response,
                                 metadata=_status_thread_metadata,
                             )
+                            if send_result is not None and not getattr(send_result, "success", True):
+                                logger.warning(
+                                    "Failed to send first response before queued message: %s",
+                                    getattr(send_result, "error", send_result),
+                                )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
                     elif first_response:

--- a/tests/gateway/test_pending_event_none.py
+++ b/tests/gateway/test_pending_event_none.py
@@ -9,6 +9,7 @@ Also verifies that internal control interrupt reasons like "Stop requested"
 do not get recycled into the pending-user-message follow-up path.
 """
 
+from pathlib import Path
 from types import SimpleNamespace
 
 from gateway.run import _is_control_interrupt_message
@@ -70,3 +71,23 @@ class TestControlInterruptMessages:
     def test_real_user_interrupt_message_still_requeues(self):
         result = _extract_pending_text(True, None, "actually use postgres instead")
         assert result == "actually use postgres instead"
+
+
+def test_queued_followup_first_response_send_does_not_clobber_agent_result():
+    """The queued-follow-up resend must not overwrite the agent result dict.
+
+    A recurring Telegram crash can happen if this path assigns
+    ``result = await adapter.send(...)``.  ``adapter.send`` returns
+    SendResult, so the later ``result.get("messages")`` would crash with
+    AttributeError.  Pin the local invariant cheaply because the full
+    gateway run path is expensive to instantiate.
+    """
+    run_py = Path(__file__).resolve().parents[2] / "gateway" / "run.py"
+    source = run_py.read_text()
+    anchor = "final stream delivery not confirmed; sending first response before continuing."
+    start = source.index(anchor)
+    window = source[start : source.index("except Exception as e:", start)]
+
+    lines = [line.strip() for line in window.splitlines()]
+    assert "send_result = await adapter.send(" in lines
+    assert "result = await adapter.send(" not in lines


### PR DESCRIPTION
## Summary
- Keep queued follow-up first-response delivery result in `send_result`, separate from the agent result dict.
- Log unsuccessful platform sends without risking a later `result.get("messages")` crash.
- Add a regression test that prevents reintroducing `result = await adapter.send(...)` in this path.

## Test plan
- `python -m py_compile gateway/run.py tests/gateway/test_pending_event_none.py`
- `python -m pytest tests/gateway/test_pending_event_none.py -q -o 'addopts='`
- Local production gateway verification: 0 new `SendResult object has no attribute get` errors after the fix loaded.

## Notes
- Opened from `duclamvan:fix/gateway-queued-followup-sendresult` into `NousResearch:main`.
- No direct push to `NousResearch/hermes-agent`.
