### PR TITLE
fix: preserve DeepSeek's UUID-signed thinking blocks on multi-turn

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import platform
+import re
 import subprocess
 from pathlib import Path
 
@@ -460,6 +461,28 @@ def _is_deepseek_anthropic_endpoint(base_url: str | None) -> bool:
     if not normalized:
         return False
     return "/anthropic" in normalized.rstrip("/").lower()
+
+
+_DEEPSEEK_UUID_SIGNATURE_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+def _is_deepseek_thinking_signature(sig: str | None) -> bool:
+    """Return True for DeepSeek's own thinking signatures (UUID format).
+
+    DeepSeek's /anthropic endpoint signs thinking blocks with the message id
+    (8-4-4-4-12 hex UUID). Anthropic-proprietary signatures are base64 long
+    strings. Distinguishing by format lets us preserve DeepSeek's own signed
+    blocks (DeepSeek self-validates) while still stripping Anthropic-signed
+    blocks that may have leaked through (DeepSeek can't validate Anthropic's).
+
+    Observation: signature value equals message id (e.g.
+    "91cfbb94-554b-4136-8e21-fa02280d56ed"), 2026-05+. See #16748.
+    """
+    if not sig:
+        return False
+    return bool(_DEEPSEEK_UUID_SIGNATURE_RE.match(sig.lower()))
 
 
 def _requires_bearer_auth(base_url: str | None) -> bool:
@@ -1691,20 +1714,35 @@ def convert_messages_to_anthropic(
 
         if _preserve_unsigned_thinking:
             # Kimi's /coding and DeepSeek's /anthropic endpoints both enable
-            # thinking server-side and require unsigned thinking blocks on
-            # replayed assistant tool-call messages.  Strip signed Anthropic
-            # blocks (neither upstream can validate Anthropic signatures) but
-            # preserve the unsigned ones we synthesised from reasoning_content.
+            # thinking server-side and require thinking blocks to round-trip
+            # on replayed assistant tool-call messages.
+            #
+            # Kimi: keep unsigned thinking (synthesised from reasoning_content),
+            # strip Anthropic-signed blocks (Kimi can't validate them).
+            #
+            # DeepSeek: also keep DeepSeek-own-signed blocks (UUID format =
+            # message id, not Anthropic's base64). DeepSeek self-validates
+            # these on replay; stripping causes "content[].thinking must be
+            # passed back" 400s. Anthropic-signed leaks (e.g. base64 sig)
+            # still get stripped — DeepSeek can't validate Anthropic's.
+            # See hermes-agent#16748 (originally documented as unsigned, but
+            # 2026-05+ responses include UUID-format DeepSeek signatures).
+            is_deepseek = _is_deepseek_anthropic_endpoint(base_url)
             new_content = []
             for b in m["content"]:
                 if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
                     new_content.append(b)
                     continue
-                if b.get("signature") or b.get("data"):
-                    # Anthropic-signed block — upstream can't validate, strip
+                sig = b.get("signature")
+                if sig or b.get("data"):
+                    if is_deepseek and _is_deepseek_thinking_signature(sig):
+                        # DeepSeek's own UUID signature — keep, DeepSeek validates
+                        new_content.append(b)
+                        continue
+                    # Anthropic-signed block (base64) or other unrecognized —
+                    # neither Kimi nor DeepSeek can validate, strip.
                     continue
-                # Unsigned thinking (synthesised from reasoning_content) —
-                # keep it: the upstream needs it for message-history validation.
+                # Unsigned thinking (synthesised from reasoning_content) — keep
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
         elif _is_third_party or idx != last_assistant_idx:

--- a/tests/agent/test_deepseek_anthropic_thinking.py
+++ b/tests/agent/test_deepseek_anthropic_thinking.py
@@ -240,3 +240,43 @@ class TestDeepSeekAnthropicPreservesThinking:
             "Non-DeepSeek third-party endpoints must keep the generic "
             "strip-all-thinking behaviour — unsigned blocks get rejected."
         )
