### PR TITLE
feat(agent): per-operation retry limit + setup wizard surface (salvage #18585)

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -76,12 +76,25 @@ class ToolCallGuardrailConfig:
     same_tool_failure_halt_after: int = 8
     no_progress_warn_after: int = 2
     no_progress_block_after: int = 5
+    # Per-operation retry limit: blocks when the exact same tool+args call has
+    # been made (regardless of outcome) more than this many consecutive times.
+    # 0 = disabled.  When set via the ``max_consecutive_identical_calls`` alias,
+    # hard_stop_enabled is auto-enabled.
+    consecutive_identical_block_after: int = 0
     idempotent_tools: frozenset[str] = field(default_factory=lambda: IDEMPOTENT_TOOL_NAMES)
     mutating_tools: frozenset[str] = field(default_factory=lambda: MUTATING_TOOL_NAMES)
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any] | None) -> "ToolCallGuardrailConfig":
-        """Build config from the `tool_loop_guardrails` config.yaml section."""
+        """Build config from the `tool_loop_guardrails` config.yaml section.
+
+        Supports user-friendly aliases (from issue #18504):
+        - ``max_retries_per_operation``: sets ``exact_failure_block_after`` and
+          auto-enables ``hard_stop_enabled`` when present.
+        - ``max_consecutive_identical_calls``: sets
+          ``consecutive_identical_block_after`` and auto-enables
+          ``hard_stop_enabled`` when present.
+        """
         if not isinstance(data, Mapping):
             return cls()
 
@@ -93,9 +106,33 @@ class ToolCallGuardrailConfig:
             hard_stop_after = {}
 
         defaults = cls()
+
+        # --- user-friendly aliases from issue #18504 ---
+        max_retries = _nonneg_int_or_none(data.get("max_retries_per_operation"))
+        max_consec = _nonneg_int_or_none(data.get("max_consecutive_identical_calls"))
+
+        hard_stop = _as_bool(data.get("hard_stop_enabled"), defaults.hard_stop_enabled)
+        if max_retries is not None or max_consec is not None:
+            hard_stop = True
+
+        exact_failure_block = _positive_int(
+            hard_stop_after.get("exact_failure", data.get("exact_failure_block_after")),
+            defaults.exact_failure_block_after,
+        )
+        if max_retries is not None and max_retries > 0:
+            exact_failure_block = max_retries
+
+        consec_block = _nonneg_int_or_none(
+            hard_stop_after.get("consecutive_identical", data.get("consecutive_identical_block_after"))
+        )
+        if consec_block is None:
+            consec_block = defaults.consecutive_identical_block_after
+        if max_consec is not None:
+            consec_block = max_consec
+
         return cls(
             warnings_enabled=_as_bool(data.get("warnings_enabled"), defaults.warnings_enabled),
-            hard_stop_enabled=_as_bool(data.get("hard_stop_enabled"), defaults.hard_stop_enabled),
+            hard_stop_enabled=hard_stop,
             exact_failure_warn_after=_positive_int(
                 warn_after.get("exact_failure", data.get("exact_failure_warn_after")),
                 defaults.exact_failure_warn_after,
@@ -108,10 +145,7 @@ class ToolCallGuardrailConfig:
                 warn_after.get("idempotent_no_progress", data.get("no_progress_warn_after")),
                 defaults.no_progress_warn_after,
             ),
-            exact_failure_block_after=_positive_int(
-                hard_stop_after.get("exact_failure", data.get("exact_failure_block_after")),
-                defaults.exact_failure_block_after,
-            ),
+            exact_failure_block_after=exact_failure_block,
             same_tool_failure_halt_after=_positive_int(
                 hard_stop_after.get("same_tool_failure", data.get("same_tool_failure_halt_after")),
                 defaults.same_tool_failure_halt_after,
@@ -120,6 +154,7 @@ class ToolCallGuardrailConfig:
                 hard_stop_after.get("idempotent_no_progress", data.get("no_progress_block_after")),
                 defaults.no_progress_block_after,
             ),
+            consecutive_identical_block_after=consec_block,
         )
 
 
