### PR TITLE
fix: prevent INSECURE_NO_AUTH usage on non-localhost bindings

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -125,7 +125,15 @@ class WebhookAdapter(BasePlatformAdapter):
                     f"Set 'secret' on the route or globally. "
                     f"For testing without auth, set secret to '{_INSECURE_NO_AUTH}'."
                 )
-
+          # Safety rail: Prevent INSECURE_NO_AUTH on non-localhost bindings
+            if secret == _INSECURE_NO_AUTH:
+                if self._host not in ("127.0.0.1", "localhost"):
+                    raise ValueError(
+                        f"[webhook] Route '{name}' uses INSECURE_NO_AUTH secret "
+                        f"but is bound to non-localhost host '{self._host}'. "
+                        f"INSECURE_NO_AUTH is for local testing only. "
+                        f"Refusing to start to prevent accidental exposure."
+                    )
             # deliver_only routes bypass the agent — the POST body becomes a
             # direct push notification via the configured delivery target.
             # Validate up-front so misconfiguration surfaces at startup rather


### PR DESCRIPTION
## Summary

Adds a safety rail to prevent accidental exposure of `INSECURE_NO_AUTH` in production-like environments.

As discussed in #19333, while `INSECURE_NO_AUTH` is a valid testing escape hatch, using it on a non-localhost binding (e.g., `0.0.0.0`) poses a significant security risk.

This PR implements the maintainer's suggestion:
- If a route uses `INSECURE_NO_AUTH` AND the gateway is bound to a non-localhost host, the gateway now **refuses to start** with a clear error message.
- Localhost usage (127.0.0.1) remains unaffected for developer convenience.

## Security Impact

Prevents accidental deployment of unauthenticated webhooks to public interfaces while preserving the local testing workflow.

## Files Changed

- `gateway/platforms/webhook.py`: Added validation check in `connect()` method.