### PR TITLE
fix(dashboard): replace undefined resumeId with resumeParam

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -552,7 +552,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     });
 
     // WebSocket
-    const url = buildWsUrl(token, resumeId, channel);
+    const url = buildWsUrl(token, resumeParam, channel);
     const ws = new WebSocket(url);
     ws.binaryType = "arraybuffer";
     wsRef.current = ws;
@@ -657,7 +657,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         copyResetRef.current = null;
       }
     };
-  }, [channel, resumeId]);
+  }, [channel, resumeParam]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.


### PR DESCRIPTION
## Description
The variable `resumeId` was renamed to `resumeParam` in commit a0758cd1e9, but two usage sites (lines 555 and 660) were missed in the partial fix (commit b12a5a72b), causing TypeScript build errors.

## Changes
- Line 555: `buildWsUrl(token, resumeId, channel)` → `buildWsUrl(token, resumeParam, channel)`
- Line 660: `[channel, resumeId]` → `[channel, resumeParam]` in dependency array

## Fixes
- TypeScript error: "Cannot find name 'resumeId'" in ChatPage.tsx
- Build failure when running `npm run build` in the web directory

## Testing
- `npm run build` now completes successfully
- Verified the same bug exists in the main branch via GitHub raw file inspection