### PR TITLE
Fix dashboard cron schedule submission

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15,6 +15,7 @@ import importlib.util
 import json
 import logging
 import os
+import re
 import secrets
 import subprocess
 import sys
@@ -2287,6 +2288,22 @@ class CronJobUpdate(BaseModel):
     updates: dict
 
 
+def _normalize_dashboard_cron_schedule(schedule: str) -> str:
+    """Normalize schedule text submitted through the dashboard/API boundary."""
+    normalized = " ".join(str(schedule or "").strip().split())
+    time_match = re.fullmatch(r"(\d{1,2}):(\d{2})", normalized)
+    if not time_match:
+        return normalized
+
+    hour = int(time_match.group(1))
+    minute = int(time_match.group(2))
+    if hour > 23 or minute > 59:
+        raise ValueError(
+            f"Invalid daily time schedule '{normalized}'. Use HH:MM from 00:00 to 23:59"
+        )
+    return f"{minute} {hour} * * *"
+
+
 @app.get("/api/cron/jobs")
 async def list_cron_jobs():
     from cron.jobs import list_jobs
@@ -2306,7 +2323,8 @@ async def get_cron_job(job_id: str):
 async def create_cron_job(body: CronJobCreate):
     from cron.jobs import create_job
     try:
-        job = create_job(prompt=body.prompt, schedule=body.schedule,
+        schedule = _normalize_dashboard_cron_schedule(body.schedule)
+        job = create_job(prompt=body.prompt, schedule=schedule,
                          name=body.name, deliver=body.deliver)
         return job
     except Exception as e:
@@ -2883,7 +2901,6 @@ async def get_models_analytics(days: int = 30):
 # though uvicorn binds to 127.0.0.1.
 # ---------------------------------------------------------------------------
 
-import re
 import asyncio
 
 from hermes_cli.pty_bridge import PtyBridge, PtyUnavailableError

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -591,6 +591,54 @@ class TestNewEndpoints:
         resp = self.client.get("/api/cron/jobs/nonexistent-id")
         assert resp.status_code == 404
 
+    def test_cron_create_preserves_spaced_cron_expression(self, monkeypatch):
+        import cron.jobs as cron_jobs
+
+        captured = {}
+
+        def fake_create_job(**kwargs):
+            captured.update(kwargs)
+            return {"id": "job-1", **kwargs}
+
+        monkeypatch.setattr(cron_jobs, "create_job", fake_create_job)
+
+        resp = self.client.post(
+            "/api/cron/jobs",
+            json={
+                "prompt": "Send digest",
+                "schedule": "30    9   *   *   *",
+                "name": "Digest",
+                "deliver": "local",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert captured["schedule"] == "30 9 * * *"
+
+    def test_cron_create_converts_daily_time_to_cron_expression(self, monkeypatch):
+        import cron.jobs as cron_jobs
+
+        captured = {}
+
+        def fake_create_job(**kwargs):
+            captured.update(kwargs)
+            return {"id": "job-1", **kwargs}
+
+        monkeypatch.setattr(cron_jobs, "create_job", fake_create_job)
+
+        resp = self.client.post(
+            "/api/cron/jobs",
+            json={
+                "prompt": "Send digest",
+                "schedule": "09:30",
+                "name": "Digest",
+                "deliver": "local",
+            },
+        )
+
+        assert resp.status_code == 200
+        assert captured["schedule"] == "30 9 * * *"
+
     # --- Profiles ---
 
     def test_profiles_list_includes_default(self):

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -23,6 +23,17 @@ function formatTime(iso?: string | null): string {
   return d.toLocaleString();
 }
 
+function normalizeScheduleForCreate(value: string): string {
+  const normalized = value.trim().replace(/\s+/g, " ");
+  const timeMatch = normalized.match(/^(\d{1,2}):(\d{2})$/);
+  if (!timeMatch) return normalized;
+
+  const hour = Number(timeMatch[1]);
+  const minute = Number(timeMatch[2]);
+  if (hour > 23 || minute > 59) return normalized;
+  return `${minute} ${hour} * * *`;
+}
+
 const STATUS_TONE: Record<string, "success" | "warning" | "destructive"> = {
   enabled: "success",
   scheduled: "success",
@@ -57,7 +68,8 @@ export default function CronPage() {
   }, [loadJobs]);
 
   const handleCreate = async () => {
-    if (!prompt.trim() || !schedule.trim()) {
+    const normalizedSchedule = normalizeScheduleForCreate(schedule);
+    if (!prompt.trim() || !normalizedSchedule) {
       showToast(`${t.cron.prompt} & ${t.cron.schedule} required`, "error");
       return;
     }
@@ -65,7 +77,7 @@ export default function CronPage() {
     try {
       await api.createCronJob({
         prompt: prompt.trim(),
-        schedule: schedule.trim(),
+        schedule: normalizedSchedule,
         name: name.trim() || undefined,
         deliver,
       });
@@ -202,6 +214,10 @@ export default function CronPage() {
                 <Label htmlFor="cron-schedule">{t.cron.schedule}</Label>
                 <Input
                   id="cron-schedule"
+                  type="text"
+                  inputMode="text"
+                  autoComplete="off"
+                  spellCheck={false}
                   placeholder={t.cron.schedulePlaceholder}
                   value={schedule}
                   onChange={(e) => setSchedule(e.target.value)}


### PR DESCRIPTION
## Summary
- normalize dashboard/API cron schedule text before creating jobs so spaced cron expressions are preserved
- convert daily time input like `09:30` to `30 9 * * *` on both the dashboard and API boundary
- force the dashboard schedule field to remain a plain text input without autocomplete interference

## Why This Matters
Issue [#20610](https://github.com/NousResearch/hermes-agent/issues/20610) reports that dashboard cron creation mis-parses schedules so the backend receives only the hour fragment. This PR keeps the fix narrowly on the dashboard/API boundary: preserve spaced cron expressions, normalize daily-time input before submission, and avoid autocomplete interference in the schedule field without broad scheduler or UI redesign.

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -k cron` -> 4 passed, 4 warnings
- `python -m py_compile hermes_cli/web_server.py`
- `git diff --check`

## Note
- `npm run build` could not be completed locally because this checkout's web dependencies are incomplete and `npm ci` is blocked by local npm/proxy configuration while fetching `zustand` (`fetch() proxy.url must be a non-empty string`).

Closes NousResearch/hermes-agent#20610
