### PR TITLE
fix(gateway): log agent task failures instead of silently losing usage data (salvage #21159)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1326,8 +1326,8 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 result, agent_usage = await agent_task
                 usage = agent_usage or usage
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning("Agent task %s failed, usage data lost: %s", completion_id, exc)
 
             # Finish chunk
             finish_chunk = {

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -98,6 +98,7 @@ AUTHOR_MAP = {
     "74554762+wmagev@users.noreply.github.com": "wmagev",
     "ashermorse@icloud.com": "ashermorse",
     "happy5318@users.noreply.github.com": "happy5318",
+    "anatoliygranichenko@gmail.com": "wabrent",
     "chengoak@users.noreply.github.com": "chengoak",
     "mrhanoi@outlook.com": "qxxaa",
     "guillaume.meyer@outlook.com": "guillaumemeyer",


### PR DESCRIPTION
## Summary
API server streaming path now logs agent task failures at warning level instead of silently swallowing them — aligns with the sibling Responses-streaming site (~L1790) which already uses `logger.error`.

## Changes
- `gateway/platforms/api_server.py`: replace `except Exception: pass` with `logger.warning("Agent task %s failed, usage data lost: %s", completion_id, exc)` at the chat-completions streaming finalizer.

## Validation
Compile check passes. No new tests (single-line observability change in a best-effort usage-collection path).

Closes #21159 via salvage. Co-authored by @wabrent.