### PR TITLE
fix(rate-guard): respect HERMES_HOME in nous_rate_guard fallback path

### DIFF
--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -17,6 +17,7 @@ import logging
 import os
 import tempfile
 import time
+from pathlib import Path
 from typing import Any, Mapping, Optional
 from utils import atomic_replace
 
@@ -27,13 +28,21 @@ _STATE_FILENAME = "nous.json"
 
 
 def _state_path() -> str:
-    """Return the path to the Nous rate limit state file."""
+    """Return the path to the Nous rate limit state file.
+
+    The ImportError fallback honors ``HERMES_HOME`` so that Docker
+    deployments (``HERMES_HOME=/opt/data``) and non-default profiles
+    (``HERMES_HOME=~/.hermes/profiles/<name>``) don't silently write
+    rate-limit state into ``~/.hermes`` while the rest of the process
+    reads from the configured root.  See issue #18594.
+    """
     try:
         from hermes_constants import get_hermes_home
-        base = get_hermes_home()
+        base = Path(get_hermes_home())
     except ImportError:
-        base = os.path.join(os.path.expanduser("~"), ".hermes")
-    return os.path.join(base, _STATE_SUBDIR, _STATE_FILENAME)
+        env_home = os.environ.get("HERMES_HOME", "").strip()
+        base = Path(env_home) if env_home else Path.home() / ".hermes"
+    return str(base / _STATE_SUBDIR / _STATE_FILENAME)
 
 
 def _parse_reset_seconds(headers: Optional[Mapping[str, str]]) -> Optional[float]:

--- a/tests/agent/test_nous_rate_guard_hermes_home.py
+++ b/tests/agent/test_nous_rate_guard_hermes_home.py
@@ -1,0 +1,65 @@
+"""Tests for _state_path's HERMES_HOME awareness in agent/nous_rate_guard.py.
+
+Regression for the ImportError fallback path which previously hardcoded
+``~/.hermes`` and ignored ``HERMES_HOME``, breaking Docker deployments
+(``HERMES_HOME=/opt/data``) and non-default profiles
+(``HERMES_HOME=~/.hermes/profiles/<name>``).  See issue #18594 and the
+narrowed extraction of issue #20633.
+"""
+
+import sys
+from pathlib import Path
+
+
+def _reload_rate_guard():
+    """Force a fresh import so module-level state can't leak between tests."""
+    sys.modules.pop("agent.nous_rate_guard", None)
+    from agent import nous_rate_guard
+    return nous_rate_guard
+
+
+def test_state_path_respects_hermes_home_env(tmp_path, monkeypatch):
+    """When HERMES_HOME is set, _state_path returns a path under it."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    rg = _reload_rate_guard()
+    path = Path(rg._state_path())
+
+    assert tmp_path in path.parents
+    assert path.name == rg._STATE_FILENAME
+    assert path.parent.name == rg._STATE_SUBDIR
+
+
+def test_state_path_respects_hermes_home_when_import_fails(tmp_path, monkeypatch):
+    """If hermes_constants cannot be imported, the env var still wins."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    # Block the import inside _state_path's try clause.
+    monkeypatch.setitem(sys.modules, "hermes_constants", None)
+
+    rg = _reload_rate_guard()
+    path = Path(rg._state_path())
+
+    assert tmp_path in path.parents
+    assert path.name == rg._STATE_FILENAME
+
+
+def test_state_path_falls_back_to_home_when_env_unset_and_import_fails(monkeypatch):
+    """No env var + ImportError → ~/.hermes/<subdir>/<file>."""
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setitem(sys.modules, "hermes_constants", None)
+
+    rg = _reload_rate_guard()
+    path = Path(rg._state_path())
+
+    assert path == Path.home() / ".hermes" / rg._STATE_SUBDIR / rg._STATE_FILENAME
+
+
+def test_state_path_ignores_blank_hermes_home(monkeypatch):
+    """An empty/whitespace HERMES_HOME falls through to ~/.hermes."""
+    monkeypatch.setenv("HERMES_HOME", "   ")
+    monkeypatch.setitem(sys.modules, "hermes_constants", None)
+
+    rg = _reload_rate_guard()
+    path = Path(rg._state_path())
+
+    assert path == Path.home() / ".hermes" / rg._STATE_SUBDIR / rg._STATE_FILENAME


### PR DESCRIPTION
# fix(rate-guard): respect HERMES_HOME in nous_rate_guard fallback path

## Problem

`agent/nous_rate_guard.py::_state_path` resolves the rate-limit state file via `hermes_constants.get_hermes_home()`, but the `ImportError` fallback hardcodes `os.path.expanduser("~/.hermes")` and ignores `HERMES_HOME`. Any deployment where `HERMES_HOME` is set but `hermes_constants` cannot be imported (frozen builds, embedded layouts, partial installs) silently writes rate-limit state into `~/.hermes` while the rest of the process reads from the configured root.

This is the same class of bug fixed in #18594. It manifests in:

- **Docker** (`HERMES_HOME=/opt/data` per `Dockerfile` and `docker/entrypoint.sh`).
- **Profile mode** (`HERMES_HOME=~/.hermes/profiles/<name>`).

It's a narrow extraction from #20633 — that issue is too broad for one PR; this fix is the single concrete code-level bug we found while investigating.

## Fix

`_state_path`'s `ImportError` fallback now honors `HERMES_HOME`, then falls back to `Path.home() / ".hermes"`. Switches to `pathlib.Path` per the `CONTRIBUTING.md` cross-platform guidance.

## Notes

- Rate-limit state is intentionally ephemeral (TTL-bounded; recomputed from headers on the next 429). No migration needed for users whose state file moves on the next run.
- Empty/whitespace `HERMES_HOME` falls through to `~/.hermes` (mirrors `get_hermes_home` semantics).

## Tests

New file: `tests/agent/test_nous_rate_guard_hermes_home.py`

- `test_state_path_respects_hermes_home_env`
- `test_state_path_respects_hermes_home_when_import_fails`
- `test_state_path_falls_back_to_home_when_env_unset_and_import_fails`
- `test_state_path_ignores_blank_hermes_home`

All existing `rate_guard` tests still pass (36 / 36).

## Verification

```bash
uv run pytest tests/agent/test_nous_rate_guard_hermes_home.py -q
uv run pytest tests/agent/ -q -k rate_guard
uv run ruff check agent/nous_rate_guard.py tests/agent/test_nous_rate_guard_hermes_home.py
```

## References

- Same bug class as #18594.
- Narrow extraction from #20633.
