### PR TITLE
fix(delegate): detect ACP abort and unrelated summaries as failed

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1555,12 +1555,18 @@ def _run_single_child(
             )
             _summary_lower = summary.strip().lower()
             _is_acp_abort = any(m in _summary_lower for m in _acp_abort_markers)
+            def _looks_like_bare_model_identifier(text: str) -> bool:
+                """True if text is just a raw model identifier with no task content."""
+                import re as _re
+                return bool(_re.match(
+                    r"^(claude|gpt|gemini|sonnet|opus|haiku)[\s:_-]?\S*$",
+                    text.strip(), _re.IGNORECASE
+                ))
             _is_model_name_only = (
                 effective_acp_command is not None
-                and len(summary.strip()) < 120
-                and any(m in _summary_lower for m in
-                        ("claude", "gpt", "gemini", "sonnet", "opus", "haiku"))
+                and len(summary.strip()) < 60
                 and api_calls == 0
+                and _looks_like_bare_model_identifier(summary.strip())
             )
             if _is_acp_abort:
                 status = "failed"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1546,10 +1546,30 @@ def _run_single_child(
         if interrupted:
             status = "interrupted"
         elif summary:
-            # A summary means the subagent produced usable output.
-            # exit_reason ("completed" vs "max_iterations") already
-            # tells the parent *how* the task ended.
-            status = "completed"
+            # ACP child agents can return summaries unrelated to the task
+            # (e.g. model name strings) or abort markers when
+            # requestPermission() is cancelled (issue #20807).
+            _acp_abort_markers = (
+                "tool use aborted", "tool_use aborted",
+                "requestpermission", "permission cancelled", "signal.aborted",
+            )
+            _summary_lower = summary.strip().lower()
+            _is_acp_abort = any(m in _summary_lower for m in _acp_abort_markers)
+            _is_model_name_only = (
+                effective_acp_command is not None
+                and len(summary.strip()) < 120
+                and any(m in _summary_lower for m in
+                        ("claude", "gpt", "gemini", "sonnet", "opus", "haiku"))
+                and api_calls == 0
+            )
+            if _is_acp_abort:
+                status = "failed"
+                summary = f"[ACP tool execution aborted] {summary}"
+            elif _is_model_name_only:
+                status = "failed"
+                summary = "[ACP returned unrelated summary - no task work detected] " + summary
+            else:
+                status = "completed"
         else:
             status = "failed"
 


### PR DESCRIPTION
## Problem

When using ACP child agents, `delegate_task` marked tasks as completed if any summary was returned — even when:
1. The child aborted tool execution (`requestPermission` cancelled, `signal.aborted`) and returned `Tool use aborted` text
2. The child returned a model-name-only string (e.g. `Claude Sonnet 4.6 (...)`) unrelated to the task with 0 API calls

## Fix

Detect both cases and surface them as `failed` with a descriptive prefix so the parent agent knows the task was not completed.

Fixes #20807