### PR TITLE
feat(gateway): add pre_callback_query_dispatch plugin hook for Telegram inline keyboard callbacks

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1919,6 +1919,18 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         data = query.data
         query_message = getattr(query, "message", None)
+
+        hook_result = await self._fire_plugin_hook(
+            "pre_callback_query_dispatch",
+            data=data,
+            chat_id=str(query_message.chat_id) if query_message else None,
+            user_id=str(query.from_user.id) if query.from_user else None,
+            message_id=str(query_message.message_id) if query_message else None,
+            raw_query=query,
+        )
+        if hook_result and hook_result.get("action") == "skip":
+            return
+
         query_chat_id = getattr(query_message, "chat_id", None)
         query_chat = getattr(query_message, "chat", None)
         query_chat_type = getattr(query_chat, "type", None)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -101,6 +101,14 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Telegram callback query pre-dispatch hook. Fired at the top of
+    # _handle_callback_query (TelegramAdapter), BEFORE any built-in handler
+    # checks data prefix. Plugins return a dict to influence flow:
+    #   {"action": "skip"}   -> claim the callback; built-in handling is suppressed
+    #   {"action": "allow"} / None -> fall through to built-in handling
+    # Kwargs: data (str), chat_id (str|None), user_id (str|None),
+    #         message_id (str|None), raw_query (CallbackQuery).
+    "pre_callback_query_dispatch",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs user approval -- fires BOTH for CLI-interactive prompts
     # and for gateway/ACP approvals (Telegram, Discord, Slack, TUI, etc.).

