### PR TITLE
fix(kanban): make dashboard board pin authoritative over server current file (#20879)

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -112,17 +112,30 @@
 
   function writeSelectedBoard(slug) {
     try {
-      if (slug && slug !== "default") window.localStorage.setItem(LS_BOARD_KEY, slug);
+      // Persist the user's dashboard-side board pin even for "default".
+      // Previously this stripped "default" to keep localStorage empty,
+      // but the fetch layer read that absence as "no opinion" and fell
+      // through to the server-side ``current`` file — which the board
+      // switcher also writes. Result: selecting the default tab after
+      // creating a new board with "switch" checked showed the new
+      // board's (wrong) data because the URL omitted ``?board=`` and
+      // the backend happily returned whichever board was "current".
+      // Persisting every selection keeps the dashboard's board opinion
+      // independent of the CLI's active board, which was the original
+      // design intent. Regression: #20879.
+      if (slug) window.localStorage.setItem(LS_BOARD_KEY, slug);
       else window.localStorage.removeItem(LS_BOARD_KEY);
     } catch (_e) { /* ignore quota / private mode */ }
   }
 
   function withBoard(url, board) {
-    // Append ?board=<slug> when a non-default board is active. Omitted
-    // for default so the URL stays clean and the backend falls through
-    // to its own resolution chain (env var → ``current`` file →
-    // default) which is already correct.
-    if (!board || board === "default") return url;
+    // Always append ?board=<slug> when we have one picked — including
+    // "default". Omitting the param would fall through to the backend's
+    // resolution chain (env var → ``current`` file → default), which
+    // means the dashboard's tab selection gets silently overridden by
+    // whatever board the CLI or "switch" checkbox last activated.
+    // Regression: #20879.
+    if (!board) return url;
     const sep = url.indexOf("?") >= 0 ? "&" : "?";
     return `${url}${sep}board=${encodeURIComponent(board)}`;
   }
@@ -447,9 +460,11 @@
           token: token,
         };
         // Pin the WS stream to the currently-selected board so events
-        // from other boards don't bleed in. Only set for non-default so
-        // single-board installs keep the cleaner URL.
-        if (board && board !== "default") qsParams.board = board;
+        // from other boards don't bleed in. Includes "default" so the
+        // dashboard's own board pin always wins over the server-side
+        // ``current`` file — same rationale as ``withBoard()`` above.
+        // Regression: #20879.
+        if (board) qsParams.board = board;
         const qs = new URLSearchParams(qsParams);
         const url = `${proto}//${window.location.host}${API}/events?${qs}`;
         let ws;


### PR DESCRIPTION
Dashboard board-tab selection is now authoritative over the server-side `current` file. Selecting the original board's tab after creating a new board with "switch" checked no longer renders as empty cards with a correct count badge.

Closes #20879.

## Root cause

The dashboard stored `"default"` as `null` in localStorage and stripped `?board=default` from every REST + WebSocket URL. When the user created a new board via the UI with "switch" checked, the server flipped its `current` file to the new board. Clicking the original tab set `board = "default"` in-memory, which the fetch layer read as "no opinion" and omitted the query param — so the backend's resolution chain (env → `current` file → default) returned the new board's data for every `/board` call, even though the tab said default.

The `/boards` endpoint hits each board's DB directly for count badges, which is why the tab count was correct while the column cards were for the wrong board.

## Fix

Three call sites in `plugins/kanban/dashboard/dist/index.js`:

1. `writeSelectedBoard()` — persists every selection, including `"default"`, so the dashboard has a board pin to attach on the next page load.
2. `withBoard(url, board)` — always appends `?board=<slug>` when a board is selected. No more short-circuit on `"default"`.
3. WebSocket builder in `openWs()` — same: always include `board` in the query string.

The backend already accepts `?board=default` explicitly (via `_resolve_board` + `_normalize_board_slug`, landed in #19653), so no server change is needed.

## Validation

Contract verified live (in-process TestClient against the worktree's FastAPI router):

| Request | Response |
|---|---|
| `GET /board` (no param) — bug shape | returns `proj2`'s tasks (backend falls through to `current` file) |
| `GET /board?board=default` — fix | returns `default`'s tasks |
| `GET /board?board=proj2` | returns `proj2`'s tasks (sanity) |

Reproduced the reporter's exact sequence: create default + task → create proj2 with switch (flips `current`) → default tab without `?board=` returns proj2's data. With the fix, clicking default tab sends `?board=default` and gets default's tasks back.

Tests: `tests/plugins/test_kanban_dashboard_plugin.py` — **68 passed** (no regressions).

Pre-existing unrelated failure in `tests/hermes_cli/test_kanban_boards.py::test_boards_create_and_switch` confirmed on `main` without this patch — untouched by this PR.

## Closes

- Closes #20879 (reported by @alycda — thank you for the detailed root-cause analysis; the actual fix was narrower than your proposed Part 1 since the WS backend already accepts `board`, but your diagnosis of the "REST/WS scope mismatch" was spot on)
