### PR TITLE
refactor(gateway): run auth checks before processing hooks

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1218,6 +1218,7 @@ class BasePlatformAdapter(ABC):
         self.config = config
         self.platform = platform
         self._message_handler: Optional[MessageHandler] = None
+        self._pre_message_handler: Optional[Callable[[MessageEvent], Awaitable[Optional[MessageEvent]]]] = None
         self._running = False
         self._fatal_error_code: Optional[str] = None
         self._fatal_error_message: Optional[str] = None
@@ -1391,6 +1392,22 @@ class BasePlatformAdapter(ABC):
         an optional response string.
         """
         self._message_handler = handler
+
+    def set_pre_message_handler(self, handler: Callable[[MessageEvent], Awaitable[Optional[MessageEvent]]]) -> None:
+        """
+        Set a pre-check handler that gates whether the processing pipeline
+        should run at all.
+
+        Called in ``_process_message_background`` *before*
+        ``on_processing_start``.  If it returns ``False`` the entire
+        pipeline (hooks + message handler) is skipped — no reactions,
+        no typing indicators, no agent dispatch.
+
+        The gateway sets this to perform authorization, plugin gating,
+        and other early-return checks that must not trigger visible
+        processing-lifecycle side effects (e.g. Discord 👀 reactions).
+        """
+        self._pre_message_handler = handler
 
     def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
         """Set an optional handler for messages arriving during active sessions."""
@@ -2708,24 +2725,13 @@ class BasePlatformAdapter(ABC):
         # Fall back to a new Event only if the entry was removed externally.
         interrupt_event = self._active_sessions.get(session_key) or asyncio.Event()
         self._active_sessions[session_key] = interrupt_event
-        
-        # Start continuous typing indicator (refreshes every 2 seconds)
-        _thread_metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
-        _keep_typing_kwargs = {"metadata": _thread_metadata}
-        try:
-            _keep_typing_sig = inspect.signature(self._keep_typing)
-        except (TypeError, ValueError):
-            _keep_typing_sig = None
-        if _keep_typing_sig is None or "stop_event" in _keep_typing_sig.parameters:
-            _keep_typing_kwargs["stop_event"] = interrupt_event
-        typing_task = asyncio.create_task(
-            self._keep_typing(
-                event.source.chat_id,
-                **_keep_typing_kwargs,
-            )
-        )
+
+        typing_task = None  # Created after pre-check gate passes
+        processing_started = False
 
         async def _stop_typing_task() -> None:
+            if typing_task is None:
+                return
             typing_task.cancel()
             try:
                 await asyncio.wait_for(asyncio.shield(typing_task), timeout=0.5)
@@ -2734,9 +2740,41 @@ class BasePlatformAdapter(ABC):
                 # typing task is already cancelled; if the parent task is also
                 # cancelling, let this message-processing task unwind now.
                 pass
-        
+
         try:
+            # ── Pre-check gate ──────────────────────────────────────────
+            # Run the pre-message handler (set by GatewayRunner) BEFORE any
+            # visible processing-lifecycle side effects (reactions, typing).
+            # If it returns None the entire pipeline is skipped — no
+            # on_processing_start/complete hooks, no agent dispatch.
+            # This keeps authorization, plugin gating, and other early-return
+            # checks from triggering reactions on messages that will never be
+            # processed.
+            if self._pre_message_handler is not None:
+                event = await self._pre_message_handler(event)
+                if event is None:
+                    return
+
+            # Start continuous typing indicator (refreshes every 2 seconds).
+            # Only launched AFTER authorization passes — unauthorized users
+            # never see a typing indicator
+            _thread_metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+            _keep_typing_kwargs = {"metadata": _thread_metadata}
+            try:
+                _keep_typing_sig = inspect.signature(self._keep_typing)
+            except (TypeError, ValueError):
+                _keep_typing_sig = None
+            if _keep_typing_sig is None or "stop_event" in _keep_typing_sig.parameters:
+                _keep_typing_kwargs["stop_event"] = interrupt_event
+            typing_task = asyncio.create_task(
+                self._keep_typing(
+                    event.source.chat_id,
+                    **_keep_typing_kwargs,
+                )
+            )
+
             await self._run_processing_hook("on_processing_start", event)
+            processing_started = True
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
@@ -3007,14 +3045,16 @@ class BasePlatformAdapter(ABC):
                 return  # Drain task owns the session now.
                 
         except asyncio.CancelledError:
-            current_task = asyncio.current_task()
-            outcome = ProcessingOutcome.CANCELLED
-            if current_task is None or current_task not in self._expected_cancelled_tasks:
-                outcome = ProcessingOutcome.FAILURE
-            await self._run_processing_hook("on_processing_complete", event, outcome)
+            if processing_started:
+                current_task = asyncio.current_task()
+                outcome = ProcessingOutcome.CANCELLED
+                if current_task is None or current_task not in self._expected_cancelled_tasks:
+                    outcome = ProcessingOutcome.FAILURE
+                await self._run_processing_hook("on_processing_complete", event, outcome)
             raise
         except Exception as e:
-            await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
+            if processing_started:
+                await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
             # Send the error to the user so they aren't left with radio silence
             try:

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -192,15 +192,6 @@ class SignalAdapter(BasePlatformAdapter):
         group_allowed_str = os.getenv("SIGNAL_GROUP_ALLOWED_USERS", "")
         self.group_allow_from = set(_parse_comma_list(group_allowed_str))
 
-        # DM allowlist — mirrors SIGNAL_ALLOWED_USERS checked by run.py.
-        # Stored here so the reaction hooks can skip unauthorized senders
-        # (reactions fire before run.py's auth gate, so without this check
-        # every inbound DM from any contact gets a 👀 reaction).
-        # "*" means all users allowed (open mode); empty means no restriction
-        # recorded at adapter level (run.py still enforces auth separately).
-        dm_allowed_str = os.getenv("SIGNAL_ALLOWED_USERS", "*")
-        self.dm_allow_from = set(_parse_comma_list(dm_allowed_str))
-
         # HTTP client
         self.client: Optional[httpx.AsyncClient] = None
 
@@ -1440,21 +1431,9 @@ class SignalAdapter(BasePlatformAdapter):
         return (author, ts)
 
     def _reactions_enabled(self, event: "MessageEvent" = None) -> bool:
-        """Check if message reactions are enabled for this event.
-
-        Two gates:
-        1. SIGNAL_REACTIONS env var — set to false/0/no to disable globally.
-        2. DM allowlist — if SIGNAL_ALLOWED_USERS is set, only react to
-           messages from senders in that list.  This prevents unauthorized
-           contacts from seeing the 👀 reaction (which fires before run.py's
-           auth gate and would otherwise reveal that a bot is listening).
-        """
+        """Check if message reactions are enabled for this event."""
         if os.getenv("SIGNAL_REACTIONS", "true").lower() in ("false", "0", "no"):
             return False
-        if event is not None:
-            sender = getattr(getattr(event, "source", None), "user_id", None)
-            if sender and "*" not in self.dm_allow_from and sender not in self.dm_allow_from:
-                return False
         return True
 
     async def on_processing_start(self, event: MessageEvent) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2933,6 +2933,7 @@ class GatewayRunner:
             
             # Set up message + fatal error handlers
             adapter.set_message_handler(self._handle_message)
+            adapter.set_pre_message_handler(self._pre_handle_message)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -3825,6 +3826,7 @@ class GatewayRunner:
                         continue
 
                     adapter.set_message_handler(self._handle_message)
+                    adapter.set_pre_message_handler(self._pre_handle_message)
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
                     adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -4643,24 +4645,23 @@ class GatewayRunner:
 
         await adapter.send(source.chat_id, content, metadata=metadata)
 
-    async def _handle_message(self, event: MessageEvent) -> Optional[str]:
-        """
-        Handle an incoming message from any platform.
-        
-        This is the core message processing pipeline:
-        1. Check user authorization
-        2. Check for commands (/new, /reset, etc.)
-        3. Check for running agent and interrupt if needed
-        4. Get or create session
-        5. Build context for agent
-        6. Run agent conversation
-        7. Return response
+    async def _pre_handle_message(self, event: MessageEvent) -> Optional[MessageEvent]:
+        """Pre-check gate: returns event (possibly modified) if processing should proceed.
+
+        Called by ``_process_message_background`` *before*
+        ``on_processing_start`` so that authorization, plugin gating, and
+        other early-return checks never trigger visible processing-lifecycle
+        side effects (reactions, typing indicators).
+
+        This is the single choke point for ``_is_user_authorized`` — the
+        main handler (``_handle_message``) no longer checks it.
         """
         source = event.source
 
         # Internal events (e.g. background-process completion notifications)
         # are system-generated and must skip user authorization.
