### PR TITLE
fix(doctor): skip availability warnings for user-disabled toolsets

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1341,7 +1341,10 @@ def run_doctor(args):
             else:
                 check_warn(item["name"], "(system dependency not met)")
 
-        # Count disabled tools with API key requirements
+        # Count disabled tools with API key requirements.
+        # NOTE: `unavailable` has already been filtered by
+        # `_apply_doctor_tool_availability_overrides`, which drops toolsets the
+        # user disabled on every platform. No second filter is needed here.
         api_disabled = [u for u in unavailable if (u.get("missing_vars") or u.get("env_vars"))]
         if api_disabled:
             issues.append("Run 'hermes setup' to configure missing API keys for full tool access")

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -125,10 +125,39 @@ def _doctor_tool_availability_detail(toolset: str) -> str:
     return ""
 
 
+def _toolsets_disabled_on_every_platform() -> set[str]:
+    """Return toolset keys the user has removed from every configured platform.
+
+    A toolset registered in code but absent from every entry in
+    ``platform_toolsets`` is one the user has opted out of via
+    ``hermes tools disable``. Doctor should not nag about its missing API
+    keys — the user has stated they don't intend to use it.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+    except Exception:
+        return set()
+    pts = cfg.get("platform_toolsets") or {}
+    if not isinstance(pts, dict) or not pts:
+        return set()
+    enabled_anywhere: set[str] = set()
+    for platform_list in pts.values():
+        if isinstance(platform_list, list):
+            enabled_anywhere.update(str(ts) for ts in platform_list)
+    try:
+        from tools.registry import registry as _reg
+        all_toolsets = set(_reg.get_registered_toolset_names())
+    except Exception:
+        return set()
+    return all_toolsets - enabled_anywhere
+
+
 def _apply_doctor_tool_availability_overrides(available: list[str], unavailable: list[dict]) -> tuple[list[str], list[dict]]:
     """Adjust runtime-gated tool availability for doctor diagnostics."""
     updated_available = list(available)
     updated_unavailable = []
+    user_disabled = _toolsets_disabled_on_every_platform()
     for item in unavailable:
         name = item.get("name")
         if _is_kanban_worker_env_gate(item):
@@ -138,6 +167,10 @@ def _apply_doctor_tool_availability_overrides(available: list[str], unavailable:
         if name == "honcho" and _honcho_is_configured_for_doctor():
             if "honcho" not in updated_available:
                 updated_available.append("honcho")
+            continue
+        if name in user_disabled:
+            # User opted out via `hermes tools disable <name>`. Skip the
+            # missing-API-key warning entirely.
             continue
         updated_unavailable.append(item)
     return updated_available, updated_unavailable

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -168,6 +168,140 @@ class TestDoctorToolAvailabilityOverrides:
         assert doctor._doctor_tool_availability_detail("kanban") == "(runtime-gated; loaded only for dispatcher-spawned workers)"
 
 
+class TestToolsetsDisabledOnEveryPlatform:
+    """Tests for the helper that identifies user-disabled toolsets so
+    doctor doesn't nag about their missing API keys."""
+
+    def _patch_config_and_registry(
+        self,
+        monkeypatch,
+        *,
+        config: dict | None,
+        registered: list[str] | None,
+        config_raises: bool = False,
+        registry_raises: bool = False,
+    ) -> None:
+        import hermes_cli.config as cli_config
+        import tools.registry as registry_mod
+
+        if config_raises:
+            def _boom(*_a, **_kw):
+                raise RuntimeError("config blew up")
+            monkeypatch.setattr(cli_config, "load_config", _boom)
+        else:
+            monkeypatch.setattr(cli_config, "load_config", lambda: config)
+
+        class _FakeRegistry:
+            def get_registered_toolset_names(self):
+                if registry_raises:
+                    raise RuntimeError("registry blew up")
+                return list(registered or [])
+
+        monkeypatch.setattr(registry_mod, "registry", _FakeRegistry())
+
+    def test_returns_toolsets_absent_from_every_platform(self, monkeypatch):
+        self._patch_config_and_registry(
+            monkeypatch,
+            config={"platform_toolsets": {"cli": ["terminal"], "tui": ["terminal"]}},
+            registered=["terminal", "web", "honcho"],
+        )
+
+        disabled = doctor._toolsets_disabled_on_every_platform()
+
+        assert disabled == {"web", "honcho"}
+
+    def test_keeps_toolset_enabled_on_at_least_one_platform(self, monkeypatch):
+        # `web` is on tui but not cli — still considered enabled.
+        self._patch_config_and_registry(
+            monkeypatch,
+            config={"platform_toolsets": {"cli": ["terminal"], "tui": ["terminal", "web"]}},
+            registered=["terminal", "web"],
+        )
+
+        assert doctor._toolsets_disabled_on_every_platform() == set()
+
+    def test_fails_open_when_load_config_raises(self, monkeypatch):
+        self._patch_config_and_registry(
+            monkeypatch,
+            config=None,
+            registered=["terminal", "web"],
+            config_raises=True,
+        )
+
+        assert doctor._toolsets_disabled_on_every_platform() == set()
+
+    def test_fails_open_when_registry_raises(self, monkeypatch):
+        self._patch_config_and_registry(
+            monkeypatch,
+            config={"platform_toolsets": {"cli": ["terminal"]}},
+            registered=None,
+            registry_raises=True,
+        )
+
+        assert doctor._toolsets_disabled_on_every_platform() == set()
+
+    def test_returns_empty_when_platform_toolsets_missing(self, monkeypatch):
+        self._patch_config_and_registry(
+            monkeypatch,
+            config={},
+            registered=["terminal", "web"],
+        )
+
+        assert doctor._toolsets_disabled_on_every_platform() == set()
+
+
+class TestDoctorOverridesRespectDisabledToolsets:
+    """Integration-style tests proving _apply_doctor_tool_availability_overrides
+    drops user-disabled toolsets from the unavailable list."""
+
+    def test_drops_user_disabled_toolset_from_unavailable(self, monkeypatch):
+        monkeypatch.setattr(
+            doctor, "_toolsets_disabled_on_every_platform", lambda: {"web"}
+        )
+
+        web_entry = {"name": "web", "env_vars": ["EXA_API_KEY"], "tools": ["web_search"]}
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [], [web_entry]
+        )
+
+        assert available == []
+        assert unavailable == []
+
+    def test_keeps_warning_for_enabled_toolset(self, monkeypatch):
+        monkeypatch.setattr(
+            doctor, "_toolsets_disabled_on_every_platform", lambda: set()
+        )
+
+        web_entry = {"name": "web", "env_vars": ["EXA_API_KEY"], "tools": ["web_search"]}
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [], [web_entry]
+        )
+
+        assert available == []
+        assert unavailable == [web_entry]
+
+    def test_honcho_and_kanban_overrides_run_before_disabled_check(self, monkeypatch):
+        # honcho is "user_disabled" in this fake set, but the honcho-configured
+        # branch should fire first and mark it available.
+        monkeypatch.setattr(doctor, "_honcho_is_configured_for_doctor", lambda: True)
+        monkeypatch.setattr(
+            doctor, "_toolsets_disabled_on_every_platform", lambda: {"honcho", "kanban"}
+        )
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [],
+            [
+                {"name": "honcho", "env_vars": [], "tools": ["query_user_context"]},
+                {"name": "kanban", "env_vars": [], "tools": ["kanban_show"]},
+            ],
+        )
+
+        assert "honcho" in available
+        assert "kanban" in available
+        assert unavailable == []
+
+
 class TestHonchoDoctorConfigDetection:
     def test_reports_configured_when_enabled_with_api_key(self, monkeypatch):
         fake_config = SimpleNamespace(enabled=True, api_key="***")


