### PR TITLE
fix(security): force-redact context compression summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -684,7 +684,7 @@ class ContextCompressor(ContextEngine):
         parts = []
         for msg in turns:
             role = msg.get("role", "unknown")
-            content = redact_sensitive_text(msg.get("content") or "")
+            content = redact_sensitive_text(msg.get("content") or "", force=True)
 
             # Tool results: keep enough content for the summarizer
             if role == "tool":
@@ -705,7 +705,7 @@ class ContextCompressor(ContextEngine):
                         if isinstance(tc, dict):
                             fn = tc.get("function", {})
                             name = fn.get("name", "?")
-                            args = redact_sensitive_text(fn.get("arguments", ""))
+                            args = redact_sensitive_text(fn.get("arguments", ""), force=True)
                             # Truncate long arguments but keep enough for context
                             if len(args) > self._TOOL_ARGS_MAX:
                                 args = args[:self._TOOL_ARGS_HEAD] + "..."
@@ -891,7 +891,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 content = str(content) if content else ""
             # Redact the summary output as well — the summarizer LLM may
             # ignore prompt instructions and echo back secrets verbatim.
-            summary = redact_sensitive_text(content.strip())
+            summary = redact_sensitive_text(content.strip(), force=True)
             # Store for iterative updates on next compaction
             self._previous_summary = summary
             self._summary_failure_cooldown_until = 0.0

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1,7 +1,9 @@
 """Tests for agent/context_compressor.py — compression logic, thresholds, truncation fallback."""
 
+import json
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 
 from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
 
@@ -221,6 +223,82 @@ class TestNonStringContent:
             "api_key": "codex-token",
             "api_mode": "codex_responses",
         }
+
+
+class TestSummarySerializationRedaction:
+    def test_summary_serialization_force_redacts_message_content_when_global_redaction_disabled(self, monkeypatch):
+        from agent import redact as redact_module
+
+        monkeypatch.setattr(redact_module, "_REDACT_ENABLED", False)
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        secret = "sk-proj-abc123def456ghi789jkl012"
+        serialized = c._serialize_for_summary([
+            {"role": "user", "content": f"Here is my API key: {secret}"},
+            {"role": "tool", "tool_call_id": "call_1", "content": f"Authorization: Bearer {secret}"},
+        ])
+
+        assert secret not in serialized
+        assert "Authorization: Bearer" in serialized
+        assert "***" in serialized
+
+    def test_summary_serialization_force_redacts_tool_call_arguments_when_global_redaction_disabled(self, monkeypatch):
+        from agent import redact as redact_module
+
+        monkeypatch.setattr(redact_module, "_REDACT_ENABLED", False)
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        secret = "sk-proj-abc123def456ghi789jkl012"
+        serialized = c._serialize_for_summary([
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "write_file",
+                            "arguments": json.dumps({
+                                "path": ".env",
+                                "content": f"OPENAI_API_KEY={secret}",
+                            }),
+                        },
+                    }
+                ],
+            }
+        ])
+
+        assert secret not in serialized
+        assert "OPENAI_API_KEY" in serialized
+        assert "***" in serialized
+
+    def test_generate_summary_force_redacts_summary_output_when_global_redaction_disabled(self, monkeypatch):
+        from agent import redact as redact_module
+
+        monkeypatch.setattr(redact_module, "_REDACT_ENABLED", False)
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        secret = "sk-proj-abc123def456ghi789jkl012"
+        mock_response.choices[0].message.content = f"summary echoed {secret}"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            summary = c._generate_summary([
+                {"role": "user", "content": f"use {secret}"},
+                {"role": "assistant", "content": "ok"},
+            ])
+
+        assert summary is not None
+        assert secret not in summary
+        assert "sk-pro..." in summary
 
 
 class TestSummaryFailureCooldown:


### PR DESCRIPTION
## What does this PR do?

This fixes a security boundary gap in context compaction summary generation.

`ContextCompressor._serialize_for_summary()` prepares conversation history for the auxiliary summarizer, and the resulting summary may persist across later compactions. The method docstring already states that content is redacted before serialization so secrets do not leak into the auxiliary model or into compacted summaries. In practice, the summary path was calling `redact_sensitive_text()` without `force=True`, which meant default installations with global redaction disabled could still send raw secrets through this path.

This PR makes context-compression summaries always enforce redaction at that boundary:

- message content serialized for the auxiliary summarizer is force-redacted
- assistant tool-call arguments serialized for the auxiliary summarizer are force-redacted
- auxiliary summarizer output is force-redacted before being stored as the compacted summary

This keeps the existing user-facing redaction preference unchanged everywhere else while ensuring the compaction summary path never returns raw secrets.

## Related Issue

No tracked issue.

This fixes a source-level security mismatch between the documented behavior of `ContextCompressor` and the actual summary-serialization path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/context_compressor.py` to call `redact_sensitive_text(..., force=True)` when serializing message content for summary generation
- Updated `agent/context_compressor.py` to call `redact_sensitive_text(..., force=True)` when serializing assistant tool-call arguments for summary generation
- Updated `agent/context_compressor.py` to force-redact auxiliary summarizer output before storing the compacted summary
- Added regression tests in `tests/agent/test_context_compressor.py` covering:
  - forced redaction of serialized message content when global redaction is disabled
  - forced redaction of serialized tool-call arguments when global redaction is disabled
  - forced redaction of summarizer output when global redaction is disabled

## How to Test

1. Run `python -m pytest tests/agent/test_context_compressor.py -q`
2. Verify the suite passes, including the new `TestSummarySerializationRedaction` coverage
3. Optionally reproduce manually by disabling global redaction and confirming `_serialize_for_summary()` / `_generate_summary()` no longer retain raw secrets in serialized summary content

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (WSL)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validation run:

```bash
python -m pytest tests/agent/test_context_compressor.py -q
71 passed, 71 warnings in 68.73s
```

Manual verification with global redaction disabled confirmed the fix closes both leak paths:

- `_serialize_for_summary()` no longer retains the original secret value in serialized message content, tool results, or tool-call arguments
- `_generate_summary()` no longer retains the original secret value when the auxiliary summarizer echoes it back
