### PR TITLE
feat(dashboard): add --allowed-host flag for reverse proxy support

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8422,6 +8422,7 @@ def cmd_dashboard(args):
         open_browser=not args.no_open,
         allow_public=getattr(args, "insecure", False),
         embedded_chat=embedded_chat,
+        allowed_hosts=getattr(args, "allowed_hosts", []),
     )
 
 
@@ -10609,6 +10610,17 @@ Examples:
         "--insecure",
         action="store_true",
         help="Allow binding to non-localhost (DANGEROUS: exposes API keys on the network)",
+    )
+    dashboard_parser.add_argument(
+        "--allowed-host",
+        dest="allowed_hosts",
+        action="append",
+        default=[],
+        help=(
+            "Extra Host header value to accept (repeatable). "
+            "Useful when proxying via Tailscale Serve or a reverse proxy "
+            "that rewrites the Host header."
+        ),
     )
     dashboard_parser.add_argument(
         "--tui",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -147,7 +147,7 @@ _LOOPBACK_HOST_VALUES: frozenset = frozenset({
 })
 
 
-def _is_accepted_host(host_header: str, bound_host: str) -> bool:
+def _is_accepted_host(host_header: str, bound_host: str, extra_hosts: list[str] | None = None) -> bool:
     """True if the Host header targets the interface we bound to.
 
     Accepts:
@@ -155,6 +155,7 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     - Loopback aliases when bound to loopback
     - Any host when bound to 0.0.0.0 (explicit opt-in to non-loopback,
       no protection possible at this layer)
+    - Any hostname listed in *extra_hosts* (e.g. Tailscale tailnet FQDN)
     """
     if not host_header:
         return False
@@ -175,6 +176,10 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     else:
         host_only = h.rsplit(":", 1)[0] if ":" in h else h
     host_only = host_only.lower()
+
+    # Check extra allowed hosts first (e.g. Tailscale tailnet FQDN).
+    if extra_hosts and host_only in extra_hosts:
+        return True
 
     # 0.0.0.0 bind means operator explicitly opted into all-interfaces
     # (requires --insecure per web_server.start_server). No Host-layer
@@ -208,7 +213,8 @@ async def host_header_middleware(request: Request, call_next):
     bound_host = getattr(app.state, "bound_host", None)
     if bound_host:
         host_header = request.headers.get("host", "")
-        if not _is_accepted_host(host_header, bound_host):
+        extra_hosts = getattr(app.state, "allowed_hosts", [])
+        if not _is_accepted_host(host_header, bound_host, extra_hosts):
             return JSONResponse(
                 status_code=400,
                 content={
@@ -4023,6 +4029,7 @@ def start_server(
     allow_public: bool = False,
     *,
     embedded_chat: bool = False,
+    allowed_hosts: list[str] | None = None,
 ):
     """Start the web UI server."""
     import uvicorn
@@ -4049,6 +4056,7 @@ def start_server(
     # PTY child uses to publish events to the dashboard sidebar.
     app.state.bound_host = host
     app.state.bound_port = port
+    app.state.allowed_hosts = [h.lower() for h in (allowed_hosts or [])]
 
     if open_browser:
         import webbrowser


### PR DESCRIPTION
## Problem

The dashboard's Host header validation (anti-DNS-rebinding, GHSA-ppp5-vxwm-4cf7) rejects any request whose Host doesn't match the bound interface. This makes it impossible to run behind a reverse proxy like Tailscale Serve that rewrites the Host header to the proxy's hostname.

## Solution

Add a repeatable `--allowed-host` CLI flag that registers extra accepted Host header values:

```bash
hermes dashboard --no-open --allowed-host machine.tailnet.ts.net
```

Changes:
- `web_server.py`: `_is_accepted_host()` gains an `extra_hosts` parameter, checked before existing logic. Stored on `app.state` by `start_server()`.
- `main.py`: New `--allowed-host` arg on the dashboard subparser, threaded through to `start_server()`.

No changes to existing behavior — the flag is additive and defaults to empty.