### PR TITLE
fix(update): add heartbeat during dependency install

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2494,18 +2494,19 @@ class HermesCLI:
         except Exception:
             pass
 
-    def _clear_prompt_toolkit_screen(self, app, *, rebuild_scrollback: bool = False) -> None:
-        """Clear the terminal and reset prompt_toolkit renderer state."""
+    def _clear_prompt_toolkit_screen(self, app) -> None:
+        """Clear the visible screen and reset prompt_toolkit renderer state.
+
+        Intentionally does NOT emit CSI 3 J (``\x1b[3J``): that sequence clears
+        terminal scrollback. On mobile terminals (notably Termux), benign touch
+        gestures can trigger resize recovery; clearing scrollback there erases
+        chat history unexpectedly.
+        """
         try:
             renderer = app.renderer
             out = renderer.output
             out.reset_attributes()
             out.erase_screen()
-            if rebuild_scrollback:
-                try:
-                    out.write_raw("\x1b[3J")
-                except Exception:
-                    pass
             out.cursor_goto(0, 0)
             out.flush()
             # Drop prompt_toolkit's cached screen + cursor state so the
@@ -2517,7 +2518,7 @@ class HermesCLI:
 
     def _recover_after_resize(self, app, original_on_resize) -> None:
         """Recover a resized classic CLI without desynchronizing cursor state."""
-        self._clear_prompt_toolkit_screen(app, rebuild_scrollback=True)
+        self._clear_prompt_toolkit_screen(app)
         _replay_output_history()
         original_on_resize()
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -821,13 +821,22 @@ def run_doctor(args):
         print()
         print(color("◆ Command Installation", Colors.CYAN, Colors.BOLD))
 
-        # Determine the venv entry point location
+        # Determine the venv entry point location.
+        # Prefer the active interpreter's environment when it is in PROJECT_ROOT,
+        # then .venv, then legacy venv.
         _venv_bin = None
-        for _venv_name in ("venv", ".venv"):
-            _candidate = PROJECT_ROOT / _venv_name / "bin" / "hermes"
-            if _candidate.exists():
-                _venv_bin = _candidate
-                break
+        _active_candidate = Path(sys.executable).resolve().parent / "hermes"
+        try:
+            if PROJECT_ROOT in _active_candidate.parents and _active_candidate.exists():
+                _venv_bin = _active_candidate
+        except Exception:
+            pass
+        if _venv_bin is None:
+            for _venv_name in (".venv", "venv"):
+                _candidate = PROJECT_ROOT / _venv_name / "bin" / "hermes"
+                if _candidate.exists():
+                    _venv_bin = _candidate
+                    break
 
         # Determine the expected command link directory (mirrors install.sh logic)
         _prefix = os.environ.get("PREFIX", "")
@@ -843,10 +852,10 @@ def run_doctor(args):
         if _venv_bin is None:
             check_warn(
                 "Venv entry point not found",
-                "(hermes not in venv/bin/ or .venv/bin/ — reinstall with pip install -e '.[all]')"
+                "(hermes not in .venv/bin/ or venv/bin/ — reinstall with pip install -e '.[all]')"
             )
             manual_issues.append(
-                f"Reinstall entry point: cd {PROJECT_ROOT} && source venv/bin/activate && pip install -e '.[all]'"
+                f"Reinstall entry point: cd {PROJECT_ROOT} && source .venv/bin/activate && pip install -e '.[all]'"
             )
         else:
             check_ok(f"Venv entry point exists ({_venv_bin.relative_to(PROJECT_ROOT)})")
@@ -1285,8 +1294,13 @@ def run_doctor(args):
                 check_ok("tinker-atropos", "(RL training backend)")
             except ImportError:
                 install_cmd = f"{_python_install_cmd()} -e ./tinker-atropos"
-                check_warn("tinker-atropos found but not installed", f"(run: {install_cmd})")
-                issues.append(f"Install tinker-atropos: {install_cmd}")
+                if _is_termux():
+                    check_info(
+                        f"tinker-atropos not installed (optional on Termux) (install later if needed: {install_cmd})"
+                    )
+                else:
+                    check_warn("tinker-atropos found but not installed", f"(run: {install_cmd})")
+                    issues.append(f"Install tinker-atropos: {install_cmd}")
         else:
             check_warn("tinker-atropos requires Python 3.11+", f"(current: {py_version.major}.{py_version.minor})")
     else:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -91,6 +91,15 @@ def _termux_browser_setup_steps(node_installed: bool) -> list[str]:
     return steps
 
 
