### PR TITLE
fix(credential_pool): recover exhausted entries on endpoint changes

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -29,6 +29,7 @@ from hermes_cli.auth import (
     _resolve_zai_base_url,
     _save_auth_store,
     _save_provider_state,
+    detect_zai_endpoint,
     read_credential_pool,
     write_credential_pool,
 )
@@ -58,6 +59,15 @@ SOURCE_MANUAL = "manual"
 
 STRATEGY_FILL_FIRST = "fill_first"
 STRATEGY_ROUND_ROBIN = "round_robin"
+
+# Providers that cache a runtime-detected endpoint in
+# ``provider_state.<provider>.detected_endpoint`` and therefore benefit from
+# syncing pool entries against that cache.  The detector mapping also drives
+# cooldown re-probes after an exhausted entry becomes retryable.
+_PROVIDER_ENDPOINT_DETECTORS = {
+    "zai": detect_zai_endpoint,
+}
+_PROVIDERS_WITH_ENDPOINT_DETECTION = frozenset(_PROVIDER_ENDPOINT_DETECTORS)
 STRATEGY_RANDOM = "random"
 STRATEGY_LEAST_USED = "least_used"
 SUPPORTED_POOL_STRATEGIES = {
@@ -594,6 +604,131 @@ class CredentialPool:
             logger.debug("Failed to sync Nous entry from auth.json: %s", exc)
         return entry
 
+    def _sync_endpoint_from_provider_state(self, entry: PooledCredential) -> PooledCredential:
+        """Sync a pool entry's base_url from provider_state when endpoints can change.
+
+        Some providers (Z.AI, and potentially others in future) have multiple API
+        surfaces and cache the working endpoint in ``provider_state.<provider>.detected_endpoint``.
+        When a pool entry was seeded with one endpoint but runtime resolution later
+        detected a different working endpoint, the pool entry's ``base_url`` becomes
+        stale and the entry may stay exhausted on the wrong endpoint indefinitely.
+
+        This method checks provider_state for a cached endpoint that differs from
+        the entry's current base_url. If found, it adopts the new endpoint and
+        clears exhaustion so the entry can be retried immediately.
+
+        Returns the updated entry (or the original if no change was needed).
+        """
+        if self.provider not in _PROVIDERS_WITH_ENDPOINT_DETECTION:
+            return entry
+        try:
+            with _auth_store_lock():
+                auth_store = _load_auth_store()
+                state = _load_provider_state(auth_store, self.provider)
+            if not isinstance(state, dict):
+                return entry
+            detected = state.get("detected_endpoint")
+            if not isinstance(detected, dict):
+                return entry
+            detected_url = detected.get("base_url", "").rstrip("/")
+            entry_url = (entry.base_url or "").rstrip("/")
+            if detected_url and detected_url != entry_url:
+                logger.debug(
+                    "Pool entry %s: syncing %s endpoint from auth.json %s -> %s",
+                    entry.id, self.provider, entry_url, detected_url,
+                )
+                updated = replace(
+                    entry,
+                    base_url=detected_url,
+                    last_status=None,
+                    last_status_at=None,
+                    last_error_code=None,
+                    last_error_reason=None,
+                    last_error_message=None,
+                    last_error_reset_at=None,
+                )
+                self._replace_entry(entry, updated)
+                self._persist()
+                return updated
+        except Exception as exc:
+            logger.debug("Failed to sync %s entry endpoint from auth.json: %s", self.provider, exc)
+        return entry
+
+    def _reprobe_endpoint_after_cooldown(
+        self,
+        cleared: PooledCredential,
+        previous_error: tuple[Any, Any, Any],
+        now: datetime,
+    ) -> tuple[PooledCredential, bool]:
+        """Re-probe the provider's endpoint after an exhausted entry's cooldown expired.
+
+        Quota on multi-surface providers (e.g. Z.AI regular vs coding-plan) can
+        shift between endpoints while an entry is in cooldown.  Once the cooldown
+        clears, re-run endpoint detection so we don't hand out a base_url that
+        no longer has quota.
+
+        Returns ``(entry, changed)`` where ``changed`` indicates the caller
+        should persist updated state.  On probe failure the entry is restored
+        to ``STATUS_EXHAUSTED`` with the original error context preserved.
+        """
+        detector = _PROVIDER_ENDPOINT_DETECTORS.get(self.provider)
+        if detector is None:
+            return cleared, False
+        api_key = cleared.access_token or ""
+        if not api_key:
+            return cleared, False
+
+        previous_error_code, previous_error_reason, previous_error_message = previous_error
+
+        try:
+            detected = detector(api_key, timeout=8.0)
+        except Exception as exc:
+            logger.debug(
+                "Pool entry %s: %s re-probe error: %s",
+                cleared.id, self.provider, exc,
+            )
+            entry = replace(
+                cleared,
+                last_status=STATUS_EXHAUSTED,
+                last_status_at=now,
+                last_error_code=previous_error_code,
+                last_error_reason=previous_error_reason,
+                last_error_message=previous_error_message,
+                last_error_reset_at=None,
+            )
+            self._replace_entry(cleared, entry)
+            return entry, True
+
+        if detected and detected.get("base_url"):
+            new_url = detected["base_url"].rstrip("/")
+            old_url = (cleared.base_url or "").rstrip("/")
+            if new_url != old_url:
+                logger.debug(
+                    "Pool entry %s: re-probed %s endpoint %s -> %s",
+                    cleared.id, self.provider, old_url, new_url,
+                )
+                entry = replace(cleared, base_url=new_url)
+                self._replace_entry(cleared, entry)
+                return entry, True
+            return cleared, False
+
+        # Probe failed — no endpoint works, keep exhausted with original error.
+        logger.debug(
+            "Pool entry %s: %s re-probe failed, keeping exhausted",
+            cleared.id, self.provider,
+        )
+        entry = replace(
+            cleared,
+            last_status=STATUS_EXHAUSTED,
+            last_status_at=now,
+            last_error_code=previous_error_code,
+            last_error_reason=previous_error_reason,
+            last_error_message=previous_error_message,
+            last_error_reset_at=None,
+        )
+        self._replace_entry(cleared, entry)
+        return entry, True
+
     def _sync_device_code_entry_to_auth_store(self, entry: PooledCredential) -> None:
         """Write refreshed pool entry tokens back to auth.json providers.
 
@@ -883,11 +1018,23 @@ class CredentialPool:
                 if synced is not entry:
                     entry = synced
                     cleared_any = True
+            # For providers with multiple endpoints cached in provider_state,
+            # sync the detected endpoint from auth.json before checking exhaustion.
+            # This prevents entries from staying stranded on a stale base_url
+            # after runtime resolution has found a different working endpoint.
+            if entry.last_status == STATUS_EXHAUSTED:
+                synced = self._sync_endpoint_from_provider_state(entry)
+                if synced is not entry:
+                    entry = synced
+                    cleared_any = True
             if entry.last_status == STATUS_EXHAUSTED:
                 exhausted_until = _exhausted_until(entry)
                 if exhausted_until is not None and now < exhausted_until:
                     continue
                 if clear_expired:
+                    previous_error_code = entry.last_error_code
+                    previous_error_reason = entry.last_error_reason
+                    previous_error_message = entry.last_error_message
                     cleared = replace(
                         entry,
                         last_status=STATUS_OK,
@@ -900,6 +1047,18 @@ class CredentialPool:
                     self._replace_entry(entry, cleared)
                     entry = cleared
                     cleared_any = True
+                    # For providers with endpoint detection, re-probe after
+                    # cooldown clears to ensure the cached base_url is still
+                    # valid.  Quota may have shifted between endpoints.
+                    entry, endpoint_changed = self._reprobe_endpoint_after_cooldown(
+                        cleared,
+                        (previous_error_code, previous_error_reason, previous_error_message),
+                        now,
+                    )
+                    if endpoint_changed:
+                        cleared_any = True
+                    if entry.last_status == STATUS_EXHAUSTED:
+                        continue
             if refresh and self._entry_needs_refresh(entry):
                 refreshed = self._refresh_entry(entry, force=False)
                 if refreshed is None:

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1641,3 +1641,160 @@ def test_codex_exhausted_entry_stays_stuck_without_auth_store_update(tmp_path, m
     # still skips it.
     available = pool._available_entries(clear_expired=True, refresh=False)
     assert available == []
+
+
+def test_zai_exhausted_entry_recovers_when_detected_endpoint_changes(tmp_path, monkeypatch):
+    """Z.AI entries can be stuck on the wrong billing surface.
+
+    Regression for GLM/Z.AI coding-plan accounts: the pool entry may have
+    been seeded with the regular endpoint, then exhausted with 429
+    "insufficient balance" even though the same key has quota on the coding
+    endpoint. Once endpoint detection has found the coding endpoint, an
+    exhausted profile entry should adopt it and become selectable immediately.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("ZAI_API_KEY", "zai-key")
+    now = time.time()
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "zai": {
+                    "detected_endpoint": {
+                        "base_url": "https://api.z.ai/api/coding/paas/v4",
+                        "endpoint_id": "coding-global",
+                        "model": "glm-5.1",
+                        "label": "Global (Coding Plan)",
+                        "key_hash": "unused-in-pool-sync",
+                    }
+                }
+            },
+            "credential_pool": {
+                "zai": [
+                    {
+                        "id": "zai-1",
+                        "label": "ZAI_API_KEY",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "env:ZAI_API_KEY",
+                        "access_token": "zai-key",
+                        "base_url": "https://api.z.ai/api/paas/v4",
+                        "last_status": "exhausted",
+                        "last_status_at": now,
+                        "last_error_code": 429,
+                        "last_error_reason": "1305",
+                        "last_error_message": "Insufficient balance or no resource package",
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("zai")
+    available = pool._available_entries(clear_expired=True, refresh=False)
+
+    assert len(available) == 1
+    assert available[0].base_url == "https://api.z.ai/api/coding/paas/v4"
+    assert available[0].last_status is None
+    assert available[0].last_error_code is None
+
+
+def test_zai_expired_entry_reprobes_endpoint_before_reuse(tmp_path, monkeypatch):
+    """After Z.AI cooldown, re-probe before sending traffic to a stale URL."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("ZAI_API_KEY", "zai-key")
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "zai": [
+                    {
+                        "id": "zai-1",
+                        "label": "ZAI_API_KEY",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "env:ZAI_API_KEY",
+                        "access_token": "zai-key",
+                        "base_url": "https://api.z.ai/api/paas/v4",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time() - 3700,
+                        "last_error_code": 429,
+                        "last_error_reason": "1305",
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent import credential_pool as credential_pool_mod
+    from agent.credential_pool import load_pool
+
+    monkeypatch.setitem(
+        credential_pool_mod._PROVIDER_ENDPOINT_DETECTORS,
+        "zai",
+        lambda api_key, timeout=8.0: {
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+            "id": "coding-global",
+            "model": "glm-5.1",
+            "label": "Global (Coding Plan)",
+        },
+    )
+
+    pool = load_pool("zai")
+    available = pool._available_entries(clear_expired=True, refresh=False)
+
+    assert len(available) == 1
+    assert available[0].base_url == "https://api.z.ai/api/coding/paas/v4"
+    assert available[0].last_status == "ok"
+
+
+def test_zai_failed_reprobe_keeps_entry_unavailable(tmp_path, monkeypatch):
+    """Do not resurrect an expired Z.AI entry when no endpoint currently works."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("ZAI_API_KEY", "zai-key")
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "zai": [
+                    {
+                        "id": "zai-1",
+                        "label": "ZAI_API_KEY",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "env:ZAI_API_KEY",
+                        "access_token": "zai-key",
+                        "base_url": "https://api.z.ai/api/paas/v4",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time() - 3700,
+                        "last_error_code": 429,
+                        "last_error_reason": "1305",
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent import credential_pool as credential_pool_mod
+    from agent.credential_pool import load_pool
+
+    monkeypatch.setitem(
+        credential_pool_mod._PROVIDER_ENDPOINT_DETECTORS,
+        "zai",
+        lambda api_key, timeout=8.0: None,
+    )
+
+    pool = load_pool("zai")
+    available = pool._available_entries(clear_expired=True, refresh=False)
+
+    assert available == []
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = persisted["credential_pool"]["zai"][0]
+    assert entry["last_status"] == "exhausted"
+    assert entry["last_error_code"] == 429
+


### PR DESCRIPTION
## Symptom

A credential pool entry can remain `exhausted` on a stale `base_url` even after runtime provider resolution has detected a different working endpoint.

The concrete case is Z.AI regular vs coding-plan API surfaces: endpoint detection can cache the working coding-plan endpoint in `provider_state.zai.detected_endpoint`, while the pool entry remains stuck on the regular endpoint and is skipped before that newer auth state is used.

## Root cause

`CredentialPool._available_entries()` checks exhaustion before syncing endpoint state from `auth.json`. For providers with multiple API surfaces, that leaves the pool entry stranded on an endpoint that no longer reflects the provider's detected working URL.

## Fix

- Add `_sync_endpoint_from_provider_state()` to adopt `provider_state.<provider>.detected_endpoint` when it differs from the pool entry's cached `base_url`.
- Clear exhaustion only when the detected endpoint actually changes, so the entry can be retried on the working endpoint immediately.
- Re-probe provider endpoint detectors after an exhausted entry's cooldown expires, before returning the entry to callers.
- Keep the entry exhausted if no endpoint currently works, preserving the original error context.

The sync/re-probe mechanism is provider-agnostic; Z.AI is the first opted-in detector via `_PROVIDER_ENDPOINT_DETECTORS`.

## Related context

- Related to #5668's credential-pool cooldown/recovery path, but with a different root cause: stale provider endpoint state rather than transient auth failure.
- Similar class of stale provider state to #19083, where cached provider/base-url identity can lead to using the wrong credential path.
- Also relevant to endpoint-selection/fallback patterns discussed around #21248.

## Test plan

```bash
pytest tests/agent/test_credential_pool.py -q
```

Result: `46 passed`.