### PR TITLE
Add Slack and Discord approval box tools

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3429,6 +3429,51 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=str(e))
 
+    async def send_deliverable_approval(
+        self, chat_id: str, record: Dict[str, Any], thread_id: Optional[str] = None,
+        approve_label: str = "Approve", revise_label: str = "Needs Work",
+        reject_label: str = "Reject",
+    ) -> SendResult:
+        """Send an interactive approval box for external deliverables/drafts."""
+        if not self._client or not DISCORD_AVAILABLE:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            target_id = thread_id or chat_id
+            channel = self._client.get_channel(int(target_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(target_id))
+
+            title = str(record.get("title") or "Approval requested")
+            body = str(record.get("body") or "")
+            max_desc = 4088
+            desc = body if len(body) <= max_desc else body[: max_desc - 3] + "..."
+            embed = discord.Embed(
+                title=title,
+                description=desc,
+                color=discord.Color.orange(),
+            )
+            drive_link = str(record.get("drive_link") or "")
+            artifact_path = str(record.get("artifact_path") or "")
+            if drive_link:
+                embed.add_field(name="Drive link", value=f"[Open deliverable]({drive_link})", inline=False)
+            if artifact_path:
+                embed.add_field(name="Local path", value=f"`{artifact_path}`", inline=False)
+            embed.add_field(name="Approval ID", value=f"`{record.get('approval_id')}`", inline=False)
+
+            view = DeliverableApprovalView(
+                approval_id=str(record.get("approval_id") or ""),
+                allowed_user_ids=self._allowed_user_ids,
+                allowed_role_ids=self._allowed_role_ids,
+                approve_label=approve_label,
+                revise_label=revise_label,
+                reject_label=reject_label,
+            )
+            msg = await channel.send(embed=embed, view=view)
+            return SendResult(success=True, message_id=str(msg.id))
+        except Exception as e:
+            return SendResult(success=False, error=str(e))
+
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str,
         confirm_id: str, metadata: Optional[dict] = None,
@@ -4175,6 +4220,80 @@ def _component_check_auth(
 
 
 if DISCORD_AVAILABLE:
+
+    class DeliverableApprovalView(discord.ui.View):
+        """Three-button approval view for external deliverables and drafts."""
+
+        def __init__(
+            self,
+            approval_id: str,
+            allowed_user_ids: set,
+            allowed_role_ids: Optional[set] = None,
+            approve_label: str = "Approve",
+            revise_label: str = "Needs Work",
+            reject_label: str = "Reject",
+        ):
+            super().__init__(timeout=None)
+            self.approval_id = approval_id
+            self.allowed_user_ids = allowed_user_ids
+            self.allowed_role_ids = allowed_role_ids or set()
+            self.resolved = False
+            # discord.py creates Button children from decorators before __init__
+            # completes, so customize labels here.
+            if len(self.children) >= 3:
+                self.children[0].label = approve_label
+                self.children[1].label = revise_label
+                self.children[2].label = reject_label
+
+        def _check_auth(self, interaction: discord.Interaction) -> bool:
+            return _component_check_auth(
+                interaction, self.allowed_user_ids, self.allowed_role_ids,
+            )
+
+        async def _resolve(
+            self, interaction: discord.Interaction, status: str,
+            color: discord.Color,
+        ):
+            if self.resolved:
+                await interaction.response.send_message(
+                    "This approval has already been resolved.", ephemeral=True
+                )
+                return
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized to approve deliverables.", ephemeral=True
+                )
+                return
+            self.resolved = True
+            display_name = getattr(interaction.user, "display_name", None) or str(interaction.user)
+            try:
+                from tools.approval_box_state import decision_label, resolve_record
+                record = resolve_record(self.approval_id, status, display_name)
+                final_status = record.get("status", status) if record else status
+                footer_text = decision_label(final_status, display_name)
+            except Exception as exc:
+                logger.error("Failed to resolve deliverable approval: %s", exc, exc_info=True)
+                footer_text = f"Resolved by {display_name}"
+
+            embed = interaction.message.embeds[0] if interaction.message.embeds else None
+            if embed:
+                embed.color = color
+                embed.set_footer(text=footer_text)
+            for child in self.children:
+                child.disabled = True
+            await interaction.response.edit_message(embed=embed, view=self)
+
+        @discord.ui.button(label="Approve", style=discord.ButtonStyle.green)
+        async def approve(self, interaction: discord.Interaction, button: discord.ui.Button):
+            await self._resolve(interaction, "approved", discord.Color.green())
+
+        @discord.ui.button(label="Needs Work", style=discord.ButtonStyle.grey)
+        async def needs_work(self, interaction: discord.Interaction, button: discord.ui.Button):
+            await self._resolve(interaction, "needs_work", discord.Color.gold())
+
+        @discord.ui.button(label="Reject", style=discord.ButtonStyle.red)
+        async def reject(self, interaction: discord.Interaction, button: discord.ui.Button):
+            await self._resolve(interaction, "rejected", discord.Color.red())
 
     class ExecApprovalView(discord.ui.View):
         """

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -660,6 +660,15 @@ class SlackAdapter(BasePlatformAdapter):
             ):
                 self._app.action(_action_id)(self._handle_slash_confirm_action)
 
+            # Register Block Kit action handlers for deliverable approval boxes
+            # (Approve / Needs Work / Reject; see tools/approval_box_tool.py).
+            for _action_id in (
+                "hermes_deliverable_approve",
+                "hermes_deliverable_needs_work",
+                "hermes_deliverable_reject",
+            ):
+                self._app.action(_action_id)(self._handle_deliverable_approval_action)
+
             # Start Socket Mode handler in background
             self._handler = AsyncSocketModeHandler(self._app, app_token, proxy=proxy_url)
             _apply_slack_proxy(self._handler.client, proxy_url)
@@ -2237,6 +2246,73 @@ class SlackAdapter(BasePlatformAdapter):
             logger.error("[Slack] send_exec_approval failed: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def send_deliverable_approval(
+        self, chat_id: str, record: Dict[str, Any], thread_ts: Optional[str] = None,
+        approve_label: str = "Approve", revise_label: str = "Needs Work",
+        reject_label: str = "Reject",
+    ) -> SendResult:
+        """Send a Block Kit approval box for external deliverables/drafts."""
+        if not self._app:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            approval_id = str(record.get("approval_id", ""))
+            title = str(record.get("title") or "Approval requested")
+            body = str(record.get("body") or "")
+            drive_link = str(record.get("drive_link") or "")
+            artifact_path = str(record.get("artifact_path") or "")
+            text = body[:2800] + "..." if len(body) > 2800 else body
+
+            section_text = f"*{title}*\n\n{text}"
+            fields = []
+            if drive_link:
+                fields.append({"type": "mrkdwn", "text": f"*Drive link:*\n<{drive_link}|Open deliverable>"})
+            if artifact_path:
+                fields.append({"type": "mrkdwn", "text": f"*Local path:*\n`{artifact_path}`"})
+            fields.append({"type": "mrkdwn", "text": f"*Approval ID:*\n`{approval_id}`"})
+
+            blocks = [
+                {"type": "section", "text": {"type": "mrkdwn", "text": section_text}},
+                {"type": "section", "fields": fields},
+                {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "text": {"type": "plain_text", "text": approve_label},
+                            "style": "primary",
+                            "action_id": "hermes_deliverable_approve",
+                            "value": approval_id,
+                        },
+                        {
+                            "type": "button",
+                            "text": {"type": "plain_text", "text": revise_label},
+                            "action_id": "hermes_deliverable_needs_work",
+                            "value": approval_id,
+                        },
+                        {
+                            "type": "button",
+                            "text": {"type": "plain_text", "text": reject_label},
+                            "style": "danger",
+                            "action_id": "hermes_deliverable_reject",
+                            "value": approval_id,
+                        },
+                    ],
+                },
+            ]
+            kwargs: Dict[str, Any] = {
+                "channel": chat_id,
+                "text": f"Approval requested: {title}",
+                "blocks": blocks,
+            }
+            if thread_ts:
+                kwargs["thread_ts"] = thread_ts
+            result = await self._get_client(chat_id).chat_postMessage(**kwargs)
+            return SendResult(success=True, message_id=result.get("ts", ""), raw_response=result)
+        except Exception as e:
+            logger.error("[Slack] send_deliverable_approval failed: %s", e, exc_info=True)
+            return SendResult(success=False, error=str(e))
+
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str,
         confirm_id: str, metadata: Optional[Dict[str, Any]] = None,
@@ -2398,6 +2474,59 @@ class SlackAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             logger.error("Failed to resolve slash-confirm from Slack button: %s", exc, exc_info=True)
+
+    async def _handle_deliverable_approval_action(self, ack, body, action) -> None:
+        """Handle Approve / Needs Work / Reject clicks for deliverable boxes."""
+        await ack()
+
+        action_id = action.get("action_id", "")
+        approval_id = action.get("value", "")
+        message = body.get("message", {})
+        msg_ts = message.get("ts", "")
+        channel_id = body.get("channel", {}).get("id", "")
+        user_name = body.get("user", {}).get("name", "unknown")
+        user_id = body.get("user", {}).get("id", "")
+
+        allowed_csv = os.getenv("SLACK_ALLOWED_USERS", "").strip()
+        if allowed_csv:
+            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
+            if "*" not in allowed_ids and user_id not in allowed_ids:
+                logger.warning(
+                    "[Slack] Unauthorized deliverable approval click by %s (%s) — ignoring",
+                    user_name, user_id,
+                )
+                return
+
+        status_map = {
+            "hermes_deliverable_approve": "approved",
+            "hermes_deliverable_needs_work": "needs_work",
+            "hermes_deliverable_reject": "rejected",
+        }
+        status = status_map.get(action_id, "rejected")
+
+        try:
+            from tools.approval_box_state import decision_label, resolve_record
+            record = resolve_record(approval_id, status, user_name)
+            decision_text = decision_label(record.get("status", status) if record else status, user_name)
+        except Exception as exc:
+            logger.error("[Slack] Failed to resolve deliverable approval: %s", exc, exc_info=True)
+            decision_text = f"Resolved by {user_name}"
+
+        original_blocks = message.get("blocks", [])
+        kept_blocks = [b for b in original_blocks if b.get("type") != "actions"]
+        kept_blocks.append({
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": decision_text}],
+        })
+        try:
+            await self._get_client(channel_id).chat_update(
+                channel=channel_id,
+                ts=msg_ts,
+                text=decision_text,
+                blocks=kept_blocks,
+            )
+        except Exception as exc:
+            logger.warning("[Slack] Failed to update deliverable approval message: %s", exc)
 
     async def _handle_approval_action(self, ack, body, action) -> None:
         """Handle an approval button click from Block Kit."""

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -291,6 +291,7 @@ class TestCheckFnExceptionHandling:
 class TestBuiltinDiscovery:
     def test_matches_previous_manual_builtin_tool_set(self):
         expected = {
+            "tools.approval_box_tool",
             "tools.browser_cdp_tool",
             "tools.browser_dialog_tool",
             "tools.browser_tool",

--- a/tools/approval_box_state.py
+++ b/tools/approval_box_state.py
@@ -1,0 +1,115 @@
+"""Persistent state for deliverable approval boxes.
+
+Unlike shell-command approvals, deliverable approvals do not unblock a waiting
+agent thread. They are an audit trail and a mobile-friendly review surface: an
+agent posts a draft/artifact with Approve / Needs Work / Reject buttons, and the
+platform callback records the decision under ``HERMES_HOME/approval_boxes`` while
+updating the original message.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from hermes_constants import get_hermes_home
+
+VALID_STATUSES = {"pending", "approved", "needs_work", "rejected"}
+
+
+def _state_dir() -> Path:
+    path = Path(get_hermes_home()) / "approval_boxes"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _state_path(approval_id: str) -> Path:
+    safe = "".join(ch for ch in approval_id if ch.isalnum() or ch in "-_")
+    return _state_dir() / f"{safe}.json"
+
+
+def new_id() -> str:
+    return f"appr_{uuid.uuid4().hex[:16]}"
+
+
+def create_record(
+    *,
+    platform: str,
+    target: str,
+    title: str,
+    body: str,
+    drive_link: str = "",
+    artifact_path: str = "",
+    message_id: str = "",
+    status: str = "pending",
+) -> Dict[str, Any]:
+    approval_id = new_id()
+    now = time.time()
+    record: Dict[str, Any] = {
+        "approval_id": approval_id,
+        "platform": platform,
+        "target": target,
+        "title": title,
+        "body": body,
+        "drive_link": drive_link,
+        "artifact_path": artifact_path,
+        "message_id": message_id,
+        "status": status,
+        "created_at": now,
+        "updated_at": now,
+        "decision": None,
+        "decided_by": None,
+    }
+    save_record(record)
+    return record
+
+
+def load_record(approval_id: str) -> Optional[Dict[str, Any]]:
+    path = _state_path(approval_id)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def save_record(record: Dict[str, Any]) -> None:
+    approval_id = str(record.get("approval_id") or "")
+    if not approval_id:
+        raise ValueError("approval record missing approval_id")
+    tmp = _state_path(approval_id).with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(record, indent=2, ensure_ascii=False), encoding="utf-8")
+    os.replace(tmp, _state_path(approval_id))
+
+
+def resolve_record(approval_id: str, status: str, decided_by: str = "") -> Optional[Dict[str, Any]]:
+    if status not in VALID_STATUSES - {"pending"}:
+        raise ValueError(f"invalid approval status: {status}")
+    record = load_record(approval_id)
+    if not record:
+        return None
+    # First click wins. Keep the original decision if already resolved.
+    if record.get("status") != "pending":
+        return record
+    record["status"] = status
+    record["decision"] = status
+    record["decided_by"] = decided_by
+    record["updated_at"] = time.time()
+    save_record(record)
+    return record
+
+
+def decision_label(status: str, decided_by: str = "") -> str:
+    who = f" by {decided_by}" if decided_by else ""
+    labels = {
+        "approved": f"✅ Approved{who}",
+        "needs_work": f"🛠️ Needs work{who}",
+        "rejected": f"❌ Rejected{who}",
+        "pending": "⏳ Pending approval",
+    }
+    return labels.get(status, f"Resolved{who}")

