### PR TITLE
fix: improve session resume search

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21,6 +21,7 @@ import logging
 import os
 import re
 import shlex
+import sqlite3
 import sys
 import signal
 import tempfile
@@ -10085,6 +10086,330 @@ class GatewayRunner:
             else:
                 return f"📌 Session: `{session_id}`\nNo title set. Usage: `/title My Session Name`"
 
+    _RESUME_EXCLUDE_SOURCES = ("tool", "cron", "tool-call audit")
+
+    @staticmethod
+    def _resume_escape_like(value: str) -> str:
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+    @staticmethod
+    def _resume_preview(value: Any, limit: int = 90) -> str:
+        if value is None:
+            return ""
+        text = str(value).replace("\r", " ").replace("\n", " ")
+        text = re.sub(r"\s+", " ", text).strip()
+        if len(text) > limit:
+            return text[: limit - 3].rstrip() + "..."
+        return text
+
+    def _resume_current_profile_name(self) -> str:
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            return get_active_profile_name()
+        except Exception:
+            return "default"
+
+    def _resume_profile_for_db_path(self, db_path: Path) -> str:
+        try:
+            from hermes_constants import get_default_hermes_root
+            root = get_default_hermes_root().resolve()
+            resolved = Path(db_path).resolve()
+            if resolved == root / "state.db":
+                return "default"
+            profiles_root = root / "profiles"
+            rel = resolved.relative_to(profiles_root)
+            if len(rel.parts) >= 2 and rel.parts[1] == "state.db":
+                return rel.parts[0]
+        except Exception:
+            pass
+        return self._resume_current_profile_name()
+
+    def _resume_profile_db_paths(self) -> List[Dict[str, Any]]:
+        """Return readable profile state DBs, with the live SessionDB first."""
+        current_db_path = Path(getattr(self._session_db, "db_path", "state.db"))
+        current_profile = self._resume_profile_for_db_path(current_db_path)
+        rows: List[Dict[str, Any]] = [
+            {
+                "profile": current_profile,
+                "path": current_db_path,
+                "current": True,
+            }
+        ]
+
+        try:
+            from hermes_constants import get_default_hermes_root
+            root = get_default_hermes_root()
+            current_resolved = current_db_path.resolve()
+            root_resolved = root.resolve()
+            try:
+                current_resolved.relative_to(root_resolved)
+                scan_profiles = True
+            except ValueError:
+                # Unit tests and custom db_path callers often use a temp DB.
+                # Do not accidentally scan the operator's real ~/.hermes then.
+                scan_profiles = False
+            if scan_profiles:
+                rows.append({"profile": "default", "path": root / "state.db", "current": False})
+                profiles_root = root / "profiles"
+                if profiles_root.is_dir():
+                    for entry in sorted(profiles_root.iterdir()):
+                        if entry.is_dir():
+                            rows.append({
+                                "profile": entry.name,
+                                "path": entry / "state.db",
+                                "current": False,
+                            })
+        except Exception as e:
+            logger.debug("Failed to enumerate profile state DBs for /resume: %s", e)
+
+        deduped: List[Dict[str, Any]] = []
+        seen: set[str] = set()
+        for row in rows:
+            path = Path(row["path"])
+            try:
+                key = str(path.resolve())
+            except Exception:
+                key = str(path)
+            if key in seen or not path.exists():
+                continue
+            seen.add(key)
+            row = dict(row)
+            row["path"] = path
+            row["current"] = bool(row.get("current")) or key == str(current_db_path.resolve())
+            deduped.append(row)
+        return deduped
+
+    def _resume_open_readonly_conn(self, db_path: Path) -> Optional[sqlite3.Connection]:
+        try:
+            uri = f"file:{db_path.resolve()}?mode=ro"
+            conn = sqlite3.connect(uri, uri=True, timeout=1.0)
+            conn.row_factory = sqlite3.Row
+            return conn
+        except Exception as e:
+            logger.debug("Could not open profile state DB read-only (%s): %s", db_path, e)
+            return None
+
+    def _resume_query_conn(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        profile: str,
+        query: str = "",
+        limit: int = 20,
+    ) -> List[Dict[str, Any]]:
+        exclude = list(self._RESUME_EXCLUDE_SOURCES)
+        exclude_sql = ",".join("?" for _ in exclude)
+        child_filter = (
+            "(s.parent_session_id IS NULL"
+            " OR EXISTS (SELECT 1 FROM sessions p"
+            "            WHERE p.id = s.parent_session_id"
+            "            AND p.end_reason = 'branched'"
+            "            AND s.started_at >= p.ended_at))"
+        )
+
+        if not query:
+            sql = f"""
+                SELECT s.id, s.title, s.source, s.started_at,
+                    COALESCE((SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = s.id), s.started_at) AS last_active,
+                    COALESCE((
+                        SELECT m.content FROM messages m
+                        WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                        ORDER BY m.timestamp, m.id LIMIT 1
+                    ), '') AS preview,
+                    'title' AS match_kind
+                FROM sessions s
+                WHERE s.title IS NOT NULL AND TRIM(s.title) != ''
+                  AND s.source NOT IN ({exclude_sql})
+                  AND {child_filter}
+                ORDER BY last_active DESC, s.started_at DESC, s.id DESC
+                LIMIT ?
+            """
+            params = [*exclude, limit]
+        else:
+            escaped = self._resume_escape_like(query)
+            like = f"%{escaped}%"
+            sql = f"""
+                WITH RECURSIVE visible_sessions AS (
+                    SELECT s.id, s.title, s.source, s.started_at
+                    FROM sessions s
+                    WHERE s.source NOT IN ({exclude_sql})
+                      AND {child_filter}
+                ),
+                chain(root_id, cur_id) AS (
+                    SELECT id, id FROM visible_sessions
+                    UNION ALL
+                    SELECT c.root_id, child.id
+                    FROM chain c
+                    JOIN sessions parent ON parent.id = c.cur_id
+                    JOIN sessions child ON child.parent_session_id = c.cur_id
+                    WHERE parent.end_reason = 'compression'
+                      AND child.started_at >= parent.ended_at
+                ),
+                title_matches AS (
+                    SELECT s.id, s.title, s.source, s.started_at,
+                        COALESCE((SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = s.id), s.started_at) AS last_active,
+                        COALESCE((
+                            SELECT m.content FROM messages m
+                            WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
+                            ORDER BY m.timestamp, m.id LIMIT 1
+                        ), '') AS preview,
+                        'title' AS match_kind,
+                        0 AS rank
+                    FROM visible_sessions s
+                    WHERE (s.title LIKE ? ESCAPE '\\' OR s.id LIKE ? ESCAPE '\\')
+                ),
+                body_matches AS (
+                    SELECT s.id, s.title, s.source, s.started_at,
+                        COALESCE(MAX(m.timestamp), s.started_at) AS last_active,
+                        COALESCE((
+                            SELECT mm.content FROM messages mm
+                            JOIN chain pc ON pc.cur_id = mm.session_id
+                            WHERE pc.root_id = s.id
+                              AND (mm.content LIKE ? ESCAPE '\\'
+                                   OR mm.tool_name LIKE ? ESCAPE '\\'
+                                   OR mm.tool_calls LIKE ? ESCAPE '\\')
+                            ORDER BY mm.timestamp DESC, mm.id DESC LIMIT 1
+                        ), '') AS preview,
+                        'body' AS match_kind,
+                        1 AS rank
+                    FROM visible_sessions s
+                    JOIN chain c ON c.root_id = s.id
+                    JOIN messages m ON m.session_id = c.cur_id
+                    WHERE (m.content LIKE ? ESCAPE '\\'
+                           OR m.tool_name LIKE ? ESCAPE '\\'
+                           OR m.tool_calls LIKE ? ESCAPE '\\')
+                    GROUP BY s.id
+                ),
+                combined AS (
+                    SELECT * FROM title_matches
+                    UNION ALL
+                    SELECT * FROM body_matches
+                    WHERE id NOT IN (SELECT id FROM title_matches)
+                )
+                SELECT * FROM combined
+                ORDER BY rank ASC, last_active DESC, started_at DESC, id DESC
+                LIMIT ?
+            """
+            params = [
+                *exclude,
+                like, like,
+                like, like, like,
+                like, like, like,
+                limit,
+            ]
+
+        try:
+            rows = [dict(row) for row in conn.execute(sql, params).fetchall()]
+        except Exception as e:
+            logger.debug("Resume candidate query failed for profile %s: %s", profile, e)
+            return []
+
+        candidates: List[Dict[str, Any]] = []
+        for row in rows:
+            candidates.append({
+                "profile": profile,
+                "source": row.get("source") or "",
+                "id": row.get("id") or "",
+                "title": row.get("title") or "",
+                "preview": self._resume_preview(row.get("preview")),
+                "last_active": row.get("last_active") or row.get("started_at") or 0,
+                "match_kind": row.get("match_kind") or "",
+            })
+        return candidates
+
+    def _resume_collect_candidates(
+        self,
+        *,
+        query: str = "",
+        limit: int = 20,
+    ) -> List[Dict[str, Any]]:
+        candidates: List[Dict[str, Any]] = []
+        for db_info in self._resume_profile_db_paths():
+            conn = self._resume_open_readonly_conn(db_info["path"])
+            if conn is None:
+                continue
+            try:
+                rows = self._resume_query_conn(
+                    conn,
+                    profile=db_info["profile"],
+                    query=query,
+                    limit=limit,
+                )
+            finally:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+            for row in rows:
+                row["current_profile"] = bool(db_info.get("current"))
+                row["db_path"] = str(db_info["path"])
+                candidates.append(row)
+
+        candidates.sort(
+            key=lambda c: (
+                0 if c.get("current_profile") else 1,
+                0 if c.get("match_kind") == "title" else 1,
+                -(float(c.get("last_active") or 0)),
+            )
+        )
+        return candidates[:limit]
+
+    def _resume_format_candidates(
+        self,
+        candidates: List[Dict[str, Any]],
+        *,
+        heading: str = "📋 **Resume Candidates**",
+        usage: str = "Run `/resume <session id>` or `/resume <exact title>` to switch.",
+    ) -> str:
+        lines = [heading, ""]
+        for c in candidates:
+            title = c.get("title") or "(untitled)"
+            preview = c.get("preview") or ""
+            preview_part = f"\n  preview: _{preview}_" if preview else ""
+            lines.append(
+                f"• **{title}**"
+                f"\n  profile: `{c.get('profile', '')}`"
+                f"  source: `{c.get('source', '')}`"
+                f"  id: `{c.get('id', '')}`"
+                f"{preview_part}"
+            )
+        lines.append("")
+        lines.append(usage)
+        return "\n".join(lines)
+
+    async def _resume_switch_current_profile(
+        self,
+        *,
+        source: SessionSource,
+        session_key: str,
+        target_id: str,
+        requested_name: str,
+    ) -> str:
+        try:
+            target_id = self._session_db.resolve_resume_session_id(target_id)
+        except Exception as e:
+            logger.debug("Failed to resolve resume continuation for %s: %s", target_id, e)
+
+        current_entry = self.session_store.get_or_create_session(source)
+        if current_entry.session_id == target_id:
+            title = self._session_db.get_session_title(target_id) or requested_name or target_id
+            return f"📌 Already on session **{title}**."
+
+        self._release_running_agent_state(session_key)
+
+        new_entry = self.session_store.switch_session(session_key, target_id)
+        if not new_entry:
+            return "Failed to switch session."
+        self._clear_session_boundary_security_state(session_key)
+        self._evict_cached_agent(session_key)
+
+        title = self._session_db.get_session_title(target_id) or requested_name or target_id
+        history = self.session_store.load_transcript(target_id)
+        msg_count = len([m for m in history if m.get("role") == "user"]) if history else 0
+        msg_part = f" ({msg_count} message{'s' if msg_count != 1 else ''})" if msg_count else ""
+
+        return f"↻ Resumed session **{title}**{msg_part}. Conversation restored."
+
     async def _handle_resume_command(self, event: MessageEvent) -> str:
         """Handle /resume command — switch to a previously-named session."""
         if not self._session_db:
