### PR TITLE
feat(discord): add OpenAI Realtime voice bridge

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -136,6 +136,10 @@ class VoiceReceiver:
         self._vc = voice_client
         self._allowed_user_ids = allowed_user_ids or set()
         self._running = False
+        # Optional low-latency PCM tap used by the OpenAI Realtime bridge.
+        # Called from discord.py's socket reader thread with decoded 48 kHz
+        # stereo PCM16 and the best-known user_id (0 if not mapped yet).
+        self.realtime_pcm_callback: Optional[Callable[[int, bytes], None]] = None
 
         # Decryption
         self._secret_key: Optional[bytes] = None
@@ -368,8 +372,14 @@ class VoiceReceiver:
                 self._decoders[ssrc] = discord.opus.Decoder()
             pcm = self._decoders[ssrc].decode(decrypted)
             with self._lock:
+                user_id = self._ssrc_to_user.get(ssrc, 0)
                 self._buffers[ssrc].extend(pcm)
                 self._last_packet_time[ssrc] = time.monotonic()
+            if self.realtime_pcm_callback:
+                try:
+                    self.realtime_pcm_callback(user_id, pcm)
+                except Exception as cb_err:
+                    logger.debug("Realtime PCM callback failed for SSRC %s: %s", ssrc, cb_err)
         except Exception as e:
             logger.debug("Opus decode error for SSRC %s: %s", ssrc, e)
             return
@@ -406,6 +416,10 @@ class VoiceReceiver:
 
     def check_silence(self) -> list:
         """Return list of (user_id, pcm_bytes) for completed utterances."""
+        # True realtime mode streams PCM directly to OpenAI Realtime; do not
+        # also emit turn-based Whisper transcripts into the normal agent loop.
+        if self.realtime_pcm_callback:
+            return []
         now = time.monotonic()
         completed = []
 
@@ -512,6 +526,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # Phase 2: voice listening
         self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
+        self._realtime_bridges: Dict[int, Any] = {}  # guild_id -> OpenAIRealtimeDiscordBridge
         self._voice_input_callback: Optional[Callable] = None  # set by run.py
         self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
         # Track threads where the bot has participated so follow-up messages
@@ -1644,6 +1659,8 @@ class DiscordAdapter(BasePlatformAdapter):
     async def leave_voice_channel(self, guild_id: int) -> None:
         """Disconnect from the voice channel in a guild."""
         async with self._voice_locks.setdefault(guild_id, asyncio.Lock()):
+            # Stop realtime bridge first, then the utterance receiver.
+            await self.stop_realtime_voice_bridge(guild_id)
             # Stop voice receiver first
             receiver = self._voice_receivers.pop(guild_id, None)
             if receiver:
@@ -1669,6 +1686,12 @@ class DiscordAdapter(BasePlatformAdapter):
         vc = self._voice_clients.get(guild_id)
         if not vc or not vc.is_connected():
             return False
+
+        # Realtime mode owns the voice client's continuous PCM playback source.
+        # Do not interrupt it with file-based TTS.
+        if guild_id in self._realtime_bridges:
+            logger.debug("Skipping file TTS playback because realtime bridge is active (guild=%d)", guild_id)
+            return True
 
         # Pause voice receiver while playing (echo prevention)
         receiver = self._voice_receivers.get(guild_id)
@@ -1706,6 +1729,63 @@ class DiscordAdapter(BasePlatformAdapter):
         finally:
             if receiver:
                 receiver.resume()
+
+    async def start_realtime_voice_bridge(
+        self,
+        guild_id: int,
+        *,
+        api_key: str,
+        model: str = "gpt-realtime",
+        voice: str = "alloy",
+        instructions: str = "",
+    ) -> bool:
+        """Start true duplex OpenAI Realtime audio for an existing VC."""
+        vc = self._voice_clients.get(guild_id)
+        receiver = self._voice_receivers.get(guild_id)
+        if not vc or not vc.is_connected() or receiver is None:
+            return False
+        await self.stop_realtime_voice_bridge(guild_id)
+        from gateway.platforms.discord_realtime import OpenAIRealtimeDiscordBridge
+
+        bridge = OpenAIRealtimeDiscordBridge(
+            api_key=api_key,
+            voice_client=vc,
+            model=model,
+            voice=voice,
+            instructions=instructions or (
+                "You are Hermes speaking in a Discord voice channel. "
+                "Keep replies short, conversational, and interruptible."
+            ),
+        )
+        bridge.start()
+        receiver.realtime_pcm_callback = lambda _user_id, pcm: bridge.accept_discord_pcm(pcm)
+        self._realtime_bridges[guild_id] = bridge
+        logger.info("OpenAI Realtime voice bridge started (guild=%d model=%s voice=%s)", guild_id, model, voice)
+        return True
+
+    async def stop_realtime_voice_bridge(self, guild_id: int) -> None:
+        """Stop the OpenAI Realtime bridge without leaving the Discord VC."""
+        bridge = self._realtime_bridges.pop(guild_id, None)
+        receiver = self._voice_receivers.get(guild_id)
+        if receiver:
+            receiver.realtime_pcm_callback = None
+        if bridge:
+            bridge.stop()
+            logger.info("OpenAI Realtime voice bridge stopped (guild=%d)", guild_id)
+
+    def get_realtime_voice_status(self, guild_id: int) -> Optional[Dict[str, Any]]:
+        bridge = self._realtime_bridges.get(guild_id)
+        if not bridge:
+            return None
+        status = bridge.status()
+        return {
+            "connected": status.connected,
+            "input_bytes": status.input_bytes,
+            "output_bytes": status.output_bytes,
+            "last_input_at": status.last_input_at,
+            "last_output_at": status.last_output_at,
+            "last_error": status.last_error,
+        }
 
     async def get_user_voice_channel(self, guild_id: int, user_id: str):
         """Return the voice channel the user is currently in, or None."""

