### PR TITLE
fix(telegram): preserve approval audit context

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -643,8 +643,10 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         # Interactive model picker state per chat
         self._model_picker_state: Dict[str, dict] = {}
-        # Approval button state: message_id → session_key
-        self._approval_state: Dict[int, str] = {}
+        # Approval button state: approval_id -> request context used by callbacks.
+        # Values are dicts with session_key/chat_id/message_id/text/requested_at;
+        # legacy string session_key values are still accepted for in-flight prompts.
+        self._approval_state: Dict[int, Any] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
@@ -4635,13 +4637,65 @@ class TelegramAdapter(BasePlatformAdapter):
 
             msg = await self._send_message_with_thread_fallback(**kwargs)
 
-            # Store session_key keyed by approval_id for the callback handler
-            self._approval_state[approval_id] = session_key
+            # Store request context keyed by approval_id for the callback handler
+            # so the edited result can retain command/reason audit details.
+            self._approval_state[approval_id] = {
+                "session_key": session_key,
+                "chat_id": str(chat_id),
+                "message_id": str(msg.message_id),
+                "text": text,
+                "requested_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+            }
 
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.warning("[%s] send_exec_approval failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
+
+    @staticmethod
+    def _telegram_user_field(user: Any, field: str) -> Optional[str]:
+        value = getattr(user, field, None)
+        if value is None:
+            return None
+        if not isinstance(value, (str, int)):
+            return None
+        text = str(value).strip()
+        return text if text else None
+
+    @classmethod
+    def _format_approval_operator(cls, user: Any) -> str:
+        first_name = cls._telegram_user_field(user, "first_name")
+        last_name = cls._telegram_user_field(user, "last_name")
+        username = cls._telegram_user_field(user, "username")
+        user_id = cls._telegram_user_field(user, "id")
+
+        name = " ".join(part for part in (first_name, last_name) if part)
+        details: list[str] = []
+        if username:
+            details.append(f"@{username}")
+        if user_id:
+            details.append(f"id {user_id}")
+        if name and details:
+            return f"{name} ({', '.join(details)})"
+        if name:
+            return name
+        if details:
+            return ", ".join(details)
+        return "unknown Telegram user"
+
+    @staticmethod
+    def _format_approval_resolution_text(
+        original_text: str,
+        label: str,
+        operator: str,
+        requested_at: str,
+    ) -> str:
+        return (
+            f"{original_text}\n\n"
+            f"<b>Result:</b> {_html.escape(label)}\n"
+            f"<b>Handled by:</b> {_html.escape(operator)}\n"
+            f"<b>Requested at:</b> {_html.escape(requested_at)}"
+        )
 
     async def send_slash_confirm(
         self, chat_id: str, title: str, message: str, session_key: str,
@@ -5377,10 +5431,19 @@ class TelegramAdapter(BasePlatformAdapter):
                     await query.answer(text="⛔ You are not authorized to approve commands.")
                     return
 
-                session_key = self._approval_state.pop(approval_id, None)
-                if not session_key:
+                approval_state = self._approval_state.pop(approval_id, None)
+                if not approval_state:
                     await query.answer(text="This approval has already been resolved.")
                     return
+                if isinstance(approval_state, dict):
+                    session_key = approval_state["session_key"]
+                    original_text = approval_state.get("text")
+                    requested_at = approval_state.get("requested_at")
+                else:
+                    # Legacy in-flight value: bare session_key string.
+                    session_key = approval_state
+                    original_text = None
+                    requested_at = None
 
                 # Map choice to human-readable label
                 label_map = {
@@ -5389,16 +5452,29 @@ class TelegramAdapter(BasePlatformAdapter):
                     "always": "✅ Approved permanently",
                     "deny": "❌ Denied",
                 }
-                user_display = getattr(query.from_user, "first_name", "User")
+                user_display = self._format_approval_operator(query.from_user)
                 label = label_map.get(choice, "Resolved")
 
                 await query.answer(text=label)
 
-                # Edit message to show decision, remove buttons
+                # Edit message to show decision, remove buttons.
+                # Prefer preserving the original HTML approval request so the
+                # command/reason remain auditable in chat history.
                 try:
+                    if original_text and requested_at:
+                        edit_text = self._format_approval_resolution_text(
+                            original_text,
+                            label,
+                            user_display,
+                            requested_at,
+                        )
+                        parse_mode = ParseMode.HTML
+                    else:
+                        edit_text = self.format_message(f"{label} by {user_display}")
+                        parse_mode = ParseMode.MARKDOWN_V2
                     await query.edit_message_text(
-                        text=self.format_message(f"{label} by {user_display}"),
-                        parse_mode=ParseMode.MARKDOWN_V2,
+                        text=edit_text,
+                        parse_mode=parse_mode,
                         reply_markup=None,
                     )
                 except Exception:

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -161,10 +161,33 @@ class TestTelegramExecApproval:
             session_key="my-session-key",
         )
 
-        # The approval_id should map to the session_key
+        # The approval_id should map to the request context used by callbacks.
         assert len(adapter._approval_state) == 1
         approval_id = list(adapter._approval_state.keys())[0]
-        assert adapter._approval_state[approval_id] == "my-session-key"
+        assert adapter._approval_state[approval_id]["session_key"] == "my-session-key"
+
+    @pytest.mark.asyncio
+    async def test_stores_approval_request_context_for_audit(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 42
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        await adapter.send_exec_approval(
+            chat_id="12345",
+            command="rm -rf /important",
+            session_key="my-session-key",
+            description="dangerous deletion",
+        )
+
+        approval_id = list(adapter._approval_state.keys())[0]
+        state = adapter._approval_state[approval_id]
+        assert state["session_key"] == "my-session-key"
+        assert state["chat_id"] == "12345"
+        assert state["message_id"] == "42"
+        assert "rm -rf /important" in state["text"]
+        assert "dangerous deletion" in state["text"]
+        assert "requested_at" in state
 
     @pytest.mark.asyncio
     async def test_sends_in_thread(self):
@@ -312,6 +335,93 @@ class TestTelegramApprovalCallback:
 
         # State should be cleaned up
         assert 1 not in adapter._approval_state
+
+    @pytest.mark.asyncio
+    async def test_approval_click_preserves_request_text_and_adds_operator_details(self):
+        adapter = _make_adapter()
+        adapter._approval_state[1] = {
+            "session_key": "agent:main:telegram:group:12345:99",
+            "chat_id": "12345",
+            "message_id": "42",
+            "text": (
+                "⚠️ <b>Command Approval Required</b>\n\n"
+                "<pre>rm -rf /important</pre>\n\n"
+                "Reason: dangerous deletion"
+            ),
+            "requested_at": "2026-05-07T09:30:00+00:00",
+        }
+
+        query = AsyncMock()
+        query.data = "ea:once:1"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.id = 222
+        query.from_user.first_name = "Norbert"
+        query.from_user.last_name = None
+        query.from_user.username = "norbert"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1):
+                await adapter._handle_callback_query(update, context)
+
+        edit_kwargs = query.edit_message_text.call_args[1]
+        edited_text = edit_kwargs["text"]
+        assert "Command Approval Required" in edited_text
+        assert "rm -rf /important" in edited_text
+        assert "dangerous deletion" in edited_text
+        assert "Approved once" in edited_text
+        assert "Norbert" in edited_text
+        assert "@norbert" in edited_text
+        assert "222" in edited_text
+        assert "2026-05-07T09:30:00+00:00" in edited_text
+        assert "HTML" in repr(edit_kwargs["parse_mode"])
+        assert edit_kwargs["reply_markup"] is None
+        assert 1 not in adapter._approval_state
+
+    @pytest.mark.asyncio
+    async def test_approval_resolution_html_escapes_operator_details(self):
+        """Operator identity in the HTML audit footer must be escaped."""
+        adapter = _make_adapter()
+        adapter._approval_state[4] = {
+            "session_key": "agent:main:telegram:group:12345:99",
+            "chat_id": "12345",
+            "message_id": "42",
+            "text": "⚠️ <b>Command Approval Required</b>\n\n<pre>ls</pre>\n\nReason: check",
+            "requested_at": "2026-05-07T09:30:00+00:00",
+        }
+
+        query = AsyncMock()
+        query.data = "ea:once:4"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.id = 222
+        query.from_user.first_name = "Alice<Bob>"
+        query.from_user.last_name = None
+        query.from_user.username = "a&b"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "*"}, clear=False):
+            with patch("tools.approval.resolve_gateway_approval", return_value=1):
+                await adapter._handle_callback_query(update, context)
+
+        edit_kwargs = query.edit_message_text.call_args[1]
+        edited_text = edit_kwargs["text"]
+        assert "Alice&lt;Bob&gt;" in edited_text
+        assert "@a&amp;b" in edited_text
+        assert "HTML" in repr(edit_kwargs["parse_mode"])
 
     @pytest.mark.asyncio
     async def test_resume_typing_after_inline_approval(self):


### PR DESCRIPTION
## Summary
- Preserve the original Telegram exec approval prompt after an inline button is clicked, so the chat history still shows the reviewed command and reason.
- Store approval request context with the session key, including chat/message ids and request timestamp, for callback resolution and audit readability.
- Append the approval result, operator identity, and original request timestamp when removing the inline keyboard.
- Add regression tests that verify request context is stored and edited approval messages retain the reviewed command details.

## Why
Telegram previously replaced the full approval request with a short result such as `Approved once by User`. That removed the command and reason from the visible chat history, making it hard to audit which command was approved or denied.

## Tests
- `scripts/run_tests.sh tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_format.py tests/gateway/test_telegram_topic_mode.py`
- `/Users/cl/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/platforms/telegram.py`
- `git diff --check origin/main..HEAD`