### PR TITLE
fix(approval): catch sudo with stdin/askpass/shell privilege flags

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -965,3 +965,140 @@ class TestFailClosedUnderPromptToolkit:
             assert result == "once"
         finally:
             ptc.get_app_or_none = orig
+
+
+class TestDetectSudoStdin:
+    """Sudo with stdin / askpass / shell / list-privileges flags (#17873 cat 4).
+
+    An LLM-driven agent has no TTY, so the sudo invocations that succeed
+    without human interaction are those reading the password from stdin
+    (-S / --stdin) or via an askpass helper (-A / --askpass). The
+    shell-launch (-s) and list-privileges (-a) flags are also gated since
+    they are privilege-relevant invocations the agent can chain after
+    acquiring the password.
+
+    `_normalize_command_for_detection` lowercases input before pattern
+    matching, so -S/-s and -A/-a are indistinguishable at the regex
+    layer; both letter-pairs are gated.
+    """
+
+    # Positive cases (must match)
+
+    def test_canonical_pipe_to_sudo_S_detected(self):
+        is_dangerous, _, desc = detect_dangerous_command(
+            "echo pwd | sudo -S whoami"
+        )
+        assert is_dangerous is True
+        assert "sudo" in desc.lower()
+
+    def test_long_flag_stdin_detected(self):
+        is_dangerous, _, _ = detect_dangerous_command("sudo --stdin id")
+        assert is_dangerous is True
+
+    def test_non_interactive_plus_stdin_detected(self):
+        is_dangerous, _, _ = detect_dangerous_command("sudo -n -S id")
+        assert is_dangerous is True
+
+    def test_user_then_stdin_detected(self):
+        # Codex audit caught that the original "leading flags only" regex
+        # missed this form because `-u root` has a flag-argument (`root`)
+        # that broke the (?:\s+-[^\s]+)* loop. The lazy [^;|&\n]*? class
+        # consumes flag-args without spanning command separators.
+        is_dangerous, _, _ = detect_dangerous_command(
+            "sudo -u root -S whoami"
+        )
+        assert is_dangerous is True
+
+    def test_long_non_interactive_plus_stdin_detected(self):
+        is_dangerous, _, _ = detect_dangerous_command(
+            "sudo --non-interactive -S whoami"
+        )
+        assert is_dangerous is True
+
+    def test_long_user_equals_stdin_detected(self):
+        is_dangerous, _, _ = detect_dangerous_command(
+            "sudo --user=root -S id"
+        )
+        assert is_dangerous is True
+
+    def test_herestring_input_detected(self):
+        is_dangerous, _, _ = detect_dangerous_command(
+            "sudo -S id <<< 'mypwd'"
+        )
+        assert is_dangerous is True
+
+    def test_combined_short_flags_nS_detected(self):
+        # `-nS` packs `-n` and `-S` into one arg; second pattern catches.
+        is_dangerous, _, _ = detect_dangerous_command("sudo -nS id")
+        assert is_dangerous is True
+
+    def test_printf_form_detected(self):
+        is_dangerous, _, _ = detect_dangerous_command(
+            'printf "%s\\n" "$PW" | sudo -S id'
+        )
+        assert is_dangerous is True
+
+    def test_askpass_short_flag_detected(self):
+        is_dangerous, _, _ = detect_dangerous_command("sudo -A id")
+        assert is_dangerous is True
+
+    def test_askpass_long_flag_detected(self):
+        is_dangerous, _, _ = detect_dangerous_command("sudo --askpass id")
+        assert is_dangerous is True
+
+    def test_two_sudo_invocations_second_caught(self):
+        # The first sudo here is benign (no -S); the second has -S.
+        # Lazy [^;|&\n]*? does NOT span past `;`, so re.search anchors
+        # on the second sudo invocation independently.
+        is_dangerous, _, _ = detect_dangerous_command(
+            "sudo whoami; sudo -S id"
+        )
+        assert is_dangerous is True
+
+    # Negative cases (must NOT match)
+
+    def test_plain_sudo_safe(self):
+        is_dangerous, _, _ = detect_dangerous_command("sudo whoami")
+        assert is_dangerous is False
+
+    def test_sudo_interactive_shell_safe(self):
+        is_dangerous, _, _ = detect_dangerous_command("sudo -i")
+        assert is_dangerous is False
+
+    def test_sudo_with_user_no_stdin_flag_safe(self):
+        is_dangerous, _, _ = detect_dangerous_command("sudo -u root -i")
+        assert is_dangerous is False
+
+    def test_man_sudo_safe(self):
+        is_dangerous, _, _ = detect_dangerous_command("man sudo")
+        assert is_dangerous is False
+
+    def test_which_sudo_safe(self):
+        is_dangerous, _, _ = detect_dangerous_command("which sudo")
+        assert is_dangerous is False
+
+    def test_sudo_user_env_reference_safe(self):
+        is_dangerous, _, _ = detect_dangerous_command(
+            "echo SUDO_USER=$SUDO_USER"
+        )
+        assert is_dangerous is False
+
+    def test_apt_install_sudo_safe(self):
+        is_dangerous, _, _ = detect_dangerous_command("apt install sudo")
+        assert is_dangerous is False
+
+    def test_ls_etc_sudoers_safe(self):
+        is_dangerous, _, _ = detect_dangerous_command("ls /etc/sudoers")
+        assert is_dangerous is False
+
+    def test_pseudosudo_safe_word_boundary(self):
+        # `\bsudo\b` requires a word boundary; `pseudosudo` has none
+        # before `sudo`, so should not trigger.
+        is_dangerous, _, _ = detect_dangerous_command("pseudosudo -S id")
+        assert is_dangerous is False
+
+    def test_unrelated_redirection_safe(self):
+        is_dangerous, _, _ = detect_dangerous_command(
+            "make 2>&1 | tee build.log"
+        )
+        assert is_dangerous is False

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -289,6 +289,25 @@ DANGEROUS_PATTERNS = [
     # a script is first made executable then immediately run. The script
     # content may contain dangerous commands that individual patterns miss.
     (r'\bchmod\s+\+x\b.*[;&|]+\s*\./', "chmod +x followed by immediate execution"),
+    # Sudo with stdin / askpass / shell / list-privs flags. An LLM-driven
+    # agent has no TTY, so sudo invocations that succeed without human
+    # interaction are those reading the password from stdin (-S/--stdin)
+    # or via an askpass helper (-A/--askpass). The shell-launch (-s) and
+    # list-privileges (-a) flags are also gated since they are
+    # privilege-relevant invocations the agent can chain after acquiring
+    # the password (e.g. read SUDO_PASSWORD from .env -> sudo -S -s ->
+    # root shell). Plain `sudo cmd` (no flag) is TTY-bound and excluded.
+    # `_normalize_command_for_detection` lowercases input before pattern
+    # matching, so case variants of S/s and A/a collapse — both forms
+    # are gated below. Lazy `[^;|&\n]*?` allows flag arguments (e.g.
+    # `sudo -u root -S whoami`) without spanning command separators. See
+    # #17873 category 4.
+    (r'\bsudo\b[^;|&\n]*?\s+(?:-s\b|--stdin\b|-a\b|--askpass\b)',
+     "sudo with privilege flag (stdin/askpass/shell/list)"),
+    # Combined short-flag form: -nS, -ns, -sa, -las — sudo flags packed
+    # into a single -X token. Catches the same threat class.
+    (r'\bsudo\b[^;|&\n]*?\s+-[a-z]*[sa][a-z]*\b',
+     "sudo with combined-flag privilege escalation"),
 ]
 
 


