### PR TITLE
fix(gateway): expose native image cache paths to tools

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5707,6 +5707,13 @@ class GatewayRunner:
                         pending_native = {}
                         self._pending_native_image_paths_by_session = pending_native
                     pending_native[session_key] = list(image_paths)
+                    path_lines = "\n".join(f"- {path}" for path in image_paths)
+                    attachment_note = (
+                        "[The user sent image attachment(s). They are attached "
+                        "to this turn for vision, and cached locally for tools "
+                        f"at:\n{path_lines}]"
+                    )
+                    message_text = f"{attachment_note}\n\n{message_text}" if message_text else attachment_note
                     logger.info(
                         "Image routing: native (model supports vision). %d image(s) will be attached inline.",
                         len(image_paths),

--- a/tests/gateway/test_native_image_buffer_isolation.py
+++ b/tests/gateway/test_native_image_buffer_isolation.py
@@ -59,6 +59,22 @@ async def test_native_image_buffer_isolated_per_session():
 
 
 @pytest.mark.asyncio
+async def test_native_image_context_includes_tool_visible_cached_path():
+    runner = _make_runner()
+    source = _source("chat-a")
+
+    message = await runner._prepare_inbound_message_text(
+        event=_image_event(source, "/tmp/a.png"),
+        source=source,
+        history=[],
+    )
+
+    assert "cached locally for tools" in message
+    assert "/tmp/a.png" in message
+    assert "see image" in message
+
+
+@pytest.mark.asyncio
 async def test_native_image_buffer_not_cleared_by_other_sessions_without_images():
     runner = _make_runner()
     source_a = _source("chat-a")


### PR DESCRIPTION
Closes #20899

## Summary
- include cached local image attachment paths in the gateway text context when native image routing is used
- keep the native multimodal image attachment path unchanged for models that support vision
- add a regression test proving the prepared native-image message exposes the cached path for tool use

## Why
Telegram photos are already cached locally before reaching the agent, but when native image routing is selected the model receives pixels inline and the text context did not include the cached path. That leaves file/terminal tools without an obvious handle for requests like “put this image in this folder.”

## Verification
- `scripts/run_tests.sh tests/gateway/test_native_image_buffer_isolation.py tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_photo_interrupts.py`
  - `43 passed in 1.87s`
- `git diff --check`