@@ -10095,75 +10420,75 @@ class GatewayRunner:
         name = event.get_command_args().strip()
 
         if not name:
-            # List recent titled sessions for this user/platform
+            # List recent titled sessions across sources in the current
+            # profile, plus readable sibling profile DBs when available.
             try:
-                user_source = source.platform.value if source.platform else None
-                sessions = self._session_db.list_sessions_rich(
-                    source=user_source, limit=10
-                )
-                titled = [s for s in sessions if s.get("title")]
+                titled = self._resume_collect_candidates(limit=10)
                 if not titled:
                     return (
                         "No named sessions found.\n"
                         "Use `/title My Session` to name your current session, "
                         "then `/resume My Session` to return to it later."
                     )
-                lines = ["📋 **Named Sessions**\n"]
-                for s in titled[:10]:
-                    title = s["title"]
-                    preview = s.get("preview", "")[:40]
-                    preview_part = f" — _{preview}_" if preview else ""
-                    lines.append(f"• **{title}**{preview_part}")
-                lines.append("\nUsage: `/resume <session name>`")
-                return "\n".join(lines)
+                return self._resume_format_candidates(
+                    titled[:10],
+                    heading="📋 **Named Sessions**",
+                    usage="Usage: `/resume <session id or exact title>`",
+                )
             except Exception as e:
                 logger.debug("Failed to list titled sessions: %s", e)
                 return f"Could not list sessions: {e}"
 
