### PR TITLE
fix(agent): reload memory after model switch

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2449,7 +2449,7 @@ class AIAgent:
             )
 
         # ── Invalidate cached system prompt so it rebuilds next turn ──
-        self._cached_system_prompt = None
+        self._invalidate_system_prompt()
 
         # ── Update _primary_runtime so the change persists across turns ──
         _cc = self.context_compressor if hasattr(self, "context_compressor") and self.context_compressor else None
@@ -5466,8 +5466,9 @@ class AIAgent:
         so the rebuilt prompt captures any writes from this session.
         """
         self._cached_system_prompt = None
-        if self._memory_store:
-            self._memory_store.load_from_disk()
+        memory_store = getattr(self, "_memory_store", None)
+        if memory_store:
+            memory_store.load_from_disk()
 
     @staticmethod
     def _deterministic_call_id(fn_name: str, arguments: str, index: int = 0) -> str:

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -72,3 +72,21 @@ def test_switch_model_without_config_context_length():
         mock_ctx_len.assert_called_once()
         call_kwargs = mock_ctx_len.call_args.kwargs
         assert call_kwargs.get("config_context_length") is None
+
+
+def test_switch_model_reloads_memory_before_next_prompt():
+    """A model switch should rebuild prompt context from the latest memory on disk."""
+    agent = _make_agent_with_compressor(config_context_length=None)
+    agent._cached_system_prompt = "cached prompt"
+    agent._memory_store = MagicMock()
+
+    with patch("agent.model_metadata.get_model_context_length", return_value=128_000):
+        agent.switch_model(
+            "new-model",
+            "openrouter",
+            api_key="sk-new",
+            base_url="https://openrouter.ai/api/v1",
+        )
+
+    assert agent._cached_system_prompt is None
+    agent._memory_store.load_from_disk.assert_called_once()


### PR DESCRIPTION
## Summary
- route `AIAgent.switch_model()` through the existing system-prompt invalidation helper
- reload the built-in memory store from disk when a model switch invalidates prompt context
- make the invalidation helper tolerate partially constructed test agents without `_memory_store`

## Why
Fixes #17013's narrow built-in memory regression: switching models cleared the cached prompt but did not refresh `MEMORY.md`/`USER.md` from disk before the next prompt was rebuilt. The existing `_invalidate_system_prompt()` path already does that after compression; model switching should use the same path.

This does not attempt a broader conversation-compaction architecture rewrite. It preserves the current in-place model switch behavior and closes the testable memory refresh gap called out in the issue comments.

## Tests
- `scripts/run_tests.sh tests/run_agent/test_switch_model_context.py tests/run_agent/test_switch_model_fallback_prune.py tests/hermes_cli/test_model_switch_opencode_anthropic.py` -> `19 passed, 4 warnings`
- `git diff --check` -> passed

Fixes #17013
