### PR TITLE
feat(api): add GET/DELETE /api/memory endpoints for management backend

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -12,6 +12,8 @@ Exposes an HTTP server with endpoints:
 - GET  /v1/runs/{run_id}           — retrieve current run status
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
 - POST /v1/runs/{run_id}/stop    — interrupt a running agent
+- GET  /api/memory                 — list curated memory entries (MEMORY.md / USER.md)
+- DELETE /api/memory               — clear or remove curated memory entries
 - GET  /health                     — health check
 - GET  /health/detailed            — rich status for cross-container dashboard probing
 
@@ -2490,6 +2492,112 @@ class APIServerAdapter(BasePlatformAdapter):
             return web.json_response({"error": str(e)}, status=500)
 
     # ------------------------------------------------------------------
+    # Memory management API
+    #
+    # The built-in ``memory`` tool persists curated entries to
+    # ``~/.hermes/memories/MEMORY.md`` (agent notes) and ``USER.md``
+    # (user profile).  These two endpoints expose the stores to a
+    # management backend so it can list and prune entries without
+    # shelling out to ``hermes memory reset``.
+    #
+    # Note: this only covers the built-in file-backed store.  External
+    # memory providers (Honcho, retaindb, supermemory, ...) have their
+    # own delete APIs and are not proxied here.
+    # ------------------------------------------------------------------
+
+    _VALID_MEMORY_TARGETS = ("all", "memory", "user")
+
+    @staticmethod
+    def _parse_memory_target(request: "web.Request") -> tuple[str, Optional["web.Response"]]:
+        target = (request.query.get("target") or "all").strip().lower()
+        if target not in APIServerAdapter._VALID_MEMORY_TARGETS:
+            return target, web.json_response(
+                {"error": "target must be one of 'all', 'memory', 'user'"},
+                status=400,
+            )
+        return target, None
+
+    async def _handle_get_memory(self, request: "web.Request") -> "web.Response":
+        """GET /api/memory[?target=memory|user|all] — list curated memory entries.
+
+        Returns a JSON object keyed by target name; each value contains the
+        entries plus usage stats (char_count, char_limit, usage_percent).
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        target, target_err = self._parse_memory_target(request)
+        if target_err is not None:
+            return target_err
+        try:
+            from tools.memory_tool import MemoryStore
+            store = MemoryStore()
+            store.load_from_disk()
+            targets = ("memory", "user") if target == "all" else (target,)
+            payload = {t: store.snapshot(t) for t in targets}
+            return web.json_response(payload)
+        except Exception as e:
+            logger.exception("Failed to read memory")
+            return web.json_response({"error": str(e)}, status=500)
+
+    async def _handle_delete_memory(self, request: "web.Request") -> "web.Response":
+        """DELETE /api/memory[?target=memory|user|all][&old_text=...].
+
+        Two modes:
+        - With ``old_text``: removes the single entry containing that
+          substring from the given target (target must be ``memory`` or
+          ``user``, not ``all``).
+        - Without ``old_text``: clears every entry from the target(s).
+          With ``target=all`` (default), both stores are wiped.
+
+        The on-disk file is rewritten atomically.  The system-prompt
+        snapshot of any already-running session is unaffected — those
+        sessions need to restart to see the change, just like ``hermes
+        memory reset``.
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        target, target_err = self._parse_memory_target(request)
+        if target_err is not None:
+            return target_err
+        old_text = (request.query.get("old_text") or "").strip()
+        try:
+            from tools.memory_tool import MemoryStore
+            store = MemoryStore()
+            if old_text:
+                if target == "all":
+                    return web.json_response(
+                        {"error": "old_text requires target='memory' or target='user'"},
+                        status=400,
+                    )
+                result = store.remove(target, old_text)
+                if not result.get("success"):
+                    return web.json_response(
+                        {"error": result.get("error", "Entry not found"), "matches": result.get("matches")},
+                        status=404 if "No entry matched" in str(result.get("error", "")) else 400,
+                    )
+                return web.json_response({
+                    "ok": True,
+                    "target": target,
+                    "removed": old_text,
+                    "remaining": store.snapshot(target),
+                })
+
+            targets = ("memory", "user") if target == "all" else (target,)
+            cleared = {}
+            for t in targets:
+                result = store.clear(t)
+                cleared[t] = {
+                    "removed": result.get("removed", 0),
+                    "entry_count": result.get("entry_count", 0),
+                }
+            return web.json_response({"ok": True, "target": target, "cleared": cleared})
+        except Exception as e:
+            logger.exception("Failed to delete memory")
+            return web.json_response({"error": str(e)}, status=500)
+
+    # ------------------------------------------------------------------
     # Output extraction helper
     # ------------------------------------------------------------------
 
