### PR TITLE
fix(agent): wrap schema loading in try/except to prevent registration on failure

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -225,10 +225,21 @@ class MemoryManager:
                 return
             self._has_external = True
 
+        # Collect tool schemas BEFORE mutating state — if schema loading
+        # fails the provider must NOT be registered (fixes #9948).
+        try:
+            schemas = provider.get_tool_schemas()
+        except Exception as exc:
+            logger.error(
+                "Memory provider '%s' failed during schema loading: %s — NOT registered",
+                provider.name, exc,
+            )
+            return
+
         self._providers.append(provider)
 
         # Index tool names → provider for routing
-        for schema in provider.get_tool_schemas():
+        for schema in schemas:
             tool_name = schema.get("name", "")
             if tool_name and tool_name not in self._tool_to_provider:
                 self._tool_to_provider[tool_name] = provider
@@ -244,7 +255,7 @@ class MemoryManager:
         logger.info(
             "Memory provider '%s' registered (%d tools)",
             provider.name,
-            len(provider.get_tool_schemas()),
+            len(schemas),
         )
 
     @property

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -162,6 +162,17 @@ class TestMemoryManager:
         assert [p.name for p in mgr.providers] == ["builtin", "mem0"]
         assert len(mgr.providers) == 2
 
+    def test_schema_loading_failure_prevents_registration(self):
+        """If get_tool_schemas() raises, the provider is NOT registered (fixes #9948)."""
+        mgr = MemoryManager()
+        bad = FakeMemoryProvider("bad")
+        bad.get_tool_schemas = MagicMock(side_effect=RuntimeError("schema boom"))
+
+        mgr.add_provider(bad)  # must not raise
+
+        assert len(mgr.providers) == 0
+        assert mgr.get_provider("bad") is None
+
     def test_system_prompt_merges_blocks(self):
         mgr = MemoryManager()
         p1 = FakeMemoryProvider("builtin")


### PR DESCRIPTION
## What

If `get_tool_schemas()` raises during `add_provider()`, the provider is now NOT registered. Previously the bare call would propagate the exception and the provider would already be appended to `self._providers`, leaving the manager in a corrupted state.

## How

- Schema loading (`get_tool_schemas()`) now happens **before** `self._providers.append(provider)` — if it fails, the method logs an error and returns early, keeping the manager state clean.
- The returned `schemas` list is reused for the indexing loop and the info log, eliminating the redundant third `get_tool_schemas()` call.

## Test

- `test_schema_loading_failure_prevents_registration` — verifies that a provider whose `get_tool_schemas()` raises is silently rejected (no exception propagation, `providers` stays empty).

Fixes #9948