### PR TITLE
feat(webui): add HERA-198 control-plane canary cockpit

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import secrets
+import shutil
 import subprocess
 import sys
 import threading
@@ -505,6 +506,310 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
         except Exception:
             continue
     return False, None
+
+
+_CONTROL_PLANE_CLI_LOCK = threading.Lock()
+
+_CONTROL_PLANE_DISABLED_REASONS = {
+    "supabase_cli_missing": "Supabase CLI not found on server PATH",
+    "control_plane_query_failed": "Control-plane read query failed",
+    "control_plane_invalid_json": "Control-plane query returned invalid JSON",
+    "control_plane_unexpected_shape": "Control-plane query returned an unexpected shape",
+}
+
+
+def _redact_control_plane_error(text: str) -> str:
+    """Return a generic client-safe CLI error without credential details."""
+    if not text:
+        return _CONTROL_PLANE_DISABLED_REASONS["control_plane_query_failed"]
+    return "Control-plane read query failed; check server logs or Supabase CLI link state."
+
+
+def _control_plane_workdir() -> Path:
+    configured = os.environ.get("HERMES_CONTROL_PLANE_WORKDIR")
+    if configured:
+        return Path(configured).expanduser()
+    return get_hermes_home() / "webui-workspace"
+
+
+def _run_supabase_control_plane_read(sql: str) -> Tuple[Optional[List[Dict[str, Any]]], Optional[Dict[str, Any]]]:
+    """Run a read-only Supabase CLI query against the linked control-plane project.
+
+    The browser never receives Supabase credentials. The server shells out to
+    the already-authenticated CLI and returns a disabled state instead of
+    raising if the CLI/link/workdir is unavailable.
+    """
+    supabase = shutil.which("supabase")
+    if not supabase:
+        return None, {
+            "enabled": False,
+            "reason": "supabase_cli_missing",
+            "message": _CONTROL_PLANE_DISABLED_REASONS["supabase_cli_missing"],
+        }
+
+    cmd = [supabase, "db", "query", "--linked", "-o", "json", sql]
+    try:
+        with _CONTROL_PLANE_CLI_LOCK:
+            proc = subprocess.run(
+                cmd,
+                cwd=str(_control_plane_workdir()),
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+    except Exception:  # pragma: no cover - defensive around local CLI failures
+        return None, {
+            "enabled": False,
+            "reason": "control_plane_query_failed",
+            "message": _redact_control_plane_error(""),
+        }
+
+    if proc.returncode != 0:
+        return None, {
+            "enabled": False,
+            "reason": "control_plane_query_failed",
+            "message": _redact_control_plane_error(proc.stderr or proc.stdout),
+        }
+
+    stdout = (proc.stdout or "").strip()
+    if stdout.startswith("Initialising login role..."):
+        stdout = stdout.split("\n", 1)[1].strip() if "\n" in stdout else ""
+    try:
+        parsed = json.loads(stdout or "[]")
+    except json.JSONDecodeError:
+        return None, {
+            "enabled": False,
+            "reason": "control_plane_invalid_json",
+            "message": _CONTROL_PLANE_DISABLED_REASONS["control_plane_invalid_json"],
+        }
+    if not isinstance(parsed, list):
+        return None, {
+            "enabled": False,
+            "reason": "control_plane_unexpected_shape",
+            "message": _CONTROL_PLANE_DISABLED_REASONS["control_plane_unexpected_shape"],
+        }
+    return parsed, None
+
+
+def _control_plane_payload_query() -> str:
+    return """
+with latest as (
+  select
+    id::text,
+    report_type,
+    run_ref,
+    status,
+    report_date::text,
+    title,
+    summary_kr,
+    obsidian_ref,
+    paperclip_parent_ref,
+    created_at::text,
+    updated_at::text
+  from hermes_reports.report_runs
+  where report_type = 'morning_brief'
+  order by created_at desc
+  limit 1
+), latest_id as (
+  select id::uuid as id from latest
+), counts as (
+  select jsonb_build_object(
+    'report_runs', (select count(*) from hermes_reports.report_runs),
+    'report_sections', (select count(*) from hermes_reports.report_sections),
+    'source_anchors', (select count(*) from hermes_sources.source_anchors),
+    'delivery_events', (select count(*) from hermes_notify.delivery_events),
+    'audit_events', (select count(*) from hermes_audit.audit_events)
+  ) as payload
+)
+select jsonb_build_object(
+  'enabled', true,
+  'status', 'ok',
+  'mode', 'read_only',
+  'project', 'hermes-control-plane',
+  'updated_at', now()::text,
+  'run', (select to_jsonb(latest) from latest),
+  'sections', coalesce((
+    select jsonb_agg(to_jsonb(s) order by s.section_order)
+    from (
+      select section_key, section_order, title, body_md, judgment_label, created_at::text
+      from hermes_reports.report_sections
+      where report_run_id in (select id from latest_id)
+      order by section_order
+    ) s
+  ), '[]'::jsonb),
+  'sources', coalesce((
+    select jsonb_agg(to_jsonb(src) order by src.created_at)
+    from (
+      select source_ref, source_title, publisher, published_at::text, observed_at::text,
+             timing_label, quality_label, claim_ref, created_at::text
+      from hermes_sources.source_anchors
+      where report_run_id in (select id from latest_id)
+      order by created_at
+    ) src
+  ), '[]'::jsonb),
+  'delivery_events', coalesce((
+    select jsonb_agg(to_jsonb(d) order by d.created_at)
+    from (
+      select
+             channel,
+             case
+               when channel = 'dry_run'
+                    and delivery_status = 'dry_run'
+                    and target_ref like 'telegram://dry-run/%'
+                 then target_ref
+               else '[redacted]'
+             end as target_ref,
+             case
+               when channel = 'dry_run' and delivery_status = 'dry_run'
+                 then payload_summary
+               else null
+             end as payload_summary,
+             delivery_status,
+             delivered_at::text,
+             null::text as error_summary,
+             created_at::text
+      from hermes_notify.delivery_events
+      where report_run_id in (select id from latest_id)
+        and channel = 'dry_run'
+        and delivery_status = 'dry_run'
+      order by created_at
+    ) d
+  ), '[]'::jsonb),
+  'audit_events', coalesce((
+    select jsonb_agg(to_jsonb(a) order by a.created_at)
+    from (
+      select event_type, subject_ref, actor_ref, source_refs, artifact_refs,
+             summary, verification_status, created_at::text
+      from hermes_audit.audit_events
+      where event_type = 'canary_insert'
+      order by created_at desc
+      limit 5
+    ) a
+  ), '[]'::jsonb),
+  'counts', (select payload from counts),
+  'boundaries', jsonb_build_object(
+    'writes_enabled', false,
+    'telegram_send_enabled', false,
+    'obsidian_authority_edit_enabled', false,
+    'cron_change_enabled', false
+  )
+) as payload;
+"""
+
+
+def _get_control_plane_morning_brief_payload() -> Dict[str, Any]:
+    rows, disabled = _run_supabase_control_plane_read(_control_plane_payload_query())
+    if disabled is not None:
+        return disabled
+    if not rows:
+        return {
+            "enabled": False,
+            "reason": "control_plane_empty_response",
+            "message": "Control-plane read query returned no rows",
+        }
+    payload = rows[0].get("payload") if isinstance(rows[0], dict) else None
+    if not isinstance(payload, dict):
+        return {
+            "enabled": False,
+            "reason": "control_plane_unexpected_shape",
+            "message": _CONTROL_PLANE_DISABLED_REASONS["control_plane_unexpected_shape"],
+        }
+    return payload
+
+
+def _first_dry_run_target_ref(delivery_events: Any) -> str:
+    if not isinstance(delivery_events, list):
+        return "telegram://dry-run/hera-198"
+    for event in delivery_events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("channel") == "dry_run" and event.get("delivery_status") == "dry_run":
+            target_ref = event.get("target_ref")
+            if (
+                isinstance(target_ref, str)
+                and target_ref.strip().startswith("telegram://dry-run/")
+            ):
+                return target_ref.strip()
+    return "telegram://dry-run/hera-198"
+
+
+def _build_morning_brief_telegram_preview(canary: Dict[str, Any]) -> Dict[str, Any]:
+    run = canary.get("run") if isinstance(canary.get("run"), dict) else {}
+    counts = canary.get("counts") if isinstance(canary.get("counts"), dict) else {}
+    boundaries = canary.get("boundaries") if isinstance(canary.get("boundaries"), dict) else {}
+    delivery_events = canary.get("delivery_events")
+
+    title = str(run.get("title") or "Morning Brief Canary")
+    status = str(run.get("status") or canary.get("status") or "unknown")
+    project = str(canary.get("project") or "hermes-control-plane")
+    target_ref = _first_dry_run_target_ref(delivery_events)
+    report_sections = counts.get("report_sections", len(canary.get("sections") or []))
+    source_anchors = counts.get("source_anchors", len(canary.get("sources") or []))
+    delivery_status = "dry_run"
+    if isinstance(delivery_events, list) and delivery_events:
+        first = delivery_events[0] if isinstance(delivery_events[0], dict) else {}
+        delivery_status = str(first.get("delivery_status") or "dry_run")
+
+    message_text = "\n".join([
+        f"[HERA-198] {title} 준비됨",
+        "",
+        f"상태: {status}",
+        f"대상: {project} read-only canary",
+        f"섹션: {report_sections}",
+        f"소스: {source_anchors}",
+        f"전달상태: {delivery_status}",
+        "",
+        "처리 이유: Supabase control-plane → WebUI cockpit readback 통과 후 Telegram 알림 계약을 실제 발송 전 dry-run으로 검증.",
+    ])
+
+    max_length = 600
+    return {
+        "enabled": True,
+        "status": "ok",
+        "mode": "dry_run_preview",
+        "project": project,
+        "target_ref": target_ref,
+        "channel": "telegram",
+        "send_enabled": False,
+        "write_enabled": False,
+        "message_text": message_text,
+        "message_length": len(message_text),
+        "validation": {
+            "length_ok": len(message_text) <= max_length,
+            "max_length": max_length,
+            "requires_approval_before_send": True,
+            "no_telegram_send_performed": True,
+            "no_supabase_write_performed": True,
+            "no_cron_change_performed": True,
+            "no_obsidian_authority_edit_performed": True,
+        },
+        "source": {
+            "run_ref": run.get("run_ref"),
+            "report_status": status,
+            "control_plane_mode": canary.get("mode"),
+        },
+        "boundaries": {
+            "writes_enabled": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "cron_change_enabled": False,
+            **boundaries,
+        },
+    }
+
+
+@app.get("/api/control-plane/morning-brief-canary")
+def get_control_plane_morning_brief_canary():
+    return _get_control_plane_morning_brief_payload()
+
+
+@app.get("/api/control-plane/morning-brief-canary/telegram-preview")
+def get_control_plane_morning_brief_telegram_preview():
+    canary = _get_control_plane_morning_brief_payload()
+    if not canary.get("enabled"):
+        return canary
+    return _build_morning_brief_telegram_preview(canary)
 
 
 @app.get("/api/status")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -191,6 +191,303 @@ class TestWebServerEndpoints:
         assert resp.json()["gateway_state"] == "startup_failed"
         assert resp.json()["gateway_platforms"] == {}
 
+
+    def test_control_plane_canary_requires_session_token(self):
+        import hermes_cli.web_server as web_server
+
+        resp = self.client.get(
+            "/api/control-plane/morning-brief-canary",
+            headers={web_server._SESSION_HEADER_NAME: "invalid-token"},
+        )
+
+        assert resp.status_code == 401
+
+    def test_control_plane_canary_disabled_when_supabase_missing(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: None)
+        resp = self.client.get("/api/control-plane/morning-brief-canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["reason"] == "supabase_cli_missing"
+
+
+    def test_control_plane_error_message_does_not_leak_cli_secrets(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        class Completed:
+            returncode = 1
+            stdout = ""
+            stderr = "failed postgresql://user:secret@db.example.com:5432/postgres service_role eyJabc"
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(
+            web_server.subprocess,
+            "run",
+            lambda *args, **kwargs: Completed(),
+        )
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["reason"] == "control_plane_query_failed"
+        message = data["message"].lower()
+        assert "secret" not in message
+        assert "postgresql://" not in message
+        assert "service_role" not in message
+        assert "eyj" not in message
+
+    def test_control_plane_exception_message_does_not_leak_cli_command(self, monkeypatch, tmp_path):
+        import subprocess
+        import hermes_cli.web_server as web_server
+
+        def fake_run(*args, **kwargs):
+            raise subprocess.TimeoutExpired(
+                cmd=[
+                    "/usr/bin/supabase",
+                    "db",
+                    "query",
+                    "--linked",
+                    "select * from hermes_notify.delivery_events where target_ref = 'telegram:999000111'",
+                ],
+                timeout=30,
+            )
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["reason"] == "control_plane_query_failed"
+        message = data["message"].lower()
+        assert "supabase" not in message
+        assert "hermes_notify" not in message
+        assert "999000111" not in message
+        assert "delivery_events" not in message
+
+    def test_control_plane_cli_query_uses_serialization_lock(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        class Completed:
+            returncode = 0
+            stderr = ""
+            stdout = json.dumps([{"payload": {"enabled": True, "mode": "read_only"}}])
+
+        class FakeLock:
+            entered = False
+            exited = False
+
+            def __enter__(self):
+                self.entered = True
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.exited = True
+                return False
+
+        fake_lock = FakeLock()
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(web_server, "_CONTROL_PLANE_CLI_LOCK", fake_lock)
+        monkeypatch.setattr(web_server.subprocess, "run", lambda *args, **kwargs: Completed())
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary")
+
+        assert resp.status_code == 200
+        assert resp.json()["enabled"] is True
+        assert fake_lock.entered is True
+        assert fake_lock.exited is True
+
+    def test_control_plane_canary_returns_read_only_payload(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        class Completed:
+            returncode = 0
+            stderr = ""
+            stdout = json.dumps([
+                {
+                    "payload": {
+                        "enabled": True,
+                        "status": "ok",
+                        "mode": "read_only",
+                        "project": "hermes-control-plane",
+                        "run": {
+                            "title": "HERA-198 Morning Brief Canary",
+                            "run_ref": "hermes://canary/HERA-198/morning-brief/phase1",
+                            "status": "generated",
+                        },
+                        "sections": [{"section_key": "summary", "section_order": 1}],
+                        "sources": [{"source_ref": "hermes://design/HERA-198/schema-domain-map"}],
+                        "delivery_events": [{"channel": "dry_run", "delivery_status": "dry_run"}],
+                        "audit_events": [{"event_type": "canary_insert"}],
+                        "counts": {"report_runs": 1},
+                        "boundaries": {
+                            "writes_enabled": False,
+                            "telegram_send_enabled": False,
+                            "obsidian_authority_edit_enabled": False,
+                            "cron_change_enabled": False,
+                        },
+                    }
+                }
+            ])
+
+        calls = []
+
+        def fake_run(cmd, cwd, check, capture_output, text, timeout):
+            calls.append({"cmd": cmd, "cwd": cwd, "check": check, "timeout": timeout})
+            return Completed()
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["mode"] == "read_only"
+        assert data["run"]["title"] == "HERA-198 Morning Brief Canary"
+        assert data["boundaries"]["writes_enabled"] is False
+        assert calls
+        assert calls[0]["cmd"][:5] == ["/usr/bin/supabase", "db", "query", "--linked", "-o"]
+        sql = calls[0]["cmd"][-1].lower()
+        assert "insert into" not in sql
+        assert "update " not in sql
+        assert "delete from" not in sql
+        assert "target_ref like 'telegram://dry-run/%'" in sql
+        assert "and channel = 'dry_run'" in sql
+        assert "null::text as error_summary" in sql
+
+    def test_control_plane_telegram_preview_requires_session_token(self):
+        import hermes_cli.web_server as web_server
+
+        resp = self.client.get(
+            "/api/control-plane/morning-brief-canary/telegram-preview",
+            headers={web_server._SESSION_HEADER_NAME: "invalid-token"},
+        )
+
+        assert resp.status_code == 401
+
+    def test_control_plane_telegram_preview_is_dry_run_and_read_only(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        class Completed:
+            returncode = 0
+            stderr = ""
+            stdout = json.dumps([
+                {
+                    "payload": {
+                        "enabled": True,
+                        "status": "ok",
+                        "mode": "read_only",
+                        "project": "hermes-control-plane",
+                        "run": {
+                            "title": "HERA-198 Morning Brief Canary",
+                            "run_ref": "hermes://canary/HERA-198/morning-brief/phase1",
+                            "status": "generated",
+                            "summary_kr": "Supabase control-plane readback 통과.",
+                        },
+                        "sections": [{"section_key": "summary", "section_order": 1}],
+                        "sources": [{"source_ref": "hermes://design/HERA-198/schema-domain-map"}],
+                        "delivery_events": [
+                            {
+                                "channel": "dry_run",
+                                "delivery_status": "dry_run",
+                                "target_ref": "telegram://dry-run/hera-198",
+                            }
+                        ],
+                        "audit_events": [{"event_type": "canary_insert"}],
+                        "counts": {
+                            "report_runs": 1,
+                            "report_sections": 1,
+                            "source_anchors": 1,
+                            "delivery_events": 1,
+                            "audit_events": 1,
+                        },
+                        "boundaries": {
+                            "writes_enabled": False,
+                            "telegram_send_enabled": False,
+                            "obsidian_authority_edit_enabled": False,
+                            "cron_change_enabled": False,
+                        },
+                    }
+                }
+            ])
+
+        calls = []
+
+        def fake_run(cmd, cwd, check, capture_output, text, timeout):
+            calls.append({"cmd": cmd, "cwd": cwd, "check": check, "timeout": timeout})
+            return Completed()
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary/telegram-preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["mode"] == "dry_run_preview"
+        assert data["send_enabled"] is False
+        assert data["write_enabled"] is False
+        assert data["target_ref"] == "telegram://dry-run/hera-198"
+        assert data["validation"]["length_ok"] is True
+        assert data["validation"]["requires_approval_before_send"] is True
+        assert "처리 이유:" in data["message_text"]
+        assert "HERA-198 Morning Brief Canary" in data["message_text"]
+        assert "dry_run" in data["message_text"]
+        assert calls
+        sql = calls[0]["cmd"][-1].lower()
+        assert "insert into" not in sql
+        assert "update " not in sql
+        assert "delete from" not in sql
+
+    def test_control_plane_telegram_preview_propagates_disabled_state(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: None)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary/telegram-preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["reason"] == "supabase_cli_missing"
+
+    def test_control_plane_telegram_preview_rejects_non_dry_run_target_refs(self):
+        import hermes_cli.web_server as web_server
+
+        preview = web_server._build_morning_brief_telegram_preview({
+            "enabled": True,
+            "project": "hermes-control-plane",
+            "run": {"title": "Canary", "status": "generated"},
+            "delivery_events": [
+                {
+                    "channel": "telegram",
+                    "delivery_status": "sent",
+                    "target_ref": "telegram:999000111",
+                }
+            ],
+            "counts": {},
+            "boundaries": {},
+        })
+
+        assert preview["target_ref"] == "telegram://dry-run/hera-198"
+        assert "999000111" not in preview["message_text"]
+
     def test_get_config_schema(self):
         resp = self.client.get("/api/config/schema")
         assert resp.status_code == 200

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -63,6 +63,7 @@ import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import ModelsPage from "@/pages/ModelsPage";
 import CronPage from "@/pages/CronPage";
+import ControlPlanePage from "@/pages/ControlPlanePage";
 import ProfilesPage from "@/pages/ProfilesPage";
 import SkillsPage from "@/pages/SkillsPage";
 import PluginsPage from "@/pages/PluginsPage";
@@ -102,6 +103,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
   "/logs": LogsPage,
+  "/control-plane": ControlPlanePage,
   "/cron": CronPage,
   "/skills": SkillsPage,
   "/plugins": PluginsPage,
@@ -139,6 +141,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
     icon: Cpu,
   },
   { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
+  { path: "/control-plane", label: "Control Plane", icon: Database },
   { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
   { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -45,6 +45,12 @@ async function getSessionToken(): Promise<string> {
 
 export const api = {
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
+  getMorningBriefCanary: () =>
+    fetchJSON<MorningBriefCanaryResponse>("/api/control-plane/morning-brief-canary"),
+  getMorningBriefTelegramPreview: () =>
+    fetchJSON<MorningBriefTelegramPreviewResponse>(
+      "/api/control-plane/morning-brief-canary/telegram-preview",
+    ),
   getSessions: (limit = 20, offset = 0) =>
     fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
   getSessionMessages: (id: string) =>
@@ -562,6 +568,115 @@ export interface SessionSearchResult {
 
 export interface SessionSearchResponse {
   results: SessionSearchResult[];
+}
+
+
+export interface MorningBriefRun {
+  id?: string;
+  report_type?: string;
+  run_ref?: string;
+  status?: string;
+  report_date?: string;
+  title?: string;
+  summary_kr?: string | null;
+  obsidian_ref?: string | null;
+  paperclip_parent_ref?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface MorningBriefSection {
+  section_key?: string;
+  section_order?: number;
+  title?: string;
+  body_md?: string;
+  judgment_label?: string | null;
+  created_at?: string;
+}
+
+export interface MorningBriefSourceAnchor {
+  source_ref?: string;
+  source_title?: string | null;
+  publisher?: string | null;
+  published_at?: string | null;
+  observed_at?: string | null;
+  timing_label?: string | null;
+  quality_label?: string | null;
+  claim_ref?: string | null;
+  created_at?: string;
+}
+
+export interface MorningBriefDeliveryEvent {
+  channel?: string;
+  target_ref?: string | null;
+  payload_summary?: string;
+  delivery_status?: string;
+  delivered_at?: string | null;
+  error_summary?: string | null;
+  created_at?: string;
+}
+
+export interface MorningBriefAuditEvent {
+  event_type?: string;
+  subject_ref?: string | null;
+  actor_ref?: string;
+  source_refs?: unknown[];
+  artifact_refs?: unknown[];
+  summary?: string;
+  verification_status?: string | null;
+  created_at?: string;
+}
+
+export interface MorningBriefCanaryResponse {
+  enabled: boolean;
+  reason?: string;
+  message?: string;
+  status?: string;
+  mode?: "read_only" | string;
+  project?: string;
+  updated_at?: string;
+  run?: MorningBriefRun | null;
+  sections?: MorningBriefSection[];
+  sources?: MorningBriefSourceAnchor[];
+  delivery_events?: MorningBriefDeliveryEvent[];
+  audit_events?: MorningBriefAuditEvent[];
+  counts?: Record<string, number>;
+  boundaries?: {
+    writes_enabled?: boolean;
+    telegram_send_enabled?: boolean;
+    obsidian_authority_edit_enabled?: boolean;
+    cron_change_enabled?: boolean;
+  };
+}
+
+export interface MorningBriefTelegramPreviewResponse {
+  enabled: boolean;
+  reason?: string;
+  message?: string;
+  status?: string;
+  mode?: "dry_run_preview" | string;
+  project?: string;
+  target_ref?: string;
+  channel?: "telegram" | string;
+  send_enabled?: boolean;
+  write_enabled?: boolean;
+  message_text?: string;
+  message_length?: number;
+  validation?: {
+    length_ok?: boolean;
+    max_length?: number;
+    requires_approval_before_send?: boolean;
+    no_telegram_send_performed?: boolean;
+    no_supabase_write_performed?: boolean;
+    no_cron_change_performed?: boolean;
+    no_obsidian_authority_edit_performed?: boolean;
+  };
+  source?: {
+    run_ref?: string | null;
+    report_status?: string;
+    control_plane_mode?: string;
+  };
+  boundaries?: MorningBriefCanaryResponse["boundaries"];
 }
 
 // ── Model info types ──────────────────────────────────────────────────

--- a/web/src/pages/ControlPlanePage.tsx
+++ b/web/src/pages/ControlPlanePage.tsx
@@ -1,0 +1,259 @@
+import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { Database, MessageSquareText, RefreshCw, ShieldCheck } from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  api,
+  type MorningBriefCanaryResponse,
+  type MorningBriefTelegramPreviewResponse,
+} from "@/lib/api";
+import { usePageHeader } from "@/contexts/usePageHeader";
+
+function JsonList({ value }: { value: unknown[] | undefined }) {
+  if (!value || value.length === 0) {
+    return <p className="text-sm text-muted-foreground">No rows.</p>;
+  }
+  return (
+    <div className="space-y-2">
+      {value.map((item, index) => (
+        <pre
+          key={index}
+          className="overflow-auto rounded-md border border-current/15 bg-black/20 p-3 font-mono-ui text-[11px] leading-4 text-muted-foreground normal-case"
+        >
+          {JSON.stringify(item, null, 2)}
+        </pre>
+      ))}
+    </div>
+  );
+}
+
+function BoundaryBadge({ label, value }: { label: string; value?: boolean }) {
+  return (
+    <Badge tone={value ? "destructive" : "success"} className="text-[10px]">
+      {label}: {value ? "enabled" : "off"}
+    </Badge>
+  );
+}
+
+export default function ControlPlanePage() {
+  const [data, setData] = useState<MorningBriefCanaryResponse | null>(null);
+  const [telegramPreview, setTelegramPreview] =
+    useState<MorningBriefTelegramPreviewResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { setAfterTitle, setEnd } = usePageHeader();
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setTelegramPreview(null);
+
+    try {
+      const canary = await api.getMorningBriefCanary();
+      setData(canary);
+    } catch {
+      setData(null);
+      setError("Control-plane read failed; check server logs or Supabase CLI link state.");
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const preview = await api.getMorningBriefTelegramPreview();
+      setTelegramPreview(preview);
+    } catch {
+      setTelegramPreview({
+        enabled: false,
+        reason: "telegram_preview_unavailable",
+        message: "Telegram preview unavailable; control-plane readback can still be shown.",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useLayoutEffect(() => {
+    setAfterTitle(
+      <span className="flex items-center gap-2">
+        {loading && <Spinner className="shrink-0 text-base text-primary" />}
+        <Badge tone={loading && !data ? "secondary" : data?.enabled ? "success" : "secondary"} className="text-[10px]">
+          {loading && !data ? "loading canary" : data?.enabled ? "read-only canary" : "not configured"}
+        </Badge>
+      </span>,
+    );
+    setEnd(
+      <Button
+        type="button"
+        size="sm"
+        outlined
+        onClick={refresh}
+        disabled={loading}
+        prefix={loading ? <Spinner /> : <RefreshCw />}
+      >
+        Refresh
+      </Button>,
+    );
+    return () => {
+      setAfterTitle(null);
+      setEnd(null);
+    };
+  }, [data?.enabled, loading, refresh, setAfterTitle, setEnd]);
+
+  const run = data?.run;
+  const boundaries = data?.boundaries ?? {};
+
+  return (
+    <div className="flex flex-col gap-4 normal-case">
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <CardTitle className="flex items-center gap-2 text-sm uppercase">
+            <Database className="h-4 w-4" />
+            HERA-198 Control Plane Canary
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 p-4">
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          {data && !data.enabled && (
+            <div className="rounded-md border border-warning/30 bg-warning/10 p-3">
+              <p className="text-sm font-semibold uppercase text-warning">Disabled</p>
+              <p className="text-sm text-muted-foreground">{data.reason}: {data.message}</p>
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2 uppercase">
+            <Badge tone="secondary" className="text-[10px]">project: {loading && !data ? "loading" : data?.project ?? "unknown"}</Badge>
+            <Badge tone="secondary" className="text-[10px]">mode: {data?.mode ?? "read-only"}</Badge>
+            <Badge tone="secondary" className="text-[10px]">updated: {data?.updated_at ?? "-"}</Badge>
+          </div>
+          <div className="flex flex-wrap gap-2 uppercase">
+            <BoundaryBadge label="writes" value={boundaries.writes_enabled} />
+            <BoundaryBadge label="telegram" value={boundaries.telegram_send_enabled} />
+            <BoundaryBadge label="obsidian authority" value={boundaries.obsidian_authority_edit_enabled} />
+            <BoundaryBadge label="cron" value={boundaries.cron_change_enabled} />
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <Card>
+          <CardHeader className="py-3 px-4">
+            <CardTitle className="text-sm uppercase">Latest Morning Brief Run</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 p-4 text-sm">
+            {run ? (
+              <>
+                <p className="font-semibold text-foreground">{run.title}</p>
+                <p className="text-muted-foreground">{run.summary_kr}</p>
+                <dl className="grid gap-2 md:grid-cols-2">
+                  <div><dt className="text-xs uppercase text-muted-foreground">Status</dt><dd>{run.status}</dd></div>
+                  <div><dt className="text-xs uppercase text-muted-foreground">Date</dt><dd>{run.report_date}</dd></div>
+                  <div className="md:col-span-2"><dt className="text-xs uppercase text-muted-foreground">Run ref</dt><dd className="break-all font-mono-ui text-xs">{run.run_ref}</dd></div>
+                  <div className="md:col-span-2"><dt className="text-xs uppercase text-muted-foreground">Obsidian ref</dt><dd className="break-all font-mono-ui text-xs">{run.obsidian_ref}</dd></div>
+                  <div className="md:col-span-2"><dt className="text-xs uppercase text-muted-foreground">Paperclip ref</dt><dd className="break-all font-mono-ui text-xs">{run.paperclip_parent_ref}</dd></div>
+                </dl>
+              </>
+            ) : loading ? (
+              <p className="text-muted-foreground">Loading Morning Brief run…</p>
+            ) : (
+              <p className="text-muted-foreground">No Morning Brief run found.</p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="py-3 px-4">
+            <CardTitle className="flex items-center gap-2 text-sm uppercase">
+              <ShieldCheck className="h-4 w-4" />
+              Counts / Verification
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-4">
+            <div className="grid gap-2 md:grid-cols-2">
+              {Object.entries(data?.counts ?? {}).map(([key, value]) => (
+                <div key={key} className="rounded-md border border-current/15 p-3">
+                  <p className="text-xs uppercase text-muted-foreground">{key}</p>
+                  <p className="text-lg font-semibold text-foreground">{value}</p>
+                </div>
+              ))}
+              {loading && !data && (
+                <p className="text-sm text-muted-foreground">Loading verification counts…</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <CardTitle className="flex items-center gap-2 text-sm uppercase">
+            <MessageSquareText className="h-4 w-4" />
+            Telegram Dry-run Payload Preview
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 p-4">
+          {telegramPreview && !telegramPreview.enabled && (
+            <div className="rounded-md border border-warning/30 bg-warning/10 p-3">
+              <p className="text-sm font-semibold uppercase text-warning">Preview disabled</p>
+              <p className="text-sm text-muted-foreground">
+                {telegramPreview.reason}: {telegramPreview.message}
+              </p>
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2 uppercase">
+            <Badge tone="secondary" className="text-[10px]">
+              channel: {telegramPreview?.channel ?? "telegram"}
+            </Badge>
+            <Badge tone="secondary" className="text-[10px]">
+              mode: {telegramPreview?.mode ?? "dry-run preview"}
+            </Badge>
+            <Badge tone={telegramPreview?.send_enabled ? "destructive" : "success"} className="text-[10px]">
+              send: {telegramPreview?.send_enabled ? "enabled" : "off"}
+            </Badge>
+            <Badge tone={telegramPreview?.write_enabled ? "destructive" : "success"} className="text-[10px]">
+              supabase write: {telegramPreview?.write_enabled ? "enabled" : "off"}
+            </Badge>
+            <Badge tone={telegramPreview?.validation?.length_ok ? "success" : "secondary"} className="text-[10px]">
+              length: {telegramPreview?.message_length ?? 0}/{telegramPreview?.validation?.max_length ?? 600}
+            </Badge>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-muted-foreground">Target ref</p>
+            <p className="break-all font-mono-ui text-xs text-foreground">
+              {telegramPreview?.target_ref ?? "telegram://dry-run/hera-198"}
+            </p>
+          </div>
+          <pre className="whitespace-pre-wrap rounded-md border border-current/15 bg-black/20 p-3 text-sm leading-6 text-foreground normal-case">
+            {telegramPreview?.message_text ?? "No preview generated."}
+          </pre>
+          <p className="text-xs text-muted-foreground normal-case">
+            Dry-run only: no Telegram send, no Supabase write, no cron change, no Obsidian authority edit.
+          </p>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <Card>
+          <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Sections</CardTitle></CardHeader>
+          <CardContent className="p-4"><JsonList value={data?.sections} /></CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Source Anchors</CardTitle></CardHeader>
+          <CardContent className="p-4"><JsonList value={data?.sources} /></CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Delivery Events</CardTitle></CardHeader>
+          <CardContent className="p-4"><JsonList value={data?.delivery_events} /></CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Audit Events</CardTitle></CardHeader>
+          <CardContent className="p-4"><JsonList value={data?.audit_events} /></CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a read-only HERA-198 control-plane canary endpoint backed by server-side Supabase CLI readback.
- Add WebUI `/control-plane` cockpit navigation/page for Morning Brief canary status and Telegram dry-run preview.
- Keep Telegram preview read-only: no send, no WebUI write path.
- Add generic error handling/redaction, delivery-event sanitization, and a process-local Supabase CLI serialization lock.

## Safety / Scope
- Canary/read-only cockpit only; this is not production activation.
- No browser Supabase credentials.
- No Supabase writes from WebUI endpoints.
- No Telegram sends from preview endpoint.
- No Obsidian authority edits.
- No cron/routine changes.
- No existing report bulk migration.

## Verification
- Core rules sync: synced, drift items empty.
- `python -m py_compile hermes_cli/web_server.py`: PASS.
- HERA-198 relevant backend subset: 11 passed.
- Broader backend subset excluding known unrelated websocket flaky: 146 passed.
- `npm exec -- tsc -b`: PASS.
- `npm --prefix web run build`: PASS with Node 20.19.0.
- Portability/path scan: actionable hits 0.
- Sensitive/path artifact scans: unresolved hits 0.
- Independent blocker review issue resolved: Supabase CLI readback serialized with lock.

## Known Note
- Full default xdist run has an intermittent, unrelated timeout in `TestPtyWebSocket::test_pub_broadcasts_to_events_subscribers`; it passes in isolation/subset and is not changed by this PR.
