### PR TITLE
fix(web): rename resumeId to resumeParam in ChatPage.tsx

### DIFF
--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -552,7 +552,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     });
 
     // WebSocket
-    const url = buildWsUrl(token, resumeId, channel);
+    const url = buildWsUrl(token, resumeParam, channel);
     const ws = new WebSocket(url);
     ws.binaryType = "arraybuffer";
     wsRef.current = ws;
@@ -657,7 +657,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         copyResetRef.current = null;
       }
     };
-  }, [channel, resumeId]);
+  }, [channel, resumeParam]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.


### PR DESCRIPTION
fix(web): rename resumeId to resumeParam in ChatPage.tsx

The latest commit b12a5a72b (Follow latest child session on dashboard resume) renamed the local variable resumeId to resumeParam, but missed updating two remaining references in ChatPage.tsx (lines 555 and 660). This causes a TypeScript compilation error:
    
    
    src/pages/ChatPage.tsx(555,35): error TS2304: Cannot find name 'resumeId'.
    src/pages/ChatPage.tsx(660,16): error TS2304: Cannot find name 'resumeId'.
    
    
    Changes
    
    - Line 555: resumeId → resumeParam
    - Line 660: resumeId → resumeParam
    
    Verified that npm run build now completes successfully.