### PR TITLE
feat(config): implement profile config inheritance from default

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -240,8 +240,11 @@ def get_container_exec_info() -> Optional[dict]:
 # =============================================================================
 
 # Re-export from hermes_constants — canonical definition lives there.
-from hermes_constants import get_hermes_home  # noqa: F811,E402
+from hermes_constants import get_hermes_home, get_default_config_path  # noqa: F811,E402
 from utils import atomic_replace
+
+# Sentinel value for load_config: auto-detect inheritance from config content.
+_AUTO_INHERIT = object()
 
 def get_config_path() -> Path:
     """Get the main config file path."""
@@ -3867,8 +3870,77 @@ def read_raw_config() -> Dict[str, Any]:
     return data
 
 
-def load_config() -> Dict[str, Any]:
-    """Load configuration from ~/.hermes/config.yaml.
+def _is_override(key: str, profile_raw: dict, parent_raw: dict) -> bool:
+    """Check if a key in profile config is an explicit override.
+    
+    Returns True if the key is present in profile_raw and differs from
+    parent_raw. Python dict equality handles deep comparison of nested
+    dicts, so nested structures are compared by value, not by reference.
+    Returns False if the key is absent from profile_raw or only present
+    in parent_raw.
+    """
+    if key not in profile_raw:
+        return False
+    if key not in parent_raw:
+        return True  # new key, not inherited
+    # Compare values (deep comparison for dicts)
+    return profile_raw[key] != parent_raw[key]
+
+
+def _should_inherit(config_path: Path) -> Optional[Path]:
+    """Check if profile should inherit from default config.
+
+    Returns the path to inherit from (~/.hermes/config.yaml) if inheritance
+    is enabled, or None if the profile should use standalone config.
+
+    Detection logic:
+    1. If config has explicit `inherit: false` flag → no inheritance
+    2. If config has `# This profile inherits` comment header → inheritance enabled
+    3. Otherwise → no inheritance (backward compatible)
+
+    Returns None if default config doesn't exist (graceful degradation).
+    """
+    if not config_path.exists():
+        # No config file at all → inherit from default if it exists
+        default_path = get_default_config_path()
+        return default_path if default_path.exists() else None
+
+    # Check for explicit inherit flag
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+    except Exception:
+        return None
+
+    if not isinstance(raw, dict):
+        return None
+
+    # Explicit opt-out
+    if raw.get("inherit") is False:
+        return None
+
+    # Check for inheritance comment header (heuristic)
+    content = config_path.read_text(encoding="utf-8")
+    if "# This profile inherits" in content:
+        default_path = get_default_config_path()
+        return default_path if default_path.exists() else None
+
+    # Default: no inheritance for existing configs (backward compatible)
+    return None
+
+
+def load_config(inherit_from: Optional[Path] | type[_AUTO_INHERIT] = _AUTO_INHERIT) -> Dict[str, Any]:
+    """Load configuration with optional inheritance.
+
+    Args:
+        inherit_from: Path to parent config to inherit from.
+            - None → explicitly NO inheritance (uses DEFAULT_CONFIG as base)
+            - _AUTO_INHERIT (default/omit) → auto-detect from config content
+            - <Path> → inherit from specific path
+
+    Resolution order:
+    1. Load parent config (if inherit_from provided or auto-detected)
+    2. Deep merge with profile config (profile values win)
 
     Cached on the config file's (mtime_ns, size). Returns a deepcopy of
     the cached value when unchanged, since most call sites mutate the
@@ -3891,7 +3963,20 @@ def load_config() -> Dict[str, Any]:
     if cached is not None and cache_key is not None and cached[:2] == cache_key:
         return copy.deepcopy(cached[2])
 
-    config = copy.deepcopy(DEFAULT_CONFIG)
+    # Auto-detect inheritance if not explicitly provided
+    if inherit_from is _AUTO_INHERIT:
+        inherit_from = _should_inherit(config_path)
+
+    # Start with parent config if inheritance enabled
+    if inherit_from and inherit_from.exists():
+        try:
+            with open(inherit_from, encoding="utf-8") as f:
+                parent_config = yaml.safe_load(f) or {}
+            config = copy.deepcopy(parent_config) if isinstance(parent_config, dict) else {}
+        except Exception:
+            config = copy.deepcopy(DEFAULT_CONFIG)
+    else:
+        config = copy.deepcopy(DEFAULT_CONFIG)
 
     if cache_key is not None:
         try:
