### PR TITLE
fix(mcp): preserve image content blocks

### DIFF
--- a/tests/tools/test_mcp_structured_content.py
+++ b/tests/tools/test_mcp_structured_content.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import pathlib
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -11,11 +12,20 @@ from tools import mcp_tool
 
 
 class _FakeContentBlock:
-    """Minimal content block with .text and .type attributes."""
+    """Minimal text content block with .text and .type attributes."""
 
     def __init__(self, text: str, block_type: str = "text"):
         self.text = text
         self.type = block_type
+
+
+class _FakeImageContentBlock:
+    """Minimal image content block with MCP ImageContent attributes."""
+
+    def __init__(self, data: str, mime_type: str = "image/png"):
+        self.type = "image"
+        self.data = data
+        self.mimeType = mime_type
 
 
 class _FakeCallToolResult:
@@ -140,3 +150,36 @@ class TestStructuredContentPreservation:
         raw = handler({})
         data = json.loads(raw)
         assert data["result"] == payload
+
+    def test_image_content_blocks_are_preserved(self, _patch_mcp_server, tmp_path, monkeypatch):
+        """Image blocks from MCP tool results are materialized and surfaced."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        session = _patch_mcp_server
+        image_bytes = b"fake-png-bytes"
+        image_b64 = "ZmFrZS1wbmctYnl0ZXM="
+        session.call_tool = AsyncMock(
+            return_value=_FakeCallToolResult(
+                content=[
+                    _FakeContentBlock("metadata"),
+                    _FakeImageContentBlock(image_b64, "image/png"),
+                ],
+            )
+        )
+
+        handler = mcp_tool._make_tool_handler("test-server", "my-tool", 30.0)
+        raw = handler({})
+        data = json.loads(raw)
+
+        assert data["result"] == "metadata"
+        assert data["content_blocks"] == [
+            {
+                "type": "image",
+                "mimeType": "image/png",
+                "path": data["content_blocks"][0]["path"],
+                "size_bytes": len(image_bytes),
+            }
+        ]
+        image_path = data["content_blocks"][0]["path"]
+        assert image_path.endswith(".png")
+        assert (tmp_path / "cache" / "mcp").resolve() in pathlib.Path(image_path).resolve().parents
+        assert pathlib.Path(image_path).read_bytes() == image_bytes

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -70,11 +70,14 @@ Thread safety:
 """
 
 import asyncio
+import base64
+import binascii
 import concurrent.futures
 import inspect
 import json
 import logging
 import math
+import mimetypes
 import os
 import re
 import shutil
@@ -1927,6 +1930,66 @@ def _interrupted_call_result() -> str:
     }, ensure_ascii=False)
 
 
+def _safe_mcp_name(value: str) -> str:
+    """Return a filesystem-safe fragment for MCP cache paths."""
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(value)).strip(".-")
+    return safe or "mcp"
+
+
+def _extension_for_mime_type(mime_type: str) -> str:
+    """Return a stable file extension for an MCP image MIME type."""
+    normalized = (mime_type or "application/octet-stream").split(";", 1)[0].strip().lower()
+    explicit = {
+        "image/jpeg": ".jpg",
+        "image/png": ".png",
+        "image/gif": ".gif",
+        "image/webp": ".webp",
+        "image/svg+xml": ".svg",
+        "image/bmp": ".bmp",
+    }
+    if normalized in explicit:
+        return explicit[normalized]
+    guessed = mimetypes.guess_extension(normalized) or ".bin"
+    return ".jpg" if guessed == ".jpe" else guessed
+
+
+def _materialize_mcp_image_block(block, server_name: str, tool_name: str) -> Dict[str, Any]:
+    """Persist an MCP ImageContent block and return JSON-safe metadata."""
+    mime_type = str(getattr(block, "mimeType", "application/octet-stream") or "application/octet-stream")
+    raw_data = getattr(block, "data", "")
+    try:
+        if isinstance(raw_data, bytes):
+            raw_data = raw_data.decode("ascii")
+        image_bytes = base64.b64decode(str(raw_data), validate=True)
+    except (binascii.Error, UnicodeDecodeError, ValueError) as exc:
+        logger.warning(
+            "MCP server '%s' tool '%s' returned invalid image data: %s",
+            server_name,
+            tool_name,
+            exc,
+        )
+        return {
+            "type": "image",
+            "mimeType": mime_type,
+            "error": "invalid base64 image data",
+        }
+
+    from hermes_constants import get_hermes_home
+
+    cache_dir = get_hermes_home() / "cache" / "mcp" / _safe_mcp_name(server_name)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    ext = _extension_for_mime_type(mime_type)
+    filename = f"{int(time.time_ns())}-{_safe_mcp_name(tool_name)}{ext}"
+    path = cache_dir / filename
+    path.write_bytes(image_bytes)
+    return {
+        "type": "image",
+        "mimeType": mime_type,
+        "path": str(path),
+        "size_bytes": len(image_bytes),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Config loading
 # ---------------------------------------------------------------------------
@@ -2054,11 +2117,18 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     )
                 }, ensure_ascii=False)
 
