### PR TITLE
feat: add Codex native web search support

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
 
 logger = logging.getLogger(__name__)
+_CODEX_NATIVE_WEB_SEARCH_TOOL_TYPES = {"web_search", "web_search_preview"}
 
 
 # Matches Codex/Harmony tool-call serialization that occasionally leaks into
@@ -638,8 +639,8 @@ def _preflight_codex_api_kwargs(
             if not isinstance(tool, dict):
                 raise ValueError(f"Codex Responses tools[{idx}] must be an object.")
             tool_type = tool.get("type")
-            if tool_type == "web_search":
-                normalized_web_search: Dict[str, Any] = {"type": "web_search"}
+            if tool_type in _CODEX_NATIVE_WEB_SEARCH_TOOL_TYPES:
+                normalized_web_search: Dict[str, Any] = {"type": tool_type}
                 external_web_access = tool.get("external_web_access")
                 if external_web_access is not None:
                     normalized_web_search["external_web_access"] = _codex_bool(external_web_access)

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -637,8 +637,24 @@ def _preflight_codex_api_kwargs(
         for idx, tool in enumerate(tools):
             if not isinstance(tool, dict):
                 raise ValueError(f"Codex Responses tools[{idx}] must be an object.")
-            if tool.get("type") != "function":
-                raise ValueError(f"Codex Responses tools[{idx}] has unsupported type {tool.get('type')!r}.")
+            tool_type = tool.get("type")
+            if tool_type == "web_search":
+                normalized_web_search: Dict[str, Any] = {"type": "web_search"}
+                external_web_access = tool.get("external_web_access")
+                if external_web_access is not None:
+                    normalized_web_search["external_web_access"] = _codex_bool(external_web_access)
+                for optional_key in (
+                    "filters",
+                    "user_location",
+                    "search_context_size",
+                    "search_content_types",
+                ):
+                    if optional_key in tool and tool[optional_key] is not None:
+                        normalized_web_search[optional_key] = tool[optional_key]
+                normalized_tools.append(normalized_web_search)
+                continue
+            if tool_type != "function":
+                raise ValueError(f"Codex Responses tools[{idx}] has unsupported type {tool_type!r}.")
 
             name = tool.get("name")
             parameters = tool.get("parameters")
@@ -782,6 +798,90 @@ def _extract_responses_reasoning_text(item: Any) -> str:
     return ""
 
 
+def _codex_json_safe(value: Any) -> Any:
+    """Convert SDK response objects into JSON-serializable trace data."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, list):
+        return [_codex_json_safe(v) for v in value]
+    if isinstance(value, tuple):
+        return [_codex_json_safe(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _codex_json_safe(v) for k, v in value.items() if v is not None}
+    if hasattr(value, "model_dump"):
+        try:
+            return _codex_json_safe(value.model_dump(exclude_none=True))
+        except TypeError:
+            return _codex_json_safe(value.model_dump())
+        except Exception:
+            pass
+    if hasattr(value, "__dict__"):
+        return {
+            str(k): _codex_json_safe(v)
+            for k, v in vars(value).items()
+            if not str(k).startswith("_") and v is not None
+        }
+    return str(value)
+
+
+def _extract_codex_web_search_item(item: Any, item_status: Optional[str]) -> Dict[str, Any]:
+    """Extract a compact trace from a native Responses web_search_call item."""
+    trace: Dict[str, Any] = {"type": "web_search_call"}
+    item_id = getattr(item, "id", None)
+    if isinstance(item_id, str) and item_id:
+        trace["id"] = item_id
+    if item_status:
+        trace["status"] = item_status
+
+    action = getattr(item, "action", None)
+    if action is not None:
+        action_data = _codex_json_safe(action)
+        if isinstance(action_data, dict) and action_data:
+            trace["action"] = action_data
+
+    for key in ("query", "queries", "results"):
+        value = getattr(item, key, None)
+        if value is not None:
+            trace[key] = _codex_json_safe(value)
+    return trace
+
+
+def _codex_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"", "0", "false", "off", "no", "disabled", "disable", "none"}:
+            return False
+        if normalized in {"1", "true", "on", "yes", "live", "enabled", "enable"}:
+            return True
+    return bool(value)
+
+
+def _extract_responses_message_content_parts(item: Any) -> List[Dict[str, Any]]:
+    """Extract JSON-safe output_text parts, including citation annotations."""
+    content = getattr(item, "content", None)
+    if not isinstance(content, list):
+        return []
+
+    parts: List[Dict[str, Any]] = []
+    for part in content:
+        ptype = getattr(part, "type", None)
+        if ptype not in {"output_text", "text"}:
+            continue
+        text = getattr(part, "text", None)
+        if not isinstance(text, str) or not text:
+            continue
+        raw_part: Dict[str, Any] = {"type": "output_text", "text": text}
+        annotations = getattr(part, "annotations", None)
+        if isinstance(annotations, list) and annotations:
+            raw_part["annotations"] = _codex_json_safe(annotations)
+        parts.append(raw_part)
+    return parts
+
+
 # ---------------------------------------------------------------------------
 # Full response normalization
 # ---------------------------------------------------------------------------
@@ -825,6 +925,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
     reasoning_parts: List[str] = []
     reasoning_items_raw: List[Dict[str, Any]] = []
     message_items_raw: List[Dict[str, Any]] = []
+    web_search_items_raw: List[Dict[str, Any]] = []
     tool_calls: List[Any] = []
     has_incomplete_items = response_status in {"queued", "in_progress", "incomplete"}
     saw_commentary_phase = False
@@ -853,11 +954,14 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             message_text = _extract_responses_message_text(item)
             if message_text:
                 content_parts.append(message_text)
+                message_content = _extract_responses_message_content_parts(item) or [
+                    {"type": "output_text", "text": message_text}
+                ]
                 raw_message_item: Dict[str, Any] = {
                     "type": "message",
                     "role": "assistant",
                     "status": _normalize_responses_message_status(item_status),
-                    "content": [{"type": "output_text", "text": message_text}],
+                    "content": message_content,
                 }
                 item_id = getattr(item, "id", None)
                 if isinstance(item_id, str) and item_id:
@@ -888,6 +992,8 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
                             raw_summary.append({"type": "summary_text", "text": text})
                     raw_item["summary"] = raw_summary
                 reasoning_items_raw.append(raw_item)
+        elif item_type == "web_search_call":
+            web_search_items_raw.append(_extract_codex_web_search_item(item, item_status))
         elif item_type == "function_call":
             if item_status in {"queued", "in_progress", "incomplete"}:
                 continue
@@ -978,6 +1084,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
         reasoning_details=None,
         codex_reasoning_items=reasoning_items_raw or None,
         codex_message_items=message_items_raw or None,
+        codex_web_search_items=web_search_items_raw or None,
     )
 
     if tool_calls:

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -115,14 +115,19 @@ class ChatCompletionsTransport(ProviderTransport):
         """Messages are already in OpenAI format — sanitize Codex leaks only.
 
         Strips Codex Responses API fields (``codex_reasoning_items`` /
-        ``codex_message_items`` on the message, ``call_id``/``response_item_id``
-        on tool_calls) that strict chat-completions providers reject with 400/422.
+        ``codex_message_items`` / ``codex_web_search_items`` on the message,
+        ``call_id``/``response_item_id`` on tool_calls) that strict
+        chat-completions providers reject with 400/422.
         """
         needs_sanitize = False
         for msg in messages:
             if not isinstance(msg, dict):
                 continue
-            if "codex_reasoning_items" in msg or "codex_message_items" in msg:
+            if (
+                "codex_reasoning_items" in msg
+                or "codex_message_items" in msg
+                or "codex_web_search_items" in msg
+            ):
                 needs_sanitize = True
                 break
             tool_calls = msg.get("tool_calls")
@@ -145,6 +150,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 continue
             msg.pop("codex_reasoning_items", None)
             msg.pop("codex_message_items", None)
+            msg.pop("codex_web_search_items", None)
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 for tc in tool_calls:

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -5,7 +5,35 @@ This transport owns format conversion and normalization — NOT client lifecycle
 streaming, or the _run_codex_stream() call path.
 """
 
+import os
 from typing import Any, Dict, List, Optional
+
+
+_CODEX_WEB_SEARCH_DISABLED = {"", "0", "false", "off", "no", "disabled", "disable", "none"}
+_CODEX_WEB_SEARCH_CACHED = {"cached", "cache"}
+_CODEX_WEB_SEARCH_LIVE = {"1", "true", "on", "yes", "live", "search"}
+
+
+def _codex_native_web_search_tool(mode: Any) -> Optional[Dict[str, Any]]:
+    """Return a native Responses ``web_search`` tool for Codex mode values.
+
+    Matches the open-source Codex CLI shape:
+    - ``cached`` => ``external_web_access: false``
+    - ``live`` / truthy => ``external_web_access: true``
+    - disabled / empty => no tool
+    """
+    if mode is None:
+        return None
+    if isinstance(mode, bool):
+        return {"type": "web_search", "external_web_access": True} if mode else None
+    normalized = str(mode).strip().lower().replace("-", "_")
+    if normalized in _CODEX_WEB_SEARCH_DISABLED:
+        return None
+    if normalized in _CODEX_WEB_SEARCH_CACHED:
+        return {"type": "web_search", "external_web_access": False}
+    if normalized in _CODEX_WEB_SEARCH_LIVE:
+        return {"type": "web_search", "external_web_access": True}
+    return None
 
 from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
@@ -89,11 +117,22 @@ class ResponsesApiTransport(ProviderTransport):
         _effort_clamp = {"minimal": "low"}
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
 
+        responses_tools = _responses_tools(tools)
+        if is_codex_backend:
+            native_web_search_mode = params.get("native_web_search_mode")
+            if native_web_search_mode is None:
+                native_web_search_mode = os.getenv("HERMES_CODEX_WEB_SEARCH")
+            native_web_search_tool = _codex_native_web_search_tool(native_web_search_mode)
+            if native_web_search_tool:
+                responses_tools = list(responses_tools or [])
+                if not any(isinstance(t, dict) and t.get("type") == "web_search" for t in responses_tools):
+                    responses_tools.append(native_web_search_tool)
+
         kwargs = {
             "model": model,
             "instructions": instructions,
             "input": _chat_messages_to_responses_input(payload_messages),
-            "tools": _responses_tools(tools),
+            "tools": responses_tools,
             "tool_choice": "auto",
             "parallel_tool_calls": True,
             "store": False,
@@ -189,6 +228,8 @@ class ResponsesApiTransport(ProviderTransport):
             provider_data["codex_reasoning_items"] = msg.codex_reasoning_items
         if msg and hasattr(msg, "codex_message_items") and msg.codex_message_items:
             provider_data["codex_message_items"] = msg.codex_message_items
+        if msg and hasattr(msg, "codex_web_search_items") and msg.codex_web_search_items:
+            provider_data["codex_web_search_items"] = msg.codex_web_search_items
         if msg and hasattr(msg, "reasoning_details") and msg.reasoning_details:
             provider_data["reasoning_details"] = msg.reasoning_details
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -12,6 +12,30 @@ from typing import Any, Dict, List, Optional
 _CODEX_WEB_SEARCH_DISABLED = {"", "0", "false", "off", "no", "disabled", "disable", "none"}
 _CODEX_WEB_SEARCH_CACHED = {"cached", "cache"}
 _CODEX_WEB_SEARCH_LIVE = {"1", "true", "on", "yes", "live", "search"}
+_CODEX_NATIVE_WEB_SEARCH_TOOL_TYPES = {"web_search", "web_search_preview"}
+_CODEX_WEB_SEARCH_SOURCES_INCLUDE = "web_search_call.action.sources"
+
+
+def _is_managed_web_search_tool(tool: Any) -> bool:
+    return isinstance(tool, dict) and tool.get("type") == "function" and tool.get("name") == "web_search"
+
+
+def _has_native_web_search_tool(tools: Any) -> bool:
+    return isinstance(tools, list) and any(
+        isinstance(tool, dict) and tool.get("type") in _CODEX_NATIVE_WEB_SEARCH_TOOL_TYPES
+        for tool in tools
+    )
+
+
+def _ensure_codex_web_search_sources_include(kwargs: Dict[str, Any]) -> None:
+    includes = kwargs.get("include")
+    if isinstance(includes, list):
+        merged = list(includes)
+    else:
+        merged = []
+    if _CODEX_WEB_SEARCH_SOURCES_INCLUDE not in merged:
+        merged.append(_CODEX_WEB_SEARCH_SOURCES_INCLUDE)
+    kwargs["include"] = merged
 
 
 def _codex_native_web_search_tool(mode: Any) -> Optional[Dict[str, Any]]:
@@ -125,7 +149,12 @@ class ResponsesApiTransport(ProviderTransport):
             native_web_search_tool = _codex_native_web_search_tool(native_web_search_mode)
             if native_web_search_tool:
                 responses_tools = list(responses_tools or [])
-                if not any(isinstance(t, dict) and t.get("type") == "web_search" for t in responses_tools):
+                # Avoid presenting both the provider-native Responses web_search
+                # tool and Hermes's managed function tool with the same visible
+                # name. Native search still emits normal Hermes search progress,
+                # while web_extract/browser tools remain available if enabled.
+                responses_tools = [tool for tool in responses_tools if not _is_managed_web_search_tool(tool)]
+                if not _has_native_web_search_tool(responses_tools):
                     responses_tools.append(native_web_search_tool)
 
         kwargs = {
@@ -158,6 +187,9 @@ class ResponsesApiTransport(ProviderTransport):
         request_overrides = params.get("request_overrides")
         if request_overrides:
             kwargs.update(request_overrides)
+
+        if is_codex_backend and _has_native_web_search_tool(kwargs.get("tools")):
+            _ensure_codex_web_search_sources_include(kwargs)
 
         if is_codex_backend:
             prompt_cache_key = kwargs.get("prompt_cache_key")

--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -131,6 +131,11 @@ class NormalizedResponse:
         pd = self.provider_data or {}
         return pd.get("codex_message_items")
 
+    @property
+    def codex_web_search_items(self):
+        pd = self.provider_data or {}
+        return pd.get("codex_web_search_items")
+
 
 # ---------------------------------------------------------------------------
 # Factory helpers

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6543,6 +6543,7 @@ class GatewayRunner:
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    messages=agent_messages,
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -25,6 +25,7 @@ piecemeal, the footer is sent as a separate trailing message via
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from typing import Any, Iterable, Optional
@@ -89,6 +90,212 @@ def resolve_footer_config(
     return resolved
 
 
+def _parse_json_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+            return parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            return {}
+    return {}
+
+
+def _count_web_results(payload: dict[str, Any]) -> Optional[int]:
+    data = payload.get("data")
+    if isinstance(data, dict):
+        for key in ("web", "results"):
+            results = data.get(key)
+            if isinstance(results, list):
+                return len(results)
+    results = payload.get("results")
+    if isinstance(results, list):
+        return len(results)
+    web = payload.get("web")
+    if isinstance(web, list):
+        return len(web)
+    return None
+
+
+def _tool_call_metadata(messages: Iterable[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    meta: dict[str, dict[str, Any]] = {}
+    for msg in messages or []:
+        if not isinstance(msg, dict):
+            continue
+        for tc in msg.get("tool_calls") or []:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function") or {}
+            if not isinstance(fn, dict):
+                continue
+            call_id = tc.get("id")
+            if not call_id:
+                continue
+            meta[str(call_id)] = {
+                "name": fn.get("name") or tc.get("name") or "",
+                "args": _parse_json_object(fn.get("arguments")),
+            }
+    return meta
+
+
+def _codex_item_to_search_trace(item: dict[str, Any]) -> Optional[dict[str, Any]]:
+    if not isinstance(item, dict):
+        return None
+    action = item.get("action") if isinstance(item.get("action"), dict) else {}
+    action_type = str(action.get("type") or item.get("type") or "")
+    if action_type in {"open_page", "find_in_page"}:
+        url = action.get("url") or action.get("page_url")
+        if not url:
+            return None
+        return {
+            "kind": "extract",
+            "source": "provider_native",
+            "provider": "codex",
+            "tool": "web_extract",
+            "urls": [str(url)],
+            "status": item.get("status") or "completed",
+        }
+    if action_type and action_type not in {"search", "web_search_call"}:
+        return None
+    queries = action.get("queries") if isinstance(action.get("queries"), list) else []
+    query = action.get("query") or item.get("query") or (queries[0] if queries else "")
+    if query and query not in queries:
+        queries = [query, *queries]
+    if not query and not queries:
+        return None
+    return {
+        "kind": "search",
+        "source": "provider_native",
+        "provider": "codex",
+        "tool": "web_search",
+        "query": str(query or queries[0]),
+        "queries": [str(q) for q in queries if q],
+        "status": item.get("status") or "completed",
+    }
+
+
+def extract_search_traces_from_messages(messages: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Extract normalized search traces from the current user turn.
+
+    The normalized shape lets the gateway render one UX for provider-native
+    search (Codex Responses ``web_search_call``) and Hermes web tools
+    (``web_search`` / ``web_extract``) without exposing provider-specific raw
+    metadata in the final response.
+
+    Gateway histories may include previous turns, so by default we scope traces
+    to messages after the latest user message. This matches normal tool-progress
+    UX: the footer describes what happened for *this* reply, not every search in
+    the resumed session.
+    """
+    message_list = [m for m in (messages or []) if isinstance(m, dict)]
+    last_user_idx = max(
+        (idx for idx, msg in enumerate(message_list) if msg.get("role") == "user"),
+        default=-1,
+    )
+    turn_messages = message_list[last_user_idx + 1:] if last_user_idx >= 0 else message_list
+
+    traces: list[dict[str, Any]] = []
+    tool_meta = _tool_call_metadata(turn_messages)
+
+    for msg in turn_messages:
+        if not isinstance(msg, dict):
+            continue
+
+        for item in msg.get("codex_web_search_items") or []:
+            trace = _codex_item_to_search_trace(item)
+            if trace:
+                traces.append(trace)
+
+        if msg.get("role") != "tool":
+            continue
+        tool_name = str(msg.get("name") or "")
+        if tool_name not in {"web_search", "web_extract", "browser_navigate", "browser_open"}:
+            continue
+
+        call_meta = tool_meta.get(str(msg.get("tool_call_id") or ""), {})
+        args = call_meta.get("args") or {}
+        payload = _parse_json_object(msg.get("content"))
+        result_count = _count_web_results(payload)
+        if tool_name == "web_search":
+            query = str(args.get("query") or "")
+            trace = {
+                "kind": "search",
+                "source": "hermes_tool",
+                "provider": str(payload.get("backend") or args.get("backend") or "web"),
+                "tool": "web_search",
+                "query": query,
+                "queries": [query] if query else [],
+                "status": "completed" if payload.get("success", True) else "failed",
+            }
+            if result_count is not None:
+                trace["result_count"] = result_count
+            traces.append(trace)
+        elif tool_name == "web_extract":
+            urls = args.get("urls") if isinstance(args.get("urls"), list) else []
+            trace = {
+                "kind": "extract",
+                "source": "hermes_tool",
+                "provider": str(payload.get("backend") or args.get("backend") or "web"),
+                "tool": "web_extract",
+                "urls": [str(u) for u in urls],
+                "result_count": result_count or 0,
+                "status": "completed" if payload.get("success", True) else "failed",
+            }
+            traces.append(trace)
+        else:
+            url = str(args.get("url") or "")
+            traces.append({
+                "kind": "browse",
+                "source": "hermes_tool",
+                "provider": "browser",
+                "tool": tool_name,
+                "urls": [url] if url else [],
+                "status": "completed" if payload.get("success", True) else "failed",
+            })
+
+    return traces
+
+
+def _display_provider(trace: dict[str, Any]) -> str:
+    provider = str(trace.get("provider") or trace.get("source") or "web")
+    aliases = {"codex": "Codex", "web": "Web", "firecrawl": "Firecrawl", "tavily": "Tavily", "exa": "Exa", "parallel": "Parallel", "searxng": "SearXNG", "browser": "Browser"}
+    return aliases.get(provider.lower(), provider[:1].upper() + provider[1:])
+
+
+def _shorten(value: str, limit: int = 80) -> str:
+    value = " ".join(str(value or "").split())
+    return value if len(value) <= limit else value[: limit - 1].rstrip() + "…"
+
+
+def format_search_traces(search_traces: Iterable[dict[str, Any]] | None) -> str:
+    traces = [t for t in (search_traces or []) if isinstance(t, dict)]
+    if not traces:
+        return ""
+    trace = traces[-1]
+    provider = _display_provider(trace)
+    kind = trace.get("kind") or "search"
+    if kind == "extract":
+        count = trace.get("result_count")
+        suffix = f" ({count} pages)" if isinstance(count, int) and count >= 0 else ""
+        return f"🌐 {provider} extract{suffix}"
+    if kind == "browse":
+        urls = trace.get("urls") if isinstance(trace.get("urls"), list) else []
+        target = _shorten(urls[0]) if urls else "page"
+        return f"🌐 Browser: {target}"
+
+    query = trace.get("query") or ""
+    label = f"🔎 {provider} search"
+    if query:
+        label += f": {_shorten(str(query))}"
+    count = trace.get("result_count")
+    if isinstance(count, int):
+        label += f" ({count} result{'s' if count != 1 else ''})"
+    if len(traces) > 1:
+        label += f" +{len(traces) - 1} more"
+    return label
+
+
 def format_runtime_footer(
     *,
     model: Optional[str],
@@ -96,6 +303,7 @@ def format_runtime_footer(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    search_traces: Iterable[dict[str, Any]] | None = None,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
@@ -116,6 +324,10 @@ def format_runtime_footer(
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
             if rel:
                 parts.append(rel)
+        elif field == "search":
+            rendered = format_search_traces(search_traces)
+            if rendered:
+                parts.append(rendered)
         # Unknown field names are silently ignored.
 
     if not parts:
@@ -131,6 +343,8 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    search_traces: Iterable[dict[str, Any]] | None = None,
+    messages: Iterable[dict[str, Any]] | None = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -141,10 +355,14 @@ def build_footer_line(
     cfg = resolve_footer_config(user_config, platform_key)
     if not cfg.get("enabled"):
         return ""
+    traces = list(search_traces or [])
+    if not traces and messages:
+        traces = extract_search_traces_from_messages(messages)
     return format_runtime_footer(
         model=model,
         context_tokens=context_tokens,
         context_length=context_length,
         cwd=cwd,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        search_traces=traces,
     )

--- a/run_agent.py
+++ b/run_agent.py
@@ -1223,6 +1223,19 @@ class AIAgent:
         self.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
         self.service_tier = service_tier
         self.request_overrides = dict(request_overrides or {})
+        self._codex_native_web_search_mode = None
+        try:
+            from hermes_cli.config import load_config as _load_codex_ws_cfg
+
+            _codex_ws_cfg = _load_codex_ws_cfg().get("codex", {}) or {}
+            _codex_ws_mode = _codex_ws_cfg.get("web_search")
+            if _codex_ws_mode is not None:
+                self._codex_native_web_search_mode = str(_codex_ws_mode).strip() or None
+        except Exception:
+            pass
+        _codex_ws_env = os.getenv("HERMES_CODEX_WEB_SEARCH", "").strip()
+        if _codex_ws_env:
+            self._codex_native_web_search_mode = _codex_ws_env
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
         self._force_ascii_payload = False
         
@@ -5907,6 +5920,60 @@ class AIAgent:
     def _close_request_openai_client(self, client: Any, *, reason: str) -> None:
         self._close_openai_client(client, reason=reason, shared=False)
 
+    def _notify_codex_native_search_progress(self, item: Any) -> None:
+        """Render Codex native web_search_call items through normal tool progress.
+
+        Provider-hosted Responses tools are not Hermes function tools, so they do
+        not naturally pass through the ``tool.started`` callback used by gateway
+        platforms. When the Responses stream reports a completed native
+        ``web_search_call`` item, synthesize the same progress event shape that a
+        Hermes ``web_search`` tool call would have produced. The raw trace is
+        still preserved later by the Codex adapter; this is only display UX.
+        """
+        callback = getattr(self, "tool_progress_callback", None)
+        if not callback:
+            return
+        try:
+            if isinstance(item, dict):
+                item_type = item.get("type")
+                action = item.get("action") or {}
+            else:
+                item_type = getattr(item, "type", None)
+                action = getattr(item, "action", None) or {}
+                if hasattr(action, "model_dump"):
+                    action = action.model_dump(exclude_none=True)
+
+            if item_type != "web_search_call" or not isinstance(action, dict):
+                return
+
+            action_type = str(action.get("type") or "search")
+            if action_type in {"open_page", "find_in_page"}:
+                url = action.get("url") or action.get("page_url")
+                if not url:
+                    return
+                args = {"urls": [str(url)]}
+                if action.get("pattern"):
+                    args["pattern"] = str(action.get("pattern"))
+                callback("tool.started", "web_extract", str(url), args)
+                return
+
+            query = action.get("query")
+            if not query:
+                queries = action.get("queries")
+                if isinstance(queries, list) and queries:
+                    query = queries[0]
+            if not query:
+                return
+
+            args = {"query": str(query)}
+            # Use the existing Hermes web_search display path so Telegram/TUI
+            # renders native Codex search like every other web-search provider:
+            # e.g. `🔍 web_search: "latest news"` in the normal progress bubble,
+            # not embedded between model/context runtime footer fields.
+            callback("tool.started", "web_search", str(query), args)
+        except Exception as exc:
+            logger.debug("Codex native web-search progress callback failed: %s", exc)
+
     def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
         """Execute one streaming Responses API request and return the final response."""
         import httpx as _httpx
@@ -5960,6 +6027,7 @@ class AIAgent:
                             done_item = getattr(event, "item", None)
                             if done_item is not None:
                                 collected_output_items.append(done_item)
+                                self._notify_codex_native_search_progress(done_item)
                         # Log non-completed terminal events for diagnostics
                         elif event_type in ("response.incomplete", "response.failed"):
                             resp_obj = getattr(event, "response", None)
@@ -6063,6 +6131,7 @@ class AIAgent:
                         done_item = event.get("item")
                     if done_item is not None:
                         collected_output_items.append(done_item)
+                        self._notify_codex_native_search_progress(done_item)
                 elif event_type in ("response.output_text.delta",):
                     delta = getattr(event, "delta", "")
                     if not delta and isinstance(event, dict):
@@ -8495,6 +8564,7 @@ class AIAgent:
                 is_codex_backend=is_codex_backend,
                 is_xai_responses=is_xai_responses,
                 github_reasoning_extra=self._github_models_reasoning_extra_body() if is_github_responses else None,
+                native_web_search_mode=getattr(self, "_codex_native_web_search_mode", None),
             )
 
         # ── chat_completions (default) ─────────────────────────────────────
@@ -8904,6 +8974,13 @@ class AIAgent:
         codex_message_items = getattr(assistant_message, "codex_message_items", None)
         if codex_message_items:
             msg["codex_message_items"] = codex_message_items
+
+        # Codex Responses API: preserve native web_search_call traces for
+        # observability. These are not replayed by the Codex adapter, but
+        # keeping them in the session makes provider-side search auditable.
+        codex_web_search_items = getattr(assistant_message, "codex_web_search_items", None)
+        if codex_web_search_items:
+            msg["codex_web_search_items"] = codex_web_search_items
 
         if assistant_tool_calls:
             tool_calls = []

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -34,17 +34,20 @@ class TestChatCompletionsBasic:
         msgs = [
             {"role": "assistant", "content": "ok", "codex_reasoning_items": [{"id": "rs_1"}],
              "codex_message_items": [{"id": "msg_1", "type": "message"}],
+             "codex_web_search_items": [{"id": "ws_1", "type": "web_search_call"}],
              "tool_calls": [{"id": "call_1", "call_id": "call_1", "response_item_id": "fc_1",
                             "type": "function", "function": {"name": "t", "arguments": "{}"}}]},
         ]
         result = transport.convert_messages(msgs)
         assert "codex_reasoning_items" not in result[0]
         assert "codex_message_items" not in result[0]
+        assert "codex_web_search_items" not in result[0]
         assert "call_id" not in result[0]["tool_calls"][0]
         assert "response_item_id" not in result[0]["tool_calls"][0]
         # Original list untouched (deepcopy-on-demand)
         assert "codex_reasoning_items" in msgs[0]
         assert "codex_message_items" in msgs[0]
+        assert "codex_web_search_items" in msgs[0]
 
 
 class TestChatCompletionsBuildKwargs:

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -140,6 +140,71 @@ class TestCodexBuildKwargs:
             "x-grok-conv-id": "conv-123",
         }
 
+    def test_codex_native_web_search_live_adds_responses_tool(self, transport):
+        messages = [{"role": "user", "content": "What happened today?"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            is_codex_backend=True,
+            native_web_search_mode="live",
+        )
+
+        assert kw["tools"] == [
+            {"type": "web_search", "external_web_access": True}
+        ]
+
+    def test_codex_native_web_search_cached_adds_responses_tool(self, transport):
+        messages = [{"role": "user", "content": "What did we already know?"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            is_codex_backend=True,
+            native_web_search_mode="cached",
+        )
+
+        assert kw["tools"] == [
+            {"type": "web_search", "external_web_access": False}
+        ]
+
+    def test_codex_native_web_search_only_for_codex_backend(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            native_web_search_mode="live",
+        )
+
+        assert kw["tools"] is None
+
+    def test_preflight_allows_native_web_search_tool(self, transport):
+        sanitized = transport.preflight_kwargs({
+            "model": "gpt-5.4",
+            "instructions": "You are helpful.",
+            "input": [{"role": "user", "content": "Search the web"}],
+            "tools": [{"type": "web_search", "external_web_access": True}],
+            "store": False,
+        })
+
+        assert sanitized["tools"] == [
+            {"type": "web_search", "external_web_access": True}
+        ]
+
+    def test_preflight_parses_native_web_search_false_strings(self, transport):
+        sanitized = transport.preflight_kwargs({
+            "model": "gpt-5.4",
+            "instructions": "You are helpful.",
+            "input": [{"role": "user", "content": "Search cached context"}],
+            "tools": [{"type": "web_search", "external_web_access": "false"}],
+            "store": False,
+        })
+
+        assert sanitized["tools"] == [
+            {"type": "web_search", "external_web_access": False}
+        ]
+
     def test_minimal_effort_clamped(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(
@@ -237,6 +302,88 @@ class TestCodexNormalizeResponse:
                 "phase": "final_answer",
             }
         ]
+
+    def test_message_annotations_preserved_in_codex_message_items(self, transport):
+        r = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    status="completed",
+                    content=[
+                        SimpleNamespace(
+                            type="output_text",
+                            text="OpenAI announced updates.",
+                            annotations=[
+                                SimpleNamespace(
+                                    type="url_citation",
+                                    url="https://example.com/openai-updates",
+                                    title="OpenAI updates",
+                                    start_index=0,
+                                    end_index=6,
+                                )
+                            ],
+                        )
+                    ],
+                )
+            ],
+            status="completed",
+            model="gpt-5.4",
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.provider_data["codex_message_items"][0]["content"][0]["annotations"] == [
+            {
+                "type": "url_citation",
+                "url": "https://example.com/openai-updates",
+                "title": "OpenAI updates",
+                "start_index": 0,
+                "end_index": 6,
+            }
+        ]
+
+    def test_web_search_call_items_preserved_in_provider_data(self, transport):
+        """Native Codex web-search calls should survive normalization as trace data."""
+        r = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="web_search_call",
+                    id="ws_abc123",
+                    status="completed",
+                    action=SimpleNamespace(
+                        type="search",
+                        query="AI news this week",
+                        queries=["AI news this week", "frontier AI May 2026"],
+                    ),
+                ),
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    content=[SimpleNamespace(type="output_text", text="Found current AI news.")],
+                    status="completed",
+                ),
+            ],
+            status="completed",
+            incomplete_details=None,
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5,
+                                  input_tokens_details=None, output_tokens_details=None),
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.codex_web_search_items == [
+            {
+                "type": "web_search_call",
+                "id": "ws_abc123",
+                "status": "completed",
+                "action": {
+                    "type": "search",
+                    "query": "AI news this week",
+                    "queries": ["AI news this week", "frontier AI May 2026"],
+                },
+            }
+        ]
+        assert nr.provider_data["codex_web_search_items"] == nr.codex_web_search_items
 
     def test_tool_call_response(self, transport):
         """Normalize a Codex response with tool calls."""

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -153,6 +153,7 @@ class TestCodexBuildKwargs:
         assert kw["tools"] == [
             {"type": "web_search", "external_web_access": True}
         ]
+        assert "web_search_call.action.sources" in kw["include"]
 
     def test_codex_native_web_search_cached_adds_responses_tool(self, transport):
         messages = [{"role": "user", "content": "What did we already know?"}]
@@ -167,6 +168,60 @@ class TestCodexBuildKwargs:
         assert kw["tools"] == [
             {"type": "web_search", "external_web_access": False}
         ]
+        assert "web_search_call.action.sources" in kw["include"]
+
+    def test_codex_native_web_search_suppresses_managed_search_function(self, transport):
+        messages = [{"role": "user", "content": "What happened today?"}]
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "Hermes managed web search",
+                    "parameters": {"type": "object", "properties": {"query": {"type": "string"}}},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_extract",
+                    "description": "Hermes managed web extraction",
+                    "parameters": {"type": "object", "properties": {"urls": {"type": "array"}}},
+                },
+            },
+        ]
+
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=tools,
+            is_codex_backend=True,
+            native_web_search_mode="live",
+        )
+
+        assert kw["tools"] == [
+            {
+                "type": "function",
+                "name": "web_extract",
+                "description": "Hermes managed web extraction",
+                "strict": False,
+                "parameters": {"type": "object", "properties": {"urls": {"type": "array"}}},
+            },
+            {"type": "web_search", "external_web_access": True},
+        ]
+
+    def test_codex_native_web_search_merges_sources_include_without_duplicates(self, transport):
+        messages = [{"role": "user", "content": "Search"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            is_codex_backend=True,
+            native_web_search_mode="live",
+            request_overrides={"include": ["custom.include", "web_search_call.action.sources"]},
+        )
+
+        assert kw["include"] == ["custom.include", "web_search_call.action.sources"]
 
     def test_codex_native_web_search_only_for_codex_backend(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
@@ -203,6 +258,19 @@ class TestCodexBuildKwargs:
 
         assert sanitized["tools"] == [
             {"type": "web_search", "external_web_access": False}
+        ]
+
+    def test_preflight_allows_native_web_search_preview_tool(self, transport):
+        sanitized = transport.preflight_kwargs({
+            "model": "gpt-5.4",
+            "instructions": "You are helpful.",
+            "input": [{"role": "user", "content": "Search preview"}],
+            "tools": [{"type": "web_search_preview", "external_web_access": "true"}],
+            "store": False,
+        })
+
+        assert sanitized["tools"] == [
+            {"type": "web_search_preview", "external_web_access": True}
         ]
 
     def test_minimal_effort_clamped(self, transport):

--- a/tests/agent/transports/test_types.py
+++ b/tests/agent/transports/test_types.py
@@ -282,3 +282,15 @@ class TestNormalizedResponseBackwardCompat:
     def test_codex_message_items_none_when_absent(self):
         nr = NormalizedResponse(content="hi", tool_calls=None, finish_reason="stop")
         assert nr.codex_message_items is None
+
+    def test_codex_web_search_items_from_provider_data(self):
+        items = [{"id": "ws_1", "type": "web_search_call"}]
+        nr = NormalizedResponse(
+            content="hi", tool_calls=None, finish_reason="stop",
+            provider_data={"codex_web_search_items": items},
+        )
+        assert nr.codex_web_search_items == items
+
+    def test_codex_web_search_items_none_when_absent(self):
+        nr = NormalizedResponse(content="hi", tool_calls=None, finish_reason="stop")
+        assert nr.codex_web_search_items is None

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -11,7 +11,9 @@ from gateway.runtime_footer import (
     _home_relative_cwd,
     _model_short,
     build_footer_line,
+    extract_search_traces_from_messages,
     format_runtime_footer,
+    format_search_traces,
     resolve_footer_config,
 )
 
@@ -147,6 +149,161 @@ def test_format_footer_unknown_field_silently_ignored():
     assert out == "gpt-5.4 · 50%"
 
 
+def test_format_footer_renders_codex_native_search_trace():
+    out = format_runtime_footer(
+        model="openai/gpt-5.4",
+        context_tokens=50,
+        context_length=100,
+        cwd="",
+        fields=("search",),
+        search_traces=[
+            {
+                "source": "provider_native",
+                "provider": "codex",
+                "tool": "web_search",
+                "query": "finance: BTC",
+                "status": "completed",
+            }
+        ],
+    )
+    assert out == "🔎 Codex search: finance: BTC"
+
+
+def test_format_search_traces_summarizes_external_web_tool():
+    out = format_search_traces([
+        {
+            "source": "hermes_tool",
+            "provider": "tavily",
+            "tool": "web_search",
+            "query": "latest AI news",
+            "result_count": 5,
+            "status": "completed",
+        }
+    ])
+    assert out == "🔎 Tavily search: latest AI news (5 results)"
+
+
+def test_extract_search_traces_from_codex_and_web_search_tool_messages():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "BTC price",
+            "codex_web_search_items": [
+                {
+                    "type": "web_search_call",
+                    "status": "completed",
+                    "action": {"type": "search", "query": "finance: BTC"},
+                }
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "web_search",
+                        "arguments": '{"query": "latest AI news", "limit": 5}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "web_search",
+            "tool_call_id": "call_1",
+            "content": '{"success": true, "data": {"web": [{"url": "https://example.com/a"}, {"url": "https://example.com/b"}]}}',
+        },
+    ]
+
+    traces = extract_search_traces_from_messages(messages)
+
+    assert traces == [
+        {
+            "kind": "search",
+            "source": "provider_native",
+            "provider": "codex",
+            "tool": "web_search",
+            "query": "finance: BTC",
+            "queries": ["finance: BTC"],
+            "status": "completed",
+        },
+        {
+            "kind": "search",
+            "source": "hermes_tool",
+            "provider": "web",
+            "tool": "web_search",
+            "query": "latest AI news",
+            "queries": ["latest AI news"],
+            "result_count": 2,
+            "status": "completed",
+        },
+    ]
+
+
+def test_extract_search_traces_handles_codex_open_page_action():
+    messages = [
+        {"role": "user", "content": "open current source"},
+        {
+            "role": "assistant",
+            "codex_web_search_items": [
+                {
+                    "type": "web_search_call",
+                    "status": "completed",
+                    "action": {"type": "open_page", "url": "https://example.com/story"},
+                }
+            ],
+        },
+    ]
+
+    traces = extract_search_traces_from_messages(messages)
+
+    assert traces == [
+        {
+            "kind": "extract",
+            "source": "provider_native",
+            "provider": "codex",
+            "tool": "web_extract",
+            "urls": ["https://example.com/story"],
+            "status": "completed",
+        }
+    ]
+
+
+
+def test_extract_search_traces_defaults_to_current_user_turn_only():
+    messages = [
+        {
+            "role": "assistant",
+            "codex_web_search_items": [
+                {
+                    "type": "web_search_call",
+                    "status": "completed",
+                    "action": {"type": "search", "query": "old BTC search"},
+                }
+            ],
+        },
+        {"role": "user", "content": "search current AI news"},
+        {
+            "role": "assistant",
+            "codex_web_search_items": [
+                {
+                    "type": "web_search_call",
+                    "status": "completed",
+                    "action": {"type": "search", "query": "current AI news"},
+                }
+            ],
+        },
+    ]
+
+    traces = extract_search_traces_from_messages(messages)
+
+    assert len(traces) == 1
+    assert traces[0]["query"] == "current AI news"
+
+
 # ---------------------------------------------------------------------------
 # resolve_footer_config
 # ---------------------------------------------------------------------------
@@ -260,3 +417,31 @@ def test_build_footer_no_data_returns_empty_even_when_enabled():
     # With no TERMINAL_CWD env either
     if not os.environ.get("TERMINAL_CWD"):
         assert out == ""
+
+
+def test_build_footer_can_render_search_field_from_messages():
+    out = build_footer_line(
+        user_config={
+            "display": {
+                "runtime_footer": {"enabled": True, "fields": ["model", "search"]}
+            }
+        },
+        platform_key="telegram",
+        model="openai/gpt-5.4",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        messages=[
+            {
+                "role": "assistant",
+                "codex_web_search_items": [
+                    {
+                        "type": "web_search_call",
+                        "status": "completed",
+                        "action": {"type": "search", "query": "finance: BTC"},
+                    }
+                ],
+            }
+        ],
+    )
+    assert out == "gpt-5.4 · 🔎 Codex search: finance: BTC"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -157,9 +157,10 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, final_response=None, final_error=None, events=None):
         self._final_response = final_response
         self._final_error = final_error
+        self._events = list(events or [])
 
     def __enter__(self):
         return self
@@ -168,7 +169,7 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        return iter(self._events)
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -212,6 +213,27 @@ def test_api_mode_uses_explicit_provider_when_codex(monkeypatch):
     )
     assert agent.api_mode == "codex_responses"
     assert agent.provider == "openai-codex"
+
+
+def test_codex_web_search_env_overrides_config(monkeypatch):
+    _patch_agent_bootstrap(monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_WEB_SEARCH", "disabled")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda *a, **k: {"codex": {"web_search": "live"}})
+
+    agent = run_agent.AIAgent(
+        model="gpt-5-codex",
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="codex-token",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    assert agent._codex_native_web_search_mode == "disabled"
+
 
 
 def test_api_mode_normalizes_provider_case(monkeypatch):
@@ -396,6 +418,62 @@ def test_build_api_kwargs_copilot_responses_omits_reasoning_for_non_reasoning_mo
     assert "reasoning" not in kwargs
     assert "include" not in kwargs
     assert "prompt_cache_key" not in kwargs
+
+
+def test_run_codex_stream_reports_native_web_search_as_tool_progress(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    progress_events = []
+    agent.tool_progress_callback = lambda *args, **kwargs: progress_events.append((args, kwargs))
+    search_item = SimpleNamespace(
+        type="web_search_call",
+        status="completed",
+        action={"query": "latest world news today", "type": "search"},
+    )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _FakeResponsesStream(
+                final_response=_codex_message_response("news summary"),
+                events=[SimpleNamespace(type="response.output_item.done", item=search_item)],
+            ),
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.output[0].content[0].text == "news summary"
+    assert progress_events == [
+        (("tool.started", "web_search", "latest world news today", {"query": "latest world news today"}), {})
+    ]
+
+
+def test_run_codex_stream_reports_native_web_search_open_page_as_tool_progress(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    progress_events = []
+    agent.tool_progress_callback = lambda *args, **kwargs: progress_events.append((args, kwargs))
+    search_item = SimpleNamespace(
+        type="web_search_call",
+        status="completed",
+        action={"type": "open_page", "url": "https://example.com/story"},
+    )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _FakeResponsesStream(
+                final_response=_codex_message_response("page summary"),
+                events=[SimpleNamespace(type="response.output_item.done", item=search_item)],
+            ),
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.output[0].content[0].text == "page summary"
+    assert progress_events == [
+        (("tool.started", "web_extract", "https://example.com/story", {"urls": ["https://example.com/story"]}), {})
+    ]
 
 
 def test_run_codex_stream_retries_when_completed_event_missing(monkeypatch):

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -145,7 +145,7 @@ hermes config set codex.web_search cached    # cached/no-live mode
 hermes config set codex.web_search disabled  # off
 ```
 
-When enabled, Hermes preserves native `web_search_call` response items and citation annotations in session/provider metadata so provider-side search usage is auditable. During streaming, native Codex searches are also surfaced through the normal Hermes tool-progress UI as `web_search`/`web_extract`, so Telegram/TUI users see the same separate search-progress line as they do with Hermes's external web providers. If you prefer a compact end-of-turn summary, gateway runtime footers can optionally include a `search` field, but it is not required for the standard search-call UX.
+When enabled, Hermes requests native web-search source traces, preserves `web_search_call` response items and citation annotations in session/provider metadata, and suppresses Hermes's managed `web_search` function tool to avoid presenting two search tools with the same name. During streaming, native Codex searches are still surfaced through the normal Hermes tool-progress UI as `web_search`/`web_extract`, so Telegram/TUI users see the same separate search-progress line as they do with Hermes's external web providers. If you prefer a compact end-of-turn summary, gateway runtime footers can optionally include a `search` field, but it is not required for the standard search-call UX.
 
 For process-scoped tests, `HERMES_CODEX_WEB_SEARCH` accepts the same values and overrides `codex.web_search` from config.
 :::

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -136,6 +136,18 @@ with the Generative Language API enabled.
 
 :::info Codex Note
 The OpenAI Codex provider authenticates via device code (open a URL, enter a code). Hermes stores the resulting credentials in its own auth store under `~/.hermes/auth.json` and can import existing Codex CLI credentials from `~/.codex/auth.json` when present. No Codex CLI installation is required.
+
+Codex can also expose OpenAI's native Responses API web-search tool without configuring Hermes's external `web_search` providers. Enable it with:
+
+```bash
+hermes config set codex.web_search live      # live external web access
+hermes config set codex.web_search cached    # cached/no-live mode
+hermes config set codex.web_search disabled  # off
+```
+
+When enabled, Hermes preserves native `web_search_call` response items and citation annotations in session/provider metadata so provider-side search usage is auditable. During streaming, native Codex searches are also surfaced through the normal Hermes tool-progress UI as `web_search`/`web_extract`, so Telegram/TUI users see the same separate search-progress line as they do with Hermes's external web providers. If you prefer a compact end-of-turn summary, gateway runtime footers can optionally include a `search` field, but it is not required for the standard search-call UX.
+
+For process-scoped tests, `HERMES_CODEX_WEB_SEARCH` accepts the same values and overrides `codex.web_search` from config.
 :::
 
 :::warning


### PR DESCRIPTION
## Summary
- add `codex.web_search` / `HERMES_CODEX_WEB_SEARCH` support for injecting Codex/OpenAI native Responses `web_search` tools
- allow native `web_search` tool specs through Codex Responses preflight validation
- preserve native `web_search_call` response items in provider/session metadata for observability
- document Codex native web-search configuration

## Test Plan
- `venv/bin/python -m pytest tests/agent/transports/test_codex_transport.py tests/agent/transports/test_chat_completions.py tests/agent/transports/test_types.py tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='`