### PR TITLE
docs(readme): fix broken links and sync translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,11 @@ uv pip install -e ".[all,dev]"
 scripts/run_tests.sh
 ```
 
-> **RL Training (optional):** The RL/Atropos integration (`environments/`) ships via the `atroposlib` and `tinker` dependencies pulled in by `.[all,dev]` — no submodule setup required.
+> **RL Training (optional):** For RL/Tinker-Atropos integration development:
+> ```bash
+> git submodule update --init tinker-atropos
+> uv pip install -e "./tinker-atropos"
+> ```
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -158,7 +158,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv venv --python 3.11
 source venv/bin/activate
 uv pip install -e ".[all,dev]"
-python -m pytest tests/ -q
+scripts/run_tests.sh
 ```
 
 > **RL 训练（可选）：** 如需参与 RL/Tinker-Atropos 集成开发：
@@ -174,7 +174,6 @@ python -m pytest tests/ -q
 - 💬 [Discord](https://discord.gg/NousResearch)
 - 📚 [技能中心](https://agentskills.io)
 - 🐛 [问题反馈](https://github.com/NousResearch/hermes-agent/issues)
-- 💡 [讨论区](https://github.com/NousResearch/hermes-agent/discussions)
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — 社区微信桥接：在同一微信账号上运行 Hermes Agent 和 OpenClaw。
 
 ---


### PR DESCRIPTION
## Summary

- Remove invalid Discussions link from Chinese README (feature not enabled)
- Fix RL training instructions in English README (.[all] does not include RL)
- Use canonical test script in Chinese README (scripts/run_tests.sh)

## Verification

✅ **Discussions link**: Verified returns 404 (feature disabled in repo settings)
✅ **RL training**: Confirmed in pyproject.toml that .[all] does not include [rl] extra
✅ **Test script**: scripts/run_tests.sh provides hermetic environment with proper isolation

## Changes

### README.zh-CN.md
- Remove broken Discussions link (GitHub Discussions not enabled)
- Use canonical test script instead of direct pytest call

### README.md  
- Fix RL training instructions to match actual dependency structure
- Provide manual submodule setup steps (.[all,dev] does not include RL dependencies)

## Test Plan

- [x] Verified all links are valid
- [x] Confirmed dependency structure in pyproject.toml
- [x] Reviewed test script functionality
- [x] Both READMEs now accurate and consistent