-        # Resolve the name to a session ID.
-        target_id = self._session_db.resolve_session_by_title(name)
+        # Preserve current-profile exact ID/title/lineage behavior first.
+        target_id = None
+        try:
+            exact = self._session_db.get_session(name)
+            target_id = exact["id"] if exact else None
+        except Exception:
+            target_id = None
         if not target_id:
+            target_id = self._session_db.resolve_session_by_title(name)
+        if target_id:
+            return await self._resume_switch_current_profile(
+                source=source,
+                session_key=session_key,
+                target_id=target_id,
+                requested_name=name,
+            )
+
+        candidates = self._resume_collect_candidates(query=name, limit=10)
+        if not candidates:
             return (
                 f"No session found matching '**{name}**'.\n"
                 "Use `/resume` with no arguments to see available sessions."
             )
-        # Compression creates child continuations that hold the live transcript.
-        # Follow that chain so gateway /resume matches CLI behavior (#15000).
-        try:
-            target_id = self._session_db.resolve_resume_session_id(target_id)
-        except Exception as e:
-            logger.debug("Failed to resolve resume continuation for %s: %s", target_id, e)
 
-        # Check if already on that session
-        current_entry = self.session_store.get_or_create_session(source)
-        if current_entry.session_id == target_id:
-            return f"📌 Already on session **{name}**."
+        if len(candidates) == 1:
+            only = candidates[0]
+            if only.get("current_profile"):
+                return await self._resume_switch_current_profile(
+                    source=source,
+                    session_key=session_key,
+                    target_id=only["id"],
+                    requested_name=only.get("title") or name,
+                )
+            return self._resume_format_candidates(
+                candidates,
+                heading="📋 **Resume Candidate**",
+                usage=(
+                    "This match is in another profile, so this gateway cannot "
+                    "directly switch to that DB. Restart/use that profile and "
+                    f"run `/resume {only.get('id')}`."
+                ),
+            )
 
