### PR TITLE
feat(image-gen): honor image_gen.model from config.yaml (salvage #19376)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -874,6 +874,7 @@ AUTHOR_MAP = {
     "stevenchou.ai@gmail.com": "stevenchouai",  # PR #19221
     "leo.gong@phizchat.com": "agilejava",  # PR #19346
     "acc001k@pm.me": "acc001k",  # PR #19358
+    "kowenhao@users.noreply.github.com": "kowenhaoai",  # PR #19376
     "lxl694522264@gmail.com": "EvilDrag0n",  # PR #20651
 }
 

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -879,6 +879,21 @@ IMAGE_GENERATE_SCHEMA = {
 }
 
 
+def _read_configured_image_model():
+    """Return the value of ``image_gen.model`` from config.yaml, or None."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        if isinstance(section, dict):
+            value = section.get("model")
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    except Exception as exc:
+        logger.debug("Could not read image_gen.model: %s", exc)
+    return None
+
+
 def _read_configured_image_provider():
     """Return the value of ``image_gen.provider`` from config.yaml, or None.
 
@@ -915,6 +930,9 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
     if not configured or configured == "fal":
         return None
 
+    # Also read configured model so we can pass it to the plugin
+    configured_model = _read_configured_image_model()
+
     try:
         # Import locally so plugin discovery isn't triggered just by
         # importing this module (tests rely on that).
@@ -950,7 +968,10 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         })
 
     try:
-        result = provider.generate(prompt=prompt, aspect_ratio=aspect_ratio)
+        kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
+        if configured_model:
+            kwargs["model"] = configured_model
+        result = provider.generate(**kwargs)
     except Exception as exc:
         logger.warning(
             "Image gen provider '%s' raised: %s",


### PR DESCRIPTION
Closes #19376 via salvage.

## Summary
Plugin image-gen providers were dispatched without a model arg, leaving plugins to pick defaults. Users on OpenRouter/ComfyUI/custom had no way to pin a specific model through config. Add `image_gen.model` read; forward to plugin `.generate(...)` when set; fall through to plugin default when unset.

Backward compatible — additive only.

## Validation
`scripts/run_tests.sh tests/tools/ -k image` → 176 passed (1 pre-existing unrelated Docker test failure).

Original author: @kowenhaoai.