### PR TITLE
fix(security): close TOCTOU window when saving Claude Code OAuth credentials

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -15,6 +15,8 @@ import json
 import logging
 import os
 import platform
+import secrets
+import stat
 import subprocess
 from pathlib import Path
 
@@ -893,11 +895,34 @@ def _write_claude_code_credentials(
         existing["claudeAiOauth"] = oauth_data
 
         cred_path.parent.mkdir(parents=True, exist_ok=True)
-        _tmp_cred = cred_path.with_suffix(".tmp")
-        _tmp_cred.write_text(json.dumps(existing, indent=2), encoding="utf-8")
-        _tmp_cred.replace(cred_path)
-        # Restrict permissions (credentials file)
-        cred_path.chmod(0o600)
+        # Per-process random suffix avoids collisions between concurrent
+        # writers and stale leftovers from a prior crashed write.
+        _tmp_cred = cred_path.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")
+        try:
+            # Create the temp file atomically at 0o600. The previous
+            # write_text + post-replace chmod opened a TOCTOU window where
+            # both the temp file and the destination briefly inherited the
+            # process umask (commonly 0o644 = world-readable), exposing
+            # Claude Code OAuth tokens to other local users between create
+            # and chmod. Mirrors agent/google_oauth.py (#19673) and
+            # tools/mcp_oauth.py (#21148). Parent dir (~/.claude/) is
+            # owned by Claude Code itself, so we leave its mode alone.
+            fd = os.open(
+                str(_tmp_cred),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                stat.S_IRUSR | stat.S_IWUSR,
+            )
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(existing, fh, indent=2)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(_tmp_cred, cred_path)
+        except OSError:
+            try:
+                _tmp_cred.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
     except (OSError, IOError) as e:
         logger.debug("Failed to write refreshed credentials: %s", e)
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1,6 +1,7 @@
 """Tests for agent/anthropic_adapter.py — Anthropic Messages API adapter."""
 
 import json
+import sys
 import time
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
@@ -359,6 +360,24 @@ class TestWriteClaudeCodeCredentials:
         data = json.loads(cred_file.read_text())
         assert data["otherField"] == "keep-me"
         assert data["claudeAiOauth"]["accessToken"] == "new-tok"
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+    def test_credentials_file_created_with_0o600(self, tmp_path, monkeypatch):
+        """Refreshed Claude Code credentials must land on disk at 0o600.
+
+        Regression for the TOCTOU race where ``write_text`` + ``replace``
+        + post-write ``chmod`` left both the temp file and the destination
+        briefly readable at the process umask (commonly 0o644). Mirrors
+        the fix shipped in #19673 (google_oauth) and #21148 (mcp_oauth).
+        """
+        import stat as _stat
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        _write_claude_code_credentials("tok", "ref", 12345)
+
+        cred_file = tmp_path / ".claude" / ".credentials.json"
+        assert cred_file.exists()
+        mode = _stat.S_IMODE(cred_file.stat().st_mode)
+        assert mode == 0o600, f"creds file mode {oct(mode)} != 0o600 — TOCTOU race regressed"
 
 
 class TestResolveWithRefresh:


### PR DESCRIPTION
## Summary

`_write_claude_code_credentials` in `agent/anthropic_adapter.py` writes `~/.claude/.credentials.json` via `Path.write_text` → `replace` → post-write `chmod(0o600)`. Both the temp file and the destination briefly inherit the process umask (commonly 0o644 = world-readable) between create/replace and the chmod, exposing the OAuth access/refresh tokens to other local users on multi-user hosts.

Replace the unconditional `write_text` + post-write `chmod` with `os.open(O_WRONLY | O_CREAT | O_EXCL, mode=0o600)` so the temp file is created atomically with restrictive mode. `os.replace` then carries the 0o600 mode onto the destination, so the trailing chmod becomes unnecessary. The temp filename also gains a per-process random suffix to avoid collisions between concurrent writers and stale leftovers from a prior crashed write.

Parent dir (`~/.claude/`) is owned by Claude Code itself and shared with its native auth, so we deliberately don't tighten its mode here (unlike #21148 which owns the `HERMES_HOME/mcp-tokens/` subtree).

Same pattern as the merged fix for `agent/google_oauth.py` in #19673 and the parallel fix for `tools/mcp_oauth.py` in #21148.

## Type of Change

- [x] Bug fix
- [x] Security fix
- [x] Tests

## Changes Made

- `agent/anthropic_adapter.py`: Replace `write_text` + `replace` + post-write `chmod` in `_write_claude_code_credentials` with `os.open(O_EXCL, mode=0o600)` + `os.fdopen` + `fsync` + `os.replace`. Randomize temp filename per process. Add `secrets` and `stat` imports.
- `tests/agent/test_anthropic_adapter.py`: Add `test_credentials_file_created_with_0o600` to `TestWriteClaudeCodeCredentials` asserting the resulting file mode is 0o600 (skipped on Windows where POSIX mode bits aren't enforced).

## How to Test

1. `pytest -q tests/agent/test_anthropic_adapter.py::TestWriteClaudeCodeCredentials`
2. Confirm the new `test_credentials_file_created_with_0o600` passes.
3. Confirm pre-existing `test_writes_new_file` and `test_preserves_existing_fields` still pass (no behavior change for callers of `_write_claude_code_credentials`).

Reproducing the original race directly is timing-sensitive but observable on Linux with `inotifywait -m -e create -e attrib ~/.claude/`: the legacy code shows the temp file appearing at the process umask before the chmod, while the new code shows it created at 0o600 in a single step.

## Validation

- `pytest -q tests/agent/test_anthropic_adapter.py::TestWriteClaudeCodeCredentials` -> `3 passed`
- Tested on macOS 25.4 / Python 3.14.4. POSIX-only assertion is gated on `sys.platform`, so Windows/CI shouldn't see false failures.
- Three unrelated tests in `TestRunOauthSetupToken` were already failing on `main` before this change (xdist cross-test pollution per the in-source comment); not addressed here.