### PR TITLE
fix: misleading error when auxiliary provider credential pool is exhausted

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1735,6 +1735,10 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
     pool_present, entry = _select_pool_entry("anthropic")
     if pool_present:
         if entry is None:
+            logger.warning(
+                "Anthropic credential pool exists but all entries are exhausted. "
+                "Run `hermes auth reset anthropic` to clear exhaustion state and retry."
+            )
             return None, None
         token = explicit_api_key or _pool_runtime_api_key(entry)
     else:
@@ -3967,6 +3971,15 @@ def call_llm(
             # through OpenRouter (which causes confusing 404s).
             _explicit = (resolved_provider or "").strip().lower()
             if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                # Check if the failure is due to an exhausted credential pool
+                # rather than a missing API key — the fix is different.
+                _pool_exists, _pool_entry = _select_pool_entry(_explicit)
+                if _pool_exists and _pool_entry is None:
+                    raise RuntimeError(
+                        f"Provider '{_explicit}' credential pool is exhausted "
+                        f"(all entries marked failed). Run `hermes auth reset "
+                        f"{_explicit}` to clear exhaustion state and retry."
+                    )
                 raise RuntimeError(
                     f"Provider '{_explicit}' is set in config.yaml but no API key "
                     f"was found. Set the {_explicit.upper()}_API_KEY environment "
@@ -4318,6 +4331,15 @@ async def async_call_llm(
         if client is None:
             _explicit = (resolved_provider or "").strip().lower()
             if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                # Check if the failure is due to an exhausted credential pool
+                # rather than a missing API key — the fix is different.
+                _pool_exists, _pool_entry = _select_pool_entry(_explicit)
+                if _pool_exists and _pool_entry is None:
+                    raise RuntimeError(
+                        f"Provider '{_explicit}' credential pool is exhausted "
+                        f"(all entries marked failed). Run `hermes auth reset "
+                        f"{_explicit}` to clear exhaustion state and retry."
+                    )
                 raise RuntimeError(
                     f"Provider '{_explicit}' is set in config.yaml but no API key "
                     f"was found. Set the {_explicit.upper()}_API_KEY environment "

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2311,3 +2311,104 @@ class TestAnthropicExplicitApiKey:
         assert mock_build.call_args.args[0] == "explicit-fallback-key", (
             "resolve_provider_client must forward explicit_api_key to _try_anthropic()"
         )
+
+
+class TestExhaustedPoolErrorMessage:
+    """Regression tests for #21428: when an explicit provider's credential pool
+    is exhausted (all entries marked failed), call_llm/async_call_llm must
+    raise an error pointing the user at `hermes auth reset <provider>` —
+    NOT the misleading "no API key was found" message.
+    """
+
+    def test_call_llm_raises_pool_exhausted_message_for_explicit_provider(self):
+        """When provider='anthropic' is explicit and the pool is exhausted,
+        the RuntimeError must mention 'pool is exhausted' and the auth-reset
+        command, not the generic 'no API key' message."""
+        with patch("agent.auxiliary_client._get_cached_client", return_value=(None, None)), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)):
+            with pytest.raises(RuntimeError, match=r"pool is exhausted"):
+                call_llm(
+                    task="test",
+                    provider="anthropic",
+                    model="claude-sonnet-4-5",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+
+    def test_call_llm_pool_exhausted_message_mentions_auth_reset(self):
+        """The error must include the literal `hermes auth reset` command so
+        the user knows the exact remediation."""
+        with patch("agent.auxiliary_client._get_cached_client", return_value=(None, None)), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)):
+            with pytest.raises(RuntimeError, match=r"hermes auth reset anthropic"):
+                call_llm(
+                    task="test",
+                    provider="anthropic",
+                    model="claude-sonnet-4-5",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+
+    def test_call_llm_falls_back_to_no_api_key_when_pool_absent(self):
+        """When there is no pool at all (pool_present=False), the original
+        'no API key was found' message must still fire — that's the correct
+        diagnosis for "configured but never authenticated"."""
+        with patch("agent.auxiliary_client._get_cached_client", return_value=(None, None)), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)):
+            with pytest.raises(RuntimeError, match=r"no API key was found"):
+                call_llm(
+                    task="test",
+                    provider="anthropic",
+                    model="claude-sonnet-4-5",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+
+    def test_call_llm_pool_exhausted_skipped_for_auto_provider(self):
+        """The new pool-exhausted check only fires for explicit providers
+        (not 'auto'/'openrouter'/'custom'). For implicit auto-detection,
+        the original auto-chain fallback path is preserved."""
+        # _select_pool_entry should NOT be consulted for the explicit-error
+        # path when provider is auto/openrouter/custom — the code should
+        # fall through to the auto-detection chain instead.
+        with patch("agent.auxiliary_client._get_cached_client", return_value=(None, None)) as mock_cached, \
+             patch("agent.auxiliary_client._select_pool_entry") as mock_pool:
+            with pytest.raises(RuntimeError, match=r"No LLM provider configured"):
+                call_llm(
+                    task="test",
+                    provider="auto",
+                    model="some-model",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+            # The pool-exhausted check should not have run for "auto".
+            mock_pool.assert_not_called()
+            # _get_cached_client is called twice: once for the configured
+            # provider, once for the "auto" fallback chain (per the comment
+            # in auxiliary_client.py at the resolution site).
+            assert mock_cached.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_raises_pool_exhausted_message(self):
+        """async_call_llm has the same diagnosis path — ensure it stays
+        in sync with the sync version."""
+        with patch("agent.auxiliary_client._get_cached_client", return_value=(None, None)), \
+             patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)):
+            with pytest.raises(RuntimeError, match=r"pool is exhausted"):
+                await async_call_llm(
+                    task="test",
+                    provider="anthropic",
+                    model="claude-sonnet-4-5",
+                    messages=[{"role": "user", "content": "hi"}],
+                )
+
+    def test_try_anthropic_logs_warning_when_pool_exhausted(self, caplog):
+        """The narrower _try_anthropic() helper logs a warning before
+        returning (None, None) so operators see the real cause in logs
+        even when callers don't surface our improved error message."""
+        from agent.auxiliary_client import _try_anthropic
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)):
+            with caplog.at_level(logging.WARNING, logger="agent.auxiliary_client"):
+                client, model = _try_anthropic()
+        assert client is None and model is None
+        assert any(
+            "pool exists but all entries are exhausted" in rec.message
+            and "hermes auth reset anthropic" in rec.message
+            for rec in caplog.records
+        ), f"expected pool-exhaustion warning, got: {[r.message for r in caplog.records]}"


