### PR TITLE
fix(gateway): preserve transcript on /compress and hygiene auto-compress

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6223,6 +6223,7 @@ class GatewayRunner:
                                     skip_memory=True,
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
+                                    session_db=self._session_db,
                                 )
                                 try:
                                     _hyg_agent._print_fn = lambda *a, **kw: None
@@ -9450,6 +9451,7 @@ class GatewayRunner:
                 skip_memory=True,
                 enabled_toolsets=["memory"],
                 session_id=session_entry.session_id,
+                session_db=self._session_db,
             )
             try:
                 tmp_agent._print_fn = lambda *a, **kw: None

--- a/tests/gateway/test_compress_preserves_session_db.py
+++ b/tests/gateway/test_compress_preserves_session_db.py
@@ -1,0 +1,45 @@
+"""Regression test for issue #21301.
+
+The Gateway's manual /compress (`tmp_agent`) and Session Hygiene auto-compress
+(`_hyg_agent`) both build a temporary AIAgent. Both MUST pass
+``session_db=self._session_db`` so ``_compress_context()``'s session-rotate
+block runs and the original transcript is preserved with
+``end_reason='compression'``. Without it, ``rewrite_transcript`` overwrites
+the original session's messages, destroying searchable history.
+"""
+
+import re
+from pathlib import Path
+
+
+_RUN_PY = Path(__file__).resolve().parents[2] / "gateway" / "run.py"
+
+
+def _find_constructor_block(var_name: str) -> str:
+    src = _RUN_PY.read_text(encoding="utf-8")
+    pattern = re.compile(
+        rf"\b{re.escape(var_name)}\s*=\s*AIAgent\(\s*(.*?)\s*\)",
+        re.DOTALL,
+    )
+    matches = pattern.findall(src)
+    assert matches, f"{var_name} = AIAgent(...) not found in gateway/run.py"
+    # Return the first match — both call sites are unique by var_name.
+    return matches[0]
+
+
+def test_hyg_agent_passes_session_db():
+    """Session Hygiene auto-compress path."""
+    block = _find_constructor_block("_hyg_agent")
+    assert "session_db=self._session_db" in block, (
+        "_hyg_agent must pass session_db=self._session_db so "
+        "_compress_context preserves the original transcript (issue #21301)."
+    )
+
+
+def test_tmp_agent_passes_session_db():
+    """Manual /compress command path."""
+    block = _find_constructor_block("tmp_agent")
+    assert "session_db=self._session_db" in block, (
+        "tmp_agent must pass session_db=self._session_db so "
+        "_compress_context preserves the original transcript (issue #21301)."
+    )


### PR DESCRIPTION
Closes #21301.

## Problem

Manual `/compress` and Gateway Session Hygiene auto-compress both physically destroy the original transcript. Reproduction (per the issue):

1. Telegram/Discord gateway, 60+ message session.
2. Send `/compress`.
3. `state.db` shows the original session's `message_count` collapsed to the compressed count, `end_reason` is NULL, `parent_session_id` is NULL, no continuation session was created.

Documented behavior (sessions.md "Auto-Lineage on Compression") says the original should be closed with `end_reason='compression'` and a new continuation session should carry `parent_session_id` pointing back.

## Root cause

Both code paths build a temporary `AIAgent` for the compression run:

- `_handle_compress_command` at `gateway/run.py:9445` (`tmp_agent = AIAgent(...)`)
- Session Hygiene at `gateway/run.py:6218` (`_hyg_agent = AIAgent(...)`)

Neither passes `session_db=`. That makes `tmp_agent._session_db = None`, and `_compress_context()`'s session-rotate block is guarded by `if self._session_db:` (`run_agent.py:9048`), so it silently no-ops. `tmp_agent.session_id` never rotates.

The downstream safeguard added in 1544638f4 / cd2e180ef:

```python
new_session_id = tmp_agent.session_id
if new_session_id != session_entry.session_id:
    session_entry.session_id = new_session_id
    self.session_store._save()
self.session_store.rewrite_transcript(new_session_id, compressed)
```

assumes the rotate already happened. With `_session_db is None` it didn't, so `new_session_id == session_entry.session_id` and `rewrite_transcript` overwrites the original.

## Fix

Add `session_db=self._session_db` to both constructors:

```diff
 _hyg_agent = AIAgent(
     **_hyg_runtime,
     model=_hyg_model,
     max_iterations=4,
     quiet_mode=True,
     skip_memory=True,
     enabled_toolsets=["memory"],
     session_id=session_entry.session_id,
+    session_db=self._session_db,
 )
```

```diff
 tmp_agent = AIAgent(
     **runtime_kwargs,
     model=model,
     max_iterations=4,
     quiet_mode=True,
     skip_memory=True,
     enabled_toolsets=["memory"],
     session_id=session_entry.session_id,
+    session_db=self._session_db,
 )
```

Same shape as PR #20021 (ACP adapter) and PR #4802 (API server adapter), which fixed identical omissions in their respective tmp-agent constructors.

## Tests

New: `tests/gateway/test_compress_preserves_session_db.py` — two static-source assertions that both constructor call sites carry `session_db=self._session_db`. Avoids the SQLite + full AIAgent wiring a true integration test would need, which would be heavier than the bug. The reporter has independently validated end-to-end behavior in production (Telegram /compress on a 112-message session — original preserved, new session linked).

```bash
python -m pytest -o addopts= tests/gateway/test_compress_preserves_session_db.py -q
2 passed
```

## Out of scope

- The ACP / API server fixes referenced above. Already shipped.
- Refactoring `_compress_context()` to no longer require `session_db`. The `if self._session_db:` guard exists for non-gateway callers (one-shot CLI, etc.) and removing it would change behavior beyond this fix.