### PR TITLE
fix(model_tools): log plugin hook exceptions instead of silently swallowing them

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -730,8 +730,8 @@ def handle_function_call(
                     session_id=session_id or "",
                     tool_call_id=tool_call_id or "",
                 )
-            except Exception:
-                pass
+            except Exception as _hook_err:
+                logger.debug("pre_tool_call hook error: %s", _hook_err)
 
             if block_message is not None:
                 return json.dumps({"error": block_message}, ensure_ascii=False)
@@ -782,8 +782,8 @@ def handle_function_call(
                 tool_call_id=tool_call_id or "",
                 duration_ms=duration_ms,
             )
-        except Exception:
-            pass
+        except Exception as _hook_err:
+            logger.debug("post_tool_call hook error: %s", _hook_err)
 
         # Generic tool-result canonicalization seam: plugins receive the
         # final result string (JSON, usually) and may replace it by
@@ -807,8 +807,8 @@ def handle_function_call(
                 if isinstance(hook_result, str):
                     result = hook_result
                     break
-        except Exception:
-            pass
+        except Exception as _hook_err:
+            logger.debug("transform_tool_result hook error: %s", _hook_err)
 
         return result
 


### PR DESCRIPTION
Replaces the three bare `except Exception: pass` blocks around plugin hooks in `handle_function_call()` with `logger.debug(...)` so plugin failures are visible when debug logging is on.

## Changes
- `model_tools.py`: pre_tool_call, post_tool_call, and transform_tool_result hook sites now log the exception at DEBUG level instead of discarding it.

## Credit
Cherry-picked from @sprmn24's PR #19860 onto current main; authorship preserved.

Supersedes #19860 and #20599. #20599 attempted the same fix but unindented the `except` inside `_run_in_worker`'s nested try/finally, which produced a `SyntaxError` and an event-loop leak — that site is intentionally not touched here since it's not a plugin hook.