### PR TITLE
fix(feishu): prefer open_id over user_id in sender identity

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3546,8 +3546,10 @@ class FeishuAdapter(BasePlatformAdapter):
         open_id = getattr(sender_id, "open_id", None) or None
         user_id = getattr(sender_id, "user_id", None) or None
         union_id = getattr(sender_id, "union_id", None) or None
-        # Prefer tenant-scoped user_id; fall back to app-scoped open_id.
-        primary_id = user_id or open_id
+        # Prefer app-scoped open_id as primary; user_id (tenant-scoped) can be
+        # stale/wrong when a user is removed/re-added to the tenant.  open_id is
+        # always reliable for the current bot app context.
+        primary_id = open_id or user_id
         # bot/v3/bots/basic_batch only accepts open_id.
         name_lookup_id = open_id if is_bot else (primary_id or union_id)
         display_name = await self._resolve_sender_name_from_api(


### PR DESCRIPTION
## Problem

`_resolve_sender_profile` in `gateway/platforms/feishu.py` prioritizes `user_id` (tenant-scoped) over `open_id` (app-scoped). When a user is removed and re-added to the Feishu tenant, their `user_id` changes but `open_id` remains stable. This causes the gateway to use a stale `user_id` that does not match the approved pairing, resulting in `Unauthorized user` warnings and the bot refusing to reply.

## Fix

Swap the priority: use `open_id` as the primary identity, falling back to `user_id`. `open_id` is always reliable within a given bot app context, while `user_id` can become stale after tenant user lifecycle events.

## Changes

- `gateway/platforms/feishu.py`: In `_resolve_sender_profile`, changed `primary_id = user_id or open_id` to `primary_id = open_id or user_id`

## Testing

Repro: send a message from a Feishu user whose `user_id` differs from their `open_id`. Before fix: `Unauthorized user: <stale_user_id>`. After fix: user correctly identified by `open_id`, reply succeeds.