### PR TITLE
fix(whatsapp): deny empty bridge allowlist

### DIFF
--- a/scripts/whatsapp-bridge/allowlist.js
+++ b/scripts/whatsapp-bridge/allowlist.js
@@ -65,7 +65,7 @@ export function expandWhatsAppIdentifiers(identifier, sessionDir) {
 
 export function matchesAllowedUser(senderId, allowedUsers, sessionDir) {
   if (!allowedUsers || allowedUsers.size === 0) {
-    return true;
+    return false;
   }
 
   // "*" means allow everyone (consistent with SIGNAL_GROUP_ALLOWED_USERS)

--- a/scripts/whatsapp-bridge/allowlist.test.mjs
+++ b/scripts/whatsapp-bridge/allowlist.test.mjs
@@ -46,6 +46,18 @@ test('matchesAllowedUser accepts mapped lid sender when allowlist only contains 
   }
 });
 
+test('matchesAllowedUser denies by default when allowlist is empty', () => {
+  const sessionDir = mkdtempSync(path.join(os.tmpdir(), 'hermes-wa-allowlist-'));
+
+  try {
+    const allowedUsers = parseAllowedUsers('');
+    assert.equal(matchesAllowedUser('19175395595@s.whatsapp.net', allowedUsers, sessionDir), false);
+    assert.equal(matchesAllowedUser('267383306489914@lid', null, sessionDir), false);
+  } finally {
+    rmSync(sessionDir, { recursive: true, force: true });
+  }
+});
+
 test('matchesAllowedUser treats * as allow-all wildcard', () => {
   const sessionDir = mkdtempSync(path.join(os.tmpdir(), 'hermes-wa-allowlist-'));
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -626,7 +626,7 @@ if (PAIR_ONLY) {
     if (ALLOWED_USERS.size > 0) {
       console.log(`🔒 Allowed users: ${Array.from(ALLOWED_USERS).join(', ')}`);
     } else {
-      console.log(`⚠️  No WHATSAPP_ALLOWED_USERS set — all messages will be processed`);
+      console.log(`⚠️  No WHATSAPP_ALLOWED_USERS set — incoming messages are denied by default`);
     }
     console.log();
     startSocket();


### PR DESCRIPTION
## Summary
- make the WhatsApp bridge deny incoming non-self messages when `WHATSAPP_ALLOWED_USERS` is empty or missing
- keep `WHATSAPP_ALLOWED_USERS=*` as the explicit allow-all opt-in
- update bridge startup output so missing allowlist is described as denied by default, not open access
- add a Node regression test for empty allowlist denial

## Why
#15108 reports that the bridge allowed every sender when `WHATSAPP_ALLOWED_USERS` was unset, exposing the full agent surface to anyone who messaged the number. This flips that default to fail closed.

## Tests
- `node --test scripts/whatsapp-bridge/allowlist.test.mjs` -> 5 passed
- `scripts/run_tests.sh tests/gateway/test_unauthorized_dm_behavior.py tests/gateway/test_whatsapp_group_gating.py` -> 48 passed, 4 warnings
- `git diff --check`

Fixes #15108