### PR TITLE
fix(kanban): guard task_age against corrupt created_at values

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3672,16 +3672,26 @@ def board_stats(conn: sqlite3.Connection) -> dict:
     }
 
 
+def _safe_int(val: Optional[str]) -> Optional[int]:
+    """Parse a timestamp field to int, returning None on garbage like '%s'."""
+    if val is None:
+        return None
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        return None
+
+
 def task_age(task: Task) -> dict:
     """Return age metrics for a single task. All values are seconds or None."""
     now = int(time.time())
-    age_since_created = now - int(task.created_at) if task.created_at else None
-    age_since_started = (
-        now - int(task.started_at) if task.started_at else None
-    )
+    created = _safe_int(task.created_at)
+    started = _safe_int(task.started_at)
+    completed = _safe_int(task.completed_at)
+    age_since_created = now - created if created else None
+    age_since_started = now - started if started else None
     time_to_complete = (
-        int(task.completed_at) - int(task.started_at or task.created_at)
-        if task.completed_at else None
+        completed - (started or created) if completed else None
     )
     return {
         "created_age_seconds": age_since_created,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -135,7 +135,10 @@ def _task_dict(
     d = asdict(task)
     # Add derived age metrics so the UI can colour stale cards without
     # computing deltas client-side.
-    d["age"] = kanban_db.task_age(task)
+    try:
+        d["age"] = kanban_db.task_age(task)
+    except Exception:
+        d["age"] = {"created_age_seconds": None, "started_age_seconds": None, "time_to_complete_seconds": None}
     # Surface the latest non-null run summary so dashboards don't show
     # blank cards/drawers for tasks where the worker handed off via
     # ``task_runs.summary`` (the kanban-worker pattern) instead of


### PR DESCRIPTION
## Problem

A task with `created_at = '%s'` (literal format string instead of Unix timestamp) causes `task_age()` to crash with `ValueError: invalid literal for int() with base 10: '%s'`, which takes down the entire `GET /board` endpoint with a 500 Internal Server Error.

## Fix

Two layers of defense:

1. **`hermes_cli/kanban_db.py`** — Added `_safe_int()` helper that returns `None` on non-numeric values like `'%s'`, and refactored `task_age()` to use it instead of bare `int()` casts.

2. **`plugins/kanban/dashboard/plugin_api.py`** — Wrapped the `task_age()` call in `_task_dict()` with a try/except fallback, so a single corrupt row can never crash the entire board endpoint.

## Changes

- `hermes_cli/kanban_db.py`: +14/-6
- `plugins/kanban/dashboard/plugin_api.py`: +6/-1