### PR TITLE
[codex] Fix dashboard chat and browser voice over Tailscale

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18,6 +18,7 @@ import os
 import secrets
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import urllib.parse
@@ -77,6 +78,20 @@ _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 # In-browser Chat tab (/chat, /api/pty, …).  Off unless ``hermes dashboard --tui``
 # or HERMES_DASHBOARD_TUI=1.  Set from :func:`start_server`.
 _DASHBOARD_EMBEDDED_CHAT_ENABLED = False
+
+_DASHBOARD_VOICE_READ_CHUNK_SIZE = 1024 * 1024
+_DASHBOARD_VOICE_CONTENT_TYPE_SUFFIXES = {
+    "audio/aac": ".aac",
+    "audio/flac": ".flac",
+    "audio/mp4": ".mp4",
+    "audio/mpeg": ".mp3",
+    "audio/mp3": ".mp3",
+    "audio/ogg": ".ogg",
+    "audio/wav": ".wav",
+    "audio/wave": ".wav",
+    "audio/webm": ".webm",
+    "audio/x-wav": ".wav",
+}
 
 # Simple rate limiter for the reveal endpoint
 _reveal_timestamps: List[float] = []
@@ -147,17 +162,20 @@ _LOOPBACK_HOST_VALUES: frozenset = frozenset({
 })
 
 
-def _is_accepted_host(host_header: str, bound_host: str) -> bool:
-    """True if the Host header targets the interface we bound to.
+def _extra_accepted_hosts() -> set[str]:
+    """Dashboard hosts explicitly allowed behind a trusted local proxy."""
+    raw = os.environ.get("HERMES_DASHBOARD_ALLOWED_HOSTS", "")
+    return {
+        host.strip().lower().rsplit(":", 1)[0]
+        for host in raw.split(",")
+        if host.strip()
+    }
 
-    Accepts:
-    - Exact bound host (with or without port suffix)
-    - Loopback aliases when bound to loopback
-    - Any host when bound to 0.0.0.0 (explicit opt-in to non-loopback,
-      no protection possible at this layer)
-    """
+
+def _host_from_header(host_header: str) -> str:
+    """Return a normalized host name from an HTTP/WebSocket Host header."""
     if not host_header:
-        return False
+        return ""
     # Strip port suffix. IPv6 addresses use bracket notation:
     #   [::1]         — no port
     #   [::1]:9119    — with port
@@ -174,7 +192,21 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
             host_only = h.strip("[]")
     else:
         host_only = h.rsplit(":", 1)[0] if ":" in h else h
-    host_only = host_only.lower()
+    return host_only.lower()
+
+
+def _is_accepted_host(host_header: str, bound_host: str) -> bool:
+    """True if the Host header targets the interface we bound to.
+
+    Accepts:
+    - Exact bound host (with or without port suffix)
+    - Loopback aliases when bound to loopback
+    - Any host when bound to 0.0.0.0 (explicit opt-in to non-loopback,
+      no protection possible at this layer)
+    """
+    if not host_header:
+        return False
+    host_only = _host_from_header(host_header)
 
     # 0.0.0.0 bind means operator explicitly opted into all-interfaces
     # (requires --insecure per web_server.start_server). No Host-layer
@@ -185,7 +217,10 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     # Loopback bind: accept the loopback names
     bound_lc = bound_host.lower()
     if bound_lc in _LOOPBACK_HOST_VALUES:
-        return host_only in _LOOPBACK_HOST_VALUES
+        return (
+            host_only in _LOOPBACK_HOST_VALUES
+            or host_only in _extra_accepted_hosts()
+        )
 
     # Explicit non-loopback bind: require exact host match
     return host_only == bound_lc
@@ -2916,6 +2951,10 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
     """
     if _is_public_bind():
         return True
+    headers_get = getattr(getattr(ws, "headers", None), "get", None)
+    host_header = headers_get("host", "") if headers_get else ""
+    if _host_from_header(host_header) in _extra_accepted_hosts():
+        return True
     client_host = ws.client.host if ws.client else ""
     if not client_host:
         return True
@@ -2961,6 +3000,108 @@ def _resolve_chat_argv(
         env["HERMES_TUI_SIDECAR_URL"] = sidecar_url
 
     return list(argv), str(cwd) if cwd else None, env
+
+
+def _dashboard_voice_suffix(
+    filename: str,
+    content_type: str,
+    supported_formats: set[str],
+) -> str:
+    """Return a safe suffix for browser-recorded dashboard audio."""
+    suffix = Path(filename or "").suffix.lower()
+    if suffix in supported_formats:
+        return suffix
+
+    media_type = (content_type or "").split(";", 1)[0].strip().lower()
+    return _DASHBOARD_VOICE_CONTENT_TYPE_SUFFIXES.get(media_type, "")
+
+
+async def _write_dashboard_voice_body(
+    request: Request,
+    *,
+    suffix: str,
+    max_size: int,
+) -> str:
+    """Persist one bounded raw audio upload and return its temporary path."""
+    tmp_path = ""
+    size = 0
+    try:
+        with tempfile.NamedTemporaryFile(
+            suffix=suffix,
+            prefix="dashboard_voice_",
+            delete=False,
+        ) as tmp:
+            tmp_path = tmp.name
+            async for chunk in request.stream():
+                if not chunk:
+                    continue
+                size += len(chunk)
+                if size > max_size:
+                    raise HTTPException(status_code=413, detail="audio too large")
+                tmp.write(chunk)
+    except Exception:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+        raise
+
+    if size == 0:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise HTTPException(status_code=400, detail="empty audio upload")
+
+    return tmp_path
+
+
+@app.post("/api/voice/transcribe")
+async def dashboard_voice_transcribe(request: Request) -> dict:
+    """Transcribe microphone audio captured by the dashboard browser.
+
+    The classic CLI/TUI voice path records with ``sounddevice`` on the host
+    running Hermes.  The dashboard is often opened from another device (for
+    example a MacBook/iPhone controlling a Mac mini over Tailscale), so this
+    endpoint accepts audio recorded by ``MediaRecorder`` in the browser and
+    reuses the existing STT pipeline server-side.  The returned transcript is
+    injected into the embedded PTY by the React chat page; this endpoint does
+    not create a second chat surface.
+    """
+    from tools.transcription_tools import MAX_FILE_SIZE, SUPPORTED_FORMATS, transcribe_audio
+
+    filename = request.query_params.get("filename", "")
+    suffix = _dashboard_voice_suffix(
+        filename,
+        request.headers.get("content-type", ""),
+        SUPPORTED_FORMATS,
+    )
+    if suffix not in SUPPORTED_FORMATS:
+        raise HTTPException(status_code=415, detail="unsupported audio format")
+
+    tmp_path = await _write_dashboard_voice_body(
+        request,
+        suffix=suffix,
+        max_size=MAX_FILE_SIZE,
+    )
+    try:
+        result = await asyncio.to_thread(transcribe_audio, tmp_path)
+        if result.get("success"):
+            try:
+                from tools.voice_mode import is_whisper_hallucination
+
+                transcript = str(result.get("transcript", ""))
+                if is_whisper_hallucination(transcript):
+                    return {"success": True, "transcript": "", "filtered": True}
+            except Exception as exc:
+                _log.debug("dashboard voice hallucination filter skipped: %s", exc)
+        return result
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
 
 
 def _build_sidecar_url(channel: str) -> Optional[str]:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14,6 +14,7 @@ import hmac
 import importlib.util
 import json
 import logging
+import mimetypes
 import os
 import secrets
 import subprocess
@@ -51,7 +52,7 @@ from hermes_cli.config import (
 from gateway.status import get_running_pid, read_runtime_status
 
 try:
-    from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+    from fastapi import BackgroundTasks, FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
     from fastapi.staticfiles import StaticFiles
@@ -80,6 +81,7 @@ _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
 _DASHBOARD_EMBEDDED_CHAT_ENABLED = False
 
 _DASHBOARD_VOICE_READ_CHUNK_SIZE = 1024 * 1024
+_DASHBOARD_VOICE_TTS_MAX_CHARS = 4000
 _DASHBOARD_VOICE_CONTENT_TYPE_SUFFIXES = {
     "audio/aac": ".aac",
     "audio/flac": ".flac",
@@ -493,6 +495,10 @@ class ModelAssignment(BaseModel):
     provider: str
     model: str
     task: str = ""
+
+
+class DashboardVoiceSynthesizeRequest(BaseModel):
+    text: str
 
 
 _GATEWAY_HEALTH_URL = os.getenv("GATEWAY_HEALTH_URL")
@@ -3057,6 +3063,24 @@ async def _write_dashboard_voice_body(
     return tmp_path
 
 
+def _cleanup_dashboard_voice_paths(paths: Tuple[str, ...]) -> None:
+    """Best-effort cleanup for dashboard-generated voice artifacts."""
+    for path in paths:
+        if not path:
+            continue
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            _log.debug("dashboard voice cleanup failed for %s: %s", path, exc)
+
+
+def _dashboard_audio_media_type(path: str) -> str:
+    media_type, _encoding = mimetypes.guess_type(path)
+    return media_type or "application/octet-stream"
+
+
 @app.post("/api/voice/transcribe")
 async def dashboard_voice_transcribe(request: Request) -> dict:
     """Transcribe microphone audio captured by the dashboard browser.
@@ -3102,6 +3126,75 @@ async def dashboard_voice_transcribe(request: Request) -> dict:
             os.unlink(tmp_path)
         except OSError:
             pass
+
+
+@app.post("/api/voice/synthesize")
+async def dashboard_voice_synthesize(body: DashboardVoiceSynthesizeRequest) -> FileResponse:
+    """Synthesize dashboard speech with Hermes' configured TTS provider.
+
+    The classic ``speak_text`` path plays audio on the host that runs Hermes.
+    Dashboard users may be on another device over Tailscale, so this endpoint
+    reuses ``text_to_speech_tool`` to generate audio server-side and returns
+    the bytes for playback in the browser.
+    """
+    from tools.tts_tool import text_to_speech_tool
+
+    text = body.text.strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="text is required")
+    if len(text) > _DASHBOARD_VOICE_TTS_MAX_CHARS:
+        raise HTTPException(status_code=413, detail="text too large")
+
+    fd, requested_path = tempfile.mkstemp(
+        suffix=".mp3",
+        prefix="dashboard_tts_",
+    )
+    os.close(fd)
+    cleanup_paths = {requested_path}
+
+    try:
+        raw_result = await asyncio.to_thread(
+            text_to_speech_tool,
+            text,
+            requested_path,
+        )
+        try:
+            result = json.loads(raw_result)
+        except json.JSONDecodeError as exc:
+            raise HTTPException(
+                status_code=502,
+                detail="TTS returned an invalid response",
+            ) from exc
+
+        if not result.get("success"):
+            raise HTTPException(
+                status_code=502,
+                detail=str(result.get("error") or "TTS synthesis failed"),
+            )
+
+        file_path = str(result.get("file_path") or requested_path)
+        cleanup_paths.add(file_path)
+        if not Path(file_path).exists() or Path(file_path).stat().st_size <= 0:
+            raise HTTPException(
+                status_code=502,
+                detail="TTS synthesis produced no audio",
+            )
+
+        cleanup_task = BackgroundTasks()
+        cleanup_task.add_task(_cleanup_dashboard_voice_paths, tuple(cleanup_paths))
+        return FileResponse(
+            file_path,
+            media_type=_dashboard_audio_media_type(file_path),
+            filename=Path(file_path).name,
+            background=cleanup_task,
+        )
+    except HTTPException:
+        _cleanup_dashboard_voice_paths(tuple(cleanup_paths))
+        raise
+    except Exception as exc:
+        _cleanup_dashboard_voice_paths(tuple(cleanup_paths))
+        _log.exception("dashboard voice synthesis failed")
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
 
 
 def _build_sidecar_url(channel: str) -> Optional[str]:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2897,8 +2897,15 @@ _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
 
 
 def _is_public_bind() -> bool:
-    """True when bound to all-interfaces (operator used --insecure)."""
-    return getattr(app.state, "bound_host", "") in ("0.0.0.0", "::")
+    """True when the dashboard is reachable by non-loopback clients.
+
+    ``--insecure`` can bind either to all interfaces or to a specific private
+    interface such as a Tailscale IP.  In both cases, token-protected chat
+    WebSockets must accept non-loopback peers; otherwise the dashboard loads
+    remotely while the Chat tab closes with 4403.
+    """
+    host = getattr(app.state, "bound_host", "")
+    return host not in _LOOPBACK_HOSTS
 
 
 def _ws_client_is_allowed(ws: "WebSocket") -> bool:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -331,6 +331,115 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         assert resp.json() == {"success": True, "transcript": "", "filtered": True}
 
