### PR TITLE
docs(account_usage): add docstrings to public API functions

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -86,6 +86,15 @@ def _format_reset(dt: Optional[datetime]) -> str:
 
 
 def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, markdown: bool = False) -> list[str]:
+    """Render an AccountUsageSnapshot into display-ready lines.
+
+    Args:
+        snapshot: The usage snapshot to render, or None.
+        markdown: If True, format the header with bold markdown.
+
+    Returns:
+        List of formatted strings, or empty list when snapshot is None.
+    """
     if not snapshot:
         return []
     header = f"📈 {'**' if markdown else ''}{snapshot.title}{'**' if markdown else ''}"
@@ -311,6 +320,18 @@ def fetch_account_usage(
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
 ) -> Optional[AccountUsageSnapshot]:
+    """Fetch account usage data for a supported provider.
+
+    Args:
+        provider: Provider identifier (e.g., "anthropic", "openai-codex", "openrouter").
+            "auto", "custom", or empty short-circuit to None.
+        base_url: Base URL for the API (used by openrouter).
+        api_key: API key for the provider (used by openrouter).
+
+    Returns:
+        AccountUsageSnapshot on success, None for unsupported provider or on any error.
+        Exceptions are swallowed and turned into None.
+    """
     normalized = str(provider or "").strip().lower()
     if normalized in {"", "auto", "custom"}:
         return None


### PR DESCRIPTION
## Summary

Add Google-style docstrings to the two public functions in `agent/account_usage.py`:

- `render_account_usage_lines` — render an `AccountUsageSnapshot` into display-ready lines
- `fetch_account_usage` — dispatch to the per-provider fetcher and return a snapshot, swallowing exceptions

Pure documentation change. No behavior modification, no test changes.

## Why

Both functions are public API (no leading underscore) and exported in practice — `render_account_usage_lines` is used by the chat/dashboard to format provider-quota readouts, and `fetch_account_usage` is the entry point that callers reach for. Neither carried a docstring; both required readers to inspect the body to know that `"auto"`/`"custom"`/empty short-circuit to `None` or that the fetcher swallows all exceptions. The new docstrings record those non-obvious contracts.

## Verification

```
python -c "import agent.account_usage; print('ok')"
ok
```

Private helpers (underscore-prefixed) intentionally untouched.