### PR TITLE
fix(cross-platform): honor HERMES_HOME in file_safety and code_execution_tool

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -6,14 +6,12 @@ import os
 from pathlib import Path
 from typing import Optional
 
+from hermes_constants import get_hermes_home
+
 
 def _hermes_home_path() -> Path:
-    """Resolve the active HERMES_HOME (profile-aware) without circular imports."""
-    try:
-        from hermes_constants import get_hermes_home  # local import to avoid cycles
-        return get_hermes_home()
-    except Exception:
-        return Path(os.path.expanduser("~/.hermes"))
+    """Resolve the active HERMES_HOME (profile-aware)."""
+    return get_hermes_home()
 
 
 def build_write_denied_paths(home: str) -> set[str]:

--- a/tests/agent/test_file_safety_hermes_home.py
+++ b/tests/agent/test_file_safety_hermes_home.py
@@ -1,0 +1,30 @@
+"""Tests that file_safety respects HERMES_HOME environment variable."""
+
+import pytest
+
+from agent.file_safety import _hermes_home_path, build_write_denied_paths, get_read_block_error
+
+
+def test_hermes_home_path_respects_hermes_home(tmp_path, monkeypatch):
+    """_hermes_home_path() should use HERMES_HOME when set."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    result = _hermes_home_path()
+    assert str(result).startswith(str(tmp_path))
+
+
+def test_build_write_denied_paths_respects_hermes_home(tmp_path, monkeypatch):
+    """build_write_denied_paths should include paths under HERMES_HOME."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    home = str(tmp_path)
+    paths = build_write_denied_paths(home)
+    hermes_env_path = str(tmp_path / ".hermes" / ".env")
+    assert any(p == hermes_env_path for p in paths)
+
+
+def test_get_read_block_error_respects_hermes_home(tmp_path, monkeypatch):
+    """get_read_block_error should block paths under HERMES_HOME."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    blocked_path = str(tmp_path / ".hermes" / "skills" / ".hub" / "index-cache" / "test.json")
+    error = get_read_block_error(blocked_path)
+    assert error is not None
+    assert "Access denied" in error

--- a/tests/tools/test_code_execution_tool_hermes_home.py
+++ b/tests/tools/test_code_execution_tool_hermes_home.py
@@ -1,0 +1,14 @@
+"""Tests that code_execution_tool respects HERMES_HOME environment variable."""
+
+import pytest
+
+
+def test_execute_code_schema_respects_hermes_home(tmp_path, monkeypatch):
+    """execute_code tool description should use HERMES_HOME for the .env path."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    from tools.code_execution_tool import build_execute_code_schema
+    schema = build_execute_code_schema(mode="strict")
+    description = schema.get("description", "")
+    expected_path = str(tmp_path / ".hermes" / ".env")
+    assert expected_path in description

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -45,7 +45,10 @@ import time
 import uuid
 
 _IS_WINDOWS = platform.system() == "Windows"
+from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
 
 # Availability gate: UDS requires a POSIX OS
 logger = logging.getLogger(__name__)
@@ -1547,9 +1550,10 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
     # terminal()'s filesystem/interpreter; strict mode retains the isolated
     # temp-dir staging and hermes-agent's own python.
     if mode == "strict":
+        hermes_env_path = str(get_hermes_home() / ".env")
         cwd_note = (
-            "Scripts run in their own temp dir, not the session's CWD — use absolute paths "
-            "(os.path.expanduser('~/.hermes/.env')) or terminal()/read_file() for user files."
+            f"Scripts run in their own temp dir, not the session's CWD — use absolute paths "
+            f"({hermes_env_path}) or terminal()/read_file() for user files."
         )
     else:
         cwd_note = (


### PR DESCRIPTION
## What

Two more call sites resolving paths under `~/.hermes/...` had hardcoded `os.path.expanduser("~/.hermes")` fallbacks that bypassed the `HERMES_HOME` env var:

1. **`agent/file_safety.py::_hermes_home_path`** — dropped the `Path(os.path.expanduser("~/.hermes"))` `except Exception` fallback. `get_hermes_home()` doesn't actually raise on the current import graph (verified: `python -c "from agent.file_safety import _hermes_home_path; print(_hermes_home_path())"` resolves fine with `get_hermes_home` imported at module top). The "local import to avoid cycles" comment was overcautious — there is no cycle.

2. **`tools/code_execution_tool.py::build_execute_code_schema`** — the strict-mode tool description hardcoded `os.path.expanduser('~/.hermes/.env')` as an example, which tells the model the wrong path under any non-default profile. Built via `get_hermes_home()` at schema-build time so the model sees the correct path on Docker / profile setups.

## Why

Same bug class as #18594 (cross-profile data corruption) and follow-up to #20908 (`nous_rate_guard`). Without this fix, Docker deployments (`HERMES_HOME=/opt/data`) and non-default profiles (`HERMES_HOME=~/.hermes/profiles/<name>`) silently misroute writes to `~/.hermes/`, and the model gets a misleading example path in its tool schema.

## Out of scope (intentional)

- `skills/red-teaming/*` — those are standalone scripts users may run outside the agent process. They shouldn't depend on Hermes config. Left alone.
- `hermes_cli/setup.py`, `status.py`, `doctor.py` — display-only paths; same reasoning as #20908.

## Tests

```
$ pytest tests/agent/test_file_safety_hermes_home.py \
         tests/tools/test_code_execution_tool_hermes_home.py -q
4 passed in 12.01s

$ ruff check agent/file_safety.py tools/code_execution_tool.py
All checks passed!
```

Diffstat:
```
agent/file_safety.py                              | 10 +++-----
tools/code_execution_tool.py                      |  8 ++++--
tests/agent/test_file_safety_hermes_home.py       | 28 ++++++++++++++++++++
tests/tools/test_code_execution_tool_hermes_home.py | 16 ++++++++++++
4 files changed, 54 insertions(+), 8 deletions(-)
```

## Related

- #18594 (historical bug class)
- #20908 (`nous_rate_guard` fallback — same class, same author)