### PR TITLE
feat: add Claude CLI provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -149,6 +149,8 @@ _PROVIDER_ALIASES = {
     "minimax_cn": "minimax-cn",
     "claude": "anthropic",
     "claude-code": "anthropic",
+    "anthropic-cli": "claude-cli",
+    "claude-code-cli": "claude-cli",
     "github": "copilot",
     "github-copilot": "copilot",
     "github-model": "copilot",
@@ -1500,7 +1502,7 @@ def _validate_base_url(base_url: str) -> None:
     from urllib.parse import urlparse
 
     candidate = str(base_url or "").strip()
-    if not candidate or candidate.startswith("acp://"):
+    if not candidate or candidate.startswith("acp://") or candidate.startswith("claude-cli://"):
         return
     try:
         parsed = urlparse(candidate)
@@ -2531,31 +2533,43 @@ def resolve_provider_client(
             or _read_main_model(),
             provider,
         )
-        if provider == "copilot-acp":
+        if provider in {"copilot-acp", "claude-cli"}:
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()
             command = str(creds.get("command", "")).strip() or None
             args = list(creds.get("args") or [])
             if not final_model:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but no model "
-                    "was provided or configured"
+                    "resolve_provider_client: %s requested but no model "
+                    "was provided or configured",
+                    provider,
                 )
                 return None, None
             if not api_key or not base_url:
                 logger.warning(
-                    "resolve_provider_client: copilot-acp requested but external "
-                    "process credentials are incomplete"
+                    "resolve_provider_client: %s requested but external "
+                    "process credentials are incomplete",
+                    provider,
                 )
                 return None, None
-            from agent.copilot_acp_client import CopilotACPClient
+            if provider == "copilot-acp":
+                from agent.copilot_acp_client import CopilotACPClient
 
-            client = CopilotACPClient(
-                api_key=api_key,
-                base_url=base_url,
-                command=command,
-                args=args,
-            )
+                client = CopilotACPClient(
+                    api_key=api_key,
+                    base_url=base_url,
+                    command=command,
+                    args=args,
+                )
+            else:
+                from agent.claude_cli_client import ClaudeCLIClient
+
+                client = ClaudeCLIClient(
+                    api_key=api_key,
+                    base_url=base_url,
+                    command=command,
+                    args=args,
+                )
             logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -1,0 +1,182 @@
