### PR TITLE
feat(agent): make MemoryManager thread-safe with RLock

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import logging
 import re
 import inspect
+import threading
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
@@ -252,6 +253,7 @@ class MemoryManager:
         self._providers: List[MemoryProvider] = []
         self._tool_to_provider: Dict[str, MemoryProvider] = {}
         self._has_external: bool = False  # True once a non-builtin provider is added
+        self._lock = threading.RLock()
 
     # -- Registration --------------------------------------------------------
 
@@ -261,50 +263,54 @@ class MemoryManager:
         Built-in provider (name ``"builtin"``) is always accepted.
         Only **one** external (non-builtin) provider is allowed — a second
         attempt is rejected with a warning.
+
+        Thread-safe: protected by ``self._lock``.
         """
-        is_builtin = provider.name == "builtin"
+        with self._lock:
+            is_builtin = provider.name == "builtin"
 
-        if not is_builtin:
-            if self._has_external:
-                existing = next(
-                    (p.name for p in self._providers if p.name != "builtin"), "unknown"
-                )
-                logger.warning(
-                    "Rejected memory provider '%s' — external provider '%s' is "
-                    "already registered. Only one external memory provider is "
-                    "allowed at a time. Configure which one via memory.provider "
-                    "in config.yaml.",
-                    provider.name, existing,
-                )
-                return
-            self._has_external = True
+            if not is_builtin:
+                if self._has_external:
+                    existing = next(
+                        (p.name for p in self._providers if p.name != "builtin"), "unknown"
+                    )
+                    logger.warning(
+                        "Rejected memory provider '%s' — external provider '%s' is "
+                        "already registered. Only one external memory provider is "
+                        "allowed at a time. Configure which one via memory.provider "
+                        "in config.yaml.",
+                        provider.name, existing,
+                    )
+                    return
+                self._has_external = True
 
-        self._providers.append(provider)
+            self._providers.append(provider)
 
-        # Index tool names → provider for routing
-        for schema in provider.get_tool_schemas():
-            tool_name = schema.get("name", "")
-            if tool_name and tool_name not in self._tool_to_provider:
-                self._tool_to_provider[tool_name] = provider
-            elif tool_name in self._tool_to_provider:
-                logger.warning(
-                    "Memory tool name conflict: '%s' already registered by %s, "
-                    "ignoring from %s",
-                    tool_name,
-                    self._tool_to_provider[tool_name].name,
-                    provider.name,
-                )
+            # Index tool names → provider for routing
+            for schema in provider.get_tool_schemas():
+                tool_name = schema.get("name", "")
+                if tool_name and tool_name not in self._tool_to_provider:
+                    self._tool_to_provider[tool_name] = provider
+                elif tool_name in self._tool_to_provider:
+                    logger.warning(
+                        "Memory tool name conflict: '%s' already registered by %s, "
+                        "ignoring from %s",
+                        tool_name,
+                        self._tool_to_provider[tool_name].name,
+                        provider.name,
+                    )
 
-        logger.info(
-            "Memory provider '%s' registered (%d tools)",
-            provider.name,
-            len(provider.get_tool_schemas()),
-        )
+            logger.info(
+                "Memory provider '%s' registered (%d tools)",
+                provider.name,
+                len(provider.get_tool_schemas()),
+            )
 
     @property
     def providers(self) -> List[MemoryProvider]:
         """All registered providers in order."""
-        return list(self._providers)
+        with self._lock:
+            return list(self._providers)
 
     def get_provider(self, name: str) -> Optional[MemoryProvider]:
         """Get a provider by name, or None if not registered."""

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -379,6 +379,122 @@ class TestMemoryManager:
         assert result == "works fine"
 
 
+class TestMemoryManagerConcurrency:
+    """Thread-safety tests for MemoryManager."""
+
+    def test_concurrent_add_provider_no_duplicates(self):
+        """Multiple threads adding the same provider should not create duplicates."""
+        import threading
+        mgr = MemoryManager()
+        ext = FakeMemoryProvider("ext", tools=[
+            {"name": "ext_tool", "description": "Tool", "parameters": {}},
+        ])
+
+        def adder():
+            mgr.add_provider(ext)
+
+        threads = [threading.Thread(target=adder) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Only one provider should be registered
+        assert len(mgr.providers) == 1
+        assert mgr.providers[0].name == "ext"
+        assert mgr.has_tool("ext_tool")
+
+    def test_concurrent_add_different_providers(self):
+        """Multiple threads adding different providers — only first external wins."""
+        import threading
+        mgr = MemoryManager()
+        providers = [
+            FakeMemoryProvider(f"ext{i}", tools=[
+                {"name": f"ext{i}_tool", "description": "Tool", "parameters": {}},
+            ])
+            for i in range(5)
+        ]
+
+        threads = [threading.Thread(target=mgr.add_provider, args=(p,)) for p in providers]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Upstream only allows one external provider — the rest are rejected
+        ext_count = sum(1 for p in mgr.providers if p.name != "builtin")
+        assert ext_count == 1
+        # Exactly one tool should be registered
+        assert sum(1 for i in range(5) if mgr.has_tool(f"ext{i}_tool")) == 1
+
+    def test_concurrent_add_and_read(self):
+        """Concurrent add and providers access should not corrupt state."""
+        import threading
+        mgr = MemoryManager()
+        ext = FakeMemoryProvider("ext", tools=[
+            {"name": "ext_tool", "description": "Tool", "parameters": {}},
+        ])
+        mgr.add_provider(ext)
+
+        def adder():
+            # Try to add again (should be rejected as duplicate)
+            mgr.add_provider(ext)
+
+        def reader():
+            # Read providers list concurrently
+            _ = mgr.providers
+            _ = mgr.has_tool("ext_tool")
+
+        threads = []
+        for _ in range(5):
+            threads.append(threading.Thread(target=adder))
+            threads.append(threading.Thread(target=reader))
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # State should be consistent: provider still present
+        assert len(mgr.providers) == 1
+        assert mgr.providers[0].name == "ext"
+        assert mgr.has_tool("ext_tool")
+
+    def test_concurrent_tool_routing_while_adding(self):
+        """Tool calls during provider addition should not crash."""
+        import threading
+        mgr = MemoryManager()
+        builtin = FakeMemoryProvider("builtin", tools=[
+            {"name": "builtin_tool", "description": "Builtin", "parameters": {}},
+        ])
+        mgr.add_provider(builtin)
+
+        ext = FakeMemoryProvider("ext", tools=[
+            {"name": "ext_tool", "description": "External", "parameters": {}},
+        ])
+
+        results = []
+        def router():
+            try:
+                result = mgr.handle_tool_call("builtin_tool", {})
+                results.append(("ok", result))
+            except Exception as e:
+                results.append(("err", str(e)))
+
+        threads = [threading.Thread(target=router) for _ in range(20)]
+        threads.append(threading.Thread(target=mgr.add_provider, args=(ext,)))
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # All routing calls should have succeeded
+        errors = [r for r in results if r[0] == "err"]
+        assert len(errors) == 0, f"Concurrent routing errors: {errors}"
+        assert mgr.has_tool("ext_tool")
+
+
 class TestPluginMemoryDiscovery:
     """Memory providers are discovered from plugins/memory/ directory."""
 


### PR DESCRIPTION
## Summary
Adds `threading.RLock` to `MemoryManager` to protect `_providers` and `_tool_to_provider` state during concurrent `add_provider` operations.

Suggested as a standalone extraction from PR #17119 by @teknium1.

## Changes
- Add `self._lock = threading.RLock()` to `__init__`
- Wrap `add_provider()` body in `with self._lock:`
- Wrap `providers` property in `with self._lock:`

## Tests
Four new concurrency tests in `TestMemoryManagerConcurrency`:
- `test_concurrent_add_provider_no_duplicates` — 10 threads adding the same provider, only one registered
- `test_concurrent_add_different_providers` — 5 threads adding different providers, single-provider guard respected under contention
- `test_concurrent_add_and_read` — concurrent add + providers access, state stays consistent
- `test_concurrent_tool_routing_while_adding` — 20 threads routing tools while 1 thread adds a provider, no crashes

66/66 tests pass.