### PR TITLE
fix(gateway): preserve thread routing from cached live session sources

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1066,7 +1066,13 @@ class GatewayRunner:
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
-        self._session_sources: Dict[str, "SessionSource"] = {}
+        # LRU cache of live SessionSources keyed by session_key. Used by
+        # fallback routing paths (shutdown notifications, synthetic
+        # background-process events) when the persisted origin is missing
+        # and _parse_session_key can't recover thread_id. Capped so it
+        # cannot grow unbounded over a long-running gateway lifetime.
+        self._session_sources: "OrderedDict[str, SessionSource]" = OrderedDict()
+        self._session_sources_max = 512
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -5860,12 +5866,21 @@ class GatewayRunner:
             return
         cached_sources = getattr(self, "_session_sources", None)
         if cached_sources is None:
-            cached_sources = {}
+            cached_sources = OrderedDict()
             self._session_sources = cached_sources
         try:
             cached_sources[session_key] = dataclasses.replace(source)
         except Exception:
             logger.debug("Failed to cache live session source for %s", session_key, exc_info=True)
+            return
+        # LRU: mark as most-recently-used and trim to max size.
+        try:
+            cached_sources.move_to_end(session_key)
+            max_size = getattr(self, "_session_sources_max", 512)
+            while len(cached_sources) > max_size:
+                cached_sources.popitem(last=False)
+        except Exception:
+            pass
 
     def _get_cached_session_source(self, session_key: str):
         if not session_key:
@@ -5873,7 +5888,13 @@ class GatewayRunner:
         cached_sources = getattr(self, "_session_sources", None)
         if not cached_sources:
             return None
-        return cached_sources.get(session_key)
+        source = cached_sources.get(session_key)
+        if source is not None:
+            try:
+                cached_sources.move_to_end(session_key)
+            except Exception:
+                pass
+        return source
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1066,6 +1066,7 @@ class GatewayRunner:
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
+        self._session_sources: Dict[str, "SessionSource"] = {}
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -2430,6 +2431,9 @@ class GatewayRunner:
                     session_key,
                     e,
                 )
+
+            if source is None:
+                source = self._get_cached_session_source(session_key)
 
             if source is not None:
                 platform_str = source.platform.value
@@ -5851,6 +5855,26 @@ class GatewayRunner:
             return []
         return list(pending_native.pop(session_key, []) or [])
 
+    def _cache_session_source(self, session_key: str, source) -> None:
+        if not session_key or source is None:
+            return
+        cached_sources = getattr(self, "_session_sources", None)
+        if cached_sources is None:
+            cached_sources = {}
+            self._session_sources = cached_sources
+        try:
+            cached_sources[session_key] = dataclasses.replace(source)
+        except Exception:
+            logger.debug("Failed to cache live session source for %s", session_key, exc_info=True)
+
+    def _get_cached_session_source(self, session_key: str):
+        if not session_key:
+            return None
+        cached_sources = getattr(self, "_session_sources", None)
+        if not cached_sources:
+            return None
+        return cached_sources.get(session_key)
+
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
@@ -5865,6 +5889,7 @@ class GatewayRunner:
         # Get or create session
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        self._cache_session_source(session_key, source)
         if self._is_telegram_topic_lane(source):
             try:
                 binding = self._session_db.get_telegram_topic_binding(
@@ -11738,6 +11763,10 @@ class GatewayRunner:
                     session_key,
                     exc,
                 )
