### PR TITLE
fix(dashboard): finish resumeId -> resumeParam rename in ChatPage

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -552,7 +552,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     });
 
     // WebSocket
-    const url = buildWsUrl(token, resumeId, channel);
+    const url = buildWsUrl(token, resumeParam, channel);
     const ws = new WebSocket(url);
     ws.binaryType = "arraybuffer";
     wsRef.current = ws;
@@ -657,7 +657,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         copyResetRef.current = null;
       }
     };
-  }, [channel, resumeId]);
+  }, [channel, resumeParam]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.


### PR DESCRIPTION
## Summary
`hermes dashboard` on current main fails with `✗ Web UI build failed` for anyone who `hermes update`d in the last ~75 minutes.

Commit b12a5a72b "Follow latest child session on dashboard resume" renamed the local variable `resumeId` → `resumeParam` in `ChatPage.tsx` but missed two call sites (lines 555 and 660). `tsc -b` fails with two `TS2304: Cannot find name 'resumeId'` errors, which tanks `npm run build`.

## Changes
- `web/src/pages/ChatPage.tsx`: finish the rename at the two leftover call sites (`buildWsUrl` call + useEffect deps).

## Validation
Clean checkout of current main:
```
cd /tmp/repro3/web && npm install && npm run build
# → src/pages/ChatPage.tsx(555,35): error TS2304: Cannot find name 'resumeId'.
# → src/pages/ChatPage.tsx(660,16): error TS2304: Cannot find name 'resumeId'.
```
With this patch:
```
✓ 2048 modules transformed.
✓ built in 2.49s
```

## Credit
Supersedes #21260 by @keepcalmqqf (who proposed a 1-line alias fix). This PR finishes the rename instead so there's only one identifier for the value. Co-authored-by: qiuqfang <qiuqfang98@qq.com>.