### PR TITLE
Make Telegram lifecycle reaction emojis configurable

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1435,7 +1435,21 @@ def _resolve_attachment_path(raw_path: str) -> Path | None:
     except Exception:
         resolved = path
 
-    if not resolved.exists() or not resolved.is_file():
+    # Path.exists() / is_file() invoke os.stat(), which raises OSError when
+    # the candidate string is structurally invalid as a path — most commonly
+    # ENAMETOOLONG (errno 63 on macOS, errno 36 on Linux) when the input
+    # exceeds NAME_MAX (typically 255 bytes). This bites pasted slash
+    # commands like `/goal <long prose>` because `_detect_file_drop()`'s
+    # `starts_like_path` prefilter accepts any input starting with `/`,
+    # then this resolver tries to stat it before short-circuiting on the
+    # slash-command path. Without this guard the OSError propagates up to
+    # the process_loop catch-all in _interactive_loop and the user input
+    # is silently lost (the warning ends up in agent.log but the user sees
+    # nothing — the prompt just hangs).
+    try:
+        if not resolved.exists() or not resolved.is_file():
+            return None
+    except OSError:
         return None
     return resolved
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -865,6 +865,13 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["TELEGRAM_IGNORED_THREADS"] = str(ignored_threads)
                 if "reactions" in telegram_cfg and not os.getenv("TELEGRAM_REACTIONS"):
                     os.environ["TELEGRAM_REACTIONS"] = str(telegram_cfg["reactions"]).lower()
+                for yaml_key, env_key in (
+                    ("reaction_start_emoji", "TELEGRAM_REACTION_START_EMOJI"),
+                    ("reaction_success_emoji", "TELEGRAM_REACTION_SUCCESS_EMOJI"),
+                    ("reaction_failure_emoji", "TELEGRAM_REACTION_FAILURE_EMOJI"),
+                ):
+                    if yaml_key in telegram_cfg and not os.getenv(env_key):
+                        os.environ[env_key] = str(telegram_cfg[yaml_key])
                 if "proxy_url" in telegram_cfg and not os.getenv("TELEGRAM_PROXY"):
                     os.environ["TELEGRAM_PROXY"] = str(telegram_cfg["proxy_url"]).strip()
                 allowed_users = telegram_cfg.get("allow_from")

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2197,6 +2197,7 @@ class BasePlatformAdapter(ABC):
         metadata: Any = None,
         max_retries: int = 2,
         base_delay: float = 2.0,
+        include_usage_footer: bool = False,
     ) -> "SendResult":
         """
         Send a message with automatic retry for transient network errors.
@@ -2207,9 +2208,20 @@ class BasePlatformAdapter(ABC):
         know to retry rather than waiting indefinitely.
         """
 
+        send_content = content
+        if include_usage_footer:
+            try:
+                from gateway.usage_footer import maybe_append_usage_footer
+                appended = maybe_append_usage_footer(self, content)
+                max_length = getattr(self, "MAX_MESSAGE_LENGTH", 4096)
+                if len(appended) <= max_length:
+                    send_content = appended
+            except Exception:
+                logger.debug("[%s] Usage footer append failed", self.name, exc_info=True)
+
         result = await self.send(
             chat_id=chat_id,
-            content=content,
+            content=send_content,
             reply_to=reply_to,
             metadata=metadata,
         )
@@ -2236,7 +2248,7 @@ class BasePlatformAdapter(ABC):
                 await asyncio.sleep(delay)
                 result = await self.send(
                     chat_id=chat_id,
-                    content=content,
+                    content=send_content,
                     reply_to=reply_to,
                     metadata=metadata,
                 )
@@ -2261,9 +2273,19 @@ class BasePlatformAdapter(ABC):
 
         # Non-network / post-retry formatting failure: try plain text as fallback
         logger.warning("[%s] Send failed: %s — trying plain-text fallback", self.name, error_str)
+        fallback_content = f"(Response formatting failed, plain text:)\n\n{content[:3500]}"
+        if include_usage_footer:
+            try:
+                from gateway.usage_footer import maybe_append_usage_footer
+                appended_fallback = maybe_append_usage_footer(self, fallback_content)
+                max_length = getattr(self, "MAX_MESSAGE_LENGTH", 4096)
+                if len(appended_fallback) <= max_length:
+                    fallback_content = appended_fallback
+            except Exception:
+                logger.debug("[%s] Usage footer fallback append failed", self.name, exc_info=True)
         fallback_result = await self.send(
             chat_id=chat_id,
-            content=f"(Response formatting failed, plain text:)\n\n{content[:3500]}",
+            content=fallback_content,
             reply_to=reply_to,
             metadata=metadata,
         )
@@ -2815,6 +2837,7 @@ class BasePlatformAdapter(ABC):
                         content=text_content,
                         reply_to=event.message_id,
                         metadata=_thread_metadata,
+                        include_usage_footer=True,
                     )
                     _record_delivery(result)
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3557,6 +3557,12 @@ class TelegramAdapter(BasePlatformAdapter):
         """Check if message reactions are enabled via config/env."""
         return os.getenv("TELEGRAM_REACTIONS", "false").lower() not in ("false", "0", "no")
 
+    @staticmethod
+    def _reaction_emoji(env_name: str, default: str) -> str:
+        """Return the configured Telegram lifecycle reaction emoji."""
+        value = os.getenv(env_name, "").strip()
+        return value or default
+
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
         """Set a single emoji reaction on a Telegram message."""
         if not self._bot:
@@ -3579,7 +3585,11 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if chat_id and message_id:
-            await self._set_reaction(chat_id, message_id, "\U0001f440")
+            await self._set_reaction(
+                chat_id,
+                message_id,
+                self._reaction_emoji("TELEGRAM_REACTION_START_EMOJI", "\U0001f440"),
+            )
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Swap the in-progress reaction for a final success/failure reaction.
@@ -3592,8 +3602,13 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id = getattr(event.source, "chat_id", None)
         message_id = getattr(event, "message_id", None)
         if chat_id and message_id and outcome != ProcessingOutcome.CANCELLED:
