### PR TITLE
fix(memory): Codex 400 on 'memory' tool — strip forbidden top-level combinators + remove source allOf (salvage #21295)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -51,6 +51,7 @@ AUTHOR_MAP = {
     "piyushvp1@gmail.com": "thelumiereguy",
     "harish.kukreja@gmail.com": "counterposition",
     "cleo@edaphic.xyz": "curiouscleo",
+    "hirokazu.ogawa@kwansei.ac.jp": "hrkzogw",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
     "128259593+Gutslabs@users.noreply.github.com": "Gutslabs",
     "50326054+nocturnum91@users.noreply.github.com": "nocturnum91",

--- a/tests/tools/test_memory_tool_schema.py
+++ b/tests/tools/test_memory_tool_schema.py
@@ -1,38 +1,48 @@
+"""Schema-shape tests for the built-in memory tool.
+
+The memory tool previously used ``allOf: [{if: ..., then: {required: ...}}]``
+at the top level of ``parameters`` to hint per-action required fields.  That
+form was:
+
+  1. Ignored by every provider (Chat Completions doesn't honour ``if/then``
+     on function schemas), so it never actually enforced anything.
+  2. **Rejected outright by strict backends** — OpenAI's Codex endpoint
+     (``chatgpt.com/backend-api/codex``, gpt-5.x) returns
+     ``Invalid schema for function 'memory': schema must have type 'object'
+     and not have 'oneOf'/'anyOf'/'allOf'/'enum'/'not' at the top level``.
+
+We now rely on the runtime handler (``memory_tool()`` in ``tools/memory_tool.py``)
+to validate required fields per action and return actionable error messages.
+These tests guard the schema against regressing back to a shape strict
+backends reject.
+"""
+
 import json
+
 from tools.memory_tool import MEMORY_SCHEMA
 
 
-def test_memory_schema_requires_content_and_old_text_for_replace_action():
-    schema = MEMORY_SCHEMA["parameters"]
-    assert schema["required"] == ["action", "target"]
-
-    all_of = schema.get("allOf")
-    assert all_of, "memory schema should use conditional requirements"
-
-    replace_requirements = [
-        branch["then"].get("required", [])
-        for branch in all_of
-        if branch.get("if", {}).get("properties", {}).get("action", {}).get("const") == "replace"
-    ]
-    assert replace_requirements == [["old_text", "content"]]
+_FORBIDDEN_TOP_LEVEL_KEYS = ("allOf", "anyOf", "oneOf", "enum", "not")
 
 
-def test_memory_schema_requires_content_for_add_action():
-    add_requirements = [
-        branch["then"].get("required", [])
-        for branch in MEMORY_SCHEMA["parameters"].get("allOf", [])
-        if branch.get("if", {}).get("properties", {}).get("action", {}).get("const") == "add"
-    ]
-    assert add_requirements == [["content"]]
+def test_memory_schema_has_no_forbidden_top_level_combinators():
+    """OpenAI's Codex backend rejects these at the top level of parameters."""
+    params = MEMORY_SCHEMA["parameters"]
+    for key in _FORBIDDEN_TOP_LEVEL_KEYS:
+        assert key not in params, (
+            f"top-level {key!r} in memory tool parameters will break the "
+            "Codex backend (chatgpt.com/backend-api/codex). Per-action "
+            "required-field checks belong in the runtime handler, not the schema."
+        )
 
 
-def test_memory_schema_requires_old_text_for_remove_action():
-    remove_requirements = [
-        branch["then"].get("required", [])
-        for branch in MEMORY_SCHEMA["parameters"].get("allOf", [])
-        if branch.get("if", {}).get("properties", {}).get("action", {}).get("const") == "remove"
-    ]
-    assert remove_requirements == [["old_text"]]
+def test_memory_schema_is_well_formed():
+    params = MEMORY_SCHEMA["parameters"]
+    assert params["type"] == "object"
+    assert params["required"] == ["action", "target"]
+    # Nested ``enum`` on property values is fine — only top-level is forbidden.
+    assert params["properties"]["action"]["enum"] == ["add", "replace", "remove"]
+    assert params["properties"]["target"]["enum"] == ["memory", "user"]
 
 
 def test_memory_schema_is_json_serializable():

--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -302,3 +302,61 @@ def test_strip_none_returns_zero():
     tools, stripped = strip_pattern_and_format(None)
     assert tools is None
     assert stripped == 0
+
+
+def test_top_level_allof_stripped_for_codex_backend_compat():
+    """OpenAI Codex backend rejects top-level allOf/oneOf/anyOf/enum/not."""
+    tools = [_tool("memory", {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["add", "replace"]},
+            "content": {"type": "string"},
+        },
+        "required": ["action"],
+        "allOf": [
+            {
+                "if": {"properties": {"action": {"const": "add"}}, "required": ["action"]},
+                "then": {"required": ["content"]},
+            },
+        ],
+    })]
+    out = sanitize_tool_schemas(tools)
+    params = out[0]["function"]["parameters"]
+    assert "allOf" not in params
+    # Properties and required survive.
+    assert params["required"] == ["action"]
+    assert "content" in params["properties"]
+
+
+def test_top_level_oneof_anyof_enum_not_stripped():
+    """All five forbidden top-level combinators are dropped."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+        "oneOf": [{"required": ["x"]}],
+        "anyOf": [{"required": ["x"]}],
+        "enum": ["bogus-top-level"],
+        "not": {"required": ["y"]},
+    })]
+    out = sanitize_tool_schemas(tools)
+    params = out[0]["function"]["parameters"]
+    for key in ("oneOf", "anyOf", "enum", "not"):
+        assert key not in params, f"{key} should be stripped from top level"
+
+
+def test_nested_allof_preserved():
+    """Combinators inside a property's schema are preserved (only top is strict)."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "config": {
+                "type": "object",
+                "properties": {"mode": {"type": "string"}},
+                "allOf": [{"required": ["mode"]}],
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    nested = out[0]["function"]["parameters"]["properties"]["config"]
+    assert "allOf" in nested
+    assert nested["allOf"] == [{"required": ["mode"]}]

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -560,29 +560,6 @@ MEMORY_SCHEMA = {
             },
         },
         "required": ["action", "target"],
