### PR TITLE
fix(tui-gateway): close sidecar sessions on disconnect

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -79,6 +79,22 @@ def test_dispatch_rejects_non_object_params():
     }
 
 
+def test_session_create_marks_close_on_disconnect():
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "session.create",
+            "params": {"close_on_disconnect": "true"},
+        }
+    )
+
+    sid = resp["result"]["session_id"]
+    try:
+        assert server._sessions[sid]["close_on_disconnect"] is True
+    finally:
+        server._sessions.pop(sid, None)
+
+
 def test_voice_toggle_returns_configured_record_key(monkeypatch):
     monkeypatch.setattr(
         server,
@@ -753,6 +769,70 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
         assert ("on_session_finalize", "session-key") in calls["hooks"]
     finally:
         server._sessions.pop("sid", None)
+
+
+def test_close_sessions_for_transport_closes_sidecar_worker(monkeypatch):
+    closed_workers: list[str] = []
+    finalized: list[str] = []
+    closed_agents: list[str] = []
+    unregistered: list[str] = []
+    transport = object()
+
+    class _FakeWorker:
+        def close(self):
+            closed_workers.append("worker")
+
+    class _FakeAgent:
+        def close(self):
+            closed_agents.append("agent")
+
+    monkeypatch.setattr(
+        server,
+        "_finalize_session",
+        lambda session, end_reason="tui_close": finalized.append(end_reason),
+    )
+    import tools.approval as _approval
+
+    monkeypatch.setattr(
+        _approval,
+        "unregister_gateway_notify",
+        lambda key: unregistered.append(key),
+    )
+
+    server._sessions["sidecar"] = _session(
+        agent=_FakeAgent(),
+        session_key="sidecar-key",
+        slash_worker=_FakeWorker(),
+        transport=transport,
+        close_on_disconnect=True,
+    )
+
+    try:
+        server._close_sessions_for_transport(transport, end_reason="ws_disconnect")
+
+        assert "sidecar" not in server._sessions
+        assert finalized == ["ws_disconnect"]
+        assert closed_agents == ["agent"]
+        assert closed_workers == ["worker"]
+        assert unregistered == ["sidecar-key"]
+    finally:
+        server._sessions.pop("sidecar", None)
+
+
+def test_close_sessions_for_transport_preserves_normal_session():
+    transport = object()
+    server._sessions["normal"] = _session(
+        transport=transport,
+        close_on_disconnect=False,
+    )
+
+    try:
+        server._close_sessions_for_transport(transport, end_reason="ws_disconnect")
+
+        assert "normal" in server._sessions
+        assert server._sessions["normal"]["transport"] is server._stdio_transport
+    finally:
+        server._sessions.pop("normal", None)
 
 
 def test_init_session_fires_reset_hook(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -318,15 +318,57 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
             pass
 
 
+def _coerce_close_on_disconnect(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    if value is None:
+        return False
+    return bool(value)
+
+
+def _close_session_by_id(sid: str, *, end_reason: str = "tui_close") -> bool:
+    session = _sessions.pop(sid, None)
+    if not session:
+        return False
+    _finalize_session(session, end_reason=end_reason)
+    try:
+        from tools.approval import unregister_gateway_notify
+
+        unregister_gateway_notify(session["session_key"])
+    except Exception:
+        pass
+    try:
+        agent = session.get("agent")
+        if agent and hasattr(agent, "close"):
+            agent.close()
+    except Exception:
+        pass
+    try:
+        worker = session.get("slash_worker")
+        if worker:
+            worker.close()
+    except Exception:
+        pass
+    return True
+
+
+def _close_sessions_for_transport(
+    transport: Any, *, end_reason: str = "ws_disconnect"
+) -> None:
+    for sid, session in list(_sessions.items()):
+        if session.get("transport") is not transport:
+            continue
+        if session.get("close_on_disconnect"):
+            _close_session_by_id(sid, end_reason=end_reason)
+        else:
+            session["transport"] = _stdio_transport
+
+
 def _shutdown_sessions() -> None:
-    for session in list(_sessions.values()):
-        _finalize_session(session, end_reason="tui_shutdown")
-        try:
-            worker = session.get("slash_worker")
-            if worker:
-                worker.close()
-        except Exception:
-            pass
+    for sid in list(_sessions.keys()):
+        _close_session_by_id(sid, end_reason="tui_shutdown")
 
 
 atexit.register(_shutdown_sessions)
@@ -1896,6 +1938,7 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
         "tool_progress_mode": _load_tool_progress_mode(),
         "edit_snapshots": {},
         "tool_started_at": {},
+        "close_on_disconnect": False,
         # Pin async event emissions to whichever transport created the
         # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
         "transport": current_transport() or _stdio_transport,
@@ -2065,6 +2108,9 @@ def _(rid, params: dict) -> dict:
     sid = uuid.uuid4().hex[:8]
     key = _new_session_key()
     cols = int(params.get("cols", 80))
+    close_on_disconnect = _coerce_close_on_disconnect(
+        params.get("close_on_disconnect")
+    )
     _enable_gateway_prompts()
 
     ready = threading.Event()
@@ -2087,6 +2133,7 @@ def _(rid, params: dict) -> dict:
         "slash_worker": None,
         "tool_progress_mode": _load_tool_progress_mode(),
         "tool_started_at": {},
+        "close_on_disconnect": close_on_disconnect,
         "transport": current_transport() or _stdio_transport,
     }
 
@@ -2605,29 +2652,7 @@ def _(rid, params: dict) -> dict:
 @method("session.close")
 def _(rid, params: dict) -> dict:
     sid = params.get("session_id", "")
-    session = _sessions.pop(sid, None)
-    if not session:
-        return _ok(rid, {"closed": False})
-    _finalize_session(session)
-    try:
-        from tools.approval import unregister_gateway_notify
-
-        unregister_gateway_notify(session["session_key"])
-    except Exception:
-        pass
-    try:
-        agent = session.get("agent")
-        if agent and hasattr(agent, "close"):
-            agent.close()
-    except Exception:
-        pass
-    try:
-        worker = session.get("slash_worker")
-        if worker:
-            worker.close()
-    except Exception:
-        pass
-    return _ok(rid, {"closed": True})
+    return _ok(rid, {"closed": _close_session_by_id(sid)})
 
 
 @method("session.branch")

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -162,11 +162,10 @@ async def handle_ws(ws: Any) -> None:
     finally:
         transport.close()
 
-        # Detach the transport from any sessions it owned so later emits
-        # fall back to stdio instead of crashing into a closed socket.
-        for _, sess in list(server._sessions.items()):
-            if sess.get("transport") is transport:
-                sess["transport"] = server._stdio_transport
+        # Preserve the historical "session survives reconnect" behavior for
+        # normal TUI sessions, but eagerly close explicit sidecar sessions
+        # whose slash worker should not outlive this websocket.
+        server._close_sessions_for_transport(transport, end_reason="ws_disconnect")
 
         try:
             await ws.close()

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -119,7 +119,9 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
         if (cancelled) {
           return;
         }
-        return gw.request<{ session_id: string }>("session.create", {});
+        return gw.request<{ session_id: string }>("session.create", {
+          close_on_disconnect: true,
+        });
       })
       .then((created) => {
         if (cancelled || !created?.session_id) {


### PR DESCRIPTION
## What does this PR do?

Fixes the dashboard sidecar session lifecycle leak behind `#21370`.

The underlying issue is not that `tui_gateway.slash_worker` forgets to exit on its own. That subprocess is intentionally persistent for real TUI sessions so slash commands can reuse the same worker. The leak happens because dashboard sidecar sessions created over `/api/ws` can outlive their websocket connection: on disconnect, the server previously only detached the transport and kept the session record alive in `tui_gateway.server._sessions`, which also kept the session's `slash_worker` alive.

This PR adds an explicit `close_on_disconnect` session mode for short-lived sidecar sessions, closes those sessions server-side when their websocket disconnects, and leaves the historical reconnect behavior unchanged for normal TUI sessions.

## Related Issue

Fixes #21370

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `close_on_disconnect` parsing and storage in `tui_gateway/server.py` for `session.create`.
- Added a shared `_close_session_by_id()` helper so `session.close`, websocket disconnect cleanup, and process shutdown all use the same teardown path for finalize hooks, agent cleanup, notify unregistration, and slash-worker shutdown.
- Added `_close_sessions_for_transport()` so websocket disconnect cleanup only closes explicitly marked sidecar sessions and still falls back to stdio for normal sessions.
- Updated `tui_gateway/ws.py` to use the shared transport/session cleanup helper.
- Updated `web/src/components/ChatSidebar.tsx` to create its sidecar session with `close_on_disconnect: true`.
- Added regression tests covering:
  - `session.create` storing the close-on-disconnect flag
  - websocket-disconnect cleanup closing marked sidecar sessions and their workers
  - websocket-disconnect cleanup preserving normal sessions

## How to Test

1. Run the targeted TUI gateway regression tests:
   `python -m pytest tests/test_tui_gateway_server.py -q -k "close_on_disconnect or close_sessions_for_transport or session_close_commits_memory_and_fires_finalize_hook or session_create_close_race_does_not_orphan_worker or session_create_no_race_keeps_worker_alive"`
2. Verify the dashboard frontend still compiles:
   `cd web && npm run build`
3. Optional manual repro for the original issue:
   start `hermes dashboard`, open the dashboard chat/sidebar, disconnect/close the websocket client, and confirm sidecar `python -m tui_gateway.slash_worker` processes do not accumulate for the disconnected sidecar session.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (WSL)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

- Targeted backend regression:
  `6 passed in 20.47s`
- Frontend build:
  `cd web && npm run build`
  `✓ built in 51.47s`
- Note: I did not run a full dashboard/browser end-to-end repro locally for this PR.
