### PR TITLE
fix(ci): harden nix lockfile fix workflow

### DIFF
--- a/.github/workflows/nix-lockfile-fix.yml
+++ b/.github/workflows/nix-lockfile-fix.yml
@@ -175,6 +175,16 @@ jobs:
               repo: context.repo.repo,
               pull_number: Number(prNumber),
             });
+
+            const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
+            if (pr.head.repo.full_name !== baseRepo) {
+              core.setFailed(
+                `Refusing to apply lockfile fixes to fork PR #${pr.number} (${pr.head.repo.full_name}). ` +
+                'This workflow runs with repository write permissions; ask the contributor to run `nix run .#fix-lockfiles` locally.'
+              );
+              return;
+            }
+
             core.setOutput('ref', pr.head.ref);
             core.setOutput('repo', pr.head.repo.name);
             core.setOutput('owner', pr.head.repo.owner.login);
@@ -199,11 +209,15 @@ jobs:
           repository: ${{ steps.resolve.outputs.owner }}/${{ steps.resolve.outputs.repo }}
           ref: ${{ steps.resolve.outputs.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
           fetch-depth: 0
 
-      - uses: ./.github/actions/nix-setup
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25  # v22
+
+      - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c  # v17
         with:
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          name: hermes-agent
+        continue-on-error: true
 
       - name: Apply lockfile hashes
         id: apply
@@ -212,13 +226,30 @@ jobs:
       - name: Commit & push
         if: steps.apply.outputs.changed == 'true'
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASH_ENV: /dev/null
+          ENV: /dev/null
+          GIT_CONFIG_GLOBAL: /dev/null
+          GIT_CONFIG_NOSYSTEM: "1"
         run: |
           set -euo pipefail
+
+          unexpected="$(git diff --name-only | grep -Ev '^nix/(tui|web)\.nix$' || true)"
+          if [ -n "$unexpected" ]; then
+            echo "::error::Unexpected modified files: $unexpected"
+            exit 1
+          fi
+
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add nix/tui.nix nix/web.nix
-          git commit -m "fix(nix): refresh npm lockfile hashes"
-          git push
+          git -c core.hooksPath=/dev/null commit -m "fix(nix): refresh npm lockfile hashes"
+
+          auth_header="$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 -w 0)"
+          git -c core.hooksPath=/dev/null \
+            -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
+            push origin "HEAD:${{ steps.resolve.outputs.ref }}"
 
       - name: Update sticky (applied)
         if: steps.apply.outputs.changed == 'true' && steps.resolve.outputs.pr != ''

--- a/tests/test_nix_lockfile_workflow_security.py
+++ b/tests/test_nix_lockfile_workflow_security.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "nix-lockfile-fix.yml"
+
+
+def _load_workflow() -> dict:
+    return yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+
+
+def _fix_job_steps() -> list[dict]:
+    return _load_workflow()["jobs"]["fix"]["steps"]
+
+
+def _step_named(name: str) -> dict:
+    for step in _fix_job_steps():
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"missing workflow step: {name}")
+
+
+def test_pr_lockfile_fix_rejects_fork_prs_before_checkout() -> None:
+    script = _step_named("Authorize & resolve PR")["with"]["script"]
+
+    assert "pr.head.repo.full_name" in script
+    assert "context.repo.owner" in script
+    assert "context.repo.repo" in script
+    assert "core.setFailed" in script
+    assert "fork PR" in script
+
+
+def test_pr_lockfile_fix_uses_trusted_setup_action_for_pr_code() -> None:
+    setup_steps = [
+        step
+        for step in _fix_job_steps()
+        if step.get("uses", "").endswith(
+            "/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25"
+        )
+        or step.get("uses", "").endswith(
+            "/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c"
+        )
+    ]
+
+    assert len(setup_steps) == 2
+    assert all(not step["uses"].startswith("./") for step in setup_steps)
+
+
+def test_pr_lockfile_fix_does_not_expose_tokens_to_checked_out_pr_code() -> None:
+    checkout = next(
+        step
+        for step in _fix_job_steps()
+        if step.get("uses", "").startswith("actions/checkout@")
+    )
+
+    assert checkout["with"]["persist-credentials"] == "false"
+
+    workflow_text = WORKFLOW.read_text(encoding="utf-8")
+    pr_fix_text = workflow_text.split("# \u2500\u2500 PR fix", 1)[1]
+    assert "secrets.CACHIX_AUTH_TOKEN" not in pr_fix_text


### PR DESCRIPTION
## Summary

The comment/manual Nix lockfile fixer ran in base-repo context with write permissions and then checked out the PR head before setting up Nix. For fork PRs, a maintainer clicking the checkbox could run PR-controlled workflow or Nix code while repository credentials and the Cachix auth token were available, creating a secret and write-token exposure path.

## Root cause

The `fix` job resolved `pr.head.repo` and `pr.head.ref` and checked that branch out directly with the repository `GITHUB_TOKEN`, then invoked `./.github/actions/nix-setup` from that checkout with `secrets.CACHIX_AUTH_TOKEN`. The checkout also persisted credentials, so code run later from the PR worktree could observe or influence token-bearing state.

## What changed

The PR fix path now rejects fork PRs before checkout, uses pinned Nix/Cachix setup actions instead of PR-controlled local action metadata, omits the Cachix auth token, disables persisted checkout credentials, validates that only expected Nix files changed, and pushes same-repo fixes with a one-step token while disabling git hooks.

## Validation

- Reproduced on `Hermes Agent v0.12.0 (2026.4.30)` / `49c3c2e0d` by adding `tests/test_nix_lockfile_workflow_security.py` and confirming it failed on current `main`.
- `pytest tests/test_nix_lockfile_workflow_security.py -q`
- `git diff --check`
- Attempted `bash scripts/run_tests.sh`; stopped after widespread unrelated baseline failures appeared by 20% completion.

## Notes

No issue reference.
