### PR TITLE
fix(gateway): log runtime-status write failures with rate-limiting (salvage #21158)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1307,8 +1307,8 @@ class BasePlatformAdapter(ABC):
         try:
             from gateway.status import write_runtime_status
             write_runtime_status(platform=self.platform.value, platform_state="connected", error_code=None, error_message=None)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Failed to write runtime status (connected) for %s: %s", self.platform.value, exc)
 
     def _mark_disconnected(self) -> None:
         self._running = False
@@ -1317,8 +1317,8 @@ class BasePlatformAdapter(ABC):
         try:
             from gateway.status import write_runtime_status
             write_runtime_status(platform=self.platform.value, platform_state="disconnected", error_code=None, error_message=None)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Failed to write runtime status (disconnected) for %s: %s", self.platform.value, exc)
 
     def _set_fatal_error(self, code: str, message: str, *, retryable: bool) -> None:
         self._running = False
@@ -1333,8 +1333,8 @@ class BasePlatformAdapter(ABC):
                 error_code=code,
                 error_message=message,
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning("Failed to write runtime status (fatal) for %s: %s", self.platform.value, exc)
 
     async def _notify_fatal_error(self) -> None:
         handler = self._fatal_error_handler

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1304,37 +1304,52 @@ class BasePlatformAdapter(ABC):
         self._fatal_error_code = None
         self._fatal_error_message = None
         self._fatal_error_retryable = True
-        try:
-            from gateway.status import write_runtime_status
-            write_runtime_status(platform=self.platform.value, platform_state="connected", error_code=None, error_message=None)
-        except Exception as exc:
-            logger.warning("Failed to write runtime status (connected) for %s: %s", self.platform.value, exc)
+        self._write_runtime_status_safe("connected", platform_state="connected", error_code=None, error_message=None)
 
     def _mark_disconnected(self) -> None:
         self._running = False
         if self.has_fatal_error:
             return
-        try:
-            from gateway.status import write_runtime_status
-            write_runtime_status(platform=self.platform.value, platform_state="disconnected", error_code=None, error_message=None)
-        except Exception as exc:
-            logger.warning("Failed to write runtime status (disconnected) for %s: %s", self.platform.value, exc)
+        self._write_runtime_status_safe("disconnected", platform_state="disconnected", error_code=None, error_message=None)
 
     def _set_fatal_error(self, code: str, message: str, *, retryable: bool) -> None:
         self._running = False
         self._fatal_error_code = code
         self._fatal_error_message = message
         self._fatal_error_retryable = retryable
+        self._write_runtime_status_safe("fatal", platform_state="fatal", error_code=code, error_message=message)
+
+    def _write_runtime_status_safe(self, context: str, **kwargs) -> None:
+        """Write runtime status; log first failure per context at warning, rest at debug.
+
+        Status writes can fail on permissions, ENOSPC, missing status dir, etc.
+        A persistently failing status dir used to be silent (``except: pass``).
+        Logging every failure would spam the log on reconnect loops, so this
+        surfaces the first failure per (platform, context) at warning level and
+        downgrades subsequent failures to debug.
+        """
         try:
             from gateway.status import write_runtime_status
-            write_runtime_status(
-                platform=self.platform.value,
-                platform_state="fatal",
-                error_code=code,
-                error_message=message,
-            )
+            write_runtime_status(platform=self.platform.value, **kwargs)
         except Exception as exc:
-            logger.warning("Failed to write runtime status (fatal) for %s: %s", self.platform.value, exc)
+            # Use getattr so object.__new__(...) test harnesses that skip __init__
+            # don't blow up on attribute access.
+            logged = getattr(self, "_status_write_logged", None)
+            if logged is None:
+                logged = set()
+                try:
+                    self._status_write_logged = logged
+                except Exception:
+                    pass
+            key = (self.platform.value, context)
+            if key not in logged:
+                logger.warning(
+                    "Failed to write runtime status (%s) for %s: %s (further failures at debug level)",
+                    context, self.platform.value, exc,
+                )
+                logged.add(key)
+            else:
+                logger.debug("Failed to write runtime status (%s) for %s: %s", context, self.platform.value, exc)
 
     async def _notify_fatal_error(self) -> None:
         handler = self._fatal_error_handler


### PR DESCRIPTION
## Summary
Gateway platform adapters now surface runtime-status write failures to the log instead of silently swallowing them, with rate-limiting so a persistently broken status dir doesn't spam on every reconnect.

## Changes
- `gateway/platforms/base.py`: salvage @wabrent's original three-hunk change (replace `except: pass` with `logger.warning` in `_mark_connected`/`_mark_disconnected`/`_set_fatal_error`), then consolidate the three try/write/except blocks into a shared `_write_runtime_status_safe()` helper.

## Improvements during salvage
- First failure per (platform, context) logs at warning level with the exception detail; subsequent failures downgrade to debug. This avoids log-spam on reconnect loops when the status dir is persistently broken (permissions, ENOSPC).
- Uses `getattr` for the per-instance `_status_write_logged` set so test harnesses that bypass `__init__` via `object.__new__(Adapter)` (a common pattern in `tests/gateway/`) still work.

## Validation
- `scripts/run_tests.sh tests/gateway/ -k 'base or platform'`: **335 passed, 7 skipped**.
- E2E: simulated persistent `PermissionError` from `write_runtime_status()` called 5× on "connected" + 2× on "fatal" → exactly 2 WARNINGs, 5 DEBUGs. Happy path: zero log output. `object.__new__(Adapter)` harness does not crash on `getattr` fallback.
- Compile check passes.

Closes #21158 via salvage. Co-authored by @wabrent.