### PR TITLE
fix: harden codex responses normalization and opencode runtime base-url handling

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -748,18 +748,25 @@ def _preflight_codex_api_kwargs(
 # Response extraction helpers
 # ---------------------------------------------------------------------------
 
+def _response_field(obj: Any, name: str, default: Any = None) -> Any:
+    """Read a Responses object field from SDK objects or raw JSON dicts."""
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
 def _extract_responses_message_text(item: Any) -> str:
     """Extract assistant text from a Responses message output item."""
-    content = getattr(item, "content", None)
+    content = _response_field(item, "content")
     if not isinstance(content, list):
         return ""
 
     chunks: List[str] = []
     for part in content:
-        ptype = getattr(part, "type", None)
+        ptype = _response_field(part, "type")
         if ptype not in {"output_text", "text"}:
             continue
-        text = getattr(part, "text", None)
+        text = _response_field(part, "text")
         if isinstance(text, str) and text:
             chunks.append(text)
     return "".join(chunks).strip()
@@ -767,16 +774,16 @@ def _extract_responses_message_text(item: Any) -> str:
 
 def _extract_responses_reasoning_text(item: Any) -> str:
     """Extract a compact reasoning text from a Responses reasoning item."""
-    summary = getattr(item, "summary", None)
+    summary = _response_field(item, "summary")
     if isinstance(summary, list):
         chunks: List[str] = []
         for part in summary:
-            text = getattr(part, "text", None)
+            text = _response_field(part, "text")
             if isinstance(text, str) and text:
                 chunks.append(text)
         if chunks:
             return "\n".join(chunks).strip()
-    text = getattr(item, "text", None)
+    text = _response_field(item, "text")
     if isinstance(text, str) and text:
         return text.strip()
     return ""
@@ -788,12 +795,12 @@ def _extract_responses_reasoning_text(item: Any) -> str:
 
 def _normalize_codex_response(response: Any) -> tuple[Any, str]:
     """Normalize a Responses API object to an assistant_message-like object."""
-    output = getattr(response, "output", None)
+    output = _response_field(response, "output")
     if not isinstance(output, list) or not output:
         # The Codex backend can return empty output when the answer was
         # delivered entirely via stream events. Check output_text as a
         # last-resort fallback before raising.
-        out_text = getattr(response, "output_text", None)
+        out_text = _response_field(response, "output_text")
         if isinstance(out_text, str) and out_text.strip():
             logger.debug(
                 "Codex response has empty output but output_text is present (%d chars); "
@@ -803,18 +810,21 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
                 type="message", role="assistant", status="completed",
                 content=[SimpleNamespace(type="output_text", text=out_text.strip())],
             )]
-            response.output = output
+            if isinstance(response, dict):
+                response["output"] = output
+            else:
+                response.output = output
         else:
             raise RuntimeError("Responses API returned no output items")
 
-    response_status = getattr(response, "status", None)
+    response_status = _response_field(response, "status")
     if isinstance(response_status, str):
         response_status = response_status.strip().lower()
     else:
         response_status = None
 
     if response_status in {"failed", "cancelled"}:
-        error_obj = getattr(response, "error", None)
+        error_obj = _response_field(response, "error")
         if isinstance(error_obj, dict):
             error_msg = error_obj.get("message") or str(error_obj)
         else:
@@ -831,8 +841,8 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
     saw_final_answer_phase = False
 
     for item in output:
-        item_type = getattr(item, "type", None)
-        item_status = getattr(item, "status", None)
+        item_type = _response_field(item, "type")
+        item_status = _response_field(item, "status")
         if isinstance(item_status, str):
             item_status = item_status.strip().lower()
         else:
@@ -842,7 +852,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             has_incomplete_items = True
 
         if item_type == "message":
-            item_phase = getattr(item, "phase", None)
+            item_phase = _response_field(item, "phase")
             normalized_phase = None
             if isinstance(item_phase, str):
                 normalized_phase = item_phase.strip().lower()
@@ -859,7 +869,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
                     "status": _normalize_responses_message_status(item_status),
                     "content": [{"type": "output_text", "text": message_text}],
                 }
