### PR TITLE
fix(memory): harden OpenViking local resource uploads

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -35,6 +35,8 @@ import uuid
 import zipfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
@@ -43,6 +45,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_ENDPOINT = "http://127.0.0.1:1933"
 _TIMEOUT = 30.0
+_REMOTE_RESOURCE_PREFIXES = ("http://", "https://", "git@", "ssh://", "git://")
 
 
 # ---------------------------------------------------------------------------
@@ -331,6 +334,40 @@ def _zip_directory(dir_path: Path) -> Path:
                 arcname = str(file_path.relative_to(dir_path)).replace("\\", "/")
                 zipf.write(file_path, arcname=arcname)
     return zip_path
+
+
+def _is_windows_absolute_path(value: str) -> bool:
+    return (
+        len(value) >= 3
+        and value[0].isalpha()
+        and value[1] == ":"
+        and value[2] in ("/", "\\")
+    )
+
+
+def _is_remote_resource_source(value: str) -> bool:
+    return value.startswith(_REMOTE_RESOURCE_PREFIXES)
+
+
+def _is_local_path_reference(value: str) -> bool:
+    if not value or "\n" in value or "\r" in value:
+        return False
+    if _is_remote_resource_source(value):
+        return False
+    if _is_windows_absolute_path(value):
+        return True
+    return (
+        value.startswith(("/", "./", "../", "~/", ".\\", "..\\", "~\\"))
+        or "/" in value
+        or "\\" in value
+    )
+
+
+def _path_from_file_uri(uri: str) -> Path | str:
+    parsed = urlparse(uri)
+    if parsed.netloc not in ("", "localhost"):
+        return f"Unsupported non-local file URI: {uri}"
+    return Path(url2pathname(parsed.path)).expanduser()
 
 
 # ---------------------------------------------------------------------------
@@ -837,23 +874,39 @@ class OpenVikingMemoryProvider(MemoryProvider):
             if key in args and args[key] not in (None, ""):
                 payload[key] = args[key]
 
-        source_path = Path(url).expanduser()
-        cleanup_path: Optional[Path] = None
-        if source_path.exists():
-            if source_path.is_dir():
-                payload["source_name"] = source_path.name
-                cleanup_path = _zip_directory(source_path)
-                upload_path = cleanup_path
-            elif source_path.is_file():
-                payload["source_name"] = source_path.name
-                upload_path = source_path
-            else:
-                return tool_error(f"Unsupported local resource path: {url}")
-            payload["temp_file_id"] = self._client.upload_temp_file(upload_path)
+        parsed_url = urlparse(url)
+        if _is_remote_resource_source(url):
+            source_path = None
+        elif parsed_url.scheme == "file":
+            source_path = _path_from_file_uri(url)
+            if isinstance(source_path, str):
+                return tool_error(source_path)
+        elif parsed_url.scheme and not _is_windows_absolute_path(url):
+            source_path = None
         else:
-            payload["path"] = url
+            source_path = Path(url).expanduser()
 
+        cleanup_path: Optional[Path] = None
         try:
+            if source_path is not None:
+                if source_path.exists():
+                    if source_path.is_dir():
+                        payload["source_name"] = source_path.name
+                        cleanup_path = _zip_directory(source_path)
+                        upload_path = cleanup_path
+                    elif source_path.is_file():
+                        payload["source_name"] = source_path.name
+                        upload_path = source_path
+                    else:
+                        return tool_error(f"Unsupported local resource path: {url}")
+                    payload["temp_file_id"] = self._client.upload_temp_file(upload_path)
+                elif _is_local_path_reference(url):
+                    return tool_error(f"Local resource path does not exist: {url}")
+                else:
+                    payload["path"] = url
+            else:
+                payload["path"] = url
+
             resp = self._client.post("/api/v1/resources", payload)
             result = resp.get("result", {})
         finally:

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -110,14 +110,10 @@ class _VikingClient:
     def _url(self, path: str) -> str:
         return f"{self._endpoint}{path}"
 
