### PR TITLE
Add Slack extension hooks for plugins

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -10,6 +10,7 @@ Uses slack-bolt (Python) with Socket Mode for:
 
 import asyncio
 import contextvars
+import inspect
 import json
 import logging
 import os
@@ -623,9 +624,21 @@ class SlackAdapter(BasePlatformAdapter):
             # manifest's request URL, but it will not deliver an event for
             # a slash command the manifest doesn't declare.
             from hermes_cli.commands import slack_native_slashes
+            from hermes_cli.plugins import (
+                get_slack_extension_action_handlers,
+                get_slack_extension_slash_commands,
+                get_slack_extension_view_handlers,
+            )
             import re as _re
 
-            _slash_names = [name for name, _d, _h in slack_native_slashes()]
+            _slack_extension_slashes = get_slack_extension_slash_commands()
+            _slack_extension_slash_names = {
+                command.name for command in _slack_extension_slashes
+            }
+            _slash_names = [
+                name for name, _d, _h in slack_native_slashes()
+                if name not in _slack_extension_slash_names
+            ]
             if _slash_names:
                 _slash_pattern = _re.compile(
                     r"^/(?:" + "|".join(_re.escape(n) for n in _slash_names) + r")$"
@@ -642,7 +655,38 @@ class SlackAdapter(BasePlatformAdapter):
                 )
                 await self._handle_slash_command(command)
 
+            for _extension_command in _slack_extension_slashes:
+                async def handle_slack_extension_command(
+                    ack,
+                    command,
+                    _extension_command=_extension_command,
+                ):
+                    if _extension_command.ack_text is not None:
+                        await ack(
+                            response_type="ephemeral",
+                            text=_extension_command.ack_text,
+                        )
+                    await self._invoke_slack_extension_handler(
+                        _extension_command.handler,
+                        adapter=self,
+                        ack=ack,
+                        command=command,
+                    )
+
+                self._app.command(f"/{_extension_command.name}")(
+                    handle_slack_extension_command
+                )
+
             # Register Block Kit action handlers for approval buttons
+            _reserved_action_ids = {
+                "hermes_approve_once",
+                "hermes_approve_session",
+                "hermes_approve_always",
+                "hermes_deny",
+                "hermes_confirm_once",
+                "hermes_confirm_always",
+                "hermes_confirm_cancel",
+            }
             for _action_id in (
                 "hermes_approve_once",
                 "hermes_approve_session",
@@ -659,6 +703,57 @@ class SlackAdapter(BasePlatformAdapter):
                 "hermes_confirm_cancel",
             ):
                 self._app.action(_action_id)(self._handle_slash_confirm_action)
+
+            for _extension_action in get_slack_extension_action_handlers():
+                _extension_action_key = getattr(
+                    _extension_action.action_id,
+                    "pattern",
+                    _extension_action.action_id,
+                )
+                if _extension_action_key in _reserved_action_ids:
+                    logger.warning(
+                        "[Slack] Skipping plugin action handler '%s' because it "
+                        "conflicts with a built-in Slack action.",
+                        _extension_action_key,
+                    )
+                    continue
+
+                async def handle_slack_extension_action(
+                    ack,
+                    body,
+                    action,
+                    _extension_action=_extension_action,
+                ):
+                    await self._invoke_slack_extension_handler(
+                        _extension_action.handler,
+                        adapter=self,
+                        ack=ack,
+                        body=body,
+                        action=action,
+                    )
+
+                self._app.action(_extension_action.action_id)(
+                    handle_slack_extension_action
+                )
+
+            for _extension_view in get_slack_extension_view_handlers():
+                async def handle_slack_extension_view(
+                    ack,
+                    body,
+                    view,
+                    _extension_view=_extension_view,
+                ):
+                    await self._invoke_slack_extension_handler(
+                        _extension_view.handler,
+                        adapter=self,
+                        ack=ack,
+                        body=body,
+                        view=view,
+                    )
+
+                self._app.view(_extension_view.callback_id)(
+                    handle_slack_extension_view
+                )
 
             # Start Socket Mode handler in background
             self._handler = AsyncSocketModeHandler(self._app, app_token, proxy=proxy_url)
