### PR TITLE
fix(discord): sniff image magic bytes so Anthropic vision accepts media_type

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -118,6 +118,25 @@ def _build_allowed_mentions():
     )
 
 
+def _sniff_image_mime(head: bytes) -> Optional[str]:
+    """Return the canonical image MIME for the leading bytes, or None.
+
+    Covers the four formats Hermes already advertises as supported
+    (PNG / JPEG / GIF / WEBP). Used to defeat Discord-reported MIMEs that
+    disagree with the actual file bytes — Anthropic's vision API rejects
+    such mismatches with HTTP 400 (issue #21049).
+    """
+    if head.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if head.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if head[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    if len(head) >= 12 and head[:4] == b"RIFF" and head[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
 class VoiceReceiver:
     """Captures and decodes voice audio from a Discord voice channel.
 
@@ -3899,8 +3918,19 @@ class DiscordAdapter(BasePlatformAdapter):
                     if ext not in (".jpg", ".jpeg", ".png", ".gif", ".webp"):
                         ext = ".jpg"
                     cached_path = await self._cache_discord_image(att, ext)
+                    # Discord-reported Content-Type can disagree with the
+                    # actual file bytes (e.g. image/webp for a PNG). Anthropic
+                    # validates media_type vs. magic bytes and rejects the
+                    # mismatch (issue #21049). Sniff the first 12 bytes from
+                    # the cached file and prefer the sniffed MIME when known.
+                    sniffed_mime: Optional[str] = None
+                    try:
+                        with open(cached_path, "rb") as _f:
+                            sniffed_mime = _sniff_image_mime(_f.read(12))
+                    except Exception:
+                        sniffed_mime = None
                     media_urls.append(cached_path)
-                    media_types.append(content_type)
+                    media_types.append(sniffed_mime or content_type)
                     print(f"[Discord] Cached user image: {cached_path}", flush=True)
                 except Exception as e:
                     print(f"[Discord] Failed to cache image attachment: {e}", flush=True)

--- a/tests/gateway/test_discord_image_mime_sniff.py
+++ b/tests/gateway/test_discord_image_mime_sniff.py
@@ -1,0 +1,50 @@
+"""Regression tests for issue #21049.
+
+Discord's reported Content-Type can disagree with the actual image
+bytes. Anthropic now validates media_type against magic bytes and
+rejects mismatches with HTTP 400. ``_sniff_image_mime`` returns the
+canonical MIME for the leading bytes so the gateway can override the
+Discord-reported value when it is wrong.
+"""
+
+from gateway.platforms.discord import _sniff_image_mime
+
+
+_PNG_HEAD = b"\x89PNG\r\n\x1a\n" + b"\x00" * 4
+_JPEG_HEAD = b"\xff\xd8\xff\xe0" + b"\x00" * 8
+_GIF87_HEAD = b"GIF87a" + b"\x00" * 6
+_GIF89_HEAD = b"GIF89a" + b"\x00" * 6
+_WEBP_HEAD = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP"
+
+
+def test_sniff_png():
+    assert _sniff_image_mime(_PNG_HEAD) == "image/png"
+
+
+def test_sniff_jpeg():
+    assert _sniff_image_mime(_JPEG_HEAD) == "image/jpeg"
+
+
+def test_sniff_gif87():
+    assert _sniff_image_mime(_GIF87_HEAD) == "image/gif"
+
+
+def test_sniff_gif89():
+    assert _sniff_image_mime(_GIF89_HEAD) == "image/gif"
+
+
+def test_sniff_webp():
+    assert _sniff_image_mime(_WEBP_HEAD) == "image/webp"
+
+
+def test_sniff_unknown_returns_none():
+    assert _sniff_image_mime(b"<html>forbidden</html>") is None
+
+
+def test_sniff_too_short_returns_none_for_webp_check():
+    """The WEBP check requires >=12 bytes; shorter input must not crash."""
+    assert _sniff_image_mime(b"RIFF") is None
+
+
+def test_sniff_empty_returns_none():
+    assert _sniff_image_mime(b"") is None


### PR DESCRIPTION
Closes #21049.

## Problem

Discord-reported attachment `Content-Type` can disagree with the actual file bytes — e.g. an attachment served as `image/webp` may actually be PNG bytes. Anthropic's vision API validates `source.media_type` against the file's magic bytes and rejects the mismatch:

```
HTTP 400 invalid_request_error
messages.0.content.1.image.source.base64: The image was specified using
the image/webp media type, but the image appears to be a image/png image
```

Every Discord image attachment to a native Anthropic vision model 400s and silently rolls over to the configured fallback provider, bypassing the user's prepaid Anthropic balance. Regression introduced when #16506 (native multimodal routing) intersected with Anthropic's tightened media_type validation.

## Fix

Add a small magic-byte sniffer covering the four formats already advertised as supported:

```python
def _sniff_image_mime(head: bytes) -> Optional[str]:
    if head.startswith(b"\x89PNG\r\n\x1a\n"):           return "image/png"
    if head.startswith(b"\xff\xd8\xff"):                return "image/jpeg"
    if head[:6] in (b"GIF87a", b"GIF89a"):              return "image/gif"
    if len(head) >= 12 and head[:4] == b"RIFF" and head[8:12] == b"WEBP":
        return "image/webp"
    return None
```

After `_cache_discord_image()` writes the file, read the first 12 bytes and prefer the sniffed MIME. Fall back to the Discord-reported `Content-Type` only when the sniff is unknown — preserving today's behavior for any non-standard image type.

The audio and document branches are untouched. `_cache_discord_image()`'s public signature is preserved (existing tests in `test_discord_attachment_download.py` still expect a `str` return).

## Tests

8 new pure-function tests in `tests/gateway/test_discord_image_mime_sniff.py` covering PNG, JPEG, GIF87/89, WEBP, unknown bytes, short input, and empty input.

```
$ python -m pytest -o addopts= tests/gateway/test_discord_image_mime_sniff.py -q
........ [100%]
8 passed in 2.24s
```

Existing Discord attachment tests still pass (no regressions).