### PR TITLE
fix(mcp): reconnect dead stdio before breaker probe

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -179,6 +179,57 @@ def test_circuit_breaker_reopens_on_probe_failure(monkeypatch, tmp_path):
         _cleanup(mcp_tool, "srv")
 
 
+def test_half_open_dead_stdio_requests_reconnect_without_probe(monkeypatch, tmp_path):
+    """A half-open probe must not reuse a stdio session whose child died."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    call_count = {"n": 0}
+
+    async def _call_tool_unused(*a, **kw):
+        call_count["n"] += 1
+        raise AssertionError("dead stdio session should not be probed")
+
+    server = _install_stub_server(mcp_tool, "srv", _call_tool_unused)
+    server._transport_kind = "stdio"
+    server._stdio_child_pids = {424242}
+    # Force the reconnect helper down the direct event.set path so the test
+    # can assert synchronously without depending on the background MCP loop.
+    monkeypatch.setattr(mcp_tool, "_mcp_loop", None)
+
+    def _fake_kill(pid, sig):
+        assert pid == 424242
+        assert sig == 0
+        raise ProcessLookupError
+
+    monkeypatch.setattr(mcp_tool.os, "kill", _fake_kill)
+
+    try:
+        mcp_tool._server_error_counts["srv"] = mcp_tool._CIRCUIT_BREAKER_THRESHOLD
+        fake_now = [1000.0]
+
+        def _fake_monotonic():
+            return fake_now[0]
+
+        monkeypatch.setattr(mcp_tool.time, "monotonic", _fake_monotonic)
+        if hasattr(mcp_tool, "_server_breaker_opened_at"):
+            mcp_tool._server_breaker_opened_at["srv"] = fake_now[0]
+        cooldown = getattr(mcp_tool, "_CIRCUIT_BREAKER_COOLDOWN_SEC", 60.0)
+        fake_now[0] += cooldown + 1.0
+
+        handler = _make_tool_handler("srv", "tool1", 10.0)
+        result = handler({})
+        parsed = json.loads(result)
+
+        assert "stale" in parsed.get("error", "").lower(), parsed
+        server._reconnect_event.set.assert_called_once()
+        assert call_count["n"] == 0
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
 def test_circuit_breaker_cleared_on_reconnect(monkeypatch, tmp_path):
     """When the auth-recovery path successfully reconnects the server,
     the breaker should be cleared so subsequent calls aren't gated on a

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -868,7 +868,8 @@ class MCPServerTask:
         "_task", "_ready", "_shutdown_event", "_reconnect_event",
         "_tools", "_error", "_config",
         "_sampling", "_registered_tool_names", "_auth_type", "_refresh_lock",
-        "_rpc_lock", "_pending_refresh_tasks",
+        "_rpc_lock", "_pending_refresh_tasks", "_transport_kind",
+        "_stdio_child_pids",
     )
 
     def __init__(self, name: str):
@@ -899,6 +900,8 @@ class MCPServerTask:
         # transports for conservative per-server ordering.
         self._rpc_lock = asyncio.Lock()
         self._pending_refresh_tasks: set[asyncio.Task] = set()
+        self._transport_kind: str = ""
+        self._stdio_child_pids: set[int] = set()
 
     def _is_http(self) -> bool:
         """Check if this server uses HTTP transport."""
@@ -1091,6 +1094,8 @@ class MCPServerTask:
 
     async def _run_stdio(self, config: dict):
         """Run the server using stdio transport."""
+        self._transport_kind = "stdio"
+        self._stdio_child_pids = set()
         command = config.get("command")
         args = config.get("args", [])
         user_env = config.get("env")
@@ -1138,6 +1143,7 @@ class MCPServerTask:
                 # Capture the newly spawned subprocess PID for force-kill cleanup.
                 new_pids = _snapshot_child_pids() - pids_before
                 if new_pids:
+                    self._stdio_child_pids = set(new_pids)
                     with _lock:
                         for _pid in new_pids:
                             _stdio_pids[_pid] = self.name
@@ -1148,6 +1154,7 @@ class MCPServerTask:
                     self.session = session
                     await self._discover_tools()
                     self._ready.set()
