### PR TITLE
feat: add Pinecone memory embedding foundation

### DIFF
--- a/agent/memory_embeddings.py
+++ b/agent/memory_embeddings.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Any, Optional
+
+from agent.auxiliary_client import resolve_provider_client
+from hermes_cli.config import load_config
+
+_DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
+_DEFAULT_EMBEDDING_PROVIDER = "openrouter"
+_CHUNK_ID_PREFIX = "memory-chunk"
+
+
+class MemoryEmbedder:
+    """Thin embedding wrapper for memory ingestion and retrieval.
+
+    Provider/model resolution comes from explicit constructor overrides first,
+    then ``config.yaml`` ``memory.embedding_*`` keys when present, and finally
+    the ``MEMORY_EMBEDDING_*`` environment variables.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        client: Any = None,
+        config: Optional[dict[str, Any]] = None,
+    ) -> None:
+        self._config = config if config is not None else load_config()
+        memory_cfg = self._config.get("memory", {}) if isinstance(self._config, dict) else {}
+        self.provider = (
+            provider
+            or (memory_cfg.get("embedding_provider") if isinstance(memory_cfg, dict) else None)
+            or os.getenv("MEMORY_EMBEDDING_PROVIDER")
+            or _DEFAULT_EMBEDDING_PROVIDER
+        )
+        requested_model = (
+            model
+            or (memory_cfg.get("embedding_model") if isinstance(memory_cfg, dict) else None)
+            or os.getenv("MEMORY_EMBEDDING_MODEL")
+            or _DEFAULT_EMBEDDING_MODEL
+        )
+        self.client, resolved_model = (client, requested_model)
+        if self.client is None:
+            self.client, resolved_model = resolve_provider_client(self.provider, requested_model)
+        if self.client is None:
+            raise RuntimeError(
+                f"Unable to initialize memory embedding client for provider {self.provider!r}"
+            )
+        self.model = resolved_model or requested_model
+
+    @staticmethod
+    def content_hash(text: str) -> str:
+        return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+    @classmethod
+    def chunk_id_for_text(cls, text: str, *, prefix: str = _CHUNK_ID_PREFIX) -> str:
+        return f"{prefix}:{cls.content_hash(text)}"
+
+    def chunk_ids_for_texts(self, texts: list[str], *, prefix: str = _CHUNK_ID_PREFIX) -> list[str]:
+        return [self.chunk_id_for_text(text, prefix=prefix) for text in texts]
+
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        response = self.client.embeddings.create(model=self.model, input=texts)
+        return [list(item.embedding) for item in response.data]
+
+    def embed_query(self, text: str) -> list[float]:
+        response = self.client.embeddings.create(model=self.model, input=text)
+        if not response.data:
+            raise RuntimeError("Embedding provider returned no vectors for query")
+        return list(response.data[0].embedding)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -960,6 +960,16 @@ DEFAULT_CONFIG = {
         "user_profile_enabled": True,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        "pinecone_enabled": False,
+        "pinecone_namespace": "",
+        "pinecone_top_k": 8,
+        "pinecone_min_score": 0.0,
+        "pinecone_max_context_items": 8,
+        "pinecone_retrieval_enabled_platforms": [],
+        "pinecone_ingest_session_summaries": True,
+        "pinecone_ingest_topic_files": True,
+        "pinecone_ingest_skills": True,
+        "pinecone_fail_open": True,
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".
@@ -1336,7 +1346,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 23,
+    "_config_version": 24,
 }
 
 # =============================================================================
@@ -1352,6 +1362,10 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
+    24: [
+        "PINECONE_API_KEY", "PINECONE_INDEX_HOST", "PINECONE_INDEX_NAME",
+        "PINECONE_NAMESPACE", "MEMORY_EMBEDDING_MODEL", "MEMORY_EMBEDDING_PROVIDER",
+    ],
 }
 
 # Required environment variables with metadata for migration prompts.
@@ -1993,6 +2007,52 @@ OPTIONAL_ENV_VARS = {
         "description": "Base URL for self-hosted Honcho instances (no API key needed)",
         "prompt": "Honcho base URL (e.g. http://localhost:8000)",
         "category": "tool",
+    },
+
+    # ── Pinecone memory retrieval ──
+    "PINECONE_API_KEY": {
+        "description": "Pinecone API key for vector memory retrieval",
+        "prompt": "Pinecone API key",
+        "url": "https://app.pinecone.io/",
+        "password": True,
+        "category": "tool",
+    },
+    "PINECONE_INDEX_HOST": {
+        "description": "Pinecone index host URL",
+        "prompt": "Pinecone index host",
+        "url": None,
+        "password": False,
+        "category": "tool",
+    },
+    "PINECONE_INDEX_NAME": {
+        "description": "Pinecone index name",
+        "prompt": "Pinecone index name",
+        "url": None,
+        "password": False,
+        "category": "tool",
+    },
+    "PINECONE_NAMESPACE": {
+        "description": "Default Pinecone namespace for Hermes memory",
+        "prompt": "Pinecone namespace",
+        "url": None,
+        "password": False,
+        "category": "tool",
+    },
+    "MEMORY_EMBEDDING_MODEL": {
+        "description": "Embedding model used for Hermes memory vectors",
+        "prompt": "Memory embedding model",
+        "url": None,
+        "password": False,
+        "category": "tool",
+        "advanced": True,
+    },
+    "MEMORY_EMBEDDING_PROVIDER": {
+        "description": "Provider used for Hermes memory embeddings",
+        "prompt": "Memory embedding provider",
+        "url": None,
+        "password": False,
+        "category": "tool",
+        "advanced": True,
     },
 
     # ── Langfuse observability ──

--- a/tests/agent/test_memory_embeddings.py
+++ b/tests/agent/test_memory_embeddings.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+
+from agent.memory_embeddings import MemoryEmbedder
+
+
+class _FakeEmbeddingsAPI:
+    def __init__(self):
+        self.calls = []
+
+    def create(self, *, model, input):
+        self.calls.append({"model": model, "input": input})
+        if isinstance(input, list):
+            data = [SimpleNamespace(embedding=[float(i), float(i) + 0.5]) for i, _ in enumerate(input)]
+        else:
+            data = [SimpleNamespace(embedding=[1.0, 2.0, 3.0])]
+        return SimpleNamespace(data=data)
+
+
+class _FakeClient:
+    def __init__(self):
+        self.embeddings = _FakeEmbeddingsAPI()
+
+
+def test_embed_texts_batches_inputs(monkeypatch):
+    fake_client = _FakeClient()
+    monkeypatch.setattr(
+        "agent.memory_embeddings.resolve_provider_client",
+        lambda provider, model: (fake_client, model),
+    )
+
+    embedder = MemoryEmbedder(provider="openrouter", model="text-embedding-test")
+    vectors = embedder.embed_texts(["alpha", "beta"])
+
+    assert vectors == [[0.0, 0.5], [1.0, 1.5]]
+    assert fake_client.embeddings.calls == [
+        {"model": "text-embedding-test", "input": ["alpha", "beta"]}
+    ]
+
+
+def test_embed_query_uses_single_string_input(monkeypatch):
+    fake_client = _FakeClient()
+    monkeypatch.setattr(
+        "agent.memory_embeddings.resolve_provider_client",
+        lambda provider, model: (fake_client, model),
+    )
+
+    embedder = MemoryEmbedder(provider="openrouter", model="text-embedding-test")
+    vector = embedder.embed_query("find this")
+
+    assert vector == [1.0, 2.0, 3.0]
+    assert fake_client.embeddings.calls == [
+        {"model": "text-embedding-test", "input": "find this"}
+    ]
+
+
+def test_chunk_id_generation_is_stable_and_content_based(monkeypatch):
+    fake_client = _FakeClient()
+    monkeypatch.setattr(
+        "agent.memory_embeddings.resolve_provider_client",
+        lambda provider, model: (fake_client, model),
+    )
+
+    embedder = MemoryEmbedder(provider="openrouter", model="text-embedding-test")
+
+    text = "same input text"
+    same_id = embedder.chunk_id_for_text(text)
+
+    assert same_id == embedder.chunk_id_for_text(text)
+    assert same_id == "memory-chunk:df5a302847fc7c0cdba82e0c6c263841bff5dc3d80eb693889b66d4d6f650f8d"
+    assert same_id != embedder.chunk_id_for_text("different text")
+    assert embedder.chunk_ids_for_texts([text, "different text"]) == [
+        same_id,
+        embedder.chunk_id_for_text("different text"),
+    ]

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -379,6 +379,53 @@ class TestSanitizeEnvLines:
             assert fixes == 0
 
 
+class TestMemoryPineconeConfig:
+    def test_memory_defaults_include_pinecone_settings(self):
+        memory_cfg = DEFAULT_CONFIG["memory"]
+        assert memory_cfg["pinecone_enabled"] is False
+        assert memory_cfg["pinecone_namespace"] == ""
+        assert memory_cfg["pinecone_top_k"] == 8
+        assert memory_cfg["pinecone_min_score"] == 0.0
+        assert memory_cfg["pinecone_max_context_items"] == 8
+        assert memory_cfg["pinecone_retrieval_enabled_platforms"] == []
+        assert memory_cfg["pinecone_ingest_session_summaries"] is True
+        assert memory_cfg["pinecone_ingest_topic_files"] is True
+        assert memory_cfg["pinecone_ingest_skills"] is True
+        assert memory_cfg["pinecone_fail_open"] is True
+
+    def test_migrate_config_adds_pinecone_defaults_without_overwriting_existing_values(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 23,
+                    "memory": {
+                        "provider": "builtin",
+                        "pinecone_enabled": True,
+                        "pinecone_top_k": 42,
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+        assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+        assert raw["memory"]["pinecone_enabled"] is True
+        assert raw["memory"]["pinecone_top_k"] == 42
+        assert raw["memory"]["pinecone_namespace"] == ""
+        assert raw["memory"]["pinecone_min_score"] == 0.0
+        assert raw["memory"]["pinecone_max_context_items"] == 8
+        assert raw["memory"]["pinecone_retrieval_enabled_platforms"] == []
+        assert raw["memory"]["pinecone_ingest_session_summaries"] is True
+        assert raw["memory"]["pinecone_ingest_topic_files"] is True
+        assert raw["memory"]["pinecone_ingest_skills"] is True
+        assert raw["memory"]["pinecone_fail_open"] is True
+
+
 class TestOptionalEnvVarsRegistry:
     """Verify that key env vars are registered in OPTIONAL_ENV_VARS."""
 
@@ -386,6 +433,16 @@ class TestOptionalEnvVarsRegistry:
         """TAVILY_API_KEY is listed in OPTIONAL_ENV_VARS."""
         from hermes_cli.config import OPTIONAL_ENV_VARS
         assert "TAVILY_API_KEY" in OPTIONAL_ENV_VARS
+
+    def test_pinecone_and_memory_embedding_env_vars_registered(self):
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        assert OPTIONAL_ENV_VARS["PINECONE_API_KEY"]["password"] is True
+        assert OPTIONAL_ENV_VARS["PINECONE_INDEX_HOST"]["category"] == "tool"
+        assert OPTIONAL_ENV_VARS["PINECONE_INDEX_NAME"]["category"] == "tool"
+        assert OPTIONAL_ENV_VARS["PINECONE_NAMESPACE"]["category"] == "tool"
+        assert OPTIONAL_ENV_VARS["MEMORY_EMBEDDING_MODEL"]["advanced"] is True
+        assert OPTIONAL_ENV_VARS["MEMORY_EMBEDDING_PROVIDER"]["advanced"] is True
 
     def test_tavily_api_key_is_tool_category(self):
         """TAVILY_API_KEY is in the 'tool' category."""


### PR DESCRIPTION
## Summary
- add Pinecone memory config defaults and optional env metadata to the Hermes config surface
- implement `agent/memory_embeddings.py` with provider-routed embedding calls and deterministic content-hash chunk IDs
- add focused regression coverage for config migration/defaults and memory embedding behavior

## Test Plan
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_config.py tests/agent/test_memory_embeddings.py -q`
- `$HOME/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/hermes_cli/ tests/agent/test_memory_embeddings.py -q` *(fails due to pre-existing unrelated Hermes CLI suite issues, primarily missing `fastapi`/`uvicorn` for web server tests plus other baseline failures in bedrock/gateway/update tests)*

Closes WAT-1370
