### PR TITLE
fix(kanban): heartbeat tool extends claim TTL, not just last_heartbeat_at

### DIFF
--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -214,6 +214,61 @@ def test_heartbeat_without_note(worker_env):
     assert d["ok"] is True
 
 
+def test_heartbeat_extends_claim_expires(worker_env):
+    """The kanban_heartbeat tool MUST extend claim_expires, not just
+    update last_heartbeat_at — otherwise long-running workers loop the
+    heartbeat tool diligently and still get reclaimed by
+    release_stale_claims at DEFAULT_CLAIM_TTL_SECONDS.
+
+    Regression test for the bug where _handle_heartbeat called
+    heartbeat_worker but never heartbeat_claim, so claim_expires sat
+    static while last_heartbeat_at advanced.
+    """
+    import time as _time
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    # Rewind claim_expires into the past so any forward movement is
+    # unambiguous (avoids time.sleep flakiness).
+    conn = kb.connect()
+    try:
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ? WHERE id = ?",
+            (1, worker_env),
+        )
+        conn.commit()
+        before = conn.execute(
+            "SELECT claim_expires FROM tasks WHERE id = ?", (worker_env,)
+        ).fetchone()["claim_expires"]
+    finally:
+        conn.close()
+    assert before == 1
+
+    out = kt._handle_heartbeat({"note": "still alive"})
+    assert json.loads(out).get("ok") is True
+
+    conn = kb.connect()
+    try:
+        after = conn.execute(
+            "SELECT claim_expires FROM tasks WHERE id = ?", (worker_env,)
+        ).fetchone()["claim_expires"]
+    finally:
+        conn.close()
+
+    now = int(_time.time())
+    # claim_expires should be roughly now + DEFAULT_CLAIM_TTL_SECONDS.
+    # We assert a generous floor (now + half the default TTL) to keep the
+    # test stable against future TTL changes.
+    assert after > before, (
+        f"claim_expires did not advance ({before} -> {after}); workers "
+        f"would be reclaimed at TTL despite heartbeating"
+    )
+    assert after >= now + (kb.DEFAULT_CLAIM_TTL_SECONDS // 2), (
+        f"claim_expires={after} is suspiciously close to now={now}; "
+        f"expected at least now + {kb.DEFAULT_CLAIM_TTL_SECONDS // 2}"
+    )
+
+
 def test_comment_happy_path(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_comment({

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -315,7 +315,15 @@ def _handle_block(args: dict, **kw) -> str:
 
 
 def _handle_heartbeat(args: dict, **kw) -> str:
-    """Signal that the worker is still alive during a long operation."""
+    """Signal that the worker is still alive during a long operation.
+
+    Extends the claim TTL via ``heartbeat_claim`` AND records a heartbeat
+    event via ``heartbeat_worker``. Without the ``heartbeat_claim`` half,
+    a diligent worker that loops this tool while a single tool call
+    blocks the agent for >DEFAULT_CLAIM_TTL_SECONDS still gets reclaimed
+    by ``release_stale_claims`` — which is exactly the trap that
+    ``heartbeat_claim``'s docstring warns against.
+    """
     tid = _default_task_id(args.get("task_id"))
     if not tid:
         return tool_error(
@@ -328,6 +336,14 @@ def _handle_heartbeat(args: dict, **kw) -> str:
     try:
         kb, conn = _connect()
         try:
+            # Extend the claim TTL first. The dispatcher pins
+            # HERMES_KANBAN_CLAIM_LOCK in the worker env at spawn time
+            # (see _default_spawn in kanban_db.py); falling back to the
+            # default _claimer_id() covers locally-driven workers that
+            # never went through the dispatcher path.
+            claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK")
+            kb.heartbeat_claim(conn, tid, claimer=claim_lock)
+
             ok = kb.heartbeat_worker(
                 conn,
                 tid,


### PR DESCRIPTION
## Summary

- `kanban_heartbeat` tool now extends `claim_expires` by also calling `heartbeat_claim`, fixing the bug where diligent workers calling the tool in a loop were still reclaimed at the 15-minute TTL.
- Adds a regression test in `tests/tools/test_kanban_tools.py` that fails against the unfixed code.

Closes #21147 (the issue I just filed describing the root cause). Underlying cause for the symptom in #21141 (#21141 covers the orthogonal post-reclaim cleanup half).

## The bug

`tools/kanban_tools.py::_handle_heartbeat` was calling `heartbeat_worker` (records a heartbeat event + updates `last_heartbeat_at`) but never `heartbeat_claim` (extends `claim_expires`). `release_stale_claims` reads `claim_expires`, not `last_heartbeat_at`, so a worker looping the tool perfectly was still reclaimed at the default 15-minute TTL.

`heartbeat_claim`'s docstring even spells the contract:

> *"Workers that know they'll exceed 15 minutes should call this every few minutes to keep ownership."*

…but no caller in the worker tool path invoked it, and `heartbeat_claim` itself isn't exposed as a tool.

## The fix

```python
# Extend the claim TTL first. The dispatcher pins
# HERMES_KANBAN_CLAIM_LOCK in the worker env at spawn time
# (see _default_spawn in kanban_db.py); falling back to the
# default _claimer_id() covers locally-driven workers that
# never went through the dispatcher path.
claim_lock = os.environ.get("HERMES_KANBAN_CLAIM_LOCK")
kb.heartbeat_claim(conn, tid, claimer=claim_lock)

ok = kb.heartbeat_worker(conn, tid, ...)
```

The dispatcher already pins `HERMES_KANBAN_CLAIM_LOCK` in the worker env at spawn time (`hermes_cli/kanban_db.py:3291`), so the env-read produces an exact lock match in the dispatcher path. Locally-driven (non-dispatcher) workers fall back to `_claimer_id()`, which is what `claim_task` itself uses by default — same identity, same match.

If `heartbeat_claim` returns False (worker no longer owns the claim), we don't error out — we let the subsequent `heartbeat_worker` call surface the standard "not running" error so the worker can exit cleanly. This preserves existing tool behavior on the "you've already been reclaimed" path.

## Test

`tests/tools/test_kanban_tools.py::test_heartbeat_extends_claim_expires` rewinds `claim_expires` into the past via direct SQL, calls the tool, and asserts the new value is at least `now + DEFAULT_CLAIM_TTL_SECONDS // 2`.

Verified the test fails against the old code (`claim_expires did not advance (1 -> 1)`) and passes against the fix. Full `tests/tools/test_kanban_tools.py` + `tests/hermes_cli/test_kanban_db.py` run green (99 passed).

## Test plan

- [x] `pytest tests/tools/test_kanban_tools.py -k heartbeat -v` — 4 passed
- [x] `pytest tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_db.py` — 99 passed
- [x] Sanity-checked new test fails against the unfixed code, then passes against the fix