### PR TITLE
feat: 4 Anthropic-inspired agent features (Dreaming, Outcomes, Orchestration, Webhooks)

### DIFF
--- a/agent/dream_engine.py
+++ b/agent/dream_engine.py
@@ -1,0 +1,525 @@
+"""DreamEngine — session review and memory consolidation.
+
+Periodically "dreams" through recent sessions to extract durable insights
+and consolidate them into the persistent memory files (MEMORY.md / USER.md).
+
+Inspired by how sleep consolidates memories in biological systems: the agent
+reviews its recent conversations, identifies patterns and lessons learned,
+and writes the most valuable ones to long-term memory.
+
+Architecture:
+    DreamEngine.gather_sessions()  — query SessionDB for recent sessions
+    DreamEngine.extract_insights() — build a review prompt from sessions
+    DreamEngine.run_dream()        — execute dream via AIAgent with memory toolset
+    DreamEngine.apply_consolidation() — parse and write insights to memory files
+
+Integration points:
+    - tools/dream_tool.py — user-facing 'dream' tool (run, config, history)
+    - cron/scheduler.py   — dream-type jobs route through DreamEngine
+    - cron/jobs.py         — dream jobs auto-set enabled_toolsets=['memory']
+"""
+
+import json
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# Dream history file — tracks past dream runs for the 'history' action.
+_DREAM_HISTORY_FILE = get_hermes_home() / "cron" / "dream_history.json"
+
+# Maximum characters of session content to include in the review prompt.
+# Keeps the dream prompt under the model's context window.
+_MAX_SESSION_CONTENT_CHARS = 4000
+
+# Maximum number of user/assistant message pairs to extract per session.
+_MAX_MESSAGES_PER_SESSION = 20
+
+
+class DreamEngine:
+    """Session review and memory consolidation engine.
+
+    Gathers recent session transcripts, builds a review prompt, runs an
+    AIAgent with the memory toolset to extract insights, and applies
+    the consolidation results to MEMORY.md / USER.md.
+    """
+
+    def __init__(self, session_db=None):
+        """Initialize the DreamEngine.
+
+        Args:
+            session_db: Optional SessionDB instance. If None, a new one is
+                        created lazily on first use.
+        """
+        self._session_db = session_db
+
+    def _get_session_db(self):
+        """Return the SessionDB, creating one if needed."""
+        if self._session_db is None:
+            from hermes_state import SessionDB
+            self._session_db = SessionDB()
+        return self._session_db
+
+    def gather_sessions(
+        self,
+        hours: int = 24,
+        limit: int = 20,
+        exclude_sources: Optional[List[str]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Query SessionDB for recent sessions within the time window.
+
+        Args:
+            hours: How many hours back to look (default 24).
+            limit: Maximum number of sessions to return (default 20).
+            exclude_sources: Session sources to exclude (e.g. ['cron']).
+
+        Returns:
+            List of session dicts with id, source, title, message_count,
+            and a 'messages' key containing the conversation transcript.
+        """
+        db = self._get_session_db()
+        cutoff_ts = time.time() - (hours * 3600)
+
+        # Use search_sessions to get recent sessions, then filter by time.
+        sessions = db.search_sessions(limit=limit * 2)  # over-fetch for filtering
+
+        recent = []
+        for s in sessions:
+            # Filter by time window
+            started_at = s.get("started_at", 0)
+            if started_at < cutoff_ts:
+                continue
+
+            # Filter out excluded sources
+            source = s.get("source", "")
+            if exclude_sources and source in exclude_sources:
+                continue
+
+            # Skip cron sessions (they're the dream itself or other scheduled work)
+            if source == "cron":
+                continue
+
+            session_id = s.get("id", "")
+            if not session_id:
+                continue
+
+            # Fetch messages for this session
+            try:
+                messages = db.get_messages(session_id)
+            except Exception as e:
+                logger.debug("DreamEngine: failed to get messages for %s: %s", session_id, e)
+                messages = []
+
+            # Build a compact transcript
+            transcript = self._compact_transcript(messages)
+            if not transcript:
+                continue
+
+            recent.append({
+                "id": session_id,
+                "source": source,
+                "title": s.get("title", ""),
+                "message_count": s.get("message_count", 0),
+                "started_at": started_at,
+                "transcript": transcript,
+            })
+
+            if len(recent) >= limit:
+                break
+
+        logger.info("DreamEngine: gathered %d sessions from the last %d hours", len(recent), hours)
+        return recent
+
+    def _compact_transcript(self, messages: List[Dict[str, Any]]) -> str:
+        """Build a compact text transcript from session messages.
+
+        Extracts only user and assistant messages (skipping tool calls/results),
+        limited to _MAX_MESSAGES_PER_SESSION pairs and _MAX_SESSION_CONTENT_CHARS
+        total characters.
+        """
+        pairs = []
+        for msg in messages:
+            role = msg.get("role", "")
+            content = msg.get("content") or ""
+            if not content:
+                continue
+            # Skip system messages and tool results
+            if role in ("system", "tool"):
+                continue
+            # Truncate individual messages
+            if len(content) > 500:
+                content = content[:500] + "..."
+            pairs.append(f"[{role}]: {content}")
+
+            if len(pairs) >= _MAX_MESSAGES_PER_SESSION:
+                break
+
+        transcript = "\n".join(pairs)
+        if len(transcript) > _MAX_SESSION_CONTENT_CHARS:
+            transcript = transcript[:_MAX_SESSION_CONTENT_CHARS] + "\n...[truncated]"
+
+        return transcript
+
+    def extract_insights(self, sessions: List[Dict[str, Any]]) -> str:
+        """Build the dream review prompt from gathered sessions.
+
+        Args:
+            sessions: List of session dicts from gather_sessions().
+
+        Returns:
+            A prompt string for the dream agent to analyze.
+        """
+        if not sessions:
+            return ""
+
+        session_blocks = []
+        for i, s in enumerate(sessions, 1):
+            title = s.get("title", "Untitled") or "Untitled"
+            source = s.get("source", "unknown")
+            msg_count = s.get("message_count", 0)
+            transcript = s.get("transcript", "")
+
+            block = (
+                f"### Session {i}: {title}\n"
+                f"Source: {source} | Messages: {msg_count}\n"
+                f"```\n{transcript}\n```\n"
+            )
+            session_blocks.append(block)
+
+        sessions_text = "\n".join(session_blocks)
+
+        prompt = (
+            "You are in a memory consolidation cycle (\"dreaming\"). Your task is to\n"
+            "review recent sessions and extract durable insights worth remembering.\n\n"
+            "ANALYZE these session transcripts and identify:\n"
+            "1. **User preferences** — communication style, habits, pet peeves, "
+            "recurring requests\n"
+            "2. **Environment facts** — tools, configs, project structures, "
+            "OS details discovered\n"
+            "3. **Lessons learned** — mistakes to avoid, successful patterns, "
+            "workflow optimizations\n"
+            "4. **Corrections** — times the user corrected you or said 'remember this'\n\n"
+            "For EACH insight worth saving, output it as a JSON object in a JSON array:\n"
+            "```json\n"
+            "[\n"
+            '  {"target": "memory", "content": "insight text here"},\n'
+            '  {"target": "user", "content": "user preference here"}\n'
+            "]\n"
+            "```\n\n"
+            "RULES:\n"
+            "- Only include genuinely useful, non-obvious insights\n"
+            "- Skip trivial facts, temporary task state, or things easily re-discovered\n"
+            "- Each entry should be concise (1-2 sentences max)\n"
+            "- 'target': 'memory' for environment/technical notes, 'user' for user profile\n"
+            "- If nothing worth saving, output an empty array: []\n"
+            "- Do NOT duplicate existing memory entries\n\n"
+            f"## Recent Sessions ({len(sessions)} sessions)\n\n"
+            f"{sessions_text}\n"
+        )
+
+        return prompt
+
+    def run_dream(self, agent=None, sessions: Optional[List[Dict[str, Any]]] = None,
+                  hours: int = 24, limit: int = 20) -> Dict[str, Any]:
+        """Execute a dream cycle: gather sessions, run agent, apply results.
+
+        Args:
+            agent: Optional pre-configured AIAgent. If None, creates one with
+                   the memory toolset.
+            sessions: Optional pre-gathered sessions. If None, gathers them.
+            hours: Look-back window for gathering sessions.
+            limit: Max sessions to gather.
+
+        Returns:
+            Dict with keys: success, insights_count, entries_written, error.
+        """
+        result = {
+            "success": False,
+            "insights_count": 0,
+            "entries_written": 0,
+            "sessions_reviewed": 0,
+            "error": None,
+        }
+
+        try:
+            # Gather sessions
+            if sessions is None:
+                sessions = self.gather_sessions(hours=hours, limit=limit)
+
+            result["sessions_reviewed"] = len(sessions)
+
+            if not sessions:
+                result["success"] = True
+                result["error"] = "No recent sessions to review"
+                self._record_history(result)
+                return result
+
+            # Build the dream prompt
+            dream_prompt = self.extract_insights(sessions)
+            if not dream_prompt:
+                result["success"] = True
+                result["error"] = "No content to analyze"
+                self._record_history(result)
+                return result
+
+            # Run the dream agent
+            if agent is None:
+                agent = self._create_dream_agent()
+
+            logger.info("DreamEngine: running dream with %d sessions", len(sessions))
+
+            # Use run_conversation for the full interface
+            agent_result = agent.run_conversation(dream_prompt)
+            response = agent_result.get("final_response", "") if isinstance(agent_result, dict) else str(agent_result)
+
+            # Parse insights from the response
+            entries = self._parse_insights(response)
+            result["insights_count"] = len(entries)
+
+            # Apply consolidation
+            if entries:
+                written = self.apply_consolidation(entries)
+                result["entries_written"] = written
+
+            result["success"] = True
+            logger.info(
+                "DreamEngine: dream complete — %d insights found, %d entries written",
+                result["insights_count"], result["entries_written"],
+            )
+
+        except Exception as e:
+            logger.exception("DreamEngine: dream failed: %s", e)
+            result["error"] = str(e)
+
+        self._record_history(result)
+        return result
+
+    def _create_dream_agent(self):
+        """Create an AIAgent configured for dreaming (memory toolset only)."""
+        from run_agent import AIAgent
+
+        # Load config for model/provider resolution
+        cfg = {}
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config() or {}
+        except Exception:
+            pass
+
+        model = ""
+        model_cfg = cfg.get("model", {})
+        if isinstance(model_cfg, str):
+            model = model_cfg
+        elif isinstance(model_cfg, dict):
+            model = model_cfg.get("default", "")
+
+        # Resolve provider
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        runtime = resolve_runtime_provider()
+
+        agent = AIAgent(
+            model=model or runtime.get("model", ""),
+            api_key=runtime.get("api_key"),
+            base_url=runtime.get("base_url"),
+            provider=runtime.get("provider"),
+            enabled_toolsets=["memory"],
+            quiet_mode=True,
+            skip_memory=True,
+            skip_context_files=True,
+            platform="cron",
+            session_id=f"dream_{int(time.time())}",
+        )
+
+        return agent
+
+    def _parse_insights(self, response: str) -> List[Dict[str, str]]:
+        """Parse the dream agent's response into insight entries.
+
+        Looks for JSON arrays in the response. Handles markdown code fences.
+
+        Returns:
+            List of dicts with 'target' and 'content' keys.
+        """
+        entries = []
+
+        # Try to find JSON array in the response
+        text = response.strip()
+
+        # Strip markdown code fences if present
+        if "```" in text:
+            import re
+            # Find the last JSON block (the final answer, not examples)
+            blocks = re.findall(r'```(?:json)?\s*\n([\s\S]*?)\n```', text)
+            for block in reversed(blocks):
+                try:
+                    parsed = json.loads(block.strip())
+                    if isinstance(parsed, list):
+                        entries = parsed
+                        break
+                except json.JSONDecodeError:
+                    continue
+
+        # If no fenced block found, try parsing the whole response
+        if not entries:
+            try:
+                parsed = json.loads(text)
+                if isinstance(parsed, list):
+                    entries = parsed
+            except json.JSONDecodeError:
+                pass
+
+        # Validate entries
+        valid = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            target = entry.get("target", "").strip()
+            content = entry.get("content", "").strip()
+            if target in ("memory", "user") and content:
+                valid.append({"target": target, "content": content})
+
+        return valid
+
+    def apply_consolidation(self, entries: List[Dict[str, str]]) -> int:
+        """Write dream insights to MEMORY.md and/or USER.md.
+
+        Uses the MemoryStore to add entries, respecting character limits
+        and deduplication.
+
+        Args:
+            entries: List of dicts with 'target' and 'content' keys.
+
+        Returns:
+            Number of entries successfully written.
+        """
+        from tools.memory_tool import MemoryStore
+
+        store = MemoryStore()
+        store.load_from_disk()
+
+        written = 0
+        for entry in entries:
+            target = entry["target"]
+            content = entry["content"]
+
+            try:
+                result = store.add(target, content)
+                if result.get("success"):
+                    written += 1
+                    logger.debug("DreamEngine: wrote to %s: %s", target, content[:80])
+                else:
+                    error = result.get("error", "unknown")
+                    # Don't log "already exists" as a warning — it's expected
+                    if "already exists" in str(error).lower():
+                        logger.debug("DreamEngine: skipping duplicate in %s", target)
+                    else:
+                        logger.warning("DreamEngine: failed to write to %s: %s", target, error)
+            except Exception as e:
+                logger.warning("DreamEngine: error writing to %s: %s", target, e)
+
+        return written
+
+    def _record_history(self, result: Dict[str, Any]) -> None:
+        """Record a dream run in the history file for the 'history' action."""
+        try:
+            _DREAM_HISTORY_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+            history = []
+            if _DREAM_HISTORY_FILE.exists():
+                try:
+                    with open(_DREAM_HISTORY_FILE, "r", encoding="utf-8") as f:
+                        history = json.load(f)
+                except (json.JSONDecodeError, OSError):
+                    history = []
+
+            from hermes_time import now as _hermes_now
+            entry = {
+                "timestamp": _hermes_now().isoformat(),
+                "success": result.get("success", False),
+                "sessions_reviewed": result.get("sessions_reviewed", 0),
+                "insights_count": result.get("insights_count", 0),
+                "entries_written": result.get("entries_written", 0),
+                "error": result.get("error"),
+            }
+            history.append(entry)
+
+            # Keep only last 50 entries
+            if len(history) > 50:
+                history = history[-50:]
+
+            with open(_DREAM_HISTORY_FILE, "w", encoding="utf-8") as f:
+                json.dump(history, f, indent=2)
+
+        except Exception as e:
+            logger.debug("DreamEngine: failed to record history: %s", e)
+
+    def get_history(self, limit: int = 10) -> List[Dict[str, Any]]:
+        """Return recent dream run history.
+
+        Args:
+            limit: Maximum entries to return.
+
+        Returns:
+            List of dream run records.
+        """
+        if not _DREAM_HISTORY_FILE.exists():
+            return []
+
+        try:
+            with open(_DREAM_HISTORY_FILE, "r", encoding="utf-8") as f:
+                history = json.load(f)
+            return history[-limit:]
+        except (json.JSONDecodeError, OSError):
+            return []
+
+    def get_config(self) -> Dict[str, Any]:
+        """Return current dreaming configuration from config.yaml.
+
+        Returns:
+            Dict with dreaming config keys and their values.
+        """
+        cfg = {}
+        try:
+            from hermes_cli.config import load_config
+            full_cfg = load_config() or {}
+            cfg = full_cfg.get("dreaming", {})
+        except Exception:
+            pass
+
+        return {
+            "enabled": cfg.get("enabled", True),
+            "schedule": cfg.get("schedule", "0 3 * * *"),
+            "hours": cfg.get("hours", 24),
+            "limit": cfg.get("limit", 20),
+            "deliver": cfg.get("deliver", "local"),
+        }
+
+    def build_dream_prompt(self, job: dict) -> str:
+        """Build the effective prompt for a dream-type cron job.
+
+        Called by cron/scheduler.py when it detects job type == 'dream'.
+        This replaces the normal _build_job_prompt path for dream jobs.
+
+        Args:
+            job: The cron job dict.
+
+        Returns:
+            The dream prompt string.
+        """
+        hours = job.get("dream_hours", 24)
+        limit = job.get("dream_limit", 20)
+
+        sessions = self.gather_sessions(hours=hours, limit=limit)
+
+        if not sessions:
+            return (
+                "[SILENT] Dream cycle: no recent sessions to review. "
+                "Nothing to consolidate."
+            )
+
+        return self.extract_insights(sessions)

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -1,0 +1,269 @@
+"""Orchestrator — Async multi-agent task manager with DAG dependencies.
+
+Provides persistent, cross-turn task orchestration with:
+- Fire-and-forget async delegation
+- DAG-based task dependency resolution
+- Progress tracking across turns
+- Integration with WebhookDispatcher for completion callbacks
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
+
+log = logging.getLogger(__name__)
+
+
+class TaskStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class OrchestrationTask:
+    """A single orchestrated task."""
+    task_id: str
+    goal: str
+    context: str = ""
+    toolsets: List[str] = field(default_factory=list)
+    status: TaskStatus = TaskStatus.PENDING
+    depends_on: List[str] = field(default_factory=list)
+    result: Optional[Dict[str, Any]] = None
+    progress: str = ""
+    started_at: Optional[float] = None
+    completed_at: Optional[float] = None
+    error: Optional[str] = None
+    subagent_id: Optional[str] = None
+
+    @property
+    def duration_seconds(self) -> Optional[float]:
+        if self.started_at and self.completed_at:
+            return self.completed_at - self.started_at
+        return None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "goal": self.goal[:200],
+            "status": self.status.value,
+            "depends_on": self.depends_on,
+            "progress": self.progress,
+            "duration_seconds": self.duration_seconds,
+            "error": self.error,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+        }
+
+
+class Orchestrator:
+    """Persistent multi-agent orchestrator that survives across turns."""
+
+    def __init__(self, agent_factory: Callable, max_workers: int = 4,
+                 webhook_dispatcher=None):
+        """
+        Args:
+            agent_factory: Callable(toolsets, skip_memory) -> AIAgent
+            max_workers: Max concurrent tasks.
+            webhook_dispatcher: Optional WebhookDispatcher for completion callbacks.
+        """
+        self._agent_factory = agent_factory
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
+        self._tasks: Dict[str, OrchestrationTask] = {}
+        self._futures: Dict[str, Future] = {}
+        self._lock = threading.Lock()
+        self._webhook_dispatcher = webhook_dispatcher
+        self._callbacks: List[Callable] = []
+
+    def submit(self, goal: str, context: str = "", depends_on: Optional[List[str]] = None,
+               toolsets: Optional[List[str]] = None) -> str:
+        """Submit an async task. Returns task_id immediately.
+
+        If depends_on is specified, the task won't start until all dependencies complete.
+        """
+        task_id = f"task_{uuid.uuid4().hex[:12]}"
+        task = OrchestrationTask(
+            task_id=task_id,
+            goal=goal,
+            context=context,
+            toolsets=toolsets or [],
+            depends_on=depends_on or [],
+        )
+
+        with self._lock:
+            self._tasks[task_id] = task
+
+        # If no dependencies, submit immediately
+        if not depends_on:
+            self._submit_to_executor(task)
+        else:
+            log.info("Task %s waiting for dependencies: %s", task_id, depends_on)
+
+        return task_id
+
+    def get_status(self, task_id: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Get status of one or all tasks."""
+        with self._lock:
+            if task_id:
+                task = self._tasks.get(task_id)
+                return [task.to_dict()] if task else []
+            return [t.to_dict() for t in self._tasks.values()]
+
+    def wait(self, task_id: str, timeout: float = 300) -> Dict[str, Any]:
+        """Block until a specific task completes."""
+        future = self._futures.get(task_id)
+        if not future:
+            task = self._tasks.get(task_id)
+            if task and task.status in (TaskStatus.COMPLETED, TaskStatus.FAILED):
+                return task.to_dict() if task else {}
+            return {"status": "error", "message": f"Task {task_id} not found or not running"}
+
+        try:
+            result = future.result(timeout=timeout)
+            return result
+        except TimeoutError:
+            return {"status": "timeout", "task_id": task_id}
+        except Exception as e:
+            return {"status": "error", "task_id": task_id, "error": str(e)}
+
+    def cancel(self, task_id: str) -> bool:
+        """Request cancellation of a running task."""
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return False
+            if task.status in (TaskStatus.COMPLETED, TaskStatus.CANCELLED):
+                return False
+
+            task.status = TaskStatus.CANCELLED
+            task.completed_at = time.time()
+
+            # Cancel the future if possible
+            future = self._futures.get(task_id)
+            if future:
+                future.cancel()
+
+            self._resolve_dependencies()
+            return True
+
+    def register_callback(self, callback: Callable):
+        """Register a callback for task completion events."""
+        self._callbacks.append(callback)
+
+    def _submit_to_executor(self, task: OrchestrationTask):
+        """Submit task to the thread pool executor."""
+        task.status = TaskStatus.RUNNING
+        task.started_at = time.time()
+
+        future = self._executor.submit(self._run_task, task)
+        self._futures[task.task_id] = future
+
+        future.add_done_callback(
+            lambda f, tid=task.task_id: self._on_future_done(tid, f)
+        )
+
+    def _run_task(self, task: OrchestrationTask) -> Dict[str, Any]:
+        """Execute a task using an AIAgent."""
+        try:
+            agent = self._agent_factory(
+                toolsets=task.toolsets or None,
+                skip_memory=True,
+            )
+            result = agent.run_conversation(
+                user_message=task.goal + ("\n\nContext: " + task.context if task.context else ""),
+                max_turns=10,
+            )
+            return result if isinstance(result, dict) else {"response": str(result)}
+        except Exception as e:
+            log.error("Task %s failed: %s", task.task_id, e)
+            raise
+
+    def _on_future_done(self, task_id: str, future: Future):
+        """Callback when a future completes."""
+        with self._lock:
+            task = self._tasks.get(task_id)
+            if not task:
+                return
+
+            if task.status == TaskStatus.CANCELLED:
+                return
+
+            if future.exception():
+                task.status = TaskStatus.FAILED
+                task.error = str(future.exception())
+            else:
+                task.status = TaskStatus.COMPLETED
+                task.result = future.result()
+
+            task.completed_at = time.time()
+
+        # Fire webhook
+        if self._webhook_dispatcher:
+            event = "task.completed" if task.status == TaskStatus.COMPLETED else "task.failed"
+            self._webhook_dispatcher.dispatch(event, task.to_dict())
+
+        # Fire callbacks
+        for cb in self._callbacks:
+            try:
+                cb(task_id, task.to_dict())
+            except Exception as e:
+                log.warning("Callback error for task %s: %s", task_id, e)
+
+        # Resolve dependent tasks
+        self._resolve_dependencies()
+
+    def _resolve_dependencies(self):
+        """Check which pending tasks have all deps satisfied, submit them."""
+        with self._lock:
+            for task in self._tasks.values():
+                if task.status != TaskStatus.PENDING:
+                    continue
+                if not task.depends_on:
+                    continue
+
+                all_done = all(
+                    self._tasks.get(dep, OrchestrationTask(task_id="", goal="")).status
+                    in (TaskStatus.COMPLETED, TaskStatus.CANCELLED)
+                    for dep in task.depends_on
+                )
+
+                if all_done:
+                    # Check if any dependency failed
+                    any_failed = any(
+                        self._tasks.get(dep, OrchestrationTask(task_id="", goal="")).status
+                        == TaskStatus.FAILED
+                        for dep in task.depends_on
+                    )
+                    if any_failed:
+                        task.status = TaskStatus.FAILED
+                        task.error = "Dependency failed"
+                        task.completed_at = time.time()
+                    else:
+                        self._submit_to_executor(task)
+
+    def shutdown(self, wait: bool = True):
+        """Shutdown the executor."""
+        self._executor.shutdown(wait=wait)
+
+    def summary(self) -> Dict[str, Any]:
+        """Get orchestrator summary."""
+        with self._lock:
+            counts = {}
+            for status in TaskStatus:
+                counts[status.value] = sum(
+                    1 for t in self._tasks.values() if t.status == status
+                )
+            return {
+                "total_tasks": len(self._tasks),
+                "status_counts": counts,
+                "active_futures": len([f for f in self._futures.values() if not f.done()]),
+            }

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -14,6 +14,7 @@ import threading
 import time
 import uuid
 from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
@@ -80,7 +81,7 @@ class Orchestrator:
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
         self._tasks: Dict[str, OrchestrationTask] = {}
         self._futures: Dict[str, Future] = {}
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._webhook_dispatcher = webhook_dispatcher
         self._callbacks: List[Callable] = []
 
@@ -102,11 +103,11 @@ class Orchestrator:
         with self._lock:
             self._tasks[task_id] = task
 
-        # If no dependencies, submit immediately
-        if not depends_on:
-            self._submit_to_executor(task)
-        else:
-            log.info("Task %s waiting for dependencies: %s", task_id, depends_on)
+            # If no dependencies, submit immediately
+            if not depends_on:
+                self._submit_to_executor(task)
+            else:
+                log.info("Task %s waiting for dependencies: %s", task_id, depends_on)
 
         return task_id
 
@@ -130,7 +131,7 @@ class Orchestrator:
         try:
             result = future.result(timeout=timeout)
             return result
-        except TimeoutError:
+        except (TimeoutError, FuturesTimeoutError):
             return {"status": "timeout", "task_id": task_id}
         except Exception as e:
             return {"status": "error", "task_id": task_id, "error": str(e)}
@@ -180,7 +181,6 @@ class Orchestrator:
             )
             result = agent.run_conversation(
                 user_message=task.goal + ("\n\nContext: " + task.context if task.context else ""),
-                max_turns=10,
             )
             return result if isinstance(result, dict) else {"response": str(result)}
         except Exception as e:
@@ -230,8 +230,16 @@ class Orchestrator:
                 if not task.depends_on:
                     continue
 
+                # Check for unknown dependencies — fail the task immediately
+                unknown_deps = [dep for dep in task.depends_on if dep not in self._tasks]
+                if unknown_deps:
+                    task.status = TaskStatus.FAILED
+                    task.error = f"Unknown dependencies: {', '.join(unknown_deps)}"
+                    task.completed_at = time.time()
+                    continue
+
                 all_done = all(
-                    self._tasks.get(dep, OrchestrationTask(task_id="", goal="")).status
+                    self._tasks[dep].status
                     in (TaskStatus.COMPLETED, TaskStatus.CANCELLED)
                     for dep in task.depends_on
                 )

--- a/agent/outcomes.py
+++ b/agent/outcomes.py
@@ -1,0 +1,243 @@
+"""Outcomes Engine — Rubric-based grading for agent outputs.
+
+Provides LLM-as-judge grading against configurable rubrics,
+with a review loop that retries when output quality is below threshold.
+
+Config:
+    Rubrics stored in ~/.hermes/rubrics/<name>.yaml
+    Outcomes stored in state.db outcomes table
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class RubricCriterion:
+    """A single grading criterion."""
+    criterion: str
+    weight: float
+    description: str
+
+
+@dataclass
+class Rubric:
+    """A grading rubric with weighted criteria."""
+    name: str
+    description: str
+    criteria: List[RubricCriterion]
+    pass_threshold: float = 0.7
+
+
+@dataclass
+class Outcome:
+    """Result of grading an output against a rubric."""
+    rubric_name: str
+    scores: Dict[str, float]  # criterion -> score (0.0-1.0)
+    total_score: float
+    passed: bool
+    feedback: str
+    session_id: str = ""
+    timestamp: float = field(default_factory=time.time)
+
+
+class OutcomeEngine:
+    """Grades agent outputs against rubrics."""
+
+    def __init__(self, rubrics_dir: Path, session_db=None):
+        self._rubrics_dir = rubrics_dir
+        self._session_db = session_db
+
+    def load_rubric(self, name: str) -> Optional[Rubric]:
+        """Load rubric from ~/.hermes/rubrics/<name>.yaml."""
+        rubric_file = self._rubrics_dir / f"{name}.yaml"
+        if not rubric_file.exists():
+            # Try .yml
+            rubric_file = self._rubrics_dir / f"{name}.yml"
+        if not rubric_file.exists():
+            log.warning("Rubric not found: %s", name)
+            return None
+
+        try:
+            import yaml
+            with open(rubric_file, "r") as f:
+                data = yaml.safe_load(f)
+        except ImportError:
+            # Fallback: parse simple YAML manually
+            data = self._parse_simple_yaml(rubric_file)
+
+        criteria = []
+        for c in data.get("criteria", []):
+            criteria.append(RubricCriterion(
+                criterion=c.get("criterion", c.get("name", "")),
+                weight=c.get("weight", 1.0),
+                description=c.get("description", ""),
+            ))
+
+        return Rubric(
+            name=data.get("name", name),
+            description=data.get("description", ""),
+            criteria=criteria,
+            pass_threshold=data.get("pass_threshold", 0.7),
+        )
+
+    def list_rubrics(self) -> List[str]:
+        """List available rubric names."""
+        if not self._rubrics_dir.exists():
+            return []
+        return [
+            f.stem for f in sorted(self._rubrics_dir.glob("*.yaml"))
+        ] + [
+            f.stem for f in sorted(self._rubrics_dir.glob("*.yml"))
+        ]
+
+    def grade(self, rubric: Rubric, output: str, context: str = "") -> Outcome:
+        """Grade output against rubric criteria using LLM-as-judge.
+
+        This builds a grading prompt. In actual use, an AIAgent would execute it.
+        For tool usage, we return a structured grading request.
+        """
+        criteria_text = "\n".join(
+            f"- {c.criterion} (weight: {c.weight}): {c.description}"
+            for c in rubric.criteria
+        )
+
+        grading_prompt = (
+            f"Grade the following output against the rubric \"{rubric.name}\".\n\n"
+            f"**Rubric Criteria:**\n{criteria_text}\n\n"
+            f"**Pass Threshold:** {rubric.pass_threshold}\n\n"
+            f"**Context:** {context}\n\n"
+            f"**Output to Grade:**\n{output}\n\n"
+            f"Respond with a JSON object:\n"
+            f'{{"scores": {{"criterion_name": 0.0-1.0, ...}}, '
+            f'"total_score": 0.0-1.0, "feedback": "detailed feedback"}}'
+        )
+
+        # For now, return the prompt for an agent to execute
+        # In a full implementation, this would spawn a grading agent
+        return Outcome(
+            rubric_name=rubric.name,
+            scores={c.criterion: 0.0 for c in rubric.criteria},
+            total_score=0.0,
+            passed=False,
+            feedback="Grading requires LLM execution. Use the outcomes tool.",
+        )
+
+    def review_loop(self, rubric: Rubric, task_fn, max_retries: int = 2,
+                    context: str = "") -> Outcome:
+        """Run task, grade output, retry with feedback if below threshold.
+
+        Args:
+            rubric: The rubric to grade against.
+            task_fn: Callable that returns the output string.
+            max_retries: Maximum retry attempts.
+            context: Additional context for grading.
+        """
+        for attempt in range(max_retries + 1):
+            output = task_fn()
+            outcome = self.grade(rubric, output, context)
+
+            if outcome.passed:
+                log.info("Passed on attempt %d/%d", attempt + 1, max_retries + 1)
+                return outcome
+
+            if attempt < max_retries:
+                log.info(
+                    "Failed attempt %d/%d (score=%.2f, threshold=%.2f). Retrying...",
+                    attempt + 1, max_retries + 1,
+                    outcome.total_score, rubric.pass_threshold,
+                )
+
+        return outcome
+
+    def store_outcome(self, outcome: Outcome) -> bool:
+        """Persist outcome to state.db."""
+        if not self._session_db:
+            return False
+        try:
+            if hasattr(self._session_db, 'store_outcome'):
+                self._session_db.store_outcome(
+                    session_id=outcome.session_id,
+                    rubric_name=outcome.rubric_name,
+                    total_score=outcome.total_score,
+                    passed=outcome.passed,
+                    scores_json=json.dumps(outcome.scores),
+                    feedback=outcome.feedback,
+                    timestamp=outcome.timestamp,
+                )
+                return True
+        except Exception as e:
+            log.error("Failed to store outcome: %s", e)
+        return False
+
+    def get_outcomes(self, limit: int = 20) -> List[Dict[str, Any]]:
+        """Retrieve recent outcomes."""
+        if not self._session_db:
+            return []
+        try:
+            if hasattr(self._session_db, 'get_outcomes'):
+                return self._session_db.get_outcomes(limit=limit)
+        except Exception as e:
+            log.error("Failed to get outcomes: %s", e)
+        return []
+
+    def _parse_simple_yaml(self, path: Path) -> Dict:
+        """Minimal YAML parser for rubric files (fallback when PyYAML unavailable)."""
+        import re
+        data = {"criteria": []}
+        current_criterion = None
+
+        with open(path, "r") as f:
+            for line in f:
+                line = line.rstrip()
+                if not line or line.startswith("#"):
+                    continue
+
+                # Top-level key: value
+                match = re.match(r"^(\w+):\s*(.+)$", line)
+                if match and not line.startswith("  "):
+                    key, val = match.groups()
+                    if key == "pass_threshold":
+                        data[key] = float(val)
+                    elif key != "criteria":
+                        data[key] = val.strip().strip('"').strip("'")
+
+                # Criterion block
+                if line.strip().startswith("- criterion:"):
+                    if current_criterion:
+                        data["criteria"].append(current_criterion)
+                    name = line.split(":", 1)[1].strip().strip('"').strip("'")
+                    current_criterion = {"criterion": name, "weight": 1.0, "description": ""}
+                elif current_criterion:
+                    m = re.match(r"^\s+(\w+):\s*(.+)$", line)
+                    if m:
+                        k, v = m.groups()
+                        if k == "weight":
+                            current_criterion[k] = float(v)
+                        else:
+                            current_criterion[k] = v.strip().strip('"').strip("'")
+
+            if current_criterion:
+                data["criteria"].append(current_criterion)
+
+        return data
+
+    def to_dict(self, outcome: Outcome) -> Dict[str, Any]:
+        """Serialize Outcome to dict."""
+        return {
+            "rubric_name": outcome.rubric_name,
+            "scores": outcome.scores,
+            "total_score": outcome.total_score,
+            "passed": outcome.passed,
+            "feedback": outcome.feedback,
+            "session_id": outcome.session_id,
+            "timestamp": outcome.timestamp,
+        }

--- a/agent/outcomes.py
+++ b/agent/outcomes.py
@@ -100,35 +100,71 @@ class OutcomeEngine:
         ]
 
     def grade(self, rubric: Rubric, output: str, context: str = "") -> Outcome:
-        """Grade output against rubric criteria using LLM-as-judge.
+        """Grade output against rubric criteria using heuristic scoring.
 
-        This builds a grading prompt. In actual use, an AIAgent would execute it.
-        For tool usage, we return a structured grading request.
+        In production, this can be overridden to use an LLM-as-judge.
+        The built-in heuristic scores based on keyword relevance and output quality.
         """
-        criteria_text = "\n".join(
-            f"- {c.criterion} (weight: {c.weight}): {c.description}"
-            for c in rubric.criteria
+        if not output or not output.strip():
+            return Outcome(
+                rubric_name=rubric.name,
+                scores={c.criterion: 0.0 for c in rubric.criteria},
+                total_score=0.0,
+                passed=False,
+                feedback="Output is empty — nothing to grade.",
+            )
+
+        output_lower = output.lower()
+        output_words = set(output_lower.split())
+        scores: Dict[str, float] = {}
+
+        for criterion in rubric.criteria:
+            # Extract keywords from criterion name and description
+            desc_words = set(criterion.description.lower().split())
+            criterion_words = set(criterion.criterion.lower().replace("_", " ").replace("-", " ").split())
+            keywords = {w for w in (desc_words | criterion_words) if len(w) > 3}
+
+            # Keyword overlap score
+            if keywords:
+                overlap = len(keywords & output_words)
+                keyword_score = min(overlap / max(len(keywords) * 0.5, 1), 1.0)
+            else:
+                keyword_score = 0.5  # no keywords → neutral
+
+            # Thoroughness: log-scaled output length (diminishing returns)
+            import math
+            length_score = min(math.log2(max(len(output), 1)) / 12.0, 1.0)  # 4096 chars → 1.0
+
+            # Combined: 60% relevance, 40% thoroughness
+            score = round(0.6 * keyword_score + 0.4 * length_score, 3)
+            scores[criterion.criterion] = score
+
+        # Weighted total
+        total_weight = sum(c.weight for c in rubric.criteria) or 1.0
+        total_score = round(
+            sum(scores[c.criterion] * c.weight for c in rubric.criteria) / total_weight,
+            3,
         )
 
-        grading_prompt = (
-            f"Grade the following output against the rubric \"{rubric.name}\".\n\n"
-            f"**Rubric Criteria:**\n{criteria_text}\n\n"
-            f"**Pass Threshold:** {rubric.pass_threshold}\n\n"
-            f"**Context:** {context}\n\n"
-            f"**Output to Grade:**\n{output}\n\n"
-            f"Respond with a JSON object:\n"
-            f'{{"scores": {{"criterion_name": 0.0-1.0, ...}}, '
-            f'"total_score": 0.0-1.0, "feedback": "detailed feedback"}}'
-        )
+        passed = total_score >= rubric.pass_threshold
 
-        # For now, return the prompt for an agent to execute
-        # In a full implementation, this would spawn a grading agent
+        # Build feedback
+        feedback_parts = []
+        for c in rubric.criteria:
+            s = scores[c.criterion]
+            if s < 0.3:
+                feedback_parts.append(f"- {c.criterion}: very low ({s:.2f}). Needs significant improvement.")
+            elif s < rubric.pass_threshold:
+                feedback_parts.append(f"- {c.criterion}: below threshold ({s:.2f}).")
+            else:
+                feedback_parts.append(f"- {c.criterion}: acceptable ({s:.2f}).")
+
         return Outcome(
             rubric_name=rubric.name,
-            scores={c.criterion: 0.0 for c in rubric.criteria},
-            total_score=0.0,
-            passed=False,
-            feedback="Grading requires LLM execution. Use the outcomes tool.",
+            scores=scores,
+            total_score=total_score,
+            passed=passed,
+            feedback="\n".join(feedback_parts) if feedback_parts else "No criteria evaluated.",
         )
 
     def review_loop(self, rubric: Rubric, task_fn, max_retries: int = 2,

--- a/agent/webhook_dispatcher.py
+++ b/agent/webhook_dispatcher.py
@@ -121,8 +121,14 @@ class WebhookDispatcher:
         return False
 
     def list_webhooks(self) -> List[Dict[str, Any]]:
-        """List all registered webhooks."""
-        return [w.to_dict() for w in self._webhooks.values()]
+        """List all registered webhooks (secret is redacted)."""
+        results = []
+        for w in self._webhooks.values():
+            d = w.to_dict()
+            if d.get("secret"):
+                d["secret"] = "***"
+            results.append(d)
+        return results
 
     def get_webhook(self, webhook_id: str) -> Optional[WebhookConfig]:
         """Get a specific webhook config."""

--- a/agent/webhook_dispatcher.py
+++ b/agent/webhook_dispatcher.py
@@ -1,0 +1,240 @@
+"""Webhook Dispatcher — Outbound webhook delivery for task/cron completion.
+
+Fires HTTP POST callbacks when tasks or cron jobs complete.
+Supports HMAC-SHA256 signing and exponential backoff retry.
+
+Config (config.yaml):
+    webhooks:
+        - url: "https://example.com/callback"
+          events: ["task.completed", "cron.completed"]
+          secret: "my-hmac-secret"   # optional
+          headers: {}                # optional custom headers
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class WebhookConfig:
+    """Configuration for a single webhook endpoint."""
+    id: str
+    url: str
+    events: List[str]
+    secret: Optional[str] = None
+    headers: Dict[str, str] = field(default_factory=dict)
+    enabled: bool = True
+    created_at: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "url": self.url,
+            "events": self.events,
+            "secret": self.secret,
+            "headers": self.headers,
+            "enabled": self.enabled,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "WebhookConfig":
+        return cls(
+            id=data.get("id", ""),
+            url=data.get("url", ""),
+            events=data.get("events", []),
+            secret=data.get("secret"),
+            headers=data.get("headers", {}),
+            enabled=data.get("enabled", True),
+            created_at=data.get("created_at", ""),
+        )
+
+
+class WebhookDispatcher:
+    """Outbound webhook delivery for async task/cron completion."""
+
+    WEBHOOKS_FILE = "webhooks.json"
+    MAX_RETRIES = 3
+    BACKOFF_BASE = 2  # seconds
+
+    def __init__(self, hermes_home: Path):
+        self._hermes_home = hermes_home
+        self._webhooks_file = hermes_home / self.WEBHOOKS_FILE
+        self._webhooks: Dict[str, WebhookConfig] = {}
+        self._load()
+
+    def _load(self):
+        """Load webhooks from disk."""
+        if self._webhooks_file.exists():
+            try:
+                with open(self._webhooks_file, "r") as f:
+                    data = json.load(f)
+                for item in data.get("webhooks", []):
+                    config = WebhookConfig.from_dict(item)
+                    self._webhooks[config.id] = config
+            except Exception as e:
+                log.warning("Failed to load webhooks: %s", e)
+
+    def _save(self):
+        """Persist webhooks to disk."""
+        data = {
+            "webhooks": [w.to_dict() for w in self._webhooks.values()]
+        }
+        self._webhooks_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(self._webhooks_file, "w") as f:
+            json.dump(data, f, indent=2)
+
+    def register(self, url: str, events: List[str], secret: Optional[str] = None,
+                 headers: Optional[Dict[str, str]] = None) -> str:
+        """Register a webhook endpoint. Returns webhook_id."""
+        webhook_id = f"wh_{uuid.uuid4().hex[:12]}"
+        config = WebhookConfig(
+            id=webhook_id,
+            url=url,
+            events=events,
+            secret=secret,
+            headers=headers or {},
+            created_at=time.strftime("%Y-%m-%dT%H:%M:%S"),
+        )
+        self._webhooks[webhook_id] = config
+        self._save()
+        log.info("Registered webhook %s -> %s (events: %s)", webhook_id, url, events)
+        return webhook_id
+
+    def unregister(self, webhook_id: str) -> bool:
+        """Remove a webhook registration."""
+        if webhook_id in self._webhooks:
+            del self._webhooks[webhook_id]
+            self._save()
+            return True
+        return False
+
+    def list_webhooks(self) -> List[Dict[str, Any]]:
+        """List all registered webhooks."""
+        return [w.to_dict() for w in self._webhooks.values()]
+
+    def get_webhook(self, webhook_id: str) -> Optional[WebhookConfig]:
+        """Get a specific webhook config."""
+        return self._webhooks.get(webhook_id)
+
+    def dispatch(self, event: str, payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Fire webhooks matching the event type.
+
+        Returns list of delivery results: [{webhook_id, url, status_code, success}]
+        """
+        import urllib.request
+        import urllib.error
+
+        results = []
+        matching = [
+            w for w in self._webhooks.values()
+            if w.enabled and (event in w.events or "*" in w.events)
+        ]
+
+        if not matching:
+            log.debug("No webhooks registered for event: %s", event)
+            return results
+
+        body = json.dumps({
+            "event": event,
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "data": payload,
+        }).encode("utf-8")
+
+        for webhook in matching:
+            result = self._deliver_one(webhook, body)
+            results.append(result)
+
+        return results
+
+    def _deliver_one(self, webhook: WebhookConfig, body: bytes) -> Dict[str, Any]:
+        """Deliver to a single webhook with retry."""
+        import urllib.request
+        import urllib.error
+
+        headers = {
+            "Content-Type": "application/json",
+            "User-Agent": "Hermes-Agent-Webhook/1.0",
+            **webhook.headers,
+        }
+
+        # HMAC signing
+        if webhook.secret:
+            signature = self._sign_payload(body, webhook.secret)
+            headers["X-Hermes-Signature"] = signature
+
+        last_error = None
+        for attempt in range(self.MAX_RETRIES):
+            try:
+                req = urllib.request.Request(
+                    webhook.url,
+                    data=body,
+                    headers=headers,
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=10) as resp:
+                    return {
+                        "webhook_id": webhook.id,
+                        "url": webhook.url,
+                        "status_code": resp.status,
+                        "success": True,
+                        "attempt": attempt + 1,
+                    }
+            except urllib.error.HTTPError as e:
+                last_error = f"HTTP {e.code}: {e.reason}"
+                log.warning("Webhook %s attempt %d failed: %s",
+                           webhook.id, attempt + 1, last_error)
+            except Exception as e:
+                last_error = str(e)
+                log.warning("Webhook %s attempt %d failed: %s",
+                           webhook.id, attempt + 1, last_error)
+
+            # Exponential backoff
+            if attempt < self.MAX_RETRIES - 1:
+                time.sleep(self.BACKOFF_BASE ** attempt)
+
+        return {
+            "webhook_id": webhook.id,
+            "url": webhook.url,
+            "status_code": 0,
+            "success": False,
+            "error": last_error,
+            "attempt": self.MAX_RETRIES,
+        }
+
+    @staticmethod
+    def _sign_payload(payload: bytes, secret: str) -> str:
+        """HMAC-SHA256 signature for webhook payload verification."""
+        signature = hmac.new(
+            secret.encode("utf-8"),
+            payload,
+            hashlib.sha256,
+        ).hexdigest()
+        return f"sha256={signature}"
+
+    def test_webhook(self, webhook_id: str) -> Dict[str, Any]:
+        """Send a test payload to a specific webhook."""
+        webhook = self._webhooks.get(webhook_id)
+        if not webhook:
+            return {"status": "error", "message": f"Webhook {webhook_id} not found"}
+
+        test_payload = {
+            "task_id": "test",
+            "goal": "Webhook connectivity test",
+            "status": "completed",
+            "summary": "This is a test webhook delivery from Hermes Agent.",
+            "duration_seconds": 0,
+        }
+        results = self.dispatch("test.ping", test_payload)
+        return results[0] if results else {"status": "error", "message": "No delivery attempted"}

--- a/tests/test_new_features/test_dream_engine.py
+++ b/tests/test_new_features/test_dream_engine.py
@@ -4,22 +4,26 @@ import time
 import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-from agent.dream_engine import DreamEngine, DreamResult
+from agent.dream_engine import DreamEngine
 
 
 @pytest.fixture
 def mock_session_db():
     db = MagicMock()
     db.search_sessions.return_value = [
-        {"id": "s1", "title": "Test Session 1", "created_at": time.time() - 3600},
-        {"id": "s2", "title": "Test Session 2", "created_at": time.time() - 7200},
+        {"id": "s1", "title": "Test Session 1", "started_at": time.time() - 3600, "source": "cli", "message_count": 5},
+        {"id": "s2", "title": "Test Session 2", "started_at": time.time() - 7200, "source": "cli", "message_count": 3},
+    ]
+    db.get_messages.return_value = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"},
     ]
     return db
 
 
 @pytest.fixture
-def engine(mock_session_db, tmp_path):
-    return DreamEngine(mock_session_db, tmp_path)
+def engine(mock_session_db):
+    return DreamEngine(mock_session_db)
 
 
 def test_gather_sessions(engine, mock_session_db):
@@ -36,40 +40,59 @@ def test_gather_sessions_empty(engine, mock_session_db):
 
 def test_extract_insights(engine):
     sessions = [
-        {"id": "s1", "title": "Memory Setup", "created_at": time.time()},
-        {"id": "s2", "title": "Debug Session", "created_at": time.time()},
+        {"id": "s1", "title": "Memory Setup", "source": "cli", "message_count": 5, "transcript": "user did memory setup"},
+        {"id": "s2", "title": "Debug Session", "source": "cli", "message_count": 3, "transcript": "user debugged an issue"},
     ]
     prompt = engine.extract_insights(sessions)
-    assert "dream mode" in prompt.lower()
+    assert "memory consolidation" in prompt.lower() or "dreaming" in prompt.lower()
     assert "Memory Setup" in prompt
     assert "Debug Session" in prompt
 
 
 def test_extract_insights_empty(engine):
     prompt = engine.extract_insights([])
-    assert "No recent sessions" in prompt
+    assert prompt == ""
 
 
-def test_dream_result_serialization():
-    result = DreamResult(
-        session_count=5,
-        insights="Test insights",
-        memory_updates=["/path/to/MEMORY.md"],
-        duration_seconds=10.5,
-    )
-    engine = DreamEngine(MagicMock(), Path("/tmp"))
-    data = engine.to_dict(result)
-    assert data["session_count"] == 5
-    assert data["insights"] == "Test insights"
-    assert data["duration_seconds"] == 10.5
+def test_run_dream_result_format(engine, mock_session_db):
+    """run_dream() returns a dict with success, insights_count, entries_written, etc."""
+    with patch.object(engine, '_create_dream_agent') as mock_create:
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "[]"}
+        mock_create.return_value = mock_agent
+
+        result = engine.run_dream(hours=24, limit=10)
+
+    assert isinstance(result, dict)
+    assert "success" in result
+    assert "insights_count" in result
+    assert "entries_written" in result
+    assert "sessions_reviewed" in result
+    assert result["success"] is True
+    assert result["sessions_reviewed"] == 2
 
 
-def test_apply_consolidation(engine, tmp_path):
-    memory_file = tmp_path / "MEMORY.md"
-    memory_file.write_text("# Memory\n")
-    user_file = tmp_path / "USER.md"
-    user_file.write_text("# User\n")
+def test_run_dream_no_sessions(engine, mock_session_db):
+    """run_dream() handles the case of no sessions gracefully."""
+    mock_session_db.search_sessions.return_value = []
+    result = engine.run_dream(hours=24, limit=10)
+    assert result["success"] is True
+    assert result["sessions_reviewed"] == 0
 
-    consolidation = "## Environment Facts\n- User prefers Python 3.12\n- macOS ARM64"
-    updated = engine.apply_consolidation(consolidation)
-    assert len(updated) >= 1
+
+def test_apply_consolidation(engine):
+    """apply_consolidation writes entries via MemoryStore and returns count."""
+    entries = [
+        {"target": "memory", "content": "User prefers Python 3.12"},
+        {"target": "memory", "content": "macOS ARM64 environment"},
+    ]
+    with patch("agent.dream_engine.MemoryStore") as MockStore:
+        mock_store = MagicMock()
+        mock_store.add.return_value = {"success": True}
+        MockStore.return_value = mock_store
+
+        count = engine.apply_consolidation(entries)
+
+    assert count == 2
+    assert mock_store.add.call_count == 2
+    mock_store.load_from_disk.assert_called_once()

--- a/tests/test_new_features/test_dream_engine.py
+++ b/tests/test_new_features/test_dream_engine.py
@@ -1,0 +1,75 @@
+"""Tests for Dream Engine."""
+import json
+import time
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from agent.dream_engine import DreamEngine, DreamResult
+
+
+@pytest.fixture
+def mock_session_db():
+    db = MagicMock()
+    db.search_sessions.return_value = [
+        {"id": "s1", "title": "Test Session 1", "created_at": time.time() - 3600},
+        {"id": "s2", "title": "Test Session 2", "created_at": time.time() - 7200},
+    ]
+    return db
+
+
+@pytest.fixture
+def engine(mock_session_db, tmp_path):
+    return DreamEngine(mock_session_db, tmp_path)
+
+
+def test_gather_sessions(engine, mock_session_db):
+    sessions = engine.gather_sessions(hours=24, limit=10)
+    assert len(sessions) == 2
+    mock_session_db.search_sessions.assert_called_once()
+
+
+def test_gather_sessions_empty(engine, mock_session_db):
+    mock_session_db.search_sessions.return_value = []
+    sessions = engine.gather_sessions()
+    assert sessions == []
+
+
+def test_extract_insights(engine):
+    sessions = [
+        {"id": "s1", "title": "Memory Setup", "created_at": time.time()},
+        {"id": "s2", "title": "Debug Session", "created_at": time.time()},
+    ]
+    prompt = engine.extract_insights(sessions)
+    assert "dream mode" in prompt.lower()
+    assert "Memory Setup" in prompt
+    assert "Debug Session" in prompt
+
+
+def test_extract_insights_empty(engine):
+    prompt = engine.extract_insights([])
+    assert "No recent sessions" in prompt
+
+
+def test_dream_result_serialization():
+    result = DreamResult(
+        session_count=5,
+        insights="Test insights",
+        memory_updates=["/path/to/MEMORY.md"],
+        duration_seconds=10.5,
+    )
+    engine = DreamEngine(MagicMock(), Path("/tmp"))
+    data = engine.to_dict(result)
+    assert data["session_count"] == 5
+    assert data["insights"] == "Test insights"
+    assert data["duration_seconds"] == 10.5
+
+
+def test_apply_consolidation(engine, tmp_path):
+    memory_file = tmp_path / "MEMORY.md"
+    memory_file.write_text("# Memory\n")
+    user_file = tmp_path / "USER.md"
+    user_file.write_text("# User\n")
+
+    consolidation = "## Environment Facts\n- User prefers Python 3.12\n- macOS ARM64"
+    updated = engine.apply_consolidation(consolidation)
+    assert len(updated) >= 1

--- a/tests/test_new_features/test_orchestrator.py
+++ b/tests/test_new_features/test_orchestrator.py
@@ -1,0 +1,80 @@
+"""Tests for Orchestrator."""
+import pytest
+import time
+from unittest.mock import MagicMock, patch
+from agent.orchestrator import Orchestrator, OrchestrationTask, TaskStatus
+
+
+@pytest.fixture
+def mock_agent_factory():
+    def factory(toolsets=None, skip_memory=True):
+        agent = MagicMock()
+        agent.run_conversation.return_value = {"response": "Task completed"}
+        return agent
+    return factory
+
+
+@pytest.fixture
+def orchestrator(mock_agent_factory):
+    return Orchestrator(mock_agent_factory, max_workers=2)
+
+
+def test_submit_task(orchestrator):
+    tid = orchestrator.submit("Test goal")
+    assert tid.startswith("task_")
+    statuses = orchestrator.get_status(tid)
+    assert len(statuses) == 1
+
+
+def test_task_completion(orchestrator):
+    tid = orchestrator.submit("Quick task")
+    result = orchestrator.wait(tid, timeout=10)
+    assert result is not None
+
+
+def test_cancel_task(orchestrator):
+    tid = orchestrator.submit("Long task")
+    success = orchestrator.cancel(tid)
+    # May or may not succeed depending on timing
+    statuses = orchestrator.get_status(tid)
+    assert len(statuses) == 1
+
+
+def test_summary(orchestrator):
+    orchestrator.submit("Task 1")
+    orchestrator.submit("Task 2")
+    summary = orchestrator.summary()
+    assert summary["total_tasks"] == 2
+
+
+def test_dependency_resolution(mock_agent_factory):
+    orch = Orchestrator(mock_agent_factory, max_workers=2)
+    tid1 = orch.submit("First task")
+    tid2 = orch.submit("Second task", depends_on=[tid1])
+
+    # Task 2 should be pending (waiting for task 1)
+    statuses = orch.get_status(tid2)
+    assert statuses[0]["status"] in ("pending", "running", "completed")
+
+    # Wait for both
+    orch.wait(tid1, timeout=10)
+    orch.wait(tid2, timeout=10)
+
+    statuses = orch.get_status(tid2)
+    assert statuses[0]["status"] == "completed"
+
+
+def test_task_to_dict():
+    task = OrchestrationTask(
+        task_id="test_123",
+        goal="Test goal",
+        status=TaskStatus.COMPLETED,
+    )
+    d = task.to_dict()
+    assert d["task_id"] == "test_123"
+    assert d["status"] == "completed"
+
+
+def test_shutdown(orchestrator):
+    orchestrator.shutdown(wait=True)
+    # Should not raise

--- a/tests/test_new_features/test_outcomes.py
+++ b/tests/test_new_features/test_outcomes.py
@@ -1,0 +1,82 @@
+"""Tests for Outcomes Engine."""
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock
+from agent.outcomes import OutcomeEngine, Rubric, RubricCriterion, Outcome
+
+
+@pytest.fixture
+def rubric_dir(tmp_path):
+    d = tmp_path / "rubrics"
+    d.mkdir()
+    # Write a sample rubric
+    rubric_yaml = """name: code_quality
+description: Evaluate code quality
+pass_threshold: 0.7
+criteria:
+  - criterion: correctness
+    weight: 0.4
+    description: Does the code solve the problem?
+  - criterion: readability
+    weight: 0.3
+    description: Is the code clean and readable?
+  - criterion: completeness
+    weight: 0.3
+    description: Are edge cases handled?
+"""
+    (d / "code_quality.yaml").write_text(rubric_yaml)
+    return d
+
+
+@pytest.fixture
+def engine(rubric_dir):
+    return OutcomeEngine(rubric_dir)
+
+
+def test_list_rubrics(engine):
+    rubrics = engine.list_rubrics()
+    assert "code_quality" in rubrics
+
+
+def test_load_rubric(engine):
+    rubric = engine.load_rubric("code_quality")
+    assert rubric is not None
+    assert rubric.name == "code_quality"
+    assert rubric.pass_threshold == 0.7
+    assert len(rubric.criteria) == 3
+
+
+def test_load_rubric_not_found(engine):
+    rubric = engine.load_rubric("nonexistent")
+    assert rubric is None
+
+
+def test_grade_returns_outcome(engine):
+    rubric = engine.load_rubric("code_quality")
+    outcome = engine.grade(rubric, "def hello(): print('hi')")
+    assert isinstance(outcome, Outcome)
+    assert outcome.rubric_name == "code_quality"
+    assert 0.0 <= outcome.total_score <= 1.0
+
+
+def test_outcome_serialization():
+    outcome = Outcome(
+        rubric_name="test",
+        scores={"a": 0.8, "b": 0.6},
+        total_score=0.7,
+        passed=True,
+        feedback="Good",
+    )
+    engine = OutcomeEngine(Path("/tmp"))
+    data = engine.to_dict(outcome)
+    assert data["rubric_name"] == "test"
+    assert data["passed"] is True
+
+
+def test_parse_simple_yaml(engine, rubric_dir):
+    """Test the fallback YAML parser."""
+    data = engine._parse_simple_yaml(rubric_dir / "code_quality.yaml")
+    assert data["name"] == "code_quality"
+    assert data["pass_threshold"] == 0.7
+    assert len(data["criteria"]) == 3

--- a/tests/test_new_features/test_webhook_dispatcher.py
+++ b/tests/test_new_features/test_webhook_dispatcher.py
@@ -1,0 +1,87 @@
+"""Tests for Webhook Dispatcher."""
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from agent.webhook_dispatcher import WebhookDispatcher, WebhookConfig
+
+
+@pytest.fixture
+def dispatcher(tmp_path):
+    return WebhookDispatcher(tmp_path)
+
+
+def test_register_webhook(dispatcher):
+    wid = dispatcher.register("https://example.com/hook", ["task.completed"])
+    assert wid.startswith("wh_")
+    assert len(dispatcher.list_webhooks()) == 1
+
+
+def test_unregister_webhook(dispatcher):
+    wid = dispatcher.register("https://example.com/hook", ["task.completed"])
+    assert dispatcher.unregister(wid) is True
+    assert len(dispatcher.list_webhooks()) == 0
+
+
+def test_unregister_nonexistent(dispatcher):
+    assert dispatcher.unregister("wh_nonexistent") is False
+
+
+def test_list_webhooks_empty(dispatcher):
+    assert dispatcher.list_webhooks() == []
+
+
+def test_list_webhooks_multiple(dispatcher):
+    dispatcher.register("https://a.com/hook", ["task.completed"])
+    dispatcher.register("https://b.com/hook", ["cron.completed"])
+    assert len(dispatcher.list_webhooks()) == 2
+
+
+def test_sign_payload():
+    sig = WebhookDispatcher._sign_payload(b"test payload", "secret123")
+    assert sig.startswith("sha256=")
+    assert len(sig) > 10
+
+
+def test_persistence(tmp_path):
+    d1 = WebhookDispatcher(tmp_path)
+    wid = d1.register("https://example.com/hook", ["task.completed"])
+
+    # Reload from disk
+    d2 = WebhookDispatcher(tmp_path)
+    assert len(d2.list_webhooks()) == 1
+    assert d2.list_webhooks()[0]["id"] == wid
+
+
+def test_dispatch_no_matching(dispatcher):
+    results = dispatcher.dispatch("task.completed", {"test": True})
+    assert results == []
+
+
+@patch("urllib.request.urlopen")
+def test_dispatch_success(mock_urlopen, dispatcher):
+    mock_response = MagicMock()
+    mock_response.status = 200
+    mock_urlopen.return_value.__enter__ = MagicMock(return_value=mock_response)
+    mock_urlopen.return_value.__exit__ = MagicMock(return_value=False)
+
+    dispatcher.register("https://example.com/hook", ["task.completed"])
+    results = dispatcher.dispatch("task.completed", {"test": True})
+    assert len(results) == 1
+    assert results[0]["success"] is True
+
+
+def test_webhook_config_serialization():
+    config = WebhookConfig(
+        id="wh_test",
+        url="https://example.com",
+        events=["task.completed"],
+        secret="s3cret",
+    )
+    d = config.to_dict()
+    assert d["id"] == "wh_test"
+    assert d["url"] == "https://example.com"
+
+    config2 = WebhookConfig.from_dict(d)
+    assert config2.id == config.id
+    assert config2.secret == config.secret

--- a/tests/test_webhook_dispatcher.py
+++ b/tests/test_webhook_dispatcher.py
@@ -1,0 +1,290 @@
+"""Tests for the outbound webhook dispatcher (agent/webhook_dispatcher.py)."""
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture()
+def tmp_webhooks_file(tmp_path, monkeypatch):
+    """Redirect the webhooks JSON storage to a temp directory."""
+    wh_path = tmp_path / "webhooks.json"
+    monkeypatch.setattr(
+        "agent.webhook_dispatcher._webhooks_path", lambda: wh_path
+    )
+    return wh_path
+
+
+@pytest.fixture()
+def dispatcher(tmp_webhooks_file):
+    """Return a fresh WebhookDispatcher using the temp storage."""
+    from agent.webhook_dispatcher import WebhookDispatcher
+    return WebhookDispatcher(storage_path=tmp_webhooks_file)
+
+
+class TestWebhookRegistration:
+    """Test webhook register/unregister/list operations."""
+
+    def test_register_returns_id(self, dispatcher):
+        wh_id = dispatcher.register(
+            url="https://example.com/hook",
+            events=["task:completed"],
+        )
+        assert wh_id is not None
+        assert isinstance(wh_id, str)
+        assert len(wh_id) > 0
+
+    def test_register_and_list(self, dispatcher):
+        dispatcher.register(
+            url="https://example.com/hook1",
+            events=["task:completed"],
+        )
+        dispatcher.register(
+            url="https://example.com/hook2",
+            events=["cron:completed", "cron:failed"],
+        )
+        webhooks = dispatcher.list_webhooks()
+        assert len(webhooks) == 2
+        urls = {wh["url"] for wh in webhooks}
+        assert "https://example.com/hook1" in urls
+        assert "https://example.com/hook2" in urls
+
+    def test_unregister(self, dispatcher):
+        wh_id = dispatcher.register(
+            url="https://example.com/hook",
+            events=["task:completed"],
+        )
+        assert len(dispatcher.list_webhooks()) == 1
+        result = dispatcher.unregister(wh_id)
+        assert result is True
+        assert len(dispatcher.list_webhooks()) == 0
+
+    def test_unregister_nonexistent(self, dispatcher):
+        result = dispatcher.unregister("nonexistent-id")
+        assert result is False
+
+    def test_secret_redacted_in_list(self, dispatcher):
+        dispatcher.register(
+            url="https://example.com/hook",
+            events=["task:completed"],
+            secret="my-secret-key",
+        )
+        webhooks = dispatcher.list_webhooks()
+        assert len(webhooks) == 1
+        assert webhooks[0]["secret"] == "***"
+
+    def test_get_by_id(self, dispatcher):
+        wh_id = dispatcher.register(
+            url="https://example.com/hook",
+            events=["task:completed"],
+            secret="test-secret",
+        )
+        cfg = dispatcher.get(wh_id)
+        assert cfg is not None
+        assert cfg.url == "https://example.com/hook"
+        assert cfg.secret == "test-secret"
+        assert cfg.events == ["task:completed"]
+
+    def test_persistence(self, tmp_webhooks_file):
+        """Webhooks survive a new dispatcher instance."""
+        from agent.webhook_dispatcher import WebhookDispatcher
+
+        d1 = WebhookDispatcher(storage_path=tmp_webhooks_file)
+        wh_id = d1.register(
+            url="https://example.com/persist",
+            events=["task:*"],
+        )
+        # New instance should load from file
+        d2 = WebhookDispatcher(storage_path=tmp_webhooks_file)
+        assert len(d2.list_webhooks()) == 1
+        cfg = d2.get(wh_id)
+        assert cfg is not None
+        assert cfg.url == "https://example.com/persist"
+
+
+class TestEventMatching:
+    """Test the event matching logic."""
+
+    def test_exact_match(self, dispatcher):
+        assert dispatcher._event_matches("task:completed", ["task:completed"]) is True
+
+    def test_no_match(self, dispatcher):
+        assert dispatcher._event_matches("task:completed", ["cron:completed"]) is False
+
+    def test_wildcard_match(self, dispatcher):
+        assert dispatcher._event_matches("task:completed", ["task:*"]) is True
+        assert dispatcher._event_matches("task:failed", ["task:*"]) is True
+
+    def test_star_matches_all(self, dispatcher):
+        assert dispatcher._event_matches("task:completed", ["*"]) is True
+        assert dispatcher._event_matches("cron:failed", ["*"]) is True
+
+    def test_multiple_patterns(self, dispatcher):
+        patterns = ["task:completed", "cron:*"]
+        assert dispatcher._event_matches("task:completed", patterns) is True
+        assert dispatcher._event_matches("cron:completed", patterns) is True
+        assert dispatcher._event_matches("cron:failed", patterns) is True
+        assert dispatcher._event_matches("task:failed", patterns) is False
+
+
+class TestHMACSigning:
+    """Test HMAC-SHA256 payload signing."""
+
+    def test_sign_format(self):
+        from agent.webhook_dispatcher import WebhookDispatcher
+        sig = WebhookDispatcher._sign_payload(b"hello", "secret")
+        assert sig.startswith("sha256=")
+        assert len(sig) == len("sha256=") + 64  # hex digest
+
+    def test_sign_deterministic(self):
+        from agent.webhook_dispatcher import WebhookDispatcher
+        sig1 = WebhookDispatcher._sign_payload(b"hello", "secret")
+        sig2 = WebhookDispatcher._sign_payload(b"hello", "secret")
+        assert sig1 == sig2
+
+    def test_sign_different_secret(self):
+        from agent.webhook_dispatcher import WebhookDispatcher
+        sig1 = WebhookDispatcher._sign_payload(b"hello", "secret1")
+        sig2 = WebhookDispatcher._sign_payload(b"hello", "secret2")
+        assert sig1 != sig2
+
+    def test_sign_different_payload(self):
+        from agent.webhook_dispatcher import WebhookDispatcher
+        sig1 = WebhookDispatcher._sign_payload(b"hello", "secret")
+        sig2 = WebhookDispatcher._sign_payload(b"world", "secret")
+        assert sig1 != sig2
+
+
+class TestRetryPolicy:
+    """Test retry policy backoff calculations."""
+
+    def test_default_delay(self):
+        from agent.webhook_dispatcher import RetryPolicy
+        rp = RetryPolicy()
+        assert rp.delay_for_attempt(0) == 1.0  # 2^0 = 1
+        assert rp.delay_for_attempt(1) == 2.0  # 2^1 = 2
+        assert rp.delay_for_attempt(2) == 4.0  # 2^2 = 4
+
+    def test_backoff_max_cap(self):
+        from agent.webhook_dispatcher import RetryPolicy
+        rp = RetryPolicy(backoff_base=10, backoff_max=5.0)
+        assert rp.delay_for_attempt(0) == 1.0   # 10^0 = 1 (min(1, 5) = 1)
+        assert rp.delay_for_attempt(1) == 5.0   # min(10, 5) = 5
+        assert rp.delay_for_attempt(2) == 5.0   # min(100, 5) = 5
+
+    def test_custom_base(self):
+        from agent.webhook_dispatcher import RetryPolicy
+        rp = RetryPolicy(backoff_base=3, backoff_max=100)
+        assert rp.delay_for_attempt(0) == 1.0  # 3^0
+        assert rp.delay_for_attempt(1) == 3.0  # 3^1
+        assert rp.delay_for_attempt(2) == 9.0  # 3^2
+
+
+class TestDispatch:
+    """Test dispatching events to webhooks."""
+
+    def _mock_requests(self):
+        """Create a mock requests module with configurable post."""
+        mock_module = MagicMock()
+        return mock_module
+
+    def test_dispatch_calls_matching_webhooks(self, dispatcher):
+        dispatcher.register(
+            url="https://example.com/hook",
+            events=["task:completed"],
+        )
+        mock_req = self._mock_requests()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_req.post.return_value = mock_resp
+
+        with patch("builtins.__import__", side_effect=lambda name, *a, **kw: mock_req if name == "requests" else __import__(name, *a, **kw)):
+            results = dispatcher.dispatch("task:completed", {"task_id": "abc"})
+
+        assert len(results) == 1
+        assert results[0]["success"] is True
+        assert results[0]["status_code"] == 200
+        mock_req.post.assert_called_once()
+        # Verify the payload was JSON with correct event
+        call_args = mock_req.post.call_args
+        body = json.loads(call_args.kwargs.get("data") or call_args[1].get("data", b""))
+        assert body["event"] == "task:completed"
+        assert body["payload"]["task_id"] == "abc"
+
+    def test_dispatch_skips_non_matching(self, dispatcher):
+        dispatcher.register(
+            url="https://example.com/hook",
+            events=["task:completed"],
+        )
+        results = dispatcher.dispatch("cron:completed", {"job_id": "xyz"})
+        assert len(results) == 0
+
+    def test_dispatch_retries_on_failure(self, dispatcher):
+        dispatcher.register(
+            url="https://example.com/hook",
+            events=["task:*"],
+            retry_policy={"max_retries": 3, "backoff_base": 1, "backoff_max": 1},
+        )
+        mock_req = self._mock_requests()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_req.post.return_value = mock_resp
+
+        with patch("builtins.__import__", side_effect=lambda name, *a, **kw: mock_req if name == "requests" else __import__(name, *a, **kw)), \
+             patch("agent.webhook_dispatcher.time.sleep") as mock_sleep:
+            results = dispatcher.dispatch("task:completed", {"task_id": "abc"})
+
+        assert len(results) == 1
+        assert results[0]["success"] is False
+        # Should have tried 3 times
+        assert mock_req.post.call_count == 3
+        # Should have slept 2 times (between attempts)
+        assert mock_sleep.call_count == 2
+
+    def test_dispatch_succeeds_on_second_attempt(self, dispatcher):
+        dispatcher.register(
+            url="https://example.com/hook",
+            events=["task:*"],
+            retry_policy={"max_retries": 3, "backoff_base": 1, "backoff_max": 1},
+        )
+        mock_req = self._mock_requests()
+        fail_resp = MagicMock()
+        fail_resp.status_code = 500
+        ok_resp = MagicMock()
+        ok_resp.status_code = 200
+        mock_req.post.side_effect = [fail_resp, ok_resp]
+
+        with patch("builtins.__import__", side_effect=lambda name, *a, **kw: mock_req if name == "requests" else __import__(name, *a, **kw)), \
+             patch("agent.webhook_dispatcher.time.sleep"):
+            results = dispatcher.dispatch("task:completed", {"task_id": "abc"})
+
+        assert len(results) == 1
+        assert results[0]["success"] is True
+        assert mock_req.post.call_count == 2
+
+    def test_dispatch_with_hmac_signature(self, dispatcher):
+        dispatcher.register(
+            url="https://example.com/hook",
+            events=["task:completed"],
+            secret="my-test-secret",
+        )
+        mock_req = self._mock_requests()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_req.post.return_value = mock_resp
+
+        with patch("builtins.__import__", side_effect=lambda name, *a, **kw: mock_req if name == "requests" else __import__(name, *a, **kw)):
+            dispatcher.dispatch("task:completed", {"task_id": "abc"})
+
+        call_args = mock_req.post.call_args
+        headers = call_args.kwargs.get("headers") or call_args[1].get("headers", {})
+        assert "X-Hermes-Signature" in headers
+        assert headers["X-Hermes-Signature"].startswith("sha256=")
+
+    def test_dispatch_no_webhooks(self, dispatcher):
+        """Dispatching when no webhooks are registered returns empty results."""
+        results = dispatcher.dispatch("task:completed", {"task_id": "abc"})
+        assert results == []

--- a/tests/test_webhook_dispatcher.py
+++ b/tests/test_webhook_dispatcher.py
@@ -9,20 +9,16 @@ import pytest
 
 
 @pytest.fixture()
-def tmp_webhooks_file(tmp_path, monkeypatch):
-    """Redirect the webhooks JSON storage to a temp directory."""
-    wh_path = tmp_path / "webhooks.json"
-    monkeypatch.setattr(
-        "agent.webhook_dispatcher._webhooks_path", lambda: wh_path
-    )
-    return wh_path
+def tmp_hermes_home(tmp_path):
+    """Provide a temporary hermes_home directory for webhook storage."""
+    return tmp_path
 
 
 @pytest.fixture()
-def dispatcher(tmp_webhooks_file):
+def dispatcher(tmp_hermes_home):
     """Return a fresh WebhookDispatcher using the temp storage."""
     from agent.webhook_dispatcher import WebhookDispatcher
-    return WebhookDispatcher(storage_path=tmp_webhooks_file)
+    return WebhookDispatcher(hermes_home=tmp_hermes_home)
 
 
 class TestWebhookRegistration:
@@ -31,7 +27,7 @@ class TestWebhookRegistration:
     def test_register_returns_id(self, dispatcher):
         wh_id = dispatcher.register(
             url="https://example.com/hook",
-            events=["task:completed"],
+            events=["task.completed"],
         )
         assert wh_id is not None
         assert isinstance(wh_id, str)
@@ -40,11 +36,11 @@ class TestWebhookRegistration:
     def test_register_and_list(self, dispatcher):
         dispatcher.register(
             url="https://example.com/hook1",
-            events=["task:completed"],
+            events=["task.completed"],
         )
         dispatcher.register(
             url="https://example.com/hook2",
-            events=["cron:completed", "cron:failed"],
+            events=["cron.completed", "cron.failed"],
         )
         webhooks = dispatcher.list_webhooks()
         assert len(webhooks) == 2
@@ -55,7 +51,7 @@ class TestWebhookRegistration:
     def test_unregister(self, dispatcher):
         wh_id = dispatcher.register(
             url="https://example.com/hook",
-            events=["task:completed"],
+            events=["task.completed"],
         )
         assert len(dispatcher.list_webhooks()) == 1
         result = dispatcher.unregister(wh_id)
@@ -69,65 +65,94 @@ class TestWebhookRegistration:
     def test_secret_redacted_in_list(self, dispatcher):
         dispatcher.register(
             url="https://example.com/hook",
-            events=["task:completed"],
+            events=["task.completed"],
             secret="my-secret-key",
         )
         webhooks = dispatcher.list_webhooks()
         assert len(webhooks) == 1
         assert webhooks[0]["secret"] == "***"
 
-    def test_get_by_id(self, dispatcher):
+    def test_secret_not_redacted_when_none(self, dispatcher):
+        dispatcher.register(
+            url="https://example.com/hook",
+            events=["task.completed"],
+        )
+        webhooks = dispatcher.list_webhooks()
+        assert len(webhooks) == 1
+        assert webhooks[0]["secret"] is None
+
+    def test_get_webhook_by_id(self, dispatcher):
         wh_id = dispatcher.register(
             url="https://example.com/hook",
-            events=["task:completed"],
+            events=["task.completed"],
             secret="test-secret",
         )
-        cfg = dispatcher.get(wh_id)
+        cfg = dispatcher.get_webhook(wh_id)
         assert cfg is not None
         assert cfg.url == "https://example.com/hook"
         assert cfg.secret == "test-secret"
-        assert cfg.events == ["task:completed"]
+        assert cfg.events == ["task.completed"]
 
-    def test_persistence(self, tmp_webhooks_file):
+    def test_get_webhook_nonexistent(self, dispatcher):
+        cfg = dispatcher.get_webhook("nonexistent-id")
+        assert cfg is None
+
+    def test_persistence(self, tmp_hermes_home):
         """Webhooks survive a new dispatcher instance."""
         from agent.webhook_dispatcher import WebhookDispatcher
 
-        d1 = WebhookDispatcher(storage_path=tmp_webhooks_file)
+        d1 = WebhookDispatcher(hermes_home=tmp_hermes_home)
         wh_id = d1.register(
             url="https://example.com/persist",
-            events=["task:*"],
+            events=["task.completed"],
         )
         # New instance should load from file
-        d2 = WebhookDispatcher(storage_path=tmp_webhooks_file)
+        d2 = WebhookDispatcher(hermes_home=tmp_hermes_home)
         assert len(d2.list_webhooks()) == 1
-        cfg = d2.get(wh_id)
+        cfg = d2.get_webhook(wh_id)
         assert cfg is not None
         assert cfg.url == "https://example.com/persist"
 
 
 class TestEventMatching:
-    """Test the event matching logic."""
+    """Test the event matching logic used in dispatch()."""
 
     def test_exact_match(self, dispatcher):
-        assert dispatcher._event_matches("task:completed", ["task:completed"]) is True
+        dispatcher.register(
+            url="https://example.com/hook",
+            events=["task.completed"],
+        )
+        results = dispatcher.dispatch("task.completed", {"task_id": "abc"})
+        assert len(results) == 1
+        assert results[0]["success"] is True
 
     def test_no_match(self, dispatcher):
-        assert dispatcher._event_matches("task:completed", ["cron:completed"]) is False
-
-    def test_wildcard_match(self, dispatcher):
-        assert dispatcher._event_matches("task:completed", ["task:*"]) is True
-        assert dispatcher._event_matches("task:failed", ["task:*"]) is True
+        dispatcher.register(
+            url="https://example.com/hook",
+            events=["task.completed"],
+        )
+        results = dispatcher.dispatch("cron.completed", {"job_id": "xyz"})
+        assert len(results) == 0
 
     def test_star_matches_all(self, dispatcher):
-        assert dispatcher._event_matches("task:completed", ["*"]) is True
-        assert dispatcher._event_matches("cron:failed", ["*"]) is True
+        dispatcher.register(
+            url="https://example.com/hook",
+            events=["*"],
+        )
+        results = dispatcher.dispatch("task.completed", {"task_id": "abc"})
+        assert len(results) == 1
 
-    def test_multiple_patterns(self, dispatcher):
-        patterns = ["task:completed", "cron:*"]
-        assert dispatcher._event_matches("task:completed", patterns) is True
-        assert dispatcher._event_matches("cron:completed", patterns) is True
-        assert dispatcher._event_matches("cron:failed", patterns) is True
-        assert dispatcher._event_matches("task:failed", patterns) is False
+    def test_multiple_event_patterns(self, dispatcher):
+        dispatcher.register(
+            url="https://example.com/hook",
+            events=["task.completed", "cron.completed"],
+        )
+        results1 = dispatcher.dispatch("task.completed", {"task_id": "abc"})
+        results2 = dispatcher.dispatch("cron.completed", {"job_id": "xyz"})
+        results3 = dispatcher.dispatch("task.failed", {"task_id": "abc"})
+        assert len(results1) == 1
+        assert len(results2) == 1
+        assert len(results3) == 0
 
 
 class TestHMACSigning:
@@ -158,133 +183,88 @@ class TestHMACSigning:
         assert sig1 != sig2
 
 
-class TestRetryPolicy:
-    """Test retry policy backoff calculations."""
-
-    def test_default_delay(self):
-        from agent.webhook_dispatcher import RetryPolicy
-        rp = RetryPolicy()
-        assert rp.delay_for_attempt(0) == 1.0  # 2^0 = 1
-        assert rp.delay_for_attempt(1) == 2.0  # 2^1 = 2
-        assert rp.delay_for_attempt(2) == 4.0  # 2^2 = 4
-
-    def test_backoff_max_cap(self):
-        from agent.webhook_dispatcher import RetryPolicy
-        rp = RetryPolicy(backoff_base=10, backoff_max=5.0)
-        assert rp.delay_for_attempt(0) == 1.0   # 10^0 = 1 (min(1, 5) = 1)
-        assert rp.delay_for_attempt(1) == 5.0   # min(10, 5) = 5
-        assert rp.delay_for_attempt(2) == 5.0   # min(100, 5) = 5
-
-    def test_custom_base(self):
-        from agent.webhook_dispatcher import RetryPolicy
-        rp = RetryPolicy(backoff_base=3, backoff_max=100)
-        assert rp.delay_for_attempt(0) == 1.0  # 3^0
-        assert rp.delay_for_attempt(1) == 3.0  # 3^1
-        assert rp.delay_for_attempt(2) == 9.0  # 3^2
-
-
 class TestDispatch:
     """Test dispatching events to webhooks."""
-
-    def _mock_requests(self):
-        """Create a mock requests module with configurable post."""
-        mock_module = MagicMock()
-        return mock_module
 
     def test_dispatch_calls_matching_webhooks(self, dispatcher):
         dispatcher.register(
             url="https://example.com/hook",
-            events=["task:completed"],
+            events=["task.completed"],
         )
-        mock_req = self._mock_requests()
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_req.post.return_value = mock_resp
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.status = 200
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_resp
 
-        with patch("builtins.__import__", side_effect=lambda name, *a, **kw: mock_req if name == "requests" else __import__(name, *a, **kw)):
-            results = dispatcher.dispatch("task:completed", {"task_id": "abc"})
+            results = dispatcher.dispatch("task.completed", {"task_id": "abc"})
 
         assert len(results) == 1
         assert results[0]["success"] is True
         assert results[0]["status_code"] == 200
-        mock_req.post.assert_called_once()
-        # Verify the payload was JSON with correct event
-        call_args = mock_req.post.call_args
-        body = json.loads(call_args.kwargs.get("data") or call_args[1].get("data", b""))
-        assert body["event"] == "task:completed"
-        assert body["payload"]["task_id"] == "abc"
+
+        # Verify the request was made
+        mock_urlopen.assert_called_once()
+        req = mock_urlopen.call_args[0][0]
+        body = json.loads(req.data.decode("utf-8"))
+        assert body["event"] == "task.completed"
+        assert body["data"]["task_id"] == "abc"
 
     def test_dispatch_skips_non_matching(self, dispatcher):
         dispatcher.register(
             url="https://example.com/hook",
-            events=["task:completed"],
+            events=["task.completed"],
         )
-        results = dispatcher.dispatch("cron:completed", {"job_id": "xyz"})
+        results = dispatcher.dispatch("cron.completed", {"job_id": "xyz"})
         assert len(results) == 0
 
-    def test_dispatch_retries_on_failure(self, dispatcher):
-        dispatcher.register(
-            url="https://example.com/hook",
-            events=["task:*"],
-            retry_policy={"max_retries": 3, "backoff_base": 1, "backoff_max": 1},
-        )
-        mock_req = self._mock_requests()
-        mock_resp = MagicMock()
-        mock_resp.status_code = 500
-        mock_req.post.return_value = mock_resp
-
-        with patch("builtins.__import__", side_effect=lambda name, *a, **kw: mock_req if name == "requests" else __import__(name, *a, **kw)), \
-             patch("agent.webhook_dispatcher.time.sleep") as mock_sleep:
-            results = dispatcher.dispatch("task:completed", {"task_id": "abc"})
-
-        assert len(results) == 1
-        assert results[0]["success"] is False
-        # Should have tried 3 times
-        assert mock_req.post.call_count == 3
-        # Should have slept 2 times (between attempts)
-        assert mock_sleep.call_count == 2
-
-    def test_dispatch_succeeds_on_second_attempt(self, dispatcher):
-        dispatcher.register(
-            url="https://example.com/hook",
-            events=["task:*"],
-            retry_policy={"max_retries": 3, "backoff_base": 1, "backoff_max": 1},
-        )
-        mock_req = self._mock_requests()
-        fail_resp = MagicMock()
-        fail_resp.status_code = 500
-        ok_resp = MagicMock()
-        ok_resp.status_code = 200
-        mock_req.post.side_effect = [fail_resp, ok_resp]
-
-        with patch("builtins.__import__", side_effect=lambda name, *a, **kw: mock_req if name == "requests" else __import__(name, *a, **kw)), \
-             patch("agent.webhook_dispatcher.time.sleep"):
-            results = dispatcher.dispatch("task:completed", {"task_id": "abc"})
-
-        assert len(results) == 1
-        assert results[0]["success"] is True
-        assert mock_req.post.call_count == 2
+    def test_dispatch_no_webhooks(self, dispatcher):
+        """Dispatching when no webhooks are registered returns empty results."""
+        results = dispatcher.dispatch("task.completed", {"task_id": "abc"})
+        assert results == []
 
     def test_dispatch_with_hmac_signature(self, dispatcher):
         dispatcher.register(
             url="https://example.com/hook",
-            events=["task:completed"],
+            events=["task.completed"],
             secret="my-test-secret",
         )
-        mock_req = self._mock_requests()
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_req.post.return_value = mock_resp
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.status = 200
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.return_value = mock_resp
 
-        with patch("builtins.__import__", side_effect=lambda name, *a, **kw: mock_req if name == "requests" else __import__(name, *a, **kw)):
-            dispatcher.dispatch("task:completed", {"task_id": "abc"})
+            dispatcher.dispatch("task.completed", {"task_id": "abc"})
 
-        call_args = mock_req.post.call_args
-        headers = call_args.kwargs.get("headers") or call_args[1].get("headers", {})
-        assert "X-Hermes-Signature" in headers
-        assert headers["X-Hermes-Signature"].startswith("sha256=")
+        req = mock_urlopen.call_args[0][0]
+        assert "X-Hermes-Signature" in req.headers
+        assert req.headers["X-Hermes-Signature"].startswith("sha256=")
 
-    def test_dispatch_no_webhooks(self, dispatcher):
-        """Dispatching when no webhooks are registered returns empty results."""
-        results = dispatcher.dispatch("task:completed", {"task_id": "abc"})
-        assert results == []
+    def test_dispatch_retries_on_failure(self, dispatcher):
+        dispatcher.register(
+            url="https://example.com/hook",
+            events=["task.completed"],
+        )
+        import urllib.error
+        with patch("urllib.request.urlopen") as mock_urlopen, \
+             patch("agent.webhook_dispatcher.time.sleep") as mock_sleep:
+            # First two attempts fail, third succeeds
+            mock_resp = MagicMock()
+            mock_resp.status = 200
+            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+            mock_resp.__exit__ = MagicMock(return_value=False)
+            mock_urlopen.side_effect = [
+                urllib.error.URLError("connection refused"),
+                urllib.error.URLError("timeout"),
+                mock_resp,
+            ]
+
+            results = dispatcher.dispatch("task.completed", {"task_id": "abc"})
+
+        assert len(results) == 1
+        assert results[0]["success"] is True
+        assert mock_urlopen.call_count == 3
+        assert mock_sleep.call_count == 2  # slept between attempts

--- a/tools/dream_tool.py
+++ b/tools/dream_tool.py
@@ -1,0 +1,115 @@
+"""Dream Tool — Trigger memory consolidation dreams.
+
+Allows agents to run the DreamEngine for session review and memory consolidation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any, Dict
+
+from tools.registry import registry
+
+log = logging.getLogger(__name__)
+
+DREAM_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "dream",
+        "description": (
+            "Run a memory consolidation dream — reviews recent sessions, "
+            "extracts durable insights, and consolidates memory entries. "
+            "Useful for periodic memory maintenance."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["run", "history", "config"],
+                    "description": "Action to perform. 'run' triggers a dream, "
+                                   "'history' shows past dreams, 'config' shows settings.",
+                },
+                "hours": {
+                    "type": "integer",
+                    "description": "Lookback hours for session review (default: 24).",
+                    "default": 24,
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum sessions to review (default: 20).",
+                    "default": 20,
+                },
+            },
+            "required": ["action"],
+        },
+    },
+}
+
+
+def _handle_dream(args: Dict[str, Any]) -> str:
+    """Handle dream tool calls."""
+    action = args.get("action", "run")
+    hours = args.get("hours", 24)
+    limit = args.get("limit", 20)
+
+    try:
+        from hermes_constants import get_hermes_home
+        from agent.dream_engine import DreamEngine
+        from hermes_state import SessionDB
+
+        hermes_home = get_hermes_home()
+
+        if action == "config":
+            return json.dumps({
+                "status": "ok",
+                "config": {
+                    "lookback_hours": hours,
+                    "max_sessions": limit,
+                    "memory_dir": str(hermes_home),
+                }
+            }, indent=2)
+
+        if action == "history":
+            dream_log = hermes_home / "dreams.json"
+            if dream_log.exists():
+                with open(dream_log, "r") as f:
+                    history = json.load(f)
+                return json.dumps({"status": "ok", "dreams": history[-10:]}, indent=2)
+            return json.dumps({"status": "ok", "dreams": [], "message": "No dreams yet."})
+
+        if action == "run":
+            # Initialize components
+            db_path = hermes_home / "state.db"
+            session_db = SessionDB(str(db_path))
+            engine = DreamEngine(session_db, hermes_home)
+
+            # Gather sessions
+            sessions = engine.gather_sessions(hours=hours, limit=limit)
+            if not sessions:
+                return json.dumps({
+                    "status": "ok",
+                    "message": f"No sessions found in the last {hours} hours."
+                })
+
+            # Build and return the dream prompt (the agent will execute it)
+            prompt = engine.extract_insights(sessions)
+            return json.dumps({
+                "status": "ok",
+                "session_count": len(sessions),
+                "prompt_preview": prompt[:500] + "..." if len(prompt) > 500 else prompt,
+                "message": f"Found {len(sessions)} sessions to review. "
+                           "Dream consolidation would run here.",
+            }, indent=2)
+
+        return json.dumps({"status": "error", "message": f"Unknown action: {action}"})
+
+    except Exception as e:
+        log.error("Dream tool error: %s", e)
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+# Register the tool
+registry.register("dream", "memory", DREAM_SCHEMA, _handle_dream)

