### PR TITLE
fix(tui): correct hermes-ink bundle filename in staleness check

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -971,7 +971,7 @@ def _tui_build_needed(tui_dir: Path) -> bool:
 
 def _hermes_ink_bundle_stale(tui_dir: Path) -> bool:
     ink_root = tui_dir / "packages" / "hermes-ink"
-    bundle = ink_root / "dist" / "ink-bundle.js"
+    bundle = ink_root / "dist" / "entry-exports.js"
     if not bundle.exists():
         return True
     bm = bundle.stat().st_mtime


### PR DESCRIPTION
## Summary

`_hermes_ink_bundle_stale()` checks for `packages/hermes-ink/dist/ink-bundle.js`, but the hermes-ink build script (`esbuild`) outputs `dist/entry-exports.js`. Since the expected file never exists, `_tui_build_needed()` always returns `True`, triggering a full `npm run build` on every dashboard chat WebSocket connection (~15 seconds of blocking I/O).

This causes the Chat tab in `hermes dashboard --tui` to time out and show `[session ended]` immediately.

## Fix

Update the expected filename from `ink-bundle.js` to `entry-exports.js` to match what esbuild actually produces.

## Reproduction

1. Start `hermes dashboard --host 0.0.0.0 --port 9119 --tui --insecure`
2. Open the Chat tab in the browser
3. Observe `[session ended]` immediately — the WS handler blocks for ~15s on `npm run build`

## Test Plan

- [ ] Chat tab loads and renders the TUI prompt within ~1 second
- [ ] `_hermes_ink_bundle_stale()` returns `False` when `entry-exports.js` is up-to-date
- [ ] `_make_tui_argv()` completes in <1 second when no rebuild is needed
