### PR TITLE
Add Feishu Open Platform tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@
   <a href="https://discord.gg/NousResearch"><img src="https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://github.com/NousResearch/hermes-agent/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License: MIT"></a>
   <a href="https://nousresearch.com"><img src="https://img.shields.io/badge/Built%20by-Nous%20Research-blueviolet?style=for-the-badge" alt="Built by Nous Research"></a>
-  <a href="README.zh-CN.md"><img src="https://img.shields.io/badge/Lang-中文-red?style=for-the-badge" alt="中文"></a>
 </p>
 
 **The self-improving AI agent built by [Nous Research](https://nousresearch.com).** It's the only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, searches its own past conversations, and builds a deepening model of who you are across sessions. Run it on a $5 VPS, a GPU cluster, or serverless infrastructure that costs nearly nothing when idle. It's not tied to your laptop — talk to it from Telegram while it works on a cloud VM.
 
-Use any model you want — [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai) (200+ models), [NVIDIA NIM](https://build.nvidia.com) (Nemotron), [Xiaomi MiMo](https://platform.xiaomimimo.com), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), [Hugging Face](https://huggingface.co), OpenAI, or your own endpoint. Switch with `hermes model` — no code changes, no lock-in.
+Use any model you want — [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai) (200+ models), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), OpenAI, or your own endpoint. Switch with `hermes model` — no code changes, no lock-in.
 
 <table>
 <tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>
@@ -22,7 +21,7 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), [Open
 <tr><td><b>A closed learning loop</b></td><td>Agent-curated memory with periodic nudges. Autonomous skill creation after complex tasks. Skills self-improve during use. FTS5 session search with LLM summarization for cross-session recall. <a href="https://github.com/plastic-labs/honcho">Honcho</a> dialectic user modeling. Compatible with the <a href="https://agentskills.io">agentskills.io</a> open standard.</td></tr>
 <tr><td><b>Scheduled automations</b></td><td>Built-in cron scheduler with delivery to any platform. Daily reports, nightly backups, weekly audits — all in natural language, running unattended.</td></tr>
 <tr><td><b>Delegates and parallelizes</b></td><td>Spawn isolated subagents for parallel workstreams. Write Python scripts that call tools via RPC, collapsing multi-step pipelines into zero-context-cost turns.</td></tr>
-<tr><td><b>Runs anywhere, not just your laptop</b></td><td>Seven terminal backends — local, Docker, SSH, Singularity, Modal, Daytona, and Vercel Sandbox. Daytona and Modal offer serverless persistence — your agent's environment hibernates when idle and wakes on demand, costing nearly nothing between sessions. Run it on a $5 VPS or a GPU cluster.</td></tr>
+<tr><td><b>Runs anywhere, not just your laptop</b></td><td>Six terminal backends — local, Docker, SSH, Daytona, Singularity, and Modal. Daytona and Modal offer serverless persistence — your agent's environment hibernates when idle and wakes on demand, costing nearly nothing between sessions. Run it on a $5 VPS or a GPU cluster.</td></tr>
 <tr><td><b>Research-ready</b></td><td>Batch trajectory generation, Atropos RL environments, trajectory compression for training the next generation of tool-calling models.</td></tr>
 </table>
 
@@ -77,7 +76,7 @@ Hermes has two entry points: start the terminal UI with `hermes`, or run the gat
 | Set a personality | `/personality [name]` | `/personality [name]` |
 | Retry or undo the last turn | `/retry`, `/undo` | `/retry`, `/undo` |
 | Compress context / check usage | `/compress`, `/usage`, `/insights [--days N]` | `/compress`, `/usage`, `/insights [days]` |
-| Browse skills | `/skills` or `/<skill-name>` | `/<skill-name>` |
+| Browse skills | `/skills` or `/<skill-name>` | `/skills` or `/<skill-name>` |
 | Interrupt current work | `Ctrl+C` or send a new message | `/stop` or send a new message |
 | Platform-specific status | `/platforms` | `/status`, `/sethome` |
 
@@ -95,6 +94,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [CLI Usage](https://hermes-agent.nousresearch.com/docs/user-guide/cli) | Commands, keybindings, personalities, sessions |
 | [Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) | Config file, providers, models, all options |
 | [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
+| [Feishu Open Platform Tools](tools/README-feishu-open-platform.md) | Docx, Bitable/Base, Drive, and Wiki automation via Feishu/Lark Open Platform |
 | [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security) | Command approval, DM pairing, container isolation |
 | [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools) | 40+ tools, toolset system, terminal backends |
 | [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) | Procedural memory, Skills Hub, creating skills |
@@ -142,26 +142,23 @@ See `hermes claw migrate --help` for all options, or use the `openclaw-migration
 
 We welcome contributions! See the [Contributing Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing) for development setup, code style, and PR process.
 
-Quick start for contributors — clone and go with `setup-hermes.sh`:
+Quick start for contributors:
 
 ```bash
 git clone https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
-./setup-hermes.sh     # installs uv, creates venv, installs .[all], symlinks ~/.local/bin/hermes
-./hermes              # auto-detects the venv, no need to `source` first
-```
-
-Manual path (equivalent to the above):
-
-```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv venv --python 3.11
 source venv/bin/activate
 uv pip install -e ".[all,dev]"
-scripts/run_tests.sh
+python -m pytest tests/ -q
 ```
 
-> **RL Training (optional):** The RL/Atropos integration (`environments/`) ships via the `atroposlib` and `tinker` dependencies pulled in by `.[all,dev]` — no submodule setup required.
+> **RL Training (optional):** To work on the RL/Tinker-Atropos integration:
+> ```bash
+> git submodule update --init tinker-atropos
+> uv pip install -e "./tinker-atropos"
+> ```
 
 ---
 
@@ -170,7 +167,7 @@ scripts/run_tests.sh
 - 💬 [Discord](https://discord.gg/NousResearch)
 - 📚 [Skills Hub](https://agentskills.io)
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
-- 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 💡 [Discussions](https://github.com/NousResearch/hermes-agent/discussions)
 
 ---
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -24,10 +24,9 @@ import json
 import asyncio
 import logging
 import threading
-import time
 from typing import Dict, Any, List, Optional, Tuple
 
-from tools.registry import discover_builtin_tools, registry
+from tools.registry import registry
 from toolsets import resolve_toolset, validate_toolset
 
 logger = logging.getLogger(__name__)
@@ -107,58 +106,11 @@ def _run_async(coro):
         loop = None
 
     if loop and loop.is_running():
-        # Inside an async context (gateway, RL env) — run in a fresh thread
-        # with its own event loop we own a reference to, so on timeout we
-        # can cancel the task inside that loop (ThreadPoolExecutor.cancel()
-        # only works on not-yet-started futures — it's a no-op on a running
-        # worker, which previously leaked the thread on every 300 s timeout).
+        # Inside an async context (gateway, RL env) — run in a fresh thread.
         import concurrent.futures
-
-        worker_loop: Optional[asyncio.AbstractEventLoop] = None
-        loop_ready = threading.Event()
-
-        def _run_in_worker():
-            nonlocal worker_loop
-            worker_loop = asyncio.new_event_loop()
-            loop_ready.set()
-            try:
-                asyncio.set_event_loop(worker_loop)
-                return worker_loop.run_until_complete(coro)
-            finally:
-                try:
-                    # Cancel anything still pending (e.g. task cancelled
-                    # externally via call_soon_threadsafe on timeout).
-                    pending = asyncio.all_tasks(worker_loop)
-                    for t in pending:
-                        t.cancel()
-                    if pending:
-                        worker_loop.run_until_complete(
-                            asyncio.gather(*pending, return_exceptions=True)
-                        )
-                except Exception:
-                    pass
-                worker_loop.close()
-
-        pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        future = pool.submit(_run_in_worker)
-        try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(asyncio.run, coro)
             return future.result(timeout=300)
-        except concurrent.futures.TimeoutError:
-            # Cancel the coroutine inside its own loop so the worker thread
-            # can wind down instead of running forever.
-            if loop_ready.wait(timeout=1.0) and worker_loop is not None:
-                try:
-                    for t in asyncio.all_tasks(worker_loop):
-                        worker_loop.call_soon_threadsafe(t.cancel)
-                except RuntimeError:
-                    # Loop already closed — nothing to cancel.
-                    pass
-            raise
-        finally:
-            # wait=False: don't block the caller on a stuck coroutine. We've
-            # already requested cancellation above; the worker will exit
-            # once the coroutine observes it (usually at the next await).
-            pool.shutdown(wait=False)
 
     # If we're on a worker thread (e.g., parallel tool execution in
     # delegate_task), use a per-thread persistent loop.  This avoids
@@ -177,20 +129,56 @@ def _run_async(coro):
 # Tool Discovery  (importing each module triggers its registry.register calls)
 # =============================================================================
 
-discover_builtin_tools()
+def _discover_tools():
+    """Import all tool modules to trigger their registry.register() calls.
 
-# MCP tool discovery (external MCP servers from config) used to run here as
-# a module-level side effect.  It was removed because discover_mcp_tools()
-# internally uses a blocking future.result(timeout=120) wait, and the
-# gateway lazy-imports this module from inside the asyncio event loop on
-# the first user message — freezing Discord/Telegram heartbeats for up to
-# 120s whenever any configured MCP server was slow or unreachable (#16856).
-#
-# Each entry point now runs discovery explicitly at its own startup:
-#   - gateway/run.py            -> start_gateway() uses run_in_executor
-#   - cli.py, hermes_cli/*      -> inline on startup (no event loop)
-#   - tui_gateway/server.py     -> inline on startup (no event loop)
-#   - acp_adapter/server.py     -> asyncio.to_thread on session init
+    Wrapped in a function so import errors in optional tools (e.g., fal_client
+    not installed) don't prevent the rest from loading.
+    """
+    _modules = [
+        "tools.web_tools",
+        "tools.terminal_tool",
+        "tools.file_tools",
+        "tools.vision_tools",
+        "tools.mixture_of_agents_tool",
+        "tools.image_generation_tool",
+        "tools.skills_tool",
+        "tools.skill_manager_tool",
+        "tools.browser_tool",
+        "tools.cronjob_tools",
+        "tools.rl_training_tool",
+        "tools.tts_tool",
+        "tools.todo_tool",
+        "tools.memory_tool",
+        "tools.session_search_tool",
+        "tools.clarify_tool",
+        "tools.code_execution_tool",
+        "tools.delegate_tool",
+        "tools.process_registry",
+        "tools.send_message_tool",
+        "tools.feishu_doc_tool",
+        "tools.feishu_bitable_tool",
+        "tools.feishu_drive_tool",
+        "tools.feishu_wiki_tool",
+        # "tools.honcho_tools",  # Removed — Honcho is now a memory provider plugin
+        "tools.homeassistant_tool",
+    ]
+    import importlib
+    for mod_name in _modules:
+        try:
+            importlib.import_module(mod_name)
+        except Exception as e:
+            logger.warning("Could not import tool module %s: %s", mod_name, e)
+
+
+_discover_tools()
+
+# MCP tool discovery (external MCP servers from config)
+try:
+    from tools.mcp_tool import discover_mcp_tools
+    discover_mcp_tools()
+except Exception as e:
+    logger.debug("MCP tool discovery failed: %s", e)
 
 # Plugin tool discovery (user/project/pip plugins)
 try:
@@ -247,27 +235,6 @@ _LEGACY_TOOLSET_MAP = {
 # get_tool_definitions  (the main schema provider)
 # =============================================================================
 
-# Module-level memoization for get_tool_definitions(). Keyed on
-# (frozenset(enabled_toolsets), frozenset(disabled_toolsets), registry._generation).
-# Hot callers (gateway runner, AIAgent.__init__) invoke this on every turn
-# with quiet_mode=True; caching avoids ~7 ms of registry walking + schema
-# filtering + check_fn probing per call. Only active when quiet_mode=True
-# because quiet_mode=False has stdout side effects (tool-selection prints).
-#
-# Invalidation happens transparently via the registry's _generation counter,
-# which bumps on register() / deregister() / register_toolset_alias(). The
-# inner check_fn TTL cache in registry.py handles environment drift (Docker
-# daemon start/stop, env var changes, etc.) on a 30 s horizon.
-_tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
-
-
-def _clear_tool_defs_cache() -> None:
-    """Drop memoized get_tool_definitions() results. Called when dynamic
-    schema dependencies change (e.g. discord capability cache reset,
-    execute_code sandbox reconfigured)."""
-    _tool_defs_cache.clear()
-
-
 def get_tool_definitions(
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
@@ -286,58 +253,6 @@ def get_tool_definitions(
     Returns:
         Filtered list of OpenAI-format tool definitions.
     """
-    # Fast path: memoized result when the caller doesn't need stdout prints.
-    # The cache key captures every argument-level input; the registry
-    # generation captures registry mutations (MCP refresh, plugin load).
-    # check_fn results are TTL-cached one level down, inside
-    # registry.get_definitions. The config-mtime fingerprint below captures
-    # user-visible config edits that affect dynamic schemas (execute_code
-    # mode, discord action allowlist, etc.) without needing an explicit
-    # invalidate hook on every config-writer.
-    if quiet_mode:
-        try:
-            from hermes_cli.config import get_config_path
-            cfg_path = get_config_path()
-            cfg_stat = cfg_path.stat()
-            cfg_fp = (cfg_stat.st_mtime_ns, cfg_stat.st_size)
-        except (FileNotFoundError, OSError, ImportError):
-            cfg_fp = None
-        cache_key = (
-            frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
-            frozenset(disabled_toolsets) if disabled_toolsets else None,
-            registry._generation,
-            cfg_fp,
-        )
-        cached = _tool_defs_cache.get(cache_key)
-        if cached is not None:
-            # Update _last_resolved_tool_names so downstream callers see
-            # consistent state even on a cache hit.
-            global _last_resolved_tool_names
-            _last_resolved_tool_names = [t["function"]["name"] for t in cached]
-            # Return a shallow copy of the list but share the dict references —
-            # schemas are treated as read-only by all known callers.
-            return list(cached)
-
-    result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode)
-    if quiet_mode:
-        # Cache the freshly-computed list, but hand callers a shallow copy so
-        # downstream mutations (e.g. run_agent appending memory/LCM tool
-        # schemas to self.tools) don't poison the cache. Without this, a
-        # long-lived Gateway process accumulates duplicate tool names across
-        # agent inits and providers that enforce unique tool names
-        # (DeepSeek, Xiaomi MiMo, Moonshot Kimi) reject the request with
-        # HTTP 400. Mirrors the cache-hit path above. (issue #17335)
-        _tool_defs_cache[cache_key] = result
-        return list(result)
-    return result
-
-
-def _compute_tool_definitions(
-    enabled_toolsets: List[str] = None,
-    disabled_toolsets: List[str] = None,
-    quiet_mode: bool = False,
-) -> List[Dict[str, Any]]:
-    """Uncached implementation of :func:`get_tool_definitions`."""
     # Determine which tool names the caller wants
     tools_to_include: set = set()
 
@@ -356,17 +271,12 @@ def _compute_tool_definitions(
             else:
                 if not quiet_mode:
                     print(f"⚠️  Unknown toolset: {toolset_name}")
-    else:
-        # Default: start with everything
+
+    elif disabled_toolsets:
         from toolsets import get_all_toolsets
         for ts_name in get_all_toolsets():
             tools_to_include.update(resolve_toolset(ts_name))
 
-    # Always apply disabled toolsets as a subtraction step at the end.
-    # This ensures that even if a composite toolset (like hermes-cli)
-    # is enabled, any tools belonging to a disabled toolset are strictly
-    # stripped out. See issue #17309.
-    if disabled_toolsets:
         for toolset_name in disabled_toolsets:
             if validate_toolset(toolset_name):
                 resolved = resolve_toolset(toolset_name)
@@ -381,6 +291,10 @@ def _compute_tool_definitions(
             else:
                 if not quiet_mode:
                     print(f"⚠️  Unknown toolset: {toolset_name}")
+    else:
+        from toolsets import get_all_toolsets
+        for ts_name in get_all_toolsets():
+            tools_to_include.update(resolve_toolset(ts_name))
 
     # Plugin-registered tools are now resolved through the normal toolset
     # path — validate_toolset() / resolve_toolset() / get_all_toolsets()
@@ -402,42 +316,13 @@ def _compute_tool_definitions(
     # execute_code" even when the API key isn't configured or the toolset is
     # disabled (#560-discord).
     if "execute_code" in available_tool_names:
-        from tools.code_execution_tool import SANDBOX_ALLOWED_TOOLS, build_execute_code_schema, _get_execution_mode
+        from tools.code_execution_tool import SANDBOX_ALLOWED_TOOLS, build_execute_code_schema
         sandbox_enabled = SANDBOX_ALLOWED_TOOLS & available_tool_names
-        dynamic_schema = build_execute_code_schema(sandbox_enabled, mode=_get_execution_mode())
+        dynamic_schema = build_execute_code_schema(sandbox_enabled)
         for i, td in enumerate(filtered_tools):
             if td.get("function", {}).get("name") == "execute_code":
                 filtered_tools[i] = {"type": "function", "function": dynamic_schema}
                 break
-
-    # Rebuild discord / discord_admin schemas based on the bot's privileged
-    # intents (detected from GET /applications/@me) and the user's action
-    # allowlist in config.  Hides actions the bot's intents don't support so
-    # the model never attempts them, and annotates fetch_messages when the
-    # MESSAGE_CONTENT intent is missing.
-    _discord_schema_fns = {
-        "discord": "get_dynamic_schema_core",
-        "discord_admin": "get_dynamic_schema_admin",
-    }
-    for discord_tool_name in _discord_schema_fns:
-        if discord_tool_name in available_tool_names:
-            try:
-                from tools import discord_tool as _dt
-                schema_fn = getattr(_dt, _discord_schema_fns[discord_tool_name])
-                dynamic = schema_fn()
-            except Exception:
-                dynamic = None
-            if dynamic is None:
-                filtered_tools = [
-                    t for t in filtered_tools
-                    if t.get("function", {}).get("name") != discord_tool_name
-                ]
-                available_tool_names.discard(discord_tool_name)
-            else:
-                for i, td in enumerate(filtered_tools):
-                    if td.get("function", {}).get("name") == discord_tool_name:
-                        filtered_tools[i] = {"type": "function", "function": dynamic}
-                        break
 
     # Strip web tool cross-references from browser_navigate description when
     # web_search / web_extract are not available.  The static schema says
@@ -469,18 +354,6 @@ def _compute_tool_definitions(
     global _last_resolved_tool_names
     _last_resolved_tool_names = [t["function"]["name"] for t in filtered_tools]
 
-    # Sanitize schemas for broad backend compatibility. llama.cpp's
-    # json-schema-to-grammar converter (used by its OAI server to build
-    # GBNF tool-call parsers) rejects some shapes that cloud providers
-    # silently accept — bare "type": "object" with no properties,
-    # string-valued schema nodes from malformed MCP servers, etc. This
-    # is a no-op for schemas that are already well-formed.
-    try:
-        from tools.schema_sanitizer import sanitize_tool_schemas
-        filtered_tools = sanitize_tool_schemas(filtered_tools)
-    except Exception as e:  # pragma: no cover — defensive
-        logger.warning("Schema sanitization skipped: %s", e)
-
     return filtered_tools
 
 
@@ -511,12 +384,6 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
 
     Handles ``"type": "integer"``, ``"type": "number"``, ``"type": "boolean"``,
     and union types (``"type": ["integer", "string"]``).
-
-    Also wraps bare scalar values in a single-element list when the schema
-    declares ``"type": "array"``.  Open-weight models (DeepSeek, Qwen, GLM)
-    sometimes emit ``{"urls": "https://a.com"}`` when the tool expects
-    ``{"urls": ["https://a.com"]}``; wrapping here avoids a confusing tool
-    failure on what is otherwise a well-formed call.
     """
     if not args or not isinstance(args, dict):
         return args
@@ -529,63 +396,31 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
     if not properties:
         return args
 
-    for key, value in list(args.items()):
+    for key, value in args.items():
+        if not isinstance(value, str):
+            continue
         prop_schema = properties.get(key)
         if not prop_schema:
             continue
         expected = prop_schema.get("type")
-
-        # Wrap bare non-list values when the schema declares ``array``.
-        # Strings still go through _coerce_value first so JSON-encoded
-        # arrays (``'["a","b"]'``) get parsed and nullable ``"null"``
-        # becomes ``None`` rather than ``["null"]``.
-        # ``None`` itself is preserved — we don't know whether the model
-        # meant "omit" or "empty list", and tools with sensible defaults
-        # (e.g. read_file's normalize_read_pagination) already handle it.
-        if expected == "array" and value is not None and not isinstance(value, (list, tuple)):
-            if isinstance(value, str):
-                coerced = _coerce_value(value, expected, schema=prop_schema)
-                if coerced is not value:
-                    # _coerce_value handled it (JSON-parsed list or
-                    # nullable "null" → None).
-                    args[key] = coerced
-                    continue
-                args[key] = [value]
-                logger.info(
-                    "coerce_tool_args: wrapped bare string in list for %s.%s",
-                    tool_name, key,
-                )
-                continue
-            args[key] = [value]
-            logger.info(
-                "coerce_tool_args: wrapped bare %s in list for %s.%s",
-                type(value).__name__, tool_name, key,
-            )
+        if not expected:
             continue
-
-        if not isinstance(value, str):
-            continue
-        if not expected and not _schema_allows_null(prop_schema):
-            continue
-        coerced = _coerce_value(value, expected, schema=prop_schema)
+        coerced = _coerce_value(value, expected)
         if coerced is not value:
             args[key] = coerced
 
     return args
 
 
-def _coerce_value(value: str, expected_type, schema: dict | None = None):
+def _coerce_value(value: str, expected_type):
     """Attempt to coerce a string *value* to *expected_type*.
 
     Returns the original string when coercion is not applicable or fails.
     """
-    if _schema_allows_null(schema) and value.strip().lower() == "null":
-        return None
-
     if isinstance(expected_type, list):
         # Union type — try each in order, return first successful coercion
         for t in expected_type:
-            result = _coerce_value(value, t, schema=schema)
+            result = _coerce_value(value, t)
             if result is not value:
                 return result
         return value
@@ -594,57 +429,6 @@ def _coerce_value(value: str, expected_type, schema: dict | None = None):
         return _coerce_number(value, integer_only=(expected_type == "integer"))
     if expected_type == "boolean":
         return _coerce_boolean(value)
-    if expected_type == "array":
-        return _coerce_json(value, list)
-    if expected_type == "object":
-        return _coerce_json(value, dict)
-    if expected_type == "null" and value.strip().lower() == "null":
-        return None
-    return value
-
-
-def _schema_allows_null(schema: dict | None) -> bool:
-    """Return True when a JSON Schema fragment explicitly permits null."""
-    if not isinstance(schema, dict):
-        return False
-
-    schema_type = schema.get("type")
-    if schema_type == "null":
-        return True
-    if isinstance(schema_type, list) and "null" in schema_type:
-        return True
-    if schema.get("nullable") is True:
-        return True
-
-    for union_key in ("anyOf", "oneOf"):
-        variants = schema.get(union_key)
-        if not isinstance(variants, list):
-            continue
-        for variant in variants:
-            if isinstance(variant, dict) and variant.get("type") == "null":
-                return True
-
-    return False
-
-
-def _coerce_json(value: str, expected_python_type: type):
-    """Parse *value* as JSON when the schema expects an array or object.
-
-    Handles model output drift where a complex oneOf/discriminated-union schema
-    causes the LLM to emit the array/object as a JSON string instead of a native
-    structure.  Returns the original string if parsing fails or yields the wrong
-    Python type.
-    """
-    try:
-        parsed = json.loads(value)
-    except (ValueError, TypeError):
-        return value
-    if isinstance(parsed, expected_python_type):
-        logger.debug(
-            "coerce_tool_args: coerced string to %s via json.loads",
-            expected_python_type.__name__,
-        )
-        return parsed
     return value
 
 
@@ -654,9 +438,9 @@ def _coerce_number(value: str, integer_only: bool = False):
         f = float(value)
     except (ValueError, OverflowError):
         return value
-    # Guard against inf/nan — not JSON-serializable, keep original string
+    # Guard against inf/nan before int() conversion
     if f != f or f == float("inf") or f == float("-inf"):
-        return value
+        return f
     # If it looks like an integer (no fractional part), return int
     if f == int(f):
         return int(f)
@@ -684,7 +468,6 @@ def handle_function_call(
     session_id: Optional[str] = None,
     user_task: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
-    skip_pre_tool_call_hook: bool = False,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -705,54 +488,32 @@ def handle_function_call(
     # Coerce string arguments to their schema-declared types (e.g. "42"→42)
     function_args = coerce_tool_args(function_name, function_args)
 
+    # Notify the read-loop tracker when a non-read/search tool runs,
+    # so the *consecutive* counter resets (reads after other work are fine).
+    if function_name not in _READ_SEARCH_TOOLS:
+        try:
+            from tools.file_tools import notify_other_tool_call
+            notify_other_tool_call(task_id or "default")
+        except Exception:
+            pass  # file_tools may not be loaded yet
+
     try:
         if function_name in _AGENT_LOOP_TOOLS:
             return json.dumps({"error": f"{function_name} must be handled by the agent loop"})
 
-        # Check plugin hooks for a block directive (unless caller already
-        # checked — e.g. run_agent._invoke_tool passes skip=True to
-        # avoid double-firing the hook).
-        #
-        # Single-fire contract: pre_tool_call fires exactly once per tool
-        # execution. get_pre_tool_call_block_message() internally calls
-        # invoke_hook("pre_tool_call", ...) and returns the first block
-        # directive (if any), so observer plugins see the hook on that same
-        # pass. When skip=True, the caller already fired it — do nothing
-        # here.
-        if not skip_pre_tool_call_hook:
-            block_message: Optional[str] = None
-            try:
-                from hermes_cli.plugins import get_pre_tool_call_block_message
-                block_message = get_pre_tool_call_block_message(
-                    function_name,
-                    function_args,
-                    task_id=task_id or "",
-                    session_id=session_id or "",
-                    tool_call_id=tool_call_id or "",
-                )
-            except Exception:
-                pass
+        try:
+            from hermes_cli.plugins import invoke_hook
+            invoke_hook(
+                "pre_tool_call",
+                tool_name=function_name,
+                args=function_args,
+                task_id=task_id or "",
+                session_id=session_id or "",
+                tool_call_id=tool_call_id or "",
+            )
+        except Exception:
+            pass
 
-            if block_message is not None:
-                return json.dumps({"error": block_message}, ensure_ascii=False)
-
-        # Notify the read-loop tracker when a non-read/search tool runs,
-        # so the *consecutive* counter resets (reads after other work are fine).
-        if function_name not in _READ_SEARCH_TOOLS:
-            try:
-                from tools.file_tools import notify_other_tool_call
-                notify_other_tool_call(task_id or "default")
-            except Exception:
-                pass  # file_tools may not be loaded yet
-
-        # Measure tool dispatch latency so post_tool_call and
-        # transform_tool_result hooks can observe per-tool duration.
-        # Inspired by Claude Code 2.1.119, which added ``duration_ms`` to
-        # PostToolUse hook inputs so plugin authors can build latency
-        # dashboards, budget alerts, and regression canaries without having
-        # to wrap every tool manually.  We use monotonic() so the value is
-        # unaffected by wall-clock adjustments during the call.
-        _dispatch_start = time.monotonic()
         if function_name == "execute_code":
             # Prefer the caller-provided list so subagents can't overwrite
             # the parent's tool set via the process-global.
@@ -768,7 +529,6 @@ def handle_function_call(
                 task_id=task_id,
                 user_task=user_task,
             )
-        duration_ms = int((time.monotonic() - _dispatch_start) * 1000)
 
         try:
             from hermes_cli.plugins import invoke_hook
@@ -780,33 +540,7 @@ def handle_function_call(
                 task_id=task_id or "",
                 session_id=session_id or "",
                 tool_call_id=tool_call_id or "",
-                duration_ms=duration_ms,
             )
-        except Exception:
-            pass
-
-        # Generic tool-result canonicalization seam: plugins receive the
-        # final result string (JSON, usually) and may replace it by
-        # returning a string from transform_tool_result. Runs after
-        # post_tool_call (which stays observational) and before the result
-        # is appended back into conversation context. Fail-open; the first
-        # valid string return wins; non-string returns are ignored.
-        try:
-            from hermes_cli.plugins import invoke_hook
-            hook_results = invoke_hook(
-                "transform_tool_result",
-                tool_name=function_name,
-                args=function_args,
-                result=result,
-                task_id=task_id or "",
-                session_id=session_id or "",
-                tool_call_id=tool_call_id or "",
-                duration_ms=duration_ms,
-            )
-            for hook_result in hook_results:
-                if isinstance(hook_result, str):
-                    result = hook_result
-                    break
         except Exception:
             pass
 
@@ -814,7 +548,7 @@ def handle_function_call(
 
     except Exception as e:
         error_msg = f"Error executing {function_name}: {str(e)}"
-        logger.exception(error_msg)
+        logger.error(error_msg)
         return json.dumps({"error": error_msg}, ensure_ascii=False)
 
 

--- a/tests/tools/test_feishu_bitable_tool.py
+++ b/tests/tools/test_feishu_bitable_tool.py
@@ -1,0 +1,75 @@
+import json
+
+from tools import feishu_bitable_tool as bitable
+
+
+def _patch(monkeypatch):
+    calls = []
+    monkeypatch.setattr(bitable, "request_json", lambda method, uri, **kwargs: calls.append((method, uri, kwargs)) or {"ok": True})
+    return calls
+
+
+def test_create_app_calls_endpoint(monkeypatch):
+    calls = _patch(monkeypatch)
+    result = json.loads(bitable._create_app({"name": "PM Base", "folder_token": "fld"}))
+    assert result["success"] is True
+    assert calls[0][0] == "POST"
+    assert calls[0][1].endswith("/apps")
+    assert calls[0][2]["body"] == {"name": "PM Base", "folder_token": "fld"}
+
+
+def test_list_tables_requires_app_token():
+    assert "app_token required" in json.loads(bitable._list_tables({}))["error"]
+
+
+def test_list_tables_calls_endpoint(monkeypatch):
+    calls = _patch(monkeypatch)
+    result = json.loads(bitable._list_tables({"app_token": "app", "page_size": 10}))
+    assert result["success"] is True
+    assert calls[0][0] == "GET"
+    assert calls[0][1].endswith("/tables")
+    assert calls[0][2]["paths"] == {"app_token": "app"}
+    assert calls[0][2]["queries"]["page_size"] == 10
+
+
+def test_get_fields_requires_table_id():
+    assert "table_id required" in json.loads(bitable._get_fields({"app_token": "app"}))["error"]
+
+
+def test_update_table_and_field_shapes(monkeypatch):
+    calls = _patch(monkeypatch)
+    bitable._update_table({"app_token": "app", "table_id": "tbl", "name": "项目任务"})
+    bitable._create_field({"app_token": "app", "table_id": "tbl", "field_name": "模块", "type": 3, "property": {"options": [{"name": "A"}]}})
+    bitable._update_field({"app_token": "app", "table_id": "tbl", "field_id": "fld", "field_name": "状态", "type": 3})
+    assert calls[0][0] == "PATCH"
+    assert calls[0][2]["body"] == {"name": "项目任务"}
+    assert calls[1][0] == "POST"
+    assert calls[1][2]["body"]["field_name"] == "模块"
+    assert calls[1][2]["body"]["type"] == 3
+    assert calls[2][0] == "PUT"
+    assert calls[2][2]["paths"]["field_id"] == "fld"
+
+
+def test_search_records_posts_search_body(monkeypatch):
+    calls = _patch(monkeypatch)
+    bitable._search_records({"app_token": "app", "table_id": "tbl", "filter": {"x": 1}})
+    assert calls[0][0] == "POST"
+    assert calls[0][1].endswith("/records/search")
+    assert calls[0][2]["body"] == {"filter": {"x": 1}}
+
+
+def test_create_record_requires_fields_object():
+    assert "fields must be a non-empty object" in json.loads(bitable._create_record({"app_token": "app", "table_id": "tbl"}))["error"]
+
+
+def test_create_update_delete_record_shapes(monkeypatch):
+    calls = _patch(monkeypatch)
+    bitable._create_record({"app_token": "app", "table_id": "tbl", "fields": {"Name": "A"}})
+    bitable._update_record({"app_token": "app", "table_id": "tbl", "record_id": "rec", "fields": {"Name": "B"}})
+    bitable._delete_record({"app_token": "app", "table_id": "tbl", "record_id": "rec"})
+
+    assert calls[0][0] == "POST"
+    assert calls[0][2]["body"] == {"fields": {"Name": "A"}}
+    assert calls[1][0] == "PUT"
+    assert calls[1][2]["paths"]["record_id"] == "rec"
+    assert calls[2][0] == "DELETE"

--- a/tests/tools/test_feishu_doc_tool.py
+++ b/tests/tools/test_feishu_doc_tool.py
@@ -1,0 +1,123 @@
+import json
+
+from tools import feishu_doc_tool as doc
+
+
+def test_doc_read_requires_token():
+    result = json.loads(doc._handle_doc_read({}))
+    assert "doc_token is required" in result["error"]
+
+
+def test_doc_read_calls_raw_content(monkeypatch):
+    calls = []
+
+    def fake_request(method, uri, **kwargs):
+        calls.append((method, uri, kwargs))
+        return {"content": "hello"}
+
+    monkeypatch.setattr(doc, "request_json", fake_request)
+
+    result = json.loads(doc._handle_doc_read({"doc_token": "doc123"}))
+
+    assert result["success"] is True
+    assert result["content"] == "hello"
+    assert calls[0][0] == "GET"
+    assert calls[0][1].endswith("/raw_content")
+    assert calls[0][2]["paths"] == {"document_id": "doc123"}
+
+
+def test_doc_create_requires_title():
+    result = json.loads(doc._handle_doc_create({}))
+    assert "title is required" in result["error"]
+
+
+def test_doc_create_sends_title_and_folder(monkeypatch):
+    calls = []
+    monkeypatch.setattr(doc, "request_json", lambda method, uri, **kwargs: calls.append((method, uri, kwargs)) or {"document": {"document_id": "d"}})
+
+    result = json.loads(doc._handle_doc_create({"title": "PRD", "folder_token": "fld"}))
+
+    assert result["success"] is True
+    assert calls[0][0] == "POST"
+    assert calls[0][2]["body"] == {"title": "PRD", "folder_token": "fld"}
+
+
+def test_doc_append_text_builds_paragraph_blocks(monkeypatch):
+    calls = []
+    monkeypatch.setattr(doc, "request_json", lambda method, uri, **kwargs: calls.append((method, uri, kwargs)) or {"children": [1, 2]})
+
+    result = json.loads(doc._handle_doc_append_text({"doc_token": "doc", "text": "one\ntwo"}))
+
+    assert result["success"] is True
+    body = calls[0][2]["body"]
+    assert len(body["children"]) == 2
+    assert calls[0][2]["paths"] == {"document_id": "doc", "block_id": "doc"}
+
+
+def test_doc_append_markdown_converts_to_native_blocks(monkeypatch):
+    calls = []
+
+    def fake_request(method, uri, **kwargs):
+        calls.append((method, uri, kwargs))
+        if uri.endswith("/blocks/convert"):
+            return {"blocks": [{"block_id": "b", "block_type": 3, "heading1": {"elements": []}}], "first_level_block_ids": ["b"]}
+        return {"children": [{"block_type": 3}]}
+
+    monkeypatch.setattr(doc, "request_json", fake_request)
+
+    result = json.loads(doc._handle_doc_append_markdown({"doc_token": "doc", "markdown": "# Title"}))
+
+    assert result["success"] is True
+    assert result["block_count"] == 1
+    assert calls[0][1].endswith("/blocks/convert")
+    assert calls[1][2]["body"]["children"][0]["block_type"] == 3
+
+
+def test_convert_markdown_uses_first_level_order(monkeypatch):
+    def fake_request(method, uri, **kwargs):
+        return {
+            "blocks": [
+                {"block_id": "second", "block_type": 2},
+                {"block_id": "first", "block_type": 3},
+            ],
+            "first_level_block_ids": ["first", "second"],
+        }
+
+    monkeypatch.setattr(doc, "request_json", fake_request)
+
+    blocks = doc._convert_markdown("# Title\n\nBody")
+
+    assert [block["block_id"] for block in blocks] == ["first", "second"]
+
+
+def test_insert_blocks_chunks_feishu_limit(monkeypatch):
+    calls = []
+    monkeypatch.setattr(doc, "request_json", lambda method, uri, **kwargs: calls.append((method, uri, kwargs)) or {"children": kwargs["body"]["children"]})
+
+    data = doc._insert_blocks("doc", [{"block_type": 2, "i": i} for i in range(51)])
+
+    assert len(data["children"]) == 51
+    assert len(calls) == 2
+    assert len(calls[0][2]["body"]["children"]) == 50
+    assert len(calls[1][2]["body"]["children"]) == 1
+
+
+def test_doc_replace_markdown_clears_then_inserts(monkeypatch):
+    calls = []
+
+    def fake_request(method, uri, **kwargs):
+        calls.append((method, uri, kwargs))
+        if uri.endswith("/blocks/convert"):
+            return {"blocks": [{"block_id": "b", "block_type": 4, "heading2": {"elements": []}}], "first_level_block_ids": ["b"]}
+        if uri.endswith("/blocks"):
+            return {"items": [{"block_type": 1}, {"block_type": 2, "parent_id": "doc"}]}
+        return {}
+
+    monkeypatch.setattr(doc, "request_json", fake_request)
+
+    result = json.loads(doc._handle_doc_replace_markdown({"doc_token": "doc", "markdown": "## Title"}))
+
+    assert result["success"] is True
+    assert result["deleted_blocks"] == 1
+    assert [call[0] for call in calls] == ["POST", "GET", "DELETE", "POST"]
+    assert calls[2][2]["body"] == {"start_index": 0, "end_index": 1}

--- a/tests/tools/test_feishu_drive_tool.py
+++ b/tests/tools/test_feishu_drive_tool.py
@@ -1,0 +1,49 @@
+import json
+
+from tools import feishu_drive_tool as drive
+
+
+def _patch(monkeypatch):
+    calls = []
+    monkeypatch.setattr(drive, "request_json", lambda method, uri, **kwargs: calls.append((method, uri, kwargs)) or {"ok": True})
+    return calls
+
+
+def test_get_meta_requires_file_token():
+    assert "file_token is required" in json.loads(drive._get_meta({}))["error"]
+
+
+def test_get_meta_uses_batch_meta_endpoint(monkeypatch):
+    calls = _patch(monkeypatch)
+    drive._get_meta({"file_token": "tok", "file_type": "docx"})
+    assert calls[0][0] == "POST"
+    assert calls[0][1].endswith("/metas/batch_query")
+    assert calls[0][2]["body"] == {"request_docs": [{"doc_token": "tok", "doc_type": "docx"}]}
+
+
+def test_search_files_requires_query():
+    assert "query is required" in json.loads(drive._search_files({}))["error"]
+
+
+def test_search_files_posts_search_key(monkeypatch):
+    calls = _patch(monkeypatch)
+    drive._search_files({"query": "prd", "page_size": 20})
+    assert calls[0][0] == "POST"
+    assert calls[0][1].endswith("/files/search")
+    assert calls[0][2]["body"] == {"search_key": "prd"}
+    assert calls[0][2]["queries"]["page_size"] == 20
+
+
+def test_create_folder_requires_name():
+    assert "name is required" in json.loads(drive._create_folder({}))["error"]
+
+
+def test_comments_and_reply(monkeypatch):
+    calls = _patch(monkeypatch)
+    drive._list_comments({"file_token": "file", "is_whole": True})
+    drive._reply_comment({"file_token": "file", "comment_id": "c", "content": "ok"})
+    assert calls[0][0] == "GET"
+    assert calls[0][2]["paths"] == {"file_token": "file"}
+    assert calls[1][0] == "POST"
+    assert calls[1][2]["paths"] == {"file_token": "file", "comment_id": "c"}
+    assert "reply" in calls[1][2]["body"]

--- a/tests/tools/test_feishu_openapi.py
+++ b/tests/tools/test_feishu_openapi.py
@@ -1,0 +1,52 @@
+import json
+import sys
+import types
+
+import pytest
+
+from tools.feishu_openapi import (
+    FeishuOpenAPIError,
+    _normalize_queries,
+    check_feishu_openapi_requirements,
+    load_settings,
+)
+
+
+def test_load_settings_reads_feishu_env(monkeypatch):
+    monkeypatch.setenv("FEISHU_APP_ID", "app")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret")
+    monkeypatch.setenv("FEISHU_DOMAIN", "lark")
+
+    settings = load_settings()
+
+    assert settings.app_id == "app"
+    assert settings.app_secret == "secret"
+    assert settings.domain_name == "lark"
+    assert settings.base_url == "https://open.larksuite.com"
+
+
+def test_check_requirements_false_without_credentials(monkeypatch):
+    monkeypatch.delenv("FEISHU_APP_ID", raising=False)
+    monkeypatch.delenv("FEISHU_APP_SECRET", raising=False)
+
+    assert check_feishu_openapi_requirements() is False
+
+
+def test_check_requirements_true_with_fake_lark(monkeypatch):
+    monkeypatch.setenv("FEISHU_APP_ID", "app")
+    monkeypatch.setenv("FEISHU_APP_SECRET", "secret")
+    monkeypatch.setitem(sys.modules, "lark_oapi", types.SimpleNamespace())
+
+    assert check_feishu_openapi_requirements() is True
+
+
+def test_normalize_queries_drops_empty_and_stringifies_bool():
+    assert _normalize_queries({"a": 1, "b": True, "c": None, "d": ""}) == [("a", "1"), ("b", "true")]
+
+
+def test_feishu_openapi_error_carries_code_and_data():
+    err = FeishuOpenAPIError("bad", code=999, data={"msg": "bad"})
+
+    assert str(err) == "bad"
+    assert err.code == 999
+    assert err.data == {"msg": "bad"}

--- a/tests/tools/test_feishu_wiki_tool.py
+++ b/tests/tools/test_feishu_wiki_tool.py
@@ -1,0 +1,49 @@
+import json
+
+from tools import feishu_wiki_tool as wiki
+
+
+def _patch(monkeypatch):
+    calls = []
+    monkeypatch.setattr(wiki, "request_json", lambda method, uri, **kwargs: calls.append((method, uri, kwargs)) or {"ok": True})
+    return calls
+
+
+def test_list_spaces_calls_endpoint(monkeypatch):
+    calls = _patch(monkeypatch)
+    wiki._list_spaces({"page_size": 5})
+    assert calls[0][0] == "GET"
+    assert calls[0][1].endswith("/spaces")
+    assert calls[0][2]["queries"]["page_size"] == 5
+
+
+def test_list_nodes_requires_space_id():
+    assert "space_id is required" in json.loads(wiki._list_nodes({}))["error"]
+
+
+def test_list_nodes_calls_space_nodes(monkeypatch):
+    calls = _patch(monkeypatch)
+    wiki._list_nodes({"space_id": "sp", "parent_node_token": "parent"})
+    assert calls[0][0] == "GET"
+    assert calls[0][2]["paths"] == {"space_id": "sp"}
+    assert calls[0][2]["queries"]["parent_node_token"] == "parent"
+
+
+def test_get_node_requires_node_token():
+    assert "node_token is required" in json.loads(wiki._get_node({"space_id": "sp"}))["error"]
+
+
+def test_get_node_calls_endpoint(monkeypatch):
+    calls = _patch(monkeypatch)
+    wiki._get_node({"space_id": "sp", "node_token": "node"})
+    assert calls[0][0] == "GET"
+    assert calls[0][2]["paths"] == {"space_id": "sp", "node_token": "node"}
+
+
+def test_create_node_body(monkeypatch):
+    calls = _patch(monkeypatch)
+    wiki._create_node({"space_id": "sp", "parent_node_token": "parent", "title": "Doc", "obj_token": "doc"})
+    assert calls[0][0] == "POST"
+    assert calls[0][2]["paths"] == {"space_id": "sp"}
+    assert calls[0][2]["body"]["title"] == "Doc"
+    assert calls[0][2]["body"]["obj_token"] == "doc"

--- a/tools/README-feishu-open-platform.md
+++ b/tools/README-feishu-open-platform.md
@@ -1,0 +1,263 @@
+# Feishu/Lark Open Platform Tools
+
+Hermes includes an opt-in `feishu` toolset for automating Feishu/Lark office workflows beyond chat messaging. The tools operate on Docx cloud documents, Bitable/Base project tables, Drive files/folders, and Wiki nodes through Feishu Open Platform APIs.
+
+These tools are intentionally separate from the Feishu messaging gateway:
+
+- `gateway/platforms/feishu.py` handles IM messages, images, files, cards, reactions, and message-resource downloads.
+- `tools/feishu_*.py` handles business-office APIs such as documents, bases, Drive metadata, folders, comments, and Wiki nodes.
+
+## Contents
+
+- [Architecture](#architecture)
+- [Installation and configuration](#installation-and-configuration)
+- [Permissions](#permissions)
+- [Tool inventory](#tool-inventory)
+- [Usage examples](#usage-examples)
+- [Ownership and collaboration](#ownership-and-collaboration)
+- [Testing](#testing)
+- [Operational notes](#operational-notes)
+- [Security considerations](#security-considerations)
+
+## Architecture
+
+| File | Responsibility |
+| --- | --- |
+| `tools/feishu_openapi.py` | Shared Feishu/Lark client helper, lazy `lark_oapi` import, environment loading, path/query/body request handling, and normalized Open Platform error handling. |
+| `tools/feishu_doc_tool.py` | Docx read/create/plain-text append/Markdown-to-native-block append/Markdown-to-native-block replace. |
+| `tools/feishu_bitable_tool.py` | Bitable/Base app creation, table rename, field schema management, and record CRUD/search. |
+| `tools/feishu_drive_tool.py` | Drive metadata, search, folder creation, comments, and comment replies. |
+| `tools/feishu_wiki_tool.py` | Wiki spaces, nodes, node metadata, and node creation. |
+| `toolsets.py` | Registers the opt-in `feishu` toolset. |
+| `model_tools.py` | Imports the tool modules so the registry can discover their schemas. |
+| `skills/productivity/feishu-project-workspace-management/SKILL.md` | Reusable workflow for Feishu project workspaces: Drive folders, native Docx documents, and Bitable project management. |
+
+The tools use Hermes' standard registry pattern (`tools.registry.registry.register`) and return JSON strings via `tool_result` / `tool_error`.
+
+## Installation and configuration
+
+Install Hermes with the Feishu optional dependency:
+
+```bash
+uv pip install -e ".[feishu]"
+# or, for a full local development environment
+uv pip install -e ".[all,dev]"
+```
+
+Configure credentials in the environment or `~/.hermes/.env`:
+
+```bash
+FEISHU_APP_ID=cli_xxx
+FEISHU_APP_SECRET=xxx
+FEISHU_DOMAIN=feishu      # use "lark" for https://open.larksuite.com
+```
+
+Supported domain values:
+
+| Value | Base URL |
+| --- | --- |
+| `feishu` | `https://open.feishu.cn` |
+| `lark` | `https://open.larksuite.com` |
+
+Enable the `feishu` toolset in the CLI/tool configuration when you want these tools available to the model.
+
+## Permissions
+
+A chat bot permission alone is not sufficient. The Feishu/Lark app must have the relevant Open Platform scopes for the resources it will operate on.
+
+Recommended permission groups:
+
+- Docs/Docx: create, read, update document blocks, raw content read.
+- Bitable/Base: create apps, manage tables/fields, read/write records.
+- Drive: search files, metadata, create folders, comments, permissions/members if ownership transfer is required.
+- Wiki: list spaces/nodes and create/read nodes.
+
+Target resources must also be visible to the app. For user-owned resources, share the document/base/folder/wiki space with the app or place new resources in a folder the app can access.
+
+## Tool inventory
+
+### Docx
+
+| Tool | Purpose |
+| --- | --- |
+| `feishu_doc_read` | Read raw content from a Docx cloud document. |
+| `feishu_doc_create` | Create a Docx cloud document, optionally under a Drive folder token. |
+| `feishu_doc_append_text` | Append plain paragraph text. Use only when plain text is desired. |
+| `feishu_doc_append_markdown` | Convert Markdown to native Docx blocks and append it. Preferred for formatted content. |
+| `feishu_doc_replace_markdown` | Delete current document body and replace it with Markdown converted to native Docx blocks. |
+
+### Bitable/Base
+
+| Tool | Purpose |
+| --- | --- |
+| `feishu_bitable_create_app` | Create a Base app, optionally under a Drive folder token. |
+| `feishu_bitable_list_tables` | List tables in a Base. |
+| `feishu_bitable_update_table` | Rename/update a table. |
+| `feishu_bitable_get_fields` | Read a table's field schema. |
+| `feishu_bitable_create_field` | Create a field. Common type codes: `1` Text, `3` SingleSelect, `5` DateTime, `17` Attachment. |
+| `feishu_bitable_update_field` | Update a field's name/type/property. |
+| `feishu_bitable_search_records` | Search records with optional view/filter/sort/field selection. |
+| `feishu_bitable_create_record` | Create one record. |
+| `feishu_bitable_update_record` | Update one record. |
+| `feishu_bitable_delete_record` | Delete one record by explicit record ID. |
+
+### Drive
+
+| Tool | Purpose |
+| --- | --- |
+| `feishu_drive_get_meta` | Batch-query Drive metadata for a token/type. |
+| `feishu_drive_search_files` | Search Drive files by keyword. |
+| `feishu_drive_create_folder` | Create a Drive folder. |
+| `feishu_drive_list_comments` | List comments for a Drive-backed file. |
+| `feishu_drive_reply_comment` | Reply to a comment. |
+
+### Wiki
+
+| Tool | Purpose |
+| --- | --- |
+| `feishu_wiki_list_spaces` | List visible Wiki spaces. |
+| `feishu_wiki_list_nodes` | List nodes in a Wiki space. |
+| `feishu_wiki_get_node` | Get metadata for a Wiki node. |
+| `feishu_wiki_create_node` | Create a Wiki node, optionally mounting an existing object token. |
+
+## Usage examples
+
+### Create a formatted Docx document
+
+Use native Docx block conversion for professional documents. Do **not** write Markdown headings with `feishu_doc_append_text`; that produces literal `#` text instead of real headings.
+
+```python
+from tools import feishu_doc_tool as doc
+
+created = doc._handle_doc_create({"title": "Project Overview"})
+# extract document_id/doc_token from the JSON result
+
+doc._handle_doc_replace_markdown({
+    "doc_token": "DOCX_TOKEN",
+    "markdown": """
+# Project Overview
+
+## Goals
+
+- Define the MVP
+- Ship the first milestone
+""".strip(),
+})
+```
+
+Implementation details:
+
+- Markdown is converted via `POST /open-apis/docx/v1/documents/blocks/convert`.
+- Converted blocks are reordered by `first_level_block_ids` before insertion.
+- Body replacement deletes children via `/children/batch_delete`.
+- Block insertion is chunked to respect the 50-child-per-request Feishu limit.
+
+### Create a Bitable project management base
+
+A project management base typically includes:
+
+- `任务名称` — Text
+- `状态` — SingleSelect: 未开始, 进行中, 阻塞, 待评审, 已完成
+- `计划完成日期` — DateTime
+- `模块` — SingleSelect
+- `优先级` — SingleSelect: P0, P1, P2, P3
+- `负责人` — Text
+- `任务说明` — Text
+- `验收标准` — Text
+- `风险/阻塞` — Text
+- `最近更新` — DateTime
+
+Use `feishu_bitable_create_app`, then rename the default table, create/update fields, and seed records.
+
+### Build a full project workspace
+
+Use the `feishu-project-workspace-management` skill for repeatable project setup:
+
+1. Create a Drive project folder and subfolders.
+2. Create native Docx project docs (overview, PRD, architecture, meeting notes).
+3. Create a Bitable/Base for task/project management.
+4. Transfer ownership to the target project owner and keep the app as editor.
+5. Verify by reading back docs, listing Bitable tables/fields/records, and checking Drive metadata.
+
+## Ownership and collaboration
+
+For Drive-backed documents and bases, the live-validated owner-transfer flow is:
+
+1. Grant the target user edit access:
+
+```http
+PATCH /open-apis/drive/v1/permissions/:token/members/:member_id?type=<docx|bitable>&member_type=openid
+{"perm": "edit"}
+```
+
+2. Transfer ownership:
+
+```http
+POST /open-apis/drive/v1/permissions/:token/members/transfer_owner?type=<docx|bitable>&need_notification=false
+{"member_type": "openid", "member_id": "<open_id>"}
+```
+
+3. Verify metadata:
+
+```http
+POST /open-apis/drive/v1/metas/batch_query
+{"request_docs": [{"doc_token": "...", "doc_type": "docx"}]}
+```
+
+`owner_id` should equal the target user's `open_id`.
+
+## Testing
+
+Focused test suite:
+
+```bash
+source venv/bin/activate
+python -m pytest \
+  tests/tools/test_feishu_openapi.py \
+  tests/tools/test_feishu_doc_tool.py \
+  tests/tools/test_feishu_bitable_tool.py \
+  tests/tools/test_feishu_drive_tool.py \
+  tests/tools/test_feishu_wiki_tool.py \
+  -q
+```
+
+Tool discovery smoke test:
+
+```bash
+source venv/bin/activate
+python - <<'PY'
+import model_tools
+from toolsets import resolve_toolset
+required = {
+    "feishu_doc_read", "feishu_doc_create", "feishu_doc_append_text",
+    "feishu_doc_append_markdown", "feishu_doc_replace_markdown",
+    "feishu_bitable_create_app", "feishu_bitable_list_tables",
+    "feishu_bitable_update_table", "feishu_bitable_get_fields",
+    "feishu_bitable_create_field", "feishu_bitable_update_field",
+    "feishu_bitable_search_records", "feishu_bitable_create_record",
+    "feishu_bitable_update_record", "feishu_bitable_delete_record",
+    "feishu_drive_get_meta", "feishu_drive_search_files",
+    "feishu_drive_create_folder", "feishu_drive_list_comments",
+    "feishu_drive_reply_comment", "feishu_wiki_list_spaces",
+    "feishu_wiki_list_nodes", "feishu_wiki_get_node", "feishu_wiki_create_node",
+}
+assert required <= set(model_tools.get_all_tool_names())
+assert required <= set(resolve_toolset("feishu"))
+print("schema discovery ok")
+PY
+```
+
+## Operational notes
+
+- `doc_token`, `file_token`, `app_token`, `table_id`, `record_id`, and Wiki node tokens are different identifiers and are not interchangeable.
+- Feishu IM attachment `file_key` values are not Drive file tokens.
+- Bitable date/datetime record values should use millisecond timestamps.
+- Read Bitable field schemas before writing records; field values are type-specific.
+- Keep tool modules import-safe without credentials. `lark_oapi` is imported lazily inside the shared OpenAPI helper.
+
+## Security considerations
+
+- Do not log `FEISHU_APP_SECRET` or tenant access tokens.
+- Avoid default-enabling the `feishu` toolset for users who have not configured Feishu credentials.
+- Prefer explicit record IDs for destructive operations such as record deletion.
+- Report permission/ownership transfer failures explicitly; do not silently leave app-owned project artifacts when a human owner is required.

--- a/tools/feishu_bitable_tool.py
+++ b/tools/feishu_bitable_tool.py
@@ -1,0 +1,158 @@
+"""Feishu Bitable/Base tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools.feishu_openapi import FeishuOpenAPIError, check_feishu_openapi_requirements, request_json
+from tools.registry import registry, tool_error, tool_result
+
+_APPS_URI = "/open-apis/bitable/v1/apps"
+_TABLES_URI = "/open-apis/bitable/v1/apps/:app_token/tables"
+_TABLE_URI = "/open-apis/bitable/v1/apps/:app_token/tables/:table_id"
+_FIELDS_URI = "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/fields"
+_FIELD_URI = "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/fields/:field_id"
+_RECORDS_URI = "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records"
+_RECORD_URI = "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records/:record_id"
+
+
+def _s(args: dict[str, Any], name: str) -> str:
+    return str(args.get(name) or "").strip()
+
+
+def _require(args: dict[str, Any], *names: str) -> str | None:
+    missing = [name for name in names if not _s(args, name)]
+    return f"{', '.join(missing)} required" if missing else None
+
+
+def _page_queries(args: dict[str, Any]) -> dict[str, Any]:
+    return {"page_size": args.get("page_size"), "page_token": args.get("page_token")}
+
+
+def _call(method: str, uri: str, *, args: dict[str, Any], paths: dict[str, Any], queries=None, body=None, **kwargs: Any) -> str:
+    try:
+        data = request_json(method, uri, paths=paths, queries=queries, body=body, client=kwargs.get("client"))
+        return tool_result({"success": True, "data": data})
+    except FeishuOpenAPIError as exc:
+        return tool_error(str(exc), code=exc.code, data=exc.data)
+
+
+def _create_app(args: dict[str, Any], **kwargs: Any) -> str:
+    name = _s(args, "name")
+    if not name:
+        return tool_error("name is required")
+    body = {"name": name}
+    if args.get("folder_token"):
+        body["folder_token"] = args["folder_token"]
+    return _call("POST", _APPS_URI, args=args, paths={}, body=body, **kwargs)
+
+
+def _list_tables(args: dict[str, Any], **kwargs: Any) -> str:
+    if err := _require(args, "app_token"):
+        return tool_error(err)
+    return _call("GET", _TABLES_URI, args=args, paths={"app_token": _s(args, "app_token")}, queries=_page_queries(args), **kwargs)
+
+
+def _update_table(args: dict[str, Any], **kwargs: Any) -> str:
+    if err := _require(args, "app_token", "table_id", "name"):
+        return tool_error(err)
+    return _call("PATCH", _TABLE_URI, args=args, paths={"app_token": _s(args, "app_token"), "table_id": _s(args, "table_id")}, body={"name": _s(args, "name")}, **kwargs)
+
+
+def _get_fields(args: dict[str, Any], **kwargs: Any) -> str:
+    if err := _require(args, "app_token", "table_id"):
+        return tool_error(err)
+    return _call("GET", _FIELDS_URI, args=args, paths={"app_token": _s(args, "app_token"), "table_id": _s(args, "table_id")}, queries=_page_queries(args), **kwargs)
+
+
+def _create_field(args: dict[str, Any], **kwargs: Any) -> str:
+    if err := _require(args, "app_token", "table_id", "field_name", "type"):
+        return tool_error(err)
+    body: dict[str, Any] = {"field_name": _s(args, "field_name"), "type": args.get("type")}
+    if args.get("property") is not None:
+        body["property"] = args["property"]
+    if args.get("description") is not None:
+        body["description"] = args["description"]
+    return _call("POST", _FIELDS_URI, args=args, paths={"app_token": _s(args, "app_token"), "table_id": _s(args, "table_id")}, body=body, **kwargs)
+
+
+def _update_field(args: dict[str, Any], **kwargs: Any) -> str:
+    if err := _require(args, "app_token", "table_id", "field_id", "field_name", "type"):
+        return tool_error(err)
+    body: dict[str, Any] = {"field_name": _s(args, "field_name"), "type": args.get("type")}
+    if args.get("property") is not None:
+        body["property"] = args["property"]
+    if args.get("description") is not None:
+        body["description"] = args["description"]
+    return _call("PUT", _FIELD_URI, args=args, paths={"app_token": _s(args, "app_token"), "table_id": _s(args, "table_id"), "field_id": _s(args, "field_id")}, body=body, **kwargs)
+
+
+def _search_records(args: dict[str, Any], **kwargs: Any) -> str:
+    if err := _require(args, "app_token", "table_id"):
+        return tool_error(err)
+    body: dict[str, Any] = {}
+    for key in ("view_id", "field_names", "sort", "filter", "automatic_fields"):
+        if args.get(key) not in (None, ""):
+            body[key] = args[key]
+    return _call(
+        "POST",
+        _RECORDS_URI + "/search",
+        args=args,
+        paths={"app_token": _s(args, "app_token"), "table_id": _s(args, "table_id")},
+        queries=_page_queries(args),
+        body=body,
+        **kwargs,
+    )
+
+
+def _create_record(args: dict[str, Any], **kwargs: Any) -> str:
+    if err := _require(args, "app_token", "table_id"):
+        return tool_error(err)
+    fields = args.get("fields")
+    if not isinstance(fields, dict) or not fields:
+        return tool_error("fields must be a non-empty object")
+    return _call("POST", _RECORDS_URI, args=args, paths={"app_token": _s(args, "app_token"), "table_id": _s(args, "table_id")}, body={"fields": fields}, **kwargs)
+
+
+def _update_record(args: dict[str, Any], **kwargs: Any) -> str:
+    if err := _require(args, "app_token", "table_id", "record_id"):
+        return tool_error(err)
+    fields = args.get("fields")
+    if not isinstance(fields, dict) or not fields:
+        return tool_error("fields must be a non-empty object")
+    return _call("PUT", _RECORD_URI, args=args, paths={"app_token": _s(args, "app_token"), "table_id": _s(args, "table_id"), "record_id": _s(args, "record_id")}, body={"fields": fields}, **kwargs)
+
+
+def _delete_record(args: dict[str, Any], **kwargs: Any) -> str:
+    if err := _require(args, "app_token", "table_id", "record_id"):
+        return tool_error(err)
+    return _call("DELETE", _RECORD_URI, args=args, paths={"app_token": _s(args, "app_token"), "table_id": _s(args, "table_id"), "record_id": _s(args, "record_id")}, **kwargs)
+
+
+def _schema(name: str, description: str, props: dict[str, Any], required: list[str]) -> dict[str, Any]:
+    base = {
+        "app_token": {"type": "string", "description": "Bitable app/base token."},
+        "table_id": {"type": "string", "description": "Bitable table ID."},
+        "record_id": {"type": "string", "description": "Bitable record ID."},
+        "page_size": {"type": "integer", "description": "Page size for paginated list/search calls."},
+        "page_token": {"type": "string", "description": "Pagination token."},
+    }
+    base.update(props)
+    return {"name": name, "description": description, "parameters": {"type": "object", "properties": base, "required": required}}
+
+
+_COMMON = dict(check_fn=check_feishu_openapi_requirements, requires_env=["FEISHU_APP_ID", "FEISHU_APP_SECRET"], emoji="🧮", toolset="feishu")
+
+for _name, _handler, _description, _props, _required in [
+    ("feishu_bitable_create_app", _create_app, "Create a Feishu Bitable/Base app.", {"name": {"type": "string"}, "folder_token": {"type": "string", "description": "Optional Drive folder token."}}, ["name"]),
+    ("feishu_bitable_list_tables", _list_tables, "List tables in a Feishu Bitable/Base app.", {}, ["app_token"]),
+    ("feishu_bitable_update_table", _update_table, "Rename/update a Feishu Bitable table.", {"name": {"type": "string"}}, ["app_token", "table_id", "name"]),
+    ("feishu_bitable_get_fields", _get_fields, "List fields for a Feishu Bitable table.", {}, ["app_token", "table_id"]),
+    ("feishu_bitable_create_field", _create_field, "Create a field in a Feishu Bitable table. Use field type codes from Feishu Bitable, e.g. 1 Text, 3 SingleSelect, 5 DateTime, 17 Attachment.", {"field_name": {"type": "string"}, "type": {"type": "integer"}, "property": {"type": "object"}, "description": {"type": "string"}}, ["app_token", "table_id", "field_name", "type"]),
+    ("feishu_bitable_update_field", _update_field, "Update a Feishu Bitable field name/type/property.", {"field_id": {"type": "string"}, "field_name": {"type": "string"}, "type": {"type": "integer"}, "property": {"type": "object"}, "description": {"type": "string"}}, ["app_token", "table_id", "field_id", "field_name", "type"]),
+    ("feishu_bitable_search_records", _search_records, "Search records in a Feishu Bitable table with optional filter/sort/view parameters.", {"view_id": {"type": "string"}, "field_names": {"type": "array", "items": {"type": "string"}}, "sort": {"type": "array"}, "filter": {"type": "object"}, "automatic_fields": {"type": "boolean"}}, ["app_token", "table_id"]),
+    ("feishu_bitable_create_record", _create_record, "Create one record in a Feishu Bitable table.", {"fields": {"type": "object", "description": "Record field values keyed by field name."}}, ["app_token", "table_id", "fields"]),
+    ("feishu_bitable_update_record", _update_record, "Update one record in a Feishu Bitable table.", {"fields": {"type": "object", "description": "Record field values keyed by field name."}}, ["app_token", "table_id", "record_id", "fields"]),
+    ("feishu_bitable_delete_record", _delete_record, "Delete one record in a Feishu Bitable table. Requires an explicit record_id.", {}, ["app_token", "table_id", "record_id"]),
+]:
+    registry.register(name=_name, handler=_handler, schema=_schema(_name, _description, _props, _required), description=_description, **_COMMON)

--- a/tools/feishu_doc_tool.py
+++ b/tools/feishu_doc_tool.py
@@ -1,131 +1,289 @@
-"""Feishu Document Tool -- read document content via Feishu/Lark API.
+"""Feishu Docx tools for standalone Open Platform document operations."""
 
-Provides ``feishu_doc_read`` for reading document content as plain text.
-Uses the same lazy-import + BaseRequest pattern as feishu_comment.py.
-"""
+from __future__ import annotations
 
-import json
-import logging
-import threading
+from typing import Any
 
+from tools.feishu_openapi import FeishuOpenAPIError, check_feishu_openapi_requirements, request_json
 from tools.registry import registry, tool_error, tool_result
 
-logger = logging.getLogger(__name__)
-
-# Thread-local storage for the lark client injected by feishu_comment handler.
-_local = threading.local()
-
-
-def set_client(client):
-    """Store a lark client for the current thread (called by feishu_comment)."""
-    _local.client = client
+_DOC_RAW_CONTENT_URI = "/open-apis/docx/v1/documents/:document_id/raw_content"
+_DOC_CREATE_URI = "/open-apis/docx/v1/documents"
+_DOC_BLOCK_CHILDREN_URI = "/open-apis/docx/v1/documents/:document_id/blocks/:block_id/children"
+_DOC_BLOCK_DELETE_CHILDREN_URI = "/open-apis/docx/v1/documents/:document_id/blocks/:block_id/children/batch_delete"
+_DOC_BLOCK_LIST_URI = "/open-apis/docx/v1/documents/:document_id/blocks"
+_DOC_BLOCK_CONVERT_URI = "/open-apis/docx/v1/documents/blocks/convert"
 
 
-def get_client():
-    """Return the lark client for the current thread, or None."""
-    return getattr(_local, "client", None)
+def _string_arg(args: dict[str, Any], name: str) -> str:
+    return str(args.get(name) or "").strip()
 
 
-# ---------------------------------------------------------------------------
-# feishu_doc_read
-# ---------------------------------------------------------------------------
-
-_RAW_CONTENT_URI = "/open-apis/docx/v1/documents/:document_id/raw_content"
-
-FEISHU_DOC_READ_SCHEMA = {
-    "name": "feishu_doc_read",
-    "description": (
-        "Read the full content of a Feishu/Lark document as plain text. "
-        "Useful when you need more context beyond the quoted text in a comment."
-    ),
-    "parameters": {
-        "type": "object",
-        "properties": {
-            "doc_token": {
-                "type": "string",
-                "description": "The document token (from the document URL or comment context).",
-            },
-        },
-        "required": ["doc_token"],
-    },
-}
-
-
-def _check_feishu():
-    try:
-        import lark_oapi  # noqa: F401
-        return True
-    except ImportError:
-        return False
-
-
-def _handle_feishu_doc_read(args: dict, **kwargs) -> str:
-    doc_token = args.get("doc_token", "").strip()
+def _handle_doc_read(args: dict[str, Any], **kwargs: Any) -> str:
+    doc_token = _string_arg(args, "doc_token")
     if not doc_token:
         return tool_error("doc_token is required")
-
-    client = get_client()
-    if client is None:
-        return tool_error("Feishu client not available (not in a Feishu comment context)")
-
     try:
-        from lark_oapi import AccessTokenType
-        from lark_oapi.core.enum import HttpMethod
-        from lark_oapi.core.model.base_request import BaseRequest
-    except ImportError:
-        return tool_error("lark_oapi not installed")
+        data = request_json("GET", _DOC_RAW_CONTENT_URI, paths={"document_id": doc_token}, client=kwargs.get("client"))
+        return tool_result({"success": True, "doc_token": doc_token, "content": data.get("content", ""), "data": data})
+    except FeishuOpenAPIError as exc:
+        return tool_error(str(exc), code=exc.code, data=exc.data)
 
-    request = (
-        BaseRequest.builder()
-        .http_method(HttpMethod.GET)
-        .uri(_RAW_CONTENT_URI)
-        .token_types({AccessTokenType.TENANT})
-        .paths({"document_id": doc_token})
-        .build()
+
+def _handle_doc_create(args: dict[str, Any], **kwargs: Any) -> str:
+    title = _string_arg(args, "title")
+    if not title:
+        return tool_error("title is required")
+    folder_token = _string_arg(args, "folder_token")
+    body: dict[str, Any] = {"title": title}
+    if folder_token:
+        body["folder_token"] = folder_token
+    try:
+        data = request_json("POST", _DOC_CREATE_URI, body=body, client=kwargs.get("client"))
+        return tool_result({"success": True, "document": data.get("document", data), "data": data})
+    except FeishuOpenAPIError as exc:
+        return tool_error(str(exc), code=exc.code, data=exc.data)
+
+
+def _paragraph_block(text: str) -> dict[str, Any]:
+    return {
+        "block_type": 2,
+        "text": {
+            "elements": [
+                {
+                    "text_run": {
+                        "content": text,
+                        "text_element_style": {},
+                    }
+                }
+            ],
+            "style": {},
+        },
+    }
+
+
+def _handle_doc_append_text(args: dict[str, Any], **kwargs: Any) -> str:
+    doc_token = _string_arg(args, "doc_token")
+    text = str(args.get("text") or "")
+    if not doc_token:
+        return tool_error("doc_token is required")
+    if not text.strip():
+        return tool_error("text is required")
+    parent_block_id = _string_arg(args, "parent_block_id") or doc_token
+    lines = [line for line in text.splitlines() if line.strip()]
+    if not lines:
+        lines = [text]
+    body = {"children": [_paragraph_block(line) for line in lines]}
+    try:
+        data = request_json(
+            "POST",
+            _DOC_BLOCK_CHILDREN_URI,
+            paths={"document_id": doc_token, "block_id": parent_block_id},
+            body=body,
+            client=kwargs.get("client"),
+        )
+        return tool_result({"success": True, "doc_token": doc_token, "appended_blocks": data.get("children", data), "data": data})
+    except FeishuOpenAPIError as exc:
+        return tool_error(str(exc), code=exc.code, data=exc.data)
+
+
+def _convert_markdown(markdown: str, *, client: Any | None = None) -> list[dict[str, Any]]:
+    data = request_json(
+        "POST",
+        _DOC_BLOCK_CONVERT_URI,
+        body={"content_type": "markdown", "content": markdown},
+        client=client,
     )
-
-    # Tool handlers run synchronously in a worker thread (no running event
-    # loop), so call the blocking lark client directly.
-    response = client.request(request)
-
-    code = getattr(response, "code", None)
-    if code != 0:
-        msg = getattr(response, "msg", "unknown error")
-        return tool_error(f"Failed to read document: code={code} msg={msg}")
-
-    raw = getattr(response, "raw", None)
-    if raw and hasattr(raw, "content"):
-        try:
-            body = json.loads(raw.content)
-            content = body.get("data", {}).get("content", "")
-            return tool_result(success=True, content=content)
-        except (json.JSONDecodeError, AttributeError):
-            pass
-
-    # Fallback: try response.data
-    data = getattr(response, "data", None)
-    if data:
-        if isinstance(data, dict):
-            content = data.get("content", "")
-        else:
-            content = getattr(data, "content", str(data))
-        return tool_result(success=True, content=content)
-
-    return tool_error("No content returned from document API")
+    blocks = data.get("blocks", [])
+    if not isinstance(blocks, list):
+        return []
+    # Feishu's convert endpoint returns first_level_block_ids as the canonical
+    # document order. The blocks array can be non-deterministic, so reorder it
+    # before insertion or rendered documents become scrambled.
+    ordered_ids = data.get("first_level_block_ids", [])
+    if isinstance(ordered_ids, list) and ordered_ids:
+        by_id = {block.get("block_id"): block for block in blocks if isinstance(block, dict)}
+        ordered = [by_id[block_id] for block_id in ordered_ids if block_id in by_id]
+        remaining = [block for block in blocks if isinstance(block, dict) and block.get("block_id") not in set(ordered_ids)]
+        return ordered + remaining
+    return blocks
 
 
-# ---------------------------------------------------------------------------
-# Registration
-# ---------------------------------------------------------------------------
+def _clear_document(doc_token: str, *, client: Any | None = None) -> int:
+    data = request_json("GET", _DOC_BLOCK_LIST_URI, paths={"document_id": doc_token}, client=client)
+    items = data.get("items", [])
+    child_count = len([item for item in items if item.get("parent_id") == doc_token and item.get("block_type") != 1])
+    if child_count:
+        request_json(
+            "DELETE",
+            _DOC_BLOCK_DELETE_CHILDREN_URI,
+            paths={"document_id": doc_token, "block_id": doc_token},
+            body={"start_index": 0, "end_index": child_count},
+            client=client,
+        )
+    return child_count
+
+
+def _insert_blocks(doc_token: str, blocks: list[dict[str, Any]], *, parent_block_id: str | None = None, client: Any | None = None) -> dict[str, Any]:
+    if not blocks:
+        return {"children": []}
+    block_id = parent_block_id or doc_token
+    all_children: list[Any] = []
+    last_data: dict[str, Any] = {}
+    # Feishu limits one documentBlockChildren.create request to 50 children.
+    for start in range(0, len(blocks), 50):
+        data = request_json(
+            "POST",
+            _DOC_BLOCK_CHILDREN_URI,
+            paths={"document_id": doc_token, "block_id": block_id},
+            body={"children": blocks[start : start + 50]},
+            client=client,
+        )
+        last_data = data
+        children = data.get("children", [])
+        if isinstance(children, list):
+            all_children.extend(children)
+    return {**last_data, "children": all_children}
+
+
+def _handle_doc_append_markdown(args: dict[str, Any], **kwargs: Any) -> str:
+    doc_token = _string_arg(args, "doc_token")
+    markdown = str(args.get("markdown") or "")
+    if not doc_token:
+        return tool_error("doc_token is required")
+    if not markdown.strip():
+        return tool_error("markdown is required")
+    client = kwargs.get("client")
+    try:
+        blocks = _convert_markdown(markdown, client=client)
+        data = _insert_blocks(doc_token, blocks, parent_block_id=_string_arg(args, "parent_block_id") or None, client=client)
+        return tool_result({"success": True, "doc_token": doc_token, "block_count": len(blocks), "data": data})
+    except FeishuOpenAPIError as exc:
+        return tool_error(str(exc), code=exc.code, data=exc.data)
+
+
+def _handle_doc_replace_markdown(args: dict[str, Any], **kwargs: Any) -> str:
+    doc_token = _string_arg(args, "doc_token")
+    markdown = str(args.get("markdown") or "")
+    if not doc_token:
+        return tool_error("doc_token is required")
+    if not markdown.strip():
+        return tool_error("markdown is required")
+    client = kwargs.get("client")
+    try:
+        blocks = _convert_markdown(markdown, client=client)
+        deleted = _clear_document(doc_token, client=client)
+        data = _insert_blocks(doc_token, blocks, client=client)
+        return tool_result({"success": True, "doc_token": doc_token, "deleted_blocks": deleted, "block_count": len(blocks), "data": data})
+    except FeishuOpenAPIError as exc:
+        return tool_error(str(exc), code=exc.code, data=exc.data)
+
 
 registry.register(
     name="feishu_doc_read",
-    toolset="feishu_doc",
-    schema=FEISHU_DOC_READ_SCHEMA,
-    handler=_handle_feishu_doc_read,
-    check_fn=_check_feishu,
-    requires_env=[],
-    is_async=False,
-    description="Read Feishu document content",
-    emoji="\U0001f4c4",
+    toolset="feishu",
+    schema={
+        "name": "feishu_doc_read",
+        "description": "Read a Feishu/Lark Docx document as plain text raw content.",
+        "parameters": {
+            "type": "object",
+            "properties": {"doc_token": {"type": "string", "description": "Docx document token from the URL."}},
+            "required": ["doc_token"],
+        },
+    },
+    handler=_handle_doc_read,
+    check_fn=check_feishu_openapi_requirements,
+    requires_env=["FEISHU_APP_ID", "FEISHU_APP_SECRET"],
+    description="Read Feishu Docx document content",
+    emoji="📄",
+)
+
+registry.register(
+    name="feishu_doc_create",
+    toolset="feishu",
+    schema={
+        "name": "feishu_doc_create",
+        "description": "Create a Feishu/Lark Docx document. Requires document create permissions and folder access if folder_token is provided.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Document title."},
+                "folder_token": {"type": "string", "description": "Optional Drive folder token; this is not an IM file_key."},
+            },
+            "required": ["title"],
+        },
+    },
+    handler=_handle_doc_create,
+    check_fn=check_feishu_openapi_requirements,
+    requires_env=["FEISHU_APP_ID", "FEISHU_APP_SECRET"],
+    description="Create a Feishu Docx document",
+    emoji="📄",
+)
+
+registry.register(
+    name="feishu_doc_append_text",
+    toolset="feishu",
+    schema={
+        "name": "feishu_doc_append_text",
+        "description": "Append plain paragraph text to a Feishu/Lark Docx document. For formatted headings/lists, prefer feishu_doc_append_markdown or feishu_doc_replace_markdown.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "doc_token": {"type": "string", "description": "Docx document token from the URL."},
+                "text": {"type": "string", "description": "Plain text to append. Non-empty lines become paragraphs."},
+                "parent_block_id": {"type": "string", "description": "Optional parent block ID. Defaults to doc_token/root."},
+            },
+            "required": ["doc_token", "text"],
+        },
+    },
+    handler=_handle_doc_append_text,
+    check_fn=check_feishu_openapi_requirements,
+    requires_env=["FEISHU_APP_ID", "FEISHU_APP_SECRET"],
+    description="Append plain text to Feishu Docx",
+    emoji="📝",
+)
+
+registry.register(
+    name="feishu_doc_append_markdown",
+    toolset="feishu",
+    schema={
+        "name": "feishu_doc_append_markdown",
+        "description": "Append Markdown as native Feishu Docx rich blocks so headings/lists render correctly.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "doc_token": {"type": "string", "description": "Docx document token from the URL."},
+                "markdown": {"type": "string", "description": "Markdown content to convert into Feishu Docx blocks."},
+                "parent_block_id": {"type": "string", "description": "Optional parent block ID. Defaults to doc_token/root."},
+            },
+            "required": ["doc_token", "markdown"],
+        },
+    },
+    handler=_handle_doc_append_markdown,
+    check_fn=check_feishu_openapi_requirements,
+    requires_env=["FEISHU_APP_ID", "FEISHU_APP_SECRET"],
+    description="Append Markdown to Feishu Docx as native blocks",
+    emoji="📝",
+)
+
+registry.register(
+    name="feishu_doc_replace_markdown",
+    toolset="feishu",
+    schema={
+        "name": "feishu_doc_replace_markdown",
+        "description": "Replace a Feishu/Lark Docx document body with Markdown converted to native rich blocks. Use for formatted documents where headings/lists should render natively.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "doc_token": {"type": "string", "description": "Docx document token from the URL."},
+                "markdown": {"type": "string", "description": "Markdown content to convert into Feishu Docx blocks."},
+            },
+            "required": ["doc_token", "markdown"],
+        },
+    },
+    handler=_handle_doc_replace_markdown,
+    check_fn=check_feishu_openapi_requirements,
+    requires_env=["FEISHU_APP_ID", "FEISHU_APP_SECRET"],
+    description="Replace Feishu Docx body with formatted Markdown",
+    emoji="📝",
 )

--- a/tools/feishu_drive_tool.py
+++ b/tools/feishu_drive_tool.py
@@ -1,429 +1,110 @@
-"""Feishu Drive Tools -- document comment operations via Feishu/Lark API.
+"""Feishu Drive tools for standalone Open Platform file and comment operations."""
 
-Provides tools for listing, replying to, and adding document comments.
-Uses the same lazy-import + BaseRequest pattern as feishu_comment.py.
-The lark client is injected per-thread by the comment event handler.
-"""
+from __future__ import annotations
 
-import json
-import logging
-import threading
+from typing import Any
 
+from tools.feishu_openapi import FeishuOpenAPIError, check_feishu_openapi_requirements, request_json
 from tools.registry import registry, tool_error, tool_result
 
-logger = logging.getLogger(__name__)
-
-# Thread-local storage for the lark client injected by feishu_comment handler.
-_local = threading.local()
-
-
-def set_client(client):
-    """Store a lark client for the current thread (called by feishu_comment)."""
-    _local.client = client
+_META_URI = "/open-apis/drive/v1/metas/batch_query"
+_SEARCH_URI = "/open-apis/drive/v1/files/search"
+_CREATE_FOLDER_URI = "/open-apis/drive/v1/files/create_folder"
+_COMMENTS_URI = "/open-apis/drive/v1/files/:file_token/comments"
+_REPLIES_URI = "/open-apis/drive/v1/files/:file_token/comments/:comment_id/replies"
 
 
-def get_client():
-    """Return the lark client for the current thread, or None."""
-    return getattr(_local, "client", None)
+def _s(args: dict[str, Any], name: str) -> str:
+    return str(args.get(name) or "").strip()
 
 
-def _check_feishu():
+def _call(method: str, uri: str, *, paths=None, queries=None, body=None, **kwargs: Any) -> str:
     try:
-        import lark_oapi  # noqa: F401
-        return True
-    except ImportError:
-        return False
+        data = request_json(method, uri, paths=paths, queries=queries, body=body, client=kwargs.get("client"))
+        return tool_result({"success": True, "data": data})
+    except FeishuOpenAPIError as exc:
+        return tool_error(str(exc), code=exc.code, data=exc.data)
 
 
-def _do_request(client, method, uri, paths=None, queries=None, body=None):
-    """Build and execute a BaseRequest, return (code, msg, data_dict)."""
-    from lark_oapi import AccessTokenType
-    from lark_oapi.core.enum import HttpMethod
-    from lark_oapi.core.model.base_request import BaseRequest
-
-    http_method = HttpMethod.GET if method == "GET" else HttpMethod.POST
-
-    builder = (
-        BaseRequest.builder()
-        .http_method(http_method)
-        .uri(uri)
-        .token_types({AccessTokenType.TENANT})
-    )
-    if paths:
-        builder = builder.paths(paths)
-    if queries:
-        builder = builder.queries(queries)
-    if body is not None:
-        builder = builder.body(body)
-
-    request = builder.build()
-
-    # Tool handlers run synchronously in a worker thread (no running event
-    # loop), so call the blocking lark client directly.
-    response = client.request(request)
-
-    code = getattr(response, "code", None)
-    msg = getattr(response, "msg", "")
-
-    # Parse response data
-    data = {}
-    raw = getattr(response, "raw", None)
-    if raw and hasattr(raw, "content"):
-        try:
-            body_json = json.loads(raw.content)
-            data = body_json.get("data", {})
-        except (json.JSONDecodeError, AttributeError):
-            pass
-    if not data:
-        resp_data = getattr(response, "data", None)
-        if isinstance(resp_data, dict):
-            data = resp_data
-        elif resp_data and hasattr(resp_data, "__dict__"):
-            data = vars(resp_data)
-
-    return code, msg, data
-
-
-# ---------------------------------------------------------------------------
-# feishu_drive_list_comments
-# ---------------------------------------------------------------------------
-
-_LIST_COMMENTS_URI = "/open-apis/drive/v1/files/:file_token/comments"
-
-FEISHU_DRIVE_LIST_COMMENTS_SCHEMA = {
-    "name": "feishu_drive_list_comments",
-    "description": (
-        "List comments on a Feishu document. "
-        "Use is_whole=true to list whole-document comments only."
-    ),
-    "parameters": {
-        "type": "object",
-        "properties": {
-            "file_token": {
-                "type": "string",
-                "description": "The document file token.",
-            },
-            "file_type": {
-                "type": "string",
-                "description": "File type (default: docx).",
-                "default": "docx",
-            },
-            "is_whole": {
-                "type": "boolean",
-                "description": "If true, only return whole-document comments.",
-                "default": False,
-            },
-            "page_size": {
-                "type": "integer",
-                "description": "Number of comments per page (max 100).",
-                "default": 100,
-            },
-            "page_token": {
-                "type": "string",
-                "description": "Pagination token for next page.",
-            },
-        },
-        "required": ["file_token"],
-    },
-}
-
-
-def _handle_list_comments(args: dict, **kwargs) -> str:
-    client = get_client()
-    if client is None:
-        return tool_error("Feishu client not available")
-
-    file_token = args.get("file_token", "").strip()
+def _get_meta(args: dict[str, Any], **kwargs: Any) -> str:
+    file_token = _s(args, "file_token")
+    file_type = _s(args, "file_type") or "docx"
     if not file_token:
-        return tool_error("file_token is required")
-
-    file_type = args.get("file_type", "docx") or "docx"
-    is_whole = args.get("is_whole", False)
-    page_size = args.get("page_size", 100)
-    page_token = args.get("page_token", "")
-
-    queries = [
-        ("file_type", file_type),
-        ("user_id_type", "open_id"),
-        ("page_size", str(page_size)),
-    ]
-    if is_whole:
-        queries.append(("is_whole", "true"))
-    if page_token:
-        queries.append(("page_token", page_token))
-
-    code, msg, data = _do_request(
-        client, "GET", _LIST_COMMENTS_URI,
-        paths={"file_token": file_token},
-        queries=queries,
-    )
-    if code != 0:
-        return tool_error(f"List comments failed: code={code} msg={msg}")
-
-    return tool_result(data)
+        return tool_error("file_token is required; Drive tokens are not IM file_key values")
+    body = {"request_docs": [{"doc_token": file_token, "doc_type": file_type}]}
+    return _call("POST", _META_URI, body=body, **kwargs)
 
 
-# ---------------------------------------------------------------------------
-# feishu_drive_list_comment_replies
-# ---------------------------------------------------------------------------
-
-_LIST_REPLIES_URI = "/open-apis/drive/v1/files/:file_token/comments/:comment_id/replies"
-
-FEISHU_DRIVE_LIST_REPLIES_SCHEMA = {
-    "name": "feishu_drive_list_comment_replies",
-    "description": "List all replies in a comment thread on a Feishu document.",
-    "parameters": {
-        "type": "object",
-        "properties": {
-            "file_token": {
-                "type": "string",
-                "description": "The document file token.",
-            },
-            "comment_id": {
-                "type": "string",
-                "description": "The comment ID to list replies for.",
-            },
-            "file_type": {
-                "type": "string",
-                "description": "File type (default: docx).",
-                "default": "docx",
-            },
-            "page_size": {
-                "type": "integer",
-                "description": "Number of replies per page (max 100).",
-                "default": 100,
-            },
-            "page_token": {
-                "type": "string",
-                "description": "Pagination token for next page.",
-            },
-        },
-        "required": ["file_token", "comment_id"],
-    },
-}
+def _search_files(args: dict[str, Any], **kwargs: Any) -> str:
+    query = _s(args, "query")
+    if not query:
+        return tool_error("query is required")
+    body = {"search_key": query}
+    for key in ("folder_token", "file_extension", "owner_id", "chat_id"):
+        if args.get(key):
+            body[key] = args[key]
+    queries = {"page_size": args.get("page_size"), "page_token": args.get("page_token")}
+    return _call("POST", _SEARCH_URI, queries=queries, body=body, **kwargs)
 
 
-def _handle_list_replies(args: dict, **kwargs) -> str:
-    client = get_client()
-    if client is None:
-        return tool_error("Feishu client not available")
-
-    file_token = args.get("file_token", "").strip()
-    comment_id = args.get("comment_id", "").strip()
-    if not file_token or not comment_id:
-        return tool_error("file_token and comment_id are required")
-
-    file_type = args.get("file_type", "docx") or "docx"
-    page_size = args.get("page_size", 100)
-    page_token = args.get("page_token", "")
-
-    queries = [
-        ("file_type", file_type),
-        ("user_id_type", "open_id"),
-        ("page_size", str(page_size)),
-    ]
-    if page_token:
-        queries.append(("page_token", page_token))
-
-    code, msg, data = _do_request(
-        client, "GET", _LIST_REPLIES_URI,
-        paths={"file_token": file_token, "comment_id": comment_id},
-        queries=queries,
-    )
-    if code != 0:
-        return tool_error(f"List replies failed: code={code} msg={msg}")
-
-    return tool_result(data)
+def _create_folder(args: dict[str, Any], **kwargs: Any) -> str:
+    name = _s(args, "name")
+    folder_token = _s(args, "folder_token")
+    if not name:
+        return tool_error("name is required")
+    body = {"name": name}
+    if folder_token:
+        body["folder_token"] = folder_token
+    return _call("POST", _CREATE_FOLDER_URI, body=body, **kwargs)
 
 
-# ---------------------------------------------------------------------------
-# feishu_drive_reply_comment
-# ---------------------------------------------------------------------------
-
-_REPLY_COMMENT_URI = "/open-apis/drive/v1/files/:file_token/comments/:comment_id/replies"
-
-FEISHU_DRIVE_REPLY_SCHEMA = {
-    "name": "feishu_drive_reply_comment",
-    "description": (
-        "Reply to a local comment thread on a Feishu document. "
-        "Use this for local (quoted-text) comments. "
-        "For whole-document comments, use feishu_drive_add_comment instead."
-    ),
-    "parameters": {
-        "type": "object",
-        "properties": {
-            "file_token": {
-                "type": "string",
-                "description": "The document file token.",
-            },
-            "comment_id": {
-                "type": "string",
-                "description": "The comment ID to reply to.",
-            },
-            "content": {
-                "type": "string",
-                "description": "The reply text content (plain text only, no markdown).",
-            },
-            "file_type": {
-                "type": "string",
-                "description": "File type (default: docx).",
-                "default": "docx",
-            },
-        },
-        "required": ["file_token", "comment_id", "content"],
-    },
-}
-
-
-def _handle_reply_comment(args: dict, **kwargs) -> str:
-    client = get_client()
-    if client is None:
-        return tool_error("Feishu client not available")
-
-    file_token = args.get("file_token", "").strip()
-    comment_id = args.get("comment_id", "").strip()
-    content = args.get("content", "").strip()
-    if not file_token or not comment_id or not content:
-        return tool_error("file_token, comment_id, and content are required")
-
-    file_type = args.get("file_type", "docx") or "docx"
-
-    body = {
-        "content": {
-            "elements": [
-                {
-                    "type": "text_run",
-                    "text_run": {"text": content},
-                }
-            ]
-        }
+def _list_comments(args: dict[str, Any], **kwargs: Any) -> str:
+    file_token = _s(args, "file_token")
+    if not file_token:
+        return tool_error("file_token is required; Drive tokens are not IM file_key values")
+    queries = {
+        "file_type": _s(args, "file_type") or "docx",
+        "user_id_type": args.get("user_id_type") or "open_id",
+        "is_whole": args.get("is_whole"),
+        "page_size": args.get("page_size"),
+        "page_token": args.get("page_token"),
     }
-
-    code, msg, data = _do_request(
-        client, "POST", _REPLY_COMMENT_URI,
-        paths={"file_token": file_token, "comment_id": comment_id},
-        queries=[("file_type", file_type)],
-        body=body,
-    )
-    if code != 0:
-        return tool_error(f"Reply comment failed: code={code} msg={msg}")
-
-    return tool_result(success=True, data=data)
+    return _call("GET", _COMMENTS_URI, paths={"file_token": file_token}, queries=queries, **kwargs)
 
 
-# ---------------------------------------------------------------------------
-# feishu_drive_add_comment
-# ---------------------------------------------------------------------------
-
-_ADD_COMMENT_URI = "/open-apis/drive/v1/files/:file_token/new_comments"
-
-FEISHU_DRIVE_ADD_COMMENT_SCHEMA = {
-    "name": "feishu_drive_add_comment",
-    "description": (
-        "Add a new whole-document comment on a Feishu document. "
-        "Use this for whole-document comments or as a fallback when "
-        "reply_comment fails with code 1069302."
-    ),
-    "parameters": {
-        "type": "object",
-        "properties": {
-            "file_token": {
-                "type": "string",
-                "description": "The document file token.",
-            },
-            "content": {
-                "type": "string",
-                "description": "The comment text content (plain text only, no markdown).",
-            },
-            "file_type": {
-                "type": "string",
-                "description": "File type (default: docx).",
-                "default": "docx",
-            },
-        },
-        "required": ["file_token", "content"],
-    },
-}
+def _reply_comment(args: dict[str, Any], **kwargs: Any) -> str:
+    file_token = _s(args, "file_token")
+    comment_id = _s(args, "comment_id")
+    content = str(args.get("content") or "")
+    if not file_token:
+        return tool_error("file_token is required; Drive tokens are not IM file_key values")
+    if not comment_id:
+        return tool_error("comment_id is required")
+    if not content.strip():
+        return tool_error("content is required")
+    queries = {"file_type": _s(args, "file_type") or "docx", "user_id_type": args.get("user_id_type") or "open_id"}
+    body = {"reply": {"content": {"elements": [{"text_run": {"text": content}}]}}}
+    return _call("POST", _REPLIES_URI, paths={"file_token": file_token, "comment_id": comment_id}, queries=queries, body=body, **kwargs)
 
 
-def _handle_add_comment(args: dict, **kwargs) -> str:
-    client = get_client()
-    if client is None:
-        return tool_error("Feishu client not available")
-
-    file_token = args.get("file_token", "").strip()
-    content = args.get("content", "").strip()
-    if not file_token or not content:
-        return tool_error("file_token and content are required")
-
-    file_type = args.get("file_type", "docx") or "docx"
-
-    body = {
-        "file_type": file_type,
-        "reply_elements": [
-            {"type": "text", "text": content},
-        ],
+def _schema(name: str, description: str, props: dict[str, Any], required: list[str]) -> dict[str, Any]:
+    common = {
+        "file_token": {"type": "string", "description": "Drive file token; not an IM message file_key."},
+        "file_type": {"type": "string", "description": "Drive file type, default docx."},
+        "page_size": {"type": "integer"},
+        "page_token": {"type": "string"},
     }
-
-    code, msg, data = _do_request(
-        client, "POST", _ADD_COMMENT_URI,
-        paths={"file_token": file_token},
-        body=body,
-    )
-    if code != 0:
-        return tool_error(f"Add comment failed: code={code} msg={msg}")
-
-    return tool_result(success=True, data=data)
+    common.update(props)
+    return {"name": name, "description": description, "parameters": {"type": "object", "properties": common, "required": required}}
 
 
-# ---------------------------------------------------------------------------
-# Registration
-# ---------------------------------------------------------------------------
+_COMMON = dict(toolset="feishu", check_fn=check_feishu_openapi_requirements, requires_env=["FEISHU_APP_ID", "FEISHU_APP_SECRET"], emoji="🗂️")
 
-registry.register(
-    name="feishu_drive_list_comments",
-    toolset="feishu_drive",
-    schema=FEISHU_DRIVE_LIST_COMMENTS_SCHEMA,
-    handler=_handle_list_comments,
-    check_fn=_check_feishu,
-    requires_env=[],
-    is_async=False,
-    description="List document comments",
-    emoji="\U0001f4ac",
-)
-
-registry.register(
-    name="feishu_drive_list_comment_replies",
-    toolset="feishu_drive",
-    schema=FEISHU_DRIVE_LIST_REPLIES_SCHEMA,
-    handler=_handle_list_replies,
-    check_fn=_check_feishu,
-    requires_env=[],
-    is_async=False,
-    description="List comment replies",
-    emoji="\U0001f4ac",
-)
-
-registry.register(
-    name="feishu_drive_reply_comment",
-    toolset="feishu_drive",
-    schema=FEISHU_DRIVE_REPLY_SCHEMA,
-    handler=_handle_reply_comment,
-    check_fn=_check_feishu,
-    requires_env=[],
-    is_async=False,
-    description="Reply to a document comment",
-    emoji="\u2709\ufe0f",
-)
-
-registry.register(
-    name="feishu_drive_add_comment",
-    toolset="feishu_drive",
-    schema=FEISHU_DRIVE_ADD_COMMENT_SCHEMA,
-    handler=_handle_add_comment,
-    check_fn=_check_feishu,
-    requires_env=[],
-    is_async=False,
-    description="Add a whole-document comment",
-    emoji="\u2709\ufe0f",
-)
+for _name, _handler, _description, _props, _required in [
+    ("feishu_drive_get_meta", _get_meta, "Get Drive metadata for a Feishu file token. Drive tokens are distinct from IM file_key values.", {}, ["file_token"]),
+    ("feishu_drive_search_files", _search_files, "Search Feishu Drive files by keyword.", {"query": {"type": "string"}, "folder_token": {"type": "string"}, "file_extension": {"type": "string"}, "owner_id": {"type": "string"}, "chat_id": {"type": "string"}}, ["query"]),
+    ("feishu_drive_create_folder", _create_folder, "Create a Feishu Drive folder.", {"name": {"type": "string"}, "folder_token": {"type": "string", "description": "Optional parent folder token."}}, ["name"]),
+    ("feishu_drive_list_comments", _list_comments, "List comments on a Feishu Drive document.", {"is_whole": {"type": "boolean"}, "user_id_type": {"type": "string"}}, ["file_token"]),
+    ("feishu_drive_reply_comment", _reply_comment, "Reply to a comment on a Feishu Drive document.", {"comment_id": {"type": "string"}, "content": {"type": "string"}, "user_id_type": {"type": "string"}}, ["file_token", "comment_id", "content"]),
+]:
+    registry.register(name=_name, handler=_handler, schema=_schema(_name, _description, _props, _required), description=_description, **_COMMON)

--- a/tools/feishu_openapi.py
+++ b/tools/feishu_openapi.py
@@ -1,0 +1,187 @@
+"""Shared Feishu/Lark Open Platform helpers for Hermes tools.
+
+This module intentionally stays independent from ``gateway.platforms.feishu``.
+The gateway adapter owns messaging transport; this helper owns standalone
+Open Platform business API calls used by tools such as Docx, Bitable, Drive,
+and Wiki.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+FEISHU_DOMAIN = "https://open.feishu.cn"
+LARK_DOMAIN = "https://open.larksuite.com"
+
+
+class FeishuOpenAPIError(RuntimeError):
+    """Raised when a Feishu Open Platform request returns a non-zero code."""
+
+    def __init__(self, message: str, *, code: int | None = None, data: dict | None = None):
+        super().__init__(message)
+        self.code = code
+        self.data = data or {}
+
+
+@dataclass(frozen=True)
+class FeishuOpenAPISettings:
+    app_id: str
+    app_secret: str
+    domain_name: str = "feishu"
+
+    @property
+    def base_url(self) -> str:
+        return LARK_DOMAIN if self.domain_name.lower() == "lark" else FEISHU_DOMAIN
+
+
+def load_settings() -> FeishuOpenAPISettings:
+    """Load Feishu settings from environment variables."""
+
+    return FeishuOpenAPISettings(
+        app_id=os.getenv("FEISHU_APP_ID", "").strip(),
+        app_secret=os.getenv("FEISHU_APP_SECRET", "").strip(),
+        domain_name=os.getenv("FEISHU_DOMAIN", os.getenv("FEISHU_DOMAIN_NAME", "feishu")).strip() or "feishu",
+    )
+
+
+def check_feishu_openapi_requirements() -> bool:
+    """Return whether lark_oapi and required credentials are available."""
+
+    settings = load_settings()
+    if not settings.app_id or not settings.app_secret:
+        return False
+    try:
+        import lark_oapi  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def get_feishu_client(client: Any | None = None) -> Any:
+    """Return an existing client or build a lark_oapi client from env settings."""
+
+    if client is not None:
+        return client
+
+    settings = load_settings()
+    if not settings.app_id or not settings.app_secret:
+        raise FeishuOpenAPIError("FEISHU_APP_ID and FEISHU_APP_SECRET are required")
+
+    try:
+        import lark_oapi as lark
+    except ImportError as exc:
+        raise FeishuOpenAPIError("lark_oapi not installed. Run: pip install 'hermes-agent[feishu]'") from exc
+
+    builder = lark.Client.builder().app_id(settings.app_id).app_secret(settings.app_secret)
+    # Python SDK versions expose different builder options. Prefer the domain
+    # setter when present, otherwise keep SDK defaults.
+    if hasattr(builder, "domain"):
+        builder = builder.domain(settings.base_url)
+    elif hasattr(builder, "open_base_url"):
+        builder = builder.open_base_url(settings.base_url)
+    return builder.build()
+
+
+def _http_method(method: str) -> Any:
+    from lark_oapi.core.enum import HttpMethod
+
+    method = method.upper()
+    return {
+        "GET": HttpMethod.GET,
+        "POST": HttpMethod.POST,
+        "PUT": HttpMethod.PUT,
+        "PATCH": getattr(HttpMethod, "PATCH", HttpMethod.PUT),
+        "DELETE": HttpMethod.DELETE,
+    }.get(method, HttpMethod.GET)
+
+
+def _normalize_queries(queries: dict[str, Any] | Iterable[tuple[str, Any]] | None) -> list[tuple[str, str]] | None:
+    if not queries:
+        return None
+    items = queries.items() if isinstance(queries, dict) else queries
+    result: list[tuple[str, str]] = []
+    for key, value in items:
+        if value is None or value == "":
+            continue
+        if isinstance(value, bool):
+            value = "true" if value else "false"
+        result.append((str(key), str(value)))
+    return result or None
+
+
+def _response_data(response: Any) -> dict[str, Any]:
+    raw = getattr(response, "raw", None)
+    if raw is not None and hasattr(raw, "content"):
+        content = raw.content
+        if isinstance(content, bytes):
+            content = content.decode("utf-8")
+        try:
+            parsed = json.loads(content or "{}")
+            if isinstance(parsed, dict):
+                return parsed
+        except (TypeError, json.JSONDecodeError):
+            pass
+
+    data = getattr(response, "data", None)
+    if isinstance(data, dict):
+        return {"code": getattr(response, "code", 0), "msg": getattr(response, "msg", ""), "data": data}
+    if data is not None:
+        if hasattr(data, "to_dict"):
+            payload = data.to_dict()
+        elif hasattr(data, "__dict__"):
+            payload = vars(data)
+        else:
+            payload = {"value": data}
+        return {"code": getattr(response, "code", 0), "msg": getattr(response, "msg", ""), "data": payload}
+
+    return {"code": getattr(response, "code", 0), "msg": getattr(response, "msg", ""), "data": {}}
+
+
+def request_json(
+    method: str,
+    uri: str,
+    *,
+    paths: dict[str, Any] | None = None,
+    queries: dict[str, Any] | Iterable[tuple[str, Any]] | None = None,
+    body: dict[str, Any] | None = None,
+    client: Any | None = None,
+) -> dict[str, Any]:
+    """Execute a Feishu Open Platform request and return its ``data`` object.
+
+    Raises ``FeishuOpenAPIError`` for SDK import/config errors and non-zero
+    Feishu response codes. Tool handlers catch this and convert to JSON errors.
+    """
+
+    client = get_feishu_client(client)
+
+    try:
+        from lark_oapi import AccessTokenType
+        from lark_oapi.core.model.base_request import BaseRequest
+    except ImportError as exc:
+        raise FeishuOpenAPIError("lark_oapi not installed. Run: pip install 'hermes-agent[feishu]'") from exc
+
+    builder = (
+        BaseRequest.builder()
+        .http_method(_http_method(method))
+        .uri(uri)
+        .token_types({AccessTokenType.TENANT})
+    )
+    if paths:
+        builder = builder.paths({str(k): str(v) for k, v in paths.items()})
+    norm_queries = _normalize_queries(queries)
+    if norm_queries:
+        builder = builder.queries(norm_queries)
+    if body is not None:
+        builder = builder.body(body)
+
+    response = client.request(builder.build())
+    payload = _response_data(response)
+    code = payload.get("code", getattr(response, "code", 0))
+    if code not in (0, None):
+        msg = payload.get("msg") or getattr(response, "msg", "unknown error")
+        raise FeishuOpenAPIError(f"Feishu API request failed: code={code} msg={msg}", code=code, data=payload)
+    data = payload.get("data", {})
+    return data if isinstance(data, dict) else {"value": data}

--- a/tools/feishu_wiki_tool.py
+++ b/tools/feishu_wiki_tool.py
@@ -1,0 +1,91 @@
+"""Feishu Wiki tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from tools.feishu_openapi import FeishuOpenAPIError, check_feishu_openapi_requirements, request_json
+from tools.registry import registry, tool_error, tool_result
+
+_SPACES_URI = "/open-apis/wiki/v2/spaces"
+_NODES_URI = "/open-apis/wiki/v2/spaces/:space_id/nodes"
+_NODE_URI = "/open-apis/wiki/v2/spaces/:space_id/nodes/:node_token"
+
+
+def _s(args: dict[str, Any], name: str) -> str:
+    return str(args.get(name) or "").strip()
+
+
+def _call(method: str, uri: str, *, paths=None, queries=None, body=None, **kwargs: Any) -> str:
+    try:
+        data = request_json(method, uri, paths=paths, queries=queries, body=body, client=kwargs.get("client"))
+        return tool_result({"success": True, "data": data})
+    except FeishuOpenAPIError as exc:
+        return tool_error(str(exc), code=exc.code, data=exc.data)
+
+
+def _list_spaces(args: dict[str, Any], **kwargs: Any) -> str:
+    queries = {"page_size": args.get("page_size"), "page_token": args.get("page_token")}
+    return _call("GET", _SPACES_URI, queries=queries, **kwargs)
+
+
+def _list_nodes(args: dict[str, Any], **kwargs: Any) -> str:
+    space_id = _s(args, "space_id")
+    if not space_id:
+        return tool_error("space_id is required")
+    queries = {
+        "parent_node_token": args.get("parent_node_token"),
+        "page_size": args.get("page_size"),
+        "page_token": args.get("page_token"),
+    }
+    return _call("GET", _NODES_URI, paths={"space_id": space_id}, queries=queries, **kwargs)
+
+
+def _get_node(args: dict[str, Any], **kwargs: Any) -> str:
+    space_id = _s(args, "space_id")
+    node_token = _s(args, "node_token")
+    if not space_id:
+        return tool_error("space_id is required")
+    if not node_token:
+        return tool_error("node_token is required")
+    return _call("GET", _NODE_URI, paths={"space_id": space_id, "node_token": node_token}, **kwargs)
+
+
+def _create_node(args: dict[str, Any], **kwargs: Any) -> str:
+    space_id = _s(args, "space_id")
+    parent_node_token = _s(args, "parent_node_token")
+    obj_type = _s(args, "obj_type") or "docx"
+    title = _s(args, "title")
+    if not space_id:
+        return tool_error("space_id is required")
+    if not parent_node_token:
+        return tool_error("parent_node_token is required")
+    if not title:
+        return tool_error("title is required")
+    body = {"parent_node_token": parent_node_token, "node_type": "origin", "obj_type": obj_type, "title": title}
+    if args.get("obj_token"):
+        body["obj_token"] = args["obj_token"]
+    return _call("POST", _NODES_URI, paths={"space_id": space_id}, body=body, **kwargs)
+
+
+def _schema(name: str, description: str, props: dict[str, Any], required: list[str]) -> dict[str, Any]:
+    common = {
+        "space_id": {"type": "string", "description": "Wiki space ID."},
+        "node_token": {"type": "string", "description": "Wiki node token."},
+        "parent_node_token": {"type": "string", "description": "Parent Wiki node token."},
+        "page_size": {"type": "integer"},
+        "page_token": {"type": "string"},
+    }
+    common.update(props)
+    return {"name": name, "description": description, "parameters": {"type": "object", "properties": common, "required": required}}
+
+
+_COMMON = dict(toolset="feishu", check_fn=check_feishu_openapi_requirements, requires_env=["FEISHU_APP_ID", "FEISHU_APP_SECRET"], emoji="📚")
+
+for _name, _handler, _description, _props, _required in [
+    ("feishu_wiki_list_spaces", _list_spaces, "List Feishu Wiki spaces visible to the app.", {}, []),
+    ("feishu_wiki_list_nodes", _list_nodes, "List Feishu Wiki nodes in a space, optionally under a parent node.", {}, ["space_id"]),
+    ("feishu_wiki_get_node", _get_node, "Get metadata for a Feishu Wiki node.", {}, ["space_id", "node_token"]),
+    ("feishu_wiki_create_node", _create_node, "Create a Feishu Wiki node, optionally linking an existing object token.", {"title": {"type": "string"}, "obj_type": {"type": "string", "description": "Object type, default docx."}, "obj_token": {"type": "string", "description": "Optional existing document/object token."}}, ["space_id", "parent_node_token", "title"]),
+]:
+    registry.register(name=_name, handler=_handler, schema=_schema(_name, _description, _props, _required), description=_description, **_COMMON)

--- a/toolsets.py
+++ b/toolsets.py
@@ -43,7 +43,7 @@ _HERMES_CORE_TOOLS = [
     "browser_navigate", "browser_snapshot", "browser_click",
     "browser_type", "browser_scroll", "browser_back",
     "browser_press", "browser_get_images",
-    "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
+    "browser_vision", "browser_console",
     # Text-to-speech
     "text_to_speech",
     # Planning & memory
@@ -60,11 +60,6 @@ _HERMES_CORE_TOOLS = [
     "send_message",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
-    # Kanban multi-agent coordination — only in schema when the agent is
-    # spawned as a kanban worker (HERMES_KANBAN_TASK env set), otherwise
-    # zero schema footprint. Gated via check_fn in tools/kanban_tools.py.
-    "kanban_show", "kanban_complete", "kanban_block", "kanban_heartbeat",
-    "kanban_comment", "kanban_create", "kanban_link",
 ]
 
 
@@ -87,12 +82,6 @@ TOOLSETS = {
     "vision": {
         "description": "Image analysis and vision tools",
         "tools": ["vision_analyze"],
-        "includes": []
-    },
-
-    "video": {
-        "description": "Video analysis and understanding tools (opt-in, not in default toolset)",
-        "tools": ["video_analyze"],
         "includes": []
     },
     
@@ -126,8 +115,7 @@ TOOLSETS = {
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
-            "browser_vision", "browser_console", "browser_cdp",
-            "browser_dialog", "web_search"
+            "browser_vision", "browser_console", "web_search"
         ],
         "includes": []
     },
@@ -141,6 +129,22 @@ TOOLSETS = {
     "messaging": {
         "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc.",
         "tools": ["send_message"],
+        "includes": []
+    },
+
+    "feishu": {
+        "description": "Feishu/Lark Open Platform business tools for Docx, Bitable, Drive, and Wiki (requires FEISHU_APP_ID/SECRET and app scopes)",
+        "tools": [
+            "feishu_doc_read", "feishu_doc_create", "feishu_doc_append_text",
+            "feishu_doc_append_markdown", "feishu_doc_replace_markdown",
+            "feishu_bitable_create_app", "feishu_bitable_list_tables", "feishu_bitable_update_table",
+            "feishu_bitable_get_fields", "feishu_bitable_create_field", "feishu_bitable_update_field",
+            "feishu_bitable_search_records",
+            "feishu_bitable_create_record", "feishu_bitable_update_record", "feishu_bitable_delete_record",
+            "feishu_drive_get_meta", "feishu_drive_search_files", "feishu_drive_create_folder",
+            "feishu_drive_list_comments", "feishu_drive_reply_comment",
+            "feishu_wiki_list_spaces", "feishu_wiki_list_nodes", "feishu_wiki_get_node", "feishu_wiki_create_node",
+        ],
         "includes": []
     },
     
@@ -163,7 +167,7 @@ TOOLSETS = {
     },
     
     "tts": {
-        "description": "Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, OpenAI, or xAI",
+        "description": "Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, or OpenAI",
         "tools": ["text_to_speech"],
         "includes": []
     },
@@ -213,72 +217,6 @@ TOOLSETS = {
         "includes": []
     },
 
-    "kanban": {
-        "description": (
-            "Kanban multi-agent coordination — only active when the agent "
-            "is spawned by the kanban dispatcher (HERMES_KANBAN_TASK env "
-            "set). The dispatcher runs inside the gateway by default; see "
-            "`kanban.dispatch_in_gateway` in config.yaml. Lets workers mark "
-            "tasks done with structured handoffs, block for human input, "
-            "heartbeat during long ops, comment on threads, and (for "
-            "orchestrators) fan out into child tasks."
-        ),
-        "tools": [
-            "kanban_show", "kanban_complete", "kanban_block",
-            "kanban_heartbeat", "kanban_comment",
-            "kanban_create", "kanban_link",
-        ],
-        "includes": [],
-    },
-
-    "discord": {
-        "description": "Discord read and participate tools (fetch messages, search members, create threads)",
-        "tools": ["discord"],
-        "includes": [],
-    },
-
-    "discord_admin": {
-        "description": "Discord server management (list channels/roles, pin messages, assign roles)",
-        "tools": ["discord_admin"],
-        "includes": [],
-    },
-
-    "yuanbao": {
-        "description": "Yuanbao platform tools - group info, member queries, DM, stickers",
-        "tools": [
-            "yb_query_group_info",
-            "yb_query_group_members",
-            "yb_send_dm",
-            "yb_search_sticker",
-            "yb_send_sticker",
-        ],
-        "includes": []
-    },
-
-    "feishu_doc": {
-        "description": "Read Feishu/Lark document content",
-        "tools": ["feishu_doc_read"],
-        "includes": []
-    },
-
-    "feishu_drive": {
-        "description": "Feishu/Lark document comment operations (list, reply, add)",
-        "tools": [
-            "feishu_drive_list_comments", "feishu_drive_list_comment_replies",
-            "feishu_drive_reply_comment", "feishu_drive_add_comment",
-        ],
-        "includes": []
-    },
-
-    "spotify": {
-        "description": "Native Spotify playback, search, playlist, album, and library tools",
-        "tools": [
-            "spotify_playback", "spotify_devices", "spotify_queue", "spotify_search",
-            "spotify_playlists", "spotify_albums", "spotify_library",
-        ],
-        "includes": []
-    },
-
 
     # Scenario-specific toolsets
     
@@ -312,7 +250,7 @@ TOOLSETS = {
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
-            "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
+            "browser_vision", "browser_console",
             "todo", "memory",
             "session_search",
             "execute_code", "delegate_task",
@@ -337,7 +275,7 @@ TOOLSETS = {
             "browser_navigate", "browser_snapshot", "browser_click",
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
-            "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
+            "browser_vision", "browser_console",
             # Planning & memory
             "todo", "memory",
             # Session history search
@@ -358,18 +296,7 @@ TOOLSETS = {
         "tools": _HERMES_CORE_TOOLS,
         "includes": []
     },
-
-    "hermes-cron": {
-        # Mirrors hermes-cli so cron's "default" toolset is the same set of
-        # core tools users see interactively — then `hermes tools` filters
-        # them down per the platform config. _DEFAULT_OFF_TOOLSETS (moa,
-        # homeassistant, rl) are excluded by _get_platform_tools() unless
-        # the user explicitly enables them.
-        "description": "Default cron toolset - same core tools as hermes-cli; gated by `hermes tools`",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
-    },
-
+    
     "hermes-telegram": {
         "description": "Telegram bot toolset - full access for personal use (terminal has safety checks)",
         "tools": _HERMES_CORE_TOOLS,
@@ -378,10 +305,7 @@ TOOLSETS = {
     
     "hermes-discord": {
         "description": "Discord bot toolset - full access (terminal has safety checks via dangerous command approval)",
-        "tools": _HERMES_CORE_TOOLS + [
-            "discord",
-            "discord_admin",
-        ],
+        "tools": _HERMES_CORE_TOOLS,
         "includes": []
     },
     
@@ -441,24 +365,12 @@ TOOLSETS = {
 
     "hermes-feishu": {
         "description": "Feishu/Lark bot toolset - enterprise messaging via Feishu/Lark (full access)",
-        "tools": _HERMES_CORE_TOOLS + [
-            "feishu_doc_read",
-            "feishu_drive_list_comments",
-            "feishu_drive_list_comment_replies",
-            "feishu_drive_reply_comment",
-            "feishu_drive_add_comment",
-        ],
+        "tools": _HERMES_CORE_TOOLS,
         "includes": []
     },
 
     "hermes-weixin": {
         "description": "Weixin bot toolset - personal WeChat messaging via iLink (full access)",
-        "tools": _HERMES_CORE_TOOLS,
-        "includes": []
-    },
-
-    "hermes-qqbot": {
-        "description": "QQBot toolset - QQ messaging via Official Bot API v2 (full access)",
         "tools": _HERMES_CORE_TOOLS,
         "includes": []
     },
@@ -472,19 +384,6 @@ TOOLSETS = {
     "hermes-wecom-callback": {
         "description": "WeCom callback toolset - enterprise self-built app messaging (full access)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
-    },
-
-    "hermes-yuanbao": {
-        "description": "Yuanbao Bot 元宝消息平台工具集 - 群信息、成员查询、私聊、贴纸表情",
-        "tools": _HERMES_CORE_TOOLS + [
-            "yb_query_group_info",
-            "yb_query_group_members",
-            "yb_send_dm",
-            "yb_search_sticker",
-            "yb_send_sticker",
-        ],
-        "module": "tools.yuanbao_tools",
         "includes": []
     },
 
@@ -503,7 +402,7 @@ TOOLSETS = {
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook", "hermes-yuanbao"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-webhook"]
     }
 }
 
@@ -520,44 +419,8 @@ def get_toolset(name: str) -> Optional[Dict[str, Any]]:
         Dict: Toolset definition with description, tools, and includes
         None: If toolset not found
     """
-    toolset = TOOLSETS.get(name)
-
-    try:
-        from tools.registry import registry
-    except Exception:
-        return toolset if toolset else None
-
-    if toolset:
-        merged_tools = sorted(
-            set(toolset.get("tools", []))
-            | set(registry.get_tool_names_for_toolset(name))
-        )
-        return {**toolset, "tools": merged_tools}
-
-    registry_toolset = name
-    description = f"Plugin toolset: {name}"
-    alias_target = registry.get_toolset_alias_target(name)
-
-    if name not in _get_plugin_toolset_names():
-        registry_toolset = alias_target
-        if not registry_toolset:
-            return None
-        description = f"MCP server '{name}' tools"
-    else:
-        reverse_aliases = {
-            canonical: alias
-            for alias, canonical in _get_registry_toolset_aliases().items()
-            if alias not in TOOLSETS
-        }
-        alias = reverse_aliases.get(name)
-        if alias:
-            description = f"MCP server '{alias}' tools"
-
-    return {
-        "description": description,
-        "tools": registry.get_tool_names_for_toolset(registry_toolset),
-        "includes": [],
-    }
+    # Return toolset definition
+    return TOOLSETS.get(name)
 
 
 def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
@@ -585,7 +448,7 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
             # Use a fresh visited set per branch to avoid cross-branch contamination
             resolved = resolve_toolset(toolset_name, visited.copy())
             all_tools.update(resolved)
-        return sorted(all_tools)
+        return list(all_tools)
 
     # Check for cycles / already-resolved (diamond deps).
     # Silently return [] — either this is a diamond (not a bug, tools already
@@ -596,29 +459,15 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
     visited.add(name)
 
     # Get toolset definition
-    toolset = get_toolset(name)
+    toolset = TOOLSETS.get(name)
     if not toolset:
-        # Auto-generate a toolset for plugin platforms (hermes-<name>).
-        # Gives them _HERMES_CORE_TOOLS plus any tools the plugin registered
-        # into a toolset matching the platform name.
-        if name.startswith("hermes-"):
-            platform_name = name[len("hermes-"):]
+        # Fall back to tool registry for plugin-provided toolsets
+        if name in _get_plugin_toolset_names():
             try:
-                from gateway.platform_registry import platform_registry
-                if platform_registry.is_registered(platform_name):
-                    plugin_tools = set(_HERMES_CORE_TOOLS)
-                    try:
-                        from tools.registry import registry
-                        plugin_tools.update(
-                            e.name for e in registry._tools.values()
-                            if e.toolset == platform_name
-                        )
-                    except Exception:
-                        pass
-                    return list(plugin_tools)
+                from tools.registry import registry
+                return [e.name for e in registry._tools.values() if e.toolset == name]
             except Exception:
                 pass
-
         return []
 
     # Collect direct tools
@@ -631,7 +480,7 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
         included_tools = resolve_toolset(included_name, visited)
         tools.update(included_tools)
     
-    return sorted(tools)
+    return list(tools)
 
 
 def resolve_multiple_toolsets(toolset_names: List[str]) -> List[str]:
@@ -650,7 +499,7 @@ def resolve_multiple_toolsets(toolset_names: List[str]) -> List[str]:
         tools = resolve_toolset(name)
         all_tools.update(tools)
     
-    return sorted(all_tools)
+    return list(all_tools)
 
 
 def _get_plugin_toolset_names() -> Set[str]:
@@ -662,21 +511,12 @@ def _get_plugin_toolset_names() -> Set[str]:
     try:
         from tools.registry import registry
         return {
-            toolset_name
-            for toolset_name in registry.get_registered_toolset_names()
-            if toolset_name not in TOOLSETS
+            entry.toolset
+            for entry in registry._tools.values()
+            if entry.toolset not in TOOLSETS
         }
     except Exception:
         return set()
-
-
-def _get_registry_toolset_aliases() -> Dict[str, str]:
-    """Return explicit toolset aliases registered in the live registry."""
-    try:
-        from tools.registry import registry
-        return registry.get_registered_toolset_aliases()
-    except Exception:
-        return {}
 
 
 def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
@@ -688,19 +528,19 @@ def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
     Returns:
         Dict: All toolset definitions
     """
-    result = dict(TOOLSETS)
-    aliases = _get_registry_toolset_aliases()
+    result = TOOLSETS.copy()
+    # Add plugin-provided toolsets (synthetic entries)
     for ts_name in _get_plugin_toolset_names():
-        display_name = ts_name
-        for alias, canonical in aliases.items():
-            if canonical == ts_name and alias not in TOOLSETS:
-                display_name = alias
-                break
-        if display_name in result:
-            continue
-        toolset = get_toolset(display_name)
-        if toolset:
-            result[display_name] = toolset
+        if ts_name not in result:
+            try:
+                from tools.registry import registry
+                tools = [e.name for e in registry._tools.values() if e.toolset == ts_name]
+                result[ts_name] = {
+                    "description": f"Plugin toolset: {ts_name}",
+                    "tools": tools,
+                }
+            except Exception:
+                pass
     return result
 
 
@@ -714,14 +554,7 @@ def get_toolset_names() -> List[str]:
         List[str]: List of toolset names
     """
     names = set(TOOLSETS.keys())
-    aliases = _get_registry_toolset_aliases()
-    for ts_name in _get_plugin_toolset_names():
-        for alias, canonical in aliases.items():
-            if canonical == ts_name and alias not in TOOLSETS:
-                names.add(alias)
-                break
-        else:
-            names.add(ts_name)
+    names |= _get_plugin_toolset_names()
     return sorted(names)
 
 
@@ -742,9 +575,8 @@ def validate_toolset(name: str) -> bool:
         return True
     if name in TOOLSETS:
         return True
-    if name in _get_plugin_toolset_names():
-        return True
-    return name in _get_registry_toolset_aliases()
+    # Check tool registry for plugin-provided toolsets
+    return name in _get_plugin_toolset_names()
 
 
 def create_custom_toolset(

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -31,25 +31,12 @@ Set it to `false` only if you explicitly want one shared conversation per chat.
 
 ## Step 1: Create a Feishu / Lark App
 
-### Recommended: Scan-to-Create (one command)
-
-```bash
-hermes gateway setup
-```
-
-Select **Feishu / Lark** and scan the QR code with your Feishu or Lark mobile app. Hermes will automatically create a bot application with the correct permissions and save the credentials.
-
-### Alternative: Manual Setup
-
-If scan-to-create is not available, the wizard falls back to manual input:
-
 1. Open the Feishu or Lark developer console:
    - Feishu: [https://open.feishu.cn/](https://open.feishu.cn/)
    - Lark: [https://open.larksuite.com/](https://open.larksuite.com/)
 2. Create a new app.
 3. In **Credentials & Basic Info**, copy the **App ID** and **App Secret**.
 4. Enable the **Bot** capability for the app.
-5. Run `hermes gateway setup`, select **Feishu / Lark**, and enter the credentials when prompted.
 
 :::warning
 Keep the App Secret private. Anyone with it can impersonate your app.
@@ -124,6 +111,25 @@ FEISHU_HOME_CHANNEL=oc_xxx
 
 - `feishu` for Feishu China
 - `lark` for Lark international
+
+## Optional: Feishu Open Platform Tools
+
+Hermes also includes an opt-in `feishu` toolset for Feishu/Lark business APIs beyond chat messaging. These tools are separate from the gateway adapter and can operate on cloud documents, Bitable/Base, Drive, and Wiki resources when the app has the required Open Platform scopes and the target resources are shared with the app.
+
+Available tool groups include:
+
+- Docx: `feishu_doc_read`, `feishu_doc_create`, `feishu_doc_append_text`, `feishu_doc_append_markdown`, `feishu_doc_replace_markdown`
+- Bitable/Base: `feishu_bitable_create_app`, `feishu_bitable_list_tables`, `feishu_bitable_update_table`, `feishu_bitable_get_fields`, `feishu_bitable_create_field`, `feishu_bitable_update_field`, `feishu_bitable_search_records`, `feishu_bitable_create_record`, `feishu_bitable_update_record`, `feishu_bitable_delete_record`
+- Drive: `feishu_drive_get_meta`, `feishu_drive_search_files`, `feishu_drive_create_folder`, `feishu_drive_list_comments`, `feishu_drive_reply_comment`
+- Wiki: `feishu_wiki_list_spaces`, `feishu_wiki_list_nodes`, `feishu_wiki_get_node`, `feishu_wiki_create_node`
+
+See [`tools/README-feishu-open-platform.md`](../../../../tools/README-feishu-open-platform.md) for architecture, permission requirements, formatted Docx writing, Bitable setup examples, ownership-transfer flow, and focused test commands.
+
+These tools use the same `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, and `FEISHU_DOMAIN` environment variables, but they require additional Feishu/Lark app permissions for Docs, Drive, Bitable, or Wiki. A chat bot permission alone is not enough.
+
+:::warning
+Feishu IM message attachment `file_key` values are different from Drive file tokens, Docx document tokens, Bitable app/table/record IDs, and Wiki node tokens. Use the token from the corresponding Feishu resource URL or API response.
+:::
 
 ## Step 4: Start the Gateway
 
@@ -201,45 +207,19 @@ FEISHU_GROUP_POLICY=allowlist   # default
 | `allowlist` | Hermes only responds to @mentions from users listed in `FEISHU_ALLOWED_USERS`. |
 | `disabled` | Hermes ignores all group messages entirely. |
 
-In all modes, the bot must be explicitly @mentioned (or @all) in the group before the message is processed. Direct messages always bypass this gate.
+In all modes, the bot must be explicitly @mentioned (or @all) in the group before the message is processed. Direct messages bypass this gate.
 
-Set `FEISHU_REQUIRE_MENTION=false` to let Hermes read all group traffic without requiring an @mention:
+### Bot Identity for @Mention Gating
 
-```bash
-FEISHU_REQUIRE_MENTION=false
-```
-
-For per-chat control, set `require_mention` on a `group_rules` entry — see [Per-Group Access Control](#per-group-access-control) below.
-
-### Bot Identity
-
-Hermes auto-detects the bot's `open_id` and display name on startup. You only need to set these manually when auto-detection cannot reach the Feishu API, or when your app uses tenant-scoped user IDs:
+For precise @mention detection in groups, the adapter needs to know the bot's identity. It can be provided explicitly:
 
 ```bash
-FEISHU_BOT_OPEN_ID=ou_xxx     # only when auto-detection fails
-FEISHU_BOT_USER_ID=xxx        # required if your app uses sender_id_type=user_id
-FEISHU_BOT_NAME=MyBot         # only when auto-detection fails
+FEISHU_BOT_OPEN_ID=ou_xxx
+FEISHU_BOT_USER_ID=xxx
+FEISHU_BOT_NAME=MyBot
 ```
 
-## Bot-to-Bot Messaging
-
-By default Hermes ignores messages sent by other bots. Enable bot-to-bot messaging when you want Hermes to participate in A2A orchestration or receive notifications from other bots in the same group.
-
-```bash
-FEISHU_ALLOW_BOTS=mentions   # default: none
-```
-
-| Value | Behavior |
-|-------|----------|
-| `none` | Ignore all messages from other bots (default). |
-| `mentions` | Accept only when the peer bot @mentions Hermes. |
-| `all` | Accept every peer bot message. |
-
-Also configurable as `feishu.allow_bots` in `config.yaml` (env wins when both are set).
-
-Peer bots do not need to be added to `FEISHU_ALLOWED_USERS` — that allowlist applies to human senders only.
-
-Grant the `application:bot.basic_info:read` scope to display peer bot names; without it, peer bots still route correctly but appear as their `open_id`.
+If none of these are set, the adapter will attempt to auto-discover the bot name via the Application Info API on startup. For this to work, grant the `admin:app.info:readonly` or `application:application:self_manage` permission scope.
 
 ## Interactive Card Actions
 
@@ -269,54 +249,6 @@ Interactive cards require **three** configuration steps in the Feishu Developer 
 :::warning
 Without all three steps, Feishu will successfully *send* interactive cards (sending only requires `im:message:send` permission), but clicking any button will return error 200340. The card appears to work — the error only surfaces when a user interacts with it.
 :::
-
-## Document Comment Intelligent Reply
-
-Beyond chat, the adapter can also answer `@`-mentions left on **Feishu/Lark documents**. When a user comments on a document (local text selection or whole-doc comment) and @-mentions the bot, Hermes reads the document plus the surrounding comment thread and posts an LLM reply inline on the thread.
-
-Powered by the `drive.notice.comment_add_v1` event, the handler:
-
-- Fetches the document content and comment timeline in parallel (20 messages for whole-doc threads, 12 for local-selection threads).
-- Runs the agent with the `feishu_doc` + `feishu_drive` toolsets scoped to that single comment session.
-- Chunks replies at 4000 chars and posts them back as threaded replies.
-- Caches per-document sessions for 1 hour with a 50-message cap so follow-up comments on the same doc keep context.
-
-### 3-Tier Access Control
-
-Document-comment replies are **explicit-grant only** — there is no implicit allow-all mode. Permissions resolve in this order (first match wins, per field):
-
-1. **Exact doc** — rule scoped to a specific document token.
-2. **Wildcard** — rule that matches a pattern of docs.
-3. **Top-level** — default rule for the workspace.
-
-Two policies are available per rule:
-
-- **`allowlist`** — a static list of users / tenants.
-- **`pairing`** — static list ∪ runtime-approved store. Useful for rollouts where moderators can grant access live.
-
-Rules live in `~/.hermes/feishu_comment_rules.json` (pairing grants in `~/.hermes/feishu_comment_pairing.json`) with mtime-cached hot-reload — edits take effect on the next comment event without restarting the gateway.
-
-CLI:
-
-```bash
-# Inspect current rules and pairing state
-python -m gateway.platforms.feishu_comment_rules status
-
-# Simulate an access check for a specific doc + user
-python -m gateway.platforms.feishu_comment_rules check <fileType:fileToken> <user_open_id>
-
-# Manage pairing grants at runtime
-python -m gateway.platforms.feishu_comment_rules pairing list
-python -m gateway.platforms.feishu_comment_rules pairing add <user_open_id>
-python -m gateway.platforms.feishu_comment_rules pairing remove <user_open_id>
-```
-
-### Required Feishu App Configuration
-
-On top of the chat/card permissions already granted, add the drive comment event:
-
-- Subscribe to `drive.notice.comment_add_v1` in **Event Subscriptions**.
-- Grant the `docs:doc:readonly` and `drive:drive:readonly` scopes so the handler can read document content.
 
 ## Media Support
 
@@ -361,11 +293,13 @@ If the Feishu API rejects the post payload (e.g., due to unsupported markdown co
 
 Plain text messages (no markdown detected) are sent as the simple `text` message type.
 
-## Processing Status Reactions
+## ACK Emoji Reactions
 
-While the agent is working, the bot shows a `Typing` reaction on your message. It's cleared when the reply arrives, or replaced with `CrossMark` if processing failed.
+When the adapter receives an inbound message, it immediately adds an ✅ (OK) emoji reaction to signal that the message was received and is being processed. This provides visual feedback before the agent completes its response.
 
-Set `FEISHU_REACTIONS=false` to turn it off.
+The reaction is persistent — it remains on the message after the response is sent, serving as a receipt marker.
+
+User reactions on bot messages are also tracked. If a user adds or removes an emoji reaction on a message sent by the bot, it is routed as a synthetic text event (`reaction:added:EMOJI_TYPE` or `reaction:removed:EMOJI_TYPE`) so the agent can respond to feedback.
 
 ## Burst Protection and Batching
 
@@ -452,9 +386,6 @@ platforms:
           policy: "blacklist"
           blacklist:
             - "ou_blocked_user"
-        "oc_free_chat":
-          policy: "open"
-          require_mention: false       # overrides FEISHU_REQUIRE_MENTION for this chat
 ```
 
 | Policy | Description |
@@ -464,8 +395,6 @@ platforms:
 | `blacklist` | Everyone except users in the group's `blacklist` can use the bot |
 | `admin_only` | Only users in the global `admins` list can use the bot in this group |
 | `disabled` | Bot ignores all messages in this group |
-
-Set `require_mention: false` on a `group_rules` entry to skip the @-mention requirement for that specific chat. When omitted, the chat inherits the global `FEISHU_REQUIRE_MENTION` value.
 
 Groups not listed in `group_rules` fall back to `default_group_policy` (defaults to the value of `FEISHU_GROUP_POLICY`).
 
@@ -486,8 +415,6 @@ Inbound messages are deduplicated using message IDs with a 24-hour TTL. The dedu
 | `FEISHU_DOMAIN` | — | `feishu` | `feishu` (China) or `lark` (international) |
 | `FEISHU_CONNECTION_MODE` | — | `websocket` | `websocket` or `webhook` |
 | `FEISHU_ALLOWED_USERS` | — | _(empty)_ | Comma-separated open_id list for user allowlist |
-| `FEISHU_ALLOW_BOTS` | — | `none` | Accept messages from other bots: `none`, `mentions`, or `all` |
-| `FEISHU_REQUIRE_MENTION` | — | `true` | Whether group messages must @mention the bot |
 | `FEISHU_HOME_CHANNEL` | — | — | Chat ID for cron/notification output |
 | `FEISHU_ENCRYPT_KEY` | — | _(empty)_ | Encrypt key for webhook signature verification |
 | `FEISHU_VERIFICATION_TOKEN` | — | _(empty)_ | Verification token for webhook payload auth |
@@ -520,9 +447,7 @@ WebSocket and per-group ACL settings are configured via `config.yaml` under `pla
 | `Webhook rejected: invalid signature` | Ensure `FEISHU_ENCRYPT_KEY` matches the encrypt key in your Feishu app config |
 | Post messages show as plain text | The Feishu API rejected the post payload; this is normal fallback behavior. Check logs for details. |
 | Images/files not received by bot | Grant `im:message` and `im:resource` permission scopes to your Feishu app |
-| Bot identity not auto-detected | Usually a transient network issue reaching Feishu's bot info endpoint. Set `FEISHU_BOT_OPEN_ID` and `FEISHU_BOT_NAME` manually as a workaround. |
-| Peer bot messages still ignored after enabling `FEISHU_ALLOW_BOTS` | Hermes can't identify itself yet — set `FEISHU_BOT_OPEN_ID` (and `FEISHU_BOT_USER_ID` if your app uses `sender_id_type=user_id`). |
-| Peer bots show as `ou_xxxxxx` instead of by name | Grant the `application:bot.basic_info:read` scope. |
+| Bot identity not auto-detected | Grant `admin:app.info:readonly` scope, or set `FEISHU_BOT_OPEN_ID` / `FEISHU_BOT_NAME` manually |
 | Error 200340 when clicking approval buttons | Enable **Interactive Card** capability and configure **Card Request URL** in the Feishu Developer Console. See [Required Feishu App Configuration](#required-feishu-app-configuration) above. |
 | `Webhook rate limit exceeded` | More than 120 requests/minute from the same IP. This is usually a misconfiguration or loop. |
 


### PR DESCRIPTION
## Summary\n- Add an opt-in Feishu/Lark Open Platform toolset for Docx, Bitable/Base, Drive, and Wiki automation\n- Add native Docx Markdown-to-block append/replace support and Bitable app/table/field management\n- Add a Feishu project workspace management skill and README documentation\n\n## Tests\n- python -m py_compile tools/feishu_openapi.py tools/feishu_doc_tool.py tools/feishu_bitable_tool.py tools/feishu_drive_tool.py tools/feishu_wiki_tool.py model_tools.py toolsets.py\n- python -m pytest tests/tools/test_feishu_openapi.py tests/tools/test_feishu_doc_tool.py tests/tools/test_feishu_bitable_tool.py tests/tools/test_feishu_drive_tool.py tests/tools/test_feishu_wiki_tool.py -q\n- schema discovery smoke test for 24 Feishu tools\n\n## Notes\n- Keeps Open Platform APIs separate from the Feishu messaging gateway\n- Repository skill uses placeholders/generic ownership guidance; private user identifiers remain outside tracked files