### PR TITLE
feat: package gateway tooling workflows

### DIFF
--- a/gateway/fd_watchdog.py
+++ b/gateway/fd_watchdog.py
@@ -1,0 +1,245 @@
+"""File-descriptor watchdog and resource observability for the gateway.
+
+Periodically logs process-level resource metrics (open FDs, thread count,
+cached async clients, socket states) and optionally triggers a clean
+restart when resource usage exceeds safe thresholds.
+
+This catches slow leaks (like the CLOSE_WAIT accumulation from
+auxiliary_client cache races) before they hit EMFILE and crash the gateway.
+"""
+
+import asyncio
+import logging
+import os
+import resource
+import subprocess
+import threading
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Metric collection ───────────────────────────────────────────────────
+
+def get_fd_count() -> int:
+    """Return the number of open file descriptors for this process."""
+    pid = os.getpid()
+    fd_dir = f"/dev/fd"
+    try:
+        return len(os.listdir(fd_dir))
+    except OSError:
+        # Fallback: try /proc on Linux
+        try:
+            return len(os.listdir(f"/proc/{pid}/fd"))
+        except OSError:
+            return -1
+
+
+def get_fd_limit() -> int:
+    """Return the soft RLIMIT_NOFILE for this process."""
+    soft, _hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    return soft
+
+
+def get_thread_count() -> int:
+    """Return the number of active threads."""
+    return threading.active_count()
+
+
+def get_cached_client_count() -> int:
+    """Return the number of entries in the auxiliary_client cache."""
+    try:
+        from agent.auxiliary_client import _client_cache, _client_cache_lock
+        with _client_cache_lock:
+            return len(_client_cache)
+    except Exception:
+        return -1
+
+
+def get_socket_states() -> Dict[str, int]:
+    """Return a dict of TCP socket states → count for this process.
+
+    Uses lsof (macOS/Linux) to enumerate sockets.  Returns empty dict
+    on failure rather than raising.
+    """
+    pid = str(os.getpid())
+    states: Dict[str, int] = {}
+    try:
+        # -i = internet sockets, -a = AND, -p = pid, -n = no DNS
+        result = subprocess.run(
+            ["lsof", "-i", "-a", "-p", pid, "-n", "-P"],
+            capture_output=True, text=True, timeout=5,
+        )
+        for line in result.stdout.splitlines()[1:]:  # skip header
+            parts = line.split()
+            if len(parts) >= 10:
+                # Last column often has state like "(ESTABLISHED)" or "(CLOSE_WAIT)"
+                state_col = parts[-1]
+                if state_col.startswith("(") and state_col.endswith(")"):
+                    state = state_col[1:-1]
+                    states[state] = states.get(state, 0) + 1
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+    return states
+
+
+def collect_metrics() -> dict:
+    """Collect all resource metrics in one snapshot."""
+    fd_count = get_fd_count()
+    fd_limit = get_fd_limit()
+    sockets = get_socket_states()
+    return {
+        "fd_count": fd_count,
+        "fd_limit": fd_limit,
+        "fd_usage_pct": round(fd_count / fd_limit * 100, 1) if fd_limit > 0 else 0,
+        "thread_count": get_thread_count(),
+        "cached_clients": get_cached_client_count(),
+        "sockets": sockets,
+        "close_wait": sockets.get("CLOSE_WAIT", 0),
+    }
+
+
+# ── Logging ─────────────────────────────────────────────────────────────
+
+def log_metrics(metrics: Optional[dict] = None) -> dict:
+    """Log current resource metrics and return them."""
+    if metrics is None:
+        metrics = collect_metrics()
+
+    socket_summary = ", ".join(
+        f"{state}={count}" for state, count in sorted(metrics["sockets"].items())
+    ) or "none"
+
+    logger.info(
+        "FD watchdog: fds=%d/%d (%.1f%%) threads=%d cached_clients=%d "
+        "close_wait=%d sockets=[%s]",
+        metrics["fd_count"], metrics["fd_limit"], metrics["fd_usage_pct"],
+        metrics["thread_count"], metrics["cached_clients"],
+        metrics["close_wait"], socket_summary,
+    )
+    return metrics
+
+
+# ── Watchdog thresholds ─────────────────────────────────────────────────
+
+DEFAULT_FD_THRESHOLD_PCT = 70   # restart if FDs > 70% of limit
+# CLOSE_WAIT threshold: some accumulation is normal for HTTP keep-alive clients
+# whose server-side connections time out before the client reuses them.  Only
+# the old catastrophic leak (pre-fix, hit 60+ in an hour) needs to trigger this.
+# Healthy steady-state is usually well under 50.
+DEFAULT_CLOSE_WAIT_THRESHOLD = 150
+DEFAULT_CHECK_INTERVAL = 300    # 5 minutes
+
+
+def should_restart(metrics: dict,
+                   fd_pct_threshold: float = DEFAULT_FD_THRESHOLD_PCT,
+                   close_wait_threshold: int = DEFAULT_CLOSE_WAIT_THRESHOLD) -> Optional[str]:
+    """Check if the gateway should restart based on resource metrics.
+
+    Returns a reason string if restart is warranted, None otherwise.
+    """
+    if metrics["fd_usage_pct"] > fd_pct_threshold:
+        return (f"FD usage {metrics['fd_count']}/{metrics['fd_limit']} "
+                f"({metrics['fd_usage_pct']}%) exceeds {fd_pct_threshold}% threshold")
+
+    if metrics["close_wait"] > close_wait_threshold:
+        return (f"CLOSE_WAIT count {metrics['close_wait']} "
+                f"exceeds threshold {close_wait_threshold}")
+
+    return None
+
+
+# ── Proactive cleanup ───────────────────────────────────────────────────
+
+def _try_cleanup() -> int:
+    """Run all available cleanup routines. Returns number of clients cleaned."""
+    cleaned = 0
+    try:
+        from agent.auxiliary_client import (
+            _client_cache, _client_cache_lock, cleanup_stale_async_clients,
+        )
+        with _client_cache_lock:
+            before = len(_client_cache)
+        cleanup_stale_async_clients()
+        with _client_cache_lock:
+            after = len(_client_cache)
+        cleaned = before - after
+    except Exception as e:
+        logger.debug("Watchdog cleanup error: %s", e)
+    return cleaned
+
+
+# ── Async watchdog task ─────────────────────────────────────────────────
+
+async def fd_watchdog_loop(
+    runner: object,
+    interval: float = DEFAULT_CHECK_INTERVAL,
+    fd_pct_threshold: float = DEFAULT_FD_THRESHOLD_PCT,
+    close_wait_threshold: int = DEFAULT_CLOSE_WAIT_THRESHOLD,
+) -> None:
+    """Background task that periodically checks resource health.
+
+    Runs inside the gateway's event loop. On threshold breach, attempts
+    cleanup first, then signals the runner to restart if still unhealthy.
+
+    Args:
+        runner: GatewayRunner instance (must have a .stop() method).
+        interval: Seconds between checks.
+        fd_pct_threshold: FD usage percentage that triggers restart.
+        close_wait_threshold: CLOSE_WAIT count that triggers restart.
+    """
+    logger.info(
+        "FD watchdog started: interval=%ds fd_threshold=%.0f%% close_wait_threshold=%d",
+        interval, fd_pct_threshold, close_wait_threshold,
+    )
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            metrics = collect_metrics()
+            log_metrics(metrics)
+
+            reason = should_restart(metrics, fd_pct_threshold, close_wait_threshold)
+            if reason:
+                logger.warning("FD watchdog: threshold breached — %s", reason)
+
+                # Try cleanup first before escalating to restart.
+                cleaned = _try_cleanup()
+                if cleaned:
+                    logger.info("FD watchdog: cleaned %d stale client(s), re-checking", cleaned)
+                    metrics = collect_metrics()
+                    log_metrics(metrics)
+                    reason = should_restart(metrics, fd_pct_threshold, close_wait_threshold)
+
+                if reason:
+                    logger.error(
+                        "FD watchdog: triggering clean restart — %s", reason
+                    )
+                    # Mark the runner as exiting with failure BEFORE stopping it.
+                    # This causes start_gateway() to return False, which causes
+                    # main() to sys.exit(1). The non-zero exit code is critical:
+                    # launchd's KeepAlive.SuccessfulExit=false only restarts the
+                    # service on unsuccessful (non-zero) exits.  A clean stop()
+                    # without this flag would exit 0 and launchd would leave the
+                    # gateway down.
+                    try:
+                        setattr(runner, "should_exit_with_failure", True)
+                        setattr(runner, "exit_reason", f"FD watchdog: {reason}")
+                    except Exception:
+                        pass
+                    try:
+                        stop_fn = getattr(runner, "stop", None)
+                        if stop_fn:
+                            if asyncio.iscoroutinefunction(stop_fn):
+                                await stop_fn()
+                            else:
+                                stop_fn()
+                    except Exception as e:
+                        logger.error("FD watchdog: failed to stop runner: %s", e)
+                        # Last resort: SIGTERM ourselves (non-zero exit)
+                        os.kill(os.getpid(), 15)
+                    return  # Exit the watchdog loop after triggering restart
+
+        except asyncio.CancelledError:
+            logger.info("FD watchdog stopped")
+            return
+        except Exception as e:
+            logger.warning("FD watchdog error: %s", e, exc_info=True)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -84,6 +84,7 @@ from gateway.platforms.telegram_network import (
     discover_fallback_ips,
     parse_fallback_ip_env,
 )
