### PR TITLE
fix(gateway): bound shutdown notification sends with asyncio.wait_for

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -50,6 +50,11 @@ from hermes_cli.config import cfg_get
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
+
+# Per-send timeout for shutdown notifications. Keeps a slow / unreachable
+# platform from holding up the whole shutdown sequence and tripping systemd's
+# TimeoutStopSec (issue #21188).
+_SHUTDOWN_NOTIFY_TIMEOUT_S = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 
@@ -2461,7 +2466,17 @@ class GatewayRunner:
                 # correct forum topic / thread.
                 metadata = {"thread_id": thread_id} if thread_id else None
 
-                result = await adapter.send(chat_id, msg, metadata=metadata)
+                try:
+                    result = await asyncio.wait_for(
+                        adapter.send(chat_id, msg, metadata=metadata),
+                        timeout=_SHUTDOWN_NOTIFY_TIMEOUT_S,
+                    )
+                except asyncio.TimeoutError:
+                    logger.debug(
+                        "Shutdown notification to %s:%s timed out after %.1fs; continuing.",
+                        platform_str, chat_id, _SHUTDOWN_NOTIFY_TIMEOUT_S,
+                    )
+                    continue
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to %s:%s: %s",
@@ -2493,10 +2508,23 @@ class GatewayRunner:
 
             try:
                 metadata = {"thread_id": home.thread_id} if home.thread_id else None
-                if metadata:
-                    result = await adapter.send(str(home.chat_id), msg, metadata=metadata)
-                else:
-                    result = await adapter.send(str(home.chat_id), msg)
+                try:
+                    if metadata:
+                        result = await asyncio.wait_for(
+                            adapter.send(str(home.chat_id), msg, metadata=metadata),
+                            timeout=_SHUTDOWN_NOTIFY_TIMEOUT_S,
+                        )
+                    else:
+                        result = await asyncio.wait_for(
+                            adapter.send(str(home.chat_id), msg),
+                            timeout=_SHUTDOWN_NOTIFY_TIMEOUT_S,
+                        )
+                except asyncio.TimeoutError:
+                    logger.debug(
+                        "Shutdown notification to home channel %s:%s timed out after %.1fs; continuing.",
+                        platform.value, home.chat_id, _SHUTDOWN_NOTIFY_TIMEOUT_S,
+                    )
+                    continue
                 if result is not None and getattr(result, "success", True) is False:
                     logger.debug(
                         "Failed to send shutdown notification to home channel %s:%s: %s",

--- a/tests/gateway/test_shutdown_notify_timeout.py
+++ b/tests/gateway/test_shutdown_notify_timeout.py
@@ -1,0 +1,44 @@
+"""Regression test for issue #21188.
+
+`Gateway._notify_active_sessions_of_shutdown` must bound every adapter
+send with ``asyncio.wait_for`` so a slow / unreachable platform (e.g.
+Discord returning 403 Forbidden after a long network wait) can never
+delay the shutdown sequence past systemd's ``TimeoutStopSec``.
+"""
+
+import asyncio
+import re
+from pathlib import Path
+
+import pytest
+
+
+_RUN_PY = Path(__file__).resolve().parents[2] / "gateway" / "run.py"
+
+
+def test_shutdown_notify_uses_wait_for_on_active_session_send():
+    """Static check: the active-session send is wrapped in asyncio.wait_for."""
+    src = _RUN_PY.read_text(encoding="utf-8")
+    # Locate the function body.
+    match = re.search(
+        r"async def _notify_active_sessions_of_shutdown\(self\).*?(?=\n    async def |\n    def )",
+        src,
+        re.DOTALL,
+    )
+    assert match, "_notify_active_sessions_of_shutdown not found in gateway/run.py"
+    body = match.group(0)
+    assert "asyncio.wait_for(" in body, (
+        "Shutdown notification sends must be bounded by asyncio.wait_for "
+        "(issue #21188)."
+    )
+    assert "_SHUTDOWN_NOTIFY_TIMEOUT_S" in body, (
+        "Use the _SHUTDOWN_NOTIFY_TIMEOUT_S module constant for the timeout."
+    )
+
+
+def test_shutdown_notify_timeout_constant_defined():
+    """Static check: the module exposes the timeout constant."""
+    src = _RUN_PY.read_text(encoding="utf-8")
+    assert re.search(r"^_SHUTDOWN_NOTIFY_TIMEOUT_S\s*=\s*\d", src, re.MULTILINE), (
+        "gateway.run must define _SHUTDOWN_NOTIFY_TIMEOUT_S at module scope."
+    )


### PR DESCRIPTION
Closes #21188.

## Problem

During gateway shutdown, `_notify_active_sessions_of_shutdown()` makes a blocking `await adapter.send(...)` for each active session and home channel. If a platform is slow or unreachable — e.g. Discord returning **403 Forbidden** after a long network wait when the bot has lost access to a channel — the send can block long enough that **systemd hits `TimeoutStopSec` and escalates to SIGKILL**, exactly as shown in the issue's logs:

```
01:01:38 systemd: Stopping hermes-gateway.service...
01:01:39 ERROR gateway.platforms.discord: Failed to send Discord message: 403 Forbidden ...
01:03:08 systemd: State stop-sigterm timed out. Killing.
```

(~90s gap between the goodbye attempt and SIGKILL escalation.)

## Fix

Wrap each `adapter.send(...)` inside `_notify_active_sessions_of_shutdown()` with `asyncio.wait_for(..., timeout=_SHUTDOWN_NOTIFY_TIMEOUT_S)` (5s). On `asyncio.TimeoutError`, log at debug and `continue` — matching the existing best-effort error path. A new module-level constant `_SHUTDOWN_NOTIFY_TIMEOUT_S = 5.0` documents the budget and ties it back to this issue.

Adapter-internal behavior is untouched. The goal is bounding the wait so a single hung platform cannot block the rest of the shutdown sequence.

## Tests

`tests/gateway/test_shutdown_notify_timeout.py` — static-source regression checks that the function uses `asyncio.wait_for` and references the constant.

```
$ python -m pytest -o addopts= tests/gateway/test_shutdown_notify_timeout.py -q
.. [100%]
2 passed in 5.57s
```