### PR TITLE
fix(tts): MiniMax TTS defaults — speech-02 + api.minimaxi.com endpoint

### DIFF
--- a/tests/tools/test_tts_tool_minimax_defaults.py
+++ b/tests/tools/test_tts_tool_minimax_defaults.py
@@ -1,0 +1,11 @@
+"""Regression test for issue #20869 - MiniMax TTS defaults update."""
+
+from tools.tts_tool import DEFAULT_MINIMAX_MODEL, DEFAULT_MINIMAX_BASE_URL
+
+
+def test_minimax_model_default():
+    assert DEFAULT_MINIMAX_MODEL == "speech-02"
+
+
+def test_minimax_base_url_default():
+    assert DEFAULT_MINIMAX_BASE_URL == "https://api.minimaxi.com/v1/t2a_v2"

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -136,9 +136,9 @@ DEFAULT_KITTENTTS_VOICE = "Jasper"
 DEFAULT_PIPER_VOICE = "en_US-lessac-medium"  # balanced size/quality
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
-DEFAULT_MINIMAX_MODEL = "speech-01"
+DEFAULT_MINIMAX_MODEL = "speech-02"
 DEFAULT_MINIMAX_VOICE_ID = "female-shaonv"
-DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.chat/v1/text_to_speech"
+DEFAULT_MINIMAX_BASE_URL = "https://api.minimaxi.com/v1/t2a_v2"
 DEFAULT_MISTRAL_TTS_MODEL = "voxtral-mini-tts-2603"
 DEFAULT_MISTRAL_TTS_VOICE_ID = "c69964a6-ab8b-4f8a-9465-ec0925096ec8"  # Paul - Neutral
 DEFAULT_XAI_VOICE_ID = "eve"
@@ -925,11 +925,19 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
 # ===========================================================================
 def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
     """
-    Generate audio using MiniMax TTS API (v1/text_to_speech).
+    Generate audio using the MiniMax TTS API.
 
-    The current API (api.minimax.chat/v1/text_to_speech) uses a simple payload
-    and returns raw audio bytes directly (Content-Type: audio/mpeg), unlike
-    the deprecated v1/t2a_v2 endpoint which returned JSON with hex-encoded audio.
+    The default endpoint is ``api.minimaxi.com/v1/t2a_v2`` (model
+    ``speech-02``). Users may override ``minimax.base_url`` and
+    ``minimax.model`` via ``tts_config`` to target other endpoints.
+
+    Both response shapes are handled:
+
+    - ``audio/*`` content-type → raw audio bytes written directly.
+    - JSON with hex-encoded audio in ``data.audio`` → decoded to bytes.
+
+    The legacy ``api.minimax.chat/v1/text_to_speech`` endpoint is no
+    longer reachable; see issue #20869.
 
     Args:
         text: Text to convert (max 10,000 characters).


### PR DESCRIPTION
# fix(tts): MiniMax TTS defaults — speech-02 + api.minimaxi.com endpoint

Closes #20869.

## What

Updates two outdated MiniMax TTS defaults in `tools/tts_tool.py`:

| Constant | Before | After |
| --- | --- | --- |
| `DEFAULT_MINIMAX_MODEL` | `"speech-01"` | `"speech-02"` |
| `DEFAULT_MINIMAX_BASE_URL` | `"https://api.minimax.chat/v1/text_to_speech"` | `"https://api.minimaxi.com/v1/t2a_v2"` |

Also refreshes the `_generate_minimax_tts` docstring so it reflects the new default endpoint and notes that both response shapes (raw `audio/*` and JSON-with-hex-audio) continue to be handled — the implementation already supports both.

## Why

`tts.provider: minimax` users hit `model_not_supported` against the `speech-01`/`api.minimax.chat` defaults because the legacy endpoint and model name have been retired by MiniMax. Reporters in #20869 had to manually `sed` the constants in their local install on every Hermes update; that workaround reverts on each upgrade.

User config still wins — anyone who already overrides `minimax.model` or `minimax.base_url` keeps their override. Only the *fallback* defaults change.

## Tests

New: `tests/tools/test_tts_tool_minimax_defaults.py`. Two tests pin the new constant values so a future accidental revert (e.g. during a merge) is caught before release.

```bash
python -m pytest -o addopts= tests/tools/test_tts_tool_minimax_defaults.py -q
2 passed
```

## Out of scope

- Migration shim for users who still rely on `api.minimax.chat`. The endpoint is gone server-side, so a shim would not help — the only correct fix is to point at `api.minimaxi.com/v1/t2a_v2`.
- Documentation update for `website/docs/tts.md` — the doc page was not yet migrated to the new endpoint when I checked, but that is a separate change with its own scope.