### PR DESCRIPTION
## Problem

When a provider's credential pool has all entries marked exhausted (e.g. from a prior 401 against a proxy), auxiliary tasks (compression, title generation, vision, etc.) fail with:

```
Provider 'anthropic' is set in config.yaml but no API key was found.
Set the ANTHROPIC_API_KEY environment variable, or switch to a different provider with `hermes model`.
```

This is misleading — the API key *is* configured and loads correctly, but the credential pool has a stale exhaustion marker that blocks the client from ever attempting to use it. The user has no way to diagnose this without inspecting `auth.json` manually.

## Root Cause

`_try_anthropic()` returns `(None, None)` silently when `_select_pool_entry()` returns `(True, None)` (pool exists, all entries exhausted). The downstream `call_llm()` / `async_call_llm()` then raises a generic "no API key" error that points to the wrong fix.

## Fix

1. **`_try_anthropic()`**: Add `logger.warning()` when pool exists but all entries are exhausted, mentioning `hermes auth reset anthropic` as the resolution.
2. **`call_llm()` and `async_call_llm()`**: Before raising the generic "no API key" RuntimeError, check if the provider has an exhausted pool. If so, raise a more accurate error pointing to `hermes auth reset <provider>`.

## After

```
Provider 'anthropic' credential pool is exhausted (all entries marked failed).
Run `hermes auth reset anthropic` to clear exhaustion state and retry.
```

## Reproduction

1. Configure `auxiliary.title_generation.provider: anthropic` with a custom proxy
2. Trigger a 401 (e.g. proxy rejects key format on first connection)
3. Pool entry gets marked exhausted permanently in `auth.json`
4. All subsequent sessions show the misleading "no API key" warning for every auxiliary task

Related: #10476 (silent provider fallback), but distinct — this is about the error *message* accuracy, not fallback notification.