### PR TITLE
fix(gateway): stop post-stream media delivery from uploading bare local paths (#20834)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8750,19 +8750,25 @@ class GatewayRunner:
         event: MessageEvent,
         adapter,
     ) -> None:
-        """Extract MEDIA: tags and local file paths from a response and deliver them.
+        """Extract MEDIA: tags from a response and deliver the attachments.
 
         Called after streaming has already sent the text to the user, so the
         text itself is already delivered — this only handles file attachments
         that the normal _process_message_background path would have caught.
+
+        Only *explicit* ``MEDIA:`` directives are promoted to uploads.  Bare
+        local filesystem paths that happen to appear in tool output or
+        inspected content are intentionally ignored here: the user-visible
+        reply has already been sent without them, so attaching those paths
+        post-stream would leak internal/stale references the assistant never
+        meant to surface.  (Fixes #20834.)
         """
         from pathlib import Path
         from urllib.parse import quote as _quote
 
         try:
             media_files, _ = adapter.extract_media(response)
-            _, cleaned = adapter.extract_images(response)
-            local_files, _ = adapter.extract_local_files(cleaned)
+            local_files: list = []  # intentionally empty — see docstring
 
             _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
 

--- a/tests/gateway/test_post_stream_media_delivery.py
+++ b/tests/gateway/test_post_stream_media_delivery.py
@@ -1,0 +1,123 @@
+"""Regression tests for _deliver_media_from_response post-stream delivery.
+
+Fixes #20834: bare local filesystem paths that appeared in tool output or
+inspected content must NOT be promoted to attachments after streaming.
+Only explicit MEDIA: directives should trigger post-stream uploads.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _make_runner():
+    """Build a minimal GatewayRunner-like object with just the method under test."""
+    from gateway.run import GatewayRunner  # noqa: PLC0415
+
+    runner = object.__new__(GatewayRunner)
+    return runner
+
+
+def _make_event(chat_id: str = "C123", thread_id: str | None = None):
+    event = MagicMock()
+    event.source.chat_id = chat_id
+    event.source.thread_id = thread_id
+    return event
+
+
+def _make_adapter(*, extract_media_return=None, extract_images_return=None, extract_local_files_return=None):
+    adapter = MagicMock()
+    adapter.name = "test-adapter"
+    adapter.extract_media.return_value = (extract_media_return or [], "")
+    adapter.extract_images.return_value = ([], "cleaned-text")
+    adapter.extract_local_files.return_value = (extract_local_files_return or [], "")
+    adapter.send_multiple_images = AsyncMock()
+    adapter.send_voice = AsyncMock()
+    adapter.send_video = AsyncMock()
+    adapter.send_document = AsyncMock()
+    return adapter
+
+
+class TestPostStreamBarePathIgnored:
+    """Bare local paths in response text must NOT trigger post-stream uploads."""
+
+    def test_bare_local_path_in_response_does_not_trigger_upload(self, tmp_path):
+        """A response that contains /path/to/image.png but no MEDIA: directive
+        must not upload anything after the text is already sent (fixes #20834)."""
+        img = tmp_path / "internal_reference.png"
+        img.write_bytes(b"PNG")
+
+        response = f"I analysed the file at {img}. No attachment intended."
+        adapter = _make_adapter(
+            extract_media_return=[],
+            extract_local_files_return=[str(img)],  # simulates old behavior
+        )
+        event = _make_event()
+        runner = _make_runner()
+
+        asyncio.run(runner._deliver_media_from_response(response, event, adapter))
+
+        adapter.send_multiple_images.assert_not_called()
+        adapter.send_document.assert_not_called()
+        adapter.send_video.assert_not_called()
+        adapter.send_voice.assert_not_called()
+
+    def test_bare_local_video_path_in_response_does_not_trigger_upload(self, tmp_path):
+        """A response containing a local video path but no MEDIA: directive must
+        not upload anything."""
+        vid = tmp_path / "captured_output.mp4"
+        vid.write_bytes(b"MP4")
+
+        response = f"Processing finished; intermediate output at {vid}."
+        adapter = _make_adapter(
+            extract_media_return=[],
+            extract_local_files_return=[str(vid)],
+        )
+        event = _make_event()
+        runner = _make_runner()
+
+        asyncio.run(runner._deliver_media_from_response(response, event, adapter))
+
+        adapter.send_video.assert_not_called()
+        adapter.send_document.assert_not_called()
+
+
+class TestPostStreamExplicitMediaDirectiveStillWorks:
+    """Explicit MEDIA: directives must continue to be delivered post-stream."""
+
+    def test_explicit_media_image_is_delivered(self, tmp_path):
+        """An explicit MEDIA: tag must still result in an image upload."""
+        img = tmp_path / "chart.png"
+        img.write_bytes(b"PNG")
+
+        response = f"Here is the chart. MEDIA:{img}"
+        adapter = _make_adapter(
+            extract_media_return=[(str(img), False)],
+        )
+        event = _make_event()
+        runner = _make_runner()
+
+        asyncio.run(runner._deliver_media_from_response(response, event, adapter))
+
+        adapter.send_multiple_images.assert_called_once()
+
+    def test_explicit_media_document_is_delivered(self, tmp_path):
+        """A non-image explicit MEDIA: file must be sent as a document."""
+        doc = tmp_path / "report.pdf"
+        doc.write_bytes(b"PDF")
+
+        response = f"Report generated. MEDIA:{doc}"
+        adapter = _make_adapter(
+            extract_media_return=[(str(doc), False)],
+        )
+        event = _make_event()
+        runner = _make_runner()
+
+        asyncio.run(runner._deliver_media_from_response(response, event, adapter))
+
+        adapter.send_document.assert_called_once()


### PR DESCRIPTION
## Summary

`_deliver_media_from_response()` was calling `extract_local_files(cleaned)` after streaming, promoting bare filesystem paths from tool output or inspected content into real file uploads — even when the visible final reply contained no intentional attachment directive.

## Root Cause

The post-stream helper reconstructed the full response context and extracted local paths from it. Any path that appeared in tool output, `cat` output, or other agent-internal content could end up as an upload after the text reply was already sent.

Representative failure (from issue):
```
INFO  [Slack] Sending response (11164 chars)
INFO  [Slack] Sending 1 image(s) in single files_upload_v2   ← unintended upload
WARNING [Slack] Skipping missing image: /.../internal_ref.png
```

## Fix

Remove the `extract_local_files(cleaned)` call from the post-stream helper. Post-stream delivery now handles **only explicit `MEDIA:` directives** (`extract_media()`) — the same directives the agent explicitly places in its response text.

Bare local path delivery continues to work in the non-streaming `_process_message_background` path, where the full response is intentionally assembled before any delivery happens.

```diff
-            _, cleaned = adapter.extract_images(response)
-            local_files, _ = adapter.extract_local_files(cleaned)
+            local_files: list = []  # intentionally empty — see docstring
```

## Testing

```bash
python -m pytest tests/gateway/test_post_stream_media_delivery.py tests/gateway/test_extract_local_files.py -q
# 41 passed
```

4 new regression tests cover:
1. bare image path in response → no upload
2. bare video path in response → no upload
3. explicit `MEDIA:` image → still delivered
4. explicit `MEDIA:` document → still delivered

## Related

Fixes #20834
Related to #16434 (visible `MEDIA:` examples in grep output causing uploads — different trigger, same class of problem)