### PR TITLE
fix: send lark-cli auth links as Feishu cards

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -66,7 +66,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List, Literal, Optional, Sequence
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
+from urllib.parse import parse_qs, urlencode, urlsplit
 from urllib.request import Request, urlopen
 
 # aiohttp/websockets are independent optional deps — import outside lark_oapi
@@ -162,6 +162,63 @@ _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_LARK_CLI_AUTH_URL_RE = re.compile(
+    r"https?://accounts\.(?:feishu\.cn|larksuite\.com)/oauth/v\d+/device/verify[^\s)]*",
+    re.IGNORECASE,
+)
+_LARK_CLI_NEARBY_CODE_RE = re.compile(
+    r"(?:授权码|user[ _-]?code)[：:\s]*([A-Za-z0-9]{2,}-[A-Za-z0-9]{2,})",
+    re.IGNORECASE,
+)
+
+
+def _detect_lark_cli_auth(content: str) -> Optional[Dict[str, str]]:
+    url_match = _LARK_CLI_AUTH_URL_RE.search(content or "")
+    if not url_match:
+        return None
+
+    url = url_match.group(0).rstrip(".,;)\"'>]")
+    parsed_query = parse_qs(urlsplit(url).query)
+    user_code = (parsed_query.get("user_code") or [""])[0]
+    if not user_code:
+        nearby = _LARK_CLI_NEARBY_CODE_RE.search(content)
+        if nearby:
+            user_code = nearby.group(1)
+    return {"url": url, "user_code": user_code}
+
+
+def _build_lark_cli_auth_card(auth: Dict[str, str]) -> str:
+    url = auth["url"]
+    user_code = auth.get("user_code") or ""
+    body_lines = ["Hermes 需要你在浏览器完成 lark-cli 设备授权。"]
+    if user_code:
+        body_lines.append(f"**授权码：** `{user_code}`")
+    body_lines.append(f"验证链接：{url}")
+    card = {
+        "config": {"wide_screen_mode": True},
+        "header": {
+            "title": {"tag": "plain_text", "content": "lark-cli 授权请求"},
+            "template": "blue",
+        },
+        "elements": [
+            {"tag": "markdown", "content": "\n".join(body_lines)},
+            {
+                "tag": "action",
+                "actions": [
+                    {
+                        "tag": "button",
+                        "text": {
+                            "tag": "plain_text",
+                            "content": f"前往授权（{user_code}）" if user_code else "前往授权",
+                        },
+                        "type": "primary",
+                        "url": url,
+                    }
+                ],
+            },
+        ],
+    }
+    return json.dumps(card, ensure_ascii=False)
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -1704,6 +1761,22 @@ class FeishuAdapter(BasePlatformAdapter):
         """Send a Feishu message."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
+
+        auth_info = _detect_lark_cli_auth(content)
+        if auth_info:
+            try:
+                response = await self._feishu_send_with_retry(
+                    chat_id=chat_id,
+                    msg_type="interactive",
+                    payload=_build_lark_cli_auth_card(auth_info),
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+                if self._response_succeeded(response):
+                    return self._finalize_send_result(response, "send failed")
+                logger.warning("[Feishu] lark-cli auth card send failed; falling back to text")
+            except Exception as exc:
+                logger.warning("[Feishu] lark-cli auth card send raised %s; falling back to text", exc)
 
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2090,6 +2090,157 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(sleeps, [])
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_lark_cli_auth_url_emits_interactive_card(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_card"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = (
+            "Please authorize lark-cli:\n"
+            "https://accounts.feishu.cn/oauth/v1/device/verify"
+            "?client_id=abc&user_code=QH9C-8N7F\n"
+            "授权码： QH9C-8N7F"
+        )
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=content))
+
+        self.assertTrue(result.success)
+        request = captured["request"]
+        self.assertEqual(request.request_body.msg_type, "interactive")
+        card = json.loads(request.request_body.content)
+        flat = json.dumps(card, ensure_ascii=False)
+        self.assertIn("QH9C-8N7F", flat)
+        self.assertIn(
+            "https://accounts.feishu.cn/oauth/v1/device/verify",
+            flat,
+        )
+
+        button = self._find_card_button(card)
+        self.assertIsNotNone(button)
+        self.assertIn("user_code=QH9C-8N7F", button["url"])
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_lark_cli_auth_card_uses_nearby_code_when_url_lacks_user_code(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_card"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = (
+            "请在浏览器完成授权：<https://accounts.feishu.cn/oauth/v1/device/verify"
+            "?client_id=abc>\n"
+            "授权码： NH4U-VS8G"
+        )
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=content))
+
+        self.assertTrue(result.success)
+        request = captured["request"]
+        self.assertEqual(request.request_body.msg_type, "interactive")
+        card = json.loads(request.request_body.content)
+        flat = json.dumps(card, ensure_ascii=False)
+        self.assertIn("NH4U-VS8G", flat)
+
+        button = self._find_card_button(card)
+        self.assertIsNotNone(button)
+        self.assertIn("NH4U-VS8G", button["text"]["content"])
+        self.assertFalse(button["url"].endswith(">"))
+        self.assertTrue(
+            button["url"].startswith(
+                "https://accounts.feishu.cn/oauth/v1/device/verify"
+            )
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_lark_cli_auth_url_falls_back_to_text_when_card_fails(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        calls = []
+
+        class _MessageAPI:
+            def create(self, request):
+                calls.append(request)
+                if request.request_body.msg_type == "interactive":
+                    raise RuntimeError("interactive rejected")
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_text"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        content = (
+            "Authorize: https://accounts.larksuite.com/oauth/v1/device/verify"
+            "?user_code=ABCD-1234"
+        )
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(adapter.send(chat_id="oc_chat", content=content))
+
+        self.assertTrue(result.success)
+        self.assertGreaterEqual(len(calls), 2)
+        self.assertEqual(calls[0].request_body.msg_type, "interactive")
+        self.assertIn(calls[-1].request_body.msg_type, ("text", "post"))
+
+    @staticmethod
+    def _find_card_button(node):
+        if isinstance(node, dict):
+            if node.get("tag") == "button" and "url" in node:
+                return node
+            for value in node.values():
+                found = TestAdapterBehavior._find_card_button(value)
+                if found:
+                    return found
+        elif isinstance(node, list):
+            for item in node:
+                found = TestAdapterBehavior._find_card_button(item)
+                if found:
+                    return found
+        return None
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_document_reply_uses_thread_flag(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## Summary
- Detect lark-cli Feishu/Lark device authorization URLs in outgoing Feishu messages
- Send an interactive card with the authorization code and browser link
- Fall back to the existing text/post send path if card delivery fails

## Security
- URL matching is restricted to accounts.feishu.cn and accounts.larksuite.com device verify paths
- No tokens, secrets, or real credentials are added
- Commit author/committer use GitHub noreply identity

## Tests
- /Users/gongqi/.hermes/hermes-agent/venv/bin/pytest tests/gateway/test_feishu.py -k "lark_cli_auth" -x -o addopts="-m 'not integration'"\n- /Users/gongqi/.hermes/hermes-agent/venv/bin/pytest tests/gateway/test_feishu.py -o addopts="-m 'not integration'"\n- /Users/gongqi/.hermes/hermes-agent/venv/bin/ruff check gateway/platforms/feishu.py tests/gateway/test_feishu.py\n- git diff --check\n- diff sensitive-field scan for secret/token/key/password patterns