### PR TITLE
fix(anthropic): reconcile keychain/file credentials when one is expired

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -703,44 +703,72 @@ def _read_claude_code_credentials_from_keychain() -> Optional[Dict[str, Any]]:
     return None
 
 
+def _read_claude_code_credentials_from_file() -> Optional[Dict[str, Any]]:
+    """Read Claude Code OAuth credentials from ~/.claude/.credentials.json.
+
+    Returns dict with {accessToken, refreshToken?, expiresAt?, source} or None.
+    """
+    cred_path = Path.home() / ".claude" / ".credentials.json"
+    if not cred_path.exists():
+        return None
+    try:
+        data = json.loads(cred_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, IOError) as e:
+        logger.debug("Failed to read ~/.claude/.credentials.json: %s", e)
+        return None
+
+    oauth_data = data.get("claudeAiOauth")
+    if not (oauth_data and isinstance(oauth_data, dict)):
+        return None
+    access_token = oauth_data.get("accessToken", "")
+    if not access_token:
+        return None
+    return {
+        "accessToken": access_token,
+        "refreshToken": oauth_data.get("refreshToken", ""),
+        "expiresAt": oauth_data.get("expiresAt", 0),
+        "source": "claude_code_credentials_file",
+    }
+
+
 def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
     """Read refreshable Claude Code OAuth credentials.
 
-    Checks two sources in order:
+    Reads from two possible sources and reconciles them:
       1. macOS Keychain (Darwin only) — "Claude Code-credentials" entry
       2. ~/.claude/.credentials.json file
+
+    Selection rules when both are present:
+      - If exactly one is non-expired, prefer that one. (Handles the case
+        where Claude Code refreshes one source but not the other — observed
+        in the wild on Claude Code 2.1.x.)
+      - Otherwise, prefer the source with the later ``expiresAt`` so that
+        any subsequent refresh uses the most recent ``refreshToken``.
 
     This intentionally excludes ~/.claude.json primaryApiKey. Opencode's
     subscription flow is OAuth/setup-token based with refreshable credentials,
     and native direct Anthropic provider usage should follow that path rather
     than auto-detecting Claude's first-party managed key.
 
-    Returns dict with {accessToken, refreshToken?, expiresAt?} or None.
+    Returns dict with {accessToken, refreshToken?, expiresAt?, source} or None.
     """
-    # Try macOS Keychain first (covers Claude Code >=2.1.114)
     kc_creds = _read_claude_code_credentials_from_keychain()
-    if kc_creds:
-        return kc_creds
+    file_creds = _read_claude_code_credentials_from_file()
 
-    # Fall back to JSON file
-    cred_path = Path.home() / ".claude" / ".credentials.json"
-    if cred_path.exists():
-        try:
-            data = json.loads(cred_path.read_text(encoding="utf-8"))
-            oauth_data = data.get("claudeAiOauth")
-            if oauth_data and isinstance(oauth_data, dict):
-                access_token = oauth_data.get("accessToken", "")
-                if access_token:
-                    return {
-                        "accessToken": access_token,
-                        "refreshToken": oauth_data.get("refreshToken", ""),
-                        "expiresAt": oauth_data.get("expiresAt", 0),
-                        "source": "claude_code_credentials_file",
-                    }
-        except (json.JSONDecodeError, OSError, IOError) as e:
-            logger.debug("Failed to read ~/.claude/.credentials.json: %s", e)
+    if kc_creds and file_creds:
+        kc_valid = is_claude_code_token_valid(kc_creds)
+        file_valid = is_claude_code_token_valid(file_creds)
+        if kc_valid and not file_valid:
+            return kc_creds
+        if file_valid and not kc_valid:
+            return file_creds
+        # Both valid or both expired: prefer the later expiresAt so the
+        # downstream refresh path uses the freshest refresh_token.
+        kc_exp = kc_creds.get("expiresAt", 0) or 0
+        file_exp = file_creds.get("expiresAt", 0) or 0
+        return kc_creds if kc_exp >= file_exp else file_creds
 
-    return None
+    return kc_creds or file_creds
 
 
 def read_claude_managed_key() -> Optional[str]:

--- a/tests/agent/test_anthropic_keychain.py
+++ b/tests/agent/test_anthropic_keychain.py
@@ -163,3 +163,107 @@ class TestReadClaudeCodeCredentialsPriority:
             creds = read_claude_code_credentials()
 
         assert creds is None
+
+
+class TestReadClaudeCodeCredentialsDesync:
+    """Reconciliation when Keychain and JSON file disagree.
+
+    Observed in the wild on Claude Code 2.1.x: a refresh updates one source
+    (commonly the JSON file) but leaves the other holding an expired token.
+    The reader must not blindly return whichever source it consulted first;
+    it must prefer the non-expired credential.
+    """
+
+    # Far-future ms-epoch — comfortably valid under is_claude_code_token_valid.
+    _FRESH = 9_999_999_999_999
+    # Past ms-epoch — comfortably expired (with the 60s buffer).
+    _EXPIRED = 1
+
+    def _setup(self, tmp_path, monkeypatch, *, file_expires_at, file_token="json-token"):
+        json_cred_file = tmp_path / ".claude" / ".credentials.json"
+        json_cred_file.parent.mkdir(parents=True)
+        json_cred_file.write_text(json.dumps({
+            "claudeAiOauth": {
+                "accessToken": file_token,
+                "refreshToken": "json-refresh",
+                "expiresAt": file_expires_at,
+            }
+        }))
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+    def _keychain_payload(self, *, access_token, expires_at, refresh_token="kc-refresh"):
+        return MagicMock(
+            returncode=0,
+            stdout=json.dumps({
+                "claudeAiOauth": {
+                    "accessToken": access_token,
+                    "refreshToken": refresh_token,
+                    "expiresAt": expires_at,
+                }
+            }),
+            stderr="",
+        )
+
+    def test_keychain_expired_file_fresh_returns_file(self, tmp_path, monkeypatch):
+        """Regression: when the Keychain holds an expired token but the JSON
+        file has a valid one, callers must receive the valid file token rather
+        than None. (Pre-fix behavior returned the expired Keychain token, and
+        downstream validity checks then yielded None — surfacing the misleading
+        ``No Anthropic credentials found`` error.)
+        """
+        self._setup(tmp_path, monkeypatch, file_expires_at=self._FRESH, file_token="fresh-file-token")
+        with patch("agent.anthropic_adapter.platform.system", return_value="Darwin"), \
+             patch("agent.anthropic_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = self._keychain_payload(
+                access_token="stale-keychain-token", expires_at=self._EXPIRED,
+            )
+            creds = read_claude_code_credentials()
+
+        assert creds is not None
+        assert creds["accessToken"] == "fresh-file-token"
+        assert creds["source"] == "claude_code_credentials_file"
+
+    def test_keychain_fresh_file_expired_returns_keychain(self, tmp_path, monkeypatch):
+        """Mirror case: file is the stale source; Keychain wins on validity."""
+        self._setup(tmp_path, monkeypatch, file_expires_at=self._EXPIRED, file_token="stale-file-token")
+        with patch("agent.anthropic_adapter.platform.system", return_value="Darwin"), \
+             patch("agent.anthropic_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = self._keychain_payload(
+                access_token="fresh-keychain-token", expires_at=self._FRESH,
+            )
+            creds = read_claude_code_credentials()
+
+        assert creds is not None
+        assert creds["accessToken"] == "fresh-keychain-token"
+        assert creds["source"] == "macos_keychain"
+
+    def test_both_valid_prefers_later_expiry_when_file_is_fresher(self, tmp_path, monkeypatch):
+        """When both are valid, the one with the later ``expiresAt`` wins so
+        that any subsequent refresh uses the freshest ``refresh_token``.
+        """
+        self._setup(tmp_path, monkeypatch, file_expires_at=self._FRESH, file_token="newer-file-token")
+        with patch("agent.anthropic_adapter.platform.system", return_value="Darwin"), \
+             patch("agent.anthropic_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = self._keychain_payload(
+                access_token="older-keychain-token", expires_at=self._FRESH - 1_000_000,
+            )
+            creds = read_claude_code_credentials()
+
+        assert creds is not None
+        assert creds["accessToken"] == "newer-file-token"
+
+    def test_both_expired_prefers_later_expiry(self, tmp_path, monkeypatch):
+        """When both are expired, return the one with the later ``expiresAt``;
+        its ``refresh_token`` is the most recently issued and most likely to
+        succeed at the OAuth refresh endpoint.
+        """
+        self._setup(tmp_path, monkeypatch, file_expires_at=self._EXPIRED + 5, file_token="newer-expired-file")
+        with patch("agent.anthropic_adapter.platform.system", return_value="Darwin"), \
+             patch("agent.anthropic_adapter.subprocess.run") as mock_run:
+            mock_run.return_value = self._keychain_payload(
+                access_token="older-expired-keychain", expires_at=self._EXPIRED,
+            )
+            creds = read_claude_code_credentials()
+
+        assert creds is not None
+        assert creds["accessToken"] == "newer-expired-file"


