### PR TITLE
fix(credentials): extend prefer-dotenv policy to remaining resolve paths

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4395,10 +4395,35 @@ def get_env_value(key: str) -> Optional[str]:
     # Check environment first
     if key in os.environ:
         return os.environ[key]
-    
+
     # Then check .env file
     env_vars = load_env()
     return env_vars.get(key)
+
+
+# NOTE: Will be reconciled with the helper from PR #20602 on rebase.
+# That PR introduces the same name+semantics in this module; this PR
+# extends the policy to credential-bearing call sites #20602 leaves
+# untouched (Azure Foundry, Nous subscription probes, tool-side helpers).
+def get_env_value_prefer_dotenv(key: str) -> Optional[str]:
+    """Get a credential value, preferring ``~/.hermes/.env`` over ``os.environ``.
+
+    Mirror of :func:`get_env_value` with the lookup order inverted.  Use
+    this on credential-RESOLVE paths (the values returned are passed to
+    upstream APIs) so that a key freshly rotated in ``~/.hermes/.env``
+    immediately wins over a stale value inherited from a parent shell.
+
+    Do NOT use on display-only paths (``hermes status``, ``hermes
+    doctor``).  Those should keep matching what the shell sees so that
+    diagnostic output reflects the user's actual environment.
+
+    See issue #20591 for the underlying bug class.
+    """
+    env_vars = load_env()
+    val = env_vars.get(key)
+    if val is None or val == "":
+        val = os.environ.get(key)
+    return val
 
 
 # =============================================================================

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -7,7 +7,14 @@ from pathlib import Path
 from typing import Dict, Iterable, Optional, Set
 
 from hermes_cli.auth import get_nous_auth_status
