### PR TITLE
fix(gateway): exclude restart requester from drain

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1004,6 +1004,7 @@ class GatewayRunner:
     _restart_task_started: bool = False
     _restart_detached: bool = False
     _restart_via_service: bool = False
+    _restart_drain_exclude_session_key: Optional[str] = None
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
@@ -1744,6 +1745,9 @@ class GatewayRunner:
         self._shutdown_event.set()
 
     def _running_agent_count(self) -> int:
+        excluded = getattr(self, "_restart_drain_exclude_session_key", None)
+        if excluded:
+            return sum(1 for session_key in self._running_agents if session_key != excluded)
         return len(self._running_agents)
 
     def _status_action_label(self) -> str:
@@ -2163,10 +2167,11 @@ class GatewayRunner:
         return None
 
     def _snapshot_running_agents(self) -> Dict[str, Any]:
+        excluded = getattr(self, "_restart_drain_exclude_session_key", None)
         return {
             session_key: agent
             for session_key, agent in self._running_agents.items()
-            if agent is not _AGENT_PENDING_SENTINEL
+            if agent is not _AGENT_PENDING_SENTINEL and session_key != excluded
         }
 
     def _queue_or_replace_pending_event(self, session_key: str, event: MessageEvent) -> None:
@@ -2372,7 +2377,8 @@ class GatewayRunner:
                 last_active_count = active_count
                 last_status_at = now
 
-        if not self._running_agents:
+        active_keys = set(snapshot)
+        if not active_keys:
             _maybe_update_status(force=True)
             return snapshot, False
 
@@ -2381,10 +2387,11 @@ class GatewayRunner:
             return snapshot, True
 
         deadline = asyncio.get_running_loop().time() + timeout
-        while self._running_agents and asyncio.get_running_loop().time() < deadline:
+        while active_keys and asyncio.get_running_loop().time() < deadline:
             _maybe_update_status()
             await asyncio.sleep(0.1)
-        timed_out = bool(self._running_agents)
+            active_keys = {key for key in active_keys if key in self._running_agents}
+        timed_out = bool(active_keys)
         _maybe_update_status(force=True)
         return snapshot, timed_out
 
@@ -2722,12 +2729,19 @@ class GatewayRunner:
                 start_new_session=True,
             )
 
-    def request_restart(self, *, detached: bool = False, via_service: bool = False) -> bool:
+    def request_restart(
+        self,
+        *,
+        detached: bool = False,
+        via_service: bool = False,
+        exclude_session_key: Optional[str] = None,
+    ) -> bool:
         if self._restart_task_started:
             return False
         self._restart_requested = True
         self._restart_detached = detached
         self._restart_via_service = via_service
+        self._restart_drain_exclude_session_key = exclude_session_key
         self._restart_task_started = True
 
         async def _run_restart() -> None:
@@ -7468,7 +7482,7 @@ class GatewayRunner:
         except Exception as e:
             logger.debug("Failed to write restart dedup marker: %s", e)
 
-        active_agents = self._running_agent_count()
+        restart_session_key = self._session_key_for_source(event.source)
         # When running under a service manager (systemd/launchd), use the
         # service restart path: exit with code 75 so the service manager
         # restarts us.  The detached subprocess approach (setsid + bash)
@@ -7476,9 +7490,18 @@ class GatewayRunner:
         # processes in the cgroup, including the detached helper.
         _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
         if _under_service:
-            self.request_restart(detached=False, via_service=True)
+            self.request_restart(
+                detached=False,
+                via_service=True,
+                exclude_session_key=restart_session_key,
+            )
         else:
-            self.request_restart(detached=True, via_service=False)
+            self.request_restart(
+                detached=True,
+                via_service=False,
+                exclude_session_key=restart_session_key,
+            )
+        active_agents = self._running_agent_count()
         if active_agents:
             return t("gateway.draining", count=active_agents)
         return EphemeralReply("♻ Restarting gateway. If you aren't notified within 60 seconds, restart from the console with `hermes gateway restart`.")

--- a/tests/e2e/test_platform_commands.py
+++ b/tests/e2e/test_platform_commands.py
@@ -17,6 +17,7 @@ import pytest
 
 from gateway.config import Platform
 from gateway.platforms.base import SendResult
+from gateway.session import build_session_key
 from tests.e2e.conftest import make_event, send_and_capture
 
 
@@ -90,13 +91,18 @@ class TestSlashCommands:
 
         monkeypatch.setenv("INVOCATION_ID", "e2e-systemd")
         runner.request_restart = MagicMock(return_value=True)
+        expected_session_key = build_session_key(make_event(platform, "restart gateway").source)
 
         send = await send_and_capture(adapter, "restart gateway", platform)
 
         send.assert_called_once()
         response_text = send.call_args[1].get("content") or send.call_args[0][1]
         assert "restart" in response_text.lower() or "draining" in response_text.lower()