--- a/tests/gateway/test_telegram_callback_query_hook.py
+++ b/tests/gateway/test_telegram_callback_query_hook.py
@@ -1,0 +1,162 @@
+"""Tests for the pre_callback_query_dispatch plugin hook on TelegramAdapter.
+
+Callback queries (inline keyboard button clicks) are handled by
+_handle_callback_query.  The pre_callback_query_dispatch hook fires at the
+top of that method so plugins can intercept and claim callbacks before any
+built-in prefix handling runs.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+def _make_adapter():
+    from gateway.platforms.telegram import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="fake-token")
+    adapter._bot = AsyncMock()
+    adapter._fire_plugin_hook = AsyncMock(return_value=None)
+    return adapter
+
+
+def _make_update(data: str = "nf:yes:42", chat_id: int = -100999, message_id: int = 1,
+                 user_id: int = 123):
+    msg = SimpleNamespace(
+        chat_id=chat_id,
+        chat=SimpleNamespace(id=chat_id, type="supergroup"),
+        message_id=message_id,
+        message_thread_id=None,
+    )
+    query = SimpleNamespace(
+        data=data,
+        message=msg,
+        from_user=SimpleNamespace(id=user_id, first_name="Tester"),
+        answer=AsyncMock(),
+        edit_message_reply_markup=AsyncMock(),
+    )
+    return SimpleNamespace(update_id=99, callback_query=query)
+
+
+# ── hook fires with correct kwargs ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_given_callback_query_when_handle_called_then_hook_fires_with_correct_kwargs():
+    # Arrange
+    adapter = _make_adapter()
+    update = _make_update(data="nf:yes:42", chat_id=-100999, message_id=7, user_id=123)
+
+    with patch.object(adapter, "_handle_model_picker_callback", new_callable=AsyncMock):
+        # Act
+        await adapter._handle_callback_query(update, context=None)
+
+    # Assert
+    adapter._fire_plugin_hook.assert_awaited_once_with(
+        "pre_callback_query_dispatch",
+        data="nf:yes:42",
+        chat_id="-100999",
+        user_id="123",
+        message_id="7",
+        raw_query=update.callback_query,
+    )
+
+
+@pytest.mark.asyncio
+async def test_given_hook_returns_skip_when_handle_called_then_built_in_handling_suppressed():
+    # Arrange
+    adapter = _make_adapter()
+    adapter._fire_plugin_hook = AsyncMock(return_value={"action": "skip"})
+    update = _make_update(data="nf:yes:42")
+    handled = []
+
+    with patch.object(adapter, "_handle_model_picker_callback",
+                      new_callable=AsyncMock,
+                      side_effect=lambda *a, **kw: handled.append("model_picker")):
+        # Act
+        await adapter._handle_callback_query(update, context=None)
+
+    # Assert — built-in branches never reached
+    assert handled == []
+    update.callback_query.answer.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_given_hook_returns_allow_when_handle_called_then_built_in_handling_continues():
+    # Arrange
+    adapter = _make_adapter()
+    adapter._fire_plugin_hook = AsyncMock(return_value={"action": "allow"})
+    update = _make_update(data="mp:some:model")
+    model_picker_called = []
+
+    with patch.object(adapter, "_handle_model_picker_callback",
+                      new_callable=AsyncMock,
+                      side_effect=lambda *a, **kw: model_picker_called.append(True)):
+        # Act
+        await adapter._handle_callback_query(update, context=None)
+
+    # Assert — model picker branch was reached
+    assert model_picker_called == [True]
+
+
+@pytest.mark.asyncio
+async def test_given_hook_returns_none_when_handle_called_then_built_in_handling_continues():
+    # Arrange
+    adapter = _make_adapter()
+    adapter._fire_plugin_hook = AsyncMock(return_value=None)
+    update = _make_update(data="mp:some:model")
+    model_picker_called = []
+
+    with patch.object(adapter, "_handle_model_picker_callback",
+                      new_callable=AsyncMock,
+                      side_effect=lambda *a, **kw: model_picker_called.append(True)):
+        # Act
+        await adapter._handle_callback_query(update, context=None)
+
+    # Assert — model picker branch was reached
+    assert model_picker_called == [True]
+
+
+@pytest.mark.asyncio
+async def test_given_no_query_data_when_handle_called_then_hook_not_fired():
+    # Arrange
+    adapter = _make_adapter()
+    update = SimpleNamespace(
+        update_id=99,
+        callback_query=SimpleNamespace(data=None, message=None, from_user=None),
+    )
+
+    # Act
+    await adapter._handle_callback_query(update, context=None)
+
+    # Assert — early-exit before hook
+    adapter._fire_plugin_hook.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_given_no_callback_query_when_handle_called_then_hook_not_fired():
+    # Arrange
+    adapter = _make_adapter()
+    update = SimpleNamespace(update_id=99, callback_query=None)
+
+    # Act
+    await adapter._handle_callback_query(update, context=None)
+
+    # Assert
+    adapter._fire_plugin_hook.assert_not_awaited()
+
+
+# ── VALID_HOOKS registration ──────────────────────────────────────────────────
+
+
+def test_pre_callback_query_dispatch_is_in_valid_hooks():
+    # Arrange / Act
+    from hermes_cli.plugins import VALID_HOOKS
+
+    # Assert
+    assert "pre_callback_query_dispatch" in VALID_HOOKS


### PR DESCRIPTION
## What does this PR do?

Adds a `pre_callback_query_dispatch` plugin hook that fires at the entry point of `_handle_callback_query` in `TelegramAdapter`, before any built-in prefix routing (`mp:`, `ea:`, `sc:`, etc.).

Plugins can register for this hook to intercept inline keyboard button clicks. Returning `{"action": "skip"}` claims the callback and suppresses all built-in handling. Returning `{"action": "allow"}` or `None` falls through to existing logic unchanged — so this is a non-breaking, purely additive change.

The motivation is to allow custom callback logic (e.g. a news-feedback plugin handling `nf:yes:<id>` / `nf:no:<id>`) to live in a plugin rather than in `telegram.py` directly. Without this hook, any customisation must be patched into core gateway files and is silently lost on `hermes update`.

## Related Issue

Fixes #21469

Extends the pattern introduced in #21461 (forum topic events → `pre_gateway_dispatch`). That issue covered messages; this one covers button interactions, which cannot be represented as `MessageEvent` objects and therefore cannot go through `pre_gateway_dispatch`.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`hermes_cli/plugins.py`**: Added `"pre_callback_query_dispatch"` to `VALID_HOOKS` with a doc-comment describing the kwargs and supported return values.
- **`gateway/platforms/telegram.py`**: Added `_fire_plugin_hook("pre_callback_query_dispatch", ...)` call at the top of `_handle_callback_query`, immediately after the `data` variable is set. Early-returns if a plugin returns `{"action": "skip"}`.
- **`tests/gateway/test_telegram_callback_query_hook.py`**: 7 new tests covering: hook fires with correct kwargs, `skip` suppresses built-in handling, `allow` and `None` fall through, early-exit when `query` or `query.data` is absent, and `pre_callback_query_dispatch` present in `VALID_HOOKS`.

## How to Test

1. `pytest tests/gateway/test_telegram_callback_query_hook.py -v` — all 7 tests pass.
2. Register a plugin hook for `pre_callback_query_dispatch` with a handler that returns `{"action": "skip"}` for a custom prefix; press an inline button with that prefix — the hook fires and built-in handling is suppressed.
3. Press a built-in button (`ea:`, `sc:`, `mp:`) — hook fires but returns `None`; built-in logic proceeds normally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A