-        # Clear any running agent for this session key
-        self._release_running_agent_state(session_key)
-
-        # Switch the session entry to point at the old session
-        new_entry = self.session_store.switch_session(session_key, target_id)
-        if not new_entry:
-            return "Failed to switch session."
-        self._clear_session_boundary_security_state(session_key)
-
-        # Evict any cached agent for this session so the next message
-        # rebuilds with the correct session_id end-to-end — mirrors
-        # /branch and /reset. Without this, the cached AIAgent (and its
-        # memory provider, which cached `_session_id` during initialize())
-        # keeps writing into the wrong session's record. See #6672.
-        self._evict_cached_agent(session_key)
-
-        # Get the title for confirmation
-        title = self._session_db.get_session_title(target_id) or name
-
-        # Count messages for context
-        history = self.session_store.load_transcript(target_id)
-        msg_count = len([m for m in history if m.get("role") == "user"]) if history else 0
-        msg_part = f" ({msg_count} message{'s' if msg_count != 1 else ''})" if msg_count else ""
-
-        return f"↻ Resumed session **{title}**{msg_part}. Conversation restored."
+        return self._resume_format_candidates(
+            candidates,
+            usage=(
+                "Multiple sessions matched. I did not switch sessions. "
+                "Run `/resume <session id>` or `/resume <exact title>`."
+            ),
+        )
 
     async def _handle_branch_command(self, event: MessageEvent) -> str:
         """Handle /branch [name] — fork the current session into a new independent copy.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -745,6 +745,157 @@ def _exec_in_container(container_info: dict, cli_args: list):
     os.execvp(exec_cmd[0], exec_cmd)
 
 
+_HUMAN_SESSION_EXCLUDE_SOURCES = ("tool", "cron", "tool-call audit")
+_FUZZY_SESSION_SCAN_LIMIT = 1000
+_FUZZY_BODY_MATCH_LIMIT = 200
+_FUZZY_BODY_DISTINCT_SESSION_LIMIT = 2
+
+
+def _human_session_exclude_sources(source: Optional[str] = None) -> Optional[list[str]]:
+    """Default noisy sources hidden from human-facing session pickers."""
+    return None if source else list(_HUMAN_SESSION_EXCLUDE_SOURCES)
+
+
+def _project_resume_tip(db, session_id: Optional[str]) -> Optional[str]:
+    if not session_id:
+        return session_id
+    try:
+        return db.get_compression_tip(session_id) or session_id
+    except Exception:
+        return session_id
+
+
+def _resolve_human_session_body_matches(db, query: str, exclude: list[str]) -> list[str]:
+    """Return distinct projected human-facing resume IDs for body/tool matches."""
+    try:
+        sanitized = db._sanitize_fts5_query(query)
+    except Exception:
+        sanitized = query
+    if not sanitized:
+        return []
+
+    try:
+        exclude_sql = ""
+        params: list[object] = [sanitized]
+        if exclude:
+            placeholders = ",".join("?" for _ in exclude)
+            exclude_sql = f"AND s.source NOT IN ({placeholders})"
+            params.extend(exclude)
+        params.extend([_FUZZY_SESSION_SCAN_LIMIT, _FUZZY_BODY_DISTINCT_SESSION_LIMIT])
+
+        sql = f"""
+            WITH RECURSIVE
+            matched(seed_id) AS (
+                SELECT session_id
+                FROM (
+                    SELECT DISTINCT m.session_id
+                    FROM messages_fts
+                    JOIN messages m ON m.id = messages_fts.rowid
+                    JOIN sessions s ON s.id = m.session_id
+                    WHERE messages_fts MATCH ?
+                      {exclude_sql}
+                    LIMIT ?
+                )
+            ),
+            chain(seed_id, cur_id, depth) AS (
+                SELECT seed_id, seed_id, 0 FROM matched
+                UNION ALL
+                SELECT c.seed_id, child.id, c.depth + 1
+                FROM chain c
+                JOIN sessions parent ON parent.id = c.cur_id
+                JOIN sessions child ON child.parent_session_id = c.cur_id
+                WHERE parent.end_reason = 'compression'
+                  AND child.started_at >= parent.ended_at
+                  AND c.depth < 100
+            ),
+            projected(resume_id) AS (
+                SELECT c.cur_id
+                FROM chain c
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM sessions parent
+                    JOIN sessions child ON child.parent_session_id = parent.id
+                    WHERE parent.id = c.cur_id
+                      AND parent.end_reason = 'compression'
+                      AND child.started_at >= parent.ended_at
+                )
+            )
+            SELECT DISTINCT resume_id
+            FROM projected
+            WHERE resume_id IS NOT NULL
+            LIMIT ?
+        """
+        with db._lock:
+            rows = db._conn.execute(sql, params).fetchall()
+        return [str(row["resume_id"] if hasattr(row, "keys") else row[0]) for row in rows]
+    except Exception:
+        pass
+
+    try:
+        body_matches = db.search_messages(
+            query,
+            exclude_sources=exclude,
+            limit=_FUZZY_BODY_MATCH_LIMIT,
+        )
+    except Exception:
+        return []
+    seen: list[str] = []
+    for match in body_matches:
+        sid = str(match.get("session_id") or "")
+        projected = _project_resume_tip(db, sid)
+        if projected and projected not in seen:
+            seen.append(projected)
+            if len(seen) >= _FUZZY_BODY_DISTINCT_SESSION_LIMIT:
+                break
+    return seen
+
+
+def _resolve_human_session_fuzzy_match(db, query: str) -> Optional[str]:
+    """Resolve a unique human-facing partial title/id/body match."""
+    needle = (query or "").strip()
+    if not needle:
+        return None
+    needle_fold = needle.casefold()
+    exclude = list(_HUMAN_SESSION_EXCLUDE_SOURCES)
+
+    def _unique_projected(ids: list[str]) -> Optional[str]:
+        seen: list[str] = []
+        for sid in ids:
+            projected = _project_resume_tip(db, sid)
+            if projected and projected not in seen:
+                seen.append(projected)
+        return seen[0] if len(seen) == 1 else None
+
+    def _find_title_or_id_matches(*, project_compression_tips: bool) -> list[str]:
+        try:
+            sessions = db.list_sessions_rich(
+                exclude_sources=exclude,
+                limit=_FUZZY_SESSION_SCAN_LIMIT,
+                order_by_last_active=True,
+                project_compression_tips=project_compression_tips,
+            )
+        except Exception:
+            return []
+
+        matches: list[str] = []
+        for session in sessions:
+            title = str(session.get("title") or "")
+            sid = str(session.get("id") or "")
+            if needle_fold in title.casefold() or needle_fold in sid.casefold():
+                matches.append(sid)
+        return matches
+
+    title_or_id_matches = _find_title_or_id_matches(project_compression_tips=True)
+    if title_or_id_matches:
+        return _unique_projected(title_or_id_matches)
+
+    title_or_id_matches = _find_title_or_id_matches(project_compression_tips=False)
+    if title_or_id_matches:
+        return _unique_projected(title_or_id_matches)
+
+    return _unique_projected(_resolve_human_session_body_matches(db, needle, exclude))
+
+
 def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
     """Resolve a session name (title) or ID to a session ID.
 