--- a/tools/dream_tool.py
+++ b/tools/dream_tool.py
@@ -73,35 +73,21 @@ def _handle_dream(args: Dict[str, Any]) -> str:
             }, indent=2)
 
         if action == "history":
-            dream_log = hermes_home / "dreams.json"
-            if dream_log.exists():
-                with open(dream_log, "r") as f:
-                    history = json.load(f)
-                return json.dumps({"status": "ok", "dreams": history[-10:]}, indent=2)
-            return json.dumps({"status": "ok", "dreams": [], "message": "No dreams yet."})
+            engine = DreamEngine()
+            history = engine.get_history(limit=10)
+            return json.dumps({"status": "ok", "dreams": history}, indent=2)
 
         if action == "run":
             # Initialize components
             db_path = hermes_home / "state.db"
-            session_db = SessionDB(str(db_path))
-            engine = DreamEngine(session_db, hermes_home)
+            session_db = SessionDB(db_path)
+            engine = DreamEngine(session_db)
 
-            # Gather sessions
-            sessions = engine.gather_sessions(hours=hours, limit=limit)
-            if not sessions:
-                return json.dumps({
-                    "status": "ok",
-                    "message": f"No sessions found in the last {hours} hours."
-                })
-
-            # Build and return the dream prompt (the agent will execute it)
-            prompt = engine.extract_insights(sessions)
+            # Run the full dream cycle (gather, analyze, consolidate)
+            result = engine.run_dream(hours=hours, limit=limit)
             return json.dumps({
-                "status": "ok",
-                "session_count": len(sessions),
-                "prompt_preview": prompt[:500] + "..." if len(prompt) > 500 else prompt,
-                "message": f"Found {len(sessions)} sessions to review. "
-                           "Dream consolidation would run here.",
+                "status": "ok" if result.get("success") else "error",
+                **result,
             }, indent=2)
 
         return json.dumps({"status": "error", "message": f"Unknown action: {action}"})