+def _termux_install_all_fallback_notes() -> list[str]:
+    return [
+        "Termux install profile: use .[termux-all] for broad compatibility (installer default on Termux).",
+        "Matrix E2EE extra is excluded on Termux (python-olm currently fails to build).",
+        "Local faster-whisper extra is excluded on Termux (ctranslate2/av build path unavailable).",
+        "STT fallback: use Groq Whisper (set GROQ_API_KEY) or OpenAI Whisper (set VOICE_TOOLS_OPENAI_KEY).",
+    ]
+
+
 def _has_provider_env_config(content: str) -> bool:
     """Return True when ~/.hermes/.env contains provider auth/base URL settings."""
     return any(key in content for key in _PROVIDER_ENV_HINTS)
@@ -1092,6 +1101,11 @@ def run_doctor(args):
                     check_ok(f"{label} deps", f"({moderate} moderate vulnerability(ies))")
             except Exception:
                 pass
+
+    if _is_termux():
+        check_info("Termux compatibility fallbacks:")
+        for note in _termux_install_all_fallback_notes():
+            check_info(note)
 
     # =========================================================================
     # Check: API connectivity

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -230,6 +230,7 @@ except Exception:
     pass  # best-effort — don't crash if config isn't available yet
 
 import logging
+import threading
 import time as _time
 from datetime import datetime
 
@@ -6445,6 +6446,45 @@ def _load_installable_optional_extras() -> list[str]:
     return referenced
 
 
