### PR TITLE
refactor(tui): deduplicate branding section lists

### DIFF
--- a/tests/test_issue20670_tui_branding_dedupe.py
+++ b/tests/test_issue20670_tui_branding_dedupe.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BRANDING = ROOT / "ui-tui" / "src" / "components" / "branding.tsx"
+SOURCE = BRANDING.read_text(encoding="utf-8")
+
+
+def test_branding_uses_shared_section_list_body_helper():
+    assert "const sectionListBody =" in SOURCE
+    assert "skillsBody" not in SOURCE
+    assert "toolsBody" not in SOURCE
+
+
+def test_branding_keeps_distinct_overflow_labels():
+    assert "'categories'" in SOURCE
+    assert "'toolsets'" in SOURCE
+    assert "overflowLabel" in SOURCE
+
+
+def test_branding_has_single_category_row_renderer():
+    assert SOURCE.count("shown.map(([k, vs])") == 1

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -1,5 +1,5 @@
 import { Box, Text, useStdout } from '@hermes/ink'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import unicodeSpinners from 'unicode-animations'
 
 import { artWidth, caduceus, CADUCEUS_WIDTH, logo, LOGO_WIDTH } from '../banner.js'
@@ -129,56 +129,42 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
     return line
   }
 
+  const sectionListBody = (
+    entries: [string, string[]][],
+    maxItems: number,
+    overflowLabel: string,
+    emptyFallback?: ReactNode
+  ) => {
+    if (emptyFallback && entries.length === 0) {
+      return emptyFallback
+    }
+
+    const shown = entries.slice(0, maxItems)
+    const overflow = entries.length - maxItems
+
+    return (
+      <>
+        {shown.map(([k, vs]) => (
+          <Text key={k} wrap="truncate">
+            <Text color={t.color.muted}>{strip(k)}: </Text>
+            <Text color={t.color.text}>{truncLine(strip(k) + ': ', vs)}</Text>
+          </Text>
+        ))}
+        {overflow > 0 && (
+          <Text color={t.color.muted}>(and {overflow} more {overflowLabel}…)</Text>
+        )}
+      </>
+    )
+  }
+
   // ── Collapsible skills section ──
   const skillEntries = Object.entries(info.skills).sort()
   const skillsTotal = flat(info.skills).length
   const skillsCatCount = skillEntries.length
 
-  const skillsBody = () => {
-    if (info.lazy && skillEntries.length === 0) {
-      return <InlineLoader label="scanning skills" t={t} />
-    }
-
-    const shown = skillEntries.slice(0, SKILLS_MAX)
-    const overflow = skillEntries.length - SKILLS_MAX
-
-    return (
-      <>
-        {shown.map(([k, vs]) => (
-          <Text key={k} wrap="truncate">
-            <Text color={t.color.muted}>{strip(k)}: </Text>
-            <Text color={t.color.text}>{truncLine(strip(k) + ': ', vs)}</Text>
-          </Text>
-        ))}
-        {overflow > 0 && (
-          <Text color={t.color.muted}>(and {overflow} more categories…)</Text>
-        )}
-      </>
-    )
-  }
-
   // ── Collapsible tools section ──
   const toolEntries = Object.entries(info.tools).sort()
   const toolsTotal = flat(info.tools).length
-
-  const toolsBody = () => {
-    const shown = toolEntries.slice(0, TOOLSETS_MAX)
-    const overflow = toolEntries.length - TOOLSETS_MAX
-
-    return (
-      <>
-        {shown.map(([k, vs]) => (
-          <Text key={k} wrap="truncate">
-            <Text color={t.color.muted}>{strip(k)}: </Text>
-            <Text color={t.color.text}>{truncLine(strip(k) + ': ', vs)}</Text>
-          </Text>
-        ))}
-        {overflow > 0 && (
-          <Text color={t.color.muted}>(and {overflow} more toolsets…)</Text>
-        )}
-      </>
-    )
-  }
 
   // ── Collapsible MCP section ──
   const mcpBody = () => (
@@ -257,7 +243,7 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
             t={t}
             title="Available Tools"
           />
-          {toolsOpen && toolsBody()}
+          {toolsOpen && sectionListBody(toolEntries, TOOLSETS_MAX, 'toolsets')}
         </Box>
 
         {/* ── Skills (collapsed by default) ── */}
@@ -270,7 +256,13 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
             t={t}
             title="Available Skills"
           />
-          {skillsOpen && skillsBody()}
+          {skillsOpen &&
+            sectionListBody(
+              skillEntries,
+              SKILLS_MAX,
+              'categories',
+              info.lazy ? <InlineLoader label="scanning skills" t={t} /> : null
+            )}
         </Box>
 
         {/* ── System Prompt (collapsed by default) ── */}


### PR DESCRIPTION
## Summary
- Replace duplicated `skillsBody` / `toolsBody` rendering in the TUI branding panel with one shared `sectionListBody` helper
- Preserve distinct overflow labels for categories vs toolsets
- Preserve the lazy skills loader behavior when skills are still scanning

## Root cause
`ui-tui/src/components/branding.tsx` had two near-identical section renderers that differed only by entry source, max count, overflow label, and the skills lazy fallback.

## Related reconnaissance
- Fixes #20670
- Checked open PRs. Nearby TUI branding/system prompt PRs exist (#20693/#20699/#20806), but no direct open PR for the `skillsBody` / `toolsBody` duplication.

## Test plan
- `python -m pytest tests/test_issue20670_tui_branding_dedupe.py -q -o addopts=`
- `(cd ui-tui && npm run type-check -- --pretty false)`
- `git diff --check`
- Static scan of added lines: 0 findings

Note: `npm ci --ignore-scripts` was used locally to install TUI test dependencies before type-checking.