### PR DESCRIPTION
## Summary

`hermes doctor` currently warns about missing API keys for **every** registered toolset, even ones the user explicitly disabled via `hermes tools disable <name>` (or by editing `platform_toolsets` in their profile config). This adds an actionable "Run 'hermes setup' to configure missing API keys" issue that points at gaps the user has already chosen not to fill.

This PR teaches the existing `_apply_doctor_tool_availability_overrides` to drop unavailable entries for toolsets that aren't enabled on **any** platform.

## Why

Concrete example — a user who uses the bundled `scrapling` MCP server for web search has no reason to set `EXA_API_KEY` / `PARALLEL_API_KEY` / `TAVILY_API_KEY` / `FIRECRAWL_API_KEY`. After they run `hermes tools disable web`, doctor still reports:

```
⚠ web (missing EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL)
...
3. Run 'hermes setup' to configure missing API keys for full tool access
```

The warning is correct in the abstract (the keys ARE missing) but actively misleading — the user has stated their intent and shouldn't be nagged.

## What changed

- `hermes_cli/doctor.py`:
  - New helper `_toolsets_disabled_on_every_platform()` returns the set difference between registered toolsets and toolsets enabled on at least one platform.
  - `_apply_doctor_tool_availability_overrides` now drops items in that set from the `unavailable` list.
  - Fails open: any failure reading config or the registry returns an empty set, preserving current behavior.
  - One-line comment at the `api_disabled` summary documenting that no second filter is needed there — `unavailable` has already been pruned upstream.