--- a/gateway/platforms/discord_realtime.py
+++ b/gateway/platforms/discord_realtime.py
@@ -376,7 +376,7 @@ class OpenAIRealtimeDiscordBridge:
             if not isinstance(frame, dict):
                 continue
             ftype = frame.get("type")
-            if ftype == "response.audio.delta":
+            if ftype in ("response.audio.delta", "response.output_audio.delta"):
                 b64 = frame.get("delta") or frame.get("audio") or ""
                 try:
                     pcm24 = base64.b64decode(b64)

--- a/gateway/platforms/discord_realtime.py
+++ b/gateway/platforms/discord_realtime.py
@@ -97,7 +97,10 @@ class QueuePCMAudioSource:
                 self._closed = True
                 break
             self._buffer.extend(chunk)
-        if not self._buffer and self._closed:
+        if not self._buffer:
+            # No model audio is available. Returning an empty frame tells
+            # discord.py playback to end instead of broadcasting padded silence
+            # forever and showing the bot as constantly speaking.
             return b""
         if len(self._buffer) < DISCORD_FRAME_BYTES:
             self._buffer.extend(b"\x00" * (DISCORD_FRAME_BYTES - len(self._buffer)))
@@ -171,9 +174,13 @@ class OpenAIRealtimeDiscordBridge:
         self._output_q: "queue.Queue[Optional[bytes]]" = queue.Queue(maxsize=400)
         self._stop = threading.Event()
         self._send_lock = threading.Lock()
+        self._playback_lock = threading.Lock()
         self._ws: Any = None
         self._rx_thread: Optional[threading.Thread] = None
         self._tx_thread: Optional[threading.Thread] = None
+        self._playback_active = False
+        self._logged_first_input = False
+        self._logged_first_output = False
         self.input_bytes = 0
         self.output_bytes = 0
         self.last_input_at: Optional[float] = None
@@ -195,7 +202,6 @@ class OpenAIRealtimeDiscordBridge:
         self._tx_thread = threading.Thread(target=self._send_loop, name="discord-openai-realtime-tx", daemon=True)
         self._rx_thread.start()
         self._tx_thread.start()
-        self._start_discord_playback()
 
     def _uses_ga_api(self) -> bool:
         # New GA-only models such as gpt-realtime-2 reject the legacy
@@ -274,6 +280,9 @@ class OpenAIRealtimeDiscordBridge:
             self._input_q.put_nowait(converted)
             self.input_bytes += len(converted)
             self.last_input_at = time.time()
+            if not self._logged_first_input:
+                self._logged_first_input = True
+                logger.info("OpenAI Realtime received first Discord PCM input (%d bytes)", len(converted))
         except queue.Full:
             # Prefer dropping old audio over building latency.
             try:
@@ -298,12 +307,35 @@ class OpenAIRealtimeDiscordBridge:
         source = _make_discord_audio_source(self._output_q)
 
         def _after(error):
+            with self._playback_lock:
+                self._playback_active = False
             if error:
                 logger.warning("Realtime Discord playback ended with error: %s", error)
 
         if self.voice_client.is_playing():
             self.voice_client.stop()
         self.voice_client.play(source, after=_after)
