### PR TITLE
feat(browser): add Steel as cloud browser provider

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -106,3 +106,4 @@ xinbenlv <zzn+pa@zzn.im> <zzn+pa@zzn.im>
 SaulJWu <saul.jj.wu@gmail.com> <saul.jj.wu@gmail.com>
 angelos <angelos@oikos.lan.home.malaiwah.com> <angelos@oikos.lan.home.malaiwah.com>
 MestreY0d4-Uninter <241404605+MestreY0d4-Uninter@users.noreply.github.com> <MestreY0d4-Uninter@users.noreply.github.com>
+nibzard <nikola.balic@gmail.com> <nikola.balic@gmail.com>

--- a/plugins/browser/steel/__init__.py
+++ b/plugins/browser/steel/__init__.py
@@ -1,0 +1,15 @@
+"""Steel cloud browser plugin — bundled, auto-loaded.
+
+Mirrors the ``plugins/browser/browserbase/`` and ``plugins/browser/firecrawl/``
+layout: ``provider.py`` holds the provider class; ``__init__.py::register``
+instantiates and registers it via the plugin context.
+"""
+
+from __future__ import annotations
+
+from plugins.browser.steel.provider import SteelBrowserProvider
+
+
+def register(ctx) -> None:
+    """Register the Steel cloud-browser provider with the plugin context."""
+    ctx.register_browser_provider(SteelBrowserProvider())

--- a/plugins/browser/steel/plugin.yaml
+++ b/plugins/browser/steel/plugin.yaml
@@ -1,0 +1,7 @@
+name: browser-steel
+version: 1.0.0
+description: "Steel (https://steel.dev) cloud browser backend. Requires STEEL_API_KEY. Connects over CDP (no Steel CLI needed for the browser path); supports residential proxies and CAPTCHA solving. Explicit-only — set browser.cloud_provider: steel."
+author: nibzard
+kind: backend
+provides_browser_providers:
+  - steel

