### PR TITLE
fix(gateway): honor fallback provider model

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -622,6 +622,7 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "command": runtime.get("command"),
                     "args": list(runtime.get("args") or []),
                     "credential_pool": runtime.get("credential_pool"),
+                    "model": entry.get("model"),
                 }
             except Exception as fb_exc:
                 logger.debug("Fallback entry %s failed: %s", entry.get("provider"), fb_exc)
@@ -1604,6 +1605,9 @@ class GatewayRunner:
             )
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
+        runtime_model = runtime_kwargs.pop("model", None)
+        if runtime_model:
+            model = runtime_model
         if override and resolved_session_key:
             model, runtime_kwargs = self._apply_session_model_override(
                 resolved_session_key, model, runtime_kwargs

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -126,6 +126,66 @@ def test_run_agent_prefers_session_override_over_global_runtime(monkeypatch):
     assert _CapturingAgent.last_init["reasoning_config"] == {"enabled": True, "effort": "high"}
 
 
+def test_gateway_fallback_runtime_model_replaces_primary_model(monkeypatch):
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.5")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_key": "sk-fallback",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+            "model": "minimax/minimax-m2.7",
+        },
+    )
+
+    runner = _make_runner()
+
+    model, runtime_kwargs = runner._resolve_session_agent_runtime()
+
+    assert model == "minimax/minimax-m2.7"
+    assert runtime_kwargs["provider"] == "openrouter"
+    assert runtime_kwargs["api_key"] == "sk-fallback"
+    assert "model" not in runtime_kwargs
+
+
+def test_try_resolve_fallback_provider_carries_configured_model(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        """
+fallback_providers:
+  - provider: openrouter
+    model: minimax/minimax-m2.7
+    base_url: https://openrouter.ai/api/v1
+    api_key: sk-fallback
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    def _fake_resolve_runtime_provider(**kwargs):
+        assert kwargs["requested"] == "openrouter"
+        assert kwargs["explicit_base_url"] == "https://openrouter.ai/api/v1"
+        assert kwargs["explicit_api_key"] == "sk-fallback"
+        return {
+            "provider": "openrouter",
+            "api_key": "sk-fallback",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "chat_completions",
+        }
+
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        _fake_resolve_runtime_provider,
+    )
+
+    runtime_kwargs = gateway_run._try_resolve_fallback_provider()
+
+    assert runtime_kwargs is not None
+    assert runtime_kwargs["provider"] == "openrouter"
+    assert runtime_kwargs["model"] == "minimax/minimax-m2.7"
+
+
 @pytest.mark.asyncio
 async def test_background_task_prefers_session_override_over_global_runtime(monkeypatch):
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})


### PR DESCRIPTION
Fixes #19411

## Summary
- carry the configured `fallback_providers[].model` through gateway fallback runtime resolution
- replace the primary configured model with that explicit fallback model before agent construction
- keep `model` out of the runtime kwargs passed to `AIAgent` after it has been consumed

## Why
When gateway auth fallback resolved a fallback provider, it kept the primary model from `model.default`. That produced inconsistent runtime state such as `provider=openrouter` with `model=gpt-5.5` even when the fallback entry configured `model: minimax/minimax-m2.7`.

## Verification
- `scripts/run_tests.sh tests/gateway/test_session_model_override_routing.py` -> 4 passed, 2 warnings
- `scripts/run_tests.sh tests/gateway/test_session_model_override_routing.py tests/gateway/test_fast_command.py` -> 8 passed, 3 warnings
- `git diff --check` -> passed

## Scope
No changes to provider resolution semantics beyond preserving the model already configured on the selected fallback entry.