+        self._playback_active = True
+
+    def _ensure_discord_playback(self) -> None:
+        """Start Discord playback only when actual model audio is queued.
+
+        Keeping a PCM source permanently attached makes Discord show the bot as
+        speaking while it is only sending padded silence. Start lazily on first
+        audio instead; the source ends after the queued audio drains, and future
+        deltas restart playback.
+        """
+        with self._playback_lock:
+            if self._playback_active:
+                return
+            try:
+                if self.voice_client and self.voice_client.is_playing():
+                    self._playback_active = True
+                    return
+                self._start_discord_playback()
+            except Exception as exc:
+                self.last_error = str(exc)
+                logger.warning("Realtime Discord playback failed to start: %s", exc)
 
     def _send_loop(self) -> None:
         while not self._stop.is_set():
@@ -355,6 +387,9 @@ class OpenAIRealtimeDiscordBridge:
                     self._enqueue_output(pcm48)
                     self.output_bytes += len(pcm48)
                     self.last_output_at = time.time()
+                    if not self._logged_first_output:
+                        self._logged_first_output = True
+                        logger.info("OpenAI Realtime produced first Discord PCM output (%d bytes)", len(pcm48))
             elif ftype == "input_audio_buffer.speech_started":
                 # Barge-in: stop any queued/spoken model audio as soon as the user speaks.
                 self._clear_output_queue()
@@ -365,10 +400,12 @@ class OpenAIRealtimeDiscordBridge:
     def _enqueue_output(self, pcm: bytes) -> None:
         try:
             self._output_q.put_nowait(pcm)
+            self._ensure_discord_playback()
         except queue.Full:
             self._clear_output_queue()
             try:
                 self._output_q.put_nowait(pcm)
+                self._ensure_discord_playback()
             except queue.Full:
                 pass
 

