### PR TITLE
fix(agent): redact secrets from assistant output

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -147,6 +147,7 @@ from agent.model_metadata import (
     query_ollama_num_ctx,
 )
 from agent.context_compressor import ContextCompressor
+from agent.redact import redact_sensitive_text
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, build_environment_hints, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
@@ -6665,6 +6666,11 @@ class AIAgent:
             return ""
         return re.sub(r"\s+", " ", text).strip()
 
+    @staticmethod
+    def _redact_agent_output_text(text: Any) -> Any:
+        """Redact secrets at user-facing assistant output boundaries."""
+        return redact_sensitive_text(text, force=True)
+
     def _interim_content_was_streamed(self, content: str) -> bool:
         visible_content = self._normalize_interim_visible_text(
             self._strip_think_blocks(content or "")
@@ -6685,6 +6691,7 @@ class AIAgent:
         visible = self._strip_think_blocks(content or "").strip()
         if not visible or visible == "(empty)":
             return
+        visible = self._redact_agent_output_text(visible)
         already_streamed = self._interim_content_was_streamed(visible)
         try:
             cb(visible, already_streamed=already_streamed)
@@ -6731,6 +6738,7 @@ class AIAgent:
                 self, "_current_streamed_assistant_text", ""
             ):
                 text = text.lstrip("\n")
+            text = self._redact_agent_output_text(text)
         if not text:
             return
         callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
@@ -6749,7 +6757,7 @@ class AIAgent:
         cb = self.reasoning_callback
         if cb is not None:
             try:
-                cb(text)
+                cb(self._redact_agent_output_text(text))
             except Exception:
                 pass
 
@@ -8784,7 +8792,11 @@ class AIAgent:
                 reasoning_text = combined or None
 
         if reasoning_text and self.verbose_logging:
-            logging.debug(f"Captured reasoning ({len(reasoning_text)} chars): {reasoning_text}")
+            logging.debug(
+                "Captured reasoning (%d chars): %s",
+                len(reasoning_text),
+                self._redact_agent_output_text(reasoning_text),
+            )
 
         if reasoning_text and self.reasoning_callback:
             # Skip callback when streaming is active — reasoning was already
@@ -8797,7 +8809,7 @@ class AIAgent:
             # CLI post-response display fallback (cli.py _reasoning_shown_this_turn).
             if not self.stream_delta_callback and not self._stream_callback:
                 try:
-                    self.reasoning_callback(reasoning_text)
+                    self.reasoning_callback(self._redact_agent_output_text(reasoning_text))
                 except Exception:
                     pass
 
@@ -8821,6 +8833,9 @@ class AIAgent:
         # compression, title generation.
         if isinstance(_san_content, str) and _san_content:
             _san_content = self._strip_think_blocks(_san_content).strip()
