### PR TITLE
docs(readme): fix misleading RL install-extras claim (salvage #19080)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ uv pip install -e ".[all,dev]"
 scripts/run_tests.sh
 ```
 
-> **RL Training (optional):** The RL/Atropos integration (`environments/`) ships via the `atroposlib` and `tinker` dependencies pulled in by `.[all,dev]` — no submodule setup required.
+> **RL Training (optional):** The RL/Atropos integration (`environments/`) — see [`CONTRIBUTING.md`](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#development-setup) for the full setup.
 
 ---
 


### PR DESCRIPTION
Closes #19080 via salvage.

## Summary
`README.md` line 163 claimed `atroposlib` and `tinker` are pulled in by `.[all,dev]`. They're only in the `[rl]` extra (`pyproject.toml` lines 94-101), which is NOT a dependency of `[all]`. A contributor following the README would not get the RL dependencies. Defer to `CONTRIBUTING.md#development-setup` which has the accurate setup steps.

Original author: @deep-name.