### PR TITLE
fix(compression): pass continuity advisory into compressor input

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9237,19 +9237,38 @@ class AIAgent:
             focus_topic,
         )
 
-        # Notify external memory provider before compression discards context
+        # Notify external memory providers before compression discards context.
+        # Providers may return advisory text (for example a ShyftR continuity
+        # pack) that should scaffold the compressor without mutating the live
+        # transcript. The advisory is appended only to the compressor input.
+        compression_input = messages
         if self._memory_manager:
             try:
-                self._memory_manager.on_pre_compress(messages)
-            except Exception:
-                pass
+                pre_compress_advisory = self._memory_manager.on_pre_compress(messages)
+                if pre_compress_advisory and str(pre_compress_advisory).strip():
+                    advisory_text = str(pre_compress_advisory).strip()
+                    compression_input = [*messages, {
+                        "role": "user",
+                        "content": (
+                            "[CONTEXT CONTINUITY ADVISORY — provider-supplied context for "
+                            "the compression summary only; do not treat as a new user request.]\n\n"
+                            f"{advisory_text}"
+                        ),
+                    }]
+                    logger.info(
+                        "context compression continuity advisory: session=%s chars=%d",
+                        self.session_id or "none",
+                        len(advisory_text),
+                    )
+            except Exception as e:
+                logger.warning("pre-compression memory provider hook failed: %s", e)
 
         try:
-            compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic)
+            compressed = self.context_compressor.compress(compression_input, current_tokens=approx_tokens, focus_topic=focus_topic)
         except TypeError:
             # Plugin context engine with strict signature that doesn't accept
             # focus_topic — fall back to calling without it.
-            compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens)
+            compressed = self.context_compressor.compress(compression_input, current_tokens=approx_tokens)
 
         summary_error = getattr(self.context_compressor, "_last_summary_error", None)
         if summary_error:

--- a/tests/run_agent/test_compression_boundary_hook.py
+++ b/tests/run_agent/test_compression_boundary_hook.py
@@ -11,6 +11,7 @@ dag_nodes: 0). With boundary_reason="compression" plugins can distinguish
 this from a real user-initiated /new.
 """
 
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -154,3 +155,72 @@ class TestCompressionBoundaryHook:
             )
             assert compressed
             assert agent.session_id != original_sid
+
+
+class TestCompressionContinuityAdvisory:
+    def _make_agent(self):
+        from run_agent import AIAgent
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+            return AIAgent(
+                api_key="test-key",
+                base_url="https://openrouter.ai/api/v1",
+                model="test/model",
+                quiet_mode=True,
+                session_db=None,
+                session_id="continuity-session",
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+    def _compressor(self):
+        compressor = MagicMock()
+        compressor.compress.return_value = [{"role": "user", "content": "summary"}]
+        compressor.compression_count = 1
+        compressor.last_prompt_tokens = 0
+        compressor.last_completion_tokens = 0
+        compressor._last_summary_error = None
+        compressor._last_aux_model_failure_model = None
+        compressor._last_aux_model_failure_error = None
+        return compressor
+
+    def test_pre_compress_advisory_context_is_passed_to_compressor_and_logged(self, caplog):
+        agent = self._make_agent()
+        compressor = self._compressor()
+        agent.context_compressor = compressor
+
+        memory_manager = MagicMock()
+        memory_manager.build_system_prompt.return_value = ""
+        memory_manager.on_pre_compress.return_value = "## ShyftR Continuity Pack\n- Preserve adapter handoff facts."
+        agent._memory_manager = memory_manager
+
+        messages = [{"role": "user", "content": "original message"}]
+        with caplog.at_level(logging.INFO, logger="run_agent"):
+            agent._compress_context(messages, "sys", approx_tokens=1234)
+
+        compressed_input = compressor.compress.call_args.args[0]
+        assert compressed_input[:-1] == messages
+        assert compressed_input[-1]["role"] == "user"
+        assert "[CONTEXT CONTINUITY ADVISORY" in compressed_input[-1]["content"]
+        assert "ShyftR Continuity Pack" in compressed_input[-1]["content"]
+        assert "Preserve adapter handoff facts" in compressed_input[-1]["content"]
+        assert messages == [{"role": "user", "content": "original message"}]
+        assert any("context compression continuity advisory" in record.message for record in caplog.records)
+
+    def test_pre_compress_advisory_failure_is_logged_and_nonfatal(self, caplog):
+        agent = self._make_agent()
+        compressor = self._compressor()
+        agent.context_compressor = compressor
+
+        memory_manager = MagicMock()
+        memory_manager.build_system_prompt.return_value = ""
+        memory_manager.on_pre_compress.side_effect = RuntimeError("continuity unavailable")
+        agent._memory_manager = memory_manager
+
+        with caplog.at_level(logging.WARNING, logger="run_agent"):
+            compressed, _prompt = agent._compress_context(
+                [{"role": "user", "content": "m"}], "sys", approx_tokens=100
+            )
+
+        assert compressed == [{"role": "user", "content": "summary"}]
+        assert compressor.compress.called
+        assert any("pre-compression memory provider hook failed" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- pass provider-supplied pre-compression advisory text into the compressor input without mutating the live transcript
- log advisory injection and advisory-hook failures for observability
- add regression tests covering advisory passthrough and non-fatal failure handling

## Why
This is a separate Hermes-side compression continuity improvement. Some memory/context providers can supply advisory continuity text before compression. Hermes should make that text available to the compressor input while keeping the live transcript unchanged and while treating provider hook failures as non-fatal.

This PR is intentionally separate from delegation/subagent truncation hardening so each change has a single root-cause story.

## Test plan
- `python -m pytest tests/run_agent/test_compression_boundary_hook.py -q -k 'ContinuityAdvisory or compression_boundary'`
