### PR TITLE
fix: keep SSE stream alive during context compression

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9294,12 +9294,21 @@ class AIAgent:
             except Exception:
                 pass
 
+        # Emit a stream delta to keep the SSE connection alive during the
+        # compression LLM call (can take 10-30s).  Without this, the frontend
+        # sees no activity and its streaming state freezes — history polling
+        # is skipped (streamingStateRef !== null) and the UI goes blank.
+        self._fire_stream_delta("\n\n[Compressing context...]\n\n")
+
         try:
             compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic)
         except TypeError:
             # Plugin context engine with strict signature that doesn't accept
             # focus_topic — fall back to calling without it.
             compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens)
+
+        # Signal compression complete — the agent is about to continue.
+        self._fire_stream_delta("\n\n[Context compressed, continuing...]\n\n")
 
         summary_error = getattr(self.context_compressor, "_last_summary_error", None)
         if summary_error:


### PR DESCRIPTION
## Problem

When the agent's context compressor fires (threshold exceeded), the `compress()` call blocks on an LLM summarization request for 10-30 seconds. During this period no `stream_delta` callbacks fire, so the SSE connection delivers only keepalive comments.

The frontend's streaming state remains non-null, which causes history polling to be skipped (`streamingStateRef !== null` guard), leaving the Web UI blank until the user manually refreshes the page.

## Root Cause

```
Agent processing → context exceeds threshold
  → _compress_context() called
  → blocks on compression LLM call (10-30s)
  → no stream_delta_callback output
  → SSE stream only has keepalive, no content
  → frontend streamingState frozen at "streaming"
  → history polling skipped (streamingStateRef !== null)
  → UI goes blank, requires page refresh
```

## Fix

Emit a lightweight stream delta before and after the compression call so the frontend sees continuous activity and does not freeze:

```python
# Before compression LLM call
self._fire_stream_delta("\n\n[Compressing context...]\n\n")

# ... compress() blocks for 10-30s ...

# After compression complete
self._fire_stream_delta("\n\n[Context compressed, continuing...]\n\n")
```

This keeps the SSE stream active, prevents the frontend streaming state from freezing, and allows history polling to resume normally after compression completes.

## Files Changed

- `run_agent.py` — added stream delta emissions around `context_compressor.compress()` in `_compress_context()`

## Testing

1. Start a long conversation in Web UI that triggers automatic compression (>57K tokens with 128K context)
2. Verify the UI shows "[Compressing context...]" during compression
3. Verify the UI shows "[Context compressed, continuing...]" after compression
4. Verify the agent continues responding normally without requiring page refresh
