### PR TITLE
fix(gateway): expand env vars in _load_gateway_config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -665,6 +665,8 @@ def load_gateway_config() -> GatewayConfig:
         if config_yaml_path.exists():
             with open(config_yaml_path, encoding="utf-8") as f:
                 yaml_cfg = yaml.safe_load(f) or {}
+            from hermes_cli.config import _expand_env_vars
+            yaml_cfg = _expand_env_vars(yaml_cfg)
 
             # Map config.yaml keys → GatewayConfig.from_dict() schema.
             # Each key overwrites whatever gateway.json may have set.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -813,7 +813,12 @@ def _load_gateway_config() -> dict:
     Uses the module-level ``_hermes_home`` (so tests that monkeypatch it
     still see their fixture) and shares the mtime-keyed raw-yaml cache
     from ``hermes_cli.config.read_raw_config`` when the paths match.
+
+    Environment variable references (``${VAR}``) are expanded so that
+    downstream consumers (model resolution, custom-provider validation)
+    never see literal template strings.
     """
+    from hermes_cli.config import _expand_env_vars
     config_path = _hermes_home / 'config.yaml'
     try:
         from hermes_cli.config import get_config_path, read_raw_config
@@ -822,7 +827,7 @@ def _load_gateway_config() -> dict:
         # direct read (keeps test fixtures with a monkeypatched
         # _hermes_home working).
         if config_path == get_config_path():
-            return read_raw_config()
+            return _expand_env_vars(read_raw_config())
     except Exception:
         pass
 
@@ -830,7 +835,7 @@ def _load_gateway_config() -> dict:
         if config_path.exists():
             import yaml
             with open(config_path, 'r', encoding='utf-8') as f:
-                return yaml.safe_load(f) or {}
+                return _expand_env_vars(yaml.safe_load(f) or {})
     except Exception:
         logger.debug("Could not load gateway config from %s", config_path)
     return {}

--- a/tests/gateway/test_load_gateway_config_env_vars.py
+++ b/tests/gateway/test_load_gateway_config_env_vars.py
@@ -1,0 +1,83 @@
+"""Regression test: _load_gateway_config() expands ${VAR} env var references."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from hermes_cli.config import _expand_env_vars
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return home
+
+
+def _load_gateway_config_via_module(hermes_home):
+    import gateway.run as gr
+
+    with patch.object(gr, "_hermes_home", hermes_home):
+        return gr._load_gateway_config()
+
+
+def test_load_gateway_config_expands_env_vars(hermes_home, monkeypatch):
+    monkeypatch.setenv("MY_TEST_BASE_URL", "https://api.example.com/v1")
+    monkeypatch.setenv("MY_TEST_API_KEY", "sk-test-123")
+
+    config = {
+        "model": {
+            "default": "test-model",
+            "base_url": "${MY_TEST_BASE_URL}",
+            "api_key": "${MY_TEST_API_KEY}",
+        },
+        "custom_providers": [
+            {
+                "name": "TestProvider",
+                "base_url": "${MY_TEST_BASE_URL}",
+                "api_key": "${MY_TEST_API_KEY}",
+                "model": "test-model",
+            }
+        ],
+    }
+    (hermes_home / "config.yaml").write_text(yaml.dump(config), encoding="utf-8")
+
+    result = _load_gateway_config_via_module(hermes_home)
+
+    assert result["model"]["base_url"] == "https://api.example.com/v1"
+    assert result["model"]["api_key"] == "sk-test-123"
+    assert result["custom_providers"][0]["base_url"] == "https://api.example.com/v1"
+
+
+def test_load_gateway_config_preserves_unresolved_vars(hermes_home, monkeypatch):
+    monkeypatch.delenv("NONEXISTENT_VAR", raising=False)
+
+    config = {
+        "model": {
+            "base_url": "${NONEXISTENT_VAR}",
+        },
+    }
+    (hermes_home / "config.yaml").write_text(yaml.dump(config), encoding="utf-8")
+
+    result = _load_gateway_config_via_module(hermes_home)
+
+    assert result["model"]["base_url"] == "${NONEXISTENT_VAR}"
+
+
+def test_load_gateway_config_no_env_vars_needed(hermes_home):
+    config = {
+        "model": {
+            "default": "test-model",
+            "base_url": "https://hardcoded.example.com/v1",
+        },
+    }
+    (hermes_home / "config.yaml").write_text(yaml.dump(config), encoding="utf-8")
+
+    result = _load_gateway_config_via_module(hermes_home)
+
+    assert result["model"]["base_url"] == "https://hardcoded.example.com/v1"


### PR DESCRIPTION
The gateway's _load_gateway_config() returned raw YAML without expanding ${VAR} references, causing custom_providers entries that use env var templates (e.g. base_url: ${ARC_BASE_URL}) to fail URL validation with spurious warnings and be silently skipped.

## What does this PR do?

`_load_gateway_config()` in `gateway/run.py` returned raw config via `read_raw_config()` without expanding `${VAR}` environment variable references. All other config loading paths (`load_config()`, the module-level config bridge at gateway startup) correctly expand env vars, but this gateway-internal helper bypassed that step. The unexpanded config was then passed to `get_compatible_custom_providers()` and model resolution code, which validated literal `${ARC_BASE_URL}` strings as URLs — failing the scheme/host check. The fix applies `_expand_env_vars()` to both return paths (the `read_raw_config()` fast path and the `yaml.safe_load` fallback), consistent with how every other config consumer works.

## Related Issue

(https://github.com/NousResearch/hermes-agent/issues/21275)

Fixes #21275

## Type of Change

- [x ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- gateway/run.py: Apply _expand_env_vars() to both return paths in _load_gateway_config() — the read_raw_config() fast path and the yaml.safe_load fallback.

## How to Test

1. Add `base_url: ${SOME_VAR}` to a `custom_providers` entry in `~/.hermes/config.yaml`, and define `SOME_VAR=https://example.com/v1` in `~/.hermes/.env`
2. Start the gateway (`hermes gateway run`)
3. **Before fix**: `WARNING hermes_cli.config: providers.?: 'base_url' value '${SOME_VAR}' is not a valid URL (no scheme or host) — skipped` appears in logs
4. **After fix**: No warning; the custom provider is resolved correctly with the expanded URL

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [N/A] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before** (gateway startup):
```
WARNING hermes_cli.config: providers.?: 'base_url' value '${ARC_BASE_URL}' is not a valid URL (no scheme or host) — skipped
INFO agent.model_metadata: Could not detect context length for model 'glm-5.1' at ${ARC_BASE_URL} — defaulting to 256,000 tokens
```

**After** (gateway startup):
```
(no warning — custom provider resolved with https://ark.cn-beijing.volces.com/api/plan/v3)
```