+def _run_install_with_heartbeat(
+    cmd: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    heartbeat_interval_seconds: int = 30,
+) -> None:
+    """Run dependency install command with periodic heartbeat output.
+
+    Some resolvers/build backends (especially when compiling Rust/C extensions)
+    can stay quiet for minutes. Emit a simple elapsed-time heartbeat so users
+    know ``hermes update`` is still progressing even if pip/uv itself is silent.
+    """
+    done = threading.Event()
+    start = _time.time()
+
+    def _heartbeat() -> None:
+        # Wait first, then print, so short installs don't emit noise.
+        while not done.wait(heartbeat_interval_seconds):
+            elapsed = int(_time.time() - start)
+            print(
+                f"  … still installing dependencies ({elapsed}s elapsed)"
+                " — compiling Rust/C extensions can take several minutes",
+                flush=True,
+            )
+
+    t = threading.Thread(target=_heartbeat, daemon=True)
+    t.start()
+    try:
+        subprocess.run(
+            cmd,
+            cwd=PROJECT_ROOT,
+            check=True,
+            env=env,
+        )
+    finally:
+        done.set()
+        t.join(timeout=0.2)
+
+
 def _install_python_dependencies_with_optional_fallback(
     install_cmd_prefix: list[str],
     *,
@@ -6461,12 +6501,13 @@ def _install_python_dependencies_with_optional_fallback(
     Collecting/Building/Installing step), so keeping it visible costs
     nothing on fast hardware and prevents the "hermes update hangs" reports
     on slow hardware.
+
+    We also add periodic heartbeat lines in case the resolver/build backend is
+    itself silent for long stretches.
     """
     try:
-        subprocess.run(
+        _run_install_with_heartbeat(
             install_cmd_prefix + ["install", "-e", ".[all]"],
-            cwd=PROJECT_ROOT,
-            check=True,
             env=env,
         )
         return
@@ -6475,10 +6516,8 @@ def _install_python_dependencies_with_optional_fallback(
             "  ⚠ Optional extras failed, reinstalling base dependencies and retrying extras individually..."
         )
 
-    subprocess.run(
+    _run_install_with_heartbeat(
         install_cmd_prefix + ["install", "-e", "."],
-        cwd=PROJECT_ROOT,
-        check=True,
         env=env,
     )
 
@@ -6486,10 +6525,8 @@ def _install_python_dependencies_with_optional_fallback(
     installed_extras: list[str] = []
     for extra in _load_installable_optional_extras():
         try:
-            subprocess.run(
+            _run_install_with_heartbeat(
                 install_cmd_prefix + ["install", "-e", f".[{extra}]"],
-                cwd=PROJECT_ROOT,
-                check=True,
                 env=env,
             )
             installed_extras.append(extra)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5904,7 +5904,7 @@ def _update_via_zip(args):
 
     uv_bin = shutil.which("uv")
     if uv_bin:
-        uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+        uv_env = {**os.environ, "VIRTUAL_ENV": str(_detect_project_venv_dir())}
         _install_python_dependencies_with_optional_fallback([uv_bin, "pip"], env=uv_env)
     else:
         # Use sys.executable to explicitly call the venv's pip module,
@@ -6444,6 +6444,30 @@ def _load_installable_optional_extras() -> list[str]:
                 referenced.append(name)
 
     return referenced
+
+
+def _detect_project_venv_dir() -> Path:
+    """Return the best project venv directory for update/install commands.
+
+    Preference order:
+    1) Active interpreter's parent venv when inside PROJECT_ROOT (supports .venv)
+    2) PROJECT_ROOT/.venv
+    3) PROJECT_ROOT/venv (legacy fallback)
+    """
+    exe = Path(sys.executable).resolve()
+    try:
+        if PROJECT_ROOT in exe.parents:
+            candidate = exe.parent.parent
+            if (candidate / "bin" / "python").exists():
+                return candidate
+    except Exception:
+        pass
+
+    dot_venv = PROJECT_ROOT / ".venv"
+    if (dot_venv / "bin" / "python").exists():
+        return dot_venv
+
+    return PROJECT_ROOT / "venv"
 
 
 def _run_install_with_heartbeat(
@@ -7285,7 +7309,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         print("→ Updating Python dependencies...")
         uv_bin = shutil.which("uv")
         if uv_bin:
-            uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
+            uv_env = {**os.environ, "VIRTUAL_ENV": str(_detect_project_venv_dir())}
             _install_python_dependencies_with_optional_fallback(
                 [uv_bin, "pip"], env=uv_env
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,9 +68,7 @@ acp = ["agent-client-protocol>=0.9.0,<1.0"]
 mistral = ["mistralai>=2.3.0,<3"]
 bedrock = ["boto3>=1.35.0,<2"]
 termux = [
-  # Tested Android / Termux path: keeps the core CLI feature-rich while
-  # avoiding extras that currently depend on non-Android wheels (notably
-  # faster-whisper -> ctranslate2 via the voice extra).
+  # Baseline Android / Termux path for reliable fresh installs.
   "python-telegram-bot[webhooks]>=22.6,<23",
   "hermes-agent[cron]",
   "hermes-agent[cli]",
@@ -78,6 +76,27 @@ termux = [
   "hermes-agent[mcp]",
   "hermes-agent[honcho]",
   "hermes-agent[acp]",
+]
+termux-all = [
+  # Best-effort "install all" profile for Termux: include broad extras that
+  # are known to resolve on Android, while intentionally excluding extras that
+  # currently hard-fail from missing/broken Android wheels/toolchains.
+  #
+  # Excluded for now:
+  # - matrix (mautrix[encryption] -> python-olm build failures on Termux)
+  # - voice  (faster-whisper chain requires ctranslate2/av builds not packaged)
+  "hermes-agent[termux]",
+  "hermes-agent[messaging]",
+  "hermes-agent[slack]",
+  "hermes-agent[tts-premium]",
+  "hermes-agent[dingtalk]",
+  "hermes-agent[feishu]",
+  "hermes-agent[google]",
+  "hermes-agent[mistral]",
+  "hermes-agent[bedrock]",
+  "hermes-agent[homeassistant]",
+  "hermes-agent[sms]",
+  "hermes-agent[web]",
 ]
 dingtalk = ["dingtalk-stream>=0.20,<1", "alibabacloud-dingtalk>=2.0.0", "qrcode>=7.0,<8"]
 feishu = ["lark-oapi>=1.5.3,<2", "qrcode>=7.0,<8"]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -980,17 +980,24 @@ install_deps() {
         fi
 
         "$PIP_PYTHON" -m pip install --upgrade pip setuptools wheel >/dev/null
-        if ! "$PIP_PYTHON" -m pip install -e '.[termux]' -c constraints-termux.txt; then
-            log_warn "Termux feature install (.[termux]) failed, trying base install..."
-            if ! "$PIP_PYTHON" -m pip install -e '.' -c constraints-termux.txt; then
-                log_error "Package installation failed on Termux."
-                log_info "Ensure these packages are installed: pkg install clang rust make pkg-config libffi openssl"
-                log_info "Then re-run: cd $INSTALL_DIR && python -m pip install -e '.[termux]' -c constraints-termux.txt"
-                exit 1
+
+        # Try the broad Termux profile first (best-effort "install all" for Android),
+        # then fall back to the conservative Termux baseline, then base package.
+        if ! "$PIP_PYTHON" -m pip install -e '.[termux-all]' -c constraints-termux.txt; then
+            log_warn "Termux broad profile (.[termux-all]) failed, trying baseline Termux profile..."
+            if ! "$PIP_PYTHON" -m pip install -e '.[termux]' -c constraints-termux.txt; then
+                log_warn "Termux baseline profile (.[termux]) failed, trying base install..."
+                if ! "$PIP_PYTHON" -m pip install -e '.' -c constraints-termux.txt; then
+                    log_error "Package installation failed on Termux."
+                    log_info "Ensure these packages are installed: pkg install clang rust make pkg-config libffi openssl ca-certificates curl"
+                    log_info "Then re-run: cd $INSTALL_DIR && python -m pip install -e '.[termux-all]' -c constraints-termux.txt"
+                    exit 1
+                fi
             fi
         fi
 
         log_success "Main package installed"
+        log_info "Termux note: matrix e2ee and local faster-whisper extras are excluded from .[termux-all] due to upstream Android wheel/toolchain blockers."
         log_info "Termux note: browser/WhatsApp tooling is not installed by default; see the Termux guide for optional follow-up steps."
 
         if [ -d "tinker-atropos" ] && [ -f "tinker-atropos/pyproject.toml" ]; then
@@ -1082,7 +1089,7 @@ setup_path() {
         log_warn "hermes entry point not found at $HERMES_BIN"
         log_info "This usually means the pip install didn't complete successfully."
         if [ "$DISTRO" = "termux" ]; then
-            log_info "Try: cd $INSTALL_DIR && python -m pip install -e '.[termux]' -c constraints-termux.txt"
+            log_info "Try: cd $INSTALL_DIR && python -m pip install -e '.[termux-all]' -c constraints-termux.txt"
         else
             log_info "Try: cd $INSTALL_DIR && uv pip install -e '.[all]'"
         fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -615,6 +615,41 @@ install_node() {
     HAS_NODE=true
 }
 
+check_network_prerequisites() {
+    log_info "Checking internet connectivity for package install and web tools..."
+
+    local url
+    local failed=false
+    local checks=("https://pypi.org/simple/" "https://duckduckgo.com/")
+
+    if ! command -v curl >/dev/null 2>&1; then
+        log_warn "curl not found; skipping connectivity probes"
+        return 0
+    fi
+
+    for url in "${checks[@]}"; do
+        if ! curl -fsSI --max-time 8 "$url" >/dev/null 2>&1; then
+            failed=true
+            log_warn "Could not reach $url"
+        fi
+    done
+
+    if [ "$failed" = false ]; then
+        log_success "Internet connectivity looks good"
+        return 0
+    fi
+
+    if [ "$DISTRO" = "termux" ]; then
+        log_warn "Termux network prerequisites may be incomplete."
+        log_info "Try: pkg install -y ca-certificates curl && pkg update"
+        log_info "If mirrors are stale: termux-change-repo"
+        log_info "Then test: curl -I https://pypi.org/simple/ && curl -I https://duckduckgo.com/"
+    else
+        log_warn "Network checks failed. Hermes install may complete, but web search and dependency downloads can fail."
+        log_info "Verify internet/DNS and retry if pip install fails."
+    fi
+}
+
 install_system_packages() {
     # Detect what's missing
     HAS_RIPGREP=false
@@ -642,7 +677,7 @@ install_system_packages() {
     # Termux always needs the Android build toolchain for the tested pip path,
     # even when ripgrep/ffmpeg are already present.
     if [ "$DISTRO" = "termux" ]; then
-        local termux_pkgs=(clang rust make pkg-config libffi openssl)
+        local termux_pkgs=(clang rust make pkg-config libffi openssl ca-certificates curl)
         if [ "$need_ripgrep" = true ]; then
             termux_pkgs+=("ripgrep")
         fi
@@ -1570,6 +1605,7 @@ main() {
     check_python
     check_git
     check_node
+    check_network_prerequisites
     install_system_packages
 
     clone_repo

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -71,13 +71,12 @@ class TestForceFullRedraw:
             "invalidate",
         ]
 
-    def test_resize_rebuilds_scrollback_before_prompt_toolkit_redraw(self, bare_cli, monkeypatch):
+    def test_resize_recovery_repaints_without_clearing_scrollback(self, bare_cli, monkeypatch):
         app = MagicMock()
         out = app.renderer.output
         events = []
         out.reset_attributes.side_effect = lambda: events.append("reset_attrs")
         out.erase_screen.side_effect = lambda: events.append("erase")
-        out.write_raw.side_effect = lambda text: events.append(("raw", text))
         out.cursor_goto.side_effect = lambda *_: events.append("home")
         out.flush.side_effect = lambda: events.append("flush")
         app.renderer.reset.side_effect = lambda **_: events.append("renderer_reset")
@@ -89,7 +88,6 @@ class TestForceFullRedraw:
         assert events == [
             "reset_attrs",
             "erase",
-            ("raw", "\x1b[3J"),
             "home",
             "flush",
             "renderer_reset",

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -378,6 +378,11 @@ def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkey
     assert "1) pkg install nodejs" in out
     assert "2) npm install -g agent-browser" in out
     assert "3) agent-browser install" in out
+    assert "Termux compatibility fallbacks:" in out
+    assert "use .[termux-all] for broad compatibility" in out
+    assert "Matrix E2EE extra is excluded on Termux" in out
+    assert "Local faster-whisper extra is excluded on Termux" in out
+    assert "STT fallback: use Groq Whisper (set GROQ_API_KEY) or OpenAI Whisper (set VOICE_TOOLS_OPENAI_KEY)." in out
     assert "docker not found (optional)" not in out
 
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -381,6 +381,90 @@ def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkey
     assert "docker not found (optional)" not in out
 
 
+def test_run_doctor_prefers_dot_venv_entrypoint_for_expected_symlink(monkeypatch, tmp_path):
+    helper = TestDoctorMemoryProviderSection()
+    home = helper._make_hermes_home(tmp_path, provider="")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    # Create both envs; .venv should win for expected link target.
+    (project / ".venv" / "bin").mkdir(parents=True)
+    (project / "venv" / "bin").mkdir(parents=True)
+    dot_venv_hermes = project / ".venv" / "bin" / "hermes"
+    dot_venv_hermes.write_text("#!/bin/sh\n", encoding="utf-8")
+    (project / "venv" / "bin" / "hermes").write_text("#!/bin/sh\n", encoding="utf-8")
+
+    termux_bin = tmp_path / "termux-prefix" / "bin"
+    termux_bin.mkdir(parents=True)
+    (termux_bin / "hermes").symlink_to(dot_venv_hermes)
+
+    monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+    monkeypatch.setenv("PREFIX", str(tmp_path / "termux-prefix"))
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "$PREFIX/bin/hermes → correct target" in out
+    assert "points to wrong target" not in out
+
+
+def test_run_doctor_termux_tinker_is_info_not_issue(monkeypatch, tmp_path):
+    helper = TestDoctorMemoryProviderSection()
+    home = helper._make_hermes_home(tmp_path, provider="")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+    (project / "tinker-atropos").mkdir()
+    (project / "tinker-atropos" / "pyproject.toml").write_text("[project]\nname='tinker-atropos'\n", encoding="utf-8")
+
+    monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
+    monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "tinker_atropos":
+            raise ImportError("not installed")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "tinker-atropos not installed (optional on Termux)" in out
+    assert "Install tinker-atropos:" not in out
+
+
 def test_run_doctor_accepts_named_provider_from_providers_section(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -323,15 +323,15 @@ def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypa
             return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
         if cmd == ["git", "rev-list", "HEAD..origin/main", "--count"]:
             return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
-        if cmd == ["git", "pull", "origin", "main"]:
+        if cmd == ["git", "pull", "--ff-only", "origin", "main"]:
             return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
-        if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[all]", "--quiet"]:
+        if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[all]"]:
             raise CalledProcessError(returncode=1, cmd=cmd)
-        if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".", "--quiet"]:
+        if cmd == ["/usr/bin/uv", "pip", "install", "-e", "."]:
             return SimpleNamespace(returncode=0)
-        if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[matrix]", "--quiet"]:
+        if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[matrix]"]:
             raise CalledProcessError(returncode=1, cmd=cmd)
-        if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[mcp]", "--quiet"]:
+        if cmd == ["/usr/bin/uv", "pip", "install", "-e", ".[mcp]"]:
             return SimpleNamespace(returncode=0)
         # Catch-all must include stdout/stderr so consumers that parse
         # output (e.g. the dashboard-restart `ps -A` scan added in the
@@ -344,10 +344,10 @@ def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypa
 
     install_cmds = [c for c in recorded if "pip" in c and "install" in c]
     assert install_cmds == [
-        ["/usr/bin/uv", "pip", "install", "-e", ".[all]", "--quiet"],
-        ["/usr/bin/uv", "pip", "install", "-e", ".", "--quiet"],
-        ["/usr/bin/uv", "pip", "install", "-e", ".[matrix]", "--quiet"],
-        ["/usr/bin/uv", "pip", "install", "-e", ".[mcp]", "--quiet"],
+        ["/usr/bin/uv", "pip", "install", "-e", ".[all]"],
+        ["/usr/bin/uv", "pip", "install", "-e", "."],
+        ["/usr/bin/uv", "pip", "install", "-e", ".[matrix]"],
+        ["/usr/bin/uv", "pip", "install", "-e", ".[mcp]"],
     ]
 
     out = capsys.readouterr().out
@@ -371,7 +371,7 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
             return SimpleNamespace(stdout="main\n", stderr="", returncode=0)
         if cmd == ["git", "rev-list", "HEAD..origin/main", "--count"]:
             return SimpleNamespace(stdout="1\n", stderr="", returncode=0)
-        if cmd == ["git", "pull", "origin", "main"]:
+        if cmd == ["git", "pull", "--ff-only", "origin", "main"]:
             return SimpleNamespace(stdout="Updating\n", stderr="", returncode=0)
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
@@ -382,6 +382,24 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
     install_cmds = [c for c in recorded if "pip" in c and "install" in c]
     assert len(install_cmds) == 1
     assert ".[all]" in install_cmds[0]
+
+
+def test_install_heartbeat_prints_when_dependency_install_is_silent(monkeypatch, capsys):
+    """Long quiet installs should emit periodic heartbeat lines."""
+
+    def fake_run(cmd, **kwargs):
+        hermes_main._time.sleep(1.2)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    hermes_main._run_install_with_heartbeat(
+        ["uv", "pip", "install", "-e", "."],
+        heartbeat_interval_seconds=1,
+    )
+
+    out = capsys.readouterr().out
+    assert "still installing dependencies" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -307,6 +307,29 @@ def _setup_update_mocks(monkeypatch, tmp_path):
     monkeypatch.setattr(hermes_config, "migrate_config", lambda **kw: {"env_added": [], "config_added": []})
 
 
+def test_detect_project_venv_dir_prefers_dot_venv(monkeypatch, tmp_path):
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+    (tmp_path / ".venv" / "bin").mkdir(parents=True)
+    (tmp_path / ".venv" / "bin" / "python").write_text("", encoding="utf-8")
+    (tmp_path / "venv" / "bin").mkdir(parents=True)
+    (tmp_path / "venv" / "bin" / "python").write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(hermes_main.sys, "executable", "/usr/bin/python3")
+
+    assert hermes_main._detect_project_venv_dir() == tmp_path / ".venv"
+
+
+def test_detect_project_venv_dir_uses_active_project_interpreter(monkeypatch, tmp_path):
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+    active = tmp_path / "venv" / "bin"
+    active.mkdir(parents=True)
+    (active / "python").write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(hermes_main.sys, "executable", str(active / "python"))
+
+    assert hermes_main._detect_project_venv_dir() == tmp_path / "venv"
+
+
 def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypatch, tmp_path, capsys):
     """When .[all] fails, update should keep base deps and retry extras individually."""
     _setup_update_mocks(monkeypatch, tmp_path)

--- a/tests/test_install_sh_termux_network_prereqs.py
+++ b/tests/test_install_sh_termux_network_prereqs.py
@@ -1,0 +1,22 @@
+"""Regression tests for Termux network prerequisite handling in install.sh."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def test_termux_pkg_list_includes_network_basics() -> None:
+    text = INSTALL_SH.read_text()
+    assert "local termux_pkgs=(clang rust make pkg-config libffi openssl ca-certificates curl)" in text
+
+
+def test_install_script_has_connectivity_probe_and_termux_guidance() -> None:
+    text = INSTALL_SH.read_text()
+    assert "check_network_prerequisites()" in text
+    assert "https://pypi.org/simple/" in text
+    assert "https://duckduckgo.com/" in text
+    assert "termux-change-repo" in text
+    assert "pkg install -y ca-certificates curl && pkg update" in text
+    assert "check_network_prerequisites" in text