--- a/gateway/platforms/discord_realtime.py
+++ b/gateway/platforms/discord_realtime.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+"""Discord voice-channel bridge for OpenAI Realtime.
+
+The bridge is intentionally small and self-contained:
+- Discord inbound voice packets arrive as 48 kHz stereo PCM16.
+- OpenAI Realtime expects 24 kHz mono PCM16 input and emits 24 kHz mono PCM16.
+- discord.py voice playback expects an AudioSource that returns 20 ms chunks of
+  48 kHz stereo PCM16 (3840 bytes) unless the source is Opus.
+
+This module does not import discord at module import time so the Discord adapter
+remains importable without optional voice dependencies.
+"""
+
+import audioop
+import base64
+import json
+import logging
+import queue
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+REALTIME_URL = "wss://api.openai.com/v1/realtime"
+DISCORD_RATE = 48_000
+DISCORD_CHANNELS = 2
+REALTIME_RATE = 24_000
+REALTIME_CHANNELS = 1
+SAMPLE_WIDTH = 2
+DISCORD_FRAME_BYTES = int(DISCORD_RATE * 0.02) * DISCORD_CHANNELS * SAMPLE_WIDTH
+
+
+def _require_ws_connect():
+    try:
+        from websockets.sync.client import connect as _connect  # type: ignore
+    except ImportError as exc:  # pragma: no cover - dependency gate
+        raise RuntimeError(
+            "websockets package is required for OpenAI Realtime; install with: pip install websockets"
+        ) from exc
+    return _connect
+
+
+def discord_pcm_to_realtime(pcm: bytes) -> bytes:
+    """Convert Discord 48 kHz stereo PCM16 to OpenAI 24 kHz mono PCM16."""
+    if not pcm:
+        return b""
+    mono = audioop.tomono(pcm, SAMPLE_WIDTH, 0.5, 0.5)
+    converted, _ = audioop.ratecv(
+        mono, SAMPLE_WIDTH, REALTIME_CHANNELS, DISCORD_RATE, REALTIME_RATE, None
+    )
+    return converted
+
+
+def realtime_pcm_to_discord(pcm: bytes) -> bytes:
+    """Convert OpenAI 24 kHz mono PCM16 to Discord 48 kHz stereo PCM16."""
+    if not pcm:
+        return b""
+    upsampled, _ = audioop.ratecv(
+        pcm, SAMPLE_WIDTH, REALTIME_CHANNELS, REALTIME_RATE, DISCORD_RATE, None
+    )
+    return audioop.tostereo(upsampled, SAMPLE_WIDTH, 1.0, 1.0)
+
+
+class QueuePCMAudioSource:
+    """PCM frame reader backed by a byte queue.
+
+    The bare class is intentionally free of a module-level discord.py import so
+    this module remains importable without optional Discord voice dependencies.
+    When handing it to discord.py, wrap it with `_make_discord_audio_source()` so
+    `VoiceClient.play()` sees an actual `discord.AudioSource` instance.
+    """
+
+    def __init__(self, pcm_queue: "queue.Queue[Optional[bytes]]") -> None:
+        self._queue = pcm_queue
+        self._buffer = bytearray()
+        self._closed = False
+
+    def is_opus(self) -> bool:
+        return False
+
+    def read(self) -> bytes:
+        if self._closed:
+            return b""
+        deadline = time.monotonic() + 0.25
+        while len(self._buffer) < DISCORD_FRAME_BYTES:
+            timeout = max(0.0, deadline - time.monotonic())
+            if timeout <= 0:
+                break
+            try:
+                chunk = self._queue.get(timeout=timeout)
+            except queue.Empty:
+                break
+            if chunk is None:
+                self._closed = True
+                break
+            self._buffer.extend(chunk)
+        if not self._buffer and self._closed:
+            return b""
+        if len(self._buffer) < DISCORD_FRAME_BYTES:
+            self._buffer.extend(b"\x00" * (DISCORD_FRAME_BYTES - len(self._buffer)))
+        out = bytes(self._buffer[:DISCORD_FRAME_BYTES])
+        del self._buffer[:DISCORD_FRAME_BYTES]
+        return out
+
+    def cleanup(self) -> None:
+        self._closed = True
+
+
+def _make_discord_audio_source(pcm_queue: "queue.Queue[Optional[bytes]]") -> Any:
+    """Create a queue-backed source that passes discord.py's AudioSource check."""
+    try:
+        import discord  # type: ignore
+    except ImportError as exc:  # pragma: no cover - dependency gate
+        raise RuntimeError("discord.py is required for Discord voice playback") from exc
+
+    audio_source_base = getattr(discord, "AudioSource", None)
+    if not isinstance(audio_source_base, type):  # pragma: no cover - test suites may install a MagicMock discord module
+        return QueuePCMAudioSource(pcm_queue)
+
+    class DiscordQueuePCMAudioSource(audio_source_base):  # type: ignore[misc, valid-type]
+        def __init__(self, queue_: "queue.Queue[Optional[bytes]]") -> None:
+            self._inner = QueuePCMAudioSource(queue_)
+
+        def is_opus(self) -> bool:
+            return self._inner.is_opus()
+
+        def read(self) -> bytes:
+            return self._inner.read()
+
+        def cleanup(self) -> None:
+            self._inner.cleanup()
+            try:
+                super().cleanup()
+            except AttributeError:
+                pass
+
+    return DiscordQueuePCMAudioSource(pcm_queue)
+
+
+@dataclass
+class RealtimeBridgeStatus:
+    connected: bool
+    input_bytes: int
+    output_bytes: int
+    last_input_at: Optional[float]
+    last_output_at: Optional[float]
+    last_error: Optional[str]
+
+
+class OpenAIRealtimeDiscordBridge:
+    """Duplex Discord voice <-> OpenAI Realtime WebSocket bridge."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        voice_client: Any,
+        model: str = "gpt-realtime-2",
+        voice: str = "alloy",
+        instructions: str = "You are Hermes in a Discord voice channel. Keep replies brief and conversational.",
+    ) -> None:
+        self.api_key = api_key
+        self.voice_client = voice_client
+        self.model = model
+        self.voice = voice
+        self.instructions = instructions
+        self._input_q: "queue.Queue[bytes]" = queue.Queue(maxsize=200)
+        self._output_q: "queue.Queue[Optional[bytes]]" = queue.Queue(maxsize=400)
+        self._stop = threading.Event()
+        self._send_lock = threading.Lock()
+        self._ws: Any = None
+        self._rx_thread: Optional[threading.Thread] = None
+        self._tx_thread: Optional[threading.Thread] = None
+        self.input_bytes = 0
+        self.output_bytes = 0
+        self.last_input_at: Optional[float] = None
+        self.last_output_at: Optional[float] = None
+        self.last_error: Optional[str] = None
+
+    def start(self) -> None:
+        connect = _require_ws_connect()
+        url = f"{REALTIME_URL}?model={self.model}"
+        headers = [("Authorization", f"Bearer {self.api_key}")]
+        if not self._uses_ga_api():
+            headers.append(("OpenAI-Beta", "realtime=v1"))
+        try:
+            self._ws = connect(url, additional_headers=headers)
+        except TypeError:  # pragma: no cover - older websockets
+            self._ws = connect(url, extra_headers=headers)
+        self._send_json(self._session_update_payload())
+        self._rx_thread = threading.Thread(target=self._recv_loop, name="discord-openai-realtime-rx", daemon=True)
+        self._tx_thread = threading.Thread(target=self._send_loop, name="discord-openai-realtime-tx", daemon=True)
+        self._rx_thread.start()
+        self._tx_thread.start()
+        self._start_discord_playback()
+
+    def _uses_ga_api(self) -> bool:
+        # New GA-only models such as gpt-realtime-2 reject the legacy
+        # OpenAI-Beta: realtime=v1 header and expect the GA session shape.
+        return self.model == "gpt-realtime-2" or self.model.startswith("gpt-realtime-2-")
+
+    def _session_update_payload(self) -> dict:
+        if self._uses_ga_api():
+            return {
+                "type": "session.update",
+                "session": {
+                    "type": "realtime",
+                    "model": self.model,
+                    "instructions": self.instructions,
+                    "audio": {
+                        "input": {
+                            "format": {"type": "audio/pcm", "rate": REALTIME_RATE},
+                            "turn_detection": {
+                                "type": "server_vad",
+                                "threshold": 0.5,
+                                "prefix_padding_ms": 300,
+                                "silence_duration_ms": 500,
+                                "create_response": True,
+                            },
+                        },
+                        "output": {
+                            "format": {"type": "audio/pcm", "rate": REALTIME_RATE},
+                            "voice": self.voice,
+                        },
+                    },
+                },
+            }
+        return {
+            "type": "session.update",
+            "session": {
+                "modalities": ["audio", "text"],
+                "instructions": self.instructions,
+                "voice": self.voice,
+                "input_audio_format": "pcm16",
+                "output_audio_format": "pcm16",
+                "turn_detection": {
+                    "type": "server_vad",
+                    "threshold": 0.5,
+                    "prefix_padding_ms": 300,
+                    "silence_duration_ms": 500,
+                    "create_response": True,
+                },
+            },
+        }
+
+    def stop(self) -> None:
+        self._stop.set()
+        try:
+            self._output_q.put_nowait(None)
+        except queue.Full:
+            pass
+        if self._ws is not None:
+            try:
+                self._ws.close()
+            except Exception:
+                pass
+            self._ws = None
+        try:
+            if self.voice_client and self.voice_client.is_playing():
+                self.voice_client.stop()
+        except Exception:
+            pass
+
+    def accept_discord_pcm(self, pcm: bytes) -> None:
+        if self._stop.is_set() or not pcm:
+            return
+        converted = discord_pcm_to_realtime(pcm)
+        if not converted:
+            return
+        try:
+            self._input_q.put_nowait(converted)
+            self.input_bytes += len(converted)
+            self.last_input_at = time.time()
+        except queue.Full:
+            # Prefer dropping old audio over building latency.
+            try:
+                self._input_q.get_nowait()
+                self._input_q.put_nowait(converted)
+            except queue.Empty:
+                pass
+
+    def status(self) -> RealtimeBridgeStatus:
+        return RealtimeBridgeStatus(
+            connected=self._ws is not None and not self._stop.is_set(),
+            input_bytes=self.input_bytes,
+            output_bytes=self.output_bytes,
+            last_input_at=self.last_input_at,
+            last_output_at=self.last_output_at,
+            last_error=self.last_error,
+        )
+
+    def _start_discord_playback(self) -> None:
+        if not self.voice_client or not self.voice_client.is_connected():
+            raise RuntimeError("Discord voice client is not connected")
+        source = _make_discord_audio_source(self._output_q)
+
+        def _after(error):
+            if error:
+                logger.warning("Realtime Discord playback ended with error: %s", error)
+
+        if self.voice_client.is_playing():
+            self.voice_client.stop()
+        self.voice_client.play(source, after=_after)
+
+    def _send_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                pcm = self._input_q.get(timeout=0.2)
+            except queue.Empty:
+                continue
+            b64 = base64.b64encode(pcm).decode("ascii")
+            try:
+                self._send_json({"type": "input_audio_buffer.append", "audio": b64})
+            except Exception as exc:
+                self.last_error = str(exc)
+                logger.warning("OpenAI Realtime input send failed: %s", exc)
+                self.stop()
+                return
+
+    def _recv_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                raw = self._ws.recv(timeout=0.5)
+            except TimeoutError:
+                continue
+            except TypeError:  # pragma: no cover - older websockets
+                raw = self._ws.recv()
+            except Exception as exc:
+                if not self._stop.is_set():
+                    self.last_error = str(exc)
+                    logger.warning("OpenAI Realtime receive failed: %s", exc)
+                self.stop()
+                return
+            if raw is None:
+                self.stop()
+                return
+            try:
+                frame = json.loads(raw) if isinstance(raw, (str, bytes, bytearray)) else raw
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(frame, dict):
+                continue
+            ftype = frame.get("type")
+            if ftype == "response.audio.delta":
+                b64 = frame.get("delta") or frame.get("audio") or ""
+                try:
+                    pcm24 = base64.b64decode(b64)
+                except (TypeError, ValueError):
+                    continue
+                pcm48 = realtime_pcm_to_discord(pcm24)
+                if pcm48:
+                    self._enqueue_output(pcm48)
+                    self.output_bytes += len(pcm48)
+                    self.last_output_at = time.time()
+            elif ftype == "input_audio_buffer.speech_started":
+                # Barge-in: stop any queued/spoken model audio as soon as the user speaks.
+                self._clear_output_queue()
+            elif ftype == "error":
+                self.last_error = str(frame.get("error") or frame)
+                logger.warning("OpenAI Realtime error: %s", self.last_error)
+
+    def _enqueue_output(self, pcm: bytes) -> None:
+        try:
+            self._output_q.put_nowait(pcm)
+        except queue.Full:
+            self._clear_output_queue()
+            try:
+                self._output_q.put_nowait(pcm)
+            except queue.Full:
+                pass
+
+    def _clear_output_queue(self) -> None:
+        while True:
+            try:
+                self._output_q.get_nowait()
+            except queue.Empty:
+                break
+
+    def _send_json(self, payload: dict) -> None:
+        if self._ws is None:
+            raise RuntimeError("OpenAI Realtime WebSocket is not connected")
+        with self._send_lock:
+            self._ws.send(json.dumps(payload))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8347,7 +8347,7 @@ class GatewayRunner:
         return None
 
     async def _handle_voice_command(self, event: MessageEvent) -> str:
-        """Handle /voice [on|off|tts|channel|leave|status] command."""
+        """Handle /voice [on|off|tts|channel|realtime|leave|status] command."""
         args = event.get_command_args().strip().lower()
         chat_id = event.source.chat_id
         platform = event.source.platform
@@ -8382,6 +8382,8 @@ class GatewayRunner:
             )
         elif args in ("channel", "join"):
             return await self._handle_voice_channel_join(event)
+        elif args in ("realtime", "rt", "live"):
+            return await self._handle_voice_channel_realtime(event)
         elif args == "leave":
             return await self._handle_voice_channel_leave(event)
         elif args == "status":
@@ -8402,6 +8404,16 @@ class GatewayRunner:
                         f"Voice channel: #{info['channel_name']}",
                         f"Participants: {info['member_count']}",
                     ]
+                    if hasattr(adapter, "get_realtime_voice_status"):
+                        rt = adapter.get_realtime_voice_status(guild_id)
+                        if rt:
+                            lines.append(
+                                "Realtime: "
+                                + ("connected" if rt.get("connected") else "disconnected")
+                                + f" (in={rt.get('input_bytes', 0)}B out={rt.get('output_bytes', 0)}B)"
+                            )
+                            if rt.get("last_error"):
+                                lines.append(f"Realtime error: {rt['last_error']}")
                     for m in info["members"]:
                         status = " (speaking)" if m.get("is_speaking") else ""
                         lines.append(f"  - {m['display_name']}{status}")
@@ -8473,6 +8485,76 @@ class GatewayRunner:
         # Join failed — clear callback
         adapter._voice_input_callback = None
         return "Failed to join voice channel. Check bot permissions (Connect + Speak)."
+
+    async def _handle_voice_channel_realtime(self, event: MessageEvent) -> str:
+        """Join the user's Discord VC and bridge it to OpenAI Realtime."""
+        adapter = self.adapters.get(event.source.platform)
+        if not hasattr(adapter, "start_realtime_voice_bridge"):
+            return "Realtime voice channels are not supported on this platform."
+
+        guild_id = self._get_guild_id(event)
+        if not guild_id:
+            return "This command only works in a Discord server."
+
+        # Ensure the bot is already in the user's channel; this also binds the
+        # text channel and starts the Discord packet receiver.
+        if not hasattr(adapter, "is_in_voice_channel") or not adapter.is_in_voice_channel(guild_id):
+            join_msg = await self._handle_voice_channel_join(event)
+            if "Joined voice channel" not in join_msg:
+                return join_msg
+
+        api_key = (
+            os.getenv("OPENAI_REALTIME_API_KEY")
+            or os.getenv("VOICE_TOOLS_OPENAI_KEY")
+            or os.getenv("OPENAI_API_KEY")
+        )
+        if not api_key:
+            return (
+                "OpenAI Realtime needs an API key. Set OPENAI_REALTIME_API_KEY "
+                "or VOICE_TOOLS_OPENAI_KEY (OPENAI_API_KEY also works), then /restart."
+            )
+
+        model = os.getenv("OPENAI_REALTIME_MODEL", "gpt-realtime-2")
+        voice = os.getenv("OPENAI_REALTIME_VOICE", "alloy")
+        instructions = os.getenv(
+            "OPENAI_REALTIME_INSTRUCTIONS",
+            "You are Hermes speaking in a Discord voice channel. Keep replies short, conversational, and interruptible.",
+        )
+        try:
+            ok = await adapter.start_realtime_voice_bridge(
+                guild_id,
+                api_key=api_key,
+                model=model,
+                voice=voice,
+                instructions=instructions,
+            )
+        except Exception as e:
+            logger.warning("Failed to start OpenAI Realtime voice bridge: %s", e, exc_info=True)
+            # If we had to join the VC for realtime, do not silently leave the
+            # old turn-based /voice channel listener running; that feels like a
+            # slow realtime model when it is actually STT -> agent -> TTS.
+            try:
+                if hasattr(adapter, "leave_voice_channel"):
+                    await adapter.leave_voice_channel(guild_id)
+            except Exception:
+                logger.debug("Failed to clean up voice channel after realtime start failure", exc_info=True)
+            return f"Failed to start OpenAI Realtime voice: {e}"
+
+        if not ok:
+            try:
+                if hasattr(adapter, "leave_voice_channel"):
+                    await adapter.leave_voice_channel(guild_id)
+            except Exception:
+                logger.debug("Failed to clean up voice channel after realtime start failure", exc_info=True)
+            return "Failed to start OpenAI Realtime voice; not falling back to the slower /voice channel path."
+
+        self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
+        self._save_voice_modes()
+        self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
+        return (
+            f"OpenAI Realtime voice is live ({model}, voice={voice}).\n"
+            "Speak in the voice channel; use /voice leave to disconnect."
+        )
 
     async def _handle_voice_channel_leave(self, event: MessageEvent) -> str:
         """Leave the Discord voice channel."""