--- a/plugins/browser/steel/provider.py
+++ b/plugins/browser/steel/provider.py
@@ -1,0 +1,249 @@
+"""Steel cloud browser provider — plugin form.
+
+Subclasses :class:`agent.browser_provider.BrowserProvider` (the plugin-facing
+ABC introduced in PR #25214), mirroring ``plugins/browser/browserbase/`` and
+``plugins/browser/firecrawl/``.
+
+Steel exposes a standard CDP websocket per session, so the provider hands the
+dispatcher a ``cdp_url`` and the provider-agnostic wrapper in
+:mod:`tools.browser_tool` drives it via ``agent-browser --cdp`` — no Steel CLI
+required for the browser path. (The standalone ``steel_scrape`` tool is a
+separate HTTP-only tool and is unaffected.)
+
+One Steel quirk is normalized here: the session's ``websocketUrl`` comes back
+without a path segment (``wss://connect.steel.dev?sessionId=...``), which makes
+some CDP clients build a malformed request-line and get ``400 Bad Request`` on
+the upgrade. We insert the ``/`` before the query and append the API key so the
+URL is ``wss://connect.steel.dev/?sessionId=...&apiKey=...``.
+
+Config keys this provider responds to::
+
+    browser:
+      cloud_provider: "steel"
+
+Auth env vars::
+
+    STEEL_API_KEY=...            # https://steel.dev
+
+Optional feature knobs::
+
+    STEEL_BASE_URL=...           # default https://api.steel.dev (self-hosted)
+    STEEL_USE_PROXY=true         # default false — residential proxy
+    STEEL_SOLVE_CAPTCHA=true     # default false — CAPTCHA solving
+    STEEL_SESSION_TIMEOUT=...     # milliseconds, integer
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from typing import Any, Dict, Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import requests
+
+from agent.browser_provider import BrowserProvider
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://api.steel.dev"
+
+
+def _truthy(value: Optional[str]) -> bool:
+    return (value or "").strip().lower() in ("1", "true", "yes")
+
+
+def _normalize_cdp_url(ws_url: str, api_key: str) -> str:
+    """Return a CDP-connectable websocket URL for *ws_url*.
+
+    Ensures a ``/`` path segment (Steel's ``websocketUrl`` omits it, which
+    trips up CDP clients during the WS upgrade) and appends ``apiKey``.
+    """
+    parts = urlsplit(ws_url)
+    path = parts.path or "/"
+    query = dict(parse_qsl(parts.query, keep_blank_values=True))
+    query["apiKey"] = api_key
+    return urlunsplit((parts.scheme, parts.netloc, path, urlencode(query), parts.fragment))
+
+
+class SteelBrowserProvider(BrowserProvider):
+    """Steel (https://steel.dev) cloud browser backend.
+
+    Headless browser sessions with optional residential proxy and CAPTCHA
+    solving. Explicit-only: activated via ``browser.cloud_provider: steel``;
+    never auto-selected (not in the registry's legacy preference walk).
+    """
+
+    @property
+    def name(self) -> str:
+        return "steel"
+
+    @property
+    def display_name(self) -> str:
+        return "Steel"
+
+    def is_available(self) -> bool:
+        return bool(os.environ.get("STEEL_API_KEY"))
+
+    # ------------------------------------------------------------------
+    # Config resolution
+    # ------------------------------------------------------------------
+
+    def _api_key(self) -> str:
+        api_key = os.environ.get("STEEL_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "Steel requires the STEEL_API_KEY environment variable. "
+                "Get your key at https://steel.dev"
+            )
+        return api_key
+
+    def _base_url(self) -> str:
+        return os.environ.get("STEEL_BASE_URL", _DEFAULT_BASE_URL).rstrip("/")
+
+    def _headers(self, api_key: str) -> Dict[str, str]:
+        return {"Content-Type": "application/json", "Steel-Api-Key": api_key}
+
+    # ------------------------------------------------------------------
+    # Session lifecycle
+    # ------------------------------------------------------------------
+
+    def create_session(self, task_id: str) -> Dict[str, object]:
+        api_key = self._api_key()
+        base_url = self._base_url()
+
+        enable_proxy = _truthy(os.environ.get("STEEL_USE_PROXY"))
+        enable_captcha = _truthy(os.environ.get("STEEL_SOLVE_CAPTCHA"))
+
+        session_config: Dict[str, object] = {}
+        if enable_proxy:
+            session_config["useProxy"] = True
+        if enable_captcha:
+            session_config["solveCaptcha"] = True
+
+        custom_timeout_ms = os.environ.get("STEEL_SESSION_TIMEOUT")
+        if custom_timeout_ms:
+            try:
+                timeout_val = int(custom_timeout_ms)
+                if timeout_val > 0:
+                    session_config["timeout"] = timeout_val
+            except ValueError:
+                logger.warning(
+                    "Invalid STEEL_SESSION_TIMEOUT value: %s", custom_timeout_ms
+                )
+
+        try:
+            response = requests.post(
+                f"{base_url}/v1/sessions",
+                headers=self._headers(api_key),
+                json=session_config,
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            raise RuntimeError(f"Steel API connection failed: {exc}") from exc
+
+        if not response.ok:
+            raise RuntimeError(
+                f"Failed to create Steel session: "
+                f"{response.status_code} {response.text}"
+            )
+
+        session_data = response.json()
+        cloud_session_id = session_data.get("id")
+        websocket_url = session_data.get("websocketUrl")
+        if not cloud_session_id or not websocket_url:
+            raise RuntimeError(
+                f"Steel session response missing id/websocketUrl: {session_data!r}"
+            )
+
+        session_name = f"hermes_{task_id}_{uuid.uuid4().hex[:8]}"
+
+        features_enabled = {
+            "proxy": enable_proxy,
+            "captcha_solving": enable_captcha,
+            "custom_timeout": "timeout" in session_config,
+        }
+
+        viewer_url = session_data.get("sessionViewerUrl")
+        if viewer_url:
+            logger.info("Steel session %s — live viewer: %s", session_name, viewer_url)
+
+        feature_str = ", ".join(k for k, v in features_enabled.items() if v) or "none"
+        logger.info(
+            "Created Steel session %s with features: %s", session_name, feature_str
+        )
+
+        result: Dict[str, object] = {
+            "session_name": session_name,
+            "bb_session_id": cloud_session_id,
+            "cdp_url": _normalize_cdp_url(websocket_url, api_key),
+            "features": features_enabled,
+        }
+        if viewer_url:
+            result["session_viewer_url"] = viewer_url
+        return result
+
+    def close_session(self, session_id: str) -> bool:
+        try:
+            api_key = self._api_key()
+        except ValueError:
+            logger.warning(
+                "Cannot close Steel session %s — missing STEEL_API_KEY", session_id
+            )
+            return False
+
+        try:
+            response = requests.post(
+                f"{self._base_url()}/v1/sessions/{session_id}/release",
+                headers=self._headers(api_key),
+                timeout=10,
+            )
+            if response.status_code in {200, 201, 204}:
+                logger.debug("Successfully closed Steel session %s", session_id)
+                return True
+            logger.warning(
+                "Failed to close Steel session %s: HTTP %s - %s",
+                session_id,
+                response.status_code,
+                response.text[:200],
+            )
+            return False
+        except Exception as e:
+            logger.error("Exception closing Steel session %s: %s", session_id, e)
+            return False
+
+    def emergency_cleanup(self, session_id: str) -> None:
+        try:
+            api_key = self._api_key()
+        except ValueError:
+            logger.warning(
+                "Cannot emergency-cleanup Steel session %s — missing STEEL_API_KEY",
+                session_id,
+            )
+            return
+        try:
+            requests.post(
+                f"{self._base_url()}/v1/sessions/{session_id}/release",
+                headers=self._headers(api_key),
+                timeout=5,
+            )
+        except Exception as e:
+            logger.debug(
+                "Emergency cleanup failed for Steel session %s: %s", session_id, e
+            )
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Steel",
+            "badge": "paid",
+            "tag": "Cloud browser with proxies and CAPTCHA solving",
+            "env_vars": [
+                {
+                    "key": "STEEL_API_KEY",
+                    "prompt": "Steel API key",
+                    "url": "https://steel.dev",
+                },
+            ],
+            "post_setup": "agent_browser",
+        }

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1295,6 +1295,8 @@ AUTHOR_MAP = {
     # Debug share upload-time redaction (May 2026)
     "dhuysamen@gmail.com": "GodsBoy",  # PR #19318
     "github@nadyahermes.anonaddy.com": "ruangraung",  # PR #42308
+    # Steel cloud browser provider
+    "nikola.balic@gmail.com": "nibzard",  # PR #21182
     "mrcoferland@gmail.com": "mrcoferland",  # PR #19023
     "chenlinfeng@ruije.com.cn": "noOne-list",  # PR #19050
     "briansu@Mac-mini.attlocal.net": "likejudy",  # PR #19052

--- a/tests/plugins/browser/test_browser_provider_plugins.py
+++ b/tests/plugins/browser/test_browser_provider_plugins.py
@@ -2,7 +2,7 @@
 
 Covers:
 
-- All three bundled plugins (browserbase, browser-use, firecrawl)
+- All four bundled plugins (browserbase, browser-use, firecrawl, steel)
   instantiate and self-report the expected ABC defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The browser_registry resolves an active provider in the documented
@@ -72,14 +72,14 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All three bundled browser plugins discover and register correctly."""
+    """All four bundled browser plugins discover and register correctly."""
 
-    def test_all_three_plugins_present_in_registry(self) -> None:
+    def test_all_bundled_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.browser_registry import list_providers
 
         names = sorted(p.name for p in list_providers())
-        assert names == ["browser-use", "browserbase", "firecrawl"]
+        assert names == ["browser-use", "browserbase", "firecrawl", "steel"]
 
     @pytest.mark.parametrize(
         "plugin_name,expected_display",
@@ -87,6 +87,7 @@ class TestBundledPluginsRegister:
             ("browserbase", "Browserbase"),
             ("browser-use", "Browser Use"),
             ("firecrawl", "Firecrawl"),
+            ("steel", "Steel"),
         ],
     )
     def test_each_plugin_has_name_and_display_name(
@@ -102,7 +103,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["browserbase", "browser-use", "firecrawl"],
+        ["browserbase", "browser-use", "firecrawl", "steel"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -121,7 +122,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["browserbase", "browser-use", "firecrawl"],
+        ["browserbase", "browser-use", "firecrawl", "steel"],
     )
     def test_each_plugin_implements_full_lifecycle(self, plugin_name: str) -> None:
         """The ABC's three lifecycle methods are all overridden."""
@@ -313,7 +314,7 @@ class TestLegacyAbcAliases:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["browserbase", "browser-use", "firecrawl"],
+        ["browserbase", "browser-use", "firecrawl", "steel"],
     )
     def test_is_configured_delegates_to_is_available(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -329,6 +330,7 @@ class TestLegacyAbcAliases:
             ("browserbase", "Browserbase"),
             ("browser-use", "Browser Use"),
             ("firecrawl", "Firecrawl"),
+            ("steel", "Steel"),
         ],
     )
     def test_provider_name_returns_display_name(
@@ -356,7 +358,7 @@ class TestPickerIntegration:
 
         rows = _plugin_browser_providers()
         names = sorted(r.get("browser_provider") for r in rows)
-        assert names == ["browser-use", "browserbase", "firecrawl"]
+        assert names == ["browser-use", "browserbase", "firecrawl", "steel"]
 
     def test_picker_rows_carry_post_setup_hook(self) -> None:
         """Every browser plugin row has post_setup='agent_browser' so

--- a/tests/plugins/browser/test_steel_provider.py
+++ b/tests/plugins/browser/test_steel_provider.py
@@ -1,0 +1,265 @@
+"""Tests for the Steel cloud browser provider plugin.
+
+Focuses on the Steel-specific behaviour that the shared
+``test_browser_provider_plugins.py`` suite does not cover:
+
+- ``_normalize_cdp_url`` — the slash-before-query fix that makes Steel's
+  ``websocketUrl`` connectable by CDP clients (the linchpin of the plugin).
+- ``create_session`` request shaping (proxy / captcha / timeout knobs) and the
+  returned metadata contract.
+- ``close_session`` hitting the ``/release`` endpoint.
+- Explicit-only registry selection (Steel is never auto-detected).
+
+Network calls are faked at the ``requests.post`` boundary, mirroring
+``tests/tools/test_managed_browserbase_and_modal.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from plugins.browser.steel import provider as steel_module
+from plugins.browser.steel.provider import SteelBrowserProvider, _normalize_cdp_url
+
+
+class _Response:
+    """Minimal stand-in for ``requests.Response``."""
+
+    def __init__(self, status_code: int = 200, payload: dict | None = None):
+        self.status_code = status_code
+        self.ok = status_code < 400
+        self._payload = payload or {}
+        self.text = "" if payload else "error body"
+
+    def json(self) -> dict:
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for k in (
+        "STEEL_API_KEY",
+        "STEEL_BASE_URL",
+        "STEEL_USE_PROXY",
+        "STEEL_SOLVE_CAPTCHA",
+        "STEEL_SESSION_TIMEOUT",
+        # Cleared so the explicit-only resolution tests can't be perturbed by
+        # another provider's credentials in the ambient environment.
+        "BROWSERBASE_API_KEY",
+        "BROWSERBASE_PROJECT_ID",
+        "BROWSER_USE_API_KEY",
+        "BROWSER_USE_GATEWAY_URL",
+        "FIRECRAWL_API_KEY",
+        "TOOL_GATEWAY_DOMAIN",
+        "TOOL_GATEWAY_USER_TOKEN",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_cdp_url — the slash fix
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeCdpUrl:
+    def test_inserts_slash_before_query_and_appends_api_key(self) -> None:
+        url = _normalize_cdp_url(
+            "wss://connect.steel.dev?sessionId=abc", "secret"
+        )
+        assert url == "wss://connect.steel.dev/?sessionId=abc&apiKey=secret"
+
+    def test_preserves_existing_path(self) -> None:
+        url = _normalize_cdp_url(
+            "wss://connect.steel.dev/cdp?sessionId=abc", "secret"
+        )
+        assert url == "wss://connect.steel.dev/cdp?sessionId=abc&apiKey=secret"
+
+    def test_handles_self_hosted_host(self) -> None:
+        url = _normalize_cdp_url(
+            "wss://steel.internal.example?sessionId=xyz", "k"
+        )
+        assert url == "wss://steel.internal.example/?sessionId=xyz&apiKey=k"
+
+
+# ---------------------------------------------------------------------------
+# is_available
+# ---------------------------------------------------------------------------
+
+
+class TestIsAvailable:
+    def test_false_without_api_key(self) -> None:
+        assert SteelBrowserProvider().is_available() is False
+
+    def test_true_with_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("STEEL_API_KEY", "k")
+        assert SteelBrowserProvider().is_available() is True
+
+
+# ---------------------------------------------------------------------------
+# create_session
+# ---------------------------------------------------------------------------
+
+
+def _ok_session_payload() -> dict:
+    return {
+        "id": "sess-123",
+        "websocketUrl": "wss://connect.steel.dev?sessionId=sess-123",
+        "sessionViewerUrl": "https://app.steel.dev/sessions/sess-123",
+    }
+
+
+class TestCreateSession:
+    def test_returns_normalized_cdp_url_and_metadata(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("STEEL_API_KEY", "secret")
+        with patch.object(
+            steel_module.requests, "post", return_value=_Response(200, _ok_session_payload())
+        ) as post:
+            session = SteelBrowserProvider().create_session("task-1")
+
+        assert session["bb_session_id"] == "sess-123"
+        assert session["cdp_url"] == (
+            "wss://connect.steel.dev/?sessionId=sess-123&apiKey=secret"
+        )
+        assert session["session_name"].startswith("hermes_task-1_")
+        assert session["session_viewer_url"].endswith("sess-123")
+        # No optional knobs set → all features off.
+        assert session["features"] == {
+            "proxy": False,
+            "captcha_solving": False,
+            "custom_timeout": False,
+        }
+        # API key travels in the Steel-Api-Key header.
+        assert post.call_args.kwargs["headers"]["Steel-Api-Key"] == "secret"
+
+    def test_request_body_reflects_env_knobs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("STEEL_API_KEY", "secret")
+        monkeypatch.setenv("STEEL_USE_PROXY", "true")
+        monkeypatch.setenv("STEEL_SOLVE_CAPTCHA", "1")
+        monkeypatch.setenv("STEEL_SESSION_TIMEOUT", "600000")
+
+        with patch.object(
+            steel_module.requests, "post", return_value=_Response(200, _ok_session_payload())
+        ) as post:
+            session = SteelBrowserProvider().create_session("task-2")
+
+        body = post.call_args.kwargs["json"]
+        assert body["useProxy"] is True
+        assert body["solveCaptcha"] is True
+        assert body["timeout"] == 600000
+        assert session["features"] == {
+            "proxy": True,
+            "captcha_solving": True,
+            "custom_timeout": True,
+        }
+
+    def test_invalid_timeout_is_ignored(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("STEEL_API_KEY", "secret")
+        monkeypatch.setenv("STEEL_SESSION_TIMEOUT", "not-a-number")
+        with patch.object(
+            steel_module.requests, "post", return_value=_Response(200, _ok_session_payload())
+        ) as post:
+            SteelBrowserProvider().create_session("task-3")
+        assert "timeout" not in post.call_args.kwargs["json"]
+
+    def test_missing_api_key_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="STEEL_API_KEY"):
+            SteelBrowserProvider().create_session("task-4")
+
+    def test_non_ok_response_raises_runtime_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("STEEL_API_KEY", "secret")
+        with patch.object(
+            steel_module.requests, "post", return_value=_Response(402, None)
+        ):
+            with pytest.raises(RuntimeError, match="Failed to create Steel session"):
+                SteelBrowserProvider().create_session("task-5")
+
+    def test_response_missing_fields_raises_runtime_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("STEEL_API_KEY", "secret")
+        with patch.object(
+            steel_module.requests, "post", return_value=_Response(200, {"id": "x"})
+        ):
+            with pytest.raises(RuntimeError, match="missing id/websocketUrl"):
+                SteelBrowserProvider().create_session("task-6")
+
+
+# ---------------------------------------------------------------------------
+# close_session / emergency_cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestCloseSession:
+    def test_release_endpoint_called_and_true_on_success(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("STEEL_API_KEY", "secret")
+        with patch.object(
+            steel_module.requests, "post", return_value=_Response(204, {})
+        ) as post:
+            ok = SteelBrowserProvider().close_session("sess-123")
+        assert ok is True
+        assert post.call_args.args[0].endswith("/v1/sessions/sess-123/release")
+
+    def test_false_when_api_key_missing(self) -> None:
+        assert SteelBrowserProvider().close_session("sess-123") is False
+
+    def test_false_on_http_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("STEEL_API_KEY", "secret")
+        with patch.object(
+            steel_module.requests, "post", return_value=_Response(500, None)
+        ):
+            assert SteelBrowserProvider().close_session("sess-123") is False
+
+
+# ---------------------------------------------------------------------------
+# Picker schema
+# ---------------------------------------------------------------------------
+
+
+class TestSetupSchema:
+    def test_schema_shape(self) -> None:
+        schema = SteelBrowserProvider().get_setup_schema()
+        assert schema["name"] == "Steel"
+        assert schema["post_setup"] == "agent_browser"
+        keys = [e["key"] for e in schema["env_vars"]]
+        assert keys == ["STEEL_API_KEY"]
+
+
+# ---------------------------------------------------------------------------
+# Registry: explicit-only selection
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrySelection:
+    def test_explicit_steel_resolves_even_when_unavailable(self) -> None:
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        from agent.browser_registry import _resolve
+
+        provider = _resolve("steel")
+        assert provider is not None
+        assert provider.name == "steel"
+        assert provider.is_available() is False
+
+    def test_steel_not_auto_selected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Steel is explicit-only — having STEEL_API_KEY set must not
+        auto-route a user to the paid cloud browser."""
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        from agent.browser_registry import _resolve
+
+        monkeypatch.setenv("STEEL_API_KEY", "k")
+        assert _resolve(None) is None

--- a/tools/steel_scrape_tool.py
+++ b/tools/steel_scrape_tool.py
@@ -1,0 +1,164 @@
+# ABOUTME: Steel scrape tool for server-side content extraction as markdown/HTML.
+# ABOUTME: Uses Steel's standalone scrape API — no browser session required.
+"""Steel Scrape Tool — extract page content via Steel's server-side scrape API.
+
+Unlike browser_navigate + browser_snapshot which use a full browser session and
+accessibility tree, this tool extracts content server-side as clean markdown or
+HTML.  It does not require an active browser session and is useful for quick
+content extraction without interactive browsing.
+
+Environment Variables:
+- STEEL_API_KEY: Required — Steel API key
+- STEEL_USE_PROXY: Optional — enable residential proxy for scraping
+"""
+
+import json
+import logging
+import os
+from typing import Optional
+
+import requests
+from tools.url_safety import is_safe_url as _is_safe_url
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://api.steel.dev"
+
+
+def check_steel_scrape_requirements() -> bool:
+    """Return True when STEEL_API_KEY is available."""
+    return bool(os.environ.get("STEEL_API_KEY"))
+
+
+def steel_scrape(
+    url: str,
+    format: str = "markdown",
+    use_proxy: Optional[bool] = None,
+) -> str:
+    """Scrape a URL via Steel's server-side API and return extracted content.
+
+    Args:
+        url: The URL to scrape.
+        format: Output format — "markdown", "html", "readability", or "cleaned_html".
+        use_proxy: Override proxy setting (defaults to STEEL_USE_PROXY env var).
+
+    Returns:
+        JSON string with extracted content, metadata, and links.
+    """
+    if not _is_safe_url(url):
+        return json.dumps({
+            "error": "Blocked: URL targets a private or internal address",
+        })
+
+    api_key = os.environ.get("STEEL_API_KEY")
+    if not api_key:
+        return json.dumps({"error": "STEEL_API_KEY not configured"})
+
+    base = os.environ.get("STEEL_BASE_URL", _DEFAULT_BASE_URL).rstrip("/")
+
+    body = {
+        "url": url,
+        "format": [format],
+    }
+
+    if use_proxy is None:
+        use_proxy = os.environ.get("STEEL_USE_PROXY", "").lower() in ("1", "true", "yes")
+    if use_proxy:
+        body["use_proxy"] = True
+
+    try:
+        response = requests.post(
+            f"{base}/v1/scrape",
+            headers={
+                "Content-Type": "application/json",
+                "Steel-Api-Key": api_key,
+            },
+            json=body,
+            timeout=60,
+        )
+
+        if not response.ok:
+            return json.dumps({
+                "error": f"Steel scrape failed: {response.status_code} {response.text[:500]}"
+            })
+
+        data = response.json()
+
+        result = {
+            "url": url,
+            "format": format,
+        }
+
+        # Extract content — try requested format first, then fall back
+        content = data.get("content", {})
+        if content.get(format):
+            result["content"] = content[format]
+        else:
+            for key in ("markdown", "readability", "cleaned_html", "html"):
+                if content.get(key):
+                    result["content"] = content[key]
+                    result["format"] = key
+                    break
+
+        metadata = data.get("metadata", {})
+        if metadata.get("title"):
+            result["title"] = metadata["title"]
+        if metadata.get("description"):
+            result["description"] = metadata["description"]
+        if metadata.get("statusCode"):
+            result["status_code"] = metadata["statusCode"]
+
+        links = data.get("links", [])
+        if links:
+            result["links_count"] = len(links)
+            result["links"] = links[:20]
+
+        return json.dumps(result, ensure_ascii=False)
+
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+# --- Schema ---
+
+STEEL_SCRAPE_SCHEMA = {
+    "name": "steel_scrape",
+    "description": (
+        "Extract content from a webpage using Steel's server-side scrape API. "
+        "Returns clean markdown or HTML without needing a browser session. "
+        "Best for quick content extraction; use browser_navigate for interactive browsing."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "URL of the webpage to scrape",
+            },
+            "format": {
+                "type": "string",
+                "enum": ["markdown", "html", "readability", "cleaned_html"],
+                "description": "Output format (default: markdown)",
+                "default": "markdown",
+            },
+        },
+        "required": ["url"],
+    },
+}
+
+
+# --- Registration ---
+
+from tools.registry import registry
+
+registry.register(
+    name="steel_scrape",
+    toolset="browser",
+    schema=STEEL_SCRAPE_SCHEMA,
+    handler=lambda args, **kw: steel_scrape(
+        url=args.get("url", ""),
+        format=args.get("format", "markdown"),
+    ),
+    check_fn=check_steel_scrape_requirements,
+    requires_env=["STEEL_API_KEY"],
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -177,11 +177,12 @@ TOOLSETS = {
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp",
-            "browser_dialog", "web_search"
+            "browser_dialog", "web_search",
+            "steel_scrape",
         ],
         "includes": []
     },
-    
+
     "cronjob": {
         "description": "Cronjob management tool - create, list, update, pause, resume, remove, and trigger scheduled tasks",
         "tools": ["cronjob"],

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -54,6 +54,7 @@ Hermes includes full browser automation with multiple backend options for naviga
 
 - **Browserbase** — Managed cloud browsers with anti-bot tooling, CAPTCHA solving, and residential proxies
 - **Browser Use** — Alternative cloud browser provider
+- **Steel** — Stealth cloud browsers with proxy rotation and CAPTCHA solving
 - **Local Chromium-family CDP** — Connect to your running Chrome, Brave, Chromium, or Edge browser using `/browser connect`
 - **Local Chromium** — Headless local browser via the `agent-browser` CLI
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -141,6 +141,11 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `BROWSERBASE_PROJECT_ID` | Browserbase project ID |
 | `BROWSER_USE_API_KEY` | Browser Use cloud browser API key ([browser-use.com](https://browser-use.com/)) |
 | `FIRECRAWL_BROWSER_TTL` | Firecrawl browser session TTL in seconds (default: 300) |
+| `STEEL_API_KEY` | Steel cloud browser API key ([steel.dev](https://steel.dev/)) |
+| `STEEL_BASE_URL` | Custom Steel API endpoint for self-hosted instances (optional) |
+| `STEEL_USE_PROXY` | Enable Steel residential proxy (`true`/`false`) |
+| `STEEL_SOLVE_CAPTCHA` | Enable Steel CAPTCHA solving (`true`/`false`) |
+| `STEEL_SESSION_TIMEOUT` | Steel session timeout in milliseconds |
 | `BROWSER_CDP_URL` | Chrome DevTools Protocol URL for local browser (set via `/browser connect`, e.g. `ws://localhost:9222`) |
 | `CAMOFOX_URL` | Camofox local anti-detection browser URL (default: `http://localhost:9377`) |
 | `CAMOFOX_USER_ID` | Optional externally managed Camofox user ID for shared visible sessions |

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -12,6 +12,7 @@ Hermes Agent includes a full browser automation toolset with multiple backend op
 - **Browserbase cloud mode** via [Browserbase](https://browserbase.com) for managed cloud browsers and anti-bot tooling
 - **Browser Use cloud mode** via [Browser Use](https://browser-use.com) as an alternative cloud browser provider
 - **Firecrawl cloud mode** via [Firecrawl](https://firecrawl.dev) for cloud browsers with built-in scraping
+- **Steel cloud mode** via [Steel](https://steel.dev) for stealth browsers with proxy rotation and CAPTCHA solving
 - **Camofox local mode** via [Camofox](https://github.com/jo-inc/camofox-browser) for local anti-detection browsing (Firefox-based fingerprint spoofing)
 - **Local Chromium-family CDP** — connect browser tools to your own Chrome, Brave, Chromium, or Edge instance using `/browser connect`
 - **Local browser mode** via the `agent-browser` CLI and a local Chromium installation
@@ -24,7 +25,7 @@ Pages are represented as **accessibility trees** (text-based snapshots), making 
 
 Key capabilities:
 
-- **Multi-provider cloud execution** — Browserbase, Browser Use, or Firecrawl — no local browser needed
+- **Multi-provider cloud execution** — Browserbase, Browser Use, Firecrawl, or Steel — no local browser needed
 - **Local Chromium-family integration** — attach to your running Chrome, Brave, Chromium, or Edge browser via CDP for hands-on browsing
 - **Built-in stealth** — random fingerprints, CAPTCHA solving, residential proxies (Browserbase)
 - **Session isolation** — each task gets its own browser session
@@ -85,6 +86,38 @@ FIRECRAWL_API_URL=http://localhost:3002
 # Session TTL in seconds (default: 300)
 FIRECRAWL_BROWSER_TTL=600
 ```
+
+### Steel cloud mode
+
+To use Steel as your cloud browser provider, add:
+
+```bash
+# Add to ~/.hermes/.env
+STEEL_API_KEY=ste-***
+```
+
+Get your API key at [steel.dev](https://steel.dev). Steel connects over CDP, so
+no extra CLI is required. Then select Steel as your browser provider:
+
+```bash
+hermes setup tools
+# → Browser Automation → Steel
+```
+
+Optional settings:
+
+```bash
+# Self-hosted Steel instance (default: https://api.steel.dev)
+STEEL_BASE_URL=https://steel.internal.example
+
+STEEL_USE_PROXY=true        # Enable residential proxy
+STEEL_SOLVE_CAPTCHA=true    # Enable CAPTCHA solving
+STEEL_SESSION_TIMEOUT=600000  # Session timeout in milliseconds
+```
+
+The standalone `steel_scrape` tool — server-side content extraction via Steel's
+HTTP API — also activates whenever `STEEL_API_KEY` is set, independent of the
+configured cloud browser provider.
 
 ### Hybrid routing: cloud for public URLs, local for LAN/localhost
 

--- a/website/docs/user-guide/features/overview.md
+++ b/website/docs/user-guide/features/overview.md
@@ -32,7 +32,7 @@ Hermes Agent includes a rich set of capabilities that extend far beyond basic ch
 ## Media & Web
 
 - **[Voice Mode](voice-mode.md)** — Full voice interaction across CLI and messaging platforms. Talk to the agent using your microphone, hear spoken replies, and have live voice conversations in Discord voice channels.
-- **[Browser Automation](browser.md)** — Full browser automation with multiple backends: Browserbase cloud, Browser Use cloud, local Chrome/Brave/Chromium/Edge via CDP, or local Chromium. Navigate websites, fill forms, and extract information.
+- **[Browser Automation](browser.md)** — Full browser automation with multiple backends: Browserbase cloud, Browser Use cloud, Steel cloud, local Chrome/Brave/Chromium/Edge via CDP, or local Chromium. Navigate websites, fill forms, and extract information.
 - **[Vision & Image Paste](vision.md)** — Multimodal vision support. Paste images from your clipboard into the CLI and ask the agent to analyze, describe, or work with them using any vision-capable model.
 - **[Image Generation](image-generation.md)** — Generate images from text prompts using FAL.ai. Nine models supported (FLUX 2 Klein/Pro, GPT-Image 1.5/2, Nano Banana Pro, Ideogram V3, Recraft V4 Pro, Qwen, Z-Image Turbo); pick one via `hermes tools`.
 - **[Voice & TTS](tts.md)** — Text-to-speech output and voice message transcription across all messaging platforms, with ten native provider options: Edge TTS (free), ElevenLabs, OpenAI TTS, MiniMax, Mistral Voxtral, Google Gemini, xAI, NeuTTS, KittenTTS, and Piper — plus custom command providers for any local TTS CLI.


### PR DESCRIPTION
Hi @teknium1 — this supersedes #5555 with a smaller, cleaner slice of the same feature.

Steel ([steel.dev](https://steel.dev)) joins Browserbase and Browser Use as a third cloud browser provider, plus a standalone `steel_scrape` tool for server-side markdown/HTML extraction (no browser session required).

## What's different from #5555

Same feature, **12 files instead of 18, +778/-60 instead of +960/-42.** The `hermes_cli/` wizard plumbing (setup wizard entry, status display, subscription routing) is intentionally deferred to a follow-up PR so the runtime path can be reviewed and merged independently.

That deferral also sidesteps a supply-chain-audit false positive: the upstream regex `(^|/)setup\.py$` matches `hermes_cli/setup.py` even though it's a CLI module, not a Python install hook. Worth tightening to `^setup\.py$` regardless.

## Two modes

- **`steel_scrape` tool** — needs only `STEEL_API_KEY`. No CLI install. Hits Steel's `/v1/scrape` API directly.
- **Full browser automation** (`browser_navigate`, `browser_click`, etc. via `cloud_provider: steel`) — additionally requires the [Steel CLI](https://github.com/steel-dev/cli), which speaks Steel's CDP dialect natively (agent-browser cannot connect to Steel's WS endpoint directly). Install hint surfaces on first browser command if the CLI is missing.

## Files

- `tools/browser_providers/steel.py` — `SteelProvider` implementation
- `tools/steel_scrape_tool.py` — server-side scrape tool
- `tools/browser_tool.py` — registration in `_PROVIDER_REGISTRY`, Steel CLI dispatch, Steel-aware bot-detection / live-viewer hints
- `toolsets.py` — register `steel_scrape` in the browser toolset
- `tests/tools/test_steel_provider.py` — 19 tests (unit + integration + e2e; integration/e2e auto-skip without `STEEL_API_KEY`)
- `tests/tools/test_registry.py` — discovery test
- `website/docs/*` — Steel mode docs + `STEEL_API_KEY` env-var entries
- `scripts/release.py` + `.mailmap` — author mapping

## Test plan

- [x] `uv run pytest tests/tools/test_steel_provider.py tests/tools/test_registry.py -q` → 78 passed locally
- [x] Targeted browser regressions: `test_browser_cleanup.py`, `test_browser_hardening.py` → green
- [ ] Full CI run on this branch