### PR TITLE
feat(feishu): allow active topic follow after mention

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1002,6 +1002,14 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(feishu_cfg, dict):
                 if "allow_bots" in feishu_cfg and not os.getenv("FEISHU_ALLOW_BOTS"):
                     os.environ["FEISHU_ALLOW_BOTS"] = str(feishu_cfg["allow_bots"]).lower()
+                if "thread_follow_enabled" in feishu_cfg and not os.getenv("HERMES_FEISHU_THREAD_FOLLOW_ENABLED"):
+                    os.environ["HERMES_FEISHU_THREAD_FOLLOW_ENABLED"] = str(
+                        feishu_cfg["thread_follow_enabled"]
+                    ).lower()
+                if "thread_follow_ttl_seconds" in feishu_cfg and not os.getenv("HERMES_FEISHU_THREAD_FOLLOW_TTL_SECONDS"):
+                    os.environ["HERMES_FEISHU_THREAD_FOLLOW_TTL_SECONDS"] = str(
+                        feishu_cfg["thread_follow_ttl_seconds"]
+                    )
 
     except Exception as e:
         logger.warning(

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -393,6 +393,8 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    thread_follow_enabled: bool = False
+    thread_follow_ttl_seconds: int = 1800
 
 
 @dataclass
@@ -1507,6 +1509,20 @@ class FeishuAdapter(BasePlatformAdapter):
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
             ),
+            thread_follow_enabled=_to_boolean(
+                extra.get(
+                    "thread_follow_enabled",
+                    os.getenv("HERMES_FEISHU_THREAD_FOLLOW_ENABLED", "false"),
+                )
+            ),
+            thread_follow_ttl_seconds=_coerce_required_int(
+                extra.get(
+                    "thread_follow_ttl_seconds",
+                    os.getenv("HERMES_FEISHU_THREAD_FOLLOW_TTL_SECONDS", "1800"),
+                ),
+                default=1800,
+                min_value=1,
+            ),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1539,6 +1555,9 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
+        self._thread_follow_enabled = settings.thread_follow_enabled
+        self._thread_follow_ttl_seconds = settings.thread_follow_ttl_seconds
+        self._thread_follow_expiry: Dict[tuple[str, str], float] = {}
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -3735,6 +3754,10 @@ class FeishuAdapter(BasePlatformAdapter):
         if self_ids and sender_ids & self_ids:
             return "self_echo"
 
+        mentioned = False
+        if require_mention or (is_bot and self._allow_bots == "mentions"):
+            mentioned = self._mentions_self(message)
+
         if is_bot:
             mode = self._allow_bots
             if mode != "mentions" and mode != "all":
@@ -3744,7 +3767,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 return "self_ids_unknown"
             # Step 4 covers mention enforcement for groups when require_mention
             # is on; check here only on paths step 4 won't reach.
-            if mode == "mentions" and not require_mention and not self._mentions_self(message):
+            if mode == "mentions" and not require_mention and not mentioned:
                 return "bot_not_mentioned"
 
         if not is_group:
@@ -3754,8 +3777,14 @@ class FeishuAdapter(BasePlatformAdapter):
             getattr(sender, "sender_id", None), chat_id, is_bot=is_bot,
         ):
             return "group_policy_rejected"
-        if require_mention and not self._mentions_self(message):
+        follow_key = self._thread_follow_key(message)
+        followed = bool(require_mention and follow_key and self._is_thread_follow_active(follow_key))
+        if require_mention and not mentioned and not followed:
             return "group_policy_rejected"
+        if mentioned:
+            self._refresh_thread_follow(follow_key)
+        elif followed and not is_bot:
+            self._refresh_thread_follow(follow_key)
         return None
 
     def _require_mention_for(self, chat_id: str) -> bool:
@@ -3763,6 +3792,34 @@ class FeishuAdapter(BasePlatformAdapter):
         if rule and rule.require_mention is not None:
             return rule.require_mention
         return self._require_mention
