### PR TITLE
fix(clipboard): OSC 52 copy broken under tmux and TUI mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4567,21 +4567,43 @@ class HermesCLI:
             _cprint(f"  {_DIM}(._.) No image found in clipboard{_RST}")
 
     def _write_osc52_clipboard(self, text: str) -> None:
-        """Copy *text* to terminal clipboard via OSC 52."""
+        """Copy *text* to terminal clipboard via OSC 52.
+
+        Writes directly to /dev/tty so the escape sequence reaches the
+        terminal even when stdout/stderr are redirected (e.g. inside the
+        prompt_toolkit TUI).  When running inside tmux ($TMUX is set) the
+        sequence is wrapped in a DCS passthrough so tmux forwards it to the
+        outer terminal instead of consuming it.
+        """
+        import os as _os
         payload = base64.b64encode(text.encode("utf-8")).decode("ascii")
-        seq = f"\x1b]52;c;{payload}\x07"
-        out = getattr(self, "_app", None)
-        output = getattr(out, "output", None) if out else None
-        if output and hasattr(output, "write_raw"):
-            output.write_raw(seq)
-            output.flush()
-            return
-        if output and hasattr(output, "write"):
-            output.write(seq)
-            output.flush()
-            return
-        sys.stdout.write(seq)
-        sys.stdout.flush()
+        # OSC 52 with BEL (\x07) terminator — standard, works in all terminals.
+        # Must use BEL, not ESC \ , because inside tmux DCS passthrough the
+        # ESC in ESC \ would get doubled, breaking the DCS framing.
+        osc52 = f"\x1b]52;c;{payload}\x07"
+        if _os.environ.get("TMUX"):
+            # Wrap in tmux DCS passthrough: ESC P tmux; <doubled-esc seq> ESC \
+            # Every ESC in the inner OSC sequence must be doubled so tmux
+            # passes it through instead of interpreting it itself.
+            inner = osc52.replace("\x1b", "\x1b\x1b")
+            seq = f"\x1bPtmux;{inner}\x1b\\"
+        else:
+            seq = osc52
+        # Always write to /dev/tty — the real terminal device — so the
+        # sequence is not lost to stdout/stderr redirection in TUI mode.
+        try:
+            with open("/dev/tty", "wb") as tty:
+                tty.write(seq.encode("ascii"))
+        except OSError:
+            # Fallback: try prompt_toolkit output, then raw stdout
+            out = getattr(self, "_app", None)
+            output = getattr(out, "output", None) if out else None
+            if output and hasattr(output, "write_raw"):
+                output.write_raw(seq)
+                output.flush()
+                return
+            sys.stdout.write(seq)
+            sys.stdout.flush()
 
     def _recover_terminal_input_modes(self, *, reason: str) -> None:
         """Best-effort reset when leaked mouse reports indicate mode drift."""

--- a/ui-tui/src/lib/osc52.ts
+++ b/ui-tui/src/lib/osc52.ts
@@ -1,3 +1,5 @@
+import { openSync, writeSync, closeSync } from 'node:fs'
+
 const ESC = '\x1b'
 const BEL = '\x07'
 const ST = `${ESC}\\`
@@ -69,5 +71,16 @@ export async function readOsc52Clipboard(querier: null | OscQuerier, timeoutMs =
   return response ? parseOsc52ClipboardData(response.data) : null
 }
 
-export const writeOsc52Clipboard = (s: string) =>
-  process.stdout.write(`\x1b]52;c;${Buffer.from(s, 'utf8').toString('base64')}\x07`)
+export const writeOsc52Clipboard = (s: string) => {
+  const seq = `\x1b]52;c;${Buffer.from(s, 'utf8').toString('base64')}\x07`
+  const wrapped = wrapForMultiplexer(seq)
+  // Write to /dev/tty when available so the sequence reaches the real
+  // terminal device even when stdout is redirected (e.g. inside a pty).
+  try {
+    const fd = openSync('/dev/tty', 'w')
+    writeSync(fd, wrapped)
+    closeSync(fd)
+  } catch {
+    process.stdout.write(wrapped)
+  }
+}


### PR DESCRIPTION
The /copy command writes text to the system clipboard via OSC 52 escape sequences.  It had two independent code paths — Python (CLI) and TypeScript (TUI) — and both were broken in similar ways when running inside tmux or when stdout was redirected (TUI mode).

Root causes
-----------
1. Neither path detected $TMUX and wrapped the OSC 52 sequence in DCS passthrough (ESC P tmux; … ESC \).  tmux consumes bare OSC 52 sequences even with allow-passthrough on — they must be wrapped.

2. Both paths wrote to stdout / process.stdout, which is redirected by prompt_toolkit (CLI) and the TUI rendering pipeline.  The escape sequence never reached the real terminal device.

3. The TUI had a correct wrapForMultiplexer() function for OSC 52 clipboard *reads* but it was never wired up for writes.

4. This bug was invisible in local development because writeClipboardText() (pbcopy/xclip) succeeds on a local machine and the OSC 52 fallback is never exercised.  It only manifests over SSH where native clipboard tools are unavailable.

Fixes
-----
cli.py (_write_osc52_clipboard):
  - Detect $TMUX, wrap in DCS passthrough when set
  - Write to /dev/tty (fallback: prompt_toolkit → stdout)
  - Keep BEL (\x07) terminator — ESC \ doubles inside DCS

ui-tui/src/lib/osc52.ts (writeOsc52Clipboard):
  - Call existing wrapForMultiplexer() for the write path
  - Write to /dev/tty (fallback: process.stdout)

Both produce the identical byte sequence as the known-working printf invocation:
  ESC P tmux ; ESC ESC ] 5 2 ; c ; base64 BEL ESC \

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

