### PR TITLE
fix(memory): require schema fields by action (salvage #19180)

### DIFF
--- a/tests/tools/test_memory_tool_schema.py
+++ b/tests/tools/test_memory_tool_schema.py
@@ -1,0 +1,39 @@
+import json
+from tools.memory_tool import MEMORY_SCHEMA
+
+
+def test_memory_schema_requires_content_and_old_text_for_replace_action():
+    schema = MEMORY_SCHEMA["parameters"]
+    assert schema["required"] == ["action", "target"]
+
+    all_of = schema.get("allOf")
+    assert all_of, "memory schema should use conditional requirements"
+
+    replace_requirements = [
+        branch["then"].get("required", [])
+        for branch in all_of
+        if branch.get("if", {}).get("properties", {}).get("action", {}).get("const") == "replace"
+    ]
+    assert replace_requirements == [["old_text", "content"]]
+
+
+def test_memory_schema_requires_content_for_add_action():
+    add_requirements = [
+        branch["then"].get("required", [])
+        for branch in MEMORY_SCHEMA["parameters"].get("allOf", [])
+        if branch.get("if", {}).get("properties", {}).get("action", {}).get("const") == "add"
+    ]
+    assert add_requirements == [["content"]]
+
+
+def test_memory_schema_requires_old_text_for_remove_action():
+    remove_requirements = [
+        branch["then"].get("required", [])
+        for branch in MEMORY_SCHEMA["parameters"].get("allOf", [])
+        if branch.get("if", {}).get("properties", {}).get("action", {}).get("const") == "remove"
+    ]
+    assert remove_requirements == [["old_text"]]
+
+
+def test_memory_schema_is_json_serializable():
+    json.dumps(MEMORY_SCHEMA)

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -560,6 +560,29 @@ MEMORY_SCHEMA = {
             },
         },
         "required": ["action", "target"],
+        "allOf": [
+            {
+                "if": {
+                    "properties": {"action": {"const": "add"}},
+                    "required": ["action"],
+                },
+                "then": {"required": ["content"]},
+            },
+            {
+                "if": {
+                    "properties": {"action": {"const": "replace"}},
+                    "required": ["action"],
+                },
+                "then": {"required": ["old_text", "content"]},
+            },
+            {
+                "if": {
+                    "properties": {"action": {"const": "remove"}},
+                    "required": ["action"],
+                },
+                "then": {"required": ["old_text"]},
+            },
+        ],
     },
 }
 


### PR DESCRIPTION
Closes #19180 via salvage. Fixes #19171.

## Summary
Memory tool schema required only `action` and `target`. Conditional on the chosen action, additional fields should be required:
- `add` → `content`
- `replace` → `old_text`, `content`
- `remove` → `old_text`

Adds `allOf` + `if/then` conditionals. Providers that consume them (OpenAI non-strict, Anthropic, DeepSeek) surface the requirement to the model at tool-call time; providers that strip unknown schema keys (Gemini) keep their pre-fix behavior. Runtime validation in `handle_function_call` was already in place — this just brings schema-level validation in line.

## Validation
`scripts/run_tests.sh tests/tools/test_memory_tool_schema.py tests/tools/test_memory_tool.py` → 37 passed.

Original author: @altmazza0-star.