-        is_internal = bool(getattr(event, "internal", False))
+        if bool(getattr(event, "internal", False)):
+            return event
 
         # Fire pre_gateway_dispatch plugin hook for user-originated messages.
         # Plugins receive the MessageEvent and may return a dict influencing flow:
@@ -4669,43 +4670,39 @@ class GatewayRunner:
         #   {"action": "allow"}   /   None          -> normal dispatch
         # Hook runs BEFORE auth so plugins can handle unauthorized senders
         # (e.g. customer handover ingest) without triggering the pairing flow.
-        if not is_internal:
-            try:
-                from hermes_cli.plugins import invoke_hook as _invoke_hook
-                _hook_results = _invoke_hook(
-                    "pre_gateway_dispatch",
-                    event=event,
-                    gateway=self,
-                    session_store=self.session_store,
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _hook_results = _invoke_hook(
+                "pre_gateway_dispatch",
+                event=event,
+                gateway=self,
+                session_store=self.session_store,
+            )
+        except Exception as _hook_exc:
+            logger.warning("pre_gateway_dispatch invocation failed: %s", _hook_exc)
+            _hook_results = []
+
+        for _result in _hook_results:
+            if not isinstance(_result, dict):
+                continue
+            _action = _result.get("action")
+            if _action == "skip":
+                logger.info(
+                    "pre_gateway_dispatch skip: reason=%s platform=%s chat=%s",
+                    _result.get("reason"),
+                    source.platform.value if source.platform else "unknown",
+                    source.chat_id or "unknown",
                 )
-            except Exception as _hook_exc:
-                logger.warning("pre_gateway_dispatch invocation failed: %s", _hook_exc)
-                _hook_results = []
+                return None
+            if _action == "rewrite":
+                _new_text = _result.get("text")
+                if isinstance(_new_text, str):
+                    event = dataclasses.replace(event, text=_new_text)
+                break
+            if _action == "allow":
+                break
 
-            for _result in _hook_results:
-                if not isinstance(_result, dict):
-                    continue
-                _action = _result.get("action")
-                if _action == "skip":
-                    logger.info(
-                        "pre_gateway_dispatch skip: reason=%s platform=%s chat=%s",
-                        _result.get("reason"),
-                        source.platform.value if source.platform else "unknown",
-                        source.chat_id or "unknown",
-                    )
-                    return None
-                if _action == "rewrite":
-                    _new_text = _result.get("text")
-                    if isinstance(_new_text, str):
-                        event = dataclasses.replace(event, text=_new_text)
-                        source = event.source
-                    break
-                if _action == "allow":
-                    break
-
-        if is_internal:
-            pass
-        elif source.user_id is None:
+        if source.user_id is None:
             # Messages with no user identity (Telegram service messages,
             # channel forwards, anonymous admin actions) cannot be
             # authorized — drop silently instead of triggering the pairing
@@ -4746,7 +4743,26 @@ class GatewayRunner:
                     # Record rate limit so subsequent messages are silently ignored
                     self.pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
-        
+
+        return event
+
+    async def _handle_message(self, event: MessageEvent) -> Optional[str]:
+        """Handle an incoming message from any platform.
+
+        Authorization and plugin gating are handled by
+        ``_pre_handle_message`` - called before this method when going
+        through the normal message-processing flow.
+
+        This is the core message processing pipeline:
+        1. Check for commands (/new, /reset, etc.)
+        2. Check for running agent and interrupt if needed
+        3. Get or create session
+        4. Build context for agent
+        5. Run agent conversation
+        6. Return response
+        """
+        source = event.source
+
         # Intercept messages that are responses to a pending /update prompt.
         # The update process (detached) wrote .update_prompt.json; the watcher
         # forwarded it to the user; now the user's reply goes back via
@@ -8060,7 +8076,9 @@ class GatewayRunner:
             channel_prompt=event.channel_prompt,
         )
         