+from gateway.todo_replies import apply_structured_todo_reply, looks_like_structured_todo_reply, parse_structured_todo_reply
 from utils import atomic_replace
 
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
@@ -268,6 +269,8 @@ class TelegramAdapter(BasePlatformAdapter):
     _SPLIT_THRESHOLD = 4000
     MEDIA_GROUP_WAIT_SECONDS = 0.8
     _GENERAL_TOPIC_THREAD_ID = "1"
+    _FRONTPAGE_OVERRIDE_COMMAND_RE = re.compile(r"^/(?:frontpage(?:-override)?|fp)(?:@\w+)?(?:\s+(.*))?$", re.IGNORECASE)
+    _DEFAULT_FRONTPAGE_ENGINE_DIR = "/Users/nickgeorge-studio/Projects/hermes-frontpage-engine"
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.TELEGRAM)
@@ -379,6 +382,170 @@ class TelegramAdapter(BasePlatformAdapter):
     @staticmethod
     def _is_thread_not_found_error(error: Exception) -> bool:
         return "thread not found" in str(error).lower()
+
+    def _frontpage_engine_dir(self) -> str:
+        configured = None
+        if getattr(self.config, "extra", None):
+            configured = self.config.extra.get("frontpage_engine_dir")
+        return str(
+            os.getenv("HERMES_FRONTPAGE_ENGINE_DIR")
+            or configured
+            or self._DEFAULT_FRONTPAGE_ENGINE_DIR
+        )
+
+    def _frontpage_override_manifest_path(self) -> Optional[str]:
+        configured = None
+        if getattr(self.config, "extra", None):
+            configured = self.config.extra.get("frontpage_override_manifest")
+        value = os.getenv("HERMES_FRONTPAGE_OVERRIDE_MANIFEST") or configured
+        if not value:
+            return None
+        return str(value)
+
+    def _parse_frontpage_override_caption(self, text: Optional[str]) -> Optional[Dict[str, Any]]:
+        if not text:
+            return None
+        raw_lines = text.splitlines()
+        if not raw_lines:
+            return None
+        first_line = raw_lines[0].strip()
+        match = self._FRONTPAGE_OVERRIDE_COMMAND_RE.match(first_line)
+        if not match:
+            return None
+
+        title = (match.group(1) or "").strip()
+        note_lines: list[str] = []
+        bias_terms: list[str] = []
+
+        for raw_line in raw_lines[1:]:
+            stripped = raw_line.strip()
+            if not stripped:
+                if note_lines:
+                    note_lines.append("")
+                continue
+            lowered = stripped.lower()
+            if lowered.startswith("title:"):
+                explicit_title = stripped.split(":", 1)[1].strip()
+                if explicit_title:
+                    title = explicit_title
+                continue
+            if lowered.startswith("bias:"):
+                bias_value = stripped.split(":", 1)[1].strip()
+                if bias_value:
+                    bias_terms.extend(term.strip() for term in bias_value.split(",") if term.strip())
+                continue
+            if lowered.startswith("note:"):
+                note_value = stripped.split(":", 1)[1].strip()
+                if note_value:
+                    note_lines.append(note_value)
+                continue
+            note_lines.append(stripped)
+
+        compact_notes = [line for line in note_lines if line.strip()]
+        if not title and compact_notes:
+            title = compact_notes[0]
+            note_lines = note_lines[1:]
+
+        note = "\n".join(note_lines).strip()
+        return {
+            "title": title or "Telegram inspiration override",
+            "note": note,
+            "bias_terms": bias_terms,
+        }
+
+    async def _write_frontpage_override_manifest(
+        self,
+        *,
+        image_path: str,
+        title: str,
+        note: str,
+        bias_terms: list[str],
+    ) -> tuple[bool, str]:
+        repo_dir = self._frontpage_engine_dir()
+        script_path = os.path.join(repo_dir, "scripts", "set-inspiration-override.mjs")
+        if not os.path.isdir(repo_dir):
+            return False, f"frontpage engine dir not found: {repo_dir}"
+        if not os.path.isfile(script_path):
+            return False, f"override writer not found: {script_path}"
+
+        command = [
+            "node",
+            script_path,
+            "--image",
+            image_path,
+            "--title",
+            title or "Telegram inspiration override",
+            "--note",
+            note or "",
+            "--source",
+            "telegram",
+        ]
+        if bias_terms:
+            command.extend(["--bias-terms", ",".join(bias_terms)])
+        manifest_path = self._frontpage_override_manifest_path()
+        if manifest_path:
+            command.extend(["--manifest", manifest_path])
+
+        proc = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=repo_dir,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_bytes, stderr_bytes = await proc.communicate()
+        stdout = stdout_bytes.decode("utf-8", errors="replace").strip()
+        stderr = stderr_bytes.decode("utf-8", errors="replace").strip()
+        if proc.returncode != 0:
+            return False, stderr or stdout or "frontpage override writer failed"
+
+        manifest = None
+        if stdout:
+            try:
+                manifest = json.loads(stdout).get("manifest")
+            except Exception:
+                manifest = None
+        return True, str(manifest or manifest_path or "next-run override staged")
+
+    async def _reply_to_media_message(self, msg: Message, content: str) -> None:
+        metadata: Dict[str, Any] = {}
+        thread_id = getattr(msg, "message_thread_id", None)
+        if thread_id is not None:
+            metadata["thread_id"] = str(thread_id)
+        await self.send(
+            str(getattr(msg.chat, "id", "")),
+            content,
+            reply_to=str(getattr(msg, "message_id", "")),
+            metadata=metadata or None,
+        )
+
+    async def _maybe_stage_frontpage_override(self, msg: Message, cached_path: str, caption_text: Optional[str]) -> bool:
+        override = self._parse_frontpage_override_caption(caption_text)
+        if not override:
+            return False
+        if getattr(msg, "media_group_id", None):
+            await self._reply_to_media_message(
+                msg,
+                "Frontpage override needs a single image, not an album. Send one photo with `/frontpage`."
+            )
+            return True
+
+        ok, detail = await self._write_frontpage_override_manifest(
+            image_path=cached_path,
+            title=override["title"],
+            note=override["note"],
+            bias_terms=override["bias_terms"],
+        )
+        if ok:
+            await self._reply_to_media_message(
+                msg,
+                f"Queued next frontpage override.\nTitle: {override['title']}\nManifest: `{detail}`"
+            )
+        else:
+            await self._reply_to_media_message(
+                msg,
+                f"Frontpage override failed: {detail}"
+            )
+        return True
 
     def _fallback_ips(self) -> list[str]:
         """Return validated fallback IPs from config (populated by _apply_env_overrides)."""