@@ -229,6 +264,7 @@ class ToolCallGuardrailController:
         self._exact_failure_counts: dict[ToolCallSignature, int] = {}
         self._same_tool_failure_counts: dict[str, int] = {}
         self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._consecutive_calls: list[ToolCallSignature] = []
         self._halt_decision: ToolGuardrailDecision | None = None
 
     @property
@@ -277,6 +313,31 @@ class ToolCallGuardrailController:
                     self._halt_decision = decision
                     return decision
 
+        # Consecutive identical call circuit breaker (issue #18504)
+        consec_limit = self.config.consecutive_identical_block_after
+        if consec_limit > 0:
+            run_length = 0
+            for prev in reversed(self._consecutive_calls):
+                if prev == signature:
+                    run_length += 1
+                else:
+                    break
+            if run_length >= consec_limit:
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="consecutive_identical_call_block",
+                    message=(
+                        f"Blocked {tool_name}: the same tool call has been made "
+                        f"{run_length} times consecutively. Stop retrying and report "
+                        "the failure to the user, or change your approach."
+                    ),
+                    tool_name=tool_name,
+                    count=run_length,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
+
         return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
     def after_call(
@@ -289,6 +350,10 @@ class ToolCallGuardrailController:
     ) -> ToolGuardrailDecision:
         args = _coerce_args(args)
         signature = ToolCallSignature.from_call(tool_name, args)
+
+        # Track consecutive identical calls (issue #18504)
+        self._consecutive_calls.append(signature)
+
         if failed is None:
             failed, _ = classify_tool_failure(tool_name, result)
 
@@ -449,6 +514,17 @@ def _positive_int(value: Any, default: int) -> int:
     except (TypeError, ValueError):
         return default
     return parsed if parsed >= 1 else default
+
+
+def _nonneg_int_or_none(value: Any) -> int | None:
+    """Parse a non-negative integer, returning None if absent or unparseable."""
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
 
 
 def _sha256(value: str) -> str:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -308,9 +308,15 @@ browser:
 # or non-progressing tool results but still let the tool execute. Hard stops are
 # opt-in circuit breakers for autonomous/cron sessions where stopping a loop is
 # preferable to spending the full iteration budget.
+#
+# User-friendly aliases (auto-enable hard_stop_enabled when set):
+#   max_retries_per_operation: 3         # block same tool+args after 3 failures
+#   max_consecutive_identical_calls: 3   # block after 3 identical calls in a row
 tool_loop_guardrails:
   warnings_enabled: true
   hard_stop_enabled: false
+  # max_retries_per_operation: 3         # alias for hard_stop_after.exact_failure
+  # max_consecutive_identical_calls: 3   # consecutive identical call circuit breaker
   warn_after:
     exact_failure: 2
     same_tool_failure: 3
@@ -319,6 +325,7 @@ tool_loop_guardrails:
     exact_failure: 5
     same_tool_failure: 8
     idempotent_no_progress: 5
+    consecutive_identical: 0             # 0 = disabled
 
 # =============================================================================
 # Context Compression (Auto-shrinks long conversations)

--- a/environments/agent_loop.py
+++ b/environments/agent_loop.py
@@ -23,6 +23,14 @@ from typing import Any, Dict, List, Optional, Set
 from model_tools import handle_function_call
 from tools.terminal_tool import get_active_env
 from tools.tool_result_storage import maybe_persist_tool_result, enforce_turn_budget
+from agent.tool_guardrails import (
+    ToolCallGuardrailConfig,
+    ToolCallGuardrailController,
+    ToolGuardrailDecision,
+    append_toolguard_guidance,
+    classify_tool_failure,
+    toolguard_synthetic_result,
+)
 
 # Thread pool for running sync tool calls that internally use asyncio.run()
 # (e.g., the Modal/Docker/Daytona terminal backends). Running them in a separate
