### PR TITLE
fix(tests): avoid asyncio DeprecationWarning in event loop fixture on 3.12+

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -627,6 +627,7 @@ AUTHOR_MAP = {
     "shenuu@gmail.com": "shenuu",
     "xiayh17@gmail.com": "xiayh0107",
     "zhujianxyz@gmail.com": "opriz",
+    "tuancanhnguyen706@gmail.com": "xxxigm",
     "asurla@nvidia.com": "anniesurla",
     "limkuan24@gmail.com": "WideLee",
     "aviralarora002@gmail.com": "AviArora02-commits",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -483,15 +483,26 @@ def _ensure_current_event_loop(request):
     A number of gateway tests still use asyncio.get_event_loop().run_until_complete(...).
     Ensure they always have a usable loop without interfering with pytest-asyncio's
     own loop management for @pytest.mark.asyncio tests.
+
+    On Python 3.12+, ``asyncio.get_event_loop_policy().get_event_loop()`` with no
+    *running* loop emits DeprecationWarning; skip that path and install a fresh
+    loop via ``new_event_loop()`` instead.
     """
     if request.node.get_closest_marker("asyncio") is not None:
         yield
         return
 
+    loop = None
     try:
-        loop = asyncio.get_event_loop_policy().get_event_loop()
+        loop = asyncio.get_running_loop()
     except RuntimeError:
-        loop = None
+        pass
+
+    if loop is None and sys.version_info < (3, 12):
+        try:
+            loop = asyncio.get_event_loop_policy().get_event_loop()
+        except RuntimeError:
+            loop = None
 
     created = loop is None or loop.is_closed()
     if created:


### PR DESCRIPTION
Salvages PR #21310 by @xxxigm onto current main.

## Summary
On Python 3.12+, the autouse `_ensure_current_event_loop` fixture emits `DeprecationWarning: There is no current event loop` for every sync test, cluttering output. Prefer `asyncio.get_running_loop()`; only fall back to the deprecated `policy.get_event_loop()` on 3.11 (which is what CI runs). On 3.12+, we fall through to the existing `new_event_loop()` branch — same outcome, no warning.

## Changes
- `tests/conftest.py`: reorder loop lookup to skip the deprecated path on 3.12+ (cherry-picked from #21310, @xxxigm)
- `scripts/release.py`: add AUTHOR_MAP entry so CI doesn't block on unmapped email

## Validation
Repro on Python 3.13: `asyncio.get_event_loop_policy().get_event_loop()` emits the DeprecationWarning on current main. With this PR's logic, zero warnings and a usable loop is still returned. CI (Python 3.11) path unchanged.

Closes #21310