### PR TITLE
fix(auxiliary): track final runtime metadata across retries

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -100,6 +100,7 @@ class _OpenAIProxy:
 OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
 from agent.credential_pool import load_pool
+from agent.model_metadata import get_model_context_length
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, normalize_proxy_env_vars
@@ -2629,7 +2630,7 @@ def get_text_auxiliary_client(
     (e.g. auxiliary.compression.model, auxiliary.web_extract.model).
     """
     provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(task or None)
-    return resolve_provider_client(
+    client, final_model = resolve_provider_client(
         provider,
         model=model,
         explicit_base_url=base_url,
@@ -2637,6 +2638,16 @@ def get_text_auxiliary_client(
         api_mode=api_mode,
         main_runtime=main_runtime,
     )
+    _track_auxiliary_task_metadata(
+        task or None,
+        client=client,
+        model=final_model,
+        provider=provider,
+        base_url=base_url,
+        api_key=api_key,
+        api_mode=api_mode,
+    )
+    return client, final_model
 
 
 def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Dict[str, Any]] = None):
@@ -2647,7 +2658,7 @@ def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Di
     Returns (None, None) when no provider is available.
     """
     provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(task or None)
-    return resolve_provider_client(
+    client, final_model = resolve_provider_client(
         provider,
         model=model,
         async_mode=True,
@@ -2656,6 +2667,16 @@ def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Di
         api_mode=api_mode,
         main_runtime=main_runtime,
     )
+    _track_auxiliary_task_metadata(
+        task or None,
+        client=client,
+        model=final_model,
+        provider=provider,
+        base_url=base_url,
+        api_key=api_key,
+        api_mode=api_mode,
+    )
+    return client, final_model
 
 
 _VISION_AUTO_PROVIDER_ORDER = (
@@ -3246,6 +3267,8 @@ def _resolve_task_provider_model(
 
 
 _DEFAULT_AUX_TIMEOUT = 30.0
+_AUXILIARY_TASK_METADATA: Dict[str, Dict[str, Any]] = {}
+_AUXILIARY_TASK_METADATA_LOCK = threading.Lock()
 
 
 def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
@@ -3274,6 +3297,206 @@ def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float
         except (ValueError, TypeError):
             pass
     return default
+
+
+def _get_task_context_length_override(task: Optional[str]) -> Optional[int]:
+    """Return auxiliary.<task>.context_length when it is a valid positive int."""
+    if not task:
+        return None
+    task_config = _get_auxiliary_task_config(task)
+    raw = task_config.get("context_length")
+    if raw is None:
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def _infer_auxiliary_provider_label(
+    configured_provider: Optional[str],
+    base_url: str,
+) -> str:
+    """Best-effort provider label for the final resolved auxiliary runtime."""
+    normalized = _normalize_aux_provider(configured_provider)
+    if normalized and normalized != "auto":
+        return normalized
+
+    runtime_base = str(base_url or "").strip().rstrip("/")
+    if not runtime_base:
+        return normalized or "auto"
+
+    if base_url_host_matches(runtime_base, "openrouter.ai"):
+        return "openrouter"
+    if (
+        base_url_host_matches(runtime_base, "inference-api.nousresearch.com")
+        or base_url_host_matches(runtime_base, "nousresearch.com")
+    ):
+        return "nous"
+    if base_url_host_matches(runtime_base, "api.anthropic.com"):
+        return "anthropic"
+    if (
+        base_url_host_matches(runtime_base, "chatgpt.com")
+        and "/backend-api/codex" in runtime_base.lower()
+    ):
+        return "openai-codex"
+    if base_url_host_matches(runtime_base, "api.githubcopilot.com"):
+        return "copilot"
+    return "custom"
+
+
+def _store_auxiliary_task_metadata(task: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """Persist the latest resolved runtime metadata for an auxiliary task."""
+    if not task:
+        return {}
+    stored = dict(metadata)
+    stored["task"] = task
+    stored["updated_at"] = time.time()
+    with _AUXILIARY_TASK_METADATA_LOCK:
+        _AUXILIARY_TASK_METADATA[task] = stored
+    return dict(stored)
+
+
+def get_auxiliary_task_metadata(task: str) -> Dict[str, Any]:
+    """Return a copy of the latest stored runtime metadata for *task*."""
+    if not task:
+        return {}
+    with _AUXILIARY_TASK_METADATA_LOCK:
+        metadata = _AUXILIARY_TASK_METADATA.get(task, {})
+    return dict(metadata)
+
+
+def detect_auxiliary_context_length(
+    model: Optional[str],
+    *,
+    base_url: str = "",
+    api_key: str = "",
+    provider: str = "",
+    config_context_length: Optional[int] = None,
+) -> Optional[int]:
+    """Resolve the effective context window for an auxiliary runtime."""
+    if not model:
+        return None
+    try:
+        return get_model_context_length(
+            model,
+            base_url=base_url,
+            api_key=api_key,
+            config_context_length=config_context_length,
+            provider=provider,
+        )
+    except Exception as exc:
+        logger.debug(
+            "Auxiliary metadata: failed to detect context length for %s at %s: %s",
+            model,
+            base_url or "default",
+            exc,
+        )
+        return None
+
+
+def _track_auxiliary_task_metadata(
+    task: Optional[str],
+    *,
+    client: Any,
+    model: Optional[str],
+    provider: Optional[str],
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    api_mode: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Store the final live runtime metadata for an auxiliary task."""
+    if not task or client is None or not model:
+        return {}
+
+    runtime_base_url = str(base_url or getattr(client, "base_url", "") or "").strip().rstrip("/")
+    runtime_api_key = str(api_key or getattr(client, "api_key", "") or "").strip()
+    resolved_provider = _infer_auxiliary_provider_label(provider, runtime_base_url)
+    context_override = _get_task_context_length_override(task)
+
+    existing = get_auxiliary_task_metadata(task)
+    same_runtime = (
+        existing.get("provider") == resolved_provider
+        and existing.get("model") == model
+        and existing.get("base_url") == runtime_base_url
+        and existing.get("api_key") == runtime_api_key
+        and existing.get("api_mode", "") == (api_mode or "")
+    )
+    context_length = existing.get("context_length") if same_runtime else None
+    if not isinstance(context_length, int) or context_length <= 0:
+        context_length = detect_auxiliary_context_length(
+            model,
+            base_url=runtime_base_url,
+            api_key=runtime_api_key,
+            provider=resolved_provider,
+            config_context_length=context_override,
+        )
+
+    return _store_auxiliary_task_metadata(
+        task,
+        {
+            "provider": resolved_provider,
+            "model": model,
+            "base_url": runtime_base_url,
+            "api_key": runtime_api_key,
+            "api_mode": api_mode or "",
+            "context_length": context_length,
+            "config_context_length": context_override,
+        },
+    )
+
+
+def resolve_auxiliary_context_length(
+    task: str,
+    *,
+    provider: str = None,
+    model: str = None,
+    base_url: str = None,
+    api_key: str = None,
+    main_runtime: Optional[Dict[str, Any]] = None,
+) -> Tuple[Optional[Any], Optional[str], Optional[int]]:
+    """Resolve an auxiliary runtime and its effective context length together."""
+    resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
+        task,
+        provider,
+        model,
+        base_url,
+        api_key,
+    )
+    client, final_model = _get_cached_client(
+        resolved_provider,
+        resolved_model,
+        base_url=resolved_base_url,
+        api_key=resolved_api_key,
+        api_mode=resolved_api_mode,
+        main_runtime=main_runtime,
+    )
+    if client is None and not resolved_base_url:
+        explicit = (resolved_provider or "").strip().lower()
+        if not explicit or explicit in {"auto", "custom"}:
+            client, final_model = _get_cached_client(
+                "auto",
+                main_runtime=main_runtime,
+            )
+            resolved_provider = "auto"
+            resolved_base_url = None
+            resolved_api_key = None
+            resolved_api_mode = None
+    if client is None or not final_model:
+        return None, None, None
+
+    metadata = _track_auxiliary_task_metadata(
+        task,
+        client=client,
+        model=final_model,
+        provider=resolved_provider,
+        base_url=resolved_base_url,
+        api_key=resolved_api_key,
+        api_mode=resolved_api_mode,
+    )
+    context_length = metadata.get("context_length")
+    return client, final_model, context_length if isinstance(context_length, int) else None
 
 
 def _get_task_extra_body(task: str) -> Dict[str, Any]:
@@ -3567,6 +3790,16 @@ def call_llm(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
+    _track_auxiliary_task_metadata(
+        task,
+        client=client,
+        model=final_model,
+        provider=resolved_provider,
+        base_url=resolved_base_url,
+        api_key=resolved_api_key,
+        api_mode=resolved_api_mode,
+    )
+
     effective_timeout = timeout if timeout is not None else _get_task_timeout(task)
 
     # Log what we're about to do — makes auxiliary operations visible
@@ -3662,6 +3895,15 @@ def call_llm(
                             task or "call")
                 if refreshed_model and refreshed_model != kwargs.get("model"):
                     kwargs["model"] = refreshed_model
+                _track_auxiliary_task_metadata(
+                    task,
+                    client=refreshed_client,
+                    model=refreshed_model or final_model,
+                    provider="nous",
+                    base_url=resolved_base_url,
+                    api_key=resolved_api_key,
+                    api_mode=resolved_api_mode,
+                )
                 return _validate_llm_response(
                     refreshed_client.chat.completions.create(**kwargs), task)
 
@@ -3705,6 +3947,15 @@ def call_llm(
                     _retry_base = str(getattr(retry_client, "base_url", "") or "")
                     if _is_anthropic_compat_endpoint(resolved_provider, _retry_base):
                         retry_kwargs["messages"] = _convert_openai_images_to_anthropic(retry_kwargs["messages"])
+                    _track_auxiliary_task_metadata(
+                        task,
+                        client=retry_client,
+                        model=retry_model or final_model,
+                        provider=resolved_provider,
+                        base_url=resolved_base_url,
+                        api_key=resolved_api_key,
+                        api_mode=resolved_api_mode,
+                    )
                     return _validate_llm_response(
                         retry_client.chat.completions.create(**retry_kwargs), task)
 
@@ -3752,6 +4003,15 @@ def call_llm(
                     tools=tools, timeout=effective_timeout,
                     extra_body=effective_extra_body,
                     base_url=str(getattr(fb_client, "base_url", "") or ""))
+                _track_auxiliary_task_metadata(
+                    task,
+                    client=fb_client,
+                    model=fb_model,
+                    provider=fb_label,
+                    base_url=str(getattr(fb_client, "base_url", "") or ""),
+                    api_key=str(getattr(fb_client, "api_key", "") or ""),
+                    api_mode="",
+                )
                 return _validate_llm_response(
                     fb_client.chat.completions.create(**fb_kwargs), task)
         raise
@@ -3886,6 +4146,16 @@ async def async_call_llm(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
+    _track_auxiliary_task_metadata(
+        task,
+        client=client,
+        model=final_model,
+        provider=resolved_provider,
+        base_url=resolved_base_url,
+        api_key=resolved_api_key,
+        api_mode=resolved_api_mode,
+    )
+
     effective_timeout = timeout if timeout is not None else _get_task_timeout(task)
 
     # Pass the client's actual base_url (not just resolved_base_url) so
@@ -3967,6 +4237,15 @@ async def async_call_llm(
                             task or "call")
                 if refreshed_model and refreshed_model != kwargs.get("model"):
                     kwargs["model"] = refreshed_model
+                _track_auxiliary_task_metadata(
+                    task,
+                    client=refreshed_client,
+                    model=refreshed_model or final_model,
+                    provider="nous",
+                    base_url=resolved_base_url,
+                    api_key=resolved_api_key,
+                    api_mode=resolved_api_mode,
+                )
                 return _validate_llm_response(
                     await refreshed_client.chat.completions.create(**kwargs), task)
 
@@ -4009,6 +4288,15 @@ async def async_call_llm(
                     _retry_base = str(getattr(retry_client, "base_url", "") or "")
                     if _is_anthropic_compat_endpoint(resolved_provider, _retry_base):
                         retry_kwargs["messages"] = _convert_openai_images_to_anthropic(retry_kwargs["messages"])
+                    _track_auxiliary_task_metadata(
+                        task,
+                        client=retry_client,
+                        model=retry_model or final_model,
+                        provider=resolved_provider,
+                        base_url=resolved_base_url,
+                        api_key=resolved_api_key,
+                        api_mode=resolved_api_mode,
+                    )
                     return _validate_llm_response(
                         await retry_client.chat.completions.create(**retry_kwargs), task)
 
@@ -4043,6 +4331,15 @@ async def async_call_llm(
                 )
                 if async_fb_model and async_fb_model != fb_kwargs.get("model"):
                     fb_kwargs["model"] = async_fb_model
+                _track_auxiliary_task_metadata(
+                    task,
+                    client=async_fb,
+                    model=async_fb_model or fb_model,
+                    provider=fb_label,
+                    base_url=str(getattr(async_fb, "base_url", "") or ""),
+                    api_key=str(getattr(async_fb, "api_key", "") or ""),
+                    api_mode="",
+                )
                 return _validate_llm_response(
                     await async_fb.chat.completions.create(**fb_kwargs), task)
         raise

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -377,6 +377,22 @@ class ContextCompressor(ContextEngine):
             int(context_length * 0.05), _SUMMARY_TOKENS_CEILING,
         )
 
+    def update_summary_model(
+        self,
+        model: str,
+        context_length: int,
+        *,
+        base_url: str = "",
+        api_key: str = "",
+        provider: str = "",
+    ) -> None:
+        """Track the resolved auxiliary runtime currently used for summaries."""
+        self.summary_runtime_model = model or ""
+        self.summary_context_length = int(context_length or 0)
+        self.summary_base_url = base_url or ""
+        self.summary_api_key = api_key or ""
+        self.summary_provider = provider or ""
+
     def __init__(
         self,
         model: str,
@@ -441,6 +457,11 @@ class ContextCompressor(ContextEngine):
         self.last_completion_tokens = 0
 
         self.summary_model = summary_model_override or ""
+        self.summary_runtime_model = self.summary_model or ""
+        self.summary_context_length = 0
+        self.summary_base_url = ""
+        self.summary_api_key = ""
+        self.summary_provider = ""
 
         # Stores the previous compaction summary for iterative updates
         self._previous_summary: Optional[str] = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -2657,26 +2657,18 @@ class AIAgent:
             return
         try:
             from agent.auxiliary_client import (
-                _resolve_task_provider_model,
-                get_text_auxiliary_client,
+                get_auxiliary_task_metadata,
+                resolve_auxiliary_context_length,
             )
             from agent.model_metadata import (
                 MINIMUM_CONTEXT_LENGTH,
-                get_model_context_length,
             )
 
-            client, aux_model = get_text_auxiliary_client(
+            client, aux_model, aux_context = resolve_auxiliary_context_length(
                 "compression",
                 main_runtime=self._current_main_runtime(),
             )
-            # Best-effort aux provider label for the warning message. The
-            # configured provider may be "auto", in which case we fall back
-            # to the client's base_url hostname so the user can still tell
-            # where the compression model is actually being called.
-            try:
-                _aux_cfg_provider, _, _, _, _ = _resolve_task_provider_model("compression")
-            except Exception:
-                _aux_cfg_provider = ""
+            aux_metadata = get_auxiliary_task_metadata("compression")
             if client is None or not aux_model:
                 msg = (
                     "⚠ No auxiliary LLM provider configured — context "
@@ -2693,17 +2685,15 @@ class AIAgent:
 
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
-
-            aux_context = get_model_context_length(
-                aux_model,
-                base_url=aux_base_url,
-                api_key=aux_api_key,
-                config_context_length=getattr(self, "_aux_compression_context_length_config", None),
-                # Each model must be resolved with its own provider so that
-                # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
-                # are invoked for the correct client, not inherited from the main model.
-                provider=(_aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(self, "provider", "")),
-            )
+            aux_provider = str(aux_metadata.get("provider", "") or "")
+            if hasattr(self, "context_compressor") and self.context_compressor:
+                self.context_compressor.update_summary_model(
+                    aux_model,
+                    aux_context or 0,
+                    base_url=aux_base_url,
+                    api_key=aux_api_key,
+                    provider=aux_provider,
+                )
 
             # Hard floor: the auxiliary compression model must have at least
             # MINIMUM_CONTEXT_LENGTH (64K) tokens of context.  The main model
@@ -2753,11 +2743,7 @@ class AIAgent:
                 # fall back to the client's base_url hostname.
                 _main_model = getattr(self, "model", "") or "?"
                 _main_provider = getattr(self, "provider", "") or ""
-                _aux_provider_label = (
-                    _aux_cfg_provider
-                    if _aux_cfg_provider and _aux_cfg_provider != "auto"
-                    else ""
-                )
+                _aux_provider_label = aux_provider
                 if not _aux_provider_label:
                     try:
                         from urllib.parse import urlparse

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -22,6 +22,8 @@ from agent.auxiliary_client import (
     _is_payment_error,
     _is_rate_limit_error,
     _normalize_aux_provider,
+    get_auxiliary_task_metadata,
+    resolve_auxiliary_context_length,
     _try_payment_fallback,
     _resolve_auto,
 )
@@ -550,6 +552,45 @@ class TestGetTextAuxiliaryClient:
         assert mock_openai.call_args.kwargs["base_url"] == "https://api.openai.com/v1"
         assert mock_openai.call_args.kwargs["api_key"] == "sk-test"
 
+    def test_get_text_auxiliary_client_tracks_shared_task_metadata(self):
+        client = MagicMock()
+        client.base_url = "https://openrouter.ai/api/v1"
+        client.api_key = "sk-openrouter"
+
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(client, "google/gemini-3-flash-preview")),
+            patch("agent.auxiliary_client.get_model_context_length", return_value=1_000_000),
+        ):
+            result_client, result_model = get_text_auxiliary_client("compression")
+
+        assert result_client is client
+        assert result_model == "google/gemini-3-flash-preview"
+        metadata = get_auxiliary_task_metadata("compression")
+        assert metadata["provider"] == "openrouter"
+        assert metadata["model"] == "google/gemini-3-flash-preview"
+        assert metadata["base_url"] == "https://openrouter.ai/api/v1"
+        assert metadata["api_key"] == "sk-openrouter"
+        assert metadata["context_length"] == 1_000_000
+
+    def test_resolve_auxiliary_context_length_uses_shared_task_store(self):
+        client = MagicMock()
+        client.base_url = "http://localhost:11434/v1"
+        client.api_key = "no-key-required"
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("custom", "qwen2.5", "http://localhost:11434/v1", "no-key-required", None)),
+            patch("agent.auxiliary_client._get_cached_client", return_value=(client, "qwen2.5")),
+            patch("agent.auxiliary_client.get_model_context_length", return_value=262_144),
+        ):
+            result_client, result_model, result_context = resolve_auxiliary_context_length("compression")
+
+        assert result_client is client
+        assert result_model == "qwen2.5"
+        assert result_context == 262_144
+        metadata = get_auxiliary_task_metadata("compression")
+        assert metadata["provider"] == "custom"
+        assert metadata["context_length"] == 262_144
+
 
 class TestVisionClientFallback:
     """Vision client auto mode resolves known-good multimodal backends."""
@@ -976,6 +1017,41 @@ class TestCallLlmPaymentFallback:
             )
         # Fallback client should have been used
         assert fallback_client.chat.completions.create.called
+
+    def test_payment_fallback_updates_shared_task_metadata_to_final_runtime(self, monkeypatch):
+        """After auto fallback, stored metadata should reflect the actual fallback runtime."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        primary_client = MagicMock()
+        primary_client.base_url = "https://openrouter.ai/api/v1"
+        primary_client.api_key = "sk-openrouter"
+        primary_client.chat.completions.create.side_effect = self._make_402_error()
+
+        fallback_client = MagicMock()
+        fallback_client.base_url = "https://inference-api.nousresearch.com/v1"
+        fallback_client.api_key = "nous-agent-key"
+        fallback_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="fallback response"))
+        ])
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("auto", "xiaomi/mimo-v2-pro", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client", return_value=(primary_client, "xiaomi/mimo-v2-pro")),
+            patch("agent.auxiliary_client._try_payment_fallback", return_value=(fallback_client, "google/gemini-3-flash-preview", "nous")),
+            patch("agent.auxiliary_client.get_model_context_length", side_effect=[256_000, 1_000_000]),
+        ):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result.choices[0].message.content == "fallback response"
+        metadata = get_auxiliary_task_metadata("compression")
+        assert metadata["provider"] == "nous"
+        assert metadata["model"] == "google/gemini-3-flash-preview"
+        assert metadata["base_url"] == "https://inference-api.nousresearch.com/v1"
+        assert metadata["api_key"] == "nous-agent-key"
+        assert metadata["context_length"] == 1_000_000
 
 # ---------------------------------------------------------------------------
 # Gate: _resolve_api_key_provider must skip anthropic when not configured
@@ -1531,6 +1607,37 @@ class TestAuxiliaryAuthRefreshRetry:
         mock_refresh.assert_called_once_with("anthropic")
         assert stale_client.chat.completions.create.call_count == 1
         assert fresh_client.chat.completions.create.call_count == 1
+
+    def test_call_llm_refresh_updates_shared_task_metadata_to_refreshed_runtime(self):
+        stale_client = MagicMock()
+        stale_client.base_url = "https://chatgpt.com/backend-api/codex"
+        stale_client.api_key = "stale-token"
+        stale_client.chat.completions.create.side_effect = _AuxAuth401("stale codex token")
+
+        fresh_client = MagicMock()
+        fresh_client.base_url = "https://chatgpt.com/backend-api/codex"
+        fresh_client.api_key = "fresh-token"
+        fresh_client.chat.completions.create.return_value = _DummyResponse("fresh-non-vision")
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model", return_value=("openai-codex", "gpt-5.4", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client", side_effect=[(stale_client, "gpt-5.4"), (fresh_client, "gpt-5.4")]),
+            patch("agent.auxiliary_client._refresh_provider_credentials", return_value=True),
+            patch("agent.auxiliary_client.get_model_context_length", side_effect=[200_000, 200_000]),
+        ):
+            resp = call_llm(
+                task="compression",
+                provider="openai-codex",
+                model="gpt-5.4",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert resp.choices[0].message.content == "fresh-non-vision"
+        metadata = get_auxiliary_task_metadata("compression")
+        assert metadata["provider"] == "openai-codex"
+        assert metadata["model"] == "gpt-5.4"
+        assert metadata["base_url"] == "https://chatgpt.com/backend-api/codex"
+        assert metadata["api_key"] == "fresh-token"
 
     @pytest.mark.asyncio
     async def test_async_call_llm_refreshes_codex_on_401_for_vision(self):

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -51,25 +51,48 @@ def _make_agent(
     return agent
 
 
+def _patch_aux_resolution(
+    *,
+    model: str,
+    context_length: int,
+    base_url: str,
+    api_key: str,
+    provider: str = "openrouter",
+):
+    client = MagicMock()
+    client.base_url = base_url
+    client.api_key = api_key
+    return (
+        patch(
+            "agent.auxiliary_client.resolve_auxiliary_context_length",
+            return_value=(client, model, context_length),
+        ),
+        patch(
+            "agent.auxiliary_client.get_auxiliary_task_metadata",
+            return_value={"provider": provider, "context_length": context_length},
+        ),
+        client,
+    )
+
+
 # ── Core warning logic ──────────────────────────────────────────────
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
-@patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_client, mock_ctx_len):
+def test_auto_corrects_threshold_when_aux_context_below_threshold():
     """Auto-correction: aux >= 64K floor but < threshold → lower threshold
     to aux_context so compression still works this session."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
     # threshold = 100,000 — aux has 80,000 (above 64K floor, below threshold)
-    mock_client = MagicMock()
-    mock_client.base_url = "https://openrouter.ai/api/v1"
-    mock_client.api_key = "sk-aux"
-    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
-
     messages = []
     agent._emit_status = lambda msg: messages.append(msg)
-
-    agent._check_compression_model_feasibility()
+    resolve_patch, metadata_patch, _client = _patch_aux_resolution(
+        model="google/gemini-3-flash-preview",
+        context_length=80_000,
+        base_url="https://openrouter.ai/api/v1",
+        api_key="sk-aux",
+    )
+    with resolve_patch, metadata_patch:
+        agent._check_compression_model_feasibility()
 
     assert len(messages) == 1
     assert "Compression model" in messages[0]
@@ -87,21 +110,20 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
     assert agent.context_compressor.threshold_tokens == 80_000
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=32_768)
-@patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_rejects_aux_below_minimum_context(mock_get_client, mock_ctx_len):
+def test_rejects_aux_below_minimum_context():
     """Hard floor: aux context < MINIMUM_CONTEXT_LENGTH (64K) → session
     refuses to start (ValueError), mirroring the main-model rejection."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
-    mock_client = MagicMock()
-    mock_client.base_url = "https://openrouter.ai/api/v1"
-    mock_client.api_key = "sk-aux"
-    mock_get_client.return_value = (mock_client, "tiny-aux-model")
-
     agent._emit_status = lambda msg: None
-
-    with pytest.raises(ValueError) as exc_info:
-        agent._check_compression_model_feasibility()
+    resolve_patch, metadata_patch, _client = _patch_aux_resolution(
+        model="tiny-aux-model",
+        context_length=32_768,
+        base_url="https://openrouter.ai/api/v1",
+        api_key="sk-aux",
+    )
+    with resolve_patch, metadata_patch:
+        with pytest.raises(ValueError) as exc_info:
+            agent._check_compression_model_feasibility()
 
     err = str(exc_info.value)
     assert "tiny-aux-model" in err
@@ -110,24 +132,63 @@ def test_rejects_aux_below_minimum_context(mock_get_client, mock_ctx_len):
     assert "below the minimum" in err
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=200_000)
-@patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_no_warning_when_aux_context_sufficient(mock_get_client, mock_ctx_len):
+def test_no_warning_when_aux_context_sufficient():
     """No warning when aux model context >= main model threshold."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
     # threshold = 100,000 — aux has 200,000 (sufficient)
-    mock_client = MagicMock()
-    mock_client.base_url = "https://openrouter.ai/api/v1"
-    mock_client.api_key = "sk-aux"
-    mock_get_client.return_value = (mock_client, "google/gemini-2.5-flash")
-
     messages = []
     agent._emit_status = lambda msg: messages.append(msg)
-
-    agent._check_compression_model_feasibility()
+    resolve_patch, metadata_patch, _client = _patch_aux_resolution(
+        model="google/gemini-2.5-flash",
+        context_length=200_000,
+        base_url="https://openrouter.ai/api/v1",
+        api_key="sk-aux",
+    )
+    with resolve_patch, metadata_patch:
+        agent._check_compression_model_feasibility()
 
     assert len(messages) == 0
     assert agent._compression_warning is None
+
+
+def test_feasibility_check_uses_shared_auxiliary_context_resolution():
+    """Compression feasibility should use the shared auxiliary metadata resolver."""
+    agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+
+    with (
+        patch(
+            "agent.auxiliary_client.resolve_auxiliary_context_length",
+            return_value=(mock_client, "google/gemini-3-flash-preview", 120_000),
+        ) as mock_resolve,
+        patch(
+            "agent.auxiliary_client.get_auxiliary_task_metadata",
+            return_value={"provider": "openrouter", "context_length": 120_000},
+        ),
+    ):
+        agent._emit_status = lambda msg: None
+        agent._check_compression_model_feasibility()
+
+    mock_resolve.assert_called_once_with(
+        "compression",
+        main_runtime={
+            "model": "test-main-model",
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-test",
+            "api_mode": "chat_completions",
+        },
+    )
+    assert agent.context_compressor.threshold_tokens == 100_000
+    agent.context_compressor.update_summary_model.assert_called_once_with(
+        "google/gemini-3-flash-preview",
+        120_000,
+        base_url="https://openrouter.ai/api/v1",
+        api_key="sk-aux",
+        provider="openrouter",
+    )
 
 
 def test_feasibility_check_passes_live_main_runtime():
@@ -143,12 +204,17 @@ def test_feasibility_check_passes_live_main_runtime():
     mock_client.base_url = "https://chatgpt.com/backend-api/codex"
     mock_client.api_key = "codex-token"
 
-    with patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(mock_client, "gpt-5.4")) as mock_get_client, \
-         patch("agent.model_metadata.get_model_context_length", return_value=200_000):
+    with patch(
+        "agent.auxiliary_client.resolve_auxiliary_context_length",
+        return_value=(mock_client, "gpt-5.4", 200_000),
+    ) as mock_resolve, patch(
+        "agent.auxiliary_client.get_auxiliary_task_metadata",
+        return_value={"provider": "openai-codex", "context_length": 200_000},
+    ):
         agent._emit_status = lambda msg: None
         agent._check_compression_model_feasibility()
 
-    mock_get_client.assert_called_once_with(
+    mock_resolve.assert_called_once_with(
         "compression",
         main_runtime={
             "model": "gpt-5.4",
@@ -160,52 +226,21 @@ def test_feasibility_check_passes_live_main_runtime():
     )
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=1_000_000)
-@patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ctx_len):
-    """auxiliary.compression.context_length from config is forwarded to
-    get_model_context_length so custom endpoints that lack /models still
-    report the correct context window (fixes #8499)."""
+def test_feasibility_check_uses_resolved_context_length_from_shared_metadata():
+    """Feasibility check should trust the shared resolver's detected context length."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.85)
-    agent._aux_compression_context_length_config = 1_000_000
-    mock_client = MagicMock()
-    mock_client.base_url = "http://custom-endpoint:8080/v1"
-    mock_client.api_key = "sk-custom"
-    mock_get_client.return_value = (mock_client, "custom/big-model")
-
     agent._emit_status = lambda msg: None
-    agent._check_compression_model_feasibility()
-
-    mock_ctx_len.assert_called_once_with(
-        "custom/big-model",
+    resolve_patch, metadata_patch, _client = _patch_aux_resolution(
+        model="custom/big-model",
+        context_length=1_000_000,
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
-        config_context_length=1_000_000,
-        provider="openrouter",
+        provider="custom",
     )
+    with resolve_patch, metadata_patch:
+        agent._check_compression_model_feasibility()
 
-
-@patch("agent.model_metadata.get_model_context_length", return_value=128_000)
-@patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_ctx_len):
-    """Non-integer context_length in config is silently ignored."""
-    agent = _make_agent(main_context=200_000, threshold_percent=0.50)
-    agent._aux_compression_context_length_config = None
-    mock_client = MagicMock()
-    mock_client.base_url = "http://custom:8080/v1"
-    mock_client.api_key = "sk-test"
-    mock_get_client.return_value = (mock_client, "custom/model")
-
-    agent._emit_status = lambda msg: None
-    agent._check_compression_model_feasibility()
-
-    mock_ctx_len.assert_called_once_with(
-        "custom/model",
-        base_url="http://custom:8080/v1",
-        api_key="sk-test",
-        config_context_length=None,
-        provider="openrouter",
-    )
+    assert agent._compression_warning is None
 
 
 def test_init_feasibility_check_uses_aux_context_override_from_config():
@@ -216,6 +251,7 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
             self.context_length = 200_000
             self.threshold_tokens = 100_000
             self.threshold_percent = 0.50
+            self.update_summary_model = MagicMock()
 
         def get_tool_schemas(self):
             return []
@@ -236,12 +272,20 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
 
     with (
         patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("hermes_logging.setup_logging"),
+        patch("hermes_logging.setup_verbose_logging"),
         patch("run_agent.get_tool_definitions", return_value=[]),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
         patch("run_agent.ContextCompressor", new=_StubCompressor),
-        patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(mock_client, "custom/big-model")),
-        patch("agent.model_metadata.get_model_context_length", return_value=1_000_000) as mock_ctx_len,
+        patch(
+            "agent.auxiliary_client.resolve_auxiliary_context_length",
+            return_value=(mock_client, "custom/big-model", 1_000_000),
+        ),
+        patch(
+            "agent.auxiliary_client.get_auxiliary_task_metadata",
+            return_value={"provider": "custom", "context_length": 1_000_000},
+        ),
     ):
         agent = AIAgent(
             api_key="test-key-1234567890",
@@ -252,20 +296,14 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         )
 
     assert agent._aux_compression_context_length_config == 1_000_000
-    mock_ctx_len.assert_called_once_with(
-        "custom/big-model",
-        base_url="http://custom-endpoint:8080/v1",
-        api_key="sk-custom",
-        config_context_length=1_000_000,
-        provider="",
-    )
+    assert agent.context_compressor.update_summary_model.called
 
 
-@patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_warns_when_no_auxiliary_provider(mock_get_client):
+@patch("agent.auxiliary_client.resolve_auxiliary_context_length")
+def test_warns_when_no_auxiliary_provider(mock_resolve):
     """Warning emitted when no auxiliary provider is configured."""
     agent = _make_agent()
-    mock_get_client.return_value = (None, None)
+    mock_resolve.return_value = (None, None, None)
 
     messages = []
     agent._emit_status = lambda msg: messages.append(msg)
@@ -290,11 +328,11 @@ def test_skips_check_when_compression_disabled():
     assert agent._compression_warning is None
 
 
-@patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_exception_does_not_crash(mock_get_client):
+@patch("agent.auxiliary_client.resolve_auxiliary_context_length")
+def test_exception_does_not_crash(mock_resolve):
     """Exceptions in the check are caught — never blocks startup."""
     agent = _make_agent()
-    mock_get_client.side_effect = RuntimeError("boom")
+    mock_resolve.side_effect = RuntimeError("boom")
 
     messages = []
     agent._emit_status = lambda msg: messages.append(msg)
@@ -306,39 +344,37 @@ def test_exception_does_not_crash(mock_get_client):
     assert len(messages) == 0
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=100_000)
-@patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_exact_threshold_boundary_no_warning(mock_get_client, mock_ctx_len):
+def test_exact_threshold_boundary_no_warning():
     """No warning when aux context exactly equals the threshold."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
-    mock_client = MagicMock()
-    mock_client.base_url = "https://openrouter.ai/api/v1"
-    mock_client.api_key = "sk-aux"
-    mock_get_client.return_value = (mock_client, "test-model")
-
     messages = []
     agent._emit_status = lambda msg: messages.append(msg)
-
-    agent._check_compression_model_feasibility()
+    resolve_patch, metadata_patch, _client = _patch_aux_resolution(
+        model="test-model",
+        context_length=100_000,
+        base_url="https://openrouter.ai/api/v1",
+        api_key="sk-aux",
+    )
+    with resolve_patch, metadata_patch:
+        agent._check_compression_model_feasibility()
 
     assert len(messages) == 0
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=99_999)
-@patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_just_below_threshold_auto_corrects(mock_get_client, mock_ctx_len):
+def test_just_below_threshold_auto_corrects():
     """Auto-correct fires when aux context is one token below the threshold
     (and above the 64K hard floor)."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
-    mock_client = MagicMock()
-    mock_client.base_url = "https://openrouter.ai/api/v1"
-    mock_client.api_key = "sk-aux"
-    mock_get_client.return_value = (mock_client, "small-model")
-
     messages = []
     agent._emit_status = lambda msg: messages.append(msg)
-
-    agent._check_compression_model_feasibility()
+    resolve_patch, metadata_patch, _client = _patch_aux_resolution(
+        model="small-model",
+        context_length=99_999,
+        base_url="https://openrouter.ai/api/v1",
+        api_key="sk-aux",
+    )
+    with resolve_patch, metadata_patch:
+        agent._check_compression_model_feasibility()
 
     assert len(messages) == 1
     assert "small-model" in messages[0]
@@ -349,20 +385,20 @@ def test_just_below_threshold_auto_corrects(mock_get_client, mock_ctx_len):
 # ── Two-phase: __init__ + run_conversation replay ───────────────────
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
-@patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_warning_stored_for_gateway_replay(mock_get_client, mock_ctx_len):
+def test_warning_stored_for_gateway_replay():
     """__init__ stores the warning; _replay sends it through status_callback."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
