### PR TITLE
fix(agent): keep Nous GPT-5 on chat completions (salvage #19850)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3065,6 +3065,10 @@ class AIAgent:
     ) -> bool:
         """Return True when this provider/model pair should use Responses API."""
         normalized_provider = (provider or "").strip().lower()
+        # Nous serves GPT-5.x models via its OpenAI-compatible chat
+        # completions endpoint; its /v1/responses endpoint returns 404.
+        if normalized_provider == "nous":
+            return False
         if normalized_provider == "copilot":
             try:
                 from hermes_cli.models import _should_use_copilot_responses_api

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -425,7 +425,7 @@ AUTHOR_MAP = {
     "camilo@tekelala.com": "tekelala",
     "vincentcharlebois@gmail.com": "vincentcharlebois",
     "aryan@synvoid.com": "aryansingh",
-    "johnsonblake1@gmail.com": "blakejohnson",
+    "johnsonblake1@gmail.com": "voteblake",
     "hcn518@gmail.com": "pedh",
     "haileymarshall005@gmail.com": "haileymarshall",
     "greer.guthrie@gmail.com": "g-guthrie",

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3729,8 +3729,8 @@ class TestMaxTokensParam:
         assert result == {"max_completion_tokens": 4096}
 
 
-class TestAzureOpenAIRouting:
-    """Verify Azure OpenAI endpoints stay on chat_completions for gpt-5.x."""
+class TestGpt5ApiModeRouting:
+    """Verify provider-specific GPT-5 API-mode routing."""
 
     def test_azure_gpt5_stays_on_chat_completions(self, agent):
         """Azure serves gpt-5.x on /chat/completions — must not upgrade to codex_responses."""
@@ -3768,6 +3768,25 @@ class TestAzureOpenAIRouting:
         ):
             agent.api_mode = "codex_responses"
         assert agent.api_mode == "codex_responses"
+
+    def test_nous_gpt5_stays_on_chat_completions(self, agent):
+        """Nous serves gpt-5.x on /chat/completions — must not upgrade to codex_responses."""
+        agent.provider = "nous"
+        agent.base_url = "https://inference-api.nousresearch.com/v1"
+        agent.api_mode = "chat_completions"
+        agent.model = "openai/gpt-5.5"
+        if (
+            agent.api_mode == "chat_completions"
+            and not agent._is_azure_openai_url()
+            and (
+                agent._is_direct_openai_url()
+                or agent._provider_model_requires_responses_api(
+                    agent.model, provider=agent.provider,
+                )
+            )
+        ):
+            agent.api_mode = "codex_responses"
+        assert agent.api_mode == "chat_completions"
 
     def test_is_azure_openai_url_detection(self, agent):
         assert agent._is_azure_openai_url("https://foo.openai.azure.com/openai/v1") is True


### PR DESCRIPTION
Salvages #19850 by @voteblake onto current main.

## Summary
Nous GPT-5 inference has been broken since 96cc55605 (Apr 14). Nous' `/v1/responses` endpoint returns 404, but the generic `gpt-5*` auto-upgrade in `_provider_model_requires_responses_api()` routes `provider=nous` + `openai/gpt-5.x` to `codex_responses` regardless. Both primary init and `_try_activate_fallback()` paths fail with HTTP 404 after 3 retries.

Fix: early-return `False` from `_provider_model_requires_responses_api()` when `provider == "nous"`. Narrowly scoped per the contributor's stated intent.

## Changes
- `run_agent.py`: +3 LOC Nous early-return in `_provider_model_requires_responses_api()` — hits both init (L1129) and fallback activation (L7763) via the shared helper.
- `tests/run_agent/test_run_agent.py`: regression test `test_nous_gpt5_stays_on_chat_completions` + rename class to `TestGpt5ApiModeRouting`.
- `scripts/release.py`: AUTHOR_MAP correction — `johnsonblake1@gmail.com` was mapped to `blakejohnson` (wrong GH user, id 866695 IBM); belongs to `voteblake` (id 5585957). Confirmed via `search/commits?author-email`. Ensures @voteblake gets credited in this release's notes.

## Validation
| | Result |
|---|---|
| `TestGpt5ApiModeRouting` (4 tests) | ✅ 4 passed |
| E2E: `AIAgent(provider='nous', model='openai/gpt-5.5', base_url=nous)` | `api_mode = chat_completions` |
| E2E: `_provider_model_requires_responses_api('gpt-5.5', provider='openrouter')` | Still `True` (regression-free) |
| E2E: `_provider_model_requires_responses_api('gpt-5.5', provider='openai-codex')` | Still `True` (regression-free) |

Closes #19850.