### PR TITLE
fix(cron): pass workdir to _run_job_script subprocess

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -652,7 +652,7 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _run_job_script(script_path: str, workdir: Optional[str] = None) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
@@ -674,6 +674,11 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         script_path: Path to the script.  Relative paths are resolved
             against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
             are also validated to ensure they stay within the scripts dir.
+        workdir: Optional absolute path to run the script from.  When set,
+            the subprocess uses this as its cwd rather than the script's
+            parent directory.  This lets data-collection scripts run from
+            the job's configured project directory (e.g. to pick up venv,
+            .env, or project-relative paths).
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -719,12 +724,18 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         argv = [sys.executable, str(path)]
 
     try:
+        # Use the job's configured workdir if available, otherwise default to
+        # the script's own directory.  This lets data-collection scripts run
+        # from the project directory so they can find venvs, .env files, and
+        # project-relative paths (the terminal/file/code-exec tools all honor
+        # workdir through TERMINAL_CWD; scripts should too).
+        _cwd = str(workdir) if workdir else str(path.parent)
         result = subprocess.run(
             argv,
             capture_output=True,
             text=True,
             timeout=script_timeout,
-            cwd=str(path.parent),
+            cwd=_cwd,
         )
         stdout = (result.stdout or "").strip()
         stderr = (result.stderr or "").strip()
@@ -1000,7 +1011,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 _prior_cwd = None
 
         try:
-            ok, output = _run_job_script(script_path)
+            ok, output = _run_job_script(script_path, workdir=_job_workdir)
         finally:
             if _prior_cwd is not None:
                 try:
@@ -1089,7 +1100,13 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script(script_path)
+        # Resolve workdir for the script subprocess so it can find project
+        # venvs, .env files, and project-relative paths.  Using a separate
+        # extraction here (rather than _job_workdir from the TERMINAL_CWD
+        # block below) because the original TERMINAL_CWD logic runs after
+        # this point and we don't want to restructure existing code.
+        _script_workdir = (job.get("workdir") or "").strip() or None
+        prerun_script = _run_job_script(script_path, workdir=_script_workdir)
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1862,7 +1862,7 @@ class TestRunJobWakeGate:
         import cron.scheduler as scheduler
 
         call_count = 0
-        def _script_stub(path):
+        def _script_stub(path, workdir=None):
             nonlocal call_count
             call_count += 1
             return (True, "regular output")
@@ -2292,3 +2292,50 @@ class TestSendMediaTimeoutCancelsFuture:
         # 2. Second file still got dispatched — one timeout doesn't abort the batch
         adapter.send_video.assert_called_once()
         assert adapter.send_video.call_args[1]["video_path"] == "/tmp/fast.mp4"
+
+
+# ---------------------------------------------------------------------------
+# _run_job_script workdir
+# ---------------------------------------------------------------------------
+
+
+class TestRunJobScriptWorkdir:
+    """_run_job_script must run the subprocess in the configured workdir."""
+
+    def test_script_runs_from_workdir_when_set(self, tmp_path, monkeypatch):
+        """Script cwd == workdir when workdir is provided."""
+        from cron.scheduler import _run_job_script
+
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        # A script that prints its working directory.
+        script = scripts_dir / "whereami.py"
+        script.write_text("import os; print(os.getcwd())")
+
+        target = tmp_path / "project"
+        target.mkdir()
+
+        ok, output = _run_job_script(str(script), workdir=str(target))
+        assert ok
+        assert str(target) in output, (
+            f"Expected script to run from {target}, got: {output}"
+        )
+
+    def test_script_runs_from_script_dir_when_no_workdir(self, tmp_path, monkeypatch):
+        """Script cwd == script parent dir when workdir is not set."""
+        from cron.scheduler import _run_job_script
+
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        script = scripts_dir / "whereami.py"
+        script.write_text("import os; print(os.getcwd())")
+
+        ok, output = _run_job_script(str(script))
+        assert ok
+        assert str(scripts_dir) in output, (
+            f"Expected script to run from {scripts_dir}, got: {output}"
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `workdir` has no effect on the `subprocess` spawned by `_run_job_script()` — the data-collection script for cron jobs always runs from `~/.hermes/scripts/` regardless of the job configured `workdir`.

**Root cause:** `_run_job_script()` hardcoded `cwd=str(path.parent)`. The function was called before `_job_workdir` was even extracted in `run_job()`.

**Fix:**
- Add `workdir` parameter to `_run_job_script()`, use it as `subprocess.run(cwd=...)` when set
- Agent wake-gate path: extract workdir before calling the script
- No_agent path: pass `workdir=_job_workdir` through existing call (original `os.chdir` untouched)

## Related Issue

Fixes #21721

## Type of Change
- 🐛 Bug fix

## Changes Made
- `cron/scheduler.py`: add `workdir` param, use for subprocess cwd
- `tests/cron/test_scheduler.py`: 2 tests verifying cwd behavior

## How to Test
```bash
pytest tests/cron/test_scheduler.py::TestRunJobScriptWorkdir -xvs
pytest tests/cron/ -q
```

## Verification
- 2 new tests: script runs from workdir when set, from script dir when not
- 331/331 cron tests pass