### PR TITLE
fix(profile): honor renamed root alias in CLI/profile helpers

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -237,6 +237,42 @@ def _get_active_profile_path() -> Path:
     return _get_default_hermes_home() / "active_profile"
 
 
+def _get_root_alias() -> Optional[str]:
+    """Return the renamed-root display alias, or None if not set/invalid.
+
+    The root profile (``~/.hermes``) is always reachable as ``default``. When
+    ``~/.hermes/default_profile_name`` contains a valid profile id, that name
+    also resolves to the root profile so users who renamed it (in WebUI or by
+    hand) see and use the new name consistently from the CLI (see #21105).
+
+    Returns ``None`` when the file is missing, empty, fails id validation,
+    equals the reserved ``default`` alias, or collides with an existing named
+    profile dir under ``~/.hermes/profiles/``.
+    """
+    try:
+        path = _get_default_hermes_home() / "default_profile_name"
+        if not path.is_file():
+            return None
+        raw = path.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return None
+    if not raw:
+        return None
+    candidate = raw.lower()
+    if candidate == "default":
+        return None
+    if not _PROFILE_ID_RE.match(candidate):
+        return None
+    # A real named profile with the same id wins; dropping the alias keeps
+    # that profile reachable rather than silently shadowing it with the root.
+    try:
+        if (_get_profiles_root() / candidate).is_dir():
+            return None
+    except OSError:
+        return None
+    return candidate
+
+
 def _get_wrapper_dir() -> Path:
     """Return the directory for wrapper scripts."""
     return Path.home() / ".local" / "bin"