@@ -3064,6 +3172,9 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/api/jobs/{job_id}/pause", self._handle_pause_job)
             self._app.router.add_post("/api/jobs/{job_id}/resume", self._handle_resume_job)
             self._app.router.add_post("/api/jobs/{job_id}/run", self._handle_run_job)
+            # Curated memory management API (built-in MEMORY.md / USER.md)
+            self._app.router.add_get("/api/memory", self._handle_get_memory)
+            self._app.router.add_delete("/api/memory", self._handle_delete_memory)
             # Structured event streaming
             self._app.router.add_post("/v1/runs", self._handle_runs)
             self._app.router.add_get("/v1/runs/{run_id}", self._handle_get_run)

--- a/tests/gateway/test_api_server_memory.py
+++ b/tests/gateway/test_api_server_memory.py
@@ -1,0 +1,299 @@
+"""Tests for the curated-memory management endpoints on the API server.
+
+Covers GET /api/memory and DELETE /api/memory:
+- list both stores / single target
+- target validation (rejects unknown values)
+- delete single entry by old_text substring
+- clear a single store
+- clear both stores (default target=all)
+- old_text + target=all is rejected
+- 404 when old_text doesn't match any entry
+- auth enforcement (401 with API_SERVER_KEY)
+"""
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {}
+    if api_key:
+        extra["key"] = api_key
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/api/memory", adapter._handle_get_memory)
+    app.router.add_delete("/api/memory", adapter._handle_delete_memory)
+    return app
+
+
+@pytest.fixture
+def memory_home(tmp_path, monkeypatch):
+    """Profile-scoped HERMES_HOME with seeded memory files."""
+    hermes_home = tmp_path / ".hermes"
+    memories = hermes_home / "memories"
+    memories.mkdir(parents=True)
+
+    # Use the canonical ENTRY_DELIMITER so MemoryStore parses the seed
+    # files the same way it would in production.
+    from tools.memory_tool import ENTRY_DELIMITER
+
+    (memories / "MEMORY.md").write_text(
+        ENTRY_DELIMITER.join([
+            "Hermes repo lives at ~/.hermes/hermes-agent",
+            "Project uses Python 3.11",
+        ]),
+        encoding="utf-8",
+    )
+    (memories / "USER.md").write_text(
+        ENTRY_DELIMITER.join([
+            "User goes by Teknium",
+            "Timezone: US Pacific",
+        ]),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home, memories
+
+
+@pytest.fixture
+def adapter():
+    return _make_adapter()
+
+
+@pytest.fixture
+def auth_adapter():
+    return _make_adapter(api_key="sk-secret")
+
+
+# ---------------------------------------------------------------------------
+# GET /api/memory
+# ---------------------------------------------------------------------------
+
+
+class TestGetMemory:
+    @pytest.mark.asyncio
+    async def test_list_all_default(self, adapter, memory_home):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/memory")
+            assert resp.status == 200
+            data = await resp.json()
+            assert set(data.keys()) == {"memory", "user"}
+            assert data["memory"]["entry_count"] == 2
+            assert "Hermes repo" in data["memory"]["entries"][0]
+            assert data["user"]["entry_count"] == 2
+            assert data["memory"]["char_limit"] > 0
+            assert 0 <= data["memory"]["usage_percent"] <= 100
+
+    @pytest.mark.asyncio
+    async def test_list_memory_target_only(self, adapter, memory_home):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/memory?target=memory")
+            assert resp.status == 200
+            data = await resp.json()
+            assert set(data.keys()) == {"memory"}
+            assert "user" not in data
+
+    @pytest.mark.asyncio
+    async def test_list_user_target_only(self, adapter, memory_home):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/memory?target=user")
+            assert resp.status == 200
+            data = await resp.json()
+            assert set(data.keys()) == {"user"}
+            assert data["user"]["entry_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_invalid_target_rejected(self, adapter, memory_home):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/memory?target=bogus")
+            assert resp.status == 400
+            data = await resp.json()
+            assert "target" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_empty_when_no_files(self, adapter, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        (hermes_home / "memories").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/memory")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["memory"]["entries"] == []
+            assert data["memory"]["entry_count"] == 0
+            assert data["user"]["entries"] == []
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/memory — single-entry removal
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteMemoryEntry:
+    @pytest.mark.asyncio
+    async def test_remove_by_old_text(self, adapter, memory_home):
+        _, memories = memory_home
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete("/api/memory?target=memory&old_text=Python%203.11")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["ok"] is True
+            assert data["target"] == "memory"
+            assert data["remaining"]["entry_count"] == 1
+
+        # File on disk reflects the removal
+        from tools.memory_tool import ENTRY_DELIMITER
+        remaining = (memories / "MEMORY.md").read_text(encoding="utf-8")
+        assert "Python 3.11" not in remaining
+        assert "Hermes repo" in remaining
+        assert ENTRY_DELIMITER not in remaining  # only one entry left
+
+    @pytest.mark.asyncio
+    async def test_remove_no_match_returns_404(self, adapter, memory_home):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete(
+                "/api/memory?target=memory&old_text=this-string-does-not-exist"
+            )
+            assert resp.status == 404
+            data = await resp.json()
+            assert "No entry matched" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_old_text_with_target_all_rejected(self, adapter, memory_home):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete("/api/memory?target=all&old_text=anything")
+            assert resp.status == 400
+            data = await resp.json()
+            assert "old_text" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/memory — clear semantics
+# ---------------------------------------------------------------------------
+
+
+class TestClearMemory:
+    @pytest.mark.asyncio
+    async def test_clear_memory_target(self, adapter, memory_home):
+        _, memories = memory_home
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete("/api/memory?target=memory")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["ok"] is True
+            assert data["cleared"]["memory"]["removed"] == 2
+            assert data["cleared"]["memory"]["entry_count"] == 0
+            assert "user" not in data["cleared"]
+
+        assert (memories / "MEMORY.md").read_text(encoding="utf-8") == ""
+        assert "Teknium" in (memories / "USER.md").read_text(encoding="utf-8")
+
+    @pytest.mark.asyncio
+    async def test_clear_user_target(self, adapter, memory_home):
+        _, memories = memory_home
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete("/api/memory?target=user")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["cleared"]["user"]["removed"] == 2
+
+        assert "Teknium" not in (memories / "USER.md").read_text(encoding="utf-8")
+        assert "Hermes repo" in (memories / "MEMORY.md").read_text(encoding="utf-8")
+
+    @pytest.mark.asyncio
+    async def test_clear_all_default(self, adapter, memory_home):
+        _, memories = memory_home
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete("/api/memory")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["target"] == "all"
+            assert data["cleared"]["memory"]["removed"] == 2
+            assert data["cleared"]["user"]["removed"] == 2
+
+        assert (memories / "MEMORY.md").read_text(encoding="utf-8") == ""
+        assert (memories / "USER.md").read_text(encoding="utf-8") == ""
+
+    @pytest.mark.asyncio
+    async def test_clear_when_already_empty(self, adapter, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        (hermes_home / "memories").mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete("/api/memory")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["cleared"]["memory"]["removed"] == 0
+            assert data["cleared"]["user"]["removed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Auth enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestAuthRequired:
+    @pytest.mark.asyncio
+    async def test_get_requires_auth(self, auth_adapter, memory_home):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/api/memory")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_delete_requires_auth(self, auth_adapter, memory_home):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete("/api/memory")
+            assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_get_with_valid_key(self, auth_adapter, memory_home):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                "/api/memory",
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_delete_with_valid_key(self, auth_adapter, memory_home):
+        _, memories = memory_home
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.delete(
+                "/api/memory?target=memory",
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            assert resp.status == 200
+
+        assert (memories / "MEMORY.md").read_text(encoding="utf-8") == ""

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -183,6 +183,57 @@ class TestMemoryStoreRemove:
         assert result["success"] is False
 
 
+class TestMemoryStoreClear:
+    def test_clear_empties_target(self, store):
+        store.add("memory", "fact A")
+        store.add("memory", "fact B")
+        result = store.clear("memory")
+        assert result["success"] is True
+        assert result["removed"] == 2
+        assert result["entry_count"] == 0
+        assert store.memory_entries == []
+
+    def test_clear_only_affects_named_target(self, store):
+        store.add("memory", "agent fact")
+        store.add("user", "user fact")
+        store.clear("memory")
+        assert store.memory_entries == []
+        assert store.user_entries == ["user fact"]
+
+    def test_clear_when_already_empty(self, store):
+        result = store.clear("memory")
+        assert result["success"] is True
+        assert result["removed"] == 0
+
+    def test_clear_persists_to_disk(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        s1 = MemoryStore()
+        s1.load_from_disk()
+        s1.add("memory", "persistent fact")
+        s1.clear("memory")
+
+        s2 = MemoryStore()
+        s2.load_from_disk()
+        assert s2.memory_entries == []
+
+
+class TestMemoryStoreSnapshotMethod:
+    def test_snapshot_returns_serializable_dict(self, store):
+        store.add("memory", "abc")
+        snap = store.snapshot("memory")
+        assert snap["entries"] == ["abc"]
+        assert snap["entry_count"] == 1
+        assert snap["char_count"] == 3
+        assert snap["char_limit"] == 500
+        assert 0 <= snap["usage_percent"] <= 100
+
+    def test_snapshot_empty_target(self, store):
+        snap = store.snapshot("user")
+        assert snap["entries"] == []
+        assert snap["entry_count"] == 0
+        assert snap["char_count"] == 0
+
+
 class TestMemoryStorePersistence:
     def test_save_and_load_roundtrip(self, tmp_path, monkeypatch):
         monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -358,6 +358,49 @@ class MemoryStore:
 
         return self._success_response(target, "Entry removed.")
 
+    def clear(self, target: str) -> Dict[str, Any]:
+        """Remove all entries from one store. Returns the count of entries
+        that were deleted.
+
+        Used by management/admin interfaces (e.g. ``hermes memory reset``,
+        the ``DELETE /api/memory`` HTTP endpoint).  Mid-session writes from
+        other processes are picked up under the file lock so we never wipe
+        a stale cached view.
+
+        The on-disk file is overwritten with an empty payload via the same
+        atomic-rename path as normal writes.  Subsequent ``load_from_disk``
+        calls will see a clean slate.
+        """
+        with self._file_lock(self._path_for(target)):
+            self._reload_target(target)
+
+            removed = len(self._entries_for(target))
+            self._set_entries(target, [])
+            self.save_to_disk(target)
+
+        resp = self._success_response(target, "All entries cleared.")
+        resp["removed"] = removed
+        return resp
+
+    def snapshot(self, target: str) -> Dict[str, Any]:
+        """Return a JSON-serializable snapshot of one store's current state.
+
+        Exposes entries, char counts, and usage for management/admin
+        callers (e.g. ``GET /api/memory``) without leaking the locking
+        primitives or other private internals.
+        """
+        entries = list(self._entries_for(target))
+        content = ENTRY_DELIMITER.join(entries) if entries else ""
+        limit = self._char_limit(target)
+        char_count = len(content)
+        return {
+            "entries": entries,
+            "entry_count": len(entries),
+            "char_count": char_count,
+            "char_limit": limit,
+            "usage_percent": min(100, int((char_count / limit) * 100)) if limit > 0 else 0,
+        }
+
     def format_for_system_prompt(self, target: str) -> Optional[str]:
         """
         Return the frozen snapshot for system prompt injection.


### PR DESCRIPTION
## Summary

Expose the built-in curated memory store (`MEMORY.md` / `USER.md`) over the API server adapter so a management backend can list and prune entries without shelling out to \`hermes memory reset\`.

## New endpoints

### \`GET /api/memory[?target=memory|user|all]\`

Returns entries plus usage stats per target. Default \`target=all\`.

\`\`\`json
{
  \"memory\": {
    \"entries\": [\"…\", \"…\"],
    \"entry_count\": 2,
    \"char_count\": 71,
    \"char_limit\": 2200,
    \"usage_percent\": 3
  },
  \"user\": { \"…\": \"…\" }
}
\`\`\`

### \`DELETE /api/memory[?target=…][&old_text=…]\`

Two modes:

- **Without \`old_text\`** — clears every entry from the target. \`target=all\` (default) wipes both stores.
- **With \`old_text\`** — removes a single entry by substring match. \`target\` must be \`memory\` or \`user\`.

Clear response:
\`\`\`json
{
  \"ok\": true,
  \"target\": \"all\",
  \"cleared\": {
    \"memory\": {\"removed\": 2, \"entry_count\": 0},
    \"user\":   {\"removed\": 2, \"entry_count\": 0}
  }
}
\`\`\`

## Why

Previously, the only way to inspect or wipe the curated memory was the interactive \`hermes memory reset\` CLI subcommand. Management/admin backends need a programmatic interface; this adds the minimum required surface (read + delete) without changing the agent-facing \`memory\` tool.

## Implementation notes

- \`MemoryStore.clear(target)\` (in \`tools/memory_tool.py\`) added with the same file-lock + atomic-rename path as \`add\`/\`remove\`. Re-reads from disk under lock so concurrent writes from other processes aren't lost.
- \`MemoryStore.snapshot(target)\` exposes a JSON-serializable view (entries + char counts + usage percent) for admin callers without leaking private internals.
- Both endpoints reuse the existing \`Authorization: Bearer <API_SERVER_KEY>\` auth path via \`_check_auth\`.
- Only the built-in file-backed store is covered. External memory providers (Honcho, retaindb, supermemory, …) still own their own delete APIs and aren't proxied here — that would require a new abstract method on \`MemoryProvider\` and is intentionally out of scope.
- Like \`hermes memory reset\`, an already-running session keeps its frozen system-prompt snapshot until next restart; this preserves the prefix cache.

## Tests

- \`tests/gateway/test_api_server_memory.py\` — 16 endpoint tests:
  - list all / single target / empty store
  - invalid target rejected
  - delete by \`old_text\` (success + 404 on no match)
  - \`old_text\` + \`target=all\` rejected
  - clear single store / both / when already empty
  - auth enforcement (401 / 200 with valid key)
- \`tests/tools/test_memory_tool.py\` — 9 unit tests for \`MemoryStore.clear()\` and \`MemoryStore.snapshot()\` covering the full matrix (empty, partial, persistence-across-instances, target isolation).

\`\`\`
55 passed, 16 warnings in 2.62s
\`\`\`

## Files

- \`tools/memory_tool.py\` — \`MemoryStore.clear()\`, \`MemoryStore.snapshot()\`
- \`gateway/platforms/api_server.py\` — \`_handle_get_memory\`, \`_handle_delete_memory\`, route registration, top-of-file docstring update
- \`tests/gateway/test_api_server_memory.py\` (new)
- \`tests/tools/test_memory_tool.py\` — added \`TestMemoryStoreClear\` and \`TestMemoryStoreSnapshotMethod\`