### PR TITLE
fix(session-db): advance flush cursor per committed message

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3813,7 +3813,7 @@ class AIAgent:
                 self._ensure_db_session()
             start_idx = len(conversation_history) if conversation_history else 0
             flush_from = max(start_idx, self._last_flushed_db_idx)
-            for msg in messages[flush_from:]:
+            for offset, msg in enumerate(messages[flush_from:]):
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
                 tool_calls_data = None
@@ -3838,6 +3838,7 @@ class AIAgent:
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
                 )
+                self._last_flushed_db_idx = flush_from + offset + 1
             self._last_flushed_db_idx = len(messages)
         except Exception as e:
             logger.warning("Session DB append_message failed: %s", e)

--- a/tests/run_agent/test_860_dedup.py
+++ b/tests/run_agent/test_860_dedup.py
@@ -101,6 +101,50 @@ class TestFlushDeduplication:
             rows = db.get_messages(agent.session_id)
             assert len(rows) == 3, f"Expected 3 total messages, got {len(rows)}"
 
+    def test_flush_advances_cursor_after_each_successful_message(self):
+        """A mid-flush DB failure must not retry already committed messages."""
+        from hermes_state import SessionDB
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = SessionDB(db_path=db_path)
+
+            agent = self._make_agent(db)
+            messages = [
+                {"role": "user", "content": "one"},
+                {"role": "assistant", "content": "two"},
+                {"role": "user", "content": "three"},
+                {"role": "assistant", "content": "four"},
+            ]
+
+            original_append = db.append_message
+            calls = 0
+
+            def flaky_append(*args, **kwargs):
+                nonlocal calls
+                calls += 1
+                if calls == 3:
+                    raise sqlite3.OperationalError("database is locked")
+                return original_append(*args, **kwargs)
+
+            db.append_message = flaky_append
+            agent._flush_messages_to_session_db(messages, [])
+
+            assert agent._last_flushed_db_idx == 2
+            rows = db.get_messages(agent.session_id)
+            assert [row["content"] for row in rows] == ["one", "two"]
+
+            db.append_message = original_append
+            agent._flush_messages_to_session_db(messages, [])
+
+            rows = db.get_messages(agent.session_id)
+            assert [row["content"] for row in rows] == [
+                "one",
+                "two",
+                "three",
+                "four",
+            ]
+
     def test_persist_session_multiple_calls_no_duplication(self):
         """Multiple _persist_session calls don't duplicate DB entries."""
         from hermes_state import SessionDB


### PR DESCRIPTION
## Summary

Fixes the remaining duplicate-write failure mode from #12563: when `_flush_messages_to_session_db()` writes several messages and one `append_message()` fails mid-loop, any earlier rows that already committed must not be retried on the next flush.

The current full-success path already avoids duplicate writes, and merged lazy-session creation work covers the missing-row side of the issue. This PR keeps the change narrow to the partial-failure cursor gap: advance `_last_flushed_db_idx` immediately after each successful append, while preserving the final success-path cursor assignment.

## Why now

Under SQLite lock contention, `append_message()` can fail after one or more earlier messages have already committed. Previously the cursor stayed at the old value until the whole loop completed, so the next persist path retried committed rows and inflated `message_count` / transcript rows.

## Test coverage

- Added `test_flush_advances_cursor_after_each_successful_message`, which simulates `database is locked` on the third append and verifies the retry resumes at the third message without duplicating the first two.

Verification run locally:

```bash
scripts/run_tests.sh tests/run_agent/test_860_dedup.py
scripts/run_tests.sh tests/run_agent/test_860_dedup.py tests/run_agent/test_compression_persistence.py tests/run_agent/test_413_compression.py tests/run_agent/test_compress_focus_plugin_fallback.py
python -m py_compile run_agent.py
git diff --check
```

Results:

- `10 passed, 4 warnings`
- `31 passed, 4 warnings`
- `py_compile` passed
- `git diff --check` passed

Fixes #12563
