### PR TITLE
fix(gateway): log /model picker provider failures

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7691,7 +7691,13 @@ class GatewayRunner:
                         custom_providers=custom_provs,
                         max_models=50,
                     )
-                except Exception:
+                except Exception as exc:
+                    logger.warning(
+                        "list_picker_providers failed for gateway /model picker; "
+                        "falling back to text list: %s",
+                        exc,
+                        exc_info=True,
+                    )
                     providers = []
 
                 if providers:

--- a/tests/gateway/test_model_command_custom_providers.py
+++ b/tests/gateway/test_model_command_custom_providers.py
@@ -1,5 +1,7 @@
 """Regression tests for gateway /model support of config.yaml custom_providers."""
 
+import logging
+
 import yaml
 import pytest
 
@@ -61,3 +63,40 @@ async def test_handle_model_command_lists_saved_custom_provider(tmp_path, monkey
     assert "Local (127.0.0.1:4141)" in result
     assert "custom:local-(127.0.0.1:4141)" in result
     assert "rotator-openrouter-coding" in result
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_logs_picker_provider_failures(
+    tmp_path, monkeypatch, caplog
+):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"model": {"default": "gpt-5.4", "provider": "openai"}}),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+    import hermes_cli.model_switch as model_switch
+
+    class PickerAdapter:
+        async def send_model_picker(self, **kwargs):
+            raise AssertionError("send_model_picker should not run after provider load failure")
+
+    def fail_picker_providers(**kwargs):
+        raise TypeError("unexpected picker kwarg")
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(model_switch, "list_picker_providers", fail_picker_providers)
+    monkeypatch.setattr(model_switch, "list_authenticated_providers", lambda **kwargs: [])
+
+    runner = _make_runner()
+    runner.adapters = {Platform.TELEGRAM: PickerAdapter()}
+    caplog.set_level(logging.WARNING, logger="gateway.run")
+
+    result = await runner._handle_model_command(_make_event())
+
+    assert result is not None
+    assert "Current: `gpt-5.4`" in result
+    assert "falling back to text list" in caplog.text
+    assert "unexpected picker kwarg" in caplog.text


### PR DESCRIPTION
## Summary

- log `list_picker_providers` exceptions in the gateway `/model` interactive picker path before falling back to the text list
- keep the existing fallback behavior unchanged for Telegram/Discord users
- add a regression test that forces the picker provider loader to raise and verifies the warning plus text fallback

## Context

Closes #20966.

Current `main` already accepts the `current_base_url` and `current_model` kwargs in `list_picker_providers` and has coverage for that passthrough. This PR addresses the remaining silent-failure part of the issue: if the picker provider loader regresses again, the gateway no longer drops into the text list with no diagnostic trail.

## Verification

```bash
scripts/run_tests.sh tests/gateway/test_model_command_custom_providers.py tests/hermes_cli/test_list_picker_providers.py
```

Result: 12 passed, 3 warnings.