-    mock_client = MagicMock()
-    mock_client.base_url = "https://openrouter.ai/api/v1"
-    mock_client.api_key = "sk-aux"
-    mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
-
     # Phase 1: __init__ — _emit_status prints (CLI) but callback is None
     vprint_messages = []
     agent._emit_status = lambda msg: vprint_messages.append(msg)
-    agent._check_compression_model_feasibility()
+    resolve_patch, metadata_patch, _client = _patch_aux_resolution(
+        model="google/gemini-3-flash-preview",
+        context_length=80_000,
+        base_url="https://openrouter.ai/api/v1",
+        api_key="sk-aux",
+    )
+    with resolve_patch, metadata_patch:
+        agent._check_compression_model_feasibility()
 
     assert len(vprint_messages) == 1  # CLI got it
     assert agent._compression_warning is not None  # stored for replay
@@ -378,18 +414,18 @@ def test_warning_stored_for_gateway_replay(mock_get_client, mock_ctx_len):
     )
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=200_000)
-@patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_no_replay_when_no_warning(mock_get_client, mock_ctx_len):
+def test_no_replay_when_no_warning():
     """_replay_compression_warning is a no-op when there's no stored warning."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
-    mock_client = MagicMock()
-    mock_client.base_url = "https://openrouter.ai/api/v1"
-    mock_client.api_key = "sk-aux"
-    mock_get_client.return_value = (mock_client, "big-model")
-
     agent._emit_status = lambda msg: None
-    agent._check_compression_model_feasibility()
+    resolve_patch, metadata_patch, _client = _patch_aux_resolution(
+        model="big-model",
+        context_length=200_000,
+        base_url="https://openrouter.ai/api/v1",
+        api_key="sk-aux",
+    )
+    with resolve_patch, metadata_patch:
+        agent._check_compression_model_feasibility()
 
     assert agent._compression_warning is None
 
@@ -410,19 +446,19 @@ def test_replay_without_callback_is_noop():
     agent._replay_compression_warning()
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
-@patch("agent.auxiliary_client.get_text_auxiliary_client")
-def test_run_conversation_clears_warning_after_replay(mock_get_client, mock_ctx_len):
+def test_run_conversation_clears_warning_after_replay():
     """After replay in run_conversation, _compression_warning is cleared
     so the warning is not sent again on subsequent turns."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
