### PR TITLE
fix(gateway): surface bootstrap failures to stderr (salvage #21157)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -498,22 +498,22 @@ try:
     _network_cfg = (_cfg if '_cfg' in dir() else {}).get("network", {})
     if isinstance(_network_cfg, dict) and _network_cfg.get("force_ipv4"):
         apply_ipv4_preference(force=True)
-except Exception:
-    print("  Warning: IPv4 preference application failed", file=sys.stderr)
+except Exception as _bootstrap_exc:
+    print(f"  Warning: IPv4 preference application failed: {_bootstrap_exc}", file=sys.stderr)
 
 # Validate config structure early — log warnings so gateway operators see problems
 try:
     from hermes_cli.config import print_config_warnings
     print_config_warnings()
-except Exception:
-    print("  Warning: config validation failed", file=sys.stderr)
+except Exception as _bootstrap_exc:
+    print(f"  Warning: config validation failed: {_bootstrap_exc}", file=sys.stderr)
 
 # Warn if user has deprecated MESSAGING_CWD / TERMINAL_CWD in .env
 try:
     from hermes_cli.config import warn_deprecated_cwd_env_vars
     warn_deprecated_cwd_env_vars()
-except Exception:
-    print("  Warning: deprecation check failed", file=sys.stderr)
+except Exception as _bootstrap_exc:
+    print(f"  Warning: deprecation check failed: {_bootstrap_exc}", file=sys.stderr)
 
 # Gateway runs in quiet mode - suppress debug output and use cwd directly (no temp dirs)
 os.environ["HERMES_QUIET"] = "1"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -499,21 +499,21 @@ try:
     if isinstance(_network_cfg, dict) and _network_cfg.get("force_ipv4"):
         apply_ipv4_preference(force=True)
 except Exception:
-    pass
+    print("  Warning: IPv4 preference application failed", file=sys.stderr)
 
 # Validate config structure early — log warnings so gateway operators see problems
 try:
     from hermes_cli.config import print_config_warnings
     print_config_warnings()
 except Exception:
-    pass
+    print("  Warning: config validation failed", file=sys.stderr)
 
 # Warn if user has deprecated MESSAGING_CWD / TERMINAL_CWD in .env
 try:
     from hermes_cli.config import warn_deprecated_cwd_env_vars
     warn_deprecated_cwd_env_vars()
 except Exception:
-    pass
+    print("  Warning: deprecation check failed", file=sys.stderr)
 
 # Gateway runs in quiet mode - suppress debug output and use cwd directly (no temp dirs)
 os.environ["HERMES_QUIET"] = "1"


### PR DESCRIPTION
## Summary
Three gateway bootstrap try/except blocks (IPv4 preference application, config-structure validation, deprecated-cwd warning) now surface failures to stderr instead of silently swallowing them. These run before `setup_logging()` has initialized file logging (L14803) and before the module-level `logger` is defined (L543), so `print(..., file=sys.stderr)` is the correct mechanism at this phase of boot.

## Changes
- `gateway/run.py`: replace `except Exception: pass` with `print(f"  Warning: ...: {exc}", file=sys.stderr)` in three pre-logger bootstrap blocks.

## Improvements during salvage
Original patch emitted a bare "Warning: X failed" with no exception text. Added the exception string so operators can actually diagnose what went wrong.

## Validation
Compile check passes. Logic is unchanged — the three blocks still can't crash gateway boot if one of the validators fails.

Closes #21157 via salvage. Co-authored by @wabrent.