### PR TITLE
feat(providers): support deepseek native api reasoning_

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -1158,7 +1158,7 @@ def main(
         providers_order (str): Comma-separated list of OpenRouter providers to try in order (e.g. "anthropic,openai,google")
         provider_sort (str): Sort providers by "price", "throughput", or "latency" (OpenRouter only)
         max_tokens (int): Maximum tokens for model responses (optional, uses model default if not set)
-        reasoning_effort (str): OpenRouter reasoning effort level: "none", "minimal", "low", "medium", "high", "xhigh" (default: "medium")
+        reasoning_effort (str): Reasoning effort level: "none", "minimal", "low", "medium", "high", "xhigh", "max" (default: "medium")
         reasoning_disabled (bool): Completely disable reasoning/thinking tokens (default: False)
         prefill_messages_file (str): Path to JSON file containing prefill messages (list of {role, content} dicts)
         max_samples (int): Only process the first N samples from the dataset (optional, processes all if not set)
@@ -1227,7 +1227,7 @@ def main(
         print("🧠 Reasoning: DISABLED (effort=none)")
     elif reasoning_effort:
         # Use specified effort level
-        valid_efforts = ["none", "minimal", "low", "medium", "high", "xhigh"]
+        valid_efforts = ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
         if reasoning_effort not in valid_efforts:
             print(f"❌ Error: --reasoning_effort must be one of: {', '.join(valid_efforts)}")
             return

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -565,7 +565,7 @@ agent:
   
   # Reasoning effort level (OpenRouter and Nous Portal)
   # Controls how much "thinking" the model does before responding.
-  # Options: "xhigh" (max), "high", "medium", "low", "minimal", "none" (disable)
+  # Options: "max", "xhigh", "high", "medium", "low", "minimal", "none" (disable)
   reasoning_effort: "medium"
   
   # Predefined personalities (use with /personality command)

--- a/cli.py
+++ b/cli.py
@@ -7677,7 +7677,7 @@ class HermesCLI:
 
         Usage:
             /reasoning              Show current effort level and display state
-            /reasoning <level>      Set reasoning effort (none, minimal, low, medium, high, xhigh)
+            /reasoning <level>      Set reasoning effort (none, minimal, low, medium, high, xhigh, max)
             /reasoning show|on      Show model thinking/reasoning in output
             /reasoning hide|off     Hide model thinking/reasoning from output
         """
@@ -7695,7 +7695,7 @@ class HermesCLI:
             display_state = "on ✓" if self.show_reasoning else "off"
             _cprint(f"  {_ACCENT}Reasoning effort:  {level}{_RST}")
             _cprint(f"  {_ACCENT}Reasoning display: {display_state}{_RST}")
-            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|show|hide>{_RST}")
+            _cprint(f"  {_DIM}Usage: /reasoning <none|minimal|low|medium|high|xhigh|max|show|hide>{_RST}")
             return
 
         arg = parts[1].strip().lower()
@@ -7721,7 +7721,7 @@ class HermesCLI:
         parsed = _parse_reasoning_config(arg)
         if parsed is None:
             _cprint(f"  {_DIM}(._.) Unknown argument: {arg}{_RST}")
-            _cprint(f"  {_DIM}Valid levels: none, minimal, low, medium, high, xhigh{_RST}")
+            _cprint(f"  {_DIM}Valid levels: none, minimal, low, medium, high, xhigh, max{_RST}")
             _cprint(f"  {_DIM}Display:      show, hide{_RST}")
             return
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -188,13 +188,13 @@ def get_subprocess_home() -> str | None:
     return None
 
 
-VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
+VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 
 
 def parse_reasoning_effort(effort: str) -> dict | None:
     """Parse a reasoning effort level into a config dict.
 
-    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh".
+    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh", "max".
     Returns None when the input is empty or unrecognized (caller uses default).
     Returns {"enabled": False} for "none".
     Returns {"enabled": True, "effort": <level>} for valid effort levels.

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -1,9 +1,55 @@
-"""DeepSeek provider profile."""
+"""DeepSeek provider profile.
+
+DeepSeek uses top-level ``reasoning_effort`` (like Kimi), not
+``extra_body.reasoning`` (like OpenRouter).  The native API accepts
+``high`` and ``max``; Hermes ``xhigh`` and ``max`` both map to ``max``,
+while ``low``/``medium``/``minimal`` map to ``high``.
+"""
+
+from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
-deepseek = ProviderProfile(
+
+_DEEPSEEK_EFFORT_MAP = {
+    "minimal": "high",
+    "low": "high",
+    "medium": "high",
+    "high": "high",
+    "xhigh": "max",
+    "max": "max",
+}
+
+
+class DeepSeekProfile(ProviderProfile):
+    """DeepSeek — top-level reasoning_effort with effort value mapping."""
+
+    def build_api_kwargs_extras(
+        self,
+        *,
+        reasoning_config: dict | None = None,
+        supports_reasoning: bool = False,
+        **context: Any,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Emit ``reasoning_effort`` as a top-level api_kwargs key.
+
+        DeepSeek does not use ``extra_body.reasoning`` — the native API
+        expects ``reasoning_effort`` directly.  Hermes effort values are
+        mapped to DeepSeek's ``high`` / ``max`` because the API only
+        supports those two levels.
+        """
+        top_level: dict[str, Any] = {}
+        if reasoning_config and isinstance(reasoning_config, dict):
+            if reasoning_config.get("enabled") is False:
+                return {}, top_level  # thinking on by default, don't emit
+            effort = str(reasoning_config.get("effort", "medium") or "medium").strip().lower()
+            mapped = _DEEPSEEK_EFFORT_MAP.get(effort, "high")
+            top_level["reasoning_effort"] = mapped
+        return {}, top_level
+
+
+deepseek = DeepSeekProfile(
     name="deepseek",
     aliases=("deepseek-chat",),
     env_vars=("DEEPSEEK_API_KEY",),

--- a/run_agent.py
+++ b/run_agent.py
@@ -8731,6 +8731,32 @@ class AIAgent:
             self._lmstudio_reasoning_options_cached(),
         )
 
+    def _resolve_deepseek_summary_reasoning_effort(self) -> str | None:
+        """Resolve a top-level ``reasoning_effort`` for the DeepSeek native API.
+
+        The iteration-limit summary path calls ``chat.completions.create()``
+        directly, bypassing the transport which would normally handle the
+        mapping through ``DeepSeekProfile.build_api_kwargs_extras``.  This
+        helper replicates that mapping so the summary path sends the same
+        ``reasoning_effort`` value that the main conversation loop does.
+        """
+        if not self.reasoning_config or not isinstance(self.reasoning_config, dict):
+            return None
+        if self.reasoning_config.get("enabled") is False:
+            return None
+        effort = str(self.reasoning_config.get("effort", "medium") or "medium").strip().lower()
+        # DeepSeek API only supports "high" and "max".
+        # low/medium/minimal → high; xhigh/max → max; high → high.
+        mapped = {
+            "minimal": "high",
+            "low": "high",
+            "medium": "high",
+            "high": "high",
+            "xhigh": "max",
+            "max": "max",
+        }.get(effort, "high")
+        return mapped
+
     def _github_models_reasoning_extra_body(self) -> dict | None:
         """Format reasoning payload for GitHub Models/OpenAI-compatible routes."""
         try:
@@ -10444,11 +10470,18 @@ class AIAgent:
                 (self.provider or "").strip().lower() == "lmstudio"
                 and self._supports_reasoning_extra_body()
             )
+            _is_deepseek_summary = (
+                (self.provider or "").strip().lower() == "deepseek"
+            )
             _lm_reasoning_effort: str | None = (
                 self._resolve_lmstudio_summary_reasoning_effort()
                 if _is_lmstudio_summary else None
             )
-            if not _is_lmstudio_summary and self._supports_reasoning_extra_body():
+            _ds_reasoning_effort: str | None = (
+                self._resolve_deepseek_summary_reasoning_effort()
+                if _is_deepseek_summary else None
+            )
+            if not _is_lmstudio_summary and not _is_deepseek_summary and self._supports_reasoning_extra_body():
                 if self.reasoning_config is not None:
                     summary_extra_body["reasoning"] = self.reasoning_config
                 else:
@@ -10477,6 +10510,8 @@ class AIAgent:
                     summary_kwargs.update(self._max_tokens_param(self.max_tokens))
                 if _lm_reasoning_effort is not None:
                     summary_kwargs["reasoning_effort"] = _lm_reasoning_effort
+                if _ds_reasoning_effort is not None:
+                    summary_kwargs["reasoning_effort"] = _ds_reasoning_effort
 
                 # Include provider routing preferences
                 provider_preferences = {}
@@ -10547,6 +10582,8 @@ class AIAgent:
                         summary_kwargs.update(self._max_tokens_param(self.max_tokens))
                     if _lm_reasoning_effort is not None:
                         summary_kwargs["reasoning_effort"] = _lm_reasoning_effort
+                    if _ds_reasoning_effort is not None:
+                        summary_kwargs["reasoning_effort"] = _ds_reasoning_effort
                     if summary_extra_body:
                         summary_kwargs["extra_body"] = summary_extra_body
 

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -256,3 +256,87 @@ class TestCustomOllamaParity:
             reasoning_config={"enabled": False, "effort": "none"},
         )
         assert kw["extra_body"]["think"] is False
+
+
+class TestDeepSeekParity:
+    """DeepSeek: top-level reasoning_effort with value mapping (high/max)."""
+
+    def test_reasoning_effort_top_level_xhigh_maps_to_max(self, transport):
+        """xhigh → max, emitted as top-level reasoning_effort."""
+        kw = transport.build_kwargs(
+            model="deepseek-chat",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("deepseek"),
+            reasoning_config={"enabled": True, "effort": "xhigh"},
+        )
+        assert kw.get("reasoning_effort") == "max"
+        assert "reasoning" not in kw.get("extra_body", {})
+
+    def test_reasoning_effort_top_level_max_passthrough(self, transport):
+        """max → max, emitted as top-level reasoning_effort."""
+        kw = transport.build_kwargs(
+            model="deepseek-chat",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("deepseek"),
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+        assert kw.get("reasoning_effort") == "max"
+        assert "reasoning" not in kw.get("extra_body", {})
+
+    def test_reasoning_effort_top_level_high_passthrough(self, transport):
+        """high → high, emitted as top-level reasoning_effort."""
+        kw = transport.build_kwargs(
+            model="deepseek-chat",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("deepseek"),
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kw.get("reasoning_effort") == "high"
+        assert "reasoning" not in kw.get("extra_body", {})
+
+    def test_reasoning_effort_medium_maps_to_high(self, transport):
+        """medium (and low/minimal) → high on DeepSeek native API."""
+        kw = transport.build_kwargs(
+            model="deepseek-chat",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("deepseek"),
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert kw.get("reasoning_effort") == "high"
+        assert "reasoning" not in kw.get("extra_body", {})
+
+    def test_reasoning_effort_low_maps_to_high(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-chat",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("deepseek"),
+            reasoning_config={"enabled": True, "effort": "low"},
+        )
+        assert kw.get("reasoning_effort") == "high"
+
+    def test_reasoning_disabled_no_effort_emitted(self, transport):
+        """When thinking is disabled, don't emit reasoning_effort."""
+        kw = transport.build_kwargs(
+            model="deepseek-chat",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("deepseek"),
+            reasoning_config={"enabled": False},
+        )
+        assert "reasoning_effort" not in kw
+        assert "reasoning" not in kw.get("extra_body", {})
+
+    def test_no_reasoning_config_no_effort(self, transport):
+        """Absent reasoning_config → no reasoning_effort emitted."""
+        kw = transport.build_kwargs(
+            model="deepseek-chat",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("deepseek"),
+        )
+        assert "reasoning_effort" not in kw


### PR DESCRIPTION
## What does this PR do?
Fix `reasoning_effort` being silently ignored when using the DeepSeek
native provider (`api.deepseek.com`). Two issues:
1. DeepSeek's native API uses **top-level** `reasoning_effort` (`high`/`max`),
   not `extra_body.reasoning`. The base `ProviderProfile` returns `({}, {})`
   for `build_api_kwargs_extras`, so the config was never sent.
2. `"max"` was not in `VALID_REASONING_EFFORTS` — setting it caused
   `Unknown reasoning_effort 'max', using default (medium)`.
## Related Issue
N/A (no existing issue)
## Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)
## Changes Made
- `hermes_constants.py`: Add `"max"` to `VALID_REASONING_EFFORTS`
- `plugins/model-providers/deepseek/__init__.py`: New `DeepSeekProfile` class
  with `build_api_kwargs_extras` emitting top-level `reasoning_effort`,
  mapping: `low`/`medium`/`minimal` → `"high"`, `xhigh`/`max` → `"max"`
- `run_agent.py`: Summary path handles deepseek like LM Studio (top-level
  `reasoning_effort`, not `extra_body.reasoning`)
- `cli.py`: `/reasoning` help text updated
- `cli-config.yaml.example`: Options comment updated
- `batch_runner.py`: Docstring + valid_efforts list updated
- `tests/providers/test_transport_parity.py`: 7 new `TestDeepSeekParity` tests
## How to Test
1. `pytest tests/providers/test_transport_parity.py -q` (26→33 tests, deepseek
   mapping coverage)
2. `pytest tests/run_agent/test_run_agent.py -k reasoning -q` (35 reasoning tests)
3. `pytest tests/providers/ -q` (90 provider tests)
4. Manual: set `reasoning_effort: xhigh` with `provider: deepseek`, verify
   `reasoning_effort: max` is sent in API request
## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04
### Documentation & Housekeeping
- [x] I've updated relevant documentation (docstrings updated) — or N/A
- [x] I've updated `cli-config.yaml.example` — config comment updated
- [x] N/A — no architecture/workflow changes
- [x] I've considered cross-platform impact — N/A (provider plugin, no OS dependency)
- [x] N/A — no tool behavior change
## Screenshots / Logs
Before (`reasoning_effort: xhigh` with `provider: deepseek`):
- `_supports_reasoning_extra_body()` returned `False`
- `reasoning_effort` was silently dropped from API request
After:
- DeepSeek profile emits `reasoning_effort` as top-level param
- `xhigh` → `"max"`, `medium` → `"high"` (per DeepSeek API spec)
- Transport parity tests verify all mappings