### PR TITLE
feat(cron): allow extended cron syntax (# and L) in schedule parser

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -157,7 +157,7 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     # Cron fields: minute hour day month weekday [year]
     parts = schedule.split()
     if len(parts) >= 5 and all(
-        re.match(r'^[\d\*\-,/]+$', p) for p in parts[:5]
+        re.match(r'^[\d\*\-,/L#?]+$', p) for p in parts[:5]
     ):
         if not HAS_CRONITER:
             raise ValueError("Cron expressions require 'croniter' package. Install with: pip install croniter")

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -113,6 +113,19 @@ class TestParseSchedule:
         with pytest.raises(ValueError):
             parse_schedule("99 99 99 99 99")
 
+    def test_cron_extended_nth_weekday(self):
+        """Issue #20858: '#' for nth weekday-of-month must reach croniter."""
+        pytest.importorskip("croniter")
+        result = parse_schedule("0 9 * * 1#2")
+        assert result["kind"] == "cron"
+        assert result["expr"] == "0 9 * * 1#2"
+
+    def test_cron_extended_last_day(self):
+        """Issue #20858: 'L' for last-day-of-month must reach croniter."""
+        pytest.importorskip("croniter")
+        result = parse_schedule("0 0 L * *")
+        assert result["kind"] == "cron"
+        assert result["expr"] == "0 0 L * *"
 
 # =========================================================================
 # compute_next_run


### PR DESCRIPTION
Closes #20858 (Phase 1).

## Problem

`parse_schedule()` validates each cron field with the character class `[\d\*\-,/]+` before handing the expression to `croniter()`. That gate rejects perfectly valid croniter-supported expressions:

| Schedule | Meaning | Before | After |
|---|---|---|---|
| `0 9 * * 1#2` | 2nd Monday of every month | rejected by parser | accepted |
| `0 0 L * *` | Last day of every month | rejected by parser | accepted |

These never reach the underlying `croniter()` validator, even though croniter handles both correctly.

## Fix

Add `L#?` to the allow-listed character class in `cron/jobs.py`:

```diff
-        re.match(r'^[\d\*\-,/]+$', p) for p in parts[:5]
+        re.match(r'^[\d\*\-,/L#?]+$', p) for p in parts[:5]
```

Invalid expressions are still caught by the subsequent `croniter(schedule)` call (the parser-level allow-list is just a fast-path filter; full validation still runs).

## Out of scope (Phase 2)

The issue notes that "last weekday of a particular month" patterns (e.g. `0 9 * * 5L` for last Friday of every month) remain unsolved because **croniter rejects `L` in the day-of-week field** — verified locally:

```
CroniterNotAlphaError: [0 9 * * 5l] is not acceptable
```

Those patterns need either a different scheduling library or the documented `[SILENT]` + script-gate workaround. Out of scope for this PR.

## Tests

Two new tests in `tests/cron/test_jobs.py`:

```
$ python -m pytest -o addopts= tests/cron/test_jobs.py::TestParseSchedule -q
......... [100%]
9 passed in 5.83s
```