### PR TITLE
fix(auxiliary): fallback on auth errors in auto mode

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3721,12 +3721,19 @@ def call_llm(
         # and providers the user never configured that got picked up by
         # the auto-detection chain.
         #
+        # ── Auth error fallback (#21165) ────────────────────────────
+        # When the resolved provider returns 401 and neither the Nous
+        # refresh path nor explicit provider credential refresh applies,
+        # fall back to an alternative provider instead of dropping the
+        # auxiliary task on the floor.
+        #
         # ── Rate-limit fallback (#13579) ─────────────────────────────
         # When the provider returns a 429 rate-limit (not billing), fall
         # back to an alternative provider instead of exhausting retries
         # against the same rate-limited endpoint.
         should_fallback = (
-            _is_payment_error(first_err)
+            _is_auth_error(first_err)
+            or _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
         )
@@ -3735,7 +3742,9 @@ def call_llm(
         # auto (the default) = best-effort fallback chain.  (#7559)
         is_auto = resolved_provider in ("auto", "", None)
         if should_fallback and is_auto:
-            if _is_payment_error(first_err):
+            if _is_auth_error(first_err):
+                reason = "auth error"
+            elif _is_payment_error(first_err):
                 reason = "payment error"
             elif _is_rate_limit_error(first_err):
                 reason = "rate limit"
@@ -4013,14 +4022,23 @@ async def async_call_llm(
                         await retry_client.chat.completions.create(**retry_kwargs), task)
 
         # ── Payment / connection / rate-limit fallback (mirrors sync call_llm) ──
+        #
+        # ── Auth error fallback (#21165) ────────────────────────────
+        # When the resolved provider returns 401 and neither the Nous
+        # refresh path nor explicit provider credential refresh applies,
+        # fall back to an alternative provider instead of dropping the
+        # auxiliary task on the floor.
         should_fallback = (
-            _is_payment_error(first_err)
+            _is_auth_error(first_err)
+            or _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
         )
         is_auto = resolved_provider in ("auto", "", None)
         if should_fallback and is_auto:
-            if _is_payment_error(first_err):
+            if _is_auth_error(first_err):
+                reason = "auth error"
+            elif _is_payment_error(first_err):
                 reason = "payment error"
             elif _is_rate_limit_error(first_err):
                 reason = "rate limit"

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -977,6 +977,72 @@ class TestCallLlmPaymentFallback:
         # Fallback client should have been used
         assert fallback_client.chat.completions.create.called
 
+    def test_401_auth_error_triggers_fallback_after_refresh_failure(self):
+        """401 auth errors should fall back when refresh is unavailable/unsuccessful."""
+        primary_client = MagicMock()
+        primary_client.base_url = "https://api.minimax.chat/v1"
+        primary_client.chat.completions.create.side_effect = _AuxAuth401("expired minimax key")
+
+        fallback_client = MagicMock()
+        fallback_client.base_url = "https://openrouter.ai/api/v1"
+        fallback_client.chat.completions.create.return_value = _DummyResponse("fallback auth response")
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("auto", "minimax/minimax-m2.7", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client",
+                  return_value=(primary_client, "minimax/minimax-m2.7")),
+            patch("agent.auxiliary_client._refresh_provider_credentials", return_value=False) as mock_refresh,
+            patch("agent.auxiliary_client._try_payment_fallback",
+                  return_value=(fallback_client, "fallback-model", "openrouter")) as mock_fallback,
+        ):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result.choices[0].message.content == "fallback auth response"
+        mock_refresh.assert_not_called()
+        mock_fallback.assert_called_once_with("auto", "compression", reason="auth error")
+        assert primary_client.chat.completions.create.call_count == 1
+        assert fallback_client.chat.completions.create.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_async_401_auth_error_triggers_fallback_after_refresh_failure(self):
+        """Async 401 auth errors should also fall back after refresh fails."""
+        primary_client = MagicMock()
+        primary_client.base_url = "https://api.minimax.chat/v1"
+        primary_client.chat.completions.create = AsyncMock(side_effect=_AuxAuth401("expired minimax key"))
+
+        fallback_sync_client = MagicMock()
+        fallback_sync_client.base_url = "https://openrouter.ai/api/v1"
+
+        fallback_async_client = MagicMock()
+        fallback_async_client.base_url = "https://openrouter.ai/api/v1"
+        fallback_async_client.chat.completions.create = AsyncMock(return_value=_DummyResponse("async fallback auth response"))
+
+        with (
+            patch("agent.auxiliary_client._resolve_task_provider_model",
+                  return_value=("auto", "minimax/minimax-m2.7", None, None, None)),
+            patch("agent.auxiliary_client._get_cached_client",
+                  return_value=(primary_client, "minimax/minimax-m2.7")),
+            patch("agent.auxiliary_client._refresh_provider_credentials", return_value=False) as mock_refresh,
+            patch("agent.auxiliary_client._try_payment_fallback",
+                  return_value=(fallback_sync_client, "fallback-model", "openrouter")) as mock_fallback,
+            patch("agent.auxiliary_client._to_async_client",
+                  return_value=(fallback_async_client, "fallback-model")),
+        ):
+            result = await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result.choices[0].message.content == "async fallback auth response"
+        mock_refresh.assert_not_called()
+        mock_fallback.assert_called_once_with("auto", "compression", reason="auth error")
+        assert primary_client.chat.completions.create.await_count == 1
+        assert fallback_async_client.chat.completions.create.await_count == 1
+
 # ---------------------------------------------------------------------------
 # Gate: _resolve_api_key_provider must skip anthropic when not configured
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes an auxiliary runtime fallback gap where `401` authentication failures did not trigger the auto-provider fallback chain.

In `agent/auxiliary_client.py`, auxiliary calls already fall back on payment errors, connection errors, and rate limits when the resolved provider is `auto`. But `401` auth errors were excluded from `should_fallback`, so auxiliary tasks like compression could fail outright after an auth error instead of trying another provider.

This PR adds auth errors to the fallback trigger in both `call_llm()` and `async_call_llm()`, while preserving the existing execution order:

1. Nous-specific auth refresh still runs first when applicable.
2. Explicit provider credential refresh still runs first for explicitly selected providers.
3. Only after those refresh paths are inapplicable or unsuccessful does `auto` mode fall back to another provider.

Note: `_try_payment_fallback()` is historical naming. It now handles multiple fallback reasons, but renaming it would be a wider refactor and is intentionally out of scope for this PR.

## Related Issue

Fixes #21165

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_is_auth_error(first_err)` to the `should_fallback` condition in sync auxiliary calls in `agent/auxiliary_client.py`.
- Added `_is_auth_error(first_err)` to the `should_fallback` condition in async auxiliary calls in `agent/auxiliary_client.py`.
- Added `reason = "auth error"` logging/dispatch branch for sync and async fallback paths.
- Added regression tests in `tests/agent/test_auxiliary_client.py` covering `401` auth failures in `auto` mode for both sync and async auxiliary calls.
- Documented the auth-error fallback path in the surrounding code comments.

## How to Test

1. Run `python3 -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`.
2. Run `python3 -m pytest -q tests/agent/test_auxiliary_client.py`.
3. Verify the new regression coverage passes for both sync and async `401` auth-error fallback paths in `auto` mode.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 --> WSL2 Ubuntu

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validation run:

```bash
python3 -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py
python3 -m pytest -q tests/agent/test_auxiliary_client.py
# 136 passed
```
