### PR TITLE
chore: simplify PR template and add flexible review policy

### DIFF
--- a/.github/PR_REVIEW_POLICY.md
+++ b/.github/PR_REVIEW_POLICY.md
@@ -1,0 +1,51 @@
+# PR Review Policy (Flexible)
+
+This repo uses a lightweight review model:
+
+- PRs should be reviewed, but process stays practical.
+- Maintainers can approve manually in GitHub UI.
+- Maintainers can also approve via CLI/agent.
+- No heavy mandatory checklist beyond baseline safety.
+
+## Recommended Review Standard
+
+Use severity tags in comments:
+- 🔴 Critical: must fix before merge
+- ⚠️ Warning: should fix before merge
+- 💡 Suggestion: optional improvement
+
+Decision guideline:
+- Approve when no critical/warning issues remain.
+- Request changes when blocking issues exist.
+- Comment for non-blocking suggestions.
+
+## Approve Manually (GitHub UI)
+
+1. Open PR
+2. Click **Files changed**
+3. Add comments if needed
+4. Click **Review changes** → **Approve**
+
+## Approve via CLI / Hermes
+
+```bash
+# approve
+gh pr review <PR_NUMBER> --approve --body "Looks good"
+
+# request changes
+gh pr review <PR_NUMBER> --request-changes --body "Please address inline comments"
+
+# non-blocking comment
+gh pr review <PR_NUMBER> --comment --body "A few suggestions"
+```
+
+## Keep It Unrestrictive
+
+Recommended repo settings:
+- Require PRs before merge: ON
+- Required approvals: 0 or 1 (team preference)
+- Auto-dismiss stale approvals: OFF (for speed) unless needed
+- Required status checks: only core CI checks
+- Allow squash merge: ON
+
+This keeps safety high while preserving fast manual control.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,75 +1,33 @@
-## What does this PR do?
+## Summary
 
-<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
-
-
-
-## Related Issue
-
-<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->
-
-Fixes #
-
-## Type of Change
-
-<!-- Check the one that applies. -->
-
-- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
-- [ ] ✨ New feature (non-breaking change that adds functionality)
-- [ ] 🔒 Security fix
-- [ ] 📝 Documentation update
-- [ ] ✅ Tests (adding or improving test coverage)
-- [ ] ♻️ Refactor (no behavior change)
-- [ ] 🎯 New skill (bundled or hub)
-
-## Changes Made
-
-<!-- List the specific changes. Include file paths for code changes. -->
+<!-- What changed and why? 2-5 bullets max. -->
 
 - 
 
-## How to Test
+## Linked Issue (optional)
 
-<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->
+<!-- e.g. Fixes #123 -->
 
-1. 
-2. 
-3. 
+## Risk Level
 
-## Checklist
+- [ ] Low (localized change)
+- [ ] Medium (touches shared paths)
+- [ ] High (security/data/infra/runtime impact)
 
-<!-- Complete these before requesting review. -->
+## Validation
 
-### Code
+<!-- Show evidence: tests run, manual checks, screenshots/logs if useful. -->
 
-- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
-- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
-- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
-- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
-- [ ] I've run `pytest tests/ -q` and all tests pass
-- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
-- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->
+- Tests/Checks run:
+- Result:
 
-### Documentation & Housekeeping
+## Reviewer Notes (optional)
 
-<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->
+<!-- Anything you specifically want reviewed? -->
 
-- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
-- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
-- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
-- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
-- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
+## Author Checklist (lightweight)
 
-## For New Skills
-
-<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->
-
-- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
-- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
-- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
-- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`
-
-## Screenshots / Logs
-
-<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
-
+- [ ] Scope is focused (no unrelated changes)
+- [ ] No secrets/tokens/credentials added
+- [ ] I validated the change locally (or explained why not)
+- [ ] Docs updated if behavior changed (or N/A)


### PR DESCRIPTION
## Summary
- Simplifies the PR template to reduce friction while keeping key safety checks
- Adds `.github/PR_REVIEW_POLICY.md` documenting flexible review guidance
- Explicitly supports manual approvals in GitHub UI or via CLI/Hermes

## Why
You asked for a less restrictive process with full manual approval control.

## Validation
- Updated only PR process docs/files
- No runtime code paths changed
