### PR TITLE
fix(cli): fall back to SelectSelector when kqueue can't watch stdin on macOS

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12139,6 +12139,30 @@ class HermesCLI:
             self._print_exit_summary()
             return
 
+        # On macOS with uv-managed Python, kqueue's selector cannot register
+        # fd 0, raising OSError(EINVAL) from kqueue.control() when prompt_toolkit
+        # calls loop.add_reader (#6393). Probe kqueue and, if it can't watch
+        # stdin, switch to a SelectSelector-backed event loop policy.
+        if sys.platform == "darwin":
+            try:
+                import selectors as _selectors
+                if hasattr(_selectors, "KqueueSelector"):
+                    _kq = _selectors.KqueueSelector()
+                    try:
+                        _kq.register(0, _selectors.EVENT_READ)
+                        _kq.unregister(0)
+                    finally:
+                        _kq.close()
+            except (OSError, ValueError, KeyError):
+                import asyncio as _aio_probe
+                import selectors as _selectors
+
+                class _SelectEventLoopPolicy(_aio_probe.DefaultEventLoopPolicy):
+                    def new_event_loop(self):
+                        return _aio_probe.SelectorEventLoop(_selectors.SelectSelector())
+
+                _aio_probe.set_event_loop_policy(_SelectEventLoopPolicy())
+
         # Run the application with patch_stdout for proper output handling
         try:
             with patch_stdout():
@@ -12155,12 +12179,20 @@ class HermesCLI:
         except (KeyError, OSError) as _stdin_err:
             # Catch selector registration failures from broken stdin (#6393)
             # and I/O errors from broken stdout during interrupt (#13710).
-            if isinstance(_stdin_err, OSError) and getattr(_stdin_err, "errno", None) == errno.EIO:
+            _errno = getattr(_stdin_err, "errno", None) if isinstance(_stdin_err, OSError) else None
+            _msg = str(_stdin_err)
+            if _errno == errno.EIO:
                 pass  # suppress broken-stdout I/O errors on interrupt (#13710)
-            elif "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err):
+            elif (
+                _errno in (errno.EINVAL, errno.EBADF)
+                or "is not registered" in _msg
+                or "Bad file descriptor" in _msg
+                or "Invalid argument" in _msg
+            ):
                 print(
                     f"\nError: stdin is not usable ({_stdin_err}).\n"
-                    "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"
+                    "This can happen with certain Python installations (e.g. uv-managed cPython on macOS)\n"
+                    "where kqueue cannot register fd 0.\n"
                     "Try reinstalling Python via pyenv or Homebrew, then re-run: hermes setup"
                 )
             else:


### PR DESCRIPTION
## What does this PR do?

On macOS with uv-managed cPython 3.11, the default `kqueue` selector cannot register fd 0, so when `prompt_toolkit` calls `loop.add_reader(0, ...)` during `app.run()`, `kqueue.control()` raises `OSError: [Errno 22] Invalid argument` (EINVAL) and the agent crashes immediately on startup. Reproduces 100% on the affected Python builds.

This PR fixes it by probing `KqueueSelector.register(0, EVENT_READ)` once at startup; if it fails, an event-loop policy is installed that returns a `SelectorEventLoop` backed by `SelectSelector` instead. `select()` works fine on stdin in this Python build, so `add_reader` succeeds and the agent launches normally. Platforms where kqueue can register fd 0 are unaffected — the probe succeeds and the default policy is used.

It also extends the existing #6393 fallback handler (which was added when this same family of bugs was first reported) to recognize EINVAL / EBADF / `"Invalid argument"`. Previously the handler only matched `"is not registered"` and `"Bad file descriptor"`, so an EINVAL leaking through (which is the actual macOS+kqueue failure mode) re-raised as a raw traceback after `Goodbye! ⚕` was printed — exactly the symptom in #5884.

## Related Issue

Fixes #5884
Re-fixes the underlying cause originally reported in #6393

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — before launching `prompt_toolkit`, probe `KqueueSelector.register(0, ...)` on macOS. On failure, install a `DefaultEventLoopPolicy` subclass whose `new_event_loop()` returns `SelectorEventLoop(SelectSelector())`. `asyncio.run()` (called inside `app.run()`) then picks up the SelectSelector-backed loop and `add_reader` works.
- `cli.py` — extend the post-`app.run()` `except (KeyError, OSError)` handler to additionally match `errno in (EINVAL, EBADF)` and `"Invalid argument"` so the friendly "reinstall Python via pyenv or Homebrew" guidance is shown if any future selector failure on stdin slips past the probe.

## How to Test

Reproducing the original crash requires uv-managed cPython on macOS. With that build:

1. `python -c "import selectors; kq = selectors.KqueueSelector(); kq.register(0, selectors.EVENT_READ)"` — confirms the OS-level failure (`OSError: [Errno 22] Invalid argument`).
2. Without this PR: `hermes` crashes with the traceback in #5884.
3. With this PR: `hermes` launches normally; piping `/exit` produces clean shutdown.

I verified all three on Darwin 24.6.0 with `cpython-3.11.15-macos-aarch64-none` (the exact build affected in #5884). On Python builds where the kqueue probe passes (Homebrew, pyenv, system Python, Linux), the new code path is a no-op.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — _did not run the full suite locally; please rely on CI_
- [ ] I've added tests for my changes — _did not add a test: the kqueue+stdin failure mode is platform- and build-specific (only fires on uv-managed cPython on macOS) and is genuinely awkward to fake portably. Happy to add one if a maintainer can suggest a reasonable mocking approach_
- [x] I've tested on my platform: macOS Sequoia (Darwin 24.6.0) with uv-managed cPython 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (internal workaround, no user-facing surface change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the workaround is gated on `sys.platform == "darwin"` and only triggers when kqueue actually fails to register fd 0; no effect on Linux/Windows or on macOS Pythons where kqueue works.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A