### PR TITLE
fix: drop overlong Codex replay message IDs

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -329,8 +329,14 @@ def _chat_messages_to_responses_input(messages: List[Dict[str, Any]]) -> List[Di
                             "content": normalized_content_parts,
                         }
                         item_id = raw_item.get("id")
-                        if isinstance(item_id, str) and item_id.strip():
-                            replay_item["id"] = item_id.strip()
+                        if isinstance(item_id, str):
+                            normalized_item_id = item_id.strip()
+                            # ChatGPT-backed Codex rejects replayed Responses item IDs
+                            # longer than 64 chars. Older/compressed/cross-provider
+                            # sessions may contain much longer synthetic IDs; drop them
+                            # while preserving the message content/status/phase.
+                            if normalized_item_id and len(normalized_item_id) <= 64:
+                                replay_item["id"] = normalized_item_id
                         phase = raw_item.get("phase")
                         if isinstance(phase, str) and phase.strip():
                             replay_item["phase"] = phase.strip()

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1603,6 +1603,49 @@ def test_codex_message_item_status_survives_conversion_and_preflight(monkeypatch
     assert normalized[0]["status"] == "in_progress"
 
 
+def test_codex_message_item_replay_drops_ids_over_64_chars(monkeypatch):
+    """ChatGPT-backed Codex rejects replayed Responses item IDs > 64 chars."""
+    agent = _build_agent(monkeypatch)
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+    kept_id = "a" * 64
+    dropped_id = "b" * 65
+    items = _chat_messages_to_responses_input([
+        {
+            "role": "assistant",
+            "content": "partial",
+            "codex_message_items": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "id": kept_id,
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": "kept"}],
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "in_progress",
+                    "id": dropped_id,
+                    "phase": "commentary",
+                    "content": [{"type": "output_text", "text": "dropped"}],
+                },
+            ],
+        }
+    ])
+
+    kept = next(item for item in items if "kept" in str(item.get("content")))
+    assert kept["id"] == kept_id
+    assert kept["status"] == "in_progress"
+    assert kept["phase"] == "commentary"
+
+    dropped = next(item for item in items if "dropped" in str(item.get("content")))
+    assert "id" not in dropped
+    assert dropped["status"] == "in_progress"
+    assert dropped["phase"] == "commentary"
+
+
 def test_duplicate_detection_distinguishes_different_codex_reasoning(monkeypatch):
     """Two consecutive reasoning-only responses with different encrypted content
     must NOT be treated as duplicates."""


### PR DESCRIPTION
## Summary
- Drop replayed Codex Responses message item IDs longer than 64 chars while preserving content/status/phase
- Keep valid IDs up to the ChatGPT-backed Codex limit
- Add a regression test for old/compressed/cross-provider sessions containing overlong replay IDs

## Scenario fixed
Telegram/gateway sessions can resume old Codex history that contains assistant `codex_message_items` with provider-expanded or synthetic `id` values longer than ChatGPT-backed Codex accepts. The backend rejects these requests with HTTP 400, which then triggers fallback to another provider (for example Copilot) even though OpenAI-Codex itself is available again.

Stripping only the invalid replay ID lets Codex treat the item as fresh while preserving the assistant message content, status, and phase.

## Test plan
- `./venv/bin/python -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_codex_message_item_replay_drops_ids_over_64_chars -q -o 'addopts='`
- `./venv/bin/python -m py_compile agent/codex_responses_adapter.py`

Note: a broader two-test pytest invocation timed out locally after the new regression test passed, so I reran the specific regression directly and compiled the adapter.