### PR TITLE
fix(web): add missing resumeId variable in ChatPage

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -155,6 +155,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // treat the current resume target as part of the PTY identity and rebuild the
   // terminal session when it changes.
   const resumeParam = searchParams.get("resume");
+  const resumeId = resumeParam;
   const channel = useMemo(() => generateChannelId(), [resumeParam]);
 
   useEffect(() => {


### PR DESCRIPTION
## What

ChatPage.tsx uses `resumeId` in two places (line 555 and 660) but the variable was never defined, causing `npm run build` to fail in the web/ directory.

## Why

The variable `resumeParam` was defined from `searchParams.get("resume")` but an alias `resumeId` was referenced without being declared.

## How to test

1. `cd web && npm run build` succeeds
2. `hermes dashboard --no-open` starts without TS errors

## Platforms tested
- macOS