### PR TITLE
fix(completion): replace _hermes "$@" with compdef in zsh script

### DIFF
--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -238,7 +238,7 @@ _hermes() {{
     esac
 }}
 
-_hermes "$@"
+compdef _hermes hermes
 """
 
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1214,7 +1214,7 @@ _hermes() {
     esac
 }
 
-_hermes "$@"
+compdef _hermes hermes
 '''
 
 


### PR DESCRIPTION
Fixes #6122

## Problem

The generated zsh completion script calls `_hermes "$@"` at the top level.
When loaded via `eval "$(hermes completion zsh)"` in `.zshrc`, this immediately
invokes `_arguments` outside a completion context, producing:

```
_arguments:comparguments:327: can only be called from completion function
```

## Fix

Replace `_hermes "$@"` with the standard `compdef` registration pattern:

```diff
-_hermes "$@"
+compdef _hermes hermes
```

This is the pattern used by `kubectl`, `uv`, `skaffold` and other tools.
The function is now only called when the user tab-completes `hermes`,
not on shell startup.

## Changes

- `hermes_cli/completion.py` — main completion script generator
- `hermes_cli/profiles.py` — profile-specific completion generator