### PR TITLE
feat(prompt-builder): per-profile skills.allow config to prevent prompt-cap degradation

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -19,6 +19,7 @@ from agent.skill_utils import (
     extract_skill_conditions,
     extract_skill_description,
     get_all_skills_dirs,
+    get_allowed_skills,
     get_disabled_skill_names,
     iter_skill_index_files,
     parse_frontmatter,
@@ -888,6 +889,38 @@ def build_skills_system_prompt(
                 category_descriptions.setdefault(cat, str(cat_desc).strip().strip("'\""))
             except Exception as e:
                 logger.debug("Could not read external skill description %s: %s", desc_file, e)
+
+    # ── Allowlist filter (per-profile skills.allow in config.yaml) ────
+    # When skills.allow is set in the active profile's config.yaml, restrict
+    # the prompt index to that subset of "category/name" identifiers.  This
+    # keeps the skills-prompt index small on profiles that have grown a large
+    # local skill catalog, without hiding any files from on-disk discovery.
+    allowed = get_allowed_skills()
+    if allowed is not None:
+        # Each entry in `allowed` is "category/skill-name". Nested categories
+        # like "mlops/training/peft" use the leaf as the frontmatter_name.
+        keep_pairs = set()
+        for entry in allowed:
+            entry = entry.strip()
+            if not entry or "/" not in entry:
+                continue
+            cat, _, name = entry.rpartition("/")
+            keep_pairs.add((cat, name))
+        filtered: dict[str, list[tuple[str, str]]] = {}
+        seen_entries = set()
+        for category, items in skills_by_category.items():
+            kept = [(n, d) for (n, d) in items if (category, n) in keep_pairs]
+            if kept:
+                filtered[category] = kept
+            for (n, _d) in kept:
+                seen_entries.add((category, n))
+        missing = [f"{c}/{n}" for (c, n) in keep_pairs if (c, n) not in seen_entries]
+        if missing:
+            logger.warning(
+                "skills.allow references %d skill(s) not found on disk; skipping: %s",
+                len(missing), ", ".join(sorted(missing)[:10]),
+            )
+        skills_by_category = filtered
 
     if not skills_by_category:
         result = ""

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -471,3 +471,41 @@ def is_valid_namespace(candidate: Optional[str]) -> bool:
     if not candidate:
         return False
     return bool(_NAMESPACE_RE.match(candidate))
+
+
+def get_allowed_skills() -> Optional[Set[str]]:
+    """Return the per-profile skills allowlist from config.yaml, if set.
+
+    Reads ``skills.allow`` from config.yaml.  Each entry is a
+    ``"category/name"`` identifier matching the on-disk skill layout
+    (e.g. ``"github/github-pr-workflow"``).  When the allowlist is set,
+    only those skills will be included in the prompt skills index.
+
+    Returns:
+        ``None`` if the key is unset/missing/malformed (current behavior —
+        all skills load).  Otherwise a ``set`` of ``"category/name"``
+        strings.  An empty set is allowed and means "no skills."
+    """
+    config_path = get_config_path()
+    if not config_path.exists():
+        return None
+    try:
+        parsed = yaml_load(config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return None
+    if "allow" not in skills_cfg:
+        return None
+    raw = skills_cfg.get("allow")
+    if raw is None:
+        return None
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, list):
+        return None
+    return {str(v).strip() for v in raw if str(v).strip()}
+

--- a/tests/agent/test_prompt_builder_allowlist.py
+++ b/tests/agent/test_prompt_builder_allowlist.py
@@ -1,0 +1,110 @@
+"""Tests for the per-profile skills.allow allowlist in prompt_builder."""
+from __future__ import annotations
+
+import logging
+import textwrap
+
+import pytest
+
+from agent.prompt_builder import (
+    build_skills_system_prompt,
+    clear_skills_system_prompt_cache,
+)
+
+
+def _write_skill(base, category, name, description="A short skill desc"):
+    d = base / "skills" / category / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n"
+    )
+
+
+def _write_config(base, body=""):
+    (base / "config.yaml").write_text(body)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+    yield
+    clear_skills_system_prompt_cache(clear_snapshot=True)
+
+
+class TestSkillsAllowlist:
+    def test_no_allow_set_includes_everything(self, monkeypatch, tmp_path):
+        """Baseline: when skills.allow is unset, all skills load (current behavior)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_skill(tmp_path, "github", "github-issues", "GitHub issues skill")
+        _write_skill(tmp_path, "creative", "ascii-art", "ASCII art generator")
+        _write_config(tmp_path, "model:\n  default: gpt-5\n")  # no skills key
+        out = build_skills_system_prompt()
+        assert "github-issues" in out
+        assert "ascii-art" in out
+
+    def test_allow_set_filters_to_those_skills_only(self, monkeypatch, tmp_path):
+        """skills.allow set with valid entries → only those load."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_skill(tmp_path, "github", "github-issues", "GitHub issues skill")
+        _write_skill(tmp_path, "github", "github-pr-workflow", "PR workflow")
+        _write_skill(tmp_path, "creative", "ascii-art", "ASCII art")
+        cfg = textwrap.dedent("""\
+            skills:
+              allow:
+                - github/github-issues
+                - creative/ascii-art
+            """)
+        _write_config(tmp_path, cfg)
+        out = build_skills_system_prompt()
+        assert "github-issues" in out
+        assert "ascii-art" in out
+        assert "github-pr-workflow" not in out
+
+    def test_allow_with_missing_entry_logs_warning_and_skips(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """Allowlist references a skill not on disk → warning, no crash, valid entries still load."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_skill(tmp_path, "github", "github-issues", "GitHub issues skill")
+        cfg = textwrap.dedent("""\
+            skills:
+              allow:
+                - github/github-issues
+                - github/does-not-exist
+                - bogus/another-missing
+            """)
+        _write_config(tmp_path, cfg)
+        with caplog.at_level(logging.WARNING):
+            out = build_skills_system_prompt()
+        assert "github-issues" in out
+        assert "does-not-exist" not in out
+        warn_msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("not found on disk" in m for m in warn_msgs), warn_msgs
+
+    def test_allow_within_cap_no_degradation_warning(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """With a tight allowlist, no 'exceeds ... cap — dropping descriptions' warning fires."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Many skills on disk, but only a small subset allowed
+        for i in range(60):
+            _write_skill(
+                tmp_path,
+                f"category{i % 6}",
+                f"skill-{i:02d}",
+                f"Description {i} " + "x" * 60,
+            )
+        cfg = textwrap.dedent("""\
+            skills:
+              allow:
+                - category0/skill-00
+                - category1/skill-01
+                - category2/skill-02
+            """)
+        _write_config(tmp_path, cfg)
+        with caplog.at_level(logging.WARNING):
+            out = build_skills_system_prompt()
+        msgs = [r.getMessage() for r in caplog.records]
+        assert not any("exceeds" in m and "cap" in m for m in msgs), msgs
+        assert "skill-00" in out
+        assert "skill-59" not in out


### PR DESCRIPTION
## Problem

On profiles that have grown a large local skills catalog (100+ skills), the
8 KB cap inside `build_skills_system_prompt` fires the progressive
degradation paths — first dropping per-skill descriptions, then dropping
entire categories — to keep the system prompt under budget. The end-state
is a skills index where the model can still see *names* but loses the
short descriptions that let it pick the right skill, and in the worst
case loses entire categories silently.

The cap exists for good reason (prompt cost / cache stability), but
there's currently no way for an operator to pre-empt the degradation by
saying "I only actually use these 30 skills out of 200 on this profile."

## Solution

Add an opt-in `skills.allow` list to the active profile's `config.yaml`.
When set, the prompt index is filtered down to that subset *before* the
size-cap logic runs, so a curated profile stays well under the cap and
never trips the degradation paths.

The allowlist only affects the **prompt index**. On-disk discovery is
unchanged: `skill_view`, `skill_index`, and `/skill_*` slash commands
still see every skill on disk. Operators can therefore tighten the
prompt without losing the ability to load any skill on demand.

### Example `config.yaml`

```yaml
skills:
  allow:
    - github/github-pr-workflow
    - creative/ascii-art
    - mlops/training/peft
```

Each entry is `category/skill-name` — the same form used by
`skills_by_category` internally. Nested categories (e.g.
`mlops/training/peft`) work via `rpartition("/")`, treating the leaf
as the frontmatter `name`.

## Backwards compatibility

- `skills.allow` unset / missing / non-list → existing behavior, all
  skills load (returns `None` from `get_allowed_skills`).
- `skills.allow: []` → empty index (explicit operator choice).
- Entries that don't match any on-disk skill log a single warning
  (`skills.allow references N skill(s) not found on disk; skipping: ...`)
  and are skipped — no crash, valid entries still load.

## Tests

`tests/agent/test_prompt_builder_allowlist.py` — 4 cases, all passing:

1. `test_no_allow_set_includes_everything` — baseline: unset key →
   current behavior.
2. `test_allow_set_filters_to_those_skills_only` — only allowlisted
   skills appear in the index.
3. `test_allow_with_missing_entry_logs_warning_and_skips` — bogus
   entries warn but don't crash; valid ones still load.
4. `test_allow_within_cap_no_degradation_warning` — with 60 skills on
   disk and a 3-entry allowlist, no "exceeds cap" warning fires.

```
$ pytest tests/agent/test_prompt_builder_allowlist.py
============================== 4 passed in 1.53s ===============================
```

## Diff scope

Three files, all additive:

- `agent/skill_utils.py` — new `get_allowed_skills()` reader (38 lines).
- `agent/prompt_builder.py` — one new import + one filter block before
  the existing index-build (33 lines).
- `tests/agent/test_prompt_builder_allowlist.py` — 4 new tests.

No existing behavior, public API, or default config is changed.
