### PR TITLE
fix: keep background process notifications out of model input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1706,24 +1706,27 @@ def _resolve_attachment_path(raw_path: str) -> Path | None:
 
 
 def _format_process_notification(evt: dict) -> "str | None":
-    """Format a process notification event into a [IMPORTANT: ...] message.
+    """Format a process notification for display only.
 
-    Handles both completion events (notify_on_complete) and watch pattern
-    match events from the unified completion_queue.
+    The returned text is a notification, not a prompt.  It must never be
+    enqueued into ``_pending_input`` because that queue represents real user
+    turns (plus explicit command-generated follow-up turns).  Re-entering
+    background process status through the normal user-input path can contaminate
+    the next turn after context compaction or interrupts.
     """
     evt_type = evt.get("type", "completion")
     _sid = evt.get("session_id", "unknown")
     _cmd = evt.get("command", "unknown")
 
-    if evt_type == "watch_disabled":
-        return f"[IMPORTANT: {evt.get('message', '')}]"
+    if evt_type in ("watch_disabled", "watch_overflow_tripped", "watch_overflow_released"):
+        return f"[Background process notice: {evt.get('message', '')}]"
 
     if evt_type == "watch_match":
         _pat = evt.get("pattern", "?")
         _out = evt.get("output", "")
         _sup = evt.get("suppressed", 0)
         text = (
-            f"[IMPORTANT: Background process {_sid} matched "
+            f"[Background process {_sid} matched "
             f"watch pattern \"{_pat}\".\n"
             f"Command: {_cmd}\n"
             f"Matched output:\n{_out}"
@@ -1737,11 +1740,74 @@ def _format_process_notification(evt: dict) -> "str | None":
     _exit = evt.get("exit_code", "?")
     _out = evt.get("output", "")
     return (
-        f"[IMPORTANT: Background process {_sid} completed "
+        f"[Background process {_sid} completed "
         f"(exit code {_exit}).\n"
         f"Command: {_cmd}\n"
         f"Output:\n{_out}]"
     )
+
+
+def _load_cli_background_notifications_mode(config: dict | None = None) -> str:
+    """Load CLI background-process notification mode from env/config."""
+    mode = os.getenv("HERMES_BACKGROUND_NOTIFICATIONS", "")
+    if not mode:
+        cfg = config if isinstance(config, dict) else CLI_CONFIG
+        display_cfg = cfg.get("display", {}) if isinstance(cfg, dict) else {}
+        raw = display_cfg.get("background_process_notifications") if isinstance(display_cfg, dict) else None
+        if raw is False:
+            mode = "off"
+        elif raw not in (None, ""):
+            mode = str(raw)
+    mode = (mode or "all").strip().lower()
+    valid = {"all", "result", "error", "off"}
+    if mode not in valid:
+        logger.warning(
+            "Unknown background_process_notifications '%s', defaulting to 'all'",
+            mode,
+        )
+        return "all"
+    return mode
+
+
+def _should_display_process_notification(evt: dict, mode: str) -> bool:
+    """Return whether a process notification should be displayed in the CLI."""
+    mode = (mode or "all").strip().lower()
+    if mode == "off":
+        return False
+    evt_type = evt.get("type", "completion")
+    if evt_type == "completion":
+        return mode in ("all", "result") or (
+            mode == "error" and evt.get("exit_code") not in (0, None)
+        )
+    # Running/watch/status events are intentionally chatty and only belong in all mode.
+    return mode == "all"
+
+
+def _drain_process_notifications_for_cli(emit=None, config: dict | None = None) -> int:
+    """Drain background process notifications without injecting user input.
+
+    Returns the number of notifications displayed.  ``emit`` is a display
+    side-channel (defaults to ``print``), not the chat input queue.
+    """
+    from tools.process_registry import process_registry
+
+    mode = _load_cli_background_notifications_mode(config)
+    displayed = 0
+    while not process_registry.completion_queue.empty():
+        evt = process_registry.completion_queue.get_nowait()
+        _evt_sid = evt.get("session_id", "")
+        if evt.get("type", "completion") == "completion" and process_registry.is_completion_consumed(_evt_sid):
+            continue
+        if not _should_display_process_notification(evt, mode):
+            continue
+        _synth = _format_process_notification(evt)
+        if _synth:
+            if emit is None:
+                print(_synth)
+            else:
+                emit(_synth)
+            displayed += 1
+    return displayed
 
 
 def _detect_file_drop(user_input: str) -> "dict | None":
@@ -13072,19 +13138,10 @@ class HermesCLI:
                         if not self._agent_running:
                             self._check_config_mcp_changes()
                             # Check for background process notifications (completions
-                            # and watch pattern matches) while agent is idle.
+                            # and watch pattern matches) while agent is idle.  Display
+                            # them out-of-band; never enqueue them as user input.
                             try:
-                                from tools.process_registry import process_registry
-                                if not process_registry.completion_queue.empty():
-                                    evt = process_registry.completion_queue.get_nowait()
-                                    # Skip if the agent already consumed this via wait/poll/log
-                                    _evt_sid = evt.get("session_id", "")
-                                    if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
-                                        pass  # already delivered via tool result
-                                    else:
-                                        _synth = _format_process_notification(evt)
-                                        if _synth:
-                                            self._pending_input.put(_synth)
+                                _drain_process_notifications_for_cli()
                             except Exception:
                                 pass
                         continue
@@ -13185,18 +13242,10 @@ class HermesCLI:
                             threading.Thread(target=_restart_recording, daemon=True).start()
 
                         # Drain process notifications (completions + watch matches)
-                        # that arrived while the agent was running.
+                        # that arrived while the agent was running.  Display them
+                        # out-of-band; never enqueue them as synthetic user turns.
                         try:
-                            from tools.process_registry import process_registry
-                            while not process_registry.completion_queue.empty():
-                                evt = process_registry.completion_queue.get_nowait()
-                                # Skip if the agent already consumed this via wait/poll/log
-                                _evt_sid = evt.get("session_id", "")
-                                if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
-                                    continue  # already delivered via tool result
-                                _synth = _format_process_notification(evt)
-                                if _synth:
-                                    self._pending_input.put(_synth)
+                            _drain_process_notifications_for_cli()
                         except Exception:
                             pass  # Non-fatal — don't break the main loop
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1040,20 +1040,20 @@ def _parse_session_key(session_key: str) -> "dict | None":
 
 
 def _format_gateway_process_notification(evt: dict) -> "str | None":
-    """Format a watch pattern event from completion_queue into a [IMPORTANT:] message."""
+    """Format a process notification for direct user-visible delivery."""
     evt_type = evt.get("type", "completion")
     _sid = evt.get("session_id", "unknown")
     _cmd = evt.get("command", "unknown")
 
-    if evt_type == "watch_disabled":
-        return f"[IMPORTANT: {evt.get('message', '')}]"
+    if evt_type in ("watch_disabled", "watch_overflow_tripped", "watch_overflow_released"):
+        return f"[Background process notice: {evt.get('message', '')}]"
 
     if evt_type == "watch_match":
         _pat = evt.get("pattern", "?")
         _out = evt.get("output", "")
         _sup = evt.get("suppressed", 0)
         text = (
-            f"[IMPORTANT: Background process {_sid} matched "
+            f"[Background process {_sid} matched "
             f"watch pattern \"{_pat}\".\n"
             f"Command: {_cmd}\n"
             f"Matched output:\n{_out}"
@@ -7750,23 +7750,31 @@ class GatewayRunner:
             # Drain watch pattern notifications that arrived during the agent run.
             # Watch events and completions share the same queue; completions are
             # already handled by the per-process watcher task above, so we only
-            # inject watch-type events here.
+            # deliver watch-type events here.  Delivery is notification-only and
+            # must not re-enter _handle_message as fake user/internal input.
             try:
                 from tools.process_registry import process_registry as _pr
+                notify_mode = self._load_background_notifications_mode()
                 _watch_events = []
                 while not _pr.completion_queue.empty():
                     evt = _pr.completion_queue.get_nowait()
                     evt_type = evt.get("type", "completion")
-                    if evt_type in {"watch_match", "watch_disabled"}:
+                    if evt_type in (
+                        "watch_match",
+                        "watch_disabled",
+                        "watch_overflow_tripped",
+                        "watch_overflow_released",
+                    ) and notify_mode == "all":
                         _watch_events.append(evt)
-                    # else: completion events are handled by the watcher task
+                    # else: completion events are handled by the watcher task;
+                    # filtered watch events are intentionally discarded.
                 for evt in _watch_events:
                     synth_text = _format_gateway_process_notification(evt)
                     if synth_text:
                         try:
-                            await self._inject_watch_notification(synth_text, evt)
+                            await self._send_process_notification(synth_text, evt)
                         except Exception as e2:
-                            logger.error("Watch notification injection error: %s", e2)
+                            logger.error("Watch notification delivery error: %s", e2)
             except Exception as e:
                 logger.debug("Watch queue drain error: %s", e)
 
@@ -13325,43 +13333,41 @@ class GatewayRunner:
             user_name=str(evt.get("user_name") or "").strip() or None,
         )
 
-    async def _inject_watch_notification(self, synth_text: str, evt: dict) -> None:
-        """Inject a watch-pattern notification as a synthetic message event.
+    async def _send_process_notification(self, synth_text: str, evt: dict) -> None:
+        """Send a process notification directly to the originating chat/thread.
 
-        Routing must come from the queued watch event itself, not from whatever
-        foreground message happened to be active when the queue was drained.
+        This is intentionally delivery-only.  Do not call
+        ``adapter.handle_message(MessageEvent(..., internal=True))`` here:
+        that routes the notification through the normal inbound-message path
+        and can turn process output into fake user input.
         """
         source = self._build_process_event_source(evt)
         if not source:
             logger.warning(
-                "Dropping watch notification with no routing metadata for process %s",
+                "Dropping process notification with no routing metadata for process %s",
                 evt.get("session_id", "unknown"),
             )
             return
         platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         adapter = None
         for p, a in self.adapters.items():
