### PR TITLE
fix(approval): add cron allowlist mode

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1149,6 +1149,7 @@ DEFAULT_CONFIG = {
     #
     # cron_mode — what to do when a cron job hits a dangerous command:
     #   deny    — block the command and let the agent find another way (default, safe)
+    #   allowlist — allow only command_allowlist entries, block everything else
     #   approve — auto-approve all dangerous commands in cron jobs
     "approvals": {
         "mode": "manual",

--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -44,6 +44,16 @@ class TestCronApprovalModeParsing:
         with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {"cron_mode": "approve"}}):
             assert _get_cron_approval_mode() == "approve"
 
+    def test_explicit_allowlist(self):
+        from unittest.mock import patch as mock_patch
+        with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {"cron_mode": "allowlist"}}):
+            assert _get_cron_approval_mode() == "allowlist"
+
+    def test_allow_list_alias(self):
+        from unittest.mock import patch as mock_patch
+        with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {"cron_mode": "allow-list"}}):
+            assert _get_cron_approval_mode() == "allowlist"
+
     def test_off_maps_to_approve(self):
         """'off' is an alias for 'approve' (matches --yolo semantics)."""
         from unittest.mock import patch as mock_patch
@@ -153,6 +163,22 @@ class TestCronDenyMode:
             # Should contain the description of what was flagged
             assert "dangerous" in result["message"].lower() or "delete" in result["message"].lower()
 
+    def test_deny_mode_blocks_even_permanent_allowlist(self, monkeypatch):
+        """cron_mode=deny should remain stricter than command_allowlist."""
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        _, pattern_key, _ = detect_dangerous_command("rm -rf /tmp/stuff")
+        approval_module.approve_permanent(pattern_key)
+
+        from unittest.mock import patch as mock_patch
+        with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
+            result = check_dangerous_command("rm -rf /tmp/stuff", "local")
+            assert not result["approved"]
+            assert "BLOCKED" in result["message"]
+
 
 class TestCronApproveMode:
     """When HERMES_CRON_SESSION is set and cron_mode=approve, dangerous commands pass through."""
@@ -167,6 +193,36 @@ class TestCronApproveMode:
         with mock_patch("tools.approval._get_cron_approval_mode", return_value="approve"):
             result = check_dangerous_command("rm -rf /tmp/stuff", "local")
             assert result["approved"]