@@ -2951,6 +3118,41 @@ class TelegramAdapter(BasePlatformAdapter):
             return True
         return self._message_matches_mention_patterns(message)
 
+    def _todo_tasks_path(self) -> Optional[str]:
+        if not getattr(self.config, "extra", None):
+            return None
+        value = self.config.extra.get("todo_tasks_path")
+        if not value:
+            return None
+        return str(value)
+
+    async def _maybe_handle_structured_todo_reply(self, message: Message) -> bool:
+        text = getattr(message, "text", None) or ""
+        reply = getattr(message, "reply_to_message", None)
+        reply_to_text = None
+        if reply is not None:
+            reply_to_text = getattr(reply, "text", None) or getattr(reply, "caption", None)
+        if not looks_like_structured_todo_reply(text, reply_to_text):
+            return False
+
+        tasks_path = self._todo_tasks_path()
+        if not tasks_path:
+            logger.warning("[%s] Structured todo reply detected but no todo_tasks_path configured", self.name)
+            return False
+
+        result = apply_structured_todo_reply(tasks_path, parse_structured_todo_reply(text))
+        metadata: Dict[str, Any] = {}
+        thread_id = getattr(message, "message_thread_id", None)
+        if thread_id is not None:
+            metadata["thread_id"] = str(thread_id)
+        await self.send(
+            chat_id=str(getattr(getattr(message, "chat", None), "id", "")),
+            content=result.render_message(),
+            reply_to=str(getattr(message, "message_id", "")),
+            metadata=metadata or None,
+        )
+        return True
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -2963,7 +3165,14 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._should_process_message(update.message):
             return
 
-        event = self._build_message_event(update.message, MessageType.TEXT, update_id=update.update_id)
+        if await self._maybe_handle_structured_todo_reply(update.message):
+            return
+
+        update_id = getattr(update, "update_id", None)
+        if update_id is None:
+            event = self._build_message_event(update.message, MessageType.TEXT)
+        else:
+            event = self._build_message_event(update.message, MessageType.TEXT, update_id=update_id)
         event.text = self._clean_bot_trigger_text(event.text)
         self._enqueue_text_event(event)
 
@@ -3194,6 +3403,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 event.media_urls = [cached_path]
                 event.media_types = [f"image/{ext.lstrip('.')}" ]
                 logger.info("[Telegram] Cached user photo at %s", cached_path)
+                if await self._maybe_stage_frontpage_override(msg, cached_path, event.text):
+                    return
                 media_group_id = getattr(msg, "media_group_id", None)
                 if media_group_id:
                     await self._queue_media_group_event(str(media_group_id), event)

