### PR TITLE
feat(qqbot): port SDK improvements in-tree (chunked upload, approval keyboards, quoted attachments)

### DIFF
--- a/gateway/platforms/qqbot/__init__.py
+++ b/gateway/platforms/qqbot/__init__.py
@@ -34,6 +34,13 @@ from .crypto import decrypt_secret, generate_bind_key  # noqa: F401
 # -- Utils -----------------------------------------------------------------
 from .utils import build_user_agent, get_api_headers, coerce_list  # noqa: F401
 
+# -- Chunked upload --------------------------------------------------------
+from .chunked_upload import (  # noqa: F401
+    ChunkedUploader,
+    UploadDailyLimitExceededError,
+    UploadFileTooLargeError,
+)
+
 __all__ = [
     # adapter
     "QQAdapter",
@@ -52,4 +59,8 @@ __all__ = [
     "build_user_agent",
     "get_api_headers",
     "coerce_list",
+    # chunked upload
+    "ChunkedUploader",
+    "UploadDailyLimitExceededError",
+    "UploadFileTooLargeError",
 ]

--- a/gateway/platforms/qqbot/__init__.py
+++ b/gateway/platforms/qqbot/__init__.py
@@ -41,6 +41,20 @@ from .chunked_upload import (  # noqa: F401
     UploadFileTooLargeError,
 )
 
+# -- Inline keyboards ------------------------------------------------------
+from .keyboards import (  # noqa: F401
+    ApprovalRequest,
+    ApprovalSender,
+    InlineKeyboard,
+    InteractionEvent,
+    build_approval_keyboard,
+    build_approval_text,
+    build_update_prompt_keyboard,
+    parse_approval_button_data,
+    parse_interaction_event,
+    parse_update_prompt_button_data,
+)
+
 __all__ = [
     # adapter
     "QQAdapter",
@@ -63,4 +77,15 @@ __all__ = [
     "ChunkedUploader",
     "UploadDailyLimitExceededError",
     "UploadFileTooLargeError",
+    # keyboards
+    "ApprovalRequest",
+    "ApprovalSender",
+    "InlineKeyboard",
+    "InteractionEvent",
+    "build_approval_keyboard",
+    "build_approval_text",
+    "build_update_prompt_keyboard",
+    "parse_approval_button_data",
+    "parse_interaction_event",
+    "parse_update_prompt_button_data",
 ]

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1031,6 +1031,13 @@ class QQAdapter(BasePlatformAdapter):
             len(voice_transcripts),
         )
 
+        # Merge any quoted-message context (message_type=103 → msg_elements[0]).
+        quoted = await self._process_quoted_context(d)
+        text = self._merge_quote_into(text, quoted["quote_block"])
+        if quoted["image_urls"]:
+            image_urls = image_urls + quoted["image_urls"]
+            image_media_types = image_media_types + quoted["image_media_types"]
+
         if not text.strip() and not image_urls:
             return
 
@@ -1088,6 +1095,13 @@ class QQAdapter(BasePlatformAdapter):
                 if text.strip()
                 else attachment_info
             )
+
+        # Merge any quoted-message context (message_type=103 → msg_elements[0]).
+        quoted = await self._process_quoted_context(d)
+        text = self._merge_quote_into(text, quoted["quote_block"])
+        if quoted["image_urls"]:
+            image_urls = image_urls + quoted["image_urls"]
+            image_media_types = image_media_types + quoted["image_media_types"]
 
         if not text.strip() and not image_urls:
             return
@@ -1156,6 +1170,13 @@ class QQAdapter(BasePlatformAdapter):
                 else attachment_info
             )
 
+        # Merge any quoted-message context (message_type=103 → msg_elements[0]).
+        quoted = await self._process_quoted_context(d)
+        text = self._merge_quote_into(text, quoted["quote_block"])
+        if quoted["image_urls"]:
+            image_urls = image_urls + quoted["image_urls"]
+            image_media_types = image_media_types + quoted["image_media_types"]
+
         if not text.strip() and not image_urls:
             return
 
@@ -1220,6 +1241,13 @@ class QQAdapter(BasePlatformAdapter):
                 else attachment_info
             )
 
+        # Merge any quoted-message context (message_type=103 → msg_elements[0]).
+        quoted = await self._process_quoted_context(d)
+        text = self._merge_quote_into(text, quoted["quote_block"])
+        if quoted["image_urls"]:
+            image_urls = image_urls + quoted["image_urls"]
+            image_media_types = image_media_types + quoted["image_media_types"]
+
         if not text.strip() and not image_urls:
             return
 
@@ -1239,6 +1267,113 @@ class QQAdapter(BasePlatformAdapter):
             timestamp=self._parse_qq_timestamp(timestamp),
         )
         await self.handle_message(event)
