### PR TITLE
fix(runtime): re-derive opencode api_mode in explicit-runtime path

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -749,6 +749,7 @@ def _resolve_explicit_runtime(
     model_cfg: Dict[str, Any],
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     explicit_api_key = str(explicit_api_key or "").strip()
     explicit_base_url = str(explicit_base_url or "").strip().rstrip("/")
@@ -866,6 +867,10 @@ def _resolve_explicit_runtime(
             api_mode = _copilot_runtime_api_mode(model_cfg, api_key)
         elif provider == "xai":
             api_mode = "codex_responses"
+        elif provider in ("opencode-zen", "opencode-go"):
+            from hermes_cli.models import opencode_model_api_mode
+            effective_model = target_model or model_cfg.get("default") or ""
+            api_mode = opencode_model_api_mode(provider, effective_model)
         else:
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
             if configured_mode:
@@ -876,6 +881,15 @@ def _resolve_explicit_runtime(
                 detected = _detect_api_mode_for_url(base_url)
                 if detected:
                     api_mode = detected
+
+        # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
+        # Anthropic SDK prepends its own /v1/messages to the base_url. Strip the
+        # trailing /v1 so the SDK constructs the correct path (e.g.
+        # https://opencode.ai/zen/v1/messages instead of .../v1/v1/messages).
+        # Mirrors the same step in _resolve_runtime_from_pool_entry.
+        if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
+            import re as _re
+            base_url = _re.sub(r"/v1/?$", "", base_url)
 
         return {
             "provider": provider,
@@ -964,6 +978,7 @@ def resolve_runtime_provider(
         model_cfg=model_cfg,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        target_model=target_model,
     )
     if explicit_runtime:
         return explicit_runtime

--- a/tests/hermes_cli/test_explicit_runtime_opencode_api_mode.py
+++ b/tests/hermes_cli/test_explicit_runtime_opencode_api_mode.py
@@ -1,0 +1,86 @@
+"""Regression tests for issue #21419.
+
+`_resolve_explicit_runtime()` must re-derive `api_mode` from the effective
+model (target_model > model_cfg.default) for opencode-zen / opencode-go,
+the same way `_resolve_runtime_from_pool_entry()` already does. Without
+this, a stale `api_mode: anthropic_messages` from a previous Claude
+session leaks onto a non-Claude opencode model, sending Anthropic-format
+requests to a chat_completions endpoint and getting 404.
+"""
+
+from hermes_cli.runtime_provider import _resolve_explicit_runtime
+
+
+def _resolve(provider: str, model_default: str, configured_api_mode: str = "anthropic_messages",
+             *, target_model: str = None):
+    return _resolve_explicit_runtime(
+        provider=provider,
+        requested_provider=provider,
+        model_cfg={"default": model_default, "api_mode": configured_api_mode},
+        explicit_api_key="sk-test",
+        explicit_base_url="https://opencode.ai/zen/v1" if provider == "opencode-zen" else "https://opencode.ai/zen/go/v1",
+        target_model=target_model,
+    )
+
+
+def test_opencode_zen_non_claude_overrides_stale_anthropic_api_mode():
+    """The bug: config has api_mode=anthropic_messages from previous Claude session,
+    but the active model is non-Claude — must resolve to chat_completions."""
+    runtime = _resolve("opencode-zen", "big-pickle", configured_api_mode="anthropic_messages")
+    assert runtime is not None
+    assert runtime["api_mode"] == "chat_completions"
+
+
+def test_opencode_zen_claude_model_resolves_anthropic_messages():
+    runtime = _resolve("opencode-zen", "claude-sonnet-4-5", configured_api_mode="chat_completions")
+    assert runtime is not None
+    assert runtime["api_mode"] == "anthropic_messages"
+    # The /v1 strip must apply: Anthropic SDK appends /v1/messages, so the
+    # base_url should end at /zen (no trailing /v1) to avoid /v1/v1/messages.
+    assert not runtime["base_url"].endswith("/v1")
+    assert runtime["base_url"].endswith("/zen")
+
+
+def test_opencode_zen_gpt_model_resolves_codex_responses():
+    runtime = _resolve("opencode-zen", "gpt-5", configured_api_mode="anthropic_messages")
+    assert runtime is not None
+    assert runtime["api_mode"] == "codex_responses"
+
+
+def test_opencode_go_minimax_resolves_anthropic_messages():
+    runtime = _resolve("opencode-go", "minimax-m2", configured_api_mode="chat_completions")
+    assert runtime is not None
+    assert runtime["api_mode"] == "anthropic_messages"
+
+
+def test_opencode_go_non_minimax_resolves_chat_completions():
+    runtime = _resolve("opencode-go", "glm-4.6", configured_api_mode="anthropic_messages")
+    assert runtime is not None
+    assert runtime["api_mode"] == "chat_completions"
+
+
+def test_target_model_overrides_model_cfg_default():
+    """A mid-session /model switch passes target_model — that must win
+    over the persisted config default."""
+    runtime = _resolve(
+        "opencode-zen",
+        "claude-sonnet-4-5",  # stale persisted default
+        configured_api_mode="anthropic_messages",
+        target_model="big-pickle",  # the model we are switching TO
+    )
+    assert runtime is not None
+    assert runtime["api_mode"] == "chat_completions"
+
+
+def test_non_opencode_provider_unchanged():
+    """Sanity: providers that are not opencode-zen / opencode-go must still
+    honour the configured api_mode (no behavioural change)."""
+    runtime = _resolve_explicit_runtime(
+        provider="kilocode",
+        requested_provider="kilocode",
+        model_cfg={"default": "anything", "api_mode": "anthropic_messages"},
+        explicit_api_key="sk-test",
+        explicit_base_url="https://api.kilo.ai/api/gateway",
+    )
+    assert runtime is not None
+    assert runtime["api_mode"] == "anthropic_messages"


### PR DESCRIPTION
## Summary

Closes #21419.

`_resolve_runtime_from_pool_entry` already calls `opencode_model_api_mode(provider, effective_model)` for opencode-zen / opencode-go (fix for #16878), so the credential-pool path correctly re-derives api_mode from the active model — preventing a stale `anthropic_messages` from a previous Claude session leaking onto a non-Claude model.

`_resolve_explicit_runtime`, used when the caller passes `explicit_api_key` / `explicit_base_url`, did not. It fell through to `_parse_api_mode(model_cfg.get("api_mode"))`, so a config carrying `api_mode: anthropic_messages` from a Claude setup still won — sending Anthropic-format requests to a non-Claude opencode model and getting 404.

## Reproduction (from #21419)

1. Set `api_mode: anthropic_messages` in config.yaml's model section (perhaps from a previous Claude-based setup).
2. Switch provider to opencode-zen with a non-Claude model (e.g. `big-pickle`).
3. Hermes sends Anthropic-format requests → 404 from OpenCode Zen.

## Changes

Mirror the pool-path behaviour in `_resolve_explicit_runtime`:

- Add `target_model: Optional[str] = None` parameter (matching `_resolve_runtime_from_pool_entry`).
- Short-circuit to `opencode_model_api_mode(provider, effective_model)` for `opencode-zen` / `opencode-go` BEFORE the configured-mode / auto-detect fallback. `effective_model = target_model or model_cfg.default or \"\"`.
- Strip trailing `/v1` from `base_url` when `api_mode` resolves to `anthropic_messages` on opencode providers, so the Anthropic SDK constructs `/v1/messages` instead of `/v1/v1/messages`. Mirrors the existing strip in the pool path.
- Pass `target_model` through from `resolve_runtime_provider()` (already a parameter there since #16878 — just plumbing).

No behavioural change for non-opencode providers; the new branch is fully bypassed.

## Tests

7 new pure-function regression tests in `tests/hermes_cli/test_explicit_runtime_opencode_api_mode.py`:

- opencode-zen + non-Claude model overrides stale `anthropic_messages` → `chat_completions`
- opencode-zen + `claude-*` preserves `anthropic_messages` AND strips trailing `/v1`
- opencode-zen + `gpt-*` resolves `codex_responses` (Codex backend)
- opencode-go + `minimax-*` resolves `anthropic_messages`
- opencode-go + non-minimax resolves `chat_completions`
- `target_model` overrides `model_cfg.default` (mid-session /model switch)
- non-opencode provider (kilocode) unchanged — sanity guard

```
$ python -m pytest -o addopts= tests/hermes_cli/test_explicit_runtime_opencode_api_mode.py -q
.......                                                                  [100%]
7 passed in 2.31s

$ python -m pytest -o addopts= tests/hermes_cli/test_runtime_provider_resolution.py -q
.........................................................................                                                                  [100%]
109 passed in 21.06s
```

All 109 existing runtime-provider-resolution tests continue to pass.

## Refs

- Closes #21419
- Refs #16878 (the same fix in the pool path)