### PR TITLE
fix(feishu): render JSON2 card sentinel as native card

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -162,6 +162,7 @@ _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_FEISHU_CARD_JSON2_SENTINEL = "FEISHU_CARD_JSON_2_0"
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -1706,7 +1707,13 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         formatted = self.format_message(content)
-        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        if self._extract_card_json2_payload(formatted) is not None:
+            # Card JSON must be sent atomically as an interactive message.  If it
+            # goes through normal text chunking, Feishu sees partial JSON and the
+            # user gets raw FEISHU_CARD_JSON_2_0 text instead of a native card.
+            chunks = [formatted]
+        else:
+            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         last_response = None
 
         try:
@@ -4004,7 +4011,78 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound payload construction and send pipeline
     # =========================================================================
 
+    @staticmethod
+    def _strip_single_markdown_fence(content: str) -> str:
+        """Strip one whole-message Markdown fence if present."""
+        stripped = (content or "").strip()
+        lines = stripped.splitlines()
+        if len(lines) >= 2 and _MARKDOWN_FENCE_OPEN_RE.match(lines[0]) and _MARKDOWN_FENCE_CLOSE_RE.match(lines[-1]):
+            return "\n".join(lines[1:-1]).strip()
+        return stripped
+
+    @classmethod
+    def _extract_card_json2_payload(cls, content: str) -> Optional[str]:
+        """Return normalized Feishu Card JSON 2.0 payload after the sentinel.
+
+        Cron/jobs can emit ``FEISHU_CARD_JSON_2_0\n{...}`` as an explicit
+        transport contract.  Treat that as a native Feishu ``interactive``
+        message instead of letting Markdown/text handling expose the raw JSON.
+        The sentinel must be the first meaningful content, optionally inside a
+        single wrapping Markdown fence; prefaced prose deliberately stays text.
+        """
+        stripped = cls._strip_single_markdown_fence(content)
+        if not stripped.startswith(_FEISHU_CARD_JSON2_SENTINEL):
+            return None
+
+        raw_json = stripped[len(_FEISHU_CARD_JSON2_SENTINEL):].lstrip()
+        raw_json = cls._strip_single_markdown_fence(raw_json)
+        if not raw_json:
+            raise ValueError("Feishu card sentinel was provided without a JSON payload")
+        try:
+            card = json.loads(raw_json)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid Feishu Card JSON 2.0 payload: {exc}") from exc
+        if not isinstance(card, dict):
+            raise ValueError("Feishu Card JSON 2.0 payload must be a JSON object")
+        if card.get("schema") != "2.0":
+            raise ValueError('Feishu Card JSON 2.0 payload must include schema: "2.0"')
+        if not isinstance(card.get("body"), dict):
+            raise ValueError("Feishu Card JSON 2.0 payload must include a body object")
+
+        config = card.setdefault("config", {})
+        if not isinstance(config, dict):
+            raise ValueError("Feishu Card JSON 2.0 config must be a JSON object")
+        config["update_multi"] = True
+        config.setdefault("width_mode", "fill")
+        return json.dumps(card, ensure_ascii=False, separators=(",", ":"))
+
+    def should_buffer_stream_update(self, content: str) -> bool:
+        """Buffer partial streaming updates while a Feishu JSON2 card is forming."""
+        stripped = self._strip_single_markdown_fence(content)
+        if not stripped.startswith(_FEISHU_CARD_JSON2_SENTINEL):
+            return False
+        try:
+            self._extract_card_json2_payload(stripped)
+        except ValueError as exc:
+            # Keep buffering only for incomplete JSON while the stream is still
+            # arriving.  Semantically invalid but syntactically complete payloads
+            # should flow through the normal send path and surface the parser
+            # error instead of hanging the stream forever.
+            message = str(exc)
+            return (
+                "Invalid Feishu Card JSON 2.0 payload" in message
+                and (
+                    "Expecting" in message
+                    or "Unterminated" in message
+                    or "Invalid control character" in message
+                )
+            )
+        return False
+
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+        card_payload = self._extract_card_json2_payload(content)
+        if card_payload is not None:
+            return "interactive", card_payload
         # Feishu post-type 'md' elements do not render markdown tables; sending
         # table content as post causes the message to appear blank on the client.
         # Force plain text for anything that looks like a markdown table.

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -348,6 +348,21 @@ class GatewayStreamConsumer:
 
                 current_update_visible = False
                 if should_edit and self._accumulated:
