### PR TITLE
fix: skip bare @ completion RPC in TUI

### DIFF
--- a/ui-tui/src/__tests__/useCompletion.test.ts
+++ b/ui-tui/src/__tests__/useCompletion.test.ts
@@ -29,6 +29,18 @@ describe('completionRequestForInput', () => {
     })
   })
 
+  it('skips completion for a bare context marker', () => {
+    expect(completionRequestForInput('@')).toBeNull()
+  })
+
+  it('still keeps context-path completion for real context queries', () => {
+    expect(completionRequestForInput('@appChrome')).toMatchObject({
+      method: 'complete.path',
+      params: { word: '@appChrome' },
+      replaceFrom: 0
+    })
+  })
+
   it('leaves plain text alone', () => {
     expect(completionRequestForInput('hello there')).toBeNull()
   })

--- a/ui-tui/src/hooks/useCompletion.ts
+++ b/ui-tui/src/hooks/useCompletion.ts
@@ -17,7 +17,7 @@ export function completionRequestForInput(
   const isSlashCommand = looksLikeSlashCommand(input)
   const pathWord = isSlashCommand ? null : (input.match(TAB_PATH_RE)?.[1] ?? null)
 
-  if (!isSlashCommand && !pathWord) {
+  if (!isSlashCommand && (!pathWord || pathWord === '@')) {
     return null
   }
 


### PR DESCRIPTION
Fixes #21123

## Summary
- stop the TUI completion hook from issuing `complete.path` for a bare `@` token
- keep `@file:` / `@folder:` / fuzzy `@foo` context completion behavior unchanged
- add a regression test for the bare `@` case and preserve coverage for real context queries

## Verification
- `./node_modules/.bin/vitest run src/__tests__/useCompletion.test.ts`
- `/Users/leongong/Desktop/LeonProjects/gho_workspace/hermes-agent/.venv/bin/python -m pytest -o addopts= tests/gateway/test_complete_path_at_filter.py`
- `git diff --check`
