### PR TITLE
fix(gateway): honor discord.no_thread_channels from config.yaml

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3551,6 +3551,27 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
 
+    def _discord_no_thread_channels(self) -> set:
+        """Return Discord channel IDs where auto-threading is suppressed.
+
+        Reads ``discord.no_thread_channels`` from ``self.config.extra`` first,
+        falling back to ``DISCORD_NO_THREAD_CHANNELS`` env var when the YAML
+        key is unset. Mirrors ``_discord_free_response_channels`` so the YAML
+        key advertised in the example config behaves consistently with its
+        sibling keys (``free_response_channels``, ``allowed_channels``).
+        """
+        raw = self.config.extra.get("no_thread_channels")
+        if raw is None:
+            raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        # Coerce non-list scalars (str/int/float) to str before splitting,
+        # matching _discord_free_response_channels.
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
+        return set()
+
     def _thread_parent_channel(self, channel: Any) -> Any:
         """Return the parent text channel when invoked from a thread."""
         return getattr(channel, "parent", None) or channel
@@ -4117,8 +4138,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # no_thread_channels: channels where bot responds directly without thread.
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
-            no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
-            no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
+            no_thread_channels = self._discord_no_thread_channels()
             skip_thread = bool(channel_ids & no_thread_channels)
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -447,16 +447,17 @@ async def test_discord_voice_linked_channel_skips_mention_requirement_and_auto_t
 
 
 @pytest.mark.asyncio
-async def test_discord_free_channel_skips_auto_thread(adapter, monkeypatch):
-    """Free-response channels must NOT auto-create threads — bot replies inline.
+async def test_discord_free_channel_skips_auto_thread_when_opted_out(adapter, monkeypatch):
+    """Free-response channels can opt out of auto-threading via the no_thread_channels list.
 
