### PR TITLE
fix(anthropic): preserve raw response content history

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1406,6 +1406,21 @@ def _extract_preserved_thinking_blocks(message: Dict[str, Any]) -> List[Dict[str
     return preserved
 
 
+def _extract_raw_anthropic_content(message: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
+    """Return exact Anthropic content blocks preserved from a prior response."""
+    raw_content = message.get("_raw_anthropic_content")
+    if not isinstance(raw_content, list) or not raw_content:
+        return None
+
+    blocks: List[Dict[str, Any]] = []
+    for block in raw_content:
+        plain_block = _to_plain_data(block)
+        if not isinstance(plain_block, dict):
+            return None
+        blocks.append(copy.deepcopy(plain_block))
+    return blocks
+
+
 def _convert_content_to_anthropic(content: Any) -> Any:
     """Convert OpenAI-style multimodal content arrays to Anthropic blocks."""
     if not isinstance(content, list):
@@ -1465,29 +1480,36 @@ def convert_messages_to_anthropic(
             continue
 
         if role == "assistant":
-            blocks = _extract_preserved_thinking_blocks(m)
-            if content:
+            from_raw_anthropic_content = False
+            raw_blocks = _extract_raw_anthropic_content(m)
+            if raw_blocks is not None:
+                blocks = raw_blocks
+                from_raw_anthropic_content = True
+            else:
+                blocks = _extract_preserved_thinking_blocks(m)
+            if content and raw_blocks is None:
                 if isinstance(content, list):
                     converted_content = _convert_content_to_anthropic(content)
                     if isinstance(converted_content, list):
                         blocks.extend(converted_content)
                 else:
                     blocks.append({"type": "text", "text": str(content)})
-            for tc in m.get("tool_calls", []):
-                if not tc or not isinstance(tc, dict):
-                    continue
-                fn = tc.get("function", {})
-                args = fn.get("arguments", "{}")
-                try:
-                    parsed_args = json.loads(args) if isinstance(args, str) else args
-                except (json.JSONDecodeError, ValueError):
-                    parsed_args = {}
-                blocks.append({
-                    "type": "tool_use",
-                    "id": _sanitize_tool_id(tc.get("id", "")),
-                    "name": fn.get("name", ""),
-                    "input": parsed_args,
-                })
+            if raw_blocks is None:
+                for tc in m.get("tool_calls", []):
+                    if not tc or not isinstance(tc, dict):
+                        continue
+                    fn = tc.get("function", {})
+                    args = fn.get("arguments", "{}")
+                    try:
+                        parsed_args = json.loads(args) if isinstance(args, str) else args
+                    except (json.JSONDecodeError, ValueError):
+                        parsed_args = {}
+                    blocks.append({
+                        "type": "tool_use",
+                        "id": _sanitize_tool_id(tc.get("id", "")),
+                        "name": fn.get("name", ""),
+                        "input": parsed_args,
+                    })
             # Kimi's /coding endpoint (Anthropic protocol) requires assistant
             # tool-call messages to carry reasoning_content when thinking is
             # enabled server-side.  Preserve it as a thinking block so Kimi
@@ -1511,13 +1533,20 @@ def convert_messages_to_anthropic(
                 isinstance(b, dict) and b.get("type") in ("thinking", "redacted_thinking")
                 for b in blocks
             )
-            if isinstance(reasoning_content, str) and not _already_has_thinking:
+            if (
+                raw_blocks is None
+                and isinstance(reasoning_content, str)
+                and not _already_has_thinking
+            ):
                 blocks.insert(0, {"type": "thinking", "thinking": reasoning_content})
             # Anthropic rejects empty assistant content
             effective = blocks or content
             if not effective or effective == "":
                 effective = [{"type": "text", "text": "(empty)"}]
-            result.append({"role": "assistant", "content": effective})
+            assistant_result = {"role": "assistant", "content": effective}
+            if from_raw_anthropic_content:
+                assistant_result["_raw_anthropic_content_preserved"] = True
+            result.append(assistant_result)
             continue
 
         if role == "tool":
@@ -1659,9 +1688,11 @@ def convert_messages_to_anthropic(
     # thinking blocks if it supports extended thinking.
     #
     # For direct Anthropic (strategy following clawdbot/OpenClaw):
-    # 1. Strip thinking/redacted_thinking from all assistant messages
-    #    EXCEPT the last one — preserves reasoning continuity on the
-    #    current tool-use chain while avoiding stale signature errors.
+    # 1. Strip thinking/redacted_thinking from reconstructed assistant
+    #    messages EXCEPT the last one. Assistant messages replayed from exact
+    #    raw Anthropic response content keep their signed thinking blocks.
+    #    This preserves reasoning continuity while avoiding stale signatures
+    #    from Hermes-synthesised or mutated blocks.
     # 2. Downgrade unsigned thinking blocks (no signature) to text —
     #    Anthropic can't validate them and will reject them.
     # 3. Strip cache_control from thinking/redacted_thinking blocks —
@@ -1707,10 +1738,16 @@ def convert_messages_to_anthropic(
                 # keep it: the upstream needs it for message-history validation.
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
-        elif _is_third_party or idx != last_assistant_idx:
+        elif _is_third_party or (
+            idx != last_assistant_idx
+            and not m.get("_raw_anthropic_content_preserved")
+        ):
             # Third-party endpoint: strip ALL thinking blocks from every
             # assistant message — signatures are Anthropic-proprietary.
-            # Direct Anthropic: strip from non-latest assistant messages only.
+            # Direct Anthropic: strip from non-latest assistant messages only
+            # unless those messages came from exact raw Anthropic response
+            # content. Raw blocks remain valid because Hermes did not
+            # reconstruct or synthesize them.
             stripped = [
                 b for b in m["content"]
                 if not (isinstance(b, dict) and b.get("type") in _THINKING_TYPES)
@@ -1745,6 +1782,8 @@ def convert_messages_to_anthropic(
         for b in m["content"]:
             if isinstance(b, dict) and b.get("type") in _THINKING_TYPES:
                 b.pop("cache_control", None)
+
+        m.pop("_raw_anthropic_content_preserved", None)
 
     return system, result
 
@@ -1966,5 +2005,3 @@ def build_anthropic_kwargs(
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
 
     return kwargs
-
-

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -94,15 +94,18 @@ class AnthropicTransport(ProviderTransport):
         reasoning_parts = []
         reasoning_details = []
         tool_calls = []
+        raw_content = []
 
         for block in response.content:
+            raw_block = _to_plain_data(block)
+            if isinstance(raw_block, dict):
+                raw_content.append(raw_block)
             if block.type == "text":
                 text_parts.append(block.text)
             elif block.type == "thinking":
                 reasoning_parts.append(block.thinking)
-                block_dict = _to_plain_data(block)
-                if isinstance(block_dict, dict):
-                    reasoning_details.append(block_dict)
+                if isinstance(raw_block, dict):
+                    reasoning_details.append(raw_block)
             elif block.type == "tool_use":
                 name = block.name
                 if strip_tool_prefix and name.startswith(_MCP_PREFIX):
@@ -118,6 +121,8 @@ class AnthropicTransport(ProviderTransport):
         finish_reason = self._STOP_REASON_MAP.get(response.stop_reason, "stop")
 
         provider_data = {}
+        if raw_content:
+            provider_data["_raw_anthropic_content"] = raw_content
         if reasoning_details:
             provider_data["reasoning_details"] = reasoning_details
 

--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -131,6 +131,11 @@ class NormalizedResponse:
         pd = self.provider_data or {}
         return pd.get("codex_message_items")
 
+    @property
+    def raw_anthropic_content(self):
+        pd = self.provider_data or {}
+        return pd.get("_raw_anthropic_content")
+
 
 # ---------------------------------------------------------------------------
 # Factory helpers

--- a/run_agent.py
+++ b/run_agent.py
@@ -568,6 +568,53 @@ def _sanitize_messages_surrogates(messages: list) -> bool:
     return found
 
 
+def _to_plain_response_data(value: Any, *, _depth: int = 0, _path: Optional[set] = None) -> Any:
+    """Convert provider SDK response objects to JSON-compatible plain data."""
+    _MAX_DEPTH = 20
+    if _depth > _MAX_DEPTH:
+        return str(value)
+
+    if _path is None:
+        _path = set()
+
+    obj_id = id(value)
+    if obj_id in _path:
+        return str(value)
+
+    if hasattr(value, "model_dump"):
+        _path.add(obj_id)
+        try:
+            dumped = value.model_dump(mode="json", exclude_none=True)
+        except TypeError:
+            dumped = value.model_dump()
+        result = _to_plain_response_data(dumped, _depth=_depth + 1, _path=_path)
+        _path.discard(obj_id)
+        return result
+    if isinstance(value, dict):
+        _path.add(obj_id)
+        result = {
+            k: _to_plain_response_data(v, _depth=_depth + 1, _path=_path)
+            for k, v in value.items()
+        }
+        _path.discard(obj_id)
+        return result
+    if isinstance(value, (list, tuple)):
+        _path.add(obj_id)
+        result = [_to_plain_response_data(v, _depth=_depth + 1, _path=_path) for v in value]
+        _path.discard(obj_id)
+        return result
+    if hasattr(value, "__dict__"):
+        _path.add(obj_id)
+        result = {
+            k: _to_plain_response_data(v, _depth=_depth + 1, _path=_path)
+            for k, v in vars(value).items()
+            if not k.startswith("_")
+        }
+        _path.discard(obj_id)
+        return result
+    return value
+
+
 def _escape_invalid_chars_in_json_strings(raw: str) -> str:
     """Escape unescaped control chars inside JSON string values.
 
@@ -8875,6 +8922,18 @@ class AIAgent:
         if "reasoning_content" not in msg and reasoning_text:
             msg["reasoning_content"] = reasoning_text
 
+        raw_anthropic_content = getattr(assistant_message, "raw_anthropic_content", None)
+        if raw_anthropic_content is None:
+            provider_data = getattr(assistant_message, "provider_data", None) or {}
+            if isinstance(provider_data, dict):
+                raw_anthropic_content = provider_data.get("_raw_anthropic_content")
+        preserved_raw_anthropic_content = _to_plain_response_data(raw_anthropic_content)
+        if (
+            isinstance(preserved_raw_anthropic_content, list)
+            and all(isinstance(block, dict) for block in preserved_raw_anthropic_content)
+        ):
+            msg["_raw_anthropic_content"] = preserved_raw_anthropic_content
+
         if hasattr(assistant_message, 'reasoning_details') and assistant_message.reasoning_details:
             # Pass reasoning_details back unmodified so providers (OpenRouter,
             # Anthropic, OpenAI) can maintain reasoning continuity across turns.
@@ -10395,7 +10454,10 @@ class AIAgent:
             for msg in messages:
                 api_msg = msg.copy()
                 self._copy_reasoning_content_for_api(msg, api_msg)
-                for internal_field in ("reasoning", "finish_reason", "_thinking_prefill"):
+                internal_fields = ["reasoning", "finish_reason", "_thinking_prefill"]
+                if self.api_mode != "anthropic_messages":
+                    internal_fields.append("_raw_anthropic_content")
+                for internal_field in internal_fields:
                     api_msg.pop(internal_field, None)
                 if _needs_sanitize:
                     self._sanitize_tool_calls_for_strict_api(api_msg)
@@ -11118,6 +11180,8 @@ class AIAgent:
                     api_msg.pop("finish_reason")
                 # Strip internal thinking-prefill marker
                 api_msg.pop("_thinking_prefill", None)
+                if self.api_mode != "anthropic_messages":
+                    api_msg.pop("_raw_anthropic_content", None)
                 # Strip Codex Responses API fields (call_id, response_item_id) for
                 # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
                 # Uses new dicts so the internal messages list retains the fields

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -26,6 +26,33 @@ from agent.anthropic_adapter import (
 from agent.transports import get_transport
 
 
+def test_anthropic_transport_exposes_raw_content_blocks():
+    from agent.transports.anthropic import AnthropicTransport
+
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(
+                type="thinking",
+                thinking="Need to inspect.",
+                signature="sig_1",
+            ),
+            SimpleNamespace(type="redacted_thinking", data="opaque_data"),
+            SimpleNamespace(type="text", text="Visible answer"),
+        ],
+        stop_reason="end_turn",
+    )
+
+    normalized = AnthropicTransport().normalize_response(response)
+
+    assert normalized.content == "Visible answer"
+    assert normalized.reasoning == "Need to inspect."
+    assert normalized.raw_anthropic_content == [
+        {"type": "thinking", "thinking": "Need to inspect.", "signature": "sig_1"},
+        {"type": "redacted_thinking", "data": "opaque_data"},
+        {"type": "text", "text": "Visible answer"},
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Auth helpers
 # ---------------------------------------------------------------------------
@@ -837,6 +864,104 @@ class TestConvertMessages:
         assert assistant_blocks[0]["thinking"] == "Need to inspect the tool result first."
         assert assistant_blocks[0]["signature"] == "sig_123"
         assert assistant_blocks[1]["type"] == "tool_use"
+
+    def test_raw_anthropic_content_preserves_old_signed_blocks(self):
+        messages = [
+            {"role": "user", "content": "Question 1"},
+            {
+                "role": "assistant",
+                "content": "flattened visible text",
+                "_raw_anthropic_content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Raw signed thought.",
+                        "signature": "sig_raw_1",
+                    },
+                    {"type": "redacted_thinking", "data": "opaque_redacted_data"},
+                    {"type": "text", "text": "raw visible text"},
+                ],
+            },
+            {"role": "user", "content": "Question 2"},
+            {"role": "assistant", "content": "Final answer"},
+        ]
+
+        _, result = convert_messages_to_anthropic(messages)
+        first_assistant = [m for m in result if m["role"] == "assistant"][0]
+        blocks = first_assistant["content"]
+
+        assert [b.get("type") for b in blocks] == [
+            "thinking",
+            "redacted_thinking",
+            "text",
+        ]
+        assert blocks[0]["signature"] == "sig_raw_1"
+        assert blocks[1]["data"] == "opaque_redacted_data"
+        assert blocks[2]["text"] == "raw visible text"
+        assert "_raw_anthropic_content_preserved" not in first_assistant
+
+    def test_raw_anthropic_content_is_source_of_truth_for_tool_use(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "_raw_anthropic_content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Use the tool.",
+                        "signature": "sig_tool",
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "call_1",
+                        "name": "test_tool",
+                        "input": {"x": 1},
+                    },
+                ],
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {"name": "test_tool", "arguments": "{\"x\": 1}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "tool output"},
+        ]
+
+        _, result = convert_messages_to_anthropic(messages)
+        assistant = next(msg for msg in result if msg["role"] == "assistant")
+        tool_uses = [
+            block for block in assistant["content"]
+            if isinstance(block, dict) and block.get("type") == "tool_use"
+        ]
+
+        assert len(tool_uses) == 1
+        assert tool_uses[0]["input"] == {"x": 1}
+
+    def test_raw_anthropic_content_thinking_stripped_for_third_party(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "flattened text",
+                "_raw_anthropic_content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "Anthropic signed thought.",
+                        "signature": "sig_raw",
+                    },
+                    {"type": "redacted_thinking", "data": "opaque_redacted_data"},
+                    {"type": "text", "text": "visible raw text"},
+                ],
+            },
+        ]
+
+        _, result = convert_messages_to_anthropic(
+            messages,
+            base_url="https://api.minimax.io/anthropic",
+        )
+        blocks = result[0]["content"]
+
+        assert [b.get("type") for b in blocks] == ["text"]
+        assert blocks[0]["text"] == "visible raw text"
 
     def test_converts_data_url_image_to_anthropic_image_block(self):
         messages = [


### PR DESCRIPTION
Fixes #17861

## Summary
- Preserve exact native Anthropic response content blocks on normalized responses and stored assistant history under `_raw_anthropic_content`.
- Replay preserved raw Anthropic blocks as the source of truth in `convert_messages_to_anthropic()`, including signed `thinking`, `redacted_thinking`, text, and tool_use ordering.
- Keep third-party Anthropic-compatible endpoints on the existing strip-all-thinking path, and avoid duplicating tool_use blocks when raw content is present.

## Verification
- `git diff --check`
- `scripts/run_tests.sh tests/agent/test_anthropic_adapter.py -k "raw_anthropic_content or preserved_thinking_blocks_are_rehydrated or thinking_stripped_from_non_last_assistant or signed_thinking_preserved_on_last_turn or unsigned_thinking_downgraded_to_text_on_last_turn or redacted_thinking or cache_control_stripped_from_thinking_blocks or multi_turn_conversation_preserves_only_last or anthropic_transport_exposes_raw_content_blocks"`
- `scripts/run_tests.sh tests/agent/test_deepseek_anthropic_thinking.py`

Local note: the full `tests/agent/test_anthropic_adapter.py` module still has three unrelated OAuth setup/keychain mock failures on this macOS runner; the affected conversion/transport tests above pass.