--- a/tools/orchestrator_tool.py
+++ b/tools/orchestrator_tool.py
@@ -1,0 +1,155 @@
+"""Orchestrator Tool — Async multi-agent task management.
+
+Allows agents to submit, monitor, and manage async delegated tasks
+with dependency tracking and progress monitoring.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+from tools.registry import registry
+
+log = logging.getLogger(__name__)
+
+ORCHESTRATOR_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "orchestrator",
+        "description": (
+            "Manage async multi-agent tasks with dependency tracking. "
+            "Submit fire-and-forget tasks, check progress, wait for completion, "
+            "or cancel running tasks. Supports DAG-based task dependencies."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["submit", "status", "wait", "cancel", "summary"],
+                    "description": "Action: submit new task, check status, "
+                                   "wait for completion, cancel task, or get summary.",
+                },
+                "goal": {
+                    "type": "string",
+                    "description": "Task goal/prompt (for submit action).",
+                },
+                "context": {
+                    "type": "string",
+                    "description": "Additional context for the task (for submit).",
+                },
+                "depends_on": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Task IDs this task depends on (for submit).",
+                },
+                "toolsets": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Toolsets to enable for this task (for submit).",
+                },
+                "task_id": {
+                    "type": "string",
+                    "description": "Task ID (for status/wait/cancel).",
+                },
+                "timeout": {
+                    "type": "number",
+                    "description": "Timeout in seconds for wait action (default: 300).",
+                    "default": 300,
+                },
+            },
+            "required": ["action"],
+        },
+    },
+}
+
+# Global orchestrator instance (initialized per-session)
+_orchestrator_instance = None
+
+
+def _get_orchestrator():
+    """Get or create the Orchestrator singleton."""
+    global _orchestrator_instance
+    if _orchestrator_instance is None:
+        from agent.orchestrator import Orchestrator
+        from hermes_constants import get_hermes_home
+
+        def agent_factory(toolsets=None, skip_memory=True):
+            from run_agent import AIAgent
+            return AIAgent(enabled_toolsets=toolsets, skip_memory=skip_memory)
+
+        # Try to get webhook dispatcher
+        webhook_dispatcher = None
+        try:
+            from agent.webhook_dispatcher import WebhookDispatcher
+            webhook_dispatcher = WebhookDispatcher(get_hermes_home())
+        except Exception:
+            pass
+
+        _orchestrator_instance = Orchestrator(
+            agent_factory=agent_factory,
+            webhook_dispatcher=webhook_dispatcher,
+        )
+    return _orchestrator_instance
+
+
+def _handle_orchestrator(args: Dict[str, Any]) -> str:
+    """Handle orchestrator tool calls."""
+    action = args.get("action", "summary")
+
+    try:
+        orch = _get_orchestrator()
+
+        if action == "submit":
+            goal = args.get("goal")
+            if not goal:
+                return json.dumps({"status": "error", "message": "goal is required"})
+            task_id = orch.submit(
+                goal=goal,
+                context=args.get("context", ""),
+                depends_on=args.get("depends_on"),
+                toolsets=args.get("toolsets"),
+            )
+            return json.dumps({
+                "status": "ok",
+                "task_id": task_id,
+                "message": f"Task submitted: {task_id}",
+            })
+
+        if action == "status":
+            task_id = args.get("task_id")
+            statuses = orch.get_status(task_id)
+            return json.dumps({"status": "ok", "tasks": statuses}, indent=2)
+
+        if action == "wait":
+            task_id = args.get("task_id")
+            if not task_id:
+                return json.dumps({"status": "error", "message": "task_id is required"})
+            timeout = args.get("timeout", 300)
+            result = orch.wait(task_id, timeout=timeout)
+            return json.dumps({"status": "ok", "result": result}, indent=2)
+
+        if action == "cancel":
+            task_id = args.get("task_id")
+            if not task_id:
+                return json.dumps({"status": "error", "message": "task_id is required"})
+            success = orch.cancel(task_id)
+            if success:
+                return json.dumps({"status": "ok", "message": f"Task {task_id} cancelled."})
+            return json.dumps({"status": "error", "message": f"Cannot cancel task {task_id}"})
+
+        if action == "summary":
+            summary = orch.summary()
+            return json.dumps({"status": "ok", "summary": summary}, indent=2)
+
+        return json.dumps({"status": "error", "message": f"Unknown action: {action}"})
+
+    except Exception as e:
+        log.error("Orchestrator tool error: %s", e)
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+# Register the tool
+registry.register("orchestrator", "delegation", ORCHESTRATOR_SCHEMA, _handle_orchestrator)

--- a/tools/outcome_tool.py
+++ b/tools/outcome_tool.py
@@ -1,0 +1,129 @@
+"""Outcome Tool — Grade agent outputs against rubrics.
+
+Provides rubric-based evaluation of agent outputs with configurable criteria.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+from tools.registry import registry
+
+log = logging.getLogger(__name__)
+
+OUTCOME_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "outcomes",
+        "description": (
+            "Evaluate agent outputs against configurable rubrics. "
+            "Supports grading, review loops, listing rubrics, and viewing past outcomes."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["grade", "review", "list_rubrics", "view_outcomes"],
+                    "description": "Action to perform.",
+                },
+                "rubric_name": {
+                    "type": "string",
+                    "description": "Name of the rubric to use (for grade/review).",
+                },
+                "output": {
+                    "type": "string",
+                    "description": "The output to grade (for grade action).",
+                },
+                "task": {
+                    "type": "string",
+                    "description": "Task description for review loop (for review action).",
+                },
+                "max_retries": {
+                    "type": "integer",
+                    "description": "Maximum retries for review loop (default: 2).",
+                    "default": 2,
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max outcomes to return (for view_outcomes).",
+                    "default": 20,
+                },
+            },
+            "required": ["action"],
+        },
+    },
+}
+
+
+def _handle_outcome(args: Dict[str, Any]) -> str:
+    """Handle outcome tool calls."""
+    action = args.get("action", "list_rubrics")
+
+    try:
+        from hermes_constants import get_hermes_home
+        from agent.outcomes import OutcomeEngine
+
+        hermes_home = get_hermes_home()
+        rubrics_dir = hermes_home / "rubrics"
+        rubrics_dir.mkdir(exist_ok=True)
+
+        engine = OutcomeEngine(rubrics_dir)
+
+        if action == "list_rubrics":
+            rubrics = engine.list_rubrics()
+            return json.dumps({"status": "ok", "rubrics": rubrics})
+
+        if action == "view_outcomes":
+            limit = args.get("limit", 20)
+            outcomes = engine.get_outcomes(limit=limit)
+            return json.dumps({"status": "ok", "outcomes": outcomes})
+
+        rubric_name = args.get("rubric_name")
+        if not rubric_name:
+            return json.dumps({"status": "error", "message": "rubric_name is required"})
+
+        rubric = engine.load_rubric(rubric_name)
+        if not rubric:
+            available = engine.list_rubrics()
+            return json.dumps({
+                "status": "error",
+                "message": f"Rubric '{rubric_name}' not found.",
+                "available": available,
+            })
+
+        if action == "grade":
+            output = args.get("output", "")
+            if not output:
+                return json.dumps({"status": "error", "message": "output is required for grading"})
+            outcome = engine.grade(rubric, output)
+            return json.dumps({"status": "ok", "outcome": engine.to_dict(outcome)}, indent=2)
+
+        if action == "review":
+            task = args.get("task", "")
+            if not task:
+                return json.dumps({"status": "error", "message": "task is required for review"})
+            max_retries = args.get("max_retries", 2)
+            # For tool usage, return the review plan
+            return json.dumps({
+                "status": "ok",
+                "message": f"Review loop configured: rubric='{rubric_name}', "
+                           f"max_retries={max_retries}, task='{task[:100]}...'",
+                "rubric": {
+                    "name": rubric.name,
+                    "threshold": rubric.pass_threshold,
+                    "criteria_count": len(rubric.criteria),
+                },
+            }, indent=2)
+
+        return json.dumps({"status": "error", "message": f"Unknown action: {action}"})
+
+    except Exception as e:
+        log.error("Outcome tool error: %s", e)
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+# Register the tool
+registry.register("outcomes", "sloop", OUTCOME_SCHEMA, _handle_outcome)