+
+    # ------------------------------------------------------------------
+    # Quoted-message handling
+    # ------------------------------------------------------------------
+
+    async def _process_quoted_context(
+            self,
+            d: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Process the quoted message a user is replying to.
+
+        When a user replies while quoting another message, the platform sets
+        ``message_type = 103`` and pushes the referenced message's content and
+        attachments inside ``msg_elements[0]``. The old adapter ignored
+        ``msg_elements`` entirely, so:
+
+        - Quoted text was surfaced only when the user typed something of
+          their own — bare quote-replies showed nothing.
+        - Quoted attachments (images, voice, files) were never downloaded
+          or described.
+        - Quoted voice messages specifically produced no transcript, so the
+          LLM had no way to see what the user was referring to.
+
+        This method parses ``msg_elements`` and runs the quoted attachments
+        through the same :meth:`_process_attachments` pipeline as the main
+        message body, so quoted voice messages get STT transcripts and
+        quoted images are cached identically.
+
+        :param d: Raw inbound message dict (from the WS dispatch payload).
+        :returns: Dict with keys:
+
+            - ``quote_block``: string to prepend to the user's text body
+              (empty when there's nothing quoted).
+            - ``image_urls``: list of cached quoted-image paths.
+            - ``image_media_types``: parallel list of image MIME types.
+        """
+        empty = {
+            "quote_block": "",
+            "image_urls": [],
+            "image_media_types": [],
+        }
+        # Short-circuit: only message_type 103 indicates a quote.
+        try:
+            if int(d.get("message_type", 0) or 0) != 103:
+                return empty
+        except (TypeError, ValueError):
+            return empty
+
+        elements = d.get("msg_elements")
+        if not isinstance(elements, list) or not elements:
+            return empty
+
+        # msg_elements[0] carries the referenced message. Additional elements
+        # (if any) are very rare in practice; we concatenate their text and
+        # union their attachments for completeness.
+        quoted_text_parts: List[str] = []
+        all_attachments: List[Dict[str, Any]] = []
+        for elem in elements:
+            if not isinstance(elem, dict):
+                continue
+            etext = str(elem.get("content", "")).strip()
+            if etext:
+                quoted_text_parts.append(etext)
+            eatts = elem.get("attachments")
+            if isinstance(eatts, list):
+                for a in eatts:
+                    if isinstance(a, dict):
+                        all_attachments.append(a)
+
+        att_result = await self._process_attachments(all_attachments)
+        quoted_voice = att_result.get("voice_transcripts") or []
+        quoted_info = att_result.get("attachment_info") or ""
+        quoted_images = att_result.get("image_urls") or []
+        quoted_image_types = att_result.get("image_media_types") or []
+
+        lines: List[str] = []
+        if quoted_text_parts:
+            lines.append(" ".join(quoted_text_parts))
+        for t in quoted_voice:
+            lines.append(t)
+        if quoted_info:
+            lines.append(quoted_info)
+
+        if not lines and not quoted_images:
+            return empty
+
+        if lines:
+            quote_block = "[Quoted message]:\n" + "\n".join(lines)
+        else:
+            # Images-only quote: give the LLM at least a marker so it knows
+            # context was referenced.
+            quote_block = "[Quoted message]: (image)"
+
+        return {
+            "quote_block": quote_block,
+            "image_urls": quoted_images,
+            "image_media_types": quoted_image_types,
+        }
+
+    @staticmethod
+    def _merge_quote_into(text: str, quote_block: str) -> str:
+        """Prepend ``quote_block`` to *text*, separated by a blank line."""
+        if not quote_block:
+            return text
+        if text.strip():
+            return f"{quote_block}\n\n{text}".strip()
+        return quote_block
 
     # ------------------------------------------------------------------
     # Attachment processing

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -119,6 +119,11 @@ from gateway.platforms.qqbot.utils import (
     coerce_list as _coerce_list_impl,
     build_user_agent,
 )
+from gateway.platforms.qqbot.chunked_upload import (
+    ChunkedUploader,
+    UploadDailyLimitExceededError,
+    UploadFileTooLargeError,
+)
 
 
 def check_qq_requirements() -> bool:
@@ -2160,42 +2165,62 @@ class QQAdapter(BasePlatformAdapter):
             reply_to: Optional[str] = None,
             file_name: Optional[str] = None,
     ) -> SendResult:
-        """Upload media and send as a native message."""
+        """Upload media and send as a native message.
+
+        Upload strategy:
+
+        - **HTTP(S) URLs** → single ``POST /v2/{users|groups}/{id}/files``
+          with ``url=...``. The QQ platform fetches the URL directly; fastest
+          path when the source is already hosted.
+        - **Local files** → three-step chunked upload (prepare / PUT parts /
+          complete). Handles files up to the platform's ~100 MB per-file
+          limit without the ~10 MB inline-base64 cap of the old adapter.
+        """
         if not self.is_connected:
             if not await self._wait_for_reconnection():
                 return SendResult(success=False, error="Not connected", retryable=True)
 
-        try:
-            # Resolve media source
-            data, content_type, resolved_name = await self._load_media(
-                media_source, file_name
+        chat_type = self._guess_chat_type(chat_id)
+        if chat_type == "guild":
+            # Guild channels don't support native media upload in the same way.
+            return SendResult(
+                success=False,
+                error="Guild media send not supported via this path",
             )
 
-            # Route
-            chat_type = self._guess_chat_type(chat_id)
-
-            if chat_type == "guild":
-                # Guild channels don't support native media upload in the same way
-                # Send as URL fallback
-                return SendResult(
-                    success=False, error="Guild media send not supported via this path"
+        try:
+            if self._is_url(media_source):
+                # URL upload — let the platform fetch it directly.
+                resolved_name = (
+                    file_name
+                    or Path(urlparse(media_source).path).name
+                    or "media"
+                )
+                upload = await self._upload_media(
+                    chat_type,
+                    chat_id,
+                    file_type,
+                    url=media_source,
+                    srv_send_msg=False,
+                    file_name=resolved_name if file_type == MEDIA_TYPE_FILE else None,
+                )
+            else:
+                # Local file — chunked upload (prepare / PUT parts / complete).
+                resolved_name, upload = await self._upload_local_file(
+                    chat_type,
+                    chat_id,
+                    media_source,
+                    file_type,
+                    file_name,
                 )
 
-            # Upload
-            upload = await self._upload_media(
-                chat_type,
-                chat_id,
-                file_type,
-                file_data=data if not self._is_url(media_source) else None,
-                url=media_source if self._is_url(media_source) else None,
-                srv_send_msg=False,
-                file_name=resolved_name if file_type == MEDIA_TYPE_FILE else None,
-            )
-
-            file_info = upload.get("file_info")
+            file_info = upload.get("file_info") or (
+                upload.get("data", {}) or {}
+            ).get("file_info")
             if not file_info:
                 return SendResult(
-                    success=False, error=f"Upload returned no file_info: {upload}"
+                    success=False,
+                    error=f"Upload returned no file_info: {upload}",
                 )
 
             # Send media message
@@ -2224,9 +2249,85 @@ class QQAdapter(BasePlatformAdapter):
                 message_id=str(send_data.get("id", uuid.uuid4().hex[:12])),
                 raw_response=send_data,
             )
+        except UploadDailyLimitExceededError as exc:
+            # Non-retryable: daily quota hit. Give the caller actionable text
+            # so the model can compose a helpful reply.
+            logger.warning(
+                "[%s] Daily upload limit exceeded for %s (%s)",
+                self._log_tag, exc.file_name, exc.file_size_human,
+            )
+            return SendResult(
+                success=False,
+                error=(
+                    f"QQ daily upload limit exceeded for {exc.file_name!r} "
+                    f"({exc.file_size_human}). Retry tomorrow."
+                ),
+                retryable=False,
+            )
+        except UploadFileTooLargeError as exc:
+            logger.warning(
+                "[%s] File too large: %s (%s, platform limit %s)",
+                self._log_tag, exc.file_name, exc.file_size_human, exc.limit_human,
+            )
+            return SendResult(
+                success=False,
+                error=(
+                    f"{exc.file_name!r} ({exc.file_size_human}) exceeds the "
+                    f"QQ per-file upload limit ({exc.limit_human})."
+                ),
+                retryable=False,
+            )
         except Exception as exc:
             logger.error("[%s] Media send failed: %s", self._log_tag, exc)
             return SendResult(success=False, error=str(exc))
+
+    async def _upload_local_file(
+            self,
+            chat_type: str,
+            chat_id: str,
+            media_source: str,
+            file_type: int,
+            file_name: Optional[str],
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Chunked-upload a local file and return ``(resolved_name, complete_response)``.
+
+        The returned ``complete_response`` contains the ``file_info`` token
+        that goes into the subsequent RichMedia message body.
+
+        :raises UploadDailyLimitExceededError: On biz_code 40093002.
+        :raises UploadFileTooLargeError: When the file exceeds the platform limit.
+        :raises FileNotFoundError: If the path does not exist.
+        :raises ValueError: If the path looks like a placeholder (``<path>``).
+        :raises RuntimeError: If the HTTP client is not initialized.
+        """
+        if not self._http_client:
+            raise RuntimeError("HTTP client not initialized — not connected?")
+
+        local_path = Path(media_source).expanduser()
+        if not local_path.is_absolute():
+            local_path = (Path.cwd() / local_path).resolve()
+
+        if not local_path.exists() or not local_path.is_file():
+            if media_source.startswith("<") or len(media_source) < 3:
+                raise ValueError(
+                    f"Invalid media source (looks like a placeholder): {media_source!r}"
+                )
+            raise FileNotFoundError(f"Media file not found: {local_path}")
+
+        resolved_name = file_name or local_path.name
+        uploader = ChunkedUploader(
+            api_request=self._api_request,
+            http_put=self._http_client.put,
+            log_tag=self._log_tag,
+        )
+        complete = await uploader.upload(
+            chat_type=chat_type,
+            target_id=chat_id,
+            file_path=str(local_path),
+            file_type=file_type,
+            file_name=resolved_name,
+        )
+        return resolved_name, complete
 
     async def _load_media(
             self, source: str, file_name: Optional[str] = None

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -41,7 +41,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 try:
@@ -123,6 +123,17 @@ from gateway.platforms.qqbot.chunked_upload import (
     ChunkedUploader,
     UploadDailyLimitExceededError,
     UploadFileTooLargeError,
+)
+from gateway.platforms.qqbot.keyboards import (
+    ApprovalRequest,
+    ApprovalSender,
+    InlineKeyboard,
+    InteractionEvent,
+    build_approval_keyboard,
+    build_update_prompt_keyboard,
+    parse_approval_button_data,
+    parse_interaction_event,
+    parse_update_prompt_button_data,
 )
 
 
@@ -212,6 +223,14 @@ class QQAdapter(BasePlatformAdapter):
 
         # Upload cache: content_hash -> {file_info, file_uuid, expires_at}
         self._upload_cache: Dict[str, Dict[str, Any]] = {}
+
+        # Inline-keyboard interaction routing. The callback (if set) is invoked
+        # for every INTERACTION_CREATE event after the adapter has already
+        # ACKed it. Callers (gateway wiring for approvals / update prompts)
+        # register via set_interaction_callback().
+        self._interaction_callback: Optional[
+            Callable[[InteractionEvent], Awaitable[None]]
+        ] = None
 
     # ------------------------------------------------------------------
     # Properties
@@ -764,6 +783,8 @@ class QQAdapter(BasePlatformAdapter):
                     "GUILD_AT_MESSAGE_CREATE",
             ):
                 asyncio.create_task(self._on_message(t, d))
+            elif t == "INTERACTION_CREATE":
+                self._create_task(self._on_interaction(d))
             else:
                 logger.debug("[%s] Unhandled dispatch: %s", self._log_tag, t)
             return
@@ -836,6 +857,111 @@ class QQAdapter(BasePlatformAdapter):
             await self._handle_guild_message(d, msg_id, content, author, timestamp)
         elif event_type == "DIRECT_MESSAGE_CREATE":
             await self._handle_dm_message(d, msg_id, content, author, timestamp)
+
+    # ------------------------------------------------------------------
+    # Inline-keyboard interactions (INTERACTION_CREATE)
+    # ------------------------------------------------------------------
+
+    def set_interaction_callback(
+        self,
+        callback: Optional[Callable[[InteractionEvent], Awaitable[None]]],
+    ) -> None:
+        """Register (or clear) the interaction callback.
+
+        Invoked once per ``INTERACTION_CREATE`` event *after* the adapter has
+        ACKed the interaction. The callback is responsible for routing the
+        button click to the right subsystem (approval resolver, update-prompt
+        resolver, etc.) based on the ``button_data`` payload.
+        """
+        self._interaction_callback = callback
+
+    async def _on_interaction(self, d: Any) -> None:
+        """Handle an ``INTERACTION_CREATE`` event.
+
+        Responsibilities:
+
+        1. Parse the raw payload into an :class:`InteractionEvent`.
+        2. ACK the interaction (``PUT /interactions/{id}``) so the client
+           stops showing a loading indicator on the button.
+        3. Dispatch to the registered interaction callback, if any.
+        """
+        if not isinstance(d, dict):
+            return
+        try:
+            event = parse_interaction_event(d)
+        except Exception as exc:
+            logger.warning(
+                "[%s] Failed to parse INTERACTION_CREATE: %s", self._log_tag, exc
+            )
+            return
+
+        if not event.id:
+            logger.warning(
+                "[%s] INTERACTION_CREATE missing id, skipping ACK", self._log_tag
+            )
+            return
+
+        # ACK the interaction promptly — per the QQ docs the client will show
+        # an error icon on the button if we don't respond quickly.
+        try:
+            await self._acknowledge_interaction(event.id)
+        except Exception as exc:
+            logger.warning(
+                "[%s] Failed to ACK interaction %s: %s",
+                self._log_tag, event.id, exc,
+            )
+
+        logger.info(
+            "[%s] Interaction: scene=%s button_data=%r operator=%s",
+            self._log_tag, event.scene, event.button_data, event.operator_openid,
+        )
+
+        callback = self._interaction_callback
+        if callback is None:
+            logger.debug(
+                "[%s] No interaction callback registered; dropping button "
+                "click %r",
+                self._log_tag, event.button_data,
+            )
+            return
+        try:
+            await callback(event)
+        except Exception as exc:
+            logger.error(
+                "[%s] Interaction callback raised: %s",
+                self._log_tag, exc, exc_info=True,
+            )
+
+    async def _acknowledge_interaction(
+            self,
+            interaction_id: str,
+            code: int = 0,
+    ) -> None:
+        """ACK a button interaction via ``PUT /interactions/{id}``.
+
+        :param interaction_id: The ``id`` field from the
+            ``INTERACTION_CREATE`` event.
+        :param code: Response code (``0`` = success).
+        """
+        if not self._http_client:
+            raise RuntimeError("HTTP client not initialized — not connected?")
+        token = await self._ensure_token()
+        headers = {
+            "Authorization": f"QQBot {token}",
+            "Content-Type": "application/json",
+            "User-Agent": build_user_agent(),
+        }
+        resp = await self._http_client.put(
+            f"{API_BASE}/interactions/{interaction_id}",
+            headers=headers,
+            json={"code": code},
+            timeout=DEFAULT_API_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            raise RuntimeError(
+                f"Interaction ACK failed [{resp.status_code}]: "
+                f"{resp.text[:200]}"
+            )
 
     async def _handle_c2c_message(
             self,
@@ -1997,26 +2123,44 @@ class QQAdapter(BasePlatformAdapter):
         return SendResult(success=False, error=error_msg, retryable=retryable)
 
     async def _send_c2c_text(
-            self, openid: str, content: str, reply_to: Optional[str] = None
+            self,
+            openid: str,
+            content: str,
+            reply_to: Optional[str] = None,
+            keyboard: Optional[InlineKeyboard] = None,
     ) -> SendResult:
-        """Send text to a C2C user via REST API."""
+        """Send text to a C2C user via REST API.
+
+        :param keyboard: Optional inline keyboard attached to the message.
+        """
         self._next_msg_seq(reply_to or openid)
         body = self._build_text_body(content, reply_to)
         if reply_to:
             body["msg_id"] = reply_to
+        if keyboard is not None:
+            body["keyboard"] = keyboard.to_dict()
 
         data = await self._api_request("POST", f"/v2/users/{openid}/messages", body)
         msg_id = str(data.get("id", uuid.uuid4().hex[:12]))
         return SendResult(success=True, message_id=msg_id, raw_response=data)
 
     async def _send_group_text(
-            self, group_openid: str, content: str, reply_to: Optional[str] = None
+            self,
+            group_openid: str,
+            content: str,
+            reply_to: Optional[str] = None,
+            keyboard: Optional[InlineKeyboard] = None,
     ) -> SendResult:
-        """Send text to a group via REST API."""
+        """Send text to a group via REST API.
+
+        :param keyboard: Optional inline keyboard attached to the message.
+        """
         self._next_msg_seq(reply_to or group_openid)
         body = self._build_text_body(content, reply_to)
         if reply_to:
             body["msg_id"] = reply_to
+        if keyboard is not None:
+            body["keyboard"] = keyboard.to_dict()
 
         data = await self._api_request(
             "POST", f"/v2/groups/{group_openid}/messages", body
@@ -2035,6 +2179,100 @@ class QQAdapter(BasePlatformAdapter):
         data = await self._api_request("POST", f"/channels/{channel_id}/messages", body)
         msg_id = str(data.get("id", uuid.uuid4().hex[:12]))
         return SendResult(success=True, message_id=msg_id, raw_response=data)
+
+    # ------------------------------------------------------------------
+    # Inline-keyboard outbound helpers (approval / update-prompt flows)
+    # ------------------------------------------------------------------
+
+    async def send_with_keyboard(
+            self,
+            chat_id: str,
+            content: str,
+            keyboard: InlineKeyboard,
+            reply_to: Optional[str] = None,
+    ) -> SendResult:
+        """Send a single text message with an inline keyboard attached.
+
+        Unlike :meth:`send`, this does NOT split long content into chunks —
+        a keyboard message has exactly one interactive surface, and splitting
+        would orphan the buttons from the first chunk. Callers should keep
+        approval/update-prompt bodies short.
+
+        Guild (channel) chats don't support inline keyboards; returns a
+        non-retryable failure for those.
+        """
+        if not self.is_connected:
+            if not await self._wait_for_reconnection():
+                return SendResult(
+                    success=False, error="Not connected", retryable=True
+                )
+
+        chat_type = self._guess_chat_type(chat_id)
+        formatted = self.format_message(content)
+        truncated = formatted[: self.MAX_MESSAGE_LENGTH]
+        try:
+            if chat_type == "c2c":
+                return await self._send_c2c_text(
+                    chat_id, truncated, reply_to, keyboard=keyboard,
+                )
+            if chat_type == "group":
+                return await self._send_group_text(
+                    chat_id, truncated, reply_to, keyboard=keyboard,
+                )
+            return SendResult(
+                success=False,
+                error=(
+                    f"Inline keyboards not supported for chat_type "
+                    f"{chat_type!r}"
+                ),
+                retryable=False,
+            )
+        except Exception as exc:
+            logger.error(
+                "[%s] send_with_keyboard failed: %s", self._log_tag, exc
+            )
+            return SendResult(success=False, error=str(exc))
+
+    async def send_approval_request(
+            self,
+            chat_id: str,
+            req: ApprovalRequest,
+            reply_to: Optional[str] = None,
+    ) -> SendResult:
+        """Send a 3-button approval request (``allow-once / allow-always / deny``).
+
+        The rendered text comes from :func:`build_approval_text`; callers can
+        override by passing a custom :class:`ApprovalRequest`.
+
+        Users click the button → ``INTERACTION_CREATE`` fires → the adapter's
+        registered :meth:`set_interaction_callback` handler decodes
+        ``button_data`` via :func:`parse_approval_button_data`.
+        """
+        from gateway.platforms.qqbot.keyboards import build_approval_text
+        return await self.send_with_keyboard(
+            chat_id,
+            build_approval_text(req),
+            build_approval_keyboard(req.session_key),
+            reply_to=reply_to,
+        )
+
+    async def send_update_prompt(
+            self,
+            chat_id: str,
+            content: str,
+            reply_to: Optional[str] = None,
+    ) -> SendResult:
+        """Send a Yes/No update-confirmation prompt with inline buttons.
+
+        Button clicks surface as ``INTERACTION_CREATE`` with
+        ``button_data = 'update_prompt:y'`` or ``'update_prompt:n'``.
+        """
+        return await self.send_with_keyboard(
+            chat_id,
+            content,
+            build_update_prompt_keyboard(),
+            reply_to=reply_to,
+        )
 
     def _build_text_body(
             self, content: str, reply_to: Optional[str] = None

--- a/gateway/platforms/qqbot/chunked_upload.py
+++ b/gateway/platforms/qqbot/chunked_upload.py
@@ -1,0 +1,603 @@
+"""QQ Bot chunked upload flow.
+
+The QQ v2 API caps inline base64 uploads (``file_data`` / ``url``) at ~10 MB.
+For files between 10 MB and ~100 MB we have to use the three-step chunked
+upload flow::
+
+    1. POST /v2/{users|groups}/{id}/upload_prepare
+       → returns upload_id, block_size, and an array of pre-signed COS part URLs.
+    2. For each part:
+         PUT the part bytes to its pre-signed COS URL,
+         then POST /v2/{users|groups}/{id}/upload_part_finish to acknowledge.
+    3. POST /v2/{users|groups}/{id}/files with {"upload_id": ...}
+       → returns the ``file_info`` token the caller uses in a RichMedia
+       message.
+
+Error-code semantics (from the QQ Bot v2 API spec):
+
+- ``40093001`` — ``upload_part_finish`` retryable. Retry until the server-provided
+  ``retry_timeout`` elapses (or a local cap).
+- ``40093002`` — daily cumulative upload quota exceeded. Not retryable; surface
+  as :class:`UploadDailyLimitExceededError` so the caller can build a
+  user-friendly reply.
+
+Exceptions:
+
+- :class:`UploadDailyLimitExceededError` — daily quota hit (non-retryable).
+- :class:`UploadFileTooLargeError` — file exceeds the platform per-file limit.
+- :class:`RuntimeError` — generic upload failure (network, part PUT, complete).
+
+Ported from WideLee's qqbot-agent-sdk v1.2.2 (``media_loader.py::ChunkedUploader``)
+so the heavy-upload path stays in-tree. Authorship preserved via Co-authored-by.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+from gateway.platforms.qqbot.constants import FILE_UPLOAD_TIMEOUT
+
+logger = logging.getLogger(__name__)
+
+
+# ── Error codes ──────────────────────────────────────────────────────
+_BIZ_CODE_DAILY_LIMIT = 40093002     # upload_prepare: daily cumulative limit
+_BIZ_CODE_PART_RETRYABLE = 40093001  # upload_part_finish: transient
+
+# ── Part upload tuning ───────────────────────────────────────────────
+_DEFAULT_CONCURRENT_PARTS = 1
+_MAX_CONCURRENT_PARTS = 10
+
+_PART_UPLOAD_TIMEOUT = 300.0        # 5 minutes per COS PUT
+_PART_UPLOAD_MAX_RETRIES = 2
+_PART_FINISH_RETRY_INTERVAL = 1.0
+_PART_FINISH_DEFAULT_TIMEOUT = 120.0
+_PART_FINISH_MAX_TIMEOUT = 600.0
+
+_COMPLETE_UPLOAD_MAX_RETRIES = 2
+_COMPLETE_UPLOAD_BASE_DELAY = 2.0
+
+# First 10,002,432 bytes used for the ``md5_10m`` hash (per QQ API spec).
+_MD5_10M_SIZE = 10_002_432
+
+
+# ── Exceptions ───────────────────────────────────────────────────────
+
+class UploadDailyLimitExceededError(Exception):
+    """Raised when ``upload_prepare`` returns biz_code 40093002.
+
+    The daily cumulative upload quota for this bot has been reached. Callers
+    should surface :attr:`file_name` + :attr:`file_size_human` so the model
+    can compose a helpful reply.
+    """
+
+    def __init__(self, file_name: str, file_size: int, message: str = "") -> None:
+        self.file_name = file_name
+        self.file_size = file_size
+        super().__init__(
+            message or f"Daily upload limit exceeded for {file_name!r}"
+        )
+
+    @property
+    def file_size_human(self) -> str:
+        return format_size(self.file_size)
+
+
+class UploadFileTooLargeError(Exception):
+    """Raised when a file exceeds the platform per-file size limit."""
+
+    def __init__(
+        self,
+        file_name: str,
+        file_size: int,
+        limit_bytes: int = 0,
+        message: str = "",
+    ) -> None:
+        self.file_name = file_name
+        self.file_size = file_size
+        self.limit_bytes = limit_bytes
+        limit_str = f" ({format_size(limit_bytes)})" if limit_bytes else ""
+        super().__init__(
+            message
+            or (
+                f"File {file_name!r} ({format_size(file_size)}) "
+                f"exceeds platform limit{limit_str}"
+            )
+        )
+
+    @property
+    def file_size_human(self) -> str:
+        return format_size(self.file_size)
+
+    @property
+    def limit_human(self) -> str:
+        return format_size(self.limit_bytes) if self.limit_bytes else "unknown"
+
+
+# ── Progress tracking ────────────────────────────────────────────────
+
+@dataclass
+class _UploadProgress:
+    total_parts: int = 0
+    total_bytes: int = 0
+    completed_parts: int = 0
+    uploaded_bytes: int = 0
+
+
+# ── Prepare-response shape ───────────────────────────────────────────
+
+@dataclass
+class _PreparePart:
+    index: int
+    presigned_url: str
+    block_size: int = 0
+
+
+@dataclass
+class _PrepareResult:
+    upload_id: str
+    block_size: int
+    parts: List[_PreparePart]
+    concurrency: int = _DEFAULT_CONCURRENT_PARTS
+    retry_timeout: float = 0.0
+
+
+def _parse_prepare_response(raw: Dict[str, Any]) -> _PrepareResult:
+    """Parse the upload_prepare API response into a normalized shape.
+
+    The API may return the response directly or wrapped in ``data``.
+    """
+    src = raw.get("data") if isinstance(raw.get("data"), dict) else raw
+    upload_id = str(src.get("upload_id", ""))
+    if not upload_id:
+        raise ValueError(
+            f"upload_prepare response missing upload_id: {str(raw)[:200]}"
+        )
+    block_size = int(src.get("block_size", 0))
+    raw_parts = src.get("parts") or src.get("part_list") or []
+    if not isinstance(raw_parts, list) or not raw_parts:
+        raise ValueError(
+            f"upload_prepare response missing parts: {str(raw)[:200]}"
+        )
+    parts: List[_PreparePart] = []
+    for p in raw_parts:
+        if not isinstance(p, dict):
+            continue
+        parts.append(
+            _PreparePart(
+                index=int(p.get("part_index") or p.get("index") or 0),
+                presigned_url=str(
+                    p.get("presigned_url") or p.get("url") or ""
+                ),
+                block_size=int(p.get("block_size", 0)),
+            )
+        )
+    return _PrepareResult(
+        upload_id=upload_id,
+        block_size=block_size,
+        parts=parts,
+        concurrency=int(src.get("concurrency", _DEFAULT_CONCURRENT_PARTS)) or _DEFAULT_CONCURRENT_PARTS,
+        retry_timeout=float(src.get("retry_timeout", 0.0) or 0.0),
+    )
+
+
+# ── Chunked upload driver ────────────────────────────────────────────
+
+ApiRequestFn = Callable[..., Awaitable[Dict[str, Any]]]
+"""Signature of the adapter's ``_api_request`` callable.
+
+We pass the bound method in rather than importing the adapter, to avoid
+circular imports and keep this module testable in isolation.
+"""
+
+
+class ChunkedUploader:
+    """Run the prepare → PUT parts → complete sequence.
+
+    :param api_request: Bound ``_api_request(method, path, body=..., timeout=...)``
+        coroutine from the adapter. Must raise ``RuntimeError`` with the biz_code
+        embedded in the message on API errors.
+    :param http_put: Coroutine ``(url, data, headers, timeout) -> response`` for
+        COS part uploads. Typically wraps ``httpx.AsyncClient.put``.
+    :param log_tag: Log prefix.
+    """
+
+    def __init__(
+        self,
+        api_request: ApiRequestFn,
+        http_put: Callable[..., Awaitable[Any]],
+        log_tag: str = "QQBot",
+    ) -> None:
+        self._api_request = api_request
+        self._http_put = http_put
+        self._log_tag = log_tag
+
+    async def upload(
+        self,
+        chat_type: str,
+        target_id: str,
+        file_path: str,
+        file_type: int,
+        file_name: str,
+    ) -> Dict[str, Any]:
+        """Run the full chunked upload and return the ``complete_upload`` response.
+
+        :param chat_type: ``'c2c'`` or ``'group'``.
+        :param target_id: User or group openid.
+        :param file_path: Absolute path to a local file.
+        :param file_type: ``MEDIA_TYPE_*`` constant.
+        :param file_name: Original filename (for upload_prepare).
+        :returns: The raw response dict from ``complete_upload`` — contains
+            ``file_info`` that the caller uses in a RichMedia message body.
+        :raises UploadDailyLimitExceededError: On biz_code 40093002.
+        :raises UploadFileTooLargeError: When the file exceeds the platform limit.
+        :raises RuntimeError: On other API or I/O failures.
+        """
+        if chat_type not in ("c2c", "group"):
+            raise ValueError(
+                f"ChunkedUploader: unsupported chat_type {chat_type!r}"
+            )
+
+        path = Path(file_path)
+        file_size = path.stat().st_size
+
+        logger.info(
+            "[%s] Chunked upload start: file=%s size=%s type=%d",
+            self._log_tag, file_name, format_size(file_size), file_type,
+        )
+
+        # Step 1: compute hashes (blocking I/O → executor).
+        hashes = await asyncio.get_running_loop().run_in_executor(
+            None, _compute_file_hashes, file_path, file_size
+        )
+
+        # Step 2: upload_prepare.
+        prepare = await self._prepare(
+            chat_type, target_id, file_type, file_name, file_size, hashes
+        )
+        max_concurrent = min(prepare.concurrency, _MAX_CONCURRENT_PARTS)
+        retry_timeout = min(
+            prepare.retry_timeout if prepare.retry_timeout > 0 else _PART_FINISH_DEFAULT_TIMEOUT,
+            _PART_FINISH_MAX_TIMEOUT,
+        )
+        logger.info(
+            "[%s] Prepared: upload_id=%s block_size=%s parts=%d concurrency=%d",
+            self._log_tag, prepare.upload_id, format_size(prepare.block_size),
+            len(prepare.parts), max_concurrent,
+        )
+
+        progress = _UploadProgress(
+            total_parts=len(prepare.parts),
+            total_bytes=file_size,
+        )
+
+        # Step 3: PUT each part + notify.
+        tasks: List[Callable[[], Awaitable[None]]] = [
+            functools.partial(
+                self._upload_one_part,
+                chat_type=chat_type,
+                target_id=target_id,
+                file_path=file_path,
+                file_size=file_size,
+                upload_id=prepare.upload_id,
+                rsp_block_size=prepare.block_size,
+                part=part,
+                retry_timeout=retry_timeout,
+                progress=progress,
+            )
+            for part in prepare.parts
+        ]
+        await _run_with_concurrency(tasks, max_concurrent)
+
+        logger.info(
+            "[%s] All %d parts uploaded, completing…",
+            self._log_tag, len(prepare.parts),
+        )
+
+        # Step 4: complete_upload (retry on transient errors).
+        return await self._complete(chat_type, target_id, prepare.upload_id)
+
+    # ──────────────────────────────────────────────────────────────────
+    # Step 1 — upload_prepare
+    # ──────────────────────────────────────────────────────────────────
+
+    async def _prepare(
+        self,
+        chat_type: str,
+        target_id: str,
+        file_type: int,
+        file_name: str,
+        file_size: int,
+        hashes: Dict[str, str],
+    ) -> _PrepareResult:
+        base = "/v2/users" if chat_type == "c2c" else "/v2/groups"
+        path = f"{base}/{target_id}/upload_prepare"
+        body = {
+            "file_type": file_type,
+            "file_name": file_name,
+            "file_size": file_size,
+            "md5": hashes["md5"],
+            "sha1": hashes["sha1"],
+            "md5_10m": hashes["md5_10m"],
+        }
+        try:
+            raw = await self._api_request(
+                "POST", path, body=body, timeout=FILE_UPLOAD_TIMEOUT
+            )
+        except RuntimeError as exc:
+            err_msg = str(exc)
+            if f"{_BIZ_CODE_DAILY_LIMIT}" in err_msg:
+                raise UploadDailyLimitExceededError(
+                    file_name, file_size, err_msg
+                ) from exc
+            raise
+        return _parse_prepare_response(raw)
+
+    # ──────────────────────────────────────────────────────────────────
+    # Step 2 — PUT one part + part_finish
+    # ──────────────────────────────────────────────────────────────────
+
+    async def _upload_one_part(
+        self,
+        chat_type: str,
+        target_id: str,
+        file_path: str,
+        file_size: int,
+        upload_id: str,
+        rsp_block_size: int,
+        part: _PreparePart,
+        retry_timeout: float,
+        progress: _UploadProgress,
+    ) -> None:
+        """PUT one part to COS, then call ``upload_part_finish``."""
+        part_index = part.index
+        # Per-part block_size wins; fall back to the response-level value.
+        actual_block_size = part.block_size if part.block_size > 0 else rsp_block_size
+        offset = (part_index - 1) * rsp_block_size
+        length = min(actual_block_size, file_size - offset)
+
+        # Read this slice of the file (blocking → executor).
+        data = await asyncio.get_running_loop().run_in_executor(
+            None, _read_file_chunk, file_path, offset, length
+        )
+        md5_hex = hashlib.md5(data).hexdigest()
+
+        logger.debug(
+            "[%s] Part %d/%d: uploading %s (offset=%d md5=%s)",
+            self._log_tag, part_index, progress.total_parts,
+            format_size(length), offset, md5_hex,
+        )
+
+        await self._put_to_presigned_url(
+            part.presigned_url, data, part_index, progress.total_parts
+        )
+        await self._part_finish_with_retry(
+            chat_type, target_id, upload_id,
+            part_index, length, md5_hex, retry_timeout,
+        )
+
+        progress.completed_parts += 1
+        progress.uploaded_bytes += length
+        logger.debug(
+            "[%s] Part %d/%d done (%d/%d total)",
+            self._log_tag, part_index, progress.total_parts,
+            progress.completed_parts, progress.total_parts,
+        )
+
+    async def _put_to_presigned_url(
+        self,
+        url: str,
+        data: bytes,
+        part_index: int,
+        total_parts: int,
+    ) -> None:
+        """PUT part data to a pre-signed COS URL with retry."""
+        last_exc: Optional[Exception] = None
+        for attempt in range(_PART_UPLOAD_MAX_RETRIES + 1):
+            try:
+                resp = await asyncio.wait_for(
+                    self._http_put(
+                        url,
+                        data=data,
+                        headers={"Content-Length": str(len(data))},
+                    ),
+                    timeout=_PART_UPLOAD_TIMEOUT,
+                )
+                # Caller's http_put is expected to return an httpx-like response.
+                status = getattr(resp, "status_code", 0)
+                if 200 <= status < 300:
+                    logger.debug(
+                        "[%s] PUT part %d/%d: %d OK",
+                        self._log_tag, part_index, total_parts, status,
+                    )
+                    return
+                body_preview = ""
+                try:
+                    body_preview = getattr(resp, "text", "")[:200]
+                except Exception:  # pragma: no cover — defensive
+                    pass
+                raise RuntimeError(
+                    f"COS PUT returned {status}: {body_preview}"
+                )
+            except Exception as exc:
+                last_exc = exc
+                if attempt < _PART_UPLOAD_MAX_RETRIES:
+                    delay = 1.0 * (2 ** attempt)
+                    logger.warning(
+                        "[%s] PUT part %d/%d attempt %d failed, retry in %.1fs: %s",
+                        self._log_tag, part_index, total_parts,
+                        attempt + 1, delay, exc,
+                    )
+                    await asyncio.sleep(delay)
+        raise RuntimeError(
+            f"Part {part_index}/{total_parts} upload failed after "
+            f"{_PART_UPLOAD_MAX_RETRIES + 1} attempts: {last_exc}"
+        )
+
+    async def _part_finish_with_retry(
+        self,
+        chat_type: str,
+        target_id: str,
+        upload_id: str,
+        part_index: int,
+        block_size: int,
+        md5: str,
+        retry_timeout: float,
+    ) -> None:
+        """Call ``upload_part_finish``, retrying on biz_code 40093001."""
+        base = "/v2/users" if chat_type == "c2c" else "/v2/groups"
+        path = f"{base}/{target_id}/upload_part_finish"
+        body = {
+            "upload_id": upload_id,
+            "part_index": part_index,
+            "block_size": block_size,
+            "md5": md5,
+        }
+
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        attempt = 0
+        while True:
+            try:
+                await self._api_request(
+                    "POST", path, body=body, timeout=FILE_UPLOAD_TIMEOUT
+                )
+                return
+            except RuntimeError as exc:
+                err_msg = str(exc)
+                if f"{_BIZ_CODE_PART_RETRYABLE}" not in err_msg:
+                    raise
+                elapsed = loop.time() - start
+                if elapsed >= retry_timeout:
+                    raise RuntimeError(
+                        f"upload_part_finish persistent retry timed out "
+                        f"after {retry_timeout:.0f}s ({attempt} retries): {exc}"
+                    ) from exc
+                attempt += 1
+                logger.debug(
+                    "[%s] part_finish retryable error, attempt %d, "
+                    "elapsed=%.1fs: %s",
+                    self._log_tag, attempt, elapsed, exc,
+                )
+                await asyncio.sleep(_PART_FINISH_RETRY_INTERVAL)
+
+    # ──────────────────────────────────────────────────────────────────
+    # Step 3 — complete_upload
+    # ──────────────────────────────────────────────────────────────────
+
+    async def _complete(
+        self,
+        chat_type: str,
+        target_id: str,
+        upload_id: str,
+    ) -> Dict[str, Any]:
+        """Call ``complete_upload`` with retry.
+
+        This reuses the ``/files`` endpoint (same as the simple URL-based upload)
+        but signals the chunked-completion path by sending only ``upload_id``.
+        """
+        base = "/v2/users" if chat_type == "c2c" else "/v2/groups"
+        path = f"{base}/{target_id}/files"
+        body = {"upload_id": upload_id}
+
+        last_exc: Optional[Exception] = None
+        for attempt in range(_COMPLETE_UPLOAD_MAX_RETRIES + 1):
+            try:
+                return await self._api_request(
+                    "POST", path, body=body, timeout=FILE_UPLOAD_TIMEOUT
+                )
+            except Exception as exc:
+                last_exc = exc
+                if attempt < _COMPLETE_UPLOAD_MAX_RETRIES:
+                    delay = _COMPLETE_UPLOAD_BASE_DELAY * (2 ** attempt)
+                    logger.warning(
+                        "[%s] complete_upload attempt %d failed, "
+                        "retry in %.1fs: %s",
+                        self._log_tag, attempt + 1, delay, exc,
+                    )
+                    await asyncio.sleep(delay)
+        raise RuntimeError(
+            f"complete_upload failed after "
+            f"{_COMPLETE_UPLOAD_MAX_RETRIES + 1} attempts: {last_exc}"
+        )
+
+
+# ── Helpers (module-level for testability) ───────────────────────────
+
+def format_size(size_bytes: int) -> str:
+    """Return a human-readable file size string (e.g. ``'12.3 MB'``)."""
+    size = float(size_bytes)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024.0:
+            return f"{size:.1f} {unit}"
+        size /= 1024.0
+    return f"{size:.1f} TB"
+
+
+def _read_file_chunk(file_path: str, offset: int, length: int) -> bytes:
+    """Read *length* bytes from *file_path* starting at *offset*.
+
+    :raises IOError: If fewer bytes were read than expected (truncated file).
+    """
+    with open(file_path, "rb") as fh:
+        fh.seek(offset)
+        data = fh.read(length)
+        if len(data) != length:
+            raise IOError(
+                f"Short read from {file_path}: expected {length} bytes at "
+                f"offset {offset}, got {len(data)} (file may be truncated)"
+            )
+        return data
+
+
+def _compute_file_hashes(file_path: str, file_size: int) -> Dict[str, str]:
+    """Compute md5, sha1, and md5_10m in a single pass."""
+    md5 = hashlib.md5()
+    sha1 = hashlib.sha1()
+    md5_10m = hashlib.md5()
+
+    need_10m = file_size > _MD5_10M_SIZE
+    bytes_read = 0
+
+    with open(file_path, "rb") as fh:
+        while True:
+            chunk = fh.read(65536)
+            if not chunk:
+                break
+            md5.update(chunk)
+            sha1.update(chunk)
+            if need_10m:
+                remaining = _MD5_10M_SIZE - bytes_read
+                if remaining > 0:
+                    md5_10m.update(chunk[:remaining])
+            bytes_read += len(chunk)
+
+    full_md5 = md5.hexdigest()
+    return {
+        "md5": full_md5,
+        "sha1": sha1.hexdigest(),
+        # For small files the "10m" hash is just the full md5.
+        "md5_10m": md5_10m.hexdigest() if need_10m else full_md5,
+    }
+
+
+async def _run_with_concurrency(
+    tasks: List[Callable[[], Awaitable[None]]],
+    concurrency: int,
+) -> None:
+    """Run a list of thunks with a bounded number in flight at once."""
+    if concurrency < 1:
+        concurrency = 1
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _wrap(thunk: Callable[[], Awaitable[None]]) -> None:
+        async with sem:
+            await thunk()
+
+    await asyncio.gather(*(_wrap(t) for t in tasks))

--- a/gateway/platforms/qqbot/keyboards.py
+++ b/gateway/platforms/qqbot/keyboards.py
@@ -1,0 +1,473 @@
+"""QQ Bot inline keyboards + approval / update-prompt senders.
+
+QQ Bot v2 supports attaching inline keyboards to outbound messages. When a
+user clicks a button, the platform dispatches an ``INTERACTION_CREATE``
+gateway event containing the button's ``data`` payload. The bot must ACK the
+interaction promptly via ``PUT /interactions/{id}`` or the user sees an
+error indicator on the button.
+
+This module provides:
+
+- :class:`InlineKeyboard` + button dataclasses — serialized into the
+  ``keyboard`` field of the outbound message body.
+- :func:`build_approval_keyboard` — 3-button ✅ once / ⭐ always / ❌ deny
+  keyboard for tool-approval flows.
+- :func:`build_update_prompt_keyboard` — Yes/No keyboard for update confirms.
+- :func:`parse_approval_button_data` / :func:`parse_update_prompt_button_data`
+  — decode the ``button_data`` payload from ``INTERACTION_CREATE``.
+- :class:`ApprovalRequest` + :class:`ApprovalSender` — high-level helper that
+  builds an approval message with keyboard and posts it to a c2c / group chat.
+
+``button_data`` formats::
+
+    approve:<session_key>:<decision>      # decision = allow-once|allow-always|deny
+    update_prompt:<answer>                # answer = y|n
+
+Ported from WideLee's qqbot-agent-sdk v1.2.2 (``approval.py`` + ``dto.py``
+keyboard types). Authorship preserved via Co-authored-by.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── button_data prefixes + patterns ──────────────────────────────────
+
+APPROVAL_BUTTON_PREFIX = "approve:"
+UPDATE_PROMPT_PREFIX = "update_prompt:"
+
+# Pattern: approve:<session_key>:<decision>
+# session_key may itself contain colons (e.g. agent:main:qqbot:c2c:OPENID),
+# so the session_key group is greedy but trails the decision.
+_APPROVAL_DATA_RE = re.compile(
+    r"^approve:(.+):(allow-once|allow-always|deny)$"
+)
+
+# Pattern: update_prompt:y | update_prompt:n
+_UPDATE_PROMPT_RE = re.compile(r"^update_prompt:(y|n)$")
+
+
+# ── Keyboard dataclasses ─────────────────────────────────────────────
+
+@dataclass
+class KeyboardButtonPermission:
+    """Button permission metadata. ``type=2`` means all users can click."""
+    type: int = 2
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"type": self.type}
+
+
+@dataclass
+class KeyboardButtonAction:
+    """What happens when the button is clicked.
+
+    :param type: ``1`` (Callback — triggers ``INTERACTION_CREATE``) or
+        ``2`` (Link — opens a URL).
+    :param data: Payload delivered in ``data.resolved.button_data`` when
+        ``type=1``.
+    :param permission: :class:`KeyboardButtonPermission`.
+    :param click_limit: Max clicks per user (``1`` = single-use).
+    """
+    type: int
+    data: str
+    permission: KeyboardButtonPermission = field(
+        default_factory=KeyboardButtonPermission
+    )
+    click_limit: int = 1
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "type": self.type,
+            "data": self.data,
+            "permission": self.permission.to_dict(),
+            "click_limit": self.click_limit,
+        }
+
+
+@dataclass
+class KeyboardButtonRenderData:
+    """Visual rendering of a button.
+
+    :param label: Pre-click label.
+    :param visited_label: Post-click label (button stays greyed in place).
+    :param style: ``0`` = grey, ``1`` = blue.
+    """
+    label: str
+    visited_label: str
+    style: int = 1
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "label": self.label,
+            "visited_label": self.visited_label,
+            "style": self.style,
+        }
+
+
+@dataclass
+class KeyboardButton:
+    """One button in a keyboard.
+
+    :param group_id: Buttons sharing a ``group_id`` are mutually exclusive —
+        clicking one greys the rest.
+    """
+    id: str
+    render_data: KeyboardButtonRenderData
+    action: KeyboardButtonAction
+    group_id: str = "default"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "render_data": self.render_data.to_dict(),
+            "action": self.action.to_dict(),
+            "group_id": self.group_id,
+        }
+
+
+@dataclass
+class KeyboardRow:
+    buttons: List[KeyboardButton] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"buttons": [b.to_dict() for b in self.buttons]}
+
+
+@dataclass
+class KeyboardContent:
+    rows: List[KeyboardRow] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"rows": [r.to_dict() for r in self.rows]}
+
+
+@dataclass
+class InlineKeyboard:
+    """Top-level keyboard payload — goes into ``MessageToCreate.keyboard``."""
+    content: KeyboardContent = field(default_factory=KeyboardContent)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"content": self.content.to_dict()}
+
+
+# ── INTERACTION_CREATE parsing ───────────────────────────────────────
+
+def parse_approval_button_data(button_data: str) -> Optional[tuple[str, str]]:
+    """Parse approval ``button_data`` into ``(session_key, decision)``.
+
+    :param button_data: Raw ``data.resolved.button_data`` from
+        ``INTERACTION_CREATE``.
+    :returns: ``(session_key, decision)`` or ``None`` if not an approval button.
+    """
+    m = _APPROVAL_DATA_RE.match(button_data or "")
+    if not m:
+        return None
+    return m.group(1), m.group(2)
+
+
+def parse_update_prompt_button_data(button_data: str) -> Optional[str]:
+    """Parse update-prompt ``button_data`` into ``'y'`` or ``'n'``."""
+    m = _UPDATE_PROMPT_RE.match(button_data or "")
+    if not m:
+        return None
+    return m.group(1)
+
+
+# ── Keyboard builders ────────────────────────────────────────────────
+
+def _make_callback_button(
+    btn_id: str,
+    label: str,
+    visited_label: str,
+    data: str,
+    style: int,
+    group_id: str,
+) -> KeyboardButton:
+    return KeyboardButton(
+        id=btn_id,
+        render_data=KeyboardButtonRenderData(
+            label=label,
+            visited_label=visited_label,
+            style=style,
+        ),
+        action=KeyboardButtonAction(type=1, data=data),
+        group_id=group_id,
+    )
+
+
+def build_approval_keyboard(session_key: str) -> InlineKeyboard:
+    """Build the 3-button approval keyboard.
+
+    Layout: ``[✅ 允许一次] [⭐ 始终允许] [❌ 拒绝]`` — all three share
+    ``group_id='approval'`` so clicking one greys out the rest.
+
+    :param session_key: Embedded into ``button_data`` so the decision
+        routes back to the right pending approval.
+    """
+    return InlineKeyboard(
+        content=KeyboardContent(
+            rows=[
+                KeyboardRow(buttons=[
+                    _make_callback_button(
+                        btn_id="allow",
+                        label="✅ 允许一次",
+                        visited_label="已允许",
+                        data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-once",
+                        style=1,
+                        group_id="approval",
+                    ),
+                    _make_callback_button(
+                        btn_id="always",
+                        label="⭐ 始终允许",
+                        visited_label="已始终允许",
+                        data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-always",
+                        style=1,
+                        group_id="approval",
+                    ),
+                    _make_callback_button(
+                        btn_id="deny",
+                        label="❌ 拒绝",
+                        visited_label="已拒绝",
+                        data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:deny",
+                        style=0,
+                        group_id="approval",
+                    ),
+                ]),
+            ]
+        )
+    )
+
+
+def build_update_prompt_keyboard() -> InlineKeyboard:
+    """Build a Yes/No keyboard for update confirmation prompts."""
+    return InlineKeyboard(
+        content=KeyboardContent(
+            rows=[
+                KeyboardRow(buttons=[
+                    _make_callback_button(
+                        btn_id="yes",
+                        label="✓ 确认",
+                        visited_label="已确认",
+                        data=f"{UPDATE_PROMPT_PREFIX}y",
+                        style=1,
+                        group_id="update_prompt",
+                    ),
+                    _make_callback_button(
+                        btn_id="no",
+                        label="✗ 取消",
+                        visited_label="已取消",
+                        data=f"{UPDATE_PROMPT_PREFIX}n",
+                        style=0,
+                        group_id="update_prompt",
+                    ),
+                ]),
+            ]
+        )
+    )
+
+
+# ── ApprovalRequest + text builder ───────────────────────────────────
+
+@dataclass
+class ApprovalRequest:
+    """Structured approval-request display data.
+
+    :param session_key: Routes the decision back to the waiting caller.
+    :param title: Short title at the top.
+    :param description: Optional longer description.
+    :param command_preview: Command text (exec approvals).
+    :param cwd: Working directory (exec approvals).
+    :param tool_name: Tool name (plugin approvals).
+    :param severity: ``'critical' | 'info' | ''``.
+    :param timeout_sec: Seconds until the approval expires.
+    """
+    session_key: str
+    title: str
+    description: str = ""
+    command_preview: str = ""
+    cwd: str = ""
+    tool_name: str = ""
+    severity: str = ""
+    timeout_sec: int = 120
+
+
+def build_approval_text(req: ApprovalRequest) -> str:
+    """Render an :class:`ApprovalRequest` into the message body (markdown)."""
+    if req.command_preview or req.cwd:
+        return _build_exec_text(req)
+    return _build_plugin_text(req)
+
+
+def _build_exec_text(req: ApprovalRequest) -> str:
+    lines: List[str] = ["🔐 **命令执行审批**", ""]
+    if req.command_preview:
+        preview = req.command_preview[:300]
+        lines.append(f"```\n{preview}\n```")
+    if req.cwd:
+        lines.append(f"📁 目录: {req.cwd}")
+    if req.title and req.title != req.command_preview:
+        lines.append(f"📋 {req.title}")
+    if req.description:
+        lines.append(f"📝 {req.description}")
+    lines.append("")
+    lines.append(f"⏱️ 超时: {req.timeout_sec} 秒")
+    return "\n".join(lines)
+
+
+def _build_plugin_text(req: ApprovalRequest) -> str:
+    icon = (
+        "🔴" if req.severity == "critical"
+        else "🔵" if req.severity == "info"
+        else "🟡"
+    )
+    lines: List[str] = [f"{icon} **审批请求**", ""]
+    lines.append(f"📋 {req.title}")
+    if req.description:
+        lines.append(f"📝 {req.description}")
+    if req.tool_name:
+        lines.append(f"🔧 工具: {req.tool_name}")
+    lines.append("")
+    lines.append(f"⏱️ 超时: {req.timeout_sec} 秒")
+    return "\n".join(lines)
+
+
+# ── ApprovalSender ───────────────────────────────────────────────────
+
+PostMessageFn = Callable[..., Awaitable[Dict[str, Any]]]
+"""Signature of an async POST to ``/v2/{users|groups}/{id}/messages``.
+
+Implementations accept a body dict and return the raw API response.
+"""
+
+
+class ApprovalSender:
+    """Send an approval-request message with an inline keyboard.
+
+    Decoupled from the adapter via callables so it can be unit-tested in
+    isolation. Pass the adapter's ``_send_message_with_keyboard`` helper
+    (or any equivalent) as ``post_message``.
+    """
+
+    def __init__(
+        self,
+        post_c2c: PostMessageFn,
+        post_group: PostMessageFn,
+        log_tag: str = "QQBot",
+    ) -> None:
+        self._post_c2c = post_c2c
+        self._post_group = post_group
+        self._log_tag = log_tag
+
+    async def send(
+        self,
+        chat_type: str,
+        chat_id: str,
+        req: ApprovalRequest,
+        msg_id: Optional[str] = None,
+    ) -> bool:
+        """Send an approval message to *chat_id*.
+
+        :param chat_type: ``'c2c'`` or ``'group'``.
+        :param chat_id: User openid or group openid.
+        :param req: :class:`ApprovalRequest`.
+        :param msg_id: Reply-to message id (required for passive messages).
+        :returns: ``True`` on success, ``False`` on failure.
+        """
+        text = build_approval_text(req)
+        keyboard = build_approval_keyboard(req.session_key)
+
+        logger.info(
+            "[%s] Sending approval request to %s:%s (session=%.20s…)",
+            self._log_tag, chat_type, chat_id, req.session_key,
+        )
+
+        try:
+            if chat_type == "c2c":
+                await self._post_c2c(chat_id, text, msg_id, keyboard)
+            elif chat_type == "group":
+                await self._post_group(chat_id, text, msg_id, keyboard)
+            else:
+                logger.warning(
+                    "[%s] Approval: unsupported chat_type %r",
+                    self._log_tag, chat_type,
+                )
+                return False
+            logger.info(
+                "[%s] Approval message sent to %s:%s",
+                self._log_tag, chat_type, chat_id,
+            )
+            return True
+        except Exception as exc:
+            logger.error(
+                "[%s] Failed to send approval message to %s:%s: %s",
+                self._log_tag, chat_type, chat_id, exc,
+            )
+            return False
+
+
+# ── INTERACTION_CREATE event shape ───────────────────────────────────
+
+@dataclass
+class InteractionEvent:
+    """Parsed ``INTERACTION_CREATE`` event payload.
+
+    See https://bot.q.qq.com/wiki/develop/api-v2/dev-prepare/interface-framework/event-emit.html
+    """
+    id: str = ""
+    """Interaction event id — required for the ``PUT /interactions/{id}`` ACK."""
+
+    type: int = 0
+    """Event type code (``11`` = message button)."""
+
+    chat_type: int = 0
+    """``0`` = guild, ``1`` = group, ``2`` = c2c."""
+
+    scene: str = ""
+    """``'guild'`` | ``'group'`` | ``'c2c'`` — human-readable scene."""
+
+    group_openid: str = ""
+    group_member_openid: str = ""
+    user_openid: str = ""
+    channel_id: str = ""
+    guild_id: str = ""
+
+    button_data: str = ""
+    button_id: str = ""
+    resolver_user_id: str = ""
+
+    @property
+    def operator_openid(self) -> str:
+        """Best available operator openid (group → member; c2c → user)."""
+        return (
+            self.group_member_openid
+            or self.user_openid
+            or self.resolver_user_id
+        )
+
+
+def parse_interaction_event(raw: Dict[str, Any]) -> InteractionEvent:
+    """Parse a raw ``INTERACTION_CREATE`` dispatch payload (``d``)."""
+    data_raw = raw.get("data") or {}
+    resolved = data_raw.get("resolved") or {}
+    scene_code = int(raw.get("chat_type", 0) or 0)
+    scene = {0: "guild", 1: "group", 2: "c2c"}.get(scene_code, "")
+    return InteractionEvent(
+        id=str(raw.get("id", "")),
+        type=int(data_raw.get("type", 0) or 0),
+        chat_type=scene_code,
+        scene=scene,
+        group_openid=str(raw.get("group_openid", "")),
+        group_member_openid=str(raw.get("group_member_openid", "")),
+        user_openid=str(raw.get("user_openid", "")),
+        channel_id=str(raw.get("channel_id", "")),
+        guild_id=str(raw.get("guild_id", "")),
+        button_data=str(resolved.get("button_data", "")),
+        button_id=str(resolved.get("button_id", "")),
+        resolver_user_id=str(resolved.get("user_id", "")),
+    )

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -626,3 +626,352 @@ class TestWaitForReconnection:
         assert not result.success
         assert result.retryable is True
         assert "Not connected" in result.error
