### PR TITLE
fix(bedrock): preserve reasoningContent in normalized responses

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -631,11 +631,18 @@ def normalize_converse_response(response: Dict) -> SimpleNamespace:
     stop_reason = response.get("stopReason", "end_turn")
 
     text_parts = []
+    reasoning_parts = []
     tool_calls = []
 
     for block in content_blocks:
         if "text" in block:
             text_parts.append(block["text"])
+        elif "reasoningContent" in block:
+            reasoning = block["reasoningContent"]
+            if isinstance(reasoning, dict):
+                thinking_text = reasoning.get("text", "")
+                if thinking_text:
+                    reasoning_parts.append(str(thinking_text))
         elif "toolUse" in block:
             tu = block["toolUse"]
             tool_calls.append(SimpleNamespace(
@@ -652,6 +659,7 @@ def normalize_converse_response(response: Dict) -> SimpleNamespace:
         role="assistant",
         content="\n".join(text_parts) if text_parts else None,
         tool_calls=tool_calls if tool_calls else None,
+        reasoning_content="\n\n".join(reasoning_parts) if reasoning_parts else None,
     )
 
     # Build usage stats
@@ -732,6 +740,7 @@ def stream_converse_with_callbacks(
         ``normalize_converse_response()``.
     """
     text_parts: List[str] = []
+    reasoning_parts: List[str] = []
     tool_calls: List[SimpleNamespace] = []
     current_tool: Optional[Dict] = None
     current_text_buffer: List[str] = []
@@ -777,8 +786,10 @@ def stream_converse_with_callbacks(
                 reasoning = delta["reasoningContent"]
                 if isinstance(reasoning, dict):
                     thinking_text = reasoning.get("text", "")
-                    if thinking_text and on_reasoning_delta:
-                        on_reasoning_delta(thinking_text)
+                    if thinking_text:
+                        reasoning_parts.append(str(thinking_text))
+                        if on_reasoning_delta:
+                            on_reasoning_delta(thinking_text)
 
         elif "contentBlockStop" in event:
             if current_tool is not None:
@@ -817,6 +828,7 @@ def stream_converse_with_callbacks(
         role="assistant",
         content="\n".join(text_parts) if text_parts else None,
         tool_calls=tool_calls if tool_calls else None,
+        reasoning_content="\n\n".join(reasoning_parts) if reasoning_parts else None,
     )
 
     usage = SimpleNamespace(

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -994,6 +994,7 @@ class TestStreamConverseWithCallbacks:
             events, on_reasoning_delta=lambda t: reasoning.append(t),
         )
         assert reasoning == ["Let me think..."]
+        assert result.choices[0].message.reasoning_content == "Let me think..."
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/transports/test_bedrock_transport.py
+++ b/tests/agent/transports/test_bedrock_transport.py
@@ -142,6 +142,24 @@ class TestBedrockNormalize:
         assert len(nr.tool_calls) == 1
         assert nr.tool_calls[0].name == "terminal"
 
+    def test_raw_reasoning_content_response(self, transport):
+        raw = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"reasoningContent": {"text": "Let me think..."}},
+                        {"text": "Answer."},
+                    ],
+                }
+            },
+            "stopReason": "end_turn",
+            "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
+        }
+        nr = transport.normalize_response(raw)
+        assert nr.reasoning == "Let me think..."
+        assert nr.content == "Answer."
+
     def test_already_normalized_response(self, transport):
         """Test normalize_response handles already-normalized SimpleNamespace (from dispatch site)."""
         pre_normalized = SimpleNamespace(


### PR DESCRIPTION
Salvage of #20366 onto current main (172 commits stale).

Bedrock thinking text now survives normalization on both raw `converse()` and streaming `converse_stream()` paths. Previously `agent/bedrock_adapter.py:normalize_converse_response()` didn't handle `reasoningContent` blocks, and the stream path only forwarded reasoning to the callback — nothing persisted onto the assistant message. The transport layer (`agent/transports/bedrock.py:108`) already reads `msg.reasoning_content`, so the field just arrived empty and `NormalizedResponse.reasoning` was always `None` even on Claude 4.6+ thinking output.

## Changes
- `agent/bedrock_adapter.py`: collect `reasoningContent.text` blocks in both `normalize_converse_response()` and `stream_converse_with_callbacks()`, attach as `reasoning_content` on the assistant SimpleNamespace.
- `tests/agent/test_bedrock_adapter.py`: assert streamed reasoning persists on the normalized message, not only via callback.
- `tests/agent/transports/test_bedrock_transport.py`: regression coverage for raw Converse with `reasoningContent`.

## Validation
| | Before | After |
|---|---|---|
| `NormalizedResponse.reasoning` on Bedrock thinking output | None | Thinking text |
| `tests/agent/test_bedrock_adapter.py` + `tests/agent/transports/test_bedrock_transport.py` | - | 137 passed |
| E2E adapter → transport chain (real imports) | reasoning lost | reasoning preserved |

Authored-by: @molvikar via cherry-pick, no follow-up fixes needed.
Closes #20366