### PR TITLE
fix(telegram): preserve thread_id=1 for forum General typing indicator

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -369,10 +369,14 @@ class TelegramAdapter(BasePlatformAdapter):
 
     @classmethod
     def _message_thread_id_for_typing(cls, thread_id: Optional[str]) -> Optional[int]:
-        # Mirrors _message_thread_id_for_send: the General forum topic (thread id
-        # "1") is represented as "no thread id" on the wire. User-created topics
-        # keep their real id so typing stays scoped to that topic.
-        if not thread_id or str(thread_id) == cls._GENERAL_TOPIC_THREAD_ID:
+        # Asymmetric with _message_thread_id_for_send on purpose. Telegram's
+        # sendMessage and sendChatAction treat thread id "1" (the forum General
+        # topic) differently: sends reject message_thread_id=1 and must omit it,
+        # but sendChatAction needs message_thread_id=1 to place the typing
+        # bubble in the General topic (omitting it hides the bubble entirely
+        # from the client's view of that topic). Preserve the real id here —
+        # sends still map "1" → None via _message_thread_id_for_send.
+        if not thread_id:
             return None
         return int(thread_id)
 

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -159,12 +159,17 @@ async def test_send_omits_general_topic_thread_id():
 
 
 @pytest.mark.asyncio
-async def test_send_typing_general_topic_uses_none_thread_id():
-    """Typing for forum General should hit the API with message_thread_id=None directly.
+async def test_send_typing_preserves_general_topic_thread_id():
+    """Typing for forum General must send message_thread_id=1, not None.
 
-    _message_thread_id_for_typing() maps the General topic (thread id "1") to None
-    the same way _message_thread_id_for_send() does, so there's no retry path — the
-    first call is already correct.
+    Asymmetric with _message_thread_id_for_send: sendMessage rejects
+    message_thread_id=1, but sendChatAction needs it to scope the typing
+    bubble to the General topic. Omitting it (message_thread_id=None) hides
+    the bubble from the General-topic view entirely.
+
+    Regression guard for the d5357f816 refactor that mapped "1" → None in
+    the typing resolver and silently killed typing indicators in every
+    forum-group General topic.
     """
     adapter = _make_adapter()
     call_log = []
@@ -177,7 +182,7 @@ async def test_send_typing_general_topic_uses_none_thread_id():
     await adapter.send_typing("-100123", metadata={"thread_id": "1"})
 
     assert call_log == [
-        {"chat_id": -100123, "action": "typing", "message_thread_id": None},
+        {"chat_id": -100123, "action": "typing", "message_thread_id": 1},
     ]
 
 


### PR DESCRIPTION
Telegram typing bubble stopped showing in forum-group General topics after May 5.

Root cause: d5357f816 made `_message_thread_id_for_typing` symmetric with the send resolver (both map thread id "1" → None). That's correct for `sendMessage` — Telegram rejects `message_thread_id=1` on sends — but wrong for `sendChatAction`, which needs the real id to scope the bubble to the General topic. Omitting it hides the bubble from that topic view entirely.

Confirmed via wire traces contributed by a community user's agent:
- Before d5357f816: `thread_id=1` → `message_thread_id=1` → visible typing
- After: `thread_id=1` → `message_thread_id=None` → no visible typing
- Other topics (e.g. 1911): unchanged — still visible

## Changes
- `gateway/platforms/telegram.py`: drop the "1 → None" mapping from `_message_thread_id_for_typing`; document the intentional asymmetry with `_message_thread_id_for_send`.
- `tests/gateway/test_telegram_thread_fallback.py`: rewrite `test_send_typing_general_topic_uses_none_thread_id` (which encoded the broken contract) as `test_send_typing_preserves_general_topic_thread_id`, asserting one call with `message_thread_id=1`.

Partial revert of d5357f816; restores 0cf7d570e's intent without re-adding the retry-fallback that 41545f7ec scoped to DM topics — with the resolver correct, the first call already hits the right wire shape.

## Validation
| case | send | typing |
|---|---|---|
| DM (no thread) | None | None |
| Forum General (thread=1) | None | **1** (was None) |
| User-created topic 22182 | 22182 | 22182 |
| DM-topics topic 55 | 55 | 55 |

11/11 tests in `test_telegram_thread_fallback.py` pass.