### PR TITLE
fix(gateway): include thread-aware delivery target in system prompt

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -607,9 +607,38 @@ def build_session_context_prompt(
         home_name = _format_untrusted_prompt_value(home.name)
         lines.append(f"- `\"{platform.value}\"` → Home channel ({home_name})")
 
+        # If the current conversation is in a thread/topic within the home channel's
+        # platform, add a thread-aware delivery target so the agent can reach this
+        # specific thread.  Without this, send_message(tool) with just the platform
+        # name delivers to the home channel but NOT the thread — a common source of
+        # "lost message" bugs.
+        if (
+            context.source.platform == platform
+            and context.source.thread_id
+            and context.source.chat_id
+        ):
+            # Show both the thread-aware target and a warning about bare platform
+            _thread_target = f"{platform.value}:{home.chat_id}:{context.source.thread_id}"
+            lines.append(
+                f"  - `\"{_thread_target}\"` → This thread (use for send_message in this conversation)"
+            )
+
     # Note about explicit targeting
     lines.append("")
-    lines.append("*For explicit targeting, use `\"platform:chat_id\"` format if the user provides a specific chat ID.*")
+    if context.source.thread_id:
+        lines.append(
+            "*For explicit targeting, use `\"platform:chat_id\"` for channels "
+            "or `\"platform:chat_id:thread_id\"` for Telegram topics and Discord threads.*"
+        )
+        # Add a prominent warning when in a thread — bare platform name goes to
+        # the home channel, NOT the current thread.
+        lines.append(
+            "*IMPORTANT: When sending to Telegram in a thread/topic, always use "
+            "the platform:chat_id:thread_id format. Using just the platform name "
+            "sends to the home channel only, NOT this thread.*"
+        )
+    else:
+        lines.append("*For explicit targeting, use `\"platform:chat_id\"` format if the user provides a specific chat ID.*")
 
     return "\n".join(lines)
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -640,8 +640,8 @@ def build_session_context_prompt(
         lines.append(
             "*IMPORTANT: When sending to this thread, always use the "
             "platform:chat_id:thread_id format. Using just the platform name "
-            "does NOT target this thread (it selects the platform's "
-            "home-channel route instead).*"
+            "does NOT target this thread; it uses the configured home-channel "
+            "route, or fails if none is configured.*"
         )
     elif supports_explicit_thread_target and redact_pii:
         lines.append(

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -607,35 +607,47 @@ def build_session_context_prompt(
         home_name = _format_untrusted_prompt_value(home.name)
         lines.append(f"- `\"{platform.value}\"` → Home channel ({home_name})")
 
-        # If the current conversation is in a thread/topic within the home channel's
-        # platform, add a thread-aware delivery target so the agent can reach this
-        # specific thread.  Without this, send_message(tool) with just the platform
-        # name delivers to the home channel but NOT the thread — a common source of
-        # "lost message" bugs.
-        if (
-            context.source.platform == platform
-            and context.source.thread_id
-            and context.source.chat_id
-        ):
-            # Show both the thread-aware target and a warning about bare platform
-            _thread_target = f"{platform.value}:{home.chat_id}:{context.source.thread_id}"
-            lines.append(
-                f"  - `\"{_thread_target}\"` → This thread (use for send_message in this conversation)"
-            )
+    # Telegram topics and Discord threads can be addressed explicitly by the
+    # send_message tool.  This target describes the source conversation, not a
+    # home-channel child, so it must be emitted even when no home is configured.
+    # A usable target necessarily contains raw routing IDs; omit it rather than
+    # advertising non-routable hashes when PII redaction is active.
+    supports_explicit_thread_target = (
+        context.source.platform in {Platform.TELEGRAM, Platform.DISCORD}
+        and bool(context.source.thread_id)
+        and bool(context.source.chat_id)
+    )
+    has_explicit_thread_target = supports_explicit_thread_target and not redact_pii
+    if has_explicit_thread_target:
+        thread_target = _format_untrusted_prompt_value(
+            f"{context.source.platform.value}:"
+            f"{context.source.chat_id}:{context.source.thread_id}"
+        )
+        lines.append(
+            f"- `{thread_target}` → This thread "
+            "(use for send_message in this conversation)"
+        )
 
     # Note about explicit targeting
     lines.append("")
-    if context.source.thread_id:
+    if has_explicit_thread_target:
         lines.append(
             "*For explicit targeting, use `\"platform:chat_id\"` for channels "
-            "or `\"platform:chat_id:thread_id\"` for Telegram topics and Discord threads.*"
+            "or `\"platform:chat_id:thread_id\"` for threads/topics.*"
         )
         # Add a prominent warning when in a thread — bare platform name goes to
         # the home channel, NOT the current thread.
         lines.append(
-            "*IMPORTANT: When sending to Telegram in a thread/topic, always use "
-            "the platform:chat_id:thread_id format. Using just the platform name "
-            "sends to the home channel only, NOT this thread.*"
+            "*IMPORTANT: When sending to this thread, always use the "
+            "platform:chat_id:thread_id format. Using just the platform name "
+            "does NOT target this thread (it selects the platform's "
+            "home-channel route instead).*"
+        )
+    elif supports_explicit_thread_target and redact_pii:
+        lines.append(
+            "*The explicit target for this thread is omitted because PII "
+            "redaction is enabled. Use `\"origin\"` for scheduled delivery "
+            "back to this thread.*"
         )
     else:
         lines.append("*For explicit targeting, use `\"platform:chat_id\"` format if the user provides a specific chat ID.*")

--- a/tests/gateway/test_pii_redaction.py
+++ b/tests/gateway/test_pii_redaction.py
@@ -1,14 +1,18 @@
 """Tests for PII redaction in gateway session context prompts."""
 
+import re
+
+from gateway.config import HomeChannel, Platform
+from gateway.delivery import DeliveryTarget
 from gateway.session import (
     SessionContext,
     SessionSource,
-    build_session_context_prompt,
+    _hash_chat_id,
     _hash_id,
     _hash_sender_id,
-    _hash_chat_id,
+    build_session_context_prompt,
 )
-from gateway.config import Platform, HomeChannel
+from tools.send_message_tool import _parse_target_ref
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +147,30 @@ class TestBuildSessionContextPromptRedaction:
         prompt = build_session_context_prompt(ctx)
 
         assert '`"telegram:-1001234567890:456"` → This thread' in prompt
+
+    def test_advertised_thread_target_round_trips_through_routing_parsers(self):
+        ctx = _make_context(
+            chat_id="-1001234567890",
+            thread_id="456",
+        )
+
+        prompt = build_session_context_prompt(ctx)
+        match = re.search(r'`"([^"]+)"` → This thread', prompt)
+        assert match is not None
+        advertised_target = match.group(1)
+
+        delivery_target = DeliveryTarget.parse(advertised_target)
+        assert delivery_target.platform == Platform.TELEGRAM
+        assert delivery_target.chat_id == ctx.source.chat_id
+        assert delivery_target.thread_id == ctx.source.thread_id
+        assert delivery_target.is_explicit is True
+
+        platform_name, target_ref = advertised_target.split(":", 1)
+        assert _parse_target_ref(platform_name, target_ref) == (
+            ctx.source.chat_id,
+            ctx.source.thread_id,
+            True,
+        )
 
     def test_redaction_omits_unusable_thread_target(self):
         home = {

--- a/tests/gateway/test_pii_redaction.py
+++ b/tests/gateway/test_pii_redaction.py
@@ -49,6 +49,7 @@ def _make_context(
     chat_id="telegram:99999",
     platform=Platform.TELEGRAM,
     home_channels=None,
+    thread_id=None,
 ):
     source = SessionSource(
         platform=platform,
@@ -56,6 +57,7 @@ def _make_context(
         chat_type="dm",
         user_id=user_id,
         user_name=user_name,
+        thread_id=thread_id,
     )
     return SessionContext(
         source=source,
@@ -108,6 +110,61 @@ class TestBuildSessionContextPromptRedaction:
         ctx = _make_context(home_channels=hc)
         prompt = build_session_context_prompt(ctx, redact_pii=False)
         assert "99999" in prompt
+
+    def test_thread_target_uses_source_chat_not_home_channel(self):
+        """A thread outside home must not be advertised as a home-channel thread."""
+        home = {
+            Platform.TELEGRAM: HomeChannel(
+                platform=Platform.TELEGRAM,
+                chat_id="home-chat",
+                name="Home Chat",
+            )
+        }
+        ctx = _make_context(
+            chat_id="-1001234567890",
+            thread_id="456",
+            home_channels=home,
+        )
+
+        prompt = build_session_context_prompt(ctx)
+
+        assert '`"telegram:-1001234567890:456"` → This thread' in prompt
+        assert '"telegram:home-chat:456"' not in prompt
+        assert "When sending to this thread" in prompt
+        assert "When sending to Telegram" not in prompt
+
+    def test_thread_target_does_not_require_home_channel(self):
+        ctx = _make_context(
+            chat_id="-1001234567890",
+            thread_id="456",
+            home_channels={},
+        )
+
+        prompt = build_session_context_prompt(ctx)
+
+        assert '`"telegram:-1001234567890:456"` → This thread' in prompt
+
+    def test_redaction_omits_unusable_thread_target(self):
+        home = {
+            Platform.TELEGRAM: HomeChannel(
+                platform=Platform.TELEGRAM,
+                chat_id="home-chat",
+                name="Home Chat",
+            )
+        }
+        ctx = _make_context(
+            chat_id="source-chat-123",
+            thread_id="source-thread-456",
+            home_channels=home,
+        )
+
+        prompt = build_session_context_prompt(ctx, redact_pii=True)
+
+        assert "source-chat-123" not in prompt
+        assert "source-thread-456" not in prompt
+        assert "→ This thread" not in prompt
+        assert "explicit target for this thread is omitted" in prompt
+        assert 'Use `"origin"` for scheduled delivery' in prompt
 
     def test_redaction_is_deterministic(self):
         ctx = _make_context(user_id="+15551234567")

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -235,6 +235,30 @@ class TestBuildSessionContextPrompt:
         assert "Discord" in prompt
         assert "cannot search" in prompt.lower() or "do not have access" in prompt.lower()
 
+    def test_discord_thread_prompt_advertises_explicit_source_target(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    token="fake-discord-token",
+                ),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="123456789012345678",
+            chat_name="Server / thread",
+            chat_type="thread",
+            thread_id="123456789012345678",
+        )
+
+        prompt = build_session_context_prompt(build_session_context(source, config))
+
+        assert (
+            '`"discord:123456789012345678:123456789012345678"` → This thread'
+            in prompt
+        )
+
     def test_discord_prompt_stable_across_message_id(self):
         """The cached system prompt must NOT vary with the triggering message_id.
 


### PR DESCRIPTION
## Problem

In a Telegram topic or Discord thread, the session prompt advertises only the bare platform delivery target. That target resolves to the configured home channel, so an agent trying to send back to the active thread can silently deliver to the wrong place.

## Fix

- Advertise the current source thread as `platform:chat_id:thread_id` for Telegram and Discord.
- Build the target from the source chat and thread, even when the source differs from the configured home channel or no home channel is configured.
- Keep the existing bare-platform home target and clearly distinguish it from the current-thread target.
- Preserve `redact_pii=True`: explicit IDs are omitted and scheduled delivery is directed to use `origin`.
- Keep the guidance platform-neutral and limited to platforms whose delivery parsers support thread targets.

## Testing

- Added prompt regressions for Telegram and Discord threads, non-home source chats, no configured home channel, and PII redaction.
- Added a round-trip regression proving the advertised target is accepted by both live `send_message` and scheduled-delivery parsers.
- Relevant gateway suite: 164 tests passed.
- Ruff clean.

## Scope

The change is confined to session delivery guidance and regression coverage; delivery parsing behavior itself is unchanged.
