### PR TITLE
fix(agent): exclude base64 image payloads from rough token estimates

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, List, Optional
 from agent.auxiliary_client import call_llm
 from agent.context_engine import ContextEngine
 from agent.model_metadata import (
+    IMAGE_TOKEN_ESTIMATE,
     MINIMUM_CONTEXT_LENGTH,
     get_model_context_length,
     estimate_messages_tokens_rough,
@@ -64,16 +65,11 @@ _PRUNED_TOOL_PLACEHOLDER = "[Old tool output cleared to save context space]"
 
 # Chars per token rough estimate
 _CHARS_PER_TOKEN = 4
-# Flat token cost per attached image part.  Real cost varies by provider and
-# dimensions (Anthropic ≈ width×height/750, GPT-4o up to ~1700 for
-# high-detail 2048×2048, Gemini 258/tile), but 1600 is a realistic ceiling
-# that keeps compression budgeting honest for multi-image conversations.
-# Matches Claude Code's IMAGE_TOKEN_ESTIMATE constant.
-_IMAGE_TOKEN_ESTIMATE = 1600
-# Same figure expressed in the char-budget currency the rest of the
-# compressor speaks in.  Used when accumulating message "content length"
-# for tail-cut decisions.
-_IMAGE_CHAR_EQUIVALENT = _IMAGE_TOKEN_ESTIMATE * _CHARS_PER_TOKEN
+# Image token cost expressed as char-budget for the compressor's tail-cut
+# decisions.  The token figure itself lives in model_metadata so the rough
+# estimators there can use the same flat cap and avoid counting base64
+# payloads as text tokens.
+_IMAGE_CHAR_EQUIVALENT = IMAGE_TOKEN_ESTIMATE * _CHARS_PER_TOKEN
 _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
 
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1454,9 +1454,58 @@ def estimate_tokens_rough(text: str) -> int:
     return (len(text) + 3) // 4
 
 
+# Flat token cost per attached image part for rough estimation.  Real cost
+# varies by provider and dimensions (Anthropic ≈ width×height/750, GPT-4o up
+# to ~1700 for high-detail 2048×2048, Gemini 258/tile), but 1600 is a
+# realistic ceiling.  Using a flat cost here avoids the failure mode where
+# `len(str(msg))` on a multimodal content list expands the base64 image
+# payload into hundreds of thousands of phantom characters — a 1MB image
+# would otherwise estimate as ~333K tokens, falsely tripping pre-flight
+# compression on short conversations.
+IMAGE_TOKEN_ESTIMATE = 1600
+_IMAGE_PART_TYPES = frozenset({"image_url", "input_image", "image"})
+
+
+def _msg_chars_image_aware(msg: Any) -> int:
+    """Per-message char count for token estimation, ignoring base64 payloads.
+
+    Multimodal content lists (OpenAI- or Anthropic-style) substitute a flat
+    ``IMAGE_TOKEN_ESTIMATE * 4`` chars per image part instead of stringifying
+    the whole dict (which would include the base64 ``data:image/...`` URL).
+    Plain-string content and non-list content fall back to ``len(str(msg))``
+    so envelope overhead (role, name, tool_call_id, ...) is preserved.
+    """
+    if not isinstance(msg, dict):
+        return len(str(msg))
+    content = msg.get("content")
+    if not isinstance(content, list):
+        return len(str(msg))
+
+    # Approximate envelope overhead: stringify the message minus content.
+    # `len(str({...}))` matches what the old code charged for non-image
+    # messages, so plain-text estimates stay calibrated.
+    envelope = {k: v for k, v in msg.items() if k != "content"}
+    total = len(str(envelope))
+
+    for part in content:
+        if isinstance(part, dict):
+            if part.get("type") in _IMAGE_PART_TYPES:
+                total += IMAGE_TOKEN_ESTIMATE * 4
+            else:
+                # Text parts: count just the text. Non-text non-image dicts
+                # (e.g. tool_result blocks) get full str() to be safe.
+                text = part.get("text")
+                total += len(text) if isinstance(text, str) else len(str(part))
+        elif isinstance(part, str):
+            total += len(part)
+        else:
+            total += len(str(part))
+    return total
+
+
 def estimate_messages_tokens_rough(messages: List[Dict[str, Any]]) -> int:
     """Rough token estimate for a message list (pre-flight only)."""
-    total_chars = sum(len(str(msg)) for msg in messages)
+    total_chars = sum(_msg_chars_image_aware(msg) for msg in messages)
     return (total_chars + 3) // 4
 
 
@@ -1477,7 +1526,7 @@ def estimate_request_tokens_rough(
     if system_prompt:
         total_chars += len(system_prompt)
     if messages:
-        total_chars += sum(len(str(msg)) for msg in messages)
+        total_chars += sum(_msg_chars_image_aware(msg) for msg in messages)
     if tools:
         total_chars += len(str(tools))
     return (total_chars + 3) // 4

--- a/tests/agent/test_compressor_image_tokens.py
+++ b/tests/agent/test_compressor_image_tokens.py
@@ -13,9 +13,9 @@ import pytest
 from agent.context_compressor import (
     _CHARS_PER_TOKEN,
     _IMAGE_CHAR_EQUIVALENT,
-    _IMAGE_TOKEN_ESTIMATE,
     _content_length_for_budget,
 )
+from agent.model_metadata import IMAGE_TOKEN_ESTIMATE as _IMAGE_TOKEN_ESTIMATE
 
 
 class TestContentLengthForBudget:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -94,14 +94,59 @@ class TestEstimateMessagesTokensRough:
         assert result > 0
         assert result == (len(str(msg)) + 3) // 4
 
-    def test_message_with_list_content(self):
-        """Vision messages with multimodal content arrays."""
+    def test_message_with_list_content_text_only(self):
+        """Multimodal content lists with only text parts: each text part
+        counts as plain `len(text)`, plus envelope overhead."""
         msg = {"role": "user", "content": [
-            {"type": "text", "text": "describe"},
-            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+            {"type": "text", "text": "describe what you see"},
         ]}
         result = estimate_messages_tokens_rough([msg])
-        assert result == (len(str(msg)) + 3) // 4
+        # Text part contributes len(text) chars; envelope adds dict overhead.
+        # The result should be > len(text)/4 (envelope) but bounded.
+        assert result > 0
+        assert result < (len(str(msg)) + 3) // 4 + 10  # close to legacy estimate
+
+    def test_image_part_does_not_inflate_with_base64_size(self):
+        """Regression for the pre-flight overcount bug: a multimodal message
+        with an image part must NOT scale with the base64 payload length.
+        Otherwise a 1MB image expands to ~333K phantom text tokens and falsely
+        trips compression on short conversations."""
+        import base64
+        small_b64 = base64.b64encode(b"\x00" * 100).decode()
+        large_b64 = base64.b64encode(b"\x00" * 1_000_000).decode()  # ~1.3MB of base64
+        small_msg = {"role": "user", "content": [
+            {"type": "text", "text": "look"},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{small_b64}"}},
+        ]}
+        large_msg = {"role": "user", "content": [
+            {"type": "text", "text": "look"},
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{large_b64}"}},
+        ]}
+        small_est = estimate_messages_tokens_rough([small_msg])
+        large_est = estimate_messages_tokens_rough([large_msg])
+        # Both should be roughly IMAGE_TOKEN_ESTIMATE (~1600). They MUST NOT
+        # differ by orders of magnitude.
+        assert abs(small_est - large_est) < 50, (
+            f"Image base64 size leaked into token estimate: "
+            f"small={small_est}, large={large_est}"
+        )
+
+    def test_anthropic_style_image_part(self):
+        """Anthropic uses {type: image, source: {data: <base64>}} instead of
+        OpenAI's {type: image_url, image_url: {url: data:...}}. Both schemas
+        must be recognized so estimates don't blow up on Anthropic-routed
+        sessions."""
+        import base64
+        b64 = base64.b64encode(b"\x00" * 500_000).decode()
+        msg = {"role": "user", "content": [
+            {"type": "text", "text": "look"},
+            {"type": "image", "source": {
+                "type": "base64", "media_type": "image/png", "data": b64,
+            }},
+        ]}
+        est = estimate_messages_tokens_rough([msg])
+        # Should be on the order of IMAGE_TOKEN_ESTIMATE, not 100K+.
+        assert est < 5000, f"Anthropic image inflated estimate: {est}"
 
 
 # =========================================================================


### PR DESCRIPTION
## Problem

The two "rough" token estimators in `agent/model_metadata.py`
(`estimate_messages_tokens_rough`, `estimate_request_tokens_rough`) sum
`len(str(msg))` over the message list. For a multimodal message whose
content list contains an `image_url` part with a base64 data-URL, that
stringification expands the image payload into the estimate as if it
were text — a 1MB image (≈1.33MB of base64) becomes ≈333K phantom
tokens.

The compressor itself doesn't suffer from this: its
`_content_length_for_budget` (`agent/context_compressor.py:77-107`)
already substitutes a flat per-image cost, explicitly to avoid the same
trap. But the rough estimators predate that fix and were never updated.

### User-visible symptom

The pre-flight compaction guard at `run_agent.py:10813` decides whether
to compress before sending a request:

```python
_preflight_tokens = estimate_request_tokens_rough(
    messages, system_prompt=..., tools=...
)
if _preflight_tokens >= self.context_compressor.threshold_tokens:
    # emit "📦 Preflight compression: ~X tokens >= Y threshold..."
    # and run up to 3 compression passes
```

For a `xiaomi/mimo-v2.5` user (1,048,576 context, default
`compression.threshold: 0.5`), the threshold is 524,288. A short
conversation with two ~1MB images already estimates as ~683K tokens,
falsely tripping pre-flight compaction. The actual token cost is on
the order of 3,200 (≈1,600 per image).

The compressor's main `_compress_context` loop then bails without
calling an LLM — its internal `_find_tail_cut_by_tokens` uses the
image-aware `_content_length_for_budget`, so it correctly identifies
there's nothing to summarize and returns early before reaching
`_generate_summary`. But the user still sees the spurious
"📦 Preflight compression: ~X tokens >= Y threshold" status alert,
and the false-positive cycle repeats every turn — both estimators
called from the same buggy `estimate_request_tokens_rough` consistently
mis-classify the same input.

| Image size | Old estimate | New estimate | Real cost |
|---|---:|---:|---:|
| 50 KB  | 17,103   | 1,607 | ~1,600 |
| 200 KB | 68,303   | 1,607 | ~1,600 |
| 1 MB   | 341,370  | 1,607 | ~1,600 |
| 2 MB   | 682,703  | 1,607 | ~1,600 |
| 5 MB   | 1,706,703 | 1,607 | ~1,600 |

### Impact surface

Twenty-six call sites consume these estimators across `cli.py`,
`gateway/run.py`, `tui_gateway/server.py`, `acp_adapter/server.py`,
`run_agent.py`, and the compressor itself (line 1453, where it
re-estimates its own output and would have been re-inflated). All of
them benefit from fixing the helper functions, no per-callsite changes
needed.

## Fix

- `agent/model_metadata.py`: add `IMAGE_TOKEN_ESTIMATE = 1600` (moved
  from `context_compressor`) and a private `_msg_chars_image_aware`
  helper that recognises OpenAI-style (`image_url`, `input_image`) and
  Anthropic-style (`image`) parts, substituting `IMAGE_TOKEN_ESTIMATE *
  4` chars per image instead of stringifying the dict.
- The two rough estimators use the helper for per-message content while
  preserving the existing envelope-overhead counting (so plain-text
  estimates are unchanged).
- `agent/context_compressor.py`: `_IMAGE_TOKEN_ESTIMATE` is now imported
  from `model_metadata` (single source of truth). `_IMAGE_CHAR_EQUIVALENT`
  derivation is unchanged.

## Test plan

- 3 new tests in `tests/agent/test_model_metadata.py`:
  - text-only multimodal content stays in the legacy ballpark
  - 100-byte image vs 1MB image — estimates must not differ by more
    than ~50 (regression test for the bug)
  - Anthropic-style `{type: image, source: {data: ...}}` is also
    recognised
- One pre-existing test that asserted the buggy behaviour
  (`test_message_with_list_content`) is rewritten as
  `test_message_with_list_content_text_only` to assert the new
  contract.
- `tests/agent/test_compressor_image_tokens.py` import updated for the
  moved `IMAGE_TOKEN_ESTIMATE` constant.
- `pytest tests/agent/test_model_metadata.py tests/agent/test_context_compressor.py tests/agent/test_compressor_image_tokens.py` — 175 passed
- `pytest tests/agent/ --ignore=tests/agent/test_bedrock_1m_context.py` — 2520 passed (the bedrock test fails identically on clean main, unrelated to this PR)
- End-to-end: with the user-reported config (`xiaomi/mimo-v2.5`, 1M context, threshold 0.5), `estimate_request_tokens_rough` on `[2× 1MB image messages]` drops from 682,739 (above the 524,288 trigger) to 3,214 (well below).