-        "allOf": [
-            {
-                "if": {
-                    "properties": {"action": {"const": "add"}},
-                    "required": ["action"],
-                },
-                "then": {"required": ["content"]},
-            },
-            {
-                "if": {
-                    "properties": {"action": {"const": "replace"}},
-                    "required": ["action"],
-                },
-                "then": {"required": ["old_text", "content"]},
-            },
-            {
-                "if": {
-                    "properties": {"action": {"const": "remove"}},
-                    "required": ["action"],
-                },
-                "then": {"required": ["old_text"]},
-            },
-        ],
     },
 }
 

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -84,6 +84,47 @@ def _sanitize_single_tool(tool: dict) -> dict:
     # argument coercion (``model_tools._schema_allows_null``) can still
     # map a model-emitted ``"null"`` string to Python ``None``.
     fn["parameters"] = strip_nullable_unions(fn["parameters"], keep_nullable_hint=True)
+    # Strip top-level combinators that strict backends (OpenAI's Codex
+    # endpoint at chatgpt.com/backend-api/codex) reject outright. Nested
+    # combinators inside properties are preserved.
+    fn["parameters"] = _strip_top_level_combinators(
+        fn["parameters"], path=fn.get("name", "<tool>")
+    )
+    return out
+
+
+_TOP_LEVEL_FORBIDDEN_KEYS = ("allOf", "anyOf", "oneOf", "enum", "not")
+
+
+def _strip_top_level_combinators(params: dict, *, path: str = "<tool>") -> dict:
+    """Drop combinator keywords from the top-level of a function parameters schema.
+
+    OpenAI's Codex backend (``chatgpt.com/backend-api/codex``) is stricter
+    than the public Functions API and rejects requests with::
+
+        Invalid schema for function 'X': schema must have type 'object' and
+        not have 'oneOf'/'anyOf'/'allOf'/'enum'/'not' at the top level.
+
+    These keywords are typically used for conditional required-fields hints
+    (``allOf: [{if: ..., then: {required: [...]}}]``). Removing them at the
+    top level discards the hint but does not change which argument *values*
+    are valid — the tool handler always re-validates required fields.
+
+    Only the *top* level is stripped; combinators nested inside a property's
+    schema are preserved (the strict rule only applies to the outermost
+    parameters object).
+    """
+    if not isinstance(params, dict):
+        return params
+    out = dict(params)
+    for key in _TOP_LEVEL_FORBIDDEN_KEYS:
+        if key in out:
+            logger.debug(
+                "schema_sanitizer[%s]: stripped top-level %r combinator "
+                "from tool parameters (strict-backend compat)",
+                path, key,
+            )
+            out.pop(key, None)
     return out
 
 


### PR DESCRIPTION
## Summary
Unblocks every user on `openai-codex` / gpt-5.x (Codex backend at `chatgpt.com/backend-api/codex`). Closes the 400 `Invalid schema for function 'memory'` loop multiple users reported in Discord today.

Root cause: PR #21238 added top-level `allOf: [{if/then/required}]` blocks to the built-in `memory` tool's parameters schema. The Codex backend rejects top-level `allOf`/`anyOf`/`oneOf`/`enum`/`not` outright; every other provider silently ignored the `if/then` hints, so they never enforced anything. The runtime handler in `memory_tool()` already validates per-action required fields with clean error messages.

## Changes
Two-layer fix — salvage @hrkzogw's sanitizer (defense-in-depth) **and** remove the bug at the source.

**Commit 1** (cherry-picked from @hrkzogw's #21295) — `tools/schema_sanitizer.py`:
- Adds `_strip_top_level_combinators()` to the central sanitizer (already run on every tool via `model_tools.get_tool_definitions()`).
- Strips top-level `allOf`/`anyOf`/`oneOf`/`enum`/`not`; preserves nested combinators inside property schemas.
- 3 new tests covering memory-shaped input, all five forbidden keywords, and nested-preservation.

**Commit 2** (follow-up) — root-cause removal:
- Drops the `allOf` block from `tools/memory_tool.py` MEMORY_SCHEMA.
- Rewrites `tests/tools/test_memory_tool_schema.py` to **guard against the forbidden shape** instead of asserting it (the old tests pinned the regression in place).
- `scripts/release.py`: AUTHOR_MAP entry for @hrkzogw.

## Validation
Targeted tests green (63 passed):
```
scripts/run_tests.sh tests/tools/test_memory_tool_schema.py tests/tools/test_schema_sanitizer.py tests/tools/test_memory_tool.py
```

E2E against live worktree code (real `get_tool_definitions()` + real `_responses_tools()` wire conversion):

| Path | Top-level keys on memory.parameters | Forbidden combinators |
|---|---|---|
| chat_completions (post-sanitize) | `['properties', 'required', 'type']` | none |
| codex_responses (post-adapter) | `['properties', 'required', 'type']` | none |
| Sanitizer vs. poisoned schema with all 5 combinators | stripped | none |

Nested `enum` on `properties.action.enum = ['add', 'replace', 'remove']` preserved (not forbidden at nested level).

## Credits
- @hrkzogw — sanitizer fix (#21295) cherry-picked with authorship preserved.
- @altmazza0-star — original intent (#19180/#21238) addressed via runtime validation, which was already in place.