### PR TITLE
fix(kanban): serialize first-use schema initialization

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -981,22 +981,58 @@ def init_db(
     return path
 
 
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row["name"] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _is_duplicate_column_error(exc: sqlite3.OperationalError, column: str) -> bool:
+    msg = str(exc).lower()
+    return "duplicate column name" in msg and column.lower() in msg
+
+
+def _ensure_column(
+    conn: sqlite3.Connection,
+    table: str,
+    column: str,
+    ddl: str,
+) -> bool:
+    """Add an optional column, tolerating another migrator winning the race.
+
+    Returns True only when this connection added the column. Duplicate-column
+    errors are suppressed only after re-reading the schema confirms that the
+    requested column now exists.
+    """
+    if column in _table_columns(conn, table):
+        return False
+    try:
+        conn.execute(ddl)
+        return True
+    except sqlite3.OperationalError as exc:
+        if not _is_duplicate_column_error(exc, column):
+            raise
+        if column not in _table_columns(conn, table):
+            raise
+        return False
+
+
 def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     """Add columns that were introduced after v1 release to legacy DBs.
 
     Called by ``init_db`` so opening an old DB is always safe.
     """
-    cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
-    if "tenant" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN tenant TEXT")
-    if "result" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN result TEXT")
-    if "idempotency_key" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN idempotency_key TEXT")
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency "
-            "ON tasks(idempotency_key)"
-        )
+    cols = _table_columns(conn, "tasks")
+    _ensure_column(conn, "tasks", "tenant", "ALTER TABLE tasks ADD COLUMN tenant TEXT")
+    _ensure_column(conn, "tasks", "result", "ALTER TABLE tasks ADD COLUMN result TEXT")
+    _ensure_column(
+        conn,
+        "tasks",
+        "idempotency_key",
+        "ALTER TABLE tasks ADD COLUMN idempotency_key TEXT",
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency "
+        "ON tasks(idempotency_key)"
+    )
     # Legacy column migration: ``spawn_failures`` → ``consecutive_failures``
     # and ``last_spawn_error`` → ``last_failure_error``.
     #
@@ -1010,60 +1046,93 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # ADD-first-then-copy is tolerant of both shapes and preserves
     # historical counter values when the legacy columns do exist.
     #
-    # NOTE: ``cols`` reflects the schema at entry to this function and is
-    # not refreshed between ALTER TABLE calls.  Every guard below checks
-    # the *original* snapshot; this is intentional and safe as long as
-    # no step depends on a column added by a previous step in the same call.
-    if "consecutive_failures" not in cols:
+    had_consecutive_failures = "consecutive_failures" in cols
+    _ensure_column(
+        conn,
+        "tasks",
+        "consecutive_failures",
+        "ALTER TABLE tasks ADD COLUMN consecutive_failures "
+        "INTEGER NOT NULL DEFAULT 0",
+    )
+    if not had_consecutive_failures and "spawn_failures" in cols:
         conn.execute(
-            "ALTER TABLE tasks ADD COLUMN consecutive_failures "
-            "INTEGER NOT NULL DEFAULT 0"
+            "UPDATE tasks SET consecutive_failures = COALESCE(spawn_failures, 0)"
         )