+
+    def test_signed_thinking_block_survives_replay(self) -> None:
+        """DeepSeek returns thinking with its OWN UUID signature (= message id).
+        DeepSeek self-validates on replay; stripping causes 400. Bug observed
+        2026-05-07 multi-turn session 20260507_115607_60c148: 7th turn 400'd
+        because Hermes treated DeepSeek's UUID signature as Anthropic-signed
+        and stripped it. Signed thinking must survive for DeepSeek.
+        """
+        from agent.anthropic_adapter import convert_messages_to_anthropic
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "the user said hi",
+                        "signature": "91cfbb94-554b-4136-8e21-fa02280d56ed",
+                    },
+                    {"type": "text", "text": "Hi there!"},
+                ],
+            },
+            {"role": "user", "content": "follow up"},
+        ]
+        _system, converted = convert_messages_to_anthropic(
+            messages, base_url="https://api.deepseek.com/anthropic"
+        )
+        assistant_msg = next(m for m in converted if m["role"] == "assistant")
+        thinking_blocks = [
+            b for b in assistant_msg["content"]
+            if isinstance(b, dict) and b.get("type") == "thinking"
+        ]
+        assert len(thinking_blocks) == 1, (
+            "DeepSeek-signed thinking block must be preserved; got "
+            f"{thinking_blocks!r}"
+        )
+        assert thinking_blocks[0].get("signature") == (
+            "91cfbb94-554b-4136-8e21-fa02280d56ed"
+        ), "Signature should be preserved verbatim for DeepSeek to validate."


### PR DESCRIPTION
## Summary

DeepSeek's `/anthropic` endpoint signs thinking blocks with the **message id (UUID format)**, not Anthropic's base64 signatures. The carve-out introduced in #16748 assumed DeepSeek thinking was unsigned and stripped any block with a `signature` field — including DeepSeek's own. Multi-turn requests then fail at turn 5–7 with:

```
Error code: 400 - {'error': {'message': 'The `content[].thinking` in the thinking mode must be passed back to the API.', 'type': 'invalid_request_error', ...}}
```

## Repro

```bash
curl -s -X POST https://api.deepseek.com/anthropic/v1/messages \
  -H "x-api-key: $KEY" \
  -H "anthropic-version: 2023-06-01" \
  -d '{"model":"deepseek-v4-pro","max_tokens":150,"thinking":{"type":"enabled","budget_tokens":100},"messages":[{"role":"user","content":"hi"}]}'
```

Returns:
```json
{
  "id": "91cfbb94-554b-4136-8e21-fa02280d56ed",
  "content": [
    {"type": "thinking", "thinking": "...", "signature": "91cfbb94-554b-4136-8e21-fa02280d56ed"},
    {"type": "text", "text": "..."}
  ]
}
```

Note: `signature` value equals `id`. Anthropic's signatures are long base64 strings — distinguishable by format.

Hit this in production at session `20260507_115607_60c148`, turn 7.

## Fix

- New helper `_is_deepseek_thinking_signature()` matches DeepSeek's own signatures via UUID regex (`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`).
- In `_preserve_unsigned_thinking`, on DeepSeek endpoint preserve thinking blocks whose signature matches the UUID format (DeepSeek self-validates these); continue to strip Anthropic-signed blocks (DeepSeek can't validate those).
- Kimi `/coding` behavior unchanged.

The `_is_deepseek_anthropic_endpoint` docstring originally noted "blocks are unsigned" — this was true at the time of #16748 but stopped being true sometime in 2026-05+. The fix is forward-compatible: if DeepSeek goes back to unsigned, the unsigned path still works; if Anthropic-signed blocks ever leak through (e.g. message replay from a different provider), they're still stripped.

## Test plan

- [x] `pytest tests/agent/test_deepseek_anthropic_thinking.py -v` — **10 passed** (1 new regression `test_signed_thinking_block_survives_replay` + 9 existing)
- [x] `pytest tests/agent/test_kimi_coding_anthropic_thinking.py -v` — **17 passed** (Kimi path unchanged)
- [x] 7-turn smoke test against real DeepSeek endpoint with `hermes chat -r <session>` — 0 errors (previously deterministic 400 at turn 7)

## Related

Re-opens / extends #16748. The original carve-out is correct in shape but the underlying DeepSeek behavior changed.