### PR TITLE
fix(gateway): add WeChat rate limit patterns to retryable errors

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1026,6 +1026,10 @@ _RETRYABLE_ERROR_PATTERNS = (
     "broken pipe",
     "remotedisconnected",
     "eoferror",
+    # WeChat/Weixin iLink rate limit errors (issue #21061)
+    "rate limited",
+    "ilink sendmessage rate limited",
+    "ret=-2",
 )
 
 


### PR DESCRIPTION
## Problem

WeChat iLink rate limit errors (`iLink sendmessage rate limited`, `ret=-2`) were not in `_RETRYABLE_ERROR_PATTERNS`, so `_send_with_retry` treated them as permanent failures and skipped both retry and the delivery-failure notice to the user (issue #21061 - bug 2).

## Fix

Add WeChat rate limit patterns to `_RETRYABLE_ERROR_PATTERNS`. After exhausting internal WeChat retries in `_send_text_chunk`, the error now triggers `_send_with_retry` exponential backoff and sends a delivery-failure notice if all retries are exhausted.

Complements #21076 which fixes bugs 1 and 3.

Fixes #21061 (partial - issue 2)