### PR TITLE
feat(cli): surface generic plugin CLI commands as top-level subcommands

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -84,6 +84,37 @@ def _require_tty(command_name: str) -> None:
         sys.exit(1)
 
 
+def _surface_generic_plugin_cli_commands(subparsers, manager) -> None:
+    """Add each plugin-registered CLI command as a top-level subparser.
+
+    ``PluginContext.register_cli_command()`` stores entries in
+    ``manager._cli_commands``. The existing ``discover_plugin_cli_commands()``
+    loop in ``main()`` only surfaces ``plugins/memory/<name>`` providers, so
+    a generic plugin that calls ``ctx.register_cli_command(name="foo", ...)``
+    has its entry recorded but never added to argparse — meaning ``hermes foo``
+    fails with ``argparse: invalid choice``.
+
+    This helper iterates the registry and adds each entry as a top-level
+    subparser. Names already present in ``subparsers.choices`` (memory loop
+    output or built-in subcommands) are skipped to avoid argparse conflicts.
+
+    Extracted to module level so it can be unit-tested with a fake
+    ``PluginManager`` without driving the full ``main()`` argparse setup.
+    """
+    for cmd_name, cmd_info in manager._cli_commands.items():
+        if cmd_name in subparsers.choices:
+            continue
+        plugin_parser = subparsers.add_parser(
+            cmd_name,
+            help=cmd_info["help"],
+            description=cmd_info.get("description", ""),
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+        )
+        cmd_info["setup_fn"](plugin_parser)
+        if cmd_info.get("handler_fn"):
+            plugin_parser.set_defaults(func=cmd_info["handler_fn"])
+
+
 # Add project root to path
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))
@@ -9763,6 +9794,22 @@ Examples:
             cmd_info["setup_fn"](plugin_parser)
     except Exception as _exc:
         logging.getLogger(__name__).debug("Plugin CLI discovery failed: %s", _exc)
+
+    # =========================================================================
+    # Surface generic third-party plugin CLI commands. See
+    # _surface_generic_plugin_cli_commands() docstring for rationale.
+    # =========================================================================
+    try:
+        from hermes_cli.plugins import get_plugin_manager
+
+        _generic_mgr = get_plugin_manager()
+        # Use no kwargs — older Hermes versions don't accept ``force=``.
+        _generic_mgr.discover_and_load()
+        _surface_generic_plugin_cli_commands(subparsers, _generic_mgr)
+    except Exception as _generic_exc:
+        logging.getLogger(__name__).debug(
+            "Generic plugin CLI discovery failed: %s", _generic_exc
+        )
 
     # =========================================================================
     # curator command — background skill maintenance

--- a/tests/hermes_cli/test_plugin_cli_registration.py
+++ b/tests/hermes_cli/test_plugin_cli_registration.py
@@ -187,3 +187,152 @@ class TestProviderCollectorCliNoop:
         )
         # Should not store anything — CLI is discovered via file convention
         assert not hasattr(collector, "_cli_commands")
