### PR TITLE
fix(kanban): preserve assignee casing in dashboard

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1777,6 +1777,10 @@
           onChange: function (e) { setAssignee(e.target.value); },
           placeholder: props.columnName === "triage" ? "specifier" : "assignee",
           className: "h-7 text-xs flex-1",
+          style: { textTransform: "none" },
+          autoCapitalize: "none",
+          autoCorrect: "off",
+          spellCheck: false,
         }),
         h(Input, {
           type: "number",
@@ -2325,6 +2329,10 @@
         },
         placeholder: "(empty = unassign)",
         className: "h-7 text-xs flex-1",
+        style: { textTransform: "none" },
+        autoCapitalize: "none",
+        autoCorrect: "off",
+        spellCheck: false,
       }),
     );
   }

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -202,8 +202,10 @@
   align-items: center;
   gap: 0.4rem;
   font-size: 0.65rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  /* Assignee/profile names are case-sensitive. Do not visually uppercase
+   * lane headers, otherwise a valid `analyst` profile appears as `ANALYST`
+   * in the WebUI and users may copy the wrong casing back into edits. */
+  letter-spacing: 0.02em;
   color: var(--color-muted-foreground);
   padding: 0 0.1rem;
 }


### PR DESCRIPTION
## Summary
- stop uppercasing per-profile Kanban lane headers so case-sensitive assignee names display exactly as stored
- disable browser auto-capitalization/correction on dashboard assignee inputs
- keep profile edits and copied assignee names consistent with lowercase profiles like `analyst`

Fixes #21320

## Validation
- `node --check plugins/kanban/dashboard/dist/index.js`
- `git diff --check origin/main..HEAD`