### PR TITLE
fix(codex): flatten legacy function-role messages for responses input

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -375,6 +375,16 @@ class _CodexCompletionsAdapter:
             if role == "system":
                 instructions = content if isinstance(content, str) else str(content)
             else:
+                # The Codex Responses input schema rejects Chat Completions
+                # transcript-only roles such as ``tool`` (HTTP 400: supported
+                # values are assistant/system/developer/user).  Auxiliary
+                # flushes receive the full session transcript, so preserve tool
+                # output as user-visible context instead of forwarding an
+                # invalid role.
+                if role not in {"assistant", "developer", "user"}:
+                    name = msg.get("name") or msg.get("tool_call_id") or role
+                    content = f"[{role} result {name}: {content}]"
+                    role = "user"
                 input_msgs.append({
                     "role": role,
                     "content": _convert_content_for_responses(content),

--- a/tests/agent/test_auxiliary_client_codex.py
+++ b/tests/agent/test_auxiliary_client_codex.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+
+from agent.auxiliary_client import _CodexCompletionsAdapter
+
+
+class _FakeStream:
+    def __init__(self):
+        self.kwargs = None
+
+    def __call__(self, **kwargs):
+        self.kwargs = kwargs
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        return iter(())
+
+    def get_final_response(self):
+        return SimpleNamespace(output=[])
+
+
+def test_codex_adapter_flattens_tool_role_messages_for_responses_input():
+    stream = _FakeStream()
+    real_client = SimpleNamespace(responses=SimpleNamespace(stream=stream))
+    adapter = _CodexCompletionsAdapter(real_client, "gpt-5.2-codex")
+
+    adapter.create(
+        messages=[
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "run a tool"},
+            {"role": "assistant", "content": None, "tool_calls": []},
+            {"role": "tool", "tool_call_id": "call_123", "content": "tool output"},
+        ],
+    )
+
+    assert stream.kwargs["instructions"] == "sys"
+    assert [m["role"] for m in stream.kwargs["input"]] == [
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert stream.kwargs["input"][-1]["content"] == "[tool result call_123: tool output]"

--- a/tests/agent/test_auxiliary_client_codex.py
+++ b/tests/agent/test_auxiliary_client_codex.py
@@ -45,3 +45,21 @@ def test_codex_adapter_flattens_tool_role_messages_for_responses_input():
         "user",
     ]
     assert stream.kwargs["input"][-1]["content"] == "[tool result call_123: tool output]"
+
+
+def test_codex_adapter_flattens_function_role_messages_for_responses_input():
+    stream = _FakeStream()
+    real_client = SimpleNamespace(responses=SimpleNamespace(stream=stream))
+    adapter = _CodexCompletionsAdapter(real_client, "gpt-5.2-codex")
+
+    adapter.create(
+        messages=[
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "call legacy function"},
+            {"role": "function", "name": "legacy_fn", "content": "legacy output"},
+        ],
+    )
+
+    assert stream.kwargs["instructions"] == "sys"
+    assert [m["role"] for m in stream.kwargs["input"]] == ["user", "user"]
+    assert stream.kwargs["input"][-1]["content"] == "[function result legacy_fn: legacy output]"


### PR DESCRIPTION
## Summary
- add focused coverage for Codex auxiliary adapter handling of legacy `function` role messages
- verify unsupported `function` role messages are flattened into `user` input entries for the Responses API
- preserve the existing tool-role flattening behavior while closing the adjacent legacy-role coverage gap

## Test Plan
- python -m pytest tests/agent/test_auxiliary_client_codex.py -q
- independent read-only review of /tmp/codex-tool-role-review.diff and live file state

## Notes
- production branch change already handled tool-role flattening; this PR adds the missing legacy function-role regression test so upstream can merge with higher confidence
