### PR TITLE
Restore session cwd on resume

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -96,6 +96,10 @@ from agent.markdown_tables import (
 # top — it transitively pulls the OpenAI SDK chain (~230 ms cold) and is only
 # needed when the user runs `/limits`. Lazy-imported inside the handler below.
 from hermes_cli.banner import _format_context_length, format_banner_version_label
+from session_workspace import (
+    current_session_workspace_metadata,
+    restore_terminal_cwd_from_session,
+)
 
 _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
 
@@ -4396,6 +4400,7 @@ class HermesCLI:
                 resolved_meta = self._session_db.get_session(self.session_id)
                 if resolved_meta:
                     session_meta = resolved_meta
+            restore_terminal_cwd_from_session(session_meta)
             restored = self._session_db.get_messages_as_conversation(self.session_id)
             if restored:
                 restored = [m for m in restored if m.get("role") != "session_meta"]
@@ -4660,6 +4665,7 @@ class HermesCLI:
             if resolved_meta:
                 session_meta = resolved_meta
 
+        restore_terminal_cwd_from_session(session_meta)
         restored = self._session_db.get_messages_as_conversation(self.session_id)
         if restored:
             restored = [m for m in restored if m.get("role") != "session_meta"]
@@ -5886,6 +5892,7 @@ class HermesCLI:
                             "max_iterations": self.max_turns,
                             "reasoning_config": self.reasoning_config,
                         },
+                        **current_session_workspace_metadata(),
                     )
                     self.agent._session_db_created = True
                 except Exception:
@@ -6145,6 +6152,7 @@ class HermesCLI:
         self.session_id = target_id
         self._resumed = True
         self._pending_title = None
+        restore_terminal_cwd_from_session(session_meta)
 
         # Load conversation history (strip transcript-only metadata entries)
         restored = self._session_db.get_messages_as_conversation(target_id)
@@ -6287,6 +6295,7 @@ class HermesCLI:
                     "reasoning_config": self.reasoning_config,
                 },
                 parent_session_id=parent_session_id,
+                **current_session_workspace_metadata(),
             )
         except Exception as e:
             _cprint(f"  Failed to create branch session: {e}")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -33,7 +33,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 13
 
 # ---------------------------------------------------------------------------
 # WAL-compatibility fallback
@@ -194,6 +194,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     model TEXT,
     model_config TEXT,
     system_prompt TEXT,
+    workspace_path TEXT,
+    last_cwd TEXT,
     parent_session_id TEXT,
     started_at REAL NOT NULL,
     ended_at REAL,
@@ -688,6 +690,8 @@ class SessionDB:
         model: str = None,
         model_config: Dict[str, Any] = None,
         system_prompt: str = None,
+        workspace_path: str = None,
+        last_cwd: str = None,
         user_id: str = None,
         parent_session_id: str = None,
     ) -> None:
@@ -695,8 +699,8 @@ class SessionDB:
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                   system_prompt, workspace_path, last_cwd, parent_session_id, started_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
@@ -704,6 +708,8 @@ class SessionDB:
                     model,
                     json.dumps(model_config) if model_config else None,
                     system_prompt,
+                    workspace_path,
+                    last_cwd,
                     parent_session_id,
                     time.time(),
                 ),
@@ -714,6 +720,20 @@ class SessionDB:
         """Create a new session record. Returns the session_id."""
         self._insert_session_row(session_id, source, **kwargs)
         return session_id
