### PR TITLE
fix(gemini): avoid assuming paid tier without quota signal

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -57,7 +57,8 @@ def probe_gemini_tier(
 
     - ``"free"``    -- key is on the free tier (unusable with Hermes)
     - ``"paid"``    -- key is on a paid tier
-    - ``"unknown"`` -- probe failed; callers should proceed without blocking.
+    - ``"unknown"`` -- probe failed or no reliable tier signal was returned;
+                      callers should proceed without blocking.
     """
     key = (api_key or "").strip()
     if not key:
@@ -113,7 +114,10 @@ def probe_gemini_tier(
         return "paid"
 
     if 200 <= resp.status_code < 300:
-        return "paid"
+        # A successful generateContent response validates the key, but Google
+        # does not consistently return rate-limit headers for either free or
+        # paid projects. Without an explicit quota signal, tier is unknown.
+        return "unknown"
 
     return "unknown"
 

--- a/tests/agent/test_gemini_free_tier_gate.py
+++ b/tests/agent/test_gemini_free_tier_gate.py
@@ -65,9 +65,9 @@ class TestProbeGeminiTier:
         resp = _mock_response(429, {}, body)
         assert _run_probe(resp) == "paid"
 
-    def test_successful_200_without_rpd_header_is_paid(self):
+    def test_successful_200_without_rpd_header_is_unknown(self):
         resp = _mock_response(200, {}, '{"candidates":[]}')
-        assert _run_probe(resp) == "paid"
+        assert _run_probe(resp) == "unknown"
 
     def test_401_returns_unknown(self):
         resp = _mock_response(401, {}, '{"error":{"code":401}}')
@@ -90,9 +90,9 @@ class TestProbeGeminiTier:
         assert probe_gemini_tier(None) == "unknown"  # type: ignore[arg-type]
 
     def test_malformed_rpd_header_falls_through(self):
-        # Non-integer header value shouldn't crash; 200 with no usable header -> paid.
+        # Non-integer header value shouldn't crash; no usable tier signal -> unknown.
         resp = _mock_response(200, {"x-ratelimit-limit-requests-per-day": "abc"}, "{}")
-        assert _run_probe(resp) == "paid"
+        assert _run_probe(resp) == "unknown"
 
     def test_openai_compat_suffix_stripped(self):
         """Base URLs ending in /openai get normalized to the native endpoint."""


### PR DESCRIPTION
## What does this PR do?

Fixes Gemini setup tier probing so a successful `generateContent` response without reliable quota headers is treated as `unknown`, not `paid`.

Google's Gemini API can return HTTP 200 without `x-ratelimit-*` headers for both free-tier and paid/billing-enabled API keys. The previous logic treated any 2xx response without headers as paid, which could make `hermes setup` print `Tier check: paid ✓` for a free-tier key.

This keeps explicit tier signals unchanged:
- `x-ratelimit-limit-requests-per-day <= 1000` still returns `free`
- `x-ratelimit-limit-requests-per-day > 1000` still returns `paid`
- Free-tier 429 bodies still return `free`

## Related Issue

Fixes #21399

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/gemini_native_adapter.py`: return `unknown` for 2xx Gemini probe responses when no reliable quota/tier signal is present.
- `tests/agent/test_gemini_free_tier_gate.py`: update probe tests to assert `unknown` for successful responses without usable RPD headers.

## How to Test

1. Run the focused test suite: `scripts/run_tests.sh tests/agent/test_gemini_free_tier_gate.py tests/hermes_cli/test_gemini_free_tier_setup_block.py`
2. Confirm the tests pass.
3. Optionally run `hermes setup` with a Gemini API key and confirm ambiguous tier probes no longer imply paid status without a reliable quota signal.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora 44 KDE

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused tests pass:

```text
scripts/run_tests.sh tests/agent/test_gemini_free_tier_gate.py tests/hermes_cli/test_gemini_free_tier_setup_block.py

26 passed in 6.39s
```