-        # Let the normal message handler process it
+        # Let the normal message handler process it - no need to check
+        # auth by calling `_pre_handle_message`: if we're here, the user
+        # has already passed it (we've gone through `_handle_message` once)
         return await self._handle_message(retry_event)
 
     # ────────────────────────────────────────────────────────────────

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -252,6 +252,7 @@ def make_adapter(platform: Platform, runner=None):
     adapter.send_typing = AsyncMock()
 
     adapter.set_message_handler(runner._handle_message)
+    adapter.set_pre_message_handler(runner._pre_handle_message)
     runner.adapters[platform_key] = adapter
 
     return adapter
@@ -405,6 +406,7 @@ def _make_discord_adapter_wired(runner=None):
     adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="e2e-resp-1"))
     adapter.send_typing = AsyncMock()
     adapter.set_message_handler(runner._handle_message)
+    adapter.set_pre_message_handler(runner._pre_handle_message)
     runner.adapters[Platform.DISCORD] = adapter
 
     return adapter, runner

--- a/tests/gateway/test_internal_event_bypass_pairing.py
+++ b/tests/gateway/test_internal_event_bypass_pairing.py
@@ -18,7 +18,6 @@ from gateway.platforms.base import MessageEvent
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -132,17 +131,10 @@ async def test_internal_event_bypasses_authorization(monkeypatch, tmp_path):
 
     monkeypatch.setattr(GatewayRunner, "_is_user_authorized", tracking_auth)
 
