### PR TITLE
fix(tests): avoid asyncio DeprecationWarning in event loop fixture on…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -483,15 +483,26 @@ def _ensure_current_event_loop(request):
     A number of gateway tests still use asyncio.get_event_loop().run_until_complete(...).
     Ensure they always have a usable loop without interfering with pytest-asyncio's
     own loop management for @pytest.mark.asyncio tests.
+
+    On Python 3.12+, ``asyncio.get_event_loop_policy().get_event_loop()`` with no
+    *running* loop emits DeprecationWarning; skip that path and install a fresh
+    loop via ``new_event_loop()`` instead.
     """
     if request.node.get_closest_marker("asyncio") is not None:
         yield
         return
 
+    loop = None
     try:
-        loop = asyncio.get_event_loop_policy().get_event_loop()
+        loop = asyncio.get_running_loop()
     except RuntimeError:
-        loop = None
+        pass
+
+    if loop is None and sys.version_info < (3, 12):
+        try:
+            loop = asyncio.get_event_loop_policy().get_event_loop()
+        except RuntimeError:
+            loop = None
 
     created = loop is None or loop.is_closed()
     if created:


### PR DESCRIPTION
## What does this PR do?

The autouse fixture _ensure_current_event_loop in tests/conftest.py calls asyncio.get_event_loop_policy().get_event_loop() to give plain synchronous tests a usable loop. On Python 3.12+, that call emits DeprecationWarning: There is no current event loop whenever no loop is currently running, which clutters the test output and is scheduled for removal in a future Python release.

This PR avoids the deprecated path on 3.12+ while preserving existing behavior:

1. Try asyncio.get_running_loop() first — never deprecated.
2. Only fall back to policy.get_event_loop() when sys.version_info < (3, 12) (keeps current behavior on 3.11 / CI).
3. On 3.12+, loop stays None and we go through the existing new_event_loop() branch — same outcome, no warning.
@pytest.mark.asyncio tests are unaffected (the fixture early-returns when the marker is present).


## Related Issue

N/A — small future-proofing fix surfaced while running the suite locally on Python 3.12.

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

tests/conftest.py — In _ensure_current_event_loop, prefer asyncio.get_running_loop() and skip policy.get_event_loop() on Python 3.12+ to avoid DeprecationWarning: There is no current event loop. Behavior on 3.11 unchanged.

- 

## How to Test

1. Activate the project venv (Python 3.12+).
2. Run a small subset: `scripts/run_tests.sh tests/test_hermes_constants.py`
3. Confirm no DeprecationWarning: There is no current event loop lines appear in the warnings summary.
4. Run a broader slice (e.g. scripts/run_tests.sh tests/gateway/test_platform_base.py) to confirm sync gateway tests still get a usable loop and pass.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

**Before (Python 3.12.5, on main):**
tests/test_hermes_constants.py::TestGetDefaultHermesRoot::test_no_hermes_home_returns_native
  /Users/.../tests/conftest.py:492: DeprecationWarning: There is no current event loop
    loop = asyncio.get_event_loop_policy().get_event_loop()
11 passed, 4 warnings in 2.96s

**After (this branch):**
11 passed in 2.0s
(no DeprecationWarning: There is no current event loop lines)

