### PR TITLE
fix(qqbot): prevent silent busy-loop when reconnect fails

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -592,6 +592,16 @@ class QQAdapter(BasePlatformAdapter):
             return True
         except Exception as exc:
             logger.warning("[%s] Reconnect failed: %s", self._log_tag, exc)
+            # Clean up stale WebSocket so _read_events() raises on next call,
+            # preventing a silent busy-loop where _read_events() returns
+            # immediately (ws.closed=True) without triggering backoff retries.
+            if self._ws:
+                try:
+                    if not self._ws.closed:
+                        await self._ws.close()
+                except Exception:
+                    pass
+                self._ws = None
             return False
 
     async def _read_events(self) -> None:


### PR DESCRIPTION
## Problem

When _reconnect() fails (e.g. DNS resolution error on api.sgroup.qq.com), self._ws was left pointing to the stale closed WebSocket. _read_events() would detect ws.closed=True and return immediately without raising an exception, causing _listen_loop to reset backoff_idx=0 on each iteration — an infinite tight loop with no reconnect attempts and no log output.

## Fix

Clean up self._ws in the _reconnect() failure path so _read_events() raises RuntimeError on next call, triggering the proper backoff retry logic.

## Testing

Reproduced on a production gateway (DNS fluctuation caused 78+ minute outage). Applied fix, restarted, QQ Bot reconnected normally.