### PR TITLE
fix(approval): honor tirith_fail_open when tirith module is unavailable

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1448,7 +1448,18 @@ def check_all_command_guards(command: str, env_type: str,
         from tools.tirith_security import check_command_security
         tirith_result = check_command_security(command)
     except ImportError:
-        pass  # tirith module not installed — allow
+        try:
+            from hermes_cli.config import load_config
+
+            sec = load_config().get("security", {}) or {}
+            if sec.get("tirith_enabled", True) and not sec.get("tirith_fail_open", True):
+                tirith_result = {
+                    "action": "block",
+                    "findings": [],
+                    "summary": "Tirith unavailable — blocked per tirith_fail_open: false",
+                }
+        except Exception:
+            pass
 
     # Dangerous command check (detection only, no approval)
     is_dangerous, pattern_key, description = detect_dangerous_command(command)


### PR DESCRIPTION
## Summary

When `security.tirith_enabled` is `true` in config but the `tirith` module cannot be
imported (e.g., not installed), the previous code unconditionally set
`tirith_result["action"] = "allow"`, bypassing any user-specified fail-open policy.

This change reads `security.tirith_fail_open` inside the `ImportError` handler. If
`tirith_enabled=true` and `tirith_fail_open=false`, an `ImportError` now produces a
`"block"` result instead of silently allowing — bringing the behavior in line with
the documented security model.

## Changes

- `tools/approval.py`: In the `except ImportError` block for the tirith import,
  check the live security config before deciding to allow. Only allow if
  `tirith_fail_open` is true (the default); otherwise synthesize a `"block"`
  result so the normal approval flow handles the unavailable security scanner.

## Verification

- `python3 -m py_compile tools/approval.py` — no syntax errors
- `ruff check tools/approval.py` — all lint checks pass
- `pytest tests/tools/test_approval.py` — 132 tests pass

Closes #20733