+                    _reset_server_error(self.name)
                     # stdio transport does not use OAuth, but we still honor
                     # _reconnect_event (e.g. future manual /mcp refresh) for
                     # consistency with _run_http.
@@ -1168,6 +1175,7 @@ class MCPServerTask:
                         except (ProcessLookupError, PermissionError, OSError):
                             continue  # process already exited — nothing to do
                         _orphan_stdio_pids.add(pid)
+                self._stdio_child_pids = set()
 
     async def _run_http(self, config: dict):
         """Run the server using HTTP/StreamableHTTP transport."""
@@ -1505,6 +1513,47 @@ def _reset_server_error(server_name: str) -> None:
     """
     _server_error_counts[server_name] = 0
     _server_breaker_opened_at.pop(server_name, None)
+
+
+def _stdio_pids_dead(server: Any) -> bool:
+    """Return True when a stdio server has only dead tracked child PIDs.
+
+    Some stdio transports can leave a session object around after the child
+    process has died.  In that state a half-open circuit-breaker probe will
+    just write into a closed pipe and re-open forever.  If PID tracking is
+    unavailable, return False and let the normal probe path decide.
+    """
+    if getattr(server, "_transport_kind", "") != "stdio":
+        return False
+    pids = set(getattr(server, "_stdio_child_pids", set()) or set())
+    if not pids:
+        return False
+    for pid in pids:
+        try:
+            os.kill(pid, 0)
+            return False
+        except ProcessLookupError:
+            continue
+        except (PermissionError, OSError):
+            return False
+    return True
+
+
+def _request_reconnect_for_dead_stdio(server_name: str, server: Any) -> None:
+    """Signal the server task to rebuild a stale stdio transport."""
+    event = getattr(server, "_reconnect_event", None)
+    if event is None:
+        return
+    loop = _mcp_loop
+    if loop is not None and loop.is_running():
+        loop.call_soon_threadsafe(event.set)
+    else:
+        event.set()
+    logger.warning(
+        "MCP server '%s': stdio child process is gone; requesting reconnect "
+        "before circuit-breaker probe.",
+        server_name,
+    )
 
 # ---------------------------------------------------------------------------
 # Auth-failure detection helpers (Task 6 of MCP OAuth consolidation)
@@ -2037,6 +2086,15 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             _bump_server_error(server_name)
             return json.dumps({
                 "error": f"MCP server '{server_name}' is not connected"
+            }, ensure_ascii=False)
+        if _stdio_pids_dead(server):
+            _request_reconnect_for_dead_stdio(server_name, server)
+            _bump_server_error(server_name)
+            return json.dumps({
+                "error": (
+                    f"MCP server '{server_name}' stdio transport is stale; "
+                    "reconnect requested. Do NOT retry this tool immediately."
+                )
             }, ensure_ascii=False)
 
         async def _call():


### PR DESCRIPTION
## Summary
- track the child PIDs owned by each stdio MCP session
- detect when a circuit-breaker half-open probe would reuse a stdio session whose child process is already gone
- request a transport reconnect and return a clean stale-transport error instead of writing into the dead pipe
- reset the MCP server error breaker when a stdio session successfully initializes

## Why
Fixes #16788. Main already has the generic half-open cooldown behavior, but the issue's distinct failure mode remains: a dead stdio subprocess can leave a stale session object behind, so every half-open probe retries the same closed pipe and re-opens the breaker forever. This patch keeps the existing breaker behavior, but refuses to probe a known-dead stdio transport.

## Scope
This only touches the stdio MCP transport liveness path and the existing MCP circuit-breaker handler. HTTP/streamable HTTP behavior is unchanged.

## Tests
- `scripts/run_tests.sh tests/tools/test_mcp_circuit_breaker.py tests/tools/test_mcp_tool_session_expired.py tests/tools/test_mcp_tool_401_handling.py tests/tools/test_mcp_tool.py` -> `210 passed, 4 warnings`
- `python -m py_compile tools/mcp_tool.py` -> passed
- `git diff --check` -> passed

Fixes #16788
