### PR TITLE
fix: lazily load extra gateway document types

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -786,6 +786,67 @@ SUPPORTED_DOCUMENT_TYPES = {
 }
 
 
+def _get_extra_document_types() -> Dict[str, str]:
+    """Return YAML-configured extra document types.
+
+    Reads ``gateway.extra_document_types`` lazily from config.yaml.  This avoids
+    loading config while this module is imported and lets config reloads affect
+    document handling without rebuilding the module-level constant.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception as exc:
+        logger.debug("Could not load extra document types from config: %s", exc)
+        return {}
+
+    gateway_cfg = cfg.get("gateway", {}) if isinstance(cfg, dict) else {}
+    extra_raw = gateway_cfg.get("extra_document_types") if isinstance(gateway_cfg, dict) else None
+    if not isinstance(extra_raw, dict):
+        return {}
+
+    extra: Dict[str, str] = {}
+    for ext, mime in extra_raw.items():
+        if not isinstance(ext, str) or not isinstance(mime, str):
+            logger.warning("Ignoring invalid document type entry: %r -> %r", ext, mime)
+            continue
+        ext = ext.strip().lower()
+        mime = mime.strip()
+        if not ext.startswith(".") or "/" not in mime:
+            logger.warning("Ignoring invalid document type entry: %r -> %r", ext, mime)
+            continue
+        extra[ext] = mime
+    return extra
+
+
+def get_supported_document_types() -> Dict[str, str]:
+    """Return built-in document types plus YAML-configured extensions."""
+    document_types = dict(SUPPORTED_DOCUMENT_TYPES)
+    document_types.update(_get_extra_document_types())
+    return document_types
+
+
+def get_document_extension_for_mime(mime_type: Optional[str]) -> str:
+    """Return the configured document extension for a MIME type, if any."""
+    if not mime_type:
+        return ""
+    mime_to_ext = {mime: ext for ext, mime in get_supported_document_types().items()}
+    return mime_to_ext.get(mime_type, "")
+
+
+def get_document_mime_type(ext: str) -> Optional[str]:
+    """Return the configured MIME type for a document extension, if supported."""
+    if not ext:
+        return None
+    return get_supported_document_types().get(ext.lower())
+
+
+def is_supported_document_type(ext: str) -> bool:
+    """Return whether a document extension is built-in or configured in YAML."""
+    return get_document_mime_type(ext) is not None
+
+
 def get_document_cache_dir() -> Path:
     """Return the document cache directory, creating it if it doesn't exist."""
     DOCUMENT_CACHE_DIR.mkdir(parents=True, exist_ok=True)

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -63,7 +63,8 @@ from gateway.platforms.base import (
     cache_audio_from_url,
     cache_audio_from_bytes,
     cache_document_from_bytes,
-    SUPPORTED_DOCUMENT_TYPES,
+    get_document_extension_for_mime,
+    get_document_mime_type,
 )
 from tools.url_safety import is_safe_url
 
@@ -4150,7 +4151,8 @@ class DiscordAdapter(BasePlatformAdapter):
                         if att.filename:
                             _, doc_ext = os.path.splitext(att.filename)
                             doc_ext = doc_ext.lower()
-                        if doc_ext in SUPPORTED_DOCUMENT_TYPES:
+                        doc_mime = get_document_mime_type(doc_ext)
+                        if doc_mime is not None:
                             msg_type = MessageType.DOCUMENT
                     break
 
@@ -4233,9 +4235,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     _, ext = os.path.splitext(att.filename)
                     ext = ext.lower()
                 if not ext and content_type:
