### PR TITLE
Add Hermes User-Agent attribution for GMI requests

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -379,6 +379,10 @@ _AI_GATEWAY_HEADERS = {
     "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
 }
 
+_HERMES_UA_HEADERS = {
+    "User-Agent": f"HermesAgent/{_HERMES_VERSION}",
+}
+
 # Nous Portal extra_body for product attribution.
 # Callers should pass this as extra_body in chat.completions.create()
 # when the auxiliary client is backed by Nous Portal.
@@ -1219,6 +1223,8 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 from hermes_cli.models import copilot_default_headers
 
                 extra["default_headers"] = copilot_default_headers()
+            elif base_url_host_matches(base_url, "api.gmi-serving.com"):
+                extra["default_headers"] = dict(_HERMES_UA_HEADERS)
             else:
                 try:
                     from providers import get_provider_profile as _gpf_aux
@@ -1254,6 +1260,8 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             from hermes_cli.models import copilot_default_headers
 
             extra["default_headers"] = copilot_default_headers()
+        elif base_url_host_matches(base_url, "api.gmi-serving.com"):
+            extra["default_headers"] = dict(_HERMES_UA_HEADERS)
         else:
             try:
                 from providers import get_provider_profile as _gpf_aux2
@@ -2077,6 +2085,8 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         )
     elif base_url_host_matches(sync_base_url, "api.kimi.com"):
         async_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+    elif base_url_host_matches(sync_base_url, "api.gmi-serving.com"):
+        async_kwargs["default_headers"] = dict(_HERMES_UA_HEADERS)
     return AsyncOpenAI(**async_kwargs), model
 
 
@@ -2492,6 +2502,8 @@ def resolve_provider_client(
             headers.update(copilot_request_headers(
                 is_agent_turn=True, is_vision=is_vision
             ))
+        elif base_url_host_matches(base_url, "api.gmi-serving.com"):
+            headers.update(_HERMES_UA_HEADERS)
         client = OpenAI(api_key=api_key, base_url=base_url,
                         **({"default_headers": headers} if headers else {}))
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1450,6 +1450,8 @@ class AIAgent:
                     client_kwargs["default_headers"] = build_or_headers()
                 elif base_url_host_matches(effective_base, "api.routermint.com"):
                     client_kwargs["default_headers"] = _routermint_headers()
+                elif base_url_host_matches(effective_base, "api.gmi-serving.com"):
+                    client_kwargs["default_headers"] = _routermint_headers()
                 elif base_url_host_matches(effective_base, "api.githubcopilot.com"):
                     from hermes_cli.models import copilot_default_headers
 
@@ -6268,6 +6270,8 @@ class AIAgent:
         elif base_url_host_matches(base_url, "ai-gateway.vercel.sh"):
             self._client_kwargs["default_headers"] = dict(_AI_GATEWAY_HEADERS)
         elif base_url_host_matches(base_url, "api.routermint.com"):
+            self._client_kwargs["default_headers"] = _routermint_headers()
+        elif base_url_host_matches(base_url, "api.gmi-serving.com"):
             self._client_kwargs["default_headers"] = _routermint_headers()
         elif base_url_host_matches(base_url, "api.githubcopilot.com"):
             from hermes_cli.models import copilot_default_headers

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -661,6 +661,7 @@ AUTHOR_MAP = {
     "mike@mikewaters.net": "mikewaters",
     "65117428+WadydX@users.noreply.github.com": "WadydX",
     "216480837+isaachuangGMICLOUD@users.noreply.github.com": "isaachuangGMICLOUD",
+    "isaac.h@gmicloud.ai": "isaachuangGMICLOUD",
     "nukuom976228@gmail.com": "hsy5571616",
     "11462216+Nan93@users.noreply.github.com": "Nan93",
     "l973401489@126.com": "zhouxiaoya12",

--- a/tests/hermes_cli/test_gmi_provider.py
+++ b/tests/hermes_cli/test_gmi_provider.py
@@ -284,6 +284,8 @@ class TestGmiAuxiliary:
         assert model == "google/gemini-3.1-flash-lite-preview"
         assert mock_openai.call_args.kwargs["api_key"] == "gmi-test-key"
         assert mock_openai.call_args.kwargs["base_url"] == "https://api.gmi-serving.com/v1"
+        headers = mock_openai.call_args.kwargs["default_headers"]
+        assert headers["User-Agent"].startswith("HermesAgent/")
 
     def test_resolve_provider_client_accepts_gmi_alias(self, monkeypatch):
         monkeypatch.setenv("GMI_API_KEY", "gmi-test-key")

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -66,6 +66,24 @@ def test_routermint_base_url_applies_user_agent_header(mock_openai):
 
 
 @patch("run_agent.OpenAI")
+def test_gmi_base_url_applies_user_agent_header(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://api.gmi-serving.com/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._apply_client_headers_for_base_url("https://api.gmi-serving.com/v1")
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["User-Agent"].startswith("HermesAgent/")
+
+
+@patch("run_agent.OpenAI")
 def test_unknown_base_url_clears_default_headers(mock_openai):
     mock_openai.return_value = MagicMock()
     agent = AIAgent(


### PR DESCRIPTION
## Summary
- Add Hermes User-Agent attribution for GMI requests to `api.gmi-serving.com`.
- Apply the header to both main model requests and auxiliary/provider-client paths.
- Add tests covering GMI request attribution.

## Verification
- `HERMES_HOME=$PWD/.tmp-hermes-home python -m pytest tests/run_agent/test_provider_attribution_headers.py tests/hermes_cli/test_gmi_provider.py -q`
- Verified GMI server logs show `request_headers.user-agent = HermesAgent/<version>`.

## Note
This is for attribution and observability, not as a security boundary.