### PR TITLE
fix: dashboard shows API key warning for local providers with 'no-key-required'

### DIFF
--- a/tests/tui_gateway/test_probe_credentials_no_key_required.py
+++ b/tests/tui_gateway/test_probe_credentials_no_key_required.py
@@ -1,0 +1,30 @@
+"""Regression test for issue #20815.
+
+Local providers (llama.cpp / llama-swap / Ollama) carry the placeholder
+api_key value ``"no-key-required"``. The dashboard credential probe must
+treat that as a valid credential, not a missing one.
+"""
+
+from types import SimpleNamespace
+
+from tui_gateway.server import _probe_credentials
+
+
+def test_probe_credentials_returns_empty_for_no_key_required():
+    """Local provider with placeholder key produces no warning."""
+    agent = SimpleNamespace(api_key="no-key-required", provider="custom")
+    assert _probe_credentials(agent) == ""
+
+
+def test_probe_credentials_warns_on_empty_key():
+    """Genuinely missing credential still produces a warning."""
+    agent = SimpleNamespace(api_key="", provider="openai")
+    warning = _probe_credentials(agent)
+    assert "openai" in warning
+    assert "No API key" in warning
+
+
+def test_probe_credentials_returns_empty_for_real_key():
+    """A real credential produces no warning."""
+    agent = SimpleNamespace(api_key="sk-real-key", provider="openai")
+    assert _probe_credentials(agent) == ""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1317,11 +1317,16 @@ def _get_usage(agent) -> dict:
 
 
 def _probe_credentials(agent) -> str:
-    """Light credential check at session creation — returns warning or ''."""
+    """Light credential check at session creation — returns warning or ''.
+
+    ``"no-key-required"`` is the placeholder Hermes assigns to keyless local
+    providers (llama.cpp / llama-swap / Ollama). It must NOT be treated as a
+    missing credential — only an actually empty key triggers the warning.
+    """
     try:
         key = getattr(agent, "api_key", "") or ""
         provider = getattr(agent, "provider", "") or ""
-        if not key or key == "no-key-required":
+        if not key:
             return f"No API key configured for provider '{provider}'. First message will fail."
     except Exception:
         pass


### PR DESCRIPTION
# fix: dashboard shows API key warning for local providers with 'no-key-required'

Closes #20815.

## Problem

The dashboard prints `No API key configured for provider 'custom'. First message will fail.` even when the active provider is a local server (llama.cpp / llama-swap / Ollama) that does not require an API key. Hermes assigns the placeholder string `"no-key-required"` to keyless local providers; that placeholder must NOT be flagged as a missing credential.

## Root cause

`tui_gateway/server.py::_probe_credentials` short-circuited on either an empty key OR the literal `"no-key-required"`:

```python
if not key or key == "no-key-required":
    return f"No API key configured for provider '{provider}'. First message will fail."
```

The second branch is the bug — it explicitly treats the keyless placeholder as a missing credential, which is the opposite of intent.

## Fix

Drop the `or key == "no-key-required"` branch. Only an actually empty key triggers the warning:

```python
if not key:
    return f"No API key configured for provider '{provider}'. First message will fail."
```

Also expanded the docstring to record why `"no-key-required"` exists, so a future maintainer doesn't re-introduce the same check.

## Tests

New: `tests/tui_gateway/test_probe_credentials_no_key_required.py` — three tests using a `SimpleNamespace` fake agent:

1. `api_key="no-key-required"` → empty warning (this is the regression).
2. `api_key=""` → warning includes the provider name (preserved behavior).
3. `api_key="sk-real"` → empty warning (preserved behavior).

```bash
python -m pytest -o addopts= tests/tui_gateway/test_probe_credentials_no_key_required.py -q
3 passed
```

## Out of scope

- Audit other call sites that test for `"no-key-required"`. The string is a Hermes-internal convention; I checked that the `_probe_credentials` site is the only one that incorrectly treats it as "missing". Other handlers either ignore the value or branch on it intentionally.
- Renaming the placeholder to a sentinel object. That would be a wider refactor and is unrelated to this user-visible bug.
