### PR TITLE
fix(cli): move return out of finally block in _voice_stop_and_transcribe (Python 3.14+)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8731,30 +8731,30 @@ class HermesCLI:
             except Exception:
                 pass
 
-            # Track consecutive no-speech cycles to avoid infinite restart loops.
-            if not submitted:
-                self._no_speech_count = getattr(self, '_no_speech_count', 0) + 1
-                if self._no_speech_count >= 3:
-                    self._voice_continuous = False
-                    self._no_speech_count = 0
-                    _cprint(f"{_DIM}No speech detected 3 times, continuous mode stopped.{_RST}")
-                    return
-            else:
+        # Track consecutive no-speech cycles to avoid infinite restart loops.
+        if not submitted:
+            self._no_speech_count = getattr(self, '_no_speech_count', 0) + 1
+            if self._no_speech_count >= 3:
+                self._voice_continuous = False
                 self._no_speech_count = 0
+                _cprint(f"{_DIM}No speech detected 3 times, continuous mode stopped.{_RST}")
+                return
+        else:
+            self._no_speech_count = 0
 
-            # If no transcript was submitted but continuous mode is active,
-            # restart recording so the user can keep talking.
-            # (When transcript IS submitted, process_loop handles restart
-            # after chat() completes.)
-            if self._voice_continuous and not submitted and not self._voice_recording:
-                def _restart_recording():
-                    try:
-                        self._voice_start_recording()
-                        if hasattr(self, '_app') and self._app:
-                            self._app.invalidate()
-                    except Exception as e:
-                        _cprint(f"{_DIM}Voice auto-restart failed: {e}{_RST}")
-                threading.Thread(target=_restart_recording, daemon=True).start()
+        # If no transcript was submitted but continuous mode is active,
+        # restart recording so the user can keep talking.
+        # (When transcript IS submitted, process_loop handles restart
+        # after chat() completes.)
+        if self._voice_continuous and not submitted and not self._voice_recording:
+            def _restart_recording():
+                try:
+                    self._voice_start_recording()
+                    if hasattr(self, '_app') and self._app:
+                        self._app.invalidate()
+                except Exception as e:
+                    _cprint(f"{_DIM}Voice auto-restart failed: {e}{_RST}")
+            threading.Thread(target=_restart_recording, daemon=True).start()
 
     def _voice_speak_response_async(self, text: str) -> None:
         """Schedule TTS and mark it pending before continuous recording can restart."""


### PR DESCRIPTION
## Summary

Fixes Python 3.14  in  caused by a  statement inside a  block.

## Problem

Python 3.14 emits  when a  appears inside a  block, because  suppresses any exception that was propagating through the  clause. This is a known Python anti-pattern since 3.8.

The  method had the following structure:


## Fix

Move the business logic outside the  block. Only the cleanup actions remain in :
- Release 
- Invalidate 
- Remove temp wav file

The following logic is now outside  (at module level of the method, dedented by one level):
- Track consecutive no-speech cycles
- Stop continuous mode after 3 no-speech events
- Restart recording in continuous mode when no transcript submitted

## Changes

- :  — 1 net line change (exact same line count, restructured indentation). All 12-space-indented content stays in ; the 16-space-indented business logic moves to module level.

## Testing



Python 3.14's  flag will confirm the fix.

## Related Issue

Closes #21088