### PR TITLE
fix(mcp): report configured timeout in MCP call errors

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -55,6 +55,7 @@ AUTHOR_MAP = {
     "128259593+Gutslabs@users.noreply.github.com": "Gutslabs",
     "50326054+nocturnum91@users.noreply.github.com": "nocturnum91",
     "abdielv@proton.me": "AJV20",
+    "mason@growagainorchids.com": "masonjames",
     "159539633+MottledShadow@users.noreply.github.com": "MottledShadow",
     "aludwin+gh@gmail.com": "adamludwin",
     "ngusev@astralinux.ru": "NikolayGusev-astra",

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -547,6 +547,43 @@ class TestRunOnMCPLoopInterrupts:
             mcp_mod._mcp_loop = old_loop
             mcp_mod._mcp_thread = old_thread
 
+    def test_timeout_reports_elapsed_and_configured_timeout(self):
+        import tools.mcp_tool as mcp_mod
+
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=loop.run_forever, daemon=True)
+        thread.start()
+
+        cancelled = threading.Event()
+
+        async def _slow_call():
+            try:
+                await asyncio.sleep(5)
+                return "done"
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        old_loop = mcp_mod._mcp_loop
+        old_thread = mcp_mod._mcp_thread
+        mcp_mod._mcp_loop = loop
+        mcp_mod._mcp_thread = thread
+
+        try:
+            with pytest.raises(TimeoutError, match=r"MCP call timed out after .*configured timeout: 0.2s"):
+                mcp_mod._run_on_mcp_loop(_slow_call(), timeout=0.2)
+
+            deadline = time.time() + 2
+            while time.time() < deadline and not cancelled.is_set():
+                time.sleep(0.05)
+            assert cancelled.is_set()
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+            thread.join(timeout=2)
+            loop.close()
+            mcp_mod._mcp_loop = old_loop
+            mcp_mod._mcp_thread = old_thread
+
 
 # ---------------------------------------------------------------------------
 # Tool registration (discovery + register)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1942,7 +1942,8 @@ def _run_on_mcp_loop(coro, timeout: float = 30):
     if loop is None or not loop.is_running():
         raise RuntimeError("MCP event loop is not running")
     future = asyncio.run_coroutine_threadsafe(coro, loop)
-    deadline = None if timeout is None else time.monotonic() + timeout
+    start_time = time.monotonic()
+    deadline = None if timeout is None else start_time + timeout
 
     while True:
         if is_interrupted():
@@ -1953,7 +1954,12 @@ def _run_on_mcp_loop(coro, timeout: float = 30):
         if deadline is not None:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                return future.result(timeout=0)
+                future.cancel()
+                elapsed = time.monotonic() - start_time
+                raise TimeoutError(
+                    f"MCP call timed out after {elapsed:.1f}s "
+                    f"(configured timeout: {float(timeout):.1f}s)"
+                )
             wait_timeout = min(wait_timeout, remaining)
 
         try:


### PR DESCRIPTION
Salvage of #10439 by @masonjames onto current main. Cherry-picked clean.

## Summary
When an MCP call exceeds its configured timeout, the error now reports both the wall-clock elapsed time and the configured timeout. Previously the timeout path returned `future.result(timeout=0)` which raises a bare `concurrent.futures.TimeoutError` with an empty string — the model saw a silent failure with no context.

Also cancels the in-flight future on timeout so the coroutine doesn't keep running in the background after the caller gives up.

## Before / after

| | `str(exc)` | model sees |
|---|---|---|
| Before | `''` | nothing — silent `TimeoutError()` |
| After | `MCP call timed out after 30.0s (configured timeout: 30.0s)` | actionable |

## Changes
- `tools/mcp_tool.py` `_run_on_mcp_loop`: track `start_time`, cancel future on timeout, raise descriptive `TimeoutError`. +8 / -2.
- `tests/tools/test_mcp_tool.py`: +37 lines of timeout-diagnostics regression coverage.
- `scripts/release.py`: AUTHOR_MAP entry for @masonjames.

## Validation
| | Result |
|---|---|
| `scripts/run_tests.sh tests/tools/test_mcp_tool.py` | 183/183 passed |
| E2E positive: 5-second coroutine with 0.3s timeout | raises `TimeoutError: MCP call timed out after 0.3s (configured timeout: 0.3s)`, wall-clock elapsed 0.30s |
| E2E non-regression: fast coroutine with 5s timeout | returns result cleanly |
| Negative control: old `future.result(timeout=0)` pattern | raises bare `TimeoutError()` with empty message — confirms bug was real |

Closes #10439. @masonjames's authorship preserved via rebase-merge.