--- a/tests/gateway/test_discord_realtime_voice.py
+++ b/tests/gateway/test_discord_realtime_voice.py
@@ -1,0 +1,118 @@
+import queue
+
+from gateway.platforms.discord_realtime import (
+    DISCORD_FRAME_BYTES,
+    OpenAIRealtimeDiscordBridge,
+    QueuePCMAudioSource,
+    _make_discord_audio_source,
+    discord_pcm_to_realtime,
+    realtime_pcm_to_discord,
+)
+
+
+def test_discord_pcm_to_realtime_halves_rate_and_mixes_to_mono():
+    # 20 ms of 48 kHz stereo PCM16: 960 frames * 2 channels * 2 bytes.
+    discord_pcm = b"\x00\x00\x01\x00" * 960
+    realtime_pcm = discord_pcm_to_realtime(discord_pcm)
+    # 20 ms of 24 kHz mono PCM16: 480 frames * 1 channel * 2 bytes.
+    assert len(realtime_pcm) == 960
+
+
+def test_realtime_pcm_to_discord_upsamples_and_expands_to_stereo():
+    # 20 ms of 24 kHz mono PCM16: 480 frames * 2 bytes. audioop.ratecv may
+    # produce one frame less for a stateless chunk; QueuePCMAudioSource pads the
+    # final Discord frame boundary.
+    realtime_pcm = b"\x01\x00" * 480
+    discord_pcm = realtime_pcm_to_discord(realtime_pcm)
+    assert DISCORD_FRAME_BYTES - 4 <= len(discord_pcm) <= DISCORD_FRAME_BYTES
+    assert len(discord_pcm) % 4 == 0
+
+
+def test_queue_pcm_audio_source_returns_20ms_frames_and_pads_short_reads():
+    q = queue.Queue()
+    q.put(b"\x01" * 100)
+    source = QueuePCMAudioSource(q)
+    frame = source.read()
+    assert len(frame) == DISCORD_FRAME_BYTES
+    assert frame.startswith(b"\x01" * 100)
+    assert frame[100:] == b"\x00" * (DISCORD_FRAME_BYTES - 100)
+    assert source.is_opus() is False
+
+
+def test_gpt_realtime_2_uses_ga_session_shape():
+    bridge = OpenAIRealtimeDiscordBridge(
+        api_key="test",
+        voice_client=None,
+        model="gpt-realtime-2",
+        voice="alloy",
+        instructions="hi",
+    )
+    payload = bridge._session_update_payload()
+    assert bridge._uses_ga_api() is True
+    assert payload["session"]["type"] == "realtime"
+    assert payload["session"]["model"] == "gpt-realtime-2"
+    assert payload["session"]["audio"]["input"]["format"] == {"type": "audio/pcm", "rate": 24000}
+    assert payload["session"]["audio"]["output"]["format"] == {"type": "audio/pcm", "rate": 24000}
+    assert "modalities" not in payload["session"]
+    assert "input_audio_format" not in payload["session"]
+
+
+def test_legacy_realtime_models_use_beta_session_shape():
+    bridge = OpenAIRealtimeDiscordBridge(
+        api_key="test",
+        voice_client=None,
+        model="gpt-realtime",
+        voice="alloy",
+        instructions="hi",
+    )
+    payload = bridge._session_update_payload()
+    assert bridge._uses_ga_api() is False
+    assert payload["session"]["modalities"] == ["audio", "text"]
+    assert payload["session"]["input_audio_format"] == "pcm16"
+    assert payload["session"]["output_audio_format"] == "pcm16"
+    assert "audio" not in payload["session"]
+
+
+def test_make_discord_audio_source_passes_discord_py_audio_source_check():
+    import discord
+
+    q = queue.Queue()
+    source = _make_discord_audio_source(q)
+
+    audio_source_type = getattr(discord, "AudioSource", None)
+    if isinstance(audio_source_type, type):
+        assert isinstance(source, audio_source_type)
+    assert source.is_opus() is False
+
+
+class _FakeVoiceClient:
+    def __init__(self):
+        self.played_source = None
+        self.stopped = False
+
+    def is_connected(self):
+        return True
+
+    def is_playing(self):
+        return False
+
+    def stop(self):
+        self.stopped = True
+
+    def play(self, source, after=None):
+        import discord
+
+        audio_source_type = getattr(discord, "AudioSource", None)
+        if isinstance(audio_source_type, type):
+            assert isinstance(source, audio_source_type)
+        self.played_source = source
+        self.after = after
+
+
+def test_start_discord_playback_uses_real_discord_audio_source():
+    voice_client = _FakeVoiceClient()
+    bridge = OpenAIRealtimeDiscordBridge(api_key="test", voice_client=voice_client)
+
+    bridge._start_discord_playback()
+
+    assert voice_client.played_source is not None

