### PR TITLE
fix(mcp): clear stale thread interrupt before MCP discovery

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -54,6 +54,7 @@ AUTHOR_MAP = {
     "127238744+teknium1@users.noreply.github.com": "teknium1",
     "128259593+Gutslabs@users.noreply.github.com": "Gutslabs",
     "50326054+nocturnum91@users.noreply.github.com": "nocturnum91",
+    "abdielv@proton.me": "AJV20",
     "159539633+MottledShadow@users.noreply.github.com": "MottledShadow",
     "aludwin+gh@gmail.com": "adamludwin",
     "ngusev@astralinux.ru": "NikolayGusev-astra",

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2922,7 +2922,19 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
 
     # Per-server timeouts are handled inside _discover_and_register_server.
     # The outer timeout is generous: 120s total for parallel discovery.
-    _run_on_mcp_loop(_discover_all(), timeout=120)
+    #
+    # Temporarily clear the interrupt flag on the current thread so that MCP
+    # discovery is never cancelled by a stale interrupt from a prior agent
+    # session (executor threads get reused and may carry old interrupt state).
+    from tools.interrupt import is_interrupted as _is_interrupted, set_interrupt as _set_interrupt
+    _was_interrupted = _is_interrupted()
+    if _was_interrupted:
+        _set_interrupt(False)
+    try:
+        _run_on_mcp_loop(_discover_all(), timeout=120)
+    finally:
+        if _was_interrupted:
+            _set_interrupt(True)
 
     # Log a summary so ACP callers get visibility into what was registered.
     with _lock:


### PR DESCRIPTION
Salvage of #10287 by @AJV20 onto current main. Cherry-picked clean.

## Summary
Clears the calling thread's stale interrupt flag before running MCP server discovery so discovery isn't immediately cancelled by interrupt state left over from a prior agent session.

## Root cause
`tools.interrupt` tracks interrupts per thread ident in `_interrupted_threads`. asyncio's executor thread pool reuses threads across sessions. When a prior agent session set its thread's interrupt flag (via Ctrl+C, gateway timeout, etc.) and the thread got pooled and later reused to run `register_mcp_servers`, the FIRST poll iteration inside `_run_on_mcp_loop` sees `is_interrupted() == True`, cancels the discovery future, and raises `InterruptedError`. MCP discovery never runs, so MCP tools never get registered, so they silently don't appear in subsequent sessions.

## Fix
Around `_run_on_mcp_loop(_discover_all(), timeout=120)` in `register_mcp_servers`: snapshot the current thread's interrupt state, temporarily clear it for the duration of discovery, restore on exit via `finally`. The user's actual interrupt semantics (if any) are preserved.

## Changes
- `tools/mcp_tool.py`: +13 / -1 around the discovery call site
- `scripts/release.py`: AUTHOR_MAP entry for @AJV20

## Note on #9930 reference
The original PR header says "Fixes #9930", but #9930 is a DIFFERENT bug (Python 3.11+ `CancelledError` escaping `except Exception` in `MCPServerTask.run()`, also still live on main). Both bugs are real and independent — this PR only fixes the stale-interrupt path. Leaving #9930 open for a follow-up.

## Validation
| | Result |
|---|---|
| `scripts/run_tests.sh tests/tools/test_mcp_tool*.py` | 199/199 passed |
| E2E positive: simulate stale interrupt on current thread, run `register_mcp_servers` with the patch | discovery runs with clear flag, original interrupt state restored on exit |
| E2E negative control: simulate stale interrupt, call `_run_on_mcp_loop` directly with no guard | raises `InterruptedError: User sent a new message` — confirms bug is real |

Closes #10287 (not #9930). @AJV20's authorship preserved via rebase-merge.