### PR TITLE
feat(gateway): per-channel model binding (Discord)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -658,6 +658,12 @@ platform_toolsets:
 #     reply_to_mode: "first"  # off | first | all
 #     extra:
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
+#
+#   discord:
+#     channel_prompts:                              # Per-channel ephemeral system prompts
+#       "1487971329297744053": "You are a helpful assistant for this channel."
+#     channel_models:                               # Per-channel model override (inherits global provider)
+#       "1487971329297744053": qwen3.5-397b-fast    # Forum threads inherit parent channel model
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Available toolsets (use these names in platform_toolsets or the toolsets list)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -776,6 +776,12 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = {str(k): v for k, v in channel_prompts.items()}
                     else:
                         bridged["channel_prompts"] = channel_prompts
+                if "channel_models" in platform_cfg:
+                    channel_models = platform_cfg["channel_models"]
+                    if isinstance(channel_models, dict):
+                        bridged["channel_models"] = {str(k): str(v) for k, v in channel_models.items()}
+                    else:
+                        bridged["channel_models"] = channel_models
                 enabled_was_explicit = "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -909,6 +909,8 @@ class MessageEvent:
     # Per-channel ephemeral system prompt (e.g. Discord channel_prompts).
     # Applied at API call time and never persisted to transcript history.
     channel_prompt: Optional[str] = None
+    # Per-channel model override (model name string, inherits global provider).
+    channel_model: Optional[str] = None
     
     # Internal flag — set for synthetic events (e.g. background process
     # completion notifications) that must bypass user authorization checks.
@@ -1145,6 +1147,34 @@ def resolve_channel_prompt(
         prompt = str(prompt).strip()
         if prompt:
             return prompt
+    return None
+
+
+def resolve_channel_model(
+    config_extra: dict,
+    channel_id: str,
+    parent_id: str | None = None,
+) -> str | None:
+    """Resolve a per-channel model override from platform config.
+
+    Looks up ``channel_models`` in the adapter's ``config.extra`` dict.
+    Prefers exact match on *channel_id*; falls back to *parent_id*
+    (forum threads inherit parent channel model).
+
+    Returns the model name string, or None if no match.
+    """
+    models = config_extra.get("channel_models") or {}
+    if not isinstance(models, dict):
+        return None
+    for key in (channel_id, parent_id):
+        if not key:
+            continue
+        model = models.get(key)
+        if model is None:
+            continue
+        model = str(model).strip()
+        if model:
+            return model
     return None
 
 

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3415,6 +3415,7 @@ class DiscordAdapter(BasePlatformAdapter):
             source=source,
             raw_message=interaction,
             channel_prompt=self._resolve_channel_prompt(channel_id, parent_id or None),
+            channel_model=self._resolve_channel_model(channel_id, parent_id or None),
         )
 
     # ------------------------------------------------------------------
@@ -3492,6 +3493,7 @@ class DiscordAdapter(BasePlatformAdapter):
         _parent_id = str(getattr(_parent_channel, "id", "") or "")
         _skills = self._resolve_channel_skills(thread_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(thread_id, _parent_id or None)
+        _channel_model = self._resolve_channel_model(thread_id, _parent_id or None)
         event = MessageEvent(
             text=text,
             message_type=MessageType.TEXT,
@@ -3499,6 +3501,7 @@ class DiscordAdapter(BasePlatformAdapter):
             raw_message=interaction,
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
+            channel_model=_channel_model,
         )
         await self.handle_message(event)
 
@@ -3518,6 +3521,11 @@ class DiscordAdapter(BasePlatformAdapter):
         """Resolve a Discord per-channel prompt, preferring the exact channel over its parent."""
         from gateway.platforms.base import resolve_channel_prompt
         return resolve_channel_prompt(self.config.extra, channel_id, parent_id)
+
+    def _resolve_channel_model(self, channel_id: str, parent_id: str | None = None) -> str | None:
+        """Resolve a Discord per-channel model override, preferring the exact channel over its parent."""
+        from gateway.platforms.base import resolve_channel_model
+        return resolve_channel_model(self.config.extra, channel_id, parent_id)
 
     def _discord_require_mention(self) -> bool:
         """Return whether Discord channel messages require a bot mention."""
@@ -4293,6 +4301,7 @@ class DiscordAdapter(BasePlatformAdapter):
         _chan_id = str(getattr(_chan, "id", ""))
         _skills = self._resolve_channel_skills(_chan_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(_chan_id, _parent_id or None)
+        _channel_model = self._resolve_channel_model(_chan_id, _parent_id or None)
 
         reply_to_id = None
         reply_to_text = None
@@ -4314,6 +4323,7 @@ class DiscordAdapter(BasePlatformAdapter):
             timestamp=message.created_at,
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
+            channel_model=_channel_model,
         )
 
         # Track thread participation so the bot won't require @mention for

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1626,6 +1626,7 @@ class GatewayRunner:
         source: Optional[SessionSource] = None,
         session_key: Optional[str] = None,
         user_config: Optional[dict] = None,
+        channel_model: Optional[str] = None,
     ) -> tuple[str, dict]:
         """Resolve model/runtime for a session, honoring session-scoped /model overrides.
 
@@ -1641,6 +1642,13 @@ class GatewayRunner:
                 resolved_session_key = None
 
         model = _resolve_gateway_model(user_config)
+        # -- Channel model binding (config.yaml channel_models) --
+        if channel_model:
+            logger.debug(
+                "Channel model override: channel_model=%s (replaces config default %s)",
+                channel_model, model,
+            )
+            model = channel_model
         override = self._session_model_overrides.get(resolved_session_key) if resolved_session_key else None
         if override:
             override_model = override.get("model", model)
@@ -1652,7 +1660,7 @@ class GatewayRunner:
             }
             if override_runtime.get("api_key"):
                 logger.debug(
-                    "Session model override (fast): session=%s config_model=%s -> override_model=%s provider=%s",
+                    "Session model override (fast): session=%s base_model=%s -> override_model=%s provider=%s",
                     resolved_session_key or "", model, override_model,
                     override_runtime.get("provider"),
                 )
@@ -1660,12 +1668,12 @@ class GatewayRunner:
             # Override exists but has no api_key — fall through to env-based
             # resolution and apply model/provider from the override on top.
             logger.debug(
-                "Session model override (no api_key, fallback): session=%s config_model=%s override_model=%s",
+                "Session model override (no api_key, fallback): session=%s base_model=%s override_model=%s",
                 resolved_session_key or "", model, override_model,
             )
         else:
             logger.debug(
-                "No session model override: session=%s config_model=%s override_keys=%s",
+                "No session model override: session=%s base_model=%s override_keys=%s",
                 resolved_session_key or "", model,
                 list(self._session_model_overrides.keys())[:5] if self._session_model_overrides else "[]",
             )
@@ -5220,6 +5228,7 @@ class GatewayRunner:
                         source=event.source,
                         message_id=event.message_id,
                         channel_prompt=event.channel_prompt,
+                        channel_model=event.channel_model,
                     )
                     self._enqueue_fifo(_quick_key, queued_event, adapter)
                 depth = self._queue_depth(_quick_key, adapter=self.adapters.get(source.platform))
@@ -5247,6 +5256,7 @@ class GatewayRunner:
                             source=event.source,
                             message_id=event.message_id,
                             channel_prompt=event.channel_prompt,
+                            channel_model=event.channel_model,
                         )
                         adapter._pending_messages[_quick_key] = queued_event
                     return "Agent still starting — /steer queued for the next turn."
@@ -5269,6 +5279,7 @@ class GatewayRunner:
                         source=event.source,
                         message_id=event.message_id,
                         channel_prompt=event.channel_prompt,
+                        channel_model=event.channel_model,
                     )
                     adapter._pending_messages[_quick_key] = queued_event
                 return "No active agent — /steer queued for the next turn."
@@ -6698,6 +6709,7 @@ class GatewayRunner:
                 run_generation=run_generation,
                 event_message_id=event.message_id,
                 channel_prompt=event.channel_prompt,
+                channel_model=event.channel_model,
             )
 
             # Stop persistent typing indicator now that the agent is done
@@ -7926,6 +7938,10 @@ class GatewayRunner:
             current_base_url = override.get("base_url", current_base_url)
             current_api_key = override.get("api_key", current_api_key)
 
+        # Fall back to channel_model when no session override is active
+        if not override and getattr(event, "channel_model", None):
+            current_model = event.channel_model
+
         # No args: show interactive picker (Telegram/Discord) or text list
         if not model_input and not explicit_provider:
             # Try interactive picker if the platform supports it
@@ -8328,6 +8344,7 @@ class GatewayRunner:
             source=source,
             raw_message=event.raw_message,
             channel_prompt=event.channel_prompt,
+            channel_model=event.channel_model,
         )
         
         # Let the normal message handler process it
@@ -8438,6 +8455,7 @@ class GatewayRunner:
                     source=event.source,
                     message_id=event.message_id,
                     channel_prompt=event.channel_prompt,
+                    channel_model=event.channel_model,
                 )
                 self._enqueue_fifo(_quick_key, kickoff_event, adapter)
             except Exception as exc:
@@ -13012,6 +13030,7 @@ class GatewayRunner:
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         channel_prompt: Optional[str] = None,
+        channel_model: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Run the agent with the given message and context.
@@ -13026,6 +13045,7 @@ class GatewayRunner:
         Supports interruption via new messages.
         """
         # ---- Proxy mode: delegate to remote API server ----
+        # Note: channel_prompt and channel_model are not forwarded in proxy mode.
         if self._get_proxy_url():
             return await self._run_agent_via_proxy(
                 message=message,
@@ -13587,6 +13607,7 @@ class GatewayRunner:
                     source=source,
                     session_key=session_key,
                     user_config=user_config,
+                    channel_model=channel_model,
                 )
                 logger.debug(
                     "run_agent resolved: model=%s provider=%s session=%s",
@@ -14787,6 +14808,7 @@ class GatewayRunner:
                 next_message = pending
                 next_message_id = None
                 next_channel_prompt = None
+                next_channel_model = None
                 if pending_event is not None:
                     next_source = getattr(pending_event, "source", None) or source
                     next_message = await self._prepare_inbound_message_text(
@@ -14798,6 +14820,7 @@ class GatewayRunner:
                         return result
                     next_message_id = getattr(pending_event, "message_id", None)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
+                    next_channel_model = getattr(pending_event, "channel_model", None)
 
                 # Restart typing indicator so the user sees activity while
                 # the follow-up turn runs.  The outer _process_message_background
@@ -14823,6 +14846,7 @@ class GatewayRunner:
                     _interrupt_depth=_interrupt_depth + 1,
                     event_message_id=next_message_id,
                     channel_prompt=next_channel_prompt,
+                    channel_model=next_channel_model,
                 )
         finally:
             # Stop progress sender, interrupt monitor, and notification task

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1106,6 +1106,7 @@ DEFAULT_CONFIG = {
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "channel_prompts": {},         # Per-channel ephemeral system prompts
+        "channel_models": {},          # Per-channel model override (deferred — not yet wired for Slack)
     },
 
     # Discord platform settings (gateway mode)
@@ -1116,6 +1117,7 @@ DEFAULT_CONFIG = {
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
+        "channel_models": {},          # Per-channel model override (model name string, inherits global provider)
         # Opt-in DM role-based auth (#12136). By default, DISCORD_ALLOWED_ROLES
         # authorizes only guild messages in the role's own guild — DMs require
         # DISCORD_ALLOWED_USERS. Set dm_role_auth_guild to a guild ID to also
@@ -1144,6 +1146,7 @@ DEFAULT_CONFIG = {
     "telegram": {
         "reactions": False,            # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
+        "channel_models": {},          # Per-chat model override (deferred — not yet wired for Telegram)
         "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
     },
 
@@ -1153,6 +1156,7 @@ DEFAULT_CONFIG = {
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "channel_prompts": {},         # Per-channel ephemeral system prompts
+        "channel_models": {},          # Per-channel model override (deferred — not yet wired for Mattermost)
     },
 
     # Matrix platform settings (gateway mode)

--- a/tests/gateway/test_discord_channel_models.py
+++ b/tests/gateway/test_discord_channel_models.py
@@ -1,0 +1,396 @@
+"""Tests for Discord channel_models resolution and injection."""
+
+import sys
+import threading
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _ensure_discord_mock():
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+    discord_mod = types.ModuleType("discord")
+    discord_mod.Intents = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.Interaction = object
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, resolve_channel_model
+from gateway.session import SessionSource
+
+
+def _make_adapter():
+    _ensure_discord_mock()
+    from gateway.platforms.discord import DiscordAdapter
+
+    adapter = object.__new__(DiscordAdapter)
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    return adapter
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="12345",
+        chat_type="thread",
+        user_id="user-1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# resolve_channel_model unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveChannelModel:
+    def test_no_config_returns_none(self):
+        assert resolve_channel_model({}, "123") is None
+
+    def test_empty_dict_returns_none(self):
+        assert resolve_channel_model({"channel_models": {}}, "123") is None
+
+    def test_non_dict_config_returns_none(self):
+        assert resolve_channel_model({"channel_models": "not a dict"}, "123") is None
+
+    def test_match_by_channel_id(self):
+        config = {"channel_models": {"100": "qwen3.5-397b-fast"}}
+        assert resolve_channel_model(config, "100") == "qwen3.5-397b-fast"
+
+    def test_match_by_parent_id_fallback(self):
+        config = {"channel_models": {"200": "glm-5-turbo"}}
+        assert resolve_channel_model(config, "999", parent_id="200") == "glm-5-turbo"
+
+    def test_exact_channel_overrides_parent(self):
+        config = {"channel_models": {"999": "model-thread", "200": "model-forum"}}
+        assert resolve_channel_model(config, "999", parent_id="200") == "model-thread"
+
+    def test_blank_model_ignored(self):
+        config = {"channel_models": {"100": "   "}}
+        assert resolve_channel_model(config, "100") is None
+
+    def test_numeric_yaml_keys_normalized_at_bridging(self):
+        """Config bridging stringifies keys; resolver expects string keys."""
+        config = {"channel_models": {"100": "good-model"}}
+        assert resolve_channel_model(config, "100") == "good-model"
+        # Pre-bridging numeric key won't match (bridging is responsible)
+        config_raw = {"channel_models": {100: "good-model"}}
+        assert resolve_channel_model(config_raw, "100") is None
+
+    def test_integer_channel_id_matched_as_string(self):
+        """channel_id passed as string; bridging ensures keys are strings."""
+        config = {"channel_models": {"100": "test-model"}}
+        assert resolve_channel_model(config, "100") == "test-model"
+
+
+# ---------------------------------------------------------------------------
+# Discord adapter _resolve_channel_model tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiscordAdapterResolveChannelModel:
+    def test_no_models_returns_none(self):
+        adapter = _make_adapter()
+        assert adapter._resolve_channel_model("123") is None
+
+    def test_match_by_channel_id(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_models": {"100": "qwen3.5-397b-fast"}}
+        assert adapter._resolve_channel_model("100") == "qwen3.5-397b-fast"
+
+    def test_match_by_parent_id(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_models": {"200": "glm-5-turbo"}}
+        assert adapter._resolve_channel_model("999", parent_id="200") == "glm-5-turbo"
+
+    def test_exact_channel_overrides_parent(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {
+            "channel_models": {"999": "thread-model", "200": "forum-model"}
+        }
+        assert adapter._resolve_channel_model("999", parent_id="200") == "thread-model"
+
+
+# ---------------------------------------------------------------------------
+# MessageEvent wiring tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiscordMessageEventChannelModel:
+    def test_build_message_event_sets_channel_model(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_models": {"321": "test-model"}}
+        adapter.build_source = MagicMock(return_value=SimpleNamespace())
+
+        interaction = SimpleNamespace(
+            channel_id=321,
+            channel=SimpleNamespace(name="general", guild=None, parent_id=None),
+            user=SimpleNamespace(id=1, display_name="Brenner"),
+        )
+        adapter._get_effective_topic = MagicMock(return_value=None)
+
+        event = adapter._build_slash_event(interaction, "/retry")
+
+        assert event.channel_model == "test-model"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_thread_session_inherits_parent_channel_model(self):
+        adapter = _make_adapter()
+        adapter.config.extra = {"channel_models": {"200": "parent-model"}}
+        adapter.build_source = MagicMock(return_value=SimpleNamespace())
+        adapter._get_effective_topic = MagicMock(return_value=None)
+        adapter.handle_message = AsyncMock()
+
+        interaction = SimpleNamespace(
+            guild=SimpleNamespace(name="Wetlands"),
+            channel=SimpleNamespace(id=200, parent=None),
+            user=SimpleNamespace(id=1, display_name="Brenner"),
+        )
+
+        await adapter._dispatch_thread_session(interaction, "999", "new-thread", "hello")
+
+        dispatched_event = adapter.handle_message.await_args.args[0]
+        assert dispatched_event.channel_model == "parent-model"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_session_agent_runtime channel_model injection tests
+# ---------------------------------------------------------------------------
+
+
+class _CapturingAgent:
+    last_init = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        self.tools = []
+
+    def run_conversation(self, user_message, conversation_history=None, task_id=None, persist_user_message=None):
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+            "completed": True,
+        }
+
+
+def _install_fake_agent(monkeypatch):
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._service_tier = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._pending_model_notes = {}
+    runner._session_db = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._session_model_overrides = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(streaming=None)
+    runner.session_store = SimpleNamespace(
+        get_or_create_session=lambda source: SimpleNamespace(session_id="session-1"),
+        load_transcript=lambda session_id: [],
+    )
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner._enrich_message_with_vision = AsyncMock(return_value="ENRICHED")
+    return runner
+
+
+class TestResolveSessionAgentRuntimeChannelModel:
+    def test_no_channel_model_uses_global_default(self, monkeypatch):
+        monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "global-model")
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {"provider": "openrouter", "api_key": "key"},
+        )
+        runner = _make_runner()
+        model, runtime = runner._resolve_session_agent_runtime(
+            user_config={},
+            channel_model=None,
+        )
+        assert model == "global-model"
+
+    def test_channel_model_overrides_global_default(self, monkeypatch):
+        monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "global-model")
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {"provider": "openrouter", "api_key": "key"},
+        )
+        runner = _make_runner()
+        model, runtime = runner._resolve_session_agent_runtime(
+            user_config={},
+            channel_model="channel-model",
+        )
+        assert model == "channel-model"
+
+    def test_session_override_wins_over_channel_model(self, monkeypatch):
+        monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "global-model")
+        runner = _make_runner()
+        runner._session_model_overrides["test-session"] = {
+            "model": "override-model",
+            "provider": "openrouter",
+            "api_key": "override-key",
+            "base_url": "https://example.com",
+            "api_mode": "chat_completions",
+        }
+        model, runtime = runner._resolve_session_agent_runtime(
+            session_key="test-session",
+            user_config={},
+            channel_model="channel-model",
+        )
+        assert model == "override-model"
+        assert runtime["api_key"] == "override-key"
+
+
+# ---------------------------------------------------------------------------
+# _run_agent end-to-end wiring test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_agent_receives_channel_model(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "global-default")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "test-key",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    _CapturingAgent.last_init = None
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:discord:thread:12345",
+        channel_model="channel-bound-model",
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init["model"] == "channel-bound-model"
+
+
+# ---------------------------------------------------------------------------
+# Retry preserves channel_model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_preserves_channel_model(monkeypatch):
+    runner = _make_runner()
+    runner.session_store = SimpleNamespace(
+        get_or_create_session=lambda source: SimpleNamespace(session_id="session-1", last_prompt_tokens=10),
+        load_transcript=lambda session_id: [
+            {"role": "user", "content": "original message"},
+            {"role": "assistant", "content": "old reply"},
+        ],
+        rewrite_transcript=MagicMock(),
+    )
+    runner._handle_message = AsyncMock(return_value="ok")
+
+    event = MessageEvent(
+        text="/retry",
+        message_type=gateway_run.MessageType.COMMAND,
+        source=_make_source(),
+        raw_message=SimpleNamespace(),
+        channel_model="retry-model",
+    )
+
+    result = await runner._handle_retry_command(event)
+
+    assert result == "ok"
+    retried_event = runner._handle_message.await_args.args[0]
+    assert retried_event.channel_model == "retry-model"
+
+
+# ---------------------------------------------------------------------------
+# Config bridging test
+# ---------------------------------------------------------------------------
+
+
+class TestConfigBridging:
+    def test_bridges_discord_channel_models_from_config_yaml(self, tmp_path, monkeypatch):
+        from gateway.config import load_gateway_config
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  channel_models:\n"
+            '    "123": qwen3.5-397b-fast\n'
+            "    456: glm-5-turbo\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].extra["channel_models"] == {
+            "123": "qwen3.5-397b-fast",
+            "456": "glm-5-turbo",
+        }
+
+    def test_bridges_stringify_values(self, tmp_path, monkeypatch):
+        """Values are coerced to strings during bridging."""
+        from gateway.config import load_gateway_config
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        # YAML may parse unquoted values as int/float
+        config_path.write_text(
+            "discord:\n"
+            "  channel_models:\n"
+            '    "123": some-model\n',
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        config = load_gateway_config()
+
+        val = config.platforms[Platform.DISCORD].extra["channel_models"]["123"]
+        assert isinstance(val, str)


### PR DESCRIPTION
## Summary

Partially Addresess #1955

Allows Discord channels to use different AI models via a `channel_models` config key, following the existing `channel_prompts` pattern exactly.

### Precedence

`/model` command → `channel_models[channel_id]` → `model.default`

### Config example

```yaml
platforms:
  discord:
    channel_models:
      "1234567890": anthropic/claude-sonnet-4
      "9876543210": ollama/llama3
```

## Approach

Minimal surface area — `Dict[str, str]` config, no new dataclass. Model string only (no provider/system_prompt override). Extensible to a full runtime bundle later.

This deliberately differs from PR #1991 which bundles model + provider + system_prompt into a `ChannelOverride` dataclass. Our rationale:

- **Smaller blast radius** — 5 production files (+77/-3 lines), follows established `channel_prompts` convention
- **No unrelated file changes** — maintainer feedback on #1991 explicitly flagged bundled changes in `delegate_tool.py`, `conftest.py`, `test_slack.py`, `test_whatsapp_connect.py` as needing removal
- **Easier to absorb** into foundational gateway rework — additive config key, no new config types
- **Discord-first** — other platforms get placeholder defaults, zero regression risk

## Changes

| File | Change |
|---|---|
| `hermes_cli/config.py` | `channel_models: {}` defaults for all platforms |
| `gateway/config.py` | Bridge `channel_models` into `PlatformConfig.extra` |
| `gateway/platforms/base.py` | `channel_model` field on `MessageEvent` + `resolve_channel_model()` helper |
| `gateway/platforms/discord.py` | `_resolve_channel_model()` method + 3 MessageEvent construction sites |
| `gateway/run.py` | `channel_model` param injection in `_resolve_session_agent_runtime` + 6 call sites |
| `cli-config.yaml.example` | Documented Discord example with `channel_models` |
| `tests/gateway/test_discord_channel_models.py` | 22 tests: resolver, adapter, MessageEvent wiring, runtime precedence, end-to-end, retry, config bridging |

## Testing

```
22 new tests — all passing
63 existing tests (channel_prompts, config) — no regressions
5031 gateway suite — 0 regressions (13 pre-existing failures unrelated)
```

### Known limitations

- **Proxy mode** silently ignores `channel_model` (same as `channel_prompt`) — the subprocess agent has its own config
- **Background tasks** (compression, summarize, cron) do not receive `channel_model` — intentional, no channel context
- **Non-Discord platforms** have config plumbing but no adapter wiring yet — mechanical follow-up

## Relation to #1991

#1991 is on hold pending foundational gateway changes (per maintainer comment). This PR offers a minimal, immediately-mergeable alternative that covers the core use case. If #1991 lands later with its `ChannelOverride` dataclass, `channel_models` can be deprecated in favor of the unified config surface.
