### PR TITLE
fix: guard memory provider initialize() against repeated calls (#20939)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -541,13 +541,31 @@ class MemoryManager:
         Automatically injects ``hermes_home`` into *kwargs* so that every
         provider can resolve profile-scoped storage paths without importing
         ``get_hermes_home()`` themselves.
+
+        Skips providers that are already initialized for the same session_id
+        to prevent resource-heavy re-initialization (e.g. spawning bridge
+        processes) on every turn.  See #20939.
         """
         if "hermes_home" not in kwargs:
             from hermes_constants import get_hermes_home
             kwargs["hermes_home"] = str(get_hermes_home())
         for provider in self._providers:
             try:
+                # Guard: skip if already initialized for the same session.
+                # Providers must still re-initialize when session_id changes
+                # (e.g. compression rotation) so per-session state refreshes.
+                # Use getattr for backward compat with subclasses that don't
+                # call super().__init__().
+                if (getattr(provider, '_initialized', False)
+                        and getattr(provider, '_initialized_session_id', '') == session_id):
+                    logger.debug(
+                        "Memory provider '%s' already initialized for session %s — skipping",
+                        provider.name, session_id,
+                    )
+                    continue
                 provider.initialize(session_id=session_id, **kwargs)
+                provider._initialized = True
+                provider._initialized_session_id = session_id
             except Exception as e:
                 logger.warning(
                     "Memory provider '%s' initialize failed: %s",

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -42,6 +42,10 @@ logger = logging.getLogger(__name__)
 class MemoryProvider(ABC):
     """Abstract base class for memory providers."""
 
+    def __init__(self) -> None:
+        self._initialized: bool = False
+        self._initialized_session_id: str = ""
+
     @property
     @abstractmethod
     def name(self) -> str:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -352,6 +352,47 @@ class TestMemoryManager:
         assert p1._init_kwargs["session_id"] == "test-123"
         assert p1._init_kwargs["platform"] == "cli"
 
+    def test_initialize_all_skips_same_session(self):
+        """Guard #20939: initialize_all skips providers already initialized
+        for the same session_id to prevent resource-heavy re-initialization
+        (e.g. spawning bridge processes) on every turn."""
+        mgr = MemoryManager()
+        p1 = FakeMemoryProvider("memos")
+        init_call_count = [0]
+        original_init = p1.initialize
+
+        def counting_init(session_id, **kwargs):
+            init_call_count[0] += 1
+            original_init(session_id, **kwargs)
+
+        p1.initialize = counting_init
+        mgr.add_provider(p1)
+
+        # First call — should initialize
+        mgr.initialize_all(session_id="sess-1", platform="cli")
+        assert init_call_count[0] == 1
+
+        # Same session — should skip
+        mgr.initialize_all(session_id="sess-1", platform="cli")
+        assert init_call_count[0] == 1
+
+        # Different session — should re-initialize
+        mgr.initialize_all(session_id="sess-2", platform="cli")
+        assert init_call_count[0] == 2
+
+    def test_initialize_guard_backward_compat_no_super_init(self):
+        """Providers that don't call super().__init__() still work
+        because the guard uses getattr with defaults."""
+        mgr = MemoryManager()
+        # FakeMemoryProvider doesn't call super().__init__()
+        p1 = FakeMemoryProvider("legacy")
+        assert not hasattr(p1, '_initialized') or not p1._initialized
+        mgr.add_provider(p1)
+
+        mgr.initialize_all(session_id="test", platform="cli")
+        assert p1._initialized is True
+        assert p1._initialized_session_id == "test"
+
     # -- Error resilience ---------------------------------------------------
 
     def test_prefetch_failure_doesnt_block(self):


### PR DESCRIPTION
## Problem

Memory providers that spawn resource-heavy processes (e.g. MemOS/memtensor's `bridge.cts` Node.js pair, ~250MB each) re-initialize on **every turn** in gateway mode, causing:

- 60-100 bridge processes per day
- 15-25GB RAM accumulation  
- Eventually OOM or service degradation

The root cause: `MemoryManager.initialize_all()` calls each provider's `initialize()` unconditionally. When the gateway recreates the `AIAgent` (cache eviction, config change, first message), `initialize()` runs again, spawning duplicate processes.

## Fix

Add an initialization guard to the `MemoryProvider` base class and `MemoryManager.initialize_all()`:

1. **`MemoryProvider.__init__`**: Track `_initialized` (bool) and `_initialized_session_id` (str)
2. **`MemoryManager.initialize_all()`**: Skip providers already initialized for the same `session_id`; re-initialize when `session_id` changes (e.g. compression rotation)
3. **Backward compatible**: Uses `getattr()` so subclasses that don't call `super().__init__()` still work

## Changes

| File | Change |
|------|--------|
| `agent/memory_provider.py` | Add `__init__` with `_initialized` + `_initialized_session_id` |
| `agent/memory_manager.py` | Guard in `initialize_all()` — skip same-session re-init |
| `tests/agent/test_memory_provider.py` | 2 new tests: same-session skip + backward compat |

## Tests

```
78 passed, 6 warnings in 3.37s
```

New tests:
- `test_initialize_all_skips_same_session` — verifies `initialize()` called once per session, not per turn
- `test_initialize_guard_backward_compat_no_super_init` — verifies providers without `super().__init__()` work via `getattr()`

Fixes #20939