- `tests/hermes_cli/test_doctor.py`:
  - `TestToolsetsDisabledOnEveryPlatform` (5 cases): set-difference correctness, single-platform exemption, fail-open on `load_config` error, fail-open on registry error, missing `platform_toolsets`.
  - `TestDoctorOverridesRespectDisabledToolsets` (3 cases): drops user-disabled toolset, keeps warning when enabled, honcho/kanban runtime overrides still fire before the disabled check.

## Relationship to #11338 / #11361 / #11648

Per @alt-glitch's note, this is the 4th PR addressing #11336. All four solve the same user complaint but intervene at different layers:

| PR | Layer | Mechanism |
|---|---|---|
| **This PR (#20863)** | Source — `_apply_doctor_tool_availability_overrides` | Drops user-disabled toolsets from `unavailable` before any consumer sees them |
| #11338 | Late — summary line | Imports `_get_platform_tools` to filter at the `api_disabled` list-comprehension |
| #11361 | Late — summary line | Imports `resolve_enabled_toolsets_for_platform` to filter at the `api_disabled` list-comprehension |
| #11648 | Late — summary line (with full doctor.py reformat) | Same late-filter approach folded into a 1144/1131-line rewrite |

Filtering at the source means the disabled toolset never reaches *any* downstream consumer — the existing `api_disabled = [...]` line stays correct without modification, and any future code that reads `unavailable` (e.g. JSON output, future probes) inherits the correct semantics for free. The late-filter PRs only patch the one symptom currently visible.

If this lands first, the doctor.py changes in #11338 / #11361 / #11648 become no-ops (the late filter would be filtering a list that no longer contains disabled items). The orthogonal changes in those PRs — atomic JSONL trajectory writes (#11361), `<REASONING_SCRATCHPAD>` false-positive fix (#11361), Gemini OAuth removal (#11338) — should be split into separate PRs regardless of which approach lands.

## Compatibility

- No new config keys, no env vars, no behavior change for users who haven't disabled anything.
- Existing kanban / honcho overrides are untouched and run before the disabled check (covered by `test_honcho_and_kanban_overrides_run_before_disabled_check`).
- Toolsets enabled on at least one platform still get the existing missing-key warning — only toolsets disabled **everywhere** are skipped.

## Test plan

- [x] `pytest tests/hermes_cli/test_doctor.py -k "ToolAvailability or ToolsetsDisabled or DoctorOverrides"` → 14 passed
- [x] Manual: `hermes tools disable web` → `hermes doctor` no longer warns about web's missing keys, and the actionable "Run 'hermes setup'…" issue disappears when web was the only complainant
- [x] Manual: re-enable web → warning returns
- [ ] Reviewer: confirm with a profile that uses default toolsets — no behavior change for users who haven't customized
