### PR TITLE
feat(telegram): route forum topic lifecycle events through plugin dispatch pipeline

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1000,6 +1000,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
                 self._handle_media_message
             ))
+            # Handle forum topic lifecycle service messages (created/edited/closed)
+            self._app.add_handler(TelegramMessageHandler(
+                filters.StatusUpdate.FORUM_TOPIC_CREATED |
+                filters.StatusUpdate.FORUM_TOPIC_EDITED |
+                filters.StatusUpdate.FORUM_TOPIC_CLOSED |
+                filters.StatusUpdate.FORUM_TOPIC_REOPENED,
+                self._handle_forum_topic_event
+            ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
             
@@ -2979,6 +2987,28 @@ class TelegramAdapter(BasePlatformAdapter):
         if self._message_mentions_bot(message):
             return True
         return self._message_matches_mention_patterns(message)
+
+    async def _handle_forum_topic_event(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Route forum topic lifecycle service messages through the dispatch pipeline.
+
+        The pre_gateway_dispatch plugin hook inspects raw_message.forum_topic_created /
+        .forum_topic_edited / .forum_topic_closed and handles board provisioning.
+        Returning {"action": "skip"} from the hook suppresses any agent response.
+        """
+        if not update.message:
+            return
+        msg = update.message
+        logger.debug(
+            "[telegram] forum_topic_event: update_id=%s created=%s closed=%s edited=%s thread_id=%s user=%s",
+            update.update_id,
+            getattr(msg, 'forum_topic_created', None),
+            getattr(msg, 'forum_topic_closed', None),
+            getattr(msg, 'forum_topic_edited', None),
+            getattr(msg, 'message_thread_id', None),
+            getattr(msg, 'from_user', None),
+        )
+        event = self._build_message_event(msg, MessageType.TEXT, update_id=update.update_id)
+        await self.handle_message(event)
 
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.

--- a/tests/gateway/test_telegram_forum_topic_events.py
+++ b/tests/gateway/test_telegram_forum_topic_events.py
@@ -1,0 +1,124 @@
+"""Tests for Telegram forum topic lifecycle event routing.
+
+Forum topic service messages (created/edited/closed/reopened) are a distinct
+Telegram update type that python-telegram-bot drops silently if no handler is
+registered.  _handle_forum_topic_event routes them through the normal dispatch
+pipeline so that pre_gateway_dispatch plugin hooks can react to them.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+
+
+def _make_adapter():
+    from gateway.platforms.telegram import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="fake-token")
+    adapter._bot = AsyncMock()
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+def _make_update(*, thread_id: int = 42, forum_topic_created=None, forum_topic_closed=None,
+                 forum_topic_edited=None, forum_topic_reopened=None):
+    msg = SimpleNamespace(
+        message_id=1,
+        date=None,
+        chat=SimpleNamespace(id=-100999, type="supergroup"),
+        message_thread_id=thread_id,
+        from_user=SimpleNamespace(id=123, username="tester"),
+        forum_topic_created=forum_topic_created,
+        forum_topic_closed=forum_topic_closed,
+        forum_topic_edited=forum_topic_edited,
+        forum_topic_reopened=forum_topic_reopened,
+        text=None,
+    )
+    return SimpleNamespace(update_id=99, message=msg)
+
+
+# ── _handle_forum_topic_event ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_given_forum_topic_created_when_handle_called_then_dispatches_event():
+    # Arrange
+    adapter = _make_adapter()
+    created = SimpleNamespace(name="Sprint 1", icon_color=0)
+    update = _make_update(thread_id=541, forum_topic_created=created)
+    built_event = MagicMock(spec=MessageEvent)
+    with patch.object(adapter, "_build_message_event", return_value=built_event):
+        # Act
+        await adapter._handle_forum_topic_event(update, context=None)
+
+    # Assert
+    adapter.handle_message.assert_awaited_once_with(built_event)
+
+
+@pytest.mark.asyncio
+async def test_given_forum_topic_closed_when_handle_called_then_dispatches_event():
+    # Arrange
+    adapter = _make_adapter()
+    update = _make_update(thread_id=541, forum_topic_closed=SimpleNamespace())
+    built_event = MagicMock(spec=MessageEvent)
+    with patch.object(adapter, "_build_message_event", return_value=built_event):
+        # Act
+        await adapter._handle_forum_topic_event(update, context=None)
+
+    # Assert
+    adapter.handle_message.assert_awaited_once_with(built_event)
+
+
+@pytest.mark.asyncio
+async def test_given_forum_topic_edited_when_handle_called_then_dispatches_event():
+    # Arrange
+    adapter = _make_adapter()
+    edited = SimpleNamespace(name="Sprint 1 (renamed)")
+    update = _make_update(thread_id=541, forum_topic_edited=edited)
+    built_event = MagicMock(spec=MessageEvent)
+    with patch.object(adapter, "_build_message_event", return_value=built_event):
+        # Act
+        await adapter._handle_forum_topic_event(update, context=None)
+
+    # Assert
+    adapter.handle_message.assert_awaited_once_with(built_event)
+
+
+@pytest.mark.asyncio
+async def test_given_no_message_when_handle_called_then_skips_silently():
+    # Arrange
+    adapter = _make_adapter()
+    update = SimpleNamespace(update_id=99, message=None)
+
+    # Act
+    await adapter._handle_forum_topic_event(update, context=None)
+
+    # Assert
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_given_forum_topic_event_when_build_message_event_called_then_uses_text_type():
+    # Arrange
+    adapter = _make_adapter()
+    update = _make_update(thread_id=570, forum_topic_created=SimpleNamespace(name="Feature X"))
+    captured = {}
+
+    def capture(msg, msg_type, **kwargs):
+        captured["msg_type"] = msg_type
+        captured["update_id"] = kwargs.get("update_id")
+        return MagicMock(spec=MessageEvent)
+
+    with patch.object(adapter, "_build_message_event", side_effect=capture):
+        # Act
+        await adapter._handle_forum_topic_event(update, context=None)
+
+    # Assert
+    assert captured["msg_type"] == MessageType.TEXT
+    assert captured["update_id"] == 99


### PR DESCRIPTION
## What does this PR do?

Registers a `MessageHandler` for `StatusUpdate.FORUM_TOPIC_CREATED | FORUM_TOPIC_EDITED | FORUM_TOPIC_CLOSED | FORUM_TOPIC_REOPENED` and adds `_handle_forum_topic_event()` to route these service messages through the standard `handle_message` path.

Without this, python-telegram-bot silently drops forum topic service messages — they carry no `.text` and no media, so none of the existing handler filters match. The new handler ensures these events reach the `pre_gateway_dispatch` plugin hook, allowing plugins to react to topic lifecycle events (e.g. provisioning a kanban board per topic, archiving resources on close) without modifying platform code.

The approach intentionally routes through the plugin hook system rather than baking in specific behavior, keeping the platform adapter unopinionated about what to do with topic events.

## Related Issue

Fixes #21461

Relates to #5488 (different approach — #5488 routes to internal `_persist_group_topic` / config.yaml storage; this PR routes through the plugin dispatch pipeline instead, making it extensible to any plugin without platform-layer changes)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/telegram.py` — registers handler for four `StatusUpdate.FORUM_TOPIC_*` filter types inside `_setup_handlers()`; adds `_handle_forum_topic_event()` which calls `_build_message_event()` and `await self.handle_message(event)` — identical pattern to `_handle_command()`
- `tests/gateway/test_telegram_forum_topic_events.py` — 5 tests: one per event type (created/closed/edited), the no-message guard, and the `MessageType.TEXT` / `update_id` passthrough to `_build_message_event()`

## How to Test

**Automated:**
```bash
pytest tests/gateway/test_telegram_forum_topic_events.py -v
```

**Live (Telegram forum supergroup):**
1. Configure Hermes with a bot in a forum supergroup
2. Register a `pre_gateway_dispatch` plugin hook that inspects `raw_message.forum_topic_created`
3. Create a topic in the group — the hook fires with `msg.forum_topic_created.name` set
4. Close/reopen/rename the topic — each triggers the hook with the corresponding attribute set
5. Confirm that returning `{"action": "skip"}` from the hook suppresses any agent reply

**Without the fix (regression check):**
- Confirm that no `forum_topic_*` events appear in gateway logs before this change (they are silently dropped)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(telegram):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #5488 is related but uses a different approach (see description)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_telegram_forum_topic_events.py -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.4.1 (Tahoe)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — `filters.StatusUpdate.*` is platform-agnostic within python-telegram-bot; no OS-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Gateway debug log showing a `forum_topic_created` event being received and dispatched after this change:

```
[telegram] forum_topic_event: update_id=12345 created=ForumTopicCreated(name='Sprint 1', icon_color=7322096) closed=None edited=None thread_id=541 user=User(id=208214988, username='chase')
[gateway] pre_gateway_dispatch hook: platform=telegram thread_id=541 forum_topic_created=ForumTopicCreated(name='Sprint 1')
```

Without the fix, neither log line appears — the update is dropped before reaching any handler.