-        if "spawn_failures" in cols:
-            conn.execute(
-                "UPDATE tasks SET consecutive_failures = COALESCE(spawn_failures, 0)"
-            )
-    if "worker_pid" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN worker_pid INTEGER")
-    if "last_failure_error" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN last_failure_error TEXT")
-        if "last_spawn_error" in cols:
-            conn.execute(
-                "UPDATE tasks SET last_failure_error = last_spawn_error"
-            )
-    if "max_runtime_seconds" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN max_runtime_seconds INTEGER")
-    if "last_heartbeat_at" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN last_heartbeat_at INTEGER")
-    if "current_run_id" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN current_run_id INTEGER")
-    if "workflow_template_id" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN workflow_template_id TEXT")
-    if "current_step_key" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN current_step_key TEXT")
-    if "skills" not in cols:
-        # JSON array of skill names the dispatcher force-loads into the
-        # worker (additive to the built-in `kanban-worker`). NULL is fine
-        # for existing rows.
-        conn.execute("ALTER TABLE tasks ADD COLUMN skills TEXT")
+    _ensure_column(
+        conn,
+        "tasks",
+        "worker_pid",
+        "ALTER TABLE tasks ADD COLUMN worker_pid INTEGER",
+    )
+    had_last_failure_error = "last_failure_error" in cols
+    _ensure_column(
+        conn,
+        "tasks",
+        "last_failure_error",
+        "ALTER TABLE tasks ADD COLUMN last_failure_error TEXT",
+    )
+    if not had_last_failure_error and "last_spawn_error" in cols:
+        conn.execute(
+            "UPDATE tasks SET last_failure_error = last_spawn_error"
+        )
+    _ensure_column(
+        conn,
+        "tasks",
+        "max_runtime_seconds",
+        "ALTER TABLE tasks ADD COLUMN max_runtime_seconds INTEGER",
+    )
+    _ensure_column(
+        conn,
+        "tasks",
+        "last_heartbeat_at",
+        "ALTER TABLE tasks ADD COLUMN last_heartbeat_at INTEGER",
+    )
+    _ensure_column(
+        conn,
+        "tasks",
+        "current_run_id",
+        "ALTER TABLE tasks ADD COLUMN current_run_id INTEGER",
+    )
+    _ensure_column(
+        conn,
+        "tasks",
+        "workflow_template_id",
+        "ALTER TABLE tasks ADD COLUMN workflow_template_id TEXT",
+    )
+    _ensure_column(
+        conn,
+        "tasks",
+        "current_step_key",
+        "ALTER TABLE tasks ADD COLUMN current_step_key TEXT",
+    )
+    # JSON array of skill names the dispatcher force-loads into the worker
+    # (additive to the built-in `kanban-worker`). NULL is fine for existing rows.
+    _ensure_column(conn, "tasks", "skills", "ALTER TABLE tasks ADD COLUMN skills TEXT")
 
-    if "max_retries" not in cols:
-        # Per-task override for the consecutive-failure circuit breaker.
-        # NULL = fall through to the dispatcher-level ``kanban.failure_limit``
-        # config, then ``DEFAULT_FAILURE_LIMIT``. Existing rows get NULL,
-        # which is the correct default (they keep the global behaviour
-        # they were getting before the column existed).
-        conn.execute("ALTER TABLE tasks ADD COLUMN max_retries INTEGER")
+    # Per-task override for the consecutive-failure circuit breaker.
+    # NULL = fall through to the dispatcher-level ``kanban.failure_limit``
+    # config, then ``DEFAULT_FAILURE_LIMIT``. Existing rows get NULL,
+    # which is the correct default (they keep the global behaviour
+    # they were getting before the column existed).
+    _ensure_column(
+        conn,
+        "tasks",
+        "max_retries",
+        "ALTER TABLE tasks ADD COLUMN max_retries INTEGER",
+    )
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
-    ev_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_events)")}
-    if "run_id" not in ev_cols:
-        conn.execute("ALTER TABLE task_events ADD COLUMN run_id INTEGER")
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_events_run "
-            "ON task_events(run_id, id)"
-        )
+    _ensure_column(
+        conn,
+        "task_events",
+        "run_id",
+        "ALTER TABLE task_events ADD COLUMN run_id INTEGER",
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_events_run "
+        "ON task_events(run_id, id)"
+    )
 
     # One-shot backfill: any task that is 'running' before runs existed
     # had its claim_lock / claim_expires / worker_pid on the task row.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -78,6 +78,7 @@ import secrets
 import sqlite3
 import subprocess
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -883,6 +884,50 @@ CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_
 # ---------------------------------------------------------------------------
 
 _INITIALIZED_PATHS: set[str] = set()