@@ -3994,8 +4079,27 @@ _COMMENTED_SECTIONS = """
 """
 
 
+def _compute_overrides_only(merged: dict, parent: dict) -> dict:
+    """Return only keys in merged that differ from parent (for inherited profiles)."""
+    overrides = {}
+    for key, value in merged.items():
+        if key not in parent:
+            overrides[key] = copy.deepcopy(value)
+        elif isinstance(value, dict) and isinstance(parent.get(key), dict):
+            diff = _compute_overrides_only(value, parent[key])
+            if diff:
+                overrides[key] = diff
+        elif value != parent[key]:
+            overrides[key] = copy.deepcopy(value)
+    return overrides
+
+
 def save_config(config: Dict[str, Any]):
-    """Save configuration to ~/.hermes/config.yaml."""
+    """Save configuration to ~/.hermes/config.yaml.
+
+    For inherited profiles, only writes keys that differ from the parent
+    config, preserving the inheritance pattern on disk.
+    """
     if is_managed():
         managed_error("save configuration")
         return
@@ -4012,6 +4116,23 @@ def save_config(config: Dict[str, Any]):
             raw_existing,
             _LAST_EXPANDED_CONFIG_BY_PATH.get(str(config_path)),
         )
+
+    # For inherited profiles, only save overrides (keys that differ from parent)
+    inherit_path = _should_inherit(config_path)
+    if inherit_path and inherit_path.exists():
+        try:
+            with open(inherit_path, encoding="utf-8") as f:
+                parent_config = yaml.safe_load(f) or {}
+            if isinstance(parent_config, dict):
+                # Normalize parent through same pipeline as merged config
+                parent_normalized = _normalize_root_model_keys(_normalize_max_turns_config(parent_config))
+                # Expand env vars on parent for consistent comparison
+                parent_expanded = _expand_env_vars(parent_normalized)
+                overrides = _compute_overrides_only(normalized, parent_expanded)
+                if overrides:
+                    normalized = overrides
+        except Exception:
+            pass  # Fall back to saving full config
 
     # Build optional commented-out sections for features that are off by
     # default or only relevant when explicitly configured.
@@ -4418,18 +4539,64 @@ def redact_key(key: str) -> str:
 def show_config():
     """Display current configuration."""
     config = load_config()
-    
+
+    # Load raw profile config and parent for inheritance comparison
+    config_path = get_config_path()
+    inherit_path = _should_inherit(config_path)
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            raw_profile = yaml.safe_load(f) or {}
+    except (FileNotFoundError, OSError):
+        raw_profile = {}
+    if inherit_path and inherit_path.exists():
+        try:
+            with open(inherit_path, encoding="utf-8") as f:
+                parent_raw = yaml.safe_load(f) or {}
+        except (FileNotFoundError, OSError):
+            parent_raw = {}
+    else:
+        parent_raw = None
+
+    # Helper to format inheritance tag for a given top-level key
+    def _tag(key: str, subkey: str = None) -> str:
+        if parent_raw is None:
+            return ""  # standalone config, no tags
+        if subkey is not None:
+            # Compare at subkey level
+            profile_val = raw_profile.get(key, {}).get(subkey)
+            parent_val = parent_raw.get(key, {}).get(subkey)
+            if profile_val is not None and profile_val != parent_val:
+                return color(" (override)", Colors.YELLOW)
+            if profile_val is None and parent_val is not None:
+                return color(" (inherited)", Colors.DIM)
+            return ""  # both absent or both same
+        if _is_override(key, raw_profile, parent_raw):
+            return color(" (override)", Colors.YELLOW)
+        return color(" (inherited)", Colors.DIM)
+
     print()
     print(color("┌─────────────────────────────────────────────────────────┐", Colors.CYAN))
     print(color("│              ⚕ Hermes Configuration                    │", Colors.CYAN))
     print(color("└─────────────────────────────────────────────────────────┘", Colors.CYAN))
-    
+
     # Paths
     print()
     print(color("◆ Paths", Colors.CYAN, Colors.BOLD))
     print(f"  Config:       {get_config_path()}")
     print(f"  Secrets:      {get_env_path()}")
     print(f"  Install:      {get_project_root()}")