+
+    def _thread_follow_key(self, message: Any) -> Optional[tuple[str, str]]:
+        """Return the chat-scoped Feishu topic key for active-thread follow."""
+        if not self._thread_follow_enabled:
+            return None
+        chat_id = getattr(message, "chat_id", "") or ""
+        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or ""
+        if not chat_id or not thread_id:
+            return None
+        return (str(chat_id), str(thread_id))
+
+    def _prune_thread_follows(self, now: Optional[float] = None) -> None:
+        now = time.time() if now is None else now
+        expired = [key for key, expiry in self._thread_follow_expiry.items() if expiry <= now]
+        for key in expired:
+            self._thread_follow_expiry.pop(key, None)
+
+    def _is_thread_follow_active(self, key: tuple[str, str]) -> bool:
+        if not self._thread_follow_enabled:
+            return False
+        now = time.time()
+        self._prune_thread_follows(now)
+        return self._thread_follow_expiry.get(key, 0.0) > now
+
+    def _refresh_thread_follow(self, key: Optional[tuple[str, str]]) -> None:
+        if not self._thread_follow_enabled or not key:
+            return
+        self._thread_follow_expiry[key] = time.time() + float(self._thread_follow_ttl_seconds)
 
     # --- Group policy ---------------------------------------------------------
 

--- a/tests/gateway/feishu_helpers.py
+++ b/tests/gateway/feishu_helpers.py
@@ -16,12 +16,14 @@ def make_sender(sender_type: str = "user", open_id: str = "ou_human",
 
 
 def make_message(message_id: str = "om_xxx", chat_type: str = "p2p",
-                 chat_id: str = "oc_1", mentions: Optional[list] = None) -> Any:
+                 chat_id: str = "oc_1", mentions: Optional[list] = None,
+                 thread_id: Optional[str] = None) -> Any:
     return SimpleNamespace(
         message_id=message_id,
         chat_type=chat_type,
         chat_id=chat_id,
         mentions=mentions,
+        thread_id=thread_id,
         content="",
         message_type="text",
     )
@@ -34,6 +36,8 @@ def make_adapter_skeleton(
     allow_bots: str = "none",
     require_mention: bool = True,
     group_policy: str = "allowlist",
+    thread_follow_enabled: bool = False,
+    thread_follow_ttl_seconds: int = 1800,
 ) -> Any:
     from gateway.platforms.feishu import FeishuAdapter
 
