### PR TITLE
fix: preserve explicit goal continuation checkpoints

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -851,6 +851,28 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     return "\n".join(parts)
 
 
+def _agent_result_has_deliverable_final_response(result: dict) -> bool:
+    """Return True when a partial agent result still contains user-facing text.
+
+    Some agent runs can end with ``completed=False`` after hitting an internal
+    budget/transport boundary even though they produced a useful final
+    checkpoint.  Cron should preserve and deliver that checkpoint instead of
+    raising ``RuntimeError(<final response>)`` and replacing it with a failure
+    wrapper.  Hard failures with an explicit error remain failures.
+    """
+    if not isinstance(result, dict):
+        return False
+    if result.get("failed") is True:
+        return False
+    final_response = (result.get("final_response") or "").strip()
+    if not final_response or final_response == "(No response generated)":
+        return False
+    error_text = str(result.get("error") or "").strip()
+    if error_text:
+        return False
+    return True
+
+
 def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     Execute a single cron job.
@@ -1332,12 +1354,18 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # job's `last_status` set to "ok". Raise so the except handler below
         # builds the proper failure tuple. (issue #17855)
         if result.get("failed") is True or result.get("completed") is False:
-            _err_text = (
-                result.get("error")
-                or (result.get("final_response") or "").strip()
-                or "agent reported failure"
+            if not _agent_result_has_deliverable_final_response(result):
+                _err_text = (
+                    result.get("error")
+                    or (result.get("final_response") or "").strip()
+                    or "agent reported failure"
+                )
+                raise RuntimeError(_err_text)
+            logger.warning(
+                "Job '%s' returned completed=false but included a deliverable final response; "
+                "delivering the response instead of converting it to a hard failure",
+                job_name,
             )
-            raise RuntimeError(_err_text)
 
         final_response = result.get("final_response", "") or ""
         # Strip leaked placeholder text that upstream may inject on empty completions.

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -48,6 +48,14 @@ DEFAULT_JUDGE_TIMEOUT = 30.0
 # Cap how much of the last response + recent messages we send to the judge.
 _JUDGE_RESPONSE_SNIPPET_CHARS = 4000
 
+# Explicit checkpoint phrases agents can use when a long-running queued goal has
+# completed one safe iteration but intentionally needs the goal loop to continue
+# on the next queued item.  This keeps the auxiliary judge from misclassifying a
+# useful per-iteration closeout as final goal completion.
+_CONTINUE_CHECKPOINT_RE = re.compile(
+    r"(?is)\bnext\s+queued\s*:.+\bgoal\s+remains\s+active\b.+\bcontinue\s+automatically\b"
+)
+
 
 CONTINUATION_PROMPT_TEMPLATE = (
     "[Continuing toward your standing goal]\n"
@@ -332,6 +340,17 @@ def judge_goal(
     return verdict, reason
 
 
+def _response_requests_goal_continuation(last_response: str) -> bool:
+    """Return True when the agent explicitly says this is a checkpoint.
+
+    Queue-style goals often complete one item per turn and intentionally end
+    with a non-final checkpoint naming the next item.  That response may look
+    "complete" to the generic auxiliary judge, so honor the explicit local
+    continuation contract before asking the judge.
+    """
+    return bool(_CONTINUE_CHECKPOINT_RE.search(last_response or ""))
+
+
 # ──────────────────────────────────────────────────────────────────────
 # GoalManager — the orchestration surface CLI + gateway talk to
 # ──────────────────────────────────────────────────────────────────────
@@ -473,7 +492,10 @@ class GoalManager:
         state.turns_used += 1
         state.last_turn_at = time.time()
 
-        verdict, reason = judge_goal(state.goal, last_response)
+        if _response_requests_goal_continuation(last_response):
+            verdict, reason = "continue", "response explicitly requested goal continuation"
+        else:
+            verdict, reason = judge_goal(state.goal, last_response)
         state.last_verdict = verdict
         state.last_reason = reason
 
@@ -532,4 +554,5 @@ __all__ = [
     "save_goal",
     "clear_goal",
     "judge_goal",
+    "_response_requests_goal_continuation",
 ]

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -7,9 +7,41 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from cron.scheduler import (
+    _resolve_origin,
+    _resolve_delivery_target,
+    _deliver_result,
+    _send_media_via_adapter,
+    run_job,
+    SILENT_MARKER,
+    _build_job_prompt,
+    _agent_result_has_deliverable_final_response,
+)
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
+
+
+class TestCronAgentResultClassification:
+    def test_partial_result_with_final_response_is_deliverable(self):
+        result = {
+            "completed": False,
+            "failed": False,
+            "final_response": "Completed one tranche. Next queued: ITEM-2.",
+        }
+
+        assert _agent_result_has_deliverable_final_response(result) is True
+
+    @pytest.mark.parametrize(
+        "result",
+        [
+            {"completed": False, "failed": True, "final_response": "checkpoint"},
+            {"completed": False, "failed": False, "error": "Response truncated due to output length limit", "final_response": ""},
+            {"completed": False, "failed": False, "final_response": "(No response generated)"},
+            {"completed": False, "failed": False, "final_response": ""},
+        ],
+    )
+    def test_hard_failures_and_empty_responses_are_not_deliverable(self, result):
+        assert _agent_result_has_deliverable_final_response(result) is False
 
 
 class TestResolveOrigin:

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -252,6 +252,33 @@ class TestGoalManager:
         assert mgr2.state.goal == "do the thing"
         assert mgr2.is_active()
 
+    def test_evaluate_after_turn_explicit_checkpoint_continues_without_judge(self, hermes_home):
+        """A non-final queue checkpoint should keep /goal alive even when it
+        contains completed-work language that a generic judge may mark done."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="eval-sid-checkpoint", default_max_turns=5)
+        mgr.set("complete queued items one at a time")
+        response = """
+        Completed TR-2858 — communication draft center baseline.
+        Commit: abc1234.
+        Checks: focused proof, upstream proof, typecheck/build, diff check, secret scan.
+        Next queued: TR-2859.
+        Goal remains active; continue automatically.
+        Boundary held: local-only, no push/deploy/hosted writes/external sends.
+        """
+
+        with patch.object(goals, "judge_goal", return_value=("done", "looks complete")) as judge:
+            decision = mgr.evaluate_after_turn(response)
+
+        judge.assert_not_called()
+        assert decision["verdict"] == "continue"
+        assert decision["should_continue"] is True
+        assert "explicitly requested goal continuation" in decision["reason"]
+        assert mgr.state.status == "active"
+        assert mgr.state.turns_used == 1
+
     def test_evaluate_after_turn_done(self, hermes_home):
         """Judge says done → status=done, no continuation."""
         from hermes_cli import goals


### PR DESCRIPTION
## Summary

- Treat explicit non-final `/goal` queue checkpoints as continuation requests before calling the auxiliary judge.
- Preserve cron agent results that have `completed=false` but include a deliverable `final_response`, instead of converting that response into `RuntimeError(<final_response>)`.
- Add regression coverage for both behaviors while keeping hard cron failures/errors/empty responses as failures.

## Motivation

Long-running queue-style goals often complete exactly one item per turn and end with a checkpoint such as:

```text
Next queued: ITEM-2.
Goal remains active; continue automatically.
```

That response can look like final completion to a generic judge because it also contains proof/check/commit closeout text. The explicit checkpoint should be honored as a continuation contract.

Cron has a related classification edge case: if an agent run produces a useful final checkpoint but internal completion metadata is partial, the scheduler can currently raise the final response as a runtime error and deliver a misleading failure wrapper. This patch keeps explicit hard failures as failures, but delivers usable final responses when there is no hard error.

## Tests

```bash
python -m pytest tests/hermes_cli/test_goals.py tests/gateway/test_goal_verdict_send.py tests/cron/test_scheduler.py -q
```

Local result: `152 passed`.