-    def _auth_headers(self) -> dict:
-        h = {
-            "X-OpenViking-Account": self._account,
-            "X-OpenViking-User": self._user,
-        }
-        if self._api_key:
-            h["X-API-Key"] = self._api_key
-        return h
+    def _multipart_headers(self) -> dict:
+        headers = self._headers()
+        headers.pop("Content-Type", None)
+        return headers
 
     def _parse_response(self, resp) -> dict:
         try:
@@ -167,7 +163,7 @@ class _VikingClient:
             resp = self._httpx.post(
                 self._url("/api/v1/resources/temp_upload"),
                 files={"file": (file_path.name, f, mime_type)},
-                headers=self._auth_headers(),
+                headers=self._multipart_headers(),
                 timeout=_TIMEOUT,
             )
         data = self._parse_response(resp)

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -27,8 +27,13 @@ from __future__ import annotations
 import atexit
 import json
 import logging
+import mimetypes
 import os
+import tempfile
 import threading
+import uuid
+import zipfile
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
@@ -105,20 +110,72 @@ class _VikingClient:
     def _url(self, path: str) -> str:
         return f"{self._endpoint}{path}"
 
+    def _auth_headers(self) -> dict:
+        h = {
+            "X-OpenViking-Account": self._account,
+            "X-OpenViking-User": self._user,
+        }
+        if self._api_key:
+            h["X-API-Key"] = self._api_key
+        return h
+
+    def _parse_response(self, resp) -> dict:
+        try:
+            data = resp.json()
+        except Exception:
+            data = None
+
+        if resp.status_code >= 400:
+            if isinstance(data, dict):
+                error = data.get("error")
+                if isinstance(error, dict):
+                    code = error.get("code", "HTTP_ERROR")
+                    message = error.get("message", resp.text)
+                    raise RuntimeError(f"{code}: {message}")
+                if data.get("status") == "error":
+                    raise RuntimeError(str(data))
+            resp.raise_for_status()
+
+        if isinstance(data, dict) and data.get("status") == "error":
+            error = data.get("error")
+            if isinstance(error, dict):
+                code = error.get("code", "OPENVIKING_ERROR")
+                message = error.get("message", "")
+                raise RuntimeError(f"{code}: {message}")
+            raise RuntimeError(str(data))
+
+        if data is None:
+            return {}
+        return data
+
     def get(self, path: str, **kwargs) -> dict:
         resp = self._httpx.get(
             self._url(path), headers=self._headers(), timeout=_TIMEOUT, **kwargs
         )
-        resp.raise_for_status()
-        return resp.json()
+        return self._parse_response(resp)
 
     def post(self, path: str, payload: dict = None, **kwargs) -> dict:
         resp = self._httpx.post(
             self._url(path), json=payload or {}, headers=self._headers(),
             timeout=_TIMEOUT, **kwargs
         )
-        resp.raise_for_status()
-        return resp.json()
+        return self._parse_response(resp)
+
+    def upload_temp_file(self, file_path: Path) -> str:
+        mime_type = mimetypes.guess_type(file_path.name)[0] or "application/octet-stream"
+        with file_path.open("rb") as f:
+            resp = self._httpx.post(
+                self._url("/api/v1/resources/temp_upload"),
+                files={"file": (file_path.name, f, mime_type)},
+                headers=self._auth_headers(),
+                timeout=_TIMEOUT,
+            )
+        data = self._parse_response(resp)
+        result = data.get("result", {})
+        temp_file_id = result.get("temp_file_id", "")
+        if not temp_file_id:
+            raise RuntimeError("OpenViking temp upload did not return temp_file_id")
+        return temp_file_id
 
     def health(self) -> bool:
         try:
