### PR TITLE
fix(tui): keep alt-screen exit clean and tighten exit summary

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -839,21 +839,18 @@ def _print_tui_exit_summary(
         if db is not None:
             db.close()
 
-    print()
-    print("Resume this session with:")
-    print(f"  hermes --tui --resume {target}")
-    if title:
-        print(f'  hermes --tui -c "{title}"')
-    print()
-    print(f"Session:        {target}")
-    if title:
-        print(f"Title:          {title}")
-    print(f"Messages:       {message_count}")
-    print(
-        "Tokens:         "
-        f"{total_tokens} (in {input_tokens}, out {output_tokens}, "
-        f"cache {cache_read_tokens + cache_write_tokens}, reasoning {reasoning_tokens})"
-    )
+    cache_total = cache_read_tokens + cache_write_tokens
+    headline = title if title else target
+    resume = f'hermes --tui -c "{title}"' if title else f"hermes --tui --resume {target}"
+    detail = f"{message_count} msgs · in {input_tokens} · out {output_tokens}"
+    if cache_total:
+        detail += f" · cache {cache_total}"
+    if reasoning_tokens:
+        detail += f" · reasoning {reasoning_tokens}"
+    detail += f" · {total_tokens} total"
+
+    sys.stdout.write(f"\r{headline} ({target})\n{detail}\n→ {resume}\n")
+    sys.stdout.flush()
 
 
 _NPM_LOCK_RUNTIME_KEYS = frozenset({"ideallyInert", "peer"})

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -485,10 +485,15 @@ def test_print_tui_exit_summary_includes_resume_and_token_totals(monkeypatch, ca
     main_mod._print_tui_exit_summary("20260409_000001_abc123")
     out = capsys.readouterr().out
 
-    assert "Resume this session with:" in out
-    assert "hermes --tui --resume 20260409_000001_abc123" in out
+    assert "demo title" in out
+    assert "20260409_000001_abc123" in out
     assert 'hermes --tui -c "demo title"' in out
-    assert "Tokens:         21 (in 10, out 6, cache 4, reasoning 1)" in out
+    assert "2 msgs" in out
+    assert "in 10" in out
+    assert "out 6" in out
+    assert "cache 4" in out
+    assert "reasoning 1" in out
+    assert "21 total" in out
 
 
 def test_print_tui_exit_summary_prefers_actual_active_session_file(
@@ -526,5 +531,5 @@ def test_print_tui_exit_summary_prefers_actual_active_session_file(
     out = capsys.readouterr().out
 
     assert seen == ["actual_session"]
-    assert "hermes --tui --resume actual_session" in out
+    assert "actual_session" in out
     assert "startup_resume" not in out

--- a/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.test.ts
@@ -1,0 +1,102 @@
+import { writeSync } from 'fs'
+import { Readable } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { renderSync } from '../root.js'
+import { EXIT_ALT_SCREEN } from '../termio/dec.js'
+
+import { AlternateScreen } from './AlternateScreen.js'
+import Box from './Box.js'
+import Text from './Text.js'
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+
+  return {
+    ...actual,
+    writeSync: vi.fn(() => 0)
+  }
+})
+
+class TestStdin extends Readable {
+  isRaw = false
+  isTTY = true
+
+  _read() {}
+
+  setRawMode(value: boolean) {
+    this.isRaw = value
+
+    return this
+  }
+}
+
+const replaceStdoutProp = (key: 'columns' | 'isTTY' | 'rows', value: number | boolean) => {
+  const descriptor = Object.getOwnPropertyDescriptor(process.stdout, key)
+
+  Object.defineProperty(process.stdout, key, { configurable: true, value })
+
+  return () => {
+    if (descriptor) {
+      Object.defineProperty(process.stdout, key, descriptor)
+    } else {
+      delete (process.stdout as unknown as Record<string, unknown>)[key]
+    }
+  }
+}
+
+describe('AlternateScreen shutdown', () => {
+  const restoreStdoutProps: Array<() => void> = []
+  let stdoutWrite: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    restoreStdoutProps.push(
+      replaceStdoutProp('columns', 40),
+      replaceStdoutProp('rows', 12),
+      replaceStdoutProp('isTTY', true)
+    )
+    stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation((() => true) as typeof process.stdout.write)
+    vi.mocked(writeSync).mockClear()
+  })
+
+  afterEach(() => {
+    stdoutWrite.mockRestore()
+
+    while (restoreStdoutProps.length) {
+      restoreStdoutProps.pop()?.()
+    }
+  })
+
+  it('does not emit a second alt-screen exit while React cleanup runs', () => {
+    const instance = renderSync(
+      React.createElement(
+        AlternateScreen,
+        null,
+        React.createElement(Box, null, React.createElement(Text, null, 'hi'))
+      ),
+      {
+        exitOnCtrlC: false,
+        patchConsole: false,
+        stdin: new TestStdin() as NodeJS.ReadStream,
+        stdout: process.stdout
+      }
+    )
+
+    stdoutWrite.mockClear()
+    vi.mocked(writeSync).mockClear()
+
+    instance.unmount()
+
+    const syncWrites = vi
+      .mocked(writeSync)
+      .mock.calls.map(([, chunk]) => String(chunk))
+      .join('')
+
+    const streamWrites = stdoutWrite.mock.calls.map(([chunk]) => String(chunk)).join('')
+
+    expect(syncWrites.split(EXIT_ALT_SCREEN)).toHaveLength(2)
+    expect(streamWrites).not.toContain(EXIT_ALT_SCREEN)
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.test.ts
@@ -4,9 +4,10 @@ import { Readable } from 'node:stream'
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import instances from '../instances.js'
 import { renderSync } from '../root.js'
 import { CURSOR_HOME, ERASE_SCREEN, ERASE_SCROLLBACK } from '../termio/csi.js'
-import { ENTER_ALT_SCREEN } from '../termio/dec.js'
+import { ENTER_ALT_SCREEN, EXIT_ALT_SCREEN } from '../termio/dec.js'
 
 import { AlternateScreen } from './AlternateScreen.js'
 import Box from './Box.js'
@@ -48,6 +49,8 @@ const replaceStdoutProp = (key: 'columns' | 'isTTY' | 'rows', value: number | bo
   }
 }
 
+const count = (value: string, needle: string) => value.split(needle).length - 1
+
 describe('AlternateScreen', () => {
   const restoreStdoutProps: Array<() => void> = []
   let stdoutWrite: ReturnType<typeof vi.spyOn>
@@ -70,8 +73,8 @@ describe('AlternateScreen', () => {
     }
   })
 
-  it('clears the alt screen without clearing host scrollback', () => {
-    const instance = renderSync(
+  const renderAltScreen = () =>
+    renderSync(
       React.createElement(AlternateScreen, null, React.createElement(Box, null, React.createElement(Text, null, 'hi'))),
       {
         exitOnCtrlC: false,
@@ -81,6 +84,9 @@ describe('AlternateScreen', () => {
       }
     )
 
+  it('clears the alt screen without clearing host scrollback', () => {
+    const instance = renderAltScreen()
+
     const mountWrites = stdoutWrite.mock.calls.map(([chunk]) => String(chunk)).join('')
 
     expect(mountWrites).toContain(ENTER_ALT_SCREEN)
@@ -89,5 +95,45 @@ describe('AlternateScreen', () => {
     expect(mountWrites).not.toContain(ERASE_SCROLLBACK)
 
     instance.unmount()
+  })
+
+  it('exits alt screen through React cleanup during normal unmount', () => {
+    const instance = renderAltScreen()
+
+    stdoutWrite.mockClear()
+    vi.mocked(writeSync).mockClear()
+
+    instance.unmount()
+
+    const syncWrites = vi
+      .mocked(writeSync)
+      .mock.calls.map(([, chunk]) => String(chunk))
+      .join('')
+
+    const streamWrites = stdoutWrite.mock.calls.map(([chunk]) => String(chunk)).join('')
+
+    expect(syncWrites).not.toContain(EXIT_ALT_SCREEN)
+    expect(count(streamWrites, EXIT_ALT_SCREEN)).toBe(1)
+  })
+
+  it('does not double-exit alt screen during process-exit cleanup', () => {
+    renderAltScreen()
+
+    const ink = instances.get(process.stdout)
+
+    stdoutWrite.mockClear()
+    vi.mocked(writeSync).mockClear()
+
+    ink?.unmount(0)
+
+    const syncWrites = vi
+      .mocked(writeSync)
+      .mock.calls.map(([, chunk]) => String(chunk))
+      .join('')
+
+    const streamWrites = stdoutWrite.mock.calls.map(([chunk]) => String(chunk)).join('')
+
+    expect(count(syncWrites, EXIT_ALT_SCREEN)).toBe(1)
+    expect(streamWrites).not.toContain(EXIT_ALT_SCREEN)
   })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.test.ts
@@ -5,7 +5,8 @@ import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderSync } from '../root.js'
-import { EXIT_ALT_SCREEN } from '../termio/dec.js'
+import { CURSOR_HOME, ERASE_SCREEN, ERASE_SCROLLBACK } from '../termio/csi.js'
+import { ENTER_ALT_SCREEN } from '../termio/dec.js'
 
 import { AlternateScreen } from './AlternateScreen.js'
 import Box from './Box.js'
@@ -47,7 +48,7 @@ const replaceStdoutProp = (key: 'columns' | 'isTTY' | 'rows', value: number | bo
   }
 }
 
-describe('AlternateScreen shutdown', () => {
+describe('AlternateScreen', () => {
   const restoreStdoutProps: Array<() => void> = []
   let stdoutWrite: ReturnType<typeof vi.spyOn>
 
@@ -69,13 +70,9 @@ describe('AlternateScreen shutdown', () => {
     }
   })
 
-  it('does not emit a second alt-screen exit while React cleanup runs', () => {
+  it('clears the alt screen without clearing host scrollback', () => {
     const instance = renderSync(
-      React.createElement(
-        AlternateScreen,
-        null,
-        React.createElement(Box, null, React.createElement(Text, null, 'hi'))
-      ),
+      React.createElement(AlternateScreen, null, React.createElement(Box, null, React.createElement(Text, null, 'hi'))),
       {
         exitOnCtrlC: false,
         patchConsole: false,
@@ -84,19 +81,13 @@ describe('AlternateScreen shutdown', () => {
       }
     )
 
-    stdoutWrite.mockClear()
-    vi.mocked(writeSync).mockClear()
+    const mountWrites = stdoutWrite.mock.calls.map(([chunk]) => String(chunk)).join('')
+
+    expect(mountWrites).toContain(ENTER_ALT_SCREEN)
+    expect(mountWrites).toContain(ERASE_SCREEN)
+    expect(mountWrites).toContain(CURSOR_HOME)
+    expect(mountWrites).not.toContain(ERASE_SCROLLBACK)
 
     instance.unmount()
-
-    const syncWrites = vi
-      .mocked(writeSync)
-      .mock.calls.map(([, chunk]) => String(chunk))
-      .join('')
-
-    const streamWrites = stdoutWrite.mock.calls.map(([chunk]) => String(chunk)).join('')
-
-    expect(syncWrites.split(EXIT_ALT_SCREEN)).toHaveLength(2)
-    expect(streamWrites).not.toContain(EXIT_ALT_SCREEN)
   })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.test.ts
@@ -97,7 +97,7 @@ describe('AlternateScreen', () => {
     instance.unmount()
   })
 
-  it('exits alt screen through React cleanup during normal unmount', () => {
+  it('exits alt screen synchronously during normal unmount', () => {
     const instance = renderAltScreen()
 
     stdoutWrite.mockClear()
@@ -112,8 +112,8 @@ describe('AlternateScreen', () => {
 
     const streamWrites = stdoutWrite.mock.calls.map(([chunk]) => String(chunk)).join('')
 
-    expect(syncWrites).not.toContain(EXIT_ALT_SCREEN)
-    expect(count(streamWrites, EXIT_ALT_SCREEN)).toBe(1)
+    expect(count(syncWrites, EXIT_ALT_SCREEN)).toBe(1)
+    expect(streamWrites).not.toContain(EXIT_ALT_SCREEN)
   })
 
   it('does not double-exit alt screen during process-exit cleanup', () => {

--- a/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.test.ts
@@ -4,9 +4,8 @@ import { Readable } from 'node:stream'
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import instances from '../instances.js'
 import { renderSync } from '../root.js'
-import { CURSOR_HOME, ERASE_SCREEN, ERASE_SCROLLBACK } from '../termio/csi.js'
+import { CURSOR_HOME, cursorPosition, ERASE_SCREEN, ERASE_SCROLLBACK } from '../termio/csi.js'
 import { ENTER_ALT_SCREEN, EXIT_ALT_SCREEN } from '../termio/dec.js'
 
 import { AlternateScreen } from './AlternateScreen.js'
@@ -16,18 +15,13 @@ import Text from './Text.js'
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs')
 
-  return {
-    ...actual,
-    writeSync: vi.fn(() => 0)
-  }
+  return { ...actual, writeSync: vi.fn(() => 0) }
 })
 
 class TestStdin extends Readable {
   isRaw = false
   isTTY = true
-
   _read() {}
-
   setRawMode(value: boolean) {
     this.isRaw = value
 
@@ -35,47 +29,46 @@ class TestStdin extends Readable {
   }
 }
 
-const replaceStdoutProp = (key: 'columns' | 'isTTY' | 'rows', value: number | boolean) => {
-  const descriptor = Object.getOwnPropertyDescriptor(process.stdout, key)
-
+const stub = (key: 'columns' | 'isTTY' | 'rows', value: number | boolean) => {
+  const prev = Object.getOwnPropertyDescriptor(process.stdout, key)
   Object.defineProperty(process.stdout, key, { configurable: true, value })
 
   return () => {
-    if (descriptor) {
-      Object.defineProperty(process.stdout, key, descriptor)
+    if (prev) {
+      Object.defineProperty(process.stdout, key, prev)
     } else {
       delete (process.stdout as unknown as Record<string, unknown>)[key]
     }
   }
 }
 
-const count = (value: string, needle: string) => value.split(needle).length - 1
+const ROWS = 12
 
 describe('AlternateScreen', () => {
-  const restoreStdoutProps: Array<() => void> = []
-  let stdoutWrite: ReturnType<typeof vi.spyOn>
+  let restore: Array<() => void>
+  let stream: ReturnType<typeof vi.fn>
+  let sync: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    restoreStdoutProps.push(
-      replaceStdoutProp('columns', 40),
-      replaceStdoutProp('rows', 12),
-      replaceStdoutProp('isTTY', true)
-    )
-    stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation((() => true) as typeof process.stdout.write)
-    vi.mocked(writeSync).mockClear()
+    restore = [stub('columns', 40), stub('rows', ROWS), stub('isTTY', true)]
+    stream = vi.fn(() => true)
+    sync = vi.fn(() => 0)
+    vi.spyOn(process.stdout, 'write').mockImplementation(stream as typeof process.stdout.write)
+    vi.mocked(writeSync).mockImplementation(sync as unknown as typeof writeSync)
   })
 
   afterEach(() => {
-    stdoutWrite.mockRestore()
-
-    while (restoreStdoutProps.length) {
-      restoreStdoutProps.pop()?.()
-    }
+    vi.restoreAllMocks()
+    restore.splice(0).forEach(fn => fn())
   })
 
-  const renderAltScreen = () =>
+  const mount = () =>
     renderSync(
-      React.createElement(AlternateScreen, null, React.createElement(Box, null, React.createElement(Text, null, 'hi'))),
+      React.createElement(
+        AlternateScreen,
+        null,
+        React.createElement(Box, null, React.createElement(Text, null, 'hi'))
+      ),
       {
         exitOnCtrlC: false,
         patchConsole: false,
@@ -84,56 +77,42 @@ describe('AlternateScreen', () => {
       }
     )
 
-  it('clears the alt screen without clearing host scrollback', () => {
-    const instance = renderAltScreen()
+  const streamBytes = () => stream.mock.calls.map(args => String(args[0])).join('')
+  const syncBytes = () => sync.mock.calls.map(args => String(args[1])).join('')
 
-    const mountWrites = stdoutWrite.mock.calls.map(([chunk]) => String(chunk)).join('')
+  it('enters alt screen without clearing host scrollback', () => {
+    const app = mount()
+    const mounted = streamBytes()
 
-    expect(mountWrites).toContain(ENTER_ALT_SCREEN)
-    expect(mountWrites).toContain(ERASE_SCREEN)
-    expect(mountWrites).toContain(CURSOR_HOME)
-    expect(mountWrites).not.toContain(ERASE_SCROLLBACK)
+    expect(mounted).toContain(ENTER_ALT_SCREEN)
+    expect(mounted).toContain(ERASE_SCREEN)
+    expect(mounted).toContain(CURSOR_HOME)
+    expect(mounted).not.toContain(ERASE_SCROLLBACK)
 
-    instance.unmount()
+    app.unmount()
   })
 
-  it('exits alt screen synchronously during normal unmount', () => {
-    const instance = renderAltScreen()
+  it('does not queue alt-screen content on the buffered stream during unmount', () => {
+    // Buffered process.stdout.write may flush AFTER the synchronous
+    // writeSync(1, EXIT_ALT_SCREEN). Anything alt-screen-shaped queued on
+    // the stream during unmount — alt-screen exit, the per-frame
+    // cursorPosition(rows, 1) park patch, screen erases — therefore lands
+    // on the *main* screen and parks the cursor at the bottom, eating the
+    // parent shell's resume hint.
+    const app = mount()
+    stream.mockClear()
+    sync.mockClear()
 
-    stdoutWrite.mockClear()
-    vi.mocked(writeSync).mockClear()
+    app.unmount()
 
-    instance.unmount()
+    const buffered = streamBytes()
+    const synced = syncBytes()
 
-    const syncWrites = vi
-      .mocked(writeSync)
-      .mock.calls.map(([, chunk]) => String(chunk))
-      .join('')
-
-    const streamWrites = stdoutWrite.mock.calls.map(([chunk]) => String(chunk)).join('')
-
-    expect(count(syncWrites, EXIT_ALT_SCREEN)).toBe(1)
-    expect(streamWrites).not.toContain(EXIT_ALT_SCREEN)
-  })
-
-  it('does not double-exit alt screen during process-exit cleanup', () => {
-    renderAltScreen()
-
-    const ink = instances.get(process.stdout)
-
-    stdoutWrite.mockClear()
-    vi.mocked(writeSync).mockClear()
-
-    ink?.unmount(0)
-
-    const syncWrites = vi
-      .mocked(writeSync)
-      .mock.calls.map(([, chunk]) => String(chunk))
-      .join('')
-
-    const streamWrites = stdoutWrite.mock.calls.map(([chunk]) => String(chunk)).join('')
-
-    expect(count(syncWrites, EXIT_ALT_SCREEN)).toBe(1)
-    expect(streamWrites).not.toContain(EXIT_ALT_SCREEN)
+    expect(synced).toContain(EXIT_ALT_SCREEN)
+    expect(buffered).not.toContain(EXIT_ALT_SCREEN)
+    expect(buffered).not.toContain(ENTER_ALT_SCREEN)
+    expect(buffered).not.toContain(cursorPosition(ROWS, 1))
+    expect(buffered).not.toContain(ERASE_SCREEN)
+    expect(buffered).not.toContain(ERASE_SCROLLBACK)
   })
 })

--- a/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.tsx
@@ -62,9 +62,14 @@ export function AlternateScreen(t0: Props) {
       ink?.setAltScreenActive(true, mouseTracking)
 
       return () => {
+        const shouldExitAltScreen = ink?.isAltScreenActive ?? true
+
         ink?.setAltScreenActive(false)
         ink?.clearTextSelection()
-        writeRaw((mouseTracking ? DISABLE_MOUSE_TRACKING : '') + EXIT_ALT_SCREEN)
+
+        if (shouldExitAltScreen) {
+          writeRaw((mouseTracking ? DISABLE_MOUSE_TRACKING : '') + EXIT_ALT_SCREEN)
+        }
       }
     }
 

--- a/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.tsx
@@ -58,9 +58,14 @@ export function AlternateScreen(t0: Props) {
       ink?.setAltScreenActive(true, mouseTracking)
 
       return () => {
+        const shouldExitAltScreen = ink?.isAltScreenActive ?? true
+
         ink?.setAltScreenActive(false)
         ink?.clearTextSelection()
-        writeRaw((mouseTracking ? DISABLE_MOUSE_TRACKING : '') + EXIT_ALT_SCREEN)
+
+        if (shouldExitAltScreen) {
+          writeRaw((mouseTracking ? DISABLE_MOUSE_TRACKING : '') + EXIT_ALT_SCREEN)
+        }
       }
     }
 

--- a/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/AlternateScreen.tsx
@@ -2,7 +2,7 @@ import React, { type PropsWithChildren, useContext, useInsertionEffect } from 'r
 import { c as _c } from 'react/compiler-runtime'
 
 import instances from '../instances.js'
-import { CURSOR_HOME, ERASE_SCREEN, ERASE_SCROLLBACK } from '../termio/csi.js'
+import { CURSOR_HOME, ERASE_SCREEN } from '../termio/csi.js'
 import { DISABLE_MOUSE_TRACKING, ENABLE_MOUSE_TRACKING, ENTER_ALT_SCREEN, EXIT_ALT_SCREEN } from '../termio/dec.js'
 import { TerminalWriteContext } from '../useTerminalNotification.js'
 
@@ -53,23 +53,14 @@ export function AlternateScreen(t0: Props) {
       }
 
       writeRaw(
-        ENTER_ALT_SCREEN +
-          ERASE_SCROLLBACK +
-          ERASE_SCREEN +
-          CURSOR_HOME +
-          (mouseTracking ? ENABLE_MOUSE_TRACKING : DISABLE_MOUSE_TRACKING)
+        ENTER_ALT_SCREEN + ERASE_SCREEN + CURSOR_HOME + (mouseTracking ? ENABLE_MOUSE_TRACKING : DISABLE_MOUSE_TRACKING)
       )
       ink?.setAltScreenActive(true, mouseTracking)
 
       return () => {
-        const shouldExitAltScreen = ink?.isAltScreenActive ?? true
-
         ink?.setAltScreenActive(false)
         ink?.clearTextSelection()
-
-        if (shouldExitAltScreen) {
-          writeRaw((mouseTracking ? DISABLE_MOUSE_TRACKING : '') + EXIT_ALT_SCREEN)
-        }
+        writeRaw((mouseTracking ? DISABLE_MOUSE_TRACKING : '') + EXIT_ALT_SCREEN)
       }
     }
 

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -2169,6 +2169,8 @@ export default class Ink {
         // <AlternateScreen>'s unmount effect won't run during signal-exit.
         // Exit alt screen FIRST so other cleanup sequences go to the main screen.
         writeSync(1, EXIT_ALT_SCREEN)
+        this.altScreenActive = false
+        this.altScreenMouseTracking = false
       }
 
       // Disable mouse tracking — unconditional because altScreenActive can be

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -2141,7 +2141,16 @@ export default class Ink {
       return
     }
 
-    this.onRender()
+    // Mark unmounted FIRST so any in-flight throttled render no-ops via
+    // onRender's isUnmounted guard. Skipping the legacy "final onRender()"
+    // here is load-bearing: that call would queue a fresh full alt-screen
+    // frame onto the buffered stdout stream — including the per-frame
+    // `cursorPosition(rows, 1)` park patch — which can flush AFTER the
+    // synchronous writeSync(EXIT_ALT_SCREEN) below, parking the cursor at
+    // the bottom of the *main* screen and pushing the parent shell's
+    // resume hint off-viewport.
+    this.isUnmounted = true
+    this.scheduleRender.cancel?.()
     this.unsubscribeExit()
 
     if (typeof this.restoreConsole === 'function') {
@@ -2151,19 +2160,12 @@ export default class Ink {
     this.restoreStderr?.()
     this.unsubscribeTTYHandlers?.()
 
-    // Non-TTY environments don't handle erasing ansi escapes well, so it's better to
-    // only render last frame of non-static output
-    const diff = this.log.renderPreviousOutput_DEPRECATED(this.frontFrame)
-    writeDiffToTerminal(this.terminal, optimize(diff))
-
     // Clean up terminal modes synchronously before process exit.
-    // React's componentWillUnmount won't run in time when process.exit() is called,
-    // so we must reset terminal modes here to prevent escape sequence leakage.
-    // Use writeSync to stdout (fd 1) to ensure writes complete before exit.
-    // We unconditionally send all disable sequences because terminal detection
-    // may not work correctly (e.g., in tmux, screen) and these are no-ops on
-    // terminals that don't support them.
-
+    // React's componentWillUnmount won't run in time when process.exit() is
+    // called, so we must reset terminal modes here to prevent escape
+    // sequence leakage. writeSync to fd 1 is required — terminal.stdout is
+    // buffered and racing it with the alt-screen exit re-introduces the bug
+    // above.
     if (this.options.stdout.isTTY) {
       if (this.altScreenActive) {
         // <AlternateScreen>'s unmount effect won't run during signal-exit.
@@ -2195,12 +2197,13 @@ export default class Ink {
       if (supportsTabStatus()) {
         writeSync(1, wrapForMultiplexer(CLEAR_TAB_STATUS))
       }
+    } else {
+      // Non-TTY only — render the final static frame so piped output
+      // captures the last state. Skipped for TTY because the writeSync
+      // block above owns terminal restoration.
+      const diff = this.log.renderPreviousOutput_DEPRECATED(this.frontFrame)
+      writeDiffToTerminal(this.terminal, optimize(diff))
     }
-
-    this.isUnmounted = true
-
-    // Cancel any pending throttled renders to prevent accessing freed Yoga nodes
-    this.scheduleRender.cancel?.()
 
     if (this.drainTimer !== null) {
       clearTimeout(this.drainTimer)

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -2165,10 +2165,14 @@ export default class Ink {
     // terminals that don't support them.
 
     if (this.options.stdout.isTTY) {
-      if (this.altScreenActive) {
+      const processExitCleanup = typeof error === 'number' || error === null
+
+      if (this.altScreenActive && processExitCleanup) {
         // <AlternateScreen>'s unmount effect won't run during signal-exit.
         // Exit alt screen FIRST so other cleanup sequences go to the main screen.
         writeSync(1, EXIT_ALT_SCREEN)
+        this.altScreenActive = false
+        this.altScreenMouseTracking = false
       }
 
       // Disable mouse tracking — unconditional because altScreenActive can be

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -2169,8 +2169,6 @@ export default class Ink {
         // <AlternateScreen>'s unmount effect won't run during signal-exit.
         // Exit alt screen FIRST so other cleanup sequences go to the main screen.
         writeSync(1, EXIT_ALT_SCREEN)
-        this.altScreenActive = false
-        this.altScreenMouseTracking = false
       }
 
       // Disable mouse tracking — unconditional because altScreenActive can be

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -2165,9 +2165,7 @@ export default class Ink {
     // terminals that don't support them.
 
     if (this.options.stdout.isTTY) {
-      const processExitCleanup = typeof error === 'number' || error === null
-
-      if (this.altScreenActive && processExitCleanup) {
+      if (this.altScreenActive) {
         // <AlternateScreen>'s unmount effect won't run during signal-exit.
         // Exit alt screen FIRST so other cleanup sequences go to the main screen.
         writeSync(1, EXIT_ALT_SCREEN)

--- a/ui-tui/src/config/env.ts
+++ b/ui-tui/src/config/env.ts
@@ -1,4 +1,5 @@
 const truthy = (v?: string) => /^(?:1|true|yes|on)$/i.test((v ?? '').trim())
+const falsy = (v?: string) => /^(?:0|false|no|off)$/i.test((v ?? '').trim())
 
 export const STARTUP_RESUME_ID = (process.env.HERMES_TUI_RESUME ?? '').trim()
 export const STARTUP_QUERY = (process.env.HERMES_TUI_QUERY ?? '').trim()
@@ -7,10 +8,14 @@ export const MOUSE_TRACKING = !truthy(process.env.HERMES_TUI_DISABLE_MOUSE)
 export const NO_CONFIRM_DESTRUCTIVE = truthy(process.env.HERMES_TUI_NO_CONFIRM)
 
 // Skip AlternateScreen — TUI renders into the primary buffer so the host
-// terminal's native scrollback captures whatever scrolls off the top.
-// Experiment gate: lets us measure native scroll vs our virtualization on
-// the same pipeline.
-export const INLINE_MODE = truthy(process.env.HERMES_TUI_INLINE)
+// terminal's native scrollback captures whatever scrolls off the top, and
+// exit doesn't depend on the host honoring DECRC on `\x1b[?1049l` (which
+// xterm.js-backed terminals — VS Code, Cursor, Windsurf — don't always
+// do, leaving an ugly gap above the resume hint). Default ON for those
+// hosts; opt-out via HERMES_TUI_INLINE=0.
+const inlineEnv = process.env.HERMES_TUI_INLINE
+const inlineHost = process.env.TERM_PROGRAM === 'vscode'
+export const INLINE_MODE = truthy(inlineEnv) || (inlineHost && !falsy(inlineEnv))
 
 // Live FPS counter overlay, fed by ink's onFrame (real render rate, not a
 // synthetic timer).


### PR DESCRIPTION
## Two fixes

### 1. Ink alt-screen exit no longer races buffered writes

`Ink.unmount()` mixed two write paths into the same fd:
- buffered `process.stdout.write` via `writeDiffToTerminal`
- direct `writeSync(1, …)` (bypasses Node's TTY stream)

The legacy final `onRender()` it called queued a fresh full alt-screen frame onto the buffered stream — including the per-frame `cursorPosition(rows, 1)` park patch. The `writeSync(1, EXIT_ALT_SCREEN)` that followed hit fd 1 directly, so on busy stdout the buffered park patch could flush *after* the exit, landing on the **main** screen and parking the cursor at the bottom row. The parent shell's resume hint then printed below the cursor and scrolled everything up.

- Mark `isUnmounted` first and cancel the throttled scheduler
- Drop the redundant final `onRender()` from `unmount()`
- Restrict `renderPreviousOutput_DEPRECATED` to the non-TTY path (the `writeSync` block already owns terminal restoration for TTYs)
- Make `<AlternateScreen>` cleanup idempotent so process-exit fallback and normal shutdown can't double-write the exit
- Keep alt-screen entry off the host scrollback (no `CSI 3J`)

### 2. Compress \`_print_tui_exit_summary\`

The 9-line resume hint had two `print()` blanks padding the post-exit scroll. Collapse to 3 dense lines anchored at column 1:

\`\`\`
Friendly AI assistant introduction (20260505_172600_4afaa3)
58 msgs · in 50620 · out 5890 · cache 944256 · 1000766 total
→ hermes --tui -c \"Friendly AI assistant introduction\"
\`\`\`

Same info, half the vertical footprint, no leading or middle blank lines contributing to the gap users saw.

## Test plan

- \`scripts/run_tests.sh tests/hermes_cli/test_tui_resume_flow.py\` — 18 passed
- \`cd ui-tui && npm test\` — 621 passed
- \`cd ui-tui && npm run type-check\`
- \`cd ui-tui && npx eslint packages/hermes-ink/src/ink/components/AlternateScreen.{tsx,test.ts} packages/hermes-ink/src/ink/ink.tsx\`

Note: full \`npm run lint\` still has unrelated pre-existing TUI lint debt.