-                    mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
-                    ext = mime_to_ext.get(content_type, "")
-                if ext not in SUPPORTED_DOCUMENT_TYPES:
+                    ext = get_document_extension_for_mime(content_type)
+                doc_mime = get_document_mime_type(ext)
+                if doc_mime is None:
                     logger.warning(
                         "[Discord] Unsupported document type '%s' (%s), skipping",
                         ext or "unknown", content_type,
@@ -4253,7 +4255,6 @@ class DiscordAdapter(BasePlatformAdapter):
                             cached_path = cache_document_from_bytes(
                                 raw_bytes, att.filename or f"document{ext}"
                             )
-                            doc_mime = SUPPORTED_DOCUMENT_TYPES[ext]
                             media_urls.append(cached_path)
                             media_types.append(doc_mime)
                             logger.info("[Discord] Cached user document: %s", cached_path)

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -133,11 +133,13 @@ from gateway.platforms.base import (
     MessageType,
     ProcessingOutcome,
     SendResult,
-    SUPPORTED_DOCUMENT_TYPES,
     cache_document_from_bytes,
     cache_image_from_url,
     cache_audio_from_bytes,
     cache_image_from_bytes,
+    get_document_extension_for_mime,
+    get_document_mime_type,
+    get_supported_document_types,
 )
 from gateway.status import acquire_scoped_lock, release_scoped_lock
 from hermes_constants import get_hermes_home
@@ -169,7 +171,6 @@ _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incor
 _IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}
 _AUDIO_EXTENSIONS = {".ogg", ".mp3", ".wav", ".m4a", ".aac", ".flac", ".opus", ".webm"}
 _VIDEO_EXTENSIONS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".m4v", ".3gp"}
-_DOCUMENT_MIME_TO_EXT = {mime: ext for ext, mime in SUPPORTED_DOCUMENT_TYPES.items()}
 _FEISHU_IMAGE_UPLOAD_TYPE = "message"
 _FEISHU_FILE_UPLOAD_TYPE = "stream"
 _FEISHU_OPUS_UPLOAD_EXTENSIONS = {".ogg", ".opus"}
@@ -2944,7 +2945,8 @@ class FeishuAdapter(BasePlatformAdapter):
     @staticmethod
     def _guess_remote_extension(url: str, *, default: str) -> str:
         ext = Path((url or "").split("?", 1)[0]).suffix.lower()
-        return ext if ext in (_IMAGE_EXTENSIONS | _AUDIO_EXTENSIONS | _VIDEO_EXTENSIONS | set(SUPPORTED_DOCUMENT_TYPES)) else default
+        document_types = get_supported_document_types()
+        return ext if ext in (_IMAGE_EXTENSIONS | _AUDIO_EXTENSIONS | _VIDEO_EXTENSIONS | set(document_types)) else default
 
     @staticmethod
     def _derive_remote_filename(file_url: str, *, content_type: str, default_name: str, default_ext: str) -> str:
@@ -3432,8 +3434,9 @@ class FeishuAdapter(BasePlatformAdapter):
                     logger.info("[Feishu] Cached message video resource at %s", cached_path)
                     return cached_path, media_type
 
-                if not Path(filename).suffix and media_type in _DOCUMENT_MIME_TO_EXT:
-                    filename = f"{filename}{_DOCUMENT_MIME_TO_EXT[media_type]}"
+                doc_ext = get_document_extension_for_mime(media_type)
+                if not Path(filename).suffix and doc_ext:
+                    filename = f"{filename}{doc_ext}"
                 cached_path = cache_document_from_bytes(raw_bytes, filename)
                 logger.info("[Feishu] Cached message document resource at %s", cached_path)
                 return cached_path, (media_type or self._guess_document_media_type(filename))
@@ -3483,7 +3486,7 @@ class FeishuAdapter(BasePlatformAdapter):
     @staticmethod
     def _guess_document_media_type(filename: str) -> str:
         ext = Path(filename or "").suffix.lower()
-        return SUPPORTED_DOCUMENT_TYPES.get(ext, mimetypes.guess_type(filename or "")[0] or "application/octet-stream")
+        return get_document_mime_type(ext) or mimetypes.guess_type(filename or "")[0] or "application/octet-stream"
 
     @staticmethod
     def _display_name_from_cached_path(path: str) -> str:

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -42,7 +42,8 @@ from gateway.platforms.base import (
     MessageType,
     ProcessingOutcome,
     SendResult,
-    SUPPORTED_DOCUMENT_TYPES,
+    get_document_extension_for_mime,
+    get_document_mime_type,
     is_host_excluded_by_no_proxy,
     resolve_proxy_url,
     safe_url_for_log,
@@ -2037,10 +2038,10 @@ class SlackAdapter(BasePlatformAdapter):
 
                     # Fallback: reverse-lookup from MIME type
                     if not ext and mimetype:
-                        mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
-                        ext = mime_to_ext.get(mimetype, "")
+                        ext = get_document_extension_for_mime(mimetype)
 
-                    if ext not in SUPPORTED_DOCUMENT_TYPES:
+                    doc_mime = get_document_mime_type(ext)
+                    if doc_mime is None:
                         continue  # Skip unsupported file types silently
 
                     # Check file size (Slack limit: 20 MB for bots)
@@ -2055,7 +2056,6 @@ class SlackAdapter(BasePlatformAdapter):
                     cached_path = cache_document_from_bytes(
                         raw_bytes, original_filename or f"document{ext}"
                     )
-                    doc_mime = SUPPORTED_DOCUMENT_TYPES[ext]
                     media_urls.append(cached_path)
                     media_types.append(doc_mime)
                     logger.debug("[Slack] Cached user document: %s", cached_path)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -75,7 +75,9 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     resolve_proxy_url,
     SUPPORTED_VIDEO_TYPES,
-    SUPPORTED_DOCUMENT_TYPES,
+    get_document_extension_for_mime,
+    get_document_mime_type,
+    get_supported_document_types,
     utf16_len,
     _prefix_within_utf16_limit,
 )
