### PR TITLE
fix(model-picker): is_current fails for bare 'custom' provider

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1666,10 +1666,20 @@ def list_authenticated_providers(
             _grp_url_norm = _pair_key[1]
             if _grp_url_norm and _grp_url_norm in _builtin_endpoints:
                 continue
+            # Match by slug OR by endpoint URL. Fixes the case where
+            # ``current_provider`` is the bare ``"custom"`` string but the
+            # slug has been resolved to ``"custom:<name>"`` (e.g.
+            # ``"custom:llama-swap"``). The URL-based fallback guarantees the
+            # active endpoint is highlighted as current in the picker even
+            # when the slug comparison misses.
+            _cur_base_norm = (current_base_url or "").strip().rstrip("/").lower()
+            _is_current = slug == current_provider or bool(
+                _cur_base_norm and _grp_url_norm == _cur_base_norm
+            )
             results.append({
                 "slug": slug,
                 "name": grp["name"],
-                "is_current": slug == current_provider,
+                "is_current": _is_current,
                 "is_user_defined": True,
                 "models": grp["models"],
                 "total_models": len(grp["models"]),

--- a/tests/hermes_cli/test_model_switch_bare_custom_current.py
+++ b/tests/hermes_cli/test_model_switch_bare_custom_current.py
@@ -1,0 +1,87 @@
+"""Regression test for issue #20811.
+
+When ``current_provider`` is the bare string ``"custom"`` and the resolved
+slug for a user-defined custom provider is ``"custom:<name>"``, the
+``/model`` picker still has to mark that row as the current one. The
+match falls back to comparing ``current_base_url`` against the group's
+endpoint URL.
+"""
+
+import hermes_cli.providers as providers_mod
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+def test_bare_custom_provider_marked_current_via_base_url(monkeypatch):
+    """``current_provider="custom"`` + matching ``current_base_url`` → is_current."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url="http://127.0.0.1:4141/v1",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "llama-swap",
+                "base_url": "http://127.0.0.1:4141/v1",
+                "model": "rotator-openrouter-coding",
+            }
+        ],
+        max_models=50,
+    )
+
+    custom_rows = [p for p in providers if p["slug"].startswith("custom:")]
+    assert custom_rows, "Expected at least one custom provider row"
+    assert any(
+        p["api_url"] == "http://127.0.0.1:4141/v1" and p["is_current"]
+        for p in custom_rows
+    ), "Custom provider matching current_base_url must have is_current=True"
+
+
+def test_bare_custom_provider_url_match_is_case_insensitive(monkeypatch):
+    """Trailing slash + uppercase host must still match."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url="http://LocalHost:4141/v1/",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "llama-swap",
+                "base_url": "http://localhost:4141/v1",
+                "model": "test-model",
+            }
+        ],
+        max_models=50,
+    )
+
+    assert any(
+        p["slug"].startswith("custom:") and p["is_current"]
+        for p in providers
+    )
+
+
+def test_non_matching_base_url_does_not_set_is_current(monkeypatch):
+    """If neither the slug nor the URL matches, is_current stays False."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url="http://127.0.0.1:9999/v1",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "llama-swap",
+                "base_url": "http://127.0.0.1:4141/v1",
+                "model": "test-model",
+            }
+        ],
+        max_models=50,
+    )
+
+    custom_rows = [p for p in providers if p["slug"].startswith("custom:")]
+    assert custom_rows, "Expected the row to be present"
+    assert all(not p["is_current"] for p in custom_rows)


### PR DESCRIPTION
# fix(model-picker): is_current fails for bare 'custom' provider

Closes #20811.

## Problem

When the active provider in `config.yaml` is the bare string `"custom"` (pointing at a local llama-swap / Ollama / similar endpoint), the `/model` picker — both in the WebUI dashboard and the gateway UIs (Telegram / Discord) — fails to highlight that custom provider as current. Some other provider row (often `copilot`) gets the `● current` marker instead, and the actual custom endpoint sorts below the fold.

## Root cause

`hermes_cli/model_switch.py::list_authenticated_providers` resolves the user's custom provider's slug to `"custom:<name>"` (e.g. `"custom:llama-swap"`), but the `is_current` check on the section-4 row was a string-equality comparison against the bare `current_provider` string:

```python
"is_current": slug == current_provider,
```

`"custom:llama-swap" == "custom"` is `False`, so the row was never marked as current. `current_base_url` is already passed into the function (and used elsewhere in the same file) but was not consulted here.

## Fix

Replace the slug-only equality with a dual check — slug *or* normalized endpoint URL. The slug check stays as the fast path; the URL fallback fires only when the slug doesn't match and there's a current base URL to compare against:

```python
_cur_base_norm = (current_base_url or "").strip().rstrip("/").lower()
_is_current = slug == current_provider or bool(
    _cur_base_norm and _grp_url_norm == _cur_base_norm
)
```

`_grp_url_norm` already comes from `_pair_key[1]`, which is built lower-cased and stripped a few lines above (line 1657 on main), so the comparison is symmetric.

## Tests

New: `tests/hermes_cli/test_model_switch_bare_custom_current.py`. Three tests cover:

1. Bare `"custom"` + matching `current_base_url` → row is `is_current=True`.
2. Trailing-slash + mixed-case URL still matches (case-insensitive, slash-tolerant).
3. Mismatched URL keeps `is_current=False` (no false positives).

```bash
python -m pytest -o addopts= tests/hermes_cli/test_model_switch_bare_custom_current.py -q
3 passed
```

## Notes

- Sort order is preserved — the existing `results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))` at line ~1690 keeps the now-correctly-marked custom row at the top of the picker.
- This is a narrow fix to section 4 only. Other `is_current` checks in sections 1, 2, 2b, 3 (lines 1247, 1360, 1433, 1522) handle different provider shapes and are not affected by this bug class.
