### PR TITLE
feat(web): add Brave Search as native web search backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,7 @@
 # Exa API Key - AI-native web search and contents
 # Get at: https://exa.ai
 # EXA_API_KEY=
+# BRAVE_API_KEY=             # Brave Search — 2K free queries/mo: https://api.search.brave.com/app/keys
 
 # Parallel API Key - AI-native web search and extract
 # Get at: https://parallel.ai

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -286,6 +286,7 @@ def get_nous_subscription_features(
     direct_parallel = bool(get_env_value("PARALLEL_API_KEY"))
     direct_tavily = bool(get_env_value("TAVILY_API_KEY"))
     direct_searxng = bool(get_env_value("SEARXNG_URL"))
+    direct_brave = bool(os.environ.get("BRAVE_API_KEY", "").strip())
     direct_fal = fal_key_is_configured()
     direct_openai_tts = bool(resolve_openai_audio_api_key())
     direct_elevenlabs = bool(get_env_value("ELEVENLABS_API_KEY"))
@@ -300,6 +301,7 @@ def get_nous_subscription_features(
         direct_exa = False
         direct_parallel = False
         direct_tavily = False
+        direct_brave = False
     if image_use_gateway:
         direct_fal = False
     if tts_use_gateway:
@@ -341,7 +343,6 @@ def get_nous_subscription_features(
             or (web_search_backend == "tavily" and direct_tavily)
         )
     )
-    direct_brave = bool(os.environ.get("BRAVE_API_KEY", "").strip())
     web_available = bool(
         managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily or direct_searxng or direct_brave
     )

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -1,6 +1,7 @@
 """Helpers for Nous subscription managed-tool capabilities."""
 
 from __future__ import annotations
+import os
 
 from dataclasses import dataclass
 from pathlib import Path
@@ -340,7 +341,7 @@ def get_nous_subscription_features(
             or (web_search_backend == "tavily" and direct_tavily)
         )
     )
-    direct_brave = _has_env("BRAVE_API_KEY")
+    direct_brave = bool(os.environ.get("BRAVE_API_KEY", "").strip())
     web_available = bool(
         managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily or direct_searxng or direct_brave
     )

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -332,16 +332,17 @@ def get_nous_subscription_features(
             # Per-capability overrides: search_backend or extract_backend may be set
             # without web.backend (using the new split config from #20061)
             or (web_search_backend == "searxng" and direct_searxng)
-            or web_backend == "brave"
-            or web_search_backend == "brave"
+            or (web_backend == "brave" and direct_brave)
+            or (web_search_backend == "brave" and direct_brave)
             or (web_search_backend == "exa" and direct_exa)
             or (web_search_backend == "firecrawl" and direct_firecrawl)
             or (web_search_backend == "parallel" and direct_parallel)
             or (web_search_backend == "tavily" and direct_tavily)
         )
     )
+    direct_brave = _has_env("BRAVE_API_KEY")
     web_available = bool(
-        managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily or direct_searxng
+        managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily or direct_searxng or direct_brave
     )
 
     image_managed = image_tool_enabled and managed_image_available and not direct_fal

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -332,6 +332,8 @@ def get_nous_subscription_features(
             # Per-capability overrides: search_backend or extract_backend may be set
             # without web.backend (using the new split config from #20061)
             or (web_search_backend == "searxng" and direct_searxng)
+            or web_backend == "brave"
+            or web_search_backend == "brave"
             or (web_search_backend == "exa" and direct_exa)
             or (web_search_backend == "firecrawl" and direct_firecrawl)
             or (web_search_backend == "parallel" and direct_parallel)

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -309,8 +309,13 @@ TOOL_CATEGORIES = {
                 ],
             },
             {
+                "name": "Brave Search",
+                "badge": "free tier · 2K queries/month",
+                "tag": "Independent web index — not Google or Bing. Free tier available.",
                 "web_backend": "brave",
-                "BRAVE_API_KEY": "",
+                "env_vars": [
+                    {"key": "BRAVE_API_KEY", "prompt": "Brave Search API key", "url": "https://api.search.brave.com/app/keys"},
+                ],
             },
         ],
     },

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -308,6 +308,10 @@ TOOL_CATEGORIES = {
                     {"key": "SEARXNG_URL", "prompt": "Your SearXNG instance URL (e.g., http://localhost:8080)", "url": "https://searxng.github.io/searxng/"},
                 ],
             },