@@ -3284,12 +3286,17 @@ class TelegramAdapter(BasePlatformAdapter):
                 # uppercase like "IMAGE/PNG").
                 doc_mime = (doc.mime_type or "").lower()
 
-                # If no extension from filename, reverse-lookup from MIME type
+                # If no extension from filename, reverse-lookup from MIME type.
+                # Prefer image/video special handling, otherwise use the lazily
+                # loaded document type map (built-ins + gateway.extra_document_types).
                 if not ext and doc_mime:
                     ext = _TELEGRAM_IMAGE_MIME_TO_EXT.get(doc_mime, "")
                     if not ext:
-                        mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
-                        ext = mime_to_ext.get(doc_mime, "")
+                        ext = get_document_extension_for_mime(doc_mime)
+
+                if not ext and doc_mime:
+                    video_mime_to_ext = {v: k for k, v in SUPPORTED_VIDEO_TYPES.items()}
+                    ext = video_mime_to_ext.get(doc_mime, "")
 
                 # Check file size early so image documents cannot bypass the
                 # document size limit by taking the image path.
@@ -3334,10 +3341,6 @@ class TelegramAdapter(BasePlatformAdapter):
                         self._enqueue_photo_event(batch_key, event)
                     return
 
-                if not ext and doc.mime_type:
-                    video_mime_to_ext = {v: k for k, v in SUPPORTED_VIDEO_TYPES.items()}
-                    ext = video_mime_to_ext.get(doc.mime_type, "")
-
                 if ext in SUPPORTED_VIDEO_TYPES:
                     file_obj = await doc.get_file()
                     video_bytes = await file_obj.download_as_bytearray()
@@ -3349,9 +3352,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     await self.handle_message(event)
                     return
 
+                mime_type = get_document_mime_type(ext)
+
                 # Check if supported
-                if ext not in SUPPORTED_DOCUMENT_TYPES:
-                    supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
+                if mime_type is None:
+                    supported_list = ", ".join(sorted(get_supported_document_types().keys()))
                     event.text = (
                         f"Unsupported document type '{ext or 'unknown'}'. "
                         f"Supported types: {supported_list}"
@@ -3365,7 +3370,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 doc_bytes = await file_obj.download_as_bytearray()
                 raw_bytes = bytes(doc_bytes)
                 cached_path = cache_document_from_bytes(raw_bytes, original_filename or f"document{ext}")
-                mime_type = SUPPORTED_DOCUMENT_TYPES[ext]
                 event.media_urls = [cached_path]
                 event.media_types = [mime_type]
                 logger.info("[Telegram] Cached user document at %s", cached_path)

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -165,9 +165,9 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
-    SUPPORTED_DOCUMENT_TYPES,
     cache_image_from_url,
     cache_audio_from_url,
+    get_document_mime_type,
 )
 
 
@@ -1133,7 +1133,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                     # Local file path — bridge already downloaded the document
                     cached_urls.append(url)
                     ext = Path(url).suffix.lower()
-                    mime = SUPPORTED_DOCUMENT_TYPES.get(ext, "application/octet-stream")
+                    mime = get_document_mime_type(ext) or "application/octet-stream"
                     media_types.append(mime)
                     print(f"[{self.name}] Using bridge-cached document: {url}", flush=True)
                 elif msg_type == MessageType.VIDEO and os.path.isabs(url):

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -16,6 +16,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     cleanup_document_cache,
     get_document_cache_dir,
+    get_supported_document_types,
 )
 
 # ---------------------------------------------------------------------------