-    # Stop execution before the agent runner so the test doesn't block in
-    # run_in_executor.  Auth check happens before _handle_message_with_agent.
-    async def _raise(*_a, **_kw):
-        raise RuntimeError("sentinel — stop here")
-    monkeypatch.setattr(GatewayRunner, "_handle_message_with_agent", _raise)
+    # _pre_handle_message is the gate that checks internal flag before auth
+    result = await runner._pre_handle_message(event)
 
-    try:
-        await runner._handle_message(event)
-    except RuntimeError:
-        pass  # Expected sentinel
-
+    assert result is not None, "Internal events should pass the pre-check"
     assert not auth_called, (
         "_is_user_authorized should NOT be called for internal events"
     )
@@ -183,17 +175,11 @@ async def test_internal_event_does_not_trigger_pairing(monkeypatch, tmp_path):
 
     runner.pairing_store.generate_code = tracking_generate
 
-    # Stop execution before the agent runner so the test doesn't block in
-    # run_in_executor.  Pairing check happens before _handle_message_with_agent.
-    async def _raise(*_a, **_kw):
-        raise RuntimeError("sentinel — stop here")
-    monkeypatch.setattr(GatewayRunner, "_handle_message_with_agent", _raise)
+    # _pre_handle_message should return True for internal events without
+    # calling any auth/pairing code.
+    result = await runner._pre_handle_message(event)
 
-    try:
-        await runner._handle_message(event)
-    except RuntimeError:
-        pass  # Expected sentinel
-
+    assert result is not None, "Internal events should pass the pre-check"
     assert not generate_called, (
         "Pairing code should NOT be generated for internal events"
     )
@@ -307,9 +293,9 @@ async def test_none_user_id_skips_pairing(monkeypatch, tmp_path):
         internal=False,
     )
 
-    result = await runner._handle_message(event)
+    result = await runner._pre_handle_message(event)
 
-    # Should return None (dropped) and NOT send any pairing message
+    # Should return False (dropped) and NOT send any pairing message
     assert result is None
     assert adapter.send.await_count == 0
 
@@ -344,8 +330,9 @@ async def test_none_user_id_does_not_generate_pairing_code(monkeypatch, tmp_path
     )
     event = MessageEvent(text="anonymous", source=source, internal=False)
 
-    await runner._handle_message(event)
+    result = await runner._pre_handle_message(event)
 
