### PR TITLE
fix(gateway): show compression activity in busy acks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2289,15 +2289,21 @@ class GatewayRunner:
                 iteration = summary.get("api_call_count", 0)
                 max_iter = summary.get("max_iterations", 0)
                 current_tool = summary.get("current_tool")
+                last_activity = summary.get("last_activity_desc")
+                seconds_since_activity = summary.get("seconds_since_activity")
                 start_ts = self._running_agents_ts.get(session_key, 0)
                 if start_ts:
                     elapsed_min = int((now - start_ts) / 60)
                     if elapsed_min > 0:
                         status_parts.append(f"{elapsed_min} min elapsed")
-                if max_iter:
-                    status_parts.append(f"iteration {iteration}/{max_iter}")
                 if current_tool:
                     status_parts.append(f"running: {current_tool}")
+                elif last_activity and last_activity != "initializing":
+                    status_parts.append(f"status: {last_activity}")
+                if max_iter and iteration:
+                    status_parts.append(f"iteration {iteration}/{max_iter}")
+                if seconds_since_activity is not None and seconds_since_activity >= 30:
+                    status_parts.append(f"last activity {int(seconds_since_activity)}s ago")
             except Exception:
                 pass
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -9236,6 +9236,11 @@ class AIAgent:
             f"{approx_tokens:,}" if approx_tokens else "unknown", self.model,
             focus_topic,
         )
+        _compression_activity = "compressing context / splitting session"
+        if approx_tokens:
+            _compression_activity += f" (~{approx_tokens:,} tokens)"
+        self._current_tool = "context compression"
+        self._touch_activity(_compression_activity)
 
         # Notify external memory provider before compression discards context
         if self._memory_manager:
@@ -9250,6 +9255,10 @@ class AIAgent:
             # Plugin context engine with strict signature that doesn't accept
             # focus_topic — fall back to calling without it.
             compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens)
+        except Exception:
+            self._current_tool = None
+            self._touch_activity("context compression failed")
+            raise
 
         summary_error = getattr(self.context_compressor, "_last_summary_error", None)
         if summary_error:
@@ -9352,6 +9361,8 @@ class AIAgent:
             logger.debug("memory manager on_session_switch (compression): %s", _me_err)
 
         # Warn on repeated compressions (quality degrades with each pass)
+        self._current_tool = None
+        self._touch_activity("context compression completed")
         _cc = self.context_compressor.compression_count
         if _cc >= 2:
             self._vprint(

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -380,6 +380,65 @@ class TestBusySessionAck:
         assert "10 min" in content  # elapsed
 
     @pytest.mark.asyncio
+    async def test_ack_shows_context_compression_without_zero_iteration_noise(self):
+        """Compression runs outside the normal agent iteration loop; don't call it iteration 0/N."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="still alive?")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 0,
+            "max_iterations": 90,
+            "current_tool": "context compression",
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "compressing context / splitting session (~120,000 tokens)",
+            "seconds_since_activity": 5.0,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 90
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "context compression" in content
+        assert "iteration 0/90" not in content
+
+    @pytest.mark.asyncio
+    async def test_ack_falls_back_to_last_activity_when_no_tool_is_active(self):
+        """Busy acks should still report useful activity when no current tool is set."""
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        event = _make_event(text="queue this")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 0,
+            "max_iterations": 90,
+            "current_tool": None,
+            "last_activity_ts": time.time() - 45,
+            "last_activity_desc": "compressing context / splitting session (~120,000 tokens)",
+            "seconds_since_activity": 45.0,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 90
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        content = adapter._send_with_retry.call_args.kwargs.get("content", "")
+        assert "status: compressing context / splitting session" in content
+        assert "last activity 45s ago" in content
+        assert "iteration 0/90" not in content
+
+    @pytest.mark.asyncio
     async def test_draining_still_works(self):
         """Draining case should still produce the drain-specific message."""
         runner, sentinel = _make_runner()

--- a/tests/run_agent/test_compress_focus_plugin_fallback.py
+++ b/tests/run_agent/test_compress_focus_plugin_fallback.py
@@ -30,6 +30,13 @@ def _make_agent_with_engine(engine):
     agent.log_prefix = ""
     agent._vprint = lambda *a, **kw: None
     agent._last_flushed_db_idx = 0
+    agent.tools = []
+    agent._current_tool = None
+    agent._last_activity_ts = 0
+    agent._last_activity_desc = "initializing"
+    agent._api_call_count = 0
+    agent.max_iterations = 90
+    agent.iteration_budget = MagicMock(used=0, max_total=90)
     # Stub the few AIAgent methods _compress_context uses.
     agent._invalidate_system_prompt = lambda *a, **kw: None
     agent._build_system_prompt = lambda *a, **kw: "new-system-prompt"
@@ -73,3 +80,38 @@ def test_compress_context_falls_back_when_engine_rejects_focus_topic():
     assert captured_kwargs == [{"current_tokens": 100}]
     # Silence unused-var warning on agent.
     assert agent.context_compressor is engine
+
+
+def test_compress_context_exposes_activity_while_summarizing():
+    """Gateway busy acks can report compression instead of a misleading iteration 0/N."""
+    observed = []
+    agent_holder = {}
+
+    class _RecordingEngine:
+        compression_count = 1
+        last_prompt_tokens = 0
+        last_completion_tokens = 0
+
+        def compress(self, messages, current_tokens=None, focus_topic=None):
+            observed.append(agent_holder["agent"].get_activity_summary())
+            return [messages[0], messages[-1]]
+
+    engine = _RecordingEngine()
+    agent = _make_agent_with_engine(engine)
+    agent_holder["agent"] = agent
+
+    messages = [
+        {"role": "user", "content": "one"},
+        {"role": "assistant", "content": "two"},
+        {"role": "user", "content": "three"},
+    ]
+
+    compressed, new_prompt = agent._compress_context(messages, "sys", approx_tokens=120_000)
+
+    assert compressed == [messages[0], messages[-1]]
+    assert new_prompt == "new-system-prompt"
+    assert observed[0]["current_tool"] == "context compression"
+    assert "compressing context / splitting session" in observed[0]["last_activity_desc"]
+    assert "120,000" in observed[0]["last_activity_desc"]
+    assert agent._current_tool is None
+    assert agent._last_activity_desc == "context compression completed"


### PR DESCRIPTION
## Summary
- mark context compression as live agent activity while `_compress_context()` runs
- include gateway-visible last-activity detail in busy acknowledgements
- suppress misleading `iteration 0/N` noise before the first real agent-loop iteration

## Why
Gateway users who message during context compression can currently see a busy ack like `iteration 0/90`, which reads like a stalled agent even though Hermes is actively compacting context. Compression happens outside the normal tool/API iteration loop, so surfacing it as activity is more accurate.

Related: #7317, #9231

## Test Plan
- `PYTHONPATH=. python3 -m py_compile run_agent.py gateway/run.py tests/gateway/test_busy_session_ack.py tests/run_agent/test_compress_focus_plugin_fallback.py`
- `PYTHONPATH=. pytest -q tests/gateway/test_busy_session_ack.py tests/run_agent/test_compress_focus_plugin_fallback.py`
