### PR TITLE
feat(gateway): add hermes gateway list to show all profiles' status (salvage #19129)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -830,6 +830,46 @@ def _print_other_profiles_gateway_status() -> None:
         pass
 
 
+def _gateway_list() -> None:
+    """List all profiles and their gateway running status.
+
+    Provides a single-command overview of every known profile and whether
+    its gateway is currently running, so multi-profile users don't have to
+    check each profile individually.
+    """
+    try:
+        from hermes_cli.profiles import list_profiles, get_active_profile_name
+    except Exception:
+        print("Unable to list profiles.")
+        return
+
+    profiles = list_profiles()
+    if not profiles:
+        print("No profiles found.")
+        return
+
+    current = get_active_profile_name()
+
+    print("Gateways:")
+    for prof in profiles:
+        marker = "✓" if prof.gateway_running else "✗"
+        label = prof.name
+        if prof.name == current:
+            label += " (current)"
+        parts = [f"  {marker} {label:<24s}"]
+        if prof.gateway_running:
+            try:
+                from gateway.status import get_running_pid
+                pid = get_running_pid(prof.path / "gateway.pid", cleanup_stale=False)
+                if pid:
+                    parts.append(f"PID {pid}")
+            except Exception:
+                pass
+        else:
+            parts.append("not running")
+        print(" — ".join(parts))
+
+
 def kill_gateway_processes(force: bool = False, exclude_pids: set | None = None,
                            all_profiles: bool = False) -> int:
     """Kill any running gateway processes. Returns count killed.
@@ -4797,6 +4837,9 @@ def _gateway_command_inner(args):
 
         # Show other profiles' gateway status for multi-profile awareness
         _print_other_profiles_gateway_status()
+
+    elif subcmd == "list":
+        _gateway_list()
 
     elif subcmd == "migrate-legacy":
         # Stop, disable, and remove legacy Hermes gateway unit files from

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8690,6 +8690,9 @@ def main():
         help="Target the Linux system-level gateway service",
     )
 
+    # gateway list
+    gateway_subparsers.add_parser("list", help="List all profiles and their gateway status")
+
     # gateway setup
     gateway_subparsers.add_parser("setup", help="Configure messaging platforms")
 


### PR DESCRIPTION
Closes #19129 via salvage. Closes #19127. Related: #19113.

## Summary
`hermes gateway list` shows gateway status across all profiles in one view:
```
Gateways:
  ✓ default (current)        — PID 207910
  ✗ builder                  — not running
```

Uses existing `list_profiles()` and `find_profile_gateway_processes()` — no new deps.

Note: The `_print_other_profiles_gateway_status()` helper referenced by the original PR is already on main (landed separately); this salvage just adds the new `list` subcommand on top.

## Validation
Live-tested: `python -c 'from hermes_cli.gateway import _gateway_list; _gateway_list()'` prints gateway table correctly on this box.
`scripts/run_tests.sh tests/hermes_cli/ -k gateway` → 317 passed (1 flaky failure in `test_setup_openclaw_migration` unrelated — passes in isolation).

Original author: @cixuuz.