+    assert result is None
     assert not generate_called, (
         "Pairing code should NOT be generated for messages with user_id=None"
     )
@@ -392,9 +379,9 @@ async def test_non_internal_event_without_user_triggers_pairing(monkeypatch, tmp
         internal=False,
     )
 
-    result = await runner._handle_message(event)
+    result = await runner._pre_handle_message(event)
 
-    # Should return None (unauthorized) and send pairing message
+    # Should return False (unauthorized) and send pairing message
     assert result is None
     assert adapter.send.await_count == 1
     sent_text = adapter.send.await_args.args[1]

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -1,7 +1,7 @@
 """Tests for the pre_gateway_dispatch plugin hook.
 
 The hook allows plugins to intercept incoming messages before auth and
-agent dispatch. It runs in _handle_message and acts on returned action
+agent dispatch. It runs in _pre_handle_message and acts on returned action
 dicts: {"action": "skip"|"rewrite"|"allow"}.
 """
 
@@ -74,7 +74,7 @@ async def test_hook_skip_short_circuits_dispatch(monkeypatch):
 
     runner, adapter = _make_runner(Platform.WHATSAPP)
 
-    result = await runner._handle_message(_make_event("hi"))
+    result = await runner._pre_handle_message(_make_event("hi"))
 
     assert result is None
     adapter.send.assert_not_awaited()