--- a/tests/gateway/test_discord_realtime_voice.py
+++ b/tests/gateway/test_discord_realtime_voice.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import queue
 
 from gateway.platforms.discord_realtime import (
@@ -132,4 +134,33 @@ def test_enqueue_output_lazily_starts_discord_playback():
 
     bridge._enqueue_output(b"\x01" * DISCORD_FRAME_BYTES)
 
+    assert voice_client.played_source is not None
+
+
+class _FakeRealtimeWebSocket:
+    def __init__(self, frames):
+        self._frames = queue.Queue()
+        for frame in frames:
+            self._frames.put(json.dumps(frame))
+        self.closed = False
+
+    def recv(self, timeout=None):
+        return self._frames.get_nowait()
+
+    def close(self):
+        self.closed = True
+
+
+def test_recv_loop_accepts_ga_output_audio_delta_event_name():
+    voice_client = _FakeVoiceClient()
+    bridge = OpenAIRealtimeDiscordBridge(api_key="test", voice_client=voice_client)
+    bridge._ws = _FakeRealtimeWebSocket([
+        {"type": "response.output_audio.delta", "delta": base64.b64encode(b"\x01\x00" * 480).decode()},
+        {"type": "response.done"},
+    ])
+
+    bridge._recv_loop()
+
+    assert bridge.output_bytes > 0
+    assert bridge.last_output_at is not None
     assert voice_client.played_source is not None

--- a/tests/gateway/test_discord_realtime_voice.py
+++ b/tests/gateway/test_discord_realtime_voice.py
@@ -39,6 +39,12 @@ def test_queue_pcm_audio_source_returns_20ms_frames_and_pads_short_reads():
     assert source.is_opus() is False
 
 
+def test_queue_pcm_audio_source_ends_when_idle_instead_of_speaking_silence():
+    source = QueuePCMAudioSource(queue.Queue())
+
+    assert source.read() == b""
+
+
 def test_gpt_realtime_2_uses_ga_session_shape():
     bridge = OpenAIRealtimeDiscordBridge(
         api_key="test",
@@ -114,5 +120,16 @@ def test_start_discord_playback_uses_real_discord_audio_source():
     bridge = OpenAIRealtimeDiscordBridge(api_key="test", voice_client=voice_client)
 
     bridge._start_discord_playback()
+
+    assert voice_client.played_source is not None
+
+
+def test_enqueue_output_lazily_starts_discord_playback():
+    voice_client = _FakeVoiceClient()
+    bridge = OpenAIRealtimeDiscordBridge(api_key="test", voice_client=voice_client)
+
+    assert voice_client.played_source is None
+
+    bridge._enqueue_output(b"\x01" * DISCORD_FRAME_BYTES)
 
     assert voice_client.played_source is not None


### PR DESCRIPTION
## Summary
- Add a Discord voice-channel to OpenAI Realtime duplex PCM bridge
- Add /voice realtime command and realtime status reporting
- Suppress the old turn-based Whisper/TTS path while realtime mode owns the VC

## Test Plan
- python -m py_compile gateway/platforms/discord.py gateway/platforms/discord_realtime.py gateway/run.py tests/gateway/test_discord_realtime_voice.py
- python -m pytest -q -o addopts='' tests/gateway/test_discord_realtime_voice.py tests/gateway/test_discord_opus.py tests/gateway/test_discord_slash_commands.py