### PR TITLE
fix(tts): rename .ogg->mp3 before opus conversion for mp3-only providers (edge-tts, minimax, xai)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8682,11 +8682,16 @@ class GatewayRunner:
             if not tts_text:
                 return
 
-            # Use .mp3 extension so edge-tts conversion to opus works correctly.
-            # The TTS tool may convert to .ogg — use file_path from result.
+            # Use .ogg extension for Telegram (native voice bubble format)
+            # so providers like ElevenLabs/OpenAI output opus natively.
+            # For other platforms, .mp3 is fine. The TTS tool's opus
+            # conversion fallback handles Edge TTS and other mp3-only providers.
+            from gateway.session_context import get_session_env
+            _platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
+            _tts_ext = "ogg" if _platform == "telegram" else "mp3"
             audio_path = os.path.join(
                 tempfile.gettempdir(), "hermes_voice",
-                f"tts_reply_{_uuid.uuid4().hex[:12]}.mp3",
+                f"tts_reply_{_uuid.uuid4().hex[:12]}.{_tts_ext}",
             )
             os.makedirs(os.path.dirname(audio_path), exist_ok=True)
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1750,9 +1750,24 @@ def text_to_speech_tool(
                     if opus_path:
                         file_str = opus_path
                 voice_compatible = file_str.endswith(".ogg")
-        elif provider in ("edge", "neutts", "minimax", "xai", "kittentts", "piper") and not file_str.endswith(".ogg"):
+        elif provider in ("edge", "neutts", "minimax", "xai", "kittentts", "piper"):
+            # These providers always output MP3/WAV regardless of the output path
+            # extension.  If the caller requested .ogg (e.g. Telegram voice reply),
+            # the provider wrote MP3 bytes into the .ogg-named file.  Rename to
+            # .mp3 first so _convert_to_opus receives a correctly-named source,
+            # then convert to real Opus.  The intermediate .mp3 is cleaned up here.
+            if file_str.endswith(".ogg"):
+                mp3_path = file_str[:-4] + ".mp3"
+                os.rename(file_str, mp3_path)
+                file_str = mp3_path
             opus_path = _convert_to_opus(file_str)
             if opus_path:
+                # Remove the intermediate .mp3 temp file
+                try:
+                    if file_str != opus_path:
+                        os.unlink(file_str)
+                except OSError:
+                    pass
                 file_str = opus_path
                 voice_compatible = True
         elif provider in ("elevenlabs", "openai", "mistral", "gemini"):


### PR DESCRIPTION
## What this fixes\n\nPR #20878 (`fix(tts): use .ogg extension for Telegram auto-TTS voice replies`) introduces platform-aware extension selection in `_send_voice_reply()`.  The change is correct for ElevenLabs/OpenAI/Mistral/Gemini — those providers honour the `.ogg` extension and output native Opus.\n\n**Bug introduced by #20878 (mp3-only providers — edge-tts, minimax, xai, neutts, kittentts, piper):**\n\n`_generate_edge_tts()` (and the other mp3-only providers) call `communicate.save(output_path)` unconditionally — they write **raw MP3 bytes regardless of the path extension**.  After generation the existing opus-conversion block was:\n\n```python\nelif provider in ("edge", "neutts", ...) and not file_str.endswith(".ogg"):\n    opus_path = _convert_to_opus(file_str)\n```\n\nWith a `.ogg` path the guard `not file_str.endswith(".ogg")` evaluates to `False`, so `_convert_to_opus` is **skipped entirely**.  The result is a `.ogg` file containing MP3 bytes — Telegram rejects it and the voice bubble silently fails.\n\n## Fix\n\nBefore calling `_convert_to_opus`, rename the mislabeled file from `.ogg` → `.mp3` so ffmpeg receives a correctly-named source.  The intermediate `.mp3` is cleaned up immediately after conversion.  The original `.mp3` path is unaffected (rename branch only reached when caller requested `.ogg`).\n\n## Verification\n\n- Non-Telegram path (`.mp3`): rename block not entered, no behaviour change.\n- Telegram + ElevenLabs/OpenAI: `voice_compatible` branch untouched, still correct.\n- Telegram + edge-tts: `.ogg` renamed to `.mp3`, `_convert_to_opus` produces real Opus, `voice_compatible = True`, Telegram renders voice bubble.\n\nCompanion fix to #20878 — handles the mp3-only provider edge case that #20878 leaves broken.\n