+            _san_content = self._redact_agent_output_text(_san_content)
+        if reasoning_text:
+            reasoning_text = self._redact_agent_output_text(reasoning_text)
 
         msg = {
             "role": "assistant",
@@ -8835,7 +8850,9 @@ class AIAgent:
             if isinstance(model_extra, dict) and "reasoning_content" in model_extra:
                 raw_reasoning_content = model_extra["reasoning_content"]
         if raw_reasoning_content is not None:
-            msg["reasoning_content"] = _sanitize_surrogates(raw_reasoning_content)
+            msg["reasoning_content"] = self._redact_agent_output_text(
+                _sanitize_surrogates(raw_reasoning_content)
+            )
         elif assistant_tool_calls and self._needs_thinking_reasoning_pad():
             # DeepSeek v4 thinking mode and Kimi / Moonshot thinking mode
             # both require reasoning_content on every assistant tool-call
@@ -10514,6 +10531,7 @@ class AIAgent:
             if final_response:
                 if "<think>" in final_response:
                     final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
+                final_response = self._redact_agent_output_text(final_response)
                 if final_response:
                     messages.append({"role": "assistant", "content": final_response})
                 else:
@@ -10557,6 +10575,7 @@ class AIAgent:
                 if final_response:
                     if "<think>" in final_response:
                         final_response = re.sub(r'<think>.*?</think>\s*', '', final_response, flags=re.DOTALL).strip()
+                    final_response = self._redact_agent_output_text(final_response)
                     if final_response:
                         messages.append({"role": "assistant", "content": final_response})
                     else:
@@ -10568,7 +10587,7 @@ class AIAgent:
             logging.warning(f"Failed to get summary response: {e}")
             final_response = f"I reached the maximum iterations ({self.max_iterations}) but couldn't summarize. Error: {str(e)}"
 
-        return final_response
+        return self._redact_agent_output_text(final_response)
 
     def run_conversation(
         self,
@@ -13886,7 +13905,9 @@ class AIAgent:
                         truncated_response_prefix = ""
                         length_continue_retries = 0
                     
-                    final_response = self._strip_think_blocks(final_response).strip()
+                    final_response = self._redact_agent_output_text(
+                        self._strip_think_blocks(final_response).strip()
+                    )
                     
                     final_msg = self._build_assistant_message(assistant_message, finish_reason)
 
@@ -13953,7 +13974,9 @@ class AIAgent:
                 # If we're near the limit, break to avoid infinite loops
                 if api_call_count >= self.max_iterations - 1:
                     _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
-                    final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
+                    final_response = self._redact_agent_output_text(
+                        f"I apologize, but I encountered repeated errors: {error_msg}"
+                    )
                     # Append as assistant so the history stays valid for
                     # session resume (avoids consecutive user messages).
                     messages.append({"role": "assistant", "content": final_response})
@@ -13977,6 +14000,9 @@ class AIAgent:
                     "— requesting summary..."
                 )
             final_response = self._handle_max_iterations(messages, api_call_count)
+
+        if final_response:
+            final_response = self._redact_agent_output_text(final_response)
         
         # Determine if conversation completed successfully
         completed = final_response is not None and api_call_count < self.max_iterations

--- a/tests/run_agent/test_agent_output_redaction.py
+++ b/tests/run_agent/test_agent_output_redaction.py
@@ -1,0 +1,83 @@
+from types import SimpleNamespace
+
+import run_agent
+
+
+def _agent():
+    agent = run_agent.AIAgent.__new__(run_agent.AIAgent)
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent.interim_assistant_callback = None
+    agent._stream_callback = None
+    agent._stream_needs_break = False
+    agent._current_streamed_assistant_text = ""
+    agent._stream_think_scrubber = None
+    agent._stream_context_scrubber = None
+    agent.verbose_logging = False
+    return agent
+
+
+def test_stream_delta_force_redacts_secret_before_callbacks():
+    agent = _agent()
+    observed = []
+    agent.stream_delta_callback = observed.append
+
+    agent._fire_stream_delta("Use OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012 now")
+
+    assert observed == ["Use OPENAI_API_KEY=*** now"]
+    assert "abc123def456ghi789jk" not in observed[0]
+
+
+def test_reasoning_delta_force_redacts_secret_before_callback():
+    agent = _agent()
+    observed = []
+    agent.reasoning_callback = observed.append
+
+    agent._fire_reasoning_delta("I saw Authorization: Bearer sk-proj-abc123def456ghi789jkl012")
+
+    assert observed == ["I saw Authorization: Bearer ***"]
+    assert "abc123def456ghi789jk" not in observed[0]
+
+
+def test_interim_assistant_callback_force_redacts_secret():
+    agent = _agent()
+    observed = {}
+    agent.interim_assistant_callback = lambda text, *, already_streamed=False: observed.update(
+        {"text": text, "already_streamed": already_streamed}
+    )
+
+    agent._emit_interim_assistant_message(
+        {
+            "role": "assistant",
+            "content": "Found api_key='sk-proj-abc123def456ghi789jkl012' in config.",
+        }
+    )
+
+    assert observed == {
+        "text": "Found api_key='sk-pro...l012' in config.",
+        "already_streamed": False,
+    }
+    assert "abc123def456ghi789jk" not in observed["text"]
+
+
+def test_build_assistant_message_force_redacts_stored_content_and_reasoning():
+    agent = _agent()
+    observed_reasoning = []
+    agent.reasoning_callback = observed_reasoning.append
+
+    msg = SimpleNamespace(
+        content="The key is OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012",
+        tool_calls=None,
+        reasoning_content="Need to avoid leaking sk-proj-reason123456789abcdefghijkl",
+        reasoning=None,
+        reasoning_details=None,
+    )
+
+    built = agent._build_assistant_message(msg, "stop")
+
+    assert built["content"] == "The key is OPENAI_API_KEY=***"
+    assert built["reasoning"] == "Need to avoid leaking sk-pro...ijkl"
+    assert built["reasoning_content"] == "Need to avoid leaking sk-pro...ijkl"
+    assert observed_reasoning == ["Need to avoid leaking sk-pro...ijkl"]
+    assert "abc123def456ghi789jk" not in built["content"]
+    assert "reason123456789abcde" not in built["reasoning"]


### PR DESCRIPTION
## Summary
- force existing secret redaction at assistant output boundaries even when general log redaction is disabled
- redact streamed deltas, interim assistant commentary, reasoning callbacks, stored assistant content/reasoning, and iteration-limit summaries
- add focused regressions for visible output, reasoning output, interim callbacks, and stored assistant messages

## Why This Matters
Issue [#20785](https://github.com/NousResearch/hermes-agent/issues/20785) reports systemic secret leakage in assistant-visible output paths. This PR keeps the response scoped to that boundary: force redaction on streamed deltas, interim commentary, reasoning callbacks, persisted assistant content, and iteration-limit summaries even when broader log-redaction settings are off.

## Verification
- `scripts/run_tests.sh tests/run_agent/test_agent_output_redaction.py`
- `scripts/run_tests.sh tests/run_agent/test_agent_output_redaction.py tests/cli/test_reasoning_command.py::TestReasoningDeltasFiredFlag tests/run_agent/test_run_agent_codex_responses.py::test_stream_delta_strips_leaked_memory_context tests/run_agent/test_run_agent_codex_responses.py::test_stream_delta_strips_leaked_memory_context_across_chunks tests/run_agent/test_run_agent_codex_responses.py::test_interim_commentary_is_not_marked_already_streamed_without_callbacks tests/run_agent/test_run_agent_codex_responses.py::test_interim_commentary_is_not_marked_already_streamed_when_stream_callback_fails tests/run_agent/test_run_agent_codex_responses.py::test_interim_commentary_preserves_assistant_content`
- `scripts/run_tests.sh tests/agent/test_redact.py tests/run_agent/test_agent_output_redaction.py`
- `python -m py_compile run_agent.py tests/run_agent/test_agent_output_redaction.py`
- `git diff --check`

Closes NousResearch/hermes-agent#20785