### PR DESCRIPTION
## What does this PR do?

Adds the only category from #17873 that's not covered by the in-flight PRs #17962 (reverse shell + download-execute) and #7993 (credential reads + curl/wget exfiltration): **sudo invocations that an LLM-driven agent can drive without TTY interaction**.

The agent has no TTY, so the sudo forms that succeed without human involvement are those reading the password from stdin (`-S` / `--stdin`) or via an askpass helper (`-A` / `--askpass`). The shell-launch (`-s`) and list-privileges (`-a`) flags are also gated since they're privilege-relevant invocations the agent can chain after acquiring the password (e.g. read SUDO_PASSWORD from `.env` → `sudo -S -s` → root shell). Plain `sudo cmd` (no flag) is TTY-bound and excluded.

Refs #17873 (category 4).

## Type of Change

- [x] 🔒 Security fix

## Changes Made

`tools/approval.py` — two new entries in `DANGEROUS_PATTERNS`:

```python
# Direct flag form: -S / --stdin / -A / --askpass appearing as a separate
# argument (with arbitrary leading sudo flags and their values, including
# `-u root`).
(r'\bsudo\b[^;|&\n]*?\s+(?:-s\b|--stdin\b|-a\b|--askpass\b)',
 "sudo with privilege flag (stdin/askpass/shell/list)"),

# Combined short-flag form: -nS, -ns, -sa, -las — sudo flags packed into
# a single -X token. Same threat class.
(r'\bsudo\b[^;|&\n]*?\s+-[a-z]*[sa][a-z]*\b',
 "sudo with combined-flag privilege escalation"),
```

