### PR TITLE
feat: add Pinecone memory client and document models

### DIFF
--- a/agent/memory_documents.py
+++ b/agent/memory_documents.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, List, Sequence
+
+_HEADER_RE = re.compile(r"^(#{1,6})\s+(.*?)\s*$")
+_WHITESPACE_RE = re.compile(r"\s+")
+_DEFAULT_MAX_CHARS = 1200
+_DEFAULT_MIN_CHARS = 400
+
+
+@dataclass(frozen=True)
+class MemorySourceRef:
+    source_kind: str
+    source_id: str
+    source_path: str = ""
+
+
+@dataclass(frozen=True)
+class MemoryChunk:
+    id: str
+    document_id: str
+    chunk_index: int
+    text: str
+    header_path: tuple[str, ...]
+    memory_type: str
+    scope: str
+    source_kind: str
+    source_id: str
+    source_path: str
+    created_at: str
+    updated_at: str
+    freshness_hint: str = "stable"
+    confidence: float = 1.0
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    canonical: bool = True
+
+    def metadata(self) -> dict[str, object]:
+        return {
+            "document_id": self.document_id,
+            "chunk_index": self.chunk_index,
+            "header_path": list(self.header_path),
+            "memory_type": self.memory_type,
+            "scope": self.scope,
+            "source_kind": self.source_kind,
+            "source_id": self.source_id,
+            "source_path": self.source_path,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "freshness_hint": self.freshness_hint,
+            "confidence": self.confidence,
+            "tags": list(self.tags),
+            "canonical": self.canonical,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryDocument:
+    source: MemorySourceRef
+    text: str
+    memory_type: str
+    scope: str
+    created_at: str
+    updated_at: str
+    freshness_hint: str = "stable"
+    confidence: float = 1.0
+    tags: tuple[str, ...] = field(default_factory=tuple)
+    canonical: bool = True
+    title: str = ""
+
+    @property
+    def id(self) -> str:
+        payload = "\n".join(
+            [
+                self.source.source_kind,
+                self.source.source_id,
+                self.source.source_path,
+                self.memory_type,
+                self.scope,
+                self.title,
+                _normalize_text(self.text),
+            ]
+        )
+        return _stable_id("doc", payload)
+
+    def chunk(self, *, max_chars: int = _DEFAULT_MAX_CHARS, min_chars: int = _DEFAULT_MIN_CHARS) -> list[MemoryChunk]:
+        sections = _split_sections(self.text)
+        assembled: list[tuple[tuple[str, ...], str]] = []
+        buffer_parts: list[str] = []
+        buffer_headers: tuple[str, ...] = tuple()
+        for headers, text in sections:
+            parts = _split_bounded(text, max_chars=max_chars)
+            for part in parts:
+                part = part.strip()
+                if not part:
+                    continue
+                if not buffer_parts:
+                    buffer_headers = headers
+                    buffer_parts = [part]
+                    continue
+                if headers != buffer_headers:
+                    assembled.append((buffer_headers, "\n\n".join(buffer_parts).strip()))
+                    buffer_headers = headers
+                    buffer_parts = [part]
+                    continue
+                current_buffer = "\n\n".join(buffer_parts)
+                candidate = "\n\n".join(buffer_parts + [part])
+                if len(candidate) <= max_chars:
+                    buffer_parts.append(part)
+                    continue
+                assembled.append((buffer_headers, current_buffer.strip()))
+                buffer_headers = headers
+                buffer_parts = [part]
+        if buffer_parts:
+            assembled.append((buffer_headers, "\n\n".join(buffer_parts).strip()))
+        assembled = _merge_small_chunks(assembled, max_chars=max_chars, min_chars=min_chars)
+
+        return [
+            MemoryChunk(
+                id=_chunk_id(self.id, headers, index, text),
+                document_id=self.id,
+                chunk_index=index,
+                text=text,
+                header_path=headers,
+                memory_type=self.memory_type,
+                scope=self.scope,
+                source_kind=self.source.source_kind,
+                source_id=self.source.source_id,
+                source_path=self.source.source_path,
+                created_at=self.created_at,
+                updated_at=self.updated_at,
+                freshness_hint=self.freshness_hint,
+                confidence=self.confidence,
+                tags=self.tags,
+                canonical=self.canonical,
+            )
+            for index, (headers, text) in enumerate(assembled)
+        ]
+
+
+def build_memory_document(
+    *,
+    text: str,
+    source_kind: str,
+    source_id: str,
+    source_path: str = "",
+    memory_type: str,
+    scope: str,
+    created_at: str | None = None,
+    updated_at: str | None = None,
+    freshness_hint: str = "stable",
+    confidence: float = 1.0,
+    tags: Sequence[str] | None = None,
+    canonical: bool = True,
+    title: str = "",
+) -> MemoryDocument:
+    now = _iso_now()
+    return MemoryDocument(
+        source=MemorySourceRef(source_kind=source_kind, source_id=source_id, source_path=source_path),
+        text=text,
+        memory_type=memory_type,
+        scope=scope,
+        created_at=created_at or now,
+        updated_at=updated_at or created_at or now,
+        freshness_hint=freshness_hint,
+        confidence=confidence,
+        tags=tuple(tags or ()),
+        canonical=canonical,
+        title=title,
+    )
+
+
+def _split_sections(text: str) -> list[tuple[tuple[str, ...], str]]:
+    headers: list[str] = []
+    sections: list[tuple[tuple[str, ...], str]] = []
+    body: list[str] = []
+
+    def flush() -> None:
+        content = "\n".join(body).strip()
+        if content:
+            sections.append((tuple(headers), content))
+        body.clear()
+
+    for raw_line in text.splitlines():
+        match = _HEADER_RE.match(raw_line)
+        if match:
+            flush()
+            level = len(match.group(1))
+            title = match.group(2).strip()
+            headers[:] = headers[: level - 1]
+            headers.append(title)
+            continue
+        body.append(raw_line)
+    flush()
+    if sections:
+        return sections
+    stripped = text.strip()
+    if headers and not body:
+        return [(tuple(headers), " ".join(headers).strip())]
+    return [(tuple(), stripped)]
+
+
+def _split_bounded(text: str, *, max_chars: int) -> list[str]:
+    paragraphs = [p.strip() for p in re.split(r"\n\s*\n", text) if p.strip()]
+    if not paragraphs:
+        return []
+    chunks: list[str] = []
+    current = ""
+    for paragraph in paragraphs:
+        candidate = paragraph if not current else f"{current}\n\n{paragraph}"
+        if len(candidate) <= max_chars:
+            current = candidate
+            continue
+        if current:
+            chunks.append(current)
+            current = ""
+        if len(paragraph) <= max_chars:
+            current = paragraph
+            continue
+        chunks.extend(_split_long_paragraph(paragraph, max_chars=max_chars))
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _split_long_paragraph(text: str, *, max_chars: int) -> list[str]:
+    words = text.split()
+    if not words:
+        return []
+    chunks: list[str] = []
+    current = words[0]
+    for word in words[1:]:
+        candidate = f"{current} {word}"
+        if len(candidate) <= max_chars:
+            current = candidate
+        else:
+            chunks.append(current)
+            current = word
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _merge_small_chunks(
+    chunks: list[tuple[tuple[str, ...], str]], *, max_chars: int, min_chars: int
+) -> list[tuple[tuple[str, ...], str]]:
+    if min_chars <= 0 or len(chunks) < 2:
+        return chunks
+    merged: list[tuple[tuple[str, ...], str]] = []
+    for headers, text in chunks:
+        text = text.strip()
+        if not text:
+            continue
+        if merged:
+            previous_headers, previous_text = merged[-1]
+            candidate = f"{previous_text}\n\n{text}"
+            if headers == previous_headers and (
+                len(previous_text) < min_chars or len(text) < min_chars
+            ) and len(candidate) <= max_chars:
+                merged[-1] = (headers, candidate)
+                continue
+        merged.append((headers, text))
+    return merged
+
+
+def _chunk_id(document_id: str, headers: Iterable[str], chunk_index: int, text: str) -> str:
+    header_key = " > ".join(headers)
+    payload = f"{document_id}\n{chunk_index}\n{header_key}\n{_normalize_text(text)}"
+    return _stable_id("chunk", payload)
+
+
+def _stable_id(prefix: str, payload: str) -> str:
+    return f"{prefix}_{hashlib.sha256(payload.encode('utf-8')).hexdigest()[:24]}"
+
+
+def _normalize_text(text: str) -> str:
+    return _WHITESPACE_RE.sub(" ", text.strip())
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/agent/pinecone_memory.py
+++ b/agent/pinecone_memory.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable
+
+logger = logging.getLogger(__name__)
+
+
+class PineconeMemoryClient:
+    """Minimal Pinecone wrapper with fail-open behavior and normalized records."""
+
+    def __init__(
+        self,
+        *,
+        config: dict[str, Any] | None = None,
+        pinecone_module: Any | None = None,
+    ) -> None:
+        self._config = config if config is not None else _load_pinecone_config()
+        self._pinecone_module = pinecone_module
+        self._index = None
+
+    def is_configured(self) -> bool:
+        return bool(self._config.get("api_key") and (self._config.get("index_name") or self._config.get("index_host")))
+
+    def upsert_records(self, records: Iterable[dict[str, Any]], *, namespace: str | None = None) -> int:
+        normalized = [self._normalize_record(record) for record in records]
+        if not normalized:
+            return 0
+        if not self.is_configured():
+            return self._on_unavailable("upsert_records", default=0, reason="missing Pinecone configuration")
+        try:
+            index = self._get_index()
+            kwargs = {"vectors": normalized}
+            effective_namespace = namespace or self._config.get("namespace")
+            if effective_namespace:
+                kwargs["namespace"] = effective_namespace
+            index.upsert(**kwargs)
+            return len(normalized)
+        except Exception as exc:
+            return self._handle_error("upsert_records", exc, default=0)
+
+    def query(
+        self,
+        *,
+        vector: list[float],
+        top_k: int = 5,
+        namespace: str | None = None,
+        filter: dict[str, Any] | None = None,
+        include_values: bool = True,
+        include_metadata: bool = True,
+    ) -> list[dict[str, Any]]:
+        if not self.is_configured():
+            return self._on_unavailable("query", default=[], reason="missing Pinecone configuration")
+        try:
+            index = self._get_index()
+            kwargs: dict[str, Any] = {
+                "vector": vector,
+                "top_k": top_k,
+                "include_values": include_values,
+                "include_metadata": include_metadata,
+            }
+            effective_namespace = namespace or self._config.get("namespace")
+            if effective_namespace:
+                kwargs["namespace"] = effective_namespace
+            if filter:
+                kwargs["filter"] = filter
+            response = index.query(**kwargs)
+            matches = getattr(response, "matches", None)
+            if matches is None and isinstance(response, dict):
+                matches = response.get("matches", [])
+            return [self._normalize_match(match) for match in (matches or [])]
+        except Exception as exc:
+            return self._handle_error("query", exc, default=[])
+
+    def delete_by_source(
+        self,
+        *,
+        source_kind: str,
+        source_id: str,
+        source_path: str | None = None,
+        namespace: str | None = None,
+    ) -> bool:
+        if not self.is_configured():
+            return self._on_unavailable("delete_by_source", default=False, reason="missing Pinecone configuration")
+        filter_payload: dict[str, Any] = {
+            "source_kind": {"$eq": source_kind},
+            "source_id": {"$eq": source_id},
+        }
+        if source_path:
+            filter_payload["source_path"] = {"$eq": source_path}
+        try:
+            index = self._get_index()
+            kwargs: dict[str, Any] = {"filter": filter_payload}
+            effective_namespace = namespace or self._config.get("namespace")
+            if effective_namespace:
+                kwargs["namespace"] = effective_namespace
+            index.delete(**kwargs)
+            return True
+        except Exception as exc:
+            return self._handle_error("delete_by_source", exc, default=False)
+
+    def _get_index(self) -> Any:
+        if self._index is not None:
+            return self._index
+        module = self._pinecone_module
+        if module is None:
+            import pinecone as module  # type: ignore[import-not-found]
+        api_key = self._config.get("api_key")
+        client = module.Pinecone(api_key=api_key)
+        index_host = self._config.get("index_host")
+        index_name = self._config.get("index_name")
+        self._index = client.Index(host=index_host) if index_host else client.Index(index_name)
+        return self._index
+
+    def _normalize_record(self, record: dict[str, Any]) -> dict[str, Any]:
+        metadata = dict(record.get("metadata") or {})
+        normalized = {
+            "id": str(record["id"]),
+            "values": list(record["values"]),
+            "metadata": metadata,
+        }
+        return normalized
+
+    def _normalize_match(self, match: Any) -> dict[str, Any]:
+        if hasattr(match, "to_dict"):
+            match = match.to_dict()
+        elif not isinstance(match, dict):
+            match = {
+                "id": getattr(match, "id", ""),
+                "values": getattr(match, "values", []) or [],
+                "metadata": getattr(match, "metadata", {}) or {},
+                "score": getattr(match, "score", None),
+            }
+        normalized = {
+            "id": str(match.get("id", "")),
+            "values": list(match.get("values") or []),
+            "metadata": dict(match.get("metadata") or {}),
+        }
+        if "score" in match and match.get("score") is not None:
+            normalized["score"] = match.get("score")
+        return normalized
+
+    def _handle_error(self, operation: str, exc: Exception, *, default: Any) -> Any:
+        if self._config.get("fail_open"):
+            logger.warning("Pinecone memory %s failed; fail-open enabled: %s", operation, exc)
+            return default
+        raise exc
+
+    def _on_unavailable(self, operation: str, *, default: Any, reason: str) -> Any:
+        if self._config.get("fail_open"):
+            logger.warning("Pinecone memory %s skipped; fail-open enabled: %s", operation, reason)
+            return default
+        raise RuntimeError(f"Pinecone memory {operation} unavailable: {reason}")
+
+
+def _load_pinecone_config() -> dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        root = load_config() or {}
+    except Exception as exc:
+        logger.debug("Failed to load Pinecone config: %s", exc)
+        root = {}
+    pinecone_cfg = root.get("pinecone") or {}
+    if not isinstance(pinecone_cfg, dict):
+        pinecone_cfg = {}
+    return {
+        "api_key": pinecone_cfg.get("api_key") or root.get("pinecone_api_key"),
+        "index_name": pinecone_cfg.get("index_name") or root.get("pinecone_index_name"),
+        "index_host": pinecone_cfg.get("index_host") or root.get("pinecone_index_host"),
+        "namespace": pinecone_cfg.get("namespace") or root.get("pinecone_namespace"),
+        "fail_open": bool(root.get("pinecone_fail_open", pinecone_cfg.get("fail_open", False))),
+    }

--- a/tests/agent/test_memory_documents.py
+++ b/tests/agent/test_memory_documents.py
@@ -1,0 +1,120 @@
+from agent.memory_documents import build_memory_document
+
+
+def test_chunking_is_header_aware_and_stable_ids():
+    text = """# Overview
+Intro paragraph about the document.
+
+## Details
+This is the first details paragraph.
+
+This is the second details paragraph.
+
+# Appendix
+Final note.
+"""
+    doc = build_memory_document(
+        text=text,
+        source_kind="note",
+        source_id="123",
+        source_path="notes/demo.md",
+        memory_type="reference",
+        scope="workspace",
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:00:00Z",
+        tags=["demo", "docs"],
+    )
+
+    first = doc.chunk(max_chars=90, min_chars=20)
+    second = doc.chunk(max_chars=90, min_chars=20)
+
+    assert [chunk.id for chunk in first] == [chunk.id for chunk in second]
+    assert first[0].header_path == ("Overview",)
+    assert any(chunk.header_path == ("Overview", "Details") for chunk in first)
+    assert first[-1].header_path == ("Appendix",)
+
+
+def test_chunk_metadata_contains_required_fields():
+    doc = build_memory_document(
+        text="Short body",
+        source_kind="file",
+        source_id="abc",
+        source_path="docs/a.txt",
+        memory_type="summary",
+        scope="project",
+        created_at="2026-02-01T00:00:00Z",
+        updated_at="2026-02-02T00:00:00Z",
+        freshness_hint="recent",
+        confidence=0.75,
+        tags=["tag1"],
+        canonical=False,
+    )
+
+    chunk = doc.chunk()[0]
+
+    assert chunk.memory_type == "summary"
+    assert chunk.scope == "project"
+    assert chunk.source_kind == "file"
+    assert chunk.source_id == "abc"
+    assert chunk.source_path == "docs/a.txt"
+    assert chunk.created_at == "2026-02-01T00:00:00Z"
+    assert chunk.updated_at == "2026-02-02T00:00:00Z"
+    assert chunk.freshness_hint == "recent"
+    assert chunk.confidence == 0.75
+    assert chunk.tags == ("tag1",)
+    assert chunk.canonical is False
+
+    metadata = chunk.metadata()
+    for field in (
+        "memory_type",
+        "scope",
+        "source_kind",
+        "source_id",
+        "source_path",
+        "created_at",
+        "updated_at",
+        "freshness_hint",
+        "confidence",
+        "tags",
+        "canonical",
+    ):
+        assert field in metadata
+
+
+def test_chunking_respects_max_chars_even_when_buffer_is_small():
+    paragraph_a = "A" * 300
+    paragraph_b = "B" * 300
+    doc = build_memory_document(
+        text=f"# Section\n{paragraph_a}\n\n{paragraph_b}",
+        source_kind="note",
+        source_id="small-buffer",
+        source_path="notes/demo.md",
+        memory_type="reference",
+        scope="workspace",
+        created_at="2026-03-01T00:00:00Z",
+        updated_at="2026-03-01T00:00:00Z",
+    )
+
+    chunks = doc.chunk(max_chars=500, min_chars=400)
+
+    assert len(chunks) == 2
+    assert all(len(chunk.text) <= 500 for chunk in chunks)
+
+
+def test_header_only_documents_keep_header_path():
+    doc = build_memory_document(
+        text="# Title",
+        source_kind="note",
+        source_id="header-only",
+        source_path="notes/title.md",
+        memory_type="reference",
+        scope="workspace",
+        created_at="2026-03-01T00:00:00Z",
+        updated_at="2026-03-01T00:00:00Z",
+    )
+
+    chunks = doc.chunk()
+
+    assert len(chunks) == 1
+    assert chunks[0].header_path == ("Title",)
+    assert chunks[0].text == "Title"

--- a/tests/agent/test_pinecone_memory.py
+++ b/tests/agent/test_pinecone_memory.py
@@ -1,0 +1,153 @@
+import logging
+
+import pytest
+
+from agent.pinecone_memory import PineconeMemoryClient
+
+
+class FakeIndex:
+    def __init__(self):
+        self.upserts = []
+        self.queries = []
+        self.deletes = []
+        self.matches = []
+        self.raise_upsert = None
+
+    def upsert(self, **kwargs):
+        if self.raise_upsert:
+            raise self.raise_upsert
+        self.upserts.append(kwargs)
+
+    def query(self, **kwargs):
+        self.queries.append(kwargs)
+        return {"matches": self.matches}
+
+    def delete(self, **kwargs):
+        self.deletes.append(kwargs)
+
+
+class FakePineconeModule:
+    def __init__(self, index):
+        self.index = index
+        self.calls = []
+
+    def Pinecone(self, api_key):
+        self.calls.append(api_key)
+        index = self.index
+
+        class Client:
+            def Index(self, name=None, host=None):
+                if host is not None:
+                    return index
+                return index
+
+        return Client()
+
+
+def test_is_configured_requires_api_key_and_index():
+    client = PineconeMemoryClient(config={"api_key": "k", "index_name": "idx", "fail_open": False})
+    assert client.is_configured() is True
+    assert PineconeMemoryClient(config={"api_key": "k", "fail_open": False}).is_configured() is False
+
+
+def test_upsert_normalizes_records_and_query_normalizes_matches():
+    index = FakeIndex()
+    module = FakePineconeModule(index)
+    client = PineconeMemoryClient(
+        config={"api_key": "k", "index_name": "idx", "fail_open": False},
+        pinecone_module=module,
+    )
+
+    written = client.upsert_records(
+        [
+            {"id": 42, "values": (0.1, 0.2), "metadata": {"source_id": "doc-1"}},
+        ],
+        namespace="memories",
+    )
+    index.matches = [{"id": 99, "values": (0.3, 0.4), "metadata": {"source_kind": "file"}, "score": 0.91}]
+    results = client.query(vector=[1.0, 2.0], top_k=3, namespace="memories")
+
+    assert written == 1
+    assert index.upserts == [{"vectors": [{"id": "42", "values": [0.1, 0.2], "metadata": {"source_id": "doc-1"}}], "namespace": "memories"}]
+    assert results == [{"id": "99", "values": [0.3, 0.4], "metadata": {"source_kind": "file"}, "score": 0.91}]
+
+
+def test_delete_by_source_uses_metadata_filter():
+    index = FakeIndex()
+    module = FakePineconeModule(index)
+    client = PineconeMemoryClient(
+        config={"api_key": "***", "index_name": "idx", "fail_open": False},
+        pinecone_module=module,
+    )
+
+    ok = client.delete_by_source(source_kind="file", source_id="abc", source_path="docs/a.md", namespace="memories")
+
+    assert ok is True
+    assert index.deletes == [{"filter": {"source_kind": {"$eq": "file"}, "source_id": {"$eq": "abc"}, "source_path": {"$eq": "docs/a.md"}}, "namespace": "memories"}]
+
+
+def test_configured_namespace_is_used_by_default():
+    index = FakeIndex()
+    client = PineconeMemoryClient(
+        config={"api_key": "***", "index_name": "idx", "namespace": "configured", "fail_open": False},
+        pinecone_module=FakePineconeModule(index),
+    )
+
+    client.upsert_records([{"id": "1", "values": [0.1], "metadata": {}}])
+    client.query(vector=[0.1])
+    client.delete_by_source(source_kind="file", source_id="abc")
+
+    assert index.upserts[0]["namespace"] == "configured"
+    assert index.queries[0]["namespace"] == "configured"
+    assert index.deletes[0]["namespace"] == "configured"
+
+
+def test_fail_open_skips_missing_configuration_with_warning(caplog):
+    client = PineconeMemoryClient(config={"fail_open": True})
+
+    with caplog.at_level(logging.WARNING, logger="agent.pinecone_memory"):
+        upserted = client.upsert_records([{"id": "1", "values": [0.1], "metadata": {}}])
+        queried = client.query(vector=[0.1])
+
+    assert upserted == 0
+    assert queried == []
+    assert "fail-open enabled" in caplog.text
+    assert "missing Pinecone configuration" in caplog.text
+
+
+def test_fail_open_swallows_sdk_exceptions(caplog):
+    index = FakeIndex()
+    index.raise_upsert = RuntimeError("sdk boom")
+    client = PineconeMemoryClient(
+        config={"api_key": "k", "index_name": "idx", "fail_open": True},
+        pinecone_module=FakePineconeModule(index),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="agent.pinecone_memory"):
+        result = client.upsert_records([{"id": "1", "values": [0.2], "metadata": {}}])
+
+    assert result == 0
+    assert "sdk boom" in caplog.text
+
+
+def test_fail_closed_raises_on_sdk_error():
+    index = FakeIndex()
+    index.raise_upsert = RuntimeError("sdk boom")
+    client = PineconeMemoryClient(
+        config={"api_key": "***", "index_name": "idx", "fail_open": False},
+        pinecone_module=FakePineconeModule(index),
+    )
+
+    with pytest.raises(RuntimeError, match="sdk boom"):
+        client.upsert_records([{"id": "1", "values": [0.2], "metadata": {}}])
+
+
+def test_delete_missing_configuration_respects_fail_open_and_fail_closed(caplog):
+    fail_open_client = PineconeMemoryClient(config={"fail_open": True})
+    with caplog.at_level(logging.WARNING, logger="agent.pinecone_memory"):
+        assert fail_open_client.delete_by_source(source_kind="file", source_id="abc") is False
+    assert "missing Pinecone configuration" in caplog.text
+
+    fail_closed_client = PineconeMemoryClient(config={"fail_open": False})
+    with pytest.raises(RuntimeError, match="missing Pinecone configuration"):
+        fail_closed_client.delete_by_source(source_kind="file", source_id="abc")


### PR DESCRIPTION
## Summary
- add a fail-open Pinecone memory client with normalized upsert/query/delete helpers
- add deterministic memory document/chunk dataclasses with header-aware chunking and stable IDs
- cover namespace defaults, score preservation, header-only docs, and bounded chunk sizing with targeted tests

## Test Plan
- `/Users/blasai/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/agent/test_pinecone_memory.py tests/agent/test_memory_documents.py -q`

Closes WAT-1371
