### PR TITLE
fix(gateway): honor top-level platform config extras

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -303,6 +303,21 @@ class PlatformConfig:
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
 
+        explicit_extra = data.get("extra")
+        extra = dict(explicit_extra) if isinstance(explicit_extra, dict) else {}
+        core_keys = {
+            "enabled",
+            "token",
+            "api_key",
+            "home_channel",
+            "reply_to_mode",
+            "gateway_restart_notification",
+            "extra",
+        }
+        for key, value in data.items():
+            if key not in core_keys and key not in extra:
+                extra[key] = value
+
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
             token=data.get("token"),
@@ -312,7 +327,7 @@ class PlatformConfig:
             gateway_restart_notification=_coerce_bool(
                 data.get("gateway_restart_notification"), True
             ),
-            extra=data.get("extra", {}),
+            extra=extra,
         )
 
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -70,6 +70,41 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
         assert restored.gateway_restart_notification is False
 
+    def test_from_dict_merges_top_level_platform_specific_fields_into_extra(self):
+        restored = PlatformConfig.from_dict(
+            {
+                "enabled": True,
+                "port": 8643,
+                "host": "127.0.0.1",
+                "key": "secret",
+                "cors_origins": ["https://example.com"],
+            }
+        )
+
+        assert restored.enabled is True
+        assert restored.extra == {
+            "port": 8643,
+            "host": "127.0.0.1",
+            "key": "secret",
+            "cors_origins": ["https://example.com"],
+        }
+
+    def test_from_dict_prefers_explicit_extra_over_top_level_platform_values(self):
+        restored = PlatformConfig.from_dict(
+            {
+                "port": 8643,
+                "host": "127.0.0.1",
+                "extra": {"port": 9000, "cors_origins": ["https://explicit.example"]},
+                "cors_origins": ["https://top-level.example"],
+            }
+        )
+
+        assert restored.extra == {
+            "port": 9000,
+            "host": "127.0.0.1",
+            "cors_origins": ["https://explicit.example"],
+        }
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):


### PR DESCRIPTION
## Summary
- salvage top-level platform config keys into `PlatformConfig.extra` during config loading
- preserve explicitly nested `extra` values when both top-level and nested values are present
- add focused regression tests for the top-level merge behavior

## Verification
- `scripts/run_tests.sh tests/gateway/test_config.py`
- independent delegated code review: passed

## Notes
- Codex was attempted first but hit a repository access / CA-bundle environment failure, so Hermes completed the fix directly.

Closes #20501