+
+    def update_session_cwd(self, session_id: str, cwd: str) -> None:
+        """Update the latest observed working directory for a session."""
+        if not cwd:
+            return
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE sessions SET last_cwd = ? WHERE id = ?",
+                (cwd, session_id),
+            )
+
+        self._execute_write(_do)
+
     def end_session(self, session_id: str, end_reason: str) -> None:
         """Mark a session as ended.
 
@@ -2863,7 +2883,6 @@ class SessionDB:
             result["error"] = str(exc)
 
         return result
-
     # ── Handoff (cross-platform session transfer) ──────────────────────────
     #
     # State machine:
@@ -2963,4 +2982,3 @@ class SessionDB:
                 (error[:500], session_id),
             )
         self._execute_write(_do)
-

--- a/run_agent.py
+++ b/run_agent.py
@@ -69,6 +69,7 @@ from datetime import datetime
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
+from session_workspace import current_session_workspace_metadata
 
 
 _OPENAI_CLS_CACHE: Optional[type] = None
@@ -2558,6 +2559,7 @@ class AIAgent:
                 system_prompt=self._cached_system_prompt,
                 user_id=None,
                 parent_session_id=self._parent_session_id,
+                **current_session_workspace_metadata(),
             )
             self._session_db_created = True
         except Exception as e:
@@ -10747,6 +10749,7 @@ class AIAgent:
                     model=self.model,
                     model_config=self._session_init_model_config,
                     parent_session_id=old_session_id,
+                    **current_session_workspace_metadata(),
                 )
                 self._session_db_created = True
                 # Auto-number the title for the continuation session
@@ -11781,6 +11784,15 @@ class AIAgent:
                     )
                 except Exception as _ver_err:
                     logging.debug("file-mutation verifier record failed: %s", _ver_err)
+
+            if not _execution_blocked and function_name == "terminal" and self._session_db:
+                try:
+                    env = get_active_env(effective_task_id)
+                    cwd = getattr(env, "cwd", None)
+                    if cwd:
+                        self._session_db.update_session_cwd(self.session_id, cwd)
+                except Exception:
+                    pass
 
             if not _execution_blocked and self.tool_progress_callback:
                 try:

--- a/session_workspace.py
+++ b/session_workspace.py
@@ -1,0 +1,40 @@
+"""Helpers for persisting and restoring session workspace context."""
+
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+def current_session_workspace_metadata() -> Dict[str, str]:
+    """Return workspace metadata for a newly-created session row."""
+    cwd = os.getenv("TERMINAL_CWD") or os.getcwd()
+    return {
+        "workspace_path": cwd,
+        "last_cwd": cwd,
+    }
+
+
+def restore_terminal_cwd_from_session(session_meta: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Restore TERMINAL_CWD from session metadata.
+
+    Local sessions only restore paths that still exist on disk. Non-local
+    backends may use sandbox paths that the host cannot validate, so they are
+    allowed through and left for terminal_tool's backend-specific guards.
+    """
+    if not session_meta:
+        return None
+
+    raw_cwd = session_meta.get("last_cwd") or session_meta.get("workspace_path")
+    if not isinstance(raw_cwd, str) or not raw_cwd.strip():
+        return None
+
+    cwd = raw_cwd.strip()
+    backend = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
+    if backend == "local":
+        candidate = Path(cwd).expanduser()
+        if not candidate.is_absolute() or not candidate.is_dir():
+            return None
+        cwd = str(candidate)
+
+    os.environ["TERMINAL_CWD"] = cwd
+    return cwd

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -610,6 +610,80 @@ class TestPreloadResumedSession:
         assert "1 user message," in output
         assert "1 user messages" not in output
 
+    def test_preload_restores_last_cwd(self, tmp_path, monkeypatch):
+        """Early --resume restores TERMINAL_CWD from session metadata."""
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        cli = _make_cli(resume="cwd_session")
+        messages = [{"role": "user", "content": "hi"}]
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {
+            "id": "cwd_session",
+            "title": None,
+            "last_cwd": str(project_dir),
+        }
+        mock_db.get_messages_as_conversation.return_value = messages
+        mock_db._conn = MagicMock()
+        cli._session_db = mock_db
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+        assert cli._preload_resumed_session() is True
+        assert os.environ["TERMINAL_CWD"] == str(project_dir)
+
+    def test_preload_ignores_missing_local_last_cwd(self, tmp_path, monkeypatch):
+        """Local --resume keeps the current cwd when saved cwd is gone."""
+        cli = _make_cli(resume="cwd_session")
+        messages = [{"role": "user", "content": "hi"}]
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {
+            "id": "cwd_session",
+            "title": None,
+            "last_cwd": str(tmp_path / "missing"),
+        }
+        mock_db.get_messages_as_conversation.return_value = messages
+        mock_db._conn = MagicMock()
+        cli._session_db = mock_db
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+        assert cli._preload_resumed_session() is True
+        assert os.environ["TERMINAL_CWD"] == str(tmp_path)
+
+
+class TestResumeCommandWorkspace:
+    """Interactive /resume restores session cwd."""
+
+    def test_resume_command_restores_last_cwd(self, tmp_path, monkeypatch):
+        from hermes_state import SessionDB
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            db.create_session("current", "cli")
+            db.create_session(
+                "target",
+                "cli",
+                workspace_path=str(project_dir),
+                last_cwd=str(project_dir),
+            )
+            db.append_message("target", "user", "hello")
+            cli = _make_cli()
+            cli._session_db.close()
+            cli._session_db = db
+            cli.session_id = "current"
+            cli.agent = None
+            monkeypatch.setenv("TERMINAL_ENV", "local")
+            monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+            cli._handle_resume_command("/resume target")
+
+            assert cli.session_id == "target"
+            assert os.environ["TERMINAL_CWD"] == str(project_dir)
+        finally:
+            db.close()
+
 
 # ── Integration: _init_agent skips when preloaded ────────────────────
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1447,13 +1447,20 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 11
+        assert version == 13
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
         cursor = db._conn.execute("PRAGMA table_info(sessions)")
         columns = {row[1] for row in cursor.fetchall()}
         assert "title" in columns