-            if p.value == platform_name:
+            if p == source.platform or p.value == platform_name:
                 adapter = a
                 break
-        if not adapter:
+        if not adapter or not source.chat_id:
             return
-        try:
-            synth_event = MessageEvent(
-                text=synth_text,
-                message_type=MessageType.TEXT,
-                source=source,
-                internal=True,
-            )
-            logger.info(
-                "Watch pattern notification — injecting for %s chat=%s thread=%s",
-                platform_name,
-                source.chat_id,
-                source.thread_id,
-            )
-            await adapter.handle_message(synth_event)
-        except Exception as e:
-            logger.error("Watch notification injection error: %s", e)
+        send_meta = {"thread_id": source.thread_id} if source.thread_id else None
+        logger.info(
+            "Process notification — delivering for %s chat=%s thread=%s",
+            platform_name,
+            source.chat_id,
+            source.thread_id,
+        )
+        await adapter.send(source.chat_id, synth_text, metadata=send_meta)
+
+    async def _inject_watch_notification(self, synth_text: str, evt: dict) -> None:
+        """Backward-compatible wrapper for direct watch notification delivery."""
+        await self._send_process_notification(synth_text, evt)
 
     async def _run_process_watcher(self, watcher: dict) -> None:
         """
@@ -13392,9 +13398,10 @@ class GatewayRunner:
         logger.debug("Process watcher started: %s (every %ss, notify=%s, agent_notify=%s)",
                       session_id, interval, notify_mode, agent_notify)
 
-        if notify_mode == "off" and not agent_notify:
+        if notify_mode == "off":
             # Still wait for the process to exit so we can log it, but don't
-            # push any messages to the user.
+            # push any messages to the user.  notify_on_complete must not
+            # bypass an explicit off setting or re-enter as a fake user turn.
             while True:
                 await asyncio.sleep(interval)
                 session = process_registry.get(session_id)
@@ -13416,19 +13423,25 @@ class GatewayRunner:
             last_output_len = current_output_len
 
             if session.exited:
-                # --- Agent-triggered completion: inject synthetic message ---
-                # Skip if the agent already consumed the result via wait/poll/log
+                # --- Agent-triggered completion: direct notification only ---
+                # Skip if the agent already consumed the result via wait/poll/log.
+                # Do not route through adapter.handle_message(), which would
+                # re-enter the inbound user-message path.
                 from tools.process_registry import process_registry as _pr_check
-                if agent_notify and not _pr_check.is_completion_consumed(session_id):
+                agent_should_notify = agent_notify and (
+                    notify_mode in ("all", "result")
+                    or (notify_mode == "error" and session.exit_code not in (0, None))
+                )
+                if agent_should_notify and not _pr_check.is_completion_consumed(session_id):
                     from tools.ansi_strip import strip_ansi
                     _out = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
                     synth_text = (
-                        f"[IMPORTANT: Background process {session_id} completed "
+                        f"[Background process {session_id} completed "
                         f"(exit code {session.exit_code}).\n"
                         f"Command: {session.command}\n"
                         f"Output:\n{_out}]"
                     )
-                    source = self._build_process_event_source({
+                    await self._send_process_notification(synth_text, {
                         "session_id": session_id,
                         "session_key": session_key,
                         "platform": platform_name,
@@ -13437,36 +13450,6 @@ class GatewayRunner:
                         "user_id": user_id,
                         "user_name": user_name,
                     })
-                    if not source:
-                        logger.warning(
-                            "Dropping completion notification with no routing metadata for process %s",
-                            session_id,
-                        )
-                        break
-
-                    adapter = None
-                    for p, a in self.adapters.items():
-                        if p == source.platform:
-                            adapter = a
-                            break
-                    if adapter and source.chat_id:
-                        try:
-                            synth_event = MessageEvent(
-                                text=synth_text,
-                                message_type=MessageType.TEXT,
-                                source=source,
-                                internal=True,
-                            )
-                            logger.info(
-                                "Process %s finished — injecting agent notification for session %s chat=%s thread=%s",
-                                session_id,
-                                session_key,
-                                source.chat_id,
-                                source.thread_id,
-                            )
-                            await adapter.handle_message(synth_event)
-                        except Exception as e:
-                            logger.error("Agent notify injection error: %s", e)
                     break
 
                 # --- Normal text-only notification ---

--- a/tests/cli/test_cli_background_process_notifications.py
+++ b/tests/cli/test_cli_background_process_notifications.py
@@ -1,0 +1,150 @@
+"""Regression tests for CLI background-process notification handling."""
+
+from __future__ import annotations
+
+import queue
+from unittest.mock import patch
+
+import cli
+
+
+class _FakeProcessRegistry:
+    def __init__(self, events=(), consumed=()):
+        self.completion_queue = queue.Queue()
+        for event in events:
+            self.completion_queue.put(event)
+        self._consumed = set(consumed)
+
+    def is_completion_consumed(self, session_id: str) -> bool:
+        return session_id in self._consumed
+
+
+def test_cli_background_notifications_off_drains_without_display():
+    """Config off suppresses notifications but still drains stale queue events."""
+    registry = _FakeProcessRegistry([
+        {
+            "type": "completion",
+            "session_id": "proc_done",
+            "command": "make test",
+            "exit_code": 0,
+            "output": "ok",
+        }
+    ])
+
+    emitted = []
+    with patch("tools.process_registry.process_registry", registry):
+        displayed = cli._drain_process_notifications_for_cli(
+            emit=emitted.append,
+            config={"display": {"background_process_notifications": "off"}},
+        )
+
+    assert displayed == 0
+    assert emitted == []
+    assert registry.completion_queue.empty()
+
+
+def test_cli_background_notifications_result_displays_only_final():
+    registry = _FakeProcessRegistry([
+        {
+            "type": "watch_match",
+            "session_id": "proc_watch",
+            "command": "server",
+            "pattern": "READY",
+            "output": "READY\n",
+        },
+        {
+            "type": "completion",
+            "session_id": "proc_done",
+            "command": "make test",
+            "exit_code": 0,
+            "output": "ok",
+        },
+    ])
+
+    emitted = []
+    with patch("tools.process_registry.process_registry", registry):
+        displayed = cli._drain_process_notifications_for_cli(
+            emit=emitted.append,
+            config={"display": {"background_process_notifications": "result"}},
+        )
+
+    assert displayed == 1
+    assert len(emitted) == 1
+    assert "proc_done completed" in emitted[0]
+    assert "proc_watch" not in emitted[0]
+    assert registry.completion_queue.empty()
+
+
+def test_cli_background_notifications_error_displays_only_failed_final():
+    registry = _FakeProcessRegistry([
+        {
+            "type": "completion",
+            "session_id": "proc_ok",
+            "command": "true",
+            "exit_code": 0,
+            "output": "",
+        },
+        {
+            "type": "completion",
+            "session_id": "proc_fail",
+            "command": "false",
+            "exit_code": 1,
+            "output": "FAILED",
+        },
+    ])
+
+    emitted = []
+    with patch("tools.process_registry.process_registry", registry):
+        displayed = cli._drain_process_notifications_for_cli(
+            emit=emitted.append,
+            config={"display": {"background_process_notifications": "error"}},
+        )
+
+    assert displayed == 1
+    assert "proc_fail completed" in emitted[0]
+    assert "proc_ok" not in emitted[0]
+
+
+def test_cli_background_notifications_skip_consumed_completion():
+    registry = _FakeProcessRegistry(
+        [
+            {
+                "type": "completion",
+                "session_id": "proc_consumed",
+                "command": "build",
+                "exit_code": 0,
+                "output": "already returned by process.wait",
+            }
+        ],
+        consumed={"proc_consumed"},
+    )
+
+    emitted = []
+    with patch("tools.process_registry.process_registry", registry):
+        displayed = cli._drain_process_notifications_for_cli(emit=emitted.append)
+
+    assert displayed == 0
+    assert emitted == []
+    assert registry.completion_queue.empty()
+
+
+def test_cli_process_notifications_do_not_depend_on_pending_input():
+    """The drain helper emits to a display side channel, not the input queue."""
+    registry = _FakeProcessRegistry([
+        {
+            "type": "completion",
+            "session_id": "proc_done",
+            "command": "make test",
+            "exit_code": 0,
+            "output": "ok",
+        }
+    ])
+    pending_input = queue.Queue()
+    emitted = []
+
+    with patch("tools.process_registry.process_registry", registry):
+        displayed = cli._drain_process_notifications_for_cli(emit=emitted.append)
+
+    assert displayed == 1
+    assert emitted
+    assert pending_input.empty()

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -267,17 +267,14 @@ async def test_inject_watch_notification_routes_from_session_store_origin(monkey
         "session_key": "agent:main:telegram:group:-100:42",
     }
 
-    await runner._inject_watch_notification("[SYSTEM: Background process matched]", evt)
+    await runner._inject_watch_notification("[Background process matched]", evt)
 
-    adapter.handle_message.assert_awaited_once()
-    synth_event = adapter.handle_message.await_args.args[0]
-    assert synth_event.internal is True
-    assert synth_event.source.platform == Platform.TELEGRAM
-    assert synth_event.source.chat_id == "-100"
-    assert synth_event.source.chat_type == "group"
-    assert synth_event.source.thread_id == "42"
-    assert synth_event.source.user_id == "123"
-    assert synth_event.source.user_name == "Emiliyan"
+    adapter.send.assert_awaited_once_with(
+        "-100",
+        "[Background process matched]",
+        metadata={"thread_id": "42"},
+    )
+    adapter.handle_message.assert_not_awaited()
 
 
 def test_build_process_event_source_falls_back_to_session_key_chat_type(monkeypatch, tmp_path):
@@ -358,19 +355,71 @@ async def test_inject_watch_notification_ignores_foreground_event_source(monkeyp
         )
     )
 
-    # The evt dict carries the correct session_key — NOT a foreground event
+    # The evt dict carries the correct session_key, not a foreground event.
     evt = {
         "session_id": "proc_cross_thread",
         "session_key": "agent:main:telegram:group:-100:42",
     }
 
-    await runner._inject_watch_notification("[SYSTEM: watch match]", evt)
+    await runner._inject_watch_notification("[Background process watch match]", evt)
 
-    adapter.handle_message.assert_awaited_once()
-    synth_event = adapter.handle_message.await_args.args[0]
-    # Must route to thread 42 (process origin), NOT some other thread
-    assert synth_event.source.thread_id == "42"
-    assert synth_event.source.user_id == "proc_owner"
+    adapter.send.assert_awaited_once_with(
+        "-100",
+        "[Background process watch match]",
+        metadata={"thread_id": "42"},
+    )
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_notify_on_complete_off_mode_does_not_reenter_message_handler(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    sessions = [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0, command="make test")]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "off")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    watcher = _watcher_dict()
+    watcher["notify_on_complete"] = True
+    await runner._run_process_watcher(watcher)
+
+    adapter.send.assert_not_awaited()
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_notify_on_complete_direct_sends_without_inbound_reentry(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    sessions = [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0, command="make test")]
+    fake_registry = _FakeRegistry(sessions)
+    fake_registry.is_completion_consumed = lambda _sid: False
+    monkeypatch.setattr(pr_module, "process_registry", fake_registry)
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "result")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    watcher = _watcher_dict(thread_id="42")
+    watcher["session_key"] = "agent:main:telegram:group:123:42"
+    watcher["user_id"] = "u1"
+    watcher["user_name"] = "owner"
+    watcher["notify_on_complete"] = True
+    await runner._run_process_watcher(watcher)
+
+    adapter.send.assert_awaited_once()
+    assert "completed" in adapter.send.await_args.args[1]
+    assert adapter.send.await_args.kwargs["metadata"] == {"thread_id": "42"}
+    adapter.handle_message.assert_not_awaited()
 
 
 def test_build_process_event_source_returns_none_for_empty_evt(monkeypatch, tmp_path):

--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -348,3 +348,18 @@ class TestCompletionConsumed:
         result = registry.poll("proc_running")
         assert result["status"] == "running"
         assert not registry.is_completion_consumed("proc_running")
+
+
+class TestBackgroundShellWrapper:
+    def test_wrap_background_shell_command_contains_user_command_in_subshell(self):
+        wrapped = ProcessRegistry._wrap_background_shell_command('set -u; printf ok')
+
+        assert wrapped.startswith('set +m; (\n')
+        assert 'set -u; printf ok' in wrapped
+        assert wrapped.endswith('exit "$_hermes_bg_status"')
+
+    def test_wrap_background_shell_command_preserves_exit_code(self):
+        wrapped = ProcessRegistry._wrap_background_shell_command('exit 7')
+
+        assert '_hermes_bg_status=$?' in wrapped
+        assert 'exit "$_hermes_bg_status"' in wrapped

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -160,8 +160,9 @@ class ProcessRegistry:
 
         # Notification queue — unified queue for all background process events.
         # Completion notifications (notify_on_complete) and watch pattern matches
-        # both land here, distinguished by "type" field.  CLI process_loop and
-        # gateway drain this after each agent turn to auto-trigger new turns.
+        # both land here, distinguished by "type" field.  CLI and gateway drain
+        # this as a notification side channel only; consumers must not feed these
+        # events back into the normal user-input path.
         import queue as _queue_mod
         self.completion_queue: _queue_mod.Queue = _queue_mod.Queue()
 
@@ -467,6 +468,18 @@ class ProcessRegistry:
                 logger.debug("Could not resolve environment temp dir: %s", exc)
         return "/tmp"
 
+    @staticmethod
+    def _wrap_background_shell_command(command: str) -> str:
+        """Wrap a local background command so shell options stay contained.
+
+        Local background commands run via the user's login shell.  If the user
+        command executes ``set -u`` / ``set -o nounset`` directly in that shell,
+        the option can affect shell rc/logout cleanup after the command returns.
+        Running the user command in a subshell preserves the command's exit code
+        while preventing option leakage into the wrapper shell.
+        """
+        return f"set +m; (\n{command}\n); _hermes_bg_status=$?; exit \"$_hermes_bg_status\""
+
     def spawn_local(
         self,
         command: str,
@@ -506,7 +519,7 @@ class ProcessRegistry:
                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
                 pty_env["PYTHONUNBUFFERED"] = "1"
                 pty_proc = _PtyProcessCls.spawn(
-                    [user_shell, "-lic", f"set +m; {command}"],
+                    [user_shell, "-lic", self._wrap_background_shell_command(command)],
                     cwd=session.cwd,
                     env=pty_env,
                     dimensions=(30, 120),
@@ -547,7 +560,7 @@ class ProcessRegistry:
         bg_env = _sanitize_subprocess_env(os.environ, env_vars)
         bg_env["PYTHONUNBUFFERED"] = "1"
         proc = subprocess.Popen(
-            [user_shell, "-lic", f"set +m; {command}"],
+            [user_shell, "-lic", self._wrap_background_shell_command(command)],
             text=True,
             cwd=session.cwd,
             env=bg_env,


### PR DESCRIPTION
## Summary
- keep CLI background process completion notifications on a display-only path instead of feeding them back as pending user input
- deliver gateway background process notifications directly to the original chat target instead of re-entering the message handler as internal user input
- contain shell option side effects from local background commands by running user commands inside a subshell wrapper

## Test Plan
- `python -m py_compile cli.py gateway/run.py tools/process_registry.py hermes_cli/kanban_db.py`
- `git diff --check origin/main...HEAD`
- `python -m pytest -o addopts= -n 4 --ignore=tests/integration --ignore=tests/e2e -m 'not integration' tests/cli/test_cli_background_process_notifications.py tests/gateway/test_background_process_notifications.py tests/tools/test_notify_on_complete.py`

Targeted pytest result: 57 passed.