### PR TITLE
fix: persist Anthropic OAuth auth state from model flow

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1265,6 +1265,61 @@ def deactivate_provider() -> None:
         _save_auth_store(auth_store)
 
 
+def activate_provider(provider_id: str) -> None:
+    """
+    Set active_provider in auth.json without writing any token state.
+
+    Used by ``hermes model`` flows that store credentials elsewhere but still
+    need ``resolve_provider()`` to pick this provider on auto-resolve.
+    """
+    if not provider_id:
+        return
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        auth_store["active_provider"] = provider_id
+        _save_auth_store(auth_store)
+
+
+def persist_anthropic_oauth_env_token(access_token: str) -> None:
+    """Persist Hermes-managed Anthropic OAuth token state in auth.json.
+
+    ``hermes model`` stores setup-token OAuth credentials in ``.env`` as
+    ``ANTHROPIC_TOKEN``. Mirror that token into both auth-store surfaces so
+    provider resolution and the credential pool agree immediately, without
+    waiting for a later pool load to seed from env.
+    """
+    token = (access_token or "").strip()
+    if not token:
+        return
+
+    source = "env:ANTHROPIC_TOKEN"
+    state = {
+        "source": source,
+        "auth_type": "oauth",
+        "access_token": token,
+        "base_url": PROVIDER_REGISTRY["anthropic"].inference_base_url,
+    }
+
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        _store_provider_state(auth_store, "anthropic", dict(state), set_active=True)
+        pool = auth_store.get("credential_pool")
+        if not isinstance(pool, dict):
+            pool = {}
+            auth_store["credential_pool"] = pool
+
+        entries = pool.get("anthropic")
+        if not isinstance(entries, list):
+            entries = []
+        retained = [
+            entry for entry in entries
+            if not (isinstance(entry, dict) and entry.get("source") == source)
+        ]
+        retained.insert(0, dict(state))
+        pool["anthropic"] = retained
+        _save_auth_store(auth_store)
+
+
 # =============================================================================
 # Provider Resolution — picks which provider to use
 # =============================================================================

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4396,6 +4396,10 @@ def save_anthropic_oauth_token(value: str, save_fn=None):
     writer("ANTHROPIC_TOKEN", value)
     writer("ANTHROPIC_API_KEY", "")
 
+    from hermes_cli.auth import persist_anthropic_oauth_env_token
+
+    persist_anthropic_oauth_env_token(value)
+
 
 def use_anthropic_claude_code_credentials(save_fn=None):
     """Use Claude Code's own credential files instead of persisting env tokens."""

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5069,7 +5069,7 @@ def _model_flow_anthropic(config, current_model=""):
     from hermes_cli.auth import (
         _prompt_model_selection,
         _save_model_choice,
-        deactivate_provider,
+        activate_provider,
     )
     from hermes_cli.config import (
         save_env_value,
@@ -5195,7 +5195,7 @@ def _model_flow_anthropic(config, current_model=""):
         model["provider"] = "anthropic"
         model.pop("base_url", None)
         save_config(cfg)
-        deactivate_provider()
+        activate_provider("anthropic")
 
         print(f"Default model set to: {selected} (via Anthropic)")
     else:

--- a/tests/hermes_cli/test_anthropic_oauth_flow.py
+++ b/tests/hermes_cli/test_anthropic_oauth_flow.py
@@ -1,5 +1,7 @@
 """Tests for Anthropic OAuth setup flow behavior."""
 
+import json
+
 from hermes_cli.config import load_env, save_env_value
 
 
@@ -50,3 +52,35 @@ def test_run_anthropic_oauth_flow_manual_token_still_persists(tmp_path, monkeypa
     assert env_vars["ANTHROPIC_TOKEN"] == "sk-ant-oat01-manual-token"
     output = capsys.readouterr().out
     assert "Setup-token saved" in output
+
+
+def test_model_flow_anthropic_oauth_persists_complete_auth_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.run_oauth_setup_token",
+        lambda: "sk-ant-oat01-from-claude-setup",
+    )
+    monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
+    monkeypatch.setattr("agent.anthropic_adapter.is_claude_code_token_valid", lambda creds: False)
+    monkeypatch.setattr("agent.anthropic_adapter._is_oauth_token", lambda key: key.startswith("sk-ant-"))
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "1")
+    monkeypatch.setattr("hermes_cli.auth._prompt_model_selection", lambda *_args, **_kwargs: "claude-test")
+
+    from hermes_cli.main import _model_flow_anthropic
+
+    _model_flow_anthropic({})
+
+    payload = json.loads((tmp_path / "auth.json").read_text())
+    assert payload["active_provider"] == "anthropic"
+
+    pool_entry = payload["credential_pool"]["anthropic"][0]
+    assert pool_entry["source"] == "env:ANTHROPIC_TOKEN"
+    assert pool_entry["auth_type"] == "oauth"
+    assert pool_entry["access_token"] == "sk-ant-oat01-from-claude-setup"
+    assert pool_entry["base_url"] == "https://api.anthropic.com"
+
+    provider_state = payload["providers"]["anthropic"]
+    assert provider_state["source"] == pool_entry["source"]
+    assert provider_state["auth_type"] == pool_entry["auth_type"]
+    assert provider_state["access_token"] == pool_entry["access_token"]
+    assert provider_state["base_url"] == pool_entry["base_url"]


### PR DESCRIPTION
## Summary
- mirrors `hermes model` Anthropic setup-token OAuth credentials into both `credential_pool.anthropic` and `providers.anthropic`
- keeps `active_provider` set to `anthropic` after the Anthropic model flow saves the selected model
- adds a regression test for the full Anthropic model flow OAuth path

## Repro
1. Run `hermes model` and choose Anthropic → Claude Pro/Max subscription OAuth.
2. Complete `claude setup-token` successfully.
3. Inspect `auth.json`.

Before this patch, `credential_pool.anthropic` could be populated while `providers` stayed `{}` and the model flow later cleared `active_provider`, so the next CLI/gateway startup reported no active provider.

## Root cause
`hermes_cli/main.py` saved `model.provider = "anthropic"` but then called `deactivate_provider()`, clearing `auth.json:active_provider`. The setup-token persistence path in `hermes_cli/config.py` also only wrote `.env`, relying on later pool seeding instead of synchronizing `providers.<provider>` and `credential_pool.<provider>` during OAuth completion.

## Test Plan
- `scripts/run_tests.sh tests/hermes_cli/test_anthropic_oauth_flow.py -q`
- `scripts/run_tests.sh tests/hermes_cli/test_anthropic_oauth_flow.py tests/hermes_cli/test_auth_provider_gate.py tests/hermes_cli/test_auth_profile_fallback.py tests/hermes_cli/test_auth_commands.py -q`

## Follow-up note
The recovery session also found stale `ANTHROPIC_API_KEY` values can coexist with OAuth state. This patch preserves the existing `ANTHROPIC_TOKEN`/`ANTHROPIC_API_KEY` clearing behavior for setup-token OAuth, but explicit env-key vs OAuth-token precedence probably deserves a separate audit/test matrix.
