### PR TITLE
fix: resolve critical runtime bugs in email parsing, process monitoring, and analytics

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -518,7 +518,8 @@ class EmailAdapter(BasePlatformAdapter):
             msg["References"] = original_msg_id
 
         msg["Date"] = formatdate(localtime=True)
-        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
+        domain = self._address.split('@')[1] if '@' in self._address else 'hermes.local'
+        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{domain}>"
         msg["Message-ID"] = msg_id
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
@@ -627,7 +628,8 @@ class EmailAdapter(BasePlatformAdapter):
             msg["References"] = original_msg_id
 
         msg["Date"] = formatdate(localtime=True)
-        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
+        domain = self._address.split('@')[1] if '@' in self._address else 'hermes.local'
+        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{domain}>"
         msg["Message-ID"] = msg_id
 
         if body:
@@ -708,7 +710,8 @@ class EmailAdapter(BasePlatformAdapter):
             msg["References"] = original_msg_id
 
         msg["Date"] = formatdate(localtime=True)
-        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
+        domain = self._address.split('@')[1] if '@' in self._address else 'hermes.local'
+        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{domain}>"
         msg["Message-ID"] = msg_id
 
         if body:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -113,7 +113,19 @@ def _get_process_start_time(pid: int) -> Optional[int]:
     stat_path = Path(f"/proc/{pid}/stat")
     try:
         # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
-        return int(stat_path.read_text().split()[21])
+        # Note: The stat file format is delimited by spaces, but the comm field
+        # (field 2) can contain spaces if wrapped in parentheses. We must parse
+        # from the last ')' to find field boundaries reliably.
+        stat_text = stat_path.read_text()
+        # Find the closing paren of the comm field — fields after are fixed
+        paren_idx = stat_text.rfind(')')
+        if paren_idx < 0:
+            return None
+        # Fields after the comm: 3:state, 4:ppid, ..., 22:starttime (0-indexed from after paren)
+        fields_after_comm = stat_text[paren_idx + 1:].split()
+        if len(fields_after_comm) < 20:  # We need field [19] (0-indexed after paren)
+            return None
+        return int(fields_after_comm[19])
     except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
         return None
 

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -498,7 +498,7 @@ export default function AnalyticsPage() {
                     },
                     {
                       label: t.analytics.totalSessions,
-                      value: `${data.totals.total_sessions} (~${(data.totals.total_sessions / days).toFixed(1)}${t.analytics.perDayAvg})`,
+                      value: `${data.totals.total_sessions} (~${days > 0 ? (data.totals.total_sessions / days).toFixed(1) : 0}${t.analytics.perDayAvg})`,
                     },
                     {
                       label: t.analytics.apiCalls,


### PR DESCRIPTION
What does this PR do?
Three runtime crashes. All defensive guards. None change behavior for valid inputs.

1. Email sender dies on a malformed address
self._address.split('@')[1] assumes EMAIL_ADDRESS is always valid. It isn't — a misconfigured env var throws IndexError and takes the sender down with it.
Added a '@' in self._address check before the split. Falls back to hermes.local if it's missing.
Affects _send_email(), _send_email_with_attachments(), _send_email_with_attachment() — lines 521, 630, 711.

2. Process monitoring breaks on names with spaces
/proc/[pid]/stat splits fine until a process name has spaces or parentheses. Linux allows both. (firefox) alone is enough to misalign every field index after it.
Replaced the naive split() with a parser that anchors from the closing ) boundary, then counts forward to starttime. Position-independent.

3. First-day analytics returns NaN
No prior data on day one means a division-by-zero in the analytics path. The dashboard showed NaN instead of 0.
Guard clause. Returns 0.

Type of change

 Bug fix (non-breaking)

What changed, and why the approach:

All three fixes are the minimal defensive layer — no refactors, no behavior changes for valid inputs, no new dependencies.
The status.py fix is the only one with real structural change. The boundary-marker approach is more explicit than the original, but it mirrors how the Linux kernel documents the field: find ), count from there.