### PR TITLE
fix(cli): honor positive display.tool_preview_length in status previews (salvage #19093)

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -852,13 +852,15 @@ def get_cute_tool_message(
         s = str(s)
         if _tool_preview_max_len == 0:
             return s  # no limit
-        return (s[:n-3] + "...") if len(s) > n else s
+        limit = _tool_preview_max_len
+        return (s[:limit-3] + "...") if len(s) > limit else s
 
     def _path(p, n=35):
         p = str(p)
         if _tool_preview_max_len == 0:
             return p  # no limit
-        return ("..." + p[-(n-3):]) if len(p) > n else p
+        limit = _tool_preview_max_len
+        return ("..." + p[-(limit-3):]) if len(p) > limit else p
 
     def _wrap(line: str) -> str:
         """Apply skin tool prefix and failure suffix."""

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -864,6 +864,7 @@ AUTHOR_MAP = {
     "briansu@Mac-mini.attlocal.net": "likejudy",  # PR #19052
     "leosma@gmail.com": "leon7609",  # PR #19069
     "nouseman666@gmail.com": "nouseman666",  # PR #19088
+    "ginwu05@gmail.com": "GinWU05",  # PR #19093
 }
 
 

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -8,10 +8,19 @@ from agent.display import (
     build_tool_preview,
     capture_local_edit_snapshot,
     extract_edit_diff,
+    get_cute_tool_message,
+    set_tool_preview_max_len,
     _render_inline_unified_diff,
     _summarize_rendered_diff_sections,
     render_edit_diff_with_delta,
 )
+
+
+@pytest.fixture(autouse=True)
+def reset_tool_preview_max_len():
+    set_tool_preview_max_len(0)
+    yield
+    set_tool_preview_max_len(0)
 
 
 class TestBuildToolPreview:
@@ -100,6 +109,45 @@ class TestBuildToolPreview:
         assert build_tool_preview("terminal", 0) is None
         assert build_tool_preview("terminal", "") is None
         assert build_tool_preview("terminal", []) is None
+
+
+class TestCuteToolMessagePreviewLength:
+    def test_terminal_preview_unlimited_when_config_is_zero(self):
+        set_tool_preview_max_len(0)
+        command = "curl -s http://localhost:9222/json/list | jq -r '.[] | select(.type==\"page\")' | head -5"
+
+        line = get_cute_tool_message("terminal", {"command": command}, 0.1)
+
+        assert command in line
+        assert "..." not in line
+
+    def test_terminal_preview_uses_positive_configured_limit(self):
+        set_tool_preview_max_len(80)
+        command = "curl -s http://localhost:9222/json/list | jq -r '.[] | select(.type==\"page\")' | head -5"
+
+        line = get_cute_tool_message("terminal", {"command": command}, 0.1)
+
+        assert command[:77] in line
+        assert "..." in line
+        assert "head -5" not in line
+
+    def test_search_files_preview_uses_positive_configured_limit_not_default(self):
+        set_tool_preview_max_len(80)
+        pattern = "function.formatToolCall.context.preview.compactPreview.maxLength.truncate"
+
+        line = get_cute_tool_message("search_files", {"pattern": pattern}, 0.1)
+
+        assert pattern in line
+        assert "..." not in line
+
+    def test_path_preview_uses_positive_configured_limit_not_default(self):
+        set_tool_preview_max_len(80)
+        path = "/tmp/hermes-test-preview-length/deeply/nested/path/test-output.txt"
+
+        line = get_cute_tool_message("read_file", {"path": path}, 0.1)
+
+        assert path in line
+        assert "..." not in line
 
 
 class TestEditDiffPreview:


### PR DESCRIPTION
Closes #19093 via salvage.

## Summary
`agent/display.py::get_cute_tool_message` treated `display.tool_preview_length` as a boolean (0=disabled, positive=enabled), but actually truncated at the hardcoded per-tool `n=35/40/42` defaults instead of the configured length. Now when the user sets `tool_preview_length: 60`, `_trunc` and `_path` actually cap at 60.

## Validation
`scripts/run_tests.sh tests/agent/test_display.py` → 29 passed.

Original author: @GinWU05.