### PR TITLE
fix(gateway): prevent per-turn agent eviction from model normalization mismatch and signature instability

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11120,6 +11120,7 @@ class GatewayRunner:
 
     def _evict_cached_agent(self, session_key: str) -> None:
         """Remove a cached agent for a session (called on /new, /model, etc)."""
+        logger.debug("Evicting cached agent for session %s", session_key)
         _lock = getattr(self, "_agent_cache_lock", None)
         if _lock:
             with _lock:
@@ -12269,10 +12270,16 @@ class GatewayRunner:
                             except KeyError:
                                 pass
                         self._init_cached_agent_for_turn(agent, _interrupt_depth)
-                        logger.debug("Reusing cached agent for session %s", session_key)
+                        logger.info("CACHE HIT: reusing agent for session %s (sig=%s)", session_key, _sig[:8])
 
             if agent is None:
                 # Config changed or first message — create fresh agent
+                _cached_for_log = cached if '_cache_lock' in dir() and cached is not None else None
+                if _cached_for_log:
+                    logger.info("CACHE MISS: sig changed (old=%s new=%s)", 
+                               _cached_for_log[1][:8], _sig[:8])
+                else:
+                    logger.info("CACHE MISS: no cached agent for session %s (sig=%s)", session_key, _sig[:8])
                 agent = AIAgent(
                     model=turn_route["model"],
                     **turn_route["runtime"],
@@ -13122,6 +13129,21 @@ class GatewayRunner:
             _run_failed = _result_for_fb.get("failed") if _result_for_fb else False
             if _agent is not None and hasattr(_agent, 'model') and not _run_failed:
                 _cfg_model = _resolve_gateway_model()
+                # Normalize _cfg_model the same way AIAgent.__init__ does
+                # (run_agent.py:1089-1090), so vendor-prefixed config values
+                # (e.g. "deepseek/deepseek-v4-pro") match the stripped agent
+                # model ("deepseek-v4-pro").  Without this, every turn evicts
+                # the cached agent unconditionally.
+                try:
+                    from hermes_cli.model_normalize import (
+                        _AGGREGATOR_PROVIDERS,
+                        normalize_model_for_provider,
+                    )
+                    _agent_provider = getattr(_agent, 'provider', '') or ''
+                    if _agent_provider not in _AGGREGATOR_PROVIDERS:
+                        _cfg_model = normalize_model_for_provider(_cfg_model, _agent_provider)
+                except Exception:
+                    pass
                 if _agent.model != _cfg_model and not self._is_intentional_model_switch(session_key, _agent.model):
                     # Fallback activated on a successful run — evict cached
                     # agent so the next message retries the primary model.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6067,6 +6067,7 @@ class GatewayRunner:
                 run_generation=run_generation,
                 event_message_id=event.message_id,
                 channel_prompt=event.channel_prompt,
+                reset_context_note=_reset_context_note,
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -11612,6 +11613,7 @@ class GatewayRunner:
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        reset_context_note: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -12288,8 +12290,8 @@ class GatewayRunner:
                 # the agent cache signature and cause per-turn evictions.
                 # Only needed for fresh agents (cache MISS); cached agents
                 # already have their frozen system prompt.
-                if _reset_context_note:
-                    combined_ephemeral = (_reset_context_note + "\n\n" + (combined_ephemeral or "")).strip()
+                if reset_context_note:
+                    combined_ephemeral = (reset_context_note + "\n\n" + (combined_ephemeral or "")).strip()
                 agent = AIAgent(
                     model=turn_route["model"],
                     **turn_route["runtime"],

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12279,7 +12279,7 @@ class GatewayRunner:
 
             if agent is None:
                 # Config changed or first message — create fresh agent
-                _cached_for_log = cached if '_cache_lock' in dir() and cached is not None else None
+                _cached_for_log = cached
                 if _cached_for_log:
                     logger.info("CACHE MISS: sig changed (old=%s new=%s)", 
                                _cached_for_log[1][:8], _sig[:8])

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5559,17 +5559,20 @@ class GatewayRunner:
         # Build the context prompt to inject
         context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
         
-        # If the previous session expired and was auto-reset, prepend a notice
-        # so the agent knows this is a fresh conversation (not an intentional /reset).
+        # If the previous session expired and was auto-reset, capture a notice
+        # for the agent BUT do NOT modify context_prompt — one-time transient
+        # notices must not contaminate the agent cache signature (which is
+        # computed from combined_ephemeral = context_prompt + ...).
+        # The notice is injected into combined_ephemeral AFTER _sig is computed.
+        _reset_context_note = None
         if getattr(session_entry, 'was_auto_reset', False):
             reset_reason = getattr(session_entry, 'auto_reset_reason', None) or 'idle'
             if reset_reason == "suspended":
-                context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"
+                _reset_context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"
             elif reset_reason == "daily":
-                context_note = "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation with no prior context.]"
+                _reset_context_note = "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation with no prior context.]"
             else:
-                context_note = "[System note: The user's previous session expired due to inactivity. This is a fresh conversation with no prior context.]"
-            context_prompt = context_note + "\n\n" + context_prompt
+                _reset_context_note = "[System note: The user's previous session expired due to inactivity. This is a fresh conversation with no prior context.]"
 
             # Send a user-facing notification explaining the reset, unless:
             # - notifications are disabled in config
@@ -12280,6 +12283,13 @@ class GatewayRunner:
                                _cached_for_log[1][:8], _sig[:8])
                 else:
                     logger.info("CACHE MISS: no cached agent for session %s (sig=%s)", session_key, _sig[:8])
+                # Inject auto-reset notice into ephemeral system prompt AFTER
+                # _sig computation so one-time transient notices don't contaminate
+                # the agent cache signature and cause per-turn evictions.
+                # Only needed for fresh agents (cache MISS); cached agents
+                # already have their frozen system prompt.
+                if _reset_context_note:
+                    combined_ephemeral = (_reset_context_note + "\n\n" + (combined_ephemeral or "")).strip()
                 agent = AIAgent(
                     model=turn_route["model"],
                     **turn_route["runtime"],

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -341,8 +341,6 @@ def build_session_context_prompt(
                 id_lines.append(f"  - Thread: `{src.thread_id}` (use as `channel_id` for fetch_messages etc.)")
             else:
                 id_lines.append(f"  - Channel: `{src.chat_id}`")
-            if src.message_id:
-                id_lines.append(f"  - Triggering message: `{src.message_id}`")
             lines.extend(id_lines)
         else:
             lines.append("")


### PR DESCRIPTION
## Summary

Fixes the root cause of per-turn agent eviction that causes memory provider bridges to spawn on every message (issue #20939).

**Two independent bugs** in the gateway agent cache were causing the cached `AIAgent` (and its `MemoryProvider`) to be destroyed and recreated on every turn instead of persisting across messages:

1. **Model normalization mismatch** — `_agent.model` (normalized by `AIAgent.__init__`) never matched `_cfg_model` (raw gateway config with vendor prefix), so the eviction check at ~L13131 fired every turn.
2. **Session signature instability** — `was_auto_reset` notice and `message_id` were feeding into the cache signature hash, causing it to flip between turns.

## Root Cause Details

### 1. Model Normalization Mismatch

`gateway/run.py` ~L13131 compares the cached agent's model against the gateway config model to decide whether to evict:

- `_agent.model` = `"deepseek-v4-pro"` (normalized by `AIAgent.__init__` via `normalize_model_for_provider`)
- `_cfg_model` = `"deepseek/deepseek-v4-pro"` (raw gateway config, vendor-prefixed)

`"deepseek-v4-pro" != "deepseek/deepseek-v4-pro"` → `_evict_cached_agent()` → `AIAgent` destroyed → `MemoryProvider` destroyed → next turn creates fresh `MemoryProvider` → `initialize()` → new bridge pair. **Every. Single. Turn.**

**Fix:** Normalize `_cfg_model` using the same `normalize_model_for_provider()` function that `AIAgent.__init__` uses, before the equality check.

### 2. Session Signature Instability

Even after the model fix, the cache signature was flip-flopping (`ec05b8ea → 67f721c3 → f3d18768 → 67f721c3`). Two unstable inputs were feeding the sig hash:

- **`was_auto_reset` notice** was prepended to `context_prompt`, which feeds into the sig hash. Being a one-turn transient flag, it flipped the sig on the first post-restart turn, then back.
- **`message_id`** was in the Discord IDs block in `build_session_context_prompt()`. Per-message value would change the sig every turn.

**Fix:** Decouple the reset notice from `context_prompt` (inject into `combined_ephemeral` after sig is computed). Remove `message_id` from the context prompt.

## Results (live gateway, ~16 hour burn-in)

```
# Bridge processes: 8 (4 sessions × 2 processes)
# Before fix: 60-100 bridges/day

# Cache log — 20+ consecutive HITs overnight:
04:56  CACHE HIT (sig=155bc36b)  Sanctuary
05:21  CACHE HIT (sig=155bc36b)
05:42  CACHE HIT (sig=155bc36b)
...
06:33  CACHE HIT (sig=155bc36b)
06:35  CACHE HIT (sig=155bc36b)

# Zero "CACHE MISS: sig changed" lines since the fix.
# Signature stable across all sessions.
```

## Commits

| Commit | Description |
|---|---|
| `d480b910b` | Fix silent post-turn agent eviction (model normalization mismatch) |
| `81ca7089f` | Fix sig instability: decouple was_auto_reset + remove message_id from hash |
| `83276fb4c` | Fix NameError from closure scoping bug in d480b910b |
| `d7e2683c3` | chore: bump Discord VOICE_TIMEOUT 300s→3600s |

## Related

- Closes #20939 (MemOS bridge spawns per turn)
- Complementary to PR #20961 — that PR adds an idempotency guard at the `MemoryProvider` layer (belt); this PR fixes the root cause of unnecessary agent evictions at the gateway layer (suspenders). Both should be applied.