-    Without this, every message in a free-response channel would spin off a
-    thread (since the channel bypasses the @mention gate), defeating the
-    lightweight-chat purpose of free-response mode.
+    Per ad4542bf6d, free-response channels no longer skip auto-thread by
+    default — users must opt out explicitly via DISCORD_NO_THREAD_CHANNELS or
+    (now, with this change honoring it from YAML) discord.no_thread_channels.
     """
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
     monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)  # default true
+    adapter.config.extra["no_thread_channels"] = ["789"]
 
     adapter._auto_create_thread = AsyncMock()
 
@@ -488,3 +489,84 @@ async def test_discord_voice_linked_parent_thread_still_requires_mention(adapter
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _discord_no_thread_channels: parser tests (mirror _discord_free_response_channels)
+# ---------------------------------------------------------------------------
+
+
+def test_discord_no_thread_channels_default_empty(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    assert adapter._discord_no_thread_channels() == set()
+
+
+def test_discord_no_thread_channels_list(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    adapter.config.extra["no_thread_channels"] = ["789", "999"]
+    assert adapter._discord_no_thread_channels() == {"789", "999"}
+
+
+def test_discord_no_thread_channels_csv_string(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    adapter.config.extra["no_thread_channels"] = "789, 999"
+    assert adapter._discord_no_thread_channels() == {"789", "999"}
+
+
+def test_discord_no_thread_channels_bare_int(adapter, monkeypatch):
+    # YAML `discord.no_thread_channels: 1499840531935662140` (single bare int)
+    # must coerce to str, matching free_response_channels behavior.
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    adapter.config.extra["no_thread_channels"] = 1499840531935662140
+    assert adapter._discord_no_thread_channels() == {"1499840531935662140"}
+
+
+def test_discord_no_thread_channels_int_list(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    adapter.config.extra["no_thread_channels"] = [1499840531935662140, 99999]
+    assert adapter._discord_no_thread_channels() == {"1499840531935662140", "99999"}
+
+
+def test_discord_no_thread_channels_empty_string(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    adapter.config.extra["no_thread_channels"] = ""
+    assert adapter._discord_no_thread_channels() == set()
+
+
+def test_discord_no_thread_channels_env_var_fallback(adapter, monkeypatch):
+    """When YAML key is unset, env var is honored (preserves existing behavior)."""
+    adapter.config.extra.pop("no_thread_channels", None)
+    monkeypatch.setenv("DISCORD_NO_THREAD_CHANNELS", "789,999")
+    assert adapter._discord_no_thread_channels() == {"789", "999"}
+
+
+def test_discord_no_thread_channels_yaml_takes_precedence_over_env(adapter, monkeypatch):
+    """When YAML key is set, env var is ignored (YAML is the source of truth)."""
+    adapter.config.extra["no_thread_channels"] = ["111"]
+    monkeypatch.setenv("DISCORD_NO_THREAD_CHANNELS", "789,999")
+    assert adapter._discord_no_thread_channels() == {"111"}
+
+
+@pytest.mark.asyncio
+async def test_discord_no_thread_channels_from_config_skips_auto_thread(adapter, monkeypatch):
+    """Channel listed in discord.no_thread_channels (YAML) must not auto-thread.
+
+    Regression guard: prior to this change, the YAML key was silently ignored
+    because the threading code read only DISCORD_NO_THREAD_CHANNELS env var.
+    """
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)  # default true
+    adapter.config.extra["no_thread_channels"] = ["789"]
+
+    adapter._auto_create_thread = AsyncMock()
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="message in no-thread channel",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()


### PR DESCRIPTION
## Summary

`gateway/platforms/discord.py` reads the auto-thread suppression list only from the `DISCORD_NO_THREAD_CHANNELS` env var, so the `discord.no_thread_channels` key in `config.yaml` — sibling to `free_response_channels` and `allowed_channels`, both of which already read from `self.config.extra` — is silently ignored.

This PR adds `_discord_no_thread_channels()` mirroring the existing `_discord_free_response_channels()` and wires the threading site to call it.

## Why this matters

Users following the `cli-config.yaml.example` style and setting

```yaml
discord:
  no_thread_channels: '1499840531935662140'
```

reasonably expect that channel to skip auto-threading. Today it doesn't — the YAML key is a no-op. After this PR it works the same way as `free_response_channels` and `allowed_channels`.

This also gives users a clean YAML-native opt-out for the auto-threading in free-response channels (the documented escape hatch from [`ad4542bf6d`](https://github.com/NousResearch/hermes-agent/commit/ad4542bf6d)'s commit message).

## Changes

1. **New helper** `_discord_no_thread_channels()` — reads `self.config.extra["no_thread_channels"]`, falls back to `DISCORD_NO_THREAD_CHANNELS` env var, accepts list or comma-separated scalar, coerces bare ints (matches the bare-int fix from `_discord_free_response_channels`).
2. **Threading site** at the auto-thread suppression check now calls the helper instead of reading the env var directly.
3. **Fixes orphaned test** `test_discord_free_channel_skips_auto_thread` — broken on `main` since [`ad4542bf6d`](https://github.com/NousResearch/hermes-agent/commit/ad4542bf6d) removed the unconditional `skip_thread` for free-response channels but didn't update or remove this test. Renamed to `..._when_opted_out` and updated to use the new YAML opt-out path, matching that commit's documented intent.

## Tests

- 8 new parser tests for `_discord_no_thread_channels` (default empty, list, CSV string, bare int, int list, empty string, env-var fallback, YAML precedence over env).
- 1 new integration test asserting a YAML-configured no-thread channel actually skips auto-threading.
- Orphaned test now passes.

Run: `pytest tests/gateway/test_discord_free_response.py` → 31 passed.

## Backwards compatibility

Fully compatible. If `discord.no_thread_channels` is unset in YAML, the helper falls through to `DISCORD_NO_THREAD_CHANNELS` env var (unchanged existing behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)