+
+    # Profile
+    # Deferred import to avoid circular dependency — profiles.py imports from config.py
+    from hermes_cli.profiles import get_active_profile
+    print()
+    print(color("◆ Profile", Colors.CYAN, Colors.BOLD))
+    active_profile = get_active_profile()
+    print(f"  Active:       {active_profile}")
+    if inherit_path:
+        print(f"  Inherits:     {inherit_path}")
+    else:
+        print(f"  {color('(standalone)', Colors.DIM)}")
     
     # API Keys
     print()
@@ -4457,8 +4624,8 @@ def show_config():
     # Model settings
     print()
     print(color("◆ Model", Colors.CYAN, Colors.BOLD))
-    print(f"  Model:        {config.get('model', 'not set')}")
-    print(f"  Max turns:    {config.get('agent', {}).get('max_turns', DEFAULT_CONFIG['agent']['max_turns'])}")
+    print(f"  Model:        {config.get('model', 'not set')}{_tag('model')}")
+    print(f"  Max turns:    {config.get('agent', {}).get('max_turns', DEFAULT_CONFIG['agent']['max_turns'])}{_tag('agent')}")
     
     # Display
     print()
@@ -4476,9 +4643,9 @@ def show_config():
     print()
     print(color("◆ Terminal", Colors.CYAN, Colors.BOLD))
     terminal = config.get('terminal', {})
-    print(f"  Backend:      {terminal.get('backend', 'local')}")
+    print(f"  Backend:      {terminal.get('backend', 'local')}{_tag('terminal', 'backend')}")
     print(f"  Working dir:  {terminal.get('cwd', '.')}")