-            # Collect text from content blocks
+            # Collect model-oriented content blocks. Text remains the primary
+            # result for backward compatibility; binary image blocks are
+            # materialized to cache files and surfaced as JSON metadata.
             parts: List[str] = []
+            content_blocks: List[Dict[str, Any]] = []
             for block in (result.content or []):
                 if hasattr(block, "text"):
                     parts.append(block.text)
+                elif hasattr(block, "data") and hasattr(block, "mimeType"):
+                    content_blocks.append(
+                        _materialize_mcp_image_block(block, server_name, tool_name)
+                    )
             text_result = "\n".join(parts) if parts else ""
 
             # Combine content + structuredContent when both are present.
@@ -2068,12 +2138,17 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             structured = getattr(result, "structuredContent", None)
             if structured is not None:
                 if text_result:
-                    return json.dumps({
+                    payload = {
                         "result": text_result,
                         "structuredContent": structured,
-                    }, ensure_ascii=False)
-                return json.dumps({"result": structured}, ensure_ascii=False)
-            return json.dumps({"result": text_result}, ensure_ascii=False)
+                    }
+                else:
+                    payload = {"result": structured}
+            else:
+                payload = {"result": text_result}
+            if content_blocks:
+                payload["content_blocks"] = content_blocks
+            return json.dumps(payload, ensure_ascii=False)
 
         def _call_once():
             return _run_on_mcp_loop(_call(), timeout=tool_timeout)


### PR DESCRIPTION
## What does this PR do?

Preserves MCP `ImageContent` blocks returned from `tools/call` results instead of silently dropping them.

Hermes already preserved text content and `structuredContent`, but MCP servers that return images (for example design/reference tools) could send valid image blocks that never reached the agent. This change materializes image blocks under `$HERMES_HOME/cache/mcp/<server>/` and includes JSON-safe metadata in the tool result, while keeping the existing text-first result shape unchanged.

## Related Issue

N/A — found while testing an MCP server that returns screen-search metadata plus image content.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_tool.py`
  - Detects MCP content blocks with `data` + `mimeType`.
  - Base64-decodes and writes images to `$HERMES_HOME/cache/mcp/<server>/`.
  - Adds a `content_blocks` array with image `mimeType`, local `path`, and `size_bytes` metadata.
  - Preserves existing `result` and `structuredContent` behavior for text-only and structured responses.
- `tests/tools/test_mcp_structured_content.py`
  - Adds regression coverage proving image content blocks are materialized and surfaced.

## How to Test

1. Run the regression test before the fix and confirm it fails because `content_blocks` is missing.
2. Run the targeted test suite:
   - `scripts/run_tests.sh tests/tools/test_mcp_structured_content.py tests/tools/test_mcp_tool.py`
3. Run the MCP tool suite:
   - `scripts/run_tests.sh tests/tools/test_mcp_*.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / Ubuntu-compatible environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Regression test fails on main before the fix:

```text
KeyError: 'content_blocks'
```

Validation after the fix:

```text
scripts/run_tests.sh tests/tools/test_mcp_structured_content.py::TestStructuredContentPreservation::test_image_content_blocks_are_preserved
1 passed

scripts/run_tests.sh tests/tools/test_mcp_structured_content.py tests/tools/test_mcp_tool.py
188 passed

scripts/run_tests.sh tests/tools/test_mcp_*.py
317 passed, 1 warning

python -m py_compile tools/mcp_tool.py tests/tools/test_mcp_structured_content.py
passed

git diff --check
passed
```

The one warning is pre-existing in `tests/tools/test_mcp_probe.py::TestProbeMcpServerTools::test_skips_disabled_servers` (`coroutine ... was never awaited`) and is unrelated to this change.
