### PR TITLE
feat(agent): add tool-budget warning and namespace prefix validation in MemoryManager

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -28,12 +28,18 @@ from __future__ import annotations
 import logging
 import re
 import inspect
+import threading
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
+
+# When the total number of memory tools registered across all providers
+# exceeds this threshold, emit a warning -- the model's tool budget may
+# be strained, leading to degraded tool selection quality.
+TOOL_BUDGET_WARN_THRESHOLD = 20
 
 
 # ---------------------------------------------------------------------------
@@ -198,6 +204,7 @@ class MemoryManager:
         self._providers: List[MemoryProvider] = []
         self._tool_to_provider: Dict[str, MemoryProvider] = {}
         self._has_external: bool = False  # True once a non-builtin provider is added
+        self._lock = threading.RLock()
 
     # -- Registration --------------------------------------------------------
 
@@ -208,44 +215,69 @@ class MemoryManager:
         Only **one** external (non-builtin) provider is allowed — a second
         attempt is rejected with a warning.
         """
-        is_builtin = provider.name == "builtin"
+        with self._lock:
+            is_builtin = provider.name == "builtin"
 
-        if not is_builtin:
-            if self._has_external:
-                existing = next(
-                    (p.name for p in self._providers if p.name != "builtin"), "unknown"
-                )
+            if not is_builtin:
+                if self._has_external:
+                    existing = next(
+                        (p.name for p in self._providers if p.name != "builtin"), "unknown"
+                    )
+                    logger.warning(
+                        "Rejected memory provider '%s' — external provider '%s' is "
+                        "already registered. Only one external memory provider is "
+                        "allowed at a time. Configure which one via memory.provider "
+                        "in config.yaml.",
+                        provider.name, existing,
+                    )
+                    return
+                self._has_external = True
+
+            self._providers.append(provider)
+
+            # Index tool names → provider for routing
+            schemas = provider.get_tool_schemas()
+            for schema in schemas:
+                tool_name = schema.get("name", "")
+                if tool_name and tool_name not in self._tool_to_provider:
+                    self._tool_to_provider[tool_name] = provider
+                elif tool_name in self._tool_to_provider:
+                    logger.warning(
+                        "Memory tool name conflict: '%s' already registered by %s, "
+                        "ignoring from %s",
+                        tool_name,
+                        self._tool_to_provider[tool_name].name,
+                        provider.name,
+                    )
+
+            # Namespace validation — warn if tool names don't follow convention
+            if provider.name != "builtin":
+                for schema in schemas:
+                    tool_name = schema.get("name", "")
+                    if tool_name and not tool_name.startswith(provider.name[:4]):
+                        logger.warning(
+                            "Provider '%s' tool '%s' does not follow naming "
+                            "convention '<provider>_<action>'.",
+                            provider.name, tool_name,
+                        )
+
+            total_tools = len(self._tool_to_provider)
+            logger.info(
+                "Memory provider '%s' registered (%d tools, %d total)",
+                provider.name,
+                len(schemas),
+                total_tools,
+            )
+
+            if total_tools > TOOL_BUDGET_WARN_THRESHOLD:
                 logger.warning(
-                    "Rejected memory provider '%s' — external provider '%s' is "
-                    "already registered. Only one external memory provider is "
-                    "allowed at a time. Configure which one via memory.provider "
-                    "in config.yaml.",
-                    provider.name, existing,
+                    "Memory tool budget warning: %d memory tools registered "
+                    "(threshold: %d). Too many tools may degrade the model's "
+                    "ability to select the right tool. Consider disabling "
+                    "unused memory providers or reducing tool count.",
+                    total_tools,
+                    TOOL_BUDGET_WARN_THRESHOLD,
                 )
-                return
-            self._has_external = True
-
-        self._providers.append(provider)
-
-        # Index tool names → provider for routing
-        for schema in provider.get_tool_schemas():
-            tool_name = schema.get("name", "")
-            if tool_name and tool_name not in self._tool_to_provider:
-                self._tool_to_provider[tool_name] = provider
-            elif tool_name in self._tool_to_provider:
-                logger.warning(
-                    "Memory tool name conflict: '%s' already registered by %s, "
-                    "ignoring from %s",
-                    tool_name,
-                    self._tool_to_provider[tool_name].name,
-                    provider.name,
-                )
-
-        logger.info(
-            "Memory provider '%s' registered (%d tools)",
-            provider.name,
-            len(provider.get_tool_schemas()),
-        )
 
     @property
     def providers(self) -> List[MemoryProvider]:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1060,3 +1060,101 @@ class TestHonchoCadenceTracking:
         p.on_turn_start(2, "second message")
         should_skip = p._injection_frequency == "first-turn" and p._turn_count > 1
         assert should_skip, "Second turn (turn 2) SHOULD be skipped"
+
+
+# ---------------------------------------------------------------------------
+# Namespace prefix and tool budget warning tests
+# ---------------------------------------------------------------------------
+
+
+class TestNamespacePrefixWarning:
+    """Warnings when provider tool names don't follow naming convention."""
+
+    def test_namespace_prefix_warning_on_mismatch(self):
+        """A warning is logged when tool names don't match provider prefix."""
+        mgr = MemoryManager()
+        # Provider name "holographic" but tools use "fact_" prefix
+        p = FakeMemoryProvider("holographic", tools=[
+            {"name": "fact_store", "description": "Store", "parameters": {}},
+        ])
+
+        with patch("agent.memory_manager.logger") as mock_log:
+            mgr.add_provider(p)
+            # Should have logged a namespace warning
+            warning_calls = [c for c in mock_log.warning.call_args_list
+                             if "naming convention" in str(c)]
+            assert len(warning_calls) >= 1
+
+    def test_namespace_prefix_no_warning_on_match(self):
+        """No namespace warning when tool names match provider prefix."""
+        mgr = MemoryManager()
+        p = FakeMemoryProvider("holographic", tools=[
+            {"name": "holographic_store", "description": "Store", "parameters": {}},
+        ])
+
+        with patch("agent.memory_manager.logger") as mock_log:
+            mgr.add_provider(p)
+            warning_calls = [c for c in mock_log.warning.call_args_list
+                             if "naming convention" in str(c)]
+            assert len(warning_calls) == 0
+
+    def test_builtin_skips_namespace_check(self):
+        """Builtin provider is exempt from namespace prefix validation."""
+        mgr = MemoryManager()
+        p = FakeMemoryProvider("builtin", tools=[
+            {"name": "random_tool", "description": "Random", "parameters": {}},
+        ])
+
+        with patch("agent.memory_manager.logger") as mock_log:
+            mgr.add_provider(p)
+            warning_calls = [c for c in mock_log.warning.call_args_list
+                             if "naming convention" in str(c)]
+            assert len(warning_calls) == 0
+
+
+class TestToolBudgetWarning:
+    """Warning when total registered memory tools exceed threshold."""
+
+    def test_tool_budget_warning_above_threshold(self):
+        """A warning is logged when total tools exceed 20."""
+        mgr = MemoryManager()
+        # Create a provider with 25 tools
+        tools = [{"name": f"ext_tool_{i}", "description": f"Tool {i}", "parameters": {}}
+                 for i in range(25)]
+        p = FakeMemoryProvider("ext", tools=tools)
+
+        with patch("agent.memory_manager.logger") as mock_log:
+            mgr.add_provider(p)
+            warning_calls = [c for c in mock_log.warning.call_args_list
+                             if "budget" in str(c).lower()]
+            assert len(warning_calls) >= 1
+
+    def test_no_budget_warning_below_threshold(self):
+        """No budget warning when tool count is at or below threshold."""
+        mgr = MemoryManager()
+        tools = [{"name": f"ext_tool_{i}", "description": f"Tool {i}", "parameters": {}}
+                 for i in range(15)]
+        p = FakeMemoryProvider("ext", tools=tools)
+
+        with patch("agent.memory_manager.logger") as mock_log:
+            mgr.add_provider(p)
+            warning_calls = [c for c in mock_log.warning.call_args_list
+                             if "budget" in str(c).lower()]
+            assert len(warning_calls) == 0
+
+    def test_budget_warning_accumulates_across_providers(self):
+        """Budget warning fires when combined tools from multiple providers exceed threshold."""
+        mgr = MemoryManager()
+        tools1 = [{"name": f"builtin_{i}", "description": f"Tool {i}", "parameters": {}}
+                  for i in range(12)]
+        tools2 = [{"name": f"ext_{i}", "description": f"Tool {i}", "parameters": {}}
+                  for i in range(12)]
+        p1 = FakeMemoryProvider("builtin", tools=tools1)
+        p2 = FakeMemoryProvider("ext", tools=tools2)
+
+        mgr.add_provider(p1)  # 12 tools, no warning
+        with patch("agent.memory_manager.logger") as mock_log:
+            mgr.add_provider(p2)  # 24 total, should warn
+            warning_calls = [c for c in mock_log.warning.call_args_list
+                             if "budget" in str(c).lower()]
+            assert len(warning_calls) >= 1


### PR DESCRIPTION
## Summary

- Adds TOOL_BUDGET_WARN_THRESHOLD = 20 — logs a warning when total memory tools across all providers exceed 20, since too many tools degrades the model's tool selection quality.
- Adds namespace prefix validation — warns when a non-builtin provider's tool names don't match the provider name prefix (naming convention).
- 6 new tests: TestNamespacePrefixWarning (3) + TestToolBudgetWarning (3).

## Changes

**agent/memory_manager.py**:
- Added TOOL_BUDGET_WARN_THRESHOLD = 20 module constant
- In add_provider(): namespace prefix check for non-builtin providers (warns on mismatch)
- In add_provider(): budget warning when total registered tools exceed threshold
- Updated info log to show per-provider and total tool counts

**tests/agent/test_memory_provider.py**:
- TestNamespacePrefixWarning: mismatch warning, match = no warning, builtin exempt
- TestToolBudgetWarning: above threshold warns, below threshold silent, accumulates across providers

## Tests

All 68 tests in tests/agent/test_memory_provider.py pass.