-                item_id = getattr(item, "id", None)
+                item_id = _response_field(item, "id")
                 if isinstance(item_id, str) and item_id:
                     raw_message_item["id"] = item_id
                 if normalized_phase:
@@ -872,18 +882,18 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             # Capture the full reasoning item for multi-turn continuity.
             # encrypted_content is an opaque blob the API needs back on
             # subsequent turns to maintain coherent reasoning chains.
-            encrypted = getattr(item, "encrypted_content", None)
+            encrypted = _response_field(item, "encrypted_content")
             if isinstance(encrypted, str) and encrypted:
                 raw_item = {"type": "reasoning", "encrypted_content": encrypted}
-                item_id = getattr(item, "id", None)
+                item_id = _response_field(item, "id")
                 if isinstance(item_id, str) and item_id:
                     raw_item["id"] = item_id
                 # Capture summary — required by the API when replaying reasoning items
-                summary = getattr(item, "summary", None)
+                summary = _response_field(item, "summary")
                 if isinstance(summary, list):
                     raw_summary = []
                     for part in summary:
-                        text = getattr(part, "text", None)
+                        text = _response_field(part, "text")
                         if isinstance(text, str):
                             raw_summary.append({"type": "summary_text", "text": text})
                     raw_item["summary"] = raw_summary
@@ -891,12 +901,12 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
         elif item_type == "function_call":
             if item_status in {"queued", "in_progress", "incomplete"}:
                 continue
-            fn_name = getattr(item, "name", "") or ""
-            arguments = getattr(item, "arguments", "{}")
+            fn_name = _response_field(item, "name", "") or ""
+            arguments = _response_field(item, "arguments", "{}")
             if not isinstance(arguments, str):
                 arguments = json.dumps(arguments, ensure_ascii=False)
-            raw_call_id = getattr(item, "call_id", None)
-            raw_item_id = getattr(item, "id", None)
+            raw_call_id = _response_field(item, "call_id")
+            raw_item_id = _response_field(item, "id")
             embedded_call_id, _ = _split_responses_tool_id(raw_item_id)
             call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id.strip() else embedded_call_id
             if not isinstance(call_id, str) or not call_id.strip():
@@ -912,12 +922,12 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
                 function=SimpleNamespace(name=fn_name, arguments=arguments),
             ))
         elif item_type == "custom_tool_call":
-            fn_name = getattr(item, "name", "") or ""
-            arguments = getattr(item, "input", "{}")
+            fn_name = _response_field(item, "name", "") or ""
+            arguments = _response_field(item, "input", "{}")
             if not isinstance(arguments, str):
                 arguments = json.dumps(arguments, ensure_ascii=False)
-            raw_call_id = getattr(item, "call_id", None)
-            raw_item_id = getattr(item, "id", None)
+            raw_call_id = _response_field(item, "call_id")
+            raw_item_id = _response_field(item, "id")
             embedded_call_id, _ = _split_responses_tool_id(raw_item_id)
             call_id = raw_call_id if isinstance(raw_call_id, str) and raw_call_id.strip() else embedded_call_id
             if not isinstance(call_id, str) or not call_id.strip():
@@ -934,8 +944,8 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
             ))
 
     final_text = "\n".join([p for p in content_parts if p]).strip()
-    if not final_text and hasattr(response, "output_text"):
-        out_text = getattr(response, "output_text", "")
+    if not final_text and _response_field(response, "output_text") is not None:
+        out_text = _response_field(response, "output_text", "")
         if isinstance(out_text, str):
             final_text = out_text.strip()
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -86,6 +86,23 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     return None
 
 
+def _normalize_provider_base_url(provider: Optional[str], base_url: str) -> str:
+    """Trim copied endpoint suffixes from provider base URLs when safe.
+
+    OpenCode's docs show full endpoint URLs (for example
+    ``.../v1/chat/completions``), but Hermes stores provider *base* URLs and
+    appends the transport path itself. Accept the copied docs URL and collapse
+    it back to the provider base so runtime resolution stays robust.
+    """
+    normalized_provider = (provider or "").strip().lower()
+    normalized_url = (base_url or "").strip().rstrip("/")
+    if not normalized_url:
+        return normalized_url
+    if normalized_provider not in {"opencode-zen", "opencode-go"}:
+        return normalized_url
+    return re.sub(r"/(?:chat/completions|responses|messages)$", "", normalized_url)
+
+
 def _auto_detect_local_model(base_url: str) -> str:
     """Query a local server for its model name when only one model is loaded."""
     if not base_url:
