### PR TITLE
docs: add DeepClaude proxy to providers docs

### DIFF
--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1394,6 +1394,65 @@ Fallback is configured exclusively through `config.yaml` — there are no enviro
 
 ---
 
+## DeepClaude Proxy
+
+[DeepClaude](https://github.com/aattaran/deepclaude) runs a local
+Anthropic-compatible proxy on 127.0.0.1:3200 that forwards `/v1/messages` to
+cheaper backends — DeepSeek V4 Pro, OpenRouter, or Fireworks — while passing
+other traffic through to Anthropic.
+
+Connect Hermes as a named custom provider with `api_mode: anthropic_messages`:
+
+```yaml
+# ~/.hermes/config.yaml
+custom_providers:
+  - name: deepclaude-proxy
+    base_url: http://127.0.0.1:3200
+    api_mode: anthropic_messages
+    api_key: dummy           # proxy does not require auth from localhost
+    models:
+      deepseek-v4-pro:
+        context_length: 128000
+      deepseek-v4-flash:
+        context_length: 128000
+
+model:
+  provider: custom:deepclaude-proxy
+  default: deepseek-v4-pro
+```
+
+Start the proxy separately (not from within Hermes):
+
+```bash
+cd /path/to/deepclaude
+export DEEPSEEK_API_KEY="sk-..."
+node proxy/start-proxy.js --port 3200
+```
+
+The proxy also supports `OPENROUTER_API_KEY` and `FIREWORKS_API_KEY` for
+alternative backends. Switch backends live without restarting Hermes:
+
+```bash
+curl -sX POST http://127.0.0.1:3200/_proxy/mode -d "backend=openrouter"
+```
+
+Pricing at a glance (vs Anthropic Opus at $15/M output):
+
+| Backend | Output /M | Proxy mode |
+|---|---|---|
+| DeepSeek | $0.87 | `deepseek` |
+| OpenRouter | $0.87 | `openrouter` |
+| Fireworks | $3.48 | `fireworks` |
+
+Limitations: DeepSeek's Anthropic endpoint does not support image/vision
+inputs; Anthropic's `cache_control` header is ignored (DeepSeek uses its own
+automatic caching).
+
+Why the proxy and not `deepclaude.sh`? The shell script wraps Claude Code CLI
+— it sets environment variables then `exec claude`, coupling Hermes' lifecycle
+to Claude Code. The proxy keeps the two independent: it runs as a standalone
+process, and Hermes treats it as an Anthropic-compatible endpoint.
+
 ## See Also
 
 - [Configuration](/docs/user-guide/configuration) — General configuration (directory structure, config precedence, terminal backends, memory, compression, and more)


### PR DESCRIPTION
Add DeepClaude Proxy section to integrations/providers.md. DeepClaude runs a local Anthropic-compatible proxy on 127.0.0.1:3200 that forwards /v1/messages to cheaper backends (DeepSeek V4 Pro, OpenRouter, Fireworks). Hermes connects via custom_providers with api_mode: anthropic_messages.

---

What does this PR do?

Add a DeepClaude Proxy cookbook section to the providers documentation
    (website/docs/integrations/providers.md), placed at the end before See Also.

DeepClaude is an external project (https://github.com/aattaran/deepclaude)
that runs a local Anthropic-compatible proxy. This PR documents how Hermes
users can connect to it as a named custom provider — no code changes to Hermes.

The section covers:
- YAML config for custom_providers with api_mode: anthropic_messages
- Proxy startup command
- Live backend switching between DeepSeek, OpenRouter, and Fireworks
- Pricing comparison table
- Limitations (vision support, prompt caching)
- Why use the proxy instead of deepclaude.sh

Related Issue
N/A — documentation addition for an external integration.

Type of Change
- [x] 📝 Documentation update

Changes Made
- website/docs/integrations/providers.md: added ## DeepClaude Proxy section (+59 lines)

How to Test
1. Preview the markdown locally
2. Confirm the new section appears at the end of integrations/providers, before See Also
3. git diff --check — no whitespace issues

Checklist

Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] pytest — N/A (docs only)
- [x] Tests — N/A (docs only)
- [x] Platform: Ubuntu 24.04 (WSL2)

Documentation & Housekeeping
- [x] I've updated relevant documentation
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform — N/A (docs only)
- [x] Tool descriptions/schemas — N/A