### PR TITLE
feat(kanban): multiline textarea for inline-create title (salvage of #20970)

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1760,6 +1760,7 @@
         value: title,
         onChange: function (e) { setTitle(e.target.value); },
         onKeyDown: function (e) {
+          if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); submit(); }
           if (e.key === "Escape") props.onCancel();
         },
         placeholder: props.columnName === "triage"

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1756,18 +1756,18 @@
       : "workspace path (optional, derived from assignee if blank)";
 
     return h("div", { className: "hermes-kanban-inline-create" },
-      h(Input, {
+      h("textarea", {
         value: title,
         onChange: function (e) { setTitle(e.target.value); },
         onKeyDown: function (e) {
-          if (e.key === "Enter") { e.preventDefault(); submit(); }
           if (e.key === "Escape") props.onCancel();
         },
         placeholder: props.columnName === "triage"
           ? "Rough idea — AI will spec it…"
           : "New task title…",
         autoFocus: true,
-        className: "h-8 text-sm",
+        className: "text-sm min-h-[2rem] max-h-32 resize-y w-full border border-input bg-transparent px-2 py-1 rounded-md focus:outline-none focus:ring-2 focus:ring-ring",
+        rows: 2,
       }),
       h("div", { className: "flex gap-2" },
         h(Input, {


### PR DESCRIPTION
Salvages #20970 by @JezzaHehn and adds a follow-up fix for Enter handling.

## What changed (contributor's commit)
Converts the kanban inline-create title field from a single-line `<Input>` to a 2-row `<textarea>` with vertical resize and an 8rem max-height cap. Useful for triage "rough idea" entries and longer task descriptions.

## Follow-up fix (this PR)
The contributor's commit dropped Enter-to-submit entirely, requiring a mouse click on Create for every single-line task. Restored the common-case shortcut while preserving multiline entry:
- Enter (no modifier) submits
- Shift+Enter inserts a newline
- Escape still cancels

Matches the convention used by Slack, Discord, and GitHub PR comment boxes.

## Files
`plugins/kanban/dashboard/dist/index.js` — direct bundle edit (dashboard source is not in-repo; precedent: PRs #a49670c, #a01c1f7).

## Credit
Original work by @JezzaHehn in #20970 — commit preserved via rebase-merge.