### PR TITLE
feat(i18n): add Irish locale and Gaeilge skin

### DIFF
--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -25,7 +25,7 @@ Language resolution order:
     3. ``display.language`` from config.yaml
     4. ``"en"`` (baseline)
 
-Supported languages: en, zh, ja, de, es, fr, tr, uk.  Unknown values fall back to en.
+Supported languages: en, zh, ja, de, es, fr, tr, uk, ga.  Unknown values fall back to en.
 """
 
 from __future__ import annotations
@@ -39,7 +39,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "ja", "de", "es", "fr", "tr", "uk")
+SUPPORTED_LANGUAGES: tuple[str, ...] = ("en", "zh", "ja", "de", "es", "fr", "tr", "uk", "ga")
 DEFAULT_LANGUAGE = "en"
 
 # Accept a few natural aliases so users who type "chinese" / "zh-CN" / "jp"
@@ -53,6 +53,7 @@ _LANGUAGE_ALIASES: dict[str, str] = {
     "french": "fr", "français": "fr", "france": "fr", "fr-fr": "fr", "fr-be": "fr", "fr-ca": "fr", "fr-ch": "fr",
     "ukrainian": "uk", "ukrainisch": "uk", "українська": "uk", "uk-ua": "uk", "ua": "uk",
     "turkish": "tr", "türkçe": "tr", "tr-tr": "tr",
+    "irish": "ga", "gaeilge": "ga", "irish-gaelic": "ga", "ga-ie": "ga",
 }
 
 _catalog_cache: dict[str, dict[str, str]] = {}

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -933,6 +933,7 @@ display:
   # Built-in skins:
   #   default        — Classic Hermes gold/kawaii
   #   ares           — Crimson/bronze war-god theme with spinner wings
+  #   gaeilge        — Irish/Gaeilge emerald, ivory, and orange theme
   #   mono           — Clean grayscale monochrome
   #   slate          — Cool blue developer-focused
   #   daylight       — Bright light-mode theme

--- a/cli.py
+++ b/cli.py
@@ -1940,7 +1940,8 @@ def _build_compact_banner() -> str:
         tiny_line = "⚕ NOUS HERMES"
     else:
         agent_name = _skin.get_branding("agent_name", "Hermes Agent") if _skin else "Hermes Agent"
-        line1 = f"{agent_name} - AI Agent Framework"
+        framework_label = _skin.get_branding("framework_label", "AI Agent Framework") if _skin else "AI Agent Framework"
+        line1 = f"{agent_name} - {framework_label}"
         tiny_line = agent_name
 
     version_line = format_banner_version_label()

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -460,14 +460,17 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         model_short = model_short[:-5]
     if len(model_short) > 28:
         model_short = model_short[:25] + "..."
-    ctx_str = f" [dim {dim}]·[/] [dim {dim}]{_format_context_length(context_length)} context[/]" if context_length else ""
-    left_lines.append(f"[{accent}]{model_short}[/]{ctx_str} [dim {dim}]·[/] [dim {dim}]Nous Research[/]")
+    context_label = _skin_branding("context_label", "context")
+    provider_label = _skin_branding("provider_label", "Nous Research")
+    session_label = _skin_branding("session_label", "Session")
+    ctx_str = f" [dim {dim}]·[/] [dim {dim}]{_format_context_length(context_length)} {context_label}[/]" if context_length else ""
+    left_lines.append(f"[{accent}]{model_short}[/]{ctx_str} [dim {dim}]·[/] [dim {dim}]{provider_label}[/]")
     left_lines.append(f"[dim {dim}]{cwd}[/]")
     if session_id:
-        left_lines.append(f"[dim {session_color}]Session: {session_id}[/]")
+        left_lines.append(f"[dim {session_color}]{session_label}: {session_id}[/]")
     left_content = "\n".join(left_lines)
 
-    right_lines = [f"[bold {accent}]Available Tools[/]"]
+    right_lines = [f"[bold {accent}]{_skin_branding('available_tools_label', 'Available Tools')}[/]"]
     toolsets_dict: Dict[str, list] = {}
 
     for tool in tools:
@@ -524,7 +527,8 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         right_lines.append(f"[dim {dim}]{toolset}:[/] {tools_str}")
 
     if remaining_toolsets > 0:
-        right_lines.append(f"[dim {dim}](and {remaining_toolsets} more toolsets...)[/]")
+        more_toolsets_template = _skin_branding("more_toolsets_template", "(and {count} more toolsets...)")
+        right_lines.append(f"[dim {dim}]{more_toolsets_template.format(count=remaining_toolsets)}[/]")
 
     # MCP Servers section (only if configured)
     try:
@@ -535,21 +539,21 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
 
     if mcp_status:
         right_lines.append("")
-        right_lines.append(f"[bold {accent}]MCP Servers[/]")
+        right_lines.append(f"[bold {accent}]{_skin_branding('mcp_servers_label', 'MCP Servers')}[/]")
         for srv in mcp_status:
             if srv["connected"]:
                 right_lines.append(
                     f"[dim {dim}]{srv['name']}[/] [{text}]({srv['transport']})[/] "
-                    f"[dim {dim}]—[/] [{text}]{srv['tools']} tool(s)[/]"
+                    f"[dim {dim}]—[/] [{text}]{srv['tools']} {_skin_branding('tools_count_label', 'tool(s)')}[/]"
                 )
             else:
                 right_lines.append(
                     f"[red]{srv['name']}[/] [dim]({srv['transport']})[/] "
-                    f"[red]— failed[/]"
+                    f"[red]— {_skin_branding('failed_label', 'failed')}[/]"
                 )
 
     right_lines.append("")
-    right_lines.append(f"[bold {accent}]Available Skills[/]")
+    right_lines.append(f"[bold {accent}]{_skin_branding('available_skills_label', 'Available Skills')}[/]")
     skills_by_category = get_available_skills()
     total_skills = sum(len(s) for s in skills_by_category.values())
 
@@ -558,27 +562,30 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
             skill_names = sorted(skills_by_category[category])
             if len(skill_names) > 8:
                 display_names = skill_names[:8]
-                skills_str = ", ".join(display_names) + f" +{len(skill_names) - 8} more"
+                skills_str = ", ".join(display_names) + f" +{len(skill_names) - 8} {_skin_branding('more_label', 'more')}"
             else:
                 skills_str = ", ".join(skill_names)
             if len(skills_str) > 50:
                 skills_str = skills_str[:47] + "..."
             right_lines.append(f"[dim {dim}]{category}:[/] [{text}]{skills_str}[/]")
     else:
-        right_lines.append(f"[dim {dim}]No skills installed[/]")
+        right_lines.append(f"[dim {dim}]{_skin_branding('no_skills_label', 'No skills installed')}[/]")
 
     right_lines.append("")
     mcp_connected = sum(1 for s in mcp_status if s["connected"]) if mcp_status else 0
-    summary_parts = [f"{len(tools)} tools", f"{total_skills} skills"]
+    summary_parts = [
+        f"{len(tools)} {_skin_branding('tools_label', 'tools')}",
+        f"{total_skills} {_skin_branding('skills_label', 'skills')}",
+    ]
     if mcp_connected:
-        summary_parts.append(f"{mcp_connected} MCP servers")
-    summary_parts.append("/help for commands")
+        summary_parts.append(f"{mcp_connected} {_skin_branding('mcp_servers_summary_label', 'MCP servers')}")
+    summary_parts.append(_skin_branding("help_for_commands_label", "/help for commands"))
     # Show active profile name when not 'default'
     try:
         from hermes_cli.profiles import get_active_profile_name
         _profile_name = get_active_profile_name()
         if _profile_name and _profile_name != "default":
-            right_lines.append(f"[bold {accent}]Profile:[/] [{text}]{_profile_name}[/]")
+            right_lines.append(f"[bold {accent}]{_skin_branding('profile_label', 'Profile')}:[/] [{text}]{_profile_name}[/]")
     except Exception:
         pass  # Never break the banner over a profiles.py bug
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -820,7 +820,7 @@ DEFAULT_CONFIG = {
         # UI language for static user-facing messages (approval prompts, a
         # handful of gateway slash-command replies).  Does NOT affect agent
         # responses, log lines, tool outputs, or slash-command descriptions.
-        # Supported: en, zh, ja, de, es, fr, tr, uk.  Unknown values fall back to en.
+        # Supported: en, zh, ja, de, es, fr, tr, uk, ga.  Unknown values fall back to en.
         "language": "en",
         # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
         # spinner), or ascii.  Live-swappable via `/indicator <style>`.

--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -195,6 +195,92 @@ _BUILTIN_SKINS: Dict[str, Dict[str, Any]] = {
         },
         "tool_prefix": "┊",
     },
+    "gaeilge": {
+        "name": "gaeilge",
+        "description": "Irish/Gaeilge theme — emerald, ivory, and orange",
+        "colors": {
+            "banner_border": "#169B62",
+            "banner_title": "#FFFFFF",
+            "banner_accent": "#FF883E",
+            "banner_dim": "#7FBF9B",
+            "banner_text": "#F7FFF7",
+            "ui_accent": "#FF883E",
+            "ui_label": "#FFFFFF",
+            "ui_ok": "#169B62",
+            "ui_error": "#E94B3C",
+            "ui_warn": "#FF883E",
+            "prompt": "#F7FFF7",
+            "input_rule": "#169B62",
+            "response_border": "#FF883E",
+            "status_bar_bg": "#0B2E1C",
+            "status_bar_text": "#F7FFF7",
+            "status_bar_strong": "#FFFFFF",
+            "status_bar_dim": "#7FBF9B",
+            "status_bar_good": "#169B62",
+            "status_bar_warn": "#FF883E",
+            "status_bar_bad": "#E94B3C",
+            "status_bar_critical": "#FF4F4F",
+            "session_label": "#FF883E",
+            "session_border": "#7FBF9B",
+        },
+        "spinner": {
+            "waiting_faces": ["(☘)", "(✦)", "(◌)", "(❋)", "(⌁)"],
+            "thinking_faces": ["(☘)", "(❋)", "(✦)", "(⌁)", "(◌)"],
+            "thinking_verbs": [
+                "ag smaoineamh", "ag fíodóireacht", "ag bailiú snáitheanna",
+                "ag léamh na gaoithe", "ag cumadh freagra", "ag cur ord ar na nótaí",
+                "ag lasadh na lóchrainne", "ag leanúint na slí",
+            ],
+            "wings": [
+                ["⟪☘", "☘⟫"],
+                ["⟪✦", "✦⟫"],
+                ["⟪❋", "❋⟫"],
+                ["⟪╸", "╺⟫"],
+            ],
+        },
+        "branding": {
+            "agent_name": "Hermes as Gaeilge",
+            "framework_label": "Creatlach Gníomhairí AI",
+            "welcome": "Fáilte go Hermes as Gaeilge. Scríobh teachtaireacht nó /help le haghaidh orduithe.",
+            "goodbye": "Slán go fóill! ☘",
+            "response_label": " ☘ Hermes ",
+            "prompt_symbol": "☘",
+            "help_header": "(☘) Orduithe ar fáil",
+            "available_tools_label": "Uirlisí ar fáil",
+            "available_skills_label": "Scileanna ar fáil",
+            "mcp_servers_label": "Freastalaithe MCP",
+            "profile_label": "Próifíl",
+            "session_label": "Seisiún",
+            "context_label": "comhthéacs",
+            "provider_label": "Nous Research",
+            "tools_count_label": "uirlis(í)",
+            "failed_label": "theip",
+            "more_label": "eile",
+            "more_toolsets_template": "(agus {count} tacar uirlisí eile...)",
+            "no_skills_label": "Níl aon scil suiteáilte",
+            "tools_label": "uirlis",
+            "skills_label": "scil",
+            "mcp_servers_summary_label": "freastalaí MCP",
+            "help_for_commands_label": "/help le haghaidh orduithe",
+        },
+        "tool_prefix": "☘",
+        "banner_logo": """[bold #169B62]██╗  ██╗███████╗██████╗ ███╗   ███╗███████╗███████╗       █████╗ ███████╗     ██████╗  █████╗ ███████╗██╗██╗      ██████╗ ███████╗[/]
+[bold #169B62]██║  ██║██╔════╝██╔══██╗████╗ ████║██╔════╝██╔════╝      ██╔══██╗██╔════╝    ██╔════╝ ██╔══██╗██╔════╝██║██║     ██╔════╝ ██╔════╝[/]
+[#FFFFFF]███████║█████╗  ██████╔╝██╔████╔██║█████╗  ███████╗█████╗███████║███████╗    ██║  ███╗███████║█████╗  ██║██║     ██║  ███╗█████╗  [/]
+[#FF883E]██╔══██║██╔══╝  ██╔══██╗██║╚██╔╝██║██╔══╝  ╚════██║╚════╝██╔══██║╚════██║    ██║   ██║██╔══██║██╔══╝  ██║██║     ██║   ██║██╔══╝  [/]
+[bold #FF883E]██║  ██║███████╗██║  ██║██║ ╚═╝ ██║███████╗███████║      ██║  ██║███████║    ╚██████╔╝██║  ██║███████╗██║███████╗╚██████╔╝███████╗[/]
+[bold #FF883E]╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝     ╚═╝╚══════╝╚══════╝      ╚═╝  ╚═╝╚══════╝     ╚═════╝ ╚═╝  ╚═╝╚══════╝╚═╝╚══════╝ ╚═════╝ ╚══════╝[/]""",
+        "banner_hero": """[#169B62]⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#169B62]⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣠⣴⣿⣿⣿⣦⣄⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[#FFFFFF]⠀⠀⠀⠀⠀⠀⠀⢀⣴⣿⠟⠋⠀☘⠀⠙⠻⣿⣦⡀⠀⠀⠀⠀⠀⠀⠀[/]
+[#FFFFFF]⠀⠀⠀⠀⠀⠀⢠⣿⠏⠀⠀⠀⠀⠀⠀⠀⠀⠹⣿⡄⠀⠀⠀⠀⠀⠀[/]
+[#FF883E]⠀⠀⠀⠀⠀⠀⣿⡟⠀⠀⠀⣀⣀⣀⣀⠀⠀⠀⢻⣿⠀⠀⠀⠀⠀⠀[/]
+[#FF883E]⠀⠀⠀⠀⠀⠀⣿⡇⠀⠀⠈⠉⠉⠉⠉⠁⠀⠀⢸⣿⠀⠀⠀⠀⠀⠀[/]
+[#169B62]⠀⠀⠀⠀⠀⠀⢿⣧⠀⠀⠀⠀☘⠀⠀⠀⠀⣼⡿⠀⠀⠀⠀⠀⠀[/]
+[#FFFFFF]⠀⠀⠀⠀⠀⠀⠈⠻⣷⣄⡀⠀⠀⠀⠀⢀⣠⣾⠟⠁⠀⠀⠀⠀⠀⠀[/]
+[#FF883E]⠀⠀⠀⠀⠀⠀⠀⠀⠈⠙⠿⣿⣿⣿⠿⠋⠁⠀⠀⠀⠀⠀⠀⠀⠀[/]
+[dim #7FBF9B]⠀⠀⠀⠀⠀⠀⠀⠀⠀fáilte isteach⠀⠀⠀⠀⠀⠀⠀⠀⠀[/]""",
+    },
     "ares": {
         "name": "ares",
         "description": "War-god theme — crimson and bronze",

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -7,7 +7,7 @@
 #
 # Keys are dotted paths; nesting below is purely for readability.  Values may
 # contain {placeholder} tokens for str.format substitution.  When adding a
-# new key, add it to EVERY locale file (en/zh/ja/de/es/fr/tr/uk) in the same commit --
+# new key, add it to EVERY locale file (en/zh/ja/de/es/fr/tr/uk/ga) in the same commit --
 # tests/agent/test_i18n.py asserts catalog parity.
 
 approval:

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -1,0 +1,26 @@
+# Catalóg teachtaireachtaí statacha Hermes -- Gaeilge
+# See locales/en.yaml for the source of truth; keep keys in sync.
+
+approval:
+  # Leid cheadaithe CLI -- taispeántar é nuair is gá d'úsáideoir ordú contúirteach a athbhreithniú.
+  dangerous_header: "⚠️  ORDÚ DÁINSÉARACH: {description}"
+  choose_long:     "      [o] uair amháin  |  [s] seisiún  |  [a] i gcónaí  |  [d] diúltaigh"
+  choose_short:    "      [o] uair amháin  |  [s] seisiún  |  [d] diúltaigh"
+  prompt_long:     "      Rogha [o/s/a/D]: "
+  prompt_short:    "      Rogha [o/s/D]: "
+  timeout:         "      ⏱ Chuaigh an t-am in éag — ordú diúltaithe"
+  allowed_once:    "      ✓ Ceadaithe uair amháin"
+  allowed_session: "      ✓ Ceadaithe don seisiún seo"
+  allowed_always:  "      ✓ Curtha leis an liosta buancheadaithe"
+  denied:          "      ✗ Diúltaithe"
+  cancelled:       "      ✗ Cealaithe"
+  blocklist_message: "Tá an t-ordú seo ar an liosta blocála neamhchoinníollach agus ní féidir é a cheadú."
+
+gateway:
+  # Freagraí teachtaire do shlais-orduithe agus d'athruithe intuigthe staid.
+  approval_expired: "⚠️ Chuaigh an ceadú in éag (níl an gníomhaire ag fanacht a thuilleadh). Iarr ar an ngníomhaire triail eile a bhaint as."
+  draining:         "⏳ Ag fanacht le {count} gníomhaire gníomhach a chríochnú roimh atosú..."
+  goal_cleared:     "✓ Sprioc glanta."
+  no_active_goal:   "Níl aon sprioc ghníomhach ann."
+  config_read_failed: "⚠️ Níorbh fhéidir config.yaml a léamh: {error}"
+  config_save_failed: "⚠️ Níorbh fhéidir an chumraíocht a shábháil: {error}"

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -95,6 +95,10 @@ def test_normalize_lang_accepts_aliases():
     assert i18n._normalize_lang("Turkish") == "tr"
     assert i18n._normalize_lang("tr-TR") == "tr"
     assert i18n._normalize_lang("türkçe") == "tr"
+    assert i18n._normalize_lang("Irish") == "ga"
+    assert i18n._normalize_lang("Gaeilge") == "ga"
+    assert i18n._normalize_lang("irish-gaelic") == "ga"
+    assert i18n._normalize_lang("ga-IE") == "ga"
 
 
 def test_normalize_lang_unknown_falls_back():
@@ -134,6 +138,7 @@ def test_t_explicit_lang():
     assert i18n.t("approval.denied", lang="zh").endswith("已拒绝")
     assert i18n.t("approval.denied", lang="uk").endswith("Відхилено")
     assert i18n.t("approval.denied", lang="tr").endswith("Reddedildi")
+    assert i18n.t("approval.denied", lang="ga").endswith("Diúltaithe")
 
 
 def test_t_formats_placeholders():

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -133,3 +133,66 @@ def test_build_welcome_banner_title_falls_back_when_no_tag():
     raw = buf.getvalue()
     assert "Hermes Agent v" in raw, "Version label missing from title"
     assert "\x1b]8;" not in raw, "OSC-8 hyperlink should not be emitted without a tag"
+
+
+def test_build_welcome_banner_uses_gaeilge_skin_labels():
+    from hermes_cli.skin_engine import set_active_skin
+
+    set_active_skin("gaeilge")
+    try:
+        with (
+            patch.object(
+                model_tools,
+                "check_tool_availability",
+                return_value=(["web"], []),
+            ),
+            patch.object(banner, "get_available_skills", return_value={}),
+            patch.object(banner, "get_update_result", return_value=None),
+            patch.object(tools.mcp_tool, "get_mcp_status", return_value=[]),
+        ):
+            console = Console(
+                record=True, force_terminal=False, color_system=None, width=160
+            )
+            banner.build_welcome_banner(
+                console=console,
+                model="anthropic/test-model",
+                cwd="/tmp/project",
+                session_id="abc123",
+                tools=[{"function": {"name": "web_search"}}],
+                get_toolset_for_tool=lambda name: "web",
+            )
+
+        output = console.export_text()
+        assert "Uirlisí ar fáil" in output
+        assert "Scileanna ar fáil" in output
+        assert "Seisiún: abc123" in output
+        assert "/help le haghaidh orduithe" in output
+    finally:
+        set_active_skin("default")
+
+
+def test_build_welcome_banner_default_more_toolsets_text_unchanged():
+    from hermes_cli.skin_engine import set_active_skin
+
+    set_active_skin("default")
+    toolsets = [f"toolset{i}" for i in range(10)]
+    tool_defs = [{"function": {"name": f"tool{i}"}} for i in range(10)]
+    tool_map = {f"tool{i}": toolsets[i] for i in range(10)}
+    with (
+        patch.object(model_tools, "check_tool_availability", return_value=([], [])),
+        patch.object(banner, "get_available_skills", return_value={}),
+        patch.object(banner, "get_update_result", return_value=None),
+        patch.object(tools.mcp_tool, "get_mcp_status", return_value=[]),
+    ):
+        console = Console(record=True, force_terminal=False, color_system=None, width=180)
+        banner.build_welcome_banner(
+            console=console,
+            model="anthropic/test-model",
+            cwd="/tmp/project",
+            tools=tool_defs,
+            get_toolset_for_tool=lambda name: tool_map[name],
+        )
+
+    output = console.export_text()
+    assert "(and 2 more toolsets...)" in output
+    assert "(+ 2 more toolsets...)" not in output

--- a/tests/hermes_cli/test_skin_engine.py
+++ b/tests/hermes_cli/test_skin_engine.py
@@ -66,6 +66,18 @@ class TestBuiltinSkins:
         assert isinstance(wings[0], tuple)
         assert len(wings[0]) == 2
 
+    def test_gaeilge_skin_loads(self):
+        from hermes_cli.skin_engine import load_skin
+
+        skin = load_skin("gaeilge")
+        assert skin.name == "gaeilge"
+        assert skin.tool_prefix == "☘"
+        assert skin.get_color("banner_border") == "#169B62"
+        assert skin.get_color("banner_accent") == "#FF883E"
+        assert skin.get_branding("agent_name") == "Hermes as Gaeilge"
+        assert skin.get_branding("available_tools_label") == "Uirlisí ar fáil"
+        assert "ag smaoineamh" in skin.spinner["thinking_verbs"]
+
     def test_mono_skin_loads(self):
         from hermes_cli.skin_engine import load_skin
         skin = load_skin("mono")
@@ -134,6 +146,7 @@ class TestSkinManagement:
         names = [s["name"] for s in skins]
         assert "default" in names
         assert "ares" in names
+        assert "gaeilge" in names
         assert "mono" in names
         assert "slate" in names
         assert "daylight" in names

--- a/tests/test_cli_skin_integration.py
+++ b/tests/test_cli_skin_integration.py
@@ -111,6 +111,16 @@ class TestCompactBannerSkinIntegration:
         assert "Poseidon Agent" in banner
         assert "NOUS HERMES" not in banner
 
+    def test_gaeilge_compact_banner_uses_localized_framework_label(self):
+        set_active_skin("gaeilge")
+
+        with patch("cli.shutil.get_terminal_size", return_value=SimpleNamespace(columns=90)), \
+             patch.dict(_build_compact_banner.__globals__, {"format_banner_version_label": lambda: "Hermes Agent v0.1.0 (test)"}):
+            banner = _build_compact_banner()
+
+        assert "Hermes as Gaeilge" in banner
+        assert "Creatlach Gníomhairí AI" in banner
+
     def test_poseidon_compact_banner_uses_skin_colors(self):
         set_active_skin("poseidon")
         skin = get_active_skin()

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1167,20 +1167,20 @@ display:
   show_cost: false        # Show estimated $ cost in the CLI status bar
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
   runtime_metadata_footer: false  # Gateway: append a runtime-context footer to final replies
-  language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | ja | de | es | fr | tr | uk
+  language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | ja | de | es | fr | tr | uk | ga
 ```
 
 ### UI language for static messages
 
 The `display.language` setting translates a small set of static user-facing messages — the CLI approval prompt, a handful of gateway slash-command replies (e.g. restart-drain notices, "approval expired", "goal cleared"). It does **not** translate agent responses, log lines, tool output, error tracebacks, or slash-command descriptions — those stay in English. If you want the agent itself to reply in another language, just tell it in your prompt or system message.
 
-Supported values: `en` (default), `zh` (Simplified Chinese), `ja` (Japanese), `de` (German), `es` (Spanish), `fr` (French), `tr` (Turkish), `uk` (Ukrainian). Unknown values fall back to English.
+Supported values: `en` (default), `zh` (Simplified Chinese), `ja` (Japanese), `de` (German), `es` (Spanish), `fr` (French), `tr` (Turkish), `uk` (Ukrainian), `ga` (Irish/Gaeilge). Unknown values fall back to English.
 
 You can also set this per-session with the `HERMES_LANGUAGE` env var, which overrides the config value.
 
 ```yaml
 display:
-  language: zh   # CLI approval prompts appear in Chinese
+  language: ga   # CLI approval prompts and some gateway replies appear in Irish/Gaeilge
 ```
 
 | Mode | What you see |

--- a/website/docs/user-guide/features/skins.md
+++ b/website/docs/user-guide/features/skins.md
@@ -34,6 +34,7 @@ display:
 |------|-------------|----------------|------------------|
 | `default` | Classic Hermes — gold and kawaii | `Hermes Agent` | Warm gold borders, cornsilk text, kawaii faces in spinners. The familiar caduceus banner. Clean and inviting. |
 | `ares` | War-god theme — crimson and bronze | `Ares Agent` | Deep crimson borders with bronze accents. Aggressive spinner verbs ("forging", "marching", "tempering steel"). Custom sword-and-shield ASCII art banner. |
+| `gaeilge` | Irish/Gaeilge theme — emerald, ivory, and orange | `Hermes as Gaeilge` | Irish tricolor palette with shamrock prompt/tool prefix, Gaeilge welcome/goodbye text, localized banner labels, and Irish-language spinner verbs. |
 | `mono` | Monochrome — clean grayscale | `Hermes Agent` | All grays — no color. Borders are `#555555`, text is `#c9d1d9`. Ideal for minimal terminal setups or screen recordings. |
 | `slate` | Cool blue — developer-focused | `Hermes Agent` | Royal blue borders (`#4169e1`), soft blue text. Calm and professional. No custom spinner — uses default faces. |
 | `daylight` | Light theme for bright terminals with dark text and cool blue accents | `Hermes Agent` | Designed for white or bright terminals. Dark slate text with blue borders, pale status surfaces, and a light completion menu that stays readable in light terminal profiles. |
@@ -97,6 +98,8 @@ Text strings used throughout the CLI interface.
 | `response_label` | Label on the response box header | ` ⚕ Hermes ` |
 | `prompt_symbol` | Symbol before the user input prompt (bare token, renderers add a trailing space) | `❯` |
 | `help_header` | Header text for the `/help` command output | `(^_^)? Available Commands` |
+
+Additional optional branding keys can localize banner labels for a skin, such as `available_tools_label`, `available_skills_label`, `profile_label`, `session_label`, and `help_for_commands_label`. Missing keys always fall back to the default English text.
 
 ### Other top-level keys
 


### PR DESCRIPTION
## What does this PR do?

<img width="1898" height="956" alt="Screenshot 2026-05-06 212630" src="https://github.com/user-attachments/assets/75475bed-ce3a-4d07-aa02-460ad53e9f04" />


Adds Irish / Gaeilge support to Hermes Agent as two independent, opt-in layers:

1. `display.language: ga` for Hermes's existing static UI message catalog.
2. A new built-in `gaeilge` skin with an Irish green / white / orange palette, shamrock prompt/tool prefix, Gaeilge welcome and goodbye text, localized banner labels, and Irish-language spinner verbs.

The default Hermes experience is unchanged. Existing users continue to get `display.language: en` and `display.skin: default` unless they explicitly opt in.

bash
hermes config set display.language ga
hermes config set [display.skin](http://display.skin/) gaeilge

## Related Issue

No related issue found.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### Irish / Gaeilge static UI locale

- Adds `ga` to `agent.i18n.SUPPORTED_LANGUAGES`.
- Adds unambiguous Irish/Gaeilge aliases:
  - `irish`
  - `gaeilge`
  - `irish-gaelic`
  - `ga-ie`
- Adds `locales/ga.yaml` with the same keys and placeholders as the English source catalog.
- Updates supported-language comments/docs in:
  - `locales/en.yaml`
  - `hermes_cli/config.py`
  - `website/docs/user-guide/configuration.md`

### Opt-in Gaeilge skin

- Adds a built-in `gaeilge` skin in `hermes_cli/skin_engine.py`.
- Includes:
  - Irish green / white / orange palette
  - shamrock prompt and tool prefix: `☘`
  - Gaeilge welcome and goodbye text
  - localized banner labels such as `Uirlisí ar fáil`, `Scileanna ar fáil`, `Próifíl`, and `Seisiún`
  - Irish-language spinner verbs
  - custom banner logo and hero art
- Adds fallback-based banner/compact-banner hooks so skins can localize labels without changing default Hermes output.

### Docs and examples

- Documents `ga` as a supported static UI language.
- Documents the new `gaeilge` skin in the Skins & Themes guide.
- Adds `gaeilge` to the built-in skin list in `cli-config.yaml.example`.

### Tests

Adds focused coverage for:

- Irish language normalization and alias handling.
- Irish catalog lookup and placeholder parity.
- `gaeilge` skin loading and listing.
- compact-banner skin branding.
- full welcome-banner localized labels.
- default fallback behavior, including preserving the existing default `and N more toolsets...` text.

## Scope Notes

This PR intentionally keeps language and skin separate:

- `display.language: ga` translates Hermes's existing static message catalog, such as approval prompts and selected gateway replies.
- `display.skin: gaeilge` changes the CLI visual presentation and banner branding.

This does **not** claim full conversational translation, STT/TTS localization, translated slash-command identifiers, translated logs, or translated tool output. Tool names, slash commands, skill names, file paths, logs, tracebacks, and model-generated prose remain unchanged unless another system/prompt config changes them.

## How to Test

Run the focused i18n/config/skin/banner test set:

bash
python -m pytest \
tests/agent/test_[i18n.py](http://i18n.py/) \
tests/hermes_cli/test_[config.py](http://config.py/) \
tests/hermes_cli/test_skin_[engine.py](http://engine.py/) \
tests/test_cli_skin_[integration.py](http://integration.py/) \
tests/hermes_cli/test_[banner.py](http://banner.py/) \
-q

Smoke-test the locale and skin together:

bash
HERMES_LANGUAGE=ga python - <<'PY'
from agent import i18n
from hermes_[cli.skin](http://cli.skin/)_engine import set_active_skin, get_active_skin

assert i18n.get_language() == 'ga'
assert set_active_skin('gaeilge')

skin = get_active_skin()
print(i18n.t('gateway.goal_cleared'))
print(skin.get_branding('welcome'))
print(skin.get_branding('available_tools_label'))
PY

Expected smoke output:

text
✓ Sprioc glanta.
Fáilte go Hermes as Gaeilge. Scríobh teachtaireacht nó /help le haghaidh orduithe.
Uirlisí ar fáil

Optional manual CLI check:

bash
hermes config set display.language ga
hermes config set [display.skin](http://display.skin/) gaeilge
hermes

Then verify the Gaeilge banner/welcome text appears. Trigger a dangerous-command approval prompt or supported gateway reply to verify the static `ga` catalog messages.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.17.0 x86_64, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — static UTF-8 YAML/catalog strings and opt-in skin branding only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

Focused test result:

text
135 passed in 13.47s

Runtime smoke output:

text
✓ Sprioc glanta.
Fáilte go Hermes as Gaeilge. Scríobh teachtaireacht nó /help le haghaidh orduithe.
Uirlisí ar fáil

## Notes for Reviewers

- Defaults are preserved: users must opt into both `display.language: ga` and/or `display.skin: gaeilge`.
- The new banner label hooks use English fallback strings so non-Gaeilge skins keep existing behavior.
- I intentionally avoided the ambiguous alias `gaelic`, since that can refer to Scottish Gaelic (`gd`).
- I attempted a local full-suite run earlier with `python -m pytest tests/ -q -o 'addopts='`, but it timed out after 600 seconds before completion. I am not claiming a local full-suite pass here; CI/full-suite validation should be authoritative before merge.