### PR TITLE
fix(gateway): resume API run events after page refresh

### DIFF
--- a/docs/superpowers/specs/2026-05-07-api-run-reconnect-design.md
+++ b/docs/superpowers/specs/2026-05-07-api-run-reconnect-design.md
@@ -1,0 +1,335 @@
+# API Run Reconnect Design
+
+Date: 2026-05-07
+
+## Goal
+
+Support resumable API-driven conversations for web clients that use Hermes'
+structured run API. If a browser, reverse proxy, or SSE client disconnects while
+an agent run is still in progress, the agent should continue running in the
+background. The client can reconnect with the same `run_id` and resume receiving
+missed lifecycle events from the last event it saw.
+
+This design applies to `POST /v1/runs` and
+`GET /v1/runs/{run_id}/events`. It intentionally does not change the existing
+OpenAI-compatible streaming behavior for `/v1/chat/completions` or
+`/v1/responses`, where a client disconnect currently interrupts the associated
+agent task.
+
+## Current Architecture
+
+Hermes uses a synchronous core agent wrapped by async platform adapters:
+
+- `run_agent.py` owns `AIAgent.run_conversation()`, the synchronous model/tool
+  loop.
+- `gateway/platforms/api_server.py` owns the OpenAI-compatible HTTP API and
+  creates `AIAgent` instances from gateway runtime configuration.
+- `hermes_state.py` owns durable conversation storage in SQLite.
+- `ResponseStore` in `gateway/platforms/api_server.py` owns Responses API
+  response chaining via `previous_response_id`.
+
+The existing `/v1/runs` API already separates run submission from observation:
+
+- `POST /v1/runs` returns a `run_id` immediately.
+- `GET /v1/runs/{run_id}` returns pollable status.
+- `GET /v1/runs/{run_id}/events` streams structured lifecycle events.
+- `POST /v1/runs/{run_id}/stop` explicitly interrupts a run.
+
+The missing piece is that the current event stream is backed by a single
+in-memory queue. When the SSE connection ends, the queue entry is removed, so a
+new connection cannot replay missed events or continue observing the same run.
+
+## Selected Approach
+
+Implement a resumable run event log in the API server:
+
+- Keep the agent run independent from the SSE subscriber connection.
+- Assign a monotonically increasing integer sequence to every run event.
+- Store events in a lightweight SQLite-backed run event store.
+- Fan out each committed live event to all connected subscribers for that
+  `run_id`.
+- On reconnect, attach and replay under a per-run sequencing discipline so
+  there is no gap between stored replay and live fanout.
+- Treat durable run metadata as the source of truth for public run status, with
+  any in-memory status dictionary acting only as a cache.
+- Retain terminal run status and event history for a bounded TTL.
+
+This keeps the change local to the API server platform adapter and follows the
+project's existing style: platform adapters orchestrate async transport concerns,
+while `AIAgent` remains the synchronous execution engine.
+
+### Architecture Fit
+
+The approach fits the current Hermes architecture because it does not move
+conversation execution out of `AIAgent` and does not change the message loop in
+`run_agent.py`. The API server continues to create the agent and pass
+`stream_delta_callback` and `tool_progress_callback`; the only change is that
+those callbacks enqueue structured events into a resumable API-server-owned
+broker instead of a single SSE queue.
+
+This mirrors the existing `ResponseStore` pattern in `api_server.py`: small
+SQLite persistence is acceptable at the platform adapter boundary when it
+supports HTTP/API semantics such as response chaining or resumable observation.
+It should not be pushed into `hermes_state.py`, which remains conversation
+storage, nor into `AIAgent`, which should stay transport-agnostic.
+
+## API Contract
+
+`POST /v1/runs` returns the existing response plus enough metadata for clients to
+subscribe:
+
+```json
+{
+  "run_id": "run_...",
+  "status": "started",
+  "session_id": "run_...",
+  "events_url": "/v1/runs/run_.../events"
+}
+```
+
+`GET /v1/runs/{run_id}/events` accepts either resume mechanism:
+
+- `Last-Event-ID: 42`
+- `GET /v1/runs/{run_id}/events?after=42`
+
+`after` and `Last-Event-ID` are exclusive sequence cursors: `after=42` means
+"send events with `sequence > 42`". If both are supplied, the explicit `after`
+query parameter takes precedence.
+
+The SSE stream emits event IDs:
+
+```text
+id: 43
+event: message.delta
+data: {"event":"message.delta","run_id":"run_...","sequence":43,"delta":"..."}
+```
+
+Terminal events such as `run.completed`, `run.failed`, and `run.cancelled` are
+also stored and replayable. If a client reconnects after a run has completed, it
+receives any missing terminal event and the stream closes cleanly. If a terminal
+run is requested with `after >= last_sequence`, there is nothing left to replay,
+so the stream closes cleanly instead of staying open for events that can no
+longer arrive.
+
+## Components
+
+### RunEventStore
+
+Add a small SQLite-backed store in `gateway/platforms/api_server.py` or a nearby
+module if the adapter becomes too large.
+
+Responsibilities:
+
+- Create tables for run events and run metadata.
+- Initialize run metadata before the background task is created.
+- Allocate the next sequence number per `run_id`.
+- Append events transactionally and return the committed sequence.
+- List events after a sequence.
+- Store the public run status payload used by `GET /v1/runs/{run_id}`.
+- Mark terminal runs and their terminal timestamp.
+- On startup, mark any non-terminal persisted runs as failed/abandoned because
+  the Python thread that was executing them cannot survive process restart.
+- Prune old terminal runs and events after TTL.
+
+Suggested tables:
+
+```sql
+CREATE TABLE IF NOT EXISTS run_events (
+    run_id TEXT NOT NULL,
+    sequence INTEGER NOT NULL,
+    event TEXT NOT NULL,
+    data TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    PRIMARY KEY (run_id, sequence)
+);
+
+CREATE TABLE IF NOT EXISTS run_meta (
+    run_id TEXT PRIMARY KEY,
+    status TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    terminal_at REAL,
+    last_sequence INTEGER NOT NULL DEFAULT 0,
+    status_data TEXT NOT NULL DEFAULT '{}'
+);
+```
+
+`status_data` stores only JSON-serializable public status fields such as
+`session_id`, `model`, `last_event`, `output`, `error`, and `usage`. It must not
+contain live `AIAgent` objects, tasks, queues, or other process-local handles.
+
+### Live Subscribers
+
+Replace the single `_run_streams[run_id] = queue` model with per-run subscriber
+sets:
+
+- `_run_subscribers: Dict[str, set[asyncio.Queue]]`
+- `_run_event_locks: Dict[str, asyncio.Lock]`
+- `_run_statuses` may remain as a hot cache, but `RunEventStore` is the source
+  of truth for `GET /v1/runs/{run_id}`.
+- `_active_run_agents` and `_active_run_tasks` remain for explicit stop support.
+
+When an event is produced:
+
+1. Marshal the event onto the API server's event loop. Executor-thread
+   callbacks must not write the store or subscriber queues directly.
+2. Under the run's event lock, append it to `RunEventStore` and receive the
+   committed sequence.
+3. Update durable run metadata and the optional `_run_statuses` cache with
+   `last_sequence` and `last_event`.
+4. Put the committed sequenced event into every active subscriber queue.
+
+All event types for one run, including terminal events, must pass through the
+same append path. This preserves sequence ordering across text deltas, tool
+events, reasoning events, and terminal events, even though the callbacks can be
+triggered from a worker thread while terminal handling runs in the async task.
+
+Terminal events are final. Once a terminal event has been committed, later
+non-terminal callbacks for the same `run_id` are ignored and logged at debug
+level rather than appended after completion.
+
+When an SSE subscriber connects:
+
+1. Parse the exclusive resume cursor from `after` or `Last-Event-ID`.
+2. Validate that the run exists in `RunEventStore`.
+3. Create a subscriber queue.
+4. Under the run's event lock, add the queue to `_run_subscribers[run_id]`,
+   capture current metadata, and list stored events with `sequence > after`.
+5. Write the replayed events to the response.
+6. Continue reading from the live queue, dropping any queued event whose
+   sequence is less than or equal to the highest replayed sequence.
+
+Registering the queue before replay, while using sequence-based de-duplication,
+closes the race where a new event could otherwise be committed after the replay
+query but before live subscription.
+
+When an SSE subscriber disconnects:
+
+1. Remove only that subscriber queue.
+2. Do not interrupt the agent.
+3. Do not cancel the run task.
+4. Do not delete the event log.
+
+### Run Lifecycle
+
+`POST /v1/runs` should initialize run metadata before creating the background
+task. The background task should emit:
+
+- `run.started` once execution begins.
+- `message.delta` for streamed assistant text.
+- `tool.started`, `tool.completed`, and `reasoning.available` from the existing
+  callbacks.
+- exactly one terminal event: `run.completed`, `run.failed`, or `run.cancelled`.
+
+The background task should not depend on a connected SSE response. It continues
+until completion, failure, or an explicit stop request even if there are zero
+active subscribers.
+
+The existing `POST /v1/runs/{run_id}/stop` remains the explicit cancellation
+path. It should still call `agent.interrupt("Stop requested via API")` and
+cancel the task as it does today.
+
+On adapter startup, `RunEventStore` should reconcile persisted non-terminal
+runs from a previous process. Because in-flight Python execution cannot be
+resurrected, each persisted `queued`, `running`, or `stopping` run should be
+marked failed with a replayable terminal event such as:
+
+```json
+{
+  "event": "run.failed",
+  "run_id": "run_...",
+  "error": "Run abandoned because the API server process restarted"
+}
+```
+
+## Error Handling
+
+- Unknown `run_id`: return `404 run_not_found`.
+- Invalid `after` value: return `400 invalid_request_error`.
+- `after` greater than current last sequence for a non-terminal run: attach
+  live and keep the connection open until new events or terminal closure.
+- `after` greater than or equal to the current last sequence for a terminal run:
+  close the stream cleanly because no more events can arrive.
+- Store write failure: log the error and fail the run with `run.failed` if the
+  event log cannot preserve resumability.
+- Subscriber send failure: remove that subscriber only.
+
+## Security
+
+The existing API key behavior remains unchanged. All run status, event, and stop
+routes continue to call `_check_auth()`.
+
+Events may contain tool previews and assistant deltas, so resumable event access
+must remain protected by the same bearer token configuration as the existing run
+endpoints.
+
+## Testing Plan
+
+Add or update tests under `tests/gateway/test_api_server_runs.py`:
+
+- Client disconnect from `/events` does not call `agent.interrupt()` and does
+  not cancel the run task.
+- Reconnect with `Last-Event-ID` replays only events with a higher sequence.
+- Reconnect with `?after=` behaves the same as `Last-Event-ID`.
+- If both `Last-Event-ID` and `?after=` are provided, `?after=` wins.
+- An event produced during reconnect replay is not lost and is not delivered
+  twice.
+- Completed runs can still replay their terminal event.
+- Completed runs requested with `after >= last_sequence` close cleanly.
+- Multiple subscribers can observe the same run without stealing events from
+  one another.
+- Events keep strictly increasing per-run sequence numbers across text, tool,
+  reasoning, and terminal events.
+- Late non-terminal callbacks after a terminal event are ignored.
+- `POST /v1/runs/{run_id}/stop` still interrupts the active agent and emits a
+  terminal cancellation/failure event.
+- TTL cleanup removes old terminal run events but does not remove running runs.
+- Adapter startup marks persisted non-terminal runs abandoned with a replayable
+  terminal failure event.
+- Auth requirements are preserved for run status, events, and stop routes.
+
+## Documentation Needed For Upstream
+
+Update project-facing documentation once the implementation lands:
+
+- API server capability response should advertise resumable run events.
+- Add a short user-facing example for:
+  1. `POST /v1/runs`
+  2. connect to `/v1/runs/{run_id}/events`
+  3. reconnect with `Last-Event-ID`
+  4. poll `/v1/runs/{run_id}` as fallback
+- Mention that resumability applies to `/v1/runs`, not the OpenAI-compatible
+  `/v1/chat/completions` streaming endpoint.
+
+## Implementation Status
+
+Implemented in `gateway/platforms/api_server.py`:
+
+- `RunEventStore` for SQLite-backed run events and public run metadata.
+- `/v1/runs` event delivery refactored from a single queue to replayable
+  multi-subscriber streams.
+- Atomic reconnect flow that registers a subscriber before replay and drops
+  duplicate queued events by sequence.
+- Startup reconciliation for persisted non-terminal runs.
+- `/v1/capabilities` advertises resumable run events.
+- Tests covering replay, completion replay, multiple subscribers, reconnect
+  after disconnect, stop behavior, auth, and startup reconciliation.
+
+Still useful before an upstream PR:
+
+- Add user-facing docs or a release note explaining the resumable run stream
+  behavior.
+- Manually verify with an external SSE client that disconnects and reconnects
+  using `Last-Event-ID`.
+
+## Non-Goals
+
+- Do not change `/v1/chat/completions` disconnect semantics.
+- Do not change `/v1/responses` disconnect semantics in this PR.
+- Do not attempt process-restart recovery of in-flight agent execution. Stored
+  events and terminal status can survive process restart, but a Python thread
+  that was running an agent cannot be resurrected after the process exits. On
+  restart, persisted non-terminal runs are marked failed/abandoned rather than
+  resumed.
+- Do not rebuild the dashboard chat transcript in React. The dashboard chat tab
+  remains PTY/TUI-backed.

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -34,7 +34,7 @@ import re
 import sqlite3
 import time
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 try:
     from aiohttp import web
