### PR TITLE
fix(gateway): scope restart interruption notices to active chats

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2399,11 +2399,17 @@ class GatewayRunner:
                 logger.debug("Failed interrupting agent during shutdown: %s", e)
 
     async def _notify_active_sessions_of_shutdown(self) -> None:
-        """Send shutdown/restart notifications to active chats and home channels.
+        """Send shutdown/restart interruption notifications to active chats.
 
         Called at the very start of stop() — adapters are still connected so
         messages can be delivered. Best-effort: individual send failures are
         logged and swallowed so they never block the shutdown sequence.
+
+        This warning is scoped to chats with active agent work. Do not broadcast
+        it to platform home channels: a home-channel ping makes an interruption
+        in one platform look like a random lifecycle notification in another.
+        The separate /restart completion path still notifies the requester and
+        configured home channels once the gateway is back online.
         """
         active = self._snapshot_running_agents()
 
@@ -2489,52 +2495,6 @@ class GatewayRunner:
                 logger.debug(
                     "Failed to send shutdown notification to %s:%s: %s",
                     platform_str, chat_id, e,
-                )
-
-        for platform, adapter in self.adapters.items():
-            home = self.config.get_home_channel(platform)
-            if not home or not home.chat_id:
-                continue
-
-            platform_cfg = self.config.platforms.get(platform)
-            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
-                logger.info(
-                    "Shutdown notification suppressed for home channel: %s has gateway_restart_notification=false",
-                    platform.value,
-                )
-                continue
-
-            dedup_key = (platform.value, str(home.chat_id), str(home.thread_id) if home.thread_id else None)
-            if dedup_key in notified:
-                continue
-
-            try:
-                metadata = {"thread_id": home.thread_id} if home.thread_id else None
-                if metadata:
-                    result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
-                else:
-                    result = await adapter.send(str(home.chat_id), msg)
-                if result is not None and getattr(result, "success", True) is False:
-                    logger.debug(
-                        "Failed to send shutdown notification to home channel %s:%s: %s",
-                        platform.value,
-                        home.chat_id,
-                        getattr(result, "error", "send returned success=False"),
-                    )
-                    continue
-
-                notified.add(dedup_key)
-                logger.info(
-                    "Sent shutdown notification to home channel %s:%s",
-                    platform.value,
-                    home.chat_id,
-                )
-            except Exception as e:
-                logger.debug(
-                    "Failed to send shutdown notification to home channel %s:%s: %s",
-                    platform.value,
-                    home.chat_id,
-                    e,
                 )
 
     def _finalize_shutdown_agents(self, active_agents: Dict[str, Any]) -> None:

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -9,8 +9,8 @@ from gateway.session import SessionSource
 
 
 class RestartTestAdapter(BasePlatformAdapter):
-    def __init__(self):
-        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+    def __init__(self, platform: Platform = Platform.TELEGRAM):
+        super().__init__(PlatformConfig(enabled=True, token="***"), platform)
         self.sent: list[str] = []
         self.sent_calls: list[tuple[str, str, object]] = []
 

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -42,6 +42,7 @@ from gateway.run import (
 )
 from gateway.session import SessionEntry, SessionSource, SessionStore
 from tests.gateway.restart_test_helpers import (
+    RestartTestAdapter,
     make_restart_runner,
     make_restart_source,
 )
@@ -933,7 +934,7 @@ async def test_restart_banner_uses_try_to_resume_wording():
 
 
 @pytest.mark.asyncio
-async def test_restart_notifies_home_channel_even_without_active_sessions():
+async def test_restart_does_not_notify_home_channel_without_active_sessions():
     runner, adapter = make_restart_runner()
     runner._restart_requested = True
     runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
@@ -944,10 +945,35 @@ async def test_restart_notifies_home_channel_even_without_active_sessions():
 
     await runner._notify_active_sessions_of_shutdown()
 
-    assert adapter.sent == [
-        "⚠️ Gateway restarting — Your current task will be interrupted. "
-        "Send any message after restart and I'll try to resume where you left off."
-    ]
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_restart_does_not_broadcast_active_session_notice_to_other_home_channels():
+    slack_adapter = RestartTestAdapter(Platform.SLACK)
+    discord_adapter = RestartTestAdapter(Platform.DISCORD)
+    runner, _ = make_restart_runner(adapter=slack_adapter)
+    runner._restart_requested = True
+    runner.config.platforms = {
+        Platform.SLACK: PlatformConfig(enabled=True, token="***"),
+        Platform.DISCORD: PlatformConfig(enabled=True, token="***"),
+    }
+    runner.adapters = {
+        Platform.SLACK: slack_adapter,
+        Platform.DISCORD: discord_adapter,
+    }
+    runner._running_agents["agent:main:slack:dm:C0AVC5PAKRP"] = MagicMock()
+    runner.config.platforms[Platform.DISCORD].home_channel = HomeChannel(
+        platform=Platform.DISCORD,
+        chat_id="1488410119489454130",
+        name="Discord Home",
+    )
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert len(slack_adapter.sent) == 1
+    assert "Gateway restarting" in slack_adapter.sent[0]
+    assert discord_adapter.sent == []
 
 
 @pytest.mark.asyncio
@@ -967,7 +993,7 @@ async def test_restart_home_channel_notification_dedupes_active_chat():
 
 
 @pytest.mark.asyncio
-async def test_restart_home_channel_notification_not_deduped_across_threads():
+async def test_restart_active_session_notification_preserves_thread_metadata():
     runner, adapter = make_restart_runner()
     runner._restart_requested = True
     session_key = "agent:main:telegram:group:999"
@@ -989,13 +1015,12 @@ async def test_restart_home_channel_notification_not_deduped_across_threads():
 
     await runner._notify_active_sessions_of_shutdown()
 
-    assert len(adapter.sent) == 2
+    assert len(adapter.sent) == 1
     assert adapter.sent_calls[0][2] == {"thread_id": "topic-7"}
-    assert adapter.sent_calls[1][2] is None
 
 
 @pytest.mark.asyncio
-async def test_restart_home_channel_notification_ignores_false_send_result():
+async def test_restart_home_channel_send_not_attempted_when_no_active_sessions():
     runner, adapter = make_restart_runner()
     runner._restart_requested = True
     runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
@@ -1007,7 +1032,7 @@ async def test_restart_home_channel_notification_ignores_false_send_result():
 
     await runner._notify_active_sessions_of_shutdown()
 
-    adapter.send.assert_called_once()
+    adapter.send.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Stop broadcasting shutdown/restart interruption banners to configured home channels
- Keep interruption notices scoped to chats with active agent work
- Add regression coverage for active Slack work not notifying a Discord home channel

## Test Plan
- `python -m pytest tests/gateway/test_restart_resume_pending.py::test_restart_does_not_notify_home_channel_without_active_sessions tests/gateway/test_restart_resume_pending.py::test_restart_does_not_broadcast_active_session_notice_to_other_home_channels -q -o 'addopts='`
- `python -m pytest tests/gateway/test_restart_resume_pending.py tests/gateway/test_restart_notification.py -q -o 'addopts='`
- `python -m ruff check gateway/run.py tests/gateway/restart_test_helpers.py tests/gateway/test_restart_resume_pending.py`

Note: `python -m pytest tests/gateway/test_restart_resume_pending.py tests/gateway/test_restart_notification.py tests/gateway/test_config.py -q -o 'addopts='` has one pre-existing unrelated failure on main: `TestLoadGatewayConfig.test_bridges_quoted_false_platform_enabled_from_config_yaml`.
