### PR TITLE
fix(kanban): make code/pre styling theme-immune across all themes (#21086)

### DIFF
--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -9,13 +9,55 @@
   width: 100%;
 }
 
-/* Override the Nous DS global `code { background: var(--midground) }` rule
-   which paints an opaque cream/yellow fill on every <code> inside the board,
-   hiding the text underneath. Kanban uses <code> for event payloads, run-meta,
-   and log panes — those need transparent backgrounds. */
-.hermes-kanban code {
-  background: transparent;
+/* ---- Code/pre reset (theme-immune default) --------------------------- *
+ *
+ * Themes (shipped AND user-installable) routinely paint every <code> and
+ * <pre> on the page with an opaque accent-color fill. That's fine for a
+ * Markdown doc page; it's wrong for the kanban plugin, which uses <code>
+ * for event payloads, run metadata, log panes, and similar raw-data
+ * surfaces that must read as plain text on the board's own background.
+ *
+ * Rather than play whack-a-mole with theme rules (the pre-#21086 approach
+ * was a single ``.hermes-kanban code { background: transparent }`` rule
+ * that lost specificity fights in the drawer context), reset EVERY
+ * <code>/<pre> inside the kanban plugin container to transparent with
+ * ``!important``, then opt back in ONLY on the class that carries
+ * intentional styling (``.hermes-kanban-md code``, the inline code pill
+ * inside rendered task-body Markdown).
+ *
+ * Net effect: any new theme, shipped or third-party, can introduce
+ * whatever global code-fill rule it wants — kanban surfaces stay clean
+ * unless the theme deliberately targets our internal class names.
+ * Regression coverage: #21086 (task-drawer event payloads unreadable
+ * across every shipped theme).
+ */
+.hermes-kanban code,
+.hermes-kanban pre,
+.hermes-kanban-drawer code,
+.hermes-kanban-drawer pre {
+  background: transparent !important;
   color: inherit;
+}
+/* The Markdown renderer intentionally paints a subtle code pill behind
+ * inline ``<code>`` inside task-body prose — but NOT inside a fenced
+ * block (those are a ``<pre class="hermes-kanban-md-code">`` with a
+ * bare ``<code>`` inside, and the pill would double up with the pre
+ * background). ``:not()`` scopes this opt-back-in to inline code only.
+ *
+ * Uses ``color-mix(currentColor ...)`` rather than ``--color-foreground``
+ * so the pill renders consistently even when a theme forgets to set
+ * ``--color-foreground`` (pre-existing safeguard from #18576).
+ */
+.hermes-kanban .hermes-kanban-md code:not(.hermes-kanban-md-code *) {
+  background: color-mix(in srgb, currentColor 8%, transparent) !important;
+}
+/* Tighten contrast on the drawer-specific payload class — it lives on
+ * its own line in the events list, so matching the muted-foreground
+ * color keeps it visually distinct from the event title without
+ * screaming for attention. */
+.hermes-kanban-event-payload,
+.hermes-kanban-drawer .hermes-kanban-event-payload {
+  color: var(--color-muted-foreground) !important;
 }
 
 /* ---- Columns layout -------------------------------------------------- */
@@ -668,7 +710,9 @@
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: 0.8rem;
   padding: 0.05rem 0.3rem;
-  background: color-mix(in srgb, var(--color-foreground) 8%, transparent);
+  /* Background is set in the code/pre reset block at the top of this
+   * file with !important, so theme-level global code rules can't knock
+   * out this intentional pill. See #21086. */
   border-radius: 3px;
   color: inherit;
 }
@@ -678,10 +722,15 @@
  * UA default on <code> elements — otherwise themes that don't set
  * --color-foreground leave code text rendering near-black on dark themes
  * (see issue #18576). */
-.hermes-kanban-md-code {
+.hermes-kanban pre.hermes-kanban-md-code {
   margin: 0.35rem 0;
   padding: 0.5rem 0.6rem;
-  background: color-mix(in srgb, currentColor 6%, transparent);
+  /* Higher specificity (``.hermes-kanban pre.hermes-kanban-md-code`` vs
+   * the reset's ``.hermes-kanban pre``) so this intentional pill wins
+   * over our own ``<pre>`` reset. ``!important`` also needed so theme
+   * rules that drop their own ``code``/``pre`` fill don't knock it out
+   * either. #21086. */
+  background: color-mix(in srgb, currentColor 6%, transparent) !important;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm, 0.25rem);
   overflow-x: auto;


### PR DESCRIPTION
Kanban `<code>`/`<pre>` styling is now theme-immune — any future user-installed theme that does the normal `code { background: ... !important }` dance cannot break Kanban's drawer, event payloads, log panes, or run-metadata surfaces.

Closes #21086.

## What changed vs. the first draft

First iteration was narrow: add `!important` to the specific offending selectors (`.hermes-kanban-event-payload`, drawer `<code>`, drawer `<pre>`). That fixed the 7 shipped themes but would have lost again to any future theme doing the same trick a slightly different way.

This version inverts the approach:

1. **Reset** every `<code>` and `<pre>` inside `.hermes-kanban` (+ `.hermes-kanban-drawer`) to `background: transparent !important`. This is the new default — anything `<code>`/`<pre>` inside kanban is guaranteed transparent unless something inside the plugin itself opts in.

2. **Opt back in** on exactly the two classes that carry intentional pill styling:
   - `.hermes-kanban .hermes-kanban-md code:not(.hermes-kanban-md-code *)` — inline code pill in rendered task-body markdown, scoped via `:not()` to exclude fenced blocks.
   - `.hermes-kanban pre.hermes-kanban-md-code` — fenced block wrapper; higher specificity than the reset so it wins cleanly.

Net effect: any theme (shipped or third-party) can introduce whatever global `code`/`pre` fill it wants — kanban surfaces stay clean unless the theme deliberately targets our internal class names, which is a conscious override rather than accidental breakage.

## Validation

**Hostile-theme robustness test:** built a synthetic worst-case theme that injects `code { background: !important }`, `pre { background: !important }`, AND `.hermes-kanban code { background: !important }`. Loaded it in a headless browser alongside the plugin CSS and read `getComputedStyle().backgroundColor` on every relevant surface:

| Surface | Expected | Got |
|---|---|---|
| Outside `.hermes-kanban` (sanity) | hostile fill | hostile fill ✓ |
| Drawer `.hermes-kanban-event-payload` (the bug) | transparent | `rgba(0, 0, 0, 0)` ✓ |
| Drawer bare `<code>` | transparent | `rgba(0, 0, 0, 0)` ✓ |
| Drawer bare `<pre>` | transparent | `rgba(0, 0, 0, 0)` ✓ |
| Markdown inline `<code>` | subtle pill | `color(srgb 1 1 1 / 0.08)` ✓ |
| Markdown fenced block `.hermes-kanban-md-code` | subtle pill | `color(srgb 1 1 1 / 0.06)` ✓ |
| Markdown fenced inner `<code>` | transparent | `rgba(0, 0, 0, 0)` ✓ |

**Live dashboard cross-theme test:** same computed-style check against a real dashboard with a real task + events, cycling through all 7 shipped themes (Hermes Teal, Teal Large, Midnight, Ember, Mono, Cyberpunk, Rosé). Every theme reports `rgba(0, 0, 0, 0)` on `.hermes-kanban-event-payload` with a theme-appropriate foreground color.

1 file, 58 insertions, 9 deletions.

## Closes

- Closes #21086 (credit @Flipsi85 — detailed bug report with working CSS workaround that informed both the original narrow fix and the motivation to generalize to a theme-immune default)
