### PR TITLE
feat(gateway): make reply snippet max length configurable

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -604,6 +604,13 @@ max_concurrent_sessions: null
 # explicitly want one shared "room brain" per group/channel.
 group_sessions_per_user: true
 
+# Maximum characters from a replied-to message to inject as context
+# in the [Replying to: "..."] prefix. Must resolve to an integer from 1 through
+# 10000; ${VAR} references may resolve to decimal integer strings. Invalid
+# values fall back to the default of 500.
+gateway:
+  reply_snippet_max_length: 500
+
 # ─────────────────────────────────────────────────────────────────────────────
 # API Server — per-client model routing
 # ─────────────────────────────────────────────────────────────────────────────

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2374,6 +2374,45 @@ def _load_gateway_config() -> dict:
     return raw
 
 
+# Bound misconfiguration so one reply cannot inject an unbounded quoted payload.
+_REPLY_SNIPPET_MAX_LENGTH_DEFAULT = 500
+_REPLY_SNIPPET_MAX_LENGTH_MIN = 1
+_REPLY_SNIPPET_MAX_LENGTH_MAX = 10_000
+
+
+def _get_reply_snippet_max_length() -> int:
+    """Return the configured reply-context budget or the safe default."""
+    config = _load_gateway_runtime_config()
+    gateway_config = config.get("gateway") if isinstance(config, dict) else None
+    if not isinstance(gateway_config, dict):
+        return _REPLY_SNIPPET_MAX_LENGTH_DEFAULT
+
+    value = gateway_config.get(
+        "reply_snippet_max_length",
+        _REPLY_SNIPPET_MAX_LENGTH_DEFAULT,
+    )
+    if isinstance(value, bool):
+        return _REPLY_SNIPPET_MAX_LENGTH_DEFAULT
+
+    if isinstance(value, int):
+        parsed_value = value
+    elif isinstance(value, str):
+        try:
+            parsed_value = int(value.strip())
+        except ValueError:
+            return _REPLY_SNIPPET_MAX_LENGTH_DEFAULT
+    else:
+        return _REPLY_SNIPPET_MAX_LENGTH_DEFAULT
+
+    if not (
+        _REPLY_SNIPPET_MAX_LENGTH_MIN
+        <= parsed_value
+        <= _REPLY_SNIPPET_MAX_LENGTH_MAX
+    ):
+        return _REPLY_SNIPPET_MAX_LENGTH_DEFAULT
+    return parsed_value
+
+
 def _load_gateway_runtime_config() -> dict:
     """Load gateway config for runtime reads, expanding supported ``${VAR}`` refs.
 
@@ -10589,14 +10628,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"{message_text}"
                 )
 
-        if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
+        reply_to_text = event.reply_to_text
+        if reply_to_text and event.reply_to_message_id:
             # Always inject the reply-to pointer — even when the quoted text
             # already appears in history. The prefix isn't deduplication, it's
             # disambiguation: it tells the agent *which* prior message the user
             # is referencing. History can contain the same or similar text
             # multiple times, and without an explicit pointer the agent has to
-            # guess (or answer for both subjects). Token overhead is minimal.
-            reply_snippet = event.reply_to_text[:500]
+            # guess (or answer for both subjects). The default keeps overhead
+            # modest, and the configurable budget remains hard-bounded.
+            reply_snippet = reply_to_text[:_get_reply_snippet_max_length()]
             if getattr(event, "reply_to_is_own_message", False):
                 message_text = (
                     f'[Replying to your previous message: "{reply_snippet}"]\n\n'

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2843,6 +2843,12 @@ DEFAULT_CONFIG = {
     # Gateway settings — control how messaging platforms (Telegram, Discord,
     # Slack, etc.) deliver agent-produced files as native attachments.
     "gateway": {
+        # Maximum characters from a replied-to message to inject in the
+        # ``[Replying to: "..."]`` context pointer. Must resolve to an integer
+        # from 1 through 10000; env refs may resolve to decimal integer strings.
+        # Invalid values fall back to 500.
+        "reply_snippet_max_length": 500,
+
         # Seconds the gateway waits for a single messaging platform to finish
         # connecting during startup (and on reconnect). Discord in particular
         # can blow past the old fixed 30s when an account has many slash

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -9,10 +9,13 @@ which prior message the user is referencing.
 """
 import pytest
 