`tests/tools/test_approval.py` — new `TestDetectSudoStdin` class with 12 positive + 9 negative cases (21 tests).

## Design notes

**Why anchor on `[^;|&\n]*?` lazy** instead of the seemingly-tighter `(?:\s+-[^\s]+)*` "leading flags only"? Because the latter only consumes flag *tokens*, not their *values*. So `sudo -u root -S whoami` — the textbook offensive form — would slip through. The lazy class consumes flag-args (like `root`) without spanning command separators (`; | & \n`), so a benign `sudo whoami; sudo -S id` still matches via `re.search` on the second sudo invocation independently.

**Why match both `-S/-s` and `-A/-a`** when only `-S` and `-A` are the privilege-relevant flags? Because `_normalize_command_for_detection` lowercases input before pattern matching (`tools/approval.py:340`), so case variants collapse. After lowercasing, `-S` and `-s` are indistinguishable. The lowercase forms are what the regex sees, and:
- `-s` (run shell) is also a privilege-relevant invocation in agent context
- `-a` (list privileges) is also recon-relevant

Both letter-pairs are gated as legitimately approval-worthy.

## Coverage matrix (empirically tested)

**Attacks (11/11 match)**:

| Command | Matched by |
|---------|------------|
| `echo pwd \| sudo -S whoami` | p1 (canonical) |
| `sudo --stdin id` | p1 (long flag) |
| `sudo -n -S id` | p1 (with `-n` non-interactive) |
| `sudo -u root -S whoami` | p1 (with flag-arg `root`) |
| `sudo --non-interactive -S whoami` | p1 |
| `sudo --user=root -S id` | p1 (long `--user=` form) |
| `sudo -S id <<< 'mypwd'` | p1 (herestring source) |
| `sudo -nS id` | p2 (combined short flags) |
| `printf "%s\n" "$PW" \| sudo -S id` | p1 (printf-pipe) |
| `sudo -A id` | p1 (askpass) |
| `sudo --askpass id` | p1 (long askpass) |

**Benign (0/10 false positives)**:

| Command | Reason |
|---------|--------|
| `sudo whoami` | no `-S`/`-A`, would block on TTY |
| `sudo -i` | interactive shell, no `-S` |
| `man sudo` | no flag |
| `which sudo` | no flag |
| `echo SUDO_USER=$SUDO_USER` | env-var reference |
| `apt install sudo` | package install |
| `sudo -u root -i` | interactive, no `-S` |
| `make 2>&1 \| tee build.log` | unrelated redirection |
| `ls /etc/sudoers` | doc lookup |
| `pseudosudo -S id` | `\bsudo\b` boundary refuses |

## Catastrophic-backtracking check

Timed pathological inputs (`sudo` + many `-x` flags, none of which are `-s/-a`):

| Length | p1 search | p2 search |
|--------|----------:|----------:|
| 2,104 chars | 0.0002s | 0.0002s |
| 21,004 chars | 0.0019s | 0.0021s |
| 100,006 chars | 0.0040s | 0.0066s |

Sub-7ms on 100K-char inputs. No catastrophic backtracking.

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_approval.py
# expected: 154 tests pass (133 existing + 21 new in TestDetectSudoStdin)
```

Verified locally: **248/248** tests pass across `test_approval.py` + adjacent `test_hardline_blocklist.py`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(approval): catch sudo with stdin/askpass/shell privilege flags`)
- [x] I searched for existing PRs (#17962, #7993 cover other #17873 categories; this is the only one not yet addressed)
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/tools/test_approval.py -q` and all tests pass
- [x] I've added tests for my changes (21 new cases in `TestDetectSudoStdin`)
- [x] I've tested on my platform: Ubuntu

### Documentation & Housekeeping

- [x] N/A — pattern set is internal; no user-facing config change

## Adjacent PRs (context, no action required from this PR)

- #17962 (briandevans) — covers #17873 categories 1 (reverse shell `nc -e`/`socat EXEC`/`bash /dev/tcp`), 2 (two-stage `curl -o && bash`)
- #7993 (SHL0MS) — covers #17873 categories 3 (credential file reads), 5 (curl/wget data exfiltration)
- This PR — covers #17873 category 4 (sudo with stdin/askpass)

After all three merge, the public Issue #17873 is fully addressed.
