### PR TITLE
feat(kanban): convert inline-create title input to multiline textarea

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1741,18 +1741,18 @@
       : "workspace path (optional, derived from assignee if blank)";
 
     return h("div", { className: "hermes-kanban-inline-create" },
-      h(Input, {
+      h("textarea", {
         value: title,
         onChange: function (e) { setTitle(e.target.value); },
         onKeyDown: function (e) {
-          if (e.key === "Enter") { e.preventDefault(); submit(); }
           if (e.key === "Escape") props.onCancel();
         },
         placeholder: props.columnName === "triage"
           ? "Rough idea — AI will spec it…"
           : "New task title…",
         autoFocus: true,
-        className: "h-8 text-sm",
+        className: "text-sm min-h-[2rem] max-h-32 resize-y w-full border border-input bg-transparent px-2 py-1 rounded-md focus:outline-none focus:ring-2 focus:ring-ring",
+        rows: 2,
       }),
       h("div", { className: "flex gap-2" },
         h(Input, {


### PR DESCRIPTION
## Problem

The title input in the kanban inline-create form is a single-line `<input>`, making it awkward for longer task descriptions or multi-line ideas.

## Solution

Convert to `<textarea>` with:
- 2-row default height
- Vertical resize
- Max-height cap (8rem)
- Same placeholder text ("Rough idea — AI will spec it…" for triage, "New task title…" for others)

## Behavior Changes

- **Enter no longer auto-submits** — type newlines freely
- **Submit via the Create button** (explicit action)
- **Escape still cancels** the form

## Screenshot

Before: Single-line input, Enter submits immediately
<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/7053d6a2-47ae-4747-bbe4-2bc35e3664ec" />

After: 2-row textarea, Create button to submit
<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/be58b61d-7b17-4bd3-92ef-e5d413368096" />

Second example showing expanded textarea for more space
<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/f54c3e0b-b92c-43cd-9dcb-88fed9a1a5a1" />

## Technical Note

This PR modifies `dist/index.js` directly because the kanban dashboard source (TypeScript/JSX) is not in this repository. The dashboard was added in commit c8684254 and shipped only as a pre-built IIFE bundle.

If maintainers have access to the source, I'm happy to provide a source-level PR instead.

## Consideration

If users prefer the single-line behavior, a future PR could add a user preference toggle. This change errs on the side of multiline-friendly for task descriptions, which is the more common use case for kanban cards.