### PR TITLE
Fix tool overflow recovery when providers reject oversized tool arrays

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import enum
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
@@ -43,6 +44,7 @@ class FailoverReason(enum.Enum):
     context_overflow = "context_overflow"  # Context too large — compress, not failover
     payload_too_large = "payload_too_large"  # 413 — compress payload
     image_too_large = "image_too_large"   # Native image part exceeds provider's per-image limit — shrink and retry
+    tools_overflow = "tools_overflow"    # Provider capped the tools array length — disable some groups and retry
 
     # Model
     model_not_found = "model_not_found"  # 404 or invalid model — fallback to different model
@@ -235,6 +237,11 @@ _PROVIDER_POLICY_BLOCKED_PATTERNS = [
     "no endpoints available matching your data policy",
     "no endpoints found matching your data policy",
 ]
+
+_TOOLS_OVERFLOW_RE = re.compile(
+    r"maximum length\s+(?P<max>\d+).*?(?:got(?: an array with)? length|but got(?: an array with)? length)\s+(?P<actual>\d+)",
+    re.IGNORECASE,
+)
 
 # Auth patterns (non-status-code signals)
 _AUTH_PATTERNS = [
@@ -745,6 +752,22 @@ def _classify_400(
         return result_fn(
             FailoverReason.image_too_large,
             retryable=True,
+        )
+
+    if "tools" in error_msg and "array too long" in error_msg:
+        error_context: dict[str, int] = {}
+        match = _TOOLS_OVERFLOW_RE.search(error_msg)
+        if match:
+            try:
+                error_context["max_tools"] = int(match.group("max"))
+                error_context["actual_tools"] = int(match.group("actual"))
+            except (TypeError, ValueError):
+                error_context = {}
+        return result_fn(
+            FailoverReason.tools_overflow,
+            retryable=True,
+            should_compress=False,
+            error_context=error_context,
         )
 
     # Context overflow from 400

--- a/run_agent.py
+++ b/run_agent.py
@@ -1618,6 +1618,7 @@ class AIAgent:
             disabled_toolsets=disabled_toolsets,
             quiet_mode=self.quiet_mode,
         )
+        self._session_disabled_toolsets: set[str] = set()
         
         # Show tool configuration and store valid tool names for validation
         self.valid_tool_names = set()
@@ -5457,6 +5458,160 @@ class AIAgent:
             return matches[0]
 
         return None
+
+    @staticmethod
+    def _tool_overflow_group_label(toolset_name: str, count: int) -> str:
+        """Human-readable label for an overflow-disable candidate."""
+        raw = str(toolset_name or "unknown")
+        if raw.startswith("mcp-"):
+            return f"MCP: {raw[4:]} ({count} tools)"
+        pretty = raw.replace("_", " ").replace("-", " ").strip()
+        if pretty.lower() == "homeassistant":
+            pretty = "Home Assistant"
+        elif pretty:
+            pretty = pretty.title()
+        else:
+            pretty = "Unknown"
+        return f"{pretty} ({count} tools)"
+
+    def _tool_overflow_candidates(self) -> list[dict[str, Any]]:
+        """Group currently loaded tools by source for overflow recovery."""
+        groups: dict[str, list[str]] = {}
+        for tool in self.tools or []:
+            fn = tool.get("function") if isinstance(tool, dict) else None
+            tool_name = fn.get("name") if isinstance(fn, dict) else None
+            if not tool_name:
+                continue
+            toolset_name = get_toolset_for_tool(tool_name) or "unknown"
+            groups.setdefault(toolset_name, []).append(tool_name)
+
+        candidates: list[dict[str, Any]] = []
+        for toolset_name, tool_names in groups.items():
+            tool_names = sorted(set(tool_names))
+            count = len(tool_names)
+            candidates.append(
+                {
+                    "toolset": toolset_name,
+                    "tool_names": tool_names,
+                    "count": count,
+                    "label": self._tool_overflow_group_label(toolset_name, count),
+                }
+            )
+
+        def _sort_key(item: dict[str, Any]) -> tuple[int, int, str]:
+            toolset_name = str(item["toolset"])
+            # Prefer trimming MCP groups before built-in toolsets — they are
+            # the common source of tool-count explosions and the safest to
+            # disable for just this session.
+            mcp_rank = 0 if toolset_name.startswith("mcp-") else 1
+            return (mcp_rank, -int(item["count"]), toolset_name)
+
+        return sorted(candidates, key=_sort_key)
+
+    def _disable_toolset_for_session(self, toolset_name: str) -> int:
+        """Remove all tools from one source group for the current session."""
+        remaining_tools: list[dict[str, Any]] = []
+        removed_names: set[str] = set()
+
+        for tool in self.tools or []:
+            fn = tool.get("function") if isinstance(tool, dict) else None
+            tool_name = fn.get("name") if isinstance(fn, dict) else None
+            if tool_name and get_toolset_for_tool(tool_name) == toolset_name:
+                removed_names.add(tool_name)
+                continue
+            remaining_tools.append(tool)
+
+        if not removed_names:
+            return 0
+
+        self.tools = remaining_tools
+        if isinstance(getattr(self, "valid_tool_names", None), set):
+            self.valid_tool_names.difference_update(removed_names)
+        else:
+            self.valid_tool_names = {
+                tool["function"]["name"]
+                for tool in self.tools or []
+                if isinstance(tool, dict) and isinstance(tool.get("function"), dict)
+            }
+        self._session_disabled_toolsets.add(toolset_name)
+        return len(removed_names)
+
+    def _recover_from_tool_overflow(
+        self,
+        *,
+        max_tools: int | None,
+        actual_tools: int | None,
+    ) -> bool:
+        """Interactively disable tool groups until the current session fits."""
+        if not self.tools:
+            return False
+
+        target_max = max_tools if isinstance(max_tools, int) and max_tools > 0 else None
+        session_changed = False
+
+        while self.tools and (target_max is None or len(self.tools) > target_max):
+            candidates = [
+                item
+                for item in self._tool_overflow_candidates()
+                if item["toolset"] not in self._session_disabled_toolsets
+            ]
+            if not candidates:
+                return False
+
+            current_count = len(self.tools)
+            prompt_lines = [
+                (
+                    f"Model {self.model or 'this model'} supports max {target_max or 'fewer'} "
+                    f"tools, but {actual_tools or current_count} are loaded."
+                ),
+                "Choose a tool group to disable for this session and retry.",
+            ]
+            for idx, candidate in enumerate(candidates[:4], start=1):
+                prompt_lines.append(f"[{idx}] {candidate['label']}")
+            question = "\n".join(prompt_lines)
+            choices = [candidate["label"] for candidate in candidates[:4]]
+
+            selected = candidates[0]
+            if callable(getattr(self, "clarify_callback", None)) and choices:
+                try:
+                    user_choice = self.clarify_callback(question, choices)
+                except Exception as exc:
+                    logger.warning(
+                        "%stool-overflow recovery: clarify callback failed: %s",
+                        self.log_prefix,
+                        exc,
+                    )
+                else:
+                    for candidate in candidates[:4]:
+                        if candidate["label"] == user_choice:
+                            selected = candidate
+                            break
+
+            removed_count = self._disable_toolset_for_session(selected["toolset"])
+            if removed_count <= 0:
+                return False
+
+            session_changed = True
+            current_count = len(self.tools or [])
+            self._vprint(
+                f"{self.log_prefix}🧰 Disabled {selected['label']} for this session. "
+                f"{current_count} tools remain loaded.",
+                force=True,
+            )
+            logger.warning(
+                "%stool-overflow recovery: disabled toolset '%s' (%d tools removed, %d remain)",
+                self.log_prefix,
+                selected["toolset"],
+                removed_count,
+                current_count,
+            )
+
+            if target_max is None or current_count <= target_max:
+                return True
+
+            actual_tools = current_count
+
+        return session_changed
 
     def _invalidate_system_prompt(self):
         """
@@ -11263,6 +11418,7 @@ class AIAgent:
             image_shrink_retry_attempted = False
             oauth_1m_beta_retry_attempted = False
             llama_cpp_grammar_retry_attempted = False
+            tool_overflow_retry_attempted = False
             has_retried_429 = False
             restart_with_compressed_messages = False
             restart_with_length_continuation = False
@@ -12194,6 +12350,22 @@ class AIAgent:
                     )
                     if recovered_with_pool:
                         continue
+
+                    if (
+                        classified.reason == FailoverReason.tools_overflow
+                        and not tool_overflow_retry_attempted
+                    ):
+                        tool_overflow_retry_attempted = True
+                        _ctx = classified.error_context or {}
+                        if self._recover_from_tool_overflow(
+                            max_tools=_ctx.get("max_tools"),
+                            actual_tools=_ctx.get("actual_tools"),
+                        ):
+                            self._vprint(
+                                f"{self.log_prefix}⚠️  Retrying with a reduced session tool set...",
+                                force=True,
+                            )
+                            continue
 
                     # Image-too-large recovery: shrink oversized native image
                     # parts in-place and retry once.  Triggered by Anthropic's

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -54,7 +54,7 @@ class TestFailoverReason:
         expected = {
             "auth", "auth_permanent", "billing", "rate_limit",
             "overloaded", "server_error", "timeout",
-            "context_overflow", "payload_too_large", "image_too_large",
+            "context_overflow", "payload_too_large", "image_too_large", "tools_overflow",
             "model_not_found", "format_error",
             "provider_policy_blocked",
             "thinking_signature", "long_context_tier",
@@ -244,6 +244,17 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.rate_limit
         assert result.retryable is True
+
+    def test_400_tools_array_too_long(self):
+        e = MockAPIError(
+            "Invalid 'tools': array too long. Expected an array with maximum length 128, "
+            "but got an array with length 131 instead.",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="copilot", model="gpt-5-mini")
+        assert result.reason == FailoverReason.tools_overflow
+        assert result.retryable is True
+        assert result.error_context == {"max_tools": 128, "actual_tools": 131}
 
     # ── Rate limit ──
 

--- a/tests/run_agent/test_tool_overflow_recovery.py
+++ b/tests/run_agent/test_tool_overflow_recovery.py
@@ -1,0 +1,85 @@
+"""Tests for session-scoped tool-overflow recovery."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def _tool(name: str) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": f"{name} tool",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+def _make_agent(*tool_names: str) -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.model = "gpt-5-mini"
+    agent.log_prefix = ""
+    agent.tools = [_tool(name) for name in tool_names]
+    agent.valid_tool_names = set(tool_names)
+    agent._session_disabled_toolsets = set()
+    agent._vprint = lambda *a, **k: None
+    agent.clarify_callback = None
+    return agent
+
+
+def test_recover_from_tool_overflow_uses_selected_group():
+    agent = _make_agent(
+        "mcp_arr_stack_a",
+        "mcp_arr_stack_b",
+        "browser_open",
+        "browser_click",
+        "terminal",
+    )
+    toolset_map = {
+        "mcp_arr_stack_a": "mcp-arr_stack",
+        "mcp_arr_stack_b": "mcp-arr_stack",
+        "browser_open": "browser",
+        "browser_click": "browser",
+        "terminal": "terminal",
+    }
+
+    with patch("run_agent.get_toolset_for_tool", side_effect=toolset_map.get):
+        browser_label = agent._tool_overflow_group_label("browser", 2)
+        agent.clarify_callback = lambda _question, _choices: browser_label
+        changed = agent._recover_from_tool_overflow(max_tools=3, actual_tools=5)
+
+    assert changed is True
+    assert agent.valid_tool_names == {"mcp_arr_stack_a", "mcp_arr_stack_b", "terminal"}
+    assert "browser" in agent._session_disabled_toolsets
+    assert len(agent.tools) == 3
+
+
+def test_recover_from_tool_overflow_prefers_mcp_group_without_prompt():
+    agent = _make_agent(
+        "mcp_arr_stack_a",
+        "mcp_arr_stack_b",
+        "mcp_arr_stack_c",
+        "browser_open",
+        "browser_click",
+        "terminal",
+    )
+    toolset_map = {
+        "mcp_arr_stack_a": "mcp-arr_stack",
+        "mcp_arr_stack_b": "mcp-arr_stack",
+        "mcp_arr_stack_c": "mcp-arr_stack",
+        "browser_open": "browser",
+        "browser_click": "browser",
+        "terminal": "terminal",
+    }
+
+    with patch("run_agent.get_toolset_for_tool", side_effect=toolset_map.get):
+        changed = agent._recover_from_tool_overflow(max_tools=4, actual_tools=6)
+
+    assert changed is True
+    assert agent.valid_tool_names == {"browser_open", "browser_click", "terminal"}
+    assert "mcp-arr_stack" in agent._session_disabled_toolsets
+    assert len(agent.tools) == 3

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -197,6 +197,22 @@ def test_items_sanitized_in_array_schema():
     assert items == {"type": "object", "properties": {}}
 
 
+def test_array_schema_missing_items_gets_fallback_items():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "specifications": {
+                "type": "array",
+                "description": "Provider omitted items entirely",
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    prop = out[0]["function"]["parameters"]["properties"]["specifications"]
+    assert prop["type"] == "array"
+    assert prop["items"] == {}
+
+
 def test_empty_tools_list_returns_empty():
     assert sanitize_tool_schemas([]) == []
 

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -21,6 +21,7 @@ The failure modes we've seen in the wild:
   optional fields (common Pydantic/MCP shape). Anthropic rejects these at
   the top of ``input_schema``; collapse them to the non-null branch.
 * Unconstrained ``additionalProperties`` on objects with empty properties.
+* Array-typed schemas with no ``items`` definition at all.
 
 This module walks the final tool schema tree (after MCP-level normalization
 and any per-tool dynamic rebuilds) and fixes the known-hostile constructs
@@ -242,6 +243,12 @@ def _sanitize_node(node: Any, path: str) -> Any:
     # llama.cpp's grammar generator can't constrain a free-form object.
     if out.get("type") == "object" and not isinstance(out.get("properties"), dict):
         out["properties"] = {}
+
+    # Some MCP schemas declare an array but omit ``items`` entirely.
+    # Strict providers reject this as an invalid function schema; a permissive
+    # empty schema is the narrowest compatible fallback.
+    if out.get("type") == "array" and "items" not in out:
+        out["items"] = {}
 
     # Prune ``required`` entries that don't exist in properties (defense
     # against malformed MCP schemas; also caught upstream for MCP tools, but


### PR DESCRIPTION
Fixes #13037

## Problem
Some providers reject requests when the serialized `tools` array exceeds their hard cap, which currently turns into a terminal 400 instead of a recoverable retry. We were also still letting array-shaped tool schemas through without `items`, which triggers a second class of provider-side 400s before the retry path can help.

## What this PR changes
- classify provider 400s that report `Invalid 'tools': array too long` as a retryable `tools_overflow` condition and capture the reported max/current counts
- sanitize array parameters that are missing `items` so strict tool-schema validators accept the request
- on the first `tools_overflow` only, group loaded tools by source, prefer trimming MCP groups first, optionally let the active `clarify_callback` pick the group, then retry with that toolset disabled for the current session

## Why this shape
- keeps recovery session-scoped; no config, registry, or persistent toolset changes
- reuses the existing agent retry path instead of adding a separate negotiation subsystem
- matches the concrete failure mode in #13037, where large MCP tool groups pushed the session over the provider cap

## Validation
- `python -m pytest tests/agent/test_error_classifier.py tests/tools/test_schema_sanitizer.py tests/run_agent/test_tool_overflow_recovery.py`
- `python -m py_compile run_agent.py agent/error_classifier.py tools/schema_sanitizer.py tests/run_agent/test_tool_overflow_recovery.py`
- `git diff --check`

## Out of scope
- persistent toolset/config changes
- multi-step tool negotiation beyond the first session-scoped recovery retry