### PR DESCRIPTION
## Summary

Closes #21107.

`agent.anthropic_adapter.read_claude_code_credentials()` returned the macOS Keychain entry as soon as one existed, without checking validity. When the Keychain held an expired token but `~/.claude/.credentials.json` held a fresh one, the downstream `is_claude_code_token_valid()` check rejected the returned creds and `resolve_anthropic_token()` returned `None` — surfacing the misleading `No Anthropic credentials found` error even though Claude Code was fully authenticated.

This PR makes the function read both sources and reconcile them, preferring whichever is non-expired (and falling back to the later `expiresAt` when both share the same validity state, so any subsequent refresh uses the freshest `refresh_token`).

See #21107 for full root-cause analysis, repro steps, and notes on the Claude Code-side desync that triggers this in the wild.

## Relationship to prior work

This is a follow-up to #12971, which introduced macOS Keychain support. That PR established the "Keychain first, then file fallback" priority chain but didn't address the case where the two sources disagree on validity — exactly what this PR fixes.

## Changes

- `agent/anthropic_adapter.py`
  - Extract a sibling `_read_claude_code_credentials_from_file()` helper to mirror the existing `_read_claude_code_credentials_from_keychain()` shape.
  - Rewrite `read_claude_code_credentials()` to read both sources, then prefer the non-expired one (or the later `expiresAt` as tiebreaker).
- `tests/agent/test_anthropic_keychain.py`
  - Add `TestReadClaudeCodeCredentialsDesync` covering the four reconciliation cases.

## Behavior preserved

- The existing `TestReadClaudeCodeCredentialsPriority::test_keychain_takes_priority_over_json_file` test still passes — both fixtures share the same `expiresAt` and the tiebreaker uses `>=`, so Keychain still wins when neither source is more recent.
- Linux/Windows paths (no Keychain available) continue to fall through to the file directly via the same code path.

## Test plan

- [x] All 16 tests in `tests/agent/test_anthropic_keychain.py` pass (12 pre-existing + 4 new):
  - `test_keychain_expired_file_fresh_returns_file` (regression case for #21107)
  - `test_keychain_fresh_file_expired_returns_keychain`
  - `test_both_valid_prefers_later_expiry_when_file_is_fresher`
  - `test_both_expired_prefers_later_expiry`
- [x] Manually verified end-to-end on the original repro: `hermes -z "ping" -m claude-haiku-4-5 --provider anthropic` succeeds after the fix where it previously raised `AuthError`.

## Out of scope

- 19 pre-existing failures in `tests/agent/test_anthropic_adapter.py` on macOS hosts that have a populated Claude Code Keychain entry — those tests don't mock `_read_claude_code_credentials_from_keychain()`. They fail identically on unmodified `origin/main`. Worth a separate cleanup PR (similar to what #16498 did for `TestReadClaudeCodeCredentials`).
- The `auth.json` `last_status: "exhausted"` flag not auto-resetting after the underlying credential recovers — flagged in #21107's "Related observation" section.

## Suggested labels

`type/bug`, `comp/agent`, `provider/anthropic`, `area/auth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)