### PR TITLE
fix(agent): avoid persisting empty-response recovery scaffolding (salvage #19184)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3792,10 +3792,20 @@ class AIAgent:
 
         Ensures conversations are never lost, even on errors or early returns.
         """
+        self._drop_trailing_empty_recovery_synthetic(messages)
         self._apply_persist_user_message_override(messages)
         self._session_messages = messages
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
+
+    def _drop_trailing_empty_recovery_synthetic(self, messages: List[Dict]) -> None:
+        """Remove private empty-response retry scaffolding from transcript tails."""
+        while (
+            messages
+            and isinstance(messages[-1], dict)
+            and messages[-1].get("_empty_recovery_synthetic")
+        ):
+            messages.pop()
 
     def _flush_messages_to_session_db(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Persist any un-flushed messages to the SQLite session store.
@@ -13706,6 +13716,7 @@ class AIAgent:
                             # APIs reject as an invalid sequence.
                             _nudge_msg = self._build_assistant_message(assistant_message, finish_reason)
                             _nudge_msg["content"] = "(empty)"
+                            _nudge_msg["_empty_recovery_synthetic"] = True
                             messages.append(_nudge_msg)
                             messages.append({
                                 "role": "user",
@@ -13714,6 +13725,7 @@ class AIAgent:
                                     "empty response. Please process the tool "
                                     "results above and continue with the task."
                                 ),
+                                "_empty_recovery_synthetic": True,
                             })
                             continue
 
@@ -13816,6 +13828,7 @@ class AIAgent:
                         # "(empty)" terminal.
                         _turn_exit_reason = "empty_response_exhausted"
                         reasoning_text = self._extract_reasoning(assistant_message)
+                        self._drop_trailing_empty_recovery_synthetic(messages)
                         assistant_msg = self._build_assistant_message(assistant_message, finish_reason)
                         assistant_msg["content"] = "(empty)"
                         messages.append(assistant_msg)
@@ -13890,14 +13903,17 @@ class AIAgent:
                     
                     final_msg = self._build_assistant_message(assistant_message, finish_reason)
 
-                    # Pop thinking-only prefill message(s) before appending
-                    # the final response.  This avoids consecutive assistant
-                    # messages which break strict-alternation providers
-                    # (Anthropic Messages API) and keeps history clean.
+                    # Pop thinking-only prefill and empty-response retry
+                    # scaffolding before appending the final response.  These
+                    # internal turns are only for the next API retry and should
+                    # not become durable transcript context.
                     while (
                         messages
                         and isinstance(messages[-1], dict)
-                        and messages[-1].get("_thinking_prefill")
+                        and (
+                            messages[-1].get("_thinking_prefill")
+                            or messages[-1].get("_empty_recovery_synthetic")
+                        )
                     ):
                         messages.pop()
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3792,18 +3792,21 @@ class AIAgent:
 
         Ensures conversations are never lost, even on errors or early returns.
         """
-        self._drop_trailing_empty_recovery_synthetic(messages)
+        self._drop_trailing_empty_response_scaffolding(messages)
         self._apply_persist_user_message_override(messages)
         self._session_messages = messages
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
 
-    def _drop_trailing_empty_recovery_synthetic(self, messages: List[Dict]) -> None:
-        """Remove private empty-response retry scaffolding from transcript tails."""
+    def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
+        """Remove private empty-response retry/failure scaffolding from transcript tails."""
         while (
             messages
             and isinstance(messages[-1], dict)
-            and messages[-1].get("_empty_recovery_synthetic")
+            and (
+                messages[-1].get("_empty_recovery_synthetic")
+                or messages[-1].get("_empty_terminal_sentinel")
+            )
         ):
             messages.pop()
 
@@ -13828,9 +13831,15 @@ class AIAgent:
                         # "(empty)" terminal.
                         _turn_exit_reason = "empty_response_exhausted"
                         reasoning_text = self._extract_reasoning(assistant_message)
-                        self._drop_trailing_empty_recovery_synthetic(messages)
+                        self._drop_trailing_empty_response_scaffolding(messages)
                         assistant_msg = self._build_assistant_message(assistant_message, finish_reason)
                         assistant_msg["content"] = "(empty)"
+                        # This is a user-facing failure sentinel for the gateway,
+                        # not real assistant content. Persisting it makes later
+                        # "continue" turns replay assistant("(empty)") as if it
+                        # were a meaningful model response, which can keep long
+                        # tool-heavy sessions stuck in empty-response loops.
+                        assistant_msg["_empty_terminal_sentinel"] = True
                         messages.append(assistant_msg)
 
                         if reasoning_text:
@@ -13913,6 +13922,7 @@ class AIAgent:
                         and (
                             messages[-1].get("_thinking_prefill")
                             or messages[-1].get("_empty_recovery_synthetic")
+                            or messages[-1].get("_empty_terminal_sentinel")
                         )
                     ):
                         messages.pop()
@@ -14004,7 +14014,11 @@ class AIAgent:
         # Clean up VM and browser for this task after conversation completes
         self._cleanup_task_resources(effective_task_id)
 