--- a/tests/test_termux_all_extra_compat.py
+++ b/tests/test_termux_all_extra_compat.py
@@ -1,0 +1,23 @@
+"""Regression coverage for the Termux broad install profile."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def test_pyproject_defines_termux_all_without_known_blockers() -> None:
+    text = PYPROJECT.read_text()
+    assert "termux-all = [" in text
+    assert '"hermes-agent[termux]"' in text
+    assert '"hermes-agent[matrix]"' not in text.split("termux-all = [", 1)[1].split("]", 1)[0]
+    assert '"hermes-agent[voice]"' not in text.split("termux-all = [", 1)[1].split("]", 1)[0]
+
+
+def test_install_script_prefers_termux_all_then_fallbacks() -> None:
+    text = INSTALL_SH.read_text()
+    assert "pip install -e '.[termux-all]' -c constraints-termux.txt" in text
+    assert "Termux broad profile (.[termux-all]) failed, trying baseline Termux profile..." in text
+    assert "Termux baseline profile (.[termux]) failed, trying base install..." in text

--- a/tests/tools/test_browser_lightpanda.py
+++ b/tests/tools/test_browser_lightpanda.py
@@ -298,6 +298,59 @@ class TestCleanupResetsEngineCache:
         assert bt._browser_engine_resolved is False
 
 
+class TestChromeFallbackOpenRouting:
+    """Regression: LP open-fallback should use the target URL directly."""
+
+    def test_open_fallback_does_not_require_lp_current_url(self):
+        import tools.browser_tool as bt
+
+        popen_calls = []
+
+        class _FakeProc:
+            returncode = 0
+
+            def wait(self, timeout=None):
+                return None
+
+        def _fake_popen(cmd, **kwargs):
+            popen_calls.append(cmd)
+            return _FakeProc()
+
+        # open -> success JSON, close -> empty JSON
+        stdout_reads = iter([
+            '{"success": true, "data": {"url": "https://example.com"}}',
+            '{"success": true, "data": {}}',
+        ])
+
+        def _fake_open(*_args, **_kwargs):
+            m = MagicMock()
+            m.__enter__.return_value.read.side_effect = lambda: next(stdout_reads)
+            m.__exit__.return_value = False
+            return m
+
+        with patch("tools.browser_tool._chromium_installed", return_value=True), \
+             patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser"), \
+             patch("tools.browser_tool._run_browser_command") as run_lp_eval, \
+             patch("subprocess.Popen", side_effect=_fake_popen), \
+             patch("os.open", return_value=99), \
+             patch("os.close"), \
+             patch("os.unlink"), \
+             patch("os.makedirs"), \
+             patch("builtins.open", side_effect=_fake_open), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value="/tmp"), \
+             patch("shutil.rmtree"):
+            result = bt._run_chrome_fallback_command(
+                task_id="lp-open-fallback",
+                command="open",
+                args=["https://example.com"],
+                timeout=10,
+            )
+
+        assert result["success"] is True
+        # No LP eval should be needed for failed open fallback.
+        run_lp_eval.assert_not_called()
+        # Ensure the temp Chrome session was asked to open the target URL.
+        assert any(cmd[-2:] == ["open", "https://example.com"] for cmd in popen_calls)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -673,15 +673,21 @@ def _run_chrome_fallback_command(
     """
     import uuid
 
