### PR TITLE
fix(skills): exclude hidden/archive dirs from _find_skill rglob (salvage #19062)

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -283,11 +283,13 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs
+    from agent.skill_utils import EXCLUDED_SKILL_DIRS, get_all_skills_dirs
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
         for skill_md in skills_dir.rglob("SKILL.md"):
+            if any(part in EXCLUDED_SKILL_DIRS for part in skill_md.parts):
+                continue
             if skill_md.parent.name == name:
                 return {"path": skill_md.parent}
     return None


### PR DESCRIPTION
Closes #19062 via salvage.

## Summary
`_find_skill()` in `tools/skill_manager_tool.py` used a bare `rglob('SKILL.md')` that would walk into `.git/`, `.github/`, `.hub/`, and `.archive/` under user skill directories. Every other skill scanner (`tools/skills_tool.py`, `agent/skill_utils.py`, `tools/skill_usage.py`) already applies `EXCLUDED_SKILL_DIRS`. Add the same guard here.

## Validation
`scripts/run_tests.sh tests/tools/ -k skill_manager` → 86 passed.

Original author: @Kailigithub.