### PR TITLE
fix: add dashboard to CLI help epilogue + Docker CI smoke test (salvage #19269)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,18 +65,30 @@ jobs:
 
       - name: Test image starts
         run: |
+          mkdir -p /tmp/hermes-test
+          sudo chown -R 10000:10000 /tmp/hermes-test
           # The image runs as the hermes user (UID 10000).  GitHub Actions
           # creates /tmp/hermes-test root-owned by default, which hermes
           # can't write to — chown it to match the in-container UID before
           # bind-mounting.  Real users doing `docker run -v ~/.hermes:...`
           # with their own UID hit the same issue and have their own
           # remediations (HERMES_UID env var, or chown locally).
-          mkdir -p /tmp/hermes-test
-          sudo chown -R 10000:10000 /tmp/hermes-test
           docker run --rm \
             -v /tmp/hermes-test:/opt/data \
             --entrypoint /opt/hermes/docker/entrypoint.sh \
             nousresearch/hermes-agent:test --help
+
+      - name: Test dashboard subcommand
+        run: |
+          mkdir -p /tmp/hermes-test
+          sudo chown -R 10000:10000 /tmp/hermes-test
+          # Verify the dashboard subcommand is included in the Docker image.
+          # This prevents regressions like #9153 where the dashboard command
+          # was present in source but missing from the published image.
+          docker run --rm \
+            -v /tmp/hermes-test:/opt/data \
+            --entrypoint /opt/hermes/docker/entrypoint.sh \
+            nousresearch/hermes-agent:test dashboard --help
 
       - name: Log in to Docker Hub
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release'

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -70,6 +70,9 @@ Examples:
     hermes logs --since 1h        Lines from the last hour
     hermes debug share             Upload debug report for support
     hermes update                 Update to latest version
+    hermes dashboard              Start web UI dashboard (port 9119)
+    hermes dashboard --stop       Stop running dashboard processes
+    hermes dashboard --status     List running dashboard processes
 
 For more help on a command:
     hermes <command> --help


### PR DESCRIPTION
Closes #19269 via salvage. Closes #9153.

## Summary
1. `hermes --help` epilogue didn't mention `hermes dashboard` — users couldn't discover the web UI from help output.
2. Docker smoke test only ran top-level `--help`, not individual subcommands — would miss a regression where a subcommand was absent from the image.

Add three dashboard lines to the help epilogue, and an independent CI step that runs `hermes dashboard --help` inside the built Docker image.

Original author: @luoyuctl.