### PR TITLE
docs(kanban): fix worker skill setup instructions too

### DIFF
--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -335,10 +335,19 @@ Any profile that should be able to work kanban tasks must load the `kanban-worke
 3. Call `kanban_heartbeat(note="...")` every few minutes during long operations.
 4. Complete with `kanban_complete(summary="...", metadata={...})`, or `kanban_block(reason="...")` if stuck.
 
-Load it with (this one is **you**, installing into a profile — not a tool call):
+`kanban-worker` is a bundled skill, synced into every profile during install and
+update — there is no separate Skills Hub install step. Verify it is present in
+whichever profile you use for kanban workers (`researcher`, `writer`, `ops`,
+etc.):
 
 ```bash
-hermes skills install devops/kanban-worker
+hermes -p <your-worker-profile> skills list | grep kanban-worker
+```
+
+If the bundled copy is missing, restore it for that profile:
+
+```bash
+hermes -p <your-worker-profile> skills reset kanban-worker --restore
 ```
 
 The dispatcher also auto-passes `--skills kanban-worker` when spawning every worker, so the worker always has the pattern library available even if a profile's default skills config doesn't include it.


### PR DESCRIPTION
Follow-up to #20958.

The worker skill section had the same stale `hermes skills install devops/kanban-worker` command. `kanban-worker` is a bundled skill (`skills/devops/kanban-worker/`), so that command fails the same way the orchestrator one did:

```
Error: Could not fetch 'devops/kanban-worker' from any source.
```

Replaces it with the same bundled-skill verification + `skills reset --restore` recovery pattern @helix4u used for the orchestrator section in #20958. Uses `<your-worker-profile>` as the placeholder since workers can be assigned to any profile (`researcher`, `writer`, `ops`, `linguist`, `reviewer`, etc.) rather than a single fixed `worker` profile.

## Validation

- `rg -n 'skills install devops/kanban' website/` returns zero hits after this change.
- Docs-only.