@@ -141,6 +149,7 @@ class HermesAgentLoop:
         max_tokens: Optional[int] = None,
         extra_body: Optional[Dict[str, Any]] = None,
         budget_config: Optional["BudgetConfig"] = None,
+        guardrail_config: Optional[ToolCallGuardrailConfig] = None,
     ):
         """
         Initialize the agent loop.
@@ -160,6 +169,10 @@ class HermesAgentLoop:
             budget_config: Tool result persistence budget. Controls per-tool
                         thresholds, per-turn aggregate budget, and preview size.
                         If None, uses DEFAULT_BUDGET (current hardcoded values).
+            guardrail_config: Per-turn tool-call loop guardrail config.  Controls
+                        repeated-failure blocking and consecutive-call circuit
+                        breakers.  If None, uses ToolCallGuardrailConfig defaults
+                        (soft warnings only).
         """
         from tools.budget_config import DEFAULT_BUDGET
         self.server = server
@@ -171,6 +184,7 @@ class HermesAgentLoop:
         self.max_tokens = max_tokens
         self.extra_body = extra_body
         self.budget_config = budget_config or DEFAULT_BUDGET
+        self.guardrail_config = guardrail_config
 
     async def run(self, messages: List[Dict[str, Any]]) -> AgentResult:
         """
@@ -185,6 +199,7 @@ class HermesAgentLoop:
         """
         reasoning_per_turn = []
         tool_errors: List[ToolError] = []
+        guardrails = ToolCallGuardrailController(self.guardrail_config)
 
         # Per-loop TodoStore for the todo tool (ephemeral, dies with the loop)
         from tools.todo_tool import TodoStore, todo_tool as _todo_tool
@@ -375,68 +390,88 @@ class HermesAgentLoop:
 
                         # Dispatch tool only if arguments parsed successfully
                         if args is not None:
-                            try:
-                                if tool_name == "terminal":
-                                    backend = os.getenv("TERMINAL_ENV", "local")
-                                    cmd_preview = args.get("command", "")[:80]
-                                    logger.info(
-                                        "[%s] $ %s", self.task_id[:8], cmd_preview,
-                                    )
-
-                                tool_submit_time = _time.monotonic()
-
-                                # Todo tool -- handle locally (needs per-loop TodoStore)
-                                if tool_name == "todo":
-                                    tool_result = _todo_tool(
-                                        todos=args.get("todos"),
-                                        merge=args.get("merge", False),
-                                        store=_todo_store,
-                                    )
-                                    tool_elapsed = _time.monotonic() - tool_submit_time
-                                elif tool_name == "memory":
-                                    tool_result = json.dumps({"error": "Memory is not available in RL environments."})
-                                    tool_elapsed = _time.monotonic() - tool_submit_time
-                                elif tool_name == "session_search":
-                                    tool_result = json.dumps({"error": "Session search is not available in RL environments."})
-                                    tool_elapsed = _time.monotonic() - tool_submit_time
-                                else:
-                                    # Run tool calls in a thread pool so backends that
-                                    # use asyncio.run() internally (modal, docker, daytona) get
-                                    # a clean event loop instead of deadlocking.
-                                    loop = asyncio.get_event_loop()
-                                    # Capture current tool_name/args for the lambda
-                                    _tn, _ta, _tid = tool_name, args, self.task_id
-                                    tool_result = await loop.run_in_executor(
-                                        _tool_executor,
-                                        lambda: handle_function_call(
-                                            _tn, _ta, task_id=_tid,
-                                            user_task=_user_task,
-                                        ),
-                                    )
-                                    tool_elapsed = _time.monotonic() - tool_submit_time
-
-                                # Log slow tools and thread pool stats for debugging
-                                pool_active = _tool_executor._work_queue.qsize()
-                                if tool_elapsed > 30:
-                                    logger.warning(
-                                        "[%s] turn %d: %s took %.1fs (pool queue=%d)",
-                                        self.task_id[:8], turn + 1, tool_name,
-                                        tool_elapsed, pool_active,
-                                    )
-                            except Exception as e:
-                                tool_result = json.dumps(
-                                    {"error": f"Tool execution failed: {type(e).__name__}: {str(e)}"}
+                            # Pre-execution guardrail check
+                            guard_decision = guardrails.before_call(tool_name, args)
+                            if not guard_decision.allows_execution:
+                                tool_result = toolguard_synthetic_result(guard_decision)
+                                logger.info(
+                                    "[%s] turn %d: guardrail blocked %s (%s)",
+                                    self.task_id[:8], turn + 1,
+                                    tool_name, guard_decision.code,
                                 )
-                                tool_errors.append(ToolError(
-                                    turn=turn + 1, tool_name=tool_name,
-                                    arguments=tool_args_raw[:200],
-                                    error=f"{type(e).__name__}: {str(e)}",
-                                    tool_result=tool_result,
-                                ))
-                                logger.error(
-                                    "Tool '%s' execution failed on turn %d: %s",
-                                    tool_name, turn + 1, e,
+                            else:
+                                try:
+                                    if tool_name == "terminal":
+                                        backend = os.getenv("TERMINAL_ENV", "local")
+                                        cmd_preview = args.get("command", "")[:80]
+                                        logger.info(
+                                            "[%s] $ %s", self.task_id[:8], cmd_preview,
+                                        )
+
+                                    tool_submit_time = _time.monotonic()
+
+                                    # Todo tool -- handle locally (needs per-loop TodoStore)
+                                    if tool_name == "todo":
+                                        tool_result = _todo_tool(
+                                            todos=args.get("todos"),
+                                            merge=args.get("merge", False),
+                                            store=_todo_store,
+                                        )
+                                        tool_elapsed = _time.monotonic() - tool_submit_time
+                                    elif tool_name == "memory":
+                                        tool_result = json.dumps({"error": "Memory is not available in RL environments."})
+                                        tool_elapsed = _time.monotonic() - tool_submit_time
+                                    elif tool_name == "session_search":
+                                        tool_result = json.dumps({"error": "Session search is not available in RL environments."})
+                                        tool_elapsed = _time.monotonic() - tool_submit_time
+                                    else:
+                                        # Run tool calls in a thread pool so backends that
+                                        # use asyncio.run() internally (modal, docker, daytona) get
+                                        # a clean event loop instead of deadlocking.
+                                        loop = asyncio.get_event_loop()
+                                        # Capture current tool_name/args for the lambda
+                                        _tn, _ta, _tid = tool_name, args, self.task_id
+                                        tool_result = await loop.run_in_executor(
+                                            _tool_executor,
+                                            lambda: handle_function_call(
+                                                _tn, _ta, task_id=_tid,
+                                                user_task=_user_task,
+                                            ),
+                                        )
+                                        tool_elapsed = _time.monotonic() - tool_submit_time
+
+                                    # Log slow tools and thread pool stats for debugging
+                                    pool_active = _tool_executor._work_queue.qsize()
+                                    if tool_elapsed > 30:
+                                        logger.warning(
+                                            "[%s] turn %d: %s took %.1fs (pool queue=%d)",
+                                            self.task_id[:8], turn + 1, tool_name,
+                                            tool_elapsed, pool_active,
+                                        )
+                                except Exception as e:
+                                    tool_result = json.dumps(
+                                        {"error": f"Tool execution failed: {type(e).__name__}: {str(e)}"}
+                                    )
+                                    tool_errors.append(ToolError(
+                                        turn=turn + 1, tool_name=tool_name,
+                                        arguments=tool_args_raw[:200],
+                                        error=f"{type(e).__name__}: {str(e)}",
+                                        tool_result=tool_result,
+                                    ))
+                                    logger.error(
+                                        "Tool '%s' execution failed on turn %d: %s",
+                                        tool_name, turn + 1, e,
+                                    )
+
+                                # Post-execution guardrail observation
+                                failed, _ = classify_tool_failure(tool_name, tool_result)
+                                after_decision = guardrails.after_call(
+                                    tool_name, args, tool_result, failed=failed,
                                 )
+                                if after_decision.action in {"warn", "halt"}:
+                                    tool_result = append_toolguard_guidance(
+                                        tool_result, after_decision,
+                                    )
 
                         # Also check if the tool returned an error in its JSON result
                         try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -646,6 +646,11 @@ DEFAULT_CONFIG = {
     # Tool loop guardrails nudge models when they repeat failed or
     # non-progressing tool calls. Soft warnings are always-on by default;
     # hard stops are opt-in so interactive CLI/TUI sessions keep flowing.
+    #
+    # User-friendly aliases (see issue #18504):
+    #   max_retries_per_operation: 3         # → exact_failure hard stop after 3
+    #   max_consecutive_identical_calls: 3   # → consecutive call circuit breaker
+    # Setting either alias auto-enables hard_stop_enabled.
     "tool_loop_guardrails": {
         "warnings_enabled": True,
         "hard_stop_enabled": False,
@@ -658,6 +663,7 @@ DEFAULT_CONFIG = {
             "exact_failure": 5,
             "same_tool_failure": 8,
             "idempotent_no_progress": 5,
+            "consecutive_identical": 0,
         },
     },
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1720,6 +1720,67 @@ def setup_agent_settings(config: dict):
     except ValueError:
         print_warning("Invalid number, keeping current value")
 
+    # ── Tool Loop Guardrails ──
+    # Circuit breakers that stop the agent from burning iterations on a broken
+    # tool call. Separate from max_iterations (which is a hard ceiling) — these
+    # fire earlier and force the agent to report the failure instead of
+    # retrying blindly. See issue #18504.
+    print_info("")
+    print_info("Tool Loop Guardrails")
+    print_info(
+        "Stop the agent retrying the same failing tool call forever. "
+        "Fires before the iteration ceiling and reports the failure."
+    )
+    print_info("  Leave either at 0 to disable.")
+
+    guardrails_cfg = config.setdefault("tool_loop_guardrails", {})
+    current_retries = guardrails_cfg.get("max_retries_per_operation", 0)
+    current_consec = guardrails_cfg.get("max_consecutive_identical_calls", 0)
+
+    retries_str = prompt(
+        "Max retries per failing tool+args (0 = disabled)",
+        str(current_retries),
+    )
+    try:
+        retries_val = int(retries_str)
+        if retries_val < 0:
+            retries_val = 0
+        if retries_val > 0:
+            guardrails_cfg["max_retries_per_operation"] = retries_val
+            guardrails_cfg["hard_stop_enabled"] = True
+        else:
+            guardrails_cfg.pop("max_retries_per_operation", None)
+    except ValueError:
+        print_warning("Invalid number, skipping max_retries_per_operation")
+
+    consec_str = prompt(
+        "Max consecutive identical calls (0 = disabled)",
+        str(current_consec),
+    )
+    try:
+        consec_val = int(consec_str)
+        if consec_val < 0:
+            consec_val = 0
+        if consec_val > 0:
+            guardrails_cfg["max_consecutive_identical_calls"] = consec_val
+            guardrails_cfg["hard_stop_enabled"] = True
+        else:
+            guardrails_cfg.pop("max_consecutive_identical_calls", None)
+    except ValueError:
+        print_warning("Invalid number, skipping max_consecutive_identical_calls")
+
+    _retries_final = guardrails_cfg.get("max_retries_per_operation", 0)
+    _consec_final = guardrails_cfg.get("max_consecutive_identical_calls", 0)
+    if _retries_final or _consec_final:
+        _parts = []
+        if _retries_final:
+            _parts.append(f"retries/op={_retries_final}")
+        if _consec_final:
+            _parts.append(f"consecutive={_consec_final}")
+        print_success(f"Tool loop guardrails: {', '.join(_parts)}")
+    else:
+        print_info("Tool loop guardrails: disabled (soft warnings only).")
+
     # ── Tool Progress Display ──
     print_info("")
     print_info("Tool Progress Display")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -49,6 +49,7 @@ AUTHOR_MAP = {
     "piyushvp1@gmail.com": "thelumiereguy",
     "harish.kukreja@gmail.com": "counterposition",
     "cleo@edaphic.xyz": "curiouscleo",
+    "altriatree@gmail.com": "TruaShamu",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
     "128259593+Gutslabs@users.noreply.github.com": "Gutslabs",
     "159539633+MottledShadow@users.noreply.github.com": "MottledShadow",

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -236,3 +236,147 @@ def test_reset_for_turn_clears_bounded_guardrail_state():
 
     assert controller.before_call("web_search", {"query": "same"}).action == "allow"
     assert controller.before_call("read_file", {"path": "/tmp/x"}).action == "allow"
+
+
+# ── Consecutive identical call tests (issue #18504) ──────────────────────
+
+
+def test_consecutive_identical_calls_disabled_by_default():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True)
+    )
+    args = {"command": "git pull"}
+    for _ in range(20):
+        assert controller.before_call("terminal", args).action == "allow"
+        controller.after_call("terminal", args, '{"exit_code":0}', failed=False)
+
+
+def test_consecutive_identical_calls_blocks_after_limit():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            consecutive_identical_block_after=3,
+            exact_failure_block_after=99,
+        )
+    )
+    args = {"command": "git pull"}
+
+    for _ in range(3):
+        assert controller.before_call("terminal", args).action == "allow"
+        controller.after_call("terminal", args, '{"exit_code":1}', failed=True)
+
+    blocked = controller.before_call("terminal", args)
+    assert blocked.action == "block"
+    assert blocked.code == "consecutive_identical_call_block"
+    assert blocked.count == 3
+
+
+def test_consecutive_identical_calls_resets_on_different_call():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            consecutive_identical_block_after=3,
+            exact_failure_block_after=99,
+        )
+    )
+    args_a = {"command": "git pull"}
+    args_b = {"command": "git status"}
+
+    controller.after_call("terminal", args_a, '{"exit_code":1}', failed=True)
+    controller.after_call("terminal", args_a, '{"exit_code":1}', failed=True)
+    # Interrupt the streak with a different call
+    controller.after_call("terminal", args_b, '{"exit_code":0}', failed=False)
+    controller.after_call("terminal", args_a, '{"exit_code":1}', failed=True)
+    controller.after_call("terminal", args_a, '{"exit_code":1}', failed=True)
+
+    # Only 2 consecutive identical calls (after the interruption)
+    assert controller.before_call("terminal", args_a).action == "allow"
+
+
+def test_consecutive_identical_calls_counts_success_too():
+    """max_consecutive_identical_calls blocks regardless of outcome."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            consecutive_identical_block_after=3,
+            exact_failure_block_after=99,
+        )
+    )
+    args = {"query": "weather"}
+
+    for _ in range(3):
+        assert controller.before_call("web_search", args).action == "allow"
+        controller.after_call("web_search", args, '{"result":"sunny"}', failed=False)
+
+    blocked = controller.before_call("web_search", args)
+    assert blocked.action == "block"
+    assert blocked.code == "consecutive_identical_call_block"
+
+
+def test_consecutive_identical_calls_cleared_by_reset_for_turn():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True,
+            consecutive_identical_block_after=2,
+        )
+    )
+    args = {"command": "git pull"}
+
+    controller.after_call("terminal", args, '{"exit_code":1}', failed=True)
+    controller.after_call("terminal", args, '{"exit_code":1}', failed=True)
+    assert controller.before_call("terminal", args).action == "block"
+
+    controller.reset_for_turn()
+    assert controller.before_call("terminal", args).action == "allow"
+
+
+# ── Config alias tests (issue #18504) ────────────────────────────────────
+
+
+def test_max_retries_per_operation_alias_sets_exact_failure_block_and_enables_hard_stop():
+    cfg = ToolCallGuardrailConfig.from_mapping({
+        "max_retries_per_operation": 3,
+    })
+    assert cfg.hard_stop_enabled is True
+    assert cfg.exact_failure_block_after == 3
+
+
+def test_max_consecutive_identical_calls_alias_sets_field_and_enables_hard_stop():
+    cfg = ToolCallGuardrailConfig.from_mapping({
+        "max_consecutive_identical_calls": 4,
+    })
+    assert cfg.hard_stop_enabled is True
+    assert cfg.consecutive_identical_block_after == 4
+
+
+def test_both_aliases_together():
+    cfg = ToolCallGuardrailConfig.from_mapping({
+        "max_retries_per_operation": 2,
+        "max_consecutive_identical_calls": 3,
+    })
+    assert cfg.hard_stop_enabled is True
+    assert cfg.exact_failure_block_after == 2
+    assert cfg.consecutive_identical_block_after == 3
+
+
+def test_aliases_zero_disables():
+    cfg = ToolCallGuardrailConfig.from_mapping({
+        "max_retries_per_operation": 0,
+        "max_consecutive_identical_calls": 0,
+    })
+    # hard_stop still auto-enabled since the keys are present
+    assert cfg.hard_stop_enabled is True
+    # but 0 means the exact_failure_block stays at default (alias val=0 → keep default)
+    assert cfg.exact_failure_block_after == 5  # default
+    assert cfg.consecutive_identical_block_after == 0  # 0 = disabled
+
+
+def test_explicit_hard_stop_after_overrides_alias():
+    cfg = ToolCallGuardrailConfig.from_mapping({
+        "max_retries_per_operation": 3,
+        "hard_stop_after": {
+            "same_tool_failure": 5,
+        },
+    })
+    assert cfg.exact_failure_block_after == 3  # from alias
+    assert cfg.same_tool_failure_halt_after == 5  # from explicit

--- a/tests/hermes_cli/test_setup_agent_settings.py
+++ b/tests/hermes_cli/test_setup_agent_settings.py
@@ -19,7 +19,7 @@ def test_setup_agent_settings_uses_displayed_max_iterations_value(tmp_path, monk
         "session_reset": {"mode": "both", "idle_minutes": 1440, "at_hour": 4},
     }
 
-    prompt_answers = iter(["60", "all", "0.5"])
+    prompt_answers = iter(["60", "0", "0", "all", "0.5"])
 
     monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: next(prompt_answers))
     monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 4)
@@ -50,7 +50,7 @@ def test_setup_agent_settings_prefers_config_over_stale_env(tmp_path, monkeypatc
         "session_reset": {"mode": "both", "idle_minutes": 1440, "at_hour": 4},
     }
 
-    prompt_answers = iter(["500", "all", "0.5"])
+    prompt_answers = iter(["500", "0", "0", "all", "0.5"])
 
     # Simulate stale .env value — the wizard must ignore this.
     monkeypatch.setattr(
@@ -76,3 +76,64 @@ def test_setup_agent_settings_prefers_config_over_stale_env(tmp_path, monkeypatc
     assert "Press Enter to keep 60." not in out
     # And the stale .env entry gets cleaned up
     assert "HERMES_MAX_ITERATIONS" in removed_keys
+
+
+def test_setup_agent_settings_writes_tool_loop_guardrail_aliases(tmp_path, monkeypatch, capsys):
+    """The wizard's guardrail prompts persist both aliases and auto-enable hard_stop."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config = {
+        "agent": {"max_turns": 90},
+        "display": {"tool_progress": "all"},
+        "compression": {"threshold": 0.50},
+        "session_reset": {"mode": "both", "idle_minutes": 1440, "at_hour": 4},
+    }
+
+    # Answers: max_iter, max_retries_per_operation, max_consecutive_identical_calls,
+    # tool_progress, compression_threshold
+    prompt_answers = iter(["90", "3", "5", "all", "0.5"])
+
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: next(prompt_answers))
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 4)
+    monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.setup.remove_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.setup.save_config", lambda *args, **kwargs: None)
+
+    setup_agent_settings(config)
+
+    guardrails = config.get("tool_loop_guardrails", {})
+    assert guardrails.get("max_retries_per_operation") == 3
+    assert guardrails.get("max_consecutive_identical_calls") == 5
+    assert guardrails.get("hard_stop_enabled") is True
+
+
+def test_setup_agent_settings_zero_guardrail_values_remove_keys(tmp_path, monkeypatch, capsys):
+    """Entering 0 should remove any previously-set alias keys."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    # Pre-existing guardrail config the user is disabling
+    config = {
+        "agent": {"max_turns": 90},
+        "display": {"tool_progress": "all"},
+        "compression": {"threshold": 0.50},
+        "session_reset": {"mode": "both", "idle_minutes": 1440, "at_hour": 4},
+        "tool_loop_guardrails": {
+            "max_retries_per_operation": 3,
+            "max_consecutive_identical_calls": 3,
+            "hard_stop_enabled": True,
+        },
+    }
+
+    prompt_answers = iter(["90", "0", "0", "all", "0.5"])
+
+    monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: next(prompt_answers))
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", lambda *args, **kwargs: 4)
+    monkeypatch.setattr("hermes_cli.setup.save_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.setup.remove_env_value", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.setup.save_config", lambda *args, **kwargs: None)
+
+    setup_agent_settings(config)
+
+    guardrails = config.get("tool_loop_guardrails", {})
+    assert "max_retries_per_operation" not in guardrails
+    assert "max_consecutive_identical_calls" not in guardrails


### PR DESCRIPTION
Salvage of #18585 (@TruaShamu / Sofia Yang) onto current main, plus a setup-wizard surface so users discover the new knobs without reading config.yaml.

## What this PR makes true
- `hermes setup` now prompts for `max_retries_per_operation` and `max_consecutive_identical_calls` in the Agent Settings section.
- `tool_loop_guardrails` config gains two user-friendly aliases that auto-enable `hard_stop_enabled`, surfacing the existing circuit-breaker behavior without requiring users to learn the nested `hard_stop_after.*` schema.
- A new `consecutive_identical_block_after` guardrail blocks when the same tool+args call has been made N times consecutively, regardless of success/failure — catches stuck retry loops that `exact_failure_block_after` misses.

## Changes

Contributor commit (cherry-picked, authorship preserved):
- `agent/tool_guardrails.py`: `consecutive_identical_block_after` field + `_consecutive_calls` tracker, alias parsing in `from_mapping()`, `_nonneg_int_or_none` helper.
- `hermes_cli/config.py`: documented aliases, added `consecutive_identical` to `hard_stop_after` defaults.
- `environments/agent_loop.py`: wires `ToolCallGuardrailController` into the RL agent loop (pre/post-call hooks around tool dispatch).
- `cli-config.yaml.example`: commented-out alias examples.
- `tests/agent/test_tool_guardrails.py`: 10 new tests.

Follow-up commit (ours):
- `hermes_cli/setup.py`: new Tool Loop Guardrails prompt block in `setup_agent_settings` (0 = disabled and pops the key, non-zero auto-enables `hard_stop_enabled`).
- `tests/hermes_cli/test_setup_agent_settings.py`: 2 new tests covering the alias write-through and the 0-removes-keys path; existing tests updated for the extra prompts.
- `scripts/release.py`: AUTHOR_MAP entry for the contributor.

## Validation
- `tests/agent/test_tool_guardrails.py`: 22/22 pass (12 existing + 10 new).
- `tests/hermes_cli/test_setup_agent_settings.py`: 4/4 pass (2 existing + 2 new).
- `tests/run_agent/test_tool_call_guardrail_runtime.py`: 7/7 pass.
- E2E: wizard-shaped config → `ToolCallGuardrailConfig.from_mapping()` → live controller firing both breakers at the configured thresholds.

Closes #18504. Credits @TruaShamu.