### PR TITLE
fix(provider): kimi-coding double /v1 in Anthropic Messages URL

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -278,11 +278,14 @@ def _resolve_runtime_from_pool_entry(
             if detected:
                 api_mode = detected
 
-    # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
-    # Anthropic SDK prepends its own /v1/messages to the base_url.  Strip the
-    # trailing /v1 so the SDK constructs the correct path (e.g.
-    # https://opencode.ai/zen/go/v1/messages instead of .../v1/v1/messages).
-    if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
+    # OpenCode and Kimi-Coding base URLs end with /v1 for OpenAI-compatible
+    # models, but the Anthropic SDK prepends its own /v1/messages to the
+    # base_url.  Strip the trailing /v1 so the SDK constructs the correct path
+    # (e.g. https://opencode.ai/zen/go/v1/messages instead of .../v1/v1/messages,
+    # and https://api.kimi.com/coding/v1/messages instead of .../coding/v1/v1/messages).
+    if api_mode == "anthropic_messages" and provider in (
+        "opencode-zen", "opencode-go", "kimi-coding", "kimi-coding-cn",
+    ):
         base_url = re.sub(r"/v1/?$", "", base_url)
 
     return {

--- a/tests/hermes_cli/test_runtime_provider_kimi_coding_v1.py
+++ b/tests/hermes_cli/test_runtime_provider_kimi_coding_v1.py
@@ -1,0 +1,68 @@
+"""Regression test for issue #21297.
+
+`kimi-coding` and `kimi-coding-cn` route through the Anthropic Messages
+protocol when the resolved ``base_url`` matches ``api.kimi.com/coding``
+(see ``_detect_api_mode_for_url``). The Anthropic SDK appends its own
+``/v1/messages`` to the configured ``base_url``, so a base URL ending in
+``/v1`` produced ``.../v1/v1/messages`` and HTTP 404 on every request.
+
+The fix adds ``kimi-coding`` / ``kimi-coding-cn`` to the post-resolve
+``/v1`` strip list (already in use for ``opencode-zen`` / ``opencode-go``).
+"""
+
+from types import SimpleNamespace
+
+from hermes_cli import runtime_provider as rp
+
+
+def _fake_entry(base_url: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        access_token="sk-kimi-test",
+        source="manual",
+        base_url=base_url,
+    )
+
+
+def test_kimi_coding_anthropic_messages_strips_trailing_v1():
+    """sk-kimi key → api.kimi.com/coding/v1 base_url. /v1 must be stripped
+    so the Anthropic SDK builds .../coding/v1/messages, not .../coding/v1/v1/messages."""
+    resolved = rp._resolve_runtime_from_pool_entry(
+        provider="kimi-coding",
+        entry=_fake_entry("https://api.kimi.com/coding/v1"),
+        requested_provider="kimi-coding",
+        model_cfg={"default": "kimi-k2.6"},
+    )
+
+    assert resolved["provider"] == "kimi-coding"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://api.kimi.com/coding"
+
+
+def test_kimi_coding_cn_anthropic_messages_strips_trailing_v1():
+    """Same fix applies to the CN endpoint when a sk-kimi key resolves to
+    api.kimi.com/coding via the CN auth path."""
+    resolved = rp._resolve_runtime_from_pool_entry(
+        provider="kimi-coding-cn",
+        entry=_fake_entry("https://api.kimi.com/coding/v1"),
+        requested_provider="kimi-coding-cn",
+        model_cfg={"default": "kimi-k2.6"},
+    )
+
+    assert resolved["provider"] == "kimi-coding-cn"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://api.kimi.com/coding"
+
+
+def test_kimi_coding_legacy_moonshot_base_url_not_stripped():
+    """Legacy api.moonshot.ai/v1 keys go through chat_completions — the /v1
+    suffix is part of the OpenAI-compat path and must NOT be stripped."""
+    resolved = rp._resolve_runtime_from_pool_entry(
+        provider="kimi-coding",
+        entry=_fake_entry("https://api.moonshot.ai/v1"),
+        requested_provider="kimi-coding",
+        model_cfg={"default": "kimi-k2"},
+    )
+
+    assert resolved["provider"] == "kimi-coding"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://api.moonshot.ai/v1"


### PR DESCRIPTION
Closes #21297.

## Problem

`kimi-coding` and `kimi-coding-cn` are auto-detected as `anthropic_messages` when the resolved base URL matches `api.kimi.com/coding` (see `_detect_api_mode_for_url`, `hermes_cli/runtime_provider.py:84`). The Anthropic SDK appends its own `/v1/messages`, so a base URL ending in `/v1` produced:

```
https://api.kimi.com/coding/v1   +   /v1/messages
= https://api.kimi.com/coding/v1/v1/messages   →   HTTP 404
```

Every request through `kimi-coding` failed with `HTTP 404: The requested resource was not found` after 3 retries.

## Root cause

The post-resolve `/v1` strip block at `hermes_cli/runtime_provider.py:285` was scoped to OpenCode only:

```python
if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
    base_url = re.sub(r"/v1/?$", "", base_url)
```

`kimi-coding` / `kimi-coding-cn` have the same OpenAI-wire base + Anthropic-wire protocol shape but were never added to the allow-list.

## Fix

Add `kimi-coding` and `kimi-coding-cn` to the same allow-list, with an updated comment that names both providers:

```diff
-    if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
+    if api_mode == "anthropic_messages" and provider in (
+        "opencode-zen", "opencode-go", "kimi-coding", "kimi-coding-cn",
+    ):
         base_url = re.sub(r"/v1/?$", "", base_url)
```

I went with the targeted allow-list rather than the defensive "always strip" variant suggested in the issue. The legacy `api.moonshot.ai/v1` endpoint for `kimi-coding` stays on `chat_completions` (the `/v1` there is part of the OpenAI-compat path and must NOT be stripped); the regression test below covers that case explicitly so a future drift doesn't break it.

## Tests

New: `tests/hermes_cli/test_runtime_provider_kimi_coding_v1.py` — three tests calling `_resolve_runtime_from_pool_entry` directly with a fake pool entry:

1. `kimi-coding` + `api.kimi.com/coding/v1` → `anthropic_messages`, base stripped to `api.kimi.com/coding`.
2. `kimi-coding-cn` + `api.kimi.com/coding/v1` → same.
3. `kimi-coding` + `api.moonshot.ai/v1` → `chat_completions`, `/v1` preserved (not in strip list, correct behavior).

```bash
python -m pytest -o addopts= tests/hermes_cli/test_runtime_provider_kimi_coding_v1.py -q
3 passed
```

## Out of scope

- The defensive "always strip /v1 when api_mode == anthropic_messages" variant. That would also catch any future Anthropic-wire third-party with a `/v1`-suffixed base URL but would change behavior for providers I haven't audited; the targeted fix mirrors the existing OpenCode pattern and is the minimal change.
- The `_resolve_kimi_base_url()` rewrite path itself. The bug surfaces only after that resolves to `api.kimi.com/coding/v1`; the strip is the correct site to fix it.