### PR TITLE
fix(gateway): keep env provider from overriding session model switches

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1563,8 +1563,9 @@ class GatewayRunner:
         """Resolve model/runtime for a session, honoring session-scoped /model overrides.
 
         If the session override already contains a complete provider bundle
-        (provider/api_key/base_url/api_mode), prefer it directly instead of
-        resolving fresh global runtime state first.
+        (provider/api_key/base_url/api_mode), prefer it directly. If the
+        override only names a provider, resolve that provider explicitly so a
+        global HERMES_INFERENCE_PROVIDER cannot leak into the session switch.
         """
         resolved_session_key = session_key
         if not resolved_session_key and source is not None:
@@ -1590,11 +1591,10 @@ class GatewayRunner:
                     override_runtime.get("provider"),
                 )
                 return override_model, override_runtime
-            # Override exists but has no api_key — fall through to env-based
-            # resolution and apply model/provider from the override on top.
             logger.debug(
-                "Session model override (no api_key, fallback): session=%s config_model=%s override_model=%s",
+                "Session model override (no api_key): session=%s config_model=%s override_model=%s provider=%s",
                 resolved_session_key or "", model, override_model,
+                override_runtime.get("provider"),
             )
         else:
             logger.debug(
@@ -1603,7 +1603,42 @@ class GatewayRunner:
                 list(self._session_model_overrides.keys())[:5] if self._session_model_overrides else "[]",
             )
 
-        runtime_kwargs = _resolve_runtime_agent_kwargs()
+        runtime_kwargs = None
+        if override and resolved_session_key and override.get("provider"):
+            try:
+                from hermes_cli.runtime_provider import (
+                    resolve_runtime_provider,
+                    format_runtime_provider_error,
+                )
+
+                runtime = resolve_runtime_provider(
+                    requested=override.get("provider"),
+                    explicit_api_key=override.get("api_key"),
+                    explicit_base_url=override.get("base_url"),
+                    target_model=override.get("model", model),
+                )
+            except Exception as exc:
+                try:
+                    message = format_runtime_provider_error(exc)
+                except Exception:
+                    message = str(exc)
+                raise RuntimeError(
+                    "Failed to resolve session model override provider "
+                    f"{override.get('provider')!r}: {message}"
+                ) from exc
+            runtime_kwargs = {
+                "api_key": runtime.get("api_key"),
+                "base_url": runtime.get("base_url"),
+                "provider": runtime.get("provider"),
+                "api_mode": runtime.get("api_mode"),
+                "command": runtime.get("command"),
+                "args": list(runtime.get("args") or []),
+                "credential_pool": runtime.get("credential_pool"),
+            }
+
+        if runtime_kwargs is None:
+            runtime_kwargs = _resolve_runtime_agent_kwargs()
+
         if override and resolved_session_key:
             model, runtime_kwargs = self._apply_session_model_override(
                 resolved_session_key, model, runtime_kwargs

--- a/tests/gateway/test_session_model_override_routing.py
+++ b/tests/gateway/test_session_model_override_routing.py
@@ -82,6 +82,77 @@ def _explode_runtime_resolution():
     )
 
 
+def test_partial_session_override_resolves_requested_provider_not_env(monkeypatch):
+    import hermes_cli.runtime_provider as runtime_provider
+
+    monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "custom:provider-a")
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", _explode_runtime_resolution
+    )
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_gateway_model",
+        lambda user_config=None: "default-model",
+    )
+
+    calls = []
+
+    def fake_resolve_runtime_provider(
+        *,
+        requested=None,
+        explicit_api_key=None,
+        explicit_base_url=None,
+        target_model=None,
+    ):
+        calls.append(
+            {
+                "requested": requested,
+                "explicit_api_key": explicit_api_key,
+                "explicit_base_url": explicit_base_url,
+                "target_model": target_model,
+            }
+        )
+        return {
+            "provider": "custom:provider-c",
+            "api_key": "provider-c-key",
+            "base_url": "https://provider-c.example/v1",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        }
+
+    monkeypatch.setattr(
+        runtime_provider, "resolve_runtime_provider", fake_resolve_runtime_provider
+    )
+
+    runner = _make_runner()
+    session_key = "agent:main:local:dm"
+    runner._session_model_overrides[session_key] = {
+        "model": "provider-c-model",
+        "provider": "custom:provider-c",
+        "api_key": None,
+        "base_url": None,
+        "api_mode": "chat_completions",
+    }
+
+    model, runtime = runner._resolve_session_agent_runtime(session_key=session_key)
+
+    assert calls == [
+        {
+            "requested": "custom:provider-c",
+            "explicit_api_key": None,
+            "explicit_base_url": None,
+            "target_model": "provider-c-model",
+        }
+    ]
+    assert model == "provider-c-model"
+    assert runtime["provider"] == "custom:provider-c"
+    assert runtime["api_key"] == "provider-c-key"
+    assert runtime["base_url"] == "https://provider-c.example/v1"
+    assert runtime["api_mode"] == "chat_completions"
+
+
 def test_run_agent_prefers_session_override_over_global_runtime(monkeypatch):
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
     monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)


### PR DESCRIPTION
## Summary
- resolve session-scoped `/model --provider` overrides against the requested provider before building a gateway agent
- prevent `HERMES_INFERENCE_PROVIDER` from leaking credentials/base URL into partial session overrides
- add a regression covering a provider-c session switch while provider-a is set in the environment

Fixes #14616.

## Verification
- `scripts/run_tests.sh tests/gateway/test_session_model_override_routing.py tests/gateway/test_model_switch_persistence.py` -> 12 passed, 3 warnings
- `python -m py_compile gateway/run.py tests/gateway/test_session_model_override_routing.py`
- `git diff --check`