-        # Persist session to both JSON log and SQLite
+        # Persist session to both JSON log and SQLite only after private retry
+        # scaffolding has been removed. Otherwise a later user "continue" turn
+        # can replay assistant("(empty)") / recovery nudges and fall into the
+        # same empty-response loop again.
+        self._drop_trailing_empty_response_scaffolding(messages)
         self._persist_session(messages, conversation_history)
 
         # ── Turn-exit diagnostic log ─────────────────────────────────────

--- a/tests/run_agent/test_empty_response_recovery_persistence.py
+++ b/tests/run_agent/test_empty_response_recovery_persistence.py
@@ -1,0 +1,66 @@
+"""Regression tests for empty-response recovery transcript persistence."""
+
+from run_agent import AIAgent
+
+
+def _agent_with_stubbed_persistence():
+    agent = AIAgent.__new__(AIAgent)
+    agent._persist_user_message_idx = None
+    agent._persist_user_message_override = None
+    agent._session_db = None
+    agent._session_messages = []
+    agent.saved_session_logs = []
+    agent.flushed_session_db_messages = []
+    agent._save_session_log = lambda messages: agent.saved_session_logs.append(
+        [m.copy() for m in messages]
+    )
+    agent._flush_messages_to_session_db = lambda messages, conversation_history=None: (
+        agent.flushed_session_db_messages.append([m.copy() for m in messages])
+    )
+    return agent
+
+
+def test_persist_session_strips_trailing_empty_recovery_scaffolding():
+    agent = _agent_with_stubbed_persistence()
+    messages = [
+        {"role": "user", "content": "run the task"},
+        {"role": "tool", "content": "{}", "tool_call_id": "call_1"},
+        {
+            "role": "assistant",
+            "content": "(empty)",
+            "_empty_recovery_synthetic": True,
+        },
+        {
+            "role": "user",
+            "content": (
+                "You just executed tool calls but returned an empty response. "
+                "Please process the tool results above and continue with the task."
+            ),
+            "_empty_recovery_synthetic": True,
+        },
+    ]
+
+    AIAgent._persist_session(agent, messages, conversation_history=[])
+
+    assert messages == [
+        {"role": "user", "content": "run the task"},
+        {"role": "tool", "content": "{}", "tool_call_id": "call_1"},
+    ]
+    assert agent.saved_session_logs[-1] == messages
+    assert all(not msg.get("_empty_recovery_synthetic") for msg in messages)
+
+
+def test_persist_session_keeps_real_terminal_empty_response():
+    agent = _agent_with_stubbed_persistence()
+    messages = [
+        {"role": "user", "content": "run the task"},
+        {"role": "assistant", "content": "(empty)"},
+    ]
+
+    AIAgent._persist_session(agent, messages, conversation_history=[])
+
+    assert messages == [
+        {"role": "user", "content": "run the task"},
+        {"role": "assistant", "content": "(empty)"},
+    ]
+    assert agent.saved_session_logs[-1] == messages

--- a/tests/run_agent/test_empty_response_recovery_persistence.py
+++ b/tests/run_agent/test_empty_response_recovery_persistence.py
@@ -50,7 +50,7 @@ def test_persist_session_strips_trailing_empty_recovery_scaffolding():
     assert all(not msg.get("_empty_recovery_synthetic") for msg in messages)
 
 
-def test_persist_session_keeps_real_terminal_empty_response():
+def test_persist_session_keeps_unmarked_terminal_empty_response():
     agent = _agent_with_stubbed_persistence()
     messages = [
         {"role": "user", "content": "run the task"},
@@ -64,3 +64,21 @@ def test_persist_session_keeps_real_terminal_empty_response():
         {"role": "assistant", "content": "(empty)"},
     ]
     assert agent.saved_session_logs[-1] == messages
+
+
+def test_persist_session_strips_marked_terminal_empty_sentinel():
+    agent = _agent_with_stubbed_persistence()
+    messages = [
+        {"role": "user", "content": "continue"},
+        {
+            "role": "assistant",
+            "content": "(empty)",
+            "_empty_terminal_sentinel": True,
+        },
+    ]
+
+    AIAgent._persist_session(agent, messages, conversation_history=[])
+
+    assert messages == [{"role": "user", "content": "continue"}]
+    assert agent.saved_session_logs[-1] == messages
+    assert all(not msg.get("_empty_terminal_sentinel") for msg in messages)


### PR DESCRIPTION
Closes #19184 via salvage.

## Summary
The post-tool empty-response recovery path appends a synthetic `(empty)` assistant message + user nudge to keep role sequence valid for the next retry. These should never become durable transcript context, but the current code persists them to session logs / SQLite.

Mark those turns with a private `_empty_recovery_synthetic` / `_empty_terminal_sentinel` flag, and strip them in:
- `_drop_trailing_empty_response_scaffolding` (called from `_finalize_*` persistence path)
- Before appending a real final response (alongside the existing `_thinking_prefill` pop)
- Before the terminal `(empty)` sentinel is written (retries exhausted)

The live-loop `messages` list still carries them during the API retry loop as before — this only affects what gets persisted.

## Validation
`scripts/run_tests.sh tests/run_agent/test_empty_response_recovery_persistence.py` → 3 passed.
`scripts/run_tests.sh tests/run_agent/ -k empty` → 63 passed.

Original author: @wxst.