### PR TITLE
fix(agent): inherit model.api_key when auxiliary base_url matches main endpoint

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -444,6 +444,43 @@ def _codex_cloudflare_headers(access_token: str) -> Dict[str, str]:
     return headers
 
 
+def _same_endpoint(base_url_a: str, base_url_b: str) -> bool:
+    """Return True when both URLs target the same network endpoint.
+
+    Compares hostname (case-insensitive) and effective port — ports are
+    inferred from the scheme when omitted (https→443, http→80) so
+    ``https://api.example.com/v1`` matches ``https://api.example.com:443/v2``.
+    Used to decide whether an auxiliary task's pinned ``base_url`` and the
+    main runtime's ``base_url`` point at the same server (and therefore can
+    share ``api_key``).
+    """
+    from urllib.parse import urlparse
+
+    def _hostport(raw: str) -> Tuple[str, Optional[int]]:
+        s = (raw or "").strip()
+        if not s:
+            return "", None
+        parsed = urlparse(s if "://" in s else f"//{s}")
+        host = (parsed.hostname or "").lower().rstrip(".")
+        try:
+            port = parsed.port
+        except ValueError:
+            port = None
+        if port is None:
+            scheme = (parsed.scheme or "").lower()
+            if scheme == "https":
+                port = 443
+            elif scheme == "http":
+                port = 80
+        return host, port
+
+    host_a, port_a = _hostport(base_url_a)
+    host_b, port_b = _hostport(base_url_b)
+    if not host_a or not host_b:
+        return False
+    return host_a == host_b and port_a == port_b
+
+
 def _to_openai_base_url(base_url: str) -> str:
     """Normalize an Anthropic-style base URL to OpenAI-compatible format.
 
@@ -2278,8 +2315,20 @@ def resolve_provider_client(
     if provider == "custom":
         if explicit_base_url:
             custom_base = _to_openai_base_url(explicit_base_url).strip()
+            # When the auxiliary endpoint shares its netloc (host + port) with
+            # the active main runtime, inherit ``model.api_key`` so users who
+            # pinned a per-task ``base_url`` (via dashboard, ``hermes setup``,
+            # or hand-edit) without also pinning ``api_key`` don't silently
+            # send ``Bearer no-key-required`` to an authenticated endpoint.
+            inherited_main_key = ""
+            if not (explicit_api_key or "").strip() and main_runtime:
+                main_base = str(main_runtime.get("base_url") or "").strip()
+                main_key = str(main_runtime.get("api_key") or "").strip()
+                if main_base and main_key and _same_endpoint(main_base, custom_base):
+                    inherited_main_key = main_key
             custom_key = (
                 (explicit_api_key or "").strip()
+                or inherited_main_key
                 or os.getenv("OPENAI_API_KEY", "").strip()
                 or "no-key-required"  # local servers don't need auth
             )

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -509,6 +509,124 @@ class TestExplicitProviderRouting:
             for record in caplog.records
         )
 
+
+class TestCustomBranchInheritsMainApiKey:
+    """provider='custom' with an empty api_key must inherit model.api_key when
+    the auxiliary base_url targets the same endpoint as the main runtime
+    (issue #21121).  Without this, a per-task base_url override silently sends
+    Bearer no-key-required to an authenticated custom endpoint and 401s.
+    """
+
+    def test_inherits_main_api_key_when_endpoint_matches(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, _ = resolve_provider_client(
+                "custom",
+                model="gemma4-31b",
+                explicit_base_url="http://localhost:8081/v1",
+                explicit_api_key="",
+                main_runtime={
+                    "provider": "custom",
+                    "model": "gemma4-31b",
+                    "base_url": "http://localhost:8081/v1",
+                    "api_key": "main-vllm-key",
+                },
+            )
+        assert client is not None
+        assert mock_openai.call_args.kwargs["api_key"] == "main-vllm-key"
+
+    def test_does_not_inherit_when_host_differs(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, _ = resolve_provider_client(
+                "custom",
+                model="gemma4-31b",
+                explicit_base_url="http://other-host.local:8081/v1",
+                explicit_api_key="",
+                main_runtime={
+                    "provider": "custom",
+                    "model": "gemma4-31b",
+                    "base_url": "http://localhost:8081/v1",
+                    "api_key": "main-vllm-key",
+                },
+            )
+        assert client is not None
+        assert mock_openai.call_args.kwargs["api_key"] == "no-key-required"
+
+    def test_does_not_inherit_when_port_differs(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, _ = resolve_provider_client(
+                "custom",
+                model="gemma4-31b",
+                explicit_base_url="http://localhost:9000/v1",
+                explicit_api_key="",
+                main_runtime={
+                    "provider": "custom",
+                    "model": "gemma4-31b",
+                    "base_url": "http://localhost:8081/v1",
+                    "api_key": "main-vllm-key",
+                },
+            )
+        assert client is not None
+        assert mock_openai.call_args.kwargs["api_key"] == "no-key-required"
+
+    def test_explicit_api_key_still_wins_over_main(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, _ = resolve_provider_client(
+                "custom",
+                model="gemma4-31b",
+                explicit_base_url="http://localhost:8081/v1",
+                explicit_api_key="task-specific-key",
+                main_runtime={
+                    "provider": "custom",
+                    "model": "gemma4-31b",
+                    "base_url": "http://localhost:8081/v1",
+                    "api_key": "main-vllm-key",
+                },
+            )
+        assert client is not None
+        assert mock_openai.call_args.kwargs["api_key"] == "task-specific-key"
+
+    def test_inherit_skipped_when_main_runtime_missing(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, _ = resolve_provider_client(
+                "custom",
+                model="gemma4-31b",
+                explicit_base_url="http://localhost:8081/v1",
+                explicit_api_key="",
+                main_runtime=None,
+            )
+        assert client is not None
+        assert mock_openai.call_args.kwargs["api_key"] == "no-key-required"
+
+    def test_default_https_port_matches_explicit_443(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, _ = resolve_provider_client(
+                "custom",
+                model="m",
+                explicit_base_url="https://api.example.com/v1",
+                explicit_api_key="",
+                main_runtime={
+                    "provider": "custom",
+                    "model": "m",
+                    "base_url": "https://api.example.com:443/v2",
+                    "api_key": "main-key",
+                },
+            )
+        assert client is not None
+        assert mock_openai.call_args.kwargs["api_key"] == "main-key"
+
+
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""
 


### PR DESCRIPTION
Fix HTTP 401 on auxiliary tasks (e.g. title generation) when an `auxiliary.<task>.base_url` is pinned but `api_key` is empty and the endpoint targets the same server as the main model.

## What changed and why
- `agent/auxiliary_client.py`: in the `provider == "custom"` branch with `explicit_base_url`, before falling back to `OPENAI_API_KEY` env or `"no-key-required"`, inherit `main_runtime["api_key"]` when the auxiliary `base_url` shares its host:port with `main_runtime["base_url"]`. This stops auxiliary calls from silently sending `Bearer no-key-required` to an authenticated custom endpoint when only `model.api_key` is configured.
- New `_same_endpoint()` helper compares hostname + effective port (https→443, http→80) so `https://api.example.com/v1` matches `https://api.example.com:443/v2` but not `http://localhost:9000` vs `http://localhost:8081`.
- The reporter also flagged a frontend bug ("dashboard 'Use as' copies `base_url` but not `api_key`"). Verified against `hermes_cli/web_server.py::set_model_assignment` — the endpoint only writes `provider` and `model`, never touching `base_url`/`api_key`. The slot's `base_url` in their config came from another path (`hermes setup`, the ConfigPage form, or a hand-edit). The runtime-side fix here addresses the actual 401 regardless of how the slot ended up that way; no frontend change needed.

## How to test
- `pytest tests/agent/test_auxiliary_client.py::TestCustomBranchInheritsMainApiKey -q` — 6 new cases: host-match inheritance, host mismatch, port mismatch, explicit api_key takes precedence, missing main_runtime, default-vs-explicit https port equivalence.
- `pytest tests/ -q -x --timeout=60 -k "auxiliary or runtime_provider or title_generator or aux_config"` — 426 passed, 4 skipped on the worktree.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #21121

<!-- autocontrib:worker-id=issue-new-53883db2 kind=pr-open -->