### PR TITLE
fix(feishu): render JSON2 card sentinel as native card

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -162,6 +162,7 @@ _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_FEISHU_CARD_JSON2_SENTINEL = "FEISHU_CARD_JSON_2_0"
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -556,6 +557,87 @@ def _build_markdown_post_payload(content: str) -> str:
         },
         ensure_ascii=False,
     )
+
+
+def _strip_single_markdown_fence(content: str) -> str:
+    """Return inner text when content is wrapped in one markdown fence."""
+    text = (content or "").strip()
+    if not text.startswith("```") or not text.endswith("```"):
+        return text
+    lines = text.splitlines()
+    if len(lines) < 2:
+        return text
+    if not _MARKDOWN_FENCE_OPEN_RE.match(lines[0].strip()):
+        return text
+    if not _MARKDOWN_FENCE_CLOSE_RE.match(lines[-1].strip()):
+        return text
+    return "\n".join(lines[1:-1]).strip()
+
+
+def _extract_feishu_card_json2_payload(content: str) -> Optional[str]:
+    """Extract a raw JSON 2.0 card payload after the Feishu card sentinel.
+
+    The gateway sends normal assistant text as Feishu text/post messages.  For
+    native cards, cron jobs and prompts can return exactly::
+
+        FEISHU_CARD_JSON_2_0
+        { ... JSON 2.0 card ... }
+
+    The JSON may be wrapped in a single markdown code fence, because some model
+    routes fence JSON by habit.  We only accept the sentinel at the very start of
+    the message (or at the start of the single wrapping fence) so ordinary prose
+    that happens to quote the sentinel is never turned into a card.
+    """
+    stripped = (content or "").strip()
+    if not stripped:
+        return None
+
+    candidates = [stripped]
+    unfenced = _strip_single_markdown_fence(stripped)
+    if unfenced != stripped:
+        candidates.append(unfenced)
+
+    for candidate in candidates:
+        if not candidate.startswith(_FEISHU_CARD_JSON2_SENTINEL):
+            continue
+        remainder = candidate[len(_FEISHU_CARD_JSON2_SENTINEL):].lstrip()
+        if not remainder:
+            return None
+        remainder = _strip_single_markdown_fence(remainder)
+        try:
+            payload = json.loads(remainder)
+        except (TypeError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        if str(payload.get("schema", "")).strip() != "2.0":
+            return None
+        if not isinstance(payload.get("body"), dict):
+            return None
+        return json.dumps(payload, ensure_ascii=False)
+    return None
+
+
+def _is_feishu_card_json2_stream(content: str) -> bool:
+    """Return True while a sentinel-prefixed JSON2 card is streaming.
+
+    Once a response starts with the card sentinel, intermediate updates must stay
+    hidden even if the JSON already parses: an edit with a visible cursor suffix
+    would make the payload invalid and leak the raw card text. The final done
+    tick sends the complete content through the normal interactive-card path.
+    """
+    stripped = (content or "").strip()
+    if not stripped:
+        return False
+    candidate = _strip_single_markdown_fence(stripped)
+    if candidate.startswith(_FEISHU_CARD_JSON2_SENTINEL) or _FEISHU_CARD_JSON2_SENTINEL.startswith(candidate):
+        return True
+    lines = stripped.splitlines()
+    if lines and _MARKDOWN_FENCE_OPEN_RE.match(lines[0].strip()):
+        inner = "\n".join(lines[1:]).strip()
+        if inner:
+            return inner.startswith(_FEISHU_CARD_JSON2_SENTINEL) or _FEISHU_CARD_JSON2_SENTINEL.startswith(inner)
+    return False
 
 
 def _build_markdown_post_rows(content: str) -> List[List[Dict[str, str]]]:
@@ -1706,7 +1788,10 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         formatted = self.format_message(content)
-        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        if _extract_feishu_card_json2_payload(formatted) is not None:
+            chunks = [formatted]
+        else:
+            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         last_response = None
 
         try:
@@ -2100,6 +2185,10 @@ class FeishuAdapter(BasePlatformAdapter):
     def format_message(self, content: str) -> str:
         """Feishu text messages are plain text by default."""
         return content.strip()
+
+    def should_buffer_stream_update(self, content: str) -> bool:
+        """Delay partial JSON2 card streams until the final response is available."""
+        return _is_feishu_card_json2_stream(content)
 
     # =========================================================================
     # Inbound event handlers
@@ -4005,6 +4094,10 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+        card_payload = _extract_feishu_card_json2_payload(content)
+        if card_payload is not None:
+            return "interactive", card_payload
+
         # Feishu post-type 'md' elements do not render markdown tables; sending
         # table content as post causes the message to appear blank on the client.
         # Force plain text for anything that looks like a markdown table.

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -346,6 +346,20 @@ class GatewayStreamConsumer:
                         or len(self._accumulated) >= self.cfg.buffer_threshold
                     )
 
