### PR TITLE
feat(runtime): record tool and cron events

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1509,11 +1509,34 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 """
         
         logger.info("Job '%s' completed successfully", job_name)
+        try:
+            from hermes_cli.runtime_events import append_runtime_event
+
+            append_runtime_event(
+                kind="job",
+                status="pass",
+                name=job_name,
+                detail=f"job_id={job_id}",
+            )
+        except Exception:
+            pass
         return True, output, final_response, None
         
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.exception("Job '%s' failed: %s", job_name, error_msg)
+        try:
+            from hermes_cli.runtime_events import append_runtime_event
+
+            append_runtime_event(
+                kind="job",
+                status="fail",
+                name=job_name,
+                detail=error_msg,
+                payload={"job_id": job_id},
+            )
+        except Exception:
+            pass
         
         output = f"""# Cron Job: {job_name} (FAILED)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5296,6 +5296,13 @@ def cmd_doctor(args):
     run_doctor(args)
 
 
+def cmd_runtime_events(args):
+    """Show recent runtime events."""
+    from hermes_cli.runtime_events import run_runtime_events
+
+    run_runtime_events(args)
+
+
 def cmd_dump(args):
     """Dump setup summary for support/debugging."""
     from hermes_cli.dump import run_dump
@@ -9315,6 +9322,20 @@ def main():
         "--fix", action="store_true", help="Attempt to fix issues automatically"
     )
     doctor_parser.set_defaults(func=cmd_doctor)
+
+    # =========================================================================
+    # runtime-events command
+    # =========================================================================
+    runtime_events_parser = subparsers.add_parser(
+        "runtime-events",
+        help="Show recent runtime tool/job/provider events",
+        description="Inspect recent runtime events such as failed tool calls and cron jobs",
+    )
+    runtime_events_parser.add_argument("--limit", type=int, default=50, help="Maximum events to show")
+    runtime_events_parser.add_argument("--kind", choices=["tool", "job", "provider", "gateway"], help="Filter by event kind")
+    runtime_events_parser.add_argument("--status", help="Filter by status, e.g. fail, error, warn, timeout")
+    runtime_events_parser.add_argument("--json", action="store_true", help="Emit JSON")
+    runtime_events_parser.set_defaults(func=cmd_runtime_events)
 
     # =========================================================================
     # dump command