--- a/tools/approval_box_tool.py
+++ b/tools/approval_box_tool.py
@@ -1,0 +1,206 @@
+"""Deliverable approval-box tools for Discord and Slack.
+
+These tools post Willie/OpenClaw-style approval boxes with interactive buttons.
+They are intentionally separate from shell command approvals: clicking a button
+records an auditable decision and updates the platform message; it does not run
+or unblock arbitrary code.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, Optional, Tuple
+
+from tools.registry import registry, tool_error
+from tools.approval_box_state import create_record
+
+logger = logging.getLogger(__name__)
+
+
+def _schema(name: str, platform_label: str, target_example: str) -> Dict[str, Any]:
+    return {
+        "name": name,
+        "description": (
+            f"Send an interactive {platform_label} approval box with Approve / Needs Work / Reject buttons. "
+            f"Use for Willie/OpenClaw-style deliverable approval posts when the delivery target is {platform_label}. "
+            f"Requires a target like {target_example}. Deliverable files must be uploaded to Google Drive first "
+            "and passed as a Google Drive link; local Hermes paths are not final delivery."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "target": {"type": "string", "description": f"{platform_label} target. Example: {target_example}"},
+                "title": {"type": "string", "description": "Approval box title"},
+                "body": {"type": "string", "description": "Main readable approval body, including the actual draft text when approving communications"},
+                "drive_link": {"type": "string", "description": "Required Google Drive deliverable link for files/artifacts"},
+                "artifact_path": {"type": "string", "description": "Optional local artifact path for traceability only; not final delivery"},
+                "approve_label": {"type": "string", "description": "Approve button label, default 'Approve'"},
+                "revise_label": {"type": "string", "description": "Needs Work button label, default 'Needs Work'"},
+                "reject_label": {"type": "string", "description": "Reject button label, default 'Reject'"},
+            },
+            "required": ["target", "title", "body"],
+        },
+    }
+
+
+DISCORD_APPROVAL_BOX_SCHEMA = _schema(
+    "discord_approval_box",
+    "Discord",
+    "'discord:1234567890', 'discord:1234567890:9876543210', or 'discord:#channel-name'",
+)
+SLACK_APPROVAL_BOX_SCHEMA = _schema(
+    "slack_approval_box",
+    "Slack",
+    "'slack:C1234567890', 'slack:C1234567890:1712345678.000100', or 'slack:#engineering'",
+)
+
+
+def _parse_target(target: str, expected_platform: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    parts = (target or "").split(":")
+    platform = parts[0].strip().lower() if parts else ""
+    if platform != expected_platform:
+        return None, None, f"target must start with {expected_platform}:"
+    if len(parts) < 2 or not parts[1].strip():
+        return None, None, "target must include a channel/chat id or channel name"
+    chat_ref = parts[1].strip()
+    thread_id = parts[2].strip() if len(parts) > 2 and parts[2].strip() else None
+
+    # Resolve #channel names through the gateway channel directory when available.
+    if chat_ref.startswith("#"):
+        try:
+            from gateway.channel_directory import resolve_channel_name
+            resolved = resolve_channel_name(expected_platform, chat_ref)
+            if not resolved:
+                return None, None, f"Could not resolve {chat_ref}; use send_message(action='list') or an explicit id"
+            rparts = resolved.split(":")
+            chat_ref = rparts[0]
+            if len(rparts) > 1 and not thread_id:
+                thread_id = rparts[1]
+        except Exception as exc:
+            return None, None, f"Could not resolve {chat_ref}: {exc}"
+    return chat_ref, thread_id, None
+
+
+def _check_gateway_or_platform() -> bool:
+    try:
+        from gateway.session_context import get_session_env
+        if get_session_env("HERMES_SESSION_PLATFORM", "") not in ("", "local"):
+            return True
+    except Exception:
+        pass
+    try:
+        from gateway.status import is_gateway_running
+        return is_gateway_running()
+    except Exception:
+        return False
+
+
+def _get_live_adapter(platform_name: str):
+    try:
+        from gateway.config import Platform
+        from gateway.run import _gateway_runner_ref
+        runner = _gateway_runner_ref()
+        if not runner:
+            return None
+        return runner.adapters.get(Platform(platform_name))
+    except Exception:
+        return None
+
+
+def _build_record(args: Dict[str, Any], platform: str, target: str) -> Dict[str, Any]:
+    return create_record(
+        platform=platform,
+        target=target,
+        title=(args.get("title") or "Approval requested").strip(),
+        body=(args.get("body") or "").strip(),
+        drive_link=(args.get("drive_link") or "").strip(),
+        artifact_path=(args.get("artifact_path") or "").strip(),
+    )
+
+
+def _result(record: Dict[str, Any], send_result: Any) -> str:
+    success = bool(getattr(send_result, "success", False)) if not isinstance(send_result, dict) else bool(send_result.get("success"))
+    message_id = getattr(send_result, "message_id", "") if not isinstance(send_result, dict) else send_result.get("message_id", "")
+    error = getattr(send_result, "error", "") if not isinstance(send_result, dict) else send_result.get("error", "")
+    if message_id:
+        record["message_id"] = message_id
+        try:
+            from tools.approval_box_state import save_record
+            save_record(record)
+        except Exception:
+            pass
+    payload = {
+        "success": success,
+        "approval_id": record.get("approval_id"),
+        "message_id": message_id,
+        "state_path": f"approval_boxes/{record.get('approval_id')}.json",
+    }
+    if error:
+        payload["error"] = str(error)
+    return json.dumps(payload)
+
+
+def _send_discord_approval_box(args: Dict[str, Any], **kw) -> str:
+    target = args.get("target", "")
+    chat_id, thread_id, error = _parse_target(target, "discord")
+    if error:
+        return tool_error(error)
+    if not args.get("body"):
+        return tool_error("body is required")
+    record = _build_record(args, "discord", target)
+    adapter = _get_live_adapter("discord")
+    if not adapter or not hasattr(adapter, "send_deliverable_approval"):
+        return tool_error("No live Discord adapter with deliverable approval support. Restart the gateway after installing this change.")
+    from model_tools import _run_async
+    send_result = _run_async(adapter.send_deliverable_approval(
+        chat_id=chat_id,
+        thread_id=thread_id,
+        record=record,
+        approve_label=args.get("approve_label") or "Approve",
+        revise_label=args.get("revise_label") or "Needs Work",
+        reject_label=args.get("reject_label") or "Reject",
+    ))
+    return _result(record, send_result)
+
+
+def _send_slack_approval_box(args: Dict[str, Any], **kw) -> str:
+    target = args.get("target", "")
+    chat_id, thread_id, error = _parse_target(target, "slack")
+    if error:
+        return tool_error(error)
+    if not args.get("body"):
+        return tool_error("body is required")
+    record = _build_record(args, "slack", target)
+    adapter = _get_live_adapter("slack")
+    if not adapter or not hasattr(adapter, "send_deliverable_approval"):
+        return tool_error("No live Slack adapter with deliverable approval support. Restart the gateway after installing this change.")
+    from model_tools import _run_async
+    send_result = _run_async(adapter.send_deliverable_approval(
+        chat_id=chat_id,
+        thread_ts=thread_id,
+        record=record,
+        approve_label=args.get("approve_label") or "Approve",
+        revise_label=args.get("revise_label") or "Needs Work",
+        reject_label=args.get("reject_label") or "Reject",
+    ))
+    return _result(record, send_result)
+
+
+registry.register(
+    name="discord_approval_box",
+    toolset="messaging",
+    schema=DISCORD_APPROVAL_BOX_SCHEMA,
+    handler=_send_discord_approval_box,
+    check_fn=_check_gateway_or_platform,
+    emoji="✅",
+)
+registry.register(
+    name="slack_approval_box",
+    toolset="messaging",
+    schema=SLACK_APPROVAL_BOX_SCHEMA,
+    handler=_send_slack_approval_box,
+    check_fn=_check_gateway_or_platform,
+    emoji="✅",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -58,6 +58,7 @@ _HERMES_CORE_TOOLS = [
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
     "send_message",
+    "discord_approval_box", "slack_approval_box",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
     # Kanban multi-agent coordination — only in schema when the agent is


### PR DESCRIPTION
Fixes #20952.\n\nAdds interactive deliverable approval box tools for Willie/OpenClaw approval workflows:\n- exposes slack_approval_box and discord_approval_box in the messaging toolset\n- posts Approve / Needs Work / Reject buttons\n- records decisions under HERMES_HOME/approval_boxes\n- updates Slack Block Kit / Discord messages after a decision\n- keeps command approvals separate from deliverable approvals\n\nVerification:\n- python -m py_compile tools/approval_box_tool.py tools/approval_box_state.py gateway/platforms/slack.py gateway/platforms/discord.py toolsets.py\n- python check confirmed messaging schemas expose slack_approval_box and discord_approval_box\n- pytest -q -o addopts='' tests/tools/test_registry.py