### PR TITLE
fix(install): remove uv exclude-newer cutoff (salvage #19488)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,3 @@ exclude = ["tinker-atropos"]
 [tool.ruff]
 exclude = ["tinker-atropos"]
 select = [] # disable all lints for now, until we've wrangled typechecks a bit more :3
-
-[tool.uv]
-exclude-newer = "7 days"

--- a/uv.lock
+++ b/uv.lock
@@ -8,10 +8,6 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
 [[package]]
 name = "agent-client-protocol"
 version = "0.9.0"


### PR DESCRIPTION
Closes #19488 and supersedes #19114 via salvage. Fixes #17795 and #19043.

## Summary
`exclude-newer = '7 days'` in `[tool.uv]` blocked mirror-backed installs and broke `uv pip install` for stable packages (setuptools, vercel) that hadn't released in the last 7 days — silently failing `hermes update`'s dependency step. Lock files handle reproducibility; the cutoff was a net negative. Drop the cutoff from both `pyproject.toml` and `uv.lock`.

## Validation
Parsed `pyproject.toml` post-change, no `exclude-newer` keys remain.

Original author: @LeonSGP43. Also thanks @shellybotmoyer for the parallel fix in #19114 — that one also removed the setting but kept a `[tool.uv]` stanza with a comment; this salvage drops the stanza entirely and the `uv.lock` metadata too.