-    print(f"  Timeout:      {terminal.get('timeout', 60)}s")
+    print(f"  Timeout:      {terminal.get('timeout', 60)}s{_tag('terminal', 'timeout')}")
     
     if terminal.get('backend') == 'docker':
         print(f"  Docker image: {terminal.get('docker_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
@@ -4515,9 +4682,9 @@ def show_config():
     print(color("◆ Context Compression", Colors.CYAN, Colors.BOLD))
     compression = config.get('compression', {})
     enabled = compression.get('enabled', True)
-    print(f"  Enabled:      {'yes' if enabled else 'no'}")
+    print(f"  Enabled:      {'yes' if enabled else 'no'}{_tag('compression')}")
     if enabled:
-        print(f"  Threshold:    {compression.get('threshold', 0.50) * 100:.0f}%")
+        print(f"  Threshold:    {compression.get('threshold', 0.50) * 100:.0f}%{_tag('compression')}")
         print(f"  Target ratio: {compression.get('target_ratio', 0.20) * 100:.0f}% of threshold preserved")
         print(f"  Protect last: {compression.get('protect_last_n', 20)} messages")
         _aux_comp = config.get('auxiliary', {}).get('compression', {})

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3894,9 +3894,10 @@ def _should_inherit(config_path: Path) -> Optional[Path]:
     is enabled, or None if the profile should use standalone config.
 
     Detection logic:
-    1. If config has explicit `inherit: false` flag → no inheritance
-    2. If config has `# This profile inherits` comment header → inheritance enabled
-    3. Otherwise → no inheritance (backward compatible)
+    1. If config has explicit `inherit: true` flag → inherit from default
+    2. If config has explicit `inherit: false` flag → no inheritance
+    3. Otherwise → no inheritance (backward compatible — existing profiles
+       with full configs remain standalone)
 
     Returns None if default config doesn't exist (graceful degradation).
     """
@@ -3905,7 +3906,6 @@ def _should_inherit(config_path: Path) -> Optional[Path]:
         default_path = get_default_config_path()
         return default_path if default_path.exists() else None
 
-    # Check for explicit inherit flag
     try:
         with open(config_path, encoding="utf-8") as f:
             raw = yaml.safe_load(f) or {}
@@ -3915,15 +3915,14 @@ def _should_inherit(config_path: Path) -> Optional[Path]:
     if not isinstance(raw, dict):
         return None
 
-    # Explicit opt-out
-    if raw.get("inherit") is False:
-        return None
-
-    # Check for inheritance comment header (heuristic)
-    content = config_path.read_text(encoding="utf-8")
-    if "# This profile inherits" in content:
+    inherit_flag = raw.get("inherit")
+    if inherit_flag is True:
         default_path = get_default_config_path()
         return default_path if default_path.exists() else None
+
+    # Explicit opt-out
+    if inherit_flag is False:
+        return None
 
     # Default: no inheritance for existing configs (backward compatible)
     return None

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8113,6 +8113,7 @@ def cmd_profile(args):
         clone = getattr(args, "clone", False)
         clone_all = getattr(args, "clone_all", False)
         no_alias = getattr(args, "no_alias", False)
+        inherits = getattr(args, "inherits", True)
 
         try:
             clone_from = getattr(args, "clone_from", None)
@@ -8123,6 +8124,7 @@ def cmd_profile(args):
                 clone_all=clone_all,
                 clone_config=clone,
                 no_alias=no_alias,
+                inherits=inherits,
             )
             print(f"\nProfile '{name}' created at {profile_dir}")
 
@@ -10497,6 +10499,11 @@ Examples:
     )
     profile_create.add_argument(
         "--no-alias", action="store_true", help="Skip wrapper script creation"
+    )
+    profile_create.add_argument(
+        "--inherits/--no-inherit",
+        default=True,
+        help="Enable inheritance from default config (default: enabled)",
     )
 
     profile_delete = profile_subparsers.add_parser("delete", help="Delete a profile")

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -81,8 +81,8 @@ INHERITANCE_SKELETON_YAML = """\
 # model: anthropic/claude-opus-4
 # max_turns: 120
 #
-# To disable inheritance, delete this file and run:
-#   hermes config set --profile {name} --no-inherit
+# To disable inheritance, set inherit: false below.
+inherit: true
 """
 
 # Template for standalone profiles (no inheritance)
@@ -93,6 +93,7 @@ FULL_CONFIG_SKELETON_YAML = """\
 # model: anthropic/claude-sonnet-4
 # max_turns: 90
 # toolsets: [terminal, file, web, search]
+inherit: false
 """
 
 
@@ -566,7 +567,7 @@ def create_profile(
     if not config_path.exists() and not (clone_from or clone_all or clone_config):
         # Only create skeleton for fresh profiles, not cloned ones
         if inherits:
-            config_path.write_text(INHERITANCE_SKELETON_YAML.format(name=name))
+            config_path.write_text(INHERITANCE_SKELETON_YAML)
         else:
             config_path.write_text(FULL_CONFIG_SKELETON_YAML)
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -71,6 +71,30 @@ _CLONE_ALL_STRIP = [
     "processes.json",
 ]
 
+# Template for profiles that inherit from default (~/.hermes/config.yaml)
+# Contains only a comment header explaining inheritance
+INHERITANCE_SKELETON_YAML = """\
+# This profile inherits from ~/.hermes/config.yaml (default profile).
+# Only specify overrides here — all other values come from the default.
+#
+# Example: change only the model and max_turns
+# model: anthropic/claude-opus-4
+# max_turns: 120
+#
+# To disable inheritance, delete this file and run:
+#   hermes config set --profile {name} --no-inherit
+"""
+
+# Template for standalone profiles (no inheritance)
+FULL_CONFIG_SKELETON_YAML = """\
+# Standalone profile configuration (no inheritance from default).
+# All configuration values must be specified here.
+#
+# model: anthropic/claude-sonnet-4
+# max_turns: 90
+# toolsets: [terminal, file, web, search]
+"""
+
 
 def _clone_all_copytree_ignore(source_dir: Path):
     """Ignore ``profiles/`` at the root of *source_dir* only.
@@ -427,6 +451,7 @@ def create_profile(
     clone_all: bool = False,
     clone_config: bool = False,
     no_alias: bool = False,
+    inherits: bool = True,
 ) -> Path:
     """Create a new profile directory.
 
@@ -444,6 +469,10 @@ def create_profile(
         skills, and selected profile identity files from the source profile.
     no_alias:
         If True, skip wrapper script creation.
+    inherits:
+        If True (default), create a skeleton config that inherits from
+        ~/.hermes/config.yaml. If False, create a standalone config
+        requiring full specification.
 
     Returns
     -------
@@ -526,6 +555,20 @@ def create_profile(
             soul_path.write_text(DEFAULT_SOUL_MD, encoding="utf-8")
         except Exception:
             pass  # best-effort — don't fail profile creation over this
+
+    # Create skeleton config.yaml only for fresh profiles (not cloning)
+    source_dir = None
+    if clone_from is not None or clone_all or clone_config:
+        # Would have been resolved earlier if cloning
+        pass
+    
+    config_path = profile_dir / "config.yaml"
+    if not config_path.exists() and not (clone_from or clone_all or clone_config):
+        # Only create skeleton for fresh profiles, not cloned ones
+        if inherits:
+            config_path.write_text(INHERITANCE_SKELETON_YAML.format(name=name))
+        else:
+            config_path.write_text(FULL_CONFIG_SKELETON_YAML)
 
     return profile_dir
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -107,6 +107,14 @@ def get_default_hermes_root() -> Path:
     return env_path
 
 
+def get_default_config_path() -> Path:
+    """Return the default profile's config.yaml path.
+    
+    Used for inheritance resolution when loading profile configs.
+    """
+    return get_default_hermes_root() / "config.yaml"
+
+
 def get_optional_skills_dir(default: Path | None = None) -> Path:
     """Return the optional-skills directory, honoring package-manager wrappers.
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1,6 +1,7 @@
 """Tests for hermes_cli configuration management."""
 
 import os
+import textwrap
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -657,3 +658,140 @@ class TestUserMessagePreviewConfig:
         preview = DEFAULT_CONFIG["display"]["user_message_preview"]
         assert preview["first_lines"] == 2
         assert preview["last_lines"] == 2
+
+class TestConfigInheritance:
+    """Tests for config inheritance feature (Issue #20270)."""
+
+    def test_deep_merge_nested_override(self):
+        """Test that deep merge correctly handles nested overrides."""
+        from hermes_cli.config import _deep_merge
+
+        base = {
+            "model": "anthropic/claude-sonnet-4",
+            "max_turns": 90,
+            "toolsets": ["terminal", "file"],
+            "terminal": {"backend": "docker", "timeout": 300},
+        }
+        override = {
+            "model": "anthropic/claude-opus-4",
+            "terminal": {"timeout": 600},
+        }
+        result = _deep_merge(base, override)
+        assert result["model"] == "anthropic/claude-opus-4"
+        assert result["max_turns"] == 90
+        assert result["toolsets"] == ["terminal", "file"]
+        assert result["terminal"]["backend"] == "docker"
+        assert result["terminal"]["timeout"] == 600
+
+    def test_deep_merge_empty_override(self):
+        """Test that empty override returns base config."""
+        from hermes_cli.config import _deep_merge
+
+        base = {"model": "test", "toolsets": ["terminal"]}
+        result = _deep_merge(base, {})
+        assert result == base
+        assert result is not base
+
+    def test_should_inherit_with_comment_header(self, tmp_path):
+        """Test inheritance detection with comment header."""
+        from hermes_cli.config import _should_inherit
+        from hermes_constants import get_default_config_path
+
+        default_path = get_default_config_path()
+        default_path.parent.mkdir(parents=True, exist_ok=True)
+        default_path.write_text("model: anthropic/claude-sonnet-4\n")
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "# This profile inherits from ~/.hermes/config.yaml\nmodel: anthropic/claude-opus-4\n"
+        )
+        inherit_from = _should_inherit(config_path)
+        assert inherit_from == default_path
+
+    def test_should_inherit_explicit_opt_out(self, tmp_path):
+        """Test that explicit inherit: false disables inheritance."""
+        from hermes_cli.config import _should_inherit
+        from hermes_constants import get_default_config_path
+
+        default_path = get_default_config_path()
+        default_path.parent.mkdir(parents=True, exist_ok=True)
+        default_path.write_text("model: anthropic/claude-sonnet-4\n")
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("inherit: false\nmodel: test-model\n")
+        inherit_from = _should_inherit(config_path)
+        assert inherit_from is None
+
+    def test_should_inherit_no_default_config(self, tmp_path):
+        """Test graceful degradation when default config doesn't exist."""
+        from hermes_cli.config import _should_inherit
+        from hermes_constants import get_default_hermes_root
+
+        default_root = get_default_hermes_root()
+        default_config = default_root / "config.yaml"
+        backup = None
+        if default_config.exists():
+            backup = default_config.read_text()
+            default_config.unlink()
+        try:
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text("# Minimal config\n")
+            inherit_from = _should_inherit(config_path)
+            assert inherit_from is None
+        finally:
+            if backup:
+                default_config.write_text(backup)
+
+    def test_load_config_with_explicit_inherit_from(self, tmp_path):
+        """Test load_config with explicit inherit_from path."""
+        from hermes_cli.config import load_config, _LOAD_CONFIG_CACHE
+
+        parent = tmp_path / "parent_config.yaml"
+        parent.write_text(textwrap.dedent("""
+            model: parent-model
+            max_turns: 90
+            toolsets: [terminal, file, web]
+            terminal:
+              backend: docker
+              timeout: 300
+        """).strip())
+        profile = tmp_path / "profile_config.yaml"
+        profile.write_text(textwrap.dedent("""
+            model: profile-model
+            terminal:
+              timeout: 600
+        """).strip())
+        import hermes_cli.config as cfg_mod
+        original_get = cfg_mod.get_config_path
+        cache_backup = _LOAD_CONFIG_CACHE.copy()
+        _LOAD_CONFIG_CACHE.clear()
+        cfg_mod.get_config_path = lambda: profile
+        try:
+            result = load_config(inherit_from=parent)
+            assert result["model"] == "profile-model"
+            assert result["agent"]["max_turns"] == 90
+            assert result["toolsets"] == ["terminal", "file", "web"]
+            assert result["terminal"]["backend"] == "docker"
+            assert result["terminal"]["timeout"] == 600
+        finally:
+            cfg_mod.get_config_path = original_get
+            _LOAD_CONFIG_CACHE.clear()
+            _LOAD_CONFIG_CACHE.update(cache_backup)
+
+    def test_load_config_explicit_no_inherit(self, tmp_path):
+        """Test load_config with inherit_from=None (explicit no inheritance)."""
+        from hermes_cli.config import load_config, _LOAD_CONFIG_CACHE
+
+        profile = tmp_path / "profile_config.yaml"
+        profile.write_text("model: standalone-model\nmax_turns: 50\n")
+        import hermes_cli.config as cfg_mod
+        original_get = cfg_mod.get_config_path
+        cache_backup = _LOAD_CONFIG_CACHE.copy()
+        _LOAD_CONFIG_CACHE.clear()
+        cfg_mod.get_config_path = lambda: profile
+        try:
+            result = load_config(inherit_from=None)
+            assert result["model"] == "standalone-model"
+            assert result["agent"]["max_turns"] == 50
+        finally:
+            cfg_mod.get_config_path = original_get
+            _LOAD_CONFIG_CACHE.clear()
+            _LOAD_CONFIG_CACHE.update(cache_backup)

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -692,8 +692,8 @@ class TestConfigInheritance:
         assert result == base
         assert result is not base
 
