### PR TITLE
fix(tui): refresh scroll height at cached bottom

### DIFF
--- a/ui-tui/src/__tests__/scroll.test.ts
+++ b/ui-tui/src/__tests__/scroll.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it, vi } from 'vitest'
 import { scrollWithSelectionBy } from '../app/scroll.js'
 
 function makeScroll(overrides: Partial<Record<string, unknown>> = {}) {
+  const getScrollHeight = (overrides.getScrollHeight as (() => number) | undefined) ?? vi.fn(() => 100)
+
   return {
+    getFreshScrollHeight: vi.fn(() => getScrollHeight()),
     getPendingDelta: vi.fn(() => 0),
-    getScrollHeight: vi.fn(() => 100),
+    getScrollHeight,
     getScrollTop: vi.fn(() => 10),
     getViewportHeight: vi.fn(() => 20),
     getViewportTop: vi.fn(() => 0),
@@ -32,6 +35,47 @@ describe('scrollWithSelectionBy', () => {
     scrollWithSelectionBy(10, { scrollRef: { current: s as never }, selection })
 
     expect(s.scrollBy).toHaveBeenCalledWith(1)
+  })
+
+  it('uses fresh scroll height when cached height would swallow a down-scroll at a fake bottom', () => {
+    const s = makeScroll({
+      getFreshScrollHeight: vi.fn(() => 34),
+      getScrollHeight: vi.fn(() => 30),
+      getScrollTop: vi.fn(() => 10),
+      getViewportHeight: vi.fn(() => 20)
+    })
+
+    const selection = {
+      captureScrolledRows: vi.fn(),
+      getState: vi.fn(() => null),
+      shiftAnchor: vi.fn(),
+      shiftSelection: vi.fn()
+    }
+
+    scrollWithSelectionBy(10, { scrollRef: { current: s as never }, selection })
+
+    expect(s.scrollBy).toHaveBeenCalledWith(4)
+  })
+
+  it('uses fresh height when pending down-scroll reaches the cached fake bottom', () => {
+    const s = makeScroll({
+      getFreshScrollHeight: vi.fn(() => 38),
+      getPendingDelta: vi.fn(() => 2),
+      getScrollHeight: vi.fn(() => 32),
+      getScrollTop: vi.fn(() => 10),
+      getViewportHeight: vi.fn(() => 20)
+    })
+
+    const selection = {
+      captureScrolledRows: vi.fn(),
+      getState: vi.fn(() => null),
+      shiftAnchor: vi.fn(),
+      shiftSelection: vi.fn()
+    }
+
+    scrollWithSelectionBy(10, { scrollRef: { current: s as never }, selection })
+
+    expect(s.scrollBy).toHaveBeenCalledWith(6)
   })
 
   it('does nothing at the edge instead of queueing dead pending deltas', () => {

--- a/ui-tui/src/app/scroll.ts
+++ b/ui-tui/src/app/scroll.ts
@@ -13,6 +13,23 @@ export interface ScrollWithSelectionOptions {
   readonly selection: SelectionApi
 }
 
+function scrollBoundsForDelta(s: ScrollBoxHandle, cur: number, delta: number) {
+  const viewport = Math.max(0, s.getViewportHeight())
+  const cachedHeight = Math.max(viewport, s.getScrollHeight())
+  let max = Math.max(0, cachedHeight - viewport)
+
+  // getScrollHeight() is render-time cached. After the streaming tail is
+  // committed into virtual history, the Yoga height can be fresher than the
+  // cached value; if we clamp only against the cached fake bottom, wheel-down
+  // becomes a no-op and no render is scheduled to reveal the real tail.
+  if (delta > 0 && cur + delta >= max - 1) {
+    const freshHeight = Math.max(viewport, s.getFreshScrollHeight())
+    max = Math.max(0, freshHeight - viewport)
+  }
+
+  return { max, viewport }
+}
+
 export function scrollWithSelectionBy(delta: number, { scrollRef, selection }: ScrollWithSelectionOptions): void {
   const s = scrollRef.current
 
@@ -21,8 +38,7 @@ export function scrollWithSelectionBy(delta: number, { scrollRef, selection }: S
   }
 
   const cur = s.getScrollTop() + s.getPendingDelta()
-  const viewport = Math.max(0, s.getViewportHeight())
-  const max = Math.max(0, s.getScrollHeight() - viewport)
+  const { max, viewport } = scrollBoundsForDelta(s, cur, delta)
   const actual = Math.max(0, Math.min(max, cur + delta)) - cur
 
   if (actual === 0) {


### PR DESCRIPTION
## Why this matters

The TUI wheel-scroll path clamps down-scroll input against `ScrollBox.getScrollHeight()`, which is a render-time cached value. After a streamed assistant response is committed into virtual history, the content wrapper's Yoga height can be fresher than that cache. If the user scrolls up and then back down during that window, Hermes can believe it reached the bottom early, compute `actual === 0`, swallow the wheel event, and never schedule the render needed to reveal the real tail.

This patch fixes that fake-bottom race by consulting `getFreshScrollHeight()` only when a down-scroll reaches the cached edge. Normal mid-transcript scrolling still uses the cached height, so the hot path stays cheap. This is not Ghostty-specific; Ghostty just makes the race easier to hit because native wheel events can arrive in bursts.

## What changed

- Add edge-gated scroll bounds in `scrollWithSelectionBy()`:
  - cached `getScrollHeight()` for normal scrolling
  - fresh Yoga height only for down-scrolls that hit/pass the cached bottom
- Preserve existing selection-shift behavior; only the scroll `max`/`viewport` source changed.
- Add regression coverage for:
  - stale cached fake bottom swallowing a down-scroll
  - pending wheel delta reaching the cached fake bottom
  - existing true-bottom no-op behavior

## Verification

- [x] `npm --prefix ui-tui test -- src/__tests__/scroll.test.ts` — new regression tests failed before the implementation and passed after it
- [x] `npm --prefix ui-tui test -- src/__tests__/scroll.test.ts src/__tests__/viewportStore.test.ts`
- [x] `npm --prefix ui-tui run type-check`
- [x] `npm --prefix ui-tui run build`
- [x] `git diff --check`
- [x] `(cd ui-tui && npm exec -- eslint src/app/scroll.ts src/__tests__/scroll.test.ts)`

## Verification notes

- `npm --prefix ui-tui run lint` is currently red on this checkout due to existing unrelated lint errors in non-touched files. The changed files pass ESLint directly.
- Manual Ghostty reproduction was not run from this non-interactive environment.
