### PR TITLE
feat(gateway): add public is_user_authorized() for pre_gateway_dispat…

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4560,6 +4560,21 @@ class GatewayRunner:
 
         return bool(check_ids & allowed_ids)
 
+    def is_user_authorized(self, source: SessionSource) -> bool:
+        """Public wrapper for plugin authors.
+
+        ``pre_gateway_dispatch`` hooks fire *before* the gateway's own auth
+        step (by design, so plugins can handle unauthorized senders without
+        triggering the pairing flow).  Plugins that return ``"allow"`` for a
+        user-originated message should call this method to ensure the sender
+        is authorized before the message reaches the agent loop.
+
+        If your hook does NOT call this, the gateway will still run the
+        normal auth check afterwards — this is a convenience for hooks that
+        need to make an early auth decision.
+        """
+        return self._is_user_authorized(source)
+
     def _get_unauthorized_dm_behavior(self, platform: Optional[Platform]) -> str:
         """Return how unauthorized DMs should be handled for a platform.
 

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -868,7 +868,11 @@ def my_callback(event, gateway, session_store, **kwargs):
 | `gateway` | `GatewayRunner` | The active gateway runner, so plugins can call `gateway.adapters[platform].send(...)` for side-channel replies (owner notifications, etc.). |
 | `session_store` | `SessionStore` | For silent transcript ingestion via `session_store.append_to_transcript(...)`. |
 
-**Fires:** In `gateway/run.py`, inside `GatewayRunner._handle_message()`, immediately after `is_internal` is computed. **Internal events skip the hook entirely** (they are system-generated — background-process completions, etc. — and must not be gate-kept by user-facing policy).
+**Fires:** In `gateway/run.py`, inside `GatewayRunner._handle_message()`, immediately after `is_internal` is computed — **before** the gateway's own auth/pairing step. **Internal events skip the hook entirely** (they are system-generated — background-process completions, etc. — and must not be gate-kept by user-facing policy).
+
+:::caution
+The hook runs **before** the gateway checks `_is_user_authorized(source)`. This is intentional — it lets plugins handle unauthorized senders without triggering the pairing flow. If your hook returns `"allow"` for a user-originated message, call `gateway.is_user_authorized(source)` to ensure the sender passes the gateway's normal allowlist / pairing checks. Otherwise the gateway will still run its own auth check after your hook returns.
+:::
 
 **Return value:** `None` or a dict. The first recognized action dict wins; remaining plugin results are ignored. Exceptions in plugin callbacks are caught and logged; the gateway always falls through to normal dispatch on error.
 


### PR DESCRIPTION
pre_gateway_dispatch hooks fire before the gateway's own auth step. Plugin authors who return 'allow' for user-originated messages need to check authorization themselves to avoid bypassing the gateway's pairing and allowlist logic.

- gateway/run.py: add public is_user_authorized(source) wrapper around the internal _is_user_authorized method
- website/docs/user-guide/features/hooks.md: add caution admonition explaining the auth ordering and pointing to the new public method

What does this PR do?

pre_gateway_dispatch hooks fire before the gateway's auth/pairing step. This is intentional — it lets plugins handle unauthorized senders without triggering the pairing flow. But plugin authors who return "allow" for a user-originated message may inadvertently bypass allowlist and pairing checks.

This PR adds a public is_user_authorized(source) method on GatewayRunner so plugin authors can easily enforce the gateway's own auth rules from within their hook. It also adds a caution admonition to the hooks documentation.

Related Issue

N/A

Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update

Changes Made

- gateway/run.py: added public is_user_authorized(source) method (+15 lines)
- website/docs/user-guide/features/hooks.md: added :::caution admonition explaining hook/auth ordering (+5 lines)

How to Test

1. Verify is_user_authorized delegates to _is_user_authorized:
   python
   from gateway.run import GatewayRunner
is_user_authorized should be a public method on GatewayRunner

2. git diff --check — no whitespace issues
3. Ruff: python -m ruff check gateway/run.py — passes

Checklist

Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run pytest tests/ -q and all tests pass — N/A (trivial wrapper, no logic change)
- [ ] I've added tests for my changes — N/A (one-line delegation)
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

Documentation & Housekeeping

- [x] I've updated relevant documentation (hooks.md)
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md / AGENTS.md — N/A
- [x] Cross-platform — N/A
- [x] Tool descriptions/schemas — N/A