### PR TITLE
feat(skills): add skills.hidden for catalog-only progressive disclosure

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -20,6 +20,7 @@ from agent.skill_utils import (
     extract_skill_description,
     get_all_skills_dirs,
     get_disabled_skill_names,
+    get_hidden_skill_names,
     iter_skill_index_files,
     parse_frontmatter,
     skill_matches_platform,
@@ -749,6 +750,12 @@ def build_skills_system_prompt(
         or ""
     )
     disabled = get_disabled_skill_names()
+    hidden = get_hidden_skill_names()
+    # Catalog filter is the union: disabled skills are off entirely (also
+    # blocked from skill_view), hidden skills only disappear from the
+    # <available_skills> block and remain loadable on demand. Both must
+    # be excluded from the system-prompt catalog.
+    catalog_excluded = disabled | hidden
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
@@ -756,6 +763,7 @@ def build_skills_system_prompt(
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
         tuple(sorted(disabled)),
+        tuple(sorted(hidden)),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -780,7 +788,7 @@ def build_skills_system_prompt(
             platforms = entry.get("platforms") or []
             if not skill_matches_platform({"platforms": platforms}):
                 continue
-            if frontmatter_name in disabled or skill_name in disabled:
+            if frontmatter_name in catalog_excluded or skill_name in catalog_excluded:
                 continue
             if not _skill_should_show(
                 entry.get("conditions") or {},
@@ -805,7 +813,7 @@ def build_skills_system_prompt(
             if not is_compatible:
                 continue
             skill_name = entry["skill_name"]
-            if entry["frontmatter_name"] in disabled or skill_name in disabled:
+            if entry["frontmatter_name"] in catalog_excluded or skill_name in catalog_excluded:
                 continue
             if not _skill_should_show(
                 extract_skill_conditions(frontmatter),
@@ -860,7 +868,7 @@ def build_skills_system_prompt(
                 frontmatter_name = entry["frontmatter_name"]
                 if frontmatter_name in seen_skill_names:
                     continue
-                if frontmatter_name in disabled or skill_name in disabled:
+                if frontmatter_name in catalog_excluded or skill_name in catalog_excluded:
                     continue
                 if not _skill_should_show(
                     extract_skill_conditions(frontmatter),

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -160,6 +160,68 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
     return _normalize_string_set(skills_cfg.get("disabled"))
 
 
+def get_hidden_skill_names(platform: str | None = None) -> Set[str]:
+    """Read *hidden* skill names from config.yaml.
+
+    Hidden skills are filtered out of the ``<available_skills>`` catalog
+    injected into the system prompt, but remain fully loadable on demand
+    via ``skill_view()``, ``/skill <name>``, autocomplete, the skills hub
+    UI, and every other code path.  The intent is **progressive
+    disclosure**: pair this with a router-style meta-skill that knows
+    when to load each off-catalog skill, so the per-turn token cost of a
+    large skill library disappears without the agent losing access.
+
+    This is distinct from ``skills.disabled`` /
+    ``skills.platform_disabled``, which is a *hard* block — disabled
+    skills are also blocked from ``skill_view()`` and listed as
+    "disabled" in the hub UI.
+
+    Resolution mirrors :func:`get_disabled_skill_names`: explicit
+    ``platform`` argument > ``HERMES_PLATFORM`` env > session-context
+    ``HERMES_SESSION_PLATFORM`` > the global ``skills.hidden`` list.
+    A platform key with an explicit list (even empty) wins over the
+    global list for that platform — same precedence model as
+    ``platform_disabled`` so user mental models compose.
+
+    Args:
+        platform: Explicit platform name (e.g. ``"discord"``).  When
+            *None*, resolves from environment / session context.
+
+    Returns:
+        Set of skill names hidden from the catalog for the resolved
+        platform.  Empty set when the config file is missing,
+        unreadable, or has no relevant entries.
+    """
+    config_path = get_config_path()
+    if not config_path.exists():
+        return set()
+    try:
+        parsed = yaml_load(config_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        logger.debug("Could not read skill config %s: %s", config_path, e)
+        return set()
+    if not isinstance(parsed, dict):
+        return set()
+
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return set()
+
+    from gateway.session_context import get_session_env
+    resolved_platform = (
+        platform
+        or os.getenv("HERMES_PLATFORM")
+        or get_session_env("HERMES_SESSION_PLATFORM")
+    )
+    if resolved_platform:
+        platform_hidden = (skills_cfg.get("platform_hidden") or {}).get(
+            resolved_platform
+        )
+        if platform_hidden is not None:
+            return _normalize_string_set(platform_hidden)
+    return _normalize_string_set(skills_cfg.get("hidden"))
+
+
 def _normalize_string_set(values) -> Set[str]:
     if values is None:
         return set()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1058,6 +1058,40 @@ DEFAULT_CONFIG = {
         # External hub installs (trusted/community sources) are always
         # scanned regardless of this setting.
         "guard_agent_created": False,
+        # Catalog visibility — progressive-disclosure controls.
+        #
+        # Two separate mechanisms:
+        #
+        #   skills.disabled / skills.platform_disabled
+        #     HARD block. Disabled skills are filtered from the
+        #     <available_skills> catalog AND blocked from
+        #     skill_view() / /skill <name> / autocomplete. Use this
+        #     to turn a skill off entirely (per-platform or globally).
+        #
+        #   skills.hidden / skills.platform_hidden
+        #     CATALOG-ONLY filter. Hidden skills disappear from
+        #     <available_skills> but remain fully loadable on demand
+        #     via skill_view(), /skill <name>, autocomplete, the hub
+        #     UI, etc. Pair with a router-style meta-skill that knows
+        #     the names so it can load them when the task calls for
+        #     them. The "I don't want this skill costing me 30 tokens
+        #     of catalog space every turn, but I still want the agent
+        #     to be ABLE to use it" knob.
+        #
+        # Both accept a flat list (global) or a per-platform map.
+        # Platform precedence: explicit list (even empty) for the
+        # active platform > global list. Active platform resolves
+        # from HERMES_PLATFORM env > HERMES_SESSION_PLATFORM (set by
+        # the gateway). On the CLI with no platform set, only the
+        # global lists apply. See website/docs/user-guide/skills/ for
+        # the full recipe.
+        #
+        # Defaults are commented out so config.yaml stays clean —
+        # add the keys explicitly only when you want to use them.
+        # "disabled": [],
+        # "platform_disabled": {"discord": []},
+        # "hidden": [],
+        # "platform_hidden": {"discord": []},
     },
 
     # Curator — background skill maintenance.

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -372,6 +372,79 @@ class TestBuildSkillsSystemPrompt:
         second = build_skills_system_prompt()
         assert "cached-skill" not in second
 
+    def test_excludes_hidden_skills(self, monkeypatch, tmp_path):
+        """Skills in skills.hidden should be filtered from the catalog
+        (but remain loadable via skill_view — which this test does NOT
+        exercise; see tests/tools/test_skills_tool.py for that side)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "tools"
+        skills_dir.mkdir(parents=True)
+
+        visible = skills_dir / "visible-skill"
+        visible.mkdir()
+        (visible / "SKILL.md").write_text(
+            "---\nname: visible-skill\ndescription: Should appear\n---\n"
+        )
+
+        hidden = skills_dir / "hidden-skill"
+        hidden.mkdir()
+        (hidden / "SKILL.md").write_text(
+            "---\nname: hidden-skill\ndescription: Should not appear in catalog\n---\n"
+        )
+
+        from unittest.mock import patch
+        with patch(
+            "agent.prompt_builder.get_hidden_skill_names",
+            return_value={"hidden-skill"},
+        ):
+            result = build_skills_system_prompt()
+
+        assert "visible-skill" in result
+        assert "hidden-skill" not in result
+
+    def test_hidden_and_disabled_compose(self, monkeypatch, tmp_path):
+        """Both hidden and disabled skills are excluded from the catalog."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_dir = tmp_path / "skills" / "tools"
+        skills_dir.mkdir(parents=True)
+        for name in ("visible", "off-skill", "hidden-skill"):
+            d = skills_dir / name
+            d.mkdir()
+            (d / "SKILL.md").write_text(f"---\nname: {name}\ndescription: x\n---\n")
+
+        from unittest.mock import patch
+        with patch(
+            "agent.prompt_builder.get_disabled_skill_names",
+            return_value={"off-skill"},
+        ), patch(
+            "agent.prompt_builder.get_hidden_skill_names",
+            return_value={"hidden-skill"},
+        ):
+            result = build_skills_system_prompt()
+
+        assert "visible" in result
+        assert "off-skill" not in result
+        assert "hidden-skill" not in result
+
+    def test_rebuilds_prompt_when_hidden_skills_change(self, monkeypatch, tmp_path):
+        """Cache key must include hidden set so flipping skills.hidden invalidates."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "tools" / "router-target"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: router-target\ndescription: Behind the router\n---\n"
+        )
+
+        first = build_skills_system_prompt()
+        assert "router-target" in first
+
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n  hidden: [router-target]\n"
+        )
+
+        second = build_skills_system_prompt()
+        assert "router-target" not in second
+
     def test_includes_setup_needed_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.delenv("MISSING_API_KEY_XYZ", raising=False)

--- a/tests/hermes_cli/test_skills_config.py
+++ b/tests/hermes_cli/test_skills_config.py
@@ -245,6 +245,156 @@ class TestGetDisabledSkillNames:
 
 
 # ---------------------------------------------------------------------------
+# get_hidden_skill_names — catalog-only filter (progressive disclosure)
+# ---------------------------------------------------------------------------
+
+class TestGetHiddenSkillNames:
+    """Tests for agent.skill_utils.get_hidden_skill_names.
+
+    Mirrors TestGetDisabledSkillNames.  Hidden skills are filtered from
+    the <available_skills> catalog only — they remain loadable via
+    skill_view().  See agent/skill_utils.py for the rationale.
+    """
+
+    def test_explicit_platform_param(self, tmp_path, monkeypatch):
+        config = tmp_path / "config.yaml"
+        config.write_text(
+            "skills:\n"
+            "  hidden:\n"
+            "    - global-hidden\n"
+            "  platform_hidden:\n"
+            "    telegram:\n"
+            "      - tg-only-hidden\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+
+        from agent.skill_utils import get_hidden_skill_names
+        result = get_hidden_skill_names(platform="telegram")
+        assert result == {"tg-only-hidden"}
+
+    def test_session_platform_env_var(self, tmp_path, monkeypatch):
+        config = tmp_path / "config.yaml"
+        config.write_text(
+            "skills:\n"
+            "  platform_hidden:\n"
+            "    discord:\n"
+            "      - discord-hidden\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_PLATFORM", raising=False)
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+
+        from agent.skill_utils import get_hidden_skill_names
+        assert get_hidden_skill_names() == {"discord-hidden"}
+
+    def test_hermes_platform_takes_precedence(self, tmp_path, monkeypatch):
+        config = tmp_path / "config.yaml"
+        config.write_text(
+            "skills:\n"
+            "  platform_hidden:\n"
+            "    telegram:\n"
+            "      - tg-hidden\n"
+            "    discord:\n"
+            "      - discord-hidden\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_PLATFORM", "telegram")
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+
+        from agent.skill_utils import get_hidden_skill_names
+        assert get_hidden_skill_names() == {"tg-hidden"}
+
+    def test_explicit_param_overrides_env_vars(self, tmp_path, monkeypatch):
+        config = tmp_path / "config.yaml"
+        config.write_text(
+            "skills:\n"
+            "  platform_hidden:\n"
+            "    telegram:\n"
+            "      - tg-hidden\n"
+            "    slack:\n"
+            "      - slack-hidden\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_PLATFORM", "telegram")
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+
+        from agent.skill_utils import get_hidden_skill_names
+        assert get_hidden_skill_names(platform="slack") == {"slack-hidden"}
+
+    def test_no_platform_returns_global(self, tmp_path, monkeypatch):
+        config = tmp_path / "config.yaml"
+        config.write_text(
+            "skills:\n"
+            "  hidden:\n"
+            "    - global-hidden\n"
+            "  platform_hidden:\n"
+            "    telegram:\n"
+            "      - tg-hidden\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+
+        from agent.skill_utils import get_hidden_skill_names
+        assert get_hidden_skill_names() == {"global-hidden"}
+
+    def test_empty_platform_list_overrides_global(self, tmp_path, monkeypatch):
+        """An explicit empty platform_hidden list wins over the global hidden list."""
+        config = tmp_path / "config.yaml"
+        config.write_text(
+            "skills:\n"
+            "  hidden:\n"
+            "    - global-hidden\n"
+            "  platform_hidden:\n"
+            "    telegram: []\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from agent.skill_utils import get_hidden_skill_names
+        assert get_hidden_skill_names(platform="telegram") == set()
+
+    def test_missing_skills_config(self, tmp_path, monkeypatch):
+        config = tmp_path / "config.yaml"
+        config.write_text("foo: bar\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from agent.skill_utils import get_hidden_skill_names
+        assert get_hidden_skill_names() == set()
+
+    def test_missing_config_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "nonexistent"))
+        from agent.skill_utils import get_hidden_skill_names
+        assert get_hidden_skill_names() == set()
+
+    def test_string_value_normalized_to_set(self, tmp_path, monkeypatch):
+        """A bare string (not a list) for hidden should still parse to a single-element set."""
+        config = tmp_path / "config.yaml"
+        config.write_text("skills:\n  hidden: only-one\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+        from agent.skill_utils import get_hidden_skill_names
+        assert get_hidden_skill_names() == {"only-one"}
+
+    def test_hidden_independent_of_disabled(self, tmp_path, monkeypatch):
+        """skills.hidden and skills.disabled are independent; hidden does NOT affect get_disabled_skill_names."""
+        config = tmp_path / "config.yaml"
+        config.write_text(
+            "skills:\n"
+            "  disabled:\n"
+            "    - off-skill\n"
+            "  hidden:\n"
+            "    - hidden-skill\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+        from agent.skill_utils import get_disabled_skill_names, get_hidden_skill_names
+        assert get_disabled_skill_names() == {"off-skill"}
+        assert get_hidden_skill_names() == {"hidden-skill"}
+
+
+# ---------------------------------------------------------------------------
 # _find_all_skills — disabled filtering
 # ---------------------------------------------------------------------------
 

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -482,6 +482,25 @@ class TestSkillView:
         assert result["success"] is False
         assert "disabled" in result["error"].lower()
 
+    def test_view_hidden_skill_still_loads(self, tmp_path, monkeypatch):
+        """Skills in skills.hidden are filtered from the catalog but MUST
+        remain loadable via skill_view.  This is the whole point of
+        progressive disclosure: the agent can still pull a hidden skill
+        on demand when a router/meta-skill knows its name.
+        """
+        # Hidden, NOT disabled — _is_skill_disabled returns False, the
+        # default behaviour of the real config-reading path.
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config = tmp_path / "config.yaml"
+        config.write_text("skills:\n  hidden: [router-target]\n")
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "router-target")
+            raw = skill_view("router-target")
+        result = json.loads(raw)
+        assert result["success"] is True, f"hidden skill should load: {result}"
+        assert result["name"] == "router-target"
+
     def test_view_enabled_skill_allowed(self, tmp_path):
         """Non-disabled skills should be viewable normally."""
         with (

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -729,6 +729,38 @@ After changing this, **restart the gateway** (`hermes gateway restart` or kill a
 Skills with very long descriptions are truncated to 40 characters in the Telegram menu to stay within payload size limits. If skills aren't appearing, it may be a total payload size issue rather than the 100 command count limit — disabling unused skills helps with both.
 :::
 
+### Skills catalog is too big — `<available_skills>` token cost
+
+**Scenario:** Your skill library has grown to 100+ skills and the `<available_skills>` block injected into every system prompt costs thousands of tokens per turn. You don't want to delete skills, but you also don't want them sitting in the catalog when the agent only uses them occasionally.
+
+**Solution:** Use `skills.hidden` (and per-platform `skills.platform_hidden`) for **progressive disclosure**.
+
+```yaml
+skills:
+  # Hidden skills disappear from <available_skills> but stay loadable
+  # via skill_view() / /skill <name>. Pair with a router-style meta-skill
+  # that knows the names so the agent can pull them on demand.
+  hidden:
+    - rarely-used-skill
+    - heavy-reference-skill
+  platform_hidden:
+    discord:
+      - cli-only-skill        # hidden from Discord catalog only
+```
+
+**`hidden` vs `disabled` — when to use which:**
+
+| | `disabled` / `platform_disabled` | `hidden` / `platform_hidden` |
+|---|---|---|
+| Catalog (system prompt) | excluded | excluded |
+| `skill_view()` / `/skill <name>` | **blocked** (hard error) | **still works** |
+| `hermes skills` UI | shown as disabled | shown normally |
+| Use case | turning a skill off | progressive disclosure |
+
+The pattern is: build a small **router skill** (always in the catalog) that documents what the hidden skills do and tells the agent when to load each one. The agent reads the router, picks the right skill, calls `skill_view("name")`, and proceeds — paying the skill's full token cost only when it's actually needed, instead of every turn.
+
+After changing this, the new catalog applies to **new sessions**. Restart the gateway or `/reset` to refresh active sessions.
+
 ### Shared thread sessions (multiple users, one conversation)
 
 **Scenario:** You have a Telegram or Discord thread where multiple people mention the bot. You want all mentions in that thread to be part of one shared conversation, not separate per-user sessions.


### PR DESCRIPTION
## What does this PR do?

Adds `skills.hidden` / `skills.platform_hidden` — a third skill-visibility state distinct from the existing `skills.disabled` / `skills.platform_disabled` hard block:

| Config key | Catalog (`<available_skills>`) | `skill_view()` / `/skill` / hub UI |
|---|---|---|
| `skills.disabled` (existing) | filtered out | **blocked** |
| `skills.hidden` (new) | filtered out | **still works** |

The motivation is **progressive disclosure for large skill libraries**. Today `skills.disabled` is binary — a skill is either eagerly listed in the system-prompt catalog every turn (paying its description cost) or off entirely (unloadable). On a busy gateway with 100+ skills the catalog can run thousands of tokens per turn just for the index. There's no way to say "I want this skill on the shelf, but not in my system prompt."

With `skills.hidden`, a router-style meta-skill can stay in the catalog, document what each off-catalog skill does, and instruct the agent to load them on demand via `skill_view()`. The agent retains full access without paying per-turn catalog tax for skills it rarely uses.

This is a non-breaking, additive change. Existing configs work unchanged.

## Related Issue

No tracking issue — happy to open one if preferred.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **`agent/skill_utils.py`** — new `get_hidden_skill_names(platform)` mirrors the resolution semantics of `get_disabled_skill_names()` (explicit param > `HERMES_PLATFORM` > `HERMES_SESSION_PLATFORM` > global `skills.hidden`; an explicit `platform_hidden.<platform>` list, even empty, wins over the global).
- **`agent/prompt_builder.py::build_skills_system_prompt`** — filter the catalog by `disabled | hidden`, and include the hidden set in the LRU cache key so config changes invalidate cleanly.
- **`tools/skills_tool.py`** — intentionally **not** changed. `skill_view`, `/skill`, autocomplete, and the hub UI keep serving hidden skills, which is the whole point.
- **`hermes_cli/config.py`** — schema docs for both `skills.hidden` and `skills.platform_hidden` alongside the existing `disabled` / `platform_disabled` keys.
- **`website/docs/reference/faq.md`** — new section explaining when to use `hidden` vs `disabled` (router-style progressive disclosure use-case).

## How to Test

```bash
# 1. Add a skill to the hidden list:
hermes config set skills.hidden '["my-rare-skill"]'

# 2. Start a session and confirm the catalog excludes it:
hermes chat -q "List skills" 
# (or check that <available_skills> in the system prompt no longer mentions it)

# 3. Load it explicitly — should still work:
/skill my-rare-skill          # in interactive session
# OR via the skill_view tool: skill_view(name="my-rare-skill")

# 4. Per-platform: hide on Discord but keep visible in CLI:
# config.yaml:
# skills:
#   platform_hidden:
#     discord: [my-rare-skill]
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(skills): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the affected tests: 243/243 passing across `tests/agent/test_prompt_builder.py`, `tests/hermes_cli/test_skills_config.py`, `tests/tools/test_skills_tool.py`, `tests/gateway/test_unavailable_skill_hint.py`
- [x] I've added tests for my changes:
  - 10 new tests for `get_hidden_skill_names` (resolution chain, env vars, empty-list-overrides-global semantics, independence from `get_disabled_skill_names`)
  - 3 new tests for `build_skills_system_prompt` (excludes hidden, composes with disabled, cache invalidates on hidden change)
  - 1 new test for `skill_view` covering the critical contract: **hidden skills must still load**
- [x] I've tested on Ubuntu 24.04 (Linux x86_64)

### Documentation & Housekeeping

- [x] Updated `website/docs/reference/faq.md` with usage guidance
- [x] Updated `hermes_cli/config.py` schema docs (matches the `disabled` / `platform_disabled` style)
- [N/A] `cli-config.yaml.example` — not present in this layout; schema lives in `hermes_cli/config.py`
- [N/A] `CONTRIBUTING.md` / `AGENTS.md` — no architectural change
- [x] No cross-platform concerns — config-only change, pure Python, no OS-specific code paths
- [N/A] Tool descriptions/schemas — no tool behavior changed (`skills_tool` deliberately untouched)

## Notes

- Behavior is purely additive. If neither `skills.hidden` nor `skills.platform_hidden` is set, the agent behaves exactly as before.
- Pairs naturally with a router-style meta-skill (one such pattern in the wild: a `<your-org>-router` skill that lives at the top of the system prompt and points the agent at hidden skills via verb tables). This PR is just the mechanism — no router skill bundled.
- The cache-key change is the only subtle bit; without it, flipping `skills.hidden` mid-session wouldn't invalidate the cached catalog string. Covered by the new "cache invalidates on hidden change" test.
