### PR TITLE
fix(runtime): honor OpenRouter config base URL

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -585,6 +585,8 @@ def _resolve_openrouter_runtime(
         if requested_norm == "auto":
             if not cfg_provider or cfg_provider == "auto":
                 use_config_base_url = True
+        elif requested_norm == "openrouter" and cfg_provider == "openrouter":
+            use_config_base_url = True
         elif requested_norm == "custom" and _config_base_url_trustworthy_for_bare_custom(
             cfg_base_url, cfg_provider
         ):

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -486,6 +486,29 @@ def test_resolve_runtime_provider_openrouter_ignores_codex_config_base_url(monke
     assert resolved["base_url"] == rp.OPENROUTER_BASE_URL
 
 
+def test_resolve_runtime_provider_openrouter_honors_config_base_url(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "https://openrouter-mirror.example.com/api/v1/",
+            "api_key": "config-key",
+        },
+    )
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["base_url"] == "https://openrouter-mirror.example.com/api/v1"
+    assert resolved["api_key"] == "config-key"
+
+
 def test_resolve_runtime_provider_auto_uses_custom_config_base_url(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- honor `model.base_url` when `requested="openrouter"` and saved config provider is `openrouter`
- keep unrelated OpenAI/Codex config base URLs from affecting explicit OpenRouter requests
- add regression coverage for explicit OpenRouter mirror config without `OPENROUTER_BASE_URL`

## Tests
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q -p no:cacheprovider -o addopts='' --tb=short`

Fixes #10622
