### PR TITLE
fix(tools): add wall-clock budget to session_search summarisation

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -442,8 +442,14 @@ prompt_caching:
 #   session_search:
 #     provider: "auto"
 #     model: ""
-#     timeout: 30
+#     timeout: 30           # Per-LLM-request timeout (one summary attempt)
 #     max_concurrency: 3    # Limit parallel summaries to reduce request-burst 429s
+#     time_budget_seconds: 90  # Overall wall-clock budget for summarising all
+#                              # matched sessions in one call. Sessions still
+#                              # running when the budget elapses are cancelled
+#                              # and fall back to raw previews. Clamped to
+#                              # [10, 600]. Raise this for slow local models;
+#                              # lower it for tight CLI responsiveness.
 #     extra_body: {}        # Provider-specific OpenAI-compatible request fields
 #                           # Example for providers that support request-body
 #                           # reasoning controls:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -879,6 +879,7 @@ DEFAULT_CONFIG = {
             "timeout": 30,
             "extra_body": {},
             "max_concurrency": 3,  # Clamp parallel summaries to avoid request-burst 429s on small providers
+            "time_budget_seconds": 90,  # Overall wall-clock budget for summarising all matched sessions; partial results returned on timeout
         },
         "skills_hub": {
             "provider": "auto",

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -10,8 +10,10 @@ from tools.session_search_tool import (
     _format_conversation,
     _truncate_around_matches,
     _get_session_search_max_concurrency,
+    _get_session_search_time_budget,
     _list_recent_sessions,
     _HIDDEN_SESSION_SOURCES,
+    DEFAULT_SESSION_SEARCH_TIME_BUDGET,
     MAX_SESSION_CHARS,
     SESSION_SEARCH_SCHEMA,
 )
@@ -239,6 +241,141 @@ class TestSessionSearchConcurrency:
         assert result["success"] is True
         assert result["count"] == 3
         assert max_seen["value"] == 1
+
+
+class TestSessionSearchTimeBudget:
+    def test_default_budget(self):
+        assert _get_session_search_time_budget() == DEFAULT_SESSION_SEARCH_TIME_BUDGET
+
+    def test_reads_configured_value(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"time_budget_seconds": 45}}},
+        )
+        assert _get_session_search_time_budget() == 45.0
+
+    def test_clamps_too_low(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"time_budget_seconds": 1}}},
+        )
+        assert _get_session_search_time_budget() == 10.0
+
+    def test_clamps_too_high(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"time_budget_seconds": 99999}}},
+        )
+        assert _get_session_search_time_budget() == 600.0
+
+    def test_invalid_value_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"auxiliary": {"session_search": {"time_budget_seconds": "soon"}}},
+        )
+        assert _get_session_search_time_budget() == DEFAULT_SESSION_SEARCH_TIME_BUDGET
+
+    def test_session_search_aborts_slow_summaries_and_returns_partial_results(
+        self, monkeypatch
+    ):
+        """Slow session summarisations must be cancelled when the time budget
+        elapses, instead of blocking session_search indefinitely (#7725)."""
+        from unittest.mock import MagicMock
+        from tools.session_search_tool import session_search
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "auxiliary": {
+                    "session_search": {
+                        "max_concurrency": 5,
+                        "time_budget_seconds": 10,  # clamps to 10s — but tiny patched budget below
+                    }
+                }
+            },
+        )
+        # Override budget to a tiny value for fast test execution. We patch
+        # the helper directly to dodge the [10, 600] clamp.
+        monkeypatch.setattr(
+            "tools.session_search_tool._get_session_search_time_budget",
+            lambda: 0.05,
+        )
+
+        async def fake_summarize(_text, _query, meta):
+            sid = meta.get("id", "?")
+            if sid == "fast":
+                return f"summary for {sid}"
+            # "slow" session never completes within the budget
+            await asyncio.sleep(5)
+            return f"summary for {sid}"  # pragma: no cover — should be cancelled
+
+        monkeypatch.setattr("tools.session_search_tool._summarize_session", fake_summarize)
+        monkeypatch.setattr("model_tools._run_async", lambda coro: asyncio.run(coro))
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {"session_id": "fast", "source": "cli", "session_started": 1709500000, "model": "m"},
+            {"session_id": "slow", "source": "cli", "session_started": 1709500001, "model": "m"},
+        ]
+
+        def _get_session(sid):
+            return {
+                "id": sid,
+                "parent_session_id": None,
+                "source": "cli",
+                "started_at": 1709500000,
+            }
+
+        mock_db.get_session.side_effect = _get_session
+        mock_db.get_messages_as_conversation.side_effect = lambda sid: [
+            {"role": "user", "content": f"message from {sid}"},
+            {"role": "assistant", "content": "response"},
+        ]
+
+        start = time.monotonic()
+        result = json.loads(session_search(query="message", db=mock_db, limit=3))
+        elapsed = time.monotonic() - start
+
+        # Must return well before the 5s sleep — proves cancellation worked.
+        assert elapsed < 2.0, f"session_search hung for {elapsed:.2f}s instead of cancelling"
+        assert result["success"] is True
+        assert result.get("time_budget_exceeded") is True
+        assert result["count"] == 2
+
+        by_id = {entry["session_id"]: entry for entry in result["results"]}
+        assert by_id["fast"]["summary"] == "summary for fast"
+        # Slow session was cancelled — falls back to raw preview.
+        assert "[Raw preview" in by_id["slow"]["summary"]
+
+    def test_no_budget_message_when_all_summaries_finish_in_time(self, monkeypatch):
+        from unittest.mock import MagicMock
+        from tools.session_search_tool import session_search
+
+        monkeypatch.setattr(
+            "tools.session_search_tool._get_session_search_time_budget",
+            lambda: 5.0,
+        )
+
+        async def fake_summarize(_text, _query, _meta):
+            return "summary"
+
+        monkeypatch.setattr("tools.session_search_tool._summarize_session", fake_summarize)
+        monkeypatch.setattr("model_tools._run_async", lambda coro: asyncio.run(coro))
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {"session_id": "s1", "source": "cli", "session_started": 1709500000, "model": "m"},
+        ]
+        mock_db.get_session.side_effect = lambda sid: {
+            "id": sid, "parent_session_id": None, "source": "cli", "started_at": 1709500000,
+        }
+        mock_db.get_messages_as_conversation.side_effect = lambda sid: [
+            {"role": "user", "content": "hello"},
+        ]
+
+        result = json.loads(session_search(query="hello", db=mock_db, limit=3))
+        assert result["success"] is True
+        assert "time_budget_exceeded" not in result
 
 
 class TestRecentSessionListing:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -27,6 +27,7 @@ from typing import Dict, Any, List, Optional, Union
 from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
 MAX_SESSION_CHARS = 100_000
 MAX_SUMMARY_TOKENS = 10000
