### PR TITLE
fix(gateway): show runtime health for service status

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3395,6 +3395,16 @@ def _runtime_health_lines() -> list[str]:
     return lines
 
 
+def _print_runtime_health_lines() -> None:
+    runtime_lines = _runtime_health_lines()
+    if not runtime_lines:
+        return
+    print()
+    print("Recent gateway health:")
+    for line in runtime_lines:
+        print(f"  {line}")
+
+
 def _setup_standard_platform(platform: dict):
     """Interactive setup for Telegram, Discord, or Slack."""
     emoji = platform["emoji"]
@@ -4825,21 +4835,18 @@ def _gateway_command_inner(args):
         if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
             systemd_status(deep, system=system, full=full)
             _print_gateway_process_mismatch(snapshot)
+            _print_runtime_health_lines()
         elif is_macos() and get_launchd_plist_path().exists():
             launchd_status(deep)
             _print_gateway_process_mismatch(snapshot)
+            _print_runtime_health_lines()
         else:
             # Check for manually running processes
             pids = list(snapshot.gateway_pids)
             if pids:
                 print(f"✓ Gateway is running (PID: {', '.join(map(str, pids))})")
                 print("  (Running manually, not as a system service)")
-                runtime_lines = _runtime_health_lines()
-                if runtime_lines:
-                    print()
-                    print("Recent gateway health:")
-                    for line in runtime_lines:
-                        print(f"  {line}")
+                _print_runtime_health_lines()
                 print()
                 if is_termux():
                     print("Termux note:")
@@ -4854,12 +4861,7 @@ def _gateway_command_inner(args):
                     print("  sudo hermes gateway install --system")
             else:
                 print("✗ Gateway is not running")
-                runtime_lines = _runtime_health_lines()
-                if runtime_lines:
-                    print()
-                    print("Recent gateway health:")
-                    for line in runtime_lines:
-                        print(f"  {line}")
+                _print_runtime_health_lines()
                 print()
                 print("To start:")
                 print("  hermes gateway run      # Run in foreground")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -882,6 +882,49 @@ class TestGatewaySystemServiceRouting:
 
         assert calls == [(False, False, True)]
 
+    def test_gateway_status_prints_runtime_health_for_systemd_service(self, monkeypatch, capsys):
+        user_unit = SimpleNamespace(exists=lambda: True)
+        system_unit = SimpleNamespace(exists=lambda: False)
+
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_systemd_unit_path",
+            lambda system=False: system_unit if system else user_unit,
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "get_gateway_runtime_snapshot",
+            lambda system=False: gateway_cli.GatewayRuntimeSnapshot(
+                manager="systemd (user)",
+                service_installed=True,
+                service_running=True,
+                gateway_pids=(1234,),
+                service_scope="user",
+            ),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "systemd_status",
+            lambda deep=False, system=False, full=False: print("service active"),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_runtime_health_lines",
+            lambda: ["⚠ feishu: need_user_authorization"],
+        )
+
+        gateway_cli.gateway_command(
+            SimpleNamespace(gateway_command="status", deep=False, system=False, full=False)
+        )
+
+        out = capsys.readouterr().out
+        assert "service active" in out
+        assert "Recent gateway health:" in out
+        assert "feishu: need_user_authorization" in out
+
     def test_gateway_install_passes_system_flags(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)


### PR DESCRIPTION
## Summary

Show persisted gateway runtime health in `hermes gateway status` even when the gateway is managed by systemd or launchd.

The existing status command already has a useful `_runtime_health_lines()` summary, but it was only printed for manual/no-process paths. On service-managed installs, the command could show service status while hiding the more actionable runtime state from `gateway_state.json`, such as a failed platform, startup issue, or stuck shutdown reason.

This matters on headless installs because the service can be active while the last runtime payload still tells you the platform-level problem that actually needs attention.

## What changed

- Added a small `_print_runtime_health_lines()` helper.
- Reused it for systemd, launchd, manual-running, and not-running status paths.
- Added coverage for systemd status printing runtime health.

## Validation

- `uv run --extra dev pytest tests/hermes_cli/test_gateway_service.py::TestGatewaySystemServiceRouting::test_gateway_status_prints_runtime_health_for_systemd_service -q`
- `uv run --extra dev python -m py_compile hermes_cli/gateway.py`
- `git diff --check`