-    mock_client = MagicMock()
-    mock_client.base_url = "https://openrouter.ai/api/v1"
-    mock_client.api_key = "sk-aux"
-    mock_get_client.return_value = (mock_client, "small-model")
-
     agent._emit_status = lambda msg: None
-    agent._check_compression_model_feasibility()
+    resolve_patch, metadata_patch, _client = _patch_aux_resolution(
+        model="small-model",
+        context_length=80_000,
+        base_url="https://openrouter.ai/api/v1",
+        api_key="sk-aux",
+    )
+    with resolve_patch, metadata_patch:
+        agent._check_compression_model_feasibility()
 
     assert agent._compression_warning is not None
 

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -17,6 +17,25 @@ import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
 
+def test_get_web_extract_auxiliary_metadata_uses_shared_task_store():
+    with patch(
+        "tools.web_tools.get_auxiliary_task_metadata",
+        return_value={
+            "provider": "openrouter",
+            "model": "google/gemini-3-flash-preview",
+            "context_length": 1_000_000,
+        },
+    ) as mock_get:
+        from tools.web_tools import get_web_extract_auxiliary_metadata
+
+        metadata = get_web_extract_auxiliary_metadata()
+
+    mock_get.assert_called_once_with("web_extract")
+    assert metadata["provider"] == "openrouter"
+    assert metadata["model"] == "google/gemini-3-flash-preview"
+    assert metadata["context_length"] == 1_000_000
+
+
 class TestFirecrawlClientConfig:
     """Test suite for Firecrawl client initialization."""
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -89,6 +89,7 @@ Firecrawl = _FirecrawlProxy()
 from agent.auxiliary_client import (
     async_call_llm,
     extract_content_or_reasoning,
+    get_auxiliary_task_metadata,
     get_async_text_auxiliary_client,
 )
 from tools.debug_helpers import DebugSession