+DEFAULT_SESSION_SEARCH_TIME_BUDGET = 90.0
 
 
 def _get_session_search_max_concurrency(default: int = 3) -> int:
@@ -48,6 +49,37 @@ def _get_session_search_max_concurrency(default: int = 3) -> int:
     except (TypeError, ValueError):
         return default
     return max(1, min(value, 5))
+
+
+def _get_session_search_time_budget(
+    default: float = DEFAULT_SESSION_SEARCH_TIME_BUDGET,
+) -> float:
+    """Read auxiliary.session_search.time_budget_seconds, clamped to [10, 600].
+
+    This is the overall wall-clock budget for summarising all matched
+    sessions in a single ``session_search`` invocation. It is independent
+    of the per-LLM-request ``timeout`` (which only bounds one HTTP call).
+    Without this budget, a slow auxiliary model with retries could keep
+    ``session_search`` running for many minutes on the CLI path, where no
+    outer ``_run_async`` deadline applies.
+    """
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+    except ImportError:
+        return default
+    aux = config.get("auxiliary", {}) if isinstance(config, dict) else {}
+    task_config = aux.get("session_search", {}) if isinstance(aux, dict) else {}
+    if not isinstance(task_config, dict):
+        return default
+    raw = task_config.get("time_budget_seconds")
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    return max(10.0, min(value, 600.0))
 
 
 def _format_timestamp(ts: Union[int, float, str, None]) -> str:
@@ -457,9 +489,23 @@ def session_search(
                     exc_info=True,
                 )
 
-        # Summarize all sessions in parallel
+        time_budget = _get_session_search_time_budget()
+        budget_exceeded = False
+
+        # Summarize all sessions in parallel under an overall time budget.
+        # Without this budget the CLI path (model_tools._run_async →
+        # tool_loop.run_until_complete) has no outer deadline, so a slow
+        # auxiliary model and retries can keep session_search running for
+        # many minutes (#7725).
         async def _summarize_all() -> List[Union[str, Exception]]:
-            """Summarize all sessions with bounded concurrency."""
+            """Summarize all sessions with bounded concurrency and a wall-clock budget.
+
+            On budget exhaustion, in-flight summary tasks are cancelled and
+            represented as ``asyncio.TimeoutError`` in the result list, so
+            the existing fallback-preview path still emits a usable entry
+            for each session.
+            """
+            nonlocal budget_exceeded
             max_concurrency = min(_get_session_search_max_concurrency(), max(1, len(tasks)))
             semaphore = asyncio.Semaphore(max_concurrency)
 
