### PR TITLE
feat(web): add TinyFish web backend

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -547,8 +547,8 @@ DEFAULT_CONFIG = {
 
     "web": {
         "backend": "",           # shared fallback — applies to both search and extract
-        "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
-        "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
+        "search_backend": "",    # per-capability override for web_search (e.g. "searxng", "tinyfish")
+        "extract_backend": "",   # per-capability override for web_extract (e.g. "tinyfish")
     },
 
     "browser": {

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -285,6 +285,7 @@ def get_nous_subscription_features(
     direct_parallel = bool(get_env_value("PARALLEL_API_KEY"))
     direct_tavily = bool(get_env_value("TAVILY_API_KEY"))
     direct_searxng = bool(get_env_value("SEARXNG_URL"))
+    direct_tinyfish = bool(get_env_value("TINYFISH_API_KEY"))
     direct_fal = fal_key_is_configured()
     direct_openai_tts = bool(resolve_openai_audio_api_key())
     direct_elevenlabs = bool(get_env_value("ELEVENLABS_API_KEY"))
@@ -329,6 +330,7 @@ def get_nous_subscription_features(
             or (web_backend == "parallel" and direct_parallel)
             or (web_backend == "tavily" and direct_tavily)
             or (web_backend == "searxng" and direct_searxng)
+            or (web_backend == "tinyfish" and direct_tinyfish)
             # Per-capability overrides: search_backend or extract_backend may be set
             # without web.backend (using the new split config from #20061)
             or (web_search_backend == "searxng" and direct_searxng)
@@ -336,10 +338,22 @@ def get_nous_subscription_features(
             or (web_search_backend == "firecrawl" and direct_firecrawl)
             or (web_search_backend == "parallel" and direct_parallel)
             or (web_search_backend == "tavily" and direct_tavily)
+            or (web_search_backend == "tinyfish" and direct_tinyfish)
+            or (web_extract_backend == "exa" and direct_exa)
+            or (web_extract_backend == "firecrawl" and direct_firecrawl)
+            or (web_extract_backend == "parallel" and direct_parallel)
+            or (web_extract_backend == "tavily" and direct_tavily)
+            or (web_extract_backend == "tinyfish" and direct_tinyfish)
         )
     )
     web_available = bool(
-        managed_web_available or direct_exa or direct_firecrawl or direct_parallel or direct_tavily or direct_searxng
+        managed_web_available
+        or direct_exa
+        or direct_firecrawl
+        or direct_parallel
+        or direct_tavily
+        or direct_tinyfish
+        or direct_searxng
     )
 
     image_managed = image_tool_enabled and managed_image_available and not direct_fal

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -309,6 +309,15 @@ TOOL_CATEGORIES = {
                 ],
             },
             {
+                "name": "TinyFish",
+                "badge": "free · search + fetch",
+                "tag": "Free web search and page fetch APIs — crawl not included",
+                "web_backend": "tinyfish",
+                "env_vars": [
+                    {"key": "TINYFISH_API_KEY", "prompt": "TinyFish API key", "url": "https://agent.tinyfish.ai/api-keys"},
+                ],
+            },
+            {
                 "name": "Brave Search (Free Tier)",
                 "badge": "free tier · search only",
                 "tag": "2,000 queries/mo free — search only (pair with any extract provider)",

--- a/tests/tools/test_web_providers_tinyfish.py
+++ b/tests/tools/test_web_providers_tinyfish.py
@@ -1,0 +1,190 @@
+"""Tests for the TinyFish Search + Fetch web provider."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
+
+class TestTinyFishProvider:
+    def test_configured_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key")
+        from tools.web_providers.tinyfish import TinyFishProvider
+
+        assert TinyFishProvider().is_configured() is True
+        assert TinyFishProvider().provider_name() == "tinyfish"
+
+    def test_not_configured_when_key_missing(self, monkeypatch):
+        monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+        from tools.web_providers.tinyfish import TinyFishProvider
+
+        assert TinyFishProvider().is_configured() is False
+
+    def test_implements_search_and_extract_interfaces(self):
+        from tools.web_providers.base import WebExtractProvider, WebSearchProvider
+        from tools.web_providers.tinyfish import TinyFishProvider
+
+        assert issubclass(TinyFishProvider, WebSearchProvider)
+        assert issubclass(TinyFishProvider, WebExtractProvider)
+
+
+class TestTinyFishSearch:
+    @staticmethod
+    def _mock_resp(json_data):
+        response = MagicMock()
+        response.json.return_value = json_data
+        response.raise_for_status = MagicMock()
+        return response
+
+    def test_search_normalizes_results_and_headers(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key")
+        monkeypatch.setenv("TINYFISH_SEARCH_LOCATION", "GB")
+        monkeypatch.setenv("TINYFISH_SEARCH_LANGUAGE", "en")
+        from tools.web_providers.tinyfish import TinyFishProvider
+
+        captured = {}
+
+        def fake_get(url, **kwargs):
+            captured.update({"url": url, **kwargs})
+            return self._mock_resp({
+                "results": [
+                    {"position": 1, "site_name": "example.com", "title": "A", "snippet": "Desc", "url": "https://example.com/a"},
+                    {"position": 2, "title": "B", "snippet": "Desc B", "url": "https://example.com/b"},
+                ],
+                "total_results": 2,
+            })
+
+        with patch("httpx.get", side_effect=fake_get):
+            result = TinyFishProvider().search("agent research", limit=1)
+
+        assert captured["url"] == "https://api.search.tinyfish.ai"
+        assert captured["headers"]["X-API-Key"] == "tf-key"
+        assert captured["params"] == {"query": "agent research", "location": "GB", "language": "en"}
+        assert result == {
+            "success": True,
+            "data": {"web": [{"title": "A", "url": "https://example.com/a", "description": "Desc", "position": 1, "site_name": "example.com"}]},
+        }
+
+    def test_search_http_error_returns_failure(self, monkeypatch):
+        import httpx
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key")
+        from tools.web_providers.tinyfish import TinyFishProvider
+
+        bad = MagicMock(status_code=429)
+        err = httpx.HTTPStatusError("429", request=MagicMock(), response=bad)
+        with patch("httpx.get", side_effect=err):
+            result = TinyFishProvider().search("q")
+
+        assert result["success"] is False
+        assert "429" in result["error"]
+
+
+class TestTinyFishFetch:
+    @staticmethod
+    def _mock_resp(json_data):
+        response = MagicMock()
+        response.json.return_value = json_data
+        response.raise_for_status = MagicMock()
+        return response
+
+    def test_extract_normalizes_results_errors_and_headers(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key")
+        from tools.web_providers.tinyfish import TinyFishProvider
+
+        captured = {}
+
+        def fake_post(url, **kwargs):
+            captured.update({"url": url, **kwargs})
+            return self._mock_resp({
+                "results": [{
+                    "url": "https://example.com",
+                    "final_url": "https://example.com/",
+                    "title": "Example",
+                    "description": "Demo",
+                    "language": "en",
+                    "text": "# Example\nContent",
+                    "format": "markdown",
+                    "latency_ms": 123,
+                }],
+                "errors": [{"url": "https://bad.invalid", "error": "fetch_error"}],
+            })
+
+        with patch("httpx.post", side_effect=fake_post):
+            result = TinyFishProvider().extract(["https://example.com", "https://bad.invalid"], format="markdown")
+
+        assert captured["url"] == "https://api.fetch.tinyfish.ai"
+        assert captured["headers"]["X-API-Key"] == "tf-key"
+        assert captured["json"] == {"urls": ["https://example.com", "https://bad.invalid"], "format": "markdown"}
+        assert result["success"] is True
+        assert result["data"][0]["url"] == "https://example.com/"
+        assert result["data"][0]["content"] == "# Example\nContent"
+        assert result["data"][0]["metadata"]["description"] == "Demo"
+        assert result["data"][1]["error"] == "fetch_error"
+
+    def test_extract_converts_json_text_to_string(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key")
+        from tools.web_providers.tinyfish import TinyFishProvider
+
+        with patch("httpx.post", return_value=self._mock_resp({
+            "results": [{"url": "https://example.com", "text": {"type": "document"}}],
+            "errors": [],
+        })):
+            result = TinyFishProvider().extract(["https://example.com"], format="json")
+
+        assert json.loads(result["data"][0]["content"]) == {"type": "document"}
+
+
+class TestTinyFishBackendWiring:
+    def test_backend_available_and_auto_detect(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+        monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+        for key in (
+            "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL", "PARALLEL_API_KEY",
+            "TAVILY_API_KEY", "EXA_API_KEY", "SEARXNG_URL", "BRAVE_SEARCH_API_KEY",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key")
+
+        assert web_tools._is_backend_available("tinyfish") is True
+        assert web_tools._get_backend() == "tinyfish"
+        assert web_tools.check_web_api_key() is True
+
+    def test_web_search_dispatches_to_tinyfish(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_get_search_backend", lambda: "tinyfish")
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+        with patch("tools.web_providers.tinyfish.TinyFishProvider.search", return_value={"success": True, "data": {"web": []}}) as mock_search:
+            result = json.loads(web_tools.web_search_tool("docs", limit=3))
+
+        assert result == {"success": True, "data": {"web": []}}
+        mock_search.assert_called_once_with("docs", 3)
+
+    def test_web_extract_dispatches_to_tinyfish(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: "tinyfish")
+        monkeypatch.setattr(web_tools, "check_auxiliary_model", lambda: False)
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+        with patch("tools.web_providers.tinyfish.TinyFishProvider.extract", return_value={
+            "success": True,
+            "data": [{"url": "https://example.com", "title": "Example", "content": "Text", "raw_content": "Text", "metadata": {}}],
+        }) as mock_extract:
+            result = json.loads(asyncio.get_event_loop().run_until_complete(web_tools.web_extract_tool(["https://example.com"])))
+
+        assert result["results"][0]["content"] == "Text"
+        mock_extract.assert_called_once_with(["https://example.com"], format="markdown")
+
+    def test_web_crawl_returns_tinyfish_no_crawl_error(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_get_backend", lambda: "tinyfish")
+        result = json.loads(asyncio.get_event_loop().run_until_complete(web_tools.web_crawl_tool("https://example.com")))
+
+        assert result["success"] is False
+        assert "tinyfish" in result["error"].lower()
+        assert "crawl" in result["error"].lower()

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -252,6 +252,7 @@ class TestBackendSelection:
     _ENV_KEYS = (
         "EXA_API_KEY",
         "PARALLEL_API_KEY",
+        "TINYFISH_API_KEY",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
         "FIRECRAWL_GATEWAY_URL",
@@ -305,6 +306,12 @@ class TestBackendSelection:
         with patch("tools.web_tools._load_web_config", return_value={"backend": "tavily"}):
             assert _get_backend() == "tavily"
 
+    def test_config_tinyfish(self):
+        """web.backend=tinyfish in config → 'tinyfish' regardless of other keys."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "tinyfish"}):
+            assert _get_backend() == "tinyfish"
+
     def test_config_tavily_overrides_env_keys(self):
         """web.backend=tavily in config → 'tavily' even if Firecrawl key set."""
         from tools.web_tools import _get_backend
@@ -353,6 +360,15 @@ class TestBackendSelection:
         with patch("tools.web_tools._load_web_config", return_value={}), \
              patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}):
             assert _get_backend() == "tavily"
+
+    def test_fallback_tinyfish_only_key(self):
+        """Only TINYFISH_API_KEY set → 'tinyfish'."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._is_tool_gateway_ready", return_value=False), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=False), \
+             patch.dict(os.environ, {"TINYFISH_API_KEY": "tf-test"}):
+            assert _get_backend() == "tinyfish"
 
     def test_fallback_tavily_with_firecrawl_prefers_firecrawl(self):
         """Tavily + Firecrawl keys, no config → 'firecrawl' (backward compat)."""
@@ -530,6 +546,7 @@ class TestCheckWebApiKey:
     _ENV_KEYS = (
         "EXA_API_KEY",
         "PARALLEL_API_KEY",
+        "TINYFISH_API_KEY",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
         "FIRECRAWL_GATEWAY_URL",
@@ -580,6 +597,11 @@ class TestCheckWebApiKey:
             from tools.web_tools import check_web_api_key
             assert check_web_api_key() is True
 
+    def test_tinyfish_key_only(self):
+        with patch.dict(os.environ, {"TINYFISH_API_KEY": "tf-test"}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is True
+
     def test_no_keys_returns_false(self):
         from tools.web_tools import check_web_api_key
         assert check_web_api_key() is False
@@ -625,3 +647,4 @@ def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 
     assert "EXA_API_KEY" in _web_requires_env()
+    assert "TINYFISH_API_KEY" in _web_requires_env()

--- a/tools/web_providers/tinyfish.py
+++ b/tools/web_providers/tinyfish.py
@@ -1,0 +1,175 @@
+"""TinyFish Search and Fetch web provider.
+
+TinyFish Search and Fetch are free on every plan (at time of writing) and use a
+single ``TINYFISH_API_KEY``. Search returns ranked web results; Fetch renders
+URLs with a real browser and returns clean extracted text.
+
+Configuration::
+
+    # ~/.hermes/.env
+    TINYFISH_API_KEY=your-key
+
+    # ~/.hermes/config.yaml
+    web:
+      backend: "tinyfish"
+
+TinyFish does not provide a crawl API through this provider; use Firecrawl or
+Tavily for ``web_crawl``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, List
+
+import httpx
+
+from tools.web_providers.base import WebExtractProvider, WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_TINYFISH_SEARCH_ENDPOINT = "https://api.search.tinyfish.ai"
+_TINYFISH_FETCH_ENDPOINT = "https://api.fetch.tinyfish.ai"
+
+
+class TinyFishProvider(WebSearchProvider, WebExtractProvider):
+    """Search and fetch via TinyFish's REST APIs."""
+
+    def provider_name(self) -> str:
+        return "tinyfish"
+
+    def is_configured(self) -> bool:
+        return bool(os.getenv("TINYFISH_API_KEY", "").strip())
+
+    def _headers(self) -> Dict[str, str]:
+        api_key = os.getenv("TINYFISH_API_KEY", "").strip()
+        if not api_key:
+            raise ValueError("TINYFISH_API_KEY is not set")
+        return {
+            "X-API-Key": api_key,
+            "Accept": "application/json",
+        }
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute a TinyFish Search request and return normalized results."""
+        try:
+            limit = max(1, min(int(limit), 100))
+        except (TypeError, ValueError):
+            limit = 5
+
+        params: Dict[str, Any] = {"query": query}
+        location = os.getenv("TINYFISH_SEARCH_LOCATION", "").strip()
+        language = os.getenv("TINYFISH_SEARCH_LANGUAGE", "").strip()
+        if location:
+            params["location"] = location
+        if language:
+            params["language"] = language
+
+        try:
+            resp = httpx.get(
+                _TINYFISH_SEARCH_ENDPOINT,
+                params=params,
+                headers=self._headers(),
+                timeout=20,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("TinyFish Search HTTP error: %s", exc)
+            return {
+                "success": False,
+                "error": f"TinyFish Search returned HTTP {exc.response.status_code}",
+            }
+        except (httpx.RequestError, ValueError) as exc:
+            logger.warning("TinyFish Search request/parse error: %s", exc)
+            return {"success": False, "error": f"TinyFish Search failed: {exc}"}
+
+        raw_results = data.get("results", []) or []
+        web_results = []
+        for i, result in enumerate(raw_results[:limit]):
+            web_results.append({
+                "title": str(result.get("title", "") or ""),
+                "url": str(result.get("url", "") or ""),
+                "description": str(result.get("snippet", "") or ""),
+                "position": int(result.get("position") or i + 1),
+                **({"site_name": result.get("site_name")} if result.get("site_name") else {}),
+            })
+
+        logger.info("TinyFish Search '%s': %d results", query, len(web_results))
+        return {"success": True, "data": {"web": web_results}}
+
+    def extract(self, urls: List[str], **kwargs) -> Dict[str, Any]:
+        """Fetch URL content with TinyFish Fetch and return normalized results."""
+        fmt = kwargs.get("format") or "markdown"
+        if fmt not in ("markdown", "html", "json"):
+            fmt = "markdown"
+
+        payload: Dict[str, Any] = {
+            "urls": urls[:10],
+            "format": fmt,
+        }
+        if kwargs.get("links") is not None:
+            payload["links"] = bool(kwargs["links"])
+        if kwargs.get("image_links") is not None:
+            payload["image_links"] = bool(kwargs["image_links"])
+
+        headers = self._headers()
+        headers["Content-Type"] = "application/json"
+
+        try:
+            resp = httpx.post(
+                _TINYFISH_FETCH_ENDPOINT,
+                json=payload,
+                headers=headers,
+                timeout=75,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("TinyFish Fetch HTTP error: %s", exc)
+            return {
+                "success": False,
+                "error": f"TinyFish Fetch returned HTTP {exc.response.status_code}",
+            }
+        except (httpx.RequestError, ValueError) as exc:
+            logger.warning("TinyFish Fetch request/parse error: %s", exc)
+            return {"success": False, "error": f"TinyFish Fetch failed: {exc}"}
+
+        results = []
+        for page in data.get("results", []) or []:
+            text = page.get("text", "")
+            if not isinstance(text, str):
+                text = json.dumps(text, ensure_ascii=False)
+            final_url = page.get("final_url") or page.get("url") or ""
+            results.append({
+                "url": final_url,
+                "title": page.get("title") or "",
+                "content": text,
+                "raw_content": text,
+                "metadata": {
+                    "sourceURL": final_url,
+                    "requestedURL": page.get("url") or "",
+                    "title": page.get("title") or "",
+                    "description": page.get("description") or "",
+                    "language": page.get("language") or "",
+                    "author": page.get("author") or "",
+                    "published_date": page.get("published_date") or "",
+                    "format": page.get("format") or fmt,
+                    "latency_ms": page.get("latency_ms"),
+                },
+            })
+
+        for error in data.get("errors", []) or []:
+            results.append({
+                "url": error.get("url", ""),
+                "title": "",
+                "content": "",
+                "raw_content": "",
+                "error": error.get("error") or "fetch_error",
+                "metadata": {"sourceURL": error.get("url", "")},
+            })
+
+        logger.info("TinyFish Fetch: %d result(s), %d error(s)", len(data.get("results", []) or []), len(data.get("errors", []) or []))
+        return {"success": True, "data": results}

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -126,7 +126,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "tinyfish"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -139,6 +139,7 @@ def _get_backend() -> str:
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
+        ("tinyfish", _has_env("TINYFISH_API_KEY")),
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
@@ -200,6 +201,8 @@ def _is_backend_available(backend: str) -> bool:
         return _has_env("TAVILY_API_KEY")
     if backend == "searxng":
         return _has_env("SEARXNG_URL")
+    if backend == "tinyfish":
+        return _has_env("TINYFISH_API_KEY")
     if backend == "brave-free":
         return _has_env("BRAVE_SEARCH_API_KEY")
     if backend == "ddgs":
@@ -288,6 +291,7 @@ def _web_requires_env() -> list[str]:
     requires = [
         "EXA_API_KEY",
         "PARALLEL_API_KEY",
+        "TINYFISH_API_KEY",
         "TAVILY_API_KEY",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
@@ -1213,6 +1217,16 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             _debug.save()
             return result_json
 
+        if backend == "tinyfish":
+            from tools.web_providers.tinyfish import TinyFishProvider
+            response_data = TinyFishProvider().search(query, limit)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
         if backend == "searxng":
             from tools.web_providers.searxng import SearXNGSearchProvider
             response_data = SearXNGSearchProvider().search(query, limit)
@@ -1386,6 +1400,12 @@ async def web_extract_tool(
                 results = await _parallel_extract(safe_urls)
             elif backend == "exa":
                 results = _exa_extract(safe_urls)
+            elif backend == "tinyfish":
+                from tools.web_providers.tinyfish import TinyFishProvider
+                raw = TinyFishProvider().extract(safe_urls, format=format or "markdown")
+                if not raw.get("success"):
+                    return json.dumps({"success": False, "error": raw.get("error", "TinyFish Fetch failed")}, ensure_ascii=False)
+                results = raw.get("data", [])
             elif backend == "tavily":
                 logger.info("Tavily extract: %d URL(s)", len(safe_urls))
                 raw = _tavily_request("extract", {
@@ -1395,7 +1415,7 @@ async def web_extract_tool(
                 results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
             elif backend in ("searxng", "brave-free", "ddgs"):
                 # These backends are search-only — they cannot extract URL content
-                _label = {"searxng": "SearXNG", "brave-free": "Brave Search (free tier)", "ddgs": "DuckDuckGo (ddgs)"}[backend]
+                _label = {"searxng": "SearXNG", "brave-free": "Brave Search (free tier)", "ddgs": "DuckDuckGo (ddgs)", "tinyfish": "TinyFish"}[backend]
                 return json.dumps({
                     "success": False,
                     "error": f"{_label} is a search-only backend and cannot extract URL content. "
@@ -1776,12 +1796,15 @@ async def web_crawl_tool(
             _debug.save()
             return cleaned_result
 
-        # SearXNG / Brave Search (free tier) / DuckDuckGo (ddgs) are search-only — they cannot crawl
-        if backend in ("searxng", "brave-free", "ddgs"):
-            _label = {"searxng": "SearXNG", "brave-free": "Brave Search (free tier)", "ddgs": "DuckDuckGo (ddgs)"}[backend]
+        # SearXNG / Brave Search (free tier) / DuckDuckGo (ddgs) are search-only; TinyFish supports fetch but not crawl.
+        if backend in ("searxng", "brave-free", "ddgs", "tinyfish"):
+            _label = {"searxng": "SearXNG", "brave-free": "Brave Search (free tier)", "ddgs": "DuckDuckGo (ddgs)", "tinyfish": "TinyFish"}[backend]
+            if backend == "tinyfish":
+                error = "TinyFish supports web_search and web_extract but cannot crawl URLs. Set FIRECRAWL_API_KEY for crawling, or use web_search + web_extract instead."
+            else:
+                error = f"{_label} is a search-only backend and cannot crawl URLs. Set FIRECRAWL_API_KEY for crawling, or use web_search instead."
             return json.dumps({
-                "error": f"{_label} is a search-only backend and cannot crawl URLs. "
-                         "Set FIRECRAWL_API_KEY for crawling, or use web_search instead.",
+                "error": error,
                 "success": False,
             }, ensure_ascii=False)
 
@@ -2080,11 +2103,11 @@ def check_firecrawl_api_key() -> bool:
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"):
+    if configured in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "tinyfish"):
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
+        for backend in ("exa", "parallel", "firecrawl", "tavily", "tinyfish", "searxng", "brave-free", "ddgs")
     )
 
 
@@ -2120,6 +2143,8 @@ if __name__ == "__main__":
             print("   Using Parallel API (https://parallel.ai)")
         elif backend == "tavily":
             print("   Using Tavily API (https://tavily.com)")
+        elif backend == "tinyfish":
+            print("   Using TinyFish Search + Fetch (free APIs)")
         elif backend == "searxng":
             print(f"   Using SearXNG (search only): {os.getenv('SEARXNG_URL', '').strip()}")
         elif backend == "brave-free":
@@ -2138,7 +2163,7 @@ if __name__ == "__main__":
     else:
         print("❌ No web search backend configured")
         print(
-            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
+            "Set EXA_API_KEY, PARALLEL_API_KEY, TINYFISH_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
             f"{_firecrawl_backend_help_suffix()}"
         )
 


### PR DESCRIPTION
## Summary
- Add TinyFish as a Hermes web backend for `web_search` and `web_extract`
- Wire `TINYFISH_API_KEY` into tool setup/status/config availability
- Add unit coverage for TinyFish Search/Fetch normalization and backend dispatch

## Test Plan
- `python3 -m py_compile tools/web_tools.py tools/web_providers/tinyfish.py hermes_cli/tools_config.py hermes_cli/nous_subscription.py hermes_cli/config.py tests/tools/test_web_providers_tinyfish.py tests/tools/test_web_tools_config.py`
- `/home/claw/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_web_providers_tinyfish.py tests/tools/test_web_tools_config.py tests/tools/test_web_providers.py tests/tools/test_web_providers_brave_free.py -o 'addopts=' -q`
- Live smoke: TinyFish search returned 2 results for `Hermes Agent NousResearch`; TinyFish fetch extracted `https://www.tinyfish.ai/` (7,409 chars)
