### PR TITLE
fix(gateway): offload model command switching

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7683,7 +7683,8 @@ class GatewayRunner:
 
             if has_picker:
                 try:
-                    providers = list_picker_providers(
+                    providers = await asyncio.to_thread(
+                        list_picker_providers,
                         current_provider=current_provider,
                         current_base_url=current_base_url,
                         current_model=current_model,
@@ -7708,7 +7709,8 @@ class GatewayRunner:
                         _chat_id: str, model_id: str, provider_slug: str
                     ) -> str:
                         """Perform the model switch and return confirmation text."""
-                        result = _switch_model(
+                        result = await asyncio.to_thread(
+                            _switch_model,
                             raw_input=model_id,
                             current_provider=_cur_provider,
                             current_model=_cur_model,
@@ -7816,7 +7818,8 @@ class GatewayRunner:
             lines = [f"Current: `{current_model or 'unknown'}` on {provider_label}", ""]
 
             try:
-                providers = list_authenticated_providers(
+                providers = await asyncio.to_thread(
+                    list_authenticated_providers,
                     current_provider=current_provider,
                     current_base_url=current_base_url,
                     current_model=current_model,
@@ -7843,7 +7846,8 @@ class GatewayRunner:
             return "\n".join(lines)
 
         # Perform the switch
-        result = _switch_model(
+        result = await asyncio.to_thread(
+            _switch_model,
             raw_input=model_input,
             current_provider=current_provider,
             current_model=current_model,

--- a/tests/gateway/test_model_command_custom_providers.py
+++ b/tests/gateway/test_model_command_custom_providers.py
@@ -1,5 +1,7 @@
 """Regression tests for gateway /model support of config.yaml custom_providers."""
 
+from types import SimpleNamespace
+
 import yaml
 import pytest
 
@@ -61,3 +63,102 @@ async def test_handle_model_command_lists_saved_custom_provider(tmp_path, monkey
     assert "Local (127.0.0.1:4141)" in result
     assert "custom:local-(127.0.0.1:4141)" in result
     assert "rotator-openrouter-coding" in result
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_offloads_text_provider_listing(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"model": {"default": "gpt-5.4", "provider": "openai-codex"}}),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+    import hermes_cli.model_switch as model_switch
+
+    calls = []
+
+    async def fake_to_thread(fn, /, *args, **kwargs):
+        calls.append(fn.__name__)
+        return fn(*args, **kwargs)
+
+    def fake_list_authenticated_providers(**_kwargs):
+        return [{
+            "name": "OpenAI Codex",
+            "slug": "openai-codex",
+            "is_current": True,
+            "models": ["gpt-5.4"],
+            "total_models": 1,
+        }]
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(gateway_run.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(model_switch, "list_authenticated_providers", fake_list_authenticated_providers)
+
+    result = await _make_runner()._handle_model_command(_make_event())
+
+    assert "OpenAI Codex" in result
+    assert "fake_list_authenticated_providers" in calls
+
+
+@pytest.mark.asyncio
+async def test_handle_model_picker_callback_offloads_model_switch(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"model": {"default": "gpt-5.4", "provider": "openai-codex"}}),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+    import hermes_cli.model_switch as model_switch
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    calls = []
+    picker_response = {}
+
+    async def fake_to_thread(fn, /, *args, **kwargs):
+        calls.append(fn.__name__)
+        return fn(*args, **kwargs)
+
+    def fake_list_picker_providers(**_kwargs):
+        return [{
+            "name": "OpenRouter",
+            "slug": "openrouter",
+            "is_current": False,
+            "models": ["openai/gpt-5.4"],
+            "total_models": 1,
+        }]
+
+    def fake_switch_model(**_kwargs):
+        return ModelSwitchResult(
+            success=True,
+            new_model="openai/gpt-5.4",
+            target_provider="openrouter",
+            provider_label="OpenRouter",
+        )
+
+    class _PickerAdapter:
+        async def send_model_picker(self, **kwargs):
+            picker_response["text"] = await kwargs["on_model_selected"](
+                kwargs["chat_id"],
+                "openai/gpt-5.4",
+                "openrouter",
+            )
+            return SimpleNamespace(success=True)
+
+    runner = _make_runner()
+    runner.adapters = {Platform.TELEGRAM: _PickerAdapter()}
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(gateway_run.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(model_switch, "list_picker_providers", fake_list_picker_providers)
+    monkeypatch.setattr(model_switch, "switch_model", fake_switch_model)
+
+    result = await runner._handle_model_command(_make_event())
+
+    assert result is None
+    assert "fake_list_picker_providers" in calls
+    assert "fake_switch_model" in calls
+    assert "Model switched to `openai/gpt-5.4`" in picker_response["text"]


### PR DESCRIPTION
## Summary

Fixes #20525.

The gateway `/model` path called synchronous model/provider helpers directly from async handlers. Those helpers can hit `models.dev` and other provider metadata paths using blocking HTTP, which can stall the Telegram gateway event loop while a user opens the picker or switches providers.

This PR keeps the change limited to the gateway command path:

- offloads picker provider listing with `asyncio.to_thread(list_picker_providers, ...)`
- offloads picker callback switching with `asyncio.to_thread(switch_model, ...)`
- offloads fallback text provider listing with `asyncio.to_thread(list_authenticated_providers, ...)`
- offloads direct `/model <name>` switching with `asyncio.to_thread(switch_model, ...)`
- adds gateway regression tests proving the text list and picker callback paths route their synchronous work through `to_thread`

## Verification

- `scripts/run_tests.sh tests/gateway/test_model_command_custom_providers.py` -> 3 passed
- `git diff --check`

## Non-goals

- Does not change model/provider resolution behavior.
- Does not alter the models.dev timeout or cache policy.
- Does not change adapter callback routing; it only moves blocking work off the event loop.
