### PR TITLE
fix(agent): route bare ollama provider through custom branch

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -159,6 +159,10 @@ _PROVIDER_ALIASES = {
     "tokenhub": "tencent-tokenhub",
     "tencent-cloud": "tencent-tokenhub",
     "tencentmaas": "tencent-tokenhub",
+    # Bare "ollama" = local server: route through the custom branch so
+    # base_url from config.yaml is honored. "ollama-cloud" is a separate
+    # API-key provider and is left unmapped. Mirrors hermes_cli/providers.py.
+    "ollama": "custom",
 }
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -83,6 +83,15 @@ class TestNormalizeAuxProvider:
         assert _normalize_aux_provider("github-copilot-acp") == "copilot-acp"
         assert _normalize_aux_provider("copilot-acp-agent") == "copilot-acp"
 
+    def test_bare_ollama_maps_to_custom(self):
+        # `provider: ollama` in config.yaml must route auxiliary traffic
+        # through the custom branch so the configured base_url is honored;
+        # otherwise it would silently fall back to OpenRouter when an
+        # OPENROUTER_API_KEY is set in the environment.
+        assert _normalize_aux_provider("ollama") == "custom"
+        # `ollama-cloud` is a separate API-key provider — keep it untouched.
+        assert _normalize_aux_provider("ollama-cloud") == "ollama-cloud"
+
 
 class TestReadCodexAccessToken:
     def test_valid_auth_store(self, tmp_path, monkeypatch):


### PR DESCRIPTION
Adds `"ollama": "custom"` to `_PROVIDER_ALIASES` in `agent/auxiliary_client.py` so that `provider: ollama` in config.yaml is normalized to the custom branch — which honors the configured `base_url` — instead of silently falling back to OpenRouter for auxiliary tasks (context compression, title generation, session search, etc.).

## What changed and why
- `agent/auxiliary_client.py`: add `"ollama": "custom"` to `_PROVIDER_ALIASES`. Before this change, `resolve_provider_client()` had no `ollama` branch, and `_normalize_aux_provider("ollama")` returned `"ollama"` unchanged, so the resolver fell through to the OpenRouter / API-key fallback whenever `OPENROUTER_API_KEY` was set in the environment — silently routing local-only configurations to a paid cloud provider. The `custom` branch already reads `explicit_base_url` from runtime config, falls back to `OPENAI_BASE_URL`, and accepts `"no-key-required"` for keyless local servers, which is exactly the behaviour wanted for local Ollama.
- This mirrors the alias already declared in `hermes_cli/providers.py:340` and `hermes_cli/models.py:922` — the CLI side already considered bare `ollama` a synonym for `custom`; the auxiliary-client path was simply out of sync.
- `ollama-cloud` (the cloud API-key provider) is intentionally left unmapped — it has its own credentials and base URL and must continue to resolve to itself.
- `tests/agent/test_auxiliary_client.py`: added `test_bare_ollama_maps_to_custom` covering both `ollama` → `custom` and `ollama-cloud` → `ollama-cloud`.

## How to test
- `pytest tests/agent/test_auxiliary_client.py::TestNormalizeAuxProvider -q`
- Manual: set `model.provider: ollama` and `model.base_url: http://localhost:11434/v1` in `config.yaml`, leave `OPENROUTER_API_KEY` set in `.env`, start a session, and confirm that auxiliary calls (e.g. session-title generation) hit the local Ollama endpoint instead of OpenRouter.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #21352

<!-- autocontrib:worker-id=issue-new-ed04b4f4 kind=pr-open -->