### PR TITLE
fix(mcp): add SSE keepalive ping task

### DIFF
--- a/tests/tools/test_mcp_sse_transport.py
+++ b/tests/tools/test_mcp_sse_transport.py
@@ -207,3 +207,48 @@ class TestSSEOAuthForwarding:
             f"sse_client was called with auth= when no OAuth was configured: "
             f"{patch_sse_client!r}"
         )
+
+
+class TestSSEKeepalive:
+    def test_sse_transport_starts_keepalive_task(self, patch_sse_client):
+        """SSE transport should scope keepalive to the SSE session lifetime."""
+        from tools.mcp_tool import MCPServerTask
+
+        server = _build_server_with_sse()
+        keepalive = AsyncMock(return_value=None)
+
+        async def drive():
+            with patch.object(MCPServerTask, "_wait_for_lifecycle_event",
+                              new=AsyncMock(return_value="shutdown")), \
+                 patch.object(MCPServerTask, "_discover_tools", new=AsyncMock()), \
+                 patch.object(MCPServerTask, "_sse_keepalive", new=keepalive):
+                await server._run_http({
+                    "url": "https://example.com/mcp/sse",
+                    "transport": "sse",
+                    "timeout": 60,
+                })
+
+        asyncio.run(drive())
+
+        assert keepalive.call_count == 1
+
+    def test_sse_keepalive_sends_ping_until_ping_fails(self):
+        """SSE keepalive should use MCP ping, not tool-list RPCs.
+
+        ``_wait_for_lifecycle_event`` has a broad lifecycle keepalive, but SSE
+        idle disconnects need a transport-scoped lightweight ping loop. The
+        loop exits cleanly once ping fails so transport teardown/reconnect can
+        own lifecycle handling.
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        server = MCPServerTask("sse-test")
+        session = MagicMock()
+        session.send_ping = AsyncMock(side_effect=[None, RuntimeError("closed")])
+        session.list_tools = AsyncMock()
+
+        asyncio.run(server._sse_keepalive(session, interval=0.01))
+
+        assert session.send_ping.await_count == 2
+        assert server._reconnect_event.is_set()
+        session.list_tools.assert_not_called()

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1170,6 +1170,30 @@ class MCPServerTask:
         self._reconnect_event.clear()
         return "reconnect"
 
+    async def _sse_keepalive(self, session, interval: float = 60.0):
+        """Ping an SSE MCP session periodically until cancelled or stale.
+
+        The generic lifecycle keepalive uses ``list_tools`` every few minutes
+        for all transports.  SSE transports also need a lightweight ping before
+        Cloudflare-Workers-style idle windows close the stream.  A failed ping
+        requests a reconnect; the transport task still owns teardown.
+        """
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                try:
+                    await session.send_ping()
+                except Exception as exc:
+                    logger.warning(
+                        "MCP server '%s' SSE keepalive failed, "
+                        "triggering reconnect: %s",
+                        self.name, exc,
+                    )
+                    self._reconnect_event.set()
+                    break
+        except asyncio.CancelledError:
+            pass
+
     async def _run_stdio(self, config: dict):
         """Run the server using stdio transport."""
         command = config.get("command")
@@ -1328,7 +1352,17 @@ class MCPServerTask:
                     self.session = session
                     await self._discover_tools()
                     self._ready.set()
-                    reason = await self._wait_for_lifecycle_event()
+                    keepalive_task = asyncio.create_task(
+                        self._sse_keepalive(session)
+                    )
+                    try:
+                        reason = await self._wait_for_lifecycle_event()
+                    finally:
+                        keepalive_task.cancel()
+                        await asyncio.gather(
+                            keepalive_task,
+                            return_exceptions=True,
+                        )
                     if reason == "reconnect":
                         logger.info(
                             "MCP server '%s': reconnect requested — "


### PR DESCRIPTION
## Summary
- adds a focused SSE keepalive task that sends lightweight MCP `send_ping()` calls while an SSE transport session is open
- requests reconnect if a ping fails, leaving transport teardown in the existing `_wait_for_lifecycle_event()` / SSE session lifecycle path
- starts and cancels the keepalive task inside the SSE-only branch so Streamable HTTP and stdio behavior are unchanged

## Context
Follow-up to #5981 after #21323 landed the timeout and OAuth-forwarding pieces. This keeps the remaining keepalive work as a small single-commit PR on current `main` and avoids resurrecting the stale branch.

Related: #3976 proposed SSE/HTTP keepalive work more broadly; this PR intentionally limits scope to the unmerged SSE keepalive coroutine.

## Test plan
- RED: `python -m pytest tests/tools/test_mcp_sse_transport.py::TestSSEKeepalive::test_sse_keepalive_sends_ping_until_ping_fails -q -o 'addopts='` failed on current main because `_sse_keepalive` did not exist
- GREEN: `python -m pytest tests/tools/test_mcp_sse_transport.py::TestSSEKeepalive -q -o 'addopts='`
- Regression: `python -m pytest tests/tools/test_mcp_tool.py tests/tools/test_mcp_sse_transport.py -q -o 'addopts='`
