### PR TITLE
fix(cron): use 0644/0755 permissions so gateway can read cron jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -72,18 +72,33 @@ def _apply_skill_fields(job: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def _secure_dir(path: Path):
-    """Set directory to owner-only access (0700). No-op on Windows."""
+    """Set directory permissions to 0755 (owner rwx, group/other rx).
+
+    The cron scheduler runs inside the gateway process which may run as a
+    different user (e.g. ``hermes``) than the agent that creates job files
+    (e.g. ``root``).  Using 0o700 prevents the gateway from reading or
+    listing files in the cron directories, making cron jobs invisible in
+    the dashboard UI.  0o755 ensures the gateway can read while only the
+    owner can write.
+    """
     try:
-        os.chmod(path, 0o700)
+        os.chmod(path, 0o755)
     except (OSError, NotImplementedError):
         pass  # Windows or other platforms where chmod is not supported
 
 
 def _secure_file(path: Path):
-    """Set file to owner-only read/write (0600). No-op on Windows."""
+    """Set file permissions to 0644 (owner r/w, group/other read-only).
+
+    The cron job creation tool runs as the agent user (often ``root`` in
+    Docker), while the gateway process that reads ``jobs.json`` typically
+    runs as a different user (e.g. ``hermes``).  Using 0o600 makes the file
+    unreadable by the gateway, so cron jobs never appear in the dashboard
+    UI.  0o644 ensures the gateway can read while only the owner can write.
+    """
     try:
         if path.exists():
-            os.chmod(path, 0o600)
+            os.chmod(path, 0o644)
     except (OSError, NotImplementedError):
         pass
 


### PR DESCRIPTION
## Problem

When cron jobs are created via the `cronjob` tool, they run as `root` (the agent process). The `save_jobs()` function calls `_secure_file()` which sets permissions to `0o600` (owner-only read/write). The gateway process that serves the dashboard UI runs as a different user (typically `hermes`), so it cannot read `jobs.json`. This makes all cron jobs invisible in the dashboard UI.

## Fix

Changed `_secure_file()` from `0o600` to `0o644` (owner r/w, group/other read) and `_secure_dir()` from `0o700` to `0o755` (owner rwx, group/other rx). The gateway only needs read access to display jobs; only the agent writes to them.

## Files Changed

- `cron/jobs.py`: `_secure_dir` → `0o755`, `_secure_file` → `0o644`