### PR TITLE
fix: expand both ${VAR} and $VAR in config values

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3656,18 +3656,24 @@ def _deep_merge(base: dict, override: dict) -> dict:
 
 
 def _expand_env_vars(obj):
-    """Recursively expand ``${VAR}`` references in config values.
+    """Recursively expand env-var references in config values.
+
+    Supported forms:
+    - ``${VAR}`` (preferred / documented)
+    - ``$VAR`` (compatibility fallback)
 
     Only string values are processed; dict keys, numbers, booleans, and
     None are left untouched.  Unresolved references (variable not in
     ``os.environ``) are kept verbatim so callers can detect them.
     """
     if isinstance(obj, str):
-        return re.sub(
-            r"\${([^}]+)}",
-            lambda m: os.environ.get(m.group(1), m.group(0)),
-            obj,
-        )
+        pattern = re.compile(r"\${([^}]+)}|\$([A-Za-z_][A-Za-z0-9_]*)")
+
+        def _replace(match):
+            var_name = match.group(1) or match.group(2)
+            return os.environ.get(var_name, match.group(0))
+
+        return pattern.sub(_replace, obj)
     if isinstance(obj, dict):
         return {k: _expand_env_vars(v) for k, v in obj.items()}
     if isinstance(obj, list):

--- a/tests/hermes_cli/test_config_env_expansion.py
+++ b/tests/hermes_cli/test_config_env_expansion.py
@@ -1,4 +1,4 @@
-"""Tests for ${ENV_VAR} substitution in config.yaml values."""
+"""Tests for env-var substitution in config.yaml values."""
 
 import os
 import pytest
@@ -12,10 +12,20 @@ class TestExpandEnvVars:
             mp.setenv("MY_KEY", "secret123")
             assert _expand_env_vars("${MY_KEY}") == "secret123"
 
+    def test_simple_shell_style_substitution(self):
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setenv("MY_KEY", "secret123")
+            assert _expand_env_vars("$MY_KEY") == "secret123"
+
     def test_missing_var_kept_verbatim(self):
         with pytest.MonkeyPatch().context() as mp:
             mp.delenv("UNDEFINED_VAR_XYZ", raising=False)
             assert _expand_env_vars("${UNDEFINED_VAR_XYZ}") == "${UNDEFINED_VAR_XYZ}"
+
+    def test_missing_shell_style_var_kept_verbatim(self):
+        with pytest.MonkeyPatch().context() as mp:
+            mp.delenv("UNDEFINED_VAR_XYZ", raising=False)
+            assert _expand_env_vars("$UNDEFINED_VAR_XYZ") == "$UNDEFINED_VAR_XYZ"
 
     def test_no_placeholder_unchanged(self):
         assert _expand_env_vars("plain-value") == "plain-value"
@@ -49,6 +59,12 @@ class TestExpandEnvVars:
             mp.setenv("HOST", "localhost")
             mp.setenv("PORT", "5432")
             assert _expand_env_vars("${HOST}:${PORT}") == "localhost:5432"
+
+    def test_mixed_placeholder_forms_in_one_string(self):
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setenv("HOST", "localhost")
+            mp.setenv("PORT", "5432")
+            assert _expand_env_vars("${HOST}:$PORT") == "localhost:5432"
 
     def test_dict_keys_not_expanded(self):
         with pytest.MonkeyPatch().context() as mp:
@@ -95,9 +111,29 @@ class TestLoadConfigExpansion:
 
         assert config["model"]["api_key"] == "${NOT_SET_XYZ_123}"
 
+    def test_load_config_expands_shell_style_env_vars(self, tmp_path, monkeypatch):
+        config_yaml = (
+            "model:\n"
+            "  api_key: $GOOGLE_API_KEY\n"
+            "auxiliary:\n"
+            "  title_generation:\n"
+            "    api_key: $MODELSCOPE_API_KEY\n"
+        )
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(config_yaml)
+
+        monkeypatch.setenv("GOOGLE_API_KEY", "gsk-test-key")
+        monkeypatch.setenv("MODELSCOPE_API_KEY", "ms-test-key")
+        monkeypatch.setitem(load_config.__globals__, "get_config_path", lambda: config_file)
+
+        config = load_config()
+
+        assert config["model"]["api_key"] == "gsk-test-key"
+        assert config["auxiliary"]["title_generation"]["api_key"] == "ms-test-key"
+
 
 class TestLoadCliConfigExpansion:
-    """Verify that load_cli_config() also expands ${VAR} references."""
+    """Verify that load_cli_config() expands both ${VAR} and $VAR references."""
 
     def test_cli_config_expands_auxiliary_api_key(self, tmp_path, monkeypatch):
         config_yaml = (
@@ -133,3 +169,20 @@ class TestLoadCliConfigExpansion:
         config = load_cli_config()
 
         assert config["auxiliary"]["vision"]["api_key"] == "${UNSET_CLI_VAR_ABC}"
+
+    def test_cli_config_expands_shell_style_auxiliary_api_key(self, tmp_path, monkeypatch):
+        config_yaml = (
+            "auxiliary:\n"
+            "  title_generation:\n"
+            "    api_key: $TEST_TITLE_KEY_XYZ\n"
+        )
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(config_yaml)
+
+        monkeypatch.setenv("TEST_TITLE_KEY_XYZ", "title-key-123")
+        monkeypatch.setattr("cli._hermes_home", tmp_path)
+
+        from cli import load_cli_config
+        config = load_cli_config()
+
+        assert config["auxiliary"]["title_generation"]["api_key"] == "title-key-123"


### PR DESCRIPTION
## Summary

- expand config env substitution to accept both `${VAR}` and shell-style `$VAR`
- preserve unresolved placeholders verbatim instead of changing fallback behavior
- add regression coverage for direct expansion plus `load_config()` / `load_cli_config()`

## Problem

Hermes users often write shell-style `$VAR` placeholders in `config.yaml`, especially for API keys copied from normal shell workflows. Before this change, Hermes only expanded `${VAR}`, so `$VAR` could pass through literally and surface later as confusing auth/config failures.

A concrete failure mode is auxiliary provider setup: a value like `$MODELSCOPE_API_KEY` survives config loading unchanged, then gets forwarded literally as the API key and produces persistent 401s even though the environment variable is set correctly.

## Changes

1. Extend `_expand_env_vars()` to expand both `${VAR}` and `$VAR`
2. Keep unresolved placeholders verbatim so existing fallback behavior remains unchanged
3. Add regression coverage for:
   - direct `$VAR` expansion
   - unresolved `$VAR` passthrough
   - mixed `${VAR}` + `$VAR`
   - `load_config()` paths
   - `load_cli_config()` paths

## Test plan

- [x] `source venv/bin/activate && pytest tests/hermes_cli/test_config_env_expansion.py -q`
- [x] `18 passed in 1.43s`

Closes #21001
