### PR TITLE
fix(agent): halt on typed tool billing blockers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -122,6 +122,7 @@ from tools.terminal_tool import (
     _get_sudo_password_callback,
 )
 from tools.tool_result_storage import maybe_persist_tool_result, enforce_turn_budget
+from tools.tool_result_signals import is_billing_blocker_signal, parse_tool_result_signal
 from tools.interrupt import set_interrupt as _set_interrupt
 from tools.browser_tool import cleanup_browser
 
@@ -9410,12 +9411,36 @@ class AIAgent:
 
     def _toolguard_controlled_halt_response(self, decision: ToolGuardrailDecision) -> str:
         tool = decision.tool_name or "a tool"
+        if decision.code == "typed_tool_billing_blocker":
+            return (
+                f"I stopped after {tool} hit a non-retryable billing blocker. "
+                "The tool returned a typed provider billing failure, so repeating "
+                "the same call would not make progress. Fix the provider credits "
+                "or billing state before retrying."
+            )
         return (
             f"I stopped retrying {tool} because it hit the tool-call guardrail "
             f"({decision.code}) after {decision.count} repeated non-progressing "
             "attempts. The last tool result explains the blocker; the next step is "
             "to change strategy instead of repeating the same call."
         )
+
+    def _maybe_apply_typed_tool_halt(self, tool_name: str, function_result: str) -> str:
+        """React only to explicit typed tool-result halt signals."""
+        signal = parse_tool_result_signal(function_result)
+        if not is_billing_blocker_signal(signal):
+            return function_result
+
+        self._set_tool_guardrail_halt(
+            ToolGuardrailDecision(
+                action="halt",
+                code="typed_tool_billing_blocker",
+                message=signal.message,
+                tool_name=tool_name,
+                count=1,
+            )
+        )
+        return function_result
 
     def _append_guardrail_observation(
         self,
@@ -9898,6 +9923,7 @@ class AIAgent:
                         function_result,
                         failed=is_error,
                     )
+                    function_result = self._maybe_apply_typed_tool_halt(function_name, function_result)
 
                 if is_error:
                     result_preview = function_result[:200] if len(function_result) > 200 else function_result
@@ -10295,6 +10321,7 @@ class AIAgent:
                     function_result,
                     failed=_is_error_result,
                 )
+                function_result = self._maybe_apply_typed_tool_halt(function_name, function_result)
                 result_preview = function_result if self.verbose_logging else (
                     function_result[:200] if len(function_result) > 200 else function_result
                 )

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from run_agent import AIAgent
+from tools.tool_result_signals import billing_blocker_tool_error
 
 
 def _make_tool_defs(*names: str) -> list[dict]:
@@ -273,3 +274,63 @@ def test_config_enabled_hard_stop_run_conversation_returns_controlled_guardrail_
         call_ids = [tc["id"] for tc in assistant_msg["tool_calls"]]
         following_results = [m for m in result["messages"] if m.get("role") == "tool" and m.get("tool_call_id") in call_ids]
         assert len(following_results) == len(call_ids)
