### PR TITLE
fix(tui): distinguish LF from Return in key parser

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/events/cmd-shortcuts.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/events/cmd-shortcuts.test.ts
@@ -30,6 +30,14 @@ describe('enhanced keyboard modifier parsing', () => {
     expect(modifyOtherShiftEnter.input).toBe('')
   })
 
+  it('treats raw LF as Ctrl+Enter for terminal text newline keybinds', () => {
+    const rawLf = new InputEvent(parseOne('\n'))
+
+    expect(rawLf.key.return).toBe(true)
+    expect(rawLf.key.ctrl).toBe(true)
+    expect(rawLf.input).toBe('')
+  })
+
   it('preserves Cmd as super for kitty keyboard CSI-u sequences', () => {
     const parsed = parseOne('\u001b[99;9u')
     const event = new InputEvent(parsed)

--- a/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/parse-keypress.ts
@@ -807,6 +807,13 @@ function parseKeypress(s: string = ''): ParsedKey {
   if (s === '\r' || s === '\n') {
     key.raw = undefined
     key.name = 'return'
+
+    // Ghostty keybinds like `shift+enter=text:\n` inject a raw LF. Treat it
+    // as Ctrl+Return so the Hermes composer inserts a newline instead of
+    // submitting, while plain Enter (CR) keeps its submit behavior.
+    if (s === '\n') {
+      key.ctrl = true
+    }
   } else if (s === '\t') {
     key.name = 'tab'
   } else if (s === '\b' || s === '\x1b\b') {


### PR DESCRIPTION
Summary

Fix Hermes TUI handling of raw LF input from terminals such as Ghostty.

Ghostty users can configure Shift+Enter / Ctrl+Enter as:

```ini
keybind = shift+enter=text:\n
keybind = ctrl+enter=text:\n
```

Codex and Hermes classic CLI treat raw LF (`\n`) as newline intent. Hermes TUI previously collapsed raw LF into ordinary Return semantics, causing Shift+Enter to submit instead of inserting a newline.

This change preserves the distinction:

- raw LF (`\n`) maps to Ctrl+Return / newline intent
- raw CR (`\r`) maps to ordinary Return / submit intent

Test Plan

- [x] `npm test -- packages/hermes-ink/src/ink/events/cmd-shortcuts.test.ts`
- [x] `npm run type-check`
- [x] `npm run build`