@@ -392,6 +392,299 @@ class ResponseStore:
         return row[0] if row else 0
 
 
+_RUN_TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+
+
+class RunEventStore:
+    """SQLite-backed event log and public metadata store for /v1/runs."""
+
+    def __init__(self, db_path: str = None):
+        if db_path is None:
+            try:
+                from hermes_cli.config import get_hermes_home
+                db_path = str(get_hermes_home() / "run_event_store.db")
+            except Exception:
+                db_path = ":memory:"
+        try:
+            self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        except Exception:
+            self._conn = sqlite3.connect(":memory:", check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        try:
+            self._conn.execute("PRAGMA journal_mode=WAL")
+        except Exception:
+            pass
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS run_events (
+                run_id TEXT NOT NULL,
+                sequence INTEGER NOT NULL,
+                event TEXT NOT NULL,
+                data TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                PRIMARY KEY (run_id, sequence)
+            )"""
+        )
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS run_meta (
+                run_id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                terminal_at REAL,
+                last_sequence INTEGER NOT NULL DEFAULT 0,
+                status_data TEXT NOT NULL DEFAULT '{}'
+            )"""
+        )
+        self._conn.commit()
+
+    @staticmethod
+    def is_terminal_status(status: str) -> bool:
+        return status in _RUN_TERMINAL_STATUSES
+
+    @staticmethod
+    def _loads(raw: Any) -> Dict[str, Any]:
+        if not raw:
+            return {}
+        try:
+            loaded = json.loads(raw)
+        except Exception:
+            return {}
+        return loaded if isinstance(loaded, dict) else {}
+
+    @staticmethod
+    def _status_payload(fields: Dict[str, Any]) -> Dict[str, Any]:
+        private = {
+            "object",
+            "run_id",
+            "status",
+            "created_at",
+            "updated_at",
+            "terminal_at",
+            "last_sequence",
+        }
+        return {k: v for k, v in fields.items() if k not in private}
+
+    def initialize_run(
+        self,
+        run_id: str,
+        *,
+        status: str = "queued",
+        created_at: float = None,
+        status_data: Dict[str, Any] = None,
+    ) -> Dict[str, Any]:
+        now = created_at if created_at is not None else time.time()
+        payload = self._status_payload(status_data or {})
+        self._conn.execute(
+            """INSERT INTO run_meta
+                (run_id, status, created_at, updated_at, terminal_at, last_sequence, status_data)
+               VALUES (?, ?, ?, ?, ?, 0, ?)""",
+            (
+                run_id,
+                status,
+                now,
+                now,
+                now if self.is_terminal_status(status) else None,
+                json.dumps(payload, default=str),
+            ),
+        )
+        self._conn.commit()
+        return self.get_status(run_id)
+
+    def update_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
+        now = time.time()
+        row = self._conn.execute(
+            "SELECT status_data, created_at, terminal_at FROM run_meta WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        if row is None:
+            return self.initialize_run(
+                run_id,
+                status=status,
+                created_at=fields.get("created_at", now),
+                status_data=fields,
+            )
+
+        payload = self._loads(row["status_data"])
+        payload.update(self._status_payload(fields))
+        terminal_at = row["terminal_at"]
+        if terminal_at is None and self.is_terminal_status(status):
+            terminal_at = now
+        self._conn.execute(
+            """UPDATE run_meta
+               SET status = ?, updated_at = ?, terminal_at = ?, status_data = ?
+               WHERE run_id = ?""",
+            (status, now, terminal_at, json.dumps(payload, default=str), run_id),
+        )
+        self._conn.commit()
+        return self.get_status(run_id)
+
+    def append_event(
+        self,
+        run_id: str,
+        event: Dict[str, Any],
+        *,
+        status: str = None,
+        terminal: bool = False,
+        status_fields: Dict[str, Any] = None,
+    ) -> Optional[Dict[str, Any]]:
+        now = time.time()
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = self._conn.execute(
+                """SELECT status, terminal_at, last_sequence, status_data
+                   FROM run_meta WHERE run_id = ?""",
+                (run_id,),
+            ).fetchone()
+            if row is None:
+                raise KeyError(run_id)
+            if row["terminal_at"] is not None:
+                self._conn.rollback()
+                return None
+
+            event_type = str(event.get("event") or "")
+            if not event_type:
+                raise ValueError("run event missing event type")
+
+            sequence = int(row["last_sequence"] or 0) + 1
+            payload = dict(event)
+            payload["event"] = event_type
+            payload["run_id"] = run_id
+            payload["sequence"] = sequence
+            payload.setdefault("timestamp", now)
+
+            self._conn.execute(
+                """INSERT INTO run_events
+                    (run_id, sequence, event, data, created_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (
+                    run_id,
+                    sequence,
+                    event_type,
+                    json.dumps(payload, default=str),
+                    now,
+                ),
+            )
+
+            public_status = status or row["status"]
+            public_data = self._loads(row["status_data"])
+            public_data.update(self._status_payload(status_fields or {}))
+            public_data["last_event"] = event_type
+            terminal_at = now if terminal else row["terminal_at"]
+            self._conn.execute(
+                """UPDATE run_meta
+                   SET status = ?, updated_at = ?, terminal_at = ?,
+                       last_sequence = ?, status_data = ?
+                   WHERE run_id = ?""",
+                (
+                    public_status,
+                    now,
+                    terminal_at,
+                    sequence,
+                    json.dumps(public_data, default=str),
+                    run_id,
+                ),
+            )
+            self._conn.commit()
+            return payload
+        except Exception:
+            self._conn.rollback()
+            raise
+
+    def get_status(self, run_id: str) -> Optional[Dict[str, Any]]:
+        row = self._conn.execute(
+            """SELECT run_id, status, created_at, updated_at, terminal_at,
+                      last_sequence, status_data
+               FROM run_meta WHERE run_id = ?""",
+            (run_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        payload = self._loads(row["status_data"])
+        status = {
+            "object": "hermes.run",
+            "run_id": row["run_id"],
+            "status": row["status"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+            "last_sequence": row["last_sequence"],
+        }
+        if row["terminal_at"] is not None:
+            status["terminal_at"] = row["terminal_at"]
+        status.update(payload)
+        status.update({
+            "object": "hermes.run",
+            "run_id": row["run_id"],
+            "status": row["status"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+            "last_sequence": row["last_sequence"],
+        })
+        return status
+
+    def list_events_after(self, run_id: str, after: int) -> List[Dict[str, Any]]:
+        rows = self._conn.execute(
+            """SELECT data FROM run_events
+               WHERE run_id = ? AND sequence > ?
+               ORDER BY sequence ASC""",
+            (run_id, after),
+        ).fetchall()
+        return [json.loads(row["data"]) for row in rows]
+
+    def count_nonterminal_runs(self) -> int:
+        rows = self._conn.execute(
+            "SELECT status, terminal_at FROM run_meta"
+        ).fetchall()
+        return sum(
+            1 for row in rows
+            if row["terminal_at"] is None and not self.is_terminal_status(row["status"])
+        )
+
+    def mark_abandoned_nonterminal(self) -> List[str]:
+        rows = self._conn.execute(
+            "SELECT run_id, status, terminal_at FROM run_meta"
+        ).fetchall()
+        abandoned: List[str] = []
+        for row in rows:
+            if row["terminal_at"] is not None or self.is_terminal_status(row["status"]):
+                continue
+            run_id = row["run_id"]
+            error = "Run abandoned because the API server process restarted"
+            self.append_event(
+                run_id,
+                {
+                    "event": "run.failed",
+                    "run_id": run_id,
+                    "timestamp": time.time(),
+                    "error": error,
+                },
+                status="failed",
+                terminal=True,
+                status_fields={"error": error},
+            )
+            abandoned.append(run_id)
+        return abandoned
+
+    def prune_terminal(self, ttl_seconds: int, *, now: float = None) -> List[str]:
+        now = now if now is not None else time.time()
+        cutoff = now - ttl_seconds
+        rows = self._conn.execute(
+            "SELECT run_id FROM run_meta WHERE terminal_at IS NOT NULL AND terminal_at < ?",
+            (cutoff,),
+        ).fetchall()
+        run_ids = [row["run_id"] for row in rows]
+        for run_id in run_ids:
+            self._conn.execute("DELETE FROM run_events WHERE run_id = ?", (run_id,))
+            self._conn.execute("DELETE FROM run_meta WHERE run_id = ?", (run_id,))
+        self._conn.commit()
+        return run_ids
+
+    def close(self) -> None:
+        try:
+            self._conn.close()
+        except Exception:
+            pass
+
+
 # ---------------------------------------------------------------------------
 # CORS middleware
 # ---------------------------------------------------------------------------
@@ -596,14 +889,20 @@ class APIServerAdapter(BasePlatformAdapter):
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
         self._response_store = ResponseStore()
-        # Active run streams: run_id -> asyncio.Queue of SSE event dicts
+        self._run_event_store = RunEventStore(extra.get("run_event_store_path"))
+        try:
+            self._run_event_store.mark_abandoned_nonterminal()
+        except Exception:
+            logger.exception("[api_server] failed to reconcile persisted run events")
+        # Back-compat debug attributes retained for tests/inspection; event
+        # delivery now uses per-run subscriber sets below.
         self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
-        # Creation timestamps for orphaned-run TTL sweep
-        self._run_streams_created: Dict[str, float] = {}
+        self._run_subscribers: Dict[str, Set["asyncio.Queue[Optional[Dict]]"]] = {}
+        self._run_event_locks: Dict[str, "asyncio.Lock"] = {}
         # Active run agent/task references for stop support
         self._active_run_agents: Dict[str, Any] = {}
         self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
-        # Pollable run status for dashboards and external control-plane UIs.
+        # Hot cache only. RunEventStore is the source of truth.
         self._run_statuses: Dict[str, Dict[str, Any]] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
 
@@ -925,6 +1224,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_submission": True,
                 "run_status": True,
                 "run_events_sse": True,
+                "run_events_resumable": True,
                 "run_stop": True,
                 "tool_progress_events": True,
                 "session_continuity_header": "X-Hermes-Session-Id",
@@ -2609,13 +2909,19 @@ class APIServerAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     _MAX_CONCURRENT_RUNS = 10  # Prevent unbounded resource allocation
-    _RUN_STREAM_TTL = 300  # seconds before orphaned runs are swept
     _RUN_STATUS_TTL = 3600  # seconds to retain terminal run status for polling
+
+    def _get_run_lock(self, run_id: str) -> "asyncio.Lock":
+        lock = self._run_event_locks.get(run_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._run_event_locks[run_id] = lock
+        return lock
 
     def _set_run_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
         """Update pollable run status without exposing private agent objects."""
         now = time.time()
-        current = self._run_statuses.get(run_id, {})
+        current = self._run_statuses.get(run_id) or self._run_event_store.get_status(run_id) or {}
         current.update({
             "object": "hermes.run",
             "run_id": run_id,
@@ -2624,24 +2930,107 @@ class APIServerAdapter(BasePlatformAdapter):
         })
         current.setdefault("created_at", fields.pop("created_at", now))
         current.update(fields)
-        self._run_statuses[run_id] = current
-        return current
+        durable = self._run_event_store.update_status(
+            run_id,
+            status,
+            **RunEventStore._status_payload(current),
+        )
+        self._run_statuses[run_id] = durable
+        return durable
+
+    async def _emit_run_event(
+        self,
+        run_id: str,
+        event: Dict[str, Any],
+        *,
+        status: str = None,
+        terminal: bool = False,
+        status_fields: Dict[str, Any] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Commit a run event, update metadata, and fan it out to live subscribers."""
+        subscribers: List["asyncio.Queue[Optional[Dict]]"] = []
+        async with self._get_run_lock(run_id):
+            try:
+                sequenced = self._run_event_store.append_event(
+                    run_id,
+                    event,
+                    status=status,
+                    terminal=terminal,
+                    status_fields=status_fields,
+                )
+            except Exception:
+                logger.exception("[api_server] failed to append run event for %s", run_id)
+                raise
+            if sequenced is None:
+                logger.debug(
+                    "[api_server] ignoring run event after terminal state for %s: %s",
+                    run_id,
+                    event.get("event"),
+                )
+                return None
+            latest = self._run_event_store.get_status(run_id)
+            if latest is not None:
+                self._run_statuses[run_id] = latest
+            subscribers = list(self._run_subscribers.get(run_id, set()))
+
+        stale: List["asyncio.Queue[Optional[Dict]]"] = []
+        for q in subscribers:
+            try:
+                q.put_nowait(sequenced)
+            except Exception:
+                stale.append(q)
+        if stale:
+            current = self._run_subscribers.get(run_id)
+            if current is not None:
+                for q in stale:
+                    current.discard(q)
+        return sequenced
+
+    def _schedule_run_event(
+        self,
+        run_id: str,
+        loop: "asyncio.AbstractEventLoop",
+        event: Dict[str, Any],
+        *,
+        status: str = None,
+        terminal: bool = False,
+        status_fields: Dict[str, Any] = None,
+    ) -> None:
+        def _create_task() -> None:
+            task = asyncio.create_task(
+                self._emit_run_event(
+                    run_id,
+                    event,
+                    status=status,
+                    terminal=terminal,
+                    status_fields=status_fields,
+                )
+            )
+            try:
+                self._background_tasks.add(task)
+            except TypeError:
+                pass
+            if hasattr(task, "add_done_callback"):
+                def _finish(done_task: "asyncio.Task") -> None:
+                    self._background_tasks.discard(done_task)
+                    try:
+                        done_task.result()
+                    except asyncio.CancelledError:
+                        pass
+                    except Exception:
+                        logger.exception("[api_server] scheduled run event failed")
+
+                task.add_done_callback(_finish)
+
+        try:
+            loop.call_soon_threadsafe(_create_task)
+        except Exception:
+            logger.debug("[api_server] failed to schedule run event for %s", run_id, exc_info=True)
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
-        """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
+        """Return a tool_progress_callback that publishes structured run events."""
         def _push(event: Dict[str, Any]) -> None:
-            self._set_run_status(
-                run_id,
-                self._run_statuses.get(run_id, {}).get("status", "running"),
-                last_event=event.get("event"),
-            )
-            q = self._run_streams.get(run_id)
-            if q is None:
-                return
-            try:
-                loop.call_soon_threadsafe(q.put_nowait, event)
-            except Exception:
-                pass
+            self._schedule_run_event(run_id, loop, event)
 
         def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
             ts = time.time()
@@ -2684,10 +3073,13 @@ class APIServerAdapter(BasePlatformAdapter):
         if key_err is not None:
             return key_err
 
-        # Enforce concurrency limit
-        if len(self._run_streams) >= self._MAX_CONCURRENT_RUNS:
+        # Enforce active run concurrency limit.
+        if self._run_event_store.count_nonterminal_runs() >= self._MAX_CONCURRENT_RUNS:
             return web.json_response(
-                _openai_error(f"Too many concurrent runs (max {self._MAX_CONCURRENT_RUNS})", code="rate_limit_exceeded"),
+                _openai_error(
+                    f"Too many concurrent runs (max {self._MAX_CONCURRENT_RUNS})",
+                    code="rate_limit_exceeded",
+                ),
                 status=429,
             )
 
@@ -2755,10 +3147,7 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id = body.get("session_id") or stored_session_id or run_id
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()
-        q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
         created_at = time.time()
-        self._run_streams[run_id] = q
-        self._run_streams_created[run_id] = created_at
 
         event_cb = self._make_run_event_callback(run_id, loop)
 
@@ -2766,27 +3155,40 @@ class APIServerAdapter(BasePlatformAdapter):
         def _text_cb(delta: Optional[str]) -> None:
             if delta is None:
                 return
-            try:
-                loop.call_soon_threadsafe(q.put_nowait, {
+            self._schedule_run_event(
+                run_id,
+                loop,
+                {
                     "event": "message.delta",
                     "run_id": run_id,
                     "timestamp": time.time(),
                     "delta": delta,
-                })
-            except Exception:
-                pass
+                },
+            )
 
-        self._set_run_status(
+        initial_status = self._run_event_store.initialize_run(
             run_id,
-            "queued",
+            status="queued",
             created_at=created_at,
-            session_id=session_id,
-            model=body.get("model", self._model_name),
+            status_data={
+                "session_id": session_id,
+                "model": body.get("model", self._model_name),
+            },
         )
+        self._run_statuses[run_id] = initial_status
 
         async def _run_and_close():
             try:
                 self._set_run_status(run_id, "running")
+                await self._emit_run_event(
+                    run_id,
+                    {
+                        "event": "run.started",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                    },
+                    status="running",
+                )
                 agent = self._create_agent(
                     ephemeral_system_prompt=ephemeral_system_prompt,
                     session_id=session_id,
@@ -2815,72 +3217,66 @@ class APIServerAdapter(BasePlatformAdapter):
                 # block below never fires — issue #15561).
                 if isinstance(result, dict) and result.get("failed"):
                     error_msg = result.get("error") or "agent run failed"
-                    q.put_nowait({
-                        "event": "run.failed",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "error": error_msg,
-                    })
-                    self._set_run_status(
+                    await self._emit_run_event(
                         run_id,
-                        "failed",
-                        error=error_msg,
-                        last_event="run.failed",
+                        {
+                            "event": "run.failed",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "error": error_msg,
+                        },
+                        status="failed",
+                        terminal=True,
+                        status_fields={"error": error_msg},
                     )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
-                    q.put_nowait({
-                        "event": "run.completed",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "output": final_response,
-                        "usage": usage,
-                    })
-                    self._set_run_status(
+                    await self._emit_run_event(
                         run_id,
-                        "completed",
-                        output=final_response,
-                        usage=usage,
-                        last_event="run.completed",
+                        {
+                            "event": "run.completed",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "output": final_response,
+                            "usage": usage,
+                        },
+                        status="completed",
+                        terminal=True,
+                        status_fields={"output": final_response, "usage": usage},
                     )
             except asyncio.CancelledError:
-                self._set_run_status(
-                    run_id,
-                    "cancelled",
-                    last_event="run.cancelled",
-                )
                 try:
-                    q.put_nowait({
-                        "event": "run.cancelled",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                    })
+                    await self._emit_run_event(
+                        run_id,
+                        {
+                            "event": "run.cancelled",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                        },
+                        status="cancelled",
+                        terminal=True,
+                    )
                 except Exception:
                     pass
                 raise
             except Exception as exc:
                 logger.exception("[api_server] run %s failed", run_id)
-                self._set_run_status(
-                    run_id,
-                    "failed",
-                    error=str(exc),
-                    last_event="run.failed",
-                )
                 try:
-                    q.put_nowait({
-                        "event": "run.failed",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "error": str(exc),
-                    })
+                    await self._emit_run_event(
+                        run_id,
+                        {
+                            "event": "run.failed",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "error": str(exc),
+                        },
+                        status="failed",
+                        terminal=True,
+                        status_fields={"error": str(exc)},
+                    )
                 except Exception:
                     pass
             finally:
-                # Sentinel: signal SSE stream to close
-                try:
-                    q.put_nowait(None)
-                except Exception:
-                    pass
                 self._active_run_agents.pop(run_id, None)
                 self._active_run_tasks.pop(run_id, None)
 
@@ -2897,7 +3293,12 @@ class APIServerAdapter(BasePlatformAdapter):
             {"X-Hermes-Session-Key": gateway_session_key} if gateway_session_key else {}
         )
         return web.json_response(
-            {"run_id": run_id, "status": "started"},
+            {
+                "run_id": run_id,
+                "status": "started",
+                "session_id": session_id,
+                "events_url": f"/v1/runs/{run_id}/events",
+            },
             status=202,
             headers=response_headers,
         )
@@ -2909,13 +3310,36 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
-        status = self._run_statuses.get(run_id)
+        status = self._run_event_store.get_status(run_id)
         if status is None:
             return web.json_response(
                 _openai_error(f"Run not found: {run_id}", code="run_not_found"),
                 status=404,
             )
+        self._run_statuses[run_id] = status
         return web.json_response(status)
+
+    @staticmethod
+    def _format_run_sse(event: Dict[str, Any]) -> bytes:
+        sequence = event.get("sequence", "")
+        event_type = event.get("event", "message")
+        payload = json.dumps(event)
+        return f"id: {sequence}\nevent: {event_type}\ndata: {payload}\n\n".encode()
+
+    @staticmethod
+    def _parse_run_after(request: "web.Request") -> tuple[Optional[int], Optional[str]]:
+        raw = request.query.get("after")
+        if raw is None:
+            raw = request.headers.get("Last-Event-ID")
+        if raw in (None, ""):
+            return 0, None
+        try:
+            after = int(str(raw))
+        except (TypeError, ValueError):
+            return None, "Invalid 'after' cursor"
+        if after < 0:
+            return None, "Invalid 'after' cursor"
+        return after, None
 
     async def _handle_run_events(self, request: "web.Request") -> "web.StreamResponse":
         """GET /v1/runs/{run_id}/events — SSE stream of structured agent lifecycle events."""
@@ -2924,16 +3348,38 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
+        after, cursor_error = self._parse_run_after(request)
+        if cursor_error:
+            return web.json_response(_openai_error(cursor_error, param="after"), status=400)
 
         # Allow subscribing slightly before the run is registered (race condition window)
         for _ in range(20):
-            if run_id in self._run_streams:
+            if self._run_event_store.get_status(run_id) is not None:
                 break
             await asyncio.sleep(0.05)
         else:
             return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
 
-        q = self._run_streams[run_id]
+        q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
+        replay_events: List[Dict[str, Any]] = []
+        highest_sent = after or 0
+        should_follow_live = False
+
+        async with self._get_run_lock(run_id):
+            status = self._run_event_store.get_status(run_id)
+            if status is None:
+                return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
+            terminal = RunEventStore.is_terminal_status(status.get("status", ""))
+            last_sequence = int(status.get("last_sequence", 0) or 0)
+            should_follow_live = not terminal
+            if should_follow_live:
+                self._run_subscribers.setdefault(run_id, set()).add(q)
+            replay_events = self._run_event_store.list_events_after(run_id, after or 0)
+            for event in replay_events:
+                highest_sent = max(highest_sent, int(event.get("sequence", 0) or 0))
+            if terminal and (after or 0) >= last_sequence:
+                replay_events = []
+                should_follow_live = False
 
         response = web.StreamResponse(
             status=200,
@@ -2946,6 +3392,13 @@ class APIServerAdapter(BasePlatformAdapter):
         await response.prepare(request)
 
         try:
+            for event in replay_events:
+                await response.write(self._format_run_sse(event))
+
+            if not should_follow_live:
+                await response.write(b": stream closed\n\n")
+                return response
+
             while True:
                 try:
                     event = await asyncio.wait_for(q.get(), timeout=30.0)
@@ -2956,13 +3409,22 @@ class APIServerAdapter(BasePlatformAdapter):
                     # Run finished — send final SSE comment and close
                     await response.write(b": stream closed\n\n")
                     break
-                payload = f"data: {json.dumps(event)}\n\n"
-                await response.write(payload.encode())
+                sequence = int(event.get("sequence", 0) or 0)
+                if sequence <= highest_sent:
+                    continue
+                highest_sent = sequence
+                await response.write(self._format_run_sse(event))
+                if RunEventStore.is_terminal_status(str(event.get("event", "")).removeprefix("run.")):
+                    await response.write(b": stream closed\n\n")
+                    break
         except Exception as exc:
             logger.debug("[api_server] SSE stream error for run %s: %s", run_id, exc)
         finally:
-            self._run_streams.pop(run_id, None)
-            self._run_streams_created.pop(run_id, None)
+            subscribers = self._run_subscribers.get(run_id)
+            if subscribers is not None:
+                subscribers.discard(q)
+                if not subscribers:
+                    self._run_subscribers.pop(run_id, None)
 
         return response
 
@@ -3007,21 +3469,20 @@ class APIServerAdapter(BasePlatformAdapter):
         return web.json_response({"run_id": run_id, "status": "stopping"})
 
     async def _sweep_orphaned_runs(self) -> None:
-        """Periodically clean up run streams that were never consumed."""
+        """Periodically prune retained terminal run events and status cache."""
         while True:
             await asyncio.sleep(60)
             now = time.time()
-            stale = [
-                run_id
-                for run_id, created_at in list(self._run_streams_created.items())
-                if now - created_at > self._RUN_STREAM_TTL
-            ]
-            for run_id in stale:
-                logger.debug("[api_server] sweeping orphaned run %s", run_id)
-                self._run_streams.pop(run_id, None)
-                self._run_streams_created.pop(run_id, None)
-                self._active_run_agents.pop(run_id, None)
-                self._active_run_tasks.pop(run_id, None)
+            try:
+                pruned = self._run_event_store.prune_terminal(self._RUN_STATUS_TTL, now=now)
+            except Exception:
+                logger.exception("[api_server] failed to prune terminal run events")
+                pruned = []
+            for run_id in pruned:
+                logger.debug("[api_server] pruned terminal run event history for %s", run_id)
+                self._run_statuses.pop(run_id, None)
+                self._run_subscribers.pop(run_id, None)
+                self._run_event_locks.pop(run_id, None)
 
             stale_statuses = [
                 run_id
@@ -3147,6 +3608,10 @@ class APIServerAdapter(BasePlatformAdapter):
         if self._runner:
             await self._runner.cleanup()
             self._runner = None
+        try:
+            self._run_event_store.close()
+        except Exception:
+            pass
         self._app = None
         logger.info("[%s] API server stopped", self.name)
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -590,6 +590,7 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["run_events_resumable"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
 

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -12,7 +12,7 @@ import asyncio
 import json
 import threading
 import time as _time
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from aiohttp import web
@@ -31,9 +31,10 @@ from gateway.platforms.api_server import (
 # ---------------------------------------------------------------------------
 
 
-def _make_adapter(api_key: str = "") -> APIServerAdapter:
+def _make_adapter(api_key: str = "", **extra_overrides) -> APIServerAdapter:
     """Create an adapter with optional API key."""
-    extra = {}
+    extra = {"run_event_store_path": ":memory:"}
+    extra.update(extra_overrides)
     if api_key:
         extra["key"] = api_key
     config = PlatformConfig(enabled=True, extra=extra)
@@ -82,6 +83,48 @@ def _make_slow_agent(**kwargs):
     mock_agent.session_total_tokens = 0
 
     return mock_agent, ready, interrupted
+
+
+def _parse_sse_events(body: str):
+    """Return decoded SSE data payloads from a response body."""
+    events = []
+    for block in body.split("\n\n"):
+        data_lines = [
+            line.removeprefix("data: ")
+            for line in block.splitlines()
+            if line.startswith("data: ")
+        ]
+        if not data_lines:
+            continue
+        events.append(json.loads("\n".join(data_lines)))
+    return events
+
+
+def _make_streaming_agent(deltas=None, final_response="done", release=None, ready=None):
+    """Create an agent factory that emits text deltas through the captured callback."""
+    deltas = list(deltas or [])
+
+    def _factory(**kwargs):
+        stream_delta_callback = kwargs.get("stream_delta_callback")
+        mock_agent = MagicMock()
+
+        def _run(user_message=None, conversation_history=None, task_id=None):
+            if ready is not None:
+                ready.set()
+            if release is not None:
+                release.wait(timeout=5)
+            for delta in deltas:
+                if stream_delta_callback is not None:
+                    stream_delta_callback(delta)
+            return {"final_response": final_response}
+
+        mock_agent.run_conversation.side_effect = _run
+        mock_agent.session_prompt_tokens = 1
+        mock_agent.session_completion_tokens = 2
+        mock_agent.session_total_tokens = 3
+        return mock_agent
+
+    return _factory
 
 
 @pytest.fixture
@@ -318,6 +361,219 @@ class TestRunEvents:
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get("/v1/runs/run_any/events")
         assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_after_query_replays_only_higher_sequences(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_create.side_effect = _make_streaming_agent(
+                    deltas=["hello"],
+                    final_response="done",
+                )
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events?after=1")
+                assert events_resp.status == 200
+                body = await events_resp.text()
+                events = _parse_sse_events(body)
+
+        assert events
+        assert all(event["sequence"] > 1 for event in events)
+        assert events[0]["event"] != "run.started"
+        assert "id: " in body
+        assert "event: " in body
+
+    @pytest.mark.asyncio
+    async def test_last_event_id_replays_only_higher_sequences(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_create.side_effect = _make_streaming_agent(
+                    deltas=["first", "second"],
+                    final_response="done",
+                )
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                events_resp = await cli.get(
+                    f"/v1/runs/{run_id}/events",
+                    headers={"Last-Event-ID": "2"},
+                )
+                body = await events_resp.text()
+                events = _parse_sse_events(body)
+
+        assert events
+        assert all(event["sequence"] > 2 for event in events)
+
+    @pytest.mark.asyncio
+    async def test_after_query_takes_precedence_over_last_event_id(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_create.side_effect = _make_streaming_agent(
+                    deltas=["one", "two"],
+                    final_response="done",
+                )
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                events_resp = await cli.get(
+                    f"/v1/runs/{run_id}/events?after=1",
+                    headers={"Last-Event-ID": "999"},
+                )
+                body = await events_resp.text()
+                events = _parse_sse_events(body)
+
+        assert events
+        assert all(event["sequence"] > 1 for event in events)
+        assert any(event["event"] == "message.delta" for event in events)
+
+    @pytest.mark.asyncio
+    async def test_completed_run_after_last_sequence_closes_cleanly(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_create.side_effect = _make_streaming_agent(
+                    deltas=["hello"],
+                    final_response="done",
+                )
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                last_sequence = status["last_sequence"]
+                events_resp = await cli.get(
+                    f"/v1/runs/{run_id}/events?after={last_sequence}"
+                )
+                assert events_resp.status == 200
+                body = await asyncio.wait_for(events_resp.text(), timeout=2.0)
+
+        assert _parse_sse_events(body) == []
+
+    @pytest.mark.asyncio
+    async def test_multiple_subscribers_each_receive_live_events(self, adapter):
+        release = threading.Event()
+        ready = threading.Event()
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_create.side_effect = _make_streaming_agent(
+                    deltas=["shared"],
+                    final_response="done",
+                    release=release,
+                    ready=ready,
+                )
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+                ready.wait(timeout=3)
+
+                first = await cli.get(f"/v1/runs/{run_id}/events")
+                second = await cli.get(f"/v1/runs/{run_id}/events")
+
+                release.set()
+
+                first_body, second_body = await asyncio.wait_for(
+                    asyncio.gather(first.text(), second.text()),
+                    timeout=5.0,
+                )
+
+        first_events = _parse_sse_events(first_body)
+        second_events = _parse_sse_events(second_body)
+        assert [event["event"] for event in first_events] == [
+            event["event"] for event in second_events
+        ]
+        assert any(event.get("delta") == "shared" for event in first_events)
+        assert any(event.get("delta") == "shared" for event in second_events)
+
+    @pytest.mark.asyncio
+    async def test_reconnect_after_disconnect_receives_missed_events(self, adapter):
+        release = threading.Event()
+        ready = threading.Event()
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_create.side_effect = _make_streaming_agent(
+                    deltas=["missed"],
+                    final_response="done",
+                    release=release,
+                    ready=ready,
+                )
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+                ready.wait(timeout=3)
+
+                first = await cli.get(f"/v1/runs/{run_id}/events")
+                first.close()
+
+                release.set()
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                second = await cli.get(f"/v1/runs/{run_id}/events")
+                body = await second.text()
+                events = _parse_sse_events(body)
+
+        assert any(event.get("delta") == "missed" for event in events)
+        assert events[-1]["event"] == "run.completed"
+
+    def test_startup_marks_persisted_running_runs_abandoned(self, tmp_path):
+        db_path = tmp_path / "run_events.db"
+        first = _make_adapter(run_event_store_path=str(db_path))
+        first._run_event_store.initialize_run(
+            "run_stale",
+            status="running",
+            created_at=_time.time(),
+            status_data={"session_id": "run_stale"},
+        )
+        first._run_event_store.close()
+
+        second = _make_adapter(run_event_store_path=str(db_path))
+        status = second._run_event_store.get_status("run_stale")
+        events = second._run_event_store.list_events_after("run_stale", 0)
+
+        assert status["status"] == "failed"
+        assert "abandoned" in status["error"]
+        assert events[-1]["event"] == "run.failed"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR fixes the structured `/v1/runs` event stream so browser refreshes, dropped SSE connections, and proxy reconnects do not interrupt observation of an in-progress agent run. Run events are now persisted, sequenced, replayable after disconnect, and fanned out to multiple live SSE subscribers without interrupting the underlying agent run.

## Why

Web clients should be able to refresh the page, recover from a dropped SSE connection, or reconnect through a proxy timeout without interrupting an in-progress agent conversation.

Previously, `/v1/runs` started the agent in the background, but event observation was tied to a single in-memory SSE queue. Once the browser page refreshed or the SSE connection closed, the queue was removed, so the client could no longer receive missed output or continue streaming the same run.

This change lets the agent keep running independently from the browser connection. A refreshed page can reconnect with the same `run_id`, replay missed events from the last seen sequence, and continue receiving live output.

## Architecture

- Adds a SQLite-backed `RunEventStore` in the API server layer.
- Keeps `AIAgent.run_conversation()` synchronous and transport-agnostic.
- Routes `stream_delta_callback` and `tool_progress_callback` into an API-server event broker.
- Replaces the single run queue with per-run multi-subscriber SSE fanout.
- Uses durable run metadata as the source of truth for `GET /v1/runs/{run_id}`.

## Key Design Choices

- Every run event gets a monotonically increasing per-run `sequence`.
- SSE emits `id:`, `event:`, and `data:` fields.
- Clients can resume with either `Last-Event-ID` or `?after=`.
- `?after=` takes precedence if both cursors are supplied.
- Reconnect registers the subscriber before replay and drops duplicate queued events by sequence.
- Terminal runs close cleanly when `after >= last_sequence`.
- Persisted non-terminal runs from a previous process are marked failed/abandoned on startup.
- `/v1/capabilities` now advertises `run_events_resumable`.

## Files

- `gateway/platforms/api_server.py`
  - Adds `RunEventStore`.
  - Refactors `/v1/runs` event delivery to durable replay plus multi-subscriber SSE.
  - Updates run status lookup, terminal cleanup, startup reconciliation, and capabilities.

- `tests/gateway/test_api_server_runs.py`
  - Adds coverage for replay cursors, reconnect after disconnect, multiple subscribers, terminal close behavior, stop behavior, and abandoned-run reconciliation.

- `tests/gateway/test_api_server.py`
  - Verifies `run_events_resumable` is advertised.

- `docs/superpowers/specs/2026-05-07-api-run-reconnect-design.md`
  - Adds the design doc with implemented architecture and upstream notes.

## Notes

- Does not affect TUI or dashboard PTY/TUI chat.
- Does not change `/v1/chat/completions` disconnect semantics.
- Does not change `/v1/responses` disconnect semantics.
- Does not attempt process-restart recovery of in-flight agent execution; only event history and terminal status are durable.
- Supersedes the closed PR #21106, which used the wrong PR title prefix.

## Test Plan

- `python -m pytest -o addopts='' tests/gateway/test_api_server_runs.py tests/gateway/test_api_server.py -q` (`162 passed`)
- `python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py`
- `git diff --check -- FETCH_HEAD..HEAD`