+import gateway.run as gateway_run
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
+from hermes_cli.config import load_config
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
 
 def _make_runner() -> GatewayRunner:
@@ -34,6 +37,34 @@ def _source() -> SessionSource:
         chat_type="private",
         user_name="Alice",
     )
+
+
+async def _prepare_reply_with_limit(
+    monkeypatch,
+    tmp_path,
+    configured_value,
+    *,
+    text_length: int = 12_000,
+) -> str:
+    """Exercise config.yaml -> gateway loader -> reply slicing end to end."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        f"gateway:\n  reply_snippet_max_length: {configured_value!r}\n",
+        encoding="utf-8",
+    )
+    source = _source()
+    result = await _make_runner()._prepare_inbound_message_text(
+        event=MessageEvent(
+            text="follow-up",
+            source=source,
+            reply_to_message_id="42",
+            reply_to_text="x" * text_length,
+        ),
+        source=source,
+        history=[],
+    )
+    assert result is not None
+    return result
 
 
 @pytest.mark.asyncio
@@ -180,3 +211,79 @@ async def test_reply_snippet_truncated_to_500_chars():
     assert result is not None
     assert result.startswith('[Replying to: "' + "x" * 500 + '"]')
     assert "x" * 501 not in result
+
+
+def test_default_reply_snippet_limit_comes_from_canonical_config(tmp_path):
+    """The default is part of merged config, not only a call-site fallback."""
+    token = set_hermes_home_override(tmp_path)
+    try:
+        assert load_config()["gateway"]["reply_snippet_max_length"] == 500
+    finally:
+        reset_hermes_home_override(token)
+
+
+@pytest.mark.asyncio
+async def test_reply_snippet_respects_configured_max_length(monkeypatch, tmp_path):
+    """A real config.yaml override propagates through the gateway loader."""
+    result = await _prepare_reply_with_limit(
+        monkeypatch,
+        tmp_path,
+        200,
+        text_length=800,
+    )
+    assert result.startswith('[Replying to: "' + "x" * 200 + '"]')
+    assert "x" * 201 not in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "configured_value",
+    [0, -1, 10_001, True, 1.5, "0", "-1", "10001", "not-an-integer"],
+)
+async def test_invalid_reply_snippet_limits_fall_back_to_500(
+    monkeypatch,
+    tmp_path,
+    configured_value,
+):
+    result = await _prepare_reply_with_limit(
+        monkeypatch,
+        tmp_path,
+        configured_value,
+    )
+    assert result.startswith('[Replying to: "' + "x" * 500 + '"]')
+    assert "x" * 501 not in result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("configured_value", "expected_length"),
+    [(1, 1), (10_000, 10_000), ("200", 200)],
+)
+async def test_reply_snippet_limit_accepts_boundaries(
+    monkeypatch,
+    tmp_path,
+    configured_value,
+    expected_length,
+):
+    result = await _prepare_reply_with_limit(
+        monkeypatch,
+        tmp_path,
+        configured_value,
+    )
+    assert result.startswith('[Replying to: "' + "x" * expected_length + '"]')
+    assert "x" * (expected_length + 1) not in result
+
+
+@pytest.mark.asyncio
+async def test_reply_snippet_limit_expands_env_var(monkeypatch, tmp_path):
+    """Runtime config expansion reaches the reply-context budget."""
+    monkeypatch.setenv("REPLY_SNIPPET_LIMIT", "200")
+    result = await _prepare_reply_with_limit(
+        monkeypatch,
+        tmp_path,
+        "${REPLY_SNIPPET_LIMIT}",
+        text_length=800,
+    )
+
+    assert result.startswith('[Replying to: "' + "x" * 200 + '"]')
+    assert "x" * 201 not in result


### PR DESCRIPTION
## What does this PR do?

`GatewayRunner._prepare_inbound_message_text()` currently truncates every replied-to message to a hardcoded 500 characters before injecting the `[Replying to: "..."]` context pointer.

This PR makes that budget configurable through:

```yaml
gateway:
  reply_snippet_max_length: 500
```

The default remains `500`, so existing behavior is unchanged.

### Validation contract

- Accepted range: `1` through `10000`, inclusive.
- Direct YAML integers and decimal integer strings produced by `${VAR}` expansion are accepted.
- Booleans, floats, non-numeric strings, `0`, negative values, and values above `10000` fall back to `500`.
- `0` does not silently disable the reply pointer.
- The hard upper bound prevents a misconfiguration from injecting an unbounded quoted payload.

The reply prefix is used for disambiguation rather than deduplication: it tells the agent which prior message the user is referencing. Some platform messages front-load context beyond 500 characters, while other users may prefer the conservative default.

## Related work

No other PR was found that adds a global configurable `gateway.reply_snippet_max_length`.

#49001 partially overlaps by changing the same shared truncation point from a hardcoded `500` to `4000` for a Feishu visibility use case. This PR keeps the backward-compatible default and allows `4000` (or another bounded value) without replacing one platform-wide constant with another.

## Type of change

- [x] New feature (non-breaking)

## Changes made

- Add `gateway.reply_snippet_max_length: 500` to canonical `DEFAULT_CONFIG`.
- Read the setting through `_load_gateway_runtime_config()` so `${VAR}` expansion and managed config overlays are honored.
- Validate type and the inclusive `1..10000` range before slicing, with a safe `500` fallback.
- Document the key, range, environment expansion, and fallback in `cli-config.yaml.example`.
- Replace the mocked config test with real temporary-`HERMES_HOME`/`config.yaml` propagation coverage.
- Add regression coverage for defaults, valid overrides, both boundaries, environment expansion, booleans, floats, numeric/non-numeric strings, zero, negative values, and values above the cap.

## How to test

```bash
python -m pytest \
  tests/gateway/test_reply_to_injection.py \
  tests/gateway/test_runtime_config_env_expansion.py \
  tests/hermes_cli/test_set_config_value.py \
  -o 'addopts=' -q

python -m ruff check \
  gateway/run.py \
  hermes_cli/config.py \
  tests/gateway/test_reply_to_injection.py

ty check tests/gateway/test_reply_to_injection.py --output-format concise
```

Local result after rebasing onto `e4ea0a0ed`:

```text
77 passed in 1.29s
ruff: All checks passed!
ty: All checks passed!
git diff --check: passed
cli-config.yaml.example: parsed successfully
```

The canonical full-suite runner was also executed on macOS 26.5.1. Its 32 failures across 13 unrelated files were reproduced on a clean `origin/main` worktree (macOS `/tmp` normalization, systemd-only tests, Keychain mocking, file-descriptor/resource flakes, and existing concurrency tests). The changed gateway/config tests introduce no branch-only failure.

## Checklist

### Code

- [x] Read the contributing guidance and `AGENTS.md` config requirements.
- [x] Conventional Commit title retained.
- [x] Searched existing PRs and documented the only partial overlap (#49001).
- [x] PR remains limited to the configurable reply-context budget.
- [x] Added canonical config-schema coverage and end-to-end runtime tests.
- [x] Tested on macOS 26.5.1.

### Documentation and housekeeping

- [x] Updated `cli-config.yaml.example`.
- [x] Added the option to canonical `DEFAULT_CONFIG`.
- [x] Considered cross-platform impact; behavior is platform-independent.
- [x] No config-version bump is needed because the new key has a backward-compatible default.

## Screenshots

N/A — configuration/runtime behavior only.
