### PR TITLE
fix(telegram): preserve vertical video metadata

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2377,6 +2377,77 @@ class TelegramAdapter(BasePlatformAdapter):
             print(f"[{self.name}] Failed to send document: {e}")
             return await super().send_document(chat_id, file_path, caption, file_name, reply_to)
 
+    def _telegram_video_metadata(self, video_path: str) -> tuple[Optional[int], Optional[int], Optional[int], Optional[str]]:
+        """Probe a local video and generate a Telegram-safe thumbnail.
+
+        Telegram can mis-detect vertical MP4s when the Bot API call omits
+        dimensions. Best-effort metadata keeps native playback vertical while
+        falling back cleanly if ffprobe/ffmpeg are unavailable.
+        """
+        width = height = duration = None
+        thumb_path = None
+
+        try:
+            import subprocess
+
+            probe_raw = subprocess.check_output(
+                [
+                    "ffprobe", "-v", "error",
+                    "-select_streams", "v:0",
+                    "-show_entries", "stream=width,height:format=duration",
+                    "-of", "json",
+                    video_path,
+                ],
+                stderr=subprocess.DEVNULL,
+                timeout=10,
+            )
+            probe = json.loads(probe_raw.decode("utf-8", errors="replace"))
+            stream = (probe.get("streams") or [{}])[0]
+            width = int(stream.get("width") or 0) or None
+            height = int(stream.get("height") or 0) or None
+            raw_duration = (probe.get("format") or {}).get("duration")
+            if raw_duration is not None:
+                duration = max(1, int(round(float(raw_duration))))
+
+            thumb_fd, thumb_path = tempfile.mkstemp(prefix="hermes_tg_video_thumb_", suffix=".jpg")
+            os.close(thumb_fd)
+            subprocess.run(
+                [
+                    "ffmpeg", "-y", "-ss", "0.5", "-i", video_path,
+                    "-frames:v", "1",
+                    "-vf", "scale='if(gt(iw,ih),320,-2)':'if(gt(ih,iw),320,-2)'",
+                    "-q:v", "3",
+                    thumb_path,
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=20,
+                check=True,
+            )
+        except Exception as exc:
+            logger.debug(
+                "[%s] Could not probe/generate video metadata for Telegram send: %s",
+                self.name,
+                exc,
+            )
+            if thumb_path:
+                try:
+                    os.unlink(thumb_path)
+                except OSError:
+                    pass
+            thumb_path = None
+
+        return width, height, duration, thumb_path
+
+    @staticmethod
+    def _safe_unlink(path: Optional[str]) -> None:
+        if not path:
+            return
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
     async def send_video(
         self,
         chat_id: str,
@@ -2390,23 +2461,36 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
 
+        thumb_path = None
         try:
             if not os.path.exists(video_path):
                 return SendResult(success=False, error=self._missing_media_path_error("Video", video_path))
 
+            width, height, duration, thumb_path = self._telegram_video_metadata(video_path)
             _thread = self._metadata_thread_id(metadata)
+            send_kwargs = {
+                "chat_id": int(chat_id),
+                "caption": caption[:1024] if caption else None,
+                "reply_to_message_id": int(reply_to) if reply_to else None,
+                "message_thread_id": self._message_thread_id_for_send(_thread),
+                "width": width,
+                "height": height,
+                "duration": duration,
+                "supports_streaming": True,
+            }
+
             with open(video_path, "rb") as f:
-                msg = await self._bot.send_video(
-                    chat_id=int(chat_id),
-                    video=f,
-                    caption=caption[:1024] if caption else None,
-                    reply_to_message_id=int(reply_to) if reply_to else None,
-                    message_thread_id=self._message_thread_id_for_send(_thread),
-                )
+                if thumb_path and os.path.exists(thumb_path):
+                    with open(thumb_path, "rb") as thumb:
+                        msg = await self._bot.send_video(video=f, thumbnail=thumb, **send_kwargs)
+                else:
+                    msg = await self._bot.send_video(video=f, **send_kwargs)
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             print(f"[{self.name}] Failed to send video: {e}")
             return await super().send_video(chat_id, video_path, caption, reply_to)
+        finally:
+            self._safe_unlink(thumb_path)
 
     async def send_image(
         self,

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -852,3 +852,47 @@ class TestSendVideo:
 
         call_kwargs = connected_adapter._bot.send_video.call_args[1]
         assert call_kwargs["message_thread_id"] == 789
+
+
+class TestTelegramSendVideo:
+    @pytest.mark.asyncio
+    async def test_send_video_passes_explicit_dimensions_and_thumbnail(self, adapter, tmp_path):
+        video_path = tmp_path / "vertical.mp4"
+        video_path.write_bytes(b"fake-video")
+        thumb_path = tmp_path / "thumb.jpg"
+        thumb_path.write_bytes(b"fake-thumb")
+
+        adapter._bot = MagicMock()
+        adapter._bot.send_video = AsyncMock(return_value=SimpleNamespace(message_id=123))
+        adapter._telegram_video_metadata = MagicMock(return_value=(720, 1280, 36, str(thumb_path)))
+
+        result = await adapter.send_video(chat_id="100", video_path=str(video_path), caption="hello")
+
+        assert result.success is True
+        adapter._bot.send_video.assert_awaited_once()
+        kwargs = adapter._bot.send_video.await_args.kwargs
+        assert kwargs["width"] == 720
+        assert kwargs["height"] == 1280
+        assert kwargs["duration"] == 36
+        assert kwargs["supports_streaming"] is True
+        assert "thumbnail" in kwargs
+        assert not thumb_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_send_video_works_without_probe_metadata(self, adapter, tmp_path):
+        video_path = tmp_path / "video.mp4"
+        video_path.write_bytes(b"fake-video")
+
+        adapter._bot = MagicMock()
+        adapter._bot.send_video = AsyncMock(return_value=SimpleNamespace(message_id=124))
+        adapter._telegram_video_metadata = MagicMock(return_value=(None, None, None, None))
+
+        result = await adapter.send_video(chat_id="100", video_path=str(video_path))
+
+        assert result.success is True
+        kwargs = adapter._bot.send_video.await_args.kwargs
+        assert kwargs["width"] is None
+        assert kwargs["height"] is None
+        assert kwargs["duration"] is None
+        assert kwargs["supports_streaming"] is True
+        assert "thumbnail" not in kwargs


### PR DESCRIPTION
## Summary

Fixes Telegram native video uploads sometimes displaying valid vertical MP4s as square videos.

The Telegram adapter previously called `send_video()` without explicit video metadata, leaving Telegram to infer width, height, duration, and thumbnail. In real Telegram testing, valid 720×1280 MP4s could arrive as square previews/playback, while the local originals remained correct 9:16.

This change probes local videos before upload and passes:

- `width`
- `height`
- `duration`
- `supports_streaming=True`
- a generated thumbnail when possible

The metadata/thumbnail probe is best-effort. If `ffprobe` or `ffmpeg` is unavailable, sending falls back to the normal native video path with `supports_streaming=True`.

## Test plan

- Added Telegram adapter tests for explicit video metadata and thumbnail forwarding
- Added fallback test when video metadata generation is unavailable
- Ran:

```bash
python -m pytest tests/gateway/test_telegram_documents.py -q
```

Result: `41 passed`

## Manual verification

A previously affected 720×1280 MP4 that Telegram displayed as square was resent through the patched Telegram adapter. The same file then arrived in Telegram as proper 9:16 in both preview and full-screen playback.
