### PR TITLE
fix(installer): set UV_NO_CONFIG=1 to avoid permission denied under sudo -u

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,6 +28,10 @@ if [ -n "${PYTHONHOME:-}" ]; then
     unset PYTHONHOME
 fi
 
+# Prevent uv from discovering config files (uv.toml, pyproject.toml) from the
+# wrong user's home directory when running under sudo -u <user>.  See #21269.
+export UV_NO_CONFIG=1
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -29,6 +29,10 @@ NC='\033[0m'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Prevent uv from discovering config files (uv.toml, pyproject.toml) from the
+# wrong user's home directory when running under sudo -u <user>.  See #21269.
+export UV_NO_CONFIG=1
+
 PYTHON_VERSION="3.11"
 
 is_termux() {


### PR DESCRIPTION
Fixes #21269

## Problem

When the installer is run via `sudo -u <service-account>`, `uv` resolves config file paths against the **process owner's** (root) home directory rather than the effective user's. This causes a `Permission denied` error when trying to read `/root/uv.toml`:

```
error: failed to open file `/root/uv.toml`: Permission denied (os error 13)
✗ Failed to install Python 3.11
```

## Root Cause

`uv` automatically discovers config files (`uv.toml`, `pyproject.toml`) by walking up from `$HOME`. Under `sudo -u`, `$HOME` is typically still `/root` (or inherited from the sudo caller), so uv tries to read root-owned files that the effective user can't access.

## Fix

Set `export UV_NO_CONFIG=1` early in both install scripts. This prevents uv from discovering any config files during installation, which is the correct behavior for a bootstrap script that manages its own isolated environment.

**Files changed:**
- `scripts/install.sh` — main installer (used by `curl | bash`)
- `setup-hermes.sh` — developer setup script (used after `git clone`)

Both scripts already clear `PYTHONPATH` and `PYTHONHOME` to prevent env leakage; `UV_NO_CONFIG=1` follows the same pattern for uv's config discovery.

## Verification

```bash
# Under sudo -u, uv commands should no longer try to read /root/uv.toml:
sudo -u nobody bash -c 'UV_NO_CONFIG=1 uv python find 3.11'
# → finds system Python without permission errors
```