+
+
+# ---------------------------------------------------------------------------
+# ChunkedUploader
+# ---------------------------------------------------------------------------
+
+class TestChunkedUploadFormatSize:
+    def test_bytes(self):
+        from gateway.platforms.qqbot.chunked_upload import format_size
+        assert format_size(100) == "100.0 B"
+
+    def test_kilobytes(self):
+        from gateway.platforms.qqbot.chunked_upload import format_size
+        assert format_size(2048) == "2.0 KB"
+
+    def test_megabytes(self):
+        from gateway.platforms.qqbot.chunked_upload import format_size
+        assert format_size(5 * 1024 * 1024) == "5.0 MB"
+
+    def test_gigabytes(self):
+        from gateway.platforms.qqbot.chunked_upload import format_size
+        assert format_size(3 * 1024 ** 3) == "3.0 GB"
+
+
+class TestChunkedUploadErrors:
+    def test_daily_limit_has_human_size(self):
+        from gateway.platforms.qqbot.chunked_upload import UploadDailyLimitExceededError
+        exc = UploadDailyLimitExceededError("demo.mp4", 12_345_678)
+        assert exc.file_name == "demo.mp4"
+        assert exc.file_size == 12_345_678
+        assert "MB" in exc.file_size_human
+        assert "demo.mp4" in str(exc)
+
+    def test_too_large_includes_limit(self):
+        from gateway.platforms.qqbot.chunked_upload import UploadFileTooLargeError
+        exc = UploadFileTooLargeError("huge.bin", 200 * 1024 * 1024, 100 * 1024 * 1024)
+        assert exc.file_name == "huge.bin"
+        assert "MB" in exc.file_size_human
+        assert "MB" in exc.limit_human
+        assert "huge.bin" in str(exc)
+
+    def test_too_large_unknown_limit(self):
+        from gateway.platforms.qqbot.chunked_upload import UploadFileTooLargeError
+        exc = UploadFileTooLargeError("f", 100, 0)
+        assert exc.limit_human == "unknown"
+
+
+class TestChunkedUploadHelpers:
+    def test_read_chunk_exact_bytes(self, tmp_path):
+        from gateway.platforms.qqbot.chunked_upload import _read_file_chunk
+        f = tmp_path / "x.bin"
+        f.write_bytes(b"0123456789abcdef")
+        assert _read_file_chunk(str(f), 2, 4) == b"2345"
+
+    def test_read_chunk_short_read_raises(self, tmp_path):
+        from gateway.platforms.qqbot.chunked_upload import _read_file_chunk
+        f = tmp_path / "x.bin"
+        f.write_bytes(b"hi")
+        with pytest.raises(IOError):
+            _read_file_chunk(str(f), 0, 100)
+
+    def test_compute_hashes_small_file(self, tmp_path):
+        from gateway.platforms.qqbot.chunked_upload import _compute_file_hashes
+        f = tmp_path / "x.bin"
+        f.write_bytes(b"hello world")
+        h = _compute_file_hashes(str(f), 11)
+        assert len(h["md5"]) == 32
+        assert len(h["sha1"]) == 40
+        # For small files md5_10m equals md5.
+        assert h["md5"] == h["md5_10m"]
+
+    def test_compute_hashes_large_file_has_distinct_md5_10m(self, tmp_path):
+        # File > 10,002,432 bytes → md5_10m is truncated, so it differs from full md5.
+        from gateway.platforms.qqbot.chunked_upload import (
+            _compute_file_hashes, _MD5_10M_SIZE,
+        )
+        f = tmp_path / "big.bin"
+        size = _MD5_10M_SIZE + 1024
+        # Two distinct byte values so the extra tail changes the full md5.
+        f.write_bytes(b"A" * _MD5_10M_SIZE + b"B" * 1024)
+        h = _compute_file_hashes(str(f), size)
+        assert h["md5"] != h["md5_10m"]
+
+    def test_parse_prepare_response_wrapped_in_data(self):
+        from gateway.platforms.qqbot.chunked_upload import _parse_prepare_response
+        raw = {
+            "data": {
+                "upload_id": "uid-42",
+                "block_size": 4096,
+                "parts": [
+                    {"part_index": 1, "presigned_url": "https://cos/1", "block_size": 4096},
+                    {"index": 2, "url": "https://cos/2"},
+                ],
+                "concurrency": 3,
+                "retry_timeout": 90,
+            }
+        }
+        r = _parse_prepare_response(raw)
+        assert r.upload_id == "uid-42"
+        assert r.block_size == 4096
+        assert len(r.parts) == 2
+        assert r.parts[0].presigned_url == "https://cos/1"
+        assert r.parts[1].index == 2
+        assert r.concurrency == 3
+        assert r.retry_timeout == 90.0
+
+    def test_parse_prepare_response_missing_upload_id_raises(self):
+        from gateway.platforms.qqbot.chunked_upload import _parse_prepare_response
+        with pytest.raises(ValueError, match="upload_id"):
+            _parse_prepare_response({"block_size": 1024, "parts": [{"index": 1, "url": "x"}]})
+
+    def test_parse_prepare_response_missing_parts_raises(self):
+        from gateway.platforms.qqbot.chunked_upload import _parse_prepare_response
+        with pytest.raises(ValueError, match="parts"):
+            _parse_prepare_response({"upload_id": "uid", "block_size": 1024, "parts": []})
+
+
+class TestChunkedUploaderFlow:
+    """End-to-end prepare / PUT / part_finish / complete flow with mocked HTTP.
+
+    Verifies the state machine matches the QQ v2 contract without hitting the network.
+    """
+
+    @pytest.mark.asyncio
+    async def test_full_upload_two_parts_success(self, tmp_path):
+        from gateway.platforms.qqbot.chunked_upload import ChunkedUploader
+
+        # Two-part file.
+        f = tmp_path / "vid.mp4"
+        f.write_bytes(b"A" * 5_000_000 + b"B" * 3_000_000)
+
+        # Mock api_request — handles prepare, part_finish, complete based on URL.
+        api_calls = []
+
+        async def fake_api_request(method, path, *, body=None, timeout=None):
+            api_calls.append((method, path, body))
+            if path.endswith("/upload_prepare"):
+                return {
+                    "upload_id": "uid-xyz",
+                    "block_size": 5_000_000,
+                    "parts": [
+                        {"part_index": 1, "presigned_url": "https://cos.example/p1"},
+                        {"part_index": 2, "presigned_url": "https://cos.example/p2"},
+                    ],
+                    "concurrency": 1,
+                }
+            if path.endswith("/upload_part_finish"):
+                return {}
+            # complete
+            return {"file_info": "FILEINFO_TOKEN", "file_uuid": "u-1"}
+
+        # Mock http_put — always returns 200.
+        put_calls = []
+
+        class _FakeResp:
+            status_code = 200
+            text = ""
+
+        async def fake_put(url, data=None, headers=None):
+            put_calls.append((url, len(data), headers))
+            return _FakeResp()
+
+        uploader = ChunkedUploader(
+            api_request=fake_api_request,
+            http_put=fake_put,
+            log_tag="QQBot:TEST",
+        )
+        result = await uploader.upload(
+            chat_type="c2c",
+            target_id="user-openid-1",
+            file_path=str(f),
+            file_type=2,  # MEDIA_TYPE_VIDEO
+            file_name="vid.mp4",
+        )
+
+        assert result["file_info"] == "FILEINFO_TOKEN"
+        # Two PUTs, one per part.
+        assert len(put_calls) == 2
+        assert put_calls[0][0] == "https://cos.example/p1"
+        assert put_calls[1][0] == "https://cos.example/p2"
+        # Prepare + 2 part_finish + complete = 4 api calls.
+        assert len(api_calls) == 4
+        assert api_calls[0][1].endswith("/upload_prepare")
+        assert api_calls[1][1].endswith("/upload_part_finish")
+        assert api_calls[2][1].endswith("/upload_part_finish")
+        # complete path reuses /files.
+        assert api_calls[3][1].endswith("/files")
+        assert api_calls[3][2] == {"upload_id": "uid-xyz"}
+
+    @pytest.mark.asyncio
+    async def test_group_paths(self, tmp_path):
+        """Group uploads hit /v2/groups/... instead of /v2/users/..."""
+        from gateway.platforms.qqbot.chunked_upload import ChunkedUploader
+
+        f = tmp_path / "a.bin"
+        f.write_bytes(b"x" * 100)
+
+        seen_paths = []
+
+        async def fake_api_request(method, path, *, body=None, timeout=None):
+            seen_paths.append(path)
+            if path.endswith("/upload_prepare"):
+                return {
+                    "upload_id": "gid-1",
+                    "block_size": 100,
+                    "parts": [{"part_index": 1, "presigned_url": "https://cos/g1"}],
+                }
+            if path.endswith("/upload_part_finish"):
+                return {}
+            return {"file_info": "GFILE"}
+
+        class _R:
+            status_code = 200
+            text = ""
+
+        async def fake_put(url, data=None, headers=None):
+            return _R()
+
+        u = ChunkedUploader(fake_api_request, fake_put, "QQBot:T")
+        await u.upload(
+            chat_type="group",
+            target_id="grp-openid-1",
+            file_path=str(f),
+            file_type=4,
+            file_name="a.bin",
+        )
+        assert all("/v2/groups/" in p for p in seen_paths)
+        assert any(p.endswith("/upload_prepare") for p in seen_paths)
+        assert any(p.endswith("/files") for p in seen_paths)
+
+    @pytest.mark.asyncio
+    async def test_daily_limit_raises_structured_error(self, tmp_path):
+        from gateway.platforms.qqbot.chunked_upload import (
+            ChunkedUploader, UploadDailyLimitExceededError,
+        )
+
+        f = tmp_path / "a.bin"
+        f.write_bytes(b"x" * 10)
+
+        async def fake_api_request(method, path, *, body=None, timeout=None):
+            # Simulate the adapter's RuntimeError with biz_code 40093002 in the message.
+            raise RuntimeError("QQ Bot API error [200] /v2/users/x/upload_prepare: biz_code=40093002 daily limit exceeded")
+
+        async def fake_put(*a, **kw):
+            raise AssertionError("PUT should not be called if prepare fails")
+
+        u = ChunkedUploader(fake_api_request, fake_put, "T")
+        with pytest.raises(UploadDailyLimitExceededError) as excinfo:
+            await u.upload(
+                chat_type="c2c",
+                target_id="u",
+                file_path=str(f),
+                file_type=4,
+                file_name="a.bin",
+            )
+        assert excinfo.value.file_name == "a.bin"
+
+    @pytest.mark.asyncio
+    async def test_part_finish_retries_on_40093001_then_succeeds(self, tmp_path):
+        """biz_code 40093001 is retryable — finish-with-retry must keep trying."""
+        from gateway.platforms.qqbot.chunked_upload import ChunkedUploader
+        import gateway.platforms.qqbot.chunked_upload as cu
+
+        # Make the retry loop fast so the test doesn't take real seconds.
+        orig_interval = cu._PART_FINISH_RETRY_INTERVAL
+        cu._PART_FINISH_RETRY_INTERVAL = 0.01
+
+        try:
+            f = tmp_path / "a.bin"
+            f.write_bytes(b"x" * 50)
+
+            finish_calls = {"n": 0}
+
+            async def fake_api_request(method, path, *, body=None, timeout=None):
+                if path.endswith("/upload_prepare"):
+                    return {
+                        "upload_id": "u",
+                        "block_size": 50,
+                        "parts": [{"part_index": 1, "presigned_url": "https://cos/1"}],
+                    }
+                if path.endswith("/upload_part_finish"):
+                    finish_calls["n"] += 1
+                    if finish_calls["n"] < 3:
+                        raise RuntimeError("biz_code=40093001 transient part finish error")
+                    return {}
+                return {"file_info": "F"}
+
+            class _R:
+                status_code = 200
+                text = ""
+
+            async def fake_put(*a, **kw):
+                return _R()
+
+            u = ChunkedUploader(fake_api_request, fake_put, "T")
+            result = await u.upload(
+                chat_type="c2c",
+                target_id="u",
+                file_path=str(f),
+                file_type=4,
+                file_name="a.bin",
+            )
+            assert result["file_info"] == "F"
+            assert finish_calls["n"] == 3  # 2 transient errors + 1 success
+        finally:
+            cu._PART_FINISH_RETRY_INTERVAL = orig_interval
+
+    @pytest.mark.asyncio
+    async def test_put_retries_transient_failure(self, tmp_path):
+        """COS PUT failures retry up to _PART_UPLOAD_MAX_RETRIES times."""
+        from gateway.platforms.qqbot.chunked_upload import ChunkedUploader
+
+        f = tmp_path / "a.bin"
+        f.write_bytes(b"x" * 20)
+
+        async def fake_api_request(method, path, *, body=None, timeout=None):
+            if path.endswith("/upload_prepare"):
+                return {
+                    "upload_id": "u",
+                    "block_size": 20,
+                    "parts": [{"part_index": 1, "presigned_url": "https://cos/1"}],
+                }
+            if path.endswith("/upload_part_finish"):
+                return {}
+            return {"file_info": "F"}
+
+        put_attempts = {"n": 0}
+
+        class _Resp:
+            def __init__(self, status, text=""):
+                self.status_code = status
+                self.text = text
+
+        async def fake_put(url, data=None, headers=None):
+            put_attempts["n"] += 1
+            if put_attempts["n"] < 2:
+                return _Resp(500, "transient")
+            return _Resp(200)
+
+        u = ChunkedUploader(fake_api_request, fake_put, "T")
+        result = await u.upload(
+            chat_type="c2c",
+            target_id="u",
+            file_path=str(f),
+            file_type=4,
+            file_name="a.bin",
+        )
+        assert result["file_info"] == "F"
+        assert put_attempts["n"] == 2

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1301,3 +1301,220 @@ class TestAdapterInteractionDispatch:
             "user_openid": "u",
             "data": {"resolved": {"button_data": "approve:s:deny"}},
         })
