### PR TITLE
fix(memory): accept old_string as old_text alias

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -1,8 +1,10 @@
 """Tests for tools/memory_tool.py — MemoryStore, security scanning, and tool dispatcher."""
 
 import json
-import pytest
 from pathlib import Path
+from typing import Any, cast
+
+import pytest
 
 from tools.memory_tool import (
     MemoryStore,
@@ -11,6 +13,7 @@ from tools.memory_tool import (
     ENTRY_DELIMITER,
     MEMORY_SCHEMA,
 )
+from tools.registry import registry
 
 
 # =========================================================================
@@ -255,3 +258,61 @@ class TestMemoryToolDispatcher:
     def test_remove_requires_old_text(self, store):
         result = json.loads(memory_tool(action="remove", store=store))
         assert result["success"] is False
+
+    def test_replace_accepts_old_string_alias(self, store):
+        store.add("memory", "old stable fact")
+
+        result = json.loads(
+            memory_tool(
+                action="replace",
+                target="memory",
+                old_string="old stable",
+                content="new stable fact",
+                store=store,
+            )
+        )
+
+        assert result["success"] is True
+        assert result["entries"] == ["new stable fact"]
+
+    def test_remove_accepts_old_string_alias(self, store):
+        store.add("memory", "temporary stable fact")
+
+        result = json.loads(
+            memory_tool(
+                action="remove",
+                target="memory",
+                old_string="temporary stable",
+                store=store,
+            )
+        )
+
+        assert result["success"] is True
+        assert result["entries"] == []
+
+    def test_schema_documents_old_string_alias(self):
+        parameters = cast(dict[str, Any], MEMORY_SCHEMA["parameters"])
+        props = cast(dict[str, dict[str, str]], parameters["properties"])
+
+        assert "old_text" in props
+        assert "old_string" in props
+        assert "alias" in props["old_string"]["description"].lower()
+
+    def test_registered_handler_accepts_old_string_alias(self, store):
+        store.add("memory", "handler old fact")
+        handler = registry._tools["memory"].handler
+
+        result = json.loads(
+            handler(
+                {
+                    "action": "replace",
+                    "target": "memory",
+                    "old_string": "handler old",
+                    "content": "handler new fact",
+                },
+                store=store,
+            )
+        )
+
+        assert result["success"] is True
+        assert result["entries"] == ["handler new fact"]

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -467,6 +467,7 @@ def memory_tool(
     target: str = "memory",
     content: str = None,
     old_text: str = None,
+    old_string: Optional[str] = None,
     store: Optional[MemoryStore] = None,
 ) -> str:
     """
@@ -480,22 +481,24 @@ def memory_tool(
     if target not in ("memory", "user"):
         return tool_error(f"Invalid target '{target}'. Use 'memory' or 'user'.", success=False)
 
+    match_text = old_text if old_text is not None else old_string
+
     if action == "add":
         if not content:
             return tool_error("Content is required for 'add' action.", success=False)
         result = store.add(target, content)
 
     elif action == "replace":
-        if not old_text:
+        if not match_text:
             return tool_error("old_text is required for 'replace' action.", success=False)
         if not content:
             return tool_error("content is required for 'replace' action.", success=False)
-        result = store.replace(target, old_text, content)
+        result = store.replace(target, match_text, content)
 
     elif action == "remove":
-        if not old_text:
+        if not match_text:
             return tool_error("old_text is required for 'remove' action.", success=False)
-        result = store.remove(target, old_text)
+        result = store.remove(target, match_text)
 
     else:
         return tool_error(f"Unknown action '{action}'. Use: add, replace, remove", success=False)
@@ -534,7 +537,8 @@ MEMORY_SCHEMA = {
         "- 'user': who the user is -- name, role, preferences, communication style, pet peeves\n"
         "- 'memory': your notes -- environment facts, project conventions, tool quirks, lessons learned\n\n"
         "ACTIONS: add (new entry), replace (update existing -- old_text identifies it), "
-        "remove (delete -- old_text identifies it).\n\n"
+        "remove (delete -- old_text identifies it). `old_string` is also accepted as "
+        "a backward-compatible alias for old_text, matching patch/skill_manage.\n\n"
         "SKIP: trivial/obvious info, things easily re-discovered, raw data dumps, and temporary task state."
     ),
     "parameters": {
@@ -558,6 +562,10 @@ MEMORY_SCHEMA = {
                 "type": "string",
                 "description": "Short unique substring identifying the entry to replace or remove."
             },
+            "old_string": {
+                "type": "string",
+                "description": "Alias for old_text. Accepted for consistency with patch and skill_manage."
+            },
         },
         "required": ["action", "target"],
     },
@@ -576,6 +584,7 @@ registry.register(
         target=args.get("target", "memory"),
         content=args.get("content"),
         old_text=args.get("old_text"),
+        old_string=args.get("old_string"),
         store=kw.get("store")),
     check_fn=check_memory_requirements,
     emoji="🧠",


### PR DESCRIPTION
## Summary
- Accept `old_string` as a backward-compatible alias for the memory tool's `old_text` parameter
- Keep `old_text` as the canonical parameter and preserve existing behavior/errors
- Document the alias in the tool schema and cover direct + registered handler paths

## Root cause
The memory tool used `old_text` for replace/remove while related editing tools (`patch`, `skill_manage`) use `old_string`. Models can generalize the surrounding tool schema pattern and call `memory` with `old_string`, causing avoidable tool-call failures.

## Related reconnaissance
- Fixes #20735
- Checked open PRs. #15859 adds action / `new_text` aliases, but does not cover `old_string` for the match parameter. This PR is intentionally narrower and compatible with that direction.

## Test plan
- `python -m py_compile tools/memory_tool.py`
- `python -m pytest tests/tools/test_memory_tool.py tests/tools/test_memory_tool_import_fallback.py -q -o addopts=`
- `git diff --check`
- Static scan of added lines: 0 findings