+
+            cached_source = self._get_cached_session_source(session_key)
+            if cached_source is not None:
+                return cached_source
 
             _parsed = _parse_session_key(session_key)
             if _parsed:

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections import OrderedDict
 from unittest.mock import AsyncMock, MagicMock
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
@@ -74,7 +75,8 @@ def make_restart_runner(
     runner._update_prompt_pending = {}
     runner._voice_mode = {}
     runner._session_model_overrides = {}
-    runner._session_sources = {}
+    runner._session_sources = OrderedDict()
+    runner._session_sources_max = 512
     runner._shutdown_all_gateway_honcho = lambda: None
     runner._update_runtime_status = MagicMock()
     runner._queue_or_replace_pending_event = GatewayRunner._queue_or_replace_pending_event.__get__(

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -74,6 +74,7 @@ def make_restart_runner(
     runner._update_prompt_pending = {}
     runner._voice_mode = {}
     runner._session_model_overrides = {}
+    runner._session_sources = {}
     runner._shutdown_all_gateway_honcho = lambda: None
     runner._update_runtime_status = MagicMock()
     runner._queue_or_replace_pending_event = GatewayRunner._queue_or_replace_pending_event.__get__(
@@ -114,6 +115,12 @@ def make_restart_runner(
     )
     runner._notify_active_sessions_of_shutdown = (
         GatewayRunner._notify_active_sessions_of_shutdown.__get__(runner, GatewayRunner)
+    )
+    runner._cache_session_source = GatewayRunner._cache_session_source.__get__(
+        runner, GatewayRunner
+    )
+    runner._get_cached_session_source = GatewayRunner._get_cached_session_source.__get__(
+        runner, GatewayRunner
     )
     runner._launch_detached_restart_command = GatewayRunner._launch_detached_restart_command.__get__(
         runner, GatewayRunner

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -304,6 +304,40 @@ def test_build_process_event_source_falls_back_to_session_key_chat_type(monkeypa
     assert source.user_name == "Emiliyan"
 
 
+def test_build_process_event_source_uses_cached_live_source_before_session_key_parse(
+    monkeypatch, tmp_path
+):
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    runner._cache_session_source(
+        "agent:main:telegram:group:-100:42",
+        SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100",
+            chat_type="group",
+            thread_id="42",
+            user_id="proc_owner",
+            user_name="alice",
+        ),
+    )
+
+    source = runner._build_process_event_source(
+        {
+            "session_id": "proc_watch",
+            "session_key": "agent:main:telegram:group:-100:42",
+        }
+    )
+
+    assert source is not None
+    assert source.platform == Platform.TELEGRAM
+    assert source.chat_id == "-100"
+    assert source.chat_type == "group"
+    assert source.thread_id == "42"
+    assert source.user_id == "proc_owner"
+    assert source.user_name == "alice"
+
+
 @pytest.mark.asyncio
 async def test_inject_watch_notification_ignores_foreground_event_source(monkeypatch, tmp_path):
     """Negative test: watch notification must NOT route to the foreground thread."""

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -603,3 +603,23 @@ async def test_send_restart_notification_logs_info_on_sendresult_success(
         f"got records: {[(r.levelname, r.getMessage()) for r in caplog.records]}"
     )
     assert not notify_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notifications_use_cached_live_thread_source_when_origin_missing():
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="parent-42", chat_type="group", thread_id="topic-7")
+    session_key = build_session_key(source)
+
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = MagicMock(origin=None)
+    runner._cache_session_source(session_key, source)
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="shutdown"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once_with(
+        "parent-42",
+        "⚠️ Gateway shutting down — Your current task will be interrupted.",
+        metadata={"thread_id": "topic-7"},
+    )


### PR DESCRIPTION
Salvage of #20325 (@Zyproth) onto current main + LRU cap follow-up.

## Summary
Threaded/group sessions were losing `thread_id` in two gateway fallback routing paths (shutdown notifications, synthetic background-process events) when persisted `SessionEntry.origin` was missing. `_parse_session_key` deliberately drops `thread_id` for group/channel keys because the 6th segment is ambiguous (thread_id vs user_id depending on isolation mode). The fix caches the live `SessionSource` in-memory and consults that cache before falling back to key parsing.

## Commits
1. `07517da` — Zyproth's original fix (authorship preserved)
2. `e7bba82` — follow-up: cap `_session_sources` at 512 entries with OrderedDict LRU eviction so long-running gateways can't accumulate stale entries forever

## Validation
- 53 targeted gateway tests pass (test_background_process_notifications.py + test_restart_notification.py)
- Full tests/gateway/ sweep: 4679/4680 pass; the one failure (`test_discord_free_channel_skips_auto_thread`) is pre-existing on clean main, unrelated

Closes #20325