-    # 1. Grab the current URL from the Lightpanda session. Use
-    # ``_engine_override=\"auto\"`` so this helper does not recursively trigger
-    # Lightpanda→Chrome fallback if the eval call itself fails.
-    url_result = _run_browser_command(
-        task_id, "eval", ["window.location.href"], timeout=10, _engine_override="auto"
-    )
+    # 1. Determine the URL Chrome should load.
+    # For a failed LP ``open <url>`` call, retry the same target directly.
+    # For all other commands, grab the current URL from the LP session.
     current_url = None
-    if url_result.get("success"):
-        current_url = url_result.get("data", {}).get("result", "").strip().strip('"').strip("'")
+    if command == "open" and args:
+        current_url = str(args[0] or "").strip()
+
+    if not current_url:
+        # Use ``_engine_override=\"auto\"`` so this helper does not recursively
+        # trigger Lightpanda→Chrome fallback if the eval call itself fails.
+        url_result = _run_browser_command(
+            task_id, "eval", ["window.location.href"], timeout=10, _engine_override="auto"
+        )
+        if url_result.get("success"):
+            current_url = url_result.get("data", {}).get("result", "").strip().strip('"').strip("'")
     if not current_url:
         logger.warning("Chrome fallback: could not determine current URL from LP session")
         return {"success": False, "error": "Chrome fallback failed: could not determine current URL"}