+_INITIALIZED_PATHS_LOCK = threading.RLock()
+
+
+def _resolve_db_path(
+    db_path: Optional[Path] = None,
+    *,
+    board: Optional[str] = None,
+) -> Path:
+    if db_path is not None:
+        return db_path
+    return kanban_db_path(board=board)
+
+
+def _open_connection(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path), isolation_level=None, timeout=30)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA synchronous=NORMAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+def _ensure_initialized(path: Path, *, force: bool = False) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    resolved = str(path.resolve())
+    if not force and resolved in _INITIALIZED_PATHS:
+        return resolved
+    with _INITIALIZED_PATHS_LOCK:
+        if not force and resolved in _INITIALIZED_PATHS:
+            return resolved
+        conn: Optional[sqlite3.Connection] = None
+        try:
+            conn = _open_connection(path)
+            conn.executescript(SCHEMA_SQL)
+            _migrate_add_optional_columns(conn)
+            _INITIALIZED_PATHS.add(resolved)
+        except Exception:
+            _INITIALIZED_PATHS.discard(resolved)
+            if conn is not None:
+                conn.close()
+            raise
+        else:
+            conn.close()
+        return resolved
 
 
 def connect(
@@ -908,26 +953,9 @@ def connect(
       ``HERMES_KANBAN_DB`` env → ``HERMES_KANBAN_BOARD`` env →
       ``<root>/kanban/current`` → ``default``.
     """
-    if db_path is not None:
-        path = db_path
-    else:
-        path = kanban_db_path(board=board)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    resolved = str(path.resolve())
-    needs_init = resolved not in _INITIALIZED_PATHS
-    conn = sqlite3.connect(str(path), isolation_level=None, timeout=30)
-    conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA journal_mode=WAL")
-    conn.execute("PRAGMA synchronous=NORMAL")
-    conn.execute("PRAGMA foreign_keys=ON")
-    if needs_init:
-        # Idempotent: runs CREATE TABLE IF NOT EXISTS + the additive
-        # migrations. Cached so subsequent connect() calls in the same
-        # process are cheap.
-        conn.executescript(SCHEMA_SQL)
-        _migrate_add_optional_columns(conn)
-        _INITIALIZED_PATHS.add(resolved)
-    return conn
+    path = _resolve_db_path(db_path, board=board)
+    _ensure_initialized(path)
+    return _open_connection(path)
 
 
 def init_db(
@@ -945,17 +973,11 @@ def init_db(
     external tools that upgrade an old DB file — can call this to
     force re-migration.
     """
-    if db_path is not None:
-        path = db_path
-    else:
-        path = kanban_db_path(board=board)
-    path.parent.mkdir(parents=True, exist_ok=True)
+    path = _resolve_db_path(db_path, board=board)
     resolved = str(path.resolve())
-    # Clear the cache entry so the underlying connect() re-runs the
-    # schema + migration pass unconditionally.
-    _INITIALIZED_PATHS.discard(resolved)
-    with contextlib.closing(connect(path)):
-        pass
+    with _INITIALIZED_PATHS_LOCK:
+        _INITIALIZED_PATHS.discard(resolved)
+    _ensure_initialized(path, force=True)
     return path
 
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -11,6 +11,7 @@ parity across every registered verb.
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ThreadPoolExecutor
 import json
 import os
 import subprocess
@@ -2838,6 +2839,35 @@ def test_legacy_db_without_skills_column_migrates(tmp_path):
     assert "skills" in keys
     assert row["skills"] is None
     conn.close()
+
+
+def test_concurrent_connect_initializes_kanban_db_once(tmp_path, monkeypatch):
+    """Concurrent first-use connect() must serialize schema initialization."""
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    resolved = str(db_path.resolve())
+    with kb._INITIALIZED_PATHS_LOCK:
+        kb._INITIALIZED_PATHS.discard(resolved)
+
+    def worker():
+        conn = kb.connect()
+        try:
+            row = conn.execute("SELECT COUNT(*) AS count FROM tasks").fetchone()
+            assert row["count"] == 0
+        finally:
+            conn.close()
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = [pool.submit(worker) for _ in range(8)]
+        for future in futures:
+            future.result()
+
+    conn = kb.connect()
+    try:
+        cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+    finally:
+        conn.close()
+    assert "consecutive_failures" in cols
 
 
 def test_legacy_spawn_failure_columns_are_copied_not_renamed(tmp_path):

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -14,6 +14,7 @@ import argparse
 from concurrent.futures import ThreadPoolExecutor
 import json
 import os
+import sqlite3
 import subprocess
 import threading
 import time
@@ -3065,6 +3066,118 @@ def test_legacy_migration_both_columns_already_present(tmp_path):
     row_again = conn.execute("SELECT * FROM tasks WHERE id = 't2'").fetchone()
     assert row_again["consecutive_failures"] == 3
     assert row_again["last_failure_error"] == "new error"
+    conn.close()
+
+
+class _DuplicateColumnRaceConnection:
+    def __init__(self, conn, race_columns: set[tuple[str, str]]):
+        self._conn = conn
+        self._race_columns = set(race_columns)
+
+    def execute(self, sql, *args, **kwargs):
+        normalized = " ".join(str(sql).lower().split())
+        for table, column in list(self._race_columns):
+            prefix = f"alter table {table} add column {column}".lower()
+            if normalized.startswith(prefix):
+                self._race_columns.remove((table, column))
+                self._conn.execute(sql, *args, **kwargs)
+                raise sqlite3.OperationalError(f"duplicate column name: {column}")
+        return self._conn.execute(sql, *args, **kwargs)
+
+
+def test_optional_column_migration_tolerates_duplicate_column_race(tmp_path):
+    """A concurrent migrator may add a column after PRAGMA but before ALTER."""
+    db_path = tmp_path / "duplicate-column-race.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            status TEXT NOT NULL,
+            created_at INTEGER NOT NULL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE task_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            payload TEXT,
+            created_at INTEGER NOT NULL
+        )
+    """)
+
+    kb._migrate_add_optional_columns(
+        _DuplicateColumnRaceConnection(conn, {("tasks", "consecutive_failures")})
+    )
+
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(tasks)")}
+    assert "consecutive_failures" in cols
+    conn.close()
+
+
+def test_idempotency_index_created_when_column_wins_race(tmp_path):
+    """Index creation must still run if another process adds the column."""
+    db_path = tmp_path / "idempotency-index-race.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            status TEXT NOT NULL,
+            created_at INTEGER NOT NULL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE task_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            payload TEXT,
+            created_at INTEGER NOT NULL
+        )
+    """)
+
+    kb._migrate_add_optional_columns(
+        _DuplicateColumnRaceConnection(conn, {("tasks", "idempotency_key")})
+    )
+
+    indexes = {r[1] for r in conn.execute("PRAGMA index_list(tasks)")}
+    assert "idx_tasks_idempotency" in indexes
+    conn.close()
+
+
+def test_event_run_index_created_when_column_wins_race(tmp_path):
+    """run_id's follow-up index must be ensured on duplicate-column races."""
+    db_path = tmp_path / "event-run-index-race.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            status TEXT NOT NULL,
+            created_at INTEGER NOT NULL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE task_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            payload TEXT,
+            created_at INTEGER NOT NULL
+        )
+    """)
+
+    kb._migrate_add_optional_columns(
+        _DuplicateColumnRaceConnection(conn, {("task_events", "run_id")})
+    )
+
+    indexes = {r[1] for r in conn.execute("PRAGMA index_list(task_events)")}
+    assert "idx_events_run" in indexes
     conn.close()
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a kanban SQLite initialization race during gateway startup.

The gateway can start the kanban notifier watcher and dispatcher watcher at nearly the same time. On their first tick, both paths can touch the same board DB and race through `hermes_cli.kanban_db.connect()` / `init_db()`. Before this change, the module-level `_INITIALIZED_PATHS` cache was checked and updated without synchronization, so two threads in the same process could both decide that the same DB path still needed schema initialization and then run `_migrate_add_optional_columns()` concurrently.

Depending on timing, startup could fail with either:

- `sqlite3.OperationalError: duplicate column name: consecutive_failures`
- `sqlite3.OperationalError: database is locked`

This PR applies the proper fix in `hermes_cli/kanban_db.py` by serializing the full first-use `check -> init -> migrate -> set` path with a module-level `threading.RLock`. Normal post-initialization connections remain unlocked.

In addition to serializing in-process first-use initialization, this PR also makes optional-column migrations tolerate duplicate-column races. If another process adds an additive migration column between `PRAGMA table_info(...)` and `ALTER TABLE ... ADD COLUMN`, `_ensure_column()` re-reads the schema and suppresses only confirmed duplicate-column races.

## Related Issue

Fixes #21374.
Fixes #21378.
Likely addresses #21708.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Serialize first-use kanban DB schema initialization with a module-level `threading.RLock` in [hermes_cli/kanban_db.py](/mnt/d/hermes-agent/hermes_cli/kanban_db.py).
- Add shared helpers so `connect()` and `init_db()` use the same locked initialization path instead of duplicating `check/init/set` logic.
- Ensure failed initialization does not mark a DB path as initialized and closes the initialization connection before re-raising.
- Keep ordinary already-initialized `connect()` calls off the global lock.
- Add a concurrent-connect regression test in [tests/hermes_cli/test_kanban_core_functionality.py](/mnt/d/hermes-agent/tests/hermes_cli/test_kanban_core_functionality.py) that exercises multiple threads opening the same fresh DB and verifies the migration columns exist afterward.
- Added `_ensure_column()` to make additive migrations duplicate-column tolerant after schema re-read confirmation.
- Updated `_migrate_add_optional_columns()` to use `_ensure_column()` for task/task_events optional columns.
- Added regression tests for duplicate-column races and follow-up index creation.- 

## How to Test

1. Run the new/updated kanban tests:
   ```bash
   python -m pytest tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_boards.py tests/tools/test_kanban_tools.py -q
   ```
2. Confirm the suite passes, including the concurrent initialization regression test.
3. Optionally reproduce the original startup shape conceptually by noting that concurrent first-use `connect()` calls against the same fresh DB no longer race into duplicate-column or early locked-DB failures.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Relevant test command:

```bash
python -m pytest tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_boards.py tests/tools/test_kanban_tools.py -q
```

Observed result:

```text
239 passed in 76.40s
```