@@ -49,6 +53,9 @@ def make_adapter_skeleton(
     adapter._allowed_group_users = frozenset()
     adapter._allow_bots = allow_bots
     adapter._require_mention = require_mention
+    adapter._thread_follow_enabled = thread_follow_enabled
+    adapter._thread_follow_ttl_seconds = thread_follow_ttl_seconds
+    adapter._thread_follow_expiry = {}
     return adapter
 
 

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -386,6 +386,141 @@ def test_admit_pipeline(case):
     assert adapter._admit(sender, message) == case["expected"]
 
 
+# --- Topic thread follow ----------------------------------------------------
+
+
+def test_feishu_load_settings_parses_thread_follow_from_extra(monkeypatch):
+    from gateway.platforms.feishu import FeishuAdapter
+
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_test")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_test")
+
+    settings = FeishuAdapter._load_settings(extra={
+        "thread_follow_enabled": True,
+        "thread_follow_ttl_seconds": 42,
+    })
+
+    assert settings.thread_follow_enabled is True
+    assert settings.thread_follow_ttl_seconds == 42
+
+
+def test_feishu_load_settings_parses_thread_follow_from_env(monkeypatch):
+    from gateway.platforms.feishu import FeishuAdapter
+
+    monkeypatch.setenv("FEISHU_APP_ID", "cli_test")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret_test")
+    monkeypatch.setenv("HERMES_FEISHU_THREAD_FOLLOW_ENABLED", "true")
+    monkeypatch.setenv("HERMES_FEISHU_THREAD_FOLLOW_TTL_SECONDS", "77")
+
+    settings = FeishuAdapter._load_settings(extra={})
+
+    assert settings.thread_follow_enabled is True
+    assert settings.thread_follow_ttl_seconds == 77
+
+
+def test_admit_thread_follow_starts_on_mentioned_topic_and_allows_followup(monkeypatch):
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self",
+        require_mention=True,
+        group_policy="open",
+        thread_follow_enabled=True,
+        thread_follow_ttl_seconds=60,
+    )
+    now = [1_000.0]
+    monkeypatch.setattr("gateway.platforms.feishu.time.time", lambda: now[0])
+    sender = make_sender(sender_type="user", open_id="ou_human")
+
+    stub_mention(adapter, True)
+    mentioned = make_message(chat_id="oc_topic", chat_type="group", thread_id="omt_topic")
+    assert adapter._admit(sender, mentioned) is None
+
+    stub_mention(adapter, False)
+    followup = make_message(chat_id="oc_topic", chat_type="group", thread_id="omt_topic")
+    assert adapter._admit(sender, followup) is None
+
+
+def test_admit_thread_follow_is_scoped_to_chat_and_thread(monkeypatch):
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self",
+        require_mention=True,
+        group_policy="open",
+        thread_follow_enabled=True,
+        thread_follow_ttl_seconds=60,
+    )
+    monkeypatch.setattr("gateway.platforms.feishu.time.time", lambda: 1_000.0)
+    sender = make_sender(sender_type="user", open_id="ou_human")
+
+    stub_mention(adapter, True)
+    assert adapter._admit(
+        sender,
+        make_message(chat_id="oc_topic", chat_type="group", thread_id="omt_topic"),
+    ) is None
+
+    stub_mention(adapter, False)
+    assert adapter._admit(
+        sender,
+        make_message(chat_id="oc_topic", chat_type="group", thread_id="omt_other"),
+    ) == "group_policy_rejected"
+    assert adapter._admit(
+        sender,
+        make_message(chat_id="oc_other", chat_type="group", thread_id="omt_topic"),
+    ) == "group_policy_rejected"
+
+
+def test_admit_thread_follow_expires_and_refreshes_on_followup(monkeypatch):
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self",
+        require_mention=True,
+        group_policy="open",
+        thread_follow_enabled=True,
+        thread_follow_ttl_seconds=10,
+    )
+    now = [1_000.0]
+    monkeypatch.setattr("gateway.platforms.feishu.time.time", lambda: now[0])
+    sender = make_sender(sender_type="user", open_id="ou_human")
+    message = make_message(chat_id="oc_topic", chat_type="group", thread_id="omt_topic")
+
+    stub_mention(adapter, True)
+    assert adapter._admit(sender, message) is None
+
+    now[0] = 1_009.0
+    stub_mention(adapter, False)
+    assert adapter._admit(sender, message) is None
+
+    # The accepted unmentioned human follow-up refreshed expiry to 1019.
+    now[0] = 1_018.0
+    assert adapter._admit(sender, message) is None
+
+    now[0] = 1_029.0
+    assert adapter._admit(sender, message) == "group_policy_rejected"
+
+
+def test_admit_thread_follow_does_not_refresh_for_bot_messages(monkeypatch):
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self",
+        allow_bots="all",
+        require_mention=True,
+        group_policy="open",
+        thread_follow_enabled=True,
+        thread_follow_ttl_seconds=10,
+    )
+    now = [1_000.0]
+    monkeypatch.setattr("gateway.platforms.feishu.time.time", lambda: now[0])
+    human = make_sender(sender_type="user", open_id="ou_human")
+    bot = make_sender(sender_type="bot", open_id="ou_peer")
+    message = make_message(chat_id="oc_topic", chat_type="group", thread_id="omt_topic")
+
+    stub_mention(adapter, True)
+    assert adapter._admit(human, message) is None
+
+    now[0] = 1_009.0
+    stub_mention(adapter, False)
+    assert adapter._admit(bot, message) is None
+
+    # Bot admission did not refresh expiry; the original 1010 expiry passed.
+    now[0] = 1_011.0
+    assert adapter._admit(human, message) == "group_policy_rejected"
+
 # --- Mention call-count semantics ------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- add opt-in Feishu topic follow mode after the bot is mentioned in a topic
- scope follow state by `(chat_id, thread_id)` with an inactivity TTL
- refresh TTL on accepted human follow-up messages, but not on bot messages
- bridge `feishu.thread_follow_enabled` / `feishu.thread_follow_ttl_seconds` through env fallbacks

## Test Plan
- [x] `./venv/bin/python -m pytest tests/gateway/test_feishu_bot_admission.py -q -o 'addopts='`
- [x] `./venv/bin/python -m pytest tests/gateway/test_feishu.py tests/gateway/test_feishu_bot_admission.py tests/gateway/test_run_progress_topics.py -q -o 'addopts='`
- [x] `/root/.hermes/scripts/hermes-feishu-topic-follow-verify.sh`

## Notes
This keeps the default mention-gated behavior unchanged. The new follow behavior is opt-in and in-memory, so a gateway restart clears active followed topics.
