### PR TITLE
fix(gateway): resume API run events after page refresh

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -43,7 +43,7 @@ import sqlite3
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 try:
     from aiohttp import web
@@ -530,6 +530,299 @@ class ResponseStore:
         return row[0] if row else 0
 
 
+_RUN_TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+
+
+class RunEventStore:
+    """SQLite-backed event log and public metadata store for /v1/runs."""
+
+    def __init__(self, db_path: str = None):
+        if db_path is None:
+            try:
+                from hermes_cli.config import get_hermes_home
+                db_path = str(get_hermes_home() / "run_event_store.db")
+            except Exception:
+                db_path = ":memory:"
+        try:
+            self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        except Exception:
+            self._conn = sqlite3.connect(":memory:", check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        try:
+            self._conn.execute("PRAGMA journal_mode=WAL")
+        except Exception:
+            pass
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS run_events (
+                run_id TEXT NOT NULL,
+                sequence INTEGER NOT NULL,
+                event TEXT NOT NULL,
+                data TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                PRIMARY KEY (run_id, sequence)
+            )"""
+        )
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS run_meta (
+                run_id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                terminal_at REAL,
+                last_sequence INTEGER NOT NULL DEFAULT 0,
+                status_data TEXT NOT NULL DEFAULT '{}'
+            )"""
+        )
+        self._conn.commit()
+
+    @staticmethod
+    def is_terminal_status(status: str) -> bool:
+        return status in _RUN_TERMINAL_STATUSES
+
+    @staticmethod
+    def _loads(raw: Any) -> Dict[str, Any]:
+        if not raw:
+            return {}
+        try:
+            loaded = json.loads(raw)
+        except Exception:
+            return {}
+        return loaded if isinstance(loaded, dict) else {}
+
+    @staticmethod
+    def _status_payload(fields: Dict[str, Any]) -> Dict[str, Any]:
+        private = {
+            "object",
+            "run_id",
+            "status",
+            "created_at",
+            "updated_at",
+            "terminal_at",
+            "last_sequence",
+        }
+        return {k: v for k, v in fields.items() if k not in private}
+
+    def initialize_run(
+        self,
+        run_id: str,
+        *,
+        status: str = "queued",
+        created_at: float = None,
+        status_data: Dict[str, Any] = None,
+    ) -> Dict[str, Any]:
+        now = created_at if created_at is not None else time.time()
+        payload = self._status_payload(status_data or {})
+        self._conn.execute(
+            """INSERT INTO run_meta
+                (run_id, status, created_at, updated_at, terminal_at, last_sequence, status_data)
+               VALUES (?, ?, ?, ?, ?, 0, ?)""",
+            (
+                run_id,
+                status,
+                now,
+                now,
+                now if self.is_terminal_status(status) else None,
+                json.dumps(payload, default=str),
+            ),
+        )
+        self._conn.commit()
+        return self.get_status(run_id)
+
+    def update_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
+        now = time.time()
+        row = self._conn.execute(
+            "SELECT status_data, created_at, terminal_at FROM run_meta WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        if row is None:
+            return self.initialize_run(
+                run_id,
+                status=status,
+                created_at=fields.get("created_at", now),
+                status_data=fields,
+            )
+
+        payload = self._loads(row["status_data"])
+        payload.update(self._status_payload(fields))
+        terminal_at = row["terminal_at"]
+        if terminal_at is None and self.is_terminal_status(status):
+            terminal_at = now
+        self._conn.execute(
+            """UPDATE run_meta
+               SET status = ?, updated_at = ?, terminal_at = ?, status_data = ?
+               WHERE run_id = ?""",
+            (status, now, terminal_at, json.dumps(payload, default=str), run_id),
+        )
+        self._conn.commit()
+        return self.get_status(run_id)
+
+    def append_event(
+        self,
+        run_id: str,
+        event: Dict[str, Any],
+        *,
+        status: str = None,
+        terminal: bool = False,
+        status_fields: Dict[str, Any] = None,
+    ) -> Optional[Dict[str, Any]]:
+        now = time.time()
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = self._conn.execute(
+                """SELECT status, terminal_at, last_sequence, status_data
+                   FROM run_meta WHERE run_id = ?""",
+                (run_id,),
+            ).fetchone()
+            if row is None:
+                raise KeyError(run_id)
+            if row["terminal_at"] is not None:
+                self._conn.rollback()
+                return None
+
+            event_type = str(event.get("event") or "")
+            if not event_type:
+                raise ValueError("run event missing event type")
+
+            sequence = int(row["last_sequence"] or 0) + 1
+            payload = dict(event)
+            payload["event"] = event_type
+            payload["run_id"] = run_id
+            payload["sequence"] = sequence
+            payload.setdefault("timestamp", now)
+
+            self._conn.execute(
+                """INSERT INTO run_events
+                    (run_id, sequence, event, data, created_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (
+                    run_id,
+                    sequence,
+                    event_type,
+                    json.dumps(payload, default=str),
+                    now,
+                ),
+            )
+
+            public_status = status or row["status"]
+            public_data = self._loads(row["status_data"])
+            public_data.update(self._status_payload(status_fields or {}))
+            public_data["last_event"] = event_type
+            terminal_at = now if terminal else row["terminal_at"]
+            self._conn.execute(
+                """UPDATE run_meta
+                   SET status = ?, updated_at = ?, terminal_at = ?,
+                       last_sequence = ?, status_data = ?
+                   WHERE run_id = ?""",
+                (
+                    public_status,
+                    now,
+                    terminal_at,
+                    sequence,
+                    json.dumps(public_data, default=str),
+                    run_id,
+                ),
+            )
+            self._conn.commit()
+            return payload
+        except Exception:
+            self._conn.rollback()
+            raise
+
+    def get_status(self, run_id: str) -> Optional[Dict[str, Any]]:
+        row = self._conn.execute(
+            """SELECT run_id, status, created_at, updated_at, terminal_at,
+                      last_sequence, status_data
+               FROM run_meta WHERE run_id = ?""",
+            (run_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        payload = self._loads(row["status_data"])
+        status = {
+            "object": "hermes.run",
+            "run_id": row["run_id"],
+            "status": row["status"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+            "last_sequence": row["last_sequence"],
+        }
+        if row["terminal_at"] is not None:
+            status["terminal_at"] = row["terminal_at"]
+        status.update(payload)
+        status.update({
+            "object": "hermes.run",
+            "run_id": row["run_id"],
+            "status": row["status"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+            "last_sequence": row["last_sequence"],
+        })
+        return status
+
+    def list_events_after(self, run_id: str, after: int) -> List[Dict[str, Any]]:
+        rows = self._conn.execute(
+            """SELECT data FROM run_events
+               WHERE run_id = ? AND sequence > ?
+               ORDER BY sequence ASC""",
+            (run_id, after),
+        ).fetchall()
+        return [json.loads(row["data"]) for row in rows]
+
+    def count_nonterminal_runs(self) -> int:
+        rows = self._conn.execute(
+            "SELECT status, terminal_at FROM run_meta"
+        ).fetchall()
+        return sum(
+            1 for row in rows
+            if row["terminal_at"] is None and not self.is_terminal_status(row["status"])
+        )
+
+    def mark_abandoned_nonterminal(self) -> List[str]:
+        rows = self._conn.execute(
+            "SELECT run_id, status, terminal_at FROM run_meta"
+        ).fetchall()
+        abandoned: List[str] = []
+        for row in rows:
+            if row["terminal_at"] is not None or self.is_terminal_status(row["status"]):
+                continue
+            run_id = row["run_id"]
+            error = "Run abandoned because the API server process restarted"
+            self.append_event(
+                run_id,
+                {
+                    "event": "run.failed",
+                    "run_id": run_id,
+                    "timestamp": time.time(),
+                    "error": error,
+                },
+                status="failed",
+                terminal=True,
+                status_fields={"error": error},
+            )
+            abandoned.append(run_id)
+        return abandoned
+
+    def prune_terminal(self, ttl_seconds: int, *, now: float = None) -> List[str]:
+        now = now if now is not None else time.time()
+        cutoff = now - ttl_seconds
+        rows = self._conn.execute(
+            "SELECT run_id FROM run_meta WHERE terminal_at IS NOT NULL AND terminal_at < ?",
+            (cutoff,),
+        ).fetchall()
+        run_ids = [row["run_id"] for row in rows]
+        for run_id in run_ids:
+            self._conn.execute("DELETE FROM run_events WHERE run_id = ?", (run_id,))
+            self._conn.execute("DELETE FROM run_meta WHERE run_id = ?", (run_id,))
+        self._conn.commit()
+        return run_ids
+
+    def close(self) -> None:
+        try:
+            self._conn.close()
+        except Exception:
+            pass
+
+
 # ---------------------------------------------------------------------------
 # CORS middleware
 # ---------------------------------------------------------------------------
@@ -752,14 +1045,20 @@ class APIServerAdapter(BasePlatformAdapter):
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
         self._response_store = ResponseStore()
-        # Active run streams: run_id -> asyncio.Queue of SSE event dicts
+        self._run_event_store = RunEventStore(extra.get("run_event_store_path"))
+        try:
+            self._run_event_store.mark_abandoned_nonterminal()
+        except Exception:
+            logger.exception("[api_server] failed to reconcile persisted run events")
+        # Back-compat debug attributes retained for tests/inspection; event
+        # delivery now uses per-run subscriber sets below.
         self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
-        # Creation timestamps for orphaned-run TTL sweep
-        self._run_streams_created: Dict[str, float] = {}
+        self._run_subscribers: Dict[str, Set["asyncio.Queue[Optional[Dict]]"]] = {}
+        self._run_event_locks: Dict[str, "asyncio.Lock"] = {}
         # Active run agent/task references for stop support
         self._active_run_agents: Dict[str, Any] = {}
         self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
-        # Pollable run status for dashboards and external control-plane UIs.
+        # Hot cache only. RunEventStore is the source of truth.
         self._run_statuses: Dict[str, Dict[str, Any]] = {}
         # Active approval session key for each run_id.  The approval core
         # resolves requests by session key, while API clients address the
@@ -1154,6 +1453,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_submission": True,
                 "run_status": True,
                 "run_events_sse": True,
+                "run_events_resumable": True,
                 "run_stop": True,
                 "run_approval_response": True,
                 "tool_progress_events": True,
@@ -3558,13 +3858,19 @@ class APIServerAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     _MAX_CONCURRENT_RUNS = 10  # Prevent unbounded resource allocation
-    _RUN_STREAM_TTL = 300  # seconds before orphaned runs are swept
     _RUN_STATUS_TTL = 3600  # seconds to retain terminal run status for polling
+
+    def _get_run_lock(self, run_id: str) -> "asyncio.Lock":
+        lock = self._run_event_locks.get(run_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._run_event_locks[run_id] = lock
+        return lock
 
     def _set_run_status(self, run_id: str, status: str, **fields: Any) -> Dict[str, Any]:
         """Update pollable run status without exposing private agent objects."""
         now = time.time()
-        current = self._run_statuses.get(run_id, {})
+        current = self._run_statuses.get(run_id) or self._run_event_store.get_status(run_id) or {}
         current.update({
             "object": "hermes.run",
             "run_id": run_id,
@@ -3573,24 +3879,107 @@ class APIServerAdapter(BasePlatformAdapter):
         })
         current.setdefault("created_at", fields.pop("created_at", now))
         current.update(fields)
-        self._run_statuses[run_id] = current
-        return current
+        durable = self._run_event_store.update_status(
+            run_id,
+            status,
+            **RunEventStore._status_payload(current),
+        )
+        self._run_statuses[run_id] = durable
+        return durable
+
+    async def _emit_run_event(
+        self,
+        run_id: str,
+        event: Dict[str, Any],
+        *,
+        status: str = None,
+        terminal: bool = False,
+        status_fields: Dict[str, Any] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Commit a run event, update metadata, and fan it out to live subscribers."""
+        subscribers: List["asyncio.Queue[Optional[Dict]]"] = []
+        async with self._get_run_lock(run_id):
+            try:
+                sequenced = self._run_event_store.append_event(
+                    run_id,
+                    event,
+                    status=status,
+                    terminal=terminal,
+                    status_fields=status_fields,
+                )
+            except Exception:
+                logger.exception("[api_server] failed to append run event for %s", run_id)
+                raise
+            if sequenced is None:
+                logger.debug(
+                    "[api_server] ignoring run event after terminal state for %s: %s",
+                    run_id,
+                    event.get("event"),
+                )
+                return None
+            latest = self._run_event_store.get_status(run_id)
+            if latest is not None:
+                self._run_statuses[run_id] = latest
+            subscribers = list(self._run_subscribers.get(run_id, set()))
+
+        stale: List["asyncio.Queue[Optional[Dict]]"] = []
+        for q in subscribers:
+            try:
+                q.put_nowait(sequenced)
+            except Exception:
+                stale.append(q)
+        if stale:
+            current = self._run_subscribers.get(run_id)
+            if current is not None:
+                for q in stale:
+                    current.discard(q)
+        return sequenced
+
+    def _schedule_run_event(
+        self,
+        run_id: str,
+        loop: "asyncio.AbstractEventLoop",
+        event: Dict[str, Any],
+        *,
+        status: str = None,
+        terminal: bool = False,
+        status_fields: Dict[str, Any] = None,
+    ) -> None:
+        def _create_task() -> None:
+            task = asyncio.create_task(
+                self._emit_run_event(
+                    run_id,
+                    event,
+                    status=status,
+                    terminal=terminal,
+                    status_fields=status_fields,
+                )
+            )
+            try:
+                self._background_tasks.add(task)
+            except TypeError:
+                pass
+            if hasattr(task, "add_done_callback"):
+                def _finish(done_task: "asyncio.Task") -> None:
+                    self._background_tasks.discard(done_task)
+                    try:
+                        done_task.result()
+                    except asyncio.CancelledError:
+                        pass
+                    except Exception:
+                        logger.exception("[api_server] scheduled run event failed")
+
+                task.add_done_callback(_finish)
+
+        try:
+            loop.call_soon_threadsafe(_create_task)
+        except Exception:
+            logger.debug("[api_server] failed to schedule run event for %s", run_id, exc_info=True)
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
-        """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
+        """Return a tool_progress_callback that publishes structured run events."""
         def _push(event: Dict[str, Any]) -> None:
-            self._set_run_status(
-                run_id,
-                self._run_statuses.get(run_id, {}).get("status", "running"),
-                last_event=event.get("event"),
-            )
-            q = self._run_streams.get(run_id)
-            if q is None:
-                return
-            try:
-                loop.call_soon_threadsafe(q.put_nowait, event)
-            except Exception:
-                pass
+            self._schedule_run_event(run_id, loop, event)
 
         def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
             ts = time.time()
@@ -3633,10 +4022,13 @@ class APIServerAdapter(BasePlatformAdapter):
         if key_err is not None:
             return key_err
 
-        # Enforce concurrency limit
-        if len(self._run_streams) >= self._MAX_CONCURRENT_RUNS:
+        # Enforce active run concurrency limit.
+        if self._run_event_store.count_nonterminal_runs() >= self._MAX_CONCURRENT_RUNS:
             return web.json_response(
-                _openai_error(f"Too many concurrent runs (max {self._MAX_CONCURRENT_RUNS})", code="rate_limit_exceeded"),
+                _openai_error(
+                    f"Too many concurrent runs (max {self._MAX_CONCURRENT_RUNS})",
+                    code="rate_limit_exceeded",
+                ),
                 status=429,
             )
 
@@ -3705,10 +4097,7 @@ class APIServerAdapter(BasePlatformAdapter):
         approval_session_key = gateway_session_key or session_id or run_id
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()
-        q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
         created_at = time.time()
-        self._run_streams[run_id] = q
-        self._run_streams_created[run_id] = created_at
         self._run_approval_sessions[run_id] = approval_session_key
 
         event_cb = self._make_run_event_callback(run_id, loop)
@@ -3717,27 +4106,40 @@ class APIServerAdapter(BasePlatformAdapter):
         def _text_cb(delta: Optional[str]) -> None:
             if delta is None:
                 return
-            try:
-                loop.call_soon_threadsafe(q.put_nowait, {
+            self._schedule_run_event(
+                run_id,
+                loop,
+                {
                     "event": "message.delta",
                     "run_id": run_id,
                     "timestamp": time.time(),
                     "delta": delta,
-                })
-            except Exception:
-                pass
+                },
+            )
 
-        self._set_run_status(
+        initial_status = self._run_event_store.initialize_run(
             run_id,
-            "queued",
+            status="queued",
             created_at=created_at,
-            session_id=session_id,
-            model=body.get("model", self._model_name),
+            status_data={
+                "session_id": session_id,
+                "model": body.get("model", self._model_name),
+            },
         )
+        self._run_statuses[run_id] = initial_status
 
         async def _run_and_close():
             try:
                 self._set_run_status(run_id, "running")
+                await self._emit_run_event(
+                    run_id,
+                    {
+                        "event": "run.started",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                    },
+                    status="running",
+                )
                 agent = self._create_agent(
                     ephemeral_system_prompt=ephemeral_system_prompt,
                     session_id=session_id,
@@ -3755,15 +4157,13 @@ class APIServerAdapter(BasePlatformAdapter):
                         "timestamp": time.time(),
                         "choices": ["once", "session", "always", "deny"],
                     })
-                    self._set_run_status(
+                    self._schedule_run_event(
                         run_id,
-                        "waiting_for_approval",
-                        last_event="approval.request",
+                        loop,
+                        event,
+                        status="waiting_for_approval",
+                        status_fields={"last_event": "approval.request"},
                     )
-                    try:
-                        loop.call_soon_threadsafe(q.put_nowait, event)
-                    except Exception:
-                        pass
 
                 def _run_sync():
                     from gateway.session_context import clear_session_vars, set_session_vars
@@ -3819,64 +4219,63 @@ class APIServerAdapter(BasePlatformAdapter):
                 # block below never fires — issue #15561).
                 if isinstance(result, dict) and result.get("failed"):
                     error_msg = result.get("error") or "agent run failed"
-                    q.put_nowait({
-                        "event": "run.failed",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "error": error_msg,
-                    })
-                    self._set_run_status(
+                    await self._emit_run_event(
                         run_id,
-                        "failed",
-                        error=error_msg,
-                        last_event="run.failed",
+                        {
+                            "event": "run.failed",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "error": error_msg,
+                        },
+                        status="failed",
+                        terminal=True,
+                        status_fields={"error": error_msg},
                     )
                 else:
                     final_response = result.get("final_response", "") if isinstance(result, dict) else ""
-                    q.put_nowait({
-                        "event": "run.completed",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "output": final_response,
-                        "usage": usage,
-                    })
-                    self._set_run_status(
+                    await self._emit_run_event(
                         run_id,
-                        "completed",
-                        output=final_response,
-                        usage=usage,
-                        last_event="run.completed",
+                        {
+                            "event": "run.completed",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "output": final_response,
+                            "usage": usage,
+                        },
+                        status="completed",
+                        terminal=True,
+                        status_fields={"output": final_response, "usage": usage},
                     )
             except asyncio.CancelledError:
-                self._set_run_status(
-                    run_id,
-                    "cancelled",
-                    last_event="run.cancelled",
-                )
                 try:
-                    q.put_nowait({
-                        "event": "run.cancelled",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                    })
+                    await self._emit_run_event(
+                        run_id,
+                        {
+                            "event": "run.cancelled",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                        },
+                        status="cancelled",
+                        terminal=True,
+                    )
                 except Exception:
                     pass
                 raise
             except Exception as exc:
                 logger.exception("[api_server] run %s failed", run_id)
-                self._set_run_status(
-                    run_id,
-                    "failed",
-                    error=str(exc),
-                    last_event="run.failed",
-                )
                 try:
-                    q.put_nowait({
-                        "event": "run.failed",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "error": str(exc),
-                    })
+                    await self._emit_run_event(
+                        run_id,
+                        {
+                            "event": "run.failed",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "error": str(exc),
+                        },
+                        status="failed",
+                        terminal=True,
+                        status_fields={"error": str(exc)},
+                    )
                 except Exception:
                     pass
             finally:
@@ -3889,11 +4288,6 @@ class APIServerAdapter(BasePlatformAdapter):
                     from tools.approval import unregister_gateway_notify
 
                     unregister_gateway_notify(approval_session_key)
-                except Exception:
-                    pass
-                # Sentinel: signal SSE stream to close
-                try:
-                    q.put_nowait(None)
                 except Exception:
                     pass
                 self._active_run_agents.pop(run_id, None)
@@ -3913,7 +4307,12 @@ class APIServerAdapter(BasePlatformAdapter):
             {"X-Hermes-Session-Key": gateway_session_key} if gateway_session_key else {}
         )
         return web.json_response(
-            {"run_id": run_id, "status": "started"},
+            {
+                "run_id": run_id,
+                "status": "started",
+                "session_id": session_id,
+                "events_url": f"/v1/runs/{run_id}/events",
+            },
             status=202,
             headers=response_headers,
         )
@@ -3925,13 +4324,36 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
-        status = self._run_statuses.get(run_id)
+        status = self._run_event_store.get_status(run_id)
         if status is None:
             return web.json_response(
                 _openai_error(f"Run not found: {run_id}", code="run_not_found"),
                 status=404,
             )
+        self._run_statuses[run_id] = status
         return web.json_response(status)
+
+    @staticmethod
+    def _format_run_sse(event: Dict[str, Any]) -> bytes:
+        sequence = event.get("sequence", "")
+        event_type = event.get("event", "message")
+        payload = json.dumps(event)
+        return f"id: {sequence}\nevent: {event_type}\ndata: {payload}\n\n".encode()
+
+    @staticmethod
+    def _parse_run_after(request: "web.Request") -> tuple[Optional[int], Optional[str]]:
+        raw = request.query.get("after")
+        if raw is None:
+            raw = request.headers.get("Last-Event-ID")
+        if raw in (None, ""):
+            return 0, None
+        try:
+            after = int(str(raw))
+        except (TypeError, ValueError):
+            return None, "Invalid 'after' cursor"
+        if after < 0:
+            return None, "Invalid 'after' cursor"
+        return after, None
 
     async def _handle_run_events(self, request: "web.Request") -> "web.StreamResponse":
         """GET /v1/runs/{run_id}/events — SSE stream of structured agent lifecycle events."""
@@ -3940,16 +4362,38 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         run_id = request.match_info["run_id"]
+        after, cursor_error = self._parse_run_after(request)
+        if cursor_error:
+            return web.json_response(_openai_error(cursor_error, param="after"), status=400)
 
         # Allow subscribing slightly before the run is registered (race condition window)
         for _ in range(20):
-            if run_id in self._run_streams:
+            if self._run_event_store.get_status(run_id) is not None:
                 break
             await asyncio.sleep(0.05)
         else:
             return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
 
-        q = self._run_streams[run_id]
+        q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
+        replay_events: List[Dict[str, Any]] = []
+        highest_sent = after or 0
+        should_follow_live = False
+
+        async with self._get_run_lock(run_id):
+            status = self._run_event_store.get_status(run_id)
+            if status is None:
+                return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
+            terminal = RunEventStore.is_terminal_status(status.get("status", ""))
+            last_sequence = int(status.get("last_sequence", 0) or 0)
+            should_follow_live = not terminal
+            if should_follow_live:
+                self._run_subscribers.setdefault(run_id, set()).add(q)
+            replay_events = self._run_event_store.list_events_after(run_id, after or 0)
+            for event in replay_events:
+                highest_sent = max(highest_sent, int(event.get("sequence", 0) or 0))
+            if terminal and (after or 0) >= last_sequence:
+                replay_events = []
+                should_follow_live = False
 
         response = web.StreamResponse(
             status=200,
@@ -3962,6 +4406,13 @@ class APIServerAdapter(BasePlatformAdapter):
         await response.prepare(request)
 
         try:
+            for event in replay_events:
+                await response.write(self._format_run_sse(event))
+
+            if not should_follow_live:
+                await response.write(b": stream closed\n\n")
+                return response
+
             while True:
                 try:
                     event = await asyncio.wait_for(q.get(), timeout=30.0)
@@ -3972,13 +4423,22 @@ class APIServerAdapter(BasePlatformAdapter):
                     # Run finished — send final SSE comment and close
                     await response.write(b": stream closed\n\n")
                     break
-                payload = f"data: {json.dumps(event)}\n\n"
-                await response.write(payload.encode())
+                sequence = int(event.get("sequence", 0) or 0)
+                if sequence <= highest_sent:
+                    continue
+                highest_sent = sequence
+                await response.write(self._format_run_sse(event))
+                if RunEventStore.is_terminal_status(str(event.get("event", "")).removeprefix("run.")):
+                    await response.write(b": stream closed\n\n")
+                    break
         except Exception as exc:
             logger.debug("[api_server] SSE stream error for run %s: %s", run_id, exc)
         finally:
-            self._run_streams.pop(run_id, None)
-            self._run_streams_created.pop(run_id, None)
+            subscribers = self._run_subscribers.get(run_id)
+            if subscribers is not None:
+                subscribers.discard(q)
+                if not subscribers:
+                    self._run_subscribers.pop(run_id, None)
 
         return response
 
@@ -4051,18 +4511,18 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         self._set_run_status(run_id, "running", last_event="approval.responded")
-        q = self._run_streams.get(run_id)
-        if q is not None:
-            try:
-                q.put_nowait({
-                    "event": "approval.responded",
-                    "run_id": run_id,
-                    "timestamp": time.time(),
-                    "choice": choice,
-                    "resolved": resolved,
-                })
-            except Exception:
-                pass
+        await self._emit_run_event(
+            run_id,
+            {
+                "event": "approval.responded",
+                "run_id": run_id,
+                "timestamp": time.time(),
+                "choice": choice,
+                "resolved": resolved,
+            },
+            status="running",
+            status_fields={"last_event": "approval.responded"},
+        )
 
         return web.json_response({
             "object": "hermes.run.approval_response",
@@ -4112,30 +4572,20 @@ class APIServerAdapter(BasePlatformAdapter):
         return web.json_response({"run_id": run_id, "status": "stopping"})
 
     async def _sweep_orphaned_runs(self) -> None:
-        """Periodically clean up run streams that were never consumed."""
+        """Periodically prune retained terminal run events and status cache."""
         while True:
             await asyncio.sleep(60)
             now = time.time()
-            stale = [
-                run_id
-                for run_id, created_at in list(self._run_streams_created.items())
-                if now - created_at > self._RUN_STREAM_TTL
-            ]
-            for run_id in stale:
-                logger.debug("[api_server] sweeping orphaned run %s", run_id)
-                try:
-                    from tools.approval import unregister_gateway_notify
-
-                    approval_session_key = self._run_approval_sessions.get(run_id)
-                    if approval_session_key:
-                        unregister_gateway_notify(approval_session_key)
-                except Exception:
-                    pass
-                self._run_streams.pop(run_id, None)
-                self._run_streams_created.pop(run_id, None)
-                self._active_run_agents.pop(run_id, None)
-                self._active_run_tasks.pop(run_id, None)
-                self._run_approval_sessions.pop(run_id, None)
+            try:
+                pruned = self._run_event_store.prune_terminal(self._RUN_STATUS_TTL, now=now)
+            except Exception:
+                logger.exception("[api_server] failed to prune terminal run events")
+                pruned = []
+            for run_id in pruned:
+                logger.debug("[api_server] pruned terminal run event history for %s", run_id)
+                self._run_statuses.pop(run_id, None)
+                self._run_subscribers.pop(run_id, None)
+                self._run_event_locks.pop(run_id, None)
 
             stale_statuses = [
                 run_id
@@ -4291,6 +4741,10 @@ class APIServerAdapter(BasePlatformAdapter):
         if self._runner:
             await self._runner.cleanup()
             self._runner = None
+        try:
+            self._run_event_store.close()
+        except Exception:
+            pass
         self._app = None
         logger.info("[%s] API server stopped", self.name)
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -42,6 +42,8 @@ import re
 import sqlite3
 import time
 import uuid
+from contextvars import ContextVar
+from functools import wraps
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
 
@@ -543,15 +545,16 @@ class RunEventStore:
                 db_path = str(get_hermes_home() / "run_event_store.db")
             except Exception:
                 db_path = ":memory:"
+        self._db_path: Optional[str] = db_path if db_path != ":memory:" else None
         try:
             self._conn = sqlite3.connect(db_path, check_same_thread=False)
         except Exception:
             self._conn = sqlite3.connect(":memory:", check_same_thread=False)
+            self._db_path = None
         self._conn.row_factory = sqlite3.Row
-        try:
-            self._conn.execute("PRAGMA journal_mode=WAL")
-        except Exception:
-            pass
+        from hermes_state import apply_wal_with_fallback
+
+        apply_wal_with_fallback(self._conn, db_label="run_event_store.db")
         self._conn.execute(
             """CREATE TABLE IF NOT EXISTS run_events (
                 run_id TEXT NOT NULL,
@@ -574,6 +577,25 @@ class RunEventStore:
             )"""
         )
         self._conn.commit()
+        self._tighten_file_permissions()
+
+    def _tighten_file_permissions(self) -> None:
+        if not self._db_path:
+            return
+        for candidate in (
+            Path(self._db_path),
+            Path(f"{self._db_path}-wal"),
+            Path(f"{self._db_path}-shm"),
+        ):
+            try:
+                if candidate.exists():
+                    candidate.chmod(0o600)
+            except OSError:
+                logger.debug(
+                    "Failed to restrict run event store permissions for %s",
+                    candidate,
+                    exc_info=True,
+                )
 
     @staticmethod
     def is_terminal_status(status: str) -> bool:
@@ -870,6 +892,28 @@ def _openai_error(message: str, err_type: str = "invalid_request_error", param: 
     }
 
 
+_api_agent_request_reservation: ContextVar[Optional[Dict[str, bool]]] = ContextVar(
+    "api_agent_request_reservation", default=None
+)
+
+
+def _admit_api_agent_request(handler):
+    @wraps(handler)
+    async def _wrapped(self, request, *args, **kwargs):
+        reservation = {"active": True}
+        token = _api_agent_request_reservation.set(reservation)
+        self._pending_agent_requests += 1
+        try:
+            return await handler(self, request, *args, **kwargs)
+        finally:
+            if reservation["active"]:
+                reservation["active"] = False
+                self._pending_agent_requests = max(0, self._pending_agent_requests - 1)
+            _api_agent_request_reservation.reset(token)
+
+    return _wrapped
+
+
 if AIOHTTP_AVAILABLE:
     @web.middleware
     async def body_limit_middleware(request, handler):
@@ -1058,6 +1102,11 @@ class APIServerAdapter(BasePlatformAdapter):
         # Active run agent/task references for stop support
         self._active_run_agents: Dict[str, Any] = {}
         self._active_run_tasks: Dict[str, "asyncio.Task"] = {}
+        self._max_concurrent_runs = self._resolve_max_concurrent_runs(
+            extra.get("max_concurrent_runs")
+        )
+        self._inflight_agent_runs = 0
+        self._pending_agent_requests = 0
         # Hot cache only. RunEventStore is the source of truth.
         self._run_statuses: Dict[str, Dict[str, Any]] = {}
         # Active approval session key for each run_id.  The approval core
@@ -1065,6 +1114,61 @@ class APIServerAdapter(BasePlatformAdapter):
         # in-flight run by run_id.
         self._run_approval_sessions: Dict[str, str] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+
+    @staticmethod
+    def _resolve_max_concurrent_runs(explicit: Any = None) -> int:
+        default = 10
+        raw = explicit
+        if raw is None:
+            try:
+                from hermes_cli.config import cfg_get, load_config
+
+                raw = cfg_get(
+                    load_config(),
+                    "gateway",
+                    "api_server",
+                    "max_concurrent_runs",
+                    default=default,
+                )
+            except Exception:
+                raw = default
+        try:
+            return max(0, int(raw))
+        except (TypeError, ValueError):
+            return default
+
+    def active_agent_work_count(self) -> int:
+        return (
+            self._pending_agent_requests
+            + self._inflight_agent_runs
+            + sum(not task.done() for task in self._active_run_tasks.values())
+        )
+
+    def _activate_admitted_request(self) -> None:
+        reservation = _api_agent_request_reservation.get()
+        if reservation and reservation["active"]:
+            reservation["active"] = False
+            self._pending_agent_requests = max(0, self._pending_agent_requests - 1)
+
+    def _concurrency_limited_response(self) -> Optional["web.Response"]:
+        limit = self._max_concurrent_runs
+        if limit <= 0:
+            return None
+        inflight = self.active_agent_work_count()
+        reservation = _api_agent_request_reservation.get()
+        if reservation and reservation["active"]:
+            inflight -= 1
+        if inflight < limit:
+            return None
+        return web.json_response(
+            _openai_error(
+                f"Too many concurrent runs (max {limit})",
+                err_type="rate_limit_error",
+                code="rate_limit_exceeded",
+            ),
+            status=429,
+            headers={"Retry-After": "1"},
+        )
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -2020,11 +2124,16 @@ class APIServerAdapter(BasePlatformAdapter):
             logger.debug("[api_server] session SSE stream error: %s", exc)
         return response
 
+    @_admit_api_agent_request
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
+
+        limited = self._concurrency_limited_response()
+        if limited is not None:
+            return limited
 
         # Parse request body
         try:
@@ -3089,11 +3198,16 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return response
 
+    @_admit_api_agent_request
     async def _handle_responses(self, request: "web.Request") -> "web.Response":
         """POST /v1/responses — OpenAI Responses API format."""
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
+
+        limited = self._concurrency_limited_response()
+        if limited is not None:
+            return limited
 
         # Long-term memory scope header (see chat_completions for details).
         gateway_session_key, key_err = self._parse_session_key_header(request)
@@ -3851,13 +3965,17 @@ class APIServerAdapter(BasePlatformAdapter):
             finally:
                 clear_session_vars(tokens)
 
-        return await loop.run_in_executor(None, _run)
+        self._activate_admitted_request()
+        self._inflight_agent_runs += 1
+        try:
+            return await loop.run_in_executor(None, _run)
+        finally:
+            self._inflight_agent_runs -= 1
 
     # ------------------------------------------------------------------
     # /v1/runs — structured event streaming
     # ------------------------------------------------------------------
 
-    _MAX_CONCURRENT_RUNS = 10  # Prevent unbounded resource allocation
     _RUN_STATUS_TTL = 3600  # seconds to retain terminal run status for polling
 
     def _get_run_lock(self, run_id: str) -> "asyncio.Lock":
@@ -4011,6 +4129,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return _callback
 
+    @_admit_api_agent_request
     async def _handle_runs(self, request: "web.Request") -> "web.Response":
         """POST /v1/runs — start an agent run, return run_id immediately."""
         auth_err = self._check_auth(request)
@@ -4022,15 +4141,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if key_err is not None:
             return key_err
 
-        # Enforce active run concurrency limit.
-        if self._run_event_store.count_nonterminal_runs() >= self._MAX_CONCURRENT_RUNS:
-            return web.json_response(
-                _openai_error(
-                    f"Too many concurrent runs (max {self._MAX_CONCURRENT_RUNS})",
-                    code="rate_limit_exceeded",
-                ),
-                status=429,
-            )
+        limited = self._concurrency_limited_response()
+        if limited is not None:
+            return limited
 
         try:
             body = await request.json()
@@ -4151,6 +4264,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
                 def _approval_notify(approval_data: Dict[str, Any]) -> None:
                     event = dict(approval_data or {})
+                    from gateway.run import _redact_approval_command
+
+                    event["command"] = _redact_approval_command(event.get("command"))
                     event.update({
                         "event": "approval.request",
                         "run_id": run_id,
@@ -4294,6 +4410,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._active_run_tasks.pop(run_id, None)
                 self._run_approval_sessions.pop(run_id, None)
 
+        self._activate_admitted_request()
         task = asyncio.create_task(_run_and_close())
         self._active_run_tasks[run_id] = task
         try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -388,6 +388,12 @@ def _telegramize_command_mentions(text: str, platform: Any) -> str:
 _AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT = 60 * 60
 
 
+def _redact_approval_command(cmd: "str | None") -> str:
+    from agent.redact import redact_sensitive_text
+
+    return redact_sensitive_text(str(cmd or ""), force=True)
+
+
 def _coerce_gateway_timestamp(value: Any) -> Optional[float]:
     """Best-effort conversion of stored gateway timestamps to epoch seconds.
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -671,6 +671,7 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["run_events_resumable"] is True
             assert data["features"]["session_continuity_header"] == "X-Hermes-Session-Id"
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
             assert data["endpoints"]["skills"] == {"method": "GET", "path": "/v1/skills"}

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -9,7 +9,9 @@ Covers:
 """
 
 import asyncio
+import json
 import threading
+import time as _time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -29,9 +31,10 @@ from gateway.platforms.api_server import (
 # ---------------------------------------------------------------------------
 
 
-def _make_adapter(api_key: str = "") -> APIServerAdapter:
+def _make_adapter(api_key: str = "", **extra_overrides) -> APIServerAdapter:
     """Create an adapter with optional API key."""
-    extra = {}
+    extra = {"run_event_store_path": ":memory:"}
+    extra.update(extra_overrides)
     if api_key:
         extra["key"] = api_key
     config = PlatformConfig(enabled=True, extra=extra)
@@ -81,6 +84,48 @@ def _make_slow_agent(**kwargs):
     mock_agent.session_total_tokens = 0
 
     return mock_agent, ready, interrupted
+
+
+def _parse_sse_events(body: str):
+    """Return decoded SSE data payloads from a response body."""
+    events = []
+    for block in body.split("\n\n"):
+        data_lines = [
+            line.removeprefix("data: ")
+            for line in block.splitlines()
+            if line.startswith("data: ")
+        ]
+        if not data_lines:
+            continue
+        events.append(json.loads("\n".join(data_lines)))
+    return events
+
+
+def _make_streaming_agent(deltas=None, final_response="done", release=None, ready=None):
+    """Create an agent factory that emits text deltas through the captured callback."""
+    deltas = list(deltas or [])
+
+    def _factory(**kwargs):
+        stream_delta_callback = kwargs.get("stream_delta_callback")
+        mock_agent = MagicMock()
+
+        def _run(user_message=None, conversation_history=None, task_id=None):
+            if ready is not None:
+                ready.set()
+            if release is not None:
+                release.wait(timeout=5)
+            for delta in deltas:
+                if stream_delta_callback is not None:
+                    stream_delta_callback(delta)
+            return {"final_response": final_response}
+
+        mock_agent.run_conversation.side_effect = _run
+        mock_agent.session_prompt_tokens = 1
+        mock_agent.session_completion_tokens = 2
+        mock_agent.session_total_tokens = 3
+        return mock_agent
+
+    return _factory
 
 
 @pytest.fixture
@@ -354,6 +399,17 @@ class TestRunEvents:
             "once",
             resolve_all=False,
         )
+        events = adapter._run_event_store.list_events_after(run_id, 0)
+        assert len(events) == 1
+        assert events[0]["event"] == "approval.responded"
+        assert events[0]["choice"] == "once"
+        assert events[0]["resolved"] == 1
+
+        status = adapter._run_event_store.get_status(run_id)
+        assert status is not None
+        assert status["status"] == "running"
+        assert status["last_event"] == "approval.responded"
+        assert status["last_sequence"] == 1
 
     @pytest.mark.asyncio
     async def test_events_not_found_returns_404(self, adapter):
@@ -368,6 +424,219 @@ class TestRunEvents:
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get("/v1/runs/run_any/events")
         assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_after_query_replays_only_higher_sequences(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_create.side_effect = _make_streaming_agent(
+                    deltas=["hello"],
+                    final_response="done",
+                )
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events?after=1")
+                assert events_resp.status == 200
+                body = await events_resp.text()
+                events = _parse_sse_events(body)
+
+        assert events
+        assert all(event["sequence"] > 1 for event in events)
+        assert events[0]["event"] != "run.started"
+        assert "id: " in body
+        assert "event: " in body
+
+    @pytest.mark.asyncio
+    async def test_last_event_id_replays_only_higher_sequences(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_create.side_effect = _make_streaming_agent(
+                    deltas=["first", "second"],
+                    final_response="done",
+                )
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                events_resp = await cli.get(
+                    f"/v1/runs/{run_id}/events",
+                    headers={"Last-Event-ID": "2"},
+                )
+                body = await events_resp.text()
+                events = _parse_sse_events(body)
+
+        assert events
+        assert all(event["sequence"] > 2 for event in events)
+
+    @pytest.mark.asyncio
+    async def test_after_query_takes_precedence_over_last_event_id(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_create.side_effect = _make_streaming_agent(
+                    deltas=["one", "two"],
+                    final_response="done",
+                )
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                events_resp = await cli.get(
+                    f"/v1/runs/{run_id}/events?after=1",
+                    headers={"Last-Event-ID": "999"},
+                )
+                body = await events_resp.text()
+                events = _parse_sse_events(body)
+
+        assert events
+        assert all(event["sequence"] > 1 for event in events)
+        assert any(event["event"] == "message.delta" for event in events)
+
+    @pytest.mark.asyncio
+    async def test_completed_run_after_last_sequence_closes_cleanly(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_create.side_effect = _make_streaming_agent(
+                    deltas=["hello"],
+                    final_response="done",
+                )
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                last_sequence = status["last_sequence"]
+                events_resp = await cli.get(
+                    f"/v1/runs/{run_id}/events?after={last_sequence}"
+                )
+                assert events_resp.status == 200
+                body = await asyncio.wait_for(events_resp.text(), timeout=2.0)
+
+        assert _parse_sse_events(body) == []
+
+    @pytest.mark.asyncio
+    async def test_multiple_subscribers_each_receive_live_events(self, adapter):
+        release = threading.Event()
+        ready = threading.Event()
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_create.side_effect = _make_streaming_agent(
+                    deltas=["shared"],
+                    final_response="done",
+                    release=release,
+                    ready=ready,
+                )
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+                ready.wait(timeout=3)
+
+                first = await cli.get(f"/v1/runs/{run_id}/events")
+                second = await cli.get(f"/v1/runs/{run_id}/events")
+
+                release.set()
+
+                first_body, second_body = await asyncio.wait_for(
+                    asyncio.gather(first.text(), second.text()),
+                    timeout=5.0,
+                )
+
+        first_events = _parse_sse_events(first_body)
+        second_events = _parse_sse_events(second_body)
+        assert [event["event"] for event in first_events] == [
+            event["event"] for event in second_events
+        ]
+        assert any(event.get("delta") == "shared" for event in first_events)
+        assert any(event.get("delta") == "shared" for event in second_events)
+
+    @pytest.mark.asyncio
+    async def test_reconnect_after_disconnect_receives_missed_events(self, adapter):
+        release = threading.Event()
+        ready = threading.Event()
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_create.side_effect = _make_streaming_agent(
+                    deltas=["missed"],
+                    final_response="done",
+                    release=release,
+                    ready=ready,
+                )
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+                ready.wait(timeout=3)
+
+                first = await cli.get(f"/v1/runs/{run_id}/events")
+                first.close()
+
+                release.set()
+                for _ in range(20):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                second = await cli.get(f"/v1/runs/{run_id}/events")
+                body = await second.text()
+                events = _parse_sse_events(body)
+
+        assert any(event.get("delta") == "missed" for event in events)
+        assert events[-1]["event"] == "run.completed"
+
+    def test_startup_marks_persisted_running_runs_abandoned(self, tmp_path):
+        db_path = tmp_path / "run_events.db"
+        first = _make_adapter(run_event_store_path=str(db_path))
+        first._run_event_store.initialize_run(
+            "run_stale",
+            status="running",
+            created_at=_time.time(),
+            status_data={"session_id": "run_stale"},
+        )
+        first._run_event_store.close()
+
+        second = _make_adapter(run_event_store_path=str(db_path))
+        status = second._run_event_store.get_status("run_stale")
+        events = second._run_event_store.list_events_after("run_stale", 0)
+
+        assert status["status"] == "failed"
+        assert "abandoned" in status["error"]
+        assert events[-1]["event"] == "run.failed"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -10,6 +10,7 @@ Covers:
 
 import asyncio
 import json
+import os
 import threading
 import time as _time
 from unittest.mock import MagicMock, patch
@@ -21,6 +22,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
+    RunEventStore,
     cors_middleware,
     security_headers_middleware,
 )
@@ -144,6 +146,48 @@ def auth_adapter():
 
 
 class TestStartRun:
+    @pytest.mark.asyncio
+    async def test_start_uses_configured_shared_concurrency_limit(self):
+        adapter = _make_adapter(max_concurrent_runs=1)
+        adapter._inflight_agent_runs = 1
+        app = _create_runs_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post("/v1/runs", json={"input": "hello"})
+            assert resp.status == 429
+            assert resp.headers["Retry-After"] == "1"
+            data = await resp.json()
+        assert data["error"]["code"] == "rate_limit_exceeded"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("path", "payload"),
+        [
+            ("/v1/chat/completions", {"messages": [{"role": "user", "content": "hi"}]}),
+            ("/v1/responses", {"input": "hi"}),
+        ],
+    )
+    async def test_shared_limit_applies_to_other_agent_endpoints(self, path, payload):
+        adapter = _make_adapter(max_concurrent_runs=1)
+        adapter._active_run_tasks["run_existing"] = asyncio.create_task(asyncio.sleep(10))
+        app = web.Application()
+        app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+        app.router.add_post("/v1/responses", adapter._handle_responses)
+
+        try:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(path, json=payload)
+                assert resp.status == 429
+                assert resp.headers["Retry-After"] == "1"
+                data = await resp.json()
+            assert data["error"]["code"] == "rate_limit_exceeded"
+        finally:
+            adapter._active_run_tasks["run_existing"].cancel()
+            await asyncio.gather(
+                adapter._active_run_tasks["run_existing"],
+                return_exceptions=True,
+            )
+
     @pytest.mark.asyncio
     async def test_start_returns_202(self, adapter):
         app = _create_runs_app(adapter)
@@ -377,6 +421,38 @@ class TestRunEvents:
                     "approval_not_active",
                     "approval_not_pending",
                 }
+
+    @pytest.mark.asyncio
+    async def test_approval_event_is_redacted_before_persistence(self, adapter):
+        app = _create_runs_app(adapter)
+        original_command = "echo sk-secret-token"
+
+        def _register_notify(_session_key, notify):
+            notify({
+                "command": original_command,
+                "description": "run command",
+            })
+
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "done"}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(adapter, "_create_agent", return_value=mock_agent),
+                patch("tools.approval.register_gateway_notify", side_effect=_register_notify),
+            ):
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await resp.json())["run_id"]
+                await adapter._active_run_tasks[run_id]
+                await asyncio.sleep(0)
+
+        events = adapter._run_event_store.list_events_after(run_id, 0)
+        approval_event = next(event for event in events if event["event"] == "approval.request")
+        assert approval_event["command"] != original_command
+        assert "sk-secret-token" not in json.dumps(approval_event)
 
     @pytest.mark.asyncio
     async def test_approval_string_false_does_not_resolve_all(self, adapter):
@@ -637,6 +713,25 @@ class TestRunEvents:
         assert status["status"] == "failed"
         assert "abandoned" in status["error"]
         assert events[-1]["event"] == "run.failed"
+
+
+class TestRunEventStoreSecurity:
+    def test_disk_store_uses_wal_fallback_and_owner_only_permissions(self, tmp_path):
+        db_path = tmp_path / "run_events.db"
+
+        with patch("hermes_state.apply_wal_with_fallback") as apply_wal:
+            store = RunEventStore(str(db_path))
+
+        try:
+            apply_wal.assert_called_once_with(store._conn, db_label="run_event_store.db")
+            if os.name != "nt":
+                assert db_path.stat().st_mode & 0o777 == 0o600
+                for suffix in ("-wal", "-shm"):
+                    sidecar = tmp_path / f"run_events.db{suffix}"
+                    if sidecar.exists():
+                        assert sidecar.stat().st_mode & 0o777 == 0o600
+        finally:
+            store.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR fixes the structured `/v1/runs` event stream so browser refreshes, dropped SSE connections, and proxy reconnects do not interrupt observation of an in-progress agent run. Run events are now persisted, sequenced, replayable after disconnect, and fanned out to multiple live SSE subscribers without interrupting the underlying agent run.

## Why

Web clients should be able to refresh the page, recover from a dropped SSE connection, or reconnect through a proxy timeout without interrupting an in-progress agent conversation.

Previously, `/v1/runs` started the agent in the background, but event observation was tied to a single in-memory SSE queue. Once the browser page refreshed or the SSE connection closed, the queue was removed, so the client could no longer receive missed output or continue streaming the same run.

This change lets the agent keep running independently from the browser connection. A refreshed page can reconnect with the same `run_id`, replay missed events from the last seen sequence, and continue receiving live output.

## Architecture

- Adds a SQLite-backed `RunEventStore` in the API server layer.
- Keeps `AIAgent.run_conversation()` synchronous and transport-agnostic.
- Routes `stream_delta_callback` and `tool_progress_callback` into an API-server event broker.
- Replaces the single run queue with per-run multi-subscriber SSE fanout.
- Uses durable run metadata as the source of truth for `GET /v1/runs/{run_id}`.

## Key Design Choices

- Every run event gets a monotonically increasing per-run `sequence`.
- SSE emits `id:`, `event:`, and `data:` fields.
- Clients can resume with either `Last-Event-ID` or `?after=`.
- `?after=` takes precedence if both cursors are supplied.
- Reconnect registers the subscriber before replay and drops duplicate queued events by sequence.
- Terminal runs close cleanly when `after >= last_sequence`.
- Persisted non-terminal runs from a previous process are marked failed/abandoned on startup.
- `/v1/capabilities` now advertises `run_events_resumable`.

## Files

- `gateway/platforms/api_server.py`
  - Adds `RunEventStore`.
  - Refactors `/v1/runs` event delivery to durable replay plus multi-subscriber SSE.
  - Updates run status lookup, terminal cleanup, startup reconciliation, and capabilities.

- `tests/gateway/test_api_server_runs.py`
  - Adds coverage for replay cursors, reconnect after disconnect, multiple subscribers, terminal close behavior, stop behavior, and abandoned-run reconciliation.

- `tests/gateway/test_api_server.py`
  - Verifies `run_events_resumable` is advertised.

## Notes

- Does not affect TUI or dashboard PTY/TUI chat.
- Does not change `/v1/chat/completions` disconnect semantics.
- Does not change `/v1/responses` disconnect semantics.
- Does not attempt process-restart recovery of in-flight agent execution; only event history and terminal status are durable.

## Test Plan

- `python -m pytest -o addopts='' tests/gateway/test_api_server_runs.py tests/gateway/test_api_server.py -q` (`162 passed`)
- `python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py`
- `git diff --check -- FETCH_HEAD..HEAD`