+                if should_edit and self._accumulated:
+                    should_buffer_update = getattr(self.adapter, "should_buffer_stream_update", None)
+                    is_mock_buffer_hook = getattr(
+                        getattr(should_buffer_update, "__class__", None),
+                        "__module__",
+                        "",
+                    ).startswith("unittest.mock")
+                    if callable(should_buffer_update) and not is_mock_buffer_hook and not got_done and not got_segment_break:
+                        try:
+                            if should_buffer_update(self._accumulated):
+                                should_edit = False
+                        except Exception:
+                            logger.debug("stream buffer gate failed", exc_info=True)
+
                 current_update_visible = False
                 if should_edit and self._accumulated:
                     # Split overflow: if accumulated text exceeds the platform

--- a/tests/gateway/test_feishu_card_json2.py
+++ b/tests/gateway/test_feishu_card_json2.py
@@ -1,0 +1,176 @@
+"""Tests for Feishu JSON 2.0 card sentinel delivery."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from gateway.platforms.base import SendResult
+
+
+_MINIMAL_CARD = {
+    "schema": "2.0",
+    "config": {"update_multi": True, "width_mode": "fill"},
+    "header": {
+        "title": {"tag": "plain_text", "content": "🚀 AI 潮流玩法雷达"},
+        "template": "turquoise",
+    },
+    "body": {
+        "elements": [
+            {
+                "tag": "markdown",
+                "element_id": "m_top",
+                "content": "30秒结论\n- Hermes no_agent cron 值得看",
+            }
+        ]
+    },
+}
+
+
+def _sentinel_payload(card: dict | None = None) -> str:
+    return "FEISHU_CARD_JSON_2_0\n" + json.dumps(card or _MINIMAL_CARD, ensure_ascii=False)
+
+
+def test_feishu_card_json2_sentinel_builds_interactive_payload():
+    from gateway.platforms.feishu import FeishuAdapter
+
+    adapter = object.__new__(FeishuAdapter)
+
+    msg_type, payload = adapter._build_outbound_payload(_sentinel_payload())
+
+    assert msg_type == "interactive"
+    assert json.loads(payload) == _MINIMAL_CARD
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "```\n" + _sentinel_payload() + "\n```",
+        "```json\n" + _sentinel_payload() + "\n```",
+        "FEISHU_CARD_JSON_2_0\n```json\n" + json.dumps(_MINIMAL_CARD, ensure_ascii=False) + "\n```",
+    ],
+)
+def test_feishu_card_json2_sentinel_accepts_wrapping_code_fences(content):
+    from gateway.platforms.feishu import FeishuAdapter
+
+    adapter = object.__new__(FeishuAdapter)
+
+    msg_type, payload = adapter._build_outbound_payload(content)
+
+    assert msg_type == "interactive"
+    assert json.loads(payload) == _MINIMAL_CARD
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "FEISHU_CARD_JSON_2_0\nnot-json",
+        "FEISHU_CARD_JSON_2_0\n[]",
+        _sentinel_payload({"schema": "1.0", "elements": []}),
+        "Here is a card:\n" + _sentinel_payload(),
+    ],
+)
+def test_feishu_card_json2_invalid_or_prefaced_content_is_not_interactive(content):
+    from gateway.platforms.feishu import FeishuAdapter
+
+    adapter = object.__new__(FeishuAdapter)
+
+    msg_type, _payload = adapter._build_outbound_payload(content)
+
+    assert msg_type != "interactive"
+
+
+@pytest.mark.asyncio
+async def test_feishu_card_json2_send_does_not_split_large_card():
+    from gateway.platforms.feishu import FeishuAdapter
+
+    class _Adapter(FeishuAdapter):
+        def __init__(self):
+            self._client = object()
+            self.calls = []
+
+        async def _feishu_send_with_retry(self, **kwargs):
+            self.calls.append(kwargs)
+            return type("Response", (), {
+                "success": lambda self: True,
+                "data": type("Data", (), {"message_id": "om_card"})(),
+            })()
+
+    large_card = dict(_MINIMAL_CARD)
+    large_card["body"] = {
+        "elements": [
+            {
+                "tag": "markdown",
+                "element_id": "m_big",
+                "content": "x" * 9000,
+            }
+        ]
+    }
+    adapter = _Adapter()
+
+    result = await adapter.send("oc_chat", _sentinel_payload(large_card))
+
+    assert result.success is True
+    assert len(adapter.calls) == 1
+    assert adapter.calls[0]["msg_type"] == "interactive"
+    assert json.loads(adapter.calls[0]["payload"])["body"]["elements"][0]["content"] == "x" * 9000
+
+
+class _FakeFeishuAdapter:
+    MAX_MESSAGE_LENGTH = 4096
+    SUPPORTS_MESSAGE_EDITING = True
+
+    def __init__(self):
+        self.sent: list[str] = []
+        self.edited: list[str] = []
+
+    def should_buffer_stream_update(self, content: str) -> bool:
+        from gateway.platforms.feishu import FeishuAdapter
+
+        return FeishuAdapter.should_buffer_stream_update(self, content)
+
+    def truncate_message(self, text: str, _limit: int) -> list[str]:
+        return [text]
+
+    async def send(self, chat_id: str, content: str, **_kwargs) -> SendResult:
+        self.sent.append(content)
+        return SendResult(success=True, message_id=f"om_{len(self.sent)}")
+
+    async def edit_message(self, chat_id: str, message_id: str, content: str, **_kwargs) -> SendResult:
+        self.edited.append(content)
+        return SendResult(success=True, message_id=message_id)
+
+
+@pytest.mark.parametrize(
+    "deltas, expected_final",
+    [
+        (["FEISHU_CARD_JSON_2_0\n", json.dumps(_MINIMAL_CARD, ensure_ascii=False)], _sentinel_payload()),
+        (["```json\nFEISHU_CARD_JSON_2_0\n", json.dumps(_MINIMAL_CARD, ensure_ascii=False), "\n```"], "```json\n" + _sentinel_payload() + "\n```"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_stream_consumer_buffers_feishu_card_json2_until_done(deltas, expected_final):
+    from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+    adapter = _FakeFeishuAdapter()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "oc_chat",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=" ▉"),
+    )
+    task = asyncio.create_task(consumer.run())
+
+    for delta in deltas:
+        consumer.on_delta(delta)
+        await asyncio.sleep(0.08)
+        assert adapter.sent == []
+        assert adapter.edited == []
+
+    consumer.finish()
+    await asyncio.wait_for(task, timeout=1)
+
+    assert adapter.sent == [expected_final]
+    assert adapter.edited == []
+    assert consumer.final_response_sent is True


### PR DESCRIPTION
## Summary
- Detect `FEISHU_CARD_JSON_2_0` responses and send the following JSON 2.0 object as a native Feishu `interactive` card instead of plain text/post markdown
- Accept common model wrapping patterns, including a single fenced JSON block around the sentinel or around the JSON payload
- Buffer sentinel-prefixed Feishu streams until the final response so partial JSON/card text is not leaked with the streaming cursor
- Avoid splitting large card JSON payloads via text chunking before sending

## Test Plan
- `/usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/gateway/test_feishu_card_json2.py tests/gateway/test_stream_consumer.py -q -o 'addopts='`
- `/usr/local/lib/hermes-agent/venv/bin/python -m pytest tests/gateway/test_feishu_card_json2.py tests/gateway/test_feishu_bot_admission.py -q -o 'addopts='`
- `/usr/local/lib/hermes-agent/venv/bin/python -m py_compile gateway/platforms/feishu.py gateway/stream_consumer.py tests/gateway/test_feishu_card_json2.py`
- `git diff --check`