@@ -230,22 +287,54 @@ REMEMBER_SCHEMA = {
 ADD_RESOURCE_SCHEMA = {
     "name": "viking_add_resource",
     "description": (
-        "Add a URL or document to the OpenViking knowledge base. "
-        "Supports web pages, GitHub repos, PDFs, markdown, code files. "
+        "Add a remote URL or local file/directory to the OpenViking knowledge base. "
+        "Remote resources must be public http(s), git, or ssh URLs. "
+        "Local files are uploaded first using OpenViking temp_upload. "
         "The system automatically parses, indexes, and generates summaries."
     ),
     "parameters": {
         "type": "object",
         "properties": {
-            "url": {"type": "string", "description": "URL or path of the resource to add."},
+            "url": {"type": "string", "description": "Remote URL or local file/directory path to add."},
             "reason": {
                 "type": "string",
                 "description": "Why this resource is relevant (improves search).",
+            },
+            "to": {
+                "type": "string",
+                "description": "Optional target viking:// URI for the resource.",
+            },
+            "parent": {
+                "type": "string",
+                "description": "Optional parent viking:// URI. Cannot be used with to.",
+            },
+            "instruction": {
+                "type": "string",
+                "description": "Optional processing instruction for semantic extraction.",
+            },
+            "wait": {
+                "type": "boolean",
+                "description": "Whether to wait for processing to complete.",
+            },
+            "timeout": {
+                "type": "number",
+                "description": "Timeout in seconds when wait is true.",
             },
         },
         "required": ["url"],
     },
 }
+
+
+def _zip_directory(dir_path: Path) -> Path:
+    """Create a temporary zip file containing a directory tree."""
+    zip_path = Path(tempfile.gettempdir()) / f"openviking_upload_{uuid.uuid4().hex}.zip"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+        for file_path in dir_path.rglob("*"):
+            if file_path.is_file():
+                arcname = str(file_path.relative_to(dir_path)).replace("\\", "/")
+                zipf.write(file_path, arcname=arcname)
+    return zip_path
 
 
 # ---------------------------------------------------------------------------
@@ -744,12 +833,36 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if not url:
             return tool_error("url is required")
 
-        payload: Dict[str, Any] = {"path": url}
-        if args.get("reason"):
-            payload["reason"] = args["reason"]
+        if args.get("to") and args.get("parent"):
+            return tool_error("Cannot specify both 'to' and 'parent'")
 
-        resp = self._client.post("/api/v1/resources", payload)
-        result = resp.get("result", {})
+        payload: Dict[str, Any] = {}
+        for key in ("reason", "to", "parent", "instruction", "wait", "timeout"):
+            if key in args and args[key] not in (None, ""):
+                payload[key] = args[key]
+
+        source_path = Path(url).expanduser()
+        cleanup_path: Optional[Path] = None
+        if source_path.exists():
+            if source_path.is_dir():
+                payload["source_name"] = source_path.name
+                cleanup_path = _zip_directory(source_path)
+                upload_path = cleanup_path
+            elif source_path.is_file():
+                payload["source_name"] = source_path.name
+                upload_path = source_path
+            else:
+                return tool_error(f"Unsupported local resource path: {url}")
+            payload["temp_file_id"] = self._client.upload_temp_file(upload_path)
+        else:
+            payload["path"] = url
+
+        try:
+            resp = self._client.post("/api/v1/resources", payload)
+            result = resp.get("result", {})
+        finally:
+            if cleanup_path:
+                cleanup_path.unlink(missing_ok=True)
 
         return json.dumps({
             "status": "added",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -56,6 +56,8 @@ AUTHOR_MAP = {
     "ngusev@astralinux.ru": "NikolayGusev-astra",
     "liuguangyong201@hellobike.com": "liuguangyong93",
     "2093036+exiao@users.noreply.github.com": "exiao",
+    "thunderggnn@gmail.com": "ggnnggez",
+    "haozhe4547@gmail.com": "ehz0ah",
     "kevyan1998@gmail.com": "kyan12",
     "rylen.anil@gmail.com": "rylena",
     "godnanijatin@gmail.com": "jatingodnani",

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -93,6 +93,32 @@ def test_tool_add_resource_uploads_existing_local_file(tmp_path):
     assert result["root_uri"] == "viking://resources/sample"
 
 
+def test_tool_add_resource_uploads_file_uri(tmp_path):
+    sample = tmp_path / "sample.md"
+    sample.write_text("# Local resource\n", encoding="utf-8")
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.upload_temp_file.return_value = "upload_sample.md"
+    provider._client.post.return_value = {
+        "status": "ok",
+        "result": {"root_uri": "viking://resources/sample"},
+    }
+
+    result = json.loads(provider._tool_add_resource({
+        "url": sample.as_uri(),
+        "reason": "file uri test",
+    }))
+
+    provider._client.upload_temp_file.assert_called_once_with(sample)
+    provider._client.post.assert_called_once_with("/api/v1/resources", {
+        "reason": "file uri test",
+        "source_name": "sample.md",
+        "temp_file_id": "upload_sample.md",
+    })
+    assert result["status"] == "added"
+    assert result["root_uri"] == "viking://resources/sample"
+
+
 def test_tool_add_resource_uploads_existing_local_directory_and_cleans_zip(tmp_path):
     docs = tmp_path / "docs"
     docs.mkdir()
@@ -149,6 +175,40 @@ def test_tool_add_resource_cleans_local_directory_zip_when_add_fails(tmp_path):
     assert not uploaded_paths[0].exists()
 
 
+def test_tool_add_resource_cleans_local_directory_zip_when_upload_fails(tmp_path):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    uploaded_paths = []
+
+    def fail_upload(path):
+        uploaded_paths.append(path)
+        raise RuntimeError("upload failed")
+
+    provider._client.upload_temp_file.side_effect = fail_upload
+
+    with pytest.raises(RuntimeError, match="upload failed"):
+        provider._tool_add_resource({"url": str(docs)})
+
+    assert uploaded_paths
+    assert not uploaded_paths[0].exists()
+    provider._client.post.assert_not_called()
+
+
+def test_tool_add_resource_rejects_missing_local_path(tmp_path):
+    missing = tmp_path / "missing.md"
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+
+    result = json.loads(provider._tool_add_resource({"url": str(missing)}))
+
+    assert result["error"] == f"Local resource path does not exist: {missing}"
+    provider._client.upload_temp_file.assert_not_called()
+    provider._client.post.assert_not_called()
+
+
 def test_tool_add_resource_sends_remote_url_as_path():
     provider = OpenVikingMemoryProvider()
     provider._client = MagicMock()
@@ -162,6 +222,28 @@ def test_tool_add_resource_sends_remote_url_as_path():
     provider._client.upload_temp_file.assert_not_called()
     provider._client.post.assert_called_once_with("/api/v1/resources", {
         "path": "https://example.com/doc.md",
+    })
+
+
+@pytest.mark.parametrize("url", [
+    "git@github.com:org/repo.git",
+    "git@ssh.dev.azure.com:v3/org/project/repo",
+    "ssh://git@github.com/org/repo.git",
+    "git://github.com/org/repo.git",
+])
+def test_tool_add_resource_sends_git_remote_sources_as_path(url):
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.post.return_value = {
+        "status": "ok",
+        "result": {"root_uri": "viking://resources/repo"},
+    }
+
+    provider._tool_add_resource({"url": url})
+
+    provider._client.upload_temp_file.assert_not_called()
+    provider._client.post.assert_called_once_with("/api/v1/resources", {
+        "path": url,
     })
 
 

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -93,6 +93,62 @@ def test_tool_add_resource_uploads_existing_local_file(tmp_path):
     assert result["root_uri"] == "viking://resources/sample"
 
 
+def test_tool_add_resource_uploads_existing_local_directory_and_cleans_zip(tmp_path):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    nested = docs / "nested"
+    nested.mkdir()
+    (nested / "api.md").write_text("# API\n", encoding="utf-8")
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    uploaded_paths = []
+    provider._client.upload_temp_file.side_effect = (
+        lambda path: uploaded_paths.append(path) or "upload_docs.zip"
+    )
+    provider._client.post.return_value = {
+        "status": "ok",
+        "result": {"root_uri": "viking://resources/docs"},
+    }
+
+    result = json.loads(provider._tool_add_resource({
+        "url": str(docs),
+        "reason": "directory test",
+        "wait": True,
+    }))
+
+    assert uploaded_paths
+    assert uploaded_paths[0].suffix == ".zip"
+    assert not uploaded_paths[0].exists()
+    provider._client.post.assert_called_once_with("/api/v1/resources", {
+        "reason": "directory test",
+        "wait": True,
+        "source_name": "docs",
+        "temp_file_id": "upload_docs.zip",
+    })
+    assert result["status"] == "added"
+    assert result["root_uri"] == "viking://resources/docs"
+
+
+def test_tool_add_resource_cleans_local_directory_zip_when_add_fails(tmp_path):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "guide.md").write_text("# Guide\n", encoding="utf-8")
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    uploaded_paths = []
+    provider._client.upload_temp_file.side_effect = (
+        lambda path: uploaded_paths.append(path) or "upload_docs.zip"
+    )
+    provider._client.post.side_effect = RuntimeError("add failed")
+
+    with pytest.raises(RuntimeError, match="add failed"):
+        provider._tool_add_resource({"url": str(docs)})
+
+    assert uploaded_paths
+    assert not uploaded_paths[0].exists()
+
+
 def test_tool_add_resource_sends_remote_url_as_path():
     provider = OpenVikingMemoryProvider()
     provider._client = MagicMock()
@@ -107,6 +163,41 @@ def test_tool_add_resource_sends_remote_url_as_path():
     provider._client.post.assert_called_once_with("/api/v1/resources", {
         "path": "https://example.com/doc.md",
     })
+
+
+def test_viking_client_upload_temp_file_uses_multipart_identity_headers(tmp_path, monkeypatch):
+    sample = tmp_path / "sample.md"
+    sample.write_text("# Local resource\n", encoding="utf-8")
+    client = _VikingClient(
+        "https://example.com",
+        api_key="test-key",
+        account="test-account",
+        user="test-user",
+        agent="test-agent",
+    )
+    captured_kwargs = {}
+
+    def capture_httpx_post(url, **kwargs):
+        captured_kwargs.update(kwargs)
+        return SimpleNamespace(
+            status_code=200,
+            text="",
+            json=lambda: {"status": "ok", "result": {"temp_file_id": "upload_sample.md"}},
+            raise_for_status=lambda: None,
+        )
+
+    monkeypatch.setattr(client._httpx, "post", capture_httpx_post)
+
+    assert client.upload_temp_file(sample) == "upload_sample.md"
+
+    assert "files" in captured_kwargs
+    assert "json" not in captured_kwargs
+    headers = captured_kwargs["headers"]
+    assert headers["X-OpenViking-Account"] == "test-account"
+    assert headers["X-OpenViking-User"] == "test-user"
+    assert headers["X-OpenViking-Agent"] == "test-agent"
+    assert headers["X-API-Key"] == "test-key"
+    assert "Content-Type" not in headers
 
 
 def test_viking_client_raises_structured_server_error():

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1,7 +1,10 @@
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from plugins.memory.openviking import OpenVikingMemoryProvider
+import pytest
+
+from plugins.memory.openviking import OpenVikingMemoryProvider, _VikingClient
 
 
 def test_tool_search_sorts_by_raw_score_across_buckets():
@@ -60,3 +63,66 @@ def test_tool_search_sorts_missing_raw_score_after_negative_scores():
     ]
     assert [entry["score"] for entry in result["results"]] == [0.1, 0.0, -0.25]
     assert result["total"] == 3
+
+
+def test_tool_add_resource_uploads_existing_local_file(tmp_path):
+    sample = tmp_path / "sample.md"
+    sample.write_text("# Local resource\n", encoding="utf-8")
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.upload_temp_file.return_value = "upload_sample.md"
+    provider._client.post.return_value = {
+        "status": "ok",
+        "result": {"root_uri": "viking://resources/sample"},
+    }
+
+    result = json.loads(provider._tool_add_resource({
+        "url": str(sample),
+        "reason": "local test",
+        "wait": True,
+    }))
+
+    provider._client.upload_temp_file.assert_called_once_with(sample)
+    provider._client.post.assert_called_once_with("/api/v1/resources", {
+        "reason": "local test",
+        "wait": True,
+        "source_name": "sample.md",
+        "temp_file_id": "upload_sample.md",
+    })
+    assert result["status"] == "added"
+    assert result["root_uri"] == "viking://resources/sample"
+
+
+def test_tool_add_resource_sends_remote_url_as_path():
+    provider = OpenVikingMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.post.return_value = {
+        "status": "ok",
+        "result": {"root_uri": "viking://resources/remote"},
+    }
+
+    provider._tool_add_resource({"url": "https://example.com/doc.md"})
+
+    provider._client.upload_temp_file.assert_not_called()
+    provider._client.post.assert_called_once_with("/api/v1/resources", {
+        "path": "https://example.com/doc.md",
+    })
+
+
+def test_viking_client_raises_structured_server_error():
+    client = _VikingClient.__new__(_VikingClient)
+    response = SimpleNamespace(
+        status_code=403,
+        text='{"status":"error"}',
+        json=lambda: {
+            "status": "error",
+            "error": {
+                "code": "PERMISSION_DENIED",
+                "message": "direct host filesystem paths are not allowed",
+            },
+        },
+        raise_for_status=lambda: None,
+    )
+
+    with pytest.raises(RuntimeError, match="PERMISSION_DENIED"):
+        client._parse_response(response)


### PR DESCRIPTION
Salvage of #19569 (which builds on #10360) onto current main.

## Summary

Makes `viking_add_resource` work with local files and directories by uploading them through OpenViking's `temp_upload` endpoint, instead of posting the host path and getting `PERMISSION_DENIED: direct host filesystem paths are not allowed`.

## Changes

- `plugins/memory/openviking/__init__.py`
  - `_VikingClient` gains `upload_temp_file()` (multipart, identity headers preserved, httpx sets Content-Type)
  - `_VikingClient._parse_response()` surfaces OpenViking's structured `{error: {code, message}}` errors as `RuntimeError("CODE: message")`
  - `_tool_add_resource` routes local files / directories / `file://` URIs through `temp_upload`, zips directories (cleaned up in `finally`), and returns a clear error for missing local paths. Git/SSH/HTTP(S) remotes continue to hit `/api/v1/resources` directly
  - `ADD_RESOURCE_SCHEMA` gains optional `to`, `parent`, `instruction`, `wait`, `timeout` fields; docstring updated
- `tests/plugins/memory/test_openviking_provider.py` — +9 tests covering local file, file:// URI, directory zip + cleanup on success/upload-failure/add-failure, missing local path, remote URL pass-through, parametrized git/ssh remotes, multipart identity headers, structured server error parsing

## Attribution

- @ggnnggez — core local-upload implementation (cherry-picked from #10360)
- @ehz0ah — hardening commits (structured error parsing, file:// URI support, missing-path rejection, git remote pass-through, zip cleanup, multipart identity headers) and expanded test coverage

Both authorships preserved via rebase-merge.

## Validation

```
scripts/run_tests.sh tests/plugins/memory/test_openviking_provider.py
15 passed in 1.09s
```

## Follow-ups

- `scripts/release.py` AUTHOR_MAP entries added for `thunderggnn@gmail.com` (ggnnggez) and `haozhe4547@gmail.com` (ehz0ah).

Closes #19569
Closes #10360