+    def test_dashboard_voice_synthesize_requires_token(self):
+        from starlette.testclient import TestClient
+        from hermes_cli.web_server import app
+
+        unauth_client = TestClient(app)
+        resp = unauth_client.post(
+            "/api/voice/synthesize",
+            json={"text": "hello"},
+        )
+
+        assert resp.status_code == 401
+
+    def test_dashboard_voice_synthesize_rejects_empty_text(self):
+        resp = self.client.post(
+            "/api/voice/synthesize",
+            json={"text": "   "},
+        )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "text is required"
+
+    def test_dashboard_voice_synthesize_rejects_large_text(self):
+        resp = self.client.post(
+            "/api/voice/synthesize",
+            json={"text": "x" * 4001},
+        )
+
+        assert resp.status_code == 413
+        assert resp.json()["detail"] == "text too large"
+
+    def test_dashboard_voice_synthesize_uses_existing_tts_and_cleans_temp(self, monkeypatch):
+        import tools.tts_tool as tts_tool
+
+        seen_paths: list[str] = []
+
+        def fake_tts(text: str, output_path: str):
+            seen_paths.append(output_path)
+            assert text == "dashboard speech"
+            assert Path(output_path).suffix == ".mp3"
+            Path(output_path).write_bytes(b"fake mp3 audio")
+            return json.dumps({
+                "success": True,
+                "file_path": output_path,
+                "provider": "edge",
+            })
+
+        monkeypatch.setattr(tts_tool, "text_to_speech_tool", fake_tts)
+
+        resp = self.client.post(
+            "/api/voice/synthesize",
+            json={"text": "dashboard speech"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("audio/mpeg")
+        assert resp.content == b"fake mp3 audio"
+        assert len(seen_paths) == 1
+        assert not Path(seen_paths[0]).exists()
+
+    def test_dashboard_voice_synthesize_cleans_converted_output(self, monkeypatch):
+        import tools.tts_tool as tts_tool
+
+        seen_paths: list[str] = []
+
+        def fake_tts(_text: str, output_path: str):
+            seen_paths.append(output_path)
+            ogg_path = str(Path(output_path).with_suffix(".ogg"))
+            Path(output_path).write_bytes(b"source mp3")
+            Path(ogg_path).write_bytes(b"fake ogg audio")
+            return json.dumps({
+                "success": True,
+                "file_path": ogg_path,
+                "provider": "edge",
+            })
+
+        monkeypatch.setattr(tts_tool, "text_to_speech_tool", fake_tts)
+
+        resp = self.client.post(
+            "/api/voice/synthesize",
+            json={"text": "dashboard speech"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("audio/ogg")
+        assert resp.content == b"fake ogg audio"
+        assert len(seen_paths) == 1
+        assert not Path(seen_paths[0]).exists()
+        assert not Path(seen_paths[0]).with_suffix(".ogg").exists()
+
+    def test_dashboard_voice_synthesize_surfaces_tts_failure(self, monkeypatch):
+        import tools.tts_tool as tts_tool
+
+        monkeypatch.setattr(
+            tts_tool,
+            "text_to_speech_tool",
+            lambda _text, _output_path: json.dumps({
+                "success": False,
+                "error": "tts unavailable",
+            }),
+        )
+
+        resp = self.client.post(
+            "/api/voice/synthesize",
+            json={"text": "dashboard speech"},
+        )
+
+        assert resp.status_code == 502
+        assert resp.json()["detail"] == "tts unavailable"
+
     def test_get_config_schema(self):
         resp = self.client.get("/api/config/schema")
         assert resp.status_code == 200

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -210,6 +210,127 @@ class TestWebServerEndpoints:
         assert web_server._is_public_bind() is False
         assert web_server._ws_client_is_allowed(ws) is False
 
+    def test_loopback_dashboard_allows_explicit_proxy_host(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_ALLOWED_HOSTS",
+            "mac-mini-de-ergonomia-mac-mini.taild069eb.ts.net",
+        )
+
+        assert web_server._is_accepted_host(
+            "mac-mini-de-ergonomia-mac-mini.taild069eb.ts.net",
+            "127.0.0.1",
+        ) is True
+
+    def test_loopback_dashboard_rejects_unlisted_proxy_host(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.delenv("HERMES_DASHBOARD_ALLOWED_HOSTS", raising=False)
+
+        assert web_server._is_accepted_host(
+            "mac-mini-de-ergonomia-mac-mini.taild069eb.ts.net",
+            "127.0.0.1",
+        ) is False
+
+    def test_chat_websocket_allows_explicit_proxy_host_on_loopback_bind(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server.app.state, "bound_host", "127.0.0.1", raising=False)
+        monkeypatch.setenv(
+            "HERMES_DASHBOARD_ALLOWED_HOSTS",
+            "mac-mini-de-ergonomia-mac-mini.taild069eb.ts.net",
+        )
+        ws = SimpleNamespace(
+            client=SimpleNamespace(host="100.101.102.103"),
+            headers={"host": "mac-mini-de-ergonomia-mac-mini.taild069eb.ts.net"},
+        )
+
+        assert web_server._is_public_bind() is False
+        assert web_server._ws_client_is_allowed(ws) is True
+
+    def test_dashboard_voice_transcribe_requires_token(self):
+        from starlette.testclient import TestClient
+        from hermes_cli.web_server import app
+
+        unauth_client = TestClient(app)
+        resp = unauth_client.post(
+            "/api/voice/transcribe",
+            content=b"fake webm",
+            headers={"Content-Type": "audio/webm"},
+        )
+
+        assert resp.status_code == 401
+
+    def test_dashboard_voice_transcribe_rejects_unsupported_audio(self):
+        resp = self.client.post(
+            "/api/voice/transcribe",
+            content=b"not audio",
+            headers={"Content-Type": "application/octet-stream"},
+        )
+
+        assert resp.status_code == 415
+
+    def test_dashboard_voice_transcribe_rejects_oversized_upload(self, monkeypatch):
+        import tools.transcription_tools as transcription_tools
+
+        monkeypatch.setattr(transcription_tools, "MAX_FILE_SIZE", 4)
+        monkeypatch.setattr(
+            transcription_tools,
+            "transcribe_audio",
+            lambda path: pytest.fail("oversized upload must not be transcribed"),
+        )
+
+        resp = self.client.post(
+            "/api/voice/transcribe",
+            content=b"12345",
+            headers={"Content-Type": "audio/webm"},
+        )
+
+        assert resp.status_code == 413
+
+    def test_dashboard_voice_transcribe_uses_existing_stt_and_cleans_temp(self, monkeypatch):
+        import tools.transcription_tools as transcription_tools
+
+        seen_paths: list[str] = []
+
+        def fake_transcribe(path: str):
+            seen_paths.append(path)
+            assert Path(path).suffix == ".webm"
+            assert Path(path).read_bytes() == b"fake webm audio"
+            return {"success": True, "transcript": "dashboard transcript"}
+
+        monkeypatch.setattr(transcription_tools, "transcribe_audio", fake_transcribe)
+
+        resp = self.client.post(
+            "/api/voice/transcribe?filename=recording.webm",
+            content=b"fake webm audio",
+            headers={"Content-Type": "audio/webm;codecs=opus"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"success": True, "transcript": "dashboard transcript"}
+        assert len(seen_paths) == 1
+        assert not Path(seen_paths[0]).exists()
+
+    def test_dashboard_voice_transcribe_filters_whisper_hallucination(self, monkeypatch):
+        import tools.transcription_tools as transcription_tools
+
+        monkeypatch.setattr(
+            transcription_tools,
+            "transcribe_audio",
+            lambda path: {"success": True, "transcript": "Thank you."},
+        )
+
+        resp = self.client.post(
+            "/api/voice/transcribe",
+            content=b"silent audio",
+            headers={"Content-Type": "audio/webm"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"success": True, "transcript": "", "filtered": True}
+
     def test_get_config_schema(self):
         resp = self.client.get("/api/config/schema")
         assert resp.status_code == 200

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -4,6 +4,7 @@ import os
 import json
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -190,6 +191,24 @@ class TestWebServerEndpoints:
         assert resp.status_code == 200
         assert resp.json()["gateway_state"] == "startup_failed"
         assert resp.json()["gateway_platforms"] == {}
+
+    def test_chat_websocket_allows_remote_client_on_tailscale_bind(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server.app.state, "bound_host", "100.64.119.29", raising=False)
+        ws = SimpleNamespace(client=SimpleNamespace(host="100.101.102.103"))
+
+        assert web_server._is_public_bind() is True
+        assert web_server._ws_client_is_allowed(ws) is True
+
+    def test_chat_websocket_rejects_remote_client_on_loopback_bind(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server.app.state, "bound_host", "127.0.0.1", raising=False)
+        ws = SimpleNamespace(client=SimpleNamespace(host="100.101.102.103"))
+
+        assert web_server._is_public_bind() is False
+        assert web_server._ws_client_is_allowed(ws) is False
 
     def test_get_config_schema(self):
         resp = self.client.get("/api/config/schema")

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -359,6 +359,16 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
   })
 
+  it('/stop interrupts the active turn without sending terminal Ctrl+C', () => {
+    patchUiState({ busy: true, sid: 'sid-abc' })
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/stop')).toBe(true)
+
+    expect(ctx.gateway.gw.request).toHaveBeenCalledWith('session.interrupt', { session_id: 'sid-abc' })
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('process.stop', {})
+  })
+
   it('renders browser connect progress messages from the gateway', async () => {
     const rpc = vi.fn(() =>
       Promise.resolve({
@@ -746,6 +756,7 @@ const buildSession = () => ({
 })
 
 const buildTranscript = () => ({
+  appendMessage: vi.fn(),
   page: vi.fn(),
   panel: vi.fn(),
   send: vi.fn(),

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -285,6 +285,7 @@ export interface SlashHandlerContext {
   }
   slashFlightRef: MutableRefObject<number>
   transcript: {
+    appendMessage: (msg: Msg) => void
     page: (text: string, title?: string) => void
     panel: (title: string, sections: PanelSection[]) => void
     send: (text: string) => void

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -17,6 +17,7 @@ import type { PanelSection } from '../../../types.js'
 import { applyDelegationStatus, getDelegationState } from '../../delegationStore.js'
 import { patchOverlayState } from '../../overlayStore.js'
 import { getSpawnHistory, pushDiskSnapshot, setDiffPair, type SpawnSnapshot } from '../../spawnHistoryStore.js'
+import { turnController } from '../../turnController.js'
 import type { SlashCommand } from '../types.js'
 
 interface SkillInfo {
@@ -63,9 +64,18 @@ interface SkillsReloadResponse {
 
 export const opsCommands: SlashCommand[] = [
   {
-    help: 'stop background processes',
+    help: 'stop the active turn and background processes',
     name: 'stop',
     run: (_arg, ctx) => {
+      if (ctx.ui.busy && ctx.sid) {
+        turnController.interruptTurn({
+          appendMessage: ctx.transcript.appendMessage,
+          gw: ctx.gateway.gw,
+          sid: ctx.sid,
+          sys: ctx.transcript.sys
+        })
+      }
+
       ctx.gateway
         .rpc<ProcessStopResponse>('process.stop', {})
         .then(

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -644,7 +644,7 @@ export function useMainApp(gw: GatewayClient) {
           setSessionStartedAt
         },
         slashFlightRef,
-        transcript: { page, panel, send, setHistoryItems, sys, trimLastExchange: session.trimLastExchange },
+        transcript: { appendMessage, page, panel, send, setHistoryItems, sys, trimLastExchange: session.trimLastExchange },
         voice: { setVoiceEnabled, setVoiceRecordKey }
       }),
     [

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "node --test tests/*.test.ts",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/lib/handsFreeVoice.ts
+++ b/web/src/lib/handsFreeVoice.ts
@@ -1,0 +1,239 @@
+export type HandsFreeState =
+  | "off"
+  | "listening"
+  | "recording"
+  | "transcribing"
+  | "thinking"
+  | "speaking";
+
+export interface HandsFreeMicStats {
+  level: number;
+  noise: number;
+  speaking: boolean;
+  threshold: number;
+}
+
+export const HANDS_FREE_INITIAL_NOISE_FLOOR = 0.01;
+export const HANDS_FREE_NOISE_ALPHA = 0.035;
+export const HANDS_FREE_MAX_UTTERANCE_MS = 30_000;
+export const HANDS_FREE_CHUNK_MAX_CHARS = 650;
+export const HANDS_FREE_STREAM_CHUNK_MIN_CHARS = 520;
+export const HANDS_FREE_METER_UPDATE_MS = 120;
+export const HANDS_FREE_BASE_SPEECH_RMS = 0.022;
+export const HANDS_FREE_BASE_SILENCE_RMS = 0.012;
+export const HANDS_FREE_SPEECH_DELTA_RMS = 0.012;
+export const HANDS_FREE_SILENCE_DELTA_RMS = 0.006;
+export const HANDS_FREE_MIN_RECORDING_MS = 650;
+export const HANDS_FREE_SILENCE_MS = 1500;
+export const HANDS_FREE_MAX_SPOKEN_CHARS = 650;
+export const HANDS_FREE_TRUNCATION_NOTICE = "Le detail est dans le chat.";
+export const HANDS_FREE_SILENT_WAV =
+  "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAESsAACJWAAACABAAZGF0YQAAAAA=";
+
+export const DEFAULT_HANDS_FREE_MIC_STATS: HandsFreeMicStats = {
+  level: 0,
+  noise: HANDS_FREE_INITIAL_NOISE_FLOOR,
+  speaking: false,
+  threshold: HANDS_FREE_BASE_SPEECH_RMS,
+};
+
+export function rmsFromTimeDomain(data: Uint8Array<ArrayBuffer>): number {
+  let sum = 0;
+  for (const sample of data) {
+    const centered = (sample - 128) / 128;
+    sum += centered * centered;
+  }
+  return Math.sqrt(sum / Math.max(1, data.length));
+}
+
+export function handsFreeSpeechThreshold(noiseFloor: number): number {
+  return Math.max(HANDS_FREE_BASE_SPEECH_RMS, noiseFloor + HANDS_FREE_SPEECH_DELTA_RMS);
+}
+
+export function handsFreeSilenceThreshold(noiseFloor: number): number {
+  return Math.max(HANDS_FREE_BASE_SILENCE_RMS, noiseFloor + HANDS_FREE_SILENCE_DELTA_RMS);
+}
+
+export function normalizeTranscriptCommand(text: string): string {
+  return text
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9\s]/g, "")
+    .replace(/\s+/g, " ");
+}
+
+export function isHandsFreeStopCommand(text: string): boolean {
+  const normalized = normalizeTranscriptCommand(text);
+  return [
+    "stop",
+    "pause",
+    "arrete",
+    "arretes",
+    "attends",
+    "silence",
+    "tais toi",
+    "coupe",
+    "stoppe",
+  ].includes(normalized);
+}
+
+export function isHandsFreeDisableCommand(text: string): boolean {
+  const normalized = normalizeTranscriptCommand(text);
+  return [
+    "arrete le mode vocal",
+    "arretes le mode vocal",
+    "coupe le mode vocal",
+    "desactive le mode vocal",
+    "quitte le mode vocal",
+    "stop hands free",
+    "stop mode vocal",
+    "stoppe le mode vocal",
+  ].includes(normalized);
+}
+
+export function sanitizeHandsFreeSpeechText(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/^MEDIA:.*$/gim, " ")
+    .replace(/^\s*\[\[audio_as_voice\]\]\s*$/gim, " ")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/[`*_>#-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function prepareHandsFreeSpeech(text: string): string {
+  let clean = sanitizeHandsFreeSpeechText(text);
+
+  if (clean.length <= HANDS_FREE_MAX_SPOKEN_CHARS) {
+    return clean;
+  }
+
+  const slice = clean.slice(0, HANDS_FREE_MAX_SPOKEN_CHARS);
+  const boundary = Math.max(
+    slice.lastIndexOf("."),
+    slice.lastIndexOf("!"),
+    slice.lastIndexOf("?"),
+    slice.lastIndexOf("\n"),
+  );
+  const minimumBoundary = Math.min(420, Math.floor(HANDS_FREE_MAX_SPOKEN_CHARS * 0.7));
+  clean = slice.slice(
+    0,
+    boundary > minimumBoundary ? boundary + 1 : HANDS_FREE_MAX_SPOKEN_CHARS,
+  ).trim();
+  return `${clean} ${HANDS_FREE_TRUNCATION_NOTICE}`;
+}
+
+export function splitHandsFreeSpeech(text: string): string[] {
+  const clean = prepareHandsFreeSpeech(text);
+  if (!clean) return [];
+
+  const sentences = clean.match(/[^.!?]+[.!?]+|[^.!?]+$/g) ?? [clean];
+  const chunks: string[] = [];
+  let current = "";
+
+  for (const rawSentence of sentences) {
+    const sentence = rawSentence.trim();
+    if (!sentence) continue;
+    if (!current) {
+      current = sentence;
+      continue;
+    }
+    if (`${current} ${sentence}`.length <= HANDS_FREE_CHUNK_MAX_CHARS) {
+      current = `${current} ${sentence}`;
+      continue;
+    }
+    chunks.push(current);
+    current = sentence;
+  }
+
+  if (current) chunks.push(current);
+  return chunks.flatMap((chunk) => {
+    if (chunk.length <= HANDS_FREE_CHUNK_MAX_CHARS * 1.5) return [chunk];
+    const parts: string[] = [];
+    for (let start = 0; start < chunk.length; start += HANDS_FREE_CHUNK_MAX_CHARS) {
+      parts.push(chunk.slice(start, start + HANDS_FREE_CHUNK_MAX_CHARS).trim());
+    }
+    return parts.filter(Boolean);
+  });
+}
+
+export function takeReadyHandsFreeSpeechChunks(
+  text: string,
+  force: boolean,
+): { chunks: string[]; rest: string } {
+  let rest = text;
+  const chunks: string[] = [];
+
+  while (rest.trim()) {
+    rest = rest.trimStart();
+    if (!force && rest.length < HANDS_FREE_STREAM_CHUNK_MIN_CHARS) break;
+
+    const slice = rest.slice(0, HANDS_FREE_CHUNK_MAX_CHARS);
+    const boundary = Math.max(
+      slice.lastIndexOf("."),
+      slice.lastIndexOf("!"),
+      slice.lastIndexOf("?"),
+      slice.lastIndexOf(","),
+      slice.lastIndexOf(";"),
+      slice.lastIndexOf(":"),
+      slice.lastIndexOf(" "),
+    );
+    const minimumBoundary = force
+      ? 0
+      : Math.min(HANDS_FREE_STREAM_CHUNK_MIN_CHARS, Math.floor(HANDS_FREE_CHUNK_MAX_CHARS * 0.75));
+
+    if (boundary > minimumBoundary || rest.length >= HANDS_FREE_CHUNK_MAX_CHARS) {
+      const end = boundary > minimumBoundary ? boundary + 1 : HANDS_FREE_CHUNK_MAX_CHARS;
+      chunks.push(rest.slice(0, end).trim());
+      rest = rest.slice(end);
+      continue;
+    }
+
+    if (force) {
+      chunks.push(rest.trim());
+      rest = "";
+      continue;
+    }
+
+    break;
+  }
+
+  if (force && rest.trim()) {
+    chunks.push(rest.trim());
+    rest = "";
+  }
+
+  return {
+    chunks: chunks.map(sanitizeHandsFreeSpeechText).filter(Boolean),
+    rest,
+  };
+}
+
+export function handsFreeStateLabel(state: HandsFreeState): string {
+  switch (state) {
+    case "listening":
+      return "ecoute";
+    case "recording":
+      return "parle";
+    case "transcribing":
+      return "stt";
+    case "thinking":
+      return "agent";
+    case "speaking":
+      return "reponse";
+    default:
+      return "hands-free";
+  }
+}
+
+export function handsFreeStatusText(state: HandsFreeState): string {
+  return handsFreeStateLabel(state);
+}
+
+export function handsFreeMeterPercent(stats: HandsFreeMicStats): number {
+  const denominator = Math.max(0.001, stats.threshold * 1.6);
+  return Math.max(3, Math.min(100, Math.round((stats.level / denominator) * 100)));
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -33,6 +33,31 @@ import { useSearchParams } from "react-router-dom";
 import { ChatSidebar } from "@/components/ChatSidebar";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
+import {
+  DEFAULT_HANDS_FREE_MIC_STATS,
+  HANDS_FREE_INITIAL_NOISE_FLOOR,
+  HANDS_FREE_MAX_SPOKEN_CHARS,
+  HANDS_FREE_MAX_UTTERANCE_MS,
+  HANDS_FREE_METER_UPDATE_MS,
+  HANDS_FREE_MIN_RECORDING_MS,
+  HANDS_FREE_NOISE_ALPHA,
+  HANDS_FREE_SILENCE_MS,
+  HANDS_FREE_SILENT_WAV,
+  HANDS_FREE_TRUNCATION_NOTICE,
+  handsFreeMeterPercent,
+  handsFreeSilenceThreshold,
+  handsFreeSpeechThreshold,
+  handsFreeStateLabel,
+  handsFreeStatusText,
+  isHandsFreeDisableCommand,
+  isHandsFreeStopCommand,
+  rmsFromTimeDomain,
+  sanitizeHandsFreeSpeechText,
+  splitHandsFreeSpeech,
+  takeReadyHandsFreeSpeechChunks,
+  type HandsFreeMicStats,
+  type HandsFreeState,
+} from "@/lib/handsFreeVoice";
 import { PluginSlot } from "@/plugins";
 
 function buildWsUrl(
@@ -217,13 +242,15 @@ async function synthesizeBrowserSpeech(text: string, token: string): Promise<Blo
   return resp.blob();
 }
 
-type HandsFreeState =
-  | "off"
-  | "listening"
-  | "recording"
-  | "transcribing"
-  | "thinking"
-  | "speaking";
+interface WakeLockSentinelLike {
+  release(): Promise<void>;
+}
+
+type WakeLockNavigator = Navigator & {
+  wakeLock?: {
+    request(type: "screen"): Promise<WakeLockSentinelLike>;
+  };
+};
 
 interface RpcEventFrame {
   method?: string;
@@ -234,81 +261,6 @@ interface RpcEventFrame {
       rendered?: string;
     };
   };
-}
-
-const HANDS_FREE_SPEECH_RMS = 0.035;
-const HANDS_FREE_SILENCE_RMS = 0.018;
-const HANDS_FREE_MIN_SPEECH_MS = 350;
-const HANDS_FREE_SILENCE_MS = 900;
-const HANDS_FREE_MAX_UTTERANCE_MS = 20_000;
-const HANDS_FREE_MAX_SPOKEN_CHARS = 900;
-const HANDS_FREE_SILENT_WAV =
-  "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAESsAACJWAAACABAAZGF0YQAAAAA=";
-
-function rmsFromTimeDomain(data: Uint8Array<ArrayBuffer>): number {
-  let sum = 0;
-  for (const sample of data) {
-    const centered = (sample - 128) / 128;
-    sum += centered * centered;
-  }
-  return Math.sqrt(sum / Math.max(1, data.length));
-}
-
-function normalizeTranscriptCommand(text: string): string {
-  return text
-    .trim()
-    .toLowerCase()
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .replace(/[^a-z0-9\s]/g, "")
-    .replace(/\s+/g, " ");
-}
-
-function isHandsFreeStopCommand(text: string): boolean {
-  const normalized = normalizeTranscriptCommand(text);
-  return normalized === "stop" || normalized === "pause" || normalized === "arrete";
-}
-
-function prepareHandsFreeSpeech(text: string): string {
-  let clean = text
-    .replace(/```[\s\S]*?```/g, " ")
-    .replace(/^MEDIA:.*$/gim, " ")
-    .replace(/^\s*\[\[audio_as_voice\]\]\s*$/gim, " ")
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
-    .replace(/[`*_>#-]+/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-
-  if (clean.length <= HANDS_FREE_MAX_SPOKEN_CHARS) {
-    return clean;
-  }
-
-  const slice = clean.slice(0, HANDS_FREE_MAX_SPOKEN_CHARS);
-  const boundary = Math.max(
-    slice.lastIndexOf("."),
-    slice.lastIndexOf("!"),
-    slice.lastIndexOf("?"),
-    slice.lastIndexOf("\n"),
-  );
-  clean = slice.slice(0, boundary > 420 ? boundary + 1 : HANDS_FREE_MAX_SPOKEN_CHARS).trim();
-  return `${clean} Le detail est dans le chat.`;
-}
-
-function handsFreeStateLabel(state: HandsFreeState): string {
-  switch (state) {
-    case "listening":
-      return "listening";
-    case "recording":
-      return "hearing";
-    case "transcribing":
-      return "stt";
-    case "thinking":
-      return "thinking";
-    case "speaking":
-      return "speaking";
-    default:
-      return "hands-free";
-  }
 }
 
 function setAudioSource(audio: HTMLAudioElement, src: string, volume: number): void {
@@ -334,6 +286,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
+  const ptyBusyRef = useRef(false);
   const recorderRef = useRef<MediaRecorder | null>(null);
   const recorderStreamRef = useRef<MediaStream | null>(null);
   const recorderChunksRef = useRef<BlobPart[]>([]);
@@ -349,13 +302,28 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const handsFreeChunksRef = useRef<BlobPart[]>([]);
   const handsFreeSpeechStartedAtRef = useRef<number>(0);
   const handsFreeLastVoiceAtRef = useRef<number>(0);
+  const handsFreeNoiseFloorRef = useRef<number>(HANDS_FREE_INITIAL_NOISE_FLOOR);
+  const handsFreeVoiceActiveSinceRef = useRef<number>(0);
+  const handsFreeMeterUpdatedAtRef = useRef<number>(0);
   const handsFreeAudioRef = useRef<HTMLAudioElement | null>(null);
   const handsFreeAudioUrlRef = useRef<string | null>(null);
   const handsFreePlaybackResolveRef = useRef<(() => void) | null>(null);
+  const handsFreePlaybackInterruptedRef = useRef(false);
+  const handsFreeWakeLockRef = useRef<WakeLockSentinelLike | null>(null);
+  const handsFreeDeltaBufferRef = useRef("");
+  const handsFreeSpeechQueueRef = useRef<string[]>([]);
+  const handsFreeSpeechWorkerRunningRef = useRef(false);
+  const handsFreeTurnCompleteRef = useRef(false);
+  const handsFreeStreamedAnyRef = useRef(false);
+  const handsFreeSpokenCharsRef = useRef(0);
+  const handsFreeSpeechTruncatedRef = useRef(false);
   const [handsFreeEnabled, setHandsFreeEnabled] = useState(false);
   const handsFreeEnabledRef = useRef(false);
   const [handsFreeState, setHandsFreeState] = useState<HandsFreeState>("off");
   const handsFreeStateRef = useRef<HandsFreeState>("off");
+  const [handsFreeMicStats, setHandsFreeMicStats] = useState<HandsFreeMicStats>(
+    DEFAULT_HANDS_FREE_MIC_STATS,
+  );
   // Exposed to the main metrics-sync effect so it can refit the terminal
   // the moment `isActive` flips back to true (display:none → display:flex
   // collapses the host's box, so ResizeObserver never fires on return).
@@ -605,7 +573,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     if (!transcribingVoice) void startBrowserRecording();
   }, [recording, startBrowserRecording, stopBrowserRecording, transcribingVoice]);
 
-  const stopHandsFreePlayback = useCallback(() => {
+  const stopHandsFreePlayback = useCallback((interrupted = false) => {
+    if (interrupted) handsFreePlaybackInterruptedRef.current = true;
     const resolve = handsFreePlaybackResolveRef.current;
     handsFreePlaybackResolveRef.current = null;
     if (resolve) resolve();
@@ -618,6 +587,38 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     if (handsFreeAudioUrlRef.current) {
       URL.revokeObjectURL(handsFreeAudioUrlRef.current);
       handsFreeAudioUrlRef.current = null;
+    }
+  }, []);
+
+  const resetHandsFreeSpeechPipeline = useCallback(() => {
+    handsFreeDeltaBufferRef.current = "";
+    handsFreeSpeechQueueRef.current = [];
+    handsFreeTurnCompleteRef.current = false;
+    handsFreeStreamedAnyRef.current = false;
+    handsFreePlaybackInterruptedRef.current = false;
+    handsFreeSpokenCharsRef.current = 0;
+    handsFreeSpeechTruncatedRef.current = false;
+    stopHandsFreePlayback();
+  }, [stopHandsFreePlayback]);
+
+  const releaseHandsFreeWakeLock = useCallback(() => {
+    const sentinel = handsFreeWakeLockRef.current;
+    handsFreeWakeLockRef.current = null;
+    if (sentinel) void sentinel.release().catch(() => {});
+  }, []);
+
+  const requestHandsFreeWakeLock = useCallback(async () => {
+    if (typeof document === "undefined" || document.visibilityState !== "visible") {
+      return;
+    }
+    const wakeLock = (navigator as WakeLockNavigator).wakeLock;
+    if (!wakeLock || handsFreeWakeLockRef.current) {
+      return;
+    }
+    try {
+      handsFreeWakeLockRef.current = await wakeLock.request("screen");
+    } catch {
+      // Wake lock is unavailable on some browsers or power modes. Voice still works.
     }
   }, []);
 
@@ -642,8 +643,17 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     }
     handsFreeRecorderRef.current = null;
     handsFreeChunksRef.current = [];
+    handsFreeDeltaBufferRef.current = "";
+    handsFreeSpeechQueueRef.current = [];
+    handsFreeTurnCompleteRef.current = false;
+    handsFreeStreamedAnyRef.current = false;
+    handsFreeSpokenCharsRef.current = 0;
+    handsFreeSpeechTruncatedRef.current = false;
 
-    handsFreeStreamRef.current?.getTracks().forEach((track) => track.stop());
+    handsFreeStreamRef.current?.getTracks().forEach((track) => {
+      track.onended = null;
+      track.stop();
+    });
     handsFreeStreamRef.current = null;
     handsFreeAnalyserRef.current = null;
     handsFreeSamplesRef.current = null;
@@ -655,7 +665,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     }
 
     stopHandsFreePlayback();
-  }, [stopHandsFreePlayback]);
+    releaseHandsFreeWakeLock();
+  }, [releaseHandsFreeWakeLock, stopHandsFreePlayback]);
 
   const disableHandsFree = useCallback((message?: string) => {
     setHandsFreeEnabledValue(false);
@@ -703,10 +714,17 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         setHandsFreeStateValue("listening");
         return;
       }
-      if (isHandsFreeStopCommand(transcript)) {
+      if (isHandsFreeDisableCommand(transcript)) {
         disableHandsFree("Hands-free voice mode stopped.");
         return;
       }
+      if (isHandsFreeStopCommand(transcript)) {
+        resetHandsFreeSpeechPipeline();
+        setHandsFreeStateValue("listening");
+        restoreTerminalInput();
+        return;
+      }
+      resetHandsFreeSpeechPipeline();
       if (injectTranscript(transcript)) {
         setHandsFreeStateValue("thinking");
       } else {
@@ -724,6 +742,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   }, [
     disableHandsFree,
     injectTranscript,
+    resetHandsFreeSpeechPipeline,
     restoreTerminalInput,
     setHandsFreeStateValue,
   ]);
@@ -748,6 +767,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     handsFreeRecorderRef.current = recorder;
     handsFreeSpeechStartedAtRef.current = now;
     handsFreeLastVoiceAtRef.current = now;
+    handsFreeVoiceActiveSinceRef.current = 0;
 
     recorder.ondataavailable = (event) => {
       if (event.data.size > 0) handsFreeChunksRef.current.push(event.data);
@@ -786,18 +806,47 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       return;
     }
 
+    const audioContext = handsFreeAudioContextRef.current;
+    if (audioContext?.state === "suspended") {
+      void audioContext.resume().catch(() => {});
+    }
+
     const analyser = handsFreeAnalyserRef.current;
     const samples = handsFreeSamplesRef.current;
     const state = handsFreeStateRef.current;
-    if (analyser && samples && (state === "listening" || state === "recording")) {
+    // Half-duplex MVP: only open a recording while the user turn is expected.
+    // During thinking/speaking, ambient speech must not interrupt Hermes.
+    if (
+      analyser &&
+      samples &&
+      (state === "listening" ||
+        state === "recording")
+    ) {
       analyser.getByteTimeDomainData(samples);
       const rms = rmsFromTimeDomain(samples);
       const now = performance.now();
+      const speechThreshold = handsFreeSpeechThreshold(handsFreeNoiseFloorRef.current);
+      const silenceThreshold = handsFreeSilenceThreshold(handsFreeNoiseFloorRef.current);
+      if (now - handsFreeMeterUpdatedAtRef.current >= HANDS_FREE_METER_UPDATE_MS) {
+        handsFreeMeterUpdatedAtRef.current = now;
+        setHandsFreeMicStats({
+          level: rms,
+          noise: handsFreeNoiseFloorRef.current,
+          speaking: rms >= speechThreshold,
+          threshold: speechThreshold,
+        });
+      }
 
-      if (state === "listening" && rms >= HANDS_FREE_SPEECH_RMS) {
-        startHandsFreeRecording();
+      if (state === "listening") {
+        if (rms < speechThreshold) {
+          handsFreeVoiceActiveSinceRef.current = 0;
+          handsFreeNoiseFloorRef.current =
+            handsFreeNoiseFloorRef.current * (1 - HANDS_FREE_NOISE_ALPHA) + rms * HANDS_FREE_NOISE_ALPHA;
+        } else {
+          startHandsFreeRecording();
+        }
       } else if (state === "recording") {
-        if (rms >= HANDS_FREE_SILENCE_RMS) {
+        if (rms >= silenceThreshold) {
           handsFreeLastVoiceAtRef.current = now;
         }
 
@@ -805,7 +854,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         const silentFor = now - handsFreeLastVoiceAtRef.current;
         if (
           elapsed >= HANDS_FREE_MAX_UTTERANCE_MS ||
-          (elapsed >= HANDS_FREE_MIN_SPEECH_MS && silentFor >= HANDS_FREE_SILENCE_MS)
+          (elapsed >= HANDS_FREE_MIN_RECORDING_MS && silentFor >= HANDS_FREE_SILENCE_MS)
         ) {
           stopHandsFreeRecording();
         }
@@ -839,7 +888,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
     try {
       await primeHandsFreeAudio();
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          autoGainControl: true,
+          echoCancellation: true,
+          noiseSuppression: true,
+        },
+      });
       const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
       if (!AudioContextCtor) {
         stream.getTracks().forEach((track) => track.stop());
@@ -851,15 +906,30 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       const analyser = audioContext.createAnalyser();
       analyser.fftSize = 2048;
       audioContext.createMediaStreamSource(stream).connect(analyser);
+      stream.getAudioTracks().forEach((track) => {
+        track.onended = () => {
+          if (handsFreeEnabledRef.current) {
+            disableHandsFree("Microphone stream ended. Restart hands-free voice mode.");
+          }
+        };
+      });
 
       cleanupHandsFreeResources();
       handsFreeStreamRef.current = stream;
       handsFreeAudioContextRef.current = audioContext;
       handsFreeAnalyserRef.current = analyser;
       handsFreeSamplesRef.current = new Uint8Array(analyser.fftSize);
+      handsFreeNoiseFloorRef.current = HANDS_FREE_INITIAL_NOISE_FLOOR;
+      handsFreeVoiceActiveSinceRef.current = 0;
+      handsFreeMeterUpdatedAtRef.current = 0;
+      setHandsFreeMicStats({
+        ...DEFAULT_HANDS_FREE_MIC_STATS,
+        threshold: handsFreeSpeechThreshold(HANDS_FREE_INITIAL_NOISE_FLOOR),
+      });
       setBanner(null);
       setHandsFreeEnabledValue(true);
       setHandsFreeStateValue("listening");
+      void requestHandsFreeWakeLock();
       handsFreeVadRafRef.current = requestAnimationFrame(() => runHandsFreeVadRef.current());
       termRef.current?.focus();
     } catch (err) {
@@ -869,7 +939,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     }
   }, [
     cleanupHandsFreeResources,
+    disableHandsFree,
     primeHandsFreeAudio,
+    requestHandsFreeWakeLock,
     recording,
     setHandsFreeEnabledValue,
     setHandsFreeStateValue,
@@ -877,65 +949,195 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     transcribingVoice,
   ]);
 
-  const speakHandsFreeResponse = useCallback(async (rawText: string) => {
-    const token = window.__HERMES_SESSION_TOKEN__;
-    const text = prepareHandsFreeSpeech(rawText);
-    if (!token || !handsFreeEnabledRef.current || !text) {
-      if (handsFreeEnabledRef.current) setHandsFreeStateValue("listening");
+  const playHandsFreeSpeechChunk = useCallback(async (text: string, token: string) => {
+    const blob = await synthesizeBrowserSpeech(text, token);
+    if (!handsFreeEnabledRef.current || handsFreePlaybackInterruptedRef.current) {
       return;
     }
 
-    setHandsFreeStateValue("speaking");
-    stopHandsFreePlayback();
+    const audio = handsFreeAudioRef.current ?? new Audio();
+    handsFreeAudioRef.current = audio;
+    const url = URL.createObjectURL(blob);
+    handsFreeAudioUrlRef.current = url;
+    setAudioSource(audio, url, 1);
 
-    try {
-      const blob = await synthesizeBrowserSpeech(text, token);
-      if (!handsFreeEnabledRef.current) {
-        return;
+    await new Promise<void>((resolve, reject) => {
+      handsFreePlaybackResolveRef.current = resolve;
+      audio.onended = () => resolve();
+      audio.onerror = () => reject(new Error("Browser audio playback failed."));
+      const playPromise = audio.play();
+      if (playPromise) {
+        playPromise.catch(reject);
       }
+    });
+  }, []);
 
-      const audio = handsFreeAudioRef.current ?? new Audio();
-      handsFreeAudioRef.current = audio;
-      const url = URL.createObjectURL(blob);
-      handsFreeAudioUrlRef.current = url;
-      setAudioSource(audio, url, 1);
+  const drainHandsFreeSpeechQueue = useCallback(async () => {
+    const token = window.__HERMES_SESSION_TOKEN__;
+    if (!token || handsFreeSpeechWorkerRunningRef.current) {
+      return;
+    }
 
-      await new Promise<void>((resolve, reject) => {
-        handsFreePlaybackResolveRef.current = resolve;
-        audio.onended = () => resolve();
-        audio.onerror = () => reject(new Error("Browser audio playback failed."));
-        const playPromise = audio.play();
-        if (playPromise) {
-          playPromise.catch(reject);
-        }
-      });
+    handsFreeSpeechWorkerRunningRef.current = true;
+    try {
+      while (
+        handsFreeEnabledRef.current &&
+        !handsFreePlaybackInterruptedRef.current &&
+        handsFreeSpeechQueueRef.current.length > 0
+      ) {
+        const chunk = handsFreeSpeechQueueRef.current.shift();
+        if (!chunk) break;
+        setHandsFreeStateValue("speaking");
+        await playHandsFreeSpeechChunk(chunk, token);
+        stopHandsFreePlayback();
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : "Voice playback failed.";
-      if (handsFreeEnabledRef.current) {
+      if (handsFreeEnabledRef.current && !handsFreePlaybackInterruptedRef.current) {
         setBanner(message);
       }
     } finally {
+      handsFreeSpeechWorkerRunningRef.current = false;
       stopHandsFreePlayback();
-      if (handsFreeEnabledRef.current) {
+
+      if (
+        handsFreeEnabledRef.current &&
+        !handsFreePlaybackInterruptedRef.current &&
+        handsFreeSpeechQueueRef.current.length > 0
+      ) {
+        void drainHandsFreeSpeechQueue();
+      } else if (
+        handsFreeEnabledRef.current &&
+        !handsFreePlaybackInterruptedRef.current &&
+        handsFreeTurnCompleteRef.current &&
+        !handsFreeDeltaBufferRef.current.trim()
+      ) {
         setHandsFreeStateValue("listening");
         restoreTerminalInput();
+      } else if (
+        handsFreeEnabledRef.current &&
+        !handsFreePlaybackInterruptedRef.current &&
+        handsFreeStateRef.current === "speaking"
+      ) {
+        setHandsFreeStateValue("thinking");
       }
     }
   }, [
+    playHandsFreeSpeechChunk,
     restoreTerminalInput,
     setHandsFreeStateValue,
     stopHandsFreePlayback,
   ]);
 
+  const queueHandsFreeSpeechChunks = useCallback((chunks: string[]) => {
+    const cleanChunks: string[] = [];
+    for (const chunk of chunks) {
+      if (handsFreeSpeechTruncatedRef.current) break;
+      const clean = sanitizeHandsFreeSpeechText(chunk);
+      if (!clean) continue;
+
+      if (clean.includes(HANDS_FREE_TRUNCATION_NOTICE)) {
+        cleanChunks.push(clean);
+        handsFreeSpokenCharsRef.current = HANDS_FREE_MAX_SPOKEN_CHARS;
+        handsFreeSpeechTruncatedRef.current = true;
+        break;
+      }
+
+      const remaining = HANDS_FREE_MAX_SPOKEN_CHARS - handsFreeSpokenCharsRef.current;
+      if (clean.length <= remaining) {
+        cleanChunks.push(clean);
+        handsFreeSpokenCharsRef.current += clean.length;
+        continue;
+      }
+
+      if (remaining > 80) {
+        const slice = clean.slice(0, remaining);
+        const boundary = Math.max(
+          slice.lastIndexOf("."),
+          slice.lastIndexOf("!"),
+          slice.lastIndexOf("?"),
+          slice.lastIndexOf(","),
+          slice.lastIndexOf(";"),
+          slice.lastIndexOf(":"),
+          slice.lastIndexOf(" "),
+        );
+        const trimmed = slice.slice(0, boundary > remaining * 0.6 ? boundary + 1 : remaining).trim();
+        cleanChunks.push(`${trimmed} ${HANDS_FREE_TRUNCATION_NOTICE}`);
+      } else {
+        cleanChunks.push(HANDS_FREE_TRUNCATION_NOTICE);
+      }
+      handsFreeSpokenCharsRef.current = HANDS_FREE_MAX_SPOKEN_CHARS;
+      handsFreeSpeechTruncatedRef.current = true;
+      break;
+    }
+    if (cleanChunks.length === 0) return;
+    handsFreeSpeechQueueRef.current.push(...cleanChunks);
+    void drainHandsFreeSpeechQueue();
+  }, [drainHandsFreeSpeechQueue]);
+
+  const flushHandsFreeDeltaBuffer = useCallback((force: boolean) => {
+    const { chunks, rest } = takeReadyHandsFreeSpeechChunks(
+      handsFreeDeltaBufferRef.current,
+      force,
+    );
+    handsFreeDeltaBufferRef.current = rest;
+    queueHandsFreeSpeechChunks(chunks);
+  }, [queueHandsFreeSpeechChunks]);
+
+  const handleHandsFreeAssistantStart = useCallback(() => {
+    if (!handsFreeEnabledRef.current) return;
+    handsFreeDeltaBufferRef.current = "";
+    handsFreeSpeechQueueRef.current = [];
+    handsFreeTurnCompleteRef.current = false;
+    handsFreeStreamedAnyRef.current = false;
+    handsFreePlaybackInterruptedRef.current = false;
+    handsFreeSpokenCharsRef.current = 0;
+    handsFreeSpeechTruncatedRef.current = false;
+  }, []);
+
+  const handleHandsFreeAssistantDelta = useCallback((text: string) => {
+    if (!handsFreeEnabledRef.current) {
+      return;
+    }
+    if (handsFreeStateRef.current !== "thinking" && handsFreeStateRef.current !== "speaking") {
+      return;
+    }
+    if (!text) {
+      return;
+    }
+
+    handsFreeStreamedAnyRef.current = true;
+    handsFreeDeltaBufferRef.current += text;
+    flushHandsFreeDeltaBuffer(false);
+  }, [flushHandsFreeDeltaBuffer]);
+
   const handleHandsFreeAssistantComplete = useCallback((text: string) => {
     if (!handsFreeEnabledRef.current) {
       return;
     }
-    if (handsFreeStateRef.current !== "thinking") {
+    if (handsFreeStateRef.current !== "thinking" && handsFreeStateRef.current !== "speaking") {
       return;
     }
-    void speakHandsFreeResponse(text);
-  }, [speakHandsFreeResponse]);
+    handsFreeTurnCompleteRef.current = true;
+    if (handsFreeStreamedAnyRef.current) {
+      flushHandsFreeDeltaBuffer(true);
+      void drainHandsFreeSpeechQueue();
+      return;
+    }
+    const fallbackChunks = splitHandsFreeSpeech(text);
+    if (fallbackChunks.length > 0) {
+      queueHandsFreeSpeechChunks(fallbackChunks);
+    } else {
+      setHandsFreeStateValue("listening");
+      restoreTerminalInput();
+    }
+  }, [
+    drainHandsFreeSpeechQueue,
+    flushHandsFreeDeltaBuffer,
+    queueHandsFreeSpeechChunks,
+    restoreTerminalInput,
+    setHandsFreeStateValue,
+  ]);
 
   const handleHandsFreeButton = useCallback(() => {
     if (handsFreeEnabledRef.current) {
@@ -977,30 +1179,52 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       if (frame.method !== "event" || !frame.params?.type) {
         return;
       }
+      const eventType = frame.params.type;
+      if (eventType === "message.start") {
+        ptyBusyRef.current = true;
+      } else if (
+        eventType === "message.complete" ||
+        eventType === "approval.request" ||
+        eventType === "clarify.request" ||
+        eventType === "error"
+      ) {
+        ptyBusyRef.current = false;
+      }
       if (
         handsFreeEnabledRef.current &&
         handsFreeStateRef.current === "thinking" &&
-        (frame.params.type === "approval.request" ||
-          frame.params.type === "clarify.request" ||
-          frame.params.type === "error")
+        (eventType === "approval.request" ||
+          eventType === "clarify.request" ||
+          eventType === "error")
       ) {
         setHandsFreeStateValue("listening");
       }
-      if (frame.params.type !== "message.complete") {
+      if (eventType === "message.start") {
+        handleHandsFreeAssistantStart();
+        return;
+      }
+      if (eventType === "message.delta") {
+        handleHandsFreeAssistantDelta(frame.params.payload?.text || "");
+        return;
+      }
+      if (eventType !== "message.complete") {
         return;
       }
       const payload = frame.params.payload;
-      const text = payload?.rendered || payload?.text || "";
+      const text = payload?.text || payload?.rendered || "";
       if (text) handleHandsFreeAssistantComplete(text);
     });
 
     return () => {
       unmounting = true;
+      ptyBusyRef.current = false;
       ws.close();
     };
   }, [
     channel,
+    handleHandsFreeAssistantDelta,
     handleHandsFreeAssistantComplete,
+    handleHandsFreeAssistantStart,
     setHandsFreeStateValue,
   ]);
 
@@ -1010,6 +1234,36 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       cleanupHandsFreeResources();
     };
   }, [cleanupHandsFreeResources]);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (!handsFreeEnabledRef.current) return;
+      if (document.visibilityState === "visible") {
+        void requestHandsFreeWakeLock();
+        const audioContext = handsFreeAudioContextRef.current;
+        if (audioContext?.state === "suspended") {
+          void audioContext.resume().catch(() => {});
+        }
+        return;
+      }
+
+      releaseHandsFreeWakeLock();
+      setBanner("Keep the dashboard visible for reliable hands-free voice mode.");
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [releaseHandsFreeWakeLock, requestHandsFreeWakeLock]);
+
+  useEffect(() => {
+    const handlePageHide = () => {
+      if (!handsFreeEnabledRef.current) return;
+      disableHandsFree("Hands-free voice mode paused by the browser. Restart it when the page is active.");
+    };
+
+    window.addEventListener("pagehide", handlePageHide);
+    return () => window.removeEventListener("pagehide", handlePageHide);
+  }, [disableHandsFree]);
 
   useEffect(() => {
     const host = hostRef.current;
@@ -1085,16 +1339,21 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       if (ev.type !== "keydown") return true;
 
       // Copy: Cmd+C on macOS, Ctrl+Shift+C on other platforms. Bare Ctrl+C
-      // is reserved for SIGINT to the TUI child — matches xterm / gnome-terminal /
-      // konsole / Windows Terminal. Ctrl+Shift+C only copies if a selection exists;
-      // without a selection it passes through to the TUI so agents can still
-      // react to the keypress.
+      // is never forwarded as a raw terminal signal in the dashboard: when
+      // Hermes is busy we route it through /stop, otherwise we swallow it so
+      // an idle chat tab cannot accidentally close its embedded PTY.
       // Paste: Cmd+V on macOS, Ctrl+Shift+V on others.  On non-secure
       // dashboard origins (for example http://100.x.y.z over Tailscale),
       // browsers block navigator.clipboard.readText(); in that case we let
       // xterm's native paste event handle the key instead of swallowing it.
       const copyModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
       const pasteModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
+      const bareCtrlC =
+        ev.ctrlKey &&
+        !ev.shiftKey &&
+        !ev.altKey &&
+        !ev.metaKey &&
+        ev.key.toLowerCase() === "c";
 
       if (copyModifier && ev.key.toLowerCase() === "c") {
         const sel = term.getSelection();
@@ -1108,8 +1367,25 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           ev.preventDefault();
           return false;
         }
-        // No selection → fall through so the TUI receives Ctrl+Shift+C
-        // (or the bare ev if the user used a different modifier).
+      }
+
+      if (bareCtrlC) {
+        const sel = term.getSelection();
+        if (sel) {
+          copyText(sel);
+          term.clearSelection();
+        } else if (ptyBusyRef.current) {
+          const s = wsRef.current;
+          if (s && s.readyState === WebSocket.OPEN) {
+            s.send("/stop");
+            setTimeout(() => {
+              const live = wsRef.current;
+              if (live && live.readyState === WebSocket.OPEN) live.send("\r");
+            }, 100);
+          }
+        }
+        ev.preventDefault();
+        return false;
       }
 
       if (pasteModifier && ev.key.toLowerCase() === "v") {
@@ -1449,9 +1725,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   //   outer flex column — sits inside the dashboard's content area
   //   row split — terminal pane (flex-1) + sidebar (fixed width, lg+)
   //   terminal wrapper — rounded, dark, padded — the "terminal window"
-  //   floating copy button — bottom-right corner, transparent with a
-  //     subtle border; stays out of the way until hovered.  Sends
-  //     `/copy\n` to Ink, which emits OSC 52 → our clipboard handler.
+  //   controls row — normal-flow browser controls below xterm, so they
+  //     never cover the TUI composer/cursor. Copy sends `/copy\n` to Ink,
+  //     which emits OSC 52 → our clipboard handler.
   //   sidebar — ChatSidebar opens its own JSON-RPC sidecar; renders
   //     model badge, tool-call list, model picker. Best-effort: if the
   //     sidecar fails to connect the terminal pane keeps working.
@@ -1563,97 +1839,122 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             className="hermes-chat-xterm-host min-h-0 min-w-0 flex-1"
           />
 
-          <div className="absolute bottom-2 left-2 z-10 flex max-w-[calc(100%-5rem)] flex-wrap gap-1.5 sm:bottom-3 sm:left-3 lg:bottom-4 lg:left-4">
-            <Button
-              ghost
-              onClick={handleVoiceButton}
-              disabled={transcribingVoice || handsFreeEnabled}
-              title={
-                recording
-                  ? "Stop browser microphone recording and transcribe"
-                  : "Record browser microphone and send transcript"
-              }
-              aria-label={
-                recording
-                  ? "Stop browser microphone recording"
-                  : "Record browser microphone"
-              }
-              className={cn(
-                "rounded border border-current/30",
-                "bg-black/20 backdrop-blur-sm",
-                "opacity-70 hover:opacity-100 hover:border-current/60",
-                "transition-opacity duration-150 normal-case font-normal tracking-normal",
-                "px-2 py-1 text-[0.65rem] sm:px-2.5 sm:py-1.5 sm:text-xs",
-                recording && "border-red-300/70 text-red-200 opacity-100",
-              )}
-              style={{ color: recording ? undefined : TERMINAL_THEME.foreground }}
-            >
-              <span className="inline-flex items-center gap-1.5">
-                <Mic className="h-3 w-3 shrink-0" />
-                <span className="hidden min-[400px]:inline tracking-wide">
-                  {recording ? "stop voice" : transcribingVoice ? "transcribing" : "voice"}
+          <div className="mt-2 flex shrink-0 flex-wrap items-center justify-between gap-2 sm:mt-3">
+            <div className="flex min-w-0 flex-1 flex-wrap gap-1.5">
+              <Button
+                ghost
+                onClick={handleVoiceButton}
+                disabled={transcribingVoice || handsFreeEnabled}
+                title={
+                  recording
+                    ? "Stop browser microphone recording and transcribe"
+                    : "Record browser microphone and send transcript"
+                }
+                aria-label={
+                  recording
+                    ? "Stop browser microphone recording"
+                    : "Record browser microphone"
+                }
+                className={cn(
+                  "rounded border border-current/30",
+                  "bg-black/20 backdrop-blur-sm",
+                  "opacity-70 hover:opacity-100 hover:border-current/60",
+                  "transition-opacity duration-150 normal-case font-normal tracking-normal",
+                  "px-2 py-1 text-[0.65rem] sm:px-2.5 sm:py-1.5 sm:text-xs",
+                  recording && "border-red-300/70 text-red-200 opacity-100",
+                )}
+                style={{ color: recording ? undefined : TERMINAL_THEME.foreground }}
+              >
+                <span className="inline-flex items-center gap-1.5">
+                  <Mic className="h-3 w-3 shrink-0" />
+                  <span className="hidden min-[400px]:inline tracking-wide">
+                    {recording ? "stop voice" : transcribingVoice ? "transcribing" : "voice"}
+                  </span>
                 </span>
-              </span>
-            </Button>
+              </Button>
+
+              <Button
+                ghost
+                onClick={handleHandsFreeButton}
+                disabled={recording || transcribingVoice}
+                title={
+                  handsFreeEnabled
+                    ? "Stop hands-free browser voice mode"
+                    : "Start hands-free browser voice mode"
+                }
+                aria-label={
+                  handsFreeEnabled
+                    ? "Stop hands-free browser voice mode"
+                    : "Start hands-free browser voice mode"
+                }
+                className={cn(
+                  "rounded border border-current/30",
+                  "bg-black/20 backdrop-blur-sm",
+                  "opacity-70 hover:opacity-100 hover:border-current/60",
+                  "transition-opacity duration-150 normal-case font-normal tracking-normal",
+                  "px-2 py-1 text-[0.65rem] sm:px-2.5 sm:py-1.5 sm:text-xs",
+                  handsFreeEnabled && "border-emerald-300/70 text-emerald-100 opacity-100",
+                  handsFreeState === "recording" && "border-red-300/70 text-red-200",
+                  handsFreeState === "speaking" && "border-sky-300/70 text-sky-100",
+                )}
+                style={{ color: handsFreeEnabled ? undefined : TERMINAL_THEME.foreground }}
+              >
+                <span className="inline-flex items-center gap-1.5">
+                  <Headphones className="h-3 w-3 shrink-0" />
+                  <span className="hidden min-[460px]:inline tracking-wide">
+                    {handsFreeStateLabel(handsFreeState)}
+                  </span>
+                </span>
+              </Button>
+
+              {handsFreeEnabled && (
+                <span
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded border border-current/25",
+                    "bg-black/20 px-2 py-1 text-[0.65rem] font-normal tracking-normal backdrop-blur-sm",
+                    "text-emerald-100 sm:px-2.5 sm:py-1.5 sm:text-xs",
+                    handsFreeState === "recording" && "text-red-200",
+                    handsFreeState === "speaking" && "text-sky-100",
+                  )}
+                  title={`mic ${handsFreeMicStats.level.toFixed(3)} / threshold ${handsFreeMicStats.threshold.toFixed(3)} / noise ${handsFreeMicStats.noise.toFixed(3)}`}
+                >
+                  <span>{handsFreeStatusText(handsFreeState)}</span>
+                  <span className="relative h-1.5 w-12 overflow-hidden rounded bg-white/15">
+                    <span
+                      className={cn(
+                        "absolute inset-y-0 left-0 rounded transition-[width] duration-100",
+                        handsFreeMicStats.speaking ? "bg-red-300/90" : "bg-emerald-300/80",
+                      )}
+                      style={{ width: `${handsFreeMeterPercent(handsFreeMicStats)}%` }}
+                    />
+                    <span className="absolute inset-y-0 left-[62.5%] w-px bg-white/55" />
+                  </span>
+                </span>
+              )}
+            </div>
 
             <Button
               ghost
-              onClick={handleHandsFreeButton}
-              disabled={recording || transcribingVoice}
-              title={
-                handsFreeEnabled
-                  ? "Stop hands-free browser voice mode"
-                  : "Start hands-free browser voice mode"
-              }
-              aria-label={
-                handsFreeEnabled
-                  ? "Stop hands-free browser voice mode"
-                  : "Start hands-free browser voice mode"
-              }
+              onClick={handleCopyLast}
+              title="Copy last assistant response as raw markdown"
+              aria-label="Copy last assistant response"
               className={cn(
-                "rounded border border-current/30",
+                "shrink-0 rounded border border-current/30",
                 "bg-black/20 backdrop-blur-sm",
-                "opacity-70 hover:opacity-100 hover:border-current/60",
+                "opacity-60 hover:opacity-100 hover:border-current/60",
                 "transition-opacity duration-150 normal-case font-normal tracking-normal",
                 "px-2 py-1 text-[0.65rem] sm:px-2.5 sm:py-1.5 sm:text-xs",
-                handsFreeEnabled && "border-emerald-300/70 text-emerald-100 opacity-100",
-                handsFreeState === "recording" && "border-red-300/70 text-red-200",
-                handsFreeState === "speaking" && "border-sky-300/70 text-sky-100",
               )}
-              style={{ color: handsFreeEnabled ? undefined : TERMINAL_THEME.foreground }}
+              style={{ color: TERMINAL_THEME.foreground }}
             >
               <span className="inline-flex items-center gap-1.5">
-                <Headphones className="h-3 w-3 shrink-0" />
-                <span className="hidden min-[460px]:inline tracking-wide">
-                  {handsFreeStateLabel(handsFreeState)}
+                <Copy className="h-3 w-3 shrink-0" />
+                <span className="hidden min-[400px]:inline tracking-wide">
+                  {copyState === "copied" ? "copied" : "copy last response"}
                 </span>
               </span>
             </Button>
           </div>
-
-          <Button
-            ghost
-            onClick={handleCopyLast}
-            title="Copy last assistant response as raw markdown"
-            aria-label="Copy last assistant response"
-            className={cn(
-              "absolute z-10",
-              "rounded border border-current/30",
-              "bg-black/20 backdrop-blur-sm",
-              "opacity-60 hover:opacity-100 hover:border-current/60",
-              "transition-opacity duration-150 normal-case font-normal tracking-normal",
-              "bottom-2 right-2 px-2 py-1 text-[0.65rem] sm:bottom-3 sm:right-3 sm:px-2.5 sm:py-1.5 sm:text-xs",
-              "lg:bottom-4 lg:right-4",
-            )}
-            style={{ color: TERMINAL_THEME.foreground }}
-          >
-            <span className="inline-flex items-center gap-1.5">
-              <Copy className="h-3 w-3 shrink-0" />
-              <span className="hidden min-[400px]:inline tracking-wide">
-                {copyState === "copied" ? "copied" : "copy last response"}
-              </span>
-            </span>
-          </Button>
         </div>
 
         {!narrow && (

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -25,7 +25,7 @@ import "@xterm/xterm/css/xterm.css";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@/components/NouiTypography";
 import { cn } from "@/lib/utils";
-import { Copy, PanelRight, X } from "lucide-react";
+import { Copy, Mic, PanelRight, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams } from "react-router-dom";
@@ -131,11 +131,66 @@ function copyText(text: string): void {
   }
 }
 
+function preferredAudioMimeType(): string {
+  if (typeof MediaRecorder === "undefined") return "";
+  const candidates = [
+    "audio/webm;codecs=opus",
+    "audio/webm",
+    "audio/mp4",
+    "audio/aac",
+  ];
+  return candidates.find((type) => MediaRecorder.isTypeSupported(type)) ?? "";
+}
+
+function extensionForAudioType(mimeType: string): string {
+  const mediaType = mimeType.split(";", 1)[0].trim().toLowerCase();
+  if (mediaType === "audio/mp4") return "mp4";
+  if (mediaType === "audio/aac") return "aac";
+  if (mediaType === "audio/ogg") return "ogg";
+  if (mediaType === "audio/wav" || mediaType === "audio/wave") return "wav";
+  return "webm";
+}
+
+async function transcribeBrowserAudio(blob: Blob, token: string): Promise<string> {
+  const type = blob.type || "audio/webm";
+  const qs = new URLSearchParams({
+    filename: `dashboard-voice.${extensionForAudioType(type)}`,
+  });
+  const resp = await fetch(`/api/voice/transcribe?${qs.toString()}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": type,
+      "X-Hermes-Session-Token": token,
+    },
+    body: blob,
+  });
+
+  let payload: { success?: boolean; transcript?: string; error?: string; detail?: string } = {};
+  try {
+    payload = await resp.json();
+  } catch {
+    // Keep the HTTP error below useful when the server returns non-JSON.
+  }
+
+  if (!resp.ok) {
+    throw new Error(payload.detail || payload.error || `transcription failed (${resp.status})`);
+  }
+  if (payload.success === false) {
+    throw new Error(payload.error || "transcription failed");
+  }
+  return payload.transcript ?? "";
+}
+
 export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const recorderStreamRef = useRef<MediaStream | null>(null);
+  const recorderChunksRef = useRef<BlobPart[]>([]);
+  const [recording, setRecording] = useState(false);
+  const [transcribingVoice, setTranscribingVoice] = useState(false);
   // Exposed to the main metrics-sync effect so it can refit the terminal
   // the moment `isActive` flips back to true (display:none → display:flex
   // collapses the host's box, so ResizeObserver never fires on return).
@@ -261,6 +316,119 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     termRef.current?.focus();
   };
 
+  const restoreTerminalInput = useCallback(() => {
+    requestAnimationFrame(() => {
+      syncMetricsRef.current?.();
+      requestAnimationFrame(() => {
+        syncMetricsRef.current?.();
+        termRef.current?.focus();
+      });
+    });
+  }, []);
+
+  const showVoiceBanner = useCallback((message: string) => {
+    setBanner(message);
+    setRecording(false);
+    setTranscribingVoice(false);
+    restoreTerminalInput();
+  }, [restoreTerminalInput]);
+
+  const injectTranscript = useCallback((text: string) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      showVoiceBanner("Chat websocket is not connected.");
+      return;
+    }
+    ws.send(text);
+    setTimeout(() => {
+      const s = wsRef.current;
+      if (s && s.readyState === WebSocket.OPEN) s.send("\r");
+    }, 100);
+    termRef.current?.focus();
+  }, [showVoiceBanner]);
+
+  const stopBrowserRecording = useCallback(() => {
+    const recorder = recorderRef.current;
+    if (!recorder) return;
+    if (recorder.state !== "inactive") recorder.stop();
+  }, []);
+
+  const startBrowserRecording = useCallback(async () => {
+    if (!window.__HERMES_SESSION_TOKEN__) {
+      showVoiceBanner("Session token unavailable. Reload the dashboard.");
+      return;
+    }
+    if (!window.isSecureContext) {
+      showVoiceBanner("Browser microphone requires HTTPS or localhost.");
+      return;
+    }
+    if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === "undefined") {
+      showVoiceBanner("Browser microphone recording is unavailable in this browser.");
+      return;
+    }
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mimeType = preferredAudioMimeType();
+      const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+      recorderChunksRef.current = [];
+      recorderRef.current = recorder;
+      recorderStreamRef.current = stream;
+
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) recorderChunksRef.current.push(event.data);
+      };
+
+      recorder.onerror = () => {
+        showVoiceBanner("Browser microphone recording failed.");
+      };
+
+      recorder.onstop = () => {
+        const chunks = recorderChunksRef.current;
+        const token = window.__HERMES_SESSION_TOKEN__;
+        recorderStreamRef.current?.getTracks().forEach((track) => track.stop());
+        recorderStreamRef.current = null;
+        recorderRef.current = null;
+        setRecording(false);
+
+        if (!token || chunks.length === 0) return;
+        const blob = new Blob(chunks, { type: recorder.mimeType || "audio/webm" });
+        setTranscribingVoice(true);
+        transcribeBrowserAudio(blob, token)
+          .then((transcript) => {
+            const clean = transcript.trim();
+            if (clean) injectTranscript(clean);
+          })
+          .catch((err: Error) => {
+            showVoiceBanner(err.message || "Voice transcription failed.");
+          })
+          .finally(() => {
+            setTranscribingVoice(false);
+            restoreTerminalInput();
+          });
+      };
+
+      recorder.start();
+      setBanner(null);
+      setRecording(true);
+      termRef.current?.focus();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "microphone permission denied";
+      recorderStreamRef.current?.getTracks().forEach((track) => track.stop());
+      recorderStreamRef.current = null;
+      recorderRef.current = null;
+      showVoiceBanner(`Microphone unavailable: ${message}`);
+    }
+  }, [injectTranscript, restoreTerminalInput, showVoiceBanner]);
+
+  const handleVoiceButton = useCallback(() => {
+    if (recording) {
+      stopBrowserRecording();
+      return;
+    }
+    if (!transcribingVoice) void startBrowserRecording();
+  }, [recording, startBrowserRecording, stopBrowserRecording, transcribingVoice]);
+
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
@@ -322,7 +490,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
         const text = new TextDecoder("utf-8").decode(bytes);
         copyText(text);
-      } catch (e) {
+      } catch {
         console.warn("[dashboard clipboard] malformed OSC 52 payload");
       }
       return true;
@@ -635,6 +803,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       if (hostSyncRaf) cancelAnimationFrame(hostSyncRaf);
       if (settleRaf1) cancelAnimationFrame(settleRaf1);
       if (settleRaf2) cancelAnimationFrame(settleRaf2);
+      recorderStreamRef.current?.getTracks().forEach((track) => track.stop());
+      recorderStreamRef.current = null;
+      recorderRef.current = null;
       ws.close();
       wsRef.current = null;
       term.dispose();
@@ -809,6 +980,40 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             ref={hostRef}
             className="hermes-chat-xterm-host min-h-0 min-w-0 flex-1"
           />
+
+          <Button
+            ghost
+            onClick={handleVoiceButton}
+            disabled={transcribingVoice}
+            title={
+              recording
+                ? "Stop browser microphone recording and transcribe"
+                : "Record browser microphone and send transcript"
+            }
+            aria-label={
+              recording
+                ? "Stop browser microphone recording"
+                : "Record browser microphone"
+            }
+            className={cn(
+              "absolute z-10",
+              "rounded border border-current/30",
+              "bg-black/20 backdrop-blur-sm",
+              "opacity-70 hover:opacity-100 hover:border-current/60",
+              "transition-opacity duration-150 normal-case font-normal tracking-normal",
+              "bottom-2 left-2 px-2 py-1 text-[0.65rem] sm:bottom-3 sm:left-3 sm:px-2.5 sm:py-1.5 sm:text-xs",
+              "lg:bottom-4 lg:left-4",
+              recording && "border-red-300/70 text-red-200 opacity-100",
+            )}
+            style={{ color: recording ? undefined : TERMINAL_THEME.foreground }}
+          >
+            <span className="inline-flex items-center gap-1.5">
+              <Mic className="h-3 w-3 shrink-0" />
+              <span className="hidden min-[400px]:inline tracking-wide">
+                {recording ? "stop voice" : transcribingVoice ? "transcribing" : "voice"}
+              </span>
+            </span>
+          </Button>
 
           <Button
             ghost

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -102,6 +102,35 @@ function terminalLineHeightForWidth(layoutWidthPx: number): number {
   return layoutWidthPx < 1024 ? 1.02 : 1.15;
 }
 
+function clipboardCanReadText(): boolean {
+  return !!navigator.clipboard?.readText && window.isSecureContext;
+}
+
+function copyText(text: string): void {
+  if (navigator.clipboard?.writeText && window.isSecureContext) {
+    navigator.clipboard.writeText(text).catch((err) => {
+      console.warn("[dashboard clipboard] direct copy failed:", err.message);
+    });
+    return;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    document.execCommand("copy");
+  } catch (err) {
+    console.warn("[dashboard clipboard] fallback copy failed:", err);
+  } finally {
+    textarea.remove();
+  }
+}
+
 export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -292,12 +321,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         const binary = atob(payload);
         const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
         const text = new TextDecoder("utf-8").decode(bytes);
-        navigator.clipboard.writeText(text).catch((err) => {
-          // Most common reason: the Clipboard API requires a user gesture.
-          // This can fail when the OSC 52 response arrives outside the
-          // original keydown event's activation. Log to aid debugging.
-          console.warn("[dashboard clipboard] OSC 52 write failed:", err.message);
-        });
+        copyText(text);
       } catch (e) {
         console.warn("[dashboard clipboard] malformed OSC 52 payload");
       }
@@ -315,7 +339,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // konsole / Windows Terminal. Ctrl+Shift+C only copies if a selection exists;
       // without a selection it passes through to the TUI so agents can still
       // react to the keypress.
-      // Paste: Cmd+Shift+V on macOS, Ctrl+Shift+V on others.
+      // Paste: Cmd+V on macOS, Ctrl+Shift+V on others.  On non-secure
+      // dashboard origins (for example http://100.x.y.z over Tailscale),
+      // browsers block navigator.clipboard.readText(); in that case we let
+      // xterm's native paste event handle the key instead of swallowing it.
       const copyModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
       const pasteModifier = isMac ? ev.metaKey : ev.ctrlKey && ev.shiftKey;
 
@@ -325,9 +352,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           // Direct writeText inside the keydown handler preserves the user
           // gesture — async round-trips through OSC 52 can lose activation
           // and fail with "Document is not focused".
-          navigator.clipboard.writeText(sel).catch((err) => {
-            console.warn("[dashboard clipboard] direct copy failed:", err.message);
-          });
+          copyText(sel);
           // Clear xterm.js's highlight after copy (matches gnome-terminal).
           term.clearSelection();
           ev.preventDefault();
@@ -338,6 +363,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       }
 
       if (pasteModifier && ev.key.toLowerCase() === "v") {
+        if (!clipboardCanReadText()) return true;
         navigator.clipboard
           .readText()
           .then((text) => {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -25,7 +25,7 @@ import "@xterm/xterm/css/xterm.css";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@/components/NouiTypography";
 import { cn } from "@/lib/utils";
-import { Copy, Mic, PanelRight, X } from "lucide-react";
+import { Copy, Headphones, Mic, PanelRight, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams } from "react-router-dom";
@@ -44,6 +44,12 @@ function buildWsUrl(
   const qs = new URLSearchParams({ token, channel });
   if (resume) qs.set("resume", resume);
   return `${proto}//${window.location.host}/api/pty?${qs.toString()}`;
+}
+
+function buildEventsWsUrl(token: string, channel: string): string {
+  const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const qs = new URLSearchParams({ token, channel });
+  return `${proto}//${window.location.host}/api/events?${qs.toString()}`;
 }
 
 // Channel id ties this chat tab's PTY child (publisher) to its sidebar
@@ -165,7 +171,14 @@ async function transcribeBrowserAudio(blob: Blob, token: string): Promise<string
     body: blob,
   });
 
-  let payload: { success?: boolean; transcript?: string; error?: string; detail?: string } = {};
+  let payload: {
+    detail?: string;
+    error?: string;
+    filtered?: boolean;
+    provider?: string;
+    success?: boolean;
+    transcript?: string;
+  } = {};
   try {
     payload = await resp.json();
   } catch {
@@ -181,6 +194,141 @@ async function transcribeBrowserAudio(blob: Blob, token: string): Promise<string
   return payload.transcript ?? "";
 }
 
+async function synthesizeBrowserSpeech(text: string, token: string): Promise<Blob> {
+  const resp = await fetch("/api/voice/synthesize", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Hermes-Session-Token": token,
+    },
+    body: JSON.stringify({ text }),
+  });
+
+  if (!resp.ok) {
+    let payload: { detail?: string; error?: string } = {};
+    try {
+      payload = await resp.json();
+    } catch {
+      // Keep the fallback HTTP status below useful for non-JSON errors.
+    }
+    throw new Error(payload.detail || payload.error || `speech synthesis failed (${resp.status})`);
+  }
+
+  return resp.blob();
+}
+
+type HandsFreeState =
+  | "off"
+  | "listening"
+  | "recording"
+  | "transcribing"
+  | "thinking"
+  | "speaking";
+
+interface RpcEventFrame {
+  method?: string;
+  params?: {
+    type?: string;
+    payload?: {
+      text?: string;
+      rendered?: string;
+    };
+  };
+}
+
+const HANDS_FREE_SPEECH_RMS = 0.035;
+const HANDS_FREE_SILENCE_RMS = 0.018;
+const HANDS_FREE_MIN_SPEECH_MS = 350;
+const HANDS_FREE_SILENCE_MS = 900;
+const HANDS_FREE_MAX_UTTERANCE_MS = 20_000;
+const HANDS_FREE_MAX_SPOKEN_CHARS = 900;
+const HANDS_FREE_SILENT_WAV =
+  "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAESsAACJWAAACABAAZGF0YQAAAAA=";
+
+function rmsFromTimeDomain(data: Uint8Array<ArrayBuffer>): number {
+  let sum = 0;
+  for (const sample of data) {
+    const centered = (sample - 128) / 128;
+    sum += centered * centered;
+  }
+  return Math.sqrt(sum / Math.max(1, data.length));
+}
+
+function normalizeTranscriptCommand(text: string): string {
+  return text
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9\s]/g, "")
+    .replace(/\s+/g, " ");
+}
+
+function isHandsFreeStopCommand(text: string): boolean {
+  const normalized = normalizeTranscriptCommand(text);
+  return normalized === "stop" || normalized === "pause" || normalized === "arrete";
+}
+
+function prepareHandsFreeSpeech(text: string): string {
+  let clean = text
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/^MEDIA:.*$/gim, " ")
+    .replace(/^\s*\[\[audio_as_voice\]\]\s*$/gim, " ")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/[`*_>#-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (clean.length <= HANDS_FREE_MAX_SPOKEN_CHARS) {
+    return clean;
+  }
+
+  const slice = clean.slice(0, HANDS_FREE_MAX_SPOKEN_CHARS);
+  const boundary = Math.max(
+    slice.lastIndexOf("."),
+    slice.lastIndexOf("!"),
+    slice.lastIndexOf("?"),
+    slice.lastIndexOf("\n"),
+  );
+  clean = slice.slice(0, boundary > 420 ? boundary + 1 : HANDS_FREE_MAX_SPOKEN_CHARS).trim();
+  return `${clean} Le detail est dans le chat.`;
+}
+
+function handsFreeStateLabel(state: HandsFreeState): string {
+  switch (state) {
+    case "listening":
+      return "listening";
+    case "recording":
+      return "hearing";
+    case "transcribing":
+      return "stt";
+    case "thinking":
+      return "thinking";
+    case "speaking":
+      return "speaking";
+    default:
+      return "hands-free";
+  }
+}
+
+function setAudioSource(audio: HTMLAudioElement, src: string, volume: number): void {
+  audio.preload = "auto";
+  audio.src = src;
+  audio.volume = volume;
+}
+
+function clearAudioSource(audio: HTMLAudioElement): void {
+  audio.pause();
+  audio.onended = null;
+  audio.onerror = null;
+  audio.removeAttribute("src");
+  audio.load();
+}
+
+function rewindAudio(audio: HTMLAudioElement): void {
+  audio.currentTime = 0;
+}
+
 export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -191,6 +339,23 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const recorderChunksRef = useRef<BlobPart[]>([]);
   const [recording, setRecording] = useState(false);
   const [transcribingVoice, setTranscribingVoice] = useState(false);
+  const handsFreeStreamRef = useRef<MediaStream | null>(null);
+  const handsFreeAudioContextRef = useRef<AudioContext | null>(null);
+  const handsFreeAnalyserRef = useRef<AnalyserNode | null>(null);
+  const handsFreeSamplesRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
+  const handsFreeVadRafRef = useRef<number>(0);
+  const runHandsFreeVadRef = useRef<() => void>(() => {});
+  const handsFreeRecorderRef = useRef<MediaRecorder | null>(null);
+  const handsFreeChunksRef = useRef<BlobPart[]>([]);
+  const handsFreeSpeechStartedAtRef = useRef<number>(0);
+  const handsFreeLastVoiceAtRef = useRef<number>(0);
+  const handsFreeAudioRef = useRef<HTMLAudioElement | null>(null);
+  const handsFreeAudioUrlRef = useRef<string | null>(null);
+  const handsFreePlaybackResolveRef = useRef<(() => void) | null>(null);
+  const [handsFreeEnabled, setHandsFreeEnabled] = useState(false);
+  const handsFreeEnabledRef = useRef(false);
+  const [handsFreeState, setHandsFreeState] = useState<HandsFreeState>("off");
+  const handsFreeStateRef = useRef<HandsFreeState>("off");
   // Exposed to the main metrics-sync effect so it can refit the terminal
   // the moment `isActive` flips back to true (display:none → display:flex
   // collapses the host's box, so ResizeObserver never fires on return).
@@ -233,6 +398,16 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
   const resumeRef = useRef<string | null>(searchParams.get("resume"));
   const channel = useMemo(() => generateChannelId(), []);
+
+  const setHandsFreeEnabledValue = useCallback((value: boolean) => {
+    handsFreeEnabledRef.current = value;
+    setHandsFreeEnabled(value);
+  }, []);
+
+  const setHandsFreeStateValue = useCallback((value: HandsFreeState) => {
+    handsFreeStateRef.current = value;
+    setHandsFreeState(value);
+  }, []);
 
   useEffect(() => {
     const mql = window.matchMedia("(max-width: 1023px)");
@@ -337,7 +512,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     const ws = wsRef.current;
     if (!ws || ws.readyState !== WebSocket.OPEN) {
       showVoiceBanner("Chat websocket is not connected.");
-      return;
+      return false;
     }
     ws.send(text);
     setTimeout(() => {
@@ -345,6 +520,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       if (s && s.readyState === WebSocket.OPEN) s.send("\r");
     }, 100);
     termRef.current?.focus();
+    return true;
   }, [showVoiceBanner]);
 
   const stopBrowserRecording = useCallback(() => {
@@ -428,6 +604,412 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     }
     if (!transcribingVoice) void startBrowserRecording();
   }, [recording, startBrowserRecording, stopBrowserRecording, transcribingVoice]);
+
+  const stopHandsFreePlayback = useCallback(() => {
+    const resolve = handsFreePlaybackResolveRef.current;
+    handsFreePlaybackResolveRef.current = null;
+    if (resolve) resolve();
+
+    const audio = handsFreeAudioRef.current;
+    if (audio) {
+      clearAudioSource(audio);
+    }
+
+    if (handsFreeAudioUrlRef.current) {
+      URL.revokeObjectURL(handsFreeAudioUrlRef.current);
+      handsFreeAudioUrlRef.current = null;
+    }
+  }, []);
+
+  const cleanupHandsFreeResources = useCallback(() => {
+    if (handsFreeVadRafRef.current) {
+      cancelAnimationFrame(handsFreeVadRafRef.current);
+      handsFreeVadRafRef.current = 0;
+    }
+
+    const recorder = handsFreeRecorderRef.current;
+    if (recorder) {
+      recorder.ondataavailable = null;
+      recorder.onerror = null;
+      recorder.onstop = null;
+      if (recorder.state !== "inactive") {
+        try {
+          recorder.stop();
+        } catch {
+          // Ignore recorder shutdown races during mode teardown.
+        }
+      }
+    }
+    handsFreeRecorderRef.current = null;
+    handsFreeChunksRef.current = [];
+
+    handsFreeStreamRef.current?.getTracks().forEach((track) => track.stop());
+    handsFreeStreamRef.current = null;
+    handsFreeAnalyserRef.current = null;
+    handsFreeSamplesRef.current = null;
+
+    const audioContext = handsFreeAudioContextRef.current;
+    handsFreeAudioContextRef.current = null;
+    if (audioContext && audioContext.state !== "closed") {
+      void audioContext.close().catch(() => {});
+    }
+
+    stopHandsFreePlayback();
+  }, [stopHandsFreePlayback]);
+
+  const disableHandsFree = useCallback((message?: string) => {
+    setHandsFreeEnabledValue(false);
+    cleanupHandsFreeResources();
+    setHandsFreeStateValue("off");
+    if (message) setBanner(message);
+    restoreTerminalInput();
+  }, [
+    cleanupHandsFreeResources,
+    restoreTerminalInput,
+    setHandsFreeEnabledValue,
+    setHandsFreeStateValue,
+  ]);
+
+  const primeHandsFreeAudio = useCallback(async () => {
+    const audio = handsFreeAudioRef.current ?? new Audio();
+    handsFreeAudioRef.current = audio;
+    setAudioSource(audio, HANDS_FREE_SILENT_WAV, 0);
+    try {
+      await audio.play();
+      audio.pause();
+      rewindAudio(audio);
+    } catch {
+      // Browsers may still allow later playback after the user gesture that
+      // enabled hands-free mode; surface a real error only if TTS playback fails.
+    } finally {
+      clearAudioSource(audio);
+      audio.volume = 1;
+    }
+  }, []);
+
+  const transcribeHandsFreeBlob = useCallback(async (blob: Blob) => {
+    const token = window.__HERMES_SESSION_TOKEN__;
+    if (!token || !handsFreeEnabledRef.current) {
+      return;
+    }
+
+    setHandsFreeStateValue("transcribing");
+    try {
+      const transcript = (await transcribeBrowserAudio(blob, token)).trim();
+      if (!handsFreeEnabledRef.current) {
+        return;
+      }
+      if (!transcript) {
+        setHandsFreeStateValue("listening");
+        return;
+      }
+      if (isHandsFreeStopCommand(transcript)) {
+        disableHandsFree("Hands-free voice mode stopped.");
+        return;
+      }
+      if (injectTranscript(transcript)) {
+        setHandsFreeStateValue("thinking");
+      } else {
+        setHandsFreeStateValue("listening");
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Voice transcription failed.";
+      if (handsFreeEnabledRef.current) {
+        setBanner(message);
+        setHandsFreeStateValue("listening");
+      }
+    } finally {
+      restoreTerminalInput();
+    }
+  }, [
+    disableHandsFree,
+    injectTranscript,
+    restoreTerminalInput,
+    setHandsFreeStateValue,
+  ]);
+
+  const stopHandsFreeRecording = useCallback(() => {
+    const recorder = handsFreeRecorderRef.current;
+    if (recorder && recorder.state !== "inactive") {
+      recorder.stop();
+    }
+  }, []);
+
+  const startHandsFreeRecording = useCallback(() => {
+    const stream = handsFreeStreamRef.current;
+    if (!stream || handsFreeRecorderRef.current) {
+      return;
+    }
+
+    const mimeType = preferredAudioMimeType();
+    const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+    const now = performance.now();
+    handsFreeChunksRef.current = [];
+    handsFreeRecorderRef.current = recorder;
+    handsFreeSpeechStartedAtRef.current = now;
+    handsFreeLastVoiceAtRef.current = now;
+
+    recorder.ondataavailable = (event) => {
+      if (event.data.size > 0) handsFreeChunksRef.current.push(event.data);
+    };
+
+    recorder.onerror = () => {
+      if (handsFreeEnabledRef.current) {
+        setBanner("Browser microphone recording failed.");
+        setHandsFreeStateValue("listening");
+      }
+      handsFreeRecorderRef.current = null;
+      handsFreeChunksRef.current = [];
+    };
+
+    recorder.onstop = () => {
+      const chunks = handsFreeChunksRef.current;
+      const type = recorder.mimeType || "audio/webm";
+      handsFreeRecorderRef.current = null;
+      handsFreeChunksRef.current = [];
+      if (!handsFreeEnabledRef.current) {
+        return;
+      }
+      if (chunks.length === 0) {
+        setHandsFreeStateValue("listening");
+        return;
+      }
+      void transcribeHandsFreeBlob(new Blob(chunks, { type }));
+    };
+
+    recorder.start();
+    setHandsFreeStateValue("recording");
+  }, [setHandsFreeStateValue, transcribeHandsFreeBlob]);
+
+  const runHandsFreeVad = useCallback(() => {
+    if (!handsFreeEnabledRef.current) {
+      return;
+    }
+
+    const analyser = handsFreeAnalyserRef.current;
+    const samples = handsFreeSamplesRef.current;
+    const state = handsFreeStateRef.current;
+    if (analyser && samples && (state === "listening" || state === "recording")) {
+      analyser.getByteTimeDomainData(samples);
+      const rms = rmsFromTimeDomain(samples);
+      const now = performance.now();
+
+      if (state === "listening" && rms >= HANDS_FREE_SPEECH_RMS) {
+        startHandsFreeRecording();
+      } else if (state === "recording") {
+        if (rms >= HANDS_FREE_SILENCE_RMS) {
+          handsFreeLastVoiceAtRef.current = now;
+        }
+
+        const elapsed = now - handsFreeSpeechStartedAtRef.current;
+        const silentFor = now - handsFreeLastVoiceAtRef.current;
+        if (
+          elapsed >= HANDS_FREE_MAX_UTTERANCE_MS ||
+          (elapsed >= HANDS_FREE_MIN_SPEECH_MS && silentFor >= HANDS_FREE_SILENCE_MS)
+        ) {
+          stopHandsFreeRecording();
+        }
+      }
+    }
+
+    handsFreeVadRafRef.current = requestAnimationFrame(() => runHandsFreeVadRef.current());
+  }, [startHandsFreeRecording, stopHandsFreeRecording]);
+
+  useEffect(() => {
+    runHandsFreeVadRef.current = runHandsFreeVad;
+  }, [runHandsFreeVad]);
+
+  const startHandsFreeMode = useCallback(async () => {
+    if (!window.__HERMES_SESSION_TOKEN__) {
+      showVoiceBanner("Session token unavailable. Reload the dashboard.");
+      return;
+    }
+    if (!window.isSecureContext) {
+      showVoiceBanner("Browser microphone requires HTTPS or localhost.");
+      return;
+    }
+    if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === "undefined") {
+      showVoiceBanner("Browser microphone recording is unavailable in this browser.");
+      return;
+    }
+    if (recording || transcribingVoice) {
+      showVoiceBanner("Stop the current voice recording before enabling hands-free mode.");
+      return;
+    }
+
+    try {
+      await primeHandsFreeAudio();
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+      if (!AudioContextCtor) {
+        stream.getTracks().forEach((track) => track.stop());
+        showVoiceBanner("Browser audio analysis is unavailable in this browser.");
+        return;
+      }
+      const audioContext = new AudioContextCtor();
+      await audioContext.resume();
+      const analyser = audioContext.createAnalyser();
+      analyser.fftSize = 2048;
+      audioContext.createMediaStreamSource(stream).connect(analyser);
+
+      cleanupHandsFreeResources();
+      handsFreeStreamRef.current = stream;
+      handsFreeAudioContextRef.current = audioContext;
+      handsFreeAnalyserRef.current = analyser;
+      handsFreeSamplesRef.current = new Uint8Array(analyser.fftSize);
+      setBanner(null);
+      setHandsFreeEnabledValue(true);
+      setHandsFreeStateValue("listening");
+      handsFreeVadRafRef.current = requestAnimationFrame(() => runHandsFreeVadRef.current());
+      termRef.current?.focus();
+    } catch (err) {
+      cleanupHandsFreeResources();
+      const message = err instanceof Error ? err.message : "microphone permission denied";
+      showVoiceBanner(`Microphone unavailable: ${message}`);
+    }
+  }, [
+    cleanupHandsFreeResources,
+    primeHandsFreeAudio,
+    recording,
+    setHandsFreeEnabledValue,
+    setHandsFreeStateValue,
+    showVoiceBanner,
+    transcribingVoice,
+  ]);
+
+  const speakHandsFreeResponse = useCallback(async (rawText: string) => {
+    const token = window.__HERMES_SESSION_TOKEN__;
+    const text = prepareHandsFreeSpeech(rawText);
+    if (!token || !handsFreeEnabledRef.current || !text) {
+      if (handsFreeEnabledRef.current) setHandsFreeStateValue("listening");
+      return;
+    }
+
+    setHandsFreeStateValue("speaking");
+    stopHandsFreePlayback();
+
+    try {
+      const blob = await synthesizeBrowserSpeech(text, token);
+      if (!handsFreeEnabledRef.current) {
+        return;
+      }
+
+      const audio = handsFreeAudioRef.current ?? new Audio();
+      handsFreeAudioRef.current = audio;
+      const url = URL.createObjectURL(blob);
+      handsFreeAudioUrlRef.current = url;
+      setAudioSource(audio, url, 1);
+
+      await new Promise<void>((resolve, reject) => {
+        handsFreePlaybackResolveRef.current = resolve;
+        audio.onended = () => resolve();
+        audio.onerror = () => reject(new Error("Browser audio playback failed."));
+        const playPromise = audio.play();
+        if (playPromise) {
+          playPromise.catch(reject);
+        }
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Voice playback failed.";
+      if (handsFreeEnabledRef.current) {
+        setBanner(message);
+      }
+    } finally {
+      stopHandsFreePlayback();
+      if (handsFreeEnabledRef.current) {
+        setHandsFreeStateValue("listening");
+        restoreTerminalInput();
+      }
+    }
+  }, [
+    restoreTerminalInput,
+    setHandsFreeStateValue,
+    stopHandsFreePlayback,
+  ]);
+
+  const handleHandsFreeAssistantComplete = useCallback((text: string) => {
+    if (!handsFreeEnabledRef.current) {
+      return;
+    }
+    if (handsFreeStateRef.current !== "thinking") {
+      return;
+    }
+    void speakHandsFreeResponse(text);
+  }, [speakHandsFreeResponse]);
+
+  const handleHandsFreeButton = useCallback(() => {
+    if (handsFreeEnabledRef.current) {
+      disableHandsFree();
+      return;
+    }
+    void startHandsFreeMode();
+  }, [disableHandsFree, startHandsFreeMode]);
+
+  useEffect(() => {
+    const token = window.__HERMES_SESSION_TOKEN__;
+    if (!token || !channel) {
+      return;
+    }
+
+    const ws = new WebSocket(buildEventsWsUrl(token, channel));
+    let unmounting = false;
+
+    ws.addEventListener("error", () => {
+      if (handsFreeEnabledRef.current && !unmounting) {
+        setBanner("Hands-free events feed disconnected.");
+      }
+    });
+
+    ws.addEventListener("close", (ev) => {
+      if (unmounting || !handsFreeEnabledRef.current || ev.code === 1000) {
+        return;
+      }
+      setBanner("Hands-free events feed disconnected.");
+    });
+
+    ws.addEventListener("message", (ev) => {
+      let frame: RpcEventFrame;
+      try {
+        frame = JSON.parse(ev.data);
+      } catch {
+        return;
+      }
+      if (frame.method !== "event" || !frame.params?.type) {
+        return;
+      }
+      if (
+        handsFreeEnabledRef.current &&
+        handsFreeStateRef.current === "thinking" &&
+        (frame.params.type === "approval.request" ||
+          frame.params.type === "clarify.request" ||
+          frame.params.type === "error")
+      ) {
+        setHandsFreeStateValue("listening");
+      }
+      if (frame.params.type !== "message.complete") {
+        return;
+      }
+      const payload = frame.params.payload;
+      const text = payload?.rendered || payload?.text || "";
+      if (text) handleHandsFreeAssistantComplete(text);
+    });
+
+    return () => {
+      unmounting = true;
+      ws.close();
+    };
+  }, [
+    channel,
+    handleHandsFreeAssistantComplete,
+    setHandsFreeStateValue,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      handsFreeEnabledRef.current = false;
+      cleanupHandsFreeResources();
+    };
+  }, [cleanupHandsFreeResources]);
 
   useEffect(() => {
     const host = hostRef.current;
@@ -981,39 +1563,73 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             className="hermes-chat-xterm-host min-h-0 min-w-0 flex-1"
           />
 
-          <Button
-            ghost
-            onClick={handleVoiceButton}
-            disabled={transcribingVoice}
-            title={
-              recording
-                ? "Stop browser microphone recording and transcribe"
-                : "Record browser microphone and send transcript"
-            }
-            aria-label={
-              recording
-                ? "Stop browser microphone recording"
-                : "Record browser microphone"
-            }
-            className={cn(
-              "absolute z-10",
-              "rounded border border-current/30",
-              "bg-black/20 backdrop-blur-sm",
-              "opacity-70 hover:opacity-100 hover:border-current/60",
-              "transition-opacity duration-150 normal-case font-normal tracking-normal",
-              "bottom-2 left-2 px-2 py-1 text-[0.65rem] sm:bottom-3 sm:left-3 sm:px-2.5 sm:py-1.5 sm:text-xs",
-              "lg:bottom-4 lg:left-4",
-              recording && "border-red-300/70 text-red-200 opacity-100",
-            )}
-            style={{ color: recording ? undefined : TERMINAL_THEME.foreground }}
-          >
-            <span className="inline-flex items-center gap-1.5">
-              <Mic className="h-3 w-3 shrink-0" />
-              <span className="hidden min-[400px]:inline tracking-wide">
-                {recording ? "stop voice" : transcribingVoice ? "transcribing" : "voice"}
+          <div className="absolute bottom-2 left-2 z-10 flex max-w-[calc(100%-5rem)] flex-wrap gap-1.5 sm:bottom-3 sm:left-3 lg:bottom-4 lg:left-4">
+            <Button
+              ghost
+              onClick={handleVoiceButton}
+              disabled={transcribingVoice || handsFreeEnabled}
+              title={
+                recording
+                  ? "Stop browser microphone recording and transcribe"
+                  : "Record browser microphone and send transcript"
+              }
+              aria-label={
+                recording
+                  ? "Stop browser microphone recording"
+                  : "Record browser microphone"
+              }
+              className={cn(
+                "rounded border border-current/30",
+                "bg-black/20 backdrop-blur-sm",
+                "opacity-70 hover:opacity-100 hover:border-current/60",
+                "transition-opacity duration-150 normal-case font-normal tracking-normal",
+                "px-2 py-1 text-[0.65rem] sm:px-2.5 sm:py-1.5 sm:text-xs",
+                recording && "border-red-300/70 text-red-200 opacity-100",
+              )}
+              style={{ color: recording ? undefined : TERMINAL_THEME.foreground }}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <Mic className="h-3 w-3 shrink-0" />
+                <span className="hidden min-[400px]:inline tracking-wide">
+                  {recording ? "stop voice" : transcribingVoice ? "transcribing" : "voice"}
+                </span>
               </span>
-            </span>
-          </Button>
+            </Button>
+
+            <Button
+              ghost
+              onClick={handleHandsFreeButton}
+              disabled={recording || transcribingVoice}
+              title={
+                handsFreeEnabled
+                  ? "Stop hands-free browser voice mode"
+                  : "Start hands-free browser voice mode"
+              }
+              aria-label={
+                handsFreeEnabled
+                  ? "Stop hands-free browser voice mode"
+                  : "Start hands-free browser voice mode"
+              }
+              className={cn(
+                "rounded border border-current/30",
+                "bg-black/20 backdrop-blur-sm",
+                "opacity-70 hover:opacity-100 hover:border-current/60",
+                "transition-opacity duration-150 normal-case font-normal tracking-normal",
+                "px-2 py-1 text-[0.65rem] sm:px-2.5 sm:py-1.5 sm:text-xs",
+                handsFreeEnabled && "border-emerald-300/70 text-emerald-100 opacity-100",
+                handsFreeState === "recording" && "border-red-300/70 text-red-200",
+                handsFreeState === "speaking" && "border-sky-300/70 text-sky-100",
+              )}
+              style={{ color: handsFreeEnabled ? undefined : TERMINAL_THEME.foreground }}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <Headphones className="h-3 w-3 shrink-0" />
+                <span className="hidden min-[460px]:inline tracking-wide">
+                  {handsFreeStateLabel(handsFreeState)}
+                </span>
+              </span>
+            </Button>
+          </div>
 
           <Button
             ghost
@@ -1061,5 +1677,6 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 declare global {
   interface Window {
     __HERMES_SESSION_TOKEN__?: string;
+    webkitAudioContext?: typeof AudioContext;
   }
 }

--- a/web/tests/handsFreeVoice.test.ts
+++ b/web/tests/handsFreeVoice.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  HANDS_FREE_CHUNK_MAX_CHARS,
+  HANDS_FREE_MAX_SPOKEN_CHARS,
+  HANDS_FREE_STREAM_CHUNK_MIN_CHARS,
+  HANDS_FREE_TRUNCATION_NOTICE,
+  handsFreeMeterPercent,
+  handsFreeSilenceThreshold,
+  handsFreeSpeechThreshold,
+  isHandsFreeDisableCommand,
+  isHandsFreeStopCommand,
+  normalizeTranscriptCommand,
+  prepareHandsFreeSpeech,
+  rmsFromTimeDomain,
+  sanitizeHandsFreeSpeechText,
+  splitHandsFreeSpeech,
+  takeReadyHandsFreeSpeechChunks,
+} from "../src/lib/handsFreeVoice.ts";
+
+test("normalizes and classifies hands-free voice commands", () => {
+  assert.equal(normalizeTranscriptCommand("  Arrête,   s'il te plaît! "), "arrete sil te plait");
+  assert.equal(isHandsFreeStopCommand("Arrête"), true);
+  assert.equal(isHandsFreeStopCommand("désactive le mode vocal"), false);
+  assert.equal(isHandsFreeDisableCommand("Désactive le mode vocal."), true);
+  assert.equal(isHandsFreeDisableCommand("stop"), false);
+});
+
+test("sanitizes dashboard media and markdown before speaking", () => {
+  const clean = sanitizeHandsFreeSpeechText(
+    "Intro **forte** [lien](https://example.com)\n```ts\nconst x = 1\n```\n[[audio_as_voice]]\nMEDIA:/tmp/voice.mp3",
+  );
+
+  assert.equal(clean, "Intro forte lien");
+});
+
+test("prepares spoken text with a global cap and a chat-detail notice", () => {
+  const longText = `${"phrase ".repeat(130)}fin.`;
+  const spoken = prepareHandsFreeSpeech(longText);
+
+  assert.ok(spoken.length <= HANDS_FREE_MAX_SPOKEN_CHARS + HANDS_FREE_TRUNCATION_NOTICE.length + 1);
+  assert.ok(spoken.endsWith(HANDS_FREE_TRUNCATION_NOTICE));
+});
+
+test("does not stream tiny TTS chunks and flushes at the end", () => {
+  const shortText = "Une phrase courte.";
+  const pending = takeReadyHandsFreeSpeechChunks(shortText, false);
+  assert.deepEqual(pending.chunks, []);
+  assert.equal(pending.rest, shortText);
+
+  const flushed = takeReadyHandsFreeSpeechChunks(shortText, true);
+  assert.deepEqual(flushed.chunks, [shortText]);
+  assert.equal(flushed.rest, "");
+});
+
+test("streams larger TTS chunks instead of one call per sentence", () => {
+  const first = "Premiere phrase. ";
+  const text = first.repeat(Math.ceil((HANDS_FREE_CHUNK_MAX_CHARS + 160) / first.length));
+  const { chunks, rest } = takeReadyHandsFreeSpeechChunks(text, false);
+
+  assert.equal(chunks.length, 1);
+  assert.ok(chunks[0].length >= HANDS_FREE_STREAM_CHUNK_MIN_CHARS);
+  assert.ok(chunks[0].length <= HANDS_FREE_CHUNK_MAX_CHARS);
+  assert.ok(rest.length > 0);
+});
+
+test("splits fallback speech into capped chunks", () => {
+  const text = `${"Segment assez long pour tester le decoupage. ".repeat(60)}fin.`;
+  const chunks = splitHandsFreeSpeech(text);
+  const spoken = chunks.join(" ");
+
+  assert.ok(chunks.length >= 1);
+  assert.ok(chunks.every((chunk) => chunk.length <= HANDS_FREE_CHUNK_MAX_CHARS * 1.5));
+  assert.ok(spoken.includes(HANDS_FREE_TRUNCATION_NOTICE));
+});
+
+test("computes adaptive VAD thresholds and RMS levels", () => {
+  assert.equal(rmsFromTimeDomain(new Uint8Array([128, 128, 128])), 0);
+  assert.ok(rmsFromTimeDomain(new Uint8Array([0, 255])) > 0.99);
+
+  assert.equal(handsFreeSpeechThreshold(0), 0.022);
+  assert.equal(handsFreeSilenceThreshold(0), 0.012);
+  assert.ok(handsFreeSpeechThreshold(0.05) > handsFreeSpeechThreshold(0));
+});
+
+test("keeps the mic meter bounded for mobile UI", () => {
+  assert.equal(handsFreeMeterPercent({ level: 0, noise: 0.01, speaking: false, threshold: 0.02 }), 3);
+  assert.equal(handsFreeMeterPercent({ level: 1, noise: 0.01, speaking: true, threshold: 0.02 }), 100);
+});


### PR DESCRIPTION
## Summary

Fixes the dashboard Chat tab for remote Tailscale usage and adds browser-based voice paths that work from the device running the dashboard, not only from the machine hosting Hermes.

- Allow dashboard WebSocket clients through an explicit `HERMES_DASHBOARD_ALLOWED_HOSTS` proxy-host allowlist when the dashboard is bound to loopback behind a trusted local HTTPS proxy.
- Add `/api/voice/transcribe` so the browser can upload recorded microphone audio and reuse the existing server-side STT pipeline.
- Add `/api/voice/synthesize` so dashboard responses can reuse the configured Hermes TTS provider and play back in the browser.
- Add a one-shot Chat voice button that records with `MediaRecorder`, sends the transcript into the embedded PTY, and restores terminal focus/layout on failures.
- Add a minimal hands-free Chat mode: browser VAD detects speech, transcribes a turn, sends it to the active agent, waits for `message.complete`, synthesizes the answer, plays it in the browser, then returns to listening.
- Cover proxy-host handling, WebSocket allowance, upload bounds, auth, cleanup, hallucination filtering, and dashboard TTS failure paths in web server tests.

## Root Cause

The dashboard could be served through Tailscale HTTPS while the embedded Chat WebSockets were still treated as non-loopback clients and rejected. Browser microphone APIs also require a secure context, so the old HTTP/Tailscale-IP access path was insufficient for remote voice usage. The classic voice/TTS flow also records and plays audio on the host machine, which breaks the expected dashboard model when the user is on a MacBook, iPhone, or other Tailscale-connected device.

## Validation

- `npx eslint src/pages/ChatPage.tsx`
- `/Users/ergonomia_mac_mini/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_web_server.py -k dashboard_voice`
- `npm run build`
- `git diff --check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py web/src/pages/ChatPage.tsx`
- Manual Tailscale HTTPS check: `/chat` loads from `https://mac-mini-de-ergonomia-mac-mini.taild069eb.ts.net/chat` and classic browser voice works remotely.

## CI Note

The `Lint (ruff + ty)` workflow can report failure on this fork PR because its final GitHub Script step tries to create/update a PR comment with a read-only `GITHUB_TOKEN`. The actual lint diff summary for commit `678bf8514` reports `ruff` new issues: none, and `ty` new issues: none.

## Notes

This PR intentionally excludes unrelated local changes in `gateway/*`, the xAI video tool files, and `web/public/voice/*`.