--- a/ui-tui/src/__tests__/messages.test.ts
+++ b/ui-tui/src/__tests__/messages.test.ts
@@ -28,6 +28,50 @@ describe('toTranscriptMessages', () => {
 })
 
 describe('MessageLine', () => {
+  it('preserves assistant text after a wrapped long list URL in narrow layouts', () => {
+    const stdout = new PassThrough()
+    const stdin = new PassThrough()
+    const stderr = new PassThrough()
+    let output = ''
+
+    Object.assign(stdout, { columns: 56, isTTY: false, rows: 24 })
+    Object.assign(stdin, { isTTY: false })
+    Object.assign(stderr, { isTTY: false })
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const text = [
+      '✅ Commit + push',
+      '',
+      '- Compare URL (ready for PR):',
+      '- https://github.com/NousResearch/hermes-agent/compare/main...adybag14-cyber:hermes-agent:fix/update-progress-heartbeat?expand=1',
+      '',
+      'If you want, I can also generate a clean PR draft body ready to paste.'
+    ].join('\n')
+
+    const instance = renderSync(
+      React.createElement(MessageLine, {
+        cols: 56,
+        msg: { role: 'assistant', text },
+        t: DEFAULT_THEME
+      }),
+      {
+        patchConsole: false,
+        stderr: stderr as NodeJS.WriteStream,
+        stdin: stdin as NodeJS.ReadStream,
+        stdout: stdout as NodeJS.WriteStream
+      }
+    )
+
+    instance.unmount()
+    instance.cleanup()
+
+    const rendered = stripAnsi(output)
+    expect(rendered).toContain('If you want, I can also generate a clean PR draft')
+    expect(rendered).toContain('body ready to paste.')
+  })
+
   it('preserves a separator after compound user prompt glyphs in transcript rows', () => {
     const stdout = new PassThrough()
     const stdin = new PassThrough()

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -687,16 +687,18 @@ function MdImpl({ compact, t, text }: MdProps) {
 
         const task = bullet[2]!.match(TASK_RE)
         const marker = task ? (task[1]!.toLowerCase() === 'x' ? '☑' : '☐') : '•'
+        const indent = ' '.repeat(indentDepth(bullet[1]!) * 2)
 
         nodes.push(
-          <Text key={key}>
+          <Box key={key}>
             <Text color={t.color.muted}>
-              {' '.repeat(indentDepth(bullet[1]!) * 2)}
+              {indent}
               {marker}{' '}
             </Text>
-
-            <MdInline t={t} text={task ? task[2]! : bullet[2]!} />
-          </Text>
+            <Box flexGrow={1}>
+              <MdInline t={t} text={task ? task[2]! : bullet[2]!} />
+            </Box>
+          </Box>
         )
         i++
 
@@ -707,15 +709,19 @@ function MdImpl({ compact, t, text }: MdProps) {
 
       if (numbered) {
         start('list')
-        nodes.push(
-          <Text key={key}>
-            <Text color={t.color.muted}>
-              {' '.repeat(indentDepth(numbered[1]!) * 2)}
-              {numbered[2]}.{' '}
-            </Text>
+        const indent = ' '.repeat(indentDepth(numbered[1]!) * 2)
+        const marker = `${numbered[2]}. `
 
-            <MdInline t={t} text={numbered[3]!} />
-          </Text>
+        nodes.push(
+          <Box key={key}>
+            <Text color={t.color.muted}>
+              {indent}
+              {marker}
+            </Text>
+            <Box flexGrow={1}>
+              <MdInline t={t} text={numbered[3]!} />
+            </Box>
+          </Box>
         )
         i++
 


### PR DESCRIPTION
# What does this PR do?

Fixes a remaining Hermes update UX hang case where dependency installation can still appear stalled on Termux/Android and other slow hardware, even after #20679 removed `pip --quiet`.

This PR adds a periodic heartbeat during dependency installation so users can see that updates are still progressing when `uv`/`pip` (or underlying build backends) are temporarily silent while compiling Rust/C extensions.

This is the right approach because:

- It is low-risk and does not alter dependency resolution behavior.
- It preserves normal `pip`/`uv` output.
- It adds explicit liveness feedback only during long silent stretches.

---

# Related Issue

Fixes #

---

# Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

---

# Changes Made

## `hermes_cli/main.py`

- Added `_run_install_with_heartbeat(...)` to wrap dependency install subprocess calls.
- Emits a periodic status line every 30s:

  ```text
  … still installing dependencies (Xs elapsed) — compiling Rust/C extensions can take several minutes
  ```

- Updated `_install_python_dependencies_with_optional_fallback(...)` to use the heartbeat wrapper for:
  - `install -e .[all]`
  - fallback `install -e .`
  - per-extra fallback installs (`install -e .[extra]`)

- Updated docstring to clarify why heartbeat is needed even with non-quiet pip output.

## `tests/hermes_cli/test_update_autostash.py`

- Updated expected pip command assertions to match current non-quiet install invocations.
- Updated mocked git pull expectation to `--ff-only` path used by current updater logic.
- Added regression test:
  - `test_install_heartbeat_prints_when_dependency_install_is_silent`

---

# How to Test

1. Run:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_update_autostash.py -q
   ```

2. Run:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_update_yes_flag.py tests/hermes_cli/test_cmd_update.py -q
   ```

3. Manual verification:
   - On a slower machine or Termux environment, run `hermes update` where dependency builds take time.
   - Verify heartbeat lines appear every ~30s during silent phases.

---

# Checklist

## Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Termux (Android, aarch64)

## Documentation & Housekeeping

- [x] I've updated relevant documentation (`README`, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is broadly useful to most users (if bundled) — see Contributing Guide
- [ ] `SKILL.md` follows the standard format (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end:
  ```bash
  hermes --toolsets skills -q "Use the X skill to do Y"
  ```

---

# Screenshots / Logs

Example heartbeat output during a long silent install phase:

```text
→ Updating Python dependencies...

… still installing dependencies (30s elapsed) — compiling Rust/C extensions can take several minutes

… still installing dependencies (60s elapsed) — compiling Rust/C extensions can take several minutes
```