### PR TITLE
fix(gateway): handle Mattermost escaped slash commands

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -748,6 +748,13 @@ class MattermostAdapter(BasePlatformAdapter):
         # Thread support: if the post is in a thread, use root_id.
         thread_id = post.get("root_id") or None
 
+        # Mattermost asks users to prefix unsupported slash commands with a
+        # space, e.g. " /stop". Treat those as commands while preserving
+        # leading whitespace for normal text.
+        stripped_message_text = message_text.lstrip()
+        if stripped_message_text.startswith("/"):
+            message_text = stripped_message_text
+
         # Determine message type.
         file_ids = post.get("file_ids") or []
         msg_type = MessageType.TEXT

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -280,6 +280,55 @@ class TestMattermostWebSocketParsing:
         assert msg_event.message_id == "post_abc"
 
     @pytest.mark.asyncio
+    async def test_dm_leading_space_slash_command_is_command(self):
+        """Mattermost users can escape slash commands by prefixing a space."""
+        post_data = {
+            "id": "post_slash",
+            "user_id": "user_123",
+            "channel_id": "dm_456",
+            "message": " /stop",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "D",
+                "sender_name": "@alice",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "/stop"
+        assert msg_event.message_type.name == "COMMAND"
+
+    @pytest.mark.asyncio
+    async def test_dm_non_command_leading_space_is_preserved(self):
+        """Only slash commands should be lstripped."""
+        post_data = {
+            "id": "post_text_space",
+            "user_id": "user_123",
+            "channel_id": "dm_456",
+            "message": "  hello",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "D",
+                "sender_name": "@alice",
+            },
+        }
+
+        await self.adapter._handle_ws_event(event)
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "  hello"
+        assert msg_event.message_type.name == "TEXT"
+
+    @pytest.mark.asyncio
     async def test_ignore_own_messages(self):
         """Messages from the bot's own user_id should be ignored."""
         post_data = {


### PR DESCRIPTION
## Summary
- Treat Mattermost messages like ` /stop` as slash commands by stripping leading whitespace only when the first non-whitespace character is `/`
- Preserve leading whitespace for normal text messages
- Add regression coverage for both command and non-command cases

Fixes #20649

## Test Plan
- RED: before the implementation change, `scripts/run_tests.sh tests/gateway/test_mattermost.py::TestMattermostWebSocketParsing::test_dm_leading_space_slash_command_is_command tests/gateway/test_mattermost.py::TestMattermostWebSocketParsing::test_dm_non_command_leading_space_is_preserved` failed with `AssertionError: assert ' /stop' == '/stop'`
- GREEN: `scripts/run_tests.sh tests/gateway/test_mattermost.py` → 45 passed, 4 warnings
- `./.venv/bin/python -m ruff check gateway/platforms/mattermost.py tests/gateway/test_mattermost.py` → All checks passed

## Notes
- `scripts/run_tests.sh tests/gateway/` was also attempted locally, but the full gateway suite hit macOS file descriptor limits (`OSError: [Errno 24] Too many open files`) after the focused Mattermost suite had passed. I did not include unrelated gateway changes in this PR.
