### PR TITLE
fix(agent): stop claiming OpenRouter Claude prompt caching

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2926,12 +2926,13 @@ class AIAgent:
 
         Returns ``(should_cache, use_native_layout)``:
           * ``should_cache`` — inject ``cache_control`` breakpoints for this
-            request (applies to OpenRouter Claude, native Anthropic, and
-            third-party gateways that speak the native Anthropic protocol).
+            request (applies to native Anthropic, third-party gateways that
+            speak the native Anthropic protocol, and explicit OpenAI-wire
+            provider allowlists).
           * ``use_native_layout`` — place markers on the *inner* content
             blocks (native Anthropic accepts and requires this layout);
-            when False markers go on the message envelope (OpenRouter and
-            OpenAI-wire proxies expect the looser layout).
+            when False markers go on inner message content blocks for
+            OpenAI-wire providers that explicitly support them.
 
         Third-party providers using the native Anthropic transport
         (``api_mode == 'anthropic_messages'`` + Claude-named model) get
@@ -2965,7 +2966,12 @@ class AIAgent:
         if is_native_anthropic:
             return True, True
         if is_openrouter and is_claude:
-            return True, False
+            # OpenRouter Claude runs through the OpenAI-compatible chat
+            # completions path. The Anthropic prompt-cache header/top-level
+            # system blocks required for Claude caching are not transmitted on
+            # that wire format, so enabling markers here only creates a false
+            # cache-hit signal.
+            return False, False
         if is_anthropic_wire and is_claude:
             # Third-party Anthropic-compatible gateway.
             return True, True

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -2,8 +2,9 @@
 
 The policy returns ``(should_cache, use_native_layout)`` for five endpoint
 classes. The test matrix pins the decision for each so a regression (e.g.
-silently dropping caching on third-party Anthropic gateways, or applying
-the native layout on OpenRouter) surfaces loudly.
+silently dropping caching on third-party Anthropic gateways, or claiming
+Claude caching on OpenRouter's OpenAI-compatible wire format) surfaces
+loudly.
 """
 
 from __future__ import annotations
@@ -54,16 +55,14 @@ class TestNativeAnthropic:
 
 
 class TestOpenRouter:
-    def test_claude_on_openrouter_caches_with_envelope_layout(self):
+    def test_claude_on_openrouter_does_not_claim_prompt_caching(self):
         agent = _make_agent(
             provider="openrouter",
             base_url="https://openrouter.ai/api/v1",
             api_mode="chat_completions",
             model="anthropic/claude-sonnet-4.6",
         )
-        should, native = agent._anthropic_prompt_cache_policy()
-        assert should is True
-        assert native is False  # OpenRouter uses envelope layout
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
 
     def test_non_claude_on_openrouter_does_not_cache(self):
         agent = _make_agent(
@@ -273,7 +272,7 @@ class TestExplicitOverrides:
         should, native = agent._anthropic_prompt_cache_policy(
             model="anthropic/claude-sonnet-4.6",
         )
-        assert (should, native) == (True, False)
+        assert (should, native) == (False, False)
 
     def test_fallback_target_evaluated_independently(self):
         # Starting on native Anthropic but falling back to OpenRouter.
@@ -289,4 +288,4 @@ class TestExplicitOverrides:
             api_mode="chat_completions",
             model="anthropic/claude-sonnet-4.6",
         )
-        assert (should, native) == (True, False)
+        assert (should, native) == (False, False)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -618,7 +618,7 @@ class TestInit:
             mock_anthropic.Anthropic.assert_called_once()
 
     def test_prompt_caching_claude_openrouter(self):
-        """Claude model via OpenRouter should enable prompt caching."""
+        """Claude via OpenRouter should not claim unsupported prompt caching."""
         with (
             patch("run_agent.get_tool_definitions", return_value=[]),
             patch("run_agent.check_toolset_requirements", return_value={}),
@@ -632,7 +632,7 @@ class TestInit:
                 skip_context_files=True,
                 skip_memory=True,
             )
-            assert a._use_prompt_caching is True
+            assert a._use_prompt_caching is False
 
     def test_prompt_caching_non_claude(self):
         """Non-Claude model should disable prompt caching."""


### PR DESCRIPTION
Closes #20957

## Summary
- disable Anthropic prompt cache markers for OpenRouter + Claude on the OpenAI-compatible chat completions path
- keep native Anthropic and third-party Anthropic Messages caching enabled
- preserve the explicit Qwen/OpenCode/OpenAI-wire allowlist that is known to honor cache_control

## Why
OpenRouter Claude requests currently use the OpenAI-compatible wire format, so Hermes cannot transmit Anthropic native prompt-cache headers/top-level system blocks on that path. Returning `(True, False)` made `_use_prompt_caching` look active even though Claude cache markers were not honored.

## Verification
- `scripts/run_tests.sh tests/run_agent/test_anthropic_prompt_cache_policy.py tests/run_agent/test_run_agent.py -k "prompt_caching or anthropic_prompt_cache_policy"`
  - `29 passed, 4 warnings in 6.26s`
- `git diff --check`