### PR TITLE
test(hermes_constants): cover parse_reasoning_effort()

### DIFF
--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -7,7 +7,12 @@ from unittest.mock import patch
 import pytest
 
 import hermes_constants
-from hermes_constants import get_default_hermes_root, is_container
+from hermes_constants import (
+    VALID_REASONING_EFFORTS,
+    get_default_hermes_root,
+    is_container,
+    parse_reasoning_effort,
+)
 
 
 class TestGetDefaultHermesRoot:
@@ -17,6 +22,7 @@ class TestGetDefaultHermesRoot:
         """When HERMES_HOME is not set, returns ~/.hermes."""
         monkeypatch.delenv("HERMES_HOME", raising=False)
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
         assert get_default_hermes_root() == tmp_path / ".hermes"
 
     def test_hermes_home_is_native(self, tmp_path, monkeypatch):
@@ -111,3 +117,57 @@ class TestIsContainer:
         # Even if we make os.path.exists return False, cached value wins
         monkeypatch.setattr(os.path, "exists", lambda p: False)
         assert is_container() is True
+
+
+class TestParseReasoningEffort:
+    """Tests for parse_reasoning_effort() — string → reasoning config dict."""
+
+    @pytest.mark.parametrize("value", ["", "   ", "\t", "\n"])
+    def test_empty_or_whitespace_returns_none(self, value):
+        """Empty / whitespace-only input falls back to caller default (None)."""
+        assert parse_reasoning_effort(value) is None
+
+    def test_none_disables_reasoning(self):
+        """The literal "none" disables reasoning explicitly."""
+        assert parse_reasoning_effort("none") == {"enabled": False}
+
+    @pytest.mark.parametrize("level", list(VALID_REASONING_EFFORTS))
+    def test_each_valid_level(self, level):
+        """Every level listed in VALID_REASONING_EFFORTS is accepted as-is."""
+        assert parse_reasoning_effort(level) == {"enabled": True, "effort": level}
+
+    @pytest.mark.parametrize(
+        "raw, expected_effort",
+        [
+            ("MEDIUM", "medium"),
+            ("High", "high"),
+            ("  low  ", "low"),
+            ("\tXHIGH\n", "xhigh"),
+            ("None", False),
+        ],
+    )
+    def test_case_and_whitespace_normalized(self, raw, expected_effort):
+        """Mixed case and surrounding whitespace are normalized before lookup."""
+        result = parse_reasoning_effort(raw)
+        if expected_effort is False:
+            assert result == {"enabled": False}
+        else:
+            assert result == {"enabled": True, "effort": expected_effort}
+
+    @pytest.mark.parametrize(
+        "value",
+        ["bogus", "very-high", "max", "0", "off", "true", "default"],
+    )
+    def test_unknown_levels_return_none(self, value):
+        """Unrecognized strings fall back to the caller default (None)."""
+        assert parse_reasoning_effort(value) is None
+
+    def test_known_supported_levels_are_documented(self):
+        """Guard against silently dropping a documented level.
+
+        The docstring promises "minimal", "low", "medium", "high", "xhigh".
+        If someone removes one from VALID_REASONING_EFFORTS without updating
+        the docstring, this test will fail and force the call out.
+        """
+        documented = {"minimal", "low", "medium", "high", "xhigh"}
+        assert documented.issubset(set(VALID_REASONING_EFFORTS))


### PR DESCRIPTION
## What does this PR do?
Adds focused unit tests for parse_reasoning_effort() in `hermes_constants.py`. The function is referenced from CLI / config code paths but had no direct tests in `tests/test_hermes_constants.py` — the test file only covered get_default_hermes_root() and is_container().

Tests are written as invariants, not snapshots, per the guidance in `AGENTS.md` (“Don't write change-detector tests”). Each level in `VALID_REASONING_EFFORTS` is parametrized so the suite stays correct when new levels are added; the “documented levels” test asserts a subset relation rather than equality so adding a new level won't break CI.

This change is test-only — no production code is modified.

## Related Issue
N/A — opportunistic test-coverage improvement.

**Type of Change**

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- tests/test_hermes_constants.py — Added TestParseReasoningEffort class covering:
      1.    empty / whitespace input → None
      2.    literal "none" → {"enabled": False}
      3.    every level in VALID_REASONING_EFFORTS → {"enabled": True, "effort": <level>}
      4.    case + surrounding whitespace normalization (MEDIUM, \tXHIGH\n, low , None, …)
      5.    unknown levels → None ("bogus", "very-high", "max", …)
      6.    invariant guard that the documented levels (minimal/low/medium/high/xhigh) remain a subset of                                                      VALID_REASONING_EFFORTS
- Imports in the same file extended to expose parse_reasoning_effort and VALID_REASONING_EFFORTS.

## How to Test

1. Activate the project venv (Python 3.11 / 3.12).
2. Run only the new test class: `scripts/run_tests.sh tests/test_hermes_constants.py::TestParseReasoningEffort -v`
3. Expected: 23 passed — every parametrized case in TestParseReasoningEffort (empty / whitespace / "none" / each level in VALID_REASONING_EFFORTS / case + whitespace normalization / unknown-level fallthrough / documented-levels invariant).
Optional — run the full file to confirm the existing tests still pass: `scripts/run_tests.sh tests/test_hermes_constants.py -v`
Expected: 34 passed (11 pre-existing + 23 new).

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs
$ scripts/run_tests.sh tests/test_hermes_constants.py::TestParseReasoningEffort -v
============================== 23 passed in 0.97s ==============================

$ scripts/run_tests.sh tests/test_hermes_constants.py -v
============================== 34 passed in 1.27s ==============================