-    def test_should_inherit_with_comment_header(self, tmp_path):
-        """Test inheritance detection with comment header."""
+    def test_should_inherit_with_explicit_true(self, tmp_path):
+        """Test inheritance detection with inherit: true YAML key."""
         from hermes_cli.config import _should_inherit
         from hermes_constants import get_default_config_path
 
@@ -701,9 +701,7 @@ class TestConfigInheritance:
         default_path.parent.mkdir(parents=True, exist_ok=True)
         default_path.write_text("model: anthropic/claude-sonnet-4\n")
         config_path = tmp_path / "config.yaml"
-        config_path.write_text(
-            "# This profile inherits from ~/.hermes/config.yaml\nmodel: anthropic/claude-opus-4\n"
-        )
+        config_path.write_text("inherit: true\nmodel: anthropic/claude-opus-4\n")
         inherit_from = _should_inherit(config_path)
         assert inherit_from == default_path
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1030,3 +1030,65 @@ class TestEdgeCases:
             delete_profile("coder", yes=True)
 
         assert get_active_profile() == "default"
+
+
+# ===================================================================
+# TestConfigInheritance
+# ===================================================================
+
+class TestProfileInheritance:
+    """Tests for profile config inheritance feature."""
+
+    def test_create_profile_with_inheritance_default(self, profile_env):
+        """New profiles inherit from default by default."""
+        tmp_path = profile_env
+        
+        profile_dir = create_profile("engineer", no_alias=True)
+        config_path = profile_dir / "config.yaml"
+        
+        assert config_path.exists()
+        content = config_path.read_text()
+        assert "# This profile inherits" in content
+
+    def test_create_profile_with_inheritance_explicit(self, profile_env):
+        """New profiles can explicitly enable inheritance."""
+        tmp_path = profile_env
+        
+        profile_dir = create_profile("researcher", no_alias=True, inherits=True)
+        config_path = profile_dir / "config.yaml"
+        
+        assert config_path.exists()
+        content = config_path.read_text()
+        assert "# This profile inherits" in content
+
+    def test_create_profile_no_inheritance(self, profile_env):
+        """Profiles can opt-out of inheritance."""
+        tmp_path = profile_env
+        
+        profile_dir = create_profile("sandbox", no_alias=True, inherits=False)
+        config_path = profile_dir / "config.yaml"
+        
+        assert config_path.exists()
+        content = config_path.read_text()
+        # Should have standalone config template, not inheritance comment
+        assert "# This profile inherits" not in content
+        assert "# Standalone profile" in content
+
+    def test_create_profile_clone_overrides_inheritance(self, profile_env):
+        """Cloning a profile preserves the cloned config (no new skeleton)."""
+        tmp_path = profile_env
+        
+        # Create source profile
+        source_dir = create_profile("source", no_alias=True, inherits=True)
+        (source_dir / "config.yaml").write_text("model: custom-model\n")
+        
+        # Clone from source
+        target_dir = create_profile("target", clone_from="source", clone_config=True, no_alias=True)
+        config_path = target_dir / "config.yaml"
+        
+        assert config_path.exists()
+        content = config_path.read_text()
+        # Should have cloned content, not inheritance skeleton
+        assert "model: custom-model" in content
+        # Since we cloned, it shouldn't have the inheritance skeleton
+        # (unless the source had it)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -47,12 +47,17 @@ The `hermes config set` command automatically routes values to the right file �
 Settings are resolved in this order (highest priority first):
 
 1. **CLI arguments** — e.g., `hermes chat --model anthropic/claude-sonnet-4` (per-invocation override)
