### PR TITLE
fix(windows): guard fcntl/termios import + add __main__.py launcher

### DIFF
--- a/hermes_cli/__main__.py
+++ b/hermes_cli/__main__.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""
+Hermes Agent CLI launcher.
+
+This wrapper should behave like the installed `hermes` command, including
+subcommands such as `gateway`, `cron`, and `doctor`.
+"""
+
+if __name__ == "__main__":
+    from hermes_cli.main import main
+    main()

--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -26,15 +26,27 @@ Design constraints:
 from __future__ import annotations
 
 import errno
-import fcntl
 import os
 import select
 import signal
 import struct
 import sys
-import termios
 import time
 from typing import Optional, Sequence
+
+# fcntl and termios are POSIX-only. The module guards PTY operations on
+# `_PTY_AVAILABLE` and raises `PtyUnavailableError` at instantiation time,
+# so the import just needs to succeed on Windows. Without this guard, any
+# command that triggers web_server.py (which imports pty_bridge
+# unconditionally) crashes at module-load time on native Windows Python.
+try:
+    import fcntl
+    import termios
+    _UNIX_TERMIO_AVAILABLE = True
+except ImportError:  # Windows
+    fcntl = None  # type: ignore
+    termios = None  # type: ignore
+    _UNIX_TERMIO_AVAILABLE = False
 
 try:
     import ptyprocess  # type: ignore

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -901,6 +901,7 @@ AUTHOR_MAP = {
     "promptsiren@gmail.com": "firefly",  # PR #18123 salvage of #16660 (ContextVars)
     "wtyopenclaw@gmail.com": "WuTianyi123",  # PR #20275 salvage of #13723 (feishu markdown)
     # pander: empty email, salvaged via PR #19665 from #16126 by @ms-alan
+    "info@bourillon.net": "Alterpolo",  # PR #21453 (Windows compat: pty_bridge + __main__)
 }
 
 


### PR DESCRIPTION
## Summary

Two small fixes for native Windows Python compatibility:

- **`hermes_cli/__main__.py`** — adds the standard package entry-point so Hermes can be invoked as `python -m hermes_cli` from a cloned repo or CI environment where the `hermes` binary is not on PATH. Delegates unconditionally to `hermes_cli.main:main()`; behaviour is byte-identical to the installed command for all subcommands and exit codes.

- **`hermes_cli/pty_bridge.py`** — guards `fcntl`/`termios` imports behind a `try/except ImportError`. Both modules are POSIX-only and absent from native Windows Python. The module already gates PTY operations on `_PTY_AVAILABLE` and raises `PtyUnavailableError` at instantiation; only the import needs to succeed. Without this guard, any command that triggers `web_server.py` (which imports `pty_bridge` unconditionally) crashes at module-load time on Windows — even commands unrelated to the PTY bridge.

- **`scripts/release.py`** — contributor email mapping for this PR's author.

## Test plan

- [ ] `python -m hermes_cli --version` on a repo checkout (no installed binary) → version string on stdout, exit 0
- [ ] `python -m hermes_cli doctor` → same output as `hermes doctor`
- [ ] On Windows native Python: `python -c "import hermes_cli.pty_bridge"` → no ImportError
- [ ] `ruff check hermes_cli/__main__.py hermes_cli/pty_bridge.py` → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)