@@ -678,6 +773,29 @@ class SlackAdapter(BasePlatformAdapter):
         finally:
             if lock_acquired and not self._running:
                 self._release_platform_lock()
+
+    async def _invoke_slack_extension_handler(self, handler, **kwargs):
+        """Invoke a plugin-provided Slack handler with compatible kwargs."""
+        call_kwargs = kwargs
+        try:
+            sig = inspect.signature(handler)
+            accepts_kwargs = any(
+                param.kind == inspect.Parameter.VAR_KEYWORD
+                for param in sig.parameters.values()
+            )
+            if not accepts_kwargs:
+                call_kwargs = {
+                    key: value
+                    for key, value in kwargs.items()
+                    if key in sig.parameters
+                }
+        except (TypeError, ValueError):
+            pass
+
+        result = handler(**call_kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
 
     async def disconnect(self) -> None:
         """Disconnect from Slack."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -991,7 +991,18 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
             continue
         _add(cmd.name, cmd.description, cmd.args_hint or "")
 
-    # Second pass: aliases.
+    # Second pass: Slack-native extension commands. These need their own
+    # manifest entries and have priority over aliases because Slack's manifest
+    # is capped at 50 slash commands.
+    try:
+        from hermes_cli.plugins import get_slack_extension_slash_commands
+
+        for command in get_slack_extension_slash_commands():
+            _add(command.name, command.description or f"Run /{command.name}", command.usage_hint or "")
+    except Exception:
+        pass
+
+    # Third pass: aliases.
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue
@@ -1000,7 +1011,7 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
             # normalization (already covered by _add dedup).
             _add(alias, f"Alias for /{cmd.name} — {cmd.description}", cmd.args_hint or "")
 
-    # Third pass: plugin commands.
+    # Fourth pass: cross-platform plugin commands.
     for name, description, args_hint in _iter_plugin_command_entries():
         _add(name, description, args_hint or "")
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -40,12 +40,13 @@ import importlib.util
 import inspect
 import logging
 import os
+import re
 import sys
 import threading
 import types
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Pattern, Sequence, Set, Union
 
 from hermes_constants import get_hermes_home
 from utils import env_var_enabled
@@ -222,8 +223,56 @@ class LoadedPlugin:
     tools_registered: List[str] = field(default_factory=list)
     hooks_registered: List[str] = field(default_factory=list)
     commands_registered: List[str] = field(default_factory=list)
+    slack_extensions_registered: int = 0
     enabled: bool = False
     error: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class SlackSlashCommand:
+    """Native Slack slash command contributed by a plugin.
+
+    This is for Slack-native UI flows that need direct Socket Mode handling,
+    immediate ACKs, and access to Slack Block Kit APIs. Text-only plugin
+    commands should continue to use :meth:`PluginContext.register_command`.
+    """
+
+    name: str
+    handler: Callable
+    description: str = ""
+    usage_hint: str = ""
+    ack_text: str | None = "Working..."
+
+
+@dataclass(frozen=True)
+class SlackActionHandler:
+    """Slack Block Kit action handler contributed by a plugin."""
+
+    action_id: str | Pattern[str]
+    handler: Callable
+
+
+@dataclass(frozen=True)
+class SlackViewHandler:
+    """Slack modal view submission handler contributed by a plugin."""
+
+    callback_id: str
+    handler: Callable
+
+
+_SLACK_COMMAND_NAME_RE = re.compile(r"[^a-z0-9_-]")
+_SLACK_COMMAND_NAME_LIMIT = 32
+
+
+def _normalize_slack_command_name(raw: str) -> str:
+    """Return a Slack-compatible command name without the leading slash."""
+    name = (raw or "").lower().strip().lstrip("/").replace(" ", "-")
+    name = _SLACK_COMMAND_NAME_RE.sub("", name)
+    return name.strip("-_")[:_SLACK_COMMAND_NAME_LIMIT]
+
+
+def _slack_handler_key(value: str | Pattern[str]) -> str:
+    return getattr(value, "pattern", value)
 
 
 # ---------------------------------------------------------------------------
@@ -376,6 +425,118 @@ class PluginContext:
             "args_hint": (args_hint or "").strip(),
         }
         logger.debug("Plugin %s registered command: /%s", self.manifest.name, clean)
+
+    # -- Slack native UI extension registration ------------------------------
+
+    def register_slack_extension(
+        self,
+        *,
+        slash_commands: Sequence[SlackSlashCommand] = (),
+        actions: Sequence[SlackActionHandler] = (),
+        views: Sequence[SlackViewHandler] = (),
+    ) -> None:
+        """Register Slack-native UI handlers for this plugin.
+
+        Use this only for Slack Block Kit flows that need direct Bolt
+        registrations (native command ACKs, ``app.action`` handlers, or modal
+        ``app.view`` handlers). Plain text slash commands should use
+        :meth:`register_command` so they work across all gateway platforms.
+        """
+        registered = 0
+
+        for command in slash_commands:
+            name = _normalize_slack_command_name(command.name)
+            if not name:
+                logger.warning(
+                    "Plugin '%s' tried to register an empty Slack slash command.",
+                    self.manifest.name,
+                )
+                continue
+            try:
+                from hermes_cli.commands import resolve_command
+                if resolve_command(name) is not None:
+                    logger.warning(
+                        "Plugin '%s' tried to register Slack command '/%s' "
+                        "which conflicts with a built-in command. Skipping.",
+                        self.manifest.name,
+                        name,
+                    )
+                    continue
+            except Exception:
+                pass
+            if name in self._manager._slack_slash_commands:
+                existing = self._manager._slack_slash_commands[name]
+                logger.warning(
+                    "Plugin '%s' tried to register duplicate Slack command '/%s' "
+                    "(already registered by '%s'). Skipping.",
+                    self.manifest.name,
+                    name,
+                    existing["plugin"],
+                )
+                continue
+            self._manager._slack_slash_commands[name] = {
+                "plugin": self.manifest.name,
+                "command": SlackSlashCommand(
+                    name=name,
+                    handler=command.handler,
+                    description=command.description,
+                    usage_hint=command.usage_hint,
+                    ack_text=command.ack_text,
+                ),
+            }
+            registered += 1
+
+        for action in actions:
+            key = _slack_handler_key(action.action_id)
+            if not key:
+                logger.warning(
+                    "Plugin '%s' tried to register an empty Slack action handler.",
+                    self.manifest.name,
+                )
+                continue
+            if key in self._manager._slack_action_keys:
+                logger.warning(
+                    "Plugin '%s' tried to register duplicate Slack action '%s'. Skipping.",
+                    self.manifest.name,
+                    key,
+                )
+                continue
+            self._manager._slack_action_keys.add(key)
+            self._manager._slack_action_handlers.append(
+                {"plugin": self.manifest.name, "handler": action}
+            )
+            registered += 1
+
+        for view in views:
+            callback_id = (view.callback_id or "").strip()
+            if not callback_id:
+                logger.warning(
+                    "Plugin '%s' tried to register an empty Slack view handler.",
+                    self.manifest.name,
+                )
+                continue
+            if callback_id in self._manager._slack_view_handlers:
+                existing = self._manager._slack_view_handlers[callback_id]
+                logger.warning(
+                    "Plugin '%s' tried to register duplicate Slack view '%s' "
+                    "(already registered by '%s'). Skipping.",
+                    self.manifest.name,
+                    callback_id,
+                    existing["plugin"],
+                )
+                continue
+            self._manager._slack_view_handlers[callback_id] = {
+                "plugin": self.manifest.name,
+                "handler": view,
+            }
+            registered += 1
+
+        if registered:
+            logger.debug(
+                "Plugin %s registered %d Slack extension handler(s)",
+                self.manifest.name,
+                registered,
+            )
 
     # -- tool dispatch -------------------------------------------------------
 
@@ -605,6 +766,10 @@ class PluginManager:
         self._cli_commands: Dict[str, dict] = {}
         self._context_engine = None  # Set by a plugin via register_context_engine()
         self._plugin_commands: Dict[str, dict] = {}  # Slash commands registered by plugins
+        self._slack_slash_commands: Dict[str, dict] = {}
+        self._slack_action_handlers: List[dict] = []
+        self._slack_action_keys: Set[str] = set()
+        self._slack_view_handlers: Dict[str, dict] = {}
         self._discovered: bool = False
         self._cli_ref = None  # Set by CLI after plugin discovery
         # Plugin skill registry: qualified name → metadata dict.
@@ -629,6 +794,10 @@ class PluginManager:
             self._plugin_tool_names.clear()
             self._cli_commands.clear()
             self._plugin_commands.clear()
+            self._slack_slash_commands.clear()
+            self._slack_action_handlers.clear()
+            self._slack_action_keys.clear()
+            self._slack_view_handlers.clear()
             self._plugin_skills.clear()
             self._context_engine = None
         self._discovered = True
@@ -1014,6 +1183,20 @@ class PluginManager:
                     c for c in self._plugin_commands
                     if self._plugin_commands[c].get("plugin") == manifest.name
                 ]
+                loaded.slack_extensions_registered = (
+                    sum(
+                        1 for entry in self._slack_slash_commands.values()
+                        if entry.get("plugin") == manifest.name
+                    )
+                    + sum(
+                        1 for entry in self._slack_action_handlers
+                        if entry.get("plugin") == manifest.name
+                    )
+                    + sum(
+                        1 for entry in self._slack_view_handlers.values()
+                        if entry.get("plugin") == manifest.name
+                    )
+                )
                 loaded.enabled = True
 
         except Exception as exc:
@@ -1138,6 +1321,7 @@ class PluginManager:
                     "tools": len(loaded.tools_registered),
                     "hooks": len(loaded.hooks_registered),
                     "commands": len(loaded.commands_registered),
+                    "slack_extensions": loaded.slack_extensions_registered,
                     "error": loaded.error,
                 }
             )
@@ -1315,6 +1499,30 @@ def get_plugin_commands() -> Dict[str, dict]:
     before any explicit discover_plugins() call.
     """
     return _ensure_plugins_discovered()._plugin_commands
+
+
+def get_slack_extension_slash_commands() -> List[SlackSlashCommand]:
+    """Return plugin-provided native Slack slash commands."""
+    manager = _ensure_plugins_discovered()
+    return [
+        entry["command"]
+        for _name, entry in sorted(manager._slack_slash_commands.items())
+    ]
+
+
+def get_slack_extension_action_handlers() -> List[SlackActionHandler]:
+    """Return plugin-provided Slack Block Kit action handlers."""
+    manager = _ensure_plugins_discovered()
+    return [entry["handler"] for entry in manager._slack_action_handlers]
+
+
+def get_slack_extension_view_handlers() -> List[SlackViewHandler]:
+    """Return plugin-provided Slack modal view handlers."""
+    manager = _ensure_plugins_discovered()
+    return [
+        entry["handler"]
+        for _callback_id, entry in sorted(manager._slack_view_handlers.items())
+    ]
 
 
 def get_plugin_toolsets() -> List[tuple]:

--- a/tests/hermes_cli/test_slack_extension_hooks.py
+++ b/tests/hermes_cli/test_slack_extension_hooks.py
@@ -1,0 +1,137 @@
+"""Tests for plugin-provided Slack native UI extension hooks."""
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.slack import SlackAdapter
+from hermes_cli.commands import slack_native_slashes
+from hermes_cli.plugins import (
+    PluginContext,
+    PluginManager,
+    PluginManifest,
+    SlackActionHandler,
+    SlackSlashCommand,
+    SlackViewHandler,
+    get_slack_extension_action_handlers,
+    get_slack_extension_slash_commands,
+    get_slack_extension_view_handlers,
+)
+
+
+def _install_manager(monkeypatch, mgr: PluginManager) -> None:
+    mgr._discovered = True
+    monkeypatch.setattr("hermes_cli.plugins._plugin_manager", mgr)
+
+
+def test_register_slack_extension_stores_handlers(monkeypatch):
+    mgr = PluginManager()
+    _install_manager(monkeypatch, mgr)
+    ctx = PluginContext(PluginManifest(name="slack-ui"), mgr)
+
+    def slash_handler(**_kwargs):
+        return None
+
+    def action_handler(**_kwargs):
+        return None
+
+    def view_handler(**_kwargs):
+        return None
+
+    ctx.register_slack_extension(
+        slash_commands=[
+            SlackSlashCommand(
+                name="/Board UI",
+                description="Open the board",
+                usage_hint="[filters]",
+                handler=slash_handler,
+                ack_text="Opening board...",
+            )
+        ],
+        actions=[SlackActionHandler("board_action", action_handler)],
+        views=[SlackViewHandler("board_view", view_handler)],
+    )
+
+    slashes = get_slack_extension_slash_commands()
+    actions = get_slack_extension_action_handlers()
+    views = get_slack_extension_view_handlers()
+
+    assert [command.name for command in slashes] == ["board-ui"]
+    assert slashes[0].description == "Open the board"
+    assert slashes[0].usage_hint == "[filters]"
+    assert slashes[0].ack_text == "Opening board..."
+    assert actions == [SlackActionHandler("board_action", action_handler)]
+    assert views == [SlackViewHandler("board_view", view_handler)]
+
+
+def test_register_slack_extension_rejects_builtin_command_collision(monkeypatch):
+    mgr = PluginManager()
+    _install_manager(monkeypatch, mgr)
+    ctx = PluginContext(PluginManifest(name="bad-slack-ui"), mgr)
+
+    ctx.register_slack_extension(
+        slash_commands=[SlackSlashCommand(name="model", handler=lambda **_: None)]
+    )
+
+    assert get_slack_extension_slash_commands() == []
+
+
+def test_register_slack_extension_rejects_duplicate_handlers(monkeypatch):
+    mgr = PluginManager()
+    _install_manager(monkeypatch, mgr)
+    first = PluginContext(PluginManifest(name="first"), mgr)
+    second = PluginContext(PluginManifest(name="second"), mgr)
+
+    first.register_slack_extension(
+        slash_commands=[SlackSlashCommand(name="board", handler=lambda **_: None)],
+        actions=[SlackActionHandler("board_action", lambda **_: None)],
+        views=[SlackViewHandler("board_view", lambda **_: None)],
+    )
+    second.register_slack_extension(
+        slash_commands=[SlackSlashCommand(name="board", handler=lambda **_: None)],
+        actions=[SlackActionHandler("board_action", lambda **_: None)],
+        views=[SlackViewHandler("board_view", lambda **_: None)],
+    )
+
+    assert len(get_slack_extension_slash_commands()) == 1
+    assert len(get_slack_extension_action_handlers()) == 1
+    assert len(get_slack_extension_view_handlers()) == 1
+
+
+def test_slack_native_slashes_includes_extension_commands(monkeypatch):
+    mgr = PluginManager()
+    _install_manager(monkeypatch, mgr)
+    ctx = PluginContext(PluginManifest(name="slack-ui"), mgr)
+    ctx.register_slack_extension(
+        slash_commands=[
+            SlackSlashCommand(
+                name="board",
+                description="Open the Kanban board",
+                handler=lambda **_: None,
+            )
+        ],
+    )
+
+    slashes = {name: (description, hint) for name, description, hint in slack_native_slashes()}
+
+    assert "board" in slashes
+    assert slashes["board"][0] == "Open the Kanban board"
+
+
+@pytest.mark.asyncio
+async def test_slack_adapter_invokes_extension_handler_with_compatible_kwargs():
+    adapter = SlackAdapter(PlatformConfig(token="xoxb-test"))
+    seen = {}
+
+    async def handler(adapter, command):
+        seen["adapter"] = adapter
+        seen["command"] = command
+
+    await adapter._invoke_slack_extension_handler(
+        handler,
+        adapter=adapter,
+        command={"command": "/board"},
+        ack=lambda **_: None,
+        ignored=True,
+    )
+
+    assert seen == {"adapter": adapter, "command": {"command": "/board"}}

--- a/tests/hermes_cli/test_slack_extension_hooks.py
+++ b/tests/hermes_cli/test_slack_extension_hooks.py
@@ -104,8 +104,8 @@ def test_slack_native_slashes_includes_extension_commands(monkeypatch):
     ctx.register_slack_extension(
         slash_commands=[
             SlackSlashCommand(
-                name="board",
-                description="Open the Kanban board",
+                name="workflow",
+                description="Open an interactive workflow",
                 handler=lambda **_: None,
             )
         ],
@@ -113,8 +113,8 @@ def test_slack_native_slashes_includes_extension_commands(monkeypatch):
 
     slashes = {name: (description, hint) for name, description, hint in slack_native_slashes()}
 
-    assert "board" in slashes
-    assert slashes["board"][0] == "Open the Kanban board"
+    assert "workflow" in slashes
+    assert slashes["workflow"][0] == "Open an interactive workflow"
 
 
 @pytest.mark.asyncio
@@ -129,9 +129,9 @@ async def test_slack_adapter_invokes_extension_handler_with_compatible_kwargs():
     await adapter._invoke_slack_extension_handler(
         handler,
         adapter=adapter,
-        command={"command": "/board"},
+        command={"command": "/workflow"},
         ack=lambda **_: None,
         ignored=True,
     )
 
-    assert seen == {"adapter": adapter, "command": {"command": "/board"}}
+    assert seen == {"adapter": adapter, "command": {"command": "/workflow"}}

--- a/website/docs/guides/build-a-hermes-plugin.md
+++ b/website/docs/guides/build-a-hermes-plugin.md
@@ -265,6 +265,7 @@ def register(ctx):
 - `ctx.register_hook()` subscribes to lifecycle events
 - `ctx.register_cli_command()` registers a CLI subcommand (e.g. `hermes my-plugin <subcommand>`)
 - `ctx.register_command()` registers an in-session slash command (e.g. `/myplugin <args>` inside CLI / gateway chat) — see [Register slash commands](#register-slash-commands) below
+- `ctx.register_slack_extension()` registers Slack-native Block Kit slash/action/view handlers for Slack-only interactive UI — see [Register Slack-native UI hooks](#register-slack-native-ui-hooks) below
 - `ctx.dispatch_tool(name, arguments)` — call any other tool (built-in or from another plugin) with the parent agent's context (approvals, credentials, task_id) wired up automatically. Useful from slash-command handlers that need to invoke `terminal`, `read_file`, or any other tool as if the model had called it directly.
 - If this function crashes, the plugin is disabled but Hermes continues fine
 
@@ -649,6 +650,65 @@ async def _handle_check(raw_args: str) -> str:
 def register(ctx):
     ctx.register_command("check", handler=_handle_check, description="Run async check")
 ```
+
+### Register Slack-native UI hooks
+
+Use `ctx.register_slack_extension()` when a plugin needs Slack-only Block Kit interactivity instead of a cross-platform text command. This is the right surface for workflows that need:
+
+- immediate native slash-command ACKs;
+- `chat.postMessage` or `chat.update` with custom blocks;
+- Block Kit button/select actions;
+- modal `view_submission` handlers.
+
+Text-only commands should still use `ctx.register_command()` so they work in CLI and every gateway. Slack extensions are intentionally Slack-specific.
+
+```python
+from hermes_cli.plugins import (
+    SlackActionHandler,
+    SlackSlashCommand,
+    SlackViewHandler,
+)
+
+
+async def open_board(adapter, command):
+    channel_id = command["channel_id"]
+    await adapter._get_client(channel_id).chat_postMessage(
+        channel=channel_id,
+        text="Board opened.",
+    )
+
+
+async def handle_board_action(ack, body, action, adapter):
+    await ack()
+    # Update a task, open a modal, or repaint a message.
+
+
+async def handle_board_view(ack, body, view, adapter):
+    await ack()
+    # Read modal state and persist changes.
+
+
+def register(ctx):
+    ctx.register_slack_extension(
+        slash_commands=[
+            SlackSlashCommand(
+                name="board",
+                description="Open the Kanban board",
+                usage_hint="[filters]",
+                ack_text="Opening board...",
+                handler=open_board,
+            ),
+        ],
+        actions=[
+            SlackActionHandler("my_plugin_board_action", handle_board_action),
+        ],
+        views=[
+            SlackViewHandler("my_plugin_board_view", handle_board_view),
+        ],
+    )
+```
+
+Slack extension slash commands are included in `hermes slack manifest --write`. After adding or removing one, regenerate the manifest and reinstall the Slack app so Slack delivers the command over Socket Mode.
 
 ### Dispatch tools from slash commands
 

--- a/website/docs/guides/build-a-hermes-plugin.md
+++ b/website/docs/guides/build-a-hermes-plugin.md
@@ -670,20 +670,20 @@ from hermes_cli.plugins import (
 )
 
 
-async def open_board(adapter, command):
+async def open_workflow(adapter, command):
     channel_id = command["channel_id"]
     await adapter._get_client(channel_id).chat_postMessage(
         channel=channel_id,
-        text="Board opened.",
+        text="Interactive workflow opened.",
     )
 
 
-async def handle_board_action(ack, body, action, adapter):
+async def handle_workflow_action(ack, body, action, adapter):
     await ack()
     # Update a task, open a modal, or repaint a message.
 
 
-async def handle_board_view(ack, body, view, adapter):
+async def handle_workflow_view(ack, body, view, adapter):
     await ack()
     # Read modal state and persist changes.
 
@@ -692,18 +692,18 @@ def register(ctx):
     ctx.register_slack_extension(
         slash_commands=[
             SlackSlashCommand(
-                name="board",
-                description="Open the Kanban board",
+                name="workflow",
+                description="Open an interactive Slack workflow",
                 usage_hint="[filters]",
-                ack_text="Opening board...",
-                handler=open_board,
+                ack_text="Opening workflow...",
+                handler=open_workflow,
             ),
         ],
         actions=[
-            SlackActionHandler("my_plugin_board_action", handle_board_action),
+            SlackActionHandler("my_plugin_workflow_action", handle_workflow_action),
         ],
         views=[
-            SlackViewHandler("my_plugin_board_view", handle_board_view),
+            SlackViewHandler("my_plugin_workflow_view", handle_workflow_view),
         ],
     )
 ```

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -100,6 +100,7 @@ Every `ctx.*` API below is available inside a plugin's `register(ctx)` function.
 | Add tools | `ctx.register_tool(name=..., toolset=..., schema=..., handler=...)` |
 | Add hooks | `ctx.register_hook("post_tool_call", callback)` |
 | Add slash commands | `ctx.register_command(name, handler, description)` — adds `/name` in CLI and gateway sessions |
+| Add Slack-native UI hooks | `ctx.register_slack_extension(...)` — registers Slack slash commands, Block Kit actions, and modal submissions for Slack-only interactive flows |
 | Dispatch tools from commands | `ctx.dispatch_tool(name, args)` — invokes a registered tool with parent-agent context auto-wired |
 | Add CLI commands | `ctx.register_cli_command(name, help, setup_fn, handler_fn)` — adds `hermes <plugin> <subcommand>` |
 | Inject messages | `ctx.inject_message(content, role="user")` — see [Injecting Messages](#injecting-messages) |
@@ -222,6 +223,7 @@ The table above shows the four plugin categories, but within "General plugins" t
 | A **tool** the LLM can call | Python plugin — `ctx.register_tool()` | [Build a Hermes Plugin](/docs/guides/build-a-hermes-plugin) · [Adding Tools](/docs/developer-guide/adding-tools) |
 | A **lifecycle hook** (pre/post LLM, session start/end, tool filter) | Python plugin — `ctx.register_hook()` | [Hooks reference](/docs/user-guide/features/hooks) · [Build a Hermes Plugin](/docs/guides/build-a-hermes-plugin) |
 | A **slash command** for the CLI / gateway | Python plugin — `ctx.register_command()` | [Build a Hermes Plugin](/docs/guides/build-a-hermes-plugin) · [Extending the CLI](/docs/developer-guide/extending-the-cli) |
+| A **Slack Block Kit UI** | Python plugin — `ctx.register_slack_extension()` | [Build a Hermes Plugin](/docs/guides/build-a-hermes-plugin#register-slack-native-ui-hooks) |
 | A **subcommand** for `hermes <thing>` | Python plugin — `ctx.register_cli_command()` | [Extending the CLI](/docs/developer-guide/extending-the-cli) |
 | A bundled **skill** that your plugin ships | Python plugin — `ctx.register_skill()` | [Creating Skills](/docs/developer-guide/creating-skills) |
 | An **inference backend** (LLM provider: OpenAI-compat, Codex, Anthropic-Messages, Bedrock) | Provider plugin — `register_provider(ProviderProfile(...))` in `plugins/model-providers/<name>/` | **[Model Provider Plugins](/docs/developer-guide/model-provider-plugin)** · [Adding Providers](/docs/developer-guide/adding-providers) |


### PR DESCRIPTION
## Summary

Adds a small Slack Block Kit extension surface for Hermes plugins. Plugins can now register:

- native Slack slash commands that ACK immediately and are handled outside the generic text-command path;
- Slack Block Kit action handlers for buttons, selects, and other interactive elements;
- Slack modal view submission handlers.

The goal is to make Slack-native interactive plugin UIs possible without requiring each plugin to patch `gateway/platforms/slack.py`.

## Why

`PluginContext.register_command()` is the right API for cross-platform text commands, but it cannot cover Slack Block Kit workflows. Interactive Slack UIs need adapter-level Bolt registrations: immediate slash command ACKs, `app.action(...)`, `app.view(...)`, and controlled access to the Slack adapter/client context.

Examples of plugin workflows that need this surface:

- an approval console with Approve / Request changes buttons;
- a task or incident dashboard with filters and detail modals;
- a triage flow that opens Slack modals and updates the original message;
- any plugin that needs Slack buttons/selects rather than plain text replies.

Today those workflows must be hardcoded in the Slack adapter. This PR gives plugin authors a supported extension point while keeping built-in Slack handlers authoritative.

## What changed

- Adds `SlackSlashCommand`, `SlackActionHandler`, and `SlackViewHandler` data classes.
- Adds `PluginContext.register_slack_extension(...)`.
- Stores plugin-provided Slack commands/actions/views in `PluginManager`.
- Includes Slack extension slash commands in `slack_native_slashes()` so `hermes slack manifest --write` can emit them.
- Wires extension commands/actions/views into `SlackAdapter.connect()`.
- Keeps extension slash commands out of the generic slash-command regex so they are handled only by their native handler.
- Adds tests for registration, collision behavior, manifest inclusion, and handler invocation.
- Documents when to use `register_slack_extension()` versus `register_command()`.

## Notes

- Built-in command names still win. A plugin cannot register `/model`, `/help`, etc.
- Duplicate Slack extension command/action/view registrations are skipped with warnings.
- Built-in Slack action IDs remain reserved.
- Text-only plugin commands should continue to use `ctx.register_command()` so they work across CLI and every gateway.
- This PR intentionally does not add a new product feature. It only adds the extension hook needed for Slack Block Kit plugin UIs.

## Tests

```bash
python3 -m py_compile hermes_cli/plugins.py hermes_cli/commands.py gateway/platforms/slack.py tests/hermes_cli/test_slack_extension_hooks.py
uv run --with pytest --with pytest-asyncio --with pytest-xdist pytest tests/hermes_cli/test_slack_extension_hooks.py tests/hermes_cli/test_commands.py::TestSlackNativeSlashes tests/hermes_cli/test_commands.py::TestSlackAppManifest
```

Result: 18 passed.

`uv` emits an existing settings warning while parsing `exclude-newer = "7 days"` in `pyproject.toml`; tests still run and pass.
