### PR TITLE
fix(dashboard): send Cache-Control on /dashboard-plugins/* assets

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3964,7 +3964,21 @@ async def serve_plugin_asset(plugin_name: str, file_path: str):
         ".woff": "font/woff",
     }
     media_type = content_types.get(suffix, "application/octet-stream")
-    return FileResponse(target, media_type=media_type)
+    # Use ``no-cache`` (not ``no-store``) so the browser keeps the asset in its
+    # cache but revalidates with the server on every load via ETag /
+    # Last-Modified, which ``FileResponse`` populates from file mtime.  The
+    # server returns 304 Not Modified when the bundle on disk is unchanged,
+    # and the full body when the plugin author ships an update.  Without this
+    # header, browsers may serve a stale plugin IIFE from the HTTP cache to
+    # ``<script>`` tags injected by the dashboard plugin loader, even after a
+    # hard refresh — leading to "function not defined" errors after a plugin
+    # update.  index.html uses ``no-store`` (line ~3237) for the same reason
+    # the SPA shell must never be cached.
+    return FileResponse(
+        target,
+        media_type=media_type,
+        headers={"Cache-Control": "no-cache"},
+    )
 
 
 def _mount_plugin_api_routes():

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2213,3 +2213,106 @@ class TestPtyWebSocket:
             ):
                 pass
         assert exc.value.code == 4400
+
+
+# ---------------------------------------------------------------------------
+# /dashboard-plugins/<plugin>/<file> — Cache-Control on plugin assets.
+#
+# The dashboard plugin loader injects each plugin's bundle as a <script src>
+# exactly once per page lifecycle.  Without an explicit Cache-Control, the
+# browser's heuristic cache can serve a stale IIFE to the script tag even
+# after a hard refresh, leading to "function not defined" errors when a
+# plugin author ships an update under the same filename.  We send
+# ``Cache-Control: no-cache`` so the browser revalidates with the server
+# every load (ETag / Last-Modified come from FileResponse) — the server
+# returns 304 when unchanged and the full body when the bundle changed.
+# ---------------------------------------------------------------------------
+
+
+class TestDashboardPluginAssetCacheControl:
+    """The /dashboard-plugins/<name>/<file> endpoint must send a
+    revalidation-friendly Cache-Control header so plugin updates are picked
+    up without manual cache clears."""
+
+    def _write_plugin(self, tmp_path, name, asset_relpath, asset_body):
+        import json
+        plug_root = tmp_path / "plugins" / name / "dashboard"
+        plug_root.mkdir(parents=True)
+        (plug_root / "manifest.json").write_text(json.dumps({
+            "name": name,
+            "label": name.title(),
+            "tab": {"path": f"/{name}"},
+            "entry": asset_relpath,
+        }))
+        asset_path = plug_root / asset_relpath
+        asset_path.parent.mkdir(parents=True, exist_ok=True)
+        asset_path.write_text(asset_body)
+        return plug_root
+
+    @pytest.fixture
+    def client_with_plugin(self, tmp_path, monkeypatch):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._write_plugin(
+            tmp_path,
+            "cachetest",
+            "dist/index.js",
+            "console.log('cachetest v1');",
+        )
+        from hermes_cli import web_server
+        web_server._dashboard_plugins_cache = None
+        web_server._get_dashboard_plugins(force_rescan=True)
+        client = TestClient(web_server.app)
+        client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+        return client
+
+    def test_plugin_asset_returns_no_cache_header(self, client_with_plugin):
+        """Plugin asset response carries Cache-Control: no-cache so the
+        browser revalidates every load and picks up plugin updates."""
+        resp = client_with_plugin.get("/dashboard-plugins/cachetest/dist/index.js")
+        assert resp.status_code == 200
+        assert resp.text == "console.log('cachetest v1');"
+        cc = resp.headers.get("cache-control", "")
+        assert "no-cache" in cc.lower(), (
+            f"plugin asset must send Cache-Control with no-cache to avoid "
+            f"stale-bundle-after-update; got {cc!r}"
+        )
+
+    def test_plugin_asset_serves_correct_media_type(self, client_with_plugin):
+        """Sanity check that the existing media-type behavior is unchanged."""
+        resp = client_with_plugin.get("/dashboard-plugins/cachetest/dist/index.js")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("application/javascript")
+
+    def test_index_html_cache_control_unchanged(self, tmp_path, monkeypatch):
+        """Regression guard: index.html keeps its no-store/no-cache/
+        must-revalidate header; this PR only changes the plugin-asset
+        endpoint, not the SPA shell."""
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+        # Stub out a minimal SPA dist so _serve_index has something to read.
+        web_dist = tmp_path / "dist"
+        web_dist.mkdir()
+        (web_dist / "index.html").write_text(
+            "<html><head></head><body>hi</body></html>"
+        )
+        (web_dist / "assets").mkdir()
+        from hermes_cli import web_server
+        monkeypatch.setattr(web_server, "WEB_DIST", web_dist)
+
+        from fastapi import FastAPI
+        app = FastAPI()
+        web_server.mount_spa(app)
+        client = TestClient(app)
+        resp = client.get("/")
+        assert resp.status_code == 200
+        cc = resp.headers.get("cache-control", "")
+        assert "no-store" in cc
+        assert "no-cache" in cc
+        assert "must-revalidate" in cc
+


### PR DESCRIPTION
## What does this PR do?

Adds `Cache-Control: no-cache` to responses from
`/dashboard-plugins/{plugin_name}/{file_path:path}`
(`hermes_cli/web_server.py::serve_plugin_asset`, line ~3932).

Without this header, browsers can serve a stale plugin bundle from
their HTTP cache to a `<script src="...">` tag injected by the
dashboard plugin loader, even after a hard refresh — leading to
"function not defined" errors after a plugin update under the same
filename. With `no-cache`, the browser keeps the asset cached but
revalidates every load via `ETag` / `Last-Modified` (FastAPI's
`FileResponse` populates both from file mtime). The server returns
`304 Not Modified` when the bundle is unchanged and the full body when
it changed.

## Related Issue

Fixes # (no existing issue — filing the PR directly since the fix is
~3 lines of code and surrounded by tests).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` — `serve_plugin_asset` now passes
  `headers={"Cache-Control": "no-cache"}` to `FileResponse`. Comment
  block explains the rationale and contrasts with the SPA shell's
  stronger `no-store, no-cache, must-revalidate` (line ~3237).
- `tests/hermes_cli/test_web_server.py` — new
  `TestDashboardPluginAssetCacheControl` class with three tests:
  - asset response carries `Cache-Control: no-cache`,
  - media-type behavior is unchanged,
  - regression guard that `index.html` still sends
    `no-store, no-cache, must-revalidate`.

## How to Test

Reproduce the bug without the fix:

```bash
# With a dashboard plugin installed (e.g. the bundled Kanban plugin),
curl -sI http://127.0.0.1:9119/dashboard-plugins/<plugin>/dist/index.js \
  | grep -i cache-control
# → no header
```

Then ship a new build of the bundle under the same filename. After a
hard refresh, the browser may still execute the old IIFE from cache —
even though `fetch()` from devtools sees the fresh bytes — because
hard-refresh does not always invalidate JS-injected `<script>` tags.

After the fix:

```bash
curl -sI http://127.0.0.1:9119/dashboard-plugins/<plugin>/dist/index.js \
  | grep -i cache-control
# → cache-control: no-cache
```

Run the new tests:

```bash
pytest tests/hermes_cli/test_web_server.py::TestDashboardPluginAssetCacheControl -v
# → 3 passed
```

Vacuous-test sniff check: I stashed the `web_server.py` change and
re-ran the new tests — `test_plugin_asset_returns_no_cache_header`
correctly fails without the fix, the regression-guard tests still
pass. Restored the fix and full
`tests/hermes_cli/test_web_server.py` (140 tests) passes.

## Discovery context

We hit this shipping a custom dashboard plugin (Surface, an Edaphic
white-label skin built entirely on top of the upstream plugin /
extension surface). Updating the plugin under the same bundle filename
caused the browser to keep running the old IIFE; `Cmd+Shift+R` and
even closing the tab were not enough — only `DevTools → Application →
Clear site data → reopen` reliably fixed it. We worked around it
locally by version-stamping the bundle filename
(`dist/index-v060.js`), but every dashboard plugin author hits the
same trap, and one upstream fix benefits everyone.

Verified through every layer of the stack (on-disk size, FastAPI
loopback, Caddy bridge, Tailscale Serve public, browser fetch with
`?bust=N`) that the bytes were correct in flight; only the browser's
script-tag execution was running stale code. The asymmetry with the
SPA shell — `index.html` already gets `no-store, no-cache,
must-revalidate` at `web_server.py:3237` — was what tipped me off to
the fix shape.

## Design choice: `no-cache` vs. `no-store, no-cache, must-revalidate`

I chose `no-cache` (revalidate every load) rather than mirroring the
SPA shell's stronger `no-store, no-cache, must-revalidate` (no caching
at all) because:

- `index.html` is small (~10 KB) and re-sending it costs little.
- Plugin bundles can be much bigger (the Surface bundle is ~85 KB;
  some plugins ship 500 KB+ minified and unminified). `no-store` would
  re-download the full body on every page load even when nothing
  changed.
- `no-cache` with `ETag` / `Last-Modified` (which `FileResponse` sets
  automatically) gives correctness — plugin updates picked up on the
  very next load — without the bandwidth penalty.

If you'd prefer to mirror the index.html precedent exactly
(`no-store, no-cache, must-revalidate`), happy to flip it; just let me
know and I'll push another commit. The test only asserts `"no-cache"
in cc.lower()`, so it accepts either.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(dashboard): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (searched issues + PRs for `plugin cache`, `Cache-Control`, `dashboard-plugins`, `stale plugin` — no match)
- [x] My PR contains **only** changes related to this fix (branched off `upstream/main`, two files modified)
- [x] I've run `pytest tests/hermes_cli/test_web_server.py -q` and all 140 tests pass
- [x] I've added tests for my changes (3 new tests; regression-guard for `index.html`; verified they fail without the fix)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (behavior change only, no public API/config surface change)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A (no architectural change)
- [x] I've considered cross-platform impact — header is set in Python, platform-independent
- [x] I've updated tool descriptions/schemas — N/A