@@ -467,11 +513,40 @@ def session_search(
                 async with semaphore:
                     return await _summarize_session(text, query, meta)
 
-            coros = [
-                _bounded_summary(text, meta)
+            futures = [
+                asyncio.ensure_future(_bounded_summary(text, meta))
                 for _, _, text, meta in tasks
             ]
-            return await asyncio.gather(*coros, return_exceptions=True)
+            if not futures:
+                return []
+
+            try:
+                _done, pending = await asyncio.wait(futures, timeout=time_budget)
+            except asyncio.CancelledError:
+                for f in futures:
+                    f.cancel()
+                raise
+
+            if pending:
+                budget_exceeded = True
+                for f in pending:
+                    f.cancel()
+                # Drain cancellations so the loop has no stranded tasks.
+                await asyncio.gather(*pending, return_exceptions=True)
+
+            results: List[Union[str, Exception, None]] = []
+            for f in futures:
+                if f.cancelled():
+                    results.append(asyncio.TimeoutError(
+                        f"Session summarization exceeded {time_budget:.0f}s budget"
+                    ))
+                    continue
+                exc = f.exception()
+                if exc is not None:
+                    results.append(exc)
+                else:
+                    results.append(f.result())
+            return results
 
         try:
             # Use _run_async() which properly manages event loops across
@@ -484,13 +559,19 @@ def session_search(
             results = _run_async(_summarize_all())
         except concurrent.futures.TimeoutError:
             logging.warning(
-                "Session summarization timed out after 60 seconds",
+                "Session summarization exceeded the outer _run_async deadline",
                 exc_info=True,
             )
             return json.dumps({
                 "success": False,
                 "error": "Session summarization timed out. Try a more specific query or reduce the limit.",
             }, ensure_ascii=False)
+
+        if budget_exceeded:
+            logging.warning(
+                "session_search exceeded time budget of %.0fs; returning partial results",
+                time_budget,
+            )
 
         summaries = []
         for (session_id, match_info, conversation_text, session_meta), result in zip(tasks, results):
@@ -525,13 +606,22 @@ def session_search(
 
             summaries.append(entry)
 
-        return json.dumps({
+        payload: Dict[str, Any] = {
             "success": True,
             "query": query,
             "results": summaries,
             "count": len(summaries),
             "sessions_searched": len(seen_sessions),
-        }, ensure_ascii=False)
+        }
+        if budget_exceeded:
+            payload["time_budget_exceeded"] = True
+            payload["message"] = (
+                f"Time budget of {time_budget:.0f}s reached before all sessions "
+                "could be summarized; some entries fall back to raw previews. "
+                "Try a more specific query, reduce 'limit', or raise "
+                "auxiliary.session_search.time_budget_seconds in your config."
+            )
+        return json.dumps(payload, ensure_ascii=False)
 
     except Exception as e:
         logging.error("Session search failed: %s", e, exc_info=True)


### PR DESCRIPTION
Bound the per-invocation runtime of `session_search` so it cannot hang for 5+ minutes when an auxiliary model is slow.

## What changed and why
- `tools/session_search_tool.py`: wrap the parallel `_summarize_session` calls in `asyncio.wait(timeout=time_budget)`; cancel any pending summaries when the budget elapses so the existing raw-preview fallback path still emits one entry per session, and surface `time_budget_exceeded: true` plus a guidance message in the response payload.
- `hermes_cli/config.py`, `cli-config.yaml.example`: add the new knob `auxiliary.session_search.time_budget_seconds` (default `90`, clamped to `[10, 600]`).
- `tools/session_search_tool.py`: helper `_get_session_search_time_budget()` reads & clamps the config value.
- `tests/tools/test_session_search.py`: new `TestSessionSearchTimeBudget` class — covers default, configured, clamping, invalid value, partial-result on slow summary cancellation, and the no-timeout happy path.

Why this is the bug:
- Issue #7725 reports `session_search` hanging for 5+ minutes on the CLI, with the SIGINT traceback pointing at `tool_loop.run_until_complete(coro)` inside `model_tools._run_async`.
- That CLI branch of `_run_async` has **no outer deadline** — the existing 300s timeout only applies in the gateway / running-loop branch.
- Each `_summarize_session` call already retries up to 3 times around a 30s per-request timeout, so a single slow session can take ~90s, and `asyncio.gather` waits for every task to finish.
- The reporter's own suggestion (`asyncio.wait_for(..., timeout=N)` with proper cancellation) is exactly the mechanism applied here.

## How to test
- `pytest tests/tools/test_session_search.py -q` — 45 tests pass, including the new `TestSessionSearchTimeBudget::test_session_search_aborts_slow_summaries_and_returns_partial_results` which proves a 5s sleep summary is cancelled in <2s when the budget is patched to 50ms, and the cancelled session falls back to `[Raw preview ...]`.
- Manually: configure `auxiliary.session_search.time_budget_seconds: 5` in `cli-config.yaml`, point `auxiliary.session_search` at a slow/local model, run `session_search` with a query that matches several sessions; verify the call returns within ~5s with `time_budget_exceeded: true` in the JSON output.

## What platforms tested on
- macOS on darwin-arm64 (local) — `pytest tests/tools/test_session_search.py` passes.
- Pre-existing unrelated failures in `tests/tools/test_delegate.py`, `test_file_staleness.py`, etc. were verified to fail on `main` as well; this PR does not touch those areas.

Fixes #7725

<!-- autocontrib:worker-id=issue-new-08ceb210 kind=pr-open -->