+
+
+# ---------------------------------------------------------------------------
+# Quoted-message handling (message_type=103 → msg_elements)
+# ---------------------------------------------------------------------------
+
+class TestProcessQuotedContext:
+    """Verify the quoted-message pipeline: text + voice STT + images + files."""
+
+    def _make_adapter(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    @pytest.mark.asyncio
+    async def test_non_quote_message_returns_empty(self):
+        adapter = self._make_adapter()
+        d = {"message_type": 0, "content": "hi"}
+        out = await adapter._process_quoted_context(d)
+        assert out == {"quote_block": "", "image_urls": [], "image_media_types": []}
+
+    @pytest.mark.asyncio
+    async def test_quote_type_but_no_elements_returns_empty(self):
+        adapter = self._make_adapter()
+        d = {"message_type": 103}
+        out = await adapter._process_quoted_context(d)
+        assert out["quote_block"] == ""
+
+    @pytest.mark.asyncio
+    async def test_quote_with_text_only(self):
+        adapter = self._make_adapter()
+        # Stub out _process_attachments since there are no attachments anyway.
+        async def fake_process(_a):
+            return {"image_urls": [], "image_media_types": [],
+                    "voice_transcripts": [], "attachment_info": ""}
+        adapter._process_attachments = fake_process  # type: ignore[assignment]
+
+        d = {
+            "message_type": 103,
+            "msg_elements": [
+                {"content": "Did you see this file?", "attachments": []},
+            ],
+        }
+        out = await adapter._process_quoted_context(d)
+        assert out["quote_block"].startswith("[Quoted message]:")
+        assert "Did you see this file?" in out["quote_block"]
+        assert out["image_urls"] == []
+
+    @pytest.mark.asyncio
+    async def test_quote_with_voice_attachment_runs_stt(self):
+        adapter = self._make_adapter()
+
+        # Capture what attachments are passed into _process_attachments.
+        captured = []
+
+        async def fake_process(atts):
+            captured.append(atts)
+            return {
+                "image_urls": [],
+                "image_media_types": [],
+                "voice_transcripts": ["[Voice] hello from the quoted audio"],
+                "attachment_info": "",
+            }
+
+        adapter._process_attachments = fake_process  # type: ignore[assignment]
+
+        d = {
+            "message_type": 103,
+            "msg_elements": [{
+                "content": "",
+                "attachments": [
+                    {"content_type": "audio/silk",
+                     "url": "https://qq-cdn/x.silk",
+                     "filename": "rec.silk"}
+                ],
+            }],
+        }
+        out = await adapter._process_quoted_context(d)
+
+        # The quoted voice attachment must actually flow through STT.
+        assert captured and len(captured[0]) == 1
+        assert captured[0][0]["content_type"] == "audio/silk"
+        assert "[Quoted message]:" in out["quote_block"]
+        assert "hello from the quoted audio" in out["quote_block"]
+
+    @pytest.mark.asyncio
+    async def test_quote_with_file_preserves_filename(self):
+        """Quoted file attachments must surface the original filename, not the CDN hash."""
+        adapter = self._make_adapter()
+
+        async def fake_process(atts):
+            # Mirror _process_attachments's behaviour: non-image/voice attachments
+            # show up in attachment_info using the real filename.
+            parts = []
+            for a in atts:
+                fn = a.get("filename") or a.get("content_type", "file")
+                parts.append(f"[Attachment: {fn}]")
+            return {
+                "image_urls": [], "image_media_types": [],
+                "voice_transcripts": [],
+                "attachment_info": "\n".join(parts),
+            }
+
+        adapter._process_attachments = fake_process  # type: ignore[assignment]
+
+        d = {
+            "message_type": 103,
+            "msg_elements": [{
+                "content": "check this",
+                "attachments": [
+                    {"content_type": "application/zip",
+                     "url": "https://qq-cdn/abc123",
+                     "filename": "quarterly-report.zip"},
+                ],
+            }],
+        }
+        out = await adapter._process_quoted_context(d)
+        assert "quarterly-report.zip" in out["quote_block"]
+        assert "check this" in out["quote_block"]
+
+    @pytest.mark.asyncio
+    async def test_quote_with_image_returns_cached_paths(self):
+        adapter = self._make_adapter()
+
+        async def fake_process(atts):
+            return {
+                "image_urls": ["/tmp/cached_q.jpg"],
+                "image_media_types": ["image/jpeg"],
+                "voice_transcripts": [],
+                "attachment_info": "",
+            }
+
+        adapter._process_attachments = fake_process  # type: ignore[assignment]
+
+        d = {
+            "message_type": 103,
+            "msg_elements": [{
+                "content": "look at this",
+                "attachments": [{"content_type": "image/jpeg", "url": "https://x"}],
+            }],
+        }
+        out = await adapter._process_quoted_context(d)
+        assert out["image_urls"] == ["/tmp/cached_q.jpg"]
+        assert out["image_media_types"] == ["image/jpeg"]
+        assert "look at this" in out["quote_block"]
+
+    @pytest.mark.asyncio
+    async def test_quote_with_image_only_no_text(self):
+        """Images-only quote still surfaces a marker so the LLM has context."""
+        adapter = self._make_adapter()
+
+        async def fake_process(atts):
+            return {
+                "image_urls": ["/tmp/only.png"],
+                "image_media_types": ["image/png"],
+                "voice_transcripts": [],
+                "attachment_info": "",
+            }
+
+        adapter._process_attachments = fake_process  # type: ignore[assignment]
+
+        d = {
+            "message_type": 103,
+            "msg_elements": [{
+                "content": "",
+                "attachments": [{"content_type": "image/png", "url": "https://x"}],
+            }],
+        }
+        out = await adapter._process_quoted_context(d)
+        assert out["quote_block"]
+        assert out["image_urls"] == ["/tmp/only.png"]
+
+    @pytest.mark.asyncio
+    async def test_multiple_elements_concatenated(self):
+        adapter = self._make_adapter()
+
+        async def fake_process(atts):
+            assert len(atts) == 2
+            return {
+                "image_urls": [], "image_media_types": [],
+                "voice_transcripts": [], "attachment_info": "",
+            }
+
+        adapter._process_attachments = fake_process  # type: ignore[assignment]
+
+        d = {
+            "message_type": 103,
+            "msg_elements": [
+                {"content": "first", "attachments": [{"content_type": "image/png", "url": "a"}]},
+                {"content": "second", "attachments": [{"content_type": "image/png", "url": "b"}]},
+            ],
+        }
+        out = await adapter._process_quoted_context(d)
+        assert "first" in out["quote_block"]
+        assert "second" in out["quote_block"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_message_type_string_returns_empty(self):
+        adapter = self._make_adapter()
+        out = await adapter._process_quoted_context(
+            {"message_type": "not-a-number", "msg_elements": [{"content": "x"}]}
+        )
+        assert out["quote_block"] == ""
+
+
+class TestMergeQuoteInto:
+    def test_empty_quote_returns_original(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        assert QQAdapter._merge_quote_into("hello", "") == "hello"
+
+    def test_empty_text_returns_only_quote(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        assert QQAdapter._merge_quote_into("", "[Quoted]") == "[Quoted]"
+
+    def test_both_present_joined_with_blank_line(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        merged = QQAdapter._merge_quote_into("hi there", "[Quoted]:\nctx")
+        assert merged == "[Quoted]:\nctx\n\nhi there"

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -975,3 +975,329 @@ class TestChunkedUploaderFlow:
         )
         assert result["file_info"] == "F"
         assert put_attempts["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Inline keyboards — approval + update-prompt flows
+# ---------------------------------------------------------------------------
+
+class TestApprovalButtonData:
+    def test_parse_allow_once(self):
+        from gateway.platforms.qqbot.keyboards import parse_approval_button_data
+        result = parse_approval_button_data("approve:agent:main:qqbot:c2c:UID:allow-once")
+        assert result == ("agent:main:qqbot:c2c:UID", "allow-once")
+
+    def test_parse_allow_always(self):
+        from gateway.platforms.qqbot.keyboards import parse_approval_button_data
+        assert parse_approval_button_data("approve:sess:allow-always") == ("sess", "allow-always")
+
+    def test_parse_deny(self):
+        from gateway.platforms.qqbot.keyboards import parse_approval_button_data
+        assert parse_approval_button_data("approve:sess:deny") == ("sess", "deny")
+
+    def test_parse_invalid_prefix_returns_none(self):
+        from gateway.platforms.qqbot.keyboards import parse_approval_button_data
+        assert parse_approval_button_data("update_prompt:y") is None
+
+    def test_parse_unknown_decision_returns_none(self):
+        from gateway.platforms.qqbot.keyboards import parse_approval_button_data
+        assert parse_approval_button_data("approve:sess:maybe") is None
+
+    def test_parse_empty_returns_none(self):
+        from gateway.platforms.qqbot.keyboards import parse_approval_button_data
+        assert parse_approval_button_data("") is None
+        assert parse_approval_button_data(None) is None  # type: ignore[arg-type]
+
+
+class TestUpdatePromptButtonData:
+    def test_parse_yes(self):
+        from gateway.platforms.qqbot.keyboards import parse_update_prompt_button_data
+        assert parse_update_prompt_button_data("update_prompt:y") == "y"
+
+    def test_parse_no(self):
+        from gateway.platforms.qqbot.keyboards import parse_update_prompt_button_data
+        assert parse_update_prompt_button_data("update_prompt:n") == "n"
+
+    def test_parse_unknown_returns_none(self):
+        from gateway.platforms.qqbot.keyboards import parse_update_prompt_button_data
+        assert parse_update_prompt_button_data("update_prompt:maybe") is None
+
+    def test_parse_wrong_prefix(self):
+        from gateway.platforms.qqbot.keyboards import parse_update_prompt_button_data
+        assert parse_update_prompt_button_data("approve:sess:deny") is None
+
+
+class TestBuildApprovalKeyboard:
+    def test_three_buttons_in_single_row(self):
+        from gateway.platforms.qqbot.keyboards import build_approval_keyboard
+        kb = build_approval_keyboard("session-1")
+        assert len(kb.content.rows) == 1
+        assert len(kb.content.rows[0].buttons) == 3
+
+    def test_button_data_embeds_session_key(self):
+        from gateway.platforms.qqbot.keyboards import build_approval_keyboard
+        kb = build_approval_keyboard("agent:main:qqbot:c2c:UID")
+        datas = [b.action.data for b in kb.content.rows[0].buttons]
+        assert datas[0] == "approve:agent:main:qqbot:c2c:UID:allow-once"
+        assert datas[1] == "approve:agent:main:qqbot:c2c:UID:allow-always"
+        assert datas[2] == "approve:agent:main:qqbot:c2c:UID:deny"
+
+    def test_buttons_share_group_id_for_mutual_exclusion(self):
+        from gateway.platforms.qqbot.keyboards import build_approval_keyboard
+        kb = build_approval_keyboard("s")
+        group_ids = {b.group_id for b in kb.content.rows[0].buttons}
+        assert group_ids == {"approval"}
+
+    def test_to_dict_has_expected_shape(self):
+        from gateway.platforms.qqbot.keyboards import build_approval_keyboard
+        kb = build_approval_keyboard("s")
+        d = kb.to_dict()
+        assert "content" in d
+        assert "rows" in d["content"]
+        assert len(d["content"]["rows"]) == 1
+        btn0 = d["content"]["rows"][0]["buttons"][0]
+        assert btn0["id"] == "allow"
+        assert btn0["action"]["type"] == 1
+        assert btn0["action"]["data"].startswith("approve:s:")
+        assert btn0["render_data"]["label"]
+        assert btn0["render_data"]["visited_label"]
+
+    def test_round_trip_parse_matches_build(self):
+        """Every button built by build_approval_keyboard is parseable."""
+        from gateway.platforms.qqbot.keyboards import (
+            build_approval_keyboard, parse_approval_button_data,
+        )
+        session_key = "agent:main:qqbot:c2c:UID123"
+        kb = build_approval_keyboard(session_key)
+        for btn in kb.content.rows[0].buttons:
+            parsed = parse_approval_button_data(btn.action.data)
+            assert parsed is not None
+            assert parsed[0] == session_key
+            assert parsed[1] in ("allow-once", "allow-always", "deny")
+
+
+class TestBuildUpdatePromptKeyboard:
+    def test_two_buttons(self):
+        from gateway.platforms.qqbot.keyboards import build_update_prompt_keyboard
+        kb = build_update_prompt_keyboard()
+        assert len(kb.content.rows[0].buttons) == 2
+
+    def test_button_data_shape(self):
+        from gateway.platforms.qqbot.keyboards import build_update_prompt_keyboard
+        kb = build_update_prompt_keyboard()
+        datas = [b.action.data for b in kb.content.rows[0].buttons]
+        assert datas == ["update_prompt:y", "update_prompt:n"]
+
+
+class TestBuildApprovalText:
+    def test_exec_approval_includes_command_preview(self):
+        from gateway.platforms.qqbot.keyboards import (
+            ApprovalRequest, build_approval_text,
+        )
+        req = ApprovalRequest(
+            session_key="s",
+            title="t",
+            command_preview="rm -rf /tmp/demo",
+            cwd="/home/user",
+            timeout_sec=60,
+        )
+        text = build_approval_text(req)
+        assert "命令执行审批" in text
+        assert "rm -rf /tmp/demo" in text
+        assert "/home/user" in text
+        assert "60" in text
+
+    def test_plugin_approval_uses_severity_icon(self):
+        from gateway.platforms.qqbot.keyboards import (
+            ApprovalRequest, build_approval_text,
+        )
+        crit = ApprovalRequest(
+            session_key="s", title="dangerous op",
+            severity="critical", tool_name="shell", timeout_sec=30,
+        )
+        assert "🔴" in build_approval_text(crit)
+
+        info = ApprovalRequest(
+            session_key="s", title="read-only", severity="info", tool_name="q",
+        )
+        assert "🔵" in build_approval_text(info)
+
+        default = ApprovalRequest(session_key="s", title="t", tool_name="x")
+        assert "🟡" in build_approval_text(default)
+
+    def test_truncates_long_commands(self):
+        from gateway.platforms.qqbot.keyboards import (
+            ApprovalRequest, build_approval_text,
+        )
+        long = "x" * 1000
+        req = ApprovalRequest(
+            session_key="s", title="t", command_preview=long, cwd="/x",
+        )
+        text = build_approval_text(req)
+        # Preview is truncated to 300 chars; 1000 "x"s would still push the
+        # body past 300, but the inline preview specifically must be capped.
+        preview_line = [
+            line for line in text.split("\n") if line.startswith("```")
+        ]
+        # 2 backtick fences; the content line in between is separate.
+        xs_in_preview = sum(line.count("x") for line in text.split("\n") if line and "```" not in line)
+        assert xs_in_preview <= 301  # 300 xs + one-off tolerance
+
+
+class TestInteractionEventParsing:
+    def test_parse_c2c_interaction(self):
+        from gateway.platforms.qqbot.keyboards import parse_interaction_event
+        raw = {
+            "id": "interaction-42",
+            "chat_type": 2,
+            "user_openid": "user-1",
+            "data": {
+                "type": 11,
+                "resolved": {
+                    "button_data": "approve:sess:allow-once",
+                    "button_id": "allow",
+                },
+            },
+        }
+        ev = parse_interaction_event(raw)
+        assert ev.id == "interaction-42"
+        assert ev.scene == "c2c"
+        assert ev.chat_type == 2
+        assert ev.user_openid == "user-1"
+        assert ev.button_data == "approve:sess:allow-once"
+        assert ev.button_id == "allow"
+        assert ev.operator_openid == "user-1"
+
+    def test_parse_group_interaction(self):
+        from gateway.platforms.qqbot.keyboards import parse_interaction_event
+        raw = {
+            "id": "i-1",
+            "chat_type": 1,
+            "group_openid": "grp-1",
+            "group_member_openid": "mem-1",
+            "data": {
+                "type": 11,
+                "resolved": {
+                    "button_data": "update_prompt:y",
+                    "button_id": "yes",
+                },
+            },
+        }
+        ev = parse_interaction_event(raw)
+        assert ev.scene == "group"
+        assert ev.group_openid == "grp-1"
+        assert ev.group_member_openid == "mem-1"
+        assert ev.operator_openid == "mem-1"  # member openid preferred in group
+
+    def test_parse_missing_data_gracefully(self):
+        from gateway.platforms.qqbot.keyboards import parse_interaction_event
+        ev = parse_interaction_event({"id": "i", "chat_type": 0})
+        assert ev.id == "i"
+        assert ev.scene == "guild"
+        assert ev.button_data == ""
+        assert ev.button_id == ""
+        assert ev.type == 0
+
+
+class TestAdapterInteractionDispatch:
+    """End-to-end verification of _on_interaction including ACK + callback."""
+
+    def _make_adapter(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    @pytest.mark.asyncio
+    async def test_callback_invoked_with_parsed_event(self):
+        adapter = self._make_adapter()
+
+        # Stub ACK so we don't require a live http_client.
+        ack_calls = []
+
+        async def fake_ack(interaction_id, code=0):
+            ack_calls.append((interaction_id, code))
+
+        adapter._acknowledge_interaction = fake_ack  # type: ignore[assignment]
+
+        received = []
+
+        async def cb(event):
+            received.append(event)
+
+        adapter.set_interaction_callback(cb)
+        await adapter._on_interaction({
+            "id": "i-1",
+            "chat_type": 2,
+            "user_openid": "user-1",
+            "data": {
+                "type": 11,
+                "resolved": {"button_data": "approve:s:deny", "button_id": "deny"},
+            },
+        })
+
+        assert len(ack_calls) == 1
+        assert ack_calls[0][0] == "i-1"
+        assert len(received) == 1
+        assert received[0].button_data == "approve:s:deny"
+        assert received[0].scene == "c2c"
+
+    @pytest.mark.asyncio
+    async def test_missing_id_skips_ack(self):
+        adapter = self._make_adapter()
+
+        ack_calls = []
+
+        async def fake_ack(interaction_id, code=0):
+            ack_calls.append(interaction_id)
+
+        adapter._acknowledge_interaction = fake_ack  # type: ignore[assignment]
+
+        callback_calls = []
+
+        async def cb(event):
+            callback_calls.append(event)
+
+        adapter.set_interaction_callback(cb)
+        await adapter._on_interaction({
+            "chat_type": 2,  # no id
+            "data": {"resolved": {"button_data": "approve:s:deny"}},
+        })
+
+        assert ack_calls == []
+        assert callback_calls == []
+
+    @pytest.mark.asyncio
+    async def test_callback_exception_does_not_propagate(self):
+        adapter = self._make_adapter()
+
+        async def fake_ack(interaction_id, code=0):
+            pass
+
+        adapter._acknowledge_interaction = fake_ack  # type: ignore[assignment]
+
+        async def bad_cb(event):
+            raise RuntimeError("boom")
+
+        adapter.set_interaction_callback(bad_cb)
+        # Should NOT raise.
+        await adapter._on_interaction({
+            "id": "i-2",
+            "chat_type": 2,
+            "user_openid": "u",
+            "data": {"resolved": {"button_data": "approve:s:deny"}},
+        })
+
+    @pytest.mark.asyncio
+    async def test_no_callback_is_harmless(self):
+        adapter = self._make_adapter()
+
+        async def fake_ack(interaction_id, code=0):
+            pass
+
+        adapter._acknowledge_interaction = fake_ack  # type: ignore[assignment]
+        # No callback set — default None.
+        await adapter._on_interaction({
+            "id": "i-3",
+            "chat_type": 2,
+            "user_openid": "u",
+            "data": {"resolved": {"button_data": "approve:s:deny"}},
+        })


### PR DESCRIPTION
Salvage PR for #21162. Ports the user-visible improvements from @WideLee's qqbot-agent-sdk back into the existing in-tree `gateway/platforms/qqbot/` subpackage — no external Git-URL dependency, no new PyPI package to trust.

## Summary

Three commits, each preserving WideLee's authorship via `Co-authored-by`:

| # | Commit | What users feel |
|---|---|---|
| 1 | `feat(qqbot): add chunked upload with structured error types` | Can send files up to the platform's ~100 MB per-file limit (was ~10 MB before). Daily-quota and size-limit errors surface as actionable text instead of opaque HTTP codes. |
| 2 | `feat(qqbot): add inline-keyboard approvals and update prompts` | QQ-native tap-to-approve for tool use (✅ allow once / ⭐ always / ❌ deny), Yes/No update-confirmation prompts, and `INTERACTION_CREATE` wiring for button routing. |
| 3 | `feat(qqbot): process attachments in quoted (reply) messages` | When a user quote-replies to a voice message, the LLM now sees the transcript. Quoted images are cached; quoted files keep their original filename. |

Deliberately **not** ported (deferred — solutions to problems we haven't confirmed we have): WebSocket session persistence across restarts, dedicated-thread WebSocket, STT WAV-caching refactor. Happy to revisit if we see READY-storm or heartbeat-timeout 4009 complaints.

## Why salvage instead of merging #21162

After a closer read of #21162 I wasn't comfortable taking a runtime dependency on a brand-new personal PyPI package published under a GitHub org name (`tencent-connect`) that isn't actually Tencent — and pulling it via Git URL specifically to bypass our `exclude-newer = "7 days"` uv policy sets a precedent I can't maintain consistently across the team. That policy exists to defend against freshly-published malicious packages. I explained this to WideLee directly in the close comment on #21162 and committed to porting the substantive work in-tree with full credit.

The code quality itself was fine; the structural concern was the dependency shape, not the logic.

## Changes

```
 gateway/platforms/qqbot/__init__.py       |  36 ++
 gateway/platforms/qqbot/adapter.py        | 536 ++++++++++++++++--
 gateway/platforms/qqbot/chunked_upload.py | 603 ++++++++++++++++++++  (new)
 gateway/platforms/qqbot/keyboards.py      | 473 ++++++++++++++++     (new)
 tests/gateway/test_qqbot.py               | 892 ++++++++++++++++++++++++++++++
 5 files changed, 2509 insertions(+), 31 deletions(-)
```

Two new in-tree modules keep the adapter reviewable. No `pyproject.toml` change — no new runtime deps.

### `gateway/platforms/qqbot/chunked_upload.py`

- `ChunkedUploader` — prepare / PUT parts / complete state machine, decoupled from the adapter via `api_request` + `http_put` callables for isolated unit testing.
- `UploadDailyLimitExceededError` (biz_code 40093002, non-retryable) and `UploadFileTooLargeError` with `file_size_human` / `limit_human` properties so the model can build user-friendly replies.
- Handles biz_code 40093001 (retryable part_finish) with the server's retry timeout capped at 10 minutes.
- Routed into `QQAdapter._send_media` for local files; URL uploads still take the fast inline path.

### `gateway/platforms/qqbot/keyboards.py`

- `InlineKeyboard` + button dataclasses that serialize to the JSON shape QQ expects.
- `build_approval_keyboard(session_key)` — 3-button layout with `group_id='approval'` (clicking one greys the rest).
- `build_update_prompt_keyboard()` — Yes/No for update confirms.
- `parse_approval_button_data()` + `parse_update_prompt_button_data()` — decode `button_data` from `INTERACTION_CREATE`.
- `parse_interaction_event(raw) → InteractionEvent` — one dataclass covering scene (guild/group/c2c), openids, button payload.

### Adapter wiring (`gateway/platforms/qqbot/adapter.py`)

- `_dispatch_payload` routes `INTERACTION_CREATE` → `_on_interaction` → ACK via `PUT /interactions/{id}` → optional user callback. Callback exceptions are caught (never propagate into the WS loop).
- `set_interaction_callback(cb)` registers a handler so gateway wiring can route approval/update-prompt clicks to their resolvers.
- New public helpers: `send_with_keyboard`, `send_approval_request`, `send_update_prompt`.
- `_send_c2c_text` / `_send_group_text` accept an optional `keyboard` kwarg.
- `_process_quoted_context` extracts `msg_elements` (message_type=103) and runs their attachments through the same STT + image-cache pipeline as the main body. All four inbound handlers call it uniformly.

## Validation

`scripts/run_tests.sh tests/gateway/test_qqbot.py` — **130 passed** (72 existing + 58 new).

| Area | New tests |
|---|---:|
| Chunked upload (format_size, hashes, helpers, full flow, error paths, retries) | 19 |
| Inline keyboards (button_data round-trip, keyboard shape, approval text, interaction dispatch) | 27 |
| Quoted-message handling (text / voice / image / file / multi-element / malformed) | 12 |

Also ran `tests/gateway/test_platform_http_client_limits.py` alongside — no regressions (137 passed combined).

## Attribution

All three commits have `Co-authored-by: WideLee <limkuan24@gmail.com>` and the commit author is WideLee — git log will attribute him correctly. Closes / salvages #21162.