### PR TITLE
fix(skills): add --yes flag support to hermes skills uninstall

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9576,6 +9576,9 @@ Examples:
         "uninstall", help="Remove a hub-installed skill"
     )
     skills_uninstall.add_argument("name", help="Skill name to remove")
+    skills_uninstall.add_argument(
+        "--yes", "-y", action="store_true", help="Skip confirmation prompt"
+    )
 
     skills_reset = skills_subparsers.add_parser(
         "reset",

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1339,7 +1339,7 @@ def skills_command(args) -> None:
     elif action == "audit":
         do_audit(name=getattr(args, "name", None))
     elif action == "uninstall":
-        do_uninstall(args.name)
+        do_uninstall(args.name, skip_confirm=getattr(args, "yes", False))
     elif action == "reset":
         do_reset(args.name, restore=getattr(args, "restore", False),
                  skip_confirm=getattr(args, "yes", False))

--- a/tests/hermes_cli/test_skills_skip_confirm.py
+++ b/tests/hermes_cli/test_skills_skip_confirm.py
@@ -121,6 +121,49 @@ class TestHandleSkillsSlashUninstallFlags:
             assert kwargs.get("invalidate_cache") is True
 
 
+class TestSkillsCommandUninstallFlags:
+    """Test flag parsing in skills_command for uninstall (CLI argparse path)."""
+
+    def test_yes_flag_sets_skip_confirm(self):
+        from hermes_cli.skills_hub import skills_command
+        from argparse import Namespace
+        args = Namespace(skills_action="uninstall", name="test-skill", yes=True)
+        with patch("hermes_cli.skills_hub.do_uninstall") as mock_uninstall:
+            skills_command(args)
+            mock_uninstall.assert_called_once()
+            _, kwargs = mock_uninstall.call_args
+            assert kwargs.get("skip_confirm") is True
+
+    def test_y_flag_short_form_sets_skip_confirm(self):
+        from hermes_cli.skills_hub import skills_command
+        from argparse import Namespace
+        args = Namespace(skills_action="uninstall", name="test-skill", yes=True)
+        with patch("hermes_cli.skills_hub.do_uninstall") as mock_uninstall:
+            skills_command(args)
+            _, kwargs = mock_uninstall.call_args
+            assert kwargs.get("skip_confirm") is True
+
+    def test_no_flag_does_not_set_skip_confirm(self):
+        from hermes_cli.skills_hub import skills_command
+        from argparse import Namespace
+        args = Namespace(skills_action="uninstall", name="test-skill", yes=False)
+        with patch("hermes_cli.skills_hub.do_uninstall") as mock_uninstall:
+            skills_command(args)
+            _, kwargs = mock_uninstall.call_args
+            assert kwargs.get("skip_confirm") is False
+
+    def test_invalidate_cache_not_passed(self):
+        """The CLI doesn't pass invalidate_cache; do_uninstall defaults to True."""
+        from hermes_cli.skills_hub import skills_command
+        from argparse import Namespace
+        args = Namespace(skills_action="uninstall", name="test-skill", yes=True)
+        with patch("hermes_cli.skills_hub.do_uninstall") as mock_uninstall:
+            skills_command(args)
+            _, kwargs = mock_uninstall.call_args
+            # CLI doesn't pass invalidate_cache for uninstall; do_uninstall defaults to True
+            assert "invalidate_cache" not in kwargs
+
+
 class TestDoInstallSkipConfirm:
     """Test that do_install respects skip_confirm parameter."""
 


### PR DESCRIPTION
## Summary

`hermes skills uninstall <name> --yes` fails with `unrecognized arguments: --yes` because:

1. **`main.py`**: the `skills_uninstall` argparse subparser never defined `--yes/-y`
2. **`skills_hub.py`**: `skills_command()` called `do_uninstall(args.name)` without forwarding `skip_confirm`, so even if `--yes` existed it was ignored

## Changes

- **hermes_cli/main.py**: add `--yes, -y` argument to `skills_uninstall` parser
- **hermes_cli/skills_hub.py**: pass `skip_confirm=getattr(args, "yes", False)` in the `uninstall` action
- **tests/hermes_cli/test_skills_skip_confirm.py**: add `TestSkillsCommandUninstallFlags` covering the CLI argparse path for uninstall

## Testing

All 19 tests in `test_skills_skip_confirm.py` pass. The fix follows the same pattern already used by `skills install` and `skills reset`.

Closes #3662