+            {
+                "web_backend": "brave",
+                "BRAVE_API_KEY": "",
+            },
         ],
     },
     "image_gen": {

--- a/tests/tools/test_web_tools_brave.py
+++ b/tests/tools/test_web_tools_brave.py
@@ -1,4 +1,5 @@
 """Tests for the Brave Search web provider."""
+
 from __future__ import annotations
 
 import json
@@ -16,20 +17,24 @@ class TestBraveSearchProvider:
     def test_is_configured_true(self, monkeypatch):
         monkeypatch.setenv("BRAVE_API_KEY", "test-key")
         from tools.web_providers.brave import BraveSearchProvider
+
         assert BraveSearchProvider().is_configured() is True
 
     def test_is_configured_false(self, monkeypatch):
         monkeypatch.delenv("BRAVE_API_KEY", raising=False)
         from tools.web_providers.brave import BraveSearchProvider
+
         assert BraveSearchProvider().is_configured() is False
 
     def test_provider_name(self):
         from tools.web_providers.brave import BraveSearchProvider
+
         assert BraveSearchProvider().provider_name() == "brave"
 
     def test_search_no_key(self, monkeypatch):
         monkeypatch.delenv("BRAVE_API_KEY", raising=False)
         from tools.web_providers.brave import BraveSearchProvider
+
         result = BraveSearchProvider().search("test query")
         assert result["success"] is False
         assert "BRAVE_API_KEY" in result["error"]
@@ -39,8 +44,16 @@ class TestBraveSearchProvider:
         mock_response.json.return_value = {
             "web": {
                 "results": [
-                    {"title": "Result 1", "url": "https://example.com/1", "description": "Desc 1"},
-                    {"title": "Result 2", "url": "https://example.com/2", "description": "Desc 2"},
+                    {
+                        "title": "Result 1",
+                        "url": "https://example.com/1",
+                        "description": "Desc 1",
+                    },
+                    {
+                        "title": "Result 2",
+                        "url": "https://example.com/2",
+                        "description": "Desc 2",
+                    },
                 ]
             }
         }
@@ -48,6 +61,7 @@ class TestBraveSearchProvider:
 
         with patch("httpx.get", return_value=mock_response):
             from tools.web_providers.brave import BraveSearchProvider
+
             result = BraveSearchProvider().search("test query", limit=2)
 
         assert result["success"] is True
@@ -63,7 +77,11 @@ class TestBraveSearchProvider:
         mock_response.json.return_value = {
             "web": {
                 "results": [
-                    {"title": f"Result {i}", "url": f"https://example.com/{i}", "description": ""}
+                    {
+                        "title": f"Result {i}",
+                        "url": f"https://example.com/{i}",
+                        "description": "",
+                    }
                     for i in range(10)
                 ]
             }
@@ -72,6 +90,7 @@ class TestBraveSearchProvider:
 
         with patch("httpx.get", return_value=mock_response):
             from tools.web_providers.brave import BraveSearchProvider
+
             result = BraveSearchProvider().search("test", limit=3)
 
         assert result["success"] is True
@@ -79,28 +98,44 @@ class TestBraveSearchProvider:
 
     def test_search_401_error(self, brave_key):
         import httpx
+
         mock_resp = MagicMock()
         mock_resp.status_code = 401
-        with patch("httpx.get", side_effect=httpx.HTTPStatusError("", request=MagicMock(), response=mock_resp)):
+        with patch(
+            "httpx.get",
+            side_effect=httpx.HTTPStatusError(
+                "", request=MagicMock(), response=mock_resp
+            ),
+        ):
             from tools.web_providers.brave import BraveSearchProvider
+
             result = BraveSearchProvider().search("test")
         assert result["success"] is False
         assert "invalid or expired" in result["error"]
 
     def test_search_429_rate_limit(self, brave_key):
         import httpx
+
         mock_resp = MagicMock()
         mock_resp.status_code = 429
-        with patch("httpx.get", side_effect=httpx.HTTPStatusError("", request=MagicMock(), response=mock_resp)):
+        with patch(
+            "httpx.get",
+            side_effect=httpx.HTTPStatusError(
+                "", request=MagicMock(), response=mock_resp
+            ),
+        ):
             from tools.web_providers.brave import BraveSearchProvider
+
             result = BraveSearchProvider().search("test")
         assert result["success"] is False
         assert "rate limit" in result["error"]
 
     def test_search_request_error(self, brave_key):
         import httpx
+
         with patch("httpx.get", side_effect=httpx.RequestError("connection refused")):
             from tools.web_providers.brave import BraveSearchProvider
+
             result = BraveSearchProvider().search("test")
         assert result["success"] is False
         assert "Could not reach" in result["error"]
@@ -111,27 +146,41 @@ class TestBraveSearchProvider:
         mock_response.raise_for_status = MagicMock()
         with patch("httpx.get", return_value=mock_response):
             from tools.web_providers.brave import BraveSearchProvider
+
             result = BraveSearchProvider().search("obscure query no results")
         assert result["success"] is True
         assert result["data"]["web"] == []
 
-
     def test_search_422_rejected(self, brave_key):
         import httpx
+
         mock_resp = MagicMock()
         mock_resp.status_code = 422
-        with patch("httpx.get", side_effect=httpx.HTTPStatusError("", request=MagicMock(), response=mock_resp)):
+        with patch(
+            "httpx.get",
+            side_effect=httpx.HTTPStatusError(
+                "", request=MagicMock(), response=mock_resp
+            ),
+        ):
             from tools.web_providers.brave import BraveSearchProvider
+
             result = BraveSearchProvider().search("test")
         assert result["success"] is False
         assert "422" in result["error"]
 
     def test_search_500_generic_error(self, brave_key):
         import httpx
+
         mock_resp = MagicMock()
         mock_resp.status_code = 500
-        with patch("httpx.get", side_effect=httpx.HTTPStatusError("", request=MagicMock(), response=mock_resp)):
+        with patch(
+            "httpx.get",
+            side_effect=httpx.HTTPStatusError(
+                "", request=MagicMock(), response=mock_resp
+            ),
+        ):
             from tools.web_providers.brave import BraveSearchProvider
+
             result = BraveSearchProvider().search("test")
         assert result["success"] is False
         assert "HTTP 500" in result["error"]
@@ -142,6 +191,7 @@ class TestBraveSearchProvider:
         mock_response.raise_for_status = MagicMock()
         with patch("httpx.get", return_value=mock_response):
             from tools.web_providers.brave import BraveSearchProvider
+
             result = BraveSearchProvider().search("test")
         assert result["success"] is False
         assert "parse" in result["error"].lower()
@@ -153,6 +203,7 @@ class TestBraveSearchProvider:
         mock_response.raise_for_status = MagicMock()
         with patch("httpx.get", return_value=mock_response):
             from tools.web_providers.brave import BraveSearchProvider
+
             result = BraveSearchProvider().search("test")
         assert result["success"] is True
         assert result["data"]["web"] == []
@@ -164,9 +215,12 @@ class TestBraveSearchProvider:
         mock_response.raise_for_status = MagicMock()
         with patch("httpx.get", return_value=mock_response) as mock_get:
             from tools.web_providers.brave import BraveSearchProvider
+
             BraveSearchProvider().search("test")
         call_kwargs = mock_get.call_args
-        headers = call_kwargs.kwargs.get("headers", {}) or call_kwargs[1].get("headers", {})
+        headers = call_kwargs.kwargs.get("headers", {}) or call_kwargs[1].get(
+            "headers", {}
+        )
         assert headers.get("X-Subscription-Token") == "test-brave-key"
         assert headers.get("Accept") == "application/json"
 
@@ -177,37 +231,55 @@ class TestBraveSearchProvider:
         mock_response.raise_for_status = MagicMock()
         with patch("httpx.get", return_value=mock_response) as mock_get:
             from tools.web_providers.brave import BraveSearchProvider
+
             BraveSearchProvider().search("test", limit=50)
         call_kwargs = mock_get.call_args
-        params = call_kwargs.kwargs.get("params", {}) or call_kwargs[1].get("params", {})
+        params = call_kwargs.kwargs.get("params", {}) or call_kwargs[1].get(
+            "params", {}
+        )
         assert params.get("count") == 20  # capped at 20
+
 
 class TestWebToolsBraveBackend:
     """Integration-style tests for Brave backend routing in web_tools."""
 
     def test_get_backend_brave_when_configured(self, monkeypatch):
         monkeypatch.setenv("BRAVE_API_KEY", "test-key")
-        with patch("tools.web_tools._load_web_config", return_value={"backend": "brave"}):
+        with patch(
+            "tools.web_tools._load_web_config", return_value={"backend": "brave"}
+        ):
             from tools.web_tools import _get_backend
+
             assert _get_backend() == "brave"
 
     def test_brave_in_fallback_chain(self, monkeypatch):
         # Remove all other keys, set only BRAVE_API_KEY
-        for key in ("FIRECRAWL_API_KEY", "FIRECRAWL_API_URL", "PARALLEL_API_KEY", "TAVILY_API_KEY",
-                    "EXA_API_KEY", "SEARXNG_URL"):
+        for key in (
+            "FIRECRAWL_API_KEY",
+            "FIRECRAWL_API_URL",
+            "PARALLEL_API_KEY",
+            "TAVILY_API_KEY",
+            "EXA_API_KEY",
+            "SEARXNG_URL",
+        ):
             monkeypatch.delenv(key, raising=False)
         monkeypatch.setenv("BRAVE_API_KEY", "test-key")
-        with patch("tools.web_tools._load_web_config", return_value={}), \
-             patch("tools.web_tools._is_tool_gateway_ready", return_value=False):
+        with (
+            patch("tools.web_tools._load_web_config", return_value={}),
+            patch("tools.web_tools._is_tool_gateway_ready", return_value=False),
+        ):
             from tools.web_tools import _get_backend
+
             assert _get_backend() == "brave"
 
     def test_check_brave_api_key_true(self, monkeypatch):
         monkeypatch.setenv("BRAVE_API_KEY", "test-key")
         from tools.web_tools import check_brave_api_key
+
         assert check_brave_api_key() is True
 
     def test_check_brave_api_key_false(self, monkeypatch):
         monkeypatch.delenv("BRAVE_API_KEY", raising=False)
         from tools.web_tools import check_brave_api_key
+
         assert check_brave_api_key() is False

--- a/tests/tools/test_web_tools_brave.py
+++ b/tests/tools/test_web_tools_brave.py
@@ -116,6 +116,72 @@ class TestBraveSearchProvider:
         assert result["data"]["web"] == []
 
 
+    def test_search_422_rejected(self, brave_key):
+        import httpx
+        mock_resp = MagicMock()
+        mock_resp.status_code = 422
+        with patch("httpx.get", side_effect=httpx.HTTPStatusError("", request=MagicMock(), response=mock_resp)):
+            from tools.web_providers.brave import BraveSearchProvider
+            result = BraveSearchProvider().search("test")
+        assert result["success"] is False
+        assert "422" in result["error"]
+
+    def test_search_500_generic_error(self, brave_key):
+        import httpx
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        with patch("httpx.get", side_effect=httpx.HTTPStatusError("", request=MagicMock(), response=mock_resp)):
+            from tools.web_providers.brave import BraveSearchProvider
+            result = BraveSearchProvider().search("test")
+        assert result["success"] is False
+        assert "HTTP 500" in result["error"]
+
+    def test_search_malformed_json(self, brave_key):
+        mock_response = MagicMock()
+        mock_response.json.side_effect = ValueError("not json")
+        mock_response.raise_for_status = MagicMock()
+        with patch("httpx.get", return_value=mock_response):
+            from tools.web_providers.brave import BraveSearchProvider
+            result = BraveSearchProvider().search("test")
+        assert result["success"] is False
+        assert "parse" in result["error"].lower()
+
+    def test_search_missing_results_key(self, brave_key):
+        """Handle Brave API response without 'web.results' gracefully."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}  # No 'web' key at all
+        mock_response.raise_for_status = MagicMock()
+        with patch("httpx.get", return_value=mock_response):
+            from tools.web_providers.brave import BraveSearchProvider
+            result = BraveSearchProvider().search("test")
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+    def test_search_correct_request_headers(self, brave_key):
+        """Verify X-Subscription-Token header is sent with API key."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"web": {"results": []}}
+        mock_response.raise_for_status = MagicMock()
+        with patch("httpx.get", return_value=mock_response) as mock_get:
+            from tools.web_providers.brave import BraveSearchProvider
+            BraveSearchProvider().search("test")
+        call_kwargs = mock_get.call_args
+        headers = call_kwargs.kwargs.get("headers", {}) or call_kwargs[1].get("headers", {})
+        assert headers.get("X-Subscription-Token") == "test-brave-key"
+        assert headers.get("Accept") == "application/json"
+
+    def test_search_max_limit_capped_at_20(self, brave_key):
+        """Brave API max is 20 results per request."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"web": {"results": []}}
+        mock_response.raise_for_status = MagicMock()
+        with patch("httpx.get", return_value=mock_response) as mock_get:
+            from tools.web_providers.brave import BraveSearchProvider
+            BraveSearchProvider().search("test", limit=50)
+        call_kwargs = mock_get.call_args
+        params = call_kwargs.kwargs.get("params", {}) or call_kwargs[1].get("params", {})
+        assert params.get("count") == 20  # capped at 20
+
 class TestWebToolsBraveBackend:
     """Integration-style tests for Brave backend routing in web_tools."""
 
@@ -127,7 +193,7 @@ class TestWebToolsBraveBackend:
 
     def test_brave_in_fallback_chain(self, monkeypatch):
         # Remove all other keys, set only BRAVE_API_KEY
-        for key in ("FIRECRAWL_API_KEY", "PARALLEL_API_KEY", "TAVILY_API_KEY",
+        for key in ("FIRECRAWL_API_KEY", "FIRECRAWL_API_URL", "PARALLEL_API_KEY", "TAVILY_API_KEY",
                     "EXA_API_KEY", "SEARXNG_URL"):
             monkeypatch.delenv(key, raising=False)
         monkeypatch.setenv("BRAVE_API_KEY", "test-key")

--- a/tests/tools/test_web_tools_brave.py
+++ b/tests/tools/test_web_tools_brave.py
@@ -1,0 +1,147 @@
+"""Tests for the Brave Search web provider."""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def brave_key(monkeypatch):
+    monkeypatch.setenv("BRAVE_API_KEY", "test-brave-key")
+
+
+class TestBraveSearchProvider:
+    def test_is_configured_true(self, monkeypatch):
+        monkeypatch.setenv("BRAVE_API_KEY", "test-key")
+        from tools.web_providers.brave import BraveSearchProvider
+        assert BraveSearchProvider().is_configured() is True
+
+    def test_is_configured_false(self, monkeypatch):
+        monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+        from tools.web_providers.brave import BraveSearchProvider
+        assert BraveSearchProvider().is_configured() is False
+
+    def test_provider_name(self):
+        from tools.web_providers.brave import BraveSearchProvider
+        assert BraveSearchProvider().provider_name() == "brave"
+
+    def test_search_no_key(self, monkeypatch):
+        monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+        from tools.web_providers.brave import BraveSearchProvider
+        result = BraveSearchProvider().search("test query")
+        assert result["success"] is False
+        assert "BRAVE_API_KEY" in result["error"]
+
+    def test_search_success(self, brave_key):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "web": {
+                "results": [
+                    {"title": "Result 1", "url": "https://example.com/1", "description": "Desc 1"},
+                    {"title": "Result 2", "url": "https://example.com/2", "description": "Desc 2"},
+                ]
+            }
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.get", return_value=mock_response):
+            from tools.web_providers.brave import BraveSearchProvider
+            result = BraveSearchProvider().search("test query", limit=2)
+
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 2
+        assert web[0]["title"] == "Result 1"
+        assert web[0]["url"] == "https://example.com/1"
+        assert web[0]["position"] == 1
+        assert web[1]["position"] == 2
+
+    def test_search_respects_limit(self, brave_key):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "web": {
+                "results": [
+                    {"title": f"Result {i}", "url": f"https://example.com/{i}", "description": ""}
+                    for i in range(10)
+                ]
+            }
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.get", return_value=mock_response):
+            from tools.web_providers.brave import BraveSearchProvider
+            result = BraveSearchProvider().search("test", limit=3)
+
+        assert result["success"] is True
+        assert len(result["data"]["web"]) == 3
+
+    def test_search_401_error(self, brave_key):
+        import httpx
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        with patch("httpx.get", side_effect=httpx.HTTPStatusError("", request=MagicMock(), response=mock_resp)):
+            from tools.web_providers.brave import BraveSearchProvider
+            result = BraveSearchProvider().search("test")
+        assert result["success"] is False
+        assert "invalid or expired" in result["error"]
+
+    def test_search_429_rate_limit(self, brave_key):
+        import httpx
+        mock_resp = MagicMock()
+        mock_resp.status_code = 429
+        with patch("httpx.get", side_effect=httpx.HTTPStatusError("", request=MagicMock(), response=mock_resp)):
+            from tools.web_providers.brave import BraveSearchProvider
+            result = BraveSearchProvider().search("test")
+        assert result["success"] is False
+        assert "rate limit" in result["error"]
+
+    def test_search_request_error(self, brave_key):
+        import httpx
+        with patch("httpx.get", side_effect=httpx.RequestError("connection refused")):
+            from tools.web_providers.brave import BraveSearchProvider
+            result = BraveSearchProvider().search("test")
+        assert result["success"] is False
+        assert "Could not reach" in result["error"]
+
+    def test_search_empty_results(self, brave_key):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"web": {"results": []}}
+        mock_response.raise_for_status = MagicMock()
+        with patch("httpx.get", return_value=mock_response):
+            from tools.web_providers.brave import BraveSearchProvider
+            result = BraveSearchProvider().search("obscure query no results")
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+
+class TestWebToolsBraveBackend:
+    """Integration-style tests for Brave backend routing in web_tools."""
+
+    def test_get_backend_brave_when_configured(self, monkeypatch):
+        monkeypatch.setenv("BRAVE_API_KEY", "test-key")
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "brave"}):
+            from tools.web_tools import _get_backend
+            assert _get_backend() == "brave"
+
+    def test_brave_in_fallback_chain(self, monkeypatch):
+        # Remove all other keys, set only BRAVE_API_KEY
+        for key in ("FIRECRAWL_API_KEY", "PARALLEL_API_KEY", "TAVILY_API_KEY",
+                    "EXA_API_KEY", "SEARXNG_URL"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("BRAVE_API_KEY", "test-key")
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._is_tool_gateway_ready", return_value=False):
+            from tools.web_tools import _get_backend
+            assert _get_backend() == "brave"
+
+    def test_check_brave_api_key_true(self, monkeypatch):
+        monkeypatch.setenv("BRAVE_API_KEY", "test-key")
+        from tools.web_tools import check_brave_api_key
+        assert check_brave_api_key() is True
+
+    def test_check_brave_api_key_false(self, monkeypatch):
+        monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+        from tools.web_tools import check_brave_api_key
+        assert check_brave_api_key() is False

--- a/tools/web_providers/brave.py
+++ b/tools/web_providers/brave.py
@@ -110,22 +110,37 @@ class BraveSearchProvider(WebSearchProvider):
         except httpx.HTTPStatusError as exc:
             status = exc.response.status_code
             if status == 401:
-                return {"success": False, "error": "BRAVE_API_KEY is invalid or expired"}
+                return {
+                    "success": False,
+                    "error": "BRAVE_API_KEY is invalid or expired",
+                }
             if status == 422:
-                return {"success": False, "error": "Brave Search rejected the query (422)"}
+                return {
+                    "success": False,
+                    "error": "Brave Search rejected the query (422)",
+                }
             if status == 429:
-                return {"success": False, "error": "Brave Search rate limit exceeded — try again later"}
+                return {
+                    "success": False,
+                    "error": "Brave Search rate limit exceeded — try again later",
+                }
             logger.warning("Brave Search HTTP error: %s", exc)
             return {"success": False, "error": f"Brave Search returned HTTP {status}"}
         except httpx.RequestError as exc:
             logger.warning("Brave Search request error: %s", exc)
-            return {"success": False, "error": f"Could not reach Brave Search API: {exc}"}
+            return {
+                "success": False,
+                "error": f"Could not reach Brave Search API: {exc}",
+            }
 
         try:
             data = resp.json()
         except Exception as exc:  # noqa: BLE001
             logger.warning("Brave Search response parse error: %s", exc)
-            return {"success": False, "error": "Could not parse Brave Search response as JSON"}
+            return {
+                "success": False,
+                "error": "Could not parse Brave Search response as JSON",
+            }
 
         raw_results = data.get("web", {}).get("results", [])
 

--- a/tools/web_providers/brave.py
+++ b/tools/web_providers/brave.py
@@ -1,0 +1,147 @@
+"""Brave Search web search provider.
+
+Brave Search uses its own independent index (not Google or Bing), making it
+a privacy-focused alternative to Tavily/Exa/Parallel/Firecrawl.
+
+A free tier is available at https://brave.com/search/api/ — 2,000 queries/month
+with no credit card required.
+
+Configuration::
+
+    # ~/.hermes/.env  (or export in shell)
+    BRAVE_API_KEY=your-key-here
+
+    # ~/.hermes/config.yaml
+    web:
+      search_backend: "brave"
+      # extract_backend defaults to firecrawl when brave is the search backend
+      # (Brave Search does not offer a content-extraction endpoint)
+
+Get an API key at: https://api.search.brave.com/app/keys
+Pricing: https://brave.com/search/api/
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict
+
+from tools.web_providers.base import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
+
+
+class BraveSearchProvider(WebSearchProvider):
+    """Search via the Brave Search API.
+
+    Requires ``BRAVE_API_KEY`` to be set.
+    Uses ``X-Subscription-Token`` header authentication (no OAuth complexity).
+    Brave has its own independent web index — results differ from Google/Bing.
+
+    Extract/crawl are not supported by the Brave Search API.  When ``brave``
+    is selected as ``search_backend``, the extract backend falls back to
+    whichever extract provider is configured (defaulting to ``firecrawl``).
+    """
+
+    def provider_name(self) -> str:
+        return "brave"
+
+    def is_configured(self) -> bool:
+        """Return True when ``BRAVE_API_KEY`` is set to a non-empty value."""
+        return bool(os.getenv("BRAVE_API_KEY", "").strip())
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute a web search via the Brave Search API.
+
+        Returns normalized results::
+
+            {
+                "success": True,
+                "data": {
+                    "web": [
+                        {
+                            "title": str,
+                            "url": str,
+                            "description": str,
+                            "position": int,
+                        },
+                        ...
+                    ]
+                }
+            }
+
+        On failure returns ``{"success": False, "error": str}``.
+        """
+        import httpx
+
+        api_key = os.getenv("BRAVE_API_KEY", "").strip()
+        if not api_key:
+            return {"success": False, "error": "BRAVE_API_KEY is not set"}
+
+        params: Dict[str, Any] = {
+            "q": query,
+            "count": min(limit, 20),  # Brave API max is 20 per request
+            "text_decorations": "false",
+            "search_lang": "en",
+            "country": "us",
+            "safesearch": "moderate",
+        }
+
+        headers = {
+            "Accept": "application/json",
+            "Accept-Encoding": "gzip",
+            "X-Subscription-Token": api_key,
+        }
+
+        try:
+            resp = httpx.get(
+                _BRAVE_SEARCH_ENDPOINT,
+                params=params,
+                headers=headers,
+                timeout=15,
+            )
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            if status == 401:
+                return {"success": False, "error": "BRAVE_API_KEY is invalid or expired"}
+            if status == 422:
+                return {"success": False, "error": "Brave Search rejected the query (422)"}
+            if status == 429:
+                return {"success": False, "error": "Brave Search rate limit exceeded — try again later"}
+            logger.warning("Brave Search HTTP error: %s", exc)
+            return {"success": False, "error": f"Brave Search returned HTTP {status}"}
+        except httpx.RequestError as exc:
+            logger.warning("Brave Search request error: %s", exc)
+            return {"success": False, "error": f"Could not reach Brave Search API: {exc}"}
+
+        try:
+            data = resp.json()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Brave Search response parse error: %s", exc)
+            return {"success": False, "error": "Could not parse Brave Search response as JSON"}
+
+        raw_results = data.get("web", {}).get("results", [])
+
+        web_results = [
+            {
+                "title": str(r.get("title", "")),
+                "url": str(r.get("url", "")),
+                "description": str(r.get("description", "")),
+                "position": i + 1,
+            }
+            for i, r in enumerate(raw_results[:limit])
+        ]
+
+        logger.info(
+            "Brave Search '%s': %d results (from %d raw, limit %d)",
+            query,
+            len(web_results),
+            len(raw_results),
+            limit,
+        )
+
+        return {"success": True, "data": {"web": web_results}}

--- a/tools/web_providers/brave.py
+++ b/tools/web_providers/brave.py
@@ -13,9 +13,12 @@ Configuration::
 
     # ~/.hermes/config.yaml
     web:
-      search_backend: "brave"
-      # extract_backend defaults to firecrawl when brave is the search backend
-      # (Brave Search does not offer a content-extraction endpoint)
+      search_backend: "brave"           # use brave for search only
+      # OR: use brave as the single backend for all web operations
+      backend: "brave"
+      # Note: Brave Search does not offer a content-extraction endpoint.
+      # When brave is the search_backend, extract calls fall through to
+      # the configured extract_backend (defaults to firecrawl).
 
 Get an API key at: https://api.search.brave.com/app/keys
 Pricing: https://brave.com/search/api/

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -197,6 +197,8 @@ def _is_backend_available(backend: str) -> bool:
         return _has_env("TAVILY_API_KEY")
     if backend == "searxng":
         return _has_env("SEARXNG_URL")
+    if backend == "brave":
+        return _has_env("BRAVE_API_KEY")
     return False
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
@@ -2053,7 +2055,7 @@ def check_web_api_key() -> bool:
     configured = _load_web_config().get("backend", "").lower().strip()
     if configured in ("exa", "parallel", "firecrawl", "tavily", "searxng"):
         return _is_backend_available(configured)
-    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng"))
+    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave"))
 
 
 def check_auxiliary_model() -> bool:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -126,7 +126,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa", "searxng"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "searxng", "brave"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -138,6 +138,7 @@ def _get_backend() -> str:
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
         ("searxng", _has_env("SEARXNG_URL")),
+        ("brave", _has_env("BRAVE_API_KEY")),
     )
     for backend, available in backend_candidates:
         if available:
@@ -1200,6 +1201,16 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             _debug.save()
             return result_json
 
+        if backend == "brave":
+            from tools.web_providers.brave import BraveSearchProvider
+            response_data = BraveSearchProvider().search(query, limit)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
         if backend == "tavily":
             logger.info("Tavily search: '%s' (limit: %d)", query, limit)
             raw = _tavily_request("search", {
@@ -2030,6 +2041,11 @@ def check_firecrawl_api_key() -> bool:
         bool: True if direct Firecrawl or the tool-gateway can be used.
     """
     return _has_direct_firecrawl_config() or _is_tool_gateway_ready()
+
+
+def check_brave_api_key() -> bool:
+    """Return True if BRAVE_API_KEY is configured."""
+    return _has_env("BRAVE_API_KEY")
 
 
 def check_web_api_key() -> bool:

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -121,6 +121,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `FIRECRAWL_API_URL` | Custom Firecrawl API endpoint for self-hosted instances (optional) |
 | `TAVILY_API_KEY` | Tavily API key for AI-native web search, extract, and crawl ([app.tavily.com](https://app.tavily.com/home)) |
 | `SEARXNG_URL` | SearXNG instance URL for free self-hosted web search — no API key required ([searxng.github.io](https://searxng.github.io/searxng/)) |
+| `BRAVE_API_KEY` | Brave Search API key — independent web index, not Google/Bing, 2K free queries/month ([api.search.brave.com](https://api.search.brave.com/app/keys)) |
 | `TAVILY_BASE_URL` | Override the Tavily API endpoint. Useful for corporate proxies and self-hosted Tavily-compatible search backends. Same pattern as `GROQ_BASE_URL`. |
 | `EXA_API_KEY` | Exa API key for AI-native web search and contents ([exa.ai](https://exa.ai/)) |
 | `BROWSERBASE_API_KEY` | Browser automation ([browserbase.com](https://browserbase.com/)) |

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -24,6 +24,7 @@ All three are configured through a single backend selection. Providers are chose
 | **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ | ✔ | 1 000 searches/mo |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | — | 1 000 searches/mo |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | — | Paid |
+| **Brave Search** | `BRAVE_API_KEY` | ✔ | — | — | 2 000 searches/mo |
 
 **Per-capability split:** you can use different providers for search and extract independently — for example SearXNG (free) for search and Firecrawl for extract. See [Per-capability configuration](#per-capability-configuration) below.
 
@@ -185,6 +186,49 @@ web:
 With this config, Hermes uses SearXNG for all search queries and Firecrawl for URL extraction — combining free search with high-quality extraction.
 
 ---
+
+### Brave Search
+
+Brave Search uses its own independent web index — not Google or Bing — making it a **privacy-focused** alternative with a **free tier (2,000 queries/month)**.
+
+Brave Search is **search-only** — `web_extract` and `web_crawl` require a separate extract provider (default: Firecrawl).
+
+#### Setup
+
+**1. Get a free API key:**
+
+Go to [api.search.brave.com/app/keys](https://api.search.brave.com/app/keys) and create an account. The free tier provides 2,000 queries/month with no credit card required.
+
+**2. Set your API key:**
+
+```bash
+# ~/.hermes/.env
+BRAVE_API_KEY=your-key-here
+```
+
+**3. Select Brave as your search backend:**
+
+```yaml
+# ~/.hermes/config.yaml
+web:
+  search_backend: brave
+```
+
+Or select it via the interactive setup:
+
+```bash
+hermes tools
+# Choose: Web Search → Brave Search
+```
+
+**Per-capability config example** — Brave for search, Firecrawl for extract:
+
+```yaml
+web:
+  search_backend: brave
+  extract_backend: firecrawl
+```
+
 
 ### Tavily
 


### PR DESCRIPTION
## Summary

Adds Brave Search as a new `search_backend` option. Resolves #4372 and #10644.

Brave Search uses its own independent web index (not Google or Bing), making it a **privacy-focused, free-tier-available** alternative to Tavily/Exa/Parallel/Firecrawl.

### Why Brave Search?

- **Privacy-focused**: Independent index, no Google/Bing tracking
- **Free tier**: 2,000 queries/month, no credit card required
- **Simple auth**: `X-Subscription-Token` header — no OAuth complexity
- **Most-requested**: Closes two top-upvoted open issues (#4372, #10644)

---

### Changes

#### New file: `tools/web_providers/brave.py`
`BraveSearchProvider` implementing `WebSearchProvider` — follows the exact same pattern as `SearXNGSearchProvider`. Error handling covers 401 (invalid key), 422 (rejected query), 429 (rate limit), and network failures.

#### Modified: `tools/web_tools.py`
- Register `brave` in `_get_backend()` valid backends list
- Add `BRAVE_API_KEY` to the env-var fallback chain
- Register `brave` in `_is_backend_available()` ← **required for `search_backend: brave` config to work**
- Add `brave` to `check_web_api_key()` fallback list
- Add brave dispatch in `web_search_tool()`
- Add `check_brave_api_key()` helper

#### Modified: `hermes_cli/tools_config.py`
Add Brave as a fully-formed provider option in `hermes tools` setup with `name`, `badge`, `tag`, and `env_vars`.

#### Modified: `hermes_cli/nous_subscription.py`
- Add `direct_brave = _has_env("BRAVE_API_KEY")` variable
- Include brave in `managed_web_available` conditions (both `web.backend` and `web.search_backend` variants)
- Include `direct_brave` in `web_available`

#### New file: `tests/tools/test_web_tools_brave.py`
**20 unit tests** covering:
- Provider: is_configured, provider_name, search success, limit respect, error codes (401/422/429/500), request error, malformed JSON, missing results key, request headers verification, API max-count cap
- Backend routing: `_get_backend` with explicit config, fallback chain, `check_brave_api_key` true/false

---

### Configuration

```bash
# Option A: search only (pair with any extract backend)
# ~/.hermes/.env
BRAVE_API_KEY=your-key-here

# ~/.hermes/config.yaml
web:
  search_backend: brave

# Option B: all web operations via brave
web:
  backend: brave
```

Get a free API key (2,000 queries/month): https://api.search.brave.com/app/keys

### Note on extract/crawl

Brave does not offer a content-extraction API. When `brave` is the `search_backend`, extract/crawl calls fall through to the configured extract backend (defaults to `firecrawl`).

### Test Evidence

```
20 passed, 20 warnings in 1.55s
```