### PR TITLE
fix: rename resumeId to resumeParam in ChatPage.tsx

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -552,7 +552,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     });
 
     // WebSocket
-    const url = buildWsUrl(token, resumeId, channel);
+    const url = buildWsUrl(token, resumeParam, channel);
     const ws = new WebSocket(url);
     ws.binaryType = "arraybuffer";
     wsRef.current = ws;
@@ -657,7 +657,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         copyResetRef.current = null;
       }
     };
-  }, [channel, resumeId]);
+  }, [channel, resumeParam]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.


### PR DESCRIPTION
## Problem

`ChatPage.tsx` references `resumeId` in two places (line 555 and 660), but the variable is actually declared as `resumeParam` on line 157. This causes a `TS2304` build error:

```
src/pages/ChatPage.tsx:555:35 - error TS2304: Cannot find name 'resumeId'.
src/pages/ChatPage.tsx:660:16 - error TS2304: Cannot find name 'resumeId'.
```

## Fix

Rename `resumeId` → `resumeParam` in both locations to match the declared variable name.