### PR TITLE
fix(send_message): wire Telegram fallback transport into one-shot sends

### DIFF
--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import logging
+import os
 import socket
 from typing import Iterable, Optional
 
@@ -145,6 +146,62 @@ def parse_fallback_ip_env(value: str | None) -> list[str]:
         return []
     parts = [part.strip() for part in value.split(",")]
     return _normalize_fallback_ips(parts)
+
+
+async def create_bot_with_fallback(token: str):
+    """Build a ``telegram.Bot`` with the same fallback transport semantics as the gateway.
+
+    Mirrors :class:`gateway.platforms.telegram.TelegramAdapter`'s network
+    setup so that one-shot Telegram send paths (``send_message`` tool,
+    cron jobs) survive networks where the system resolver returns a
+    blocked IP for ``api.telegram.org``.
+
+    Honors:
+
+    - ``HERMES_TELEGRAM_DISABLE_FALLBACK_IPS``: when truthy, skips fallback
+      probing entirely and returns a plain ``Bot``.
+    - ``HERMES_TELEGRAM_FALLBACK_IPS``: comma-separated explicit IPs.
+      When unset, IPs are auto-discovered via DNS-over-HTTPS.
+    - ``TELEGRAM_PROXY`` (and standard ``HTTPS_PROXY`` / ``HTTP_PROXY``):
+      a configured proxy takes precedence over the fallback transport.
+
+    See issue #20915.
+    """
+    from telegram import Bot
+    from telegram.request import HTTPXRequest
+
+    disable = os.getenv(
+        "HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", ""
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+    fallback_ips: list[str] = []
+    if not disable:
+        fallback_ips = parse_fallback_ip_env(
+            os.getenv("HERMES_TELEGRAM_FALLBACK_IPS")
+        )
+        if not fallback_ips:
+            try:
+                fallback_ips = await discover_fallback_ips()
+            except Exception:
+                fallback_ips = []
+
+    try:
+        from gateway.platforms.base import resolve_proxy_url
+        proxy_targets = ["api.telegram.org", *fallback_ips]
+        proxy_url = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=proxy_targets)
+    except Exception:
+        proxy_url = None
+
+    if proxy_url:
+        return Bot(token=token, request=HTTPXRequest(proxy=proxy_url))
+    if fallback_ips:
+        return Bot(
+            token=token,
+            request=HTTPXRequest(
+                httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)}
+            ),
+        )
+    return Bot(token=token)
 
 
 def _resolve_system_dns() -> set[str]:

--- a/tests/gateway/test_telegram_network_create_bot.py
+++ b/tests/gateway/test_telegram_network_create_bot.py
@@ -1,0 +1,167 @@
+"""Tests for ``gateway.platforms.telegram_network.create_bot_with_fallback``.
+
+Covers issue #20915: the one-shot ``send_message`` tool path was creating
+a plain ``telegram.Bot`` that bypasses :class:`TelegramFallbackTransport`,
+so it timed out on networks where ``api.telegram.org``'s system-DNS IP is
+blocked.  The new helper mirrors the gateway adapter's network setup.
+
+The test-suite mock for the ``telegram`` module replaces ``Bot`` and
+``HTTPXRequest`` with ``MagicMock``s, so we assert on the recorded call
+args (not on an introspected ``Bot.request`` instance).
+"""
+
+import sys
+
+import pytest
+
+from gateway.platforms import telegram_network as tnet
+
+
+@pytest.fixture
+def isolated_env(monkeypatch):
+    """Clear all env vars the helper consults."""
+    for key in [
+        "HERMES_TELEGRAM_DISABLE_FALLBACK_IPS",
+        "HERMES_TELEGRAM_FALLBACK_IPS",
+        "TELEGRAM_PROXY",
+        "HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+        "https_proxy", "http_proxy", "all_proxy",
+        "NO_PROXY", "no_proxy",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+def telegram_mocks(monkeypatch):
+    """Reset ``Bot`` / ``HTTPXRequest`` mock call records for a clean assertion.
+
+    The session-scoped mock in ``tests/gateway/conftest.py`` keeps
+    ``telegram`` and ``telegram.request`` as ``MagicMock``s; we just
+    reset their call history so each test sees a clean slate.
+    """
+    bot_cls = sys.modules["telegram"].Bot
+    httpx_request_cls = sys.modules["telegram.request"].HTTPXRequest
+    bot_cls.reset_mock()
+    httpx_request_cls.reset_mock()
+    return bot_cls, httpx_request_cls
+
+
+class TestCreateBotWithFallback:
+    """Behaviour matrix for create_bot_with_fallback."""
+
+    @pytest.mark.asyncio
+    async def test_disabled_env_skips_discovery_and_returns_plain_bot(
+        self, isolated_env, telegram_mocks, monkeypatch
+    ):
+        bot_cls, httpx_request_cls = telegram_mocks
+        monkeypatch.setenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "1")
+
+        called = {"discover": False}
+
+        async def _no_discover():
+            called["discover"] = True
+            return []
+
+        monkeypatch.setattr(tnet, "discover_fallback_ips", _no_discover)
+
+        await tnet.create_bot_with_fallback("123:abc")
+
+        assert called["discover"] is False
+        bot_cls.assert_called_once_with(token="123:abc")
+        httpx_request_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_explicit_env_ips_skip_discovery_and_use_fallback_transport(
+        self, isolated_env, telegram_mocks, monkeypatch
+    ):
+        bot_cls, httpx_request_cls = telegram_mocks
+        monkeypatch.setenv(
+            "HERMES_TELEGRAM_FALLBACK_IPS", "149.154.167.220, 149.154.165.120"
+        )
+
+        called = {"discover": False}
+
+        async def _no_discover():
+            called["discover"] = True
+            return []
+
+        monkeypatch.setattr(tnet, "discover_fallback_ips", _no_discover)
+
+        await tnet.create_bot_with_fallback("123:abc")
+
+        assert called["discover"] is False
+        httpx_request_cls.assert_called_once()
+        kwargs = httpx_request_cls.call_args.kwargs
+        transport = kwargs["httpx_kwargs"]["transport"]
+        assert isinstance(transport, tnet.TelegramFallbackTransport)
+        bot_cls.assert_called_once()
+        assert bot_cls.call_args.kwargs["token"] == "123:abc"
+        assert "request" in bot_cls.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_discovery_used_when_no_env_and_returns_ips(
+        self, isolated_env, telegram_mocks, monkeypatch
+    ):
+        bot_cls, httpx_request_cls = telegram_mocks
+
+        async def _fake_discover():
+            return ["149.154.167.220"]
+
+        monkeypatch.setattr(tnet, "discover_fallback_ips", _fake_discover)
+
+        await tnet.create_bot_with_fallback("123:abc")
+
+        httpx_request_cls.assert_called_once()
+        bot_cls.assert_called_once()
+        assert "request" in bot_cls.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_no_proxy_returns_plain_bot(
+        self, isolated_env, telegram_mocks, monkeypatch
+    ):
+        bot_cls, httpx_request_cls = telegram_mocks
+
+        async def _empty_discover():
+            return []
+
+        monkeypatch.setattr(tnet, "discover_fallback_ips", _empty_discover)
+
+        await tnet.create_bot_with_fallback("123:abc")
+
+        bot_cls.assert_called_once_with(token="123:abc")
+        httpx_request_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_discover_failure_falls_back_to_plain_bot(
+        self, isolated_env, telegram_mocks, monkeypatch
+    ):
+        bot_cls, httpx_request_cls = telegram_mocks
+
+        async def _broken_discover():
+            raise RuntimeError("dns over https unavailable")
+
+        monkeypatch.setattr(tnet, "discover_fallback_ips", _broken_discover)
+
+        await tnet.create_bot_with_fallback("123:abc")
+
+        bot_cls.assert_called_once_with(token="123:abc")
+        httpx_request_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_proxy_takes_precedence_over_fallback(
+        self, isolated_env, telegram_mocks, monkeypatch
+    ):
+        bot_cls, httpx_request_cls = telegram_mocks
+        monkeypatch.setenv("TELEGRAM_PROXY", "http://proxy.example:3128")
+        monkeypatch.setenv(
+            "HERMES_TELEGRAM_FALLBACK_IPS", "149.154.167.220"
+        )
+
+        await tnet.create_bot_with_fallback("123:abc")
+
+        httpx_request_cls.assert_called_once()
+        kwargs = httpx_request_cls.call_args.kwargs
+        # Proxy path uses the ``proxy=`` kwarg, not the fallback transport
+        assert "proxy" in kwargs
+        assert kwargs["proxy"]
+        assert "httpx_kwargs" not in kwargs

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -676,7 +676,6 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
     instead, bypassing MarkdownV2 conversion.
     """
     try:
-        from telegram import Bot
         from telegram.constants import ParseMode
 
         # Auto-detect HTML tags — if present, skip MarkdownV2 and send as HTML.
@@ -697,7 +696,14 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 formatted = message
             send_parse_mode = ParseMode.MARKDOWN_V2
 
-        bot = Bot(token=token)
+        # Use fallback-aware Bot so one-shot sends survive networks where
+        # api.telegram.org's system-DNS IP is blocked (issue #20915).
+        try:
+            from gateway.platforms.telegram_network import create_bot_with_fallback
+            bot = await create_bot_with_fallback(token)
+        except Exception:
+            from telegram import Bot
+            bot = Bot(token=token)
         int_chat_id = int(chat_id)
         media_files = media_files or []
         thread_kwargs = {}


### PR DESCRIPTION
Closes #20915.

## What

`tools/send_message_tool.py::_send_telegram` was instantiating a plain `telegram.Bot` with the default `HTTPXRequest`, bypassing the `TelegramFallbackTransport` that the gateway adapter (`gateway/platforms/telegram.py`) configures. On networks where the system DNS resolves `api.telegram.org` to a blocked IP, the gateway adapter still works but the `send_message` tool — and every cron job built on it — silently times out.

## Fix

Factored the gateway's network setup into a new async helper:

```python
# gateway/platforms/telegram_network.py
async def create_bot_with_fallback(token: str) -> Bot
```

`_send_telegram` now calls it instead of constructing `Bot(token=token)` directly.

The helper honors the same env vars as the gateway adapter:

- `HERMES_TELEGRAM_DISABLE_FALLBACK_IPS=1` — skip fallback entirely
- `HERMES_TELEGRAM_FALLBACK_IPS=ip1,ip2` — explicit fallback IPs
- `TELEGRAM_PROXY` (and standard `HTTPS_PROXY` / `HTTP_PROXY`) — proxy precedence

When no env IPs are configured, the helper auto-discovers via `discover_fallback_ips()` (DNS-over-HTTPS through Google + Cloudflare). If discovery fails or returns nothing, the helper degrades to a plain `Bot` — identical to the prior behaviour, so users on healthy networks see no change.

## Why factor a helper instead of duplicating?

The gateway adapter (`TelegramAdapter.start`) has a config-object-driven IP list, two separate request pools (one for polling, one for bot ops), and platform-specific timeout overrides. The send_message tool runs without a config object and only needs one request pool. Putting both behind one helper would either bloat the helper or duplicate the gateway's complexity in `_send_telegram`. The helper covers the **80% case** (single pool, env-driven config) that the one-shot tool path needs; the gateway keeps its bespoke setup.

## Out of scope (intentional)

- The gateway adapter (`gateway/platforms/telegram.py`) is **not migrated** to use the new helper. Its setup needs the config-object pathway and twin request pools; refactoring that is a separate cleanup.
- No changes to `cron/` — cron jobs that send Telegram messages go through `send_message_tool`, so they pick up this fix automatically.

## Tests

```
$ pytest tests/gateway/test_telegram_network_create_bot.py -q
6 passed in 13.82s

$ pytest tests/gateway/test_telegram_network.py \
         tests/gateway/test_telegram_network_reconnect.py \
         tests/gateway/test_telegram_network_create_bot.py -q
67 passed in 21.66s

$ pytest tests/tools/test_send_message_tool.py -q
95 passed in 126.27s

$ ruff check gateway/platforms/telegram_network.py \
             tools/send_message_tool.py \
             tests/gateway/test_telegram_network_create_bot.py
All checks passed!
```

The 6 new tests cover: disabled-via-env, explicit-env-IPs, discovery-success, discovery-empty, discovery-raises, and proxy-takes-precedence-over-fallback.