### PR TITLE
fix(redact): cover lowercase config secret keys

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -108,6 +108,16 @@ _ENV_ASSIGN_RE = re.compile(
     rf"([A-Z0-9_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z0-9_]{{0,50}})\s*=\s*(['\"]?)(\S+)\2",
 )
 
+# Line-oriented config patterns: spring.datasource.password=..., password: ...
+# Keep this separate from _ENV_ASSIGN_RE so lowercase source-code assignments
+# such as `api_key = config.get(...)` remain unchanged.
+_CONFIG_KEY_NAMES = r"(?:api[_-]?key|token|secret|password|passwd|credential|auth|private[_-]?key|client[_-]?secret)"
+_CONFIG_KEY_RE = rf"(?:[A-Za-z0-9]+[._-])*{_CONFIG_KEY_NAMES}(?:[._-][A-Za-z0-9]+)*"
+_CONFIG_KV_RE = re.compile(
+    rf"^([ \t]*{_CONFIG_KEY_RE})([ \t]*[:=][ \t]*)(['\"]?)([^\s#&;,(){{}}\[\]<>]+)\3([ \t]*(?:#.*)?)$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
 # JSON field patterns: "apiKey": "value", "token": "value", etc.
 _JSON_KEY_NAMES = r"(?:api_?[Kk]ey|token|secret|password|access_token|refresh_token|auth_token|bearer|secret_value|raw_secret|secret_input|key_material)"
 _JSON_FIELD_RE = re.compile(
@@ -336,6 +346,12 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
             name, quote, value = m.group(1), m.group(2), m.group(3)
             return f"{name}={quote}{_mask_token(value)}{quote}"
         text = _ENV_ASSIGN_RE.sub(_redact_env, text)
+
+        # Config files: lowercase/dotted/hyphenated keys in properties, YAML, INI.
+        def _redact_config_kv(m):
+            key, sep, quote, value, suffix = m.groups()
+            return f"{key}{sep}{quote}{_mask_token(value)}{quote}{suffix}"
+        text = _CONFIG_KV_RE.sub(_redact_config_kv, text)
 
         # JSON fields: "apiKey": "***"  (skip for code files — false positives)
         def _redact_json(m):

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -115,6 +115,50 @@ class TestEnvAssignments:
         assert "mypassword" not in result
 
 
+class TestConfigFileFormats:
+    def test_spring_boot_password(self):
+        text = "spring.datasource.password=MySecret123"
+        result = redact_sensitive_text(text)
+        assert "spring.datasource.password=" in result
+        assert "MySecret123" not in result
+
+    def test_lowercase_password(self):
+        text = "password=hunter2"
+        result = redact_sensitive_text(text)
+        assert "password=" in result
+        assert "hunter2" not in result
+
+    def test_dotted_secret_key(self):
+        text = "app.secret.key=xyz"
+        result = redact_sensitive_text(text)
+        assert "app.secret.key=" in result
+        assert "xyz" not in result
+
+    def test_yaml_style_password(self):
+        text = "  password: hunter2"
+        result = redact_sensitive_text(text)
+        assert "  password: " in result
+        assert "hunter2" not in result
+
+    def test_quoted_password(self):
+        text = "spring.password='s3cr3t'"
+        result = redact_sensitive_text(text)
+        assert "spring.password='" in result
+        assert "s3cr3t" not in result
+
+    def test_mixed_case_dotted(self):
+        text = "MyApp.Configuration.Password=pass"
+        result = redact_sensitive_text(text)
+        assert "MyApp.Configuration.Password=" in result
+        assert "pass" not in result
+
+    def test_preserves_inline_comment(self):
+        text = "spring.datasource.password=MySecret123  # local db password"
+        result = redact_sensitive_text(text)
+        assert "MySecret123" not in result
+        assert "# local db password" in result
+
+
 class TestJsonFields:
     def test_json_api_key(self):
         text = '{"apiKey": "sk-proj-abc123def456ghi789jkl012"}'


### PR DESCRIPTION
## Summary
- add a line-oriented config key/value redactor for lowercase, dotted, and hyphenated secret keys
- preserve existing code false-positive guards by keeping config redaction separate from uppercase env assignment matching
- add regression coverage for Spring properties, lowercase env-style keys, YAML, quoted values, mixed-case keys, and inline comments

## Why
#16413 reports that common config formats like `spring.datasource.password=...` bypass redaction because env assignment matching only covered uppercase keys. This can leak credentials from terminal output and logs.

## Tests
- `scripts/run_tests.sh tests/agent/test_redact.py` -> 82 passed, 4 warnings
- `python -m py_compile agent/redact.py`
- `git diff --check`

Fixes #16413