@@ -277,6 +294,8 @@ def _resolve_runtime_from_pool_entry(
             detected = _detect_api_mode_for_url(base_url)
             if detected:
                 api_mode = detected
+
+    base_url = _normalize_provider_base_url(provider, base_url)
 
     # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
     # Anthropic SDK prepends its own /v1/messages to the base_url.  Strip the

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1333,6 +1333,48 @@ def test_opencode_go_glm_defaults_to_chat_completions(monkeypatch):
     assert resolved["base_url"] == "https://opencode.ai/zen/go/v1"
 
 
+def test_opencode_go_chat_endpoint_base_url_from_config_is_normalized(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "opencode-go",
+            "default": "kimi-k2.6",
+            "base_url": "https://opencode.ai/zen/go/v1/chat/completions",
+        },
+    )
+    monkeypatch.setenv("OPENCODE_GO_API_KEY", "test-opencode-go-key")
+    monkeypatch.delenv("OPENCODE_GO_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="opencode-go")
+
+    assert resolved["provider"] == "opencode-go"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://opencode.ai/zen/go/v1"
+
+
+def test_opencode_go_messages_endpoint_base_url_from_config_is_normalized(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "opencode-go",
+            "default": "minimax-m2.7",
+            "base_url": "https://opencode.ai/zen/go/v1/messages",
+        },
+    )
+    monkeypatch.setenv("OPENCODE_GO_API_KEY", "test-opencode-go-key")
+    monkeypatch.delenv("OPENCODE_GO_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="opencode-go")
+
+    assert resolved["provider"] == "opencode-go"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://opencode.ai/zen/go"
+
+
 def test_opencode_go_model_derivation_beats_stale_persisted_api_mode(monkeypatch):
     """opencode-zen/go re-derive api_mode from the effective model on every
     resolve, ignoring any persisted ``api_mode`` in config. Refs #16878 /

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -520,6 +520,36 @@ def test_run_conversation_codex_empty_output_with_output_text(monkeypatch):
     assert result["final_response"] == "Hello from Codex"
 
 
+
+def test_normalize_codex_response_extracts_raw_dict_message_parts():
+    """Copilot Responses can return raw dict output items; recover text."""
+    from agent.codex_responses_adapter import _normalize_codex_response
+
+    response = {
+        "status": "completed",
+        "output": [
+            {
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": "OK"}],
+            }
+        ],
+    }
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "stop"
+    assert assistant_message.content == "OK"
+    assert assistant_message.codex_message_items == [
+        {
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"type": "output_text", "text": "OK"}],
+        }
+    ]
+
 def test_run_conversation_codex_empty_output_no_output_text_retries(monkeypatch):
     """When both output and output_text are empty, validation should
     correctly mark the response as invalid and trigger retry."""


### PR DESCRIPTION
## Summary
- make Codex Responses normalization robust to raw JSON/dict output items (not only SDK objects)
- add shared field accessor helper to safely read both dict and object response parts
- normalize OpenCode Go/Zen provider base URLs when users paste full endpoint paths (e.g. `/chat/completions`, `/messages`, `/responses`)
- keep api_mode derivation consistent after base URL normalization

## Why
- fixes edge cases where Copilot Responses returns dict-shaped payload items and assistant text extraction can be lost
- prevents misconfigured provider base URLs from docs-copied endpoints causing runtime path issues

## Tests
- added targeted tests for OpenCode Go base URL normalization in runtime provider resolution
- added Codex response normalization test for dict-shaped message output
- local test run:
  - `tests/hermes_cli/test_runtime_provider_resolution.py`
  - `tests/run_agent/test_run_agent_codex_responses.py`
  - result: **171 passed**

## Notes
- changes were preserved after Hermes v0.13.0 update and moved to this dedicated branch for safe isolation