+"""OpenAI-compatible shim that forwards Hermes requests to `claude -p`.
+
+Claude Code does not expose an ACP/stdout protocol today, so this adapter uses
+the stable non-interactive print mode and lets Hermes keep orchestrating tools.
+The selected Hermes model is passed through to ``claude --model``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from agent.copilot_acp_client import (
+    _build_subprocess_env,
+    _extract_tool_calls_from_text,
+    _format_messages_as_prompt,
+)
+
+CLAUDE_CLI_MARKER_BASE_URL = "claude-cli://local"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+
+
+def _normalize_claude_cli_model(model: str | None) -> str:
+    name = str(model or "").strip()
+    if not name:
+        return "sonnet"
+    if "/" in name:
+        provider, bare = name.split("/", 1)
+        if provider.lower() in {"anthropic", "claude", "claude-cli"} and bare:
+            name = bare
+    if name.startswith("claude-"):
+        return name.replace(".", "-")
+    return name
+
+
+def _timeout_seconds(timeout: Any) -> float:
+    if timeout is None:
+        return _DEFAULT_TIMEOUT_SECONDS
+    if isinstance(timeout, (int, float)):
+        return float(timeout)
+    candidates = [
+        getattr(timeout, attr, None)
+        for attr in ("read", "write", "connect", "pool", "timeout")
+    ]
+    numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
+    return max(numeric) if numeric else _DEFAULT_TIMEOUT_SECONDS
+
+
+def _resolve_command() -> str:
+    return (
+        os.getenv("HERMES_CLAUDE_CLI_COMMAND", "").strip()
+        or os.getenv("CLAUDE_CLI_PATH", "").strip()
+        or "claude"
+    )
+
+
+def _resolve_args() -> list[str]:
+    raw = os.getenv("HERMES_CLAUDE_CLI_ARGS", "").strip()
+    if raw:
+        import shlex
+
+        return shlex.split(raw)
+    return ["--no-session-persistence", "--tools", ""]
+
+
+class _ClaudeCLIChatCompletions:
+    def __init__(self, client: "ClaudeCLIClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ClaudeCLIChatNamespace:
+    def __init__(self, client: "ClaudeCLIClient"):
+        self.completions = _ClaudeCLIChatCompletions(client)
+
+
+class ClaudeCLIClient:
+    """Minimal OpenAI-client-compatible facade for Claude Code CLI."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        cwd: str | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "claude-cli"
+        self.base_url = base_url or CLAUDE_CLI_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._command = command or _resolve_command()
+        self._args = list(args if args is not None else _resolve_args())
+        self._cwd = str(Path(cwd or os.getcwd()).resolve())
+        self.chat = _ClaudeCLIChatNamespace(self)
+        self.is_closed = False
+
+    def close(self) -> None:
+        self.is_closed = True
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        **_: Any,
+    ) -> Any:
+        prompt_text = _format_messages_as_prompt(
+            messages or [],
+            model=model,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+        response_text = self._run_prompt(
+            prompt_text,
+            model=_normalize_claude_cli_model(model),
+            timeout_seconds=_timeout_seconds(timeout),
+        )
+        tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
+
+        usage = SimpleNamespace(
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+        assistant_message = SimpleNamespace(
+            content=cleaned_text,
+            tool_calls=tool_calls,
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+        )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
+        return SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            model=model or "sonnet",
+        )
+
+    def _run_prompt(self, prompt_text: str, *, model: str, timeout_seconds: float) -> str:
+        command = [
+            self._command,
+            *self._args,
+            "-p",
+            "--model",
+            model,
+            prompt_text,
+        ]
+        try:
+            proc = subprocess.run(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                cwd=self._cwd,
+                env=_build_subprocess_env(),
+                timeout=timeout_seconds,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start Claude CLI command '{self._command}'. "
+                "Install Claude Code CLI or set HERMES_CLAUDE_CLI_COMMAND/CLAUDE_CLI_PATH."
+            ) from exc
+        if proc.returncode != 0:
+            stderr = (proc.stderr or "").strip()
+            stdout = (proc.stdout or "").strip()
+            detail = stderr or stdout or f"exit code {proc.returncode}"
+            raise RuntimeError(f"Claude CLI request failed: {detail}")
+        return (proc.stdout or "").strip()

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -45,7 +45,7 @@ def _resolve_requests_verify() -> bool | str:
 # Only these are stripped — Ollama-style "model:tag" colons (e.g. "qwen3.5:27b")
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp", "claude-cli",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "stepfun", "minimax", "minimax-oauth", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "ai-gateway", "kilocode", "alibaba",
     "qwen-oauth",
@@ -1388,6 +1388,8 @@ def get_model_context_length(
                 return ctx
         except Exception:
             pass  # Fall through to models.dev
+    if effective_provider == "claude-cli":
+        effective_provider = "anthropic"
 
     if effective_provider == "nous":
         ctx = _resolve_nous_context_length(model)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -83,6 +83,7 @@ MINIMAX_OAUTH_REFRESH_SKEW_SECONDS = 60
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
+DEFAULT_CLAUDE_CLI_BASE_URL = "claude-cli://local"
 DEFAULT_OLLAMA_CLOUD_BASE_URL = "https://ollama.com/v1"
 STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
@@ -196,6 +197,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    "claude-cli": ProviderConfig(
+        id="claude-cli",
+        name="Claude Code CLI",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_CLAUDE_CLI_BASE_URL,
+        base_url_env_var="CLAUDE_CLI_BASE_URL",
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -1210,6 +1218,7 @@ def resolve_provider(
         "alibaba_coding": "alibaba-coding-plan", "alibaba-coding": "alibaba-coding-plan",
         "alibaba_coding_plan": "alibaba-coding-plan",
         "claude": "anthropic", "claude-code": "anthropic",
+        "anthropic-cli": "claude-cli", "claude-code-cli": "claude-cli",
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
@@ -3707,27 +3716,52 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    if provider_id == "claude-cli":
+        command = (
+            os.getenv("HERMES_CLAUDE_CLI_COMMAND", "").strip()
+            or os.getenv("CLAUDE_CLI_PATH", "").strip()
+            or "claude"
+        )
+        raw_args = os.getenv("HERMES_CLAUDE_CLI_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--no-session-persistence", "--tools", ""]
+    else:
+        command = (
+            os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+            or os.getenv("COPILOT_CLI_PATH", "").strip()
+            or "copilot"
+        )
+        raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 
     resolved_command = shutil.which(command) if command else None
+    logged_in = bool(resolved_command or base_url.startswith("acp+tcp://"))
+    if provider_id == "claude-cli" and resolved_command:
+        try:
+            proc = subprocess.run(
+                [resolved_command, "auth", "status", "--json"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            data = json.loads(proc.stdout or "{}")
+            logged_in = bool(data.get("loggedIn"))
+        except Exception:
+            logged_in = bool(resolved_command)
+
     return {
-        "configured": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "configured": bool(logged_in),
         "provider": provider_id,
         "name": pconfig.name,
         "command": command,
         "args": args,
         "resolved_command": resolved_command,
         "base_url": base_url,
-        "logged_in": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "logged_in": bool(logged_in),
     }
 
 
@@ -3744,7 +3778,7 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_qwen_auth_status()
     if target == "google-gemini-cli":
         return get_gemini_oauth_auth_status()
-    if target == "copilot-acp":
+    if target in {"copilot-acp", "claude-cli"}:
         return get_external_process_provider_status(target)
     # API-key providers
     pconfig = PROVIDER_REGISTRY.get(target)
@@ -3819,15 +3853,31 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    if provider_id == "claude-cli":
+        command = (
+            os.getenv("HERMES_CLAUDE_CLI_COMMAND", "").strip()
+            or os.getenv("CLAUDE_CLI_PATH", "").strip()
+            or "claude"
+        )
+        raw_args = os.getenv("HERMES_CLAUDE_CLI_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--no-session-persistence", "--tools", ""]
+    else:
+        command = (
+            os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+            or os.getenv("COPILOT_CLI_PATH", "").strip()
+            or "copilot"
+        )
+        raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
     resolved_command = shutil.which(command) if command else None
     if not resolved_command and not base_url.startswith("acp+tcp://"):
+        if provider_id == "claude-cli":
+            raise AuthError(
+                f"Could not find the Claude CLI command '{command}'. "
+                "Install Claude Code CLI or set HERMES_CLAUDE_CLI_COMMAND/CLAUDE_CLI_PATH.",
+                provider=provider_id,
+                code="missing_claude_cli",
+            )
         raise AuthError(
             f"Could not find the Copilot CLI command '{command}'. "
             "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
@@ -3837,7 +3887,7 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": provider_id,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1959,6 +1959,8 @@ def select_provider_and_model(args=None):
         _model_flow_google_gemini_cli(config, current_model)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "claude-cli":
+        _model_flow_claude_cli(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":
@@ -4135,6 +4137,70 @@ def _model_flow_copilot_acp(config, current_model=""):
         cfg["model"] = model
     model["provider"] = provider_id
     model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
+def _model_flow_claude_cli(config, current_model=""):
+    """Claude Code CLI flow using the local `claude -p` command."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "claude-cli"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = status.get("resolved_command") or status.get("command") or "claude"
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  Claude Code CLI delegates Hermes turns to `claude -p`.")
+    print("  Hermes keeps model switching and tool orchestration; Claude CLI supplies the model response.")
+    print(f"  Command: {resolved_command}")
+    print(f"  Backend marker: {effective_base}")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  {exc}")
+        print(
+            "  Set HERMES_CLAUDE_CLI_COMMAND or CLAUDE_CLI_PATH if Claude CLI is installed elsewhere."
+        )
+        return
+
+    model_list = _PROVIDER_MODELS.get(provider_id, [])
+    if model_list:
+        selected = _prompt_model_selection(model_list, current_model=current_model)
+    else:
+        try:
+            selected = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if not selected:
+        print("No change.")
+        return
+
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = creds.get("base_url") or effective_base
     model["api_mode"] = "chat_completions"
     save_config(cfg)
     deactivate_provider()
@@ -8467,7 +8533,7 @@ def _build_provider_choices() -> list[str]:
     except Exception:
         # Fallback: static list guarantees the CLI always works
         return [
-            "auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot",
+            "auto", "openrouter", "nous", "openai-codex", "copilot-acp", "claude-cli", "copilot",
             "anthropic", "gemini", "google-gemini-cli", "xai", "bedrock", "azure-foundry",
             "ollama-cloud", "huggingface", "zai", "kimi-coding", "kimi-coding-cn",
             "stepfun", "minimax", "minimax-cn", "kilocode", "xiaomi", "arcee",

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -80,6 +80,7 @@ _DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset({
 _STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
     "copilot",
     "copilot-acp",
+    "claude-cli",
     "openai-codex",
 })
 
@@ -434,7 +435,16 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
             # if the Copilot-specific path is unavailable for any reason.
             pass
 
-    # --- Copilot / Copilot ACP / openai-codex fallback:
+    if provider == "claude-cli":
+        if "/" in name:
+            prefix, bare = name.split("/", 1)
+            if prefix.lower() in {"anthropic", "claude", "claude-cli"} and bare:
+                name = bare
+        if name.startswith("claude-"):
+            return name.replace(".", "-")
+        return name
+
+    # --- Copilot / Copilot ACP / Claude CLI / openai-codex fallback:
     #     strip matching provider prefix, keep dots ---
     if provider in _STRIP_VENDOR_ONLY_PROVIDERS:
         stripped = _strip_matching_provider_prefix(name, provider)
@@ -470,4 +480,3 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 # ---------------------------------------------------------------------------
 # Batch / convenience helpers
 # ---------------------------------------------------------------------------
-

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1340,10 +1340,18 @@ def list_authenticated_providers(
                     has_creds = True
             except Exception as exc:
                 logger.debug("Anthropic external creds check failed: %s", exc)
+        if not has_creds and overlay.auth_type == "external_process":
+            try:
+                from hermes_cli.auth import get_external_process_provider_status
+
+                status = get_external_process_provider_status(hermes_slug)
+                has_creds = bool(status.get("logged_in") or status.get("configured"))
+            except Exception as exc:
+                logger.debug("External process status check failed for %s: %s", hermes_slug, exc)
         if not has_creds:
             continue
 
-        if hermes_slug in {"copilot", "copilot-acp"}:
+        if hermes_slug in {"copilot", "copilot-acp", "claude-cli"}:
             model_ids = provider_model_ids(hermes_slug)
         # For aws_sdk providers (bedrock), use live discovery so the list
         # reflects the active region (eu.*, ap.*) not the static us.* list.

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -206,6 +206,14 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "claude-cli": [
+        "sonnet",
+        "opus",
+        "haiku",
+        "claude-sonnet-4-6",
+        "claude-opus-4-7",
+        "claude-haiku-4-5",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -786,6 +794,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (reuses local Qwen CLI login)"),
     ProviderEntry("copilot",        "GitHub Copilot",           "GitHub Copilot (uses GITHUB_TOKEN or gh auth token)"),
     ProviderEntry("copilot-acp",    "GitHub Copilot ACP",       "GitHub Copilot ACP (spawns `copilot --acp --stdio`)"),
+    ProviderEntry("claude-cli",     "Claude Code CLI",          "Claude Code CLI (spawns `claude -p`; uses local Claude login)"),
     ProviderEntry("huggingface",    "Hugging Face",             "Hugging Face Inference Providers (20+ open models)"),
     ProviderEntry("gemini",         "Google AI Studio",         "Google AI Studio (Gemini models — native Gemini API)"),
     ProviderEntry("google-gemini-cli", "Google Gemini (OAuth)",   "Google Gemini via OAuth + Code Assist (free tier supported; no API key needed)"),
@@ -845,6 +854,8 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "anthropic-cli": "claude-cli",
+    "claude-code-cli": "claude-cli",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",
@@ -1953,6 +1964,8 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         except Exception:
             access_token = None
         return get_codex_model_ids(access_token=access_token)
+    if normalized == "claude-cli":
+        return list(_PROVIDER_MODELS.get("claude-cli", []))
     if normalized in {"copilot", "copilot-acp"}:
         try:
             live = _fetch_github_models(_resolve_copilot_catalog_api_key())

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -84,6 +84,12 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="acp://copilot",
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "claude-cli": HermesOverlay(
+        transport="openai_chat",
+        auth_type="external_process",
+        base_url_override="claude-cli://local",
+        base_url_env_var="CLAUDE_CLI_BASE_URL",
+    ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
         extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
@@ -263,6 +269,8 @@ ALIASES: Dict[str, str] = {
     # anthropic
     "claude": "anthropic",
     "claude-code": "anthropic",
+    "anthropic-cli": "claude-cli",
+    "claude-code-cli": "claude-cli",
 
     # github-copilot (models.dev ID)
     "copilot": "github-copilot",
@@ -353,6 +361,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "claude-cli": "Claude Code CLI",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1120,10 +1120,10 @@ def resolve_runtime_provider(
             logger.info("Google Gemini OAuth credentials failed; "
                         "falling through to next provider.")
 
-    if provider == "copilot-acp":
+    if provider in {"copilot-acp", "claude-cli"}:
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -75,6 +75,14 @@ _DEFAULT_PROVIDER_MODELS = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "claude-cli": [
+        "sonnet",
+        "opus",
+        "haiku",
+        "claude-sonnet-4-6",
+        "claude-opus-4-7",
+        "claude-haiku-4-5",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -920,6 +928,7 @@ def setup_model_provider(config: dict, *, quick: bool = False):
             "nous-api": "Nous Portal API key",
             "copilot": "GitHub Copilot",
             "copilot-acp": "GitHub Copilot ACP",
+            "claude-cli": "Claude Code CLI",
             "zai": "Z.AI / GLM",
             "kimi-coding": "Kimi / Moonshot",
             "kimi-coding-cn": "Kimi / Moonshot (China)",

--- a/plugins/model-providers/claude-cli/__init__.py
+++ b/plugins/model-providers/claude-cli/__init__.py
@@ -1,0 +1,33 @@
+"""Claude Code CLI provider profile.
+
+claude-cli uses the local Claude Code CLI in non-interactive print mode. It is
+not a REST endpoint; run_agent.py routes the marker base URL to ClaudeCLIClient.
+"""
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class ClaudeCLIProfile(ProviderProfile):
+    """Claude Code CLI external process, no REST models endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Model listing is handled by Hermes' static CLI catalog."""
+        return None
+
+
+claude_cli = ClaudeCLIProfile(
+    name="claude-cli",
+    aliases=("anthropic-cli", "claude-code-cli"),
+    api_mode="chat_completions",
+    env_vars=(),
+    base_url="claude-cli://local",
+    auth_type="external_process",
+)
+
+register_provider(claude_cli)

--- a/plugins/model-providers/claude-cli/plugin.yaml
+++ b/plugins/model-providers/claude-cli/plugin.yaml
@@ -1,0 +1,5 @@
+name: claude-cli-provider
+kind: model-provider
+version: 1.0.0
+description: Claude Code via local CLI subprocess
+author: Nous Research

--- a/run_agent.py
+++ b/run_agent.py
@@ -1441,7 +1441,7 @@ class AIAgent:
                     client_kwargs = {"api_key": api_key, "base_url": base_url}
                 if _provider_timeout is not None:
                     client_kwargs["timeout"] = _provider_timeout
-                if self.provider == "copilot-acp":
+                if self.provider in {"copilot-acp", "claude-cli"}:
                     client_kwargs["command"] = self.acp_command
                     client_kwargs["args"] = self.acp_args
                 effective_base = base_url
@@ -5586,6 +5586,17 @@ class AIAgent:
             client = CopilotACPClient(**client_kwargs)
             logger.info(
                 "Copilot ACP client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                self._client_log_context(),
+            )
+            return client
+        if self.provider == "claude-cli" or str(client_kwargs.get("base_url", "")).startswith("claude-cli://"):
+            from agent.claude_cli_client import ClaudeCLIClient
+
+            client = ClaudeCLIClient(**client_kwargs)
+            logger.info(
+                "Claude CLI client created (%s, shared=%s) %s",
                 reason,
                 shared,
                 self._client_log_context(),
@@ -11384,6 +11395,8 @@ class AIAgent:
                         self.provider == "copilot-acp"
                         or str(self.base_url or "").lower().startswith("acp://copilot")
                         or str(self.base_url or "").lower().startswith("acp+tcp://")
+                        or self.provider == "claude-cli"
+                        or str(self.base_url or "").lower().startswith("claude-cli://")
                     ):
                         _use_streaming = False
                     elif not self._has_stream_consumers():

--- a/tests/agent/test_claude_cli_client.py
+++ b/tests/agent/test_claude_cli_client.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.claude_cli_client import ClaudeCLIClient, _normalize_claude_cli_model
+
+
+def test_normalize_claude_cli_model_strips_anthropic_prefix_and_dots():
+    assert _normalize_claude_cli_model("anthropic/claude-sonnet-4.6") == "claude-sonnet-4-6"
+
+
+def test_chat_completion_runs_claude_print_mode(tmp_path):
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(returncode=0, stdout="hello from claude\n", stderr="")
+
+    client = ClaudeCLIClient(
+        command="/usr/local/bin/claude",
+        args=["--no-session-persistence", "--tools", ""],
+        cwd=str(tmp_path),
+    )
+
+    with patch("agent.claude_cli_client.subprocess.run", side_effect=fake_run):
+        response = client.chat.completions.create(
+            model="anthropic/claude-sonnet-4.6",
+            messages=[{"role": "user", "content": "Say hello"}],
+        )
+
+    assert captured["cmd"][:6] == [
+        "/usr/local/bin/claude",
+        "--no-session-persistence",
+        "--tools",
+        "",
+        "-p",
+        "--model",
+    ]
+    assert captured["cmd"][6] == "claude-sonnet-4-6"
+    assert captured["kwargs"]["cwd"] == str(tmp_path)
+    assert response.choices[0].message.content == "hello from claude"
+    assert response.choices[0].finish_reason == "stop"
+
+
+def test_chat_completion_raises_with_cli_stderr(tmp_path):
+    def fake_run(cmd, **kwargs):
+        return SimpleNamespace(returncode=1, stdout="", stderr="Not logged in")
+
+    client = ClaudeCLIClient(command="claude", args=[], cwd=str(tmp_path))
+
+    with patch("agent.claude_cli_client.subprocess.run", side_effect=fake_run):
+        with pytest.raises(RuntimeError, match="Not logged in"):
+            client.chat.completions.create(
+                model="sonnet",
+                messages=[{"role": "user", "content": "hello"}],
+            )

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -31,6 +31,7 @@ class TestProviderRegistry:
 
     @pytest.mark.parametrize("provider_id,name,auth_type", [
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
+        ("claude-cli", "Claude Code CLI", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
         ("zai", "Z.AI / GLM", "api_key"),
@@ -385,6 +386,24 @@ class TestApiKeyProviderStatus:
         assert status["args"] == ["--acp", "--stdio", "--debug"]
         assert status["base_url"] == "acp://copilot"
 
+    def test_claude_cli_status_checks_auth(self, monkeypatch):
+        class _Result:
+            stdout = '{"loggedIn": true}'
+            stderr = ""
+            returncode = 0
+
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+        monkeypatch.setattr("hermes_cli.auth.subprocess.run", lambda *a, **kw: _Result())
+
+        status = get_external_process_provider_status("claude-cli")
+
+        assert status["configured"] is True
+        assert status["logged_in"] is True
+        assert status["command"] == "claude"
+        assert status["resolved_command"] == "/usr/local/bin/claude"
+        assert status["args"] == ["--no-session-persistence", "--tools", ""]
+        assert status["base_url"] == "claude-cli://local"
+
     def test_get_auth_status_dispatches_to_external_process(self, monkeypatch):
         monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/opt/bin/{command}")
 
@@ -489,6 +508,18 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["base_url"] == "acp://copilot"
         assert creds["command"] == "/usr/local/bin/copilot"
         assert creds["args"] == ["--acp", "--stdio"]
+        assert creds["source"] == "process"
+
+    def test_resolve_claude_cli_with_local_cli(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+
+        creds = resolve_external_process_provider_credentials("claude-cli")
+
+        assert creds["provider"] == "claude-cli"
+        assert creds["api_key"] == "claude-cli"
+        assert creds["base_url"] == "claude-cli://local"
+        assert creds["command"] == "/usr/local/bin/claude"
+        assert creds["args"] == ["--no-session-persistence", "--tools", ""]
         assert creds["source"] == "process"
 
     def test_resolve_kimi_with_key(self, monkeypatch):
@@ -711,6 +742,20 @@ class TestRuntimeProviderResolution:
         assert result["base_url"] == "acp://copilot"
         assert result["command"] == "/usr/local/bin/copilot"
         assert result["args"] == ["--acp", "--stdio", "--debug"]
+
+    def test_runtime_claude_cli_uses_process_runtime(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        result = resolve_runtime_provider(requested="claude-cli")
+
+        assert result["provider"] == "claude-cli"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "claude-cli"
+        assert result["base_url"] == "claude-cli://local"
+        assert result["command"] == "/usr/local/bin/claude"
+        assert result["args"] == ["--no-session-persistence", "--tools", ""]
 
 
 # =============================================================================

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -142,6 +142,14 @@ class TestCopilotModelNormalization:
         """Copilot ACP shares the same API expectations as HTTP Copilot."""
         assert normalize_model_for_provider(model, "copilot-acp") == expected
 
+    @pytest.mark.parametrize("model,expected", [
+        ("anthropic/claude-sonnet-4.6", "claude-sonnet-4-6"),
+        ("claude-cli/claude-opus-4.7", "claude-opus-4-7"),
+        ("sonnet", "sonnet"),
+    ])
+    def test_claude_cli_normalization(self, model, expected):
+        assert normalize_model_for_provider(model, "claude-cli") == expected
+
     def test_openai_codex_still_strips_openai_prefix(self):
         """Regression: openai-codex must still strip the openai/ prefix."""
         assert normalize_model_for_provider("openai/gpt-5.4", "openai-codex") == "gpt-5.4"

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -175,6 +175,7 @@ class TestProviderLabel:
         assert provider_label("stepfun") == "StepFun Step Plan"
         assert provider_label("copilot") == "GitHub Copilot"
         assert provider_label("copilot-acp") == "GitHub Copilot ACP"
+        assert provider_label("claude-cli") == "Claude Code CLI"
         assert provider_label("auto") == "Auto"
 
     def test_unknown_provider_preserves_original_name(self):
@@ -246,6 +247,12 @@ class TestProviderModelIds:
         assert "gemini-3.1-pro-preview" in ids
         assert "copilot-acp" not in ids
         assert "claude-opus-4.6" not in ids
+
+    def test_claude_cli_returns_static_cli_aliases(self):
+        ids = provider_model_ids("claude-cli")
+
+        assert ids[:3] == ["sonnet", "opus", "haiku"]
+        assert "claude-sonnet-4-6" in ids
 
 
 # -- fetch_api_models --------------------------------------------------------

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4124,6 +4124,36 @@ def test_aiagent_uses_copilot_acp_client():
     assert mock_acp_client.call_args.kwargs["args"] == ["--acp", "--stdio"]
 
 
+def test_aiagent_uses_claude_cli_client():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI") as mock_openai,
+        patch("agent.claude_cli_client.ClaudeCLIClient") as mock_claude_cli_client,
+    ):
+        cli_client = MagicMock()
+        mock_claude_cli_client.return_value = cli_client
+
+        agent = AIAgent(
+            api_key="claude-cli",
+            base_url="claude-cli://local",
+            provider="claude-cli",
+            acp_command="/usr/local/bin/claude",
+            acp_args=["--no-session-persistence", "--tools", ""],
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.client is cli_client
+    mock_openai.assert_not_called()
+    mock_claude_cli_client.assert_called_once()
+    assert mock_claude_cli_client.call_args.kwargs["base_url"] == "claude-cli://local"
+    assert mock_claude_cli_client.call_args.kwargs["api_key"] == "claude-cli"
+    assert mock_claude_cli_client.call_args.kwargs["command"] == "/usr/local/bin/claude"
+    assert mock_claude_cli_client.call_args.kwargs["args"] == ["--no-session-persistence", "--tools", ""]
+
+
 def test_quiet_spinner_allowed_with_explicit_print_fn(agent):
     agent._print_fn = lambda *_a, **_kw: None
     with patch.object(run_agent.sys.stdout, "isatty", return_value=False):


### PR DESCRIPTION
## Summary
- add a claude-cli external-process provider backed by local Claude Code CLI print mode
- wire provider selection, runtime resolution, model normalization, and /model picker support
- add focused tests for the client, provider registry, runtime routing, model list, and AIAgent client selection

## Verification
- ./venv/bin/python -m pytest -q tests/agent/test_claude_cli_client.py tests/hermes_cli/test_api_key_providers.py::TestProviderRegistry tests/hermes_cli/test_api_key_providers.py::TestApiKeyProviderStatus::test_claude_cli_status_checks_auth tests/hermes_cli/test_api_key_providers.py::TestResolveApiKeyProviderCredentials::test_resolve_claude_cli_with_local_cli tests/hermes_cli/test_api_key_providers.py::TestRuntimeProviderResolution::test_runtime_claude_cli_uses_process_runtime tests/hermes_cli/test_model_validation.py::TestProviderLabel::test_known_labels_and_auto tests/hermes_cli/test_model_validation.py::TestProviderModelIds::test_claude_cli_returns_static_cli_aliases tests/hermes_cli/test_model_normalize.py::TestCopilotModelNormalization::test_claude_cli_normalization tests/run_agent/test_run_agent.py::test_aiagent_uses_claude_cli_client
- ./venv/bin/hermes -z "Reply exactly: HERMES_CLAUDE_CLI_OK" --provider claude-cli -m sonnet --ignore-rules
- ./venv/bin/hermes -z "Reply exactly: HERMES_CLAUDE_FULL_MODEL_OK" --provider claude-cli -m claude-sonnet-4-6 --ignore-rules