@@ -545,6 +546,11 @@ def _resolve_web_extract_auxiliary(model: Optional[str] = None) -> tuple[Optiona
         extra_body = get_auxiliary_extra_body() or {"tags": ["product=hermes-agent"]}
 
     return client, effective_model, extra_body
+
+
+def get_web_extract_auxiliary_metadata() -> Dict[str, Any]:
+    """Return the shared auxiliary runtime metadata for web_extract."""
+    return get_auxiliary_task_metadata("web_extract")
 
 
 def _get_default_summarizer_model() -> Optional[str]:


### PR DESCRIPTION
## What does this PR do?

This fixes fragmented auxiliary runtime metadata tracking for compression and web extraction.

Before this change, Hermes could resolve one auxiliary runtime up front, then silently switch to a different runtime during auth refresh, provider retry, or payment/rate-limit fallback. Downstream consumers would still reason about the original runtime, which could leave context-length checks and runtime metadata out of sync with the model that was actually used.

This PR centralizes auxiliary runtime metadata tracking in `agent/auxiliary_client.py` and updates it whenever the final live runtime changes. That keeps compression feasibility checks and web-extract metadata aligned with the real auxiliary backend and model.

## Related Issue

Fixes #21050

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a shared task-level auxiliary runtime metadata store in `agent/auxiliary_client.py`
- Added `resolve_auxiliary_context_length(...)` so compression can resolve client/model/context-length as one operation
- Updated `get_text_auxiliary_client(...)` and `get_async_text_auxiliary_client(...)` to record resolved runtime metadata
- Updated `call_llm(...)` and `async_call_llm(...)` to refresh stored metadata after auth refresh and fallback paths
- Updated `run_agent.py` compression feasibility checks to use the shared auxiliary resolver instead of recomputing context length independently
- Added `ContextCompressor.update_summary_model(...)` so the compressor tracks the actual resolved summary runtime
- Added `tools.web_tools.get_web_extract_auxiliary_metadata()` as a minimal accessor for shared web-extract runtime metadata
- Added regression tests for shared metadata storage, compression feasibility resolution, and final-runtime tracking after fallback/retry

## How to Test

1. Run:
   `python3 -m py_compile agent/auxiliary_client.py agent/context_compressor.py run_agent.py tools/web_tools.py tests/agent/test_auxiliary_client.py tests/run_agent/test_compression_feasibility.py tests/tools/test_web_tools_config.py`
2. Run:
   `python3 -m pytest -q tests/agent/test_auxiliary_client.py tests/run_agent/test_compression_feasibility.py tests/tools/test_web_tools_config.py`
3. Verify the targeted suite passes, including the new cases that assert shared metadata updates to the final runtime after payment fallback and auth refresh

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu / WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted validation:

```bash
python3 -m pytest -q tests/agent/test_auxiliary_client.py tests/run_agent/test_compression_feasibility.py tests/tools/test_web_tools_config.py
```

Result:

```text
204 passed
```
