### PR TITLE
fix(gateway): detect recycled macOS lock PIDs

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -115,6 +115,28 @@ def _get_process_start_time(pid: int) -> Optional[int]:
         # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
         return int(stat_path.read_text().split()[21])
     except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
+        pass
+
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "lstart="],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            env={**os.environ, "LC_ALL": "C"},
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    raw = (result.stdout or "").strip()
+    if not raw:
+        return None
+    try:
+        return int(datetime.strptime(" ".join(raw.split()), "%a %b %d %H:%M:%S %Y").timestamp())
+    except ValueError:
         return None
 
 
@@ -129,11 +151,25 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
     try:
         raw = cmdline_path.read_bytes()
     except (FileNotFoundError, PermissionError, OSError):
+        raw = b""
+
+    if raw:
+        return raw.replace(b"\x00", b" ").decode("utf-8", errors="ignore").strip() or None
+
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            env={**os.environ, "LC_ALL": "C"},
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError):
         return None
 
-    if not raw:
+    if result.returncode != 0:
         return None
-    return raw.replace(b"\x00", b" ").decode("utf-8", errors="ignore").strip()
+    return (result.stdout or "").strip() or None
 
 
 def _looks_like_gateway_process(pid: int) -> bool:
@@ -516,6 +552,14 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                     and current_start != existing.get("start_time")
                 ):
                     stale = True
+                if (
+                    not stale
+                    and existing.get("kind") == _GATEWAY_KIND
+                    and current_start is None
+                ):
+                    cmdline = _read_process_cmdline(existing_pid)
+                    if cmdline and not _looks_like_gateway_process(existing_pid):
+                        stale = True
                 # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
                 # processes still respond to os.kill(pid, 0) but are not
                 # actually running. Treat them as stale so --replace works.

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -8,6 +8,56 @@ from types import SimpleNamespace
 from gateway import status
 
 
+class TestProcessInspection:
+    def test_get_process_start_time_uses_ps_fallback_when_proc_unavailable(self, monkeypatch):
+        calls = []
+
+        def fake_run(args, **kwargs):
+            calls.append((args, kwargs))
+            return SimpleNamespace(returncode=0, stdout="Thu May  7 12:34:56 2026\n")
+
+        monkeypatch.setattr(status.subprocess, "run", fake_run)
+
+        value = status._get_process_start_time(42424242)
+
+        expected = int(status.datetime.strptime("Thu May 7 12:34:56 2026", "%a %b %d %H:%M:%S %Y").timestamp())
+        assert value == expected
+        assert calls[0][0] == ["ps", "-p", "42424242", "-o", "lstart="]
+        assert calls[0][1]["env"]["LC_ALL"] == "C"
+        assert calls[0][1]["timeout"] == 2
+
+    def test_get_process_start_time_returns_none_when_ps_date_unparseable(self, monkeypatch):
+        monkeypatch.setattr(
+            status.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="not a date\n"),
+        )
+
+        assert status._get_process_start_time(42424242) is None
+
+    def test_read_process_cmdline_uses_ps_fallback_when_proc_unavailable(self, monkeypatch):
+        calls = []
+
+        def fake_run(args, **kwargs):
+            calls.append((args, kwargs))
+            return SimpleNamespace(returncode=0, stdout="/usr/bin/python -m hermes_cli.main gateway\n")
+
+        monkeypatch.setattr(status.subprocess, "run", fake_run)
+
+        assert status._read_process_cmdline(42424242) == "/usr/bin/python -m hermes_cli.main gateway"
+        assert calls[0][0] == ["ps", "-p", "42424242", "-o", "command="]
+        assert calls[0][1]["env"]["LC_ALL"] == "C"
+
+    def test_read_process_cmdline_returns_none_when_ps_has_no_process(self, monkeypatch):
+        monkeypatch.setattr(
+            status.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout=""),
+        )
+
+        assert status._read_process_cmdline(42424242) is None
+
+
 class TestGatewayPidState:
     def test_write_pid_file_records_gateway_metadata(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -432,6 +482,27 @@ class TestScopedLocks:
             raise ProcessLookupError
 
         monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "telegram"
+
+    def test_acquire_scoped_lock_replaces_recycled_non_gateway_pid(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+        }))
+
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: None)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "/System/Library/FamilyControlsAgent")
 
         acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
 


### PR DESCRIPTION
## Summary
- add macOS/BSD `ps` fallbacks for gateway process start-time and command-line inspection when `/proc` is unavailable
- keep the Linux `/proc` path as the primary fast path
- treat a scoped gateway lock as stale when the stored PID is alive but its command line is clearly not a Hermes gateway, covering PID reuse on macOS
- add regression coverage for the `ps` fallbacks and recycled non-gateway PID lock cleanup

## Why
#16586 reports that a crashed macOS gateway can leave scoped platform lock files behind. If macOS later recycles that PID to an unrelated process, the current Linux-only `/proc` start-time check returns `None`, `os.kill(pid, 0)` succeeds, and Hermes permanently believes another gateway owns the Slack/Feishu/Discord token.

## Tests
- `scripts/run_tests.sh tests/gateway/test_status.py::TestProcessInspection tests/gateway/test_status.py::TestScopedLocks -q` -> 13 passed, 4 warnings
- `scripts/run_tests.sh tests/gateway/test_status.py -q` -> 47 passed, 4 warnings
- `python -m py_compile gateway/status.py tests/gateway/test_status.py`
- `git diff --check`

Fixes #16586