+
+    def test_workspace_columns_exist(self, db):
+        """Verify session workspace columns are present."""
+        cursor = db._conn.execute("PRAGMA table_info(sessions)")
+        columns = {row[1] for row in cursor.fetchall()}
+        assert "workspace_path" in columns
+        assert "last_cwd" in columns
 
     def test_topic_mode_schema_is_not_auto_migrated_on_open(self, tmp_path):
         """Opening an old DB should not add topic-mode columns until /topic opts in.
@@ -1739,12 +1746,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v9
+        # Open with SessionDB — should migrate to current schema
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 11
+        assert cursor.fetchone()[0] == 13
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -2516,6 +2523,43 @@ class TestResolveSessionByNameOrId:
 # =========================================================================
 
 class TestConcurrentWriteSafety:
+    def test_create_session_stores_workspace_context(self, db):
+        """create_session persists workspace_path and last_cwd."""
+        db.create_session(
+            session_id="workspace-session",
+            source="cli",
+            workspace_path="/repo",
+            last_cwd="/repo/subdir",
+        )
+        row = db.get_session("workspace-session")
+        assert row["workspace_path"] == "/repo"
+        assert row["last_cwd"] == "/repo/subdir"
+
+    def test_ensure_session_stores_workspace_context(self, db):
+        """ensure_session accepts workspace metadata for fallback session rows."""
+        db.ensure_session(
+            "fallback-session",
+            source="gateway",
+            workspace_path="/workspace",
+            last_cwd="/workspace/current",
+        )
+        row = db.get_session("fallback-session")
+        assert row["workspace_path"] == "/workspace"
+        assert row["last_cwd"] == "/workspace/current"
+
+    def test_update_session_cwd_updates_only_last_cwd(self, db):
+        """update_session_cwd tracks cwd changes without rewriting workspace_path."""
+        db.create_session(
+            session_id="cwd-session",
+            source="cli",
+            workspace_path="/repo",
+            last_cwd="/repo",
+        )
+        db.update_session_cwd("cwd-session", "/repo/packages/app")
+        row = db.get_session("cwd-session")
+        assert row["workspace_path"] == "/repo"
+        assert row["last_cwd"] == "/repo/packages/app"
+
     def test_create_session_insert_or_ignore_is_idempotent(self, db):
         """create_session with the same ID twice must not raise (INSERT OR IGNORE)."""
         db.create_session(session_id="dup-1", source="cli", model="m")
@@ -2939,7 +2983,6 @@ class TestFTS5ToolCallMigration:
                 "SELECT version FROM schema_version LIMIT 1"
             ).fetchone()
             version = row["version"] if hasattr(row, "keys") else row[0]
-            assert version == 11
+            assert version == 13
         finally:
             session_db.close()
-


### PR DESCRIPTION
Hi! This is a follow-up to #19154 with the missing consumer added.

In the previous PR, the schema/storage plumbing for session workspace context was clean, but it only wrote `workspace_path` / `last_cwd` and nothing read them. This version keeps the same narrow scope, but wires the stored cwd into core resume behavior so the schema bump has an immediate reader.

## Summary

- Adds `workspace_path` and `last_cwd` columns to the session store.
- Stores the current `TERMINAL_CWD` / process cwd when CLI and agent sessions are created.
- Updates `last_cwd` after terminal tool calls by reading the active terminal environment cwd.
- Restores `last_cwd` into `TERMINAL_CWD` during resume flows:
  - early `--resume` preload
  - `_init_agent()` fallback resume
  - interactive `/resume <session>`
- Keeps local restores conservative: missing/non-absolute local paths are ignored instead of breaking resume.

This means dashboards and remote clients can now rely on persisted workspace context, while the CLI itself also consumes that metadata when resuming a session.

## Tests

- `python3 -m py_compile session_workspace.py hermes_state.py cli.py run_agent.py`
- `.venv/bin/python -m pytest tests/test_hermes_state.py tests/cli/test_resume_display.py -q`
  - `254 passed`

I also attempted the broader local suite with the canonical pytest settings. The run reached `20212 passed`, but this local environment is missing optional/full extras used by unrelated tests (`acp`, `fastapi`, `numpy`, etc.), so that full run was not green locally.