-        runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+        runner.request_restart.assert_called_once_with(
+            detached=False,
+            via_service=True,
+            exclude_session_key=expected_session_key,
+        )
 
     @pytest.mark.asyncio
     async def test_plaintext_restart_gateway_in_group_stays_plain_text(self, adapter, runner, platform, monkeypatch):

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -68,6 +68,7 @@ def make_restart_runner(
     runner._restart_task_started = False
     runner._restart_detached = False
     runner._restart_via_service = False
+    runner._restart_drain_exclude_session_key = None
     runner._restart_drain_timeout = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     runner._stop_task = None
     runner._busy_input_mode = "interrupt"

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -135,7 +135,8 @@ async def test_gateway_restart_does_not_drain_requesting_active_session():
 
 
 @pytest.mark.asyncio
-async def test_restart_command_excludes_requesting_session_from_drain():
+async def test_restart_command_excludes_requesting_session_from_drain(monkeypatch):
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
     runner, _adapter = make_restart_runner()
     event = MessageEvent(text="/restart", source=make_restart_source(), message_id="restart-1")
     session_key = build_session_key(event.source)

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -113,6 +113,51 @@ async def test_gateway_stop_drains_running_agents_before_disconnect():
 
 
 @pytest.mark.asyncio
+async def test_gateway_restart_does_not_drain_requesting_active_session():
+    runner, adapter = make_restart_runner()
+    disconnect_mock = AsyncMock()
+    adapter.disconnect = disconnect_mock
+
+    source = make_restart_source()
+    session_key = build_session_key(source)
+    running_agent = MagicMock()
+    runner._running_agents = {session_key: running_agent}
+    runner._restart_drain_exclude_session_key = session_key
+    runner._restart_drain_timeout = 30.0
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        await asyncio.wait_for(runner.stop(restart=True), timeout=0.5)
+
+    running_agent.interrupt.assert_not_called()
+    disconnect_mock.assert_awaited_once()
+    assert runner._shutdown_event.is_set() is True
+    assert runner._running_agents == {}
+
+
+@pytest.mark.asyncio
+async def test_restart_command_excludes_requesting_session_from_drain():
+    runner, _adapter = make_restart_runner()
+    event = MessageEvent(text="/restart", source=make_restart_source(), message_id="restart-1")
+    session_key = build_session_key(event.source)
+    runner._running_agents = {session_key: MagicMock()}
+
+    def _request_restart(**kwargs):
+        runner._restart_drain_exclude_session_key = kwargs.get("exclude_session_key")
+        return True
+
+    runner.request_restart = MagicMock(side_effect=_request_restart)
+
+    result = await runner._handle_restart_command(event)
+
+    runner.request_restart.assert_called_once_with(
+        detached=True,
+        via_service=False,
+        exclude_session_key=session_key,
+    )
+    assert "draining" not in str(result).lower()
+
+
+@pytest.mark.asyncio
 async def test_gateway_stop_interrupts_after_drain_timeout():
     runner, adapter = make_restart_runner()
     runner._restart_drain_timeout = 0.05

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -34,7 +34,11 @@ async def test_restart_command_while_busy_requests_drain_without_interrupt(monke
 
     assert result == "⏳ Draining 1 active agent(s) before restart..."
     running_agent.interrupt.assert_not_called()
-    runner.request_restart.assert_called_once_with(detached=True, via_service=False)
+    runner.request_restart.assert_called_once_with(
+        detached=True,
+        via_service=False,
+        exclude_session_key=session_key,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -81,7 +81,11 @@ async def test_restart_command_uses_service_restart_under_systemd(tmp_path, monk
     )
 
     await runner._handle_restart_command(event)
-    runner.request_restart.assert_called_once_with(detached=False, via_service=True)
+    runner.request_restart.assert_called_once_with(
+        detached=False,
+        via_service=True,
+        exclude_session_key=build_session_key(source),
+    )
 
 
 @pytest.mark.asyncio
@@ -102,7 +106,11 @@ async def test_restart_command_uses_detached_without_systemd(tmp_path, monkeypat
     )
 
     await runner._handle_restart_command(event)
-    runner.request_restart.assert_called_once_with(detached=True, via_service=False)
+    runner.request_restart.assert_called_once_with(
+        detached=True,
+        via_service=False,
+        exclude_session_key=build_session_key(source),
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fixes #20694
- Excludes the active session that requested `/restart` from the restart drain count/snapshot so a self-restart does not wait on its own in-flight agent until the drain timeout.
- Keeps other active sessions in the normal graceful drain path.

## Verification
- `scripts/run_tests.sh tests/gateway/test_gateway_shutdown.py tests/gateway/test_restart_redelivery_dedup.py tests/gateway/test_session_race_guard.py` -> 37 passed
- `python -m py_compile gateway/run.py tests/gateway/test_gateway_shutdown.py tests/gateway/restart_test_helpers.py`
- `git diff --check`

## Overlap check
Searched current PRs for #20694/restart requester drain overlap. Existing restart PRs are adjacent, but no open PR covers excluding the requester session from the drain.