### PR TITLE
fix(agent): rebuild api_messages after provider fallback to apply reasoning requirements

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9258,6 +9258,171 @@ class AIAgent:
         # context compaction).  Don't pass null to the API.
         api_msg.pop("reasoning_content", None)
 
+
+    def _build_api_messages(
+        self,
+        messages: list[dict],
+        current_turn_user_idx: int,
+        active_system_prompt: str | None = None,
+        ext_prefetch_cache: dict | None = None,
+        plugin_user_context: str | None = None,
+    ) -> tuple[list[dict], int, int]:
+        """Build api_messages list for the current API call.
+
+        Applies provider-specific transformations (reasoning_content copy,
+        field sanitization, whitespace normalization, etc.) based on the
+        *current* self.provider/self.model settings.
+
+        This method is called both at initial build and after provider fallback
+        to ensure each attempt uses a fresh payload built with current provider
+        settings. See PR #13235 for context.
+
+        Returns:
+            (api_messages, total_chars, approx_tokens) — the built message list
+            and its size metrics for logging.
+        """
+        api_messages = []
+        for idx, msg in enumerate(messages):
+            api_msg = msg.copy()
+
+            # Inject ephemeral context into the current turn's user message.
+            # Sources: memory manager prefetch + plugin pre_llm_call hooks
+            # with target="user_message" (the default).  Both are
+            # API-call-time only — the original message in `messages` is
+            # never mutated, so nothing leaks into session persistence.
+            if idx == current_turn_user_idx and msg.get("role") == "user":
+                _injections = []
+                if ext_prefetch_cache:
+                    _fenced = build_memory_context_block(ext_prefetch_cache)
+                    if _fenced:
+                        _injections.append(_fenced)
+                if plugin_user_context:
+                    _injections.append(plugin_user_context)
+                if _injections:
+                    _base = api_msg.get("content", "")
+                    if isinstance(_base, str):
+                        api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
+
+            # For ALL assistant messages, pass reasoning back to the API
+            # This ensures multi-turn reasoning context is preserved
+            self._copy_reasoning_content_for_api(msg, api_msg)
+
+            # Remove 'reasoning' field - it's for trajectory storage only
+            # We've copied it to 'reasoning_content' for the API above
+            if "reasoning" in api_msg:
+                api_msg.pop("reasoning")
+            # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
+            if "finish_reason" in api_msg:
+                api_msg.pop("finish_reason")
+            # Strip internal thinking-prefill marker
+            api_msg.pop("_thinking_prefill", None)
+            # Strip Codex Responses API fields (call_id, response_item_id) for
+            # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
+            # Uses new dicts so the internal messages list retains the fields
+            # for Codex Responses compatibility.
+            if self._should_sanitize_tool_calls():
+                self._sanitize_tool_calls_for_strict_api(api_msg)
+            # Keep 'reasoning_details' - OpenRouter uses this for multi-turn reasoning context
+            # The signature field helps maintain reasoning continuity
+            api_messages.append(api_msg)
+
+        # Build the final system message: cached prompt + ephemeral system prompt.
+        # Ephemeral additions are API-call-time only (not persisted to session DB).
+        # External recall context is injected into the user message, not the system
+        # prompt, so the stable cache prefix remains unchanged.
+        effective_system = active_system_prompt or ""
+        if self.ephemeral_system_prompt:
+            effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+        # NOTE: Plugin context from pre_llm_call hooks is injected into the
+        # user message (see injection block above), NOT the system prompt.
+        # This is intentional — system prompt modifications break the prompt
+        # cache prefix.  The system prompt is reserved for Hermes internals.
+        if effective_system:
+            api_messages = [{"role": "system", "content": effective_system}] + api_messages
+
+        # Inject ephemeral prefill messages right after the system prompt
+        # but before conversation history. Same API-call-time-only pattern.
+        if self.prefill_messages:
+            sys_offset = 1 if effective_system else 0
+            for idx, pfm in enumerate(self.prefill_messages):
+                api_messages.insert(sys_offset + idx, pfm.copy())
+
+        # Apply Anthropic prompt caching for Claude models on native
+        # Anthropic, OpenRouter, and third-party Anthropic-compatible
+        # gateways. Auto-detected: if ``_use_prompt_caching`` is set,
+        # inject cache_control breakpoints (system + last 3 messages)
+        # to reduce input token costs by ~75% on multi-turn
+        # conversations. Layout is chosen per endpoint by
+        # ``_anthropic_prompt_cache_policy``.
+        if self._use_prompt_caching:
+            api_messages = apply_anthropic_cache_control(
+                api_messages,
+                cache_ttl=self._cache_ttl,
+                native_anthropic=self._use_native_cache_layout,
+            )
+
+        # Safety net: strip orphaned tool results / add stubs for missing
+        # results before sending to the API.  Runs unconditionally — not
+        # gated on context_compressor — so orphans from session loading or
+        # manual message manipulation are always caught.
+        api_messages = self._sanitize_api_messages(api_messages)
+
+        # Drop thinking-only assistant turns (reasoning but no visible
+        # output and no tool_calls) and merge any adjacent user messages
+        # left behind. Prevents Anthropic 400s ("The final block in an
+        # assistant message cannot be `thinking`.") and equivalent errors
+        # from third-party Anthropic-compatible gateways that can't replay
+        # a thinking-only turn. Runs on the per-call copy only — the
+        # stored conversation history keeps the reasoning block for the
+        # UI transcript and session persistence.
+        api_messages = self._drop_thinking_only_and_merge_users(api_messages)
+
+        # Normalize message whitespace and tool-call JSON for consistent
+        # prefix matching.  Ensures bit-perfect prefixes across turns,
+        # which enables KV cache reuse on local inference servers
+        # (llama.cpp, vLLM, Ollama) and improves cache hit rates for
+        # cloud providers.  Operates on api_messages (the API copy) so
+        # the original conversation history in `messages` is untouched.
+        for am in api_messages:
+            if isinstance(am.get("content"), str):
+                am["content"] = am["content"].strip()
+        for am in api_messages:
+            tcs = am.get("tool_calls")
+            if not tcs:
+                continue
+            new_tcs = []
+            for tc in tcs:
+                if isinstance(tc, dict) and "function" in tc:
+                    try:
+                        args_obj = json.loads(tc["function"]["arguments"])
+                        tc = {**tc, "function": {
+                            **tc["function"],
+                            "arguments": json.dumps(
+                                args_obj, separators=(",", ":"),
+                                sort_keys=True,
+                            ),
+                        }}
+                    except Exception:
+                        tc["function"]["arguments"] = _repair_tool_call_arguments(
+                            tc["function"]["arguments"],
+                            tc["function"].get("name", "?"),
+                        )
+                new_tcs.append(tc)
+            am["tool_calls"] = new_tcs
+
+        # Proactively strip any surrogate characters before the API call.
+        # Models served via Ollama (Kimi K2.5, GLM-5, Qwen) can return
+        # lone surrogates (U+D800-U+DFFF) that crash json.dumps() inside
+        # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
+        _sanitize_messages_surrogates(api_messages)
+
+        # Calculate approximate request size for logging
+        total_chars = sum(len(str(msg)) for msg in api_messages)
+        approx_tokens = estimate_messages_tokens_rough(api_messages)
+        
+        return api_messages, total_chars, approx_tokens
+
+
     @staticmethod
     def _sanitize_tool_calls_for_strict_api(api_msg: dict) -> dict:
         """Strip Codex Responses API fields from tool_calls for strict providers.
@@ -11289,144 +11454,19 @@ class AIAgent:
                     self.session_id or "-",
                 )
 
-            api_messages = []
-            for idx, msg in enumerate(messages):
-                api_msg = msg.copy()
+            # Build API messages using the centralized method.
+            # This ensures provider-specific transforms (reasoning_content copy,
+            # field sanitization, etc.) are applied based on current self.provider
+            # settings. After fallback activation, this block is called again to
+            # rebuild api_messages with the new provider's requirements.
+            api_messages, total_chars, approx_tokens = self._build_api_messages(
+                messages=messages,
+                current_turn_user_idx=current_turn_user_idx,
+                active_system_prompt=active_system_prompt,
+                ext_prefetch_cache=_ext_prefetch_cache,
+                plugin_user_context=_plugin_user_context,
+            )
 
-                # Inject ephemeral context into the current turn's user message.
-                # Sources: memory manager prefetch + plugin pre_llm_call hooks
-                # with target="user_message" (the default).  Both are
-                # API-call-time only — the original message in `messages` is
-                # never mutated, so nothing leaks into session persistence.
-                if idx == current_turn_user_idx and msg.get("role") == "user":
-                    _injections = []
-                    if _ext_prefetch_cache:
-                        _fenced = build_memory_context_block(_ext_prefetch_cache)
-                        if _fenced:
-                            _injections.append(_fenced)
-                    if _plugin_user_context:
-                        _injections.append(_plugin_user_context)
-                    if _injections:
-                        _base = api_msg.get("content", "")
-                        if isinstance(_base, str):
-                            api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
-
-                # For ALL assistant messages, pass reasoning back to the API
-                # This ensures multi-turn reasoning context is preserved
-                self._copy_reasoning_content_for_api(msg, api_msg)
-
-                # Remove 'reasoning' field - it's for trajectory storage only
-                # We've copied it to 'reasoning_content' for the API above
-                if "reasoning" in api_msg:
-                    api_msg.pop("reasoning")
-                # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
-                if "finish_reason" in api_msg:
-                    api_msg.pop("finish_reason")
-                # Strip internal thinking-prefill marker
-                api_msg.pop("_thinking_prefill", None)
-                # Strip Codex Responses API fields (call_id, response_item_id) for
-                # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
-                # Uses new dicts so the internal messages list retains the fields
-                # for Codex Responses compatibility.
-                if self._should_sanitize_tool_calls():
-                    self._sanitize_tool_calls_for_strict_api(api_msg)
-                # Keep 'reasoning_details' - OpenRouter uses this for multi-turn reasoning context
-                # The signature field helps maintain reasoning continuity
-                api_messages.append(api_msg)
-
-            # Build the final system message: cached prompt + ephemeral system prompt.
-            # Ephemeral additions are API-call-time only (not persisted to session DB).
-            # External recall context is injected into the user message, not the system
-            # prompt, so the stable cache prefix remains unchanged.
-            effective_system = active_system_prompt or ""
-            if self.ephemeral_system_prompt:
-                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
-            # NOTE: Plugin context from pre_llm_call hooks is injected into the
-            # user message (see injection block above), NOT the system prompt.
-            # This is intentional — system prompt modifications break the prompt
-            # cache prefix.  The system prompt is reserved for Hermes internals.
-            if effective_system:
-                api_messages = [{"role": "system", "content": effective_system}] + api_messages
-
-            # Inject ephemeral prefill messages right after the system prompt
-            # but before conversation history. Same API-call-time-only pattern.
-            if self.prefill_messages:
-                sys_offset = 1 if effective_system else 0
-                for idx, pfm in enumerate(self.prefill_messages):
-                    api_messages.insert(sys_offset + idx, pfm.copy())
-
-            # Apply Anthropic prompt caching for Claude models on native
-            # Anthropic, OpenRouter, and third-party Anthropic-compatible
-            # gateways. Auto-detected: if ``_use_prompt_caching`` is set,
-            # inject cache_control breakpoints (system + last 3 messages)
-            # to reduce input token costs by ~75% on multi-turn
-            # conversations. Layout is chosen per endpoint by
-            # ``_anthropic_prompt_cache_policy``.
-            if self._use_prompt_caching:
-                api_messages = apply_anthropic_cache_control(
-                    api_messages,
-                    cache_ttl=self._cache_ttl,
-                    native_anthropic=self._use_native_cache_layout,
-                )
-
-            # Safety net: strip orphaned tool results / add stubs for missing
-            # results before sending to the API.  Runs unconditionally — not
-            # gated on context_compressor — so orphans from session loading or
-            # manual message manipulation are always caught.
-            api_messages = self._sanitize_api_messages(api_messages)
-
-            # Drop thinking-only assistant turns (reasoning but no visible
-            # output and no tool_calls) and merge any adjacent user messages
-            # left behind. Prevents Anthropic 400s ("The final block in an
-            # assistant message cannot be `thinking`.") and equivalent errors
-            # from third-party Anthropic-compatible gateways that can't replay
-            # a thinking-only turn. Runs on the per-call copy only — the
-            # stored conversation history keeps the reasoning block for the
-            # UI transcript and session persistence.
-            api_messages = self._drop_thinking_only_and_merge_users(api_messages)
-
-            # Normalize message whitespace and tool-call JSON for consistent
-            # prefix matching.  Ensures bit-perfect prefixes across turns,
-            # which enables KV cache reuse on local inference servers
-            # (llama.cpp, vLLM, Ollama) and improves cache hit rates for
-            # cloud providers.  Operates on api_messages (the API copy) so
-            # the original conversation history in `messages` is untouched.
-            for am in api_messages:
-                if isinstance(am.get("content"), str):
-                    am["content"] = am["content"].strip()
-            for am in api_messages:
-                tcs = am.get("tool_calls")
-                if not tcs:
-                    continue
-                new_tcs = []
-                for tc in tcs:
-                    if isinstance(tc, dict) and "function" in tc:
-                        try:
-                            args_obj = json.loads(tc["function"]["arguments"])
-                            tc = {**tc, "function": {
-                                **tc["function"],
-                                "arguments": json.dumps(
-                                    args_obj, separators=(",", ":"),
-                                    sort_keys=True,
-                                ),
-                            }}
-                        except Exception:
-                            tc["function"]["arguments"] = _repair_tool_call_arguments(
-                                tc["function"]["arguments"],
-                                tc["function"].get("name", "?"),
-                            )
-                    new_tcs.append(tc)
-                am["tool_calls"] = new_tcs
-
-            # Proactively strip any surrogate characters before the API call.
-            # Models served via Ollama (Kimi K2.5, GLM-5, Qwen) can return
-            # lone surrogates (U+D800-U+DFFF) that crash json.dumps() inside
-            # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
-            _sanitize_messages_surrogates(api_messages)
-
-            # Calculate approximate request size for logging
-            total_chars = sum(len(str(msg)) for msg in api_messages)
-            approx_tokens = estimate_messages_tokens_rough(api_messages)
             
             # Thinking spinner for quiet mode (animated during API call)
             thinking_spinner = None
@@ -11504,6 +11544,14 @@ class AIAgent:
                                 retry_count = 0
                                 compression_attempts = 0
                                 primary_recovery_attempted = False
+                                # Rebuild api_messages with new provider's reasoning requirements
+                                api_messages, total_chars, approx_tokens = self._build_api_messages(
+                                messages=messages,
+                                current_turn_user_idx=current_turn_user_idx,
+                                active_system_prompt=active_system_prompt,
+                                ext_prefetch_cache=_ext_prefetch_cache,
+                                plugin_user_context=_plugin_user_context,
+                                )
                                 continue
                             # No fallback available — return with clear message
                             self._persist_session(messages, conversation_history)
@@ -11726,6 +11774,14 @@ class AIAgent:
                             retry_count = 0
                             compression_attempts = 0
                             primary_recovery_attempted = False
+                            # Rebuild api_messages with new provider's reasoning requirements
+                            api_messages, total_chars, approx_tokens = self._build_api_messages(
+                            messages=messages,
+                            current_turn_user_idx=current_turn_user_idx,
+                            active_system_prompt=active_system_prompt,
+                            ext_prefetch_cache=_ext_prefetch_cache,
+                            plugin_user_context=_plugin_user_context,
+                            )
                             continue
 
                         # Check for error field in response (some providers include this)
@@ -11796,6 +11852,14 @@ class AIAgent:
                                 retry_count = 0
                                 compression_attempts = 0
                                 primary_recovery_attempted = False
+                                # Rebuild api_messages with new provider's reasoning requirements
+                                api_messages, total_chars, approx_tokens = self._build_api_messages(
+                                messages=messages,
+                                current_turn_user_idx=current_turn_user_idx,
+                                active_system_prompt=active_system_prompt,
+                                ext_prefetch_cache=_ext_prefetch_cache,
+                                plugin_user_context=_plugin_user_context,
+                                )
                                 continue
                             self._emit_status(f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
                             logging.error(f"{self.log_prefix}Invalid API response after {max_retries} retries.")
@@ -13089,6 +13153,14 @@ class AIAgent:
                             retry_count = 0
                             compression_attempts = 0
                             primary_recovery_attempted = False
+                            # Rebuild api_messages with new provider's reasoning requirements
+                            api_messages, total_chars, approx_tokens = self._build_api_messages(
+                            messages=messages,
+                            current_turn_user_idx=current_turn_user_idx,
+                            active_system_prompt=active_system_prompt,
+                            ext_prefetch_cache=_ext_prefetch_cache,
+                            plugin_user_context=_plugin_user_context,
+                            )
                             continue
                         if api_kwargs is not None:
                             self._dump_api_request_debug(
@@ -13156,6 +13228,14 @@ class AIAgent:
                             retry_count = 0
                             compression_attempts = 0
                             primary_recovery_attempted = False
+                            # Rebuild api_messages with new provider's reasoning requirements
+                            api_messages, total_chars, approx_tokens = self._build_api_messages(
+                            messages=messages,
+                            current_turn_user_idx=current_turn_user_idx,
+                            active_system_prompt=active_system_prompt,
+                            ext_prefetch_cache=_ext_prefetch_cache,
+                            plugin_user_context=_plugin_user_context,
+                            )
                             continue
                         _final_summary = self._summarize_api_error(api_error)
                         if is_rate_limited:
@@ -14016,6 +14096,14 @@ class AIAgent:
                                     "Fallback activated after empty responses: "
                                     "now using %s on %s",
                                     self.model, self.provider,
+                                )
+                                # Rebuild api_messages with new provider's reasoning requirements
+                                api_messages, total_chars, approx_tokens = self._build_api_messages(
+                                messages=messages,
+                                current_turn_user_idx=current_turn_user_idx,
+                                active_system_prompt=active_system_prompt,
+                                ext_prefetch_cache=_ext_prefetch_cache,
+                                plugin_user_context=_plugin_user_context,
                                 )
                                 continue
 

--- a/tests/run_agent/test_build_api_messages_fallback.py
+++ b/tests/run_agent/test_build_api_messages_fallback.py
@@ -1,0 +1,250 @@
+"""Regression test: _build_api_messages() rebuild after provider fallback.
+
+When Hermes falls back from one provider (e.g. GLM-5.1) to DeepSeek via
+_try_activate_fallback(), the api_messages array must be rebuilt with the new
+provider's settings so that `_copy_reasoning_content_for_api` applies the
+correct reasoning_content padding for the target provider.
+
+Without this fix, the stale api_messages built with GLM settings (no padding
+needed) is reused after fallback to DeepSeek, causing HTTP 400::
+
+    The reasoning_content in the thinking mode must be passed back to the API.
+
+This test verifies that _build_api_messages() correctly applies provider-specific
+transformations when called directly — simulating what happens after fallback.
+
+Refs #13235 / #17212 / #17825.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_agent(provider: str = "", model: str = "", base_url: str = "") -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
+    agent.verbose_logging = False
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    # Attributes used by _build_api_messages internals
+    agent.ephemeral_system_prompt = None
+    agent.prefill_messages = []
+    agent._use_prompt_caching = False
+    agent._cache_ttl = 3600
+    agent._use_native_cache_layout = True
+    agent.api_mode = "chat_completions"
+    return agent
+
+
+def _make_assistant_msg(content: str = "Hello", reasoning: str | None = None):
+    msg = {"role": "assistant", "content": content}
+    if reasoning is not None:
+        msg["reasoning"] = reasoning
+    return msg
+
+
+def _make_user_msg(content: str = "Hi"):
+    return {"role": "user", "content": content}
+
+
+def _find_assistant(api_msgs: list[dict]) -> dict | None:
+    for msg in api_msgs:
+        if msg.get("role") == "assistant":
+            return msg
+    return None
+
+
+class TestBuildApiMessagesBasic:
+    """Method existence and basic contract."""
+
+    def test_method_exists_and_callable(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        assert callable(agent._build_api_messages)
+
+    def test_returns_correct_types(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        messages = [_make_user_msg("Hi"), _make_assistant_msg("Hello")]
+        api_msgs, total_chars, approx_tokens = agent._build_api_messages(messages, 0)
+
+        assert isinstance(api_msgs, list)
+        assert isinstance(total_chars, int)
+        assert isinstance(approx_tokens, int)
+
+    def test_preserves_message_count(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        messages = [_make_user_msg("A"), _make_assistant_msg("B")]
+        api_msgs, _, _ = agent._build_api_messages(messages, 0)
+        # Should have system + 2 messages, or just 2 if no system prompt
+        assert len(api_msgs) >= 2
+
+
+class TestBuildApiMessagesDeepSeekPadding:
+    """DeepSeek requires reasoning_content padding on all assistant messages."""
+
+    def test_deepseek_adds_padding_when_no_reasoning(self) -> None:
+        """DeepSeek should add ' ' padding for assistant msgs without reasoning field."""
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        messages = [
+            _make_user_msg("Hi"),
+            _make_assistant_msg("Hello"),  # No reasoning field
+        ]
+
+        api_msgs, _, _ = agent._build_api_messages(messages, 0)
+        assistant = _find_assistant(api_msgs)
+
+        assert assistant is not None
+        assert "reasoning_content" in assistant
+        assert assistant["reasoning_content"] == " "
+
+    def test_deepseek_promotes_reasoning_to_reasoning_content(self) -> None:
+        """When reasoning field is present, it's promoted to reasoning_content."""
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        messages = [
+            _make_user_msg("Hi"),
+            _make_assistant_msg("Hello", reasoning="I am thinking..."),
+        ]
+
+        api_msgs, _, _ = agent._build_api_messages(messages, 0)
+        assistant = _find_assistant(api_msgs)
+
+        assert assistant is not None
+        assert assistant["reasoning_content"] == "I am thinking..."
+
+    def test_deepseek_promotes_reasoning_even_with_empty_content(self) -> None:
+        """Reasoning field is promoted regardless of content presence."""
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        messages = [
+            _make_user_msg("Hi"),
+            _make_assistant_msg("", reasoning="just thinking"),
+        ]
+
+        api_msgs, _, _ = agent._build_api_messages(messages, 0)
+        # The assistant message may be dropped by _drop_thinking_only_and_merge_users
+        # if it has no content and no tool_calls. That's a separate concern; what
+        # we care about here is that _build_api_messages doesn't crash and returns
+        # a valid tuple.
+        assert isinstance(api_msgs, list)
+        assert len(api_msgs) >= 1
+
+
+class TestBuildApiMessagesGLMMode:
+    """GLM-5.1 does NOT enforce the thinking echo — padding differs from DeepSeek."""
+
+    def test_glmmode_adds_no_padding_when_no_reasoning(self) -> None:
+        """GLM should NOT add padding for assistant msgs without reasoning field."""
+        agent = _make_agent(provider="ollama", model="glm-5.1")
+        messages = [
+            _make_user_msg("Hi"),
+            _make_assistant_msg("Hello"),  # No reasoning field
+        ]
+
+        api_msgs, _, _ = agent._build_api_messages(messages, 0)
+        assistant = _find_assistant(api_msgs)
+
+        assert assistant is not None
+        # GLM does NOT need thinking padding — no reasoning_content injected
+        assert "reasoning_content" not in assistant
+
+    def test_glmmode_promotes_reasoning_to_reasoning_content(self) -> None:
+        """Reasoning field is always promoted regardless of provider."""
+        agent = _make_agent(provider="ollama", model="glm-5.1")
+        messages = [
+            _make_user_msg("Hi"),
+            _make_assistant_msg("Hello", reasoning="I am thinking..."),
+        ]
+
+        api_msgs, _, _ = agent._build_api_messages(messages, 0)
+        assistant = _find_assistant(api_msgs)
+
+        assert assistant is not None
+        # reasoning is promoted to reasoning_content regardless of provider
+        assert "reasoning_content" in assistant
+        assert assistant["reasoning_content"] == "I am thinking..."
+
+
+class TestBuildApiMessagesFallbackSimulation:
+    """This is THE bug: after fallback to DeepSeek, rebuilt messages must have padding."""
+
+    def test_fallback_from_glm_to_deepseek_adds_padding(self) -> None:
+        """Simulate fallback: messages built without padding get padding after rebuild."""
+        agent = _make_agent(provider="ollama", model="glm-5.1")
+        messages = [
+            _make_user_msg("Hi"),
+            _make_assistant_msg("Hello"),  # No reasoning field — no padding needed for GLM
+        ]
+
+        # Build with GLM — no padding
+        api_msgs_before, _, _ = agent._build_api_messages(messages, 0)
+        assistant_before = _find_assistant(api_msgs_before)
+        assert assistant_before is not None
+        assert "reasoning_content" not in assistant_before
+
+        # Simulate fallback: switch provider to DeepSeek
+        agent.provider = "deepseek"
+        agent.model = "deepseek-v4-flash"
+
+        # Rebuild — now padding IS needed
+        api_msgs_after, _, _ = agent._build_api_messages(messages, 0)
+        assistant_after = _find_assistant(api_msgs_after)
+
+        assert assistant_after is not None
+        assert "reasoning_content" in assistant_after
+        # The fix: after fallback, DeepSeek's padding requirement is satisfied
+        assert assistant_after["reasoning_content"] == " "
+
+    def test_fallback_from_deepseek_to_glm_strips_padding(self) -> None:
+        """Fallback in the opposite direction: padding requirement should be relaxed."""
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        messages = [
+            _make_user_msg("Hi"),
+            _make_assistant_msg("Hello"),  # No reasoning field
+        ]
+
+        # Build with DeepSeek — gets padding
+        api_msgs_before, _, _ = agent._build_api_messages(messages, 0)
+        assistant_before = _find_assistant(api_msgs_before)
+        assert assistant_before is not None
+        assert assistant_before["reasoning_content"] == " "
+
+        # Fallback: switch to GLM
+        agent.provider = "ollama"
+        agent.model = "glm-5.1"
+
+        api_msgs_after, _, _ = agent._build_api_messages(messages, 0)
+        assistant_after = _find_assistant(api_msgs_after)
+        assert assistant_after is not None
+        assert "reasoning_content" not in assistant_after
+
+
+class TestBuildApiMessagesPreservesOriginal:
+    """Verify _build_api_messages does not mutate the original messages list."""
+
+    def test_original_messages_unchanged(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        original_msg = _make_assistant_msg("Hello", reasoning="I am thinking...")
+        messages = [_make_user_msg("Hi"), original_msg]
+
+        agent._build_api_messages(messages, 0)
+
+        # Original should be unchanged — no reasoning_content added to source
+        assert "reasoning_content" not in original_msg
+
+    def test_system_prompt_preserved(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")
+        messages = [_make_user_msg("Hi")]
+        api_msgs, _, _ = agent._build_api_messages(messages, 0,
+                                                   active_system_prompt="You are a helpful assistant.")
+
+        system_msgs = [m for m in api_msgs if m.get("role") == "system"]
+        assert len(system_msgs) == 1
+        assert "You are a helpful assistant" in system_msgs[0]["content"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

When Hermes falls back from one provider (e.g. GLM-5.1) to DeepSeek/Kimi via `_try_activate_fallback()`, the `api_messages` array is stale — it was built before the fallback with the original provider's settings. Since `_copy_reasoning_content_for_api` runs with the original provider's model, DeepSeek-required `reasoning_content` padding is not added to assistant messages.

This causes HTTP 400 from DeepSeek:

> The reasoning_content in the thinking mode must be passed back to the API.

## Root Cause

The message-building block sits *outside* the inner retry loop. After `_try_activate_fallback()` success, the `continue` loops back to the retry loop top — *not* the message builder — so stale `api_messages` is reused with the wrong provider's settings.

## Fix

1. **Extract** the inline message-building block into `_build_api_messages()` — an instance method on `AIAgent` that returns `(api_messages, total_chars, approx_tokens)`.
2. **Replace** the inline block with a single call to the new method.
3. **Add** a `_build_api_messages()` call at all 6 `_try_activate_fallback()` sites in the retry loop to ensure `api_messages` is rebuilt with the current provider's settings before continuing.

## Testing

- 12 new regression tests in `tests/run_agent/test_build_api_messages_fallback.py`
- Covers: DeepSeek padding, GLM mode (no padding), fallback simulation (GLM→DeepSeek, DeepSeek→GLM), method contract, message immutability
- All 36 existing `test_deepseek_reasoning_content_echo.py` tests continue to pass

## Related

- Fixes #17212, #17825
- Relates to #13235 (same approach, stale PR with no reviews)