### PR TITLE
fix(auxiliary): ensure system messages precede other roles before LLM call

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3353,6 +3353,55 @@ def _convert_openai_images_to_anthropic(messages: list) -> list:
     return converted
 
 
+def _ensure_system_messages_first(messages: list) -> list:
+    """Reorder messages so any ``role="system"`` entries appear before
+    ``user`` / ``assistant`` / ``tool`` entries.
+
+    Some chat templates — notably Qwen's — enforce strict role ordering and
+    reject requests with a 400 ``System message must be at the beginning``
+    error if a system role appears after a user or assistant message.
+    Hermes auxiliary callers normally place the system prompt first, but
+    callers that prepend conversational context can produce out-of-order
+    lists.  Reorder defensively while preserving the relative order within
+    each group.  Returns the original list when no reorder is needed
+    (zero-copy fast path).
+
+    See: https://github.com/NousResearch/hermes-agent/issues/20866
+    """
+    if not messages:
+        return messages
+
+    seen_non_system = False
+    needs_reorder = False
+    for msg in messages:
+        if not isinstance(msg, dict):
+            seen_non_system = True
+            continue
+        if msg.get("role") == "system":
+            if seen_non_system:
+                needs_reorder = True
+                break
+        else:
+            seen_non_system = True
+
+    if not needs_reorder:
+        return messages
+
+    system_msgs = [
+        m for m in messages
+        if isinstance(m, dict) and m.get("role") == "system"
+    ]
+    other_msgs = [
+        m for m in messages
+        if not (isinstance(m, dict) and m.get("role") == "system")
+    ]
+    logger.warning(
+        "_build_call_kwargs: reordered %d system message(s) to the front "
+        "(some chat templates require system role at index 0)",
+        len(system_msgs),
+    )
+    return system_msgs + other_msgs
+
 
 def _build_call_kwargs(
     provider: str,
@@ -3368,7 +3417,7 @@ def _build_call_kwargs(
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
     kwargs: Dict[str, Any] = {
         "model": model,
-        "messages": messages,
+        "messages": _ensure_system_messages_first(messages),
         "timeout": timeout,
     }
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1947,6 +1947,113 @@ class TestBuildCallKwargsToolDedup:
         assert "tools" not in kwargs
 
 
+# ---------------------------------------------------------------------------
+# _build_call_kwargs — system-message ordering
+# ---------------------------------------------------------------------------
+
+class TestBuildCallKwargsSystemMessageOrdering:
+    """``_build_call_kwargs`` must place system messages before user /
+    assistant / tool messages so chat templates that enforce strict role
+    ordering accept the request.
+
+    Qwen-family models served via vLLM reject requests with a 400
+    ``System message must be at the beginning`` error if a system role
+    appears after a user or assistant message.  See:
+    https://github.com/NousResearch/hermes-agent/issues/20866
+    """
+
+    def test_system_first_is_passthrough(self):
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hi"},
+        ]
+        kwargs = _build_call_kwargs(
+            provider="custom", model="qwen3-27b", messages=messages,
+        )
+        assert kwargs["messages"] == messages
+
+    def test_no_system_message_is_passthrough(self):
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello"},
+            {"role": "user", "content": "More"},
+        ]
+        kwargs = _build_call_kwargs(
+            provider="custom", model="qwen3-27b", messages=messages,
+        )
+        assert kwargs["messages"] == messages
+
+    def test_empty_messages_list(self):
+        kwargs = _build_call_kwargs(
+            provider="custom", model="qwen3-27b", messages=[],
+        )
+        assert kwargs["messages"] == []
+
+    def test_system_after_user_is_reordered(self):
+        """RED test — fails until the ordering guard is added."""
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "system", "content": "Be terse."},
+            {"role": "assistant", "content": "ok"},
+        ]
+        kwargs = _build_call_kwargs(
+            provider="custom", model="qwen3-27b", messages=messages,
+        )
+        result = kwargs["messages"]
+        assert result[0]["role"] == "system"
+        # Non-system messages keep their original relative order.
+        non_system = [m for m in result if m.get("role") != "system"]
+        assert non_system == [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+    def test_multiple_system_messages_kept_in_order(self):
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "system", "content": "First system"},
+            {"role": "system", "content": "Second system"},
+            {"role": "user", "content": "Bye"},
+        ]
+        kwargs = _build_call_kwargs(
+            provider="custom", model="qwen3-27b", messages=messages,
+        )
+        result = kwargs["messages"]
+        assert result[0] == {"role": "system", "content": "First system"}
+        assert result[1] == {"role": "system", "content": "Second system"}
+        # Non-system messages keep their original relative order.
+        assert [m for m in result if m.get("role") != "system"] == [
+            {"role": "user", "content": "Hi"},
+            {"role": "user", "content": "Bye"},
+        ]
+
+    def test_does_not_mutate_input_list(self):
+        original = [
+            {"role": "user", "content": "Hi"},
+            {"role": "system", "content": "Be terse."},
+        ]
+        snapshot = [dict(m) for m in original]
+        _build_call_kwargs(
+            provider="custom", model="qwen3-27b", messages=original,
+        )
+        # Caller's list reference is not reordered in place.
+        assert original == snapshot
+
+    def test_logs_warning_when_reordering(self, caplog):
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {"role": "system", "content": "Be terse."},
+        ]
+        with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+            _build_call_kwargs(
+                provider="custom", model="qwen3-27b", messages=messages,
+            )
+        assert any(
+            "reordered" in rec.message and "system" in rec.message
+            for rec in caplog.records
+        )
+
+
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch):
     """Strip provider env vars so each test starts clean."""


### PR DESCRIPTION
## Summary

Some chat templates — notably Qwen's, served via vLLM — enforce strict role ordering and reject requests with a 400 `System message must be at the beginning` error when a system role appears after a user or assistant message. Hermes auxiliary tasks (compression, vision, session search, web extract, skills_hub, mcp, title generation) all funnel through `_build_call_kwargs`, but it didn't normalise role order, so any caller that prepended conversational context could trigger the rejection.

Adds `_ensure_system_messages_first` and applies it inside `_build_call_kwargs`. The helper:

- Returns the input list unchanged when no reorder is needed (zero-copy fast path for the common case).
- When reordering is required, builds a fresh list with system messages first, preserving relative order within each group.
- Logs a warning so out-of-order callers stay visible in operator logs.
- Does not mutate the caller's input list.

## Test plan

- [x] New `TestBuildCallKwargsSystemMessageOrdering` class with 7 tests (passthrough, RED reorder, multi-system ordering, empty input, mutation guard, warning log).
- [x] `pytest tests/agent/test_auxiliary_client.py` — 141 passed (7 new + 134 pre-existing).
- [x] Tested on Windows 11, Python 3.12.

Fixes #20866
