### PR TITLE
fix(whatsapp): reject strangers by default, never respond in self-chat (#8389)

### DIFF
--- a/scripts/whatsapp-bridge/allowlist.js
+++ b/scripts/whatsapp-bridge/allowlist.js
@@ -64,8 +64,12 @@ export function expandWhatsAppIdentifiers(identifier, sessionDir) {
 }
 
 export function matchesAllowedUser(senderId, allowedUsers, sessionDir) {
+  // Empty allowlist = NO ONE allowed (secure default, #8389).  Operators
+  // who want an open bot must set ``WHATSAPP_ALLOWED_USERS=*`` explicitly.
+  // Previous behaviour (empty → return true) let any stranger DM the
+  // bridge and trigger a Python-side pairing-code reply.
   if (!allowedUsers || allowedUsers.size === 0) {
-    return true;
+    return false;
   }
 
   // "*" means allow everyone (consistent with SIGNAL_GROUP_ALLOWED_USERS)

--- a/scripts/whatsapp-bridge/allowlist.test.mjs
+++ b/scripts/whatsapp-bridge/allowlist.test.mjs
@@ -57,3 +57,24 @@ test('matchesAllowedUser treats * as allow-all wildcard', () => {
     rmSync(sessionDir, { recursive: true, force: true });
   }
 });
+
+test('matchesAllowedUser rejects everyone when allowlist is empty (#8389)', () => {
+  // Regression guard: empty allowlist used to return true (allow-everyone),
+  // which let any stranger DM the bridge and trigger a Python-side
+  // pairing-code reply. Secure default is now "reject unless explicitly
+  // configured"; operators who want an open bot must set `*`.
+  const sessionDir = mkdtempSync(path.join(os.tmpdir(), 'hermes-wa-allowlist-'));
+
+  try {
+    const empty = parseAllowedUsers('');
+    assert.equal(empty.size, 0);
+    assert.equal(matchesAllowedUser('19175395595@s.whatsapp.net', empty, sessionDir), false);
+    assert.equal(matchesAllowedUser('267383306489914@lid', empty, sessionDir), false);
+
+    // Null/undefined allowlist (defensive) also rejects.
+    assert.equal(matchesAllowedUser('19175395595@s.whatsapp.net', null, sessionDir), false);
+    assert.equal(matchesAllowedUser('19175395595@s.whatsapp.net', undefined, sessionDir), false);
+  } finally {
+    rmSync(sessionDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -229,17 +229,34 @@ async function startSocket() {
         if (!isSelfChat) continue;
       }
 
-      // Check allowlist for messages from others (resolve LID ↔ phone aliases)
-      if (!msg.key.fromMe && !matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
-        try {
-          console.log(JSON.stringify({
-            event: 'ignored',
-            reason: 'allowlist_mismatch',
-            chatId,
-            senderId,
-          }));
-        } catch {}
-        continue;
+      // Handle !fromMe messages (from other people) based on mode.
+      // Self-chat mode only responds to the user's own messages to
+      // themselves — stranger DMs / group pings must never reach the
+      // Python gateway, otherwise a pairing-code reply fires in response
+      // to arbitrary incoming messages (#8389).
+      if (!msg.key.fromMe) {
+        if (WHATSAPP_MODE === 'self-chat') {
+          try {
+            console.log(JSON.stringify({
+              event: 'ignored',
+              reason: 'self_chat_mode_rejects_non_self',
+              chatId,
+              senderId,
+            }));
+          } catch {}
+          continue;
+        }
+        if (!matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
+          try {
+            console.log(JSON.stringify({
+              event: 'ignored',
+              reason: 'allowlist_mismatch',
+              chatId,
+              senderId,
+            }));
+          } catch {}
+          continue;
+        }
       }
 
       const messageContent = getMessageContent(msg);
@@ -625,8 +642,12 @@ if (PAIR_ONLY) {
     console.log(`📁 Session stored in: ${SESSION_DIR}`);
     if (ALLOWED_USERS.size > 0) {
       console.log(`🔒 Allowed users: ${Array.from(ALLOWED_USERS).join(', ')}`);
+    } else if (WHATSAPP_MODE === 'self-chat') {
+      console.log(`🔒 Self-chat mode — only your own messages to yourself are processed.`);
     } else {
-      console.log(`⚠️  No WHATSAPP_ALLOWED_USERS set — all messages will be processed`);
+      console.log(`🔒 No WHATSAPP_ALLOWED_USERS set — incoming messages are rejected.`);
+      console.log(`   Set WHATSAPP_ALLOWED_USERS=<phone> to authorize specific users,`);
+      console.log(`   or WHATSAPP_ALLOWED_USERS=* for an explicit open bot.`);
     }
     console.log();
     startSocket();


### PR DESCRIPTION
## Summary
Stranger DMs / group pings to a Hermes WhatsApp bridge no longer trigger a response. Previously, self-chat mode (the default) forwarded any incoming message to the Python gateway, which then replied with a pairing-code message to the stranger.

Closes #8389.

## Root cause (two compounding defaults)
1. **`allowlist.js::matchesAllowedUser`** returned `true` for an empty allowlist → `WHATSAPP_ALLOWED_USERS` unset (default) meant everyone passed the JS bridge gate.
2. **`bridge.js`** had no mode check on `!fromMe` messages → self-chat mode (where the operator only wants to talk to themselves) forwarded strangers anyway.

Message reached the Python gateway, `_is_user_authorized()` returned False, but `_get_unauthorized_dm_behavior()` fell back to `"pair"` → stranger got a pairing code.

## Changes
- `scripts/whatsapp-bridge/allowlist.js` — empty allowlist now returns `false`. `*` still works as the explicit allow-all wildcard (consistent with `SIGNAL_GROUP_ALLOWED_USERS`).
- `scripts/whatsapp-bridge/bridge.js` — self-chat mode hard-rejects all `!fromMe` messages at the bridge, before they ever reach the Python gateway. Bot mode still enforces the allowlist.
- `scripts/whatsapp-bridge/bridge.js` — startup log message updated per mode: self-chat shows "only your own messages to yourself are processed"; bot mode without allowlist shows explicit guidance to set `WHATSAPP_ALLOWED_USERS=<phone>` or `*`. The pre-fix message ("⚠️ No WHATSAPP_ALLOWED_USERS set — all messages will be processed") was both inaccurate post-fix and a signal that the old default was unsafe.
- `scripts/whatsapp-bridge/allowlist.test.mjs` — new regression test pinning empty→rejects, plus null/undefined defensive cases.

## Validation
Node `--test` suite: 5/5 pass (including new regression).

E2E harness via `execute_code` with real imports from the bridge modules:

| Input | Expected | Got |
|---|---|---|
| empty allowlist, phone sender | false | false |
| empty allowlist, LID sender | false | false |
| null allowlist | false | false |
| undefined allowlist | false | false |
| `*` allowlist, phone sender | true | true |
| `*` allowlist, LID sender | true | true |
| `+19175395595` allowlist, matching sender | true | true |
| `+19175395595` allowlist, other sender | false | false |

Python-side tests (`test_whatsapp_connect`, `test_whatsapp_group_gating`, `test_whatsapp_formatting`, `test_allowlist_startup_check`, `test_unauthorized_dm_behavior`): 98/99 pass. The one failure (`TestBridgeRuntimeFailure::test_closed_when_bridge_dies_phase2`) is an xdist-ordering flake — same test passes in isolation and also fails on clean main depending on test-order. Pre-existing, unrelated to this fix.

## Behaviour delta for existing users
- **Self-chat mode (default), no allowlist set**: strangers previously got a pairing-code reply from the Python gateway. Now silently dropped at the JS bridge. Strictly better — no content was ever reaching the agent anyway.
- **Bot mode, no allowlist set**: strangers previously got a pairing-code reply. Now silently dropped at the JS bridge. Operators who genuinely want an open bot (rare) must opt in with `WHATSAPP_ALLOWED_USERS=*`.
- **Any mode with a configured allowlist**: no change.

## Notes on scope
`WHATSAPP_ALLOWED_USERS` remains an env var rather than a config.yaml key — the WhatsApp bridge is a Node subprocess spawned by the Python gateway and receives its configuration through env vars (as do all allowlist vars across messaging platforms: `DISCORD_ALLOWED_USERS`, `TELEGRAM_ALLOWED_USERS`, etc.). Moving the cross-platform allowlist surface from env to config.yaml is a separate cleanup outside this security fix.