@@ -253,6 +289,10 @@ def normalize_profile_name(name: str) -> str:
     alias ``default`` is matched case-insensitively (``Default`` → ``default``).
     Dashboards and tools may pass title-cased display labels; normalize before
     validation, assignment, and subprocess spawn (see issue #18498).
+
+    A renamed root profile (``~/.hermes/default_profile_name`` — see #21105)
+    also resolves here to ``default`` so all downstream helpers route the
+    alias to the root profile without each having to know about it.
     """
     if not isinstance(name, str):
         name = str(name)
@@ -261,7 +301,11 @@ def normalize_profile_name(name: str) -> str:
         raise ValueError("profile name cannot be empty")
     if stripped.casefold() == "default":
         return "default"
-    return stripped.lower()
+    canon = stripped.lower()
+    alias = _get_root_alias()
+    if alias is not None and canon == alias:
+        return "default"
+    return canon
 
 
 def validate_profile_name(name: str) -> None:
@@ -581,8 +625,11 @@ def list_profiles() -> List[ProfileInfo]:
         model, provider = _read_config_model(default_home)
         dist_name, dist_version, dist_source = _read_distribution_meta(default_home)
         meta = read_profile_meta(default_home)
+        # Honor renamed-root display alias (#21105) — the row still has
+        # is_default=True so dashboards/CLI mark it as the root profile.
+        display_name = _get_root_alias() or "default"
         profiles.append(ProfileInfo(
-            name="default",
+            name=display_name,
             path=default_home,
             is_default=True,
             gateway_running=_check_gateway_running(default_home),
@@ -1064,7 +1111,7 @@ def get_active_profile_name() -> str:
 
     default_resolved = _get_default_hermes_home().resolve()
     if resolved == default_resolved:
-        return "default"
+        return _get_root_alias() or "default"
 
     profiles_root = _get_profiles_root().resolve()
     try:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -546,6 +546,112 @@ class TestGetActiveProfileName:
 
 
 # ===================================================================
+# TestRenamedRootAlias  (#21105)
+# ===================================================================
+
+
+def _set_root_alias(profile_env, value: str) -> None:
+    """Write a renamed-root alias file under the test root."""
+    (profile_env / ".hermes" / "default_profile_name").write_text(value)
+
+
+class TestRenamedRootAlias:
+    """Tests for the renamed-root display alias plumbing (#21105).
+
+    A non-empty ``~/.hermes/default_profile_name`` should resolve to the
+    root profile across normalize/get_profile_dir/profile_exists/
+    resolve_profile_env/list_profiles/get_active_profile_name without
+    materializing a ``profiles/<alias>/`` directory.
+    """
+
+    def test_alias_resolves_to_default_via_normalize(self, profile_env):
+        _set_root_alias(profile_env, "kinni")
+        assert normalize_profile_name("kinni") == "default"
+        assert normalize_profile_name("Kinni") == "default"
+        assert normalize_profile_name("default") == "default"  # back-compat
+
+    def test_alias_resolves_to_root_dir(self, profile_env):
+        _set_root_alias(profile_env, "kinni")
+        assert get_profile_dir("kinni") == profile_env / ".hermes"
+
+    def test_alias_resolves_via_resolve_profile_env(self, profile_env):
+        _set_root_alias(profile_env, "kinni")
+        assert resolve_profile_env("kinni") == str(profile_env / ".hermes")
+        # 'default' continues to work as a back-compat alias.
+        assert resolve_profile_env("default") == str(profile_env / ".hermes")
+
+    def test_list_profiles_displays_alias_as_root_name(self, profile_env):
+        _set_root_alias(profile_env, "kinni")
+        profiles = list_profiles()
+        root = next(p for p in profiles if p.is_default)
+        assert root.name == "kinni"
+        assert root.path == profile_env / ".hermes"
+
+    def test_get_active_profile_name_returns_alias_for_root(self, profile_env):
+        _set_root_alias(profile_env, "kinni")
+        assert get_active_profile_name() == "kinni"
+
+    def test_alias_does_not_create_named_profile_dir(self, profile_env):
+        _set_root_alias(profile_env, "kinni")
+        # Touch every read path
+        get_profile_dir("kinni")
+        resolve_profile_env("kinni")
+        list_profiles()
+        get_active_profile_name()
+        assert not (profile_env / ".hermes" / "profiles" / "kinni").exists()
+
+    def test_delete_alias_is_refused(self, profile_env):
+        _set_root_alias(profile_env, "kinni")
+        with pytest.raises(ValueError, match="default"):
+            delete_profile("kinni", yes=True)
+
+    def test_create_with_alias_name_is_refused(self, profile_env):
+        _set_root_alias(profile_env, "kinni")
+        with pytest.raises(ValueError, match="default"):
+            create_profile("kinni", no_alias=True)
+
+    def test_named_profile_wins_when_collision(self, profile_env):
+        # Real named profile shadows the alias so it stays reachable.
+        create_profile("kinni", no_alias=True)
+        _set_root_alias(profile_env, "kinni")
+        named_dir = profile_env / ".hermes" / "profiles" / "kinni"
+        assert get_profile_dir("kinni") == named_dir
+        root = next(p for p in list_profiles() if p.is_default)
+        assert root.name == "default"
+
+    def test_invalid_alias_ignored(self, profile_env):
+        _set_root_alias(profile_env, "Has Spaces!")
+        assert normalize_profile_name("kinni") == "kinni"  # alias not active
+        root = next(p for p in list_profiles() if p.is_default)
+        assert root.name == "default"
+
+    def test_empty_alias_ignored(self, profile_env):
+        _set_root_alias(profile_env, "   ")
+        root = next(p for p in list_profiles() if p.is_default)
+        assert root.name == "default"
+
+    def test_default_string_alias_ignored(self, profile_env):
+        _set_root_alias(profile_env, "default")
+        root = next(p for p in list_profiles() if p.is_default)
+        assert root.name == "default"
+
+    def test_ordinary_named_profile_unaffected_by_alias(self, profile_env):
+        _set_root_alias(profile_env, "kinni")
+        create_profile("coder", no_alias=True)
+        # Other names go through unchanged.
+        assert normalize_profile_name("coder") == "coder"
+        assert get_profile_dir("coder") == (
+            profile_env / ".hermes" / "profiles" / "coder"
+        )
+
+    def test_no_alias_file_keeps_default_name(self, profile_env):
+        # Baseline — without the file, behavior is identical to pre-#21105.
+        root = next(p for p in list_profiles() if p.is_default)
+        assert root.name == "default"
+        assert get_active_profile_name() == "default"
+
+
+# ===================================================================
 # TestResolveProfileEnv
 # ===================================================================
 


### PR DESCRIPTION
## What does this PR do?

Threads the optional `~/.hermes/default_profile_name` renamed-root alias through the CLI/profile helpers so a renamed root profile (e.g. `kinni`) resolves to `~/.hermes` consistently — `hermes profile list`, `hermes profile show kinni`, `hermes -p kinni …`, and the WebUI/profile API all see the alias as the root profile.

The fix routes the alias through `normalize_profile_name`, so every downstream helper (`get_profile_dir`, `profile_exists`, `resolve_profile_env`, `delete_profile`, `set_active_profile`, `create_profile`, `rename_profile`) auto-handles it without each having to be aware of the alias. `list_profiles` and `get_active_profile_name` surface the alias as the display name while keeping `is_default=True`. `default` continues to resolve to the root for back-compat.

The alias is silently ignored when:
- the file is missing/empty/unreadable
- the value fails `_PROFILE_ID_RE` validation
- the value equals `default`
- a real `profiles/<alias>/` directory exists (named profile wins so it stays reachable)

The CLI surface for *setting* the alias — renaming the root profile, creating a `~/.local/bin/<alias>` wrapper — is intentionally out of scope for this PR. The alias file is treated as input only; once any flow lands that writes it, this resolution layer already supports it.

## Related Issue

Fixes #21105

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor / cleanup
- [ ] Performance improvement
- [ ] Test coverage improvement

## Changes Made

- `hermes_cli/profiles.py`
  - new `_get_root_alias()` reader for `~/.hermes/default_profile_name` with strict id validation, default-collision guard, and named-profile-wins fallback
  - `normalize_profile_name` resolves the alias to `default` so callers stay alias-agnostic
  - `list_profiles` displays the alias as the root row's `name` (still `is_default=True`)
  - `get_active_profile_name` returns the alias when `HERMES_HOME` resolves to root
- `tests/hermes_cli/test_profiles.py`
  - new `TestRenamedRootAlias` class (13 cases) covering all helpers, collision/invalid/empty cases, and unaffected behavior of ordinary named profiles

## How to Test

1. Pin a renamed root alias and use the CLI:
   ```bash
   echo "kinni" > ~/.hermes/default_profile_name
   hermes profile list                  # root row labelled "kinni" (◆)
   hermes profile show kinni            # resolves to ~/.hermes
   hermes -p kinni config path          # ~/.hermes/config.yaml
   hermes -p default config path        # still works (back-compat)
   hermes profile delete kinni          # refused (root delete guard)
   ```
2. Confirm an ordinary named profile is unaffected:
   ```bash
   hermes profile create coder
   hermes -p coder config path          # ~/.hermes/profiles/coder/config.yaml
   ```
3. Confirm a real named profile shadows the alias:
   ```bash
   hermes profile create kinni
   hermes -p kinni config path          # named profile wins, alias dropped
   rm -r ~/.hermes/profiles/kinni
   ```
4. Run focused tests:
   ```bash
   pytest tests/hermes_cli/test_profiles.py -q
   ```

## Code Checklist

- [x] My code follows the [Conventional Commits](https://www.conventionalcommits.org/) format (e.g. `feat:`, `fix:`, `docs:`)
- [x] I have not opened a duplicate PR for this change
- [x] My PR contains only changes related to this fix/feature
- [x] All tests pass locally (`pytest tests/ -q`)
- [x] I have added or updated tests for my changes
- [x] I have tested on relevant platforms (macOS / Linux / WSL2 if applicable)

## Documentation Checklist

- [ ] Updated `README.md` or `docs/` if user-visible behavior changed
- [ ] Added/updated config keys in `cli-config.yaml.example` if any new YAML keys were introduced
- [ ] Updated `CONTRIBUTING.md` or `AGENTS.md` if architecture changed
- [x] Cross-platform impact considered (macOS, Linux, WSL2)