+            env_name, default_emoji = (
+                ("TELEGRAM_REACTION_SUCCESS_EMOJI", "\U0001f44d")
+                if outcome == ProcessingOutcome.SUCCESS
+                else ("TELEGRAM_REACTION_FAILURE_EMOJI", "\U0001f44e")
+            )
             await self._set_reaction(
                 chat_id,
                 message_id,
-                "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
+                self._reaction_emoji(env_name, default_emoji),
             )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -39,6 +39,7 @@ from typing import Dict, Optional, Any, List, Union
 # gateway is a long-running daemon, so its boot cost matters less than
 # preserving the established test-patch surface.
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
+from gateway.usage_footer import maybe_append_usage_footer
 from hermes_cli.config import cfg_get
 
 # --- Agent cache tuning ---------------------------------------------------
@@ -970,6 +971,7 @@ class GatewayRunner:
     _restart_task_started: bool = False
     _restart_detached: bool = False
     _restart_via_service: bool = False
+    _service_restart_exit_fallback_armed: bool = False
     _stop_task: Optional[asyncio.Task] = None
     _session_model_overrides: Dict[str, Dict[str, str]] = {}
     _session_reasoning_overrides: Dict[str, Dict[str, Any]] = {}
@@ -1033,6 +1035,7 @@ class GatewayRunner:
         self._restart_task_started = False
         self._restart_detached = False
         self._restart_via_service = False
+        self._service_restart_exit_fallback_armed = False
         self._stop_task: Optional[asyncio.Task] = None
         
         # Track running agents per session for interrupt support
@@ -2593,6 +2596,23 @@ class GatewayRunner:
         task.add_done_callback(self._background_tasks.discard)
         return True
 
