### PR TITLE
fix(doctor): skip /models health-check for Alibaba dedicated tiers

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -27,7 +27,7 @@ from hermes_cli.colors import Colors, color
 from hermes_cli.models import _HERMES_USER_AGENT
 from hermes_cli.vercel_auth import describe_vercel_auth
 from hermes_constants import OPENROUTER_MODELS_URL
-from utils import base_url_host_matches
+from utils import base_url_host_matches, base_url_hostname
 
 
 _PROVIDER_ENV_HINTS = (
@@ -1195,9 +1195,21 @@ def run_doctor(args):
             _label = _pname.ljust(20)
             # Some providers (like MiniMax) don't support /models endpoint
             if not _supports_health_check:
-                print(f"  {color('✓', Colors.GREEN)} {_label} {color('(key configured)', Colors.DIM)}")
+                sys.stdout.write(f"  {color('✓', Colors.GREEN)} {_label} {color('(key configured)', Colors.DIM)}\n")
                 continue
-            print(f"  Checking {_pname} API...", end="", flush=True)
+            # Alibaba dedicated-tier endpoints don't expose /models:
+            #   - token-plan.<region>.maas.aliyuncs.com (Token Plan)
+            #   - coding-intl.dashscope.aliyuncs.com (Coding Plan)
+            # Treat them like MiniMax CN: configured-but-unverified instead of HTTP 404.
+            _skip_url = (os.getenv(_base_env, "") if _base_env else "") or (_default_url or "")
+            if _skip_url and (
+                base_url_host_matches(_skip_url, "maas.aliyuncs.com")
+                or base_url_hostname(_skip_url).startswith(("coding-intl.", "coding."))
+            ):
+                sys.stdout.write(f"  {color('✓', Colors.GREEN)} {_label} {color('(key configured — dedicated plan, /models n/a)', Colors.DIM)}\n")
+                continue
+            sys.stdout.write(f"  Checking {_pname} API...")
+            sys.stdout.flush()
             try:
                 import httpx
                 _base = os.getenv(_base_env, "") if _base_env else ""


### PR DESCRIPTION
## Summary

Alibaba's dedicated-tier endpoints don't expose `/models`, so the doctor's API-key health-check loop returns HTTP 404 for valid keys:

- `token-plan.<region>.maas.aliyuncs.com` (Token Plan)
- `coding-intl.dashscope.aliyuncs.com` (Coding Plan)

Same pattern as MiniMax CN — skip the check and show `(key configured — dedicated plan, /models n/a)` instead of a false ⚠.

## Changes

`hermes_cli/doctor.py`: hostname-based skip applied to either the user's `DASHSCOPE_BASE_URL` / `ALIBABA_CODING_PLAN_BASE_URL` override or the profile's default URL, before the `httpx.get(_url + "/models")` call. Regular DashScope keys hitting `dashscope-intl.aliyuncs.com` are unaffected.

## Relation to #20642

The Gemini `Bearer → x-goog-api-key` fix that originally accompanied this PR has been **dropped** — #20642 lands the same fix with unit tests, so this PR is now Alibaba-only to avoid duplication. Recommend merging #20642 first.

## Verification

`hermes doctor` against `DASHSCOPE_BASE_URL=https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1` (Token Plan key `sk-sp-…`):

| Method | Result |
|---|---|
| `GET <token-plan>/models` (current behavior) | HTTP 404 → ⚠ |
| Skip + report key configured (this PR) | ✓ |

Empirical probe also confirms `coding-intl.dashscope.aliyuncs.com/v1/models` returns 404, matching the same skip path.

## Test plan

- [ ] `hermes doctor` with `DASHSCOPE_BASE_URL=https://token-plan.<region>.maas.aliyuncs.com/...` → expect `✓ Alibaba/DashScope (key configured — dedicated plan, /models n/a)`
- [ ] `hermes doctor` with `ALIBABA_CODING_PLAN_API_KEY` (default URL `coding-intl.dashscope.aliyuncs.com/v1`) → expect `✓ Alibaba Cloud (Coding Plan) (...)`
- [ ] Regular DashScope key against `dashscope-intl.aliyuncs.com` → existing behavior preserved (200/401 based on key validity)