### PR TITLE
fix(gateway): strip language tag from Slack fenced code blocks

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2085,10 +2085,25 @@ class SlackAdapter(BasePlatformAdapter):
 
         text = content
 
-        # 1) Protect fenced code blocks (``` ... ```)
+        # 1) Protect fenced code blocks (``` ... ```).  Slack's mrkdwn does not
+        # strip the optional language tag like GitHub-flavored markdown — it
+        # renders ```text\nfoo\n``` as a code block whose literal first line
+        # is "text".  Drop the tag from the opening fence before stashing.
+        # Stripping only fires for a genuine opening fence — a ``` at the
+        # start of a line, tagged with a single token (no spaces/backticks).
+        # The outer regex below deliberately matches loosely, so it can also
+        # group from a mid-line ``` (e.g. an inline ```span```); that first
+        # line is real content and must survive byte-for-byte.  This pass
+        # runs first, so match positions refer to the original message.
+        def _protect_fence(m):
+            block = m.group(0)
+            if m.start() == 0 or m.string[m.start() - 1] == "\n":
+                block = re.sub(r"\A```[^\s`]+[ \t]*(\r?\n)", r"```\1", block)
+            return _ph(block)
+
         text = re.sub(
             r"(```(?:[^\n]*\n)?[\s\S]*?```)",
-            lambda m: _ph(m.group(0)),
+            _protect_fence,
             text,
         )
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2469,7 +2469,60 @@ class TestFormatMessage:
         assert adapter.format_message("~~deleted~~") == "~deleted~"
 
     def test_code_block_preserved(self, adapter):
+        # Slack mrkdwn doesn't recognize language tags — it would render the
+        # tag as a literal first line of the code block — so the converter
+        # strips it.  Body content is still passed through verbatim.
         code = "```python\nx = **not bold**\n```"
+        assert adapter.format_message(code) == "```\nx = **not bold**\n```"
+
+    def test_code_block_strips_language_tag(self, adapter):
+        # Regression: Slack rendered a literal "text" line at the top of code
+        # blocks containing raw command output because the LLM emitted
+        # ```text fences and the converter passed them through unchanged.
+        code = "```text\nhello world\nline 2\n```"
+        assert adapter.format_message(code) == "```\nhello world\nline 2\n```"
+
+    def test_code_block_no_language_tag_unchanged(self, adapter):
+        code = "```\nplain output\n```"
+        assert adapter.format_message(code) == code
+
+    def test_inline_triple_backtick_unchanged(self, adapter):
+        # Single-line ```hello``` has no newline after the opening fence, so
+        # nothing should be stripped.
+        code = "```hello```"
+        assert adapter.format_message(code) == code
+
+    def test_mid_line_triple_backticks_content_preserved(self, adapter):
+        # The fence-protection regex matches loosely, so the inline
+        # ```pip install foo``` span is grouped as an "opening fence" whose
+        # first line is real content.  Stripping only fires for a ``` at the
+        # start of a line, so the span survives byte-for-byte.
+        text = "Use ```pip install foo``` then:\n```bash\ncode\n```"
+        assert adapter.format_message(text) == text
+
+    def test_mid_line_single_token_span_preserved(self, adapter):
+        # A single-token inline span that wraps across a newline looks
+        # exactly like a language tag — the line-start guard is what keeps
+        # the word "quotes" from being stripped as one.
+        text = "Wrap it in ```quotes\nlike this\n```"
+        assert adapter.format_message(text) == text
+
+    def test_back_to_back_fences_second_token_preserved(self, adapter):
+        # The second ``` group starts mid-line (right after the previous
+        # closing fence), so its first token is content, not a tag.
+        text = "```\nx\n``````b\ny\n```"
+        assert adapter.format_message(text) == text
+
+    def test_code_block_lang_tag_trailing_spaces_stripped(self, adapter):
+        code = "```python  \nx = 1\n```"
+        assert adapter.format_message(code) == "```\nx = 1\n```"
+
+    def test_code_block_crlf_lang_tag_stripped_preserves_crlf(self, adapter):
+        code = "```python\r\nx = 1\r\n```"
+        assert adapter.format_message(code) == "```\r\nx = 1\r\n```"
+
+    def test_code_block_crlf_no_tag_unchanged(self, adapter):
+        code = "```\r\nplain output\r\n```"
         assert adapter.format_message(code) == code
 
     def test_inline_code_preserved(self, adapter):
@@ -2623,9 +2676,9 @@ class TestFormatMessage:
     # --- Additional edge cases ---
 
     def test_message_only_code_block(self, adapter):
