### PR TITLE
fix(tts): use .ogg extension for Telegram auto-TTS voice replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8682,11 +8682,16 @@ class GatewayRunner:
             if not tts_text:
                 return
 
-            # Use .mp3 extension so edge-tts conversion to opus works correctly.
-            # The TTS tool may convert to .ogg — use file_path from result.
+            # Use .ogg extension for Telegram (native voice bubble format)
+            # so providers like ElevenLabs/OpenAI output opus natively.
+            # For other platforms, .mp3 is fine. The TTS tool's opus
+            # conversion fallback handles Edge TTS and other mp3-only providers.
+            from gateway.session_context import get_session_env
+            _platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
+            _tts_ext = "ogg" if _platform == "telegram" else "mp3"
             audio_path = os.path.join(
                 tempfile.gettempdir(), "hermes_voice",
-                f"tts_reply_{_uuid.uuid4().hex[:12]}.mp3",
+                f"tts_reply_{_uuid.uuid4().hex[:12]}.{_tts_ext}",
             )
             os.makedirs(os.path.dirname(audio_path), exist_ok=True)
 


### PR DESCRIPTION
## Bug Description

When voice mode is enabled on Telegram, the gateway auto-TTS (`_send_voice_reply`) sends audio as MP3 file attachments instead of native voice bubbles.

## Root Cause

`_send_voice_reply()` in `gateway/run.py` hardcodes `.mp3` as the output file extension (line 8689):

```python
audio_path = os.path.join(
    tempfile.gettempdir(), "hermes_voice",
    f"tts_reply_{_uuid.uuid4().hex[:12]}.mp3",
)
```

This explicit `output_path` overrides the TTS tool's platform auto-detection. The ElevenLabs provider checks `output_path.endswith(".ogg")` to choose between `opus_48000_64` (native Telegram format) and `mp3_44100_128`. Since the path ends in `.mp3`, it generates MP3 — which Telegram sends as a file attachment, not a voice bubble.

## Fix

Detect the platform from the gateway session context and use `.ogg` for Telegram, `.mp3` for everything else:

```python
from gateway.session_context import get_session_env
_platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
_tts_ext = "ogg" if _platform == "telegram" else "mp3"
audio_path = os.path.join(
    tempfile.gettempdir(), "hermes_voice",
    f"tts_reply_{_uuid.uuid4().hex[:12]}.{_tts_ext}",
)
```

The TTS tool already handles the rest — it checks the extension to select the correct codec, and its opus conversion fallback handles Edge TTS and other mp3-only providers.

## How to Verify

1. Enable voice mode on Telegram: `/voice on`
2. Send any message to the bot
3. The auto-TTS reply should appear as a native voice bubble (round, playable inline), not an MP3 file attachment

## Test Plan

- [x] Manual verification on Telegram with ElevenLabs provider
- [ ] Existing TTS tests still pass
- [ ] Voice mode on non-Telegram platforms still works (Discord, etc.)

## Risk Assessment

Low — Only affects the auto-TTS file extension. The TTS tool already has opus conversion fallbacks for providers that only output mp3 (Edge TTS). Non-Telegram platforms continue using .mp3 as before.