### PR TITLE
feat(image_gen): auto-attach session image attachments to image_generate

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -191,6 +191,59 @@ def save_b64_image(
     return path
 
 
+_REFERENCE_IMAGE_MIME_BY_SUFFIX: Dict[str, str] = {
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "png": "image/png",
+    "webp": "image/webp",
+    "gif": "image/gif",
+}
+
+
+def normalize_reference_image(value: Any) -> Optional[Dict[str, str]]:
+    """Convert a reference-image input into an OpenAI Responses ``input_image`` block.
+
+    Accepts:
+
+    * ``str`` or :class:`Path` pointing to an existing image file → read,
+      base64-encode, wrap as a ``data:`` URL.
+    * ``str`` already in ``data:image/...;base64,...`` form → passed through.
+    * ``str`` HTTP(S) URL → passed through (the API fetches it server-side).
+
+    Returns ``None`` (with a warning logged) for missing files, empty values,
+    or unrecognised types so callers can fold the result into a content array
+    without raising.
+
+    Result shape::
+
+        {"type": "input_image", "image_url": "<data-url-or-http-url>"}
+    """
+    if value is None:
+        return None
+    if isinstance(value, Path):
+        s = str(value)
+    elif isinstance(value, str):
+        s = value.strip()
+    else:
+        logger.warning(
+            "Unsupported reference_image type %s — expected str or Path",
+            type(value).__name__,
+        )
+        return None
+    if not s:
+        return None
+    if s.startswith(("data:", "http://", "https://")):
+        return {"type": "input_image", "image_url": s}
+    p = Path(s).expanduser()
+    if not p.is_file():
+        logger.warning("reference_image not found on disk: %s", p)
+        return None
+    suffix = p.suffix.lower().lstrip(".")
+    mime = _REFERENCE_IMAGE_MIME_BY_SUFFIX.get(suffix, "image/png")
+    encoded = base64.b64encode(p.read_bytes()).decode()
+    return {"type": "input_image", "image_url": f"data:{mime};base64,{encoded}"}
+
+
 def success_response(
     *,
     image: str,

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -295,7 +295,75 @@ def build_native_content_parts(
     return parts, skipped
 
 
+# ---------------------------------------------------------------------------
+# Session-scoped recent attachment register (for image_generate auto-inject)
+# ---------------------------------------------------------------------------
+#
+# When a gateway turn includes natively-attached images, the image bytes
+# reach the model as ``image_url`` content parts — the model can *see* them
+# but only as inline data, not as file paths it could pass to the
+# ``image_generate`` tool's ``reference_images`` argument.
+#
+# This register lets the gateway record the same paths under the active
+# session so the ``image_generate`` handler can auto-inject them when the
+# user follows the attachment with "edit this", "add a hat", "remove the
+# background", etc. The model just calls ``image_generate(prompt=...)``
+# and the tool handler resolves the most-recent attachment automatically.
+#
+# Lifecycle
+# ---------
+# * **Replace** — gateway calls :func:`register_recent_attached_image_paths`
+#   on every inbound turn that has native attachments. Replacing (not
+#   appending) is intentional: a new attachment shadows older ones in the
+#   same session so the model edits *the thing the user just sent*, not a
+#   stale image from earlier in the conversation.
+# * **Persist across model turns** — reads via :func:`get_recent_attached_image_paths`
+#   are non-destructive. The model can refer to the same source across
+#   multiple ``image_generate`` calls in the same session ("now make it
+#   red", "now bigger") without the user re-sending the photo.
+# * **Clear** — gateway calls :func:`clear_recent_attached_image_paths`
+#   on session reset / auto-reset so a brand-new conversation does not
+#   inherit a previous one's attachment state.
+
+_RECENT_ATTACHED_IMAGE_PATHS: Dict[str, List[str]] = {}
+
+
+def register_recent_attached_image_paths(session_key: str, paths: List[str]) -> None:
+    """Record image paths attached to the current inbound turn under
+    ``session_key``. Replaces any previously-registered paths for the session.
+
+    Called by the gateway right after consuming the per-turn pending-native
+    image paths, so the same paths are queryable from inside the
+    ``image_generate`` tool handler.
+    """
+    if not session_key:
+        return
+    _RECENT_ATTACHED_IMAGE_PATHS[session_key] = list(paths or [])
+
+
+def get_recent_attached_image_paths(session_key: str) -> List[str]:
+    """Return image paths attached to the most recent inbound turn for the
+    session, or an empty list. Non-destructive — the same paths can be read
+    again on subsequent agent turns until a new attachment replaces them or
+    the session is reset.
+    """
+    if not session_key:
+        return []
+    return list(_RECENT_ATTACHED_IMAGE_PATHS.get(session_key, []))
+
+
+def clear_recent_attached_image_paths(session_key: str) -> None:
+    """Drop the register for ``session_key``. Called by the gateway on
+    session reset / auto-reset so a fresh conversation starts clean.
+    """
+    if session_key:
+        _RECENT_ATTACHED_IMAGE_PATHS.pop(session_key, None)
+
+
 __all__ = [
     "decide_image_input_mode",
     "build_native_content_parts",
+    "register_recent_attached_image_paths",
+    "get_recent_attached_image_paths",
+    "clear_recent_attached_image_paths",
 ]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6153,6 +6153,11 @@ class GatewayRunner:
             self._set_session_reasoning_override(session_key, None)
             if hasattr(self, "_pending_model_notes"):
                 self._pending_model_notes.pop(session_key, None)
+            try:
+                from agent.image_routing import clear_recent_attached_image_paths
+                clear_recent_attached_image_paths(session_key)
+            except Exception:
+                pass
         
         # Emit session:start for new or auto-reset sessions
         _is_new_session = (
@@ -14090,6 +14095,19 @@ class GatewayRunner:
                 # runner instance don't re-attach stale images.
                 _native_imgs = self._consume_pending_native_image_paths(session_key)
                 if _native_imgs:
+                    # Make the same paths queryable from inside the
+                    # ``image_generate`` tool so the model can pass them as
+                    # ``reference_images`` (image-to-image) without having
+                    # to know the on-disk paths. Replaces any prior register
+                    # for this session — newest attachment shadows older ones.
+                    try:
+                        from agent.image_routing import register_recent_attached_image_paths
+                        register_recent_attached_image_paths(session_key, _native_imgs)
+                    except Exception as _reg_exc:
+                        logger.debug(
+                            "register_recent_attached_image_paths failed: %s",
+                            _reg_exc,
+                        )
                     try:
                         from agent.image_routing import build_native_content_parts
                         _parts, _skipped = build_native_content_parts(

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -15,6 +15,15 @@ Selection precedence for the tier (first hit wins):
 4. :data:`DEFAULT_MODEL` — ``gpt-image-2-medium``
 
 Output is saved as PNG under ``$HERMES_HOME/cache/images/``.
+
+Reference images
+----------------
+``generate(..., reference_images=[...])`` attaches one or more source images
+to the request as ``input_image`` content blocks alongside the text prompt.
+The Responses ``image_generation`` tool then conditions on those images,
+producing a true image-to-image edit rather than a fresh text-to-image
+generation. Each entry may be a file path, an existing ``data:image/...;base64,...``
+URL, or an ``http(s)://`` URL — see :func:`agent.image_gen_provider.normalize_reference_image`.
 """
 
 from __future__ import annotations
@@ -26,6 +35,7 @@ from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
     ImageGenProvider,
     error_response,
+    normalize_reference_image,
     resolve_aspect_ratio,
     save_b64_image,
     success_response,
@@ -161,7 +171,30 @@ def _build_codex_client():
         return None
 
 
-def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> Optional[str]:
+def _build_user_content(prompt: str, reference_images: Optional[List[Any]]) -> List[Dict[str, Any]]:
+    """Assemble the Responses ``content`` array for the user message.
+
+    The text prompt comes first; each successfully-normalised reference image
+    is appended as an ``input_image`` block. Unrecognised entries are skipped
+    (the helper logs a warning), so a partly-bad list still produces a usable
+    request rather than failing the whole call.
+    """
+    content: List[Dict[str, Any]] = [{"type": "input_text", "text": prompt}]
+    for ref in reference_images or []:
+        block = normalize_reference_image(ref)
+        if block is not None:
+            content.append(block)
+    return content
+
+
+def _collect_image_b64(
+    client: Any,
+    *,
+    prompt: str,
+    size: str,
+    quality: str,
+    reference_images: Optional[List[Any]] = None,
+) -> Optional[str]:
     """Stream a Codex Responses image_generation call and return the b64 image."""
     image_b64: Optional[str] = None
 
@@ -172,7 +205,7 @@ def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> 
         input=[{
             "type": "message",
             "role": "user",
-            "content": [{"type": "input_text", "text": prompt}],
+            "content": _build_user_content(prompt, reference_images),
         }],
         tools=[{
             "type": "image_generation",
@@ -274,6 +307,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
     ) -> Dict[str, Any]:
         prompt = (prompt or "").strip()
         aspect = resolve_aspect_ratio(aspect_ratio)
+        reference_images = kwargs.get("reference_images") or []
 
         if not prompt:
             return error_response(
@@ -324,6 +358,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 prompt=prompt,
                 size=size,
                 quality=meta["quality"],
+                reference_images=reference_images,
             )
         except Exception as exc:
             logger.debug("Codex image generation failed", exc_info=True)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -41,6 +41,7 @@ PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
 AUTHOR_MAP = {
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
+    "cypres0099@users.noreply.github.com": "cypres0099",
     "0x.badfriend@gmail.com": "discodirector",
     "altriatree@gmail.com": "TruaShamu",
     "m@mobrienv.dev": "mikeyobrien",

--- a/tests/agent/test_image_gen_provider_helpers.py
+++ b/tests/agent/test_image_gen_provider_helpers.py
@@ -119,3 +119,92 @@ class TestNormalizeReferenceImage:
         block = normalize_reference_image("~/ref.png")
         assert block is not None
         assert block["image_url"].startswith("data:image/png;base64,")
+
+
+class TestRecentAttachedImagePathsRegister:
+    """Cover the session-scoped attachment register that the gateway writes
+    into and the ``image_generate`` tool reads from for img2img auto-inject.
+    """
+
+    def setup_method(self, method):
+        # Reset module-level state between tests so they don't bleed.
+        from agent import image_routing
+        image_routing._RECENT_ATTACHED_IMAGE_PATHS.clear()
+
+    def teardown_method(self, method):
+        from agent import image_routing
+        image_routing._RECENT_ATTACHED_IMAGE_PATHS.clear()
+
+    def test_register_then_get_round_trip(self):
+        from agent.image_routing import (
+            register_recent_attached_image_paths,
+            get_recent_attached_image_paths,
+        )
+        register_recent_attached_image_paths("sess-A", ["/tmp/a.png", "/tmp/b.png"])
+        assert get_recent_attached_image_paths("sess-A") == ["/tmp/a.png", "/tmp/b.png"]
+
+    def test_get_returns_independent_copy(self):
+        """Mutating the returned list must not corrupt the register."""
+        from agent.image_routing import (
+            register_recent_attached_image_paths,
+            get_recent_attached_image_paths,
+        )
+        register_recent_attached_image_paths("sess-A", ["/tmp/a.png"])
+        out = get_recent_attached_image_paths("sess-A")
+        out.append("/tmp/sneaky.png")
+        assert get_recent_attached_image_paths("sess-A") == ["/tmp/a.png"]
+
+    def test_get_unknown_session_returns_empty(self):
+        from agent.image_routing import get_recent_attached_image_paths
+        assert get_recent_attached_image_paths("never-registered") == []
+
+    def test_empty_session_key_is_a_no_op(self):
+        from agent.image_routing import (
+            register_recent_attached_image_paths,
+            get_recent_attached_image_paths,
+            clear_recent_attached_image_paths,
+        )
+        register_recent_attached_image_paths("", ["/tmp/x.png"])
+        assert get_recent_attached_image_paths("") == []
+        clear_recent_attached_image_paths("")  # must not raise
+
+    def test_register_replaces_previous(self):
+        """A new attachment shadows older ones — the model edits the *latest*
+        thing the user sent, not stale state from earlier in the session.
+        """
+        from agent.image_routing import (
+            register_recent_attached_image_paths,
+            get_recent_attached_image_paths,
+        )
+        register_recent_attached_image_paths("sess-A", ["/tmp/old.png"])
+        register_recent_attached_image_paths("sess-A", ["/tmp/new.png"])
+        assert get_recent_attached_image_paths("sess-A") == ["/tmp/new.png"]
+
+    def test_clear_removes_only_target_session(self):
+        from agent.image_routing import (
+            register_recent_attached_image_paths,
+            get_recent_attached_image_paths,
+            clear_recent_attached_image_paths,
+        )
+        register_recent_attached_image_paths("sess-A", ["/tmp/a.png"])
+        register_recent_attached_image_paths("sess-B", ["/tmp/b.png"])
+        clear_recent_attached_image_paths("sess-A")
+        assert get_recent_attached_image_paths("sess-A") == []
+        assert get_recent_attached_image_paths("sess-B") == ["/tmp/b.png"]
+
+    def test_clear_unknown_session_is_noop(self):
+        from agent.image_routing import clear_recent_attached_image_paths
+        clear_recent_attached_image_paths("never-registered")  # must not raise
+
+    def test_persistent_across_reads_for_multi_turn_edits(self):
+        """Reads are non-destructive so the model can refer to the same
+        source across multiple agent turns ("now make it red", "now bigger")
+        without the user re-sending the photo.
+        """
+        from agent.image_routing import (
+            register_recent_attached_image_paths,
+            get_recent_attached_image_paths,
+        )
+        register_recent_attached_image_paths("sess-A", ["/tmp/a.png"])
+        for _ in range(3):
+            assert get_recent_attached_image_paths("sess-A") == ["/tmp/a.png"]

--- a/tests/agent/test_image_gen_provider_helpers.py
+++ b/tests/agent/test_image_gen_provider_helpers.py
@@ -1,0 +1,121 @@
+"""Tests for shared helpers in ``agent.image_gen_provider``.
+
+Today this module only covers :func:`normalize_reference_image`, which was
+introduced alongside reference-image (image-to-image) support for the
+``openai-codex`` provider. Other providers can reuse the helper as they
+gain reference-image support.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+
+from agent.image_gen_provider import normalize_reference_image
+
+
+# 1×1 transparent PNG
+_PNG_HEX = (
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000d49444154789c6300010000000500010d0a2db40000000049454e44"
+    "ae426082"
+)
+
+
+def _png_bytes() -> bytes:
+    return bytes.fromhex(_PNG_HEX)
+
+
+class TestNormalizeReferenceImage:
+    def test_none_returns_none(self):
+        assert normalize_reference_image(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert normalize_reference_image("") is None
+        assert normalize_reference_image("   ") is None
+
+    def test_unsupported_type_returns_none(self):
+        assert normalize_reference_image(12345) is None
+        assert normalize_reference_image({"path": "/tmp/x.png"}) is None
+
+    def test_data_url_passes_through(self):
+        url = "data:image/png;base64,iVBORw0KGgo="
+        block = normalize_reference_image(url)
+        assert block == {"type": "input_image", "image_url": url}
+
+    def test_http_url_passes_through(self):
+        url = "https://example.com/cat.png"
+        assert normalize_reference_image(url) == {
+            "type": "input_image",
+            "image_url": url,
+        }
+
+    def test_http_insecure_url_passes_through(self):
+        url = "http://example.com/cat.png"
+        assert normalize_reference_image(url) == {
+            "type": "input_image",
+            "image_url": url,
+        }
+
+    def test_missing_file_returns_none(self, tmp_path):
+        block = normalize_reference_image(str(tmp_path / "does-not-exist.png"))
+        assert block is None
+
+    def test_existing_png_path_str(self, tmp_path):
+        f = tmp_path / "cat.png"
+        f.write_bytes(_png_bytes())
+        block = normalize_reference_image(str(f))
+        assert block is not None
+        assert block["type"] == "input_image"
+        expected_b64 = base64.b64encode(_png_bytes()).decode()
+        assert block["image_url"] == f"data:image/png;base64,{expected_b64}"
+
+    def test_existing_path_object(self, tmp_path):
+        f = tmp_path / "cat.png"
+        f.write_bytes(_png_bytes())
+        block = normalize_reference_image(Path(f))
+        assert block is not None
+        assert block["image_url"].startswith("data:image/png;base64,")
+
+    def test_jpeg_suffix_uses_image_jpeg_mime(self, tmp_path):
+        f = tmp_path / "cat.jpg"
+        f.write_bytes(_png_bytes())  # bytes don't matter for the mime mapping
+        block = normalize_reference_image(str(f))
+        assert block is not None
+        assert block["image_url"].startswith("data:image/jpeg;base64,")
+
+    @pytest.mark.parametrize(
+        "suffix,expected_mime",
+        [
+            (".png", "image/png"),
+            (".jpg", "image/jpeg"),
+            (".jpeg", "image/jpeg"),
+            (".webp", "image/webp"),
+            (".gif", "image/gif"),
+            (".PNG", "image/png"),
+            (".JPG", "image/jpeg"),
+        ],
+    )
+    def test_mime_inferred_from_suffix(self, tmp_path, suffix, expected_mime):
+        f = tmp_path / f"ref{suffix}"
+        f.write_bytes(_png_bytes())
+        block = normalize_reference_image(str(f))
+        assert block is not None
+        assert block["image_url"].startswith(f"data:{expected_mime};base64,")
+
+    def test_unknown_suffix_falls_back_to_png_mime(self, tmp_path):
+        f = tmp_path / "ref.bin"
+        f.write_bytes(_png_bytes())
+        block = normalize_reference_image(str(f))
+        assert block is not None
+        assert block["image_url"].startswith("data:image/png;base64,")
+
+    def test_user_home_path_expansion(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        f = tmp_path / "ref.png"
+        f.write_bytes(_png_bytes())
+        block = normalize_reference_image("~/ref.png")
+        assert block is not None
+        assert block["image_url"].startswith("data:image/png;base64,")

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -283,6 +283,108 @@ class TestGenerate:
         assert "cloudflare 403" in result["error"]
 
 
+# ── Reference images (image-to-image) ──────────────────────────────────────
+
+
+class TestReferenceImages:
+    """Cover the ``reference_images`` kwarg path: extra ``input_image`` blocks
+    appended to the user content alongside the text prompt.
+    """
+
+    def _setup_capture(self, monkeypatch):
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(
+                type="image_generation_call",
+                status="generating",
+                id="ig_test",
+                result=_b64_png(),
+            )
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            final_response = SimpleNamespace(output=[], status="completed", output_text="")
+            return _FakeStream([done_event], final_response)
+
+        fake_client = SimpleNamespace(responses=SimpleNamespace(stream=_stream))
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+        return captured
+
+    def test_no_reference_images_keeps_text_only_content(self, provider, monkeypatch):
+        captured = self._setup_capture(monkeypatch)
+        result = provider.generate("a cat")
+        assert result["success"] is True
+
+        content = captured["input"][0]["content"]
+        assert len(content) == 1
+        assert content[0] == {"type": "input_text", "text": "a cat"}
+
+    def test_reference_image_data_url_appended_as_input_image(self, provider, monkeypatch):
+        captured = self._setup_capture(monkeypatch)
+        ref = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+        result = provider.generate("modify it", reference_images=[ref])
+        assert result["success"] is True
+
+        content = captured["input"][0]["content"]
+        assert len(content) == 2
+        assert content[0]["type"] == "input_text"
+        assert content[1] == {"type": "input_image", "image_url": ref}
+
+    def test_reference_image_file_path_encoded_to_data_url(
+        self, provider, monkeypatch, tmp_path
+    ):
+        f = tmp_path / "ref.png"
+        f.write_bytes(bytes.fromhex(_PNG_HEX))
+        captured = self._setup_capture(monkeypatch)
+
+        result = provider.generate("change the bg", reference_images=[str(f)])
+        assert result["success"] is True
+
+        content = captured["input"][0]["content"]
+        assert len(content) == 2
+        assert content[1]["type"] == "input_image"
+        assert content[1]["image_url"].startswith("data:image/png;base64,")
+
+    def test_multiple_reference_images_all_attached_in_order(
+        self, provider, monkeypatch, tmp_path
+    ):
+        f1 = tmp_path / "a.png"
+        f1.write_bytes(bytes.fromhex(_PNG_HEX))
+        f2 = tmp_path / "b.jpg"
+        f2.write_bytes(bytes.fromhex(_PNG_HEX))
+        captured = self._setup_capture(monkeypatch)
+
+        result = provider.generate(
+            "blend these",
+            reference_images=[str(f1), "https://example.com/c.png", str(f2)],
+        )
+        assert result["success"] is True
+
+        content = captured["input"][0]["content"]
+        assert len(content) == 4
+        assert content[0]["type"] == "input_text"
+        assert content[1]["image_url"].startswith("data:image/png;base64,")
+        assert content[2]["image_url"] == "https://example.com/c.png"
+        assert content[3]["image_url"].startswith("data:image/jpeg;base64,")
+
+    def test_unrecognised_reference_entries_are_skipped_not_fatal(
+        self, provider, monkeypatch
+    ):
+        captured = self._setup_capture(monkeypatch)
+        # Mix of one bad path and one good URL — call should succeed and only
+        # the good entry should appear in content.
+        result = provider.generate(
+            "edit",
+            reference_images=["/no/such/file/at/all.png", "https://example.com/x.png"],
+        )
+        assert result["success"] is True
+
+        content = captured["input"][0]["content"]
+        assert len(content) == 2
+        assert content[1]["image_url"] == "https://example.com/x.png"
+
+
 # ── Plugin entry point ──────────────────────────────────────────────────────
 
 

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -363,11 +363,20 @@ class TestAspectRatioNormalization:
 
 class TestRegistryIntegration:
 
-    def test_schema_exposes_only_prompt_and_aspect_ratio_to_agent(self, image_tool):
+    def test_schema_exposes_only_agent_facing_args(self, image_tool):
         """The agent-facing schema must stay tight — model selection is a
-        user-level config choice, not an agent-level arg."""
+        user-level config choice, not an agent-level arg.
+
+        ``reference_images`` is included as an optional agent-level arg
+        because image-to-image / reference-conditioned editing is something
+        the agent decides per call, not a user-level config choice.
+        """
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
-        assert set(props.keys()) == {"prompt", "aspect_ratio"}
+        assert set(props.keys()) == {"prompt", "aspect_ratio", "reference_images"}
+        # ``prompt`` stays the only required arg — reference_images and
+        # aspect_ratio must remain optional so plain text-to-image still
+        # works without any extra args.
+        assert image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["required"] == ["prompt"]
 
     def test_aspect_ratio_enum_is_three_values(self, image_tool):
         enum = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]["aspect_ratio"]["enum"]

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -97,3 +97,100 @@ class TestPluginDispatch:
         assert payload["success"] is True
         assert payload["provider"] == "codex"
         assert payload["aspect_ratio"] == "portrait"
+
+    def test_dispatch_forwards_reference_images_to_provider(self, monkeypatch, tmp_path):
+        """When the schema-level ``reference_images`` arg is non-empty, it must
+        flow through the dispatcher and land in the provider's ``generate()``
+        kwargs. Providers that do not implement reference-image support absorb
+        the kwarg via ``**kwargs`` — this test asserts the wiring, not the
+        downstream behavior.
+        """
+        from tools import image_generation_tool
+        from agent import image_gen_registry as registry_module
+        from hermes_cli import plugins as plugins_module
+
+        captured = {}
+
+        class _CaptureProvider(ImageGenProvider):
+            @property
+            def name(self) -> str:
+                return "capture"
+
+            def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+                captured.update({"prompt": prompt, "aspect_ratio": aspect_ratio, **kwargs})
+                return {
+                    "success": True,
+                    "image": "/tmp/capture.png",
+                    "model": "test-model",
+                    "prompt": prompt,
+                    "aspect_ratio": aspect_ratio,
+                    "provider": "capture",
+                }
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: capture\n")
+        image_gen_registry.register_provider(_CaptureProvider())
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "capture")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            registry_module, "get_provider",
+            lambda name: _CaptureProvider() if name == "capture" else None,
+        )
+
+        refs = ["/tmp/source-a.png", "https://example.com/source-b.png"]
+        dispatched = image_generation_tool._dispatch_to_plugin_provider(
+            "blend these",
+            "square",
+            reference_images=refs,
+        )
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is True
+        assert captured["reference_images"] == refs
+
+    def test_dispatch_omits_reference_images_kwarg_when_none(self, monkeypatch, tmp_path):
+        """An empty ``reference_images`` list should not appear in the
+        provider call kwargs at all — keeping the call shape identical to
+        the pre-PR behavior for plain text-to-image."""
+        from tools import image_generation_tool
+        from agent import image_gen_registry as registry_module
+        from hermes_cli import plugins as plugins_module
+
+        captured = {}
+
+        class _CaptureProvider(ImageGenProvider):
+            @property
+            def name(self) -> str:
+                return "capture"
+
+            def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+                captured.update({"prompt": prompt, "aspect_ratio": aspect_ratio, **kwargs})
+                return {
+                    "success": True,
+                    "image": "/tmp/capture.png",
+                    "model": "test-model",
+                    "prompt": prompt,
+                    "aspect_ratio": aspect_ratio,
+                    "provider": "capture",
+                }
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: capture\n")
+        image_gen_registry.register_provider(_CaptureProvider())
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "capture")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            registry_module, "get_provider",
+            lambda name: _CaptureProvider() if name == "capture" else None,
+        )
+
+        image_generation_tool._dispatch_to_plugin_provider("just text", "landscape")
+        assert "reference_images" not in captured
+
+        captured.clear()
+        image_generation_tool._dispatch_to_plugin_provider(
+            "still just text",
+            "landscape",
+            reference_images=[],
+        )
+        assert "reference_images" not in captured

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -194,3 +194,146 @@ class TestPluginDispatch:
             reference_images=[],
         )
         assert "reference_images" not in captured
+
+
+class TestAutoAttachReferenceImages:
+    """Cover the ``_handle_image_generate`` auto-inject path: when the
+    active session has registered attachment paths (gateway wrote them
+    after consuming a native image turn), the handler appends them to
+    the model-supplied ``reference_images`` so "edit this" Just Works
+    without the model needing to know on-disk paths.
+    """
+
+    def setup_method(self, method):
+        from agent import image_routing
+        image_routing._RECENT_ATTACHED_IMAGE_PATHS.clear()
+        # Reset session-key contextvar between tests.
+        from tools import approval
+        approval._approval_session_key.set("")
+
+    def teardown_method(self, method):
+        from agent import image_routing
+        image_routing._RECENT_ATTACHED_IMAGE_PATHS.clear()
+        from tools import approval
+        approval._approval_session_key.set("")
+
+    def _wire_capture_provider(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from agent import image_gen_registry as registry_module
+        from hermes_cli import plugins as plugins_module
+
+        captured = {}
+
+        class _CaptureProvider(ImageGenProvider):
+            @property
+            def name(self) -> str:
+                return "capture"
+
+            def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+                captured.update({"prompt": prompt, "aspect_ratio": aspect_ratio, **kwargs})
+                return {
+                    "success": True, "image": "/tmp/capture.png", "model": "test-model",
+                    "prompt": prompt, "aspect_ratio": aspect_ratio, "provider": "capture",
+                }
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: capture\n")
+        image_gen_registry.register_provider(_CaptureProvider())
+        monkeypatch.setattr(
+            image_generation_tool, "_read_configured_image_provider", lambda: "capture"
+        )
+        monkeypatch.setattr(
+            plugins_module, "_ensure_plugins_discovered", lambda *a, **kw: None
+        )
+        monkeypatch.setattr(
+            registry_module, "get_provider",
+            lambda name: _CaptureProvider() if name == "capture" else None,
+        )
+        return captured
+
+    def test_no_session_no_register_no_inject(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        captured = self._wire_capture_provider(monkeypatch, tmp_path)
+
+        image_generation_tool._handle_image_generate({"prompt": "draw a cat"})
+        assert "reference_images" not in captured
+
+    def test_session_with_register_auto_attaches(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from agent.image_routing import register_recent_attached_image_paths
+        from tools.approval import set_current_session_key
+
+        captured = self._wire_capture_provider(monkeypatch, tmp_path)
+
+        set_current_session_key("sess-X")
+        register_recent_attached_image_paths("sess-X", ["/tmp/auto.png"])
+
+        image_generation_tool._handle_image_generate({"prompt": "edit this"})
+        assert captured["reference_images"] == ["/tmp/auto.png"]
+
+    def test_explicit_refs_take_precedence_auto_appended(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from agent.image_routing import register_recent_attached_image_paths
+        from tools.approval import set_current_session_key
+
+        captured = self._wire_capture_provider(monkeypatch, tmp_path)
+
+        set_current_session_key("sess-X")
+        register_recent_attached_image_paths("sess-X", ["/tmp/auto.png", "/tmp/auto2.png"])
+
+        image_generation_tool._handle_image_generate({
+            "prompt": "blend",
+            "reference_images": ["/tmp/explicit.png"],
+        })
+        # Explicit first, auto entries appended in order, no duplicates.
+        assert captured["reference_images"] == [
+            "/tmp/explicit.png", "/tmp/auto.png", "/tmp/auto2.png",
+        ]
+
+    def test_dedup_when_explicit_overlaps_auto(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from agent.image_routing import register_recent_attached_image_paths
+        from tools.approval import set_current_session_key
+
+        captured = self._wire_capture_provider(monkeypatch, tmp_path)
+
+        set_current_session_key("sess-X")
+        register_recent_attached_image_paths("sess-X", ["/tmp/a.png", "/tmp/b.png"])
+
+        image_generation_tool._handle_image_generate({
+            "prompt": "edit",
+            "reference_images": ["/tmp/a.png"],
+        })
+        # /tmp/a.png appears once even though both explicit and auto have it.
+        assert captured["reference_images"] == ["/tmp/a.png", "/tmp/b.png"]
+
+    def test_other_session_register_does_not_leak(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from agent.image_routing import register_recent_attached_image_paths
+        from tools.approval import set_current_session_key
+
+        captured = self._wire_capture_provider(monkeypatch, tmp_path)
+
+        register_recent_attached_image_paths("other-session", ["/tmp/other.png"])
+        set_current_session_key("sess-X")  # different session
+
+        image_generation_tool._handle_image_generate({"prompt": "draw"})
+        assert "reference_images" not in captured
+
+    def test_register_persists_across_multiple_calls(self, monkeypatch, tmp_path):
+        """Reads are non-destructive: a single attachment can be referenced
+        across multiple turns ("now red", "now bigger") in the same session.
+        """
+        from tools import image_generation_tool
+        from agent.image_routing import register_recent_attached_image_paths
+        from tools.approval import set_current_session_key
+
+        captured = self._wire_capture_provider(monkeypatch, tmp_path)
+
+        set_current_session_key("sess-X")
+        register_recent_attached_image_paths("sess-X", ["/tmp/auto.png"])
+
+        for prompt in ("make it red", "now bigger", "rotate 90"):
+            image_generation_tool._handle_image_generate({"prompt": prompt})
+            assert captured["reference_images"] == ["/tmp/auto.png"]
+            captured.clear()

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -993,7 +993,7 @@ def _dispatch_to_plugin_provider(
         })
 
     try:
-        kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
+        kwargs: Dict[str, Any] = {"prompt": prompt, "aspect_ratio": aspect_ratio}
         if configured_model:
             kwargs["model"] = configured_model
         if reference_images:

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -1020,12 +1020,62 @@ def _dispatch_to_plugin_provider(
     return json.dumps(result)
 
 
+def _resolve_session_auto_reference_images() -> list:
+    """Look up image paths attached to the most recent inbound message on the
+    active gateway session, for auto-injection into ``image_generate`` calls.
+
+    Returns an empty list if the active session is unknown (e.g. CLI
+    invocation outside of a gateway context), if no attachments have been
+    registered for it, or if the lookup raises for any reason. Auto-inject
+    is a UX convenience — never let it block a generate call.
+    """
+    try:
+        from tools.approval import get_current_session_key
+        from agent.image_routing import get_recent_attached_image_paths
+
+        session_key = get_current_session_key(default="")
+        if not session_key:
+            return []
+        return get_recent_attached_image_paths(session_key)
+    except Exception as exc:
+        logger.debug("auto-resolve reference_images skipped: %s", exc)
+        return []
+
+
+def _merge_reference_images(explicit: list, auto: list) -> list:
+    """Combine explicit reference_images (from the model's tool call) with
+    auto-resolved session attachments. Explicit entries come first and win
+    duplicates, so the model can deliberately point to a different source
+    while still benefiting from auto-attachment when it doesn't.
+    """
+    merged = list(explicit or [])
+    seen = {str(x) for x in merged}
+    for p in auto or []:
+        key = str(p)
+        if key not in seen:
+            merged.append(p)
+            seen.add(key)
+    return merged
+
+
 def _handle_image_generate(args, **kw):
     prompt = args.get("prompt", "")
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
-    reference_images = args.get("reference_images") or []
+    explicit_refs = list(args.get("reference_images") or [])
+
+    # Auto-inject the most recent session attachment paths so "edit this"
+    # works without the model needing to know on-disk paths. Explicit
+    # reference_images from the model take precedence over auto-resolved
+    # ones (no overwrite, no shadowing — auto entries are appended).
+    auto_refs = _resolve_session_auto_reference_images()
+    reference_images = _merge_reference_images(explicit_refs, auto_refs)
+    if auto_refs and not explicit_refs:
+        logger.info(
+            "image_generate: auto-attaching %d session reference image(s)",
+            len(auto_refs),
+        )
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -854,11 +854,12 @@ from tools.registry import registry, tool_error
 IMAGE_GENERATE_SCHEMA = {
     "name": "image_generate",
     "description": (
-        "Generate high-quality images from text prompts. The underlying "
-        "backend (FAL, OpenAI, etc.) and model are user-configured and not "
-        "selectable by the agent. Returns either a URL or an absolute file "
-        "path in the `image` field; display it with markdown "
-        "![description](url-or-path) and the gateway will deliver it."
+        "Generate high-quality images from text prompts, optionally "
+        "conditioned on one or more reference images for image-to-image "
+        "edits. The underlying backend (FAL, OpenAI, etc.) and model are "
+        "user-configured and not selectable by the agent. Returns either a "
+        "URL or an absolute file path in the `image` field; display it with "
+        "markdown ![description](url-or-path) and the gateway will deliver it."
     ),
     "parameters": {
         "type": "object",
@@ -872,6 +873,19 @@ IMAGE_GENERATE_SCHEMA = {
                 "enum": list(VALID_ASPECT_RATIOS),
                 "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
                 "default": DEFAULT_ASPECT_RATIO,
+            },
+            "reference_images": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional reference images to condition generation on, "
+                    "for image-to-image edits or refinements. Each entry may "
+                    "be an absolute file path, a data: URL, or an http(s) URL. "
+                    "Pass when modifying or extending an existing image; omit "
+                    "for plain text-to-image. Support depends on the active "
+                    "image_gen.provider — currently honored by 'openai-codex'; "
+                    "providers without reference-image support ignore it."
+                ),
             },
         },
         "required": ["prompt"],
@@ -915,7 +929,12 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(
+    prompt: str,
+    aspect_ratio: str,
+    *,
+    reference_images: Optional[list] = None,
+):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -925,6 +944,12 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
     it does not point to ``fal`` (FAL still lives in-tree in this PR;
     a later PR ports it into ``plugins/image_gen/fal/``). Any other value
     that matches a registered plugin provider wins.
+
+    ``reference_images`` is forwarded to the provider as a kwarg when
+    non-empty. Providers that do not implement reference-image support
+    will silently ignore it (the kwarg is absorbed by ``**kwargs`` on the
+    base class) — callers can probe support via the provider's docstring
+    or a future capability flag.
     """
     configured = _read_configured_image_provider()
     if not configured or configured == "fal":
@@ -971,6 +996,8 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
         if configured_model:
             kwargs["model"] = configured_model
+        if reference_images:
+            kwargs["reference_images"] = reference_images
         result = provider.generate(**kwargs)
     except Exception as exc:
         logger.warning(
@@ -998,12 +1025,25 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    reference_images = args.get("reference_images") or []
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(
+        prompt,
+        aspect_ratio,
+        reference_images=reference_images,
+    )
     if dispatched is not None:
         return dispatched
+
+    if reference_images:
+        logger.warning(
+            "image_generate received %d reference_images but the active "
+            "backend (FAL in-tree) does not support image-to-image; "
+            "ignoring them and falling back to text-to-image.",
+            len(reference_images),
+        )
 
     return image_generate_tool(
         prompt=prompt,


### PR DESCRIPTION
## Summary

Builds on #21463 (which adds the ``reference_images`` arg to ``image_generate``) so the *end-user* flow Just Works:

> User sends a photo over a gateway platform → "add a hat" → model produces an actual image-to-image edit, not a fresh text-to-image.

Without auto-attach, the model has no way to pass the attachment as ``reference_images``: it sees the inline ``image_url`` content but not the on-disk path the tool needs. Forcing the user to type a file path defeats the point of img2img on a chat platform.

## What this changes

- New session-scoped register in ``agent.image_routing``:
  - ``register_recent_attached_image_paths(session_key, paths)`` — gateway populates this right after consuming the per-turn pending native paths.
  - ``get_recent_attached_image_paths(session_key)`` — non-destructive read so the model can refer to the same source across multiple turns (\"now red\", \"now bigger\").
  - ``clear_recent_attached_image_paths(session_key)`` — wired into the gateway's auto-reset branch so a fresh conversation does not inherit attachment state.

- ``_handle_image_generate`` resolves the active session via the existing ``tools.approval`` contextvar (already set by the gateway right before ``run_conversation`` for approval flow purposes), reads the register, and merges the paths into ``reference_images``. Explicit entries from the model's tool call take precedence; auto entries are appended (with dedup) so the model can deliberately point to a different source while still benefiting from auto-attach when it doesn't.

## End-user flow this unlocks

1. User sends a photo + \"add a dinosaur\".
2. Gateway saves the attachment, registers the path under the session, forwards both the prompt and the inline image to the model.
3. Model sees the image and calls ``image_generate(\"add a dinosaur\")`` with no ``reference_images``.
4. Tool handler auto-injects the registered path → provider receives ``reference_images=[\"/path/to/photo.jpg\"]`` → true image-to-image.

UX win is biggest on platforms where the user can't easily type a file path (iMessage, Slack, Telegram). On the CLI it's also handy because users don't typically think to pass paths.

## Backward compatibility

- New register is purely additive — nothing reads from it unless ``_handle_image_generate`` is called.
- Auto-inject is a no-op when there is no active session (CLI invocation outside of gateway), no registered paths for the session, or any lookup raises (the resolver swallows exceptions and logs at debug — never blocks a generate call).
- Explicit ``reference_images`` from the tool call still win — auto entries are appended, not overwritten.
- No ABI changes to provider plugins; they already absorb ``reference_images`` via ``**kwargs`` (per #21463).

## Tests

| File | Coverage |
|------|----------|
| ``tests/agent/test_image_gen_provider_helpers.py`` | New ``TestRecentAttachedImagePathsRegister``: round-trip, returned-list immutability, unknown-session empty, empty-session-key no-op, replace-on-new-attachment, per-session isolation, persist across multi-read. |
| ``tests/tools/test_image_generation_plugin_dispatch.py`` | New ``TestAutoAttachReferenceImages``: no-session no-inject, registered paths auto-attach, explicit-takes-precedence, dedup when explicit overlaps auto, cross-session isolation, persistence across consecutive ``image_generate`` calls in same session. |

61 tests pass in the affected area; 117 in wider sweep.

## Dependency

This PR depends on #21463 (adds the ``reference_images`` arg to the schema/dispatcher/openai-codex plugin). It can be reviewed standalone, but rebases or is best merged after #21463.

## Test plan
- [x] New unit tests cover register, get, clear, and auto-inject merge semantics
- [x] Smoke-tested live: gateway hooks fire, paths are registered, ``image_generate`` log shows ``auto-attaching N session reference image(s)``
- [ ] Optional follow-up: surface the recent attachment paths to the model in a hidden context note (\"available source images at: ...\") so it can also \*\*explicitly\*\* reference them when the auto-inject is the wrong choice (e.g. user attached two photos and only wants to edit one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)