@@ -83,29 +83,27 @@ async def test_hook_skip_short_circuits_dispatch(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_hook_rewrite_replaces_event_text(monkeypatch):
-    """A plugin returning {'action': 'rewrite', 'text': ...} mutates event.text."""
+    """A plugin returning {'action': 'rewrite', 'text': ...} returns a replaced event."""
     _clear_auth_env(monkeypatch)
     monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
-
-    seen_text = {}
 
     def _fake_hook(name, **kwargs):
         if name == "pre_gateway_dispatch":
             return [{"action": "rewrite", "text": "REWRITTEN"}]
         return []
 
-    async def _capture(event, source, _quick_key, _run_generation):
-        seen_text["value"] = event.text
-        return "ok"
-
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
 
     runner, _adapter = _make_runner(Platform.WHATSAPP)
-    runner._handle_message_with_agent = _capture  # noqa: SLF001
 
-    await runner._handle_message(_make_event("original"))
+    event = _make_event("original")
+    result = await runner._pre_handle_message(event)
 
-    assert seen_text.get("value") == "REWRITTEN"
+    # pre-check should pass (auth succeeds with allow-all) and return a new
+    # event with the rewritten text — the original event must not be mutated.
+    assert result is not None
+    assert result.text == "REWRITTEN"
+    assert event.text == "original"
 
 
 @pytest.mark.asyncio
@@ -125,9 +123,9 @@ async def test_hook_allow_falls_through_to_auth(monkeypatch):
     runner, adapter = _make_runner(Platform.WHATSAPP)
     runner.pairing_store.generate_code.return_value = "12345"
 
-    result = await runner._handle_message(_make_event("hi"))
+    result = await runner._pre_handle_message(_make_event("hi"))
 
-    # auth chain ran → pairing code was generated
+    # auth chain ran → pairing code was generated, pre-check returns None
     assert result is None
     runner.pairing_store.generate_code.assert_called_once()
 
@@ -146,8 +144,8 @@ async def test_hook_exception_does_not_break_dispatch(monkeypatch):
     runner, _adapter = _make_runner(Platform.WHATSAPP)
     runner.pairing_store.generate_code.return_value = None
 
-    # Should not raise; falls through to auth chain.
-    result = await runner._handle_message(_make_event("hi"))
+    # Should not raise; falls through to auth chain, auth fails.
+    result = await runner._pre_handle_message(_make_event("hi"))
     assert result is None
 
 
@@ -163,17 +161,14 @@ async def test_internal_events_bypass_hook(monkeypatch):
         called["count"] += 1
         return [{"action": "skip"}]
 
-    async def _capture(event, source, _quick_key, _run_generation):
-        return "ok"
-
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
 
     runner, _adapter = _make_runner(Platform.WHATSAPP)
-    runner._handle_message_with_agent = _capture  # noqa: SLF001
 
     event = _make_event("hi")
     event.internal = True
 
     # Even though the hook would say skip, internal events bypass it.
-    await runner._handle_message(event)
+    result = await runner._pre_handle_message(event)
+    assert result is not None
     assert called["count"] == 0

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -363,7 +363,7 @@ async def test_unauthorized_dm_pairs_by_default(monkeypatch):
     runner, adapter = _make_runner(Platform.WHATSAPP, config)
     runner.pairing_store.generate_code.return_value = "ABC12DEF"
 
-    result = await runner._handle_message(
+    result = await runner._pre_handle_message(
         _make_event(
             Platform.WHATSAPP,
             "15551234567@s.whatsapp.net",
@@ -394,7 +394,7 @@ async def test_unauthorized_whatsapp_dm_can_be_ignored(monkeypatch):
     )
     runner, adapter = _make_runner(Platform.WHATSAPP, config)
 
-    result = await runner._handle_message(
+    result = await runner._pre_handle_message(
         _make_event(
             Platform.WHATSAPP,
             "15551234567@s.whatsapp.net",
@@ -417,7 +417,7 @@ async def test_rate_limited_user_gets_no_response(monkeypatch):
     runner, adapter = _make_runner(Platform.WHATSAPP, config)
     runner.pairing_store._is_rate_limited.return_value = True
 
-    result = await runner._handle_message(
+    result = await runner._pre_handle_message(
         _make_event(
             Platform.WHATSAPP,
             "15551234567@s.whatsapp.net",
@@ -441,7 +441,7 @@ async def test_rejection_message_records_rate_limit(monkeypatch):
     runner, adapter = _make_runner(Platform.WHATSAPP, config)
     runner.pairing_store.generate_code.return_value = None  # triggers rejection
 
-    result = await runner._handle_message(
+    result = await runner._pre_handle_message(
         _make_event(
             Platform.WHATSAPP,
             "15551234567@s.whatsapp.net",
@@ -466,7 +466,7 @@ async def test_global_ignore_suppresses_pairing_reply(monkeypatch):
     )
     runner, adapter = _make_runner(Platform.TELEGRAM, config)
 
-    result = await runner._handle_message(
+    result = await runner._pre_handle_message(
         _make_event(
             Platform.TELEGRAM,
             "12345",
@@ -500,8 +500,8 @@ async def test_signal_with_allowlist_ignores_unauthorized_dm(monkeypatch):
     )
     runner, adapter = _make_runner(Platform.SIGNAL, config)
 
-    result = await runner._handle_message(
-        _make_event(Platform.SIGNAL, "+15559999999", "+15559999999")  # not in allowlist
+    result = await runner._pre_handle_message(
+        _make_event(Platform.SIGNAL, "+155****9999", "+155****9999")  # not in allowlist
     )
 
     assert result is None
@@ -520,7 +520,7 @@ async def test_telegram_with_allowlist_ignores_unauthorized_dm(monkeypatch):
     )
     runner, adapter = _make_runner(Platform.TELEGRAM, config)
 
-    result = await runner._handle_message(
+    result = await runner._pre_handle_message(
         _make_event(Platform.TELEGRAM, "999999999", "999999999")
     )
 
@@ -540,8 +540,8 @@ async def test_global_allowlist_ignores_unauthorized_dm(monkeypatch):
     )
     runner, adapter = _make_runner(Platform.SIGNAL, config)
 
-    result = await runner._handle_message(
-        _make_event(Platform.SIGNAL, "+15559999999", "+15559999999")
+    result = await runner._pre_handle_message(
+        _make_event(Platform.SIGNAL, "+155****9999", "+155****9999")
     )
 
     assert result is None
@@ -561,8 +561,8 @@ async def test_no_allowlist_still_pairs_by_default(monkeypatch):
     runner, adapter = _make_runner(Platform.SIGNAL, config)
     runner.pairing_store.generate_code.return_value = "PAIR1234"
 
-    result = await runner._handle_message(
-        _make_event(Platform.SIGNAL, "+15559999999", "+15559999999")
+    result = await runner._pre_handle_message(
+        _make_event(Platform.SIGNAL, "+155****9999", "+155****9999")
     )
 
     assert result is None

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -57,13 +57,16 @@ When a message arrives from any platform:
 2. **Base adapter** checks active session guard:
    - If agent is running for this session → queue message, set interrupt event
    - If `/approve`, `/deny`, `/stop` → bypass guard (dispatched inline)
-3. **GatewayRunner._handle_message()** receives the event:
+3. **GatewayRunner._pre_handle_message()** receives the event:
+   - Check authorization (see Authorization below)
+   - Early returns if not authorized
+4. **GatewayRunner._handle_message()** receives the event:
    - Resolve session key via `_session_key_for_source()` (format: `agent:main:{platform}:{chat_type}:{chat_id}`)
    - Check authorization (see Authorization below)
    - Check if it's a slash command → dispatch to command handler
    - Check if agent is already running → intercept commands like `/stop`, `/status`
    - Otherwise → create `AIAgent` instance and run conversation
-4. **Response** is sent back through the platform adapter
+5. **Response** is sent back through the platform adapter
 
 ### Session Key Format
 


### PR DESCRIPTION
## What does this PR do?

Moves authorization checks to run **before** processing-lifecycle hooks (typing indicators, reactions), fixing an info leak where unauthorized users could see "👀" reactions and potentially typing indicators before being silently dropped (Telegram).

Introduces a `_pre_message_handler` callback on `BasePlatformAdapter` that gates the entire pipeline before any visible side effects fire.

> Note: This changes a bit the message processing flow - maybe this approach isn't acceptable due to unforeseen (on my side) constraints on `_handle_message` usage, but i haven't found any in the codebase and related tests do pass, so i propose this PR.

**Flow before:**
```
_process_message_background
  ├── typing indicator          ← fires for EVERYONE, including unauthorized
  ├── on_processing_start()     ← 👀 reaction leaks "bot is listening"
  ├── _handle_message()
  │     └── _is_user_authorized() ← too late, reaction already sent
  └── on_processing_complete()
```

**Flow after:**
```
_process_message_background
  ├── _pre_message_handler()    ← auth, plugins, pairing (NEW gate)
  │     └── returns None → skip everything, no side effects
  ├── typing indicator          ← only authorized users
  ├── on_processing_start()     ← only authorized messages
  ├── _handle_message()         ← no auth checks needed
  └── on_processing_complete()  ← gated by processing_started
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue) -> it does fix the Telegram reactions/typing being shown for unauthorized users
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

|File |Change |
| -----|------------|
|`gateway/platforms/base.py`|Add `_pre_message_handler` callback + setter; call it in _process_message_background before `on_processing_start`. Move typing indicator task creation after the pre-check gate. Add `processing_started` flag to guard `on_processing_complete` in exception paths.|
|`gateway/run.py`|Extract auth + "pre_gateway_dispatch" hook + pairing logic from `_handle_message()` into new `_pre_handle_message()`. Register it as the pre-check on all adapters. `_handle_message()` no longer checks `_is_user_authorized()`.|
|`gateway/platforms/signal.py`|Remove duplicate `dm_allow_from` auth check in `_reactions_enabled()` : no longer needed since `_pre_handle_message` gates before `on_processing_start`.|
|`tests/e2e/conftest.py` | Add `set_pre_message_handler` call in adapter setups |
|`tests/gateway/test_internal_event_bypass_pairing.py`| Update tests to call `_pre_handle_message()` instead of `_handle_message()` for auth/pairing assertions. Add explicit assert `result is not None` for internal event bypass.|
|`tests/gateway/test_pre_gateway_dispatch.py`| Same migration. `rewrite` test now verifies correct return value instead of mutating through to the agent handler.|
|`tests/gateway/test_unauthorized_dm_behavior.py`| Same migration : all auth-behavior tests now exercise the pre-check gate directly.|
|`website/docs/developer-guide/gateway-internals.py`| Added `_pre_handle_message()` mention in the message-processing flow description|

## How to Test

1. Enable reactions on the Telegram gateway
2. Send a message from an unauthorized user to the bot
3. The message does not receive a reaction + no "Typing..." message is displayed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings)