@@ -770,13 +921,10 @@ def _resolve_session_by_name_or_id(name_or_id: str) -> Optional[str]:
             # Try as title (with auto-latest for lineage)
             resolved_id = db.resolve_session_by_title(name_or_id)
 
-        if resolved_id:
-            # Project forward through compression chain so resumes land on
-            # the live tip instead of a dead compressed parent.
-            try:
-                resolved_id = db.get_compression_tip(resolved_id) or resolved_id
-            except Exception:
-                pass
+        if not resolved_id:
+            resolved_id = _resolve_human_session_fuzzy_match(db, name_or_id)
+
+        resolved_id = _project_resume_tip(db, resolved_id)
 
         db.close()
         return resolved_id
@@ -10123,13 +10271,16 @@ Examples:
 
         action = args.sessions_action
 
-        # Hide third-party tool sessions by default, but honour explicit --source
+        # Hide internal/noisy sessions by default, but honour explicit --source.
         _source = getattr(args, "source", None)
-        _exclude = None if _source else ["tool"]
+        _exclude = _human_session_exclude_sources(_source)
 
         if action == "list":
             sessions = db.list_sessions_rich(
-                source=args.source, exclude_sources=_exclude, limit=args.limit
+                source=args.source,
+                exclude_sources=_exclude,
+                limit=args.limit,
+                order_by_last_active=True,
             )
             if not sessions:
                 print("No sessions found.")
@@ -10235,9 +10386,12 @@ Examples:
         elif action == "browse":
             limit = getattr(args, "limit", 500) or 500
             source = getattr(args, "source", None)
