### PR TITLE
fix(kanban): treat dashboard event-stream cancellation as normal shutdown

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1521,6 +1521,13 @@ async def stream_events(ws: WebSocket):
             await asyncio.sleep(_EVENT_POLL_SECONDS)
     except WebSocketDisconnect:
         return
+    except asyncio.CancelledError:
+        # Normal shutdown path: dashboard process exit (Ctrl-C) cancels the
+        # websocket task while it is sleeping in the poll loop.
+        # CancelledError is a BaseException in 3.8+ so the bare Exception
+        # handler below would not catch it; without this clause Uvicorn
+        # surfaces the cancellation as an application traceback. Quiet it.
+        return
     except Exception as exc:  # defensive: never crash the dashboard worker
         log.warning("Kanban event stream error: %s", exc)
         try:


### PR DESCRIPTION
# fix(kanban): treat dashboard event-stream cancellation as normal shutdown

Closes #20790.

## Problem

Stopping `hermes dashboard` with Ctrl-C while the Kanban dashboard is open prints an ASGI traceback ending in the event-stream poll loop:

```
plugins/kanban/dashboard/plugin_api.py, in stream_events
    await asyncio.sleep(_EVENT_POLL_SECONDS)
asyncio.exceptions.CancelledError
```

This is a normal shutdown path: when the dashboard process exits, Uvicorn cancels the open websocket task while it is sleeping in the 300 ms poll loop. `asyncio.CancelledError` is a `BaseException` in Python 3.8+ — the bare `except Exception:` handler immediately below the existing `WebSocketDisconnect:` clause does NOT catch it, so the cancellation surfaces as an application traceback and operator output looks like a runtime failure.

## Fix

Add an explicit `except asyncio.CancelledError: return` clause beside the existing `except WebSocketDisconnect: return`. The cancellation is treated the same as a client disconnect — quiet return, no warning.

```diff
            await asyncio.sleep(_EVENT_POLL_SECONDS)
    except WebSocketDisconnect:
        return
+    except asyncio.CancelledError:
+        # Normal shutdown path …
+        return
    except Exception as exc:  # defensive: never crash the dashboard worker
        log.warning("Kanban event stream error: %s", exc)
```

`asyncio` is already imported at the top of the file (line 38) and used a few lines above (`asyncio.to_thread`, `asyncio.sleep`), so no new import is needed.

## Why this clause and not `except (WebSocketDisconnect, asyncio.CancelledError):`

Splitting them keeps the intent explicit — disconnection (client closed the tab) and shutdown cancellation (dashboard process exiting) are conceptually different even though both warrant a quiet return. A future maintainer looking at this code will see the two paths called out separately.

## Out of scope

- Lifespan cancellation tracebacks elsewhere in the dashboard. The reporter mentions those as a possible separate symptom; they live outside this `stream_events` handler and would be a different change.
- Any behavior change for genuine errors. The bare `except Exception:` handler is preserved verbatim, so unexpected runtime failures still log a warning and try to close the socket cleanly.
