### PR TITLE
docs(kanban): fix orchestrator skill setup instructions

### DIFF
--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -403,10 +403,18 @@ kanban_complete(
 )
 ```
 
-Load it into your orchestrator profile:
+`kanban-orchestrator` is a bundled skill. It is synced into each profile during
+install and update, so there is no separate Skills Hub install step. Verify it is
+present in your orchestrator profile:
 
 ```bash
-hermes skills install devops/kanban-orchestrator
+hermes -p orchestrator skills list | grep kanban-orchestrator
+```
+
+If the bundled copy is missing, restore it for that profile:
+
+```bash
+hermes -p orchestrator skills reset kanban-orchestrator --restore
 ```
 
 For best results, pair it with a profile whose toolsets are restricted to board operations (`kanban`, `gateway`, `memory`) so the orchestrator literally cannot execute implementation tasks even if it tries.


### PR DESCRIPTION
## What does this PR do?

Fixes stale Kanban documentation that tells users to run `hermes skills install devops/kanban-orchestrator`. That command tries to fetch from the Skills Hub, but `kanban-orchestrator` is a bundled skill synced into profiles during install/update.

The updated docs tell users to verify the bundled skill in the orchestrator profile and use `hermes -p orchestrator skills reset kanban-orchestrator --restore` as the recovery path if the bundled copy is missing.

## Related Issue

Fixes docs mismatch reported in Discord support: users following the Kanban page get `Could not fetch 'devops/kanban-orchestrator' from any source.`

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `website/docs/user-guide/features/kanban.md` to remove the stale Skills Hub install command for `kanban-orchestrator`.
- Added verification and restore commands for the bundled skill in the `orchestrator` profile.

## How to Test

1. Run `rg -n "hermes skills install devops/kanban-orchestrator|Load it into your orchestrator profile" website/docs -S` and confirm no stale command remains.
2. Run `git diff --check -- website/docs/user-guide/features/kanban.md`.
3. Read the Kanban docs section and confirm it now matches the bundled skill page, which marks `kanban-orchestrator` as bundled/installed by default.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/WSL docs-only check

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Docs-only change. Local checks:

- `git diff --check -- website/docs/user-guide/features/kanban.md`
- `rg -n "hermes skills install devops/kanban-orchestrator|Load it into your orchestrator profile" website/docs -S`