-            _browse_exclude = None if source else ["tool"]
+            _browse_exclude = _human_session_exclude_sources(source)
             sessions = db.list_sessions_rich(
-                source=source, exclude_sources=_browse_exclude, limit=limit
+                source=source,
+                exclude_sources=_browse_exclude,
+                limit=limit,
+                order_by_last_active=True,
             )
             db.close()
             if not sessions:

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -39,6 +39,9 @@ def _make_runner(session_db=None, current_session_id="current_session_001",
     runner._voice_mode = {}
     runner._session_db = session_db
     runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
 
     # Compute the real session key if an event is provided
     session_key = build_session_key(event.source) if event else "agent:main:telegram:dm"
@@ -74,11 +77,11 @@ class TestHandleResumeCommand:
 
     @pytest.mark.asyncio
     async def test_list_named_sessions_when_no_arg(self, tmp_path):
-        """With no argument, lists recently titled sessions."""
+        """With no argument, lists recently titled sessions across sources."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
         db.create_session("sess_001", "telegram")
-        db.create_session("sess_002", "telegram")
+        db.create_session("sess_002", "cli")
         db.set_session_title("sess_001", "Research")
         db.set_session_title("sess_002", "Coding")
 
@@ -87,8 +90,149 @@ class TestHandleResumeCommand:
         result = await runner._handle_resume_command(event)
         assert "Research" in result
         assert "Coding" in result
+        assert "telegram" in result
+        assert "cli" in result
+        assert "sess_001" in result
+        assert "sess_002" in result
         assert "Named Sessions" in result
         db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_partial_title_multiple_candidates_does_not_switch(self, tmp_path):
+        """Partial title matches return candidates without switching on ambiguity."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("alpha_session", "telegram")
+        db.set_session_title("alpha_session", "Research Alpha")
+        db.append_message("alpha_session", "user", "alpha details")
+        db.create_session("beta_session", "discord")
+        db.set_session_title("beta_session", "Research Beta")
+        db.append_message("beta_session", "user", "beta details")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume Research")
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "Research Alpha" in result
+        assert "Research Beta" in result
+        assert "alpha_session" in result
+        assert "beta_session" in result
+        assert "session id" in result.lower()
+        runner.session_store.switch_session.assert_not_called()
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_id_prefix_does_not_bypass_ambiguous_fallback(self, tmp_path):
+        """A unique ID prefix is listed with fallback matches instead of switching."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("abc_prefix_session", "telegram")
+        db.set_session_title("abc_prefix_session", "Prefix Match")
+        db.create_session("body_session", "discord")
+        db.set_session_title("body_session", "Body Match")
+        db.append_message("body_session", "user", "notes about abc rollout")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume abc")
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "Prefix Match" in result
+        assert "Body Match" in result
+        assert "Multiple sessions matched" in result
+        runner.session_store.switch_session.assert_not_called()
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_body_keyword_unique_candidate_switches(self, tmp_path):
+        """A unique body keyword fallback can switch to the matching session."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("needle_session", "discord")
+        db.set_session_title("needle_session", "Needle Work")
+        db.append_message("needle_session", "user", "investigate zeta-vector failure")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume zeta-vector")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        assert "Needle Work" in result
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "needle_session"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_body_keyword_in_compression_child_switches_to_tip(self, tmp_path):
+        """Body fallback searches continuation children but resumes the live tip."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("compressed_root", "telegram")
+        db.set_session_title("compressed_root", "Compressed Search")
+        db.end_session("compressed_root", "compression")
+        db.create_session("compressed_child", "telegram", parent_session_id="compressed_root")
+        db.append_message("compressed_child", "user", "investigate kappa-vector regression")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume kappa-vector")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        runner.session_store.load_transcript.side_effect = (
+            lambda session_id: [{"role": "user", "content": "investigate kappa-vector regression"}]
+            if session_id == "compressed_child"
+            else []
+        )
+
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        assert "Compressed Search" in result
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "compressed_child"
+        runner.session_store.load_transcript.assert_called_with("compressed_child")
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_other_profile_candidate_does_not_switch(self, tmp_path, monkeypatch):
+        """Other-profile matches are listed with profile metadata, not DB-copied."""
+        from hermes_state import SessionDB
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        current_db = SessionDB(db_path=tmp_path / "state.db")
+        current_db.create_session("current_session_001", "telegram")
+
+        other_home = tmp_path / "profiles" / "work"
+        other_db = SessionDB(db_path=other_home / "state.db")
+        other_db.create_session("work_session", "slack")
+        other_db.set_session_title("work_session", "Work Search")
+        other_db.append_message("work_session", "user", "cross-profile epsilon notes")
+
+        event = _make_event(text="/resume epsilon")
+        runner = _make_runner(session_db=current_db, event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "Work Search" in result
+        assert "work" in result
+        assert "slack" in result
+        assert "work_session" in result
+        assert "profile" in result.lower()
+        assert "directly" in result.lower() or "直接" in result
+        runner.session_store.switch_session.assert_not_called()
+        other_db.close()
+        current_db.close()
 
     @pytest.mark.asyncio
     async def test_list_shows_usage_when_no_titled(self, tmp_path):

--- a/tests/hermes_cli/test_resolve_last_session.py
+++ b/tests/hermes_cli/test_resolve_last_session.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from hermes_cli.main import _resolve_last_session
+from hermes_cli.main import _resolve_last_session, _resolve_session_by_name_or_id
 
 
 class _FakeDB:
@@ -155,3 +155,201 @@ def test_resolve_last_session_not_limited_to_newest_started_20(tmp_path, monkeyp
 
     monkeypatch.setattr("hermes_state.SessionDB", lambda: real_session_db(db_path=state_db))
     assert _resolve_last_session("cli") == target
+
+
+def test_resolve_session_by_partial_title_ignores_recent_cron_noise(tmp_path, monkeypatch):
+    import hermes_state
+
+    from pathlib import Path
+
+    state_db = Path(tmp_path / "state.db")
+    real_session_db = hermes_state.SessionDB
+    db = real_session_db(db_path=state_db)
+    try:
+        for i in range(30):
+            sid = f"cron_noise_{i:02d}"
+            db.create_session(sid, source="cron")
+            db.set_session_title(sid, f"Nightly automation {i}")
+
+        db.create_session("cli_named_target", source="cli")
+        db.set_session_title("cli_named_target", "Pokemon Agent Development")
+    finally:
+        db.close()
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: real_session_db(db_path=state_db))
+
+    assert _resolve_session_by_name_or_id("Pokemon Agent") == "cli_named_target"
+
+
+def test_resolve_session_by_partial_title_does_not_return_cron_only_match(tmp_path, monkeypatch):
+    import hermes_state
+
+    from pathlib import Path
+
+    state_db = Path(tmp_path / "state.db")
+    real_session_db = hermes_state.SessionDB
+    db = real_session_db(db_path=state_db)
+    try:
+        db.create_session("cron_only_match", source="cron")
+        db.set_session_title("cron_only_match", "Nightly Search Report")
+    finally:
+        db.close()
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: real_session_db(db_path=state_db))
+
+    assert _resolve_session_by_name_or_id("Nightly Search") is None
+
+
+def test_resolve_session_by_message_body_unique_human_match(tmp_path, monkeypatch):
+    import hermes_state
+
+    from pathlib import Path
+
+    state_db = Path(tmp_path / "state.db")
+    real_session_db = hermes_state.SessionDB
+    db = real_session_db(db_path=state_db)
+    try:
+        db.create_session("cli_body_match", source="cli")
+        db.set_session_title("cli_body_match", "Debug Notes")
+        db.append_message("cli_body_match", "user", "investigate zeta vector failure")
+        db.create_session("cron_body_noise", source="cron")
+        db.append_message("cron_body_noise", "user", "zeta vector automated report")
+    finally:
+        db.close()
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: real_session_db(db_path=state_db))
+
+    assert _resolve_session_by_name_or_id("zeta vector") == "cli_body_match"
+
+
+def test_resolve_session_partial_title_projects_to_compression_tip(tmp_path, monkeypatch):
+    import hermes_state
+
+    from pathlib import Path
+
+    state_db = Path(tmp_path / "state.db")
+    real_session_db = hermes_state.SessionDB
+    db = real_session_db(db_path=state_db)
+    try:
+        db.create_session("compressed_root", source="cli")
+        db.set_session_title("compressed_root", "Compressed Search Work")
+        db.end_session("compressed_root", "compression")
+        db.create_session("compressed_child", source="cli", parent_session_id="compressed_root")
+        db.append_message("compressed_child", "user", "continued after compression")
+    finally:
+        db.close()
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: real_session_db(db_path=state_db))
+
+    assert _resolve_session_by_name_or_id("Compressed Search") == "compressed_child"
+
+
+def test_resolve_session_partial_title_matches_projected_compression_tip(tmp_path, monkeypatch):
+    import hermes_state
+
+    from pathlib import Path
+
+    state_db = Path(tmp_path / "state.db")
+    real_session_db = hermes_state.SessionDB
+    db = real_session_db(db_path=state_db)
+    try:
+        db.create_session("projected_root", source="cli")
+        db.set_session_title("projected_root", "Raw Compression Root")
+        db.end_session("projected_root", "compression")
+        db.create_session("projected_child_visible", source="cli", parent_session_id="projected_root")
+        db.set_session_title("projected_child_visible", "Visible Continuation Title")
+        db.append_message("projected_child_visible", "user", "continued after compression")
+    finally:
+        db.close()
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: real_session_db(db_path=state_db))
+
+    assert _resolve_session_by_name_or_id("Continuation Title") == "projected_child_visible"
+
+
+def test_resolve_session_partial_id_matches_projected_compression_tip(tmp_path, monkeypatch):
+    import hermes_state
+
+    from pathlib import Path
+
+    state_db = Path(tmp_path / "state.db")
+    real_session_db = hermes_state.SessionDB
+    db = real_session_db(db_path=state_db)
+    try:
+        db.create_session("partial_id_root", source="cli")
+        db.set_session_title("partial_id_root", "Root Title")
+        db.end_session("partial_id_root", "compression")
+        db.create_session("partial_id_child_visible", source="cli", parent_session_id="partial_id_root")
+        db.append_message("partial_id_child_visible", "user", "continued after compression")
+    finally:
+        db.close()
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: real_session_db(db_path=state_db))
+
+    assert _resolve_session_by_name_or_id("id_child_vis") == "partial_id_child_visible"
+
+
+def test_resolve_session_body_match_not_unique_past_first_20_hits(tmp_path, monkeypatch):
+    import hermes_state
+
+    from pathlib import Path
+
+    state_db = Path(tmp_path / "state.db")
+    real_session_db = hermes_state.SessionDB
+    db = real_session_db(db_path=state_db)
+    try:
+        db.create_session("body_first_twenty", source="cli")
+        for _ in range(20):
+            db.append_message("body_first_twenty", "user", "ambiguousneedle repeated hit")
+        db.create_session("body_twenty_first", source="cli")
+        db.append_message("body_twenty_first", "user", "ambiguousneedle second session")
+    finally:
+        db.close()
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: real_session_db(db_path=state_db))
+
+    assert _resolve_session_by_name_or_id("ambiguousneedle") is None
+
+
+def test_resolve_session_body_match_not_unique_past_body_match_limit(tmp_path, monkeypatch):
+    import hermes_state
+
+    from pathlib import Path
+
+    state_db = Path(tmp_path / "state.db")
+    real_session_db = hermes_state.SessionDB
+    db = real_session_db(db_path=state_db)
+    try:
+        db.create_session("body_first_limit", source="cli")
+        for _ in range(201):
+            db.append_message("body_first_limit", "user", "limitneedle repeated hit")
+        db.create_session("body_after_limit", source="cli")
+        db.append_message("body_after_limit", "user", "limitneedle second session")
+    finally:
+        db.close()
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: real_session_db(db_path=state_db))
+
+    assert _resolve_session_by_name_or_id("limitneedle") is None
+
+
+def test_resolve_session_exact_id_and_title_still_work(tmp_path, monkeypatch):
+    import hermes_state
+
+    from pathlib import Path
+
+    state_db = Path(tmp_path / "state.db")
+    real_session_db = hermes_state.SessionDB
+    db = real_session_db(db_path=state_db)
+    try:
+        db.create_session("exact_id_target", source="cron")
+        db.set_session_title("exact_id_target", "Exact Cron Title")
+        db.create_session("exact_title_target", source="cli")
+        db.set_session_title("exact_title_target", "Exact Human Title")
+    finally:
+        db.close()
+
+    monkeypatch.setattr("hermes_state.SessionDB", lambda: real_session_db(db_path=state_db))
+
+    assert _resolve_session_by_name_or_id("exact_id_target") == "exact_id_target"
+    assert _resolve_session_by_name_or_id("Exact Human Title") == "exact_title_target"

--- a/tests/hermes_cli/test_session_browse.py
+++ b/tests/hermes_cli/test_session_browse.py
@@ -15,6 +15,20 @@ import pytest
 from hermes_cli.main import _session_browse_picker
 
 
+class _RecordingSessionDB:
+    def __init__(self, rows=None):
+        self.rows = rows if rows is not None else []
+        self.calls = []
+        self.closed = False
+
+    def list_sessions_rich(self, **kwargs):
+        self.calls.append(kwargs)
+        return list(self.rows)
+
+    def close(self):
+        self.closed = True
+
+
 # ─── Sample session data ──────────────────────────────────────────────────────
 
 def _make_sessions(n=5):
@@ -449,6 +463,116 @@ class TestCmdSessionsBrowse:
                 result = _session_browse_picker(sessions)
 
         assert result == "s1"
+
+    def test_sessions_list_defaults_to_human_facing_mru_query(self, monkeypatch, capsys):
+        """Default list hides internal sources and sorts by actual activity."""
+        from hermes_cli import main as main_mod
+
+        db = _RecordingSessionDB([
+            {
+                "id": "cli_recent",
+                "source": "cli",
+                "title": "CLI Work",
+                "preview": "hello",
+                "last_active": time.time(),
+            }
+        ])
+        monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+        monkeypatch.setattr("hermes_cli.config.get_container_exec_info", lambda: None)
+        monkeypatch.setattr("sys.argv", ["hermes", "sessions", "list"])
+
+        main_mod.main()
+
+        assert db.calls == [{
+            "source": None,
+            "exclude_sources": ["tool", "cron", "tool-call audit"],
+            "limit": 20,
+            "order_by_last_active": True,
+        }]
+        assert "CLI Work" in capsys.readouterr().out
+
+    def test_sessions_list_source_filter_disables_default_exclude(self, monkeypatch, capsys):
+        """Explicit --source is honored even for normally hidden sources."""
+        from hermes_cli import main as main_mod
+
+        db = _RecordingSessionDB([
+            {
+                "id": "cron_recent",
+                "source": "cron",
+                "title": "Nightly",
+                "preview": "cron",
+                "last_active": time.time(),
+            }
+        ])
+        monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+        monkeypatch.setattr("hermes_cli.config.get_container_exec_info", lambda: None)
+        monkeypatch.setattr("sys.argv", ["hermes", "sessions", "list", "--source", "cron"])
+
+        main_mod.main()
+
+        assert db.calls == [{
+            "source": "cron",
+            "exclude_sources": None,
+            "limit": 20,
+            "order_by_last_active": True,
+        }]
+        assert "Nightly" in capsys.readouterr().out
+
+    def test_sessions_browse_defaults_to_human_facing_mru_query(self, monkeypatch, capsys):
+        """Browse uses the same human-facing MRU defaults as list."""
+        from hermes_cli import main as main_mod
+
+        db = _RecordingSessionDB([
+            {
+                "id": "tui_recent",
+                "source": "tui",
+                "title": "TUI Work",
+                "preview": "hello",
+                "last_active": time.time(),
+            }
+        ])
+        monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+        monkeypatch.setattr("hermes_cli.config.get_container_exec_info", lambda: None)
+        monkeypatch.setattr(main_mod, "_session_browse_picker", lambda sessions: None)
+        monkeypatch.setattr("sys.argv", ["hermes", "sessions", "browse"])
+
+        main_mod.main()
+
+        assert db.calls == [{
+            "source": None,
+            "exclude_sources": ["tool", "cron", "tool-call audit"],
+            "limit": 500,
+            "order_by_last_active": True,
+        }]
+        assert "Cancelled" in capsys.readouterr().out
+
+    def test_sessions_browse_source_filter_disables_default_exclude(self, monkeypatch, capsys):
+        """Explicit browse --source is honored for normally hidden sources."""
+        from hermes_cli import main as main_mod
+
+        db = _RecordingSessionDB([
+            {
+                "id": "cron_browse",
+                "source": "cron",
+                "title": "Cron Browse",
+                "preview": "cron",
+                "last_active": time.time(),
+            }
+        ])
+        monkeypatch.setattr("hermes_state.SessionDB", lambda: db)
+        monkeypatch.setattr("hermes_cli.config.get_container_exec_info", lambda: None)
+        monkeypatch.setattr(main_mod, "_session_browse_picker", lambda sessions: None)
+        monkeypatch.setattr("sys.argv", ["hermes", "sessions", "browse", "--source", "cron"])
+
+        main_mod.main()
+
+        assert db.calls == [{
+            "source": "cron",
+            "exclude_sources": None,
+            "limit": 500,
+            "order_by_last_active": True,
+        }]
+        assert "Cancelled" in capsys.readouterr().out
 
 
 # ─── Edge cases ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Exclude cron/tool/tool-call audit sessions by default from CLI session listings and resume candidates.
- Sort and resolve sessions by last activity instead of only creation/start time.
- Broaden CLI and gateway resume matching across title, ID, message/tool content, and compaction continuations while avoiding duplicate-hit false positives.

## Test Plan
- `venv/bin/python -m pytest -o addopts="" tests/hermes_cli/test_session_browse.py tests/hermes_cli/test_resolve_last_session.py tests/hermes_cli/test_tui_resume_flow.py tests/hermes_state/test_resolve_resume_session_id.py tests/test_hermes_state.py tests/gateway/test_resume_command.py -q`
- `git diff --check origin/main..HEAD`
- targeted diff secret scan