+
+
+# ── _surface_generic_plugin_cli_commands ─────────────────────────────────
+#
+# Covers the helper extracted from main()'s argparse setup that surfaces
+# every plugin-registered CLI command as a top-level ``hermes <name>``
+# subparser. Without this helper, ``register_cli_command()`` populates
+# ``manager._cli_commands`` but nothing reads it for top-level argparse,
+# so generic (non-memory) plugins are silently invisible.
+
+
+class TestSurfaceGenericPluginCliCommands:
+    def _build_parser(self):
+        """Tiny argparse skeleton matching main()'s top-level shape."""
+        parser = argparse.ArgumentParser(prog="hermes")
+        subparsers = parser.add_subparsers(dest="command")
+        return parser, subparsers
+
+    def _make_manager_with_command(
+        self,
+        name: str = "mytool",
+        setup_fn=None,
+        handler_fn=None,
+        help_text: str = "test help",
+        description: str = "test description",
+    ) -> PluginManager:
+        """Return a PluginManager whose _cli_commands has one entry."""
+        mgr = PluginManager()
+        mgr._cli_commands[name] = {
+            "name": name,
+            "help": help_text,
+            "description": description,
+            "setup_fn": setup_fn or (lambda p: p.add_argument("--flag")),
+            "handler_fn": handler_fn,
+            "plugin": "test-plugin",
+        }
+        return mgr
+
+    def test_adds_registered_command_as_top_level_subparser(self):
+        """A plugin's register_cli_command-registered name becomes invocable."""
+        from hermes_cli.main import _surface_generic_plugin_cli_commands
+
+        mgr = self._make_manager_with_command(
+            name="mytool",
+            setup_fn=lambda p: p.add_argument("--flag"),
+        )
+        parser, subparsers = self._build_parser()
+
+        _surface_generic_plugin_cli_commands(subparsers, mgr)
+
+        ns = parser.parse_args(["mytool", "--flag", "value"])
+        assert ns.command == "mytool"
+        assert ns.flag == "value"
+
+    def test_attaches_handler_via_set_defaults(self):
+        """When handler_fn is provided it lands as args.func."""
+        from hermes_cli.main import _surface_generic_plugin_cli_commands
+
+        handler = MagicMock()
+        mgr = self._make_manager_with_command(
+            name="dohandle",
+            setup_fn=lambda p: p.add_argument("arg"),
+            handler_fn=handler,
+        )
+        parser, subparsers = self._build_parser()
+
+        _surface_generic_plugin_cli_commands(subparsers, mgr)
+
+        ns = parser.parse_args(["dohandle", "VAL"])
+        assert ns.func is handler
+        assert ns.arg == "VAL"
+
+    def test_no_handler_means_no_func_default(self):
+        """A None handler_fn must not set args.func (caller dispatches manually)."""
+        from hermes_cli.main import _surface_generic_plugin_cli_commands
+
+        mgr = self._make_manager_with_command(
+            name="nofunc",
+            setup_fn=lambda p: None,
+            handler_fn=None,
+        )
+        parser, subparsers = self._build_parser()
+
+        _surface_generic_plugin_cli_commands(subparsers, mgr)
+
+        ns = parser.parse_args(["nofunc"])
+        assert ns.command == "nofunc"
+        assert not hasattr(ns, "func")
+
+    def test_skips_names_already_in_subparsers(self):
+        """A plugin can't override a built-in subcommand by re-registering its name."""
+        from hermes_cli.main import _surface_generic_plugin_cli_commands
+
+        mgr = self._make_manager_with_command(
+            name="chat",  # would conflict with the built-in `hermes chat`
+            setup_fn=lambda p: p.add_argument("--should-not-add"),
+            handler_fn=MagicMock(),
+        )
+        parser, subparsers = self._build_parser()
+
+        # Pre-register `chat` as a built-in-like subparser
+        chat_parser = subparsers.add_parser("chat", help="real chat")
+        chat_parser.add_argument("--real-flag")
+        sentinel = object()
+        chat_parser.set_defaults(func=sentinel)
+
+        _surface_generic_plugin_cli_commands(subparsers, mgr)
+
+        # Real `chat` still works
+        ns = parser.parse_args(["chat", "--real-flag", "yes"])
+        assert ns.real_flag == "yes"
+        assert ns.func is sentinel
+
+        # The plugin's `--should-not-add` was never added to `chat`
+        with pytest.raises(SystemExit):
+            parser.parse_args(["chat", "--should-not-add", "x"])
+
+    def test_iterates_multiple_registered_commands(self):
+        """Every entry in _cli_commands is surfaced (not just the first)."""
+        from hermes_cli.main import _surface_generic_plugin_cli_commands
+
+        mgr = PluginManager()
+        for name in ("alpha", "beta", "gamma"):
+            mgr._cli_commands[name] = {
+                "name": name,
+                "help": f"{name} help",
+                "description": "",
+                "setup_fn": lambda p, n=name: p.add_argument(f"--{n}-flag"),
+                "handler_fn": None,
+                "plugin": "multi-plugin",
+            }
+        parser, subparsers = self._build_parser()
+
+        _surface_generic_plugin_cli_commands(subparsers, mgr)
+
+        for name in ("alpha", "beta", "gamma"):
+            ns = parser.parse_args([name, f"--{name}-flag", "v"])
+            assert ns.command == name
+
+    def test_empty_registry_is_a_noop(self):
+        """An empty _cli_commands dict adds nothing and does not raise."""
+        from hermes_cli.main import _surface_generic_plugin_cli_commands
+
+        mgr = PluginManager()  # no _cli_commands entries
+        parser, subparsers = self._build_parser()
+
+        _surface_generic_plugin_cli_commands(subparsers, mgr)
+
+        assert subparsers.choices == {}


