### PR TITLE
fix(send_message): recognize XMPP JIDs as explicit targets

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -355,6 +355,9 @@ def _parse_target_ref(platform_name: str, target_ref: str):
     # Matrix room IDs (start with !) and user IDs (start with @) are explicit
     if platform_name == "matrix" and (target_ref.startswith("!") or target_ref.startswith("@")):
         return target_ref, None, True
+    # XMPP JIDs (user@server or room@conference.server) are explicit
+    if platform_name == "xmpp" and "@" in target_ref:
+        return target_ref, None, True
     return None, None, False
 
 


### PR DESCRIPTION
## Bug

`_parse_target_ref()` has no handler for XMPP JIDs (`user@server` or `room@conference.server`). They fall through to `return None, None, False`, causing `send_message` to fail when targeting an XMPP chat by JID.

## Fix

Add an explicit check for XMPP targets containing `@`, matching the existing Matrix pattern:

```python
# XMPP JIDs (user@server or room@conference.server) are explicit
if platform_name == "xmpp" and "@" in target_ref:
    return target_ref, None, True
```

## Context

Discovered while using the XMPP plugin adapter. Without this fix, `send_message(target='xmpp:hadrons@conference.xmpp.alchemist.ninja')` fails because the JID isn't numeric and doesn't match any other platform's pattern.