### PR TITLE
fix(agent): hint after repeated truncated tool calls

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -11266,6 +11266,7 @@ class AIAgent:
             has_retried_429 = False
             restart_with_compressed_messages = False
             restart_with_length_continuation = False
+            restart_with_truncated_tool_call_hint = False
 
             finish_reason = "stop"
             response = None  # Guard against UnboundLocalError if all retries fail
@@ -11797,18 +11798,37 @@ class AIAgent:
                         if self.api_mode in ("chat_completions", "bedrock_converse", "anthropic_messages"):
                             assistant_message = _trunc_msg
                             if assistant_message is not None and _trunc_has_tool_calls:
-                                if truncated_tool_call_retries < 1:
+                                if truncated_tool_call_retries < 2:
                                     truncated_tool_call_retries += 1
-                                    self._vprint(
-                                        f"{self.log_prefix}⚠️  Truncated tool call detected — retrying API call...",
-                                        force=True,
-                                    )
-                                    # Don't append the broken response to messages;
-                                    # just re-run the same API call from the current
-                                    # message state, giving the model another chance.
+                                    if truncated_tool_call_retries == 1:
+                                        self._vprint(
+                                            f"{self.log_prefix}⚠️  Truncated tool call detected — retrying API call...",
+                                            force=True,
+                                        )
+                                        # Don't append the broken response to messages;
+                                        # just re-run the same API call from the current
+                                        # message state, giving the model another chance.
+                                    else:
+                                        self._vprint(
+                                            f"{self.log_prefix}⚠️  Truncated tool call detected again — requesting concise arguments...",
+                                            force=True,
+                                        )
+                                        messages.append({
+                                            "role": "user",
+                                            "content": (
+                                                "[System: Your previous tool call arguments were truncated by the "
+                                                "output length limit. Retry the tool call with concise arguments. "
+                                                "If content is large, split it into smaller tool calls instead of "
+                                                "placing everything in one argument.]"
+                                            ),
+                                        })
+                                        self._session_messages = messages
+                                        self._save_session_log(messages)
+                                        restart_with_truncated_tool_call_hint = True
+                                        break
                                     continue
                                 self._vprint(
-                                    f"{self.log_prefix}⚠️  Truncated tool call response detected again — refusing to execute incomplete tool arguments.",
+                                    f"{self.log_prefix}⚠️  Truncated tool call response remained truncated — refusing to execute incomplete tool arguments.",
                                     force=True,
                                 )
                                 self._cleanup_task_resources(effective_task_id)
@@ -13088,6 +13108,9 @@ class AIAgent:
                 _boost_base = self.max_tokens if self.max_tokens else 4096
                 _boost = _boost_base * (length_continue_retries + 1)
                 self._ephemeral_max_output_tokens = min(_boost, 32768)
+                continue
+
+            if restart_with_truncated_tool_call_hint:
                 continue
 
             # Guard: if all retries exhausted without a successful response

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3229,6 +3229,84 @@ class TestRunConversation:
         mock_hfc.assert_called_once()
         assert result["final_response"] == "Done!"
 
+    def test_truncated_tool_call_second_retry_injects_concise_hint(self, agent):
+        """A second truncated tool call retry should ask for smaller arguments."""
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("write_file")
+        bad_tc = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"partial',
+            call_id="c1",
+        )
+        truncated_resp = _mock_response(
+            content="", finish_reason="length", tool_calls=[bad_tc],
+        )
+        good_tc = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"small chunk"}',
+            call_id="c2",
+        )
+        good_resp = _mock_response(
+            content="", finish_reason="stop", tool_calls=[good_tc],
+        )
+        final_resp = _mock_response(content="Done!", finish_reason="stop")
+        responses = iter([
+            truncated_resp, truncated_resp, good_resp, final_resp,
+        ])
+        captured_messages = []
+
+        def _create_with_snapshot(**kwargs):
+            captured_messages.append([dict(message) for message in kwargs["messages"]])
+            return next(responses)
+
+        agent.client.chat.completions.create.side_effect = _create_with_snapshot
+
+        with (
+            patch("run_agent.handle_function_call", return_value='{"success":true}') as mock_hfc,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("write the report")
+
+        mock_hfc.assert_called_once()
+        assert result["final_response"] == "Done!"
+
+        third_call_messages = captured_messages[2]
+        assert third_call_messages[-1]["role"] == "user"
+        assert "tool call arguments were truncated" in third_call_messages[-1]["content"]
+        assert "split it into smaller tool calls" in third_call_messages[-1]["content"]
+
+    def test_truncated_tool_call_gives_up_after_concise_retry(self, agent):
+        """If the concise retry also truncates, the agent refuses the partial tool."""
+        self._setup_agent(agent)
+        agent.valid_tool_names.add("write_file")
+        bad_tc = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"partial',
+            call_id="c1",
+        )
+        truncated_resp = _mock_response(
+            content="", finish_reason="length", tool_calls=[bad_tc],
+        )
+        agent.client.chat.completions.create.side_effect = [
+            truncated_resp, truncated_resp, truncated_resp,
+        ]
+
+        with (
+            patch("run_agent.handle_function_call") as mock_handle_function_call,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("write the report")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert "truncated due to output length limit" in result["error"]
+        assert agent.client.chat.completions.create.call_count == 3
+        mock_handle_function_call.assert_not_called()
+
     def test_truncated_tool_args_detected_when_finish_reason_not_length(self, agent):
         """When a router rewrites finish_reason from 'length' to 'tool_calls',
         truncated JSON arguments should still be detected and refused rather


### PR DESCRIPTION
## Summary

Fixes #20975.

When a model response is truncated while emitting tool-call arguments, Hermes previously retried the same request once and then gave up if the second response truncated the same way. The second attempt did not give the model any new guidance, so large argument payloads often failed deterministically.

This PR keeps the first retry unchanged, then on the second retry injects a narrow system-style user hint asking the model to use concise arguments or split large content into smaller tool calls. If that hinted retry still truncates, Hermes still refuses to execute the incomplete tool arguments.

## Scope

- Only changes truncated tool-call retry handling in the agent loop.
- Does not execute partial tool calls.
- Does not alter normal text truncation continuation behavior.

## Tests

- `scripts/run_tests.sh tests/run_agent/test_run_agent.py -k 'truncated_tool_call or length_with_tool_calls or truncated_tool_args_detected'` (`6 passed, 4 warnings`)
- `python -m py_compile run_agent.py tests/run_agent/test_run_agent.py`
- `git diff --check`