--- a/hermes_cli/runtime_events.py
+++ b/hermes_cli/runtime_events.py
@@ -1,0 +1,118 @@
+"""Lightweight runtime event log for operator diagnostics."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+from hermes_constants import get_hermes_home
+
+
+EVENTS_FILE = "runtime_events.jsonl"
+_MAX_DETAIL_CHARS = 1200
+
+
+def _events_path(hermes_home: str | Path | None = None) -> Path:
+    home = Path(hermes_home) if hermes_home is not None else get_hermes_home()
+    return home / EVENTS_FILE
+
+
+def _clean_detail(detail: Any) -> str:
+    text = "" if detail is None else str(detail)
+    if len(text) > _MAX_DETAIL_CHARS:
+        return text[: _MAX_DETAIL_CHARS - 1] + "…"
+    return text
+
+
+def append_runtime_event(
+    *,
+    kind: str,
+    status: str,
+    name: str,
+    detail: Any = None,
+    payload: dict[str, Any] | None = None,
+    hermes_home: str | Path | None = None,
+) -> None:
+    """Append one runtime event as JSONL.
+
+    This is deliberately best-effort. Runtime diagnostics must never break the
+    tool, provider, cron, or gateway path they observe.
+    """
+    try:
+        path = _events_path(hermes_home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        event = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "kind": str(kind),
+            "status": str(status),
+            "name": str(name),
+        }
+        cleaned = _clean_detail(detail)
+        if cleaned:
+            event["detail"] = cleaned
+        if payload:
+            event["payload"] = payload
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n")
+    except Exception:
+        return
+
+
+def iter_runtime_events(
+    *,
+    limit: int = 50,
+    kind: str | None = None,
+    status: str | None = None,
+    hermes_home: str | Path | None = None,
+) -> list[dict[str, Any]]:
+    """Read recent runtime events, newest last."""
+    path = _events_path(hermes_home)
+    if not path.exists():
+        return []
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+
+    events: list[dict[str, Any]] = []
+    for line in lines[-max(1, limit * 4):]:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if kind and event.get("kind") != kind:
+            continue
+        if status and event.get("status") != status:
+            continue
+        events.append(event)
+    return events[-limit:]
+
+
+def _format_event(event: dict[str, Any]) -> str:
+    detail = event.get("detail")
+    suffix = f" — {detail}" if detail else ""
+    return (
+        f"{event.get('ts', '?')} "
+        f"{event.get('kind', '?')}/{event.get('status', '?')} "
+        f"{event.get('name', '?')}{suffix}"
+    )
+
+
+def run_runtime_events(args) -> None:
+    """CLI entrypoint for ``hermes runtime-events``."""
+    events = iter_runtime_events(
+        limit=max(1, int(getattr(args, "limit", 50) or 50)),
+        kind=getattr(args, "kind", None),
+        status=getattr(args, "status", None),
+    )
+    if getattr(args, "json", False):
+        print(json.dumps(events, ensure_ascii=False, indent=2))
+        return
+    if not events:
+        print("No runtime events recorded.")
+        return
+    for event in events:
+        print(_format_event(event))

--- a/model_tools.py
+++ b/model_tools.py
@@ -676,6 +676,36 @@ def _coerce_boolean(value: str):
     return value
 
 
+def _record_tool_runtime_event(
+    function_name: str,
+    status: str,
+    detail: str,
+    *,
+    duration_ms: int | None = None,
+    session_id: str | None = None,
+    tool_call_id: str | None = None,
+) -> None:
+    try:
+        from hermes_cli.runtime_events import append_runtime_event
+
+        payload = {}
+        if duration_ms is not None:
+            payload["duration_ms"] = duration_ms
+        if session_id:
+            payload["session_id"] = session_id
+        if tool_call_id:
+            payload["tool_call_id"] = tool_call_id
+        append_runtime_event(
+            kind="tool",
+            status=status,
+            name=function_name,
+            detail=detail,
+            payload=payload or None,
+        )
+    except Exception:
+        pass
+
+
 def handle_function_call(
     function_name: str,
     function_args: Dict[str, Any],
@@ -810,11 +840,32 @@ def handle_function_call(
         except Exception as _hook_err:
             logger.debug("transform_tool_result hook error: %s", _hook_err)
 
+        try:
+            parsed_result = json.loads(result) if isinstance(result, str) else {}
+            if isinstance(parsed_result, dict) and parsed_result.get("error"):
+                _record_tool_runtime_event(
+                    function_name,
+                    "fail",
+                    str(parsed_result.get("error")),
+                    duration_ms=duration_ms,
+                    session_id=session_id,
+                    tool_call_id=tool_call_id,
+                )
+        except Exception:
+            pass
+
         return result
 
     except Exception as e:
         error_msg = f"Error executing {function_name}: {str(e)}"
         logger.exception(error_msg)
+        _record_tool_runtime_event(
+            function_name,
+            "error",
+            error_msg,
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+        )
         return json.dumps({"error": error_msg}, ensure_ascii=False)
 
 

--- a/tests/hermes_cli/test_runtime_events.py
+++ b/tests/hermes_cli/test_runtime_events.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from argparse import Namespace
+import json
+
+from hermes_cli.runtime_events import (
+    append_runtime_event,
+    iter_runtime_events,
+    run_runtime_events,
+)
+
+
+def test_runtime_events_roundtrip_and_filter(tmp_path):
+    append_runtime_event(
+        kind="tool",
+        status="fail",
+        name="send_message",
+        detail="delivery error",
+        hermes_home=tmp_path,
+    )
+    append_runtime_event(
+        kind="job",
+        status="pass",
+        name="daily-report",
+        detail="ok",
+        hermes_home=tmp_path,
+    )
+
+    events = iter_runtime_events(hermes_home=tmp_path, limit=10)
+    assert [event["kind"] for event in events] == ["tool", "job"]
+
+    failed_tools = iter_runtime_events(hermes_home=tmp_path, kind="tool", status="fail")
+    assert len(failed_tools) == 1
+    assert failed_tools[0]["name"] == "send_message"
+    assert failed_tools[0]["detail"] == "delivery error"
+
+
+def test_runtime_events_cli_json(monkeypatch, tmp_path, capsys):
+    append_runtime_event(
+        kind="tool",
+        status="error",
+        name="browser",
+        detail="timeout",
+        hermes_home=tmp_path,
+    )
+
+    monkeypatch.setattr("hermes_cli.runtime_events.get_hermes_home", lambda: tmp_path)
+    run_runtime_events(Namespace(limit=5, kind=None, status=None, json=True))
+
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload[0]["kind"] == "tool"
+    assert payload[0]["status"] == "error"


### PR DESCRIPTION
## Summary

Add a lightweight runtime event log for high-signal tool and cron failures.

When a gateway is running for days, the important failure is often not the Python exception itself; it is the sequence of "which tool failed", "which cron job failed", and "what should I inspect next". Today that usually means digging through service logs and guessing. This adds a small JSONL event trail under Hermes home and a `hermes runtime-events` command to inspect it.

## What changed

- Added `hermes_cli.runtime_events` with best-effort JSONL append/read helpers.
- Added `hermes runtime-events` with `--limit`, `--kind`, `--status`, and `--json`.
- Records failed tool results from `model_tools.handle_function_call()`.
- Records cron job pass/fail outcomes from `cron.scheduler.run_job()`.

The logging path is intentionally fail-open: diagnostics should never break the tool or job path they are observing.

## Validation

- `uv run --extra dev pytest tests/hermes_cli/test_runtime_events.py -q`
- `uv run --extra dev python -m py_compile hermes_cli/runtime_events.py model_tools.py cron/scheduler.py hermes_cli/main.py`
- `git diff --check`
