### PR TITLE
fix/ctrl backspace word delete

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -53,6 +53,7 @@ from prompt_toolkit.layout.dimension import Dimension
 from prompt_toolkit.layout.menus import CompletionsMenu
 from prompt_toolkit.widgets import TextArea
 from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
 from prompt_toolkit import print_formatted_text as _pt_print
 from prompt_toolkit.formatted_text import ANSI as _PT_ANSI
 try:
@@ -10582,6 +10583,26 @@ class HermesCLI:
             """Alt+Enter inserts a newline for multi-line input."""
             event.current_buffer.insert_text('\n')
 
+        # Patch: remove \x08 (BS / Ctrl+Backspace) from prompt_toolkit's
+        # ANSI_SEQUENCES so 0x08 falls through as a raw unmapped byte instead
+        # of being conflated with 0x7f (DEL) under Keys.ControlH.  This lets
+        # us bind word-delete to the raw 0x08 without interfering with plain
+        # Backspace (0x7f → Keys.ControlH → default single-char delete).
+        try:
+            _ansi_seqs = ANSI_SEQUENCES
+            if '\x08' in _ansi_seqs:
+                del _ansi_seqs['\x08']
+        except Exception:
+            pass
+
+        @kb.add('\x08', eager=True)
+        def handle_ctrl_backspace(event):
+            """Ctrl+Backspace (0x08): delete word backward."""
+            buf = event.current_buffer
+            pos = buf.document.find_start_of_previous_word(count=1)
+            if pos is not None:
+                count = buf.cursor_position - pos
+                buf.delete_before_cursor(count=count)
         # VSCode/Cursor bind Ctrl+G to "Find Next" at the editor level, so
         # the keystroke never reaches the embedded terminal. Alt+G is unbound
         # in those IDEs and arrives here as ('escape', 'g') — register it as

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -809,9 +809,12 @@ function parseKeypress(s: string = ''): ParsedKey {
     key.name = 'return'
   } else if (s === '\t') {
     key.name = 'tab'
-  } else if (s === '\b' || s === '\x1b\b') {
+  } else if (s === '\b') {
     key.name = 'backspace'
-    key.meta = s.charAt(0) === '\x1b'
+    key.ctrl = true
+  } else if (s === '\x1b\b') {
+    key.name = 'backspace'
+    key.meta = true
   } else if (s === '\x7f' || s === '\x1b\x7f') {
     key.name = 'backspace'
     key.meta = s.charAt(0) === '\x1b'

--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -20,6 +20,25 @@ if (!process.stdin.isTTY) {
 // terminal tab can still have mouse/focus/paste modes enabled.
 resetTerminalModes()
 
+// Enable two keyboard-protocol modes so Ctrl+modified keys (Backspace,
+// Delete, arrows, etc.) send unambiguous escape sequences instead of bare
+// bytes that look identical to their plain counterparts:
+//
+//   \x1b[>1u   Kitty Keyboard Protocol (CSI u) — pushes flag 1, "disambiguate
+//              escape codes". Terminal sends \x1b[127;5u for Ctrl+Backspace.
+//              Supported by: kitty, Ghostty, WezTerm, foot, Konsole, iTerm2,
+//              Windows Terminal (with keyboardEnhancement setting).
+//
+//   \x1b[>4;1m xterm modifyOtherKeys mode 1 — terminal sends \x1b[27;5;127~
+//              for Ctrl+Backspace. Supported by: xterm, VTE, Windows Terminal
+//              (no config needed), and most other xterm-compatible terminals.
+//
+// The TUI's input parser (parse-keypress.ts) handles both formats natively
+// and produces key.backspace=true / key.ctrl=true correctly.
+// Terminals that don't support these sequences silently ignore them.
+// Both are popped/restored by resetTerminalModes() on exit.
+process.stdout.write('\x1b[>1u\x1b[>4;1m')
+
 const gw = new GatewayClient()
 
 gw.start()

--- a/ui-tui/src/lib/terminalModes.ts
+++ b/ui-tui/src/lib/terminalModes.ts
@@ -18,6 +18,7 @@ export const TERMINAL_MODE_RESET =
   '\x1b[?1049l' + // alternate screen
   '\x1b[<u' + // kitty keyboard
   '\x1b[>4m' + // modifyOtherKeys
+  '\x1b[?9001l' + // win32-input-mode (defensive reset)
   '\x1b[0m' + // attributes
   '\x1b[?25h' // cursor visible
 


### PR DESCRIPTION
## Ctrl+Backspace word-delete in TUI and CLI

Windows Terminal (and some other terminals) sends different bytes for Ctrl+Backspace (0x08) and plain Backspace (0x7f), but both the Ink input parser and prompt_toolkit treated them identically, making Ctrl+Backspace indistinguishable from plain Backspace.

Two commits fix this at the parser/binding level across both the TUI and CLI entry points.

### Changes

**Commit 1 — `fix(tui): distinguish Ctrl+Backspace from plain Backspace`**

`ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts` — split the `\b` / `\x1b\b` handling so bare `\b` (0x08) sets `key.ctrl=true`, which triggers `wordLeft()` in the TextInput handler. Meta+`\b` still sets `key.meta=true` for Alt+Backspace; 0x7f (DEL) remains unchanged (plain backspace).

`ui-tui/src/entry.tsx` — push CSI u (`\x1b[>1u`) and xterm modifyOtherKeys (`\x1b[>4;1m`) at TUI startup so the terminal sends unambiguous escape sequences for Ctrl-modified keys. The parser already handles both formats (CSI_U_RE, MODIFY_OTHER_KEYS_RE). Terminals that don't support these sequences ignore them silently; both are cleaned up by `resetTerminalModes()` on exit.

`ui-tui/src/lib/terminalModes.ts` — add `\x1b[?9001l` (win32-input-mode disable) to the reset string as a defensive measure.

**Commit 2 — `fix(cli): map Ctrl+Backspace (0x08) to word-delete`**

`cli.py` — prompt_toolkit's `ANSI_SEQUENCES` maps both 0x08 and 0x7f to `Keys.ControlH` by design (see comment in
`ansi_escape_sequences.py`). Unregister 0x08 from `ANSI_SEQUENCES` at CLI startup so it falls through as a raw unmapped byte, then add an eager binding for the raw 0x08 that deletes the word before the cursor. Plain Backspace (0x7f) retains its default single-char behaviour.

### Cross-environment considerations

| Environment | Ctrl+BS behaviour | Mechanism |
|---|---|---|
| Windows Terminal + WSL | word-delete | OS sends 0x08; parser/binding catches it |
| xterm/VTE (Linux) | unchanged | Both send 0x7f; CSI u/modifyOtherKeys push is a no-op |
| kitty / Ghostty / WezTerm / iTerm2 | word-delete | CSI u push takes effect; parser handles via CSI_U_RE |
| macOS Apple Terminal | unchanged | Sends 0x7f for both; CSI u not supported |
| tmux | unchanged | No passthrough by default |

The CSI u and modifyOtherKeys push sequences are silently ignored by terminals that don't support them. The 0x08 parser change is only triggered when the terminal actually sends 0x08, which is not the case on most Linux terminals — zero regression in those environments.

### Testing

- Tested on Windows Terminal 1.21+ on WSL2 (Ubuntu)
- TUI (`hermes --tui`): plain BS = single-char delete, Ctrl+BS = word-delete
- CLI (`hermes`): same
- Zsh native: unaffected
- TUI test suite: 618 passed, 57 files, 0 failures
