### PR TITLE
fix(gateway): clarify manual compression estimates

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1269,6 +1269,14 @@ The user has requested that this compaction PRIORITISE preserving all informatio
         skip the LLM call when the transcript is still entirely inside
         the protected head/tail.
         """
+        # Keep this guard in sync with compress().  Without the same minimum
+        # message check, manual /compress can enter the compressor and then
+        # no-op, producing a misleading "No changes from compression" result
+        # for tiny transcripts.
+        min_for_compress = self.protect_first_n + 3 + 1
+        if len(messages) <= min_for_compress:
+            return False
+
         compress_start = self._align_boundary_forward(messages, self.protect_first_n)
         compress_end = self._find_tail_cut_by_tokens(messages, compress_start)
         return compress_start < compress_end

--- a/agent/manual_compression_feedback.py
+++ b/agent/manual_compression_feedback.py
@@ -10,6 +10,8 @@ def summarize_manual_compression(
     after_messages: Sequence[dict[str, Any]],
     before_tokens: int,
     after_tokens: int,
+    *,
+    token_label: str = "Approx request size",
 ) -> dict[str, Any]:
     """Return consistent user-facing feedback for manual compression."""
     before_count = len(before_messages)
@@ -20,17 +22,17 @@ def summarize_manual_compression(
         headline = f"No changes from compression: {before_count} messages"
         if after_tokens == before_tokens:
             token_line = (
-                f"Approx request size: ~{before_tokens:,} tokens (unchanged)"
+                f"{token_label}: ~{before_tokens:,} tokens (unchanged)"
             )
         else:
             token_line = (
-                f"Approx request size: ~{before_tokens:,} → "
+                f"{token_label}: ~{before_tokens:,} → "
                 f"~{after_tokens:,} tokens"
             )
     else:
         headline = f"Compressed: {before_count} → {after_count} messages"
         token_line = (
-            f"Approx request size: ~{before_tokens:,} → "
+            f"{token_label}: ~{before_tokens:,} → "
             f"~{after_tokens:,} tokens"
         )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9471,10 +9471,10 @@ class GatewayRunner:
             try:
                 tmp_agent._print_fn = lambda *a, **kw: None
 
-                # Estimate with system prompt + tool schemas included so the
-                # figure reflects real request pressure, not a transcript-only
-                # underestimate (#6217). Must be computed after tmp_agent is
-                # built so _cached_system_prompt/tools are populated.
+                # Estimate with the temporary compression agent's system
+                # prompt + tool schemas included.  This reflects the manual
+                # compression pass itself; the next live gateway turn may have
+                # a different prompt/tool surface.
                 _sys_prompt = getattr(tmp_agent, "_cached_system_prompt", "") or ""
                 _tools = getattr(tmp_agent, "tools", None) or None
                 approx_tokens = estimate_request_tokens_rough(
@@ -9513,6 +9513,7 @@ class GatewayRunner:
                     compressed,
                     approx_tokens,
                     new_tokens,
+                    token_label="Compression pass estimate",
                 )
                 # Detect summary-generation failure so we can surface a
                 # visible warning to the user even on the manual /compress

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -60,9 +60,13 @@ class TestCompress:
         return [{"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"} for i in range(n)]
 
     def test_too_few_messages_returns_unchanged(self, compressor):
-        msgs = self._make_messages(4)  # protect_first=2 + protect_last=2 + 1 = 5 needed
+        msgs = self._make_messages(4)
         result = compressor.compress(msgs)
         assert result == msgs
+
+    def test_too_few_messages_are_not_reported_compressible(self, compressor):
+        msgs = self._make_messages(compressor.protect_first_n + 3 + 1)
+        assert compressor.has_content_to_compress(msgs) is False
 
     def test_truncation_fallback_no_client(self, compressor):
         # compressor has client=None, so should use truncation fallback

--- a/tests/gateway/test_compress_command.py
+++ b/tests/gateway/test_compress_command.py
@@ -84,7 +84,7 @@ async def test_compress_command_reports_noop_without_success_banner():
 
     assert "No changes from compression" in result
     assert "Compressed:" not in result
-    assert "Approx request size: ~100 tokens (unchanged)" in result
+    assert "Compression pass estimate: ~100 tokens (unchanged)" in result
     agent_instance.shutdown_memory_provider.assert_called_once()
     agent_instance.close.assert_called_once()
 
@@ -123,7 +123,7 @@ async def test_compress_command_explains_when_token_estimate_rises():
         result = await runner._handle_compress_command(_make_event())
 
     assert "Compressed: 4 → 3 messages" in result
-    assert "Approx request size: ~100 → ~120 tokens" in result
+    assert "Compression pass estimate: ~100 → ~120 tokens" in result
     assert "denser summaries" in result
     agent_instance.shutdown_memory_provider.assert_called_once()
     agent_instance.close.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Fixes misleading gateway `/compress` feedback that can make a small manual compression estimate look comparable to a much larger active preflight compression estimate.

Gateway `/compress` runs through a temporary compression-only agent with `skip_memory=True` and `enabled_toolsets=["memory"]`, so its token estimate is for the compression pass, not necessarily the next live gateway request. This PR relabels that gateway feedback as a compression-pass estimate while preserving the CLI wording, since CLI manual compression estimates against the active agent.

It also keeps `ContextCompressor.has_content_to_compress()` aligned with the real compressor minimum-message guard so tiny transcripts do not enter compression and return a misleading `No changes from compression` reply.

This is still a draft/test fix for the active Discord support thread at <https://discord.com/channels/1053877538025386074/1501746179778809976/1501746179778809976>. I am waiting on either fresh logs from the reporter or local confirmation that this potential fix matches the observed gateway `/compress` behavior before running broader CI or marking the PR ready for review.

## Related Issue

No GitHub issue yet. Originating Discord support thread: <https://discord.com/channels/1053877538025386074/1501746179778809976/1501746179778809976>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py`: make `has_content_to_compress()` return false for transcripts that `compress()` would later refuse as too small.
- `agent/manual_compression_feedback.py`: add a `token_label` parameter so callers can describe what kind of estimate they are showing.
- `gateway/run.py`: label gateway `/compress` feedback as `Compression pass estimate` because the gateway path uses a temporary compression-only agent.
- `tests/agent/test_context_compressor.py`: add regression coverage for tiny transcripts not being reported compressible.
- `tests/gateway/test_compress_command.py`: update gateway `/compress` assertions for the clarified estimate label.

## How to Test

1. Run the targeted regression tests: `pytest tests/gateway/test_compress_command.py tests/cli/test_manual_compress.py tests/test_cli_manual_compress.py tests/agent/test_context_compressor.py -q`
2. Run whitespace validation: `git diff --check -- agent/context_compressor.py agent/manual_compression_feedback.py gateway/run.py tests/agent/test_context_compressor.py tests/gateway/test_compress_command.py`
3. From a running gateway, send `/compress` as a plain text message in a short session and verify it reports that there is nothing to compress yet instead of `No changes from compression: 5 messages`.
4. From a longer gateway session, run `/compress` and verify the token line says `Compression pass estimate` rather than `Approx request size`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux local targeted tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## CI Status

The `ruff + ty diff` job is currently red because the workflow successfully found no new ruff or ty issues, then failed while trying to post its summary comment back to this fork PR with `Resource not accessible by integration` / HTTP 403. The lint/type diff itself reports 0 new issues.

The full `test` job is also red from broad unrelated suite failures across Bedrock, cron, Discord, Telegram topic mode, agent cache, model provider persistence, browser Chromium checks, delegate tests, Dockerfile tests, update tests, and other areas. None of the failing CI tests are the compression tests touched by this PR.

## Screenshots / Logs

Targeted local validation:

- `pytest tests/gateway/test_compress_command.py tests/cli/test_manual_compress.py tests/test_cli_manual_compress.py tests/agent/test_context_compressor.py -q` → 80 passed
- `git diff --check -- agent/context_compressor.py agent/manual_compression_feedback.py gateway/run.py tests/agent/test_context_compressor.py tests/gateway/test_compress_command.py` → clean

Existing PR search performed for `compress estimate`, `preflight compression`, `manual compress`, `has_content_to_compress`, and `No changes from compression`; nearby compression PRs exist, but none covered this gateway temp-agent estimate label plus short-transcript eligibility mismatch.