-from hermes_cli.config import get_env_value, load_config
+# Use the prefer-dotenv variant: every get_env_value call in this module
+# is a credential probe gating subscription-feature availability, so a
+# stale shell-exported value would mask a freshly rotated .env key
+# (issue #20591).  Aliased to keep call sites unchanged.
+from hermes_cli.config import (  # noqa: F401
+    get_env_value_prefer_dotenv as get_env_value,
+    load_config,
+)
 from tools.managed_tool_gateway import is_managed_tool_gateway_ready
 from utils import is_truthy_value
 from tools.tool_backend_helpers import (

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -714,8 +714,8 @@ def _resolve_azure_foundry_runtime(
     api_key = explicit_api_key
     if not api_key:
         try:
-            from hermes_cli.config import get_env_value
-            api_key = get_env_value("AZURE_FOUNDRY_API_KEY") or ""
+            from hermes_cli.config import get_env_value_prefer_dotenv
+            api_key = get_env_value_prefer_dotenv("AZURE_FOUNDRY_API_KEY") or ""
         except Exception:
             api_key = ""
     if not api_key:

--- a/tests/hermes_cli/test_nous_subscription_credential_probe.py
+++ b/tests/hermes_cli/test_nous_subscription_credential_probe.py
@@ -1,0 +1,95 @@
+"""Tests for #20591 follow-up: prefer .env on Nous-subscription credential probes.
+
+``hermes_cli.nous_subscription`` aliases ``get_env_value`` to
+``get_env_value_prefer_dotenv``.  Every ``get_env_value`` call in that
+module is a credential probe gating subscription-feature availability —
+a stale shell-exported value masking a freshly rotated ``.env`` key
+would silently steer the user to managed-only behaviour even after they
+rotate the credential.
+
+We test ``_get_gateway_direct_credentials`` because it exercises the full
+set of probed keys (web/image_gen/tts/browser) through the alias.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_hermes_home(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a temp dir and clear known probe env vars."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for key in [
+        "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL",
+        "PARALLEL_API_KEY", "TAVILY_API_KEY", "EXA_API_KEY",
+        "ELEVENLABS_API_KEY", "BROWSER_USE_API_KEY",
+        "BROWSERBASE_API_KEY", "BROWSERBASE_PROJECT_ID",
+        "FAL_KEY", "OPENAI_API_KEY", "VOICE_TOOLS_OPENAI_KEY",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+    return home
+
+
+def _write_env_file(home: Path, **kwargs) -> None:
+    lines = [f"{k}={v}" for k, v in kwargs.items()]
+    (home / ".env").write_text("\n".join(lines) + "\n")
+
+
+class TestGatewayProbeDotEnvPriority:
+    """Probes must report direct credentials present when only .env has them."""
+
+    def test_web_probe_finds_dotenv_only_key(self, isolated_hermes_home):
+        _write_env_file(isolated_hermes_home, EXA_API_KEY="sk-exa-dotenv")
+        from hermes_cli.nous_subscription import _get_gateway_direct_credentials
+
+        creds = _get_gateway_direct_credentials()
+        assert creds["web"] is True
+
+    def test_browser_probe_finds_dotenv_only_keys(self, isolated_hermes_home):
+        _write_env_file(
+            isolated_hermes_home,
+            BROWSERBASE_API_KEY="bb-dotenv",
+            BROWSERBASE_PROJECT_ID="prj-dotenv",
+        )
+        from hermes_cli.nous_subscription import _get_gateway_direct_credentials
+
+        creds = _get_gateway_direct_credentials()
+        assert creds["browser"] is True
+
+    def test_tts_probe_finds_dotenv_only_key(self, isolated_hermes_home):
+        _write_env_file(isolated_hermes_home, ELEVENLABS_API_KEY="el-dotenv")
+        from hermes_cli.nous_subscription import _get_gateway_direct_credentials
+
+        creds = _get_gateway_direct_credentials()
+        assert creds["tts"] is True
+
+    def test_no_credentials_anywhere_yields_all_false(self, isolated_hermes_home):
+        from hermes_cli.nous_subscription import _get_gateway_direct_credentials
+
+        creds = _get_gateway_direct_credentials()
+        assert creds == {
+            "web": False,
+            "image_gen": False,
+            "tts": False,
+            "browser": False,
+        }
+
+
+class TestProbeUsesPreferDotenvAlias:
+    """The module-level ``get_env_value`` alias must be the prefer-dotenv variant.
+
+    Guards against accidental revert of the import-aliasing in the
+    follow-up rebase against PR #20602.  If somebody re-imports the
+    plain ``get_env_value`` here, every probe in the file silently
+    starts ignoring fresh ``.env`` rotations again (bug class #20591).
+    """
+
+    def test_alias_resolves_to_prefer_dotenv_helper(self):
+        from hermes_cli import nous_subscription
+        from hermes_cli.config import get_env_value_prefer_dotenv
+
+        assert nous_subscription.get_env_value is get_env_value_prefer_dotenv

--- a/tests/hermes_cli/test_runtime_provider_dotenv_priority.py
+++ b/tests/hermes_cli/test_runtime_provider_dotenv_priority.py
@@ -1,0 +1,105 @@
+"""Tests for #20591 follow-up: prefer ~/.hermes/.env on credential-resolve paths.
+
+Covers ``hermes_cli.runtime_provider._resolve_azure_foundry_runtime``: the
+runtime resolver must prefer the value in ``~/.hermes/.env`` over a stale
+``AZURE_FOUNDRY_API_KEY`` inherited from the parent shell, because the
+returned key is what's sent upstream to Azure Foundry on every request.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_hermes_home(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a temp dir and clear Azure Foundry env vars."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for key in [
+        "AZURE_FOUNDRY_API_KEY",
+        "AZURE_FOUNDRY_BASE_URL",
+        "AZURE_FOUNDRY_API_MODE",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+    return home
+
+
+def _write_env_file(home: Path, **kwargs) -> None:
+    lines = [f"{k}={v}" for k, v in kwargs.items()]
+    (home / ".env").write_text("\n".join(lines) + "\n")
+
+
+def _resolve_azure_foundry(monkeypatch):
+    """Drive the resolver with a synthetic model_cfg."""
+    from hermes_cli import runtime_provider
+
+    model_cfg = {
+        "provider": "azure-foundry",
+        "base_url": "https://example.azure.com",
+        "api_mode": "chat_completions",
+        "default": "azure-foundry/gpt-4o",
+    }
+    return runtime_provider._resolve_azure_foundry_runtime(
+        requested_provider="azure-foundry",
+        model_cfg=model_cfg,
+        explicit_api_key=None,
+        explicit_base_url=None,
+        target_model="azure-foundry/gpt-4o",
+    )
+
+
+class TestAzureFoundryDotEnvPriority:
+    """The Azure Foundry resolver must prefer .env over os.environ for the key.
+
+    This is the load-bearing behaviour for the fix: a freshly rotated
+    AZURE_FOUNDRY_API_KEY in ~/.hermes/.env must immediately win over a
+    stale value the user exported in their shell rc file.
+    """
+
+    def test_dotenv_value_wins_over_stale_environ(
+        self, isolated_hermes_home, monkeypatch
+    ):
+        _write_env_file(
+            isolated_hermes_home, AZURE_FOUNDRY_API_KEY="sk-fresh-from-dotenv"
+        )
+        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "sk-stale-from-shell")
+
+        result = _resolve_azure_foundry(monkeypatch)
+
+        assert result["api_key"] == "sk-fresh-from-dotenv"
+
+    def test_environ_used_when_dotenv_missing(
+        self, isolated_hermes_home, monkeypatch
+    ):
+        # No .env entry — fall back to os.environ (matches old behaviour).
+        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "sk-environ-only")
+
+        result = _resolve_azure_foundry(monkeypatch)
+
+        assert result["api_key"] == "sk-environ-only"
+
+    def test_dotenv_used_when_environ_missing(
+        self, isolated_hermes_home, monkeypatch
+    ):
+        _write_env_file(
+            isolated_hermes_home, AZURE_FOUNDRY_API_KEY="sk-dotenv-only"
+        )
+
+        result = _resolve_azure_foundry(monkeypatch)
+
+        assert result["api_key"] == "sk-dotenv-only"
+
+    def test_blank_dotenv_value_falls_back_to_environ(
+        self, isolated_hermes_home, monkeypatch
+    ):
+        # A blank .env entry must not mask a real shell value (a setup
+        # interruption can leave KEY= behind).
+        _write_env_file(isolated_hermes_home, AZURE_FOUNDRY_API_KEY="")
+        monkeypatch.setenv("AZURE_FOUNDRY_API_KEY", "sk-shell-fallback")
+
+        result = _resolve_azure_foundry(monkeypatch)
+
+        assert result["api_key"] == "sk-shell-fallback"

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -131,14 +131,12 @@ def fal_key_is_configured() -> bool:
     checks and CLI setup-time checks agree.  A whitespace-only value
     is treated as unset everywhere.
     """
-    value = os.getenv("FAL_KEY")
-    if value is None:
-        # Fall back to the .env file for CLI paths that may run before
-        # dotenv is loaded into os.environ.
-        try:
-            from hermes_cli.config import get_env_value
+    # Prefer ~/.hermes/.env over inherited os.environ so a freshly
+    # rotated key wins immediately (issue #20591).
+    try:
+        from hermes_cli.config import get_env_value_prefer_dotenv
 
-            value = get_env_value("FAL_KEY")
-        except Exception:
-            value = None
+        value = get_env_value_prefer_dotenv("FAL_KEY")
+    except Exception:
+        value = os.getenv("FAL_KEY")
     return bool(value and value.strip())


### PR DESCRIPTION
# fix(credentials): extend prefer-dotenv policy to remaining resolve paths

## What

Extends the prefer-dotenv lookup policy from PR [#20602](https://github.com/NousResearch/hermes-agent/pull/20602) to the credential-bearing call sites that PR leaves untouched:

1. **`hermes_cli/runtime_provider.py::_resolve_azure_foundry_runtime`** — the Azure Foundry API key now reads via `get_env_value_prefer_dotenv("AZURE_FOUNDRY_API_KEY")` so a freshly rotated key in `~/.hermes/.env` immediately wins over a stale shell-exported value.
2. **`hermes_cli/nous_subscription.py`** — the module-level `get_env_value` import is aliased to `get_env_value_prefer_dotenv`. Every call site in that file is a credential probe (EXA, FIRECRAWL, PARALLEL, TAVILY, ELEVENLABS, BROWSER_USE, BROWSERBASE_API_KEY/PROJECT_ID, etc.) that gates subscription-feature availability, so the alias is the right unit of change — the 25 internal call sites stay textually identical.
3. **`tools/tool_backend_helpers.py::fal_key_is_configured`** — switched to `get_env_value_prefer_dotenv("FAL_KEY")` for the same reason.

Display-only paths (`hermes status`, `hermes doctor`, `hermes setup`, `hermes_cli/mcp_config.py`) intentionally keep the old `get_env_value` semantics so diagnostic output continues to reflect what the user's shell sees.

## Why

Issue [#20591](https://github.com/NousResearch/hermes-agent/issues/20591) — the credential pool reads stale `os.environ` values, so a freshly rotated `.env` key gets shadowed by a value the user exported in `.bashrc`. PR #20602 fixed the central `hermes_cli/config.py` helpers; this PR completes the migration on the credential-RESOLVE paths PR #20602 didn't reach.

Without this follow-up, an Azure Foundry user who rotates their key in `~/.hermes/.env` would still hit "401 unauthorized" until they restart their shell, because `_resolve_azure_foundry_runtime` would keep handing the stale shell-exported key to the SDK on every request. Same shape of bug for every Nous-subscription tool probe.

## Depends on

[PR #20602](https://github.com/NousResearch/hermes-agent/pull/20602) (`fix/20591-resolve-prefers-dotenv`). That PR introduces `get_env_value_prefer_dotenv` in `hermes_cli/config.py` with the same name and semantics this PR uses.

This PR vendors a copy of the helper inline (with a `NOTE:` comment marking it for reconciliation) so it is testable on its own. **Rebase plan**: once #20602 merges, drop the duplicate definition in `hermes_cli/config.py`, keep all call-site changes.

## Tests

New, self-contained:
- `tests/hermes_cli/test_runtime_provider_dotenv_priority.py` (4 tests) — Azure Foundry resolver: `.env` wins over stale `os.environ`, env-only fallback, dotenv-only path, blank `.env` value falls back to env.
- `tests/hermes_cli/test_nous_subscription_credential_probe.py` (5 tests) — probes for web / browser / tts find dotenv-only credentials; "no credentials anywhere" yields all-False; module alias is pinned to the prefer-dotenv variant (regression guard against accidental revert during rebase).

```
pytest tests/hermes_cli/test_runtime_provider_dotenv_priority.py \
       tests/hermes_cli/test_nous_subscription_credential_probe.py -q
9 passed
```

Existing regression suite still green:

```
pytest tests/agent/test_credential_pool.py \
       tests/hermes_cli/test_config.py \
       tests/hermes_cli/test_anthropic_oauth_flow.py \
       tests/tools/test_credential_pool_env_fallback.py -q
103 passed, 1 pre-existing failure on main (unrelated; tracked separately)
```

`ruff check` on the changed `tests/hermes_cli/*` files: `All checks passed!`

## Out of scope (intentional)

- `hermes_cli/setup.py`, `hermes_cli/status.py`, `hermes_cli/doctor.py`, `hermes_cli/mcp_config.py` — these are diagnostic / display paths. Migrating them would make `hermes status` lie about what the running shell would see. Left untouched on purpose.
