### PR TITLE
fix: avoid stale dashboard TUI rebuild loop

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -971,7 +971,13 @@ def _tui_build_needed(tui_dir: Path) -> bool:
 
 def _hermes_ink_bundle_stale(tui_dir: Path) -> bool:
     ink_root = tui_dir / "packages" / "hermes-ink"
-    bundle = ink_root / "dist" / "ink-bundle.js"
+    # The package build script (`esbuild src/entry-exports.ts ... --outdir=dist`)
+    # emits dist/entry-exports.js.  Older builds also left an ink-bundle.js
+    # compatibility artifact behind, but the build script does not refresh it.
+    # Checking the stale compatibility file makes every TUI launch rebuild the
+    # bundle, which blocks Dashboard /api/pty long enough for the WebSocket
+    # handshake to time out and the WebUI to print "[session ended]".
+    bundle = ink_root / "dist" / "entry-exports.js"
     if not bundle.exists():
         return True
     bm = bundle.stat().st_mtime

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -26,7 +26,7 @@ def _touch_tui_entry(root: Path) -> None:
 
 
 def _touch_ink_bundle(root: Path) -> None:
-    bundle = root / "packages" / "hermes-ink" / "dist" / "ink-bundle.js"
+    bundle = root / "packages" / "hermes-ink" / "dist" / "entry-exports.js"
     bundle.parent.mkdir(parents=True, exist_ok=True)
     bundle.write_text("export {}")
 
@@ -134,5 +134,25 @@ def test_build_not_needed_when_entry_and_ink_bundle_present(tmp_path: Path, main
     _touch_tui_entry(tmp_path)
     _touch_ink(tmp_path)
     _touch_ink_bundle(tmp_path)
+
+    assert main_mod._tui_build_needed(tmp_path) is False
+
+
+def test_build_uses_current_hermes_ink_output_not_legacy_bundle(tmp_path: Path, main_mod) -> None:
+    """The hermes-ink build emits dist/entry-exports.js.
+
+    Older installs may still have a stale dist/ink-bundle.js compatibility
+    artifact, but npm run build --prefix packages/hermes-ink no longer refreshes
+    it.  The stale check must follow the actual build output or Dashboard Chat
+    rebuilds the TUI on every /api/pty connection and can time out before the
+    WebSocket handshake completes.
+    """
+    _touch_tui_entry(tmp_path)
+    _touch_ink(tmp_path)
+    _touch_ink_bundle(tmp_path)
+
+    legacy = tmp_path / "packages" / "hermes-ink" / "dist" / "ink-bundle.js"
+    legacy.write_text("legacy")
+    os.utime(legacy, (100, 100))
 
     assert main_mod._tui_build_needed(tmp_path) is False


### PR DESCRIPTION
## Summary

Fix the Dashboard Chat TUI stale check to follow the hermes-ink build output that is actually refreshed by the build script.

`ui-tui/packages/hermes-ink/package.json` builds `src/entry-exports.ts` into `dist/entry-exports.js`, but `_hermes_ink_bundle_stale()` was checking the legacy `dist/ink-bundle.js` compatibility artifact. Since that legacy file is not refreshed by `npm run build --prefix packages/hermes-ink`, installs that still have an old `ink-bundle.js` can repeatedly consider hermes-ink stale.

That makes Dashboard Chat synchronously rebuild the TUI during `/api/pty` startup, which can block long enough for the browser's WebSocket handshake to time out and render `[session ended]`.

This PR changes the stale check to use `dist/entry-exports.js` and adds a regression test proving an old/missing legacy `ink-bundle.js` no longer forces a rebuild when the current output is fresh.

Related: #20739

## Test Plan

- [x] `scripts/run_tests.sh tests/hermes_cli/test_tui_npm_install.py -q`

Local reproduction/verification on an affected install:

- Before: `_resolve_chat_argv()` took ~32s and `/api/pty` WebSocket opening handshake timed out.
- After: `_resolve_chat_argv()` took ~0.03s and `/api/pty` opened normally.
