### PR TITLE
fix(dashboard): catch asyncio.CancelledError in WebSocket stream_events

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1521,6 +1521,15 @@ async def stream_events(ws: WebSocket):
             await asyncio.sleep(_EVENT_POLL_SECONDS)
     except WebSocketDisconnect:
         return
+    except asyncio.CancelledError:
+        # Graceful shutdown: uvicorn cancels all tasks on SIGINT/SIGTERM.
+        # Close the WebSocket cleanly instead of letting CancelledError
+        # propagate as an unhandled exception in the ASGI traceback.
+        try:
+            await ws.close(code=1001)  # 1001 = Going Away
+        except Exception:
+            pass
+        return
     except Exception as exc:  # defensive: never crash the dashboard worker
         log.warning("Kanban event stream error: %s", exc)
         try:


### PR DESCRIPTION
## Problem

When the dashboard server is shut down (Ctrl+C or SIGTERM), uvicorn cancels all running async tasks. The `stream_events` WebSocket handler blocks on `asyncio.sleep(_EVENT_POLL_SECONDS)`, which raises `asyncio.CancelledError` when the task is cancelled. Without a handler for this exception, it propagates as an unhandled ASGI error, producing a long traceback on every shutdown:

```
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  ...
  File ".../plugin_api.py", line 1521, in stream_events
    await asyncio.sleep(_EVENT_POLL_SECONDS)
asyncio.exceptions.CancelledError
```

This is purely cosmetic — the server shuts down correctly — but it's noisy and looks like a crash.

## Fix

Add an explicit `except asyncio.CancelledError` clause **before** the generic `except Exception` handler in `stream_events()`. On cancellation:

1. Close the WebSocket with code `1001` (Going Away) — the standard code for server shutdown
2. Return cleanly — no traceback, no noise

The handler is placed before `except Exception` because `CancelledError` is a subclass of `BaseException` (not `Exception`) in Python 3.9+, but in Python 3.8 it inherits from `Exception`. Placing it first ensures it is caught in all Python versions, and the `return` prevents re-raising.

## Testing

- Start the dashboard: `hermes dashboard`
- Open WebSocket or browser to the dashboard
- Press Ctrl+C
- Before: long `asyncio.exceptions.CancelledError` traceback
- After: clean shutdown, no traceback