--- a/gateway/todo_replies.py
+++ b/gateway/todo_replies.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+_DIRECTIVE_PREFIXES = ("done", "doing", "add", "block", "move")
+_STATUS_BY_ACTION = {
+    "done": "done",
+    "doing": "doing",
+    "add": "todo",
+    "block": "blocked",
+    "move": "todo",
+}
+
+
+@dataclass(frozen=True)
+class TodoDirective:
+    action: str
+    title: str
+
+
+@dataclass(frozen=True)
+class TodoReplyResult:
+    directives: list[TodoDirective]
+    changes: list[str]
+    open_tasks: list[dict]
+
+    def render_message(self) -> str:
+        lines = ["Updated to-do list"]
+        for change in self.changes:
+            lines.append(f"- {change}")
+        if self.open_tasks:
+            lines.append("")
+            lines.append("Open tasks")
+            for task in self.open_tasks[:8]:
+                lines.append(f"- [{task['status']}] {task['title']}")
+        else:
+            lines.append("")
+            lines.append("Open tasks")
+            lines.append("- none")
+        return "\n".join(lines)
+
+
+def looks_like_structured_todo_reply(text: str, reply_to_text: str | None = None) -> bool:
+    directives = parse_structured_todo_reply(text)
+    if not directives:
+        return False
+    if not reply_to_text:
+        return False
+    lowered = reply_to_text.lower()
+    return "reply format" in lowered and any(f"{prefix}:" in lowered for prefix in _DIRECTIVE_PREFIXES)
+
+
+def parse_structured_todo_reply(text: str) -> list[TodoDirective]:
+    directives: list[TodoDirective] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if ":" not in line:
+            continue
+        action, remainder = line.split(":", 1)
+        action = action.strip().lower()
+        if action not in _DIRECTIVE_PREFIXES:
+            continue
+        chunks = [chunk.strip(" -•\t") for chunk in remainder.split(";")]
+        for chunk in chunks:
+            if chunk:
+                directives.append(TodoDirective(action=action, title=chunk))
+    return directives
+
+
+def apply_structured_todo_reply(tasks_path: str | Path, directives: Iterable[TodoDirective]) -> TodoReplyResult:
+    tasks_file = Path(tasks_path).expanduser()
+    tasks_file.parent.mkdir(parents=True, exist_ok=True)
+
+    data = _load_tasks(tasks_file)
+    tasks = [_normalize_task(task) for task in data.get("tasks", [])]
+    tasks = [task for task in tasks if task is not None]
+
+    changes: list[str] = []
+    applied_directives = list(directives)
+    for directive in applied_directives:
+        status = _STATUS_BY_ACTION[directive.action]
+        task = _find_task(tasks, directive.title)
+        if task is None:
+            task = {"title": directive.title, "status": status, "notes": ""}
+            tasks.append(task)
+            if directive.action == "add":
+                changes.append(f"added: {directive.title}")
+            else:
+                changes.append(f"created {status}: {directive.title}")
+            continue
+
+        previous_status = task.get("status", "todo")
+        task["status"] = status
+        if directive.action == "add":
+            if previous_status == "done":
+                changes.append(f"reopened: {directive.title}")
+            else:
+                changes.append(f"kept: {directive.title}")
+        elif previous_status == status:
+            changes.append(f"unchanged {status}: {directive.title}")
+        else:
+            changes.append(f"{previous_status} -> {status}: {directive.title}")
+
+    today = datetime.now().date().isoformat()
+    data["version"] = data.get("version", 1)
+    data["created"] = data.get("created") or today
+    data["updated"] = today
+    data["tasks"] = tasks
+    tasks_file.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    open_tasks = [task for task in tasks if task.get("status") != "done"]
+    open_tasks.sort(key=lambda task: (_status_sort_key(task.get("status", "todo")), task.get("title", "").lower()))
+    return TodoReplyResult(directives=applied_directives, changes=changes, open_tasks=open_tasks)
+
+
+def _load_tasks(tasks_file: Path) -> dict:
+    if not tasks_file.exists():
+        return {"version": 1, "created": datetime.now().date().isoformat(), "tasks": []}
+    loaded = json.loads(tasks_file.read_text(encoding="utf-8"))
+    if isinstance(loaded, dict):
+        return loaded
+    return {"version": 1, "created": datetime.now().date().isoformat(), "tasks": []}
+
+
+def _normalize_task(task) -> dict | None:
+    if isinstance(task, str):
+        title = task.strip()
+        return {"title": title, "status": "todo", "notes": ""} if title else None
+    if not isinstance(task, dict):
+        return None
+    title = str(task.get("title") or "").strip()
+    if not title:
+        return None
+    status = str(task.get("status") or "todo").strip().lower()
+    if status not in {"todo", "doing", "blocked", "done"}:
+        status = "todo"
+    return {
+        "title": title,
+        "status": status,
+        "notes": str(task.get("notes") or "").strip(),
+    }
+
+
+def _find_task(tasks: list[dict], query: str) -> dict | None:
+    needle = query.strip().lower()
+    if not needle:
+        return None
+
+    exact_matches = [task for task in tasks if task.get("title", "").strip().lower() == needle]
+    if exact_matches:
+        return exact_matches[0]
+
+    fuzzy_matches = [
+        task for task in tasks
+        if needle in task.get("title", "").strip().lower() or task.get("title", "").strip().lower() in needle
+    ]
+    if len(fuzzy_matches) == 1:
+        return fuzzy_matches[0]
+    return None
+
+
+def _status_sort_key(status: str) -> int:
+    order = {"doing": 0, "todo": 1, "blocked": 2, "done": 3}
+    return order.get(status, 99)

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -19,7 +19,10 @@ Output is saved as PNG under ``$HERMES_HOME/cache/images/``.
 
 from __future__ import annotations
 
+import base64
 import logging
