### PR TITLE
fix(pairing): preserve secure file owner

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -47,6 +47,26 @@ MAX_FAILED_ATTEMPTS = 5             # Failed approvals before lockout
 PAIRING_DIR = get_hermes_dir("platforms/pairing", "pairing")
 
 
+def _owner_group_for_write(path: Path) -> Optional[tuple[int, int]]:
+    """Return the owner/group that should keep access after atomic replace."""
+    try:
+        stat_source = path if path.exists() else path.parent
+        st = stat_source.stat()
+        return st.st_uid, st.st_gid
+    except OSError:
+        return None
+
+
+def _align_owner_group(path: Path, owner_group: Optional[tuple[int, int]]) -> None:
+    """Best-effort owner/group alignment for restrictive 0600 files."""
+    if owner_group is None or not hasattr(os, "chown"):
+        return
+    try:
+        os.chown(path, owner_group[0], owner_group[1])
+    except OSError:
+        pass  # Unsupported platform or insufficient privileges.
+
+
 def _secure_write(path: Path, data: str) -> None:
     """Write data to file with restrictive permissions (owner read/write only).
 
@@ -54,6 +74,7 @@ def _secure_write(path: Path, data: str) -> None:
     complete file or the new one — never a partial write.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
+    owner_group = _owner_group_for_write(path)
     fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
@@ -61,6 +82,7 @@ def _secure_write(path: Path, data: str) -> None:
             f.flush()
             os.fsync(f.fileno())
         atomic_replace(tmp_path, path)
+        _align_owner_group(path, owner_group)
         try:
             os.chmod(path, 0o600)
         except OSError:

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -43,6 +43,38 @@ class TestSecureWrite:
         mode = oct(target.stat().st_mode & 0o777)
         assert mode == "0o600"
 
+    def test_preserves_existing_file_owner_after_atomic_replace(self, tmp_path):
+        target = tmp_path / "secret.json"
+        target.write_text("old")
+        st = target.stat()
+
+        with patch("gateway.pairing.os.chown") as chown:
+            _secure_write(target, "new")
+
+        chown.assert_called_once_with(target, st.st_uid, st.st_gid)
+        assert target.read_text() == "new"
+        assert oct(target.stat().st_mode & 0o777) == "0o600"
+
+    def test_uses_parent_owner_for_new_secure_file(self, tmp_path):
+        target = tmp_path / "secret.json"
+        st = tmp_path.stat()
+
+        with patch("gateway.pairing.os.chown") as chown:
+            _secure_write(target, "new")
+
+        chown.assert_called_once_with(target, st.st_uid, st.st_gid)
+        assert target.read_text() == "new"
+        assert oct(target.stat().st_mode & 0o777) == "0o600"
+
+    def test_owner_alignment_failure_does_not_block_secure_write(self, tmp_path):
+        target = tmp_path / "secret.json"
+
+        with patch("gateway.pairing.os.chown", side_effect=OSError):
+            _secure_write(target, "new")
+
+        assert target.read_text() == "new"
+        assert oct(target.stat().st_mode & 0o777) == "0o600"
+
 
 # ---------------------------------------------------------------------------
 # Code generation


### PR DESCRIPTION
## Summary
- preserve the target owner/group when `_secure_write()` atomically rewrites pairing files
- fall back to the parent directory owner/group for new pairing files
- keep the write best-effort on platforms/users that cannot `chown`, while still enforcing `0600`

## Why
Pairing files are intentionally written with restrictive `0600` permissions. When the CLI approval path rewrites an existing gateway-owned file via temp-file + atomic replace, the new inode can inherit the writer process owner instead of the gateway-readable owner. Best-effort owner alignment keeps the secure permissions without making the rewritten file unreadable to the gateway user.

## Validation
- `python -m pytest tests/gateway/test_pairing.py -q -p no:cacheprovider -o addopts='' --tb=short` (32 passed)
- `python -m py_compile gateway/pairing.py tests/gateway/test_pairing.py`
- `git diff --check`