### PR DESCRIPTION
## What does this PR do?

`PluginContext.register_cli_command()` populates `manager._cli_commands`, but
`main.py` only loops over memory-provider plugins via
`discover_plugin_cli_commands()`. Generic plugins that register a CLI command
have their entry stored but never added to argparse, so `hermes <plugin>`
fails with `argparse: invalid choice`.

This adds a sibling block right after the memory-plugin loop that iterates
`manager._cli_commands` and adds each entry as a top-level subparser.
Conflicting names are skipped. The block falls through silently on errors
to match the existing pattern.

Tested with a third-party plugin that calls `register_cli_command()` inside
`register(ctx)` — before: `invalid choice`; after: invocable as a top-level
subcommand.

## Related Issue

No issue filed — happy to open one if the team prefers that flow.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

(Could reasonably be classified as a bug fix — the public API
`PluginContext.register_cli_command` exists but its effect is silently
dropped for non-memory plugins. Filed as `feat` because it surfaces a
capability that was previously inert.)

## Changes Made

- `hermes_cli/main.py`: added a sibling block right after the existing
  memory-plugin CLI discovery loop that iterates
  `get_plugin_manager()._cli_commands` and adds each entry as a top-level
  argparse subparser. Skips names already in `subparsers.choices` to avoid
  conflicts with built-in subcommands or memory-loop output. Wraps the loop
  in a try/except that logs at DEBUG to match the existing pattern.

  Net change: 34 lines added in one location, no edits to existing code.

## How to Test

1. Install any plugin whose `register(ctx)` calls
   `ctx.register_cli_command(name="foo", help="...", setup_fn=lambda p: p.add_argument("bar"))`
   (e.g. via `hermes plugins install <git-url>`).
2. Restart the gateway so plugin discovery runs against the patched `main.py`.
3. **Before this patch:** `hermes foo --help` → `argparse: invalid choice: 'foo'`.
4. **After this patch:** `hermes foo --help` shows the plugin's argparse subtree;
   `hermes foo bar baz` dispatches to the plugin's handler.
5. Built-in subcommands (`chat`, `gateway`, `plugins`, `memory`, etc.) are
   unaffected — the conflict-skip guard preserves their bindings.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass <!-- run locally before submitting; see note below -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) <!-- happy to add — see note below -->
- [x] I've tested on my platform: Linux (Ubuntu 22.04 in Docker), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(N/A — the change has an in-place comment block explaining the rationale; no user-facing docs reference this surfacing logic.)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A — no config keys touched)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(N/A — no architectural change; this enables a documented public API path that was previously inert)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A *(Pure argparse + dict iteration; no OS-specific code paths)*
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A *(N/A — CLI surfacing only, no tool behavior changes)*

## Screenshots / Logs

**Before** (third-party plugin registered via `register_cli_command`):
<img width="1769" height="99" alt="Screenshot 2026-05-06 at 23 09 32" src="https://github.com/user-attachments/assets/2e55bf28-c58d-4ed3-9be1-f3484202050b" />

**After** (same plugin, same install, patched `main.py`):
<img width="713" height="185" alt="Screenshot 2026-05-06 at 23 08 37" src="https://github.com/user-attachments/assets/7641a5af-4734-45a4-a7c8-cd36a32db241" />