+
+
+def test_run_conversation_halts_on_typed_tool_billing_blocker_without_hard_stop_config():
+    agent = _make_agent("web_search", max_iterations=10)
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("web_search", json.dumps({"query": "same"}), "c-billing")],
+        ),
+        _mock_response(content="should not be used", finish_reason="stop", tool_calls=None),
+    ]
+
+    with (
+        patch(
+            "run_agent.handle_function_call",
+            return_value=billing_blocker_tool_error(
+                "Error searching web: backend 'firecrawl' returned HTTP 402 Payment Required.",
+                provider="firecrawl",
+                status_code=402,
+            ),
+        ) as mock_hfc,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("search once")
+
+    assert mock_hfc.call_count == 1
+    assert result["turn_exit_reason"] == "guardrail_halt"
+    assert result["guardrail"]["code"] == "typed_tool_billing_blocker"
+    assert result["guardrail"]["tool_name"] == "web_search"
+    assert "non-retryable billing blocker" in result["final_response"]
+
+
+def test_run_conversation_does_not_halt_on_plain_error_text_that_mentions_payment_required():
+    agent = _make_agent("web_search", max_iterations=10)
+    agent.client.chat.completions.create.side_effect = [
+        _mock_response(
+            content="",
+            finish_reason="tool_calls",
+            tool_calls=[_mock_tool_call("web_search", json.dumps({"query": "debug"}), "c-plain")],
+        ),
+        _mock_response(content="done", finish_reason="stop", tool_calls=None),
+    ]
+
+    plain_error = json.dumps({"error": "HTTP/1.1 402 Payment Required shown in a fixture"})
+
+    with (
+        patch("run_agent.handle_function_call", return_value=plain_error) as mock_hfc,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = agent.run_conversation("debug one tool result")
+
+    assert mock_hfc.call_count == 1
+    assert result["turn_exit_reason"].startswith("text_response")
+    assert "guardrail" not in result
+    assert result["final_response"] == "done"

--- a/tests/tools/test_browser_cloud_fallback.py
+++ b/tests/tools/test_browser_cloud_fallback.py
@@ -3,12 +3,14 @@
 Covers the fallback logic in _get_session_info() when a cloud provider
 is configured but fails at runtime (issue #10883).
 """
+import json
 import logging
 from unittest.mock import Mock, patch
 
 import pytest
 
 import tools.browser_tool as browser_tool
+from tools.browser_providers.base import BrowserProviderBillingBlocker
 
 
 def _reset_session_state(monkeypatch):
@@ -164,3 +166,47 @@ class TestCloudProviderRuntimeFallback:
 
         assert session["fallback_from_cloud"] is True
         assert "invalid session" in session["fallback_reason"]
+
+    def test_billing_blocker_does_not_fall_back_to_local(self, monkeypatch):
+        """A typed billing blocker should propagate instead of hiding behind local fallback."""
+        _reset_session_state(monkeypatch)
+
+        provider = Mock()
+        provider.create_session.side_effect = BrowserProviderBillingBlocker(
+            provider="firecrawl",
+            status_code=402,
+            message="Failed to create Firecrawl browser session: 402 Payment Required",
+        )
+        monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: provider)
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: None)
+
+        with pytest.raises(BrowserProviderBillingBlocker):
+            browser_tool._get_session_info("task-billing")
+
+    def test_browser_navigate_returns_typed_billing_blocker_tool_error(self, monkeypatch):
+        """browser_navigate should surface the typed billing blocker result to the runtime."""
+        _reset_session_state(monkeypatch)
+
+        monkeypatch.setattr(
+            browser_tool,
+            "_get_session_info",
+            Mock(
+                side_effect=BrowserProviderBillingBlocker(
+                    provider="browser use",
+                    status_code=402,
+                    message="Failed to create Browser Use session: 402 Payment Required",
+                )
+            ),
+        )
+        monkeypatch.setattr(browser_tool, "_is_safe_url", lambda url: True)
+        monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: False)
+        monkeypatch.setattr(browser_tool, "_allow_private_urls", lambda: False)
+        monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: None)
+
+        result = json.loads(browser_tool.browser_navigate("https://example.com", task_id="typed-billing"))
+
+        assert result["success"] is False
+        assert result["status_code"] == 402
+        assert result["retryable"] is False
+        assert result["provider"] == "browser use"
+        assert result["_hermes_tool_signal"]["code"] == "billing_blocker"

--- a/tests/tools/test_managed_browserbase_and_modal.py
+++ b/tests/tools/test_managed_browserbase_and_modal.py
@@ -352,6 +352,85 @@ def test_browser_use_managed_gateway_uses_new_idempotency_key_for_a_new_session_
     assert first_headers["X-Idempotency-Key"] != second_headers["X-Idempotency-Key"]
 
 
+def test_firecrawl_browser_provider_raises_typed_billing_blocker_on_402():
+    _install_fake_tools_package()
+
+    class _Response:
+        status_code = 402
+        ok = False
+        text = "Payment Required"
+        headers = {}
+
+    with patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}, clear=True):
+        firecrawl_module = _load_tool_module(
+            "tools.browser_providers.firecrawl",
+            "browser_providers/firecrawl.py",
+        )
+        provider = firecrawl_module.FirecrawlProvider()
+
+        with patch.object(firecrawl_module.requests, "post", return_value=_Response()):
+            with pytest.raises(firecrawl_module.BrowserProviderBillingBlocker) as excinfo:
+                provider.create_session("task-firecrawl-402")
+
+    assert excinfo.value.status_code == 402
+    assert excinfo.value.provider == "firecrawl"
+
+
+def test_browserbase_provider_only_raises_billing_blocker_when_402_is_terminal():
+    _install_fake_tools_package()
+
+    class _Response:
+        def __init__(self, status_code, ok, text, payload=None):
+            self.status_code = status_code
+            self.ok = ok
+            self.text = text
+            self.headers = {}
+            self._payload = payload or {"id": "bb_sess", "connectUrl": "wss://bb.example"}
+
+        def json(self):
+            return self._payload
+
+    with patch.dict(
+        os.environ,
+        {
+            "BROWSERBASE_API_KEY": "bb-key",
+            "BROWSERBASE_PROJECT_ID": "bb-project",
+            "BROWSERBASE_KEEP_ALIVE": "true",
+            "BROWSERBASE_PROXIES": "true",
+        },
+        clear=True,
+    ):
+        browserbase_module = _load_tool_module(
+            "tools.browser_providers.browserbase",
+            "browser_providers/browserbase.py",
+        )
+        provider = browserbase_module.BrowserbaseProvider()
+
+        with patch.object(
+            browserbase_module.requests,
+            "post",
+            side_effect=[
+                _Response(402, False, "Payment Required"),
+                _Response(402, False, "Payment Required"),
+                _Response(402, False, "Payment Required"),
+            ],
+        ):
+            with pytest.raises(browserbase_module.BrowserProviderBillingBlocker):
+                provider.create_session("task-browserbase-terminal-402")
+
+        with patch.object(
+            browserbase_module.requests,
+            "post",
+            side_effect=[
+                _Response(402, False, "Payment Required"),
+                _Response(200, True, "", {"id": "bb_ok", "connectUrl": "wss://bb.ok"}),
+            ],
+        ):
+            session = provider.create_session("task-browserbase-recovered")
+
+    assert session["bb_session_id"] == "bb_ok"
+
+
 def test_terminal_tool_prefers_managed_modal_when_gateway_ready_and_no_direct_creds():
     _install_fake_tools_package()
     env = os.environ.copy()

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -9,6 +9,7 @@ Coverage:
 """
 
 import importlib
+import asyncio
 import json
 import os
 import sys
@@ -625,3 +626,61 @@ def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 
     assert "EXA_API_KEY" in _web_requires_env()
+
+
+def test_web_search_tool_returns_typed_billing_blocker_on_firecrawl_402():
+    response = MagicMock()
+    response.status_code = 402
+
+    class FirecrawlBillingError(Exception):
+        def __init__(self):
+            super().__init__("Payment Required")
+            self.response = response
+
+    client = MagicMock()
+    client.search.side_effect = FirecrawlBillingError()
+
+    with (
+        patch("tools.web_tools._get_backend", return_value="firecrawl"),
+        patch("tools.web_tools._get_firecrawl_client", return_value=client),
+        patch("tools.interrupt.is_interrupted", return_value=False),
+    ):
+        from tools.web_tools import web_search_tool
+
+        result = json.loads(web_search_tool("billing wall"))
+
+    assert result["success"] is False
+    assert result["retryable"] is False
+    assert result["status_code"] == 402
+    assert result["provider"] == "firecrawl"
+    assert result["_hermes_tool_signal"]["code"] == "billing_blocker"
+
+
+def test_web_extract_tool_returns_typed_billing_blocker_on_tavily_402():
+    response = MagicMock()
+    response.status_code = 402
+
+    class TavilyBillingError(Exception):
+        def __init__(self):
+            super().__init__("Payment Required")
+            self.response = response
+
+    with (
+        patch("tools.web_tools._get_backend", return_value="tavily"),
+        patch("tools.web_tools._tavily_request", side_effect=TavilyBillingError()),
+        patch("tools.web_tools.is_safe_url", return_value=True),
+        patch("tools.web_tools.check_website_access", return_value=None),
+    ):
+        from tools.web_tools import web_extract_tool
+
+        result = json.loads(
+            asyncio.get_event_loop().run_until_complete(
+                web_extract_tool(["https://example.com"], use_llm_processing=False)
+            )
+        )
+
+    assert result["success"] is False
+    assert result["retryable"] is False
+    assert result["status_code"] == 402
+    assert result["provider"] == "tavily"
+    assert result["_hermes_tool_signal"]["code"] == "billing_blocker"

--- a/tools/browser_providers/base.py
+++ b/tools/browser_providers/base.py
@@ -1,7 +1,20 @@
 """Abstract base class for cloud browser providers."""
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Dict
+
+
+@dataclass
+class BrowserProviderBillingBlocker(RuntimeError):
+    """Typed terminal billing blocker raised by browser provider wrappers."""
+
+    provider: str
+    status_code: int
+    message: str
+
+    def __post_init__(self) -> None:
+        RuntimeError.__init__(self, self.message)
 
 
 class CloudBrowserProvider(ABC):

--- a/tools/browser_providers/browser_use.py
+++ b/tools/browser_providers/browser_use.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 
 import requests
 
-from tools.browser_providers.base import CloudBrowserProvider
+from tools.browser_providers.base import BrowserProviderBillingBlocker, CloudBrowserProvider
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import managed_nous_tools_enabled, prefers_gateway
 
@@ -147,6 +147,12 @@ class BrowserUseProvider(CloudBrowserProvider):
         if not response.ok:
             if managed_mode and not _should_preserve_pending_create_key(response):
                 _clear_pending_create_key(task_id)
+            if response.status_code == 402:
+                raise BrowserProviderBillingBlocker(
+                    provider=self.provider_name().lower(),
+                    status_code=402,
+                    message="Failed to create Browser Use session: 402 Payment Required",
+                )
             raise RuntimeError(
                 f"Failed to create Browser Use session: "
                 f"{response.status_code} {response.text}"

--- a/tools/browser_providers/browserbase.py
+++ b/tools/browser_providers/browserbase.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Optional
 
 import requests
 
-from tools.browser_providers.base import CloudBrowserProvider
+from tools.browser_providers.base import BrowserProviderBillingBlocker, CloudBrowserProvider
 
 logger = logging.getLogger(__name__)
 
@@ -131,6 +131,13 @@ class BrowserbaseProvider(CloudBrowserProvider):
                     json=session_config,
                     timeout=30,
                 )
+
+        if response.status_code == 402:
+            raise BrowserProviderBillingBlocker(
+                provider=self.provider_name().lower(),
+                status_code=402,
+                message="Failed to create Browserbase session: 402 Payment Required",
+            )
 
         if not response.ok:
             raise RuntimeError(

--- a/tools/browser_providers/firecrawl.py
+++ b/tools/browser_providers/firecrawl.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 import requests
 
-from tools.browser_providers.base import CloudBrowserProvider
+from tools.browser_providers.base import BrowserProviderBillingBlocker, CloudBrowserProvider
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +53,13 @@ class FirecrawlProvider(CloudBrowserProvider):
             json=body,
             timeout=30,
         )
+
+        if response.status_code == 402:
+            raise BrowserProviderBillingBlocker(
+                provider=self.provider_name().lower(),
+                status_code=402,
+                message="Failed to create Firecrawl browser session: 402 Payment Required",
+            )
 
         if not response.ok:
             raise RuntimeError(

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -83,11 +83,12 @@ try:
 except Exception:
     _is_safe_url = lambda url: False  # noqa: E731 — fail-closed: block all if safety module unavailable
     _is_always_blocked_url = lambda url: True  # noqa: E731 — fail-closed on the floor too
-from tools.browser_providers.base import CloudBrowserProvider
+from tools.browser_providers.base import BrowserProviderBillingBlocker, CloudBrowserProvider
 from tools.browser_providers.browserbase import BrowserbaseProvider
 from tools.browser_providers.browser_use import BrowserUseProvider
 from tools.browser_providers.firecrawl import FirecrawlProvider
 from tools.tool_backend_helpers import normalize_browser_cloud_provider
+from tools.tool_result_signals import billing_blocker_tool_error
 
 # Camofox local anti-detection browser backend (optional).
 # When CAMOFOX_URL is set, all browser operations route through the
@@ -115,6 +116,15 @@ _SANE_PATH_DIRS = (
     "/bin",
 )
 _SANE_PATH = os.pathsep.join(_SANE_PATH_DIRS)
+
+
+def _browser_billing_blocker_tool_error(exc: BrowserProviderBillingBlocker) -> str:
+    """Convert a typed browser provider billing blocker into a tool error string."""
+    return billing_blocker_tool_error(
+        exc.message,
+        provider=exc.provider,
+        status_code=exc.status_code,
+    )
 
 
 @functools.lru_cache(maxsize=1)
@@ -1533,6 +1543,8 @@ def _get_session_info(task_id: Optional[str] = None) -> Dict[str, str]:
                     # CDP discovery URL instead of a raw websocket endpoint.
                     session_info = dict(session_info)
                     session_info["cdp_url"] = _resolve_cdp_override(str(session_info["cdp_url"]))
+            except BrowserProviderBillingBlocker:
+                raise
             except Exception as e:
                 provider_name = type(provider).__name__
                 logger.warning(
@@ -1732,6 +1744,8 @@ def _run_browser_command(
     # Get session info (creates Browserbase session with proxies if needed)
     try:
         session_info = _get_session_info(task_id)
+    except BrowserProviderBillingBlocker as exc:
+        return json.loads(_browser_billing_blocker_tool_error(exc))
     except Exception as e:
         logger.warning("Failed to create browser session for task=%s: %s", task_id, e)
         return {"success": False, "error": f"Failed to create browser session: {str(e)}"}
@@ -2137,7 +2151,10 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
 
     # Get session info to check if this is a new session
     # (will create one with features logged if not exists)
-    session_info = _get_session_info(nav_session_key)
+    try:
+        session_info = _get_session_info(nav_session_key)
+    except BrowserProviderBillingBlocker as exc:
+        return _browser_billing_blocker_tool_error(exc)
     is_first_nav = session_info.get("_first_nav", True)
 
     # Auto-start recording if configured and this is first navigation

--- a/tools/tool_result_signals.py
+++ b/tools/tool_result_signals.py
@@ -1,0 +1,111 @@
+"""Structured tool-result control signals.
+
+Tool handlers can embed an explicit control signal in their JSON result so the
+runtime can react to known terminal states without brittle substring matching.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from tools.registry import tool_error
+from utils import safe_json_loads
+
+
+_SIGNAL_KEY = "_hermes_tool_signal"
+_SIGNAL_VERSION = 1
+_HALT_KIND = "halt"
+_BILLING_BLOCKER_CODE = "billing_blocker"
+
+
+@dataclass(frozen=True)
+class ToolResultSignal:
+    """Typed runtime control signal emitted by a tool wrapper."""
+
+    kind: str
+    code: str
+    message: str
+    provider: str | None = None
+    status_code: int | None = None
+    retryable: bool = True
+
+
+def billing_blocker_tool_error(
+    message: str,
+    *,
+    provider: str,
+    status_code: int = 402,
+) -> str:
+    """Return a structured non-retryable billing blocker tool error."""
+
+    return tool_error(
+        message,
+        success=False,
+        retryable=False,
+        provider=provider,
+        status_code=status_code,
+        **{
+            _SIGNAL_KEY: {
+                "version": _SIGNAL_VERSION,
+                "kind": _HALT_KIND,
+                "code": _BILLING_BLOCKER_CODE,
+                "message": str(message),
+                "provider": provider,
+                "status_code": status_code,
+                "retryable": False,
+            }
+        },
+    )
+
+
+def parse_tool_result_signal(result: str | None) -> ToolResultSignal | None:
+    """Parse a structured control signal from a tool result string."""
+
+    payload = safe_json_loads(result or "")
+    if not isinstance(payload, dict):
+        return None
+
+    signal = payload.get(_SIGNAL_KEY)
+    if not isinstance(signal, dict):
+        return None
+    if signal.get("version") != _SIGNAL_VERSION:
+        return None
+
+    kind = signal.get("kind")
+    code = signal.get("code")
+    message = signal.get("message")
+    if not isinstance(kind, str) or not isinstance(code, str) or not isinstance(message, str):
+        return None
+
+    provider = signal.get("provider")
+    if provider is not None and not isinstance(provider, str):
+        provider = None
+
+    status_code_raw = signal.get("status_code")
+    status_code = status_code_raw if isinstance(status_code_raw, int) else None
+
+    retryable = signal.get("retryable")
+    if not isinstance(retryable, bool):
+        retryable = True
+
+    return ToolResultSignal(
+        kind=kind,
+        code=code,
+        message=message,
+        provider=provider,
+        status_code=status_code,
+        retryable=retryable,
+    )
+
+
+def is_billing_blocker_signal(signal: ToolResultSignal | None) -> bool:
+    """Return True when the signal means the tool hit a terminal billing wall."""
+
+    return bool(
+        signal is not None
+        and signal.kind == _HALT_KIND
+        and signal.code == _BILLING_BLOCKER_CODE
+        and signal.retryable is False
+        and signal.status_code == 402
+    )

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -98,10 +98,32 @@ from tools.managed_tool_gateway import (
     resolve_managed_tool_gateway,
 )
 from tools.tool_backend_helpers import managed_nous_tools_enabled, prefers_gateway
+from tools.tool_result_signals import billing_blocker_tool_error
 from tools.url_safety import is_safe_url
 from tools.website_policy import check_website_access
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_http_status_code(exc: BaseException) -> int | None:
+    """Extract an HTTP status code from SDK/http client exceptions when available."""
+    response = getattr(exc, "response", None)
+    for value in (getattr(exc, "status_code", None), getattr(response, "status_code", None)):
+        if isinstance(value, int):
+            return value
+    return None
+
+
+def _tool_error_from_backend_exception(exc: BaseException, *, backend: str, action: str) -> str | None:
+    """Convert explicit provider billing responses into typed tool errors."""
+    status_code = _extract_http_status_code(exc)
+    if status_code != 402:
+        return None
+    return billing_blocker_tool_error(
+        f"Error {action}: backend '{backend}' returned HTTP 402 Payment Required.",
+        provider=backend,
+        status_code=status_code,
+    )
 
 
 # ─── Backend Selection ────────────────────────────────────────────────────────
@@ -1250,6 +1272,14 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         return result_json
         
     except Exception as e:
+        backend = locals().get("backend", _get_backend())
+        typed_error = _tool_error_from_backend_exception(e, backend=backend, action="searching web")
+        if typed_error is not None:
+            debug_call_data["error"] = str(e)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return typed_error
+
         error_msg = f"Error searching web: {str(e)}"
         logger.debug("%s", error_msg)
 
@@ -1585,6 +1615,14 @@ async def web_extract_tool(
         return cleaned_result
             
     except Exception as e:
+        backend = locals().get("backend", _get_backend())
+        typed_error = _tool_error_from_backend_exception(e, backend=backend, action="extracting content")
+        if typed_error is not None:
+            debug_call_data["error"] = str(e)
+            _debug.log_call("web_extract_tool", debug_call_data)
+            _debug.save()
+            return typed_error
+
         error_msg = f"Error extracting content: {str(e)}"
         logger.debug("%s", error_msg)
         
@@ -2006,6 +2044,14 @@ async def web_crawl_tool(
         return cleaned_result
         
     except Exception as e:
+        backend = locals().get("backend", _get_backend())
+        typed_error = _tool_error_from_backend_exception(e, backend=backend, action="crawling website")
+        if typed_error is not None:
+            debug_call_data["error"] = str(e)
+            _debug.log_call("web_crawl_tool", debug_call_data)
+            _debug.save()
+            return typed_error
+
         error_msg = f"Error crawling website: {str(e)}"
         logger.debug("%s", error_msg)
         


### PR DESCRIPTION
• Follow-up to #20691 and the review here:
  https://github.com/NousResearch/hermes-agent/pull/20691#issuecomment-4397130328

  The previous version tried to halt on billing blockers by matching generic tool-result text like "Payment Required" / "Insufficient credits". That could false-positive on unrelated tool output.

  This follow-up moves billing-blocker detection to the layers that actually see the provider response, and only halts on an explicit typed signal emitted from there.

  ## What changed

  - Added a structured tool-result signal for terminal billing blockers.
  - Updated `web_tools.py` to emit that signal only when the backend exception carries an unambiguous HTTP 402.
  - Updated browser backend wrappers to do the same during session creation:
    - Firecrawl browser provider
    - Browser Use provider
    - Browserbase provider
  - Updated `run_agent` to halt only on the typed billing-blocker signal instead of substring-matching arbitrary tool output.

  ## Behavioral notes

  - Plain tool output that merely contains `402 Payment Required` text no longer triggers a halt.
  - Recoverable Browserbase 402s remain recoverable:
    - if dropping `keepAlive` / `proxies` lets session creation succeed, no blocker is emitted
    - only terminal 402s become typed billing blockers
  - Terminal browser-provider billing blockers are no longer hidden behind local fallback.

  ## Targeted verification

  - typed 402 from web tools halts
  - plain error text mentioning 402 does not halt
  - terminal browser-provider 402 does not fall back to local
  - browser navigate surfaces the typed blocker result
  - recoverable Browserbase 402 still succeeds