-2. **`~/.hermes/config.yaml`** — the primary config file for all non-secret settings
-3. **`~/.hermes/.env`** — fallback for env vars; **required** for secrets (API keys, tokens, passwords)
-4. **Built-in defaults** — hardcoded safe defaults when nothing else is set
+2. **Profile config** — the active profile's `config.yaml` (for non-default profiles with [inheritance](/docs/user-guide/profiles#config-inheritance), profile overrides win over inherited values)
+3. **`~/.hermes/config.yaml`** — the default profile's config file (inherited by new profiles automatically)
+4. **`~/.hermes/.env`** — fallback for env vars; **required** for secrets (API keys, tokens, passwords)
+5. **Built-in defaults** — hardcoded safe defaults when nothing else is set
 
 :::info Rule of Thumb
 Secrets (API keys, bot tokens, passwords) go in `.env`. Everything else (model, terminal backend, compression settings, memory limits, toolsets) goes in `config.yaml`. When both are set, `config.yaml` wins for non-secret settings.
+:::
+
+:::tip Profile Config Inheritance
+New profiles automatically inherit from `~/.hermes/config.yaml` (the default profile). This means you only specify what differs — shared settings like terminal backend, compression, and provider definitions carry over automatically. See [Config Inheritance](/docs/user-guide/profiles#config-inheritance) for details.
 :::
 
 ## Environment Variable Substitution

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -183,6 +183,118 @@ If you want this profile to work in a specific project by default, also set its 
 coder config set terminal.cwd /absolute/path/to/project
 ```
 
+## Config inheritance
+
+By default, new profiles **inherit** from the default profile's `~/.hermes/config.yaml`. This means you only specify what's different — model choice, terminal backend, toolsets, etc. — and everything else comes from the default config automatically.
+
+### How it works
+
+When you create a profile without cloning:
+
+```bash
+hermes profile create coder
+```
+
+Hermes writes a skeleton `config.yaml` with `inherit: true`:
+
+```yaml
+# This profile inherits from ~/.hermes/config.yaml (default profile).
+# Only specify overrides here — all other values come from the default.
+#
+# Example: change only the model and max_turns
+# model: anthropic/claude-opus-4
+# max_turns: 120
+#
+# To disable inheritance, set inherit: false below.
+inherit: true
+```
+
+When Hermes loads this profile's config, it:
+1. Reads `~/.hermes/config.yaml` (the default) as the base
+2. Reads the profile's `config.yaml` for overrides
+3. Deep-merges them, with profile values winning on conflicts
+
+Control inheritance with the `inherit` YAML key:
+
+```yaml
+inherit: true    # enable inheritance from default config
+inherit: false   # disable inheritance (standalone mode)
+```
+
+### Creating inherited vs standalone profiles
+
+```bash
+# Inherited (default) — only overrides needed
+hermes profile create coder
+
+# Explicitly inherited
+hermes profile create coder --inherits
+
+# Standalone — must specify everything
+hermes profile create sandbox --no-inherit
+```
+
+Cloned profiles (`--clone`, `--clone-all`, `--clone-from`) always use the cloned config as-is — no inheritance skeleton is written.
+
+### What gets inherited
+
+**Everything** from the default config is available unless overridden:
+- Model, provider, API mode
+- Terminal backend, timeout, Docker settings
+- Compression, memory, delegation settings
+- Provider definitions, fallback chains
+- All other `config.yaml` keys
+
+Only keys that differ from the parent appear in the profile's `config.yaml`. This keeps inherited profiles minimal and makes it obvious what's different.
+
+### Saving and viewing
+
+When you run `hermes config set` in an inherited profile, only the changed keys are written to disk — the inheritance pattern is preserved automatically.
+
+```bash
+coder config set model anthropic/claude-opus-4
+# Only `model: anthropic/claude-opus-4` is added to the profile's config.yaml
+# All other values still come from ~/.hermes/config.yaml
+```
+
+`hermes config` (or `coder config`) shows inheritance status:
+
+```
+◆ Profile
+  Active:       coder
+  Inherits:     /home/joe/.hermes/config.yaml
+
+◆ Model
+  Model:        anthropic/claude-opus-4 (override)
+  Max turns:    90 (inherited)
+```
+
+Values marked `(override)` are set explicitly in this profile. Values marked `(inherited)` come from the default config. Standalone profiles (no inheritance) show no tags.
+
+### Opting out
+
+To convert an inherited profile to standalone, edit the profile's `config.yaml` and change `inherit: true` to `inherit: false`:
+
+```bash
+coder config edit
+# Change `inherit: true` to `inherit: false`, then save
+```
+
+Or set it via CLI:
+
+```bash
+coder config set inherit false
+```
+
+The profile will then use its own full config with no inheritance from the default.
+
+### Use cases
+
+- **Different model, same everything else:** Create an inherited profile and override only `model`
+- **Different terminal backend:** Override only `terminal.backend`
+- **Testing/experimentation:** Inherited profile so you can change one thing without touching your main config
+- **Shared team defaults:** Set up `~/.hermes/config.yaml` with team-wide defaults, then each user creates inherited profiles for personal overrides
+
 ## Updating
 
 `hermes update` pulls code once (shared) and syncs new bundled skills to **all** profiles automatically:


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Allow profile configs to automatically inherit from ~/.hermes/config.yaml (default profile), eliminating the need to duplicate shared configuration across N profiles. Profiles now contain only overrides.


Backward compatible: existing profiles with full configs are unaffected (no inheritance comment header = standalone behavior preserved).

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #20270 

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- hermes_constants: add get_default_config_path() helper
- config.py: add _should_inherit() detection (comment header / inherit:false flag)
- config.py: add _is_override() and _compute_overrides_only() helpers
- config.py: extend load_config() with inherit_from param and _AUTO_INHERIT sentinel
- config.py: update save_config() to write only overrides for inherited profiles
- config.py: enhance show_config() with Profile section and (override)/(inherited) tags
- config.py: add _tag() helper with subkey-level accuracy for nested values
- main.py: add --inherits/--no-inherit boolean toggle to profile create
- profiles.py: add INHERITANCE_SKELETON_YAML and FULL_CONFIG_SKELETON_YAML templates
- profiles.py: update create_profile() to accept inherits parameter
- tests: add 7 config inheritance tests + 4 profile inheritance tests


## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Create a new profile using the flag `--inherit`
2. Verify an template config.yaml was made w/ no content
3. Switch to new profile
4. Check model (or any easily viewable config option) and verify it matches the default profile, even though none was set in config.yaml

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