+import mimetypes
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.image_gen_provider import (
@@ -161,7 +164,50 @@ def _build_codex_client():
         return None
 
 
-def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> Optional[str]:
+def _reference_image_to_input_url(ref: str) -> str:
+    """Normalize a reference image into a Responses API-compatible URL."""
+    value = (ref or "").strip()
+    if not value:
+        raise ValueError("Reference image entries must be non-empty strings")
+
+    lowered = value.lower()
+    if lowered.startswith("http://") or lowered.startswith("https://"):
+        return value
+    if lowered.startswith("data:image/"):
+        return value
+
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    if not path.is_file():
+        raise ValueError(f"Reference image path does not exist: {value}")
+
+    mime, _ = mimetypes.guess_type(str(path))
+    if not mime or not mime.startswith("image/"):
+        mime = "image/png"
+    b64 = base64.b64encode(path.read_bytes()).decode("ascii")
+    return f"data:{mime};base64,{b64}"
+
+
+def _build_input_parts(prompt: str, reference_images: Optional[List[str]]) -> List[Dict[str, Any]]:
+    content: List[Dict[str, Any]] = [{"type": "input_text", "text": prompt}]
+    for ref in reference_images or []:
+        content.append({
+            "type": "input_image",
+            "image_url": _reference_image_to_input_url(ref),
+            "detail": "high",
+        })
+    return [{"type": "message", "role": "user", "content": content}]
+
+
+def _collect_image_b64(
+    client: Any,
+    *,
+    prompt: str,
+    size: str,
+    quality: str,
+    reference_images: Optional[List[str]] = None,
+) -> Optional[str]:
     """Stream a Codex Responses image_generation call and return the b64 image."""
     image_b64: Optional[str] = None
 
@@ -169,11 +215,7 @@ def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> 
         model=_CODEX_CHAT_MODEL,
         store=False,
         instructions=_CODEX_INSTRUCTIONS,
-        input=[{
-            "type": "message",
-            "role": "user",
-            "content": [{"type": "input_text", "text": prompt}],
-        }],
+        input=_build_input_parts(prompt, reference_images),
         tools=[{
             "type": "image_generation",
             "model": API_MODEL,
@@ -274,6 +316,9 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
     ) -> Dict[str, Any]:
         prompt = (prompt or "").strip()
         aspect = resolve_aspect_ratio(aspect_ratio)
+        reference_images = kwargs.get("reference_images") or []
+        if not isinstance(reference_images, list):
+            reference_images = []
 
         if not prompt:
             return error_response(
@@ -324,6 +369,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 prompt=prompt,
                 size=size,
                 quality=meta["quality"],
+                reference_images=reference_images,
             )
         except Exception as exc:
             logger.debug("Codex image generation failed", exc_info=True)
@@ -364,7 +410,11 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             prompt=prompt,
             aspect_ratio=aspect,
             provider="openai-codex",
-            extra={"size": size, "quality": meta["quality"]},
+            extra={
+                "size": size,
+                "quality": meta["quality"],
+                "reference_image_count": len(reference_images),
+            },
         )
 
 

--- a/tests/gateway/test_fd_watchdog.py
+++ b/tests/gateway/test_fd_watchdog.py
@@ -1,0 +1,171 @@
+"""Tests for the FD watchdog and resource observability module."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.fd_watchdog import (
+    collect_metrics,
+    get_cached_client_count,
+    get_fd_count,
+    get_fd_limit,
+    get_thread_count,
+    log_metrics,
+    should_restart,
+)
+
+
+class TestMetricCollection:
+    """Verify individual metric collectors return sane values."""
+
+    def test_fd_count_positive(self):
+        count = get_fd_count()
+        assert count > 0, "Process must have at least stdin/stdout/stderr open"
+
+    def test_fd_limit_positive(self):
+        limit = get_fd_limit()
+        assert limit > 0
+
+    def test_thread_count_positive(self):
+        count = get_thread_count()
+        assert count >= 1, "At least the main thread must be running"
+
+    def test_cached_client_count_non_negative(self):
+        count = get_cached_client_count()
+        assert count >= 0
+
+    def test_collect_metrics_has_all_keys(self):
+        m = collect_metrics()
+        for key in ("fd_count", "fd_limit", "fd_usage_pct",
+                     "thread_count", "cached_clients", "sockets", "close_wait"):
+            assert key in m, f"Missing key: {key}"
+
+
+class TestShouldRestart:
+    """Verify threshold logic for restart decisions."""
+
+    def test_healthy_returns_none(self):
+        metrics = {
+            "fd_count": 50,
+            "fd_limit": 1024,
+            "fd_usage_pct": 4.9,
+            "close_wait": 50,
+        }
+        assert should_restart(metrics) is None
+
+    def test_fd_threshold_triggers(self):
+        metrics = {
+            "fd_count": 750,
+            "fd_limit": 1024,
+            "fd_usage_pct": 73.2,
+            "close_wait": 0,
+        }
+        reason = should_restart(metrics, fd_pct_threshold=70)
+        assert reason is not None
+        assert "73.2%" in reason
+
+    def test_close_wait_threshold_triggers(self):
+        metrics = {
+            "fd_count": 50,
+            "fd_limit": 1024,
+            "fd_usage_pct": 4.9,
+            "close_wait": 200,
+        }
+        reason = should_restart(metrics, close_wait_threshold=150)
+        assert reason is not None
+        assert "CLOSE_WAIT" in reason
+
+    def test_custom_thresholds(self):
+        metrics = {
+            "fd_count": 50,
+            "fd_limit": 100,
+            "fd_usage_pct": 50.0,
+            "close_wait": 10,
+        }
+        # Default thresholds (70%, 30) — should be fine
+        assert should_restart(metrics) is None
+        # Tighter thresholds
+        assert should_restart(metrics, fd_pct_threshold=40) is not None
+        assert should_restart(metrics, close_wait_threshold=5) is not None
+
+
+class TestLogMetrics:
+    """Verify log_metrics runs without error and returns metrics."""
+
+    def test_returns_metrics_dict(self):
+        m = log_metrics()
+        assert isinstance(m, dict)
+        assert "fd_count" in m
+
+    def test_accepts_precomputed_metrics(self):
+        fake = {
+            "fd_count": 42,
+            "fd_limit": 256,
+            "fd_usage_pct": 16.4,
+            "thread_count": 3,
+            "cached_clients": 1,
+            "close_wait": 0,
+            "sockets": {"ESTABLISHED": 5},
+        }
+        result = log_metrics(fake)
+        assert result is fake
+
+
+class TestWatchdogLoop:
+    """Verify the async watchdog loop behavior."""
+
+    @pytest.mark.asyncio
+    async def test_watchdog_cancellation(self):
+        """Watchdog should exit cleanly on cancellation."""
+        from gateway.fd_watchdog import fd_watchdog_loop
+
+        runner = MagicMock()
+        task = asyncio.create_task(fd_watchdog_loop(runner, interval=0.1))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass  # Expected
+
+    @pytest.mark.asyncio
+    async def test_watchdog_triggers_stop_on_threshold(self):
+        """When metrics breach threshold, watchdog should call runner.stop()."""
+        from gateway.fd_watchdog import fd_watchdog_loop
+
+        stop_called = asyncio.Event()
+
+        class FakeRunner:
+            async def stop(self):
+                stop_called.set()
+
+        runner = FakeRunner()
+
+        # Mock collect_metrics to return high FD usage
+        fake_metrics = {
+            "fd_count": 900,
+            "fd_limit": 1024,
+            "fd_usage_pct": 87.9,
+            "thread_count": 5,
+            "cached_clients": 3,
+            "close_wait": 50,
+            "sockets": {"CLOSE_WAIT": 50, "ESTABLISHED": 10},
+        }
+
+        with patch("gateway.fd_watchdog.collect_metrics", return_value=fake_metrics):
+            with patch("gateway.fd_watchdog._try_cleanup", return_value=0):
+                task = asyncio.create_task(
+                    fd_watchdog_loop(runner, interval=0.1,
+                                     fd_pct_threshold=70, close_wait_threshold=30)
+                )
+                # Give it time to fire
+                await asyncio.sleep(0.3)
+                if not task.done():
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+
+        assert stop_called.is_set(), "runner.stop() should have been called"

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -490,6 +490,59 @@ class TestMediaGroups:
         adapter.handle_message.assert_not_awaited()
 
 
+class TestFrontpageOverride:
+    @pytest.mark.asyncio
+    async def test_photo_caption_command_stages_override_and_replies(self, adapter):
+        adapter._bot = AsyncMock()
+        adapter._bot.username = "hermesbot"
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="77"))
+        adapter._write_frontpage_override_manifest = AsyncMock(return_value=(True, "/tmp/frontpage.json"))
+
+        photo = _make_photo(_make_file_obj(b"override"))
+        msg = _make_message(
+            caption="/frontpage urgent trend seed\nbias: election, breaking\nnote: Keep source discovery broad.",
+            photo=[photo],
+        )
+
+        with patch("gateway.platforms.telegram.cache_image_from_bytes", return_value="/tmp/override.jpg"):
+            await adapter._handle_media_message(_make_update(msg), MagicMock())
+
+        adapter._write_frontpage_override_manifest.assert_awaited_once_with(
+            image_path="/tmp/override.jpg",
+            title="urgent trend seed",
+            note="Keep source discovery broad.",
+            bias_terms=["election", "breaking"],
+        )
+        adapter.send.assert_awaited_once()
+        reply_args = adapter.send.await_args
+        assert reply_args.args[0] == "100"
+        assert "Queued next frontpage override." in reply_args.args[1]
+        assert reply_args.kwargs["reply_to"] == "42"
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_frontpage_override_rejects_albums(self, adapter):
+        adapter._bot = AsyncMock()
+        adapter._bot.username = "hermesbot"
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="78"))
+        adapter._write_frontpage_override_manifest = AsyncMock()
+
+        photo = _make_photo(_make_file_obj(b"override"))
+        msg = _make_message(
+            caption="/frontpage\nbias: urgent",
+            media_group_id="album-override",
+            photo=[photo],
+        )
+
+        with patch("gateway.platforms.telegram.cache_image_from_bytes", return_value="/tmp/override.jpg"):
+            await adapter._handle_media_message(_make_update(msg), MagicMock())
+
+        adapter._write_frontpage_override_manifest.assert_not_awaited()
+        adapter.send.assert_awaited_once()
+        assert "single image" in adapter.send.await_args.args[1]
+        adapter.handle_message.assert_not_awaited()
+
+
 # ---------------------------------------------------------------------------
 # TestSendVoice — outbound audio delivery
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_telegram_todo_replies.py
+++ b/tests/gateway/test_telegram_todo_replies.py
@@ -1,0 +1,72 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+@pytest.mark.asyncio
+async def test_handle_text_message_applies_structured_todo_reply(tmp_path):
+    from gateway.platforms.telegram import TelegramAdapter
+
+    tasks_path = tmp_path / "tasks.json"
+    tasks_path.write_text('{"version":1,"created":"2026-04-14","updated":"2026-04-14","tasks":[]}', encoding="utf-8")
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter._platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="***", extra={"todo_tasks_path": str(tasks_path)})
+    adapter.send = AsyncMock()
+    adapter._should_process_message = lambda message, is_command=False: True
+    adapter._enqueue_text_event = MagicMock()
+
+    reply_message = SimpleNamespace(text="Cronjob Response: test\n\nReply format\nadd: ...\ndoing: ...", caption=None)
+    message = SimpleNamespace(
+        text="add: pick up meds\ndoing: file taxes",
+        reply_to_message=reply_message,
+        message_id=42,
+        chat=SimpleNamespace(id=123),
+        message_thread_id=225873,
+    )
+    update = SimpleNamespace(message=message)
+
+    await adapter._handle_text_message(update, None)
+
+    adapter._enqueue_text_event.assert_not_called()
+    adapter.send.assert_awaited_once()
+    send_kwargs = adapter.send.await_args.kwargs
+    assert send_kwargs["chat_id"] == "123"
+    assert send_kwargs["reply_to"] == "42"
+    assert send_kwargs["metadata"] == {"thread_id": "225873"}
+    assert "Updated to-do list" in send_kwargs["content"]
+
+    saved = json.loads(tasks_path.read_text(encoding="utf-8"))
+    assert [task["title"] for task in saved["tasks"]] == ["pick up meds", "file taxes"]
+    assert [task["status"] for task in saved["tasks"]] == ["todo", "doing"]
+
+
+@pytest.mark.asyncio
+async def test_handle_text_message_still_enqueues_normal_text():
+    from gateway.platforms.telegram import TelegramAdapter
+    from gateway.platforms.base import MessageType
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter._platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="***")
+    adapter._should_process_message = lambda message, is_command=False: True
+    adapter._enqueue_text_event = MagicMock()
+    adapter._clean_bot_trigger_text = lambda text: text
+    adapter._build_message_event = lambda message, msg_type: SimpleNamespace(text=message.text, message_type=msg_type)
+    adapter._maybe_handle_structured_todo_reply = AsyncMock(return_value=False)
+
+    message = SimpleNamespace(text="normal message", reply_to_message=None)
+    update = SimpleNamespace(message=message)
+
+    await adapter._handle_text_message(update, None)
+
+    adapter._maybe_handle_structured_todo_reply.assert_awaited_once_with(message)
+    adapter._enqueue_text_event.assert_called_once()
+    event = adapter._enqueue_text_event.call_args.args[0]
+    assert event.text == "normal message"
+    assert event.message_type == MessageType.TEXT

--- a/tests/gateway/test_todo_replies.py
+++ b/tests/gateway/test_todo_replies.py
@@ -1,0 +1,52 @@
+import json
+
+from gateway.todo_replies import apply_structured_todo_reply, looks_like_structured_todo_reply, parse_structured_todo_reply
+
+
+def test_parse_structured_todo_reply_supports_multiple_lines_and_semicolons():
+    directives = parse_structured_todo_reply("add: write tests; ship fix\ndoing: review cron\nignore this")
+
+    assert [(item.action, item.title) for item in directives] == [
+        ("add", "write tests"),
+        ("add", "ship fix"),
+        ("doing", "review cron"),
+    ]
+
+
+def test_looks_like_structured_todo_reply_requires_reply_format_context():
+    assert looks_like_structured_todo_reply("add: ship it", "Reply format\nadd: ...\ndoing: ...") is True
+    assert looks_like_structured_todo_reply("add: ship it", None) is False
+    assert looks_like_structured_todo_reply("hello", "Reply format\nadd: ...") is False
+
+
+def test_apply_structured_todo_reply_updates_json_file(tmp_path):
+    tasks_path = tmp_path / "tasks.json"
+    tasks_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "created": "2026-04-14",
+                "updated": "2026-04-14",
+                "tasks": [
+                    {"title": "file taxes", "status": "todo", "notes": ""},
+                    {"title": "call doctor", "status": "blocked", "notes": ""},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = apply_structured_todo_reply(
+        tasks_path,
+        parse_structured_todo_reply("doing: file taxes\ndone: call doctor\nadd: pick up meds"),
+    )
+
+    saved = json.loads(tasks_path.read_text(encoding="utf-8"))
+    assert [task["status"] for task in saved["tasks"]] == ["doing", "done", "todo"]
+    assert [task["title"] for task in saved["tasks"]] == ["file taxes", "call doctor", "pick up meds"]
+    assert result.changes == [
+        "todo -> doing: file taxes",
+        "blocked -> done: call doctor",
+        "added: pick up meds",
+    ]
+    assert [task["title"] for task in result.open_tasks] == ["file taxes", "pick up meds"]

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -199,6 +199,42 @@ class TestGenerate:
         assert tool["background"] == "opaque"
         assert tool["partial_images"] == 1
 
+    def test_codex_stream_request_includes_reference_image(self, provider, monkeypatch, tmp_path):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        reference_path = tmp_path / "ref.png"
+        reference_path.write_bytes(bytes.fromhex(_PNG_HEX))
+
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(
+                type="image_generation_call",
+                status="generating",
+                id="ig_test",
+                result=_b64_png(),
+            )
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            final_response = SimpleNamespace(output=[], status="completed", output_text="")
+            return _FakeStream([done_event], final_response)
+
+        fake_client = SimpleNamespace(responses=SimpleNamespace(stream=_stream))
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+
+        result = provider.generate(
+            "preserve this source identity",
+            reference_images=[str(reference_path)],
+        )
+        assert result["success"] is True
+        assert result["reference_image_count"] == 1
+
+        content = captured["input"][0]["content"]
+        assert content[0]["type"] == "input_text"
+        assert content[1]["type"] == "input_image"
+        assert content[1]["image_url"].startswith("data:image/png;base64,")
+        assert content[1]["detail"] == "high"
+
     def test_partial_image_event_used_when_done_missing(self, provider, monkeypatch):
         """If the stream never emits output_item.done, fall back to the
         partial_image event so users at least get the latest preview frame."""

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -27,6 +27,7 @@ class _FakeCodexProvider(ImageGenProvider):
             "prompt": prompt,
             "aspect_ratio": aspect_ratio,
             "provider": "codex",
+            "reference_images": kwargs.get("reference_images", []),
         }
 
 
@@ -44,13 +45,18 @@ class TestPluginDispatch:
         monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda: None)
         monkeypatch.setattr(registry_module, "get_provider", lambda name: _FakeCodexProvider() if name == "codex" else None)
 
-        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw cat", "square")
+        dispatched = image_generation_tool._dispatch_to_plugin_provider(
+            "draw cat",
+            "square",
+            reference_images=["/tmp/ref.png"],
+        )
         payload = json.loads(dispatched)
 
         assert payload["success"] is True
         assert payload["provider"] == "codex"
         assert payload["image"] == "/tmp/codex-test.png"
         assert payload["aspect_ratio"] == "square"
+        assert payload["reference_images"] == ["/tmp/ref.png"]
 
     def test_dispatch_reports_missing_registered_provider(self, monkeypatch, tmp_path):
         from tools import image_generation_tool

--- a/tests/tools/test_toon_encoder.py
+++ b/tests/tools/test_toon_encoder.py
@@ -1,0 +1,144 @@
+"""Tests for tools/toon_encoder.py"""
+
+import json
+import pytest
+
+from tools.toon_encoder import encode_toon, _truncate_value, _ensure_definitive_empty
+
+
+class TestTruncation:
+    def test_truncates_long_strings(self):
+        data = {"body": "x" * 2000}
+        result = _truncate_value(data, limit=100)
+        assert len(result["body"]) < 200
+        assert "truncated" in result["body"]
+        assert "2000 chars total" in result["body"]
+
+    def test_preserves_short_strings(self):
+        data = {"name": "Alice"}
+        result = _truncate_value(data)
+        assert result["name"] == "Alice"
+
+    def test_truncates_nested(self):
+        data = {"results": [{"content": "y" * 3000}]}
+        result = _truncate_value(data, limit=50)
+        assert "truncated" in result["results"][0]["content"]
+
+    def test_preserves_non_strings(self):
+        data = {"count": 42, "active": True, "meta": None}
+        result = _truncate_value(data)
+        assert result == data
+
+
+class TestDefinitiveEmpty:
+    def test_adds_count_to_empty_results(self):
+        data = {"results": [], "success": True}
+        result = _ensure_definitive_empty(data)
+        assert result["count"] == 0
+
+    def test_preserves_existing_count(self):
+        data = {"results": [], "count": 0}
+        result = _ensure_definitive_empty(data)
+        assert result["count"] == 0  # not overwritten
+
+    def test_preserves_non_empty(self):
+        data = {"results": [{"id": 1}], "count": 1}
+        result = _ensure_definitive_empty(data)
+        assert result["count"] == 1
+
+    def test_handles_non_dict(self):
+        result = _ensure_definitive_empty("hello")
+        assert result == "hello"
+
+
+class TestEncodeToon:
+    def test_encodes_list_output(self):
+        data = {"results": [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}], "count": 2}
+        json_str = json.dumps(data)
+        toon_str = encode_toon(json_str, tool_name="test")
+        assert "[" in toon_str  # array header
+        assert "Alice" in toon_str
+        assert toon_str != json_str  # actually converted
+
+    def test_roundtrip(self):
+        from toon_format import decode
+        data = {"results": [{"id": 1, "name": "test"}], "count": 1}
+        json_str = json.dumps(data)
+        toon_str = encode_toon(json_str, tool_name="test", truncate=False)
+        decoded = decode(toon_str)
+        # After TOON decode, types may differ slightly (int vs str) but structure should match
+        assert "results" in decoded
+        assert len(decoded["results"]) == 1
+
+    def test_fallback_on_invalid_json(self):
+        plain = "not json at all"
+        result = encode_toon(plain, tool_name="test")
+        assert result == plain
+
+    def test_skip_list(self):
+        data = {"x": 1}
+        json_str = json.dumps(data)
+        # If we add a tool to skip list, it should return JSON unchanged
+        from tools.toon_encoder import _SKIP_TOON_TOOLS
+        # Can't easily test this without modifying the frozenset, but verify it exists
+        assert isinstance(_SKIP_TOON_TOOLS, frozenset)
+
+    def test_savings_on_realistic_output(self):
+        data = {
+            "success": True,
+            "mode": "recent",
+            "results": [
+                {"session_id": f"s{i}", "title": f"Session {i}", "source": "local",
+                 "started_at": f"April {i}, 2026", "last_active": "April 7, 2026",
+                 "message_count": i * 10, "preview": f"Preview text {i}..."}
+                for i in range(5)
+            ],
+            "count": 5,
+        }
+        json_str = json.dumps(data, ensure_ascii=False)
+        toon_str = encode_toon(json_str, tool_name="session_search", truncate=False)
+        savings = 1 - len(toon_str) / len(json_str)
+        assert savings > 0.25  # at least 25% savings
+
+
+class TestTokenSavings:
+    """Benchmark-style tests to verify savings on representative outputs."""
+
+    def _measure(self, data, tool_name="test"):
+        json_str = json.dumps(data, ensure_ascii=False)
+        toon_str = encode_toon(json_str, tool_name=tool_name, truncate=False)
+        return {
+            "json_chars": len(json_str),
+            "toon_chars": len(toon_str),
+            "savings": round((1 - len(toon_str) / len(json_str)) * 100, 1),
+        }
+
+    def test_session_search_savings(self):
+        data = {
+            "success": True,
+            "results": [
+                {"session_id": "abc", "title": "Test", "source": "local",
+                 "started_at": "April 7", "last_active": "April 7",
+                 "message_count": 20, "preview": "Some preview..."}
+            ] * 3,
+            "count": 3,
+        }
+        m = self._measure(data, "session_search")
+        assert m["savings"] > 25, f"Only {m['savings']}% savings"
+
+    def test_search_files_savings(self):
+        data = {
+            "matches": [
+                {"file": f"/path/file{i}.py", "line": i * 10, "content": f"def func{i}():", "match_count": 3}
+                for i in range(10)
+            ],
+            "total_count": 10,
+        }
+        m = self._measure(data, "search_files")
+        assert m["savings"] > 25, f"Only {m['savings']}% savings"
+
+    def test_error_savings(self):
+        data = {"error": "File not found", "success": False}
+        m = self._measure(data, "error")
+        # Errors are small, savings modest but positive
+        assert m["savings"] > 0

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -873,6 +873,12 @@ IMAGE_GENERATE_SCHEMA = {
                 "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
                 "default": DEFAULT_ASPECT_RATIO,
             },
+            "reference_images": {
+                "type": "array",
+                "description": "Optional local file paths, http(s) URLs, or data:image URLs to use as reference images for providers that support image-conditioned generation or editing.",
+                "items": {"type": "string"},
+                "maxItems": 4,
+            },
         },
         "required": ["prompt"],
     },
@@ -900,7 +906,7 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str, reference_images=None):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -914,6 +920,9 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
     configured = _read_configured_image_provider()
     if not configured or configured == "fal":
         return None
+
+    if not isinstance(reference_images, list):
+        reference_images = []
 
     try:
         # Import locally so plugin discovery isn't triggered just by
@@ -950,7 +959,11 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         })
 
     try:
-        result = provider.generate(prompt=prompt, aspect_ratio=aspect_ratio)
+        result = provider.generate(
+            prompt=prompt,
+            aspect_ratio=aspect_ratio,
+            reference_images=reference_images,
+        )
     except Exception as exc:
         logger.warning(
             "Image gen provider '%s' raised: %s",
@@ -977,10 +990,11 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    reference_images = args.get("reference_images") or []
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio, reference_images=reference_images)
     if dispatched is not None:
         return dispatched
 

--- a/tools/toon_encoder.py
+++ b/tools/toon_encoder.py
@@ -1,0 +1,152 @@
+"""
+TOON Output Encoder — AXI Principle 1 & 3
+
+Transforms tool JSON output to TOON (Token-Oriented Object Notation) format
+for ~30-40% token savings on structured data. Falls back to JSON on any error.
+
+Config: output_format in config.yaml — "json" (default) or "toon"
+
+This module sits at the registry dispatch boundary. Individual tool handlers
+are NOT modified — they continue returning json.dumps(). This module converts
+at the exit point.
+"""
+
+import json
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Lazy import — toon_format may not be installed
+_encode = None
+_encode_loaded = False
+
+
+def _get_encoder():
+    """Lazy-load the TOON encoder. Returns None if not available."""
+    global _encode, _encode_loaded
+    if not _encode_loaded:
+        _encode_loaded = True
+        try:
+            from toon_format import encode as _enc
+            _encode = _enc
+            logger.debug("TOON encoder loaded successfully")
+        except ImportError:
+            logger.warning("toon_format not installed — TOON output disabled")
+            _encode = None
+    return _encode
+
+
+# ---------------------------------------------------------------------------
+# AXI Principle 3: Content truncation
+# ---------------------------------------------------------------------------
+
+_DEFAULT_TRUNCATE_LIMIT = 1500  # chars
+
+
+def _truncate_value(value: Any, limit: int = _DEFAULT_TRUNCATE_LIMIT) -> Any:
+    """Truncate large string values in a data structure with size hints."""
+    if isinstance(value, str) and len(value) > limit:
+        return value[:limit] + f"\n... (truncated, {len(value)} chars total)"
+    if isinstance(value, dict):
+        return {k: _truncate_value(v, limit) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_truncate_value(item, limit) for item in value]
+    return value
+
+
+# ---------------------------------------------------------------------------
+# AXI Principle 5: Definitive empty states
+# ---------------------------------------------------------------------------
+
+def _ensure_definitive_empty(data: Any) -> Any:
+    """Convert ambiguous empty outputs to explicit '0 results' states."""
+    if isinstance(data, dict):
+        # Empty list results with no count
+        for key in ("results", "matches", "skills", "items", "sessions"):
+            val = data.get(key)
+            if isinstance(val, list) and len(val) == 0:
+                if "count" not in data and "total_count" not in data:
+                    data["count"] = 0
+        return data
+    return data
+
+
+# ---------------------------------------------------------------------------
+# AXI Principle 6: Structured errors
+# ---------------------------------------------------------------------------
+
+_STANDARD_ERROR_KEYS = {"error", "success", "message"}
+
+
+def _is_error_result(data: Any) -> bool:
+    """Check if the result is an error."""
+    if isinstance(data, dict):
+        if "error" in data:
+            return True
+        if data.get("success") is False:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Main encoder
+# ---------------------------------------------------------------------------
+
+# Tools that should always stay in JSON (e.g., complex nested structures
+# that TOON handles poorly, or tools where consumers expect JSON)
+_SKIP_TOON_TOOLS = frozenset({
+    # Add tool names here if they break with TOON
+})
+
+
+def encode_toon(json_str: str, tool_name: str = "", truncate: bool = True) -> str:
+    """
+    Convert a JSON tool output string to TOON format.
+
+    Args:
+        json_str: The JSON string returned by a tool handler
+        tool_name: Tool name (for skip-list and metadata)
+        truncate: Whether to apply AXI content truncation
+
+    Returns:
+        TOON string, or original JSON string on any failure
+    """
+    # Skip list check
+    if tool_name in _SKIP_TOON_TOOLS:
+        return json_str
+
+    # Get encoder
+    encoder = _get_encoder()
+    if encoder is None:
+        return json_str
+
+    try:
+        data = json.loads(json_str)
+    except (json.JSONDecodeError, TypeError):
+        # Not valid JSON — return as-is (plain text tool output)
+        return json_str
+
+    # Apply AXI transformations
+    data = _ensure_definitive_empty(data)
+
+    if truncate:
+        data = _truncate_value(data)
+
+    # Encode to TOON
+    try:
+        toon_str = encoder(data)
+        return toon_str
+    except Exception as e:
+        logger.debug("TOON encoding failed for %s: %s", tool_name, e)
+        return json_str
+
+
+def should_use_toon() -> bool:
+    """Check if TOON output is enabled in config."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return cfg.get("output_format") == "toon"
+    except Exception:
+        return False


### PR DESCRIPTION
## Summary
- Add Telegram structured to-do reply handling plus frontpage image override staging.
- Add gateway FD/CLOSE_WAIT watchdog metrics, cleanup, and restart signaling plus TOON output encoder utilities.
- Add image generation `reference_images` dispatch support for the OpenAI Codex image provider.

## Test Plan
- `git diff --check`
- `python -m compileall -q gateway/fd_watchdog.py gateway/todo_replies.py tools/toon_encoder.py plugins/image_gen/openai-codex/__init__.py tools/image_generation_tool.py gateway/platforms/telegram.py`
- `python -m pytest tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_todo_replies.py tests/gateway/test_todo_replies.py tests/gateway/test_fd_watchdog.py tests/tools/test_toon_encoder.py tests/plugins/image_gen/test_openai_codex_provider.py tests/tools/test_image_generation_plugin_dispatch.py -q -o 'addopts='`
