### PR TITLE
fix: Allow continuation retry for first message truncation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -11839,16 +11839,39 @@ class AIAgent:
                                 "error": "Response truncated due to output length limit"
                             }
                         else:
-                            # First message was truncated - mark as failed
-                            self._vprint(f"{self.log_prefix}❌ First response truncated - cannot recover", force=True)
+                            # First message was truncated — try continuation retry before giving up
+                            if length_continue_retries < 3:
+                                length_continue_retries += 1
+                                self._vprint(
+                                    f"{self.log_prefix}↻ Requesting continuation for first message "
+                                    f"({length_continue_retries}/3)...",
+                                    force=True,
+                                )
+                                continue_msg = {
+                                    "role": "user",
+                                    "content": (
+                                        "[System: Your previous response was truncated by the output "
+                                        "length limit. Continue exactly where you left off. Do not "
+                                        "restart or repeat prior text. Finish the answer directly.]"
+                                    ),
+                                }
+                                messages.append(continue_msg)
+                                self._session_messages = messages
+                                self._save_session_log(messages)
+                                restart_with_length_continuation = True
+                                continue
+
+                            # All continuation attempts exhausted — return partial response if available
+                            partial_response = self._strip_think_blocks(truncated_response_prefix).strip()
+                            self._cleanup_task_resources(effective_task_id)
                             self._persist_session(messages, conversation_history)
                             return {
-                                "final_response": None,
+                                "final_response": partial_response or None,
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
-                                "failed": True,
-                                "error": "First response truncated due to output length limit"
+                                "partial": True,
+                                "error": "First response remained truncated after 3 continuation attempts",
                             }
                     
                     # Track actual token usage from response for context management


### PR DESCRIPTION
## Summary

This fix addresses issue #20519 where users see 'Response truncated due to output length limit' error on new chats, especially on WhatsApp platform.

## Changes

- When the first response is truncated in a new chat, the agent now attempts up to 3 continuation retries instead of immediately failing
- If all continuation attempts are exhausted, the partial response content is returned instead of an error
- This matches the existing behavior for non-first message truncation

## Root Cause

Previously, when  (new chat) and the response was truncated, the code would immediately return a failed state without attempting any recovery. This fix adds continuation retry logic consistent with the existing handling for mid-conversation truncation.

## Testing

The fix follows the same pattern as the existing  logic used for non-first message truncation (lines 11760-11783 in original code).

Closes #20519