### PR TITLE
feat(docker): bootstrap auth.json from env on first boot

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -81,6 +81,20 @@ if [ ! -f "$HERMES_HOME/SOUL.md" ]; then
     cp "$INSTALL_DIR/docker/SOUL.md" "$HERMES_HOME/SOUL.md"
 fi
 
+# auth.json: bootstrap from env on first boot only.  Used by orchestrators
+# (e.g. provisioning a Hermes VPS from an account-management service) that
+# need to seed the OAuth refresh credential non-interactively, instead of
+# walking the user through `hermes setup` + the device-flow login dance.
+# Subsequent token rotations write back to the same file, which lives on a
+# persistent volume — so this env var is consumed exactly once at first
+# boot.  The `[ ! -f ... ]` guard is critical: without it, a container
+# restart would clobber a rotated refresh token with the now-stale value
+# the orchestrator originally seeded.
+if [ ! -f "$HERMES_HOME/auth.json" ] && [ -n "$HERMES_AUTH_JSON_BOOTSTRAP" ]; then
+    printf '%s' "$HERMES_AUTH_JSON_BOOTSTRAP" > "$HERMES_HOME/auth.json"
+    chmod 600 "$HERMES_HOME/auth.json"
+fi
+
 # Sync bundled skills (manifest-based so user edits are preserved)
 if [ -d "$INSTALL_DIR/skills" ]; then
     python3 "$INSTALL_DIR/tools/skills_sync.py"


### PR DESCRIPTION
## Summary

Lets orchestrators seed Hermes' OAuth refresh credential into a freshly
provisioned container non-interactively, instead of walking the user through
`hermes setup` + the device-flow dance.

If `HERMES_AUTH_JSON_BOOTSTRAP` is set and `$HERMES_HOME/auth.json` doesn't
already exist, the entrypoint writes the env var's contents to `auth.json`
(mode 600). Matches the existing first-boot-only pattern used for `.env`,
`config.yaml`, and `SOUL.md`.

## Why now

We're adding a managed Hermes VPS feature in `nous-account-service` (companion
PR: NousResearch/nous-account-service#42). NAS will mint an agent-scoped
OAuth refresh session on the user's behalf and inject it via this env var so
the container ends up in the same authenticated state as a user who completed
`hermes setup` → "Nous Portal subscription" → device flow. From there Hermes
self-rotates the refresh token to the persistent volume and self-mints
inference keys via the existing `/api/oauth/agent-key` endpoint.

The env var name is intentionally generic (not `NOUS_*`) so the feature is
reusable by any future orchestrator.

## Why the `[ ! -f auth.json ]` guard matters

Without it, every container restart would clobber the rotated refresh token
Hermes wrote back to the volume with the now-stale value the orchestrator
originally seeded. With the guard the env var is consumed exactly once at
first boot; subsequent boots see the volume's auth.json untouched.

## Test plan

- [ ] Local: `docker run -e HERMES_AUTH_JSON_BOOTSTRAP='{"version":1,...}' hermes-agent` writes the file with mode 600 on first boot.
- [ ] Local: a second `docker run` against the same volume does NOT clobber a Hermes-written rotated `auth.json`.
- [ ] Local: container without the env var behaves identically to today (no `auth.json` written, user must `hermes setup`).
- [ ] Staging: full end-to-end NAS-provisioned VPS once the companion PR (`nous-account-service#42`) is merged + the image rebuilt.