+
+
+class TestCronAllowlistMode:
+    """When cron_mode=allowlist, only command_allowlist entries pass."""
+
+    def test_allowlisted_dangerous_command_allowed(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        _, pattern_key, _ = detect_dangerous_command("rm -rf /tmp/stuff")
+        approval_module.approve_permanent(pattern_key)
+
+        from unittest.mock import patch as mock_patch
+        with mock_patch("tools.approval._get_cron_approval_mode", return_value="allowlist"):
+            result = check_dangerous_command("rm -rf /tmp/stuff", "local")
+            assert result["approved"]
+
+    def test_unlisted_dangerous_command_blocked(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        from unittest.mock import patch as mock_patch
+        with mock_patch("tools.approval._get_cron_approval_mode", return_value="allowlist"):
+            result = check_dangerous_command("rm -rf /tmp/stuff", "local")
+            assert not result["approved"]
+            assert "command_allowlist" in result["message"]
 
 
 # ---------------------------------------------------------------------------
@@ -212,6 +268,34 @@ class TestCronDenyModeAllGuards:
         with mock_patch("tools.approval._get_cron_approval_mode", return_value="approve"):
             result = check_all_command_guards("rm -rf /tmp/stuff", "local")
             assert result["approved"]
+
+    def test_combined_guard_allowlist_mode_allows_listed_pattern(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        _, pattern_key, _ = detect_dangerous_command("rm -rf /tmp/stuff")
+        approval_module.approve_permanent(pattern_key)
+
+        from unittest.mock import patch as mock_patch
+        with mock_patch("tools.approval._get_cron_approval_mode", return_value="allowlist"):
+            result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+            assert result["approved"]
+
+    def test_combined_guard_allowlist_mode_blocks_unlisted_pattern(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        from unittest.mock import patch as mock_patch
+        with mock_patch("tools.approval._get_cron_approval_mode", return_value="allowlist"):
+            result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+            assert not result["approved"]
+            assert "command_allowlist" in result["message"]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -728,11 +728,13 @@ def _get_approval_timeout() -> int:
 
 
 def _get_cron_approval_mode() -> str:
-    """Read the cron approval mode from config. Returns 'deny' or 'approve'."""
+    """Read the cron approval mode from config."""
     try:
         from hermes_cli.config import load_config
         config = load_config()
         mode = str(cfg_get(config, "approvals", "cron_mode", default="deny")).lower().strip()
+        if mode in ("allowlist", "allow-list"):
+            return "allowlist"
         if mode in ("approve", "off", "allow", "yes"):
             return "approve"
         return "deny"
@@ -825,26 +827,39 @@ def check_dangerous_command(command: str, env_type: str,
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
-    if is_approved(session_key, pattern_key):
-        return {"approved": True, "message": None}
-
     is_cli = os.getenv("HERMES_INTERACTIVE")
     is_gateway = os.getenv("HERMES_GATEWAY_SESSION")
 
     if not is_cli and not is_gateway:
         # Cron sessions: respect cron_mode config
         if os.getenv("HERMES_CRON_SESSION"):
-            if _get_cron_approval_mode() == "deny":
+            cron_mode = _get_cron_approval_mode()
+            if cron_mode == "approve":
+                return {"approved": True, "message": None}
+            if cron_mode == "allowlist" and is_approved(session_key, pattern_key):
+                return {"approved": True, "message": None}
+            if cron_mode in ("deny", "allowlist"):
+                allow_hint = (
+                    "Add this command pattern to command_allowlist or rewrite the job "
+                    "to avoid the dangerous command."
+                    if cron_mode == "allowlist"
+                    else (
+                        "Find an alternative approach that avoids this command. "
+                        "To allow dangerous commands in cron jobs, set "
+                        "approvals.cron_mode: approve in config.yaml."
+                    )
+                )
                 return {
                     "approved": False,
                     "message": (
                         f"BLOCKED: Command flagged as dangerous ({description}) "
                         "but cron jobs run without a user present to approve it. "
-                        "Find an alternative approach that avoids this command. "
-                        "To allow dangerous commands in cron jobs, set "
-                        "approvals.cron_mode: approve in config.yaml."
+                        f"{allow_hint}"
                     ),
                 }
+        return {"approved": True, "message": None}
+
+    if is_approved(session_key, pattern_key):
         return {"approved": True, "message": None}
 
     if is_gateway or os.getenv("HERMES_EXEC_ASK"):
@@ -954,20 +969,33 @@ def check_all_command_guards(command: str, env_type: str,
     if not is_cli and not is_gateway and not is_ask:
         # Cron sessions: respect cron_mode config
         if os.getenv("HERMES_CRON_SESSION"):
-            if _get_cron_approval_mode() == "deny":
-                # Run detection to get a description for the block message
-                is_dangerous, _pk, description = detect_dangerous_command(command)
-                if is_dangerous:
-                    return {
-                        "approved": False,
-                        "message": (
-                            f"BLOCKED: Command flagged as dangerous ({description}) "
-                            "but cron jobs run without a user present to approve it. "
-                            "Find an alternative approach that avoids this command. "
-                            "To allow dangerous commands in cron jobs, set "
-                            "approvals.cron_mode: approve in config.yaml."
-                        ),
-                    }
+            cron_mode = _get_cron_approval_mode()
+            if cron_mode == "approve":
+                return {"approved": True, "message": None}
+            # Run detection to get a description for the block message
+            is_dangerous, pattern_key, description = detect_dangerous_command(command)
+            if is_dangerous:
+                session_key = get_current_session_key()
+                if cron_mode == "allowlist" and is_approved(session_key, pattern_key):
+                    return {"approved": True, "message": None}
+                allow_hint = (
+                    "Add this command pattern to command_allowlist or rewrite the job "
+                    "to avoid the dangerous command."
+                    if cron_mode == "allowlist"
+                    else (
+                        "Find an alternative approach that avoids this command. "
+                        "To allow dangerous commands in cron jobs, set "
+                        "approvals.cron_mode: approve in config.yaml."
+                    )
+                )
+                return {
+                    "approved": False,
+                    "message": (
+                        f"BLOCKED: Command flagged as dangerous ({description}) "
+                        "but cron jobs run without a user present to approve it. "
+                        f"{allow_hint}"
+                    ),
+                }
         return {"approved": True, "message": None}
 
     # --- Phase 1: Gather findings from both checks ---


### PR DESCRIPTION
## Summary

Fixes #20984.

Adds an explicit `approvals.cron_mode: allowlist` mode for unattended cron sessions. `approve` still allows all non-hardline dangerous commands, `deny` blocks dangerous cron commands, and `allowlist` only permits dangerous command patterns already present in `command_allowlist`.

This keeps the hardline blocklist unconditional and updates both approval entry points used before terminal execution:
- `check_dangerous_command()`
- `check_all_command_guards()`

## Tests

- `scripts/run_tests.sh tests/tools/test_cron_approval_mode.py tests/tools/test_hardline_blocklist.py -k 'cron or hardline'` (`122 passed, 4 warnings`)
- `python -m py_compile tools/approval.py hermes_cli/config.py tests/tools/test_cron_approval_mode.py`
- `git diff --check`
