### PR TITLE
fix(gateway): expand fallback env references

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -599,6 +599,8 @@ def _try_resolve_fallback_provider() -> dict | None:
             return None
         with open(cfg_path, encoding="utf-8") as _f:
             cfg = _y.safe_load(_f) or {}
+        from hermes_cli.config import _expand_env_vars
+        cfg = _expand_env_vars(cfg)
         fb = cfg.get("fallback_providers") or cfg.get("fallback_model")
         if not fb:
             return None
@@ -2155,6 +2157,8 @@ class GatewayRunner:
             if cfg_path.exists():
                 with open(cfg_path, encoding="utf-8") as _f:
                     cfg = _y.safe_load(_f) or {}
+                from hermes_cli.config import _expand_env_vars
+                cfg = _expand_env_vars(cfg)
                 fb = cfg.get("fallback_providers") or cfg.get("fallback_model") or None
                 if fb:
                     return fb

--- a/tests/gateway/test_auth_fallback.py
+++ b/tests/gateway/test_auth_fallback.py
@@ -71,3 +71,72 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
             from gateway.run import _resolve_runtime_agent_kwargs
             with pytest.raises(RuntimeError):
                 _resolve_runtime_agent_kwargs()
+
+    def test_auth_error_expands_fallback_env_reference(self, tmp_path, monkeypatch):
+        """Gateway auth fallback should resolve ${VAR} references before client creation."""
+        from hermes_cli.auth import AuthError
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "model:\n  provider: openai-codex\n"
+            "fallback_model:\n"
+            "  provider: custom\n"
+            "  model: deepseek-chat\n"
+            "  base_url: https://api.deepseek.com/\n"
+            "  api_key: ${FALLBACK_DEEPSEEK_KEY}\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "openai-codex")
+        monkeypatch.setenv("FALLBACK_DEEPSEEK_KEY", "resolved-fallback-key")
+
+        seen_fallback_keys = []
+
+        def _mock_resolve(**kwargs):
+            requested = kwargs.get("requested", "")
+            if requested and "codex" in str(requested).lower():
+                raise AuthError("Codex token refresh failed with status 401")
+            seen_fallback_keys.append(kwargs.get("explicit_api_key"))
+            return {
+                "api_key": kwargs.get("explicit_api_key"),
+                "base_url": kwargs.get("explicit_base_url"),
+                "provider": requested,
+                "api_mode": "openai_chat",
+                "command": None,
+                "args": None,
+                "credential_pool": None,
+            }
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=_mock_resolve,
+        ):
+            from gateway.run import _resolve_runtime_agent_kwargs
+            result = _resolve_runtime_agent_kwargs()
+
+        assert seen_fallback_keys == ["resolved-fallback-key"]
+        assert result["api_key"] == "resolved-fallback-key"
+
+
+def test_load_fallback_model_expands_env_references(tmp_path, monkeypatch):
+    """Gateway's fallback model loader should match CLI config env expansion."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "fallback_model:\n"
+        "  provider: custom\n"
+        "  model: deepseek-chat\n"
+        "  api_key: ${FALLBACK_MODEL_KEY}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+    monkeypatch.setenv("FALLBACK_MODEL_KEY", "resolved-model-key")
+
+    from gateway.run import GatewayRunner
+
+    assert GatewayRunner._load_fallback_model() == {
+        "provider": "custom",
+        "model": "deepseek-chat",
+        "api_key": "resolved-model-key",
+    }


### PR DESCRIPTION
## Summary

Fixes #20974.

Gateway mode had two raw `config.yaml` fallback readers that skipped the config env expansion step used by the CLI loaders. When `fallback_model.api_key` or `fallback_providers[].api_key` contained `${VAR}`, the literal placeholder could reach fallback client creation and fail authentication.

This PR expands env references after gateway fallback YAML reads in:
- `_try_resolve_fallback_provider()` for auth-fallback runtime resolution
- `GatewayRunner._load_fallback_model()` for the fallback model chain passed to `AIAgent`

## Tests

- `scripts/run_tests.sh tests/gateway/test_auth_fallback.py` (`4 passed, 4 warnings`)
- `python -m py_compile gateway/run.py tests/gateway/test_auth_fallback.py`
- `git diff --check`