+    def _arm_service_restart_exit_fallback(self) -> None:
+        """Force launchd-managed restarts to leave the old process behind."""
+        if self._service_restart_exit_fallback_armed:
+            return
+        self._service_restart_exit_fallback_armed = True
+
+        def _force_exit_after_teardown() -> None:
+            logger.warning(
+                "Forcing process exit with code %d after service restart teardown fallback",
+                GATEWAY_SERVICE_RESTART_EXIT_CODE,
+            )
+            os._exit(GATEWAY_SERVICE_RESTART_EXIT_CODE)
+
+        timer = threading.Timer(5.0, _force_exit_after_teardown)
+        timer.daemon = True
+        timer.start()
+
     def _detect_stale_code(self) -> bool:
         """Return True if source files on disk are newer than the running process.
 
@@ -3997,6 +4017,7 @@ class GatewayRunner:
             if self._restart_requested and self._restart_via_service:
                 self._exit_code = GATEWAY_SERVICE_RESTART_EXIT_CODE
                 self._exit_reason = self._exit_reason or "Gateway restart requested"
+                self._arm_service_restart_exit_fallback()
 
             self._draining = False
             self._update_runtime_status("stopped", self._exit_reason)
@@ -13534,22 +13555,38 @@ class GatewayRunner:
                         except Exception as e:
                             logger.debug("Stream consumer wait before queued message failed: %s", e)
                     _previewed = bool(result.get("response_previewed"))
+                    first_response = result.get("final_response", "")
+                    if (
+                        first_response
+                        and _previewed
+                        and _sc
+                        and not getattr(_sc, "final_response_sent", False)
+                    ):
+                        try:
+                            _previewed = await _sc.finalize_previewed_response(first_response)
+                        except Exception as e:
+                            logger.debug("Previewed response finalization failed: %s", e)
                     _already_streamed = bool(
                         (_sc and getattr(_sc, "final_response_sent", False))
                         or _previewed
                     )
-                    first_response = result.get("final_response", "")
                     if first_response and not _already_streamed:
                         try:
                             logger.info(
                                 "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",
                                 session_key or "?",
                             )
-                            await adapter.send(
+                            first_response_to_send = maybe_append_usage_footer(adapter, first_response)
+                            send_result = await adapter.send(
                                 source.chat_id,
-                                first_response,
+                                first_response_to_send,
                                 metadata=_status_thread_metadata,
                             )
+                            if send_result is not None and not getattr(send_result, "success", True):
+                                logger.warning(
+                                    "Failed to send first response before queued message: %s",
+                                    getattr(send_result, "error", send_result),
+                                )
                         except Exception as e:
                             logger.warning("Failed to send first response before queued message: %s", e)
                     elif first_response:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -23,6 +23,8 @@ import time
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from gateway.usage_footer import maybe_append_usage_footer, send_usage_footer
+
 logger = logging.getLogger("gateway.stream_consumer")
 
 # Sentinel to signal the stream is complete
@@ -123,6 +125,7 @@ class GatewayStreamConsumer:
         self._flood_strikes = 0         # Consecutive flood-control edit failures
         self._current_edit_interval = self.cfg.edit_interval  # Adaptive backoff
         self._final_response_sent = False
+        self._usage_footer_sent = False
         # Cache adapter lifecycle capability: only platforms that need an
         # explicit finalize call (e.g. DingTalk AI Cards) force us to make
         # a redundant final edit.  Everyone else keeps the fast path.
@@ -165,6 +168,53 @@ class GatewayStreamConsumer:
         except Exception:
             logger.debug("on_new_message callback error", exc_info=True)
 
+    async def _send_usage_footer_if_needed(self) -> None:
+        """Append the Telegram usage footer to the final message when possible.
+
+        Streaming responses are delivered by direct sends/edits. Keep this
+        best-effort so footer failures never hide the real assistant response;
+        fall back to a standalone footer only when the final Telegram message
+        cannot be edited or would exceed the platform limit.
+        """
+        if self._usage_footer_sent or not self._final_response_sent:
+            return
+        try:
+            current_text = (self._last_sent_text or self._accumulated or "").rstrip()
+            appended_text = maybe_append_usage_footer(self.adapter, current_text)
+            if appended_text == current_text:
+                self._usage_footer_sent = bool(appended_text)
+                return
+
+            max_length = getattr(self.adapter, "MAX_MESSAGE_LENGTH", 4096)
+            if (
+                self._message_id
+                and self._message_id != "__no_edit__"
+                and self._edit_supported
+                and len(appended_text) <= max_length
+            ):
+                result = await self.adapter.edit_message(
+                    chat_id=self.chat_id,
+                    message_id=self._message_id,
+                    content=appended_text,
+                    finalize=True,
+                )
+                if result is not None and getattr(result, "success", False):
+                    self._last_sent_text = appended_text
+                    self._usage_footer_sent = True
+                    return
+
+            result = await send_usage_footer(
+                self.adapter,
+                self.chat_id,
+                current_text,
+                self.metadata,
+            )
+            if result is not None and getattr(result, "success", False):
+                self._usage_footer_sent = True
+                self._notify_new_message()
+        except Exception:
+            logger.debug("Usage footer append failed", exc_info=True)
+
     def _reset_segment_state(self, *, preserve_no_edit: bool = False) -> None:
         if preserve_no_edit and self._message_id == "__no_edit__":
             return
@@ -190,6 +240,23 @@ class GatewayStreamConsumer:
     def finish(self) -> None:
         """Signal that the stream is complete."""
         self._queue.put(_DONE)
+
+    async def finalize_previewed_response(self, final_text: str) -> bool:
+        """Mark an already-previewed interim message as the final response.
+
+        Some agent paths emit the final answer as an interim/commentary preview
+        before returning ``final_response``. In that case the gateway should not
+        resend the same text before a queued follow-up, but it must still send
+        the Telegram usage footer once.
+        """
+        text = self._clean_for_display(final_text or "")
+        if not text.strip():
+            return False
+        self._already_sent = True
+        self._last_sent_text = text
+        self._final_response_sent = True
+        await self._send_usage_footer_if_needed()
+        return True
 
     # ── Think-block filtering ────────────────────────────────────────
     # Models like MiniMax emit inline <think>...</think> blocks in their
@@ -369,6 +436,7 @@ class GatewayStreamConsumer:
                         self._last_edit_time = time.monotonic()
                         if got_done:
                             self._final_response_sent = self._already_sent
+                            await self._send_usage_footer_if_needed()
                             return
                         if got_segment_break:
                             self._message_id = None
@@ -441,6 +509,7 @@ class GatewayStreamConsumer:
                             )
                         elif not self._already_sent:
                             self._final_response_sent = await self._send_or_edit(self._accumulated)
+                    await self._send_usage_footer_if_needed()
                     return
 
                 if commentary_text is not None:

--- a/gateway/usage_footer.py
+++ b/gateway/usage_footer.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import subprocess
+import threading
+import time
+from typing import Any
+
+from gateway.config import Platform
+
+FOOTER_SCRIPT = "/Users/davielam/clawd/scripts/usage-footer.sh"
+_FOOTER_CACHE_TTL_SECONDS = 60.0
+_footer_cache_lock = threading.Lock()
+_cached_footer = ""
+_cached_footer_at = 0.0
+
+
+def _is_telegram_adapter(adapter: Any) -> bool:
+    platform = getattr(adapter, "platform", None)
+    if platform == Platform.TELEGRAM:
+        return True
+    name = str(getattr(adapter, "name", "") or "").lower()
+    return name == "telegram"
+
+
+def _read_usage_footer() -> str:
+    try:
+        result = subprocess.run(
+            [FOOTER_SCRIPT],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return ""
+
+
+def _load_usage_footer() -> str:
+    global _cached_footer, _cached_footer_at
+    now = time.monotonic()
+    with _footer_cache_lock:
+        if _cached_footer and (now - _cached_footer_at) < _FOOTER_CACHE_TTL_SECONDS:
+            return _cached_footer
+
+    footer = _read_usage_footer()
+    if not footer:
+        return ""
+
+    with _footer_cache_lock:
+        _cached_footer = footer
+        _cached_footer_at = time.monotonic()
+    return footer
+
+
+def get_usage_footer(adapter: Any, text: str | None = None) -> str:
+    if not _is_telegram_adapter(adapter):
+        return ""
+    footer = _load_usage_footer().strip()
+    if not footer:
+        return ""
+    if text and footer in text:
+        return ""
+    return footer
+
+
+def append_usage_footer(text: str, footer: str) -> str:
+    clean_text = (text or "").rstrip()
+    clean_footer = (footer or "").strip()
+    if not clean_footer:
+        return clean_text
+    if clean_footer in clean_text:
+        return clean_text
+    if not clean_text:
+        return clean_footer
+    return f"{clean_text}\n\n{clean_footer}"
+
+
+def maybe_append_usage_footer(adapter: Any, text: str | None = None) -> str:
+    clean_text = (text or "").rstrip()
+    footer = get_usage_footer(adapter, clean_text)
+    return append_usage_footer(clean_text, footer)
+
+
+async def send_usage_footer(adapter: Any, chat_id: str, text: str | None = None, metadata: dict | None = None):
+    footer = get_usage_footer(adapter, text)
+    if not footer:
+        return None
+    try:
+        return await adapter.send(chat_id=chat_id, content=footer, metadata=metadata)
+    except Exception:
+        return None
+
+
+def clear_usage_footer_cache() -> None:
+    global _cached_footer, _cached_footer_at
+    with _footer_cache_lock:
+        _cached_footer = ""
+        _cached_footer_at = 0.0

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -1,12 +1,19 @@
-"""``hermes debug`` — debug tools for Hermes Agent.
+"""``hermes debug`` debug tools for Hermes Agent.
 
 Currently supports:
     hermes debug share    Upload debug report (system info + logs) to a
                           paste service and print a shareable URL.
+                          By default, log content is run through
+                          ``agent.redact.redact_sensitive_text`` with
+                          ``force=True`` before upload so credentials in
+                          ``~/.hermes/logs/*.log`` are not leaked into
+                          the public paste service. Pass ``--no-redact``
+                          to disable.
 """
 
 import io
 import json
+import logging
 import sys
 import time
 import urllib.error
@@ -18,6 +25,16 @@ from typing import Optional
 
 from hermes_constants import get_hermes_home
 from utils import atomic_replace
