### PR TITLE
fix(security): scrub Copilot ACP subprocess env

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -26,6 +26,7 @@ from agent.redact import redact_sensitive_text
 
 ACP_MARKER_BASE_URL = "acp://copilot"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
+_ACP_ENV_PASSTHROUGH = "HERMES_COPILOT_ACP_ENV_PASSTHROUGH"
 
 _TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
 _TOOL_CALL_JSON_RE = re.compile(r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}", re.DOTALL)
@@ -81,8 +82,47 @@ def _resolve_home_dir() -> str:
     return "/tmp"
 
 
+def _iter_explicit_acp_env_passthrough() -> list[str]:
+    raw = os.getenv(_ACP_ENV_PASSTHROUGH, "").strip()
+    if not raw:
+        return []
+
+    seen: set[str] = set()
+    names: list[str] = []
+    for part in raw.split(","):
+        name = part.strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        names.append(name)
+    return names
+
+
+def _build_explicit_acp_passthrough_env() -> dict[str, str]:
+    try:
+        from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+    except Exception:
+        _HERMES_PROVIDER_ENV_BLOCKLIST = frozenset()
+
+    env: dict[str, str] = {}
+    for name in _iter_explicit_acp_env_passthrough():
+        if name == _ACP_ENV_PASSTHROUGH or name in _HERMES_PROVIDER_ENV_BLOCKLIST:
+            continue
+        value = os.environ.get(name)
+        if value is not None:
+            env[name] = value
+    return env
+
+
 def _build_subprocess_env() -> dict[str, str]:
-    env = os.environ.copy()
+    from tools.environments.local import _sanitize_subprocess_env
+
+    base_env = dict(os.environ)
+    base_env.pop(_ACP_ENV_PASSTHROUGH, None)
+    env = _sanitize_subprocess_env(
+        base_env,
+        extra_env=_build_explicit_acp_passthrough_env(),
+    )
     env["HOME"] = _resolve_home_dir()
     return env
 

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -10,7 +10,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from agent.copilot_acp_client import CopilotACPClient
+from agent.copilot_acp_client import CopilotACPClient, _build_subprocess_env
 
 
 class _FakeProcess:
@@ -205,3 +205,66 @@ def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
 
     assert "env" in captured["kwargs"]
     assert captured["kwargs"]["env"]["HOME"]
+
+
+def test_build_subprocess_env_filters_provider_and_gateway_secrets(monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("HOME", "/home/tester")
+    monkeypatch.setenv("LANG", "en_US.UTF-8")
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/home/tester/.config")
+    monkeypatch.setenv("LC_TIME", "en_US.UTF-8")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-abc123def456ghi789jkl012")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-secret")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "bot123456789:secret")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "discord-secret")
+    monkeypatch.setenv("HERMES_API_TOKEN", "hermes-secret")
+
+    env = _build_subprocess_env()
+
+    assert env["PATH"] == "/usr/bin"
+    assert env["HOME"] == "/home/tester"
+    assert env["LANG"] == "en_US.UTF-8"
+    assert env["XDG_CONFIG_HOME"] == "/home/tester/.config"
+    assert env["LC_TIME"] == "en_US.UTF-8"
+    assert "OPENAI_API_KEY" not in env
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "TELEGRAM_BOT_TOKEN" not in env
+    assert "DISCORD_BOT_TOKEN" not in env
+
+
+def test_build_subprocess_env_allows_explicit_passthrough(monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("CUSTOM_CA_PATH", "/tmp/ca.pem")
+    monkeypatch.setenv("HERMES_COPILOT_ACP_ENV_PASSTHROUGH", "CUSTOM_CA_PATH")
+
+    env = _build_subprocess_env()
+
+    assert env["PATH"] == "/usr/bin"
+    assert env["CUSTOM_CA_PATH"] == "/tmp/ca.pem"
+
+
+def test_build_subprocess_env_deduplicates_passthrough_entries(monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("CUSTOM_PROXY", "http://proxy.internal")
+    monkeypatch.setenv(
+        "HERMES_COPILOT_ACP_ENV_PASSTHROUGH",
+        " CUSTOM_PROXY , CUSTOM_PROXY ,, ",
+    )
+
+    env = _build_subprocess_env()
+
+    assert env["CUSTOM_PROXY"] == "http://proxy.internal"
+
+
+def test_build_subprocess_env_passthrough_cannot_restore_blocked_secret(monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-proj-abc123def456ghi789jkl012")
+    monkeypatch.setenv(
+        "HERMES_COPILOT_ACP_ENV_PASSTHROUGH",
+        "OPENAI_API_KEY",
+    )
+
+    env = _build_subprocess_env()
+
+    assert env["PATH"] == "/usr/bin"
+    assert "OPENAI_API_KEY" not in env


### PR DESCRIPTION
## What does this PR do?

Filters the environment passed to the `copilot --acp` subprocess so Hermes-managed provider and gateway secrets are scrubbed before launching the external ACP client.

Before this change, `agent/copilot_acp_client.py` used `os.environ.copy()`, which forwarded the parent process environment wholesale into the Copilot ACP subprocess. That could expose Hermes-managed API keys and messaging tokens to the child process unnecessarily.

This change reuses Hermes' existing subprocess env scrubbing path from `tools.environments.local._sanitize_subprocess_env()` instead of introducing a separate allowlist, then preserves the existing profile-aware `HOME` override for ACP processes. It also adds an ACP-specific escape hatch, `HERMES_COPILOT_ACP_ENV_PASSTHROUGH`, for non-secret variables that users explicitly need to forward.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `agent/copilot_acp_client.py` to stop passing `os.environ.copy()` directly into the Copilot ACP subprocess.
- Reused `tools.environments.local._sanitize_subprocess_env()` so ACP subprocess env filtering stays aligned with Hermes' existing subprocess secret-scrubbing logic.
- Added support for `HERMES_COPILOT_ACP_ENV_PASSTHROUGH` to explicitly forward non-blocklisted variables when needed.
- Preserved the existing `_resolve_home_dir()` behavior so ACP subprocesses still receive the correct profile-aware `HOME`.
- Added regression tests in `tests/agent/test_copilot_acp_client.py` covering secret filtering, explicit passthrough, passthrough deduplication, passthrough blocklist enforcement, and existing HOME propagation behavior.

## How to Test

1. Run `python -m pytest tests/agent/test_copilot_acp_client.py -q`
2. Confirm the suite passes and that the new env-filter tests verify provider/gateway secrets are not forwarded to the ACP subprocess.
3. Optionally set `HERMES_COPILOT_ACP_ENV_PASSTHROUGH=CUSTOM_CA_PATH` with `CUSTOM_CA_PATH=/tmp/ca.pem` and confirm `_build_subprocess_env()` includes the custom variable while still excluding blocked secrets.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python -m pytest tests/agent/test_copilot_acp_client.py -q` → `11 passed`
