### PR TITLE
fix: default API timeout to 120s and prefix system messages with [System]

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2250,7 +2250,7 @@ class BasePlatformAdapter(ABC):
                 # All retries exhausted (loop completed without break) — notify user
                 logger.error("[%s] Failed to deliver response after %d retries: %s", self.name, max_retries, error_str)
                 notice = (
-                    "\u26a0\ufe0f Message delivery failed after multiple attempts. "
+                    "[System] \u26a0\ufe0f Message delivery failed after multiple attempts. "
                     "Please try again \u2014 your request was processed but the response could not be sent."
                 )
                 try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2302,19 +2302,20 @@ class GatewayRunner:
                 pass
 
         status_detail = f" ({', '.join(status_parts)})" if status_parts else ""
+        system_prefix = "[System] "
         if is_steer_mode:
             message = (
-                f"⏩ Steered into current run{status_detail}. "
+                f"{system_prefix}⏩ Steered into current run{status_detail}. "
                 f"Your message arrives after the next tool call."
             )
         elif is_queue_mode:
             message = (
-                f"⏳ Queued for the next turn{status_detail}. "
+                f"{system_prefix}⏳ Queued for the next turn{status_detail}. "
                 f"I'll respond once the current task finishes."
             )
         else:
             message = (
-                f"⚡ Interrupting current task{status_detail}. "
+                f"{system_prefix}⚡ Interrupting current task{status_detail}. "
                 f"I'll respond to your message shortly."
             )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1347,6 +1347,11 @@ class AIAgent:
         # router-based implicit auth) can apply it consistently.  Bedrock
         # Claude uses its own timeout path and is not covered here.
         _provider_timeout = get_provider_request_timeout(self.provider, self.model)
+        # Default fallback: prevent unbounded hangs when the provider config doesn't
+        # specify request_timeout_seconds (e.g. default Ollama / local model setups).
+        # The OpenAI SDK defaults to ~600s without an explicit timeout.
+        if _provider_timeout is None:
+            _provider_timeout = 120.0
 
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -58,6 +58,7 @@ AUTHOR_MAP = {
     "252811164+adybag14-cyber@users.noreply.github.com": "adybag14-cyber",
     "14046872+tmimmanuel@users.noreply.github.com": "tmimmanuel",
     "657290301@qq.com": "IMHaoyan",
+    "puppy@hidden.dev": "HiddenPuppy",
     "revar@users.noreply.github.com": "revaraver",
     "dengtaoyuan@dengtaoyuandeMac-mini.local": "dengtaoyuan450-a11y",
     "ysfalweshcan@gmail.com": "Junass1",


### PR DESCRIPTION
Addresses #21061 — three related bugs:

## 1. Local Ollama hang (548s wait)
**Root cause**: `get_provider_request_timeout()` returns `None` when `request_timeout_seconds` isn't set in config. The OpenAI/httpx client then uses its default ~600s timeout. When Ollama is unreachable, the agent hangs for ~548s instead of fast-failing.

**Fix**: Add a 120s default fallback when no provider timeout is configured. This applies to all OpenAI-compatible providers (Ollama, vLLM, llama.cpp, etc.).

```python
if _provider_timeout is None:
    _provider_timeout = 120.0
```

## 2. Indistinguishable status messages
Busy-ack / system notifications (e.g. "Interrupting current task…", "Queued for next turn…") were sent as plain markdown, visually identical to actual agent replies. Users couldn't tell if messages were system status or agent responses.

**Fix**: Prefix all gateway status messages with `[System]`.

## 3. Delivery-failure notice also lacked a marker
When `_send_with_retry` exhausts retries, it sends a delivery-failure notice. This also had no system marker.

**Fix**: Added `[System]` prefix to the delivery-failure notice.

## Testing
- The timeout change is the most critical fix and directly addresses the 548s hang
- Status message prefixes are additive — existing markdown formatting preserved
- No breaking changes to existing APIs