+                    buffer_hook = getattr(self.adapter, "should_buffer_stream_update", None)
+                    if (
+                        not got_done
+                        and not got_segment_break
+                        and commentary_text is None
+                        and callable(buffer_hook)
+                    ):
+                        try:
+                            should_buffer = buffer_hook(self._accumulated) is True
+                        except Exception:
+                            should_buffer = False
+                        if should_buffer:
+                            await asyncio.sleep(0.05)
+                            continue
+
                     # Split overflow: if accumulated text exceeds the platform
                     # limit, split into properly sized chunks.
                     if (

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -415,6 +415,87 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_feishu_card_sentinel_as_interactive_without_truncating(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"calls": []}
+
+        card = {
+            "schema": "2.0",
+            "config": {"update_multi": True, "width_mode": "fill"},
+            "header": {"title": {"tag": "plain_text", "content": "Card"}},
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "element_id": "longBody",
+                        "content": "**重要**\n" + ("x" * 5000),
+                    }
+                ]
+            },
+        }
+        content = "FEISHU_CARD_JSON_2_0\n" + json.dumps(card, ensure_ascii=False)
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["calls"].append(request)
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_card"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send("oc_chat", content))
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_card")
+        self.assertEqual(len(captured["calls"]), 1)
+        body = captured["calls"][0].request_body
+        self.assertEqual(body.msg_type, "interactive")
+        self.assertEqual(json.loads(body.content)["schema"], "2.0")
+        self.assertEqual(json.loads(body.content)["body"]["elements"][0]["element_id"], "longBody")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_card_json2_sentinel_parser_accepts_single_wrapping_fence(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        card = {"schema": "2.0", "body": {"elements": []}}
+        content = "```json\nFEISHU_CARD_JSON_2_0\n" + json.dumps(card) + "\n```"
+        msg_type, payload = adapter._build_outbound_payload(content)
+
+        self.assertEqual(msg_type, "interactive")
+        self.assertEqual(json.loads(payload)["schema"], "2.0")
+        self.assertTrue(json.loads(payload)["config"]["update_multi"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_card_json2_sentinel_parser_does_not_accept_prefaced_prose(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        card = {"schema": "2.0", "body": {"elements": []}}
+        msg_type, payload = adapter._build_outbound_payload(
+            "Here is a card:\nFEISHU_CARD_JSON_2_0\n" + json.dumps(card)
+        )
+
+        self.assertNotEqual(msg_type, "interactive")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_get_chat_info_uses_real_feishu_chat_api(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1493,3 +1493,34 @@ class TestOnNewMessageCallback:
         await consumer.run()
 
         assert consumer.already_sent is True
+
+
+class TestFeishuCardJson2StreamingBuffer:
+    """Verify native-card sentinel streams are not leaked as raw partial JSON."""
+
+    @pytest.mark.asyncio
+    async def test_buffers_partial_card_until_done(self):
+        adapter = MagicMock()
+        adapter.REQUIRES_EDIT_FINALIZE = False
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.should_buffer_stream_update.side_effect = lambda text: text.startswith("FEISHU_CARD_JSON_2_0") and not text.endswith("}")
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_card"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_card"))
+
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            StreamConsumerConfig(edit_interval=0.0, buffer_threshold=1),
+        )
+        task = asyncio.create_task(consumer.run())
+        consumer.on_delta('FEISHU_CARD_JSON_2_0\n{"schema":"2.0",')
+        await asyncio.sleep(0.15)
+        adapter.send.assert_not_called()
+
+        consumer.on_delta('"body":{}}')
+        consumer.finish()
+        await asyncio.wait_for(task, timeout=2)
+
+        adapter.send.assert_called_once()
+        assert adapter.send.call_args[1]["content"] == 'FEISHU_CARD_JSON_2_0\n{"schema":"2.0","body":{}}'
+        assert consumer.final_response_sent is True


### PR DESCRIPTION
## Summary
- Parse final responses starting with `FEISHU_CARD_JSON_2_0` as Feishu/Lark Card JSON 2.0 native `interactive` messages.
- Send card JSON atomically so large card payloads are not split by text chunking.
- Buffer streaming partial card JSON until completion to avoid leaking raw sentinel/JSON/cursor updates.
- Accept a single wrapping Markdown fence while keeping prefaced prose as normal text.

## Test Plan
- `./venv/bin/python -m pytest tests/gateway/test_feishu.py::TestFeishuAdapterMessaging::test_send_feishu_card_sentinel_as_interactive_without_truncating tests/gateway/test_feishu.py::TestFeishuAdapterMessaging::test_card_json2_sentinel_parser_accepts_single_wrapping_fence tests/gateway/test_feishu.py::TestFeishuAdapterMessaging::test_card_json2_sentinel_parser_does_not_accept_prefaced_prose tests/gateway/test_stream_consumer.py::TestFeishuCardJson2StreamingBuffer::test_buffers_partial_card_until_done -q -o 'addopts='`
- `./venv/bin/python -m py_compile gateway/platforms/feishu.py gateway/stream_consumer.py tests/gateway/test_feishu.py tests/gateway/test_stream_consumer.py`
- `git diff --check`