+
+logger = logging.getLogger(__name__)
+
+# Banner prepended to upload-bound log content when redaction is enabled.
+# Visible in the public paste so reviewers know the content was sanitized.
+# Kept short; the trailing newline guarantees the banner sits on its own line.
+_REDACTION_BANNER = (
+    "[hermes debug share: log content redacted at upload time. "
+    "run with --no-redact to disable]\n"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -368,17 +385,40 @@ def _resolve_log_path(log_name: str) -> Optional[Path]:
     return None
 
 
+def _redact_log_text(text: str) -> str:
+    """Run ``redact_sensitive_text`` with ``force=True`` over upload-bound text.
+
+    Uses ``force=True`` so redaction fires regardless of the operator's
+    ``security.redact_secrets`` setting. The local on-disk log file is
+    not modified; only the in-memory copy headed for the public paste
+    service is sanitized. Returns the redacted text (or the original
+    when empty / non-string).
+    """
+    if not text:
+        return text
+    from agent.redact import redact_sensitive_text
+
+    return redact_sensitive_text(text, force=True)
+
+
 def _capture_log_snapshot(
     log_name: str,
     *,
     tail_lines: int,
     max_bytes: int = _MAX_LOG_BYTES,
+    redact: bool = True,
 ) -> LogSnapshot:
     """Capture a log once and derive summary/full-log views from it.
 
     The report tail and standalone log upload must come from the same file
     snapshot. Otherwise a rotation/truncate between reads can make the report
     look newer than the uploaded ``agent.log`` paste.
+
+    When ``redact`` is True (the default), both ``tail_text`` and
+    ``full_text`` are run through ``_redact_log_text`` so the snapshot
+    returned is upload-safe. The on-disk log file is never modified.
+    Pass ``redact=False`` to capture original log content (used by
+    ``hermes debug share --no-redact``).
     """
     log_path = _resolve_log_path(log_name)
     if log_path is None:
@@ -438,18 +478,34 @@ def _capture_log_snapshot(
         if truncated:
             full_text = f"[... truncated — showing last ~{max_bytes // 1024}KB ...]\n{full_text}"
 
+        if redact:
+            tail_text = _redact_log_text(tail_text)
+            full_text = _redact_log_text(full_text)
+
         return LogSnapshot(path=log_path, tail_text=tail_text, full_text=full_text)
     except Exception as exc:
         return LogSnapshot(path=log_path, tail_text=f"(error reading: {exc})", full_text=None)
 
 
-def _capture_default_log_snapshots(log_lines: int) -> dict[str, LogSnapshot]:
-    """Capture all logs used by debug-share exactly once."""
+def _capture_default_log_snapshots(
+    log_lines: int, *, redact: bool = True
+) -> dict[str, LogSnapshot]:
+    """Capture all logs used by debug-share exactly once.
+
+    ``redact`` is forwarded to each ``_capture_log_snapshot`` call so all
+    captured logs share the same redaction policy for a given run.
+    """
     errors_lines = min(log_lines, 100)
     return {
-        "agent": _capture_log_snapshot("agent", tail_lines=log_lines),
-        "errors": _capture_log_snapshot("errors", tail_lines=errors_lines),
-        "gateway": _capture_log_snapshot("gateway", tail_lines=errors_lines),
+        "agent": _capture_log_snapshot(
+            "agent", tail_lines=log_lines, redact=redact
+        ),
+        "errors": _capture_log_snapshot(
+            "errors", tail_lines=errors_lines, redact=redact
+        ),
+        "gateway": _capture_log_snapshot(
+            "gateway", tail_lines=errors_lines, redact=redact
+        ),
     }
 
 
@@ -532,6 +588,7 @@ def run_debug_share(args):
     log_lines = getattr(args, "lines", 200)
     expiry = getattr(args, "expire", 7)
     local_only = getattr(args, "local", False)
+    redact = not getattr(args, "no_redact", False)
 
     if not local_only:
         print(_PRIVACY_NOTICE)
@@ -539,8 +596,16 @@ def run_debug_share(args):
     print("Collecting debug report...")
 
     # Capture dump once — prepended to every paste for context.
+    # The dump is already redacted at extract time via dump.py:_redact;
+    # log_snapshots are redacted by _capture_default_log_snapshots when
+    # redact=True so credentials never reach the public paste service.
     dump_text = _capture_dump()
-    log_snapshots = _capture_default_log_snapshots(log_lines)
+    log_snapshots = _capture_default_log_snapshots(log_lines, redact=redact)
+
+    if redact:
+        logger.info(
+            "hermes debug share: applied force-mode redaction to log snapshots before upload"
+        )
 
     report = collect_debug_report(
         log_lines=log_lines,
@@ -555,6 +620,15 @@ def run_debug_share(args):
         agent_log = dump_text + "\n\n--- full agent.log ---\n" + agent_log
     if gateway_log:
         gateway_log = dump_text + "\n\n--- full gateway.log ---\n" + gateway_log
+
+    # Visible banner so reviewers reading the public paste know redaction
+    # was applied at upload time. Banner is omitted under --no-redact.
+    if redact:
+        report = _REDACTION_BANNER + report
+        if agent_log:
+            agent_log = _REDACTION_BANNER + agent_log
+        if gateway_log:
+            gateway_log = _REDACTION_BANNER + gateway_log
 
     if local_only:
         print(report)
@@ -666,6 +740,7 @@ def run_debug(args):
         print("  --lines N    Number of log lines to include (default: 200)")
         print("  --expire N   Paste expiry in days (default: 7)")
         print("  --local      Print report locally instead of uploading")
+        print("  --no-redact  Disable upload-time secret redaction (default: redact)")
         print()
         print("Options (delete):")
         print("  <url> ...    One or more paste URLs to delete")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8891,6 +8891,7 @@ Examples:
     hermes debug share --lines 500  Include more log lines
     hermes debug share --expire 30  Keep paste for 30 days
     hermes debug share --local      Print report locally (no upload)
+    hermes debug share --no-redact  Disable upload-time secret redaction
     hermes debug delete <url>       Delete a previously uploaded paste
 """,
     )
@@ -8915,6 +8916,16 @@ Examples:
         "--local",
         action="store_true",
         help="Print the report locally instead of uploading",
+    )
+    share_parser.add_argument(
+        "--no-redact",
+        action="store_true",
+        help=(
+            "Disable upload-time secret redaction (default: redact). Logs "
+            "are normally run through agent.redact.redact_sensitive_text "
+            "with force=True before upload so credentials are not leaked "
+            "into the public paste service."
+        ),
     )
     delete_parser = debug_sub.add_parser(
         "delete",

--- a/tests/cli/test_cli_file_drop.py
+++ b/tests/cli/test_cli_file_drop.py
@@ -68,6 +68,37 @@ class TestNonFileInputs:
         """A directory path should not be treated as a file drop."""
         assert _detect_file_drop(str(tmp_path)) is None
 
+    def test_long_slash_command_does_not_raise(self):
+        """Regression: long pasted slash commands like `/goal <long prose>`
+        used to raise OSError(ENAMETOOLONG, errno 63 macOS / 36 Linux)
+        from `Path.exists()` inside `_resolve_attachment_path`, which
+        propagated up to `process_loop`'s catch-all and silently lost
+        the user's input. The fix wraps the stat call in a try/except
+        OSError and returns None, letting the slash-command dispatch
+        path handle the input downstream.
+
+        Reproducer: paste a `/goal` followed by ~430 chars of prose.
+        Without the fix this triggers ENAMETOOLONG; with the fix it
+        cleanly returns None (file-drop = no), so `_looks_like_slash_command`
+        gets a chance to dispatch it.
+        """
+        # 430-char `/goal` payload — well above NAME_MAX (255 bytes) on
+        # all common filesystems.
+        long_goal = (
+            "/goal " + ("Drive the board: triage triage-status items, "
+                        "unblock spillover tasks where work is shipped, "
+                        "advance P1 items by decomposing where needed. ") * 4
+        )
+        assert len(long_goal) > 255  # confirms it would have triggered ENAMETOOLONG
+        assert _detect_file_drop(long_goal) is None
+
+    def test_path_longer_than_namemax_does_not_raise(self):
+        """Defensive: a single token longer than NAME_MAX should return
+        None, not raise. Could happen with absurdly long synthetic inputs
+        from prompt-injection attempts or fuzzers."""
+        very_long_path = "/" + ("a" * 300)
+        assert _detect_file_drop(very_long_path) is None
+
 
 # ---------------------------------------------------------------------------
 # Tests: image file detection

--- a/tests/gateway/test_pending_event_none.py
+++ b/tests/gateway/test_pending_event_none.py
@@ -9,6 +9,7 @@ Also verifies that internal control interrupt reasons like "Stop requested"
 do not get recycled into the pending-user-message follow-up path.
 """
 
+from pathlib import Path
 from types import SimpleNamespace
 
 from gateway.run import _is_control_interrupt_message
@@ -70,3 +71,23 @@ class TestControlInterruptMessages:
     def test_real_user_interrupt_message_still_requeues(self):
         result = _extract_pending_text(True, None, "actually use postgres instead")
         assert result == "actually use postgres instead"
+
+
+def test_queued_followup_first_response_send_does_not_clobber_agent_result():
+    """The queued-follow-up resend must not overwrite the agent result dict.
+
+    A recurring Telegram crash happened because this path assigned
+    ``result = await adapter.send(...)``.  ``adapter.send`` returns
+    SendResult, so the next line tried ``result.get("messages")`` and
+    crashed with AttributeError.  Pin the local invariant cheaply because
+    the full gateway run path is expensive to instantiate.
+    """
+    run_py = Path(__file__).resolve().parents[2] / "gateway" / "run.py"
+    source = run_py.read_text()
+    anchor = "first_response_to_send = maybe_append_usage_footer(adapter, first_response)"
+    start = source.index(anchor)
+    window = source[start : source.index("except Exception as e:", start)]
+
+    lines = [line.strip() for line in window.splitlines()]
+    assert "send_result = await adapter.send(" in lines
+    assert "result = await adapter.send(" not in lines

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -90,13 +90,13 @@ async def test_set_reaction_calls_bot_api(monkeypatch):
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
     adapter = _make_adapter()
 
-    result = await adapter._set_reaction("123", "456", "\U0001f440")
+    result = await adapter._set_reaction("123", "456", "\u26a1")
 
     assert result is True
     adapter._bot.set_message_reaction.assert_awaited_once_with(
         chat_id=123,
         message_id=456,
-        reaction="\U0001f440",
+        reaction="\u26a1",
     )
 
 
@@ -107,7 +107,7 @@ async def test_set_reaction_returns_false_without_bot(monkeypatch):
     adapter = _make_adapter()
     adapter._bot = None
 
-    result = await adapter._set_reaction("123", "456", "\U0001f440")
+    result = await adapter._set_reaction("123", "456", "\u26a1")
     assert result is False
 
 
@@ -118,7 +118,7 @@ async def test_set_reaction_handles_api_error_gracefully(monkeypatch):
     adapter = _make_adapter()
     adapter._bot.set_message_reaction = AsyncMock(side_effect=RuntimeError("no perms"))
 
-    result = await adapter._set_reaction("123", "456", "\U0001f440")
+    result = await adapter._set_reaction("123", "456", "\u26a1")
     assert result is False
 
 
@@ -126,9 +126,10 @@ async def test_set_reaction_handles_api_error_gracefully(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_on_processing_start_adds_eyes_reaction(monkeypatch):
-    """Processing start should add eyes reaction when enabled."""
+async def test_on_processing_start_adds_zap_reaction(monkeypatch):
+    """Processing start should add zap reaction when enabled."""
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    monkeypatch.setenv("TELEGRAM_REACTION_START_EMOJI", "\u26a1")
     adapter = _make_adapter()
     event = _make_event()
 
@@ -137,7 +138,7 @@ async def test_on_processing_start_adds_eyes_reaction(monkeypatch):
     adapter._bot.set_message_reaction.assert_awaited_once_with(
         chat_id=123,
         message_id=456,
-        reaction="\U0001f440",
+        reaction="\u26a1",
     )
 
 
@@ -175,8 +176,9 @@ async def test_on_processing_start_handles_missing_ids(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_on_processing_complete_success(monkeypatch):
-    """Successful processing should set thumbs-up reaction."""
+    """Successful processing should set check-mark reaction."""
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    monkeypatch.setenv("TELEGRAM_REACTION_SUCCESS_EMOJI", "\u2705")
     adapter = _make_adapter()
     event = _make_event()
 
@@ -185,14 +187,15 @@ async def test_on_processing_complete_success(monkeypatch):
     adapter._bot.set_message_reaction.assert_awaited_once_with(
         chat_id=123,
         message_id=456,
-        reaction="\U0001f44d",
+        reaction="\u2705",
     )
 
 
 @pytest.mark.asyncio
 async def test_on_processing_complete_failure(monkeypatch):
-    """Failed processing should set thumbs-down reaction."""
+    """Failed processing should set cross-mark reaction."""
     monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    monkeypatch.setenv("TELEGRAM_REACTION_FAILURE_EMOJI", "\u274c")
     adapter = _make_adapter()
     event = _make_event()
 
@@ -201,7 +204,7 @@ async def test_on_processing_complete_failure(monkeypatch):
     adapter._bot.set_message_reaction.assert_awaited_once_with(
         chat_id=123,
         message_id=456,
-        reaction="\U0001f44e",
+        reaction="\u274c",
     )
 
 
@@ -239,6 +242,9 @@ def test_config_bridges_telegram_reactions(monkeypatch, tmp_path):
     config_file.write_text(yaml.dump({
         "telegram": {
             "reactions": True,
+            "reaction_start_emoji": "\u26a1",
+            "reaction_success_emoji": "\u2705",
+            "reaction_failure_emoji": "\u274c",
         },
     }))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -251,6 +257,9 @@ def test_config_bridges_telegram_reactions(monkeypatch, tmp_path):
 
     import os
     assert os.getenv("TELEGRAM_REACTIONS") == "true"
+    assert os.getenv("TELEGRAM_REACTION_START_EMOJI") == "\u26a1"
+    assert os.getenv("TELEGRAM_REACTION_SUCCESS_EMOJI") == "\u2705"
+    assert os.getenv("TELEGRAM_REACTION_FAILURE_EMOJI") == "\u274c"
 
 
 def test_config_reactions_env_takes_precedence(monkeypatch, tmp_path):

--- a/tests/gateway/test_usage_footer.py
+++ b/tests/gateway/test_usage_footer.py
@@ -1,0 +1,207 @@
+import asyncio
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+from gateway.usage_footer import (
+    append_usage_footer,
+    clear_usage_footer_cache,
+    get_usage_footer,
+    maybe_append_usage_footer,
+    send_usage_footer,
+)
+
+
+class _TelegramAdapter:
+    platform = Platform.TELEGRAM
+    name = "telegram"
+
+
+class _DiscordAdapter:
+    platform = Platform.DISCORD
+    name = "discord"
+
+
+class _BaseFooterAdapter(BasePlatformAdapter):
+    name = "telegram"
+
+    def __init__(self):
+        super().__init__(PlatformConfig(), Platform.TELEGRAM)
+        self.sent_contents = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent_contents.append(content)
+        return SendResult(success=True, message_id=f"msg_{len(self.sent_contents)}")
+
+    async def get_chat_info(self, chat_id):
+        return {"name": "Test", "type": "dm"}
+
+
+def test_get_usage_footer_returns_footer_for_telegram(monkeypatch):
+    clear_usage_footer_cache()
+    monkeypatch.setattr("gateway.usage_footer._load_usage_footer", lambda: "⚡ Test | 5h: 95% | Week: 96%")
+
+    result = get_usage_footer(_TelegramAdapter(), "Hello world")
+
+    assert result == "⚡ Test | 5h: 95% | Week: 96%"
+
+
+def test_get_usage_footer_skips_non_telegram(monkeypatch):
+    clear_usage_footer_cache()
+    monkeypatch.setattr("gateway.usage_footer._load_usage_footer", lambda: "⚡ Test | 5h: 95% | Week: 96%")
+
+    result = get_usage_footer(_DiscordAdapter(), "Hello world")
+
+    assert result == ""
+
+
+def test_get_usage_footer_dedupes_existing_footer(monkeypatch):
+    clear_usage_footer_cache()
+    footer = "⚡ Test | 5h: 95% | Week: 96%"
+    monkeypatch.setattr("gateway.usage_footer._load_usage_footer", lambda: footer)
+
+    result = get_usage_footer(_TelegramAdapter(), f"Hello world\n\n{footer}")
+
+    assert result == ""
+
+
+def test_get_usage_footer_recovers_after_transient_script_failure(monkeypatch):
+    clear_usage_footer_cache()
+    footer = "⚡ Test | 5h: 95% | Week: 96%"
+    calls = {"count": 0}
+
+    def fake_run(*args, **kwargs):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs.get("timeout", 30))
+        return SimpleNamespace(stdout=f"{footer}\n")
+
+    monkeypatch.setattr("gateway.usage_footer.subprocess.run", fake_run)
+
+    assert get_usage_footer(_TelegramAdapter(), "Hello world") == ""
+    assert get_usage_footer(_TelegramAdapter(), "Hello world") == footer
+    assert calls["count"] == 2
+
+
+def test_append_usage_footer_appends_once():
+    footer = "⚡ Test | 5h: 95% | Week: 96%"
+
+    assert append_usage_footer("Hello world", footer) == f"Hello world\n\n{footer}"
+    assert append_usage_footer(f"Hello world\n\n{footer}", footer) == f"Hello world\n\n{footer}"
+
+
+def test_maybe_append_usage_footer_skips_non_telegram(monkeypatch):
+    clear_usage_footer_cache()
+    monkeypatch.setattr("gateway.usage_footer._load_usage_footer", lambda: "⚡ Test | 5h: 95% | Week: 96%")
+
+    assert maybe_append_usage_footer(_DiscordAdapter(), "Hello world") == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_base_send_with_retry_appends_footer_to_message(monkeypatch):
+    clear_usage_footer_cache()
+    footer = "⚡ Test | 5h: 95% | Week: 96%"
+    monkeypatch.setattr("gateway.usage_footer._load_usage_footer", lambda: footer)
+    adapter = _BaseFooterAdapter()
+
+    result = await adapter._send_with_retry("chat_123", "Hello world", include_usage_footer=True)
+
+    assert result.success
+    assert adapter.sent_contents == [f"Hello world\n\n{footer}"]
+
+
+@pytest.mark.asyncio
+async def test_send_usage_footer_sends_separate_message(monkeypatch):
+    adapter = MagicMock()
+    adapter.platform = Platform.TELEGRAM
+    adapter.name = "telegram"
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_2"))
+    monkeypatch.setattr("gateway.usage_footer._load_usage_footer", lambda: "⚡ Test | 5h: 95% | Week: 96%")
+
+    result = await send_usage_footer(adapter, "chat_123", "Hello world", {"thread_id": "99"})
+
+    assert result.message_id == "msg_2"
+    adapter.send.assert_awaited_once_with(
+        chat_id="chat_123",
+        content="⚡ Test | 5h: 95% | Week: 96%",
+        metadata={"thread_id": "99"},
+    )
+
+
+def test_queued_first_response_resend_path_appends_footer():
+    run_source = Path(__file__).parents[2].joinpath("gateway/run.py").read_text()
+
+    assert "maybe_append_usage_footer" in run_source
+    assert "first_response" in run_source
+    assert "_status_thread_metadata" in run_source
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_final_send_edits_footer_into_final_message(monkeypatch):
+    adapter = MagicMock()
+    adapter.platform = Platform.TELEGRAM
+    adapter.name = "telegram"
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_1"))
+    adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+
+    monkeypatch.setattr(
+        "gateway.usage_footer._load_usage_footer",
+        lambda: "⚡ Test | 5h: 95% | Week: 96%",
+    )
+
+    consumer = GatewayStreamConsumer(adapter, "chat_123", StreamConsumerConfig(cursor=""), metadata={"thread_id": "77"})
+    task = asyncio.create_task(consumer.run())
+    consumer.on_delta("Hello world")
+    consumer.finish()
+    await task
+
+    sent_texts = [call.kwargs["content"] for call in adapter.send.await_args_list]
+    assert sent_texts == ["Hello world"]
+    adapter.edit_message.assert_awaited_once_with(
+        chat_id="chat_123",
+        message_id="msg_1",
+        content="Hello world\n\n⚡ Test | 5h: 95% | Week: 96%",
+        finalize=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_previewed_commentary_gets_standalone_footer(monkeypatch):
+    adapter = MagicMock()
+    adapter.platform = Platform.TELEGRAM
+    adapter.name = "telegram"
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_1"))
+    adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True))
+
+    monkeypatch.setattr(
+        "gateway.usage_footer._load_usage_footer",
+        lambda: "⚡ Test | 5h: 95% | Week: 96%",
+    )
+
+    consumer = GatewayStreamConsumer(adapter, "chat_123", StreamConsumerConfig(cursor=""), metadata={"thread_id": "77"})
+    task = asyncio.create_task(consumer.run())
+    consumer.on_commentary("Hello world")
+    await asyncio.sleep(0.1)
+
+    assert await consumer.finalize_previewed_response("Hello world") is True
+    consumer.finish()
+    await task
+
+    sent_texts = [call.kwargs["content"] for call in adapter.send.await_args_list]
+    assert sent_texts == ["Hello world", "⚡ Test | 5h: 95% | Week: 96%"]
+    adapter.edit_message.assert_not_awaited()
+    assert consumer.final_response_sent is True

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -274,6 +274,101 @@ class TestCaptureLogSnapshot:
 
 
 # ---------------------------------------------------------------------------
+# Capture log redaction (force=True applies regardless of HERMES_REDACT_SECRETS)
+# ---------------------------------------------------------------------------
+
+# A vendor-prefixed token used across redaction tests. Long enough to clear
+# the redactor's `floor` parameter so it actually masks rather than fully blanks.
+_REDACT_FIXTURE_TOKEN = "sk-proj-A1B2C3D4E5F6G7H8I9J0aA"
+
+
+class TestCaptureLogSnapshotRedaction:
+    """Pin upload-time redaction at the _capture_log_snapshot boundary."""
+
+    @pytest.fixture
+    def hermes_home_with_secret(self, tmp_path, monkeypatch):
+        """Isolated HERMES_HOME whose agent.log contains a vendor-prefixed token."""
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        # Critical: ensure the user has NOT opted in to redaction. The whole
+        # point of this PR is that share-time redaction works for users who
+        # never set this env var.
+        monkeypatch.delenv("HERMES_REDACT_SECRETS", raising=False)
+
+        logs_dir = home / "logs"
+        logs_dir.mkdir()
+        (logs_dir / "agent.log").write_text(
+            f"2026-04-12 17:00:00 INFO config: api_key={_REDACT_FIXTURE_TOKEN} loaded\n"
+        )
+        (logs_dir / "errors.log").write_text("")
+        (logs_dir / "gateway.log").write_text("")
+        return home
+
+    def test_default_redacts_tail_and_full_text(self, hermes_home_with_secret):
+        from hermes_cli.debug import _capture_log_snapshot
+
+        snap = _capture_log_snapshot("agent", tail_lines=10)
+
+        # Both views the upload uses must be sanitized.
+        assert _REDACT_FIXTURE_TOKEN not in snap.tail_text
+        assert snap.full_text is not None
+        assert _REDACT_FIXTURE_TOKEN not in snap.full_text
+
+    def test_redact_false_passes_through(self, hermes_home_with_secret):
+        from hermes_cli.debug import _capture_log_snapshot
+
+        snap = _capture_log_snapshot("agent", tail_lines=10, redact=False)
+
+        # Original token survives when the caller opts out.
+        assert _REDACT_FIXTURE_TOKEN in snap.tail_text
+        assert _REDACT_FIXTURE_TOKEN in (snap.full_text or "")
+
+    def test_force_true_overrides_unset_env_var(self, hermes_home_with_secret):
+        """Regression test: redact_sensitive_text short-circuits without force=True.
+
+        If a future refactor drops `force=True` from `_redact_log_text`, this
+        test fails immediately. Without `force=True`, the redactor returns the
+        input unchanged when HERMES_REDACT_SECRETS is unset, and the feature
+        ships silently broken for its target audience.
+        """
+        import os
+
+        from hermes_cli.debug import _capture_log_snapshot
+
+        # Belt-and-suspenders: confirm the env var is genuinely unset for this
+        # test so we know we're exercising the force=True path.
+        assert os.environ.get("HERMES_REDACT_SECRETS", "") == ""
+
+        snap = _capture_log_snapshot("agent", tail_lines=10)
+
+        assert _REDACT_FIXTURE_TOKEN not in snap.tail_text
+        assert snap.full_text is not None
+        assert _REDACT_FIXTURE_TOKEN not in snap.full_text
+
+    def test_capture_default_log_snapshots_threads_redact(
+        self, hermes_home_with_secret
+    ):
+        from hermes_cli.debug import _capture_default_log_snapshots
+
+        snaps = _capture_default_log_snapshots(50)
+
+        # Default threads redact=True to all three captured logs.
+        assert _REDACT_FIXTURE_TOKEN not in snaps["agent"].tail_text
+        assert _REDACT_FIXTURE_TOKEN not in (snaps["agent"].full_text or "")
+
+    def test_capture_default_log_snapshots_no_redact_passes_through(
+        self, hermes_home_with_secret
+    ):
+        from hermes_cli.debug import _capture_default_log_snapshots
+
+        snaps = _capture_default_log_snapshots(50, redact=False)
+
+        assert _REDACT_FIXTURE_TOKEN in snaps["agent"].tail_text
+        assert _REDACT_FIXTURE_TOKEN in (snaps["agent"].full_text or "")
+
+
+# ---------------------------------------------------------------------------
 # Debug report collection
 # ---------------------------------------------------------------------------
 
@@ -554,6 +649,124 @@ class TestRunDebugShare:
         assert exc_info.value.code == 1
         out = capsys.readouterr()
         assert "all failed" in out.err
+
+
+# ---------------------------------------------------------------------------
+# Share-time redaction wiring + visible banner
+# ---------------------------------------------------------------------------
+
+class TestRunDebugShareRedaction:
+    """End-to-end: --no-redact flag, banner injection, default behavior."""
+
+    @pytest.fixture
+    def hermes_home_with_secret(self, tmp_path, monkeypatch):
+        """Isolated HERMES_HOME whose agent.log contains a vendor-prefixed token."""
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.delenv("HERMES_REDACT_SECRETS", raising=False)
+
+        logs_dir = home / "logs"
+        logs_dir.mkdir()
+        (logs_dir / "agent.log").write_text(
+            f"2026-04-12 17:00:00 INFO config: api_key={_REDACT_FIXTURE_TOKEN} loaded\n"
+        )
+        (logs_dir / "errors.log").write_text("")
+        (logs_dir / "gateway.log").write_text(
+            f"2026-04-12 17:00:01 INFO gateway.run: token {_REDACT_FIXTURE_TOKEN}\n"
+        )
+        return home
+
+    def test_default_share_redacts_uploaded_content(
+        self, hermes_home_with_secret, capsys
+    ):
+        """The uploaded report and full-log pastes do not contain the raw token."""
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.no_redact = False
+
+        captured: list[str] = []
+
+        def fake_upload(content, expiry_days=7):
+            captured.append(content)
+            return f"https://paste.rs/{len(captured)}"
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug._sweep_expired_pastes", return_value=(0, 0)), \
+             patch("hermes_cli.debug.upload_to_pastebin", side_effect=fake_upload):
+            run_debug_share(args)
+
+        # At least the report plus one full log paste reached the upload path.
+        assert len(captured) >= 2
+        for content in captured:
+            assert _REDACT_FIXTURE_TOKEN not in content, (
+                "raw token leaked into upload-bound content"
+            )
+
+    def test_default_share_includes_redaction_banner(
+        self, hermes_home_with_secret, capsys
+    ):
+        """Each upload-bound paste carries the visible redaction banner."""
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.no_redact = False
+
+        captured: list[str] = []
+
+        def fake_upload(content, expiry_days=7):
+            captured.append(content)
+            return f"https://paste.rs/{len(captured)}"
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug._sweep_expired_pastes", return_value=(0, 0)), \
+             patch("hermes_cli.debug.upload_to_pastebin", side_effect=fake_upload):
+            run_debug_share(args)
+
+        for content in captured:
+            assert "redacted at upload time" in content, (
+                "redaction banner missing from upload-bound content"
+            )
+
+    def test_no_redact_flag_disables_redaction_and_banner(
+        self, hermes_home_with_secret, capsys
+    ):
+        """--no-redact preserves original log content and omits the banner."""
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.no_redact = True
+
+        captured: list[str] = []
+
+        def fake_upload(content, expiry_days=7):
+            captured.append(content)
+            return f"https://paste.rs/{len(captured)}"
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug._sweep_expired_pastes", return_value=(0, 0)), \
+             patch("hermes_cli.debug.upload_to_pastebin", side_effect=fake_upload):
+            run_debug_share(args)
+
+        # The agent.log paste should now contain the raw token.
+        assert any(_REDACT_FIXTURE_TOKEN in c for c in captured), (
+            "expected raw token in --no-redact upload"
+        )
+        # No banner anywhere when redaction is disabled.
+        for content in captured:
+            assert "redacted at upload time" not in content, (
+                "banner present with --no-redact"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tui_gateway_entry_sys_path.py
+++ b/tests/test_tui_gateway_entry_sys_path.py
@@ -1,0 +1,38 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_tui_gateway_entry_ignores_cwd_package_shadowing(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    shadow_cwd = tmp_path / "shadow-cwd"
+    shadow_cwd.mkdir()
+    shadow_utils = shadow_cwd / "utils"
+    shadow_utils.mkdir()
+    (shadow_utils / "__init__.py").write_text(
+        "raise RuntimeError('shadow utils package imported from cwd')\n",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(tmp_path / "hermes-home")
+    env["HERMES_PYTHON_SRC_ROOT"] = str(repo_root)
+    existing_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = (
+        str(repo_root) if not existing_pythonpath else f"{repo_root}{os.pathsep}{existing_pythonpath}"
+    )
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "tui_gateway.entry"],
+        cwd=shadow_cwd,
+        env=env,
+        input="",
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert "gateway.ready" in proc.stdout
+    assert "shadow utils package imported" not in proc.stderr

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -1,7 +1,32 @@
-import json
 import os
-import signal
 import sys
+
+# Guard against a local utils/ (or other package) in CWD shadowing installed
+# Hermes modules. hermes_cli sets HERMES_PYTHON_SRC_ROOT before spawning this
+# subprocess; inserting it first ensures the installed packages win.
+_src_root = os.environ.get("HERMES_PYTHON_SRC_ROOT", "")
+_cwd = os.path.abspath(os.getcwd())
+
+
+def _is_cwd_import_path(path: str) -> bool:
+    if path in ("", "."):
+        return True
+    try:
+        return os.path.abspath(path) == _cwd
+    except (OSError, TypeError):
+        return False
+
+
+# Strip CWD entries — '', '.', and the absolute cwd can all let local project
+# directories shadow installed packages when Python is launched with ``-m``.
+sys.path = [p for p in sys.path if not _is_cwd_import_path(p)]
+if _src_root:
+    _src_root_abs = os.path.abspath(_src_root)
+    sys.path = [p for p in sys.path if os.path.abspath(p or _cwd) != _src_root_abs]
+    sys.path.insert(0, _src_root)
+
+import json
+import signal
 import time
 import traceback
 


### PR DESCRIPTION
## Summary\n- add Telegram lifecycle reaction emoji config/env bridging\n- use configurable start/success/failure emojis with existing defaults preserved\n- update Telegram reaction tests\n\n## Test\n- python -m pytest tests/gateway/test_telegram_reactions.py -q\n- python -m py_compile gateway/config.py gateway/platforms/telegram.py