### PR TITLE
fix(gateway): sync Telegram topics for title commands

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1177,6 +1177,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
                 self._handle_media_message
             ))
+            status_update_filters = getattr(filters, "StatusUpdate", None)
+            forum_topic_edited_filter = getattr(status_update_filters, "FORUM_TOPIC_EDITED", None)
+            if forum_topic_edited_filter is not None:
+                self._app.add_handler(TelegramMessageHandler(
+                    forum_topic_edited_filter,
+                    self._handle_forum_topic_edited,
+                ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
             
@@ -3557,6 +3564,28 @@ class TelegramAdapter(BasePlatformAdapter):
         
         event = self._build_message_event(update.message, MessageType.COMMAND, update_id=update.update_id)
         await self.handle_message(event)
+
+    async def _handle_forum_topic_edited(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Track Telegram topic rename service updates without sending them to the agent."""
+        if not update.message:
+            return
+        topic_edit = getattr(update.message, "forum_topic_edited", None)
+        topic_name = getattr(topic_edit, "name", None)
+        if not topic_name:
+            return
+        try:
+            event = self._build_message_event(update.message, MessageType.TEXT, update_id=update.update_id)
+        except Exception:
+            logger.debug("[%s] Failed to build event for Telegram topic edit", self.name, exc_info=True)
+            return
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        callback = getattr(runner, "_handle_telegram_topic_name_edited", None)
+        if not callable(callback):
+            return
+        try:
+            await callback(event.source, str(topic_name))
+        except Exception:
+            logger.debug("[%s] Failed to record Telegram topic edit", self.name, exc_info=True)
 
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming location/venue pin messages."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1730,8 +1730,8 @@ class GatewayRunner:
             return True
         import time as _time
         now = _time.monotonic()
-        last = self._telegram_lobby_reminder_ts.get(chat_id, 0.0)
-        if now - last < self._TELEGRAM_LOBBY_REMINDER_COOLDOWN_S:
+        last = self._telegram_lobby_reminder_ts.get(chat_id)
+        if last is not None and now - last < self._TELEGRAM_LOBBY_REMINDER_COOLDOWN_S:
             return False
         self._telegram_lobby_reminder_ts[chat_id] = now
         return True
@@ -1773,12 +1773,23 @@ class GatewayRunner:
         session_db = getattr(self, "_session_db", None)
         if session_db is None or not source.chat_id or not source.thread_id:
             return
+        managed_mode = "auto"
+        try:
+            existing = session_db.get_telegram_topic_binding(
+                chat_id=str(source.chat_id),
+                thread_id=str(source.thread_id),
+            )
+            if existing:
+                managed_mode = str(existing.get("managed_mode") or "auto")
+        except Exception:
+            logger.debug("Failed to read Telegram topic binding before rebinding", exc_info=True)
         session_db.bind_telegram_topic(
             chat_id=str(source.chat_id),
             thread_id=str(source.thread_id),
             user_id=str(source.user_id or ""),
             session_key=session_entry.session_key,
             session_id=session_entry.session_id,
+            managed_mode=managed_mode,
         )
 
     def _resolve_session_agent_runtime(
@@ -8142,6 +8153,8 @@ class GatewayRunner:
         # Set session title if provided with /new <title>
         _title_arg = event.get_command_args().strip()
         _title_note = ""
+        sanitized = None
+        title_set = False
         if _title_arg and self._session_db and new_entry:
             from hermes_state import SessionDB
             try:
@@ -8151,12 +8164,16 @@ class GatewayRunner:
                 _title_note = t("gateway.reset.title_rejected", error=str(e))
             if sanitized:
                 try:
-                    self._session_db.set_session_title(new_entry.session_id, sanitized)
-                    header = t("gateway.reset.header_titled", title=sanitized)
+                    title_set = self._session_db.set_session_title(new_entry.session_id, sanitized)
+                    if title_set:
+                        header = t("gateway.reset.header_titled", title=sanitized)
+                    else:
+                        _title_note = "\n⚠️ Session title could not be stored — session started untitled."
                 except ValueError as e:
                     _title_note = t("gateway.reset.title_error_untitled", error=str(e))
                 except Exception:
-                    pass
+                    logger.debug("Failed to set session title after /new", exc_info=True)
+                    _title_note = "\n⚠️ Session title could not be stored — session started untitled."
             elif not _title_note:
                 # sanitize_title returned empty (whitespace-only / unprintable)
                 _title_note = t("gateway.reset.title_empty_untitled")
@@ -8172,6 +8189,14 @@ class GatewayRunner:
                 self._record_telegram_topic_binding(source, new_entry)
             except Exception:
                 logger.debug("Failed to rebind Telegram topic after /new", exc_info=True)
+
+        if _title_arg and sanitized and title_set and new_entry is not None:
+            await self._rename_telegram_topic_for_session_title(
+                source,
+                new_entry.session_id,
+                sanitized,
+                force=True,
+            )
 
         # Fire plugin on_session_reset hook (new session guaranteed to exist)
         try:
@@ -10955,13 +10980,73 @@ class GatewayRunner:
             cleaned = cleaned[:117].rstrip() + "..."
         return cleaned
 
+    def _set_telegram_topic_binding_managed_mode(
+        self,
+        source: SessionSource,
+        managed_mode: str,
+    ) -> None:
+        """Best-effort update of Telegram topic binding ownership metadata."""
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None or not source.chat_id or not source.thread_id:
+            return
+        update_mode = getattr(session_db, "update_telegram_topic_binding_managed_mode", None)
+        if not callable(update_mode):
+            return
+        try:
+            update_mode(
+                chat_id=str(source.chat_id),
+                thread_id=str(source.thread_id),
+                managed_mode=managed_mode,
+            )
+        except Exception:
+            logger.debug("Failed to update Telegram topic binding managed_mode", exc_info=True)
+
+    async def _handle_telegram_topic_name_edited(
+        self,
+        source: SessionSource,
+        topic_name: str,
+    ) -> None:
+        """Track user-edited Telegram topic names so auto-title does not clobber them."""
+        if not topic_name or not self._is_telegram_topic_lane(source):
+            return
+        session_db = getattr(self, "_session_db", None)
+        if session_db is None or not source.chat_id or not source.thread_id:
+            return
+        try:
+            binding = session_db.get_telegram_topic_binding(
+                chat_id=str(source.chat_id),
+                thread_id=str(source.thread_id),
+            )
+        except Exception:
+            logger.debug("Failed to read Telegram topic binding after topic edit", exc_info=True)
+            return
+        if not binding:
+            return
+
+        current_name = self._sanitize_telegram_topic_title(topic_name)
+        expected_title = ""
+        try:
+            expected_title = session_db.get_session_title(str(binding.get("session_id") or "")) or ""
+        except Exception:
+            logger.debug("Failed to read session title after Telegram topic edit", exc_info=True)
+        expected_name = self._sanitize_telegram_topic_title(expected_title) if expected_title else ""
+        # Telegram emits the same service update for bot-initiated renames and
+        # user-initiated edits. If the new name matches the stored session title,
+        # keep Hermes ownership; otherwise treat the topic as user-managed.
+        self._set_telegram_topic_binding_managed_mode(
+            source,
+            "auto" if expected_name and current_name == expected_name else "manual",
+        )
+
     async def _rename_telegram_topic_for_session_title(
         self,
         source: SessionSource,
         session_id: str,
         title: str,
+        *,
+        force: bool = False,
     ) -> None:
-        """Best-effort rename of a Telegram DM topic when Hermes auto-titles a session."""
+        """Best-effort rename of a Telegram DM topic when a session title changes."""
         if not self._is_telegram_topic_lane(source) or not source.chat_id or not source.thread_id:
             return
 
@@ -10987,6 +11072,7 @@ class GatewayRunner:
                     return
 
         session_db = getattr(self, "_session_db", None)
+        binding = None
         if session_db is not None:
             try:
                 binding = session_db.get_telegram_topic_binding(
@@ -10994,6 +11080,8 @@ class GatewayRunner:
                     thread_id=str(source.thread_id),
                 )
                 if binding and str(binding.get("session_id") or "") != str(session_id):
+                    return
+                if binding and not force and str(binding.get("managed_mode") or "auto") != "auto":
                     return
             except Exception:
                 logger.debug("Failed to verify Telegram topic binding before rename", exc_info=True)
@@ -11010,6 +11098,8 @@ class GatewayRunner:
                     thread_id=str(source.thread_id),
                     name=topic_name,
                 )
+                if force:
+                    self._set_telegram_topic_binding_managed_mode(source, "auto")
                 return
 
             bot = getattr(adapter, "_bot", None)
@@ -11030,6 +11120,8 @@ class GatewayRunner:
                     message_thread_id=source.thread_id,
                     name=topic_name,
                 )
+            if force:
+                self._set_telegram_topic_binding_managed_mode(source, "auto")
         except Exception:
             logger.debug("Failed to rename Telegram topic for auto-generated title", exc_info=True)
 
@@ -11079,8 +11171,8 @@ class GatewayRunner:
             return True
         import time as _time
         now = _time.monotonic()
-        last = self._telegram_capability_hint_ts.get(chat_id, 0.0)
-        if now - last < self._TELEGRAM_CAPABILITY_HINT_COOLDOWN_S:
+        last = self._telegram_capability_hint_ts.get(chat_id)
+        if last is not None and now - last < self._TELEGRAM_CAPABILITY_HINT_COOLDOWN_S:
             return False
         self._telegram_capability_hint_ts[chat_id] = now
         return True
@@ -11368,6 +11460,12 @@ class GatewayRunner:
             # Set the title
             try:
                 if self._session_db.set_session_title(session_id, sanitized):
+                    await self._rename_telegram_topic_for_session_title(
+                        source,
+                        session_id,
+                        sanitized,
+                        force=True,
+                    )
                     return t("gateway.title.set_to", title=sanitized)
                 else:
                     return t("gateway.title.not_found")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2604,6 +2604,30 @@ class SessionDB:
                 return None
         return dict(row) if row else None
 
+    def update_telegram_topic_binding_managed_mode(
+        self,
+        *,
+        chat_id: str,
+        thread_id: str,
+        managed_mode: str,
+    ) -> bool:
+        """Update the ownership mode for an existing Telegram DM topic binding."""
+        def _do(conn):
+            try:
+                cursor = conn.execute(
+                    """
+                    UPDATE telegram_dm_topic_bindings
+                    SET managed_mode = ?, updated_at = ?
+                    WHERE chat_id = ? AND thread_id = ?
+                    """,
+                    (str(managed_mode), time.time(), str(chat_id), str(thread_id)),
+                )
+            except sqlite3.OperationalError:
+                return 0
+            return cursor.rowcount
+        rowcount = self._execute_write(_do)
+        return rowcount > 0
+
     def bind_telegram_topic(
         self,
         *,

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -750,6 +750,149 @@ async def test_topic_root_command_creates_and_pins_system_topic(tmp_path, monkey
 
 
 @pytest.mark.asyncio
+async def test_new_with_title_renames_current_telegram_topic(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+
+    result = await runner._handle_reset_command(
+        _make_event("/new Fix Telegram topic titles", thread_id="42")
+    )
+
+    assert "Fix Telegram topic titles" in result.text
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="Fix Telegram topic titles",
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_with_title_does_not_rename_topic_when_title_store_fails(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    runner._session_db.set_session_title = MagicMock(return_value=False)
+
+    result = await runner._handle_reset_command(
+        _make_event("/new Unsaved Topic Title", thread_id="42")
+    )
+
+    assert "could not be stored" in result.text
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_new_with_title_does_not_rename_general_telegram_topic(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    runner = _make_runner(session_db=db)
+
+    result = await runner._handle_reset_command(
+        _make_event("/new General Topic Title", thread_id="1")
+    )
+
+    assert "General Topic Title" in result.text
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_new_with_title_does_not_rename_operator_declared_topic(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    runner = _make_runner(session_db=db)
+
+    class _FakeAdapter:
+        def _get_dm_topic_info(self, chat_id, thread_id):
+            return {"name": "Research", "skill": "arxiv"}
+
+        async def rename_dm_topic(self, **kwargs):
+            return None
+
+    fake = _FakeAdapter()
+    fake.rename_dm_topic = AsyncMock()
+    runner.adapters[Platform.TELEGRAM] = fake
+
+    result = await runner._handle_reset_command(
+        _make_event("/new Operator Topic Title", thread_id="17585")
+    )
+
+    assert "Operator Topic Title" in result.text
+    fake.rename_dm_topic.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_title_command_renames_current_telegram_topic(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+
+    result = await runner._handle_title_command(
+        _make_event("/title Config Changes", thread_id="42")
+    )
+
+    assert "Session title set" in result
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_awaited_once_with(
+        chat_id="208214988",
+        thread_id="42",
+        name="Config Changes",
+    )
+
+
+@pytest.mark.asyncio
+async def test_title_command_does_not_rename_general_telegram_topic(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    runner = _make_runner(session_db=db)
+
+    result = await runner._handle_title_command(
+        _make_event("/title General Topic Title", thread_id="1")
+    )
+
+    assert "Session title set" in result
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_title_command_does_not_rename_operator_declared_topic(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    runner = _make_runner(session_db=db)
+
+    class _FakeAdapter:
+        def _get_dm_topic_info(self, chat_id, thread_id):
+            return {"name": "Research", "skill": "arxiv"}
+
+        async def rename_dm_topic(self, **kwargs):
+            return None
+
+    fake = _FakeAdapter()
+    fake.rename_dm_topic = AsyncMock()
+    runner.adapters[Platform.TELEGRAM] = fake
+
+    result = await runner._handle_title_command(
+        _make_event("/title Operator Topic Title", thread_id="17585")
+    )
+
+    assert "Session title set" in result
+    fake.rename_dm_topic.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_auto_generated_title_renames_bound_telegram_topic(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     db.apply_telegram_topic_migration()
@@ -862,8 +1005,8 @@ def test_general_topic_is_treated_as_root_lobby(tmp_path):
 def test_lobby_reminder_is_debounced_per_chat(tmp_path):
     """Consecutive root-DM prompts should only surface one lobby reminder per cooldown."""
     db = SessionDB(db_path=tmp_path / "state.db")
-    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
     runner = _make_runner(session_db=db)
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
 
     source = _make_source(thread_id=None)
     assert runner._should_send_telegram_lobby_reminder(source) is True
@@ -872,11 +1015,30 @@ def test_lobby_reminder_is_debounced_per_chat(tmp_path):
     assert runner._should_send_telegram_lobby_reminder(source) is False
 
     # A different chat gets its own window.
-    other = _make_source(thread_id=None)
-    # Swap chat_id so the debounce key is different.
     from dataclasses import replace
+    other = _make_source(thread_id=None)
     other = replace(other, chat_id="999999999")
     assert runner._should_send_telegram_lobby_reminder(other) is True
+
+
+def test_telegram_debounce_first_call_allows_short_uptime(tmp_path, monkeypatch):
+    """First debounce hit must pass even when monotonic() is below the cooldown.
+
+    Fresh Linux CI runners can have a process monotonic clock below 300s; a
+    missing timestamp is not the same thing as a timestamp at zero. Cute bug.
+    """
+    import time
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    runner = _make_runner(session_db=db)
+    source = _make_source(thread_id=None)
+    monkeypatch.setattr(time, "monotonic", lambda: 12.0)
+
+    assert runner._should_send_telegram_lobby_reminder(source) is True
+    assert runner._should_send_telegram_capability_hint(source) is True
+    assert runner._should_send_telegram_lobby_reminder(source) is False
+    assert runner._should_send_telegram_capability_hint(source) is False
+
 
 
 def test_binding_survives_session_deletion_via_cascade(tmp_path):
@@ -1051,4 +1213,139 @@ async def test_topic_refuses_unauthorized_user(tmp_path, monkeypatch):
 
 
 
+def test_topic_off_resets_debounce_counters(tmp_path):
+    """Disabling topic mode clears per-chat debounce state."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    runner = _make_runner(session_db=db)
 
+    source = _make_source()
+    # Prime the debounce counters.
+    assert runner._should_send_telegram_lobby_reminder(source) is True
+    assert runner._should_send_telegram_capability_hint(source) is True
+    assert runner._should_send_telegram_lobby_reminder(source) is False
+    assert runner._should_send_telegram_capability_hint(source) is False
+
+    # /topic off resets them.
+    result = runner._disable_telegram_topic_mode_for_chat(source)
+    assert "OFF" in result or "off" in result
+
+    # Re-enable and verify counters reset (so the first reminder/hint
+    # after re-enabling can land immediately).
+    db.enable_telegram_topic_mode(chat_id="208214988", user_id="208214988")
+    assert runner._should_send_telegram_lobby_reminder(source) is True
+    assert runner._should_send_telegram_capability_hint(source) is True
+
+
+@pytest.mark.asyncio
+async def test_auto_generated_title_does_not_rename_user_modified_topic(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+        managed_mode="manual",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+
+    await runner._rename_telegram_topic_for_session_title(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Auto-generated title should not clobber manual topic name",
+    )
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_telegram_topic_edit_marks_binding_manual_and_blocks_auto_rename(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.set_session_title("sess-topic", "Hermes Title")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+    source = _make_source(thread_id="42")
+
+    await runner._handle_telegram_topic_name_edited(source, "My hand-written topic name")
+
+    binding = db.get_telegram_topic_binding(chat_id="208214988", thread_id="42")
+    assert binding["managed_mode"] == "manual"
+
+    await runner._rename_telegram_topic_for_session_title(
+        source,
+        "sess-topic",
+        "Auto title after reset",
+    )
+
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.assert_not_called()
+
+
+def test_rebinding_topic_preserves_manual_managed_mode(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-old", source="telegram", user_id="208214988")
+    db.create_session("sess-new", source="telegram", user_id="208214988")
+    source = _make_source(thread_id="42")
+    session_key = "agent:main:telegram:dm:208214988:42"
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key=session_key,
+        session_id="sess-old",
+        managed_mode="manual",
+    )
+    runner = _make_runner(session_db=db)
+
+    runner._record_telegram_topic_binding(
+        source,
+        SessionEntry(
+            session_key=session_key,
+            session_id="sess-new",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            origin=source,
+        ),
+    )
+
+    binding = db.get_telegram_topic_binding(chat_id="208214988", thread_id="42")
+    assert binding["session_id"] == "sess-new"
+    assert binding["managed_mode"] == "manual"
+
+
+@pytest.mark.asyncio
+async def test_bot_matching_topic_edit_keeps_binding_auto(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.set_session_title("sess-topic", "Hermes Title")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+        managed_mode="manual",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda source: True
+
+    await runner._handle_telegram_topic_name_edited(_make_source(thread_id="42"), "Hermes Title")
+
+    binding = db.get_telegram_topic_binding(chat_id="208214988", thread_id="42")
+    assert binding["managed_mode"] == "auto"


### PR DESCRIPTION
## What does this PR do?

Synchronizes Telegram DM topic names when users manually title sessions from command paths, and prevents later auto-title generation from clobbering topics the user renamed by hand.

- `/new <title>` now renames the current Telegram topic only after the new session title is successfully stored.
- `/title <title>` now uses the guarded Telegram topic rename helper after title storage succeeds.
- User-edited Telegram topic names are detected from `FORUM_TOPIC_EDITED` service updates and marked manual.
- Auto-generated titles skip manual topic bindings; explicit `/new <title>` and `/title <title>` can still force Hermes-managed names.
- Rebinding a topic preserves manual ownership metadata instead of silently flipping it back to auto-managed.
- Root/General Telegram topics and operator-declared `extra.dm_topics` are protected from accidental renames.
- Title storage failures surface a user-visible warning instead of silently leaving topic/session state inconsistent.

This keeps the behavior controlled through the existing topic-lane, binding, operator-topic, and best-effort adapter safeguards already in `GatewayRunner`.

## Related Issue

Related: #20681, #14462, #16408, #9921

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - Gate `/new <title>` topic rename on successful `set_session_title()` persistence.
  - Call `_rename_telegram_topic_for_session_title()` from `/new <title>` and `/title <title>` command paths with an explicit-force path for user commands.
  - Skip auto-generated title renames when the Telegram topic binding is marked manual.
  - Preserve `managed_mode` when rebinding a topic to a new session.
  - Keep rename best-effort through the existing helper, including root/General, binding, and operator-declared topic safeguards.
- `gateway/platforms/telegram.py`
  - Register a `FORUM_TOPIC_EDITED` handler when supported by the Telegram library.
  - Forward topic edit service updates to the runner without sending them to the agent.
- `hermes_state.py`
  - Add a targeted helper to update Telegram topic binding `managed_mode` metadata.
- `tests/gateway/test_telegram_topic_mode.py`
  - Cover successful rename for `/new <title>` and `/title <title>` in Telegram topic lanes.
  - Cover no-rename behavior when title storage fails.
  - Cover no-rename behavior for Telegram General/root topics.
  - Cover no-rename behavior for operator-declared topics.
  - Cover manual topic edits blocking later auto-title renames.
  - Cover bot-matching topic edits keeping Hermes ownership as auto-managed.
  - Cover rebinding preserving manual ownership metadata.
  - Cover `/topic off` resetting topic-mode debounce counters.

## How to Test

1. `git diff --check origin/main...HEAD`
2. `python -m pytest -q tests/gateway/test_telegram_topic_mode.py`
3. `python -m pytest -q tests/gateway -k 'telegram_topic or topic_mode or title or reset'`
4. `python -m ruff check --ignore E402,E731,E401 gateway/platforms/telegram.py gateway/run.py hermes_state.py tests/gateway/test_telegram_topic_mode.py`
5. Added-line static scan for secrets/shell/eval/pickle/SQL injection: no findings

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
git diff --check origin/main...HEAD
# passed

python -m pytest -q tests/gateway/test_telegram_topic_mode.py
41 passed in 2.09s

python -m pytest -q tests/gateway -k 'telegram_topic or topic_mode or title or reset'
115 passed, 1 skipped, 16 warnings in 10.27s

python -m ruff check --ignore E402,E731,E401 gateway/platforms/telegram.py gateway/run.py hermes_state.py tests/gateway/test_telegram_topic_mode.py
All checks passed!

Added-line static scan
STATIC_SCAN_FINDINGS: none
```