-        """Entire message is a fenced code block — no conversion."""
+        """Entire message is a fenced code block — body preserved, lang tag dropped."""
         code = "```python\nx = 1\n```"
-        assert adapter.format_message(code) == code
+        assert adapter.format_message(code) == "```\nx = 1\n```"
 
     def test_multiline_mixed_formatting(self, adapter):
         """Multi-line message with headers, bold, links, code, and blockquotes."""
@@ -2753,7 +2806,8 @@ class TestEditMessageStreamingPipeline:
         assert result.success is True
         kwargs = adapter._app.client.chat_update.call_args.kwargs
         assert kwargs["text"].startswith("*Result:*")
-        assert "```python\nprint('hello')\n```" in kwargs["text"]
+        # Language tag is stripped — Slack mrkdwn would render it as a literal line
+        assert "```\nprint('hello')\n```" in kwargs["text"]
 
     @pytest.mark.asyncio
     async def test_edit_message_formats_blockquote_in_stream(self, adapter):


### PR DESCRIPTION
## Summary

Slack's `mrkdwn` does not strip the optional language tag from fenced code blocks the way GitHub-flavored markdown does — it renders the tag as a literal first line of the rendered code block. When the agent emitted ` ```text ` fences around raw command output (a common LLM habit), every such block in Slack arrived looking like:

```
text
<the actual command output>
```

`format_message()` "protects" fenced code blocks by stashing them verbatim behind a placeholder, so the language tag survived all the way to `chat_postMessage`. This PR drops the tag from the opening fence before stashing.

> **Update 2026-07-15:** rebased onto current `main` and ported to `plugins/platforms/slack/adapter.py` following the adapter migration in 5600105 (the original patch targeted the now-removed `gateway/platforms/slack.py`). While porting, the strip was hardened: it now only fires for a genuine opening fence — a ` ``` ` at the **start of a line**, tagged with a **single token** (no spaces/backticks) — and preserves the original (CR)LF. Adversarial old-vs-new fuzzing showed the original `\A```[^\n]*\n` substitution could silently delete real content when the deliberately loose fence-protection regex groups a *mid-line* ` ``` ` (e.g. an inline ` ```span``` ` wrapping across a newline) as an "opening fence". With the line-start guard, the only behavioral delta vs `main` is the tag strip itself.

## Why this is still relevant now that Block Kit rendering is on main

The Block Kit `markdown` rendering path (#8552 / #19108) is on `main`, but it does not cover this: `render_blocks()` intercepts fenced code itself (into `rich_text_preformatted`) and never routes fences through `format_message()`, while `format_message()` remains the producer of every surface that is still plain mrkdwn:

- the **plain-text fallback** field sent alongside blocks on every message — Slack uses it for notifications, search indexing, screen readers, and quoted/forwarded message previews;
- **slash-command ephemeral replies** (`response_url` path);
- **standalone cron delivery** (`chat.postMessage` without the in-process adapter);
- any message where the block renderer declines and the caller falls back to `text`.

Without this fix, all of those surfaces still leak the literal `text` line.

## Changes

| File | Change |
|------|--------|
| `plugins/platforms/slack/adapter.py` | `format_message()` now strips the language tag from the opening fence inside the code-block protection step. Stripping requires a line-start fence and a single-token tag; the original line ending is preserved. |
| `tests/gateway/test_slack.py` | Updated 3 existing assertions that expected lang-tag preservation; added 9 regression tests: the ` ```text ` case mirroring the bug, bare/single-line fences left untouched, tags with trailing spaces, CRLF fences (tagged and untagged), mid-line ` ``` ` spans (multi-word and single-token), and back-to-back fences. |

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/test_slack.py tests/gateway/test_slack_block_kit.py tests/gateway/test_slack_block_kit_adapter.py` — 283 passed, 0 failed
- [x] Full `tests/gateway/` run — only pre-existing failures unrelated to this change (WeCom optional XML dependency, a startup-restart race test), reproduced identically on pristine `main`
- [x] Adversarial differential fuzz (20,000 generated messages, `main`'s `format_message` vs this branch): no deviation beyond the intended single-token tag strip on line-start fences
- [x] Manually verified on a live Slack workspace (pre-migration adapter; the fence-stripping behavior for the ` ```text ` case is identical): messages from the agent containing ` ```text\n…\n``` ` no longer render a literal `text` line at the top of the code block
- [x] No cross-platform impact — change is confined to the Slack adapter's `format_message()`
- [x] `ruff check` clean on both files

## Tested on

- Linux, Python 3.12.

Related: #8552, #19108
