### PR TITLE
fix(dashboard): rebuild PTY channel when /chat?resume=<id> changes

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -148,7 +148,21 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   );
 
   const resumeRef = useRef<string | null>(searchParams.get("resume"));
-  const channel = useMemo(() => generateChannelId(), []);
+  // `channel` is bumped to force a full PTY teardown + rebuild whenever the
+  // user asks to resume a different session via `/chat?resume=<id>`.
+  // ChatPage is mounted persistently across tab switches (see App.tsx),
+  // so the WS-setup effect (keyed on [channel]) would otherwise never
+  // re-run — clicking "Play" on /sessions would silently keep the
+  // previous PTY child / session attached. See #resume-button bug.
+  const [channel, setChannel] = useState<string>(() => generateChannelId());
+
+  useEffect(() => {
+    const next = searchParams.get("resume");
+    if (!next) return;
+    if (next === resumeRef.current && wsRef.current) return;
+    resumeRef.current = next;
+    setChannel(generateChannelId());
+  }, [searchParams]);
 
   useEffect(() => {
     const mql = window.matchMedia("(max-width: 1023px)");


### PR DESCRIPTION
## Summary

The Play button on the dashboard's `/sessions` page is supposed to navigate to `/chat?resume=<id>` and hot-swap the embedded TUI to the requested session. In practice it appeared to do nothing — the user was pulled back into whatever session the chat tab had attached on first mount.

## Root cause

`ChatPage` is rendered persistently outside React Router's `<Routes>` (see `App.tsx` line 99 comment) so its host PTY survives tab switches. As a side-effect:

- `channel` was a one-shot `useMemo([])`
- The big WS-setup effect is keyed on `[channel]`
- `resumeRef` was initialized once from `searchParams.get('resume')`

When the URL changed to `/chat?resume=<new-id>`, the effect never re-ran, the WS query string still carried the original `resume` (or none), and the previous PTY child stayed attached. The new resume id was silently dropped.

## Fix

Promote `channel` from `useMemo` to `useState` and add an effect that watches `searchParams`. A non-empty `resume` that differs from the last applied value (or arrives while no WS is connected) regenerates the channel id, forcing the WS-setup effect to tear down the old PTY and rebuild against the requested session.

15 lines, single file, no behavior change for users who never use the Play button.

## Verification

Manual repro:

1. Open dashboard, start a chat in `/chat` (session A attaches).
2. Switch to `/sessions`, click ▶ on a different session B.
3. **Before:** URL changes to `/chat?resume=<B>` but the terminal still shows session A's transcript and any new prompt continues session A.
4. **After:** terminal briefly shows `[session ended]`, then a fresh TUI boots bound to session B with B's hydrated history.

Confirmed working end-to-end on macOS Chrome — this PR description was actually written from inside a session resumed via the fixed Play button.