### PR TITLE
docs(gateway): mention Weixin in gateway help and docstrings

### DIFF
--- a/gateway/__init__.py
+++ b/gateway/__init__.py
@@ -2,7 +2,7 @@
 Hermes Gateway - Multi-platform messaging integration.
 
 This module provides a unified gateway for connecting the Hermes agent
-to various messaging platforms (Telegram, Discord, WhatsApp) with:
+to various messaging platforms (Telegram, Discord, WhatsApp, Weixin, and more) with:
 - Session management (persistent conversations with reset policies)
 - Dynamic context injection (agent knows where messages come from)
 - Delivery routing (cron job outputs to appropriate channels)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2,7 +2,7 @@
 Gateway configuration management.
 
 Handles loading and validating configuration for:
-- Connected platforms (Telegram, Discord, WhatsApp)
+- Connected platforms (Telegram, Discord, WhatsApp, Weixin, and more)
 - Home channels for each platform
 - Session reset policies
 - Delivery preferences

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1,7 +1,7 @@
 """
 Base platform adapter interface.
 
-All platform adapters (Telegram, Discord, WhatsApp) inherit from this
+All platform adapters (Telegram, Discord, WhatsApp, Weixin, and others) inherit from this
 and implement the required methods.
 """
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8569,7 +8569,7 @@ def main():
     gateway_parser = subparsers.add_parser(
         "gateway",
         help="Messaging gateway management",
-        description="Manage the messaging gateway (Telegram, Discord, WhatsApp)",
+        description="Manage the messaging gateway (Telegram, Discord, WhatsApp, Weixin, and more)",
     )
     gateway_subparsers = gateway_parser.add_subparsers(dest="gateway_command")
 


### PR DESCRIPTION
The gateway supports Weixin (WeChat) but the CLI help text and several docstrings only listed Telegram, Discord, and WhatsApp.

- hermes_cli/main.py: gateway help text now mentions Weixin
- gateway/init.py: module docstring updated
- gateway/config.py: config module docstring updated
- gateway/platforms/base.py: base adapter docstring updated

What does this PR do?

hermes gateway --help says Manage the messaging gateway (Telegram, Discord, WhatsApp) but the gateway actually supports Weixin (WeChat) as a first-class platform. This updates the help text and related docstrings to mention Weixin.

Related Issue

N/A

Type of Change

- [x] 📝 Documentation update

Changes Made

- hermes_cli/main.py: (Telegram, Discord, WhatsApp) → (Telegram, Discord, WhatsApp, Weixin, and more)
- gateway/init.py: same
- gateway/config.py: same
- gateway/platforms/base.py: (Telegram, Discord, WhatsApp) → (Telegram, Discord, WhatsApp, Weixin, and others)

4 files, 4 lines changed.

How to Test

1. hermes gateway --help — should show (Telegram, Discord, WhatsApp, Weixin, and more)
2. git diff --check — no whitespace issues

Checklist

Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] pytest — N/A (docstrings only)
- [x] Tests — N/A
- [x] Platform: Ubuntu 24.04 (WSL2)

Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings)
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform — N/A
- [x] Tool descriptions/schemas — N/A