@@ -155,3 +156,61 @@ class TestSupportedDocumentTypes:
     )
     def test_expected_extensions_present(self, ext):
         assert ext in SUPPORTED_DOCUMENT_TYPES
+
+    def test_get_supported_document_types_includes_yaml_extra_types(self, monkeypatch):
+        def fake_load_config():
+            return {
+                "gateway": {
+                    "extra_document_types": {
+                        ".torrent": "application/x-bittorrent",
+                    }
+                }
+            }
+
+        monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+
+        document_types = get_supported_document_types()
+
+        assert document_types[".torrent"] == "application/x-bittorrent"
+        assert document_types[".pdf"] == "application/pdf"
+
+    def test_get_supported_document_types_is_lazy_and_reflects_config_changes(self, monkeypatch):
+        configs = [
+            {"gateway": {"extra_document_types": {".foo": "application/x-foo"}}},
+            {"gateway": {"extra_document_types": {".bar": "application/x-bar"}}},
+        ]
+
+        def fake_load_config():
+            return configs.pop(0)
+
+        monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+
+        first = get_supported_document_types()
+        second = get_supported_document_types()
+
+        assert ".foo" in first
+        assert ".bar" not in first
+        assert ".bar" in second
+        assert ".foo" not in second
+
+    def test_get_supported_document_types_ignores_invalid_extra_types(self, monkeypatch):
+        def fake_load_config():
+            return {
+                "gateway": {
+                    "extra_document_types": {
+                        ".torrent": "application/x-bittorrent",
+                        "bad": "application/x-bad",
+                        ".badmime": "not-a-mime",
+                        ".notstr": 123,
+                    }
+                }
+            }
+
+        monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+
+        document_types = get_supported_document_types()
+
+        assert document_types[".torrent"] == "application/x-bittorrent"
+        assert "bad" not in document_types
+        assert ".badmime" not in document_types
+        assert ".notstr" not in document_types

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -295,6 +295,36 @@ class TestDocumentDownloadBlock:
         assert "could not be read as an image" in event.text
 
     @pytest.mark.asyncio
+    async def test_yaml_extra_document_type_cached(self, adapter, monkeypatch):
+        """gateway.extra_document_types should be honored when the document arrives."""
+        def fake_load_config():
+            return {
+                "gateway": {
+                    "extra_document_types": {
+                        ".torrent": "application/x-bittorrent",
+                    }
+                }
+            }
+
+        monkeypatch.setattr("hermes_cli.config.load_config", fake_load_config)
+        content = b"torrent bytes"
+        file_obj = _make_file_obj(content)
+        doc = _make_document(
+            file_name="movie.torrent",
+            mime_type="application/x-bittorrent",
+            file_size=len(content),
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+
+        assert event.media_urls and event.media_urls[0].endswith("movie.torrent")
+        assert event.media_types == ["application/x-bittorrent"]
+
+    @pytest.mark.asyncio
     async def test_oversized_file_rejected(self, adapter):
         doc = _make_document(file_name="huge.pdf", file_size=25 * 1024 * 1024)
         msg = _make_message(document=doc)


### PR DESCRIPTION
## Summary
- Make `gateway.extra_document_types` YAML config extend gateway document handling lazily, when documents are processed
- Remove the previous env-var fallback and avoid module-level `load_config()` at import time
- Route Telegram, Discord, Slack, Feishu, and WhatsApp document MIME/extension lookup through the lazy helper
- Rebased onto latest `origin/main` and preserved the newer Telegram image-as-document handling while adding lazy document type lookup around it

## Test Plan
- `python -m pytest tests/gateway/test_document_cache.py tests/gateway/test_telegram_documents.py -q` → 67 passed
- `python -m pytest tests/gateway/test_feishu.py tests/gateway/test_feishu_comment_rules.py tests/gateway/test_slack.py -q` → 408 passed
- `python -m py_compile gateway/platforms/base.py gateway/platforms/telegram.py gateway/platforms/discord.py gateway/platforms/slack.py gateway/platforms/feishu.py gateway/platforms/whatsapp.py`
- `git diff --check`

Notes: `tests/gateway/test_discord_document_handling.py` currently has pre-existing failures from SSRF URL blocking in the test fixture; verified the same failures on a stashed baseline.

Follow-up to #19149, addressing maintainer feedback: lazy/on-demand YAML lookup only, no import-time config load, no env fallback.
