### PR TITLE
feat(gateway): add --graceful flag to restart for cgroup-safe SIGUSR1 restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4652,6 +4652,27 @@ def _gateway_command_inner(args):
                 print(f"✓ Stopped {get_service_name()} service")
     
     elif subcmd == "restart":
+        graceful = getattr(args, 'graceful', False)
+
+        # --graceful: drain-aware SIGUSR1 restart, safe from cron subprocesses
+        # inside the gateway's cgroup. Unlike systemctl restart, SIGUSR1 only
+        # signals the main process — the sending process and any sibling cron
+        # children survive the stop phase. systemd's Restart=always brings the
+        # gateway back.
+        if graceful:
+            from gateway.status import get_running_pid
+            pid = get_running_pid()
+            if pid is None:
+                print("✗ No running gateway PID found (gateway.pid missing or stale)")
+                sys.exit(1)
+            drain_timeout = parse_restart_drain_timeout(None)
+            ok = _graceful_restart_via_sigusr1(pid, drain_timeout)
+            if ok:
+                print(f"✓ Graceful restart signalled (PID {pid}). Gateway will restart via service manager.")
+                return
+            print("✗ Graceful restart failed — falling back to service restart")
+            # Fall through to the normal restart path below
+
         # Try service first, fall back to killing and restarting
         service_available = False
         system = getattr(args, 'system', False)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8648,6 +8648,11 @@ def main():
         action="store_true",
         help="Kill ALL gateway processes across all profiles before restarting",
     )
+    gateway_restart.add_argument(
+        "--graceful",
+        action="store_true",
+        help="Send SIGUSR1 for a drain-aware graceful restart (safe from within cron jobs)",
+    )
 
     # gateway status
     gateway_status = gateway_subparsers.add_parser("status", help="Show gateway status")


### PR DESCRIPTION
## Summary

Adds `hermes gateway restart --graceful` which sends `SIGUSR1` to the running gateway process instead of running `systemctl restart`. Safe to call from cron jobs inside the gateway's cgroup.

## Problem

When a cron job runs `systemctl restart` from inside the gateway's systemd cgroup, systemd kills the entire cgroup during the stop phase — including the running restart command. The new gateway never starts.

## Solution

The gateway already has a `SIGUSR1` handler that drains in-flight sessions and exits gracefully. With `Restart=always`, the process manager brings it back. Since SIGUSR1 only signals the **main process**, the cron job and sibling subprocesses survive.

## Changes

- Added `--graceful` flag to `hermes gateway restart` subcommand
- Uses existing `_graceful_restart_via_sigusr1()` helper + `get_running_pid()`
- Falls back to normal service restart if graceful path fails

## Usage

```
hermes gateway restart --graceful   # safe from cron jobs
hermes gateway restart                # existing systemctl restart
```

Closes https://github.com/NousResearch/hermes-agent/issues/21189