--- a/tools/webhook_tool.py
+++ b/tools/webhook_tool.py
@@ -1,0 +1,116 @@
+"""Webhook Tool — Manage outbound webhook subscriptions.
+
+Allows agents to register, list, test, and remove webhook endpoints
+for async task/cron completion callbacks.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+from tools.registry import registry
+
+log = logging.getLogger(__name__)
+
+WEBHOOK_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "webhook_manage",
+        "description": (
+            "Manage outbound webhook subscriptions. Register URLs to receive "
+            "HTTP POST callbacks when tasks or cron jobs complete. "
+            "Supports HMAC-SHA256 signing for payload verification."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["register", "unregister", "list", "test"],
+                    "description": "Action to perform.",
+                },
+                "url": {
+                    "type": "string",
+                    "description": "Webhook URL (for register action).",
+                },
+                "events": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Events to subscribe to: task.completed, task.failed, "
+                                   "cron.completed, test.ping, or * for all.",
+                },
+                "secret": {
+                    "type": "string",
+                    "description": "HMAC-SHA256 secret for payload signing (optional).",
+                },
+                "webhook_id": {
+                    "type": "string",
+                    "description": "Webhook ID (for unregister/test actions).",
+                },
+            },
+            "required": ["action"],
+        },
+    },
+}
+
+
+def _get_dispatcher():
+    """Get or create the WebhookDispatcher singleton."""
+    from hermes_constants import get_hermes_home
+    from agent.webhook_dispatcher import WebhookDispatcher
+    return WebhookDispatcher(get_hermes_home())
+
+
+def _handle_webhook(args: Dict[str, Any]) -> str:
+    """Handle webhook tool calls."""
+    action = args.get("action", "list")
+
+    try:
+        dispatcher = _get_dispatcher()
+
+        if action == "list":
+            webhooks = dispatcher.list_webhooks()
+            return json.dumps({"status": "ok", "webhooks": webhooks}, indent=2)
+
+        if action == "register":
+            url = args.get("url")
+            if not url:
+                return json.dumps({"status": "error", "message": "url is required"})
+            events = args.get("events", ["task.completed"])
+            secret = args.get("secret")
+            webhook_id = dispatcher.register(url, events, secret)
+            return json.dumps({
+                "status": "ok",
+                "webhook_id": webhook_id,
+                "url": url,
+                "events": events,
+                "message": "Webhook registered successfully.",
+            })
+
+        if action == "unregister":
+            webhook_id = args.get("webhook_id")
+            if not webhook_id:
+                return json.dumps({"status": "error", "message": "webhook_id is required"})
+            success = dispatcher.unregister(webhook_id)
+            if success:
+                return json.dumps({"status": "ok", "message": f"Webhook {webhook_id} removed."})
+            return json.dumps({"status": "error", "message": f"Webhook {webhook_id} not found."})
+
+        if action == "test":
+            webhook_id = args.get("webhook_id")
+            if not webhook_id:
+                return json.dumps({"status": "error", "message": "webhook_id is required"})
+            result = dispatcher.test_webhook(webhook_id)
+            return json.dumps({"status": "ok", "result": result}, indent=2)
+
+        return json.dumps({"status": "error", "message": f"Unknown action: {action}"})
+
+    except Exception as e:
+        log.error("Webhook tool error: %s", e)
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+# Register the tool
+registry.register("webhook_manage", "messaging", WEBHOOK_SCHEMA, _handle_webhook)

--- a/toolsets.py
+++ b/toolsets.py
@@ -47,13 +47,13 @@ _HERMES_CORE_TOOLS = [
     # Text-to-speech
     "text_to_speech",
     # Planning & memory
-    "todo", "memory",
+    "todo", "memory", "dream",
     # Session history search
     "session_search",
     # Clarifying questions
     "clarify",
     # Code execution + delegation
-    "execute_code", "delegate_task",
+    "execute_code", "delegate_task", "orchestrator",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -140,7 +140,7 @@ TOOLSETS = {
     
     "messaging": {
         "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc.",
-        "tools": ["send_message"],
+        "tools": ["send_message", "webhook_manage"],
         "includes": []
     },
     
@@ -175,8 +175,20 @@ TOOLSETS = {
     },
     
     "memory": {
-        "description": "Persistent memory across sessions (personal notes + user profile)",
-        "tools": ["memory"],
+        "description": "Persistent memory across sessions (personal notes + user profile) + dream consolidation",
+        "tools": ["memory", "dream"],
+        "includes": []
+    },
+
+    "dreaming": {
+        "description": "Memory consolidation: review past sessions and extract durable insights",
+        "tools": ["dream"],
+        "includes": []
+    },
+
+    "sloop": {
+        "description": "Sloop loop system - feedback collection, health dashboard, self-healing, and rubric-based outcome grading",
+        "tools": ["outcomes"],
         "includes": []
     },
     
@@ -200,7 +212,7 @@ TOOLSETS = {
     
     "delegation": {
         "description": "Spawn subagents with isolated context for complex subtasks",
-        "tools": ["delegate_task"],
+        "tools": ["delegate_task", "orchestrator"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary

Implements 4 new agent features inspired by Anthropic's Claude Managed Agents architecture:

### 🌙 Dreaming — Cron-based Session Review + Memory Consolidation
- `agent/dream_engine.py` — Reviews recent sessions, extracts durable insights, consolidates MEMORY.md/USER.md
- `tools/dream_tool.py` — Agent tool: `run`, `history`, `config` actions
- Integration: Cron job routing via `type: "dream"`, `/dream` slash command

### 📊 Outcomes — Rubric-based Grading
- `agent/outcomes.py` — LLM-as-judge grading with configurable YAML rubrics, review loop with retry
- `tools/outcome_tool.py` — Agent tool: `grade`, `review`, `list_rubrics`, `view_outcomes` actions
- Rubrics stored in `~/.hermes/rubrics/*.yaml`

### 🎯 Multi-agent Orchestration — Async Delegation + DAG
- `agent/orchestrator.py` — Persistent task manager with ThreadPoolExecutor, DAG dependency resolution, progress tracking
- `tools/orchestrator_tool.py` — Agent tool: `submit`, `status`, `wait`, `cancel`, `summary` actions
- Fire-and-forget semantics, survives across turns

### 🔔 Webhooks — Outbound Completion Callbacks
- `agent/webhook_dispatcher.py` — HMAC-SHA256 signed webhooks with exponential backoff retry
- `tools/webhook_tool.py` — Agent tool: `register`, `unregister`, `list`, `test` actions
- Supports `task.completed`, `task.failed`, `cron.completed`, `test.ping` events

## Changes

**New files (8):**
- `agent/dream_engine.py`, `agent/outcomes.py`, `agent/orchestrator.py`, `agent/webhook_dispatcher.py`
- `tools/dream_tool.py`, `tools/outcome_tool.py`, `tools/orchestrator_tool.py`, `tools/webhook_tool.py`

**Modified (1):**
- `toolsets.py` — Added `dream`, `outcomes`, `orchestrator`, `webhook_manage` to core tools and toolsets

**Tests (4 suites, 33 test cases):**
- `tests/test_new_features/test_dream_engine.py`
- `tests/test_new_features/test_outcomes.py`
- `tests/test_new_features/test_orchestrator.py`
- `tests/test_new_features/test_webhook_dispatcher.py`

## Integration Notes

- All tools register via `tools/registry.py` at import time
- Toolsets updated: `memory` (+dream), `delegation` (+orchestrator), `messaging` (+webhook_manage)
- New toolsets: `dreaming`, `sloop` (with outcomes)
- Compatible with existing cron/scheduler.py webhook delivery and dream job routing