### PR TITLE
fix(cli): preserve Ctrl+Enter multiline input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1781,9 +1781,14 @@ _TERMINAL_INPUT_MODE_RESET_SEQ = (
 
 
 def _bind_prompt_submit_keys(kb, handler) -> None:
-    """Bind both CR and LF terminal Enter forms to the submit handler."""
-    for key in ("enter", "c-j"):
-        kb.add(key)(handler)
+    """Bind the normal Enter key to the submit handler.
+
+    prompt_toolkit maps ``enter`` to Control-M (CR).  Do not also bind
+    Control-J (LF) here: many terminal emulators send LF for Ctrl+Enter,
+    and Hermes has historically used that chord for inserting a newline in
+    the multiline prompt.
+    """
+    kb.add("enter")(handler)
 
 
 def _disable_prompt_toolkit_cpr_warning(app) -> None:
@@ -10567,6 +10572,11 @@ class HermesCLI:
         @kb.add('escape', 'enter')
         def handle_alt_enter(event):
             """Alt+Enter inserts a newline for multi-line input."""
+            event.current_buffer.insert_text('\n')
+
+        @kb.add('c-j')
+        def handle_ctrl_enter(event):
+            """Ctrl+Enter (LF / c-j) inserts a newline for multi-line input."""
             event.current_buffer.insert_text('\n')
 
         # VSCode/Cursor bind Ctrl+G to "Find Next" at the editor level, so

--- a/tests/cli/test_cli_prompt_keybindings.py
+++ b/tests/cli/test_cli_prompt_keybindings.py
@@ -1,0 +1,24 @@
+"""Tests for Hermes CLI prompt key binding semantics."""
+
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.keys import Keys
+
+from cli import _bind_prompt_submit_keys
+
+
+def _bound_key_tuples(kb: KeyBindings):
+    return {binding.keys for binding in kb.bindings}
+
+
+def test_submit_binding_uses_normal_enter_only_not_ctrl_j():
+    """Ctrl+Enter arrives as c-j in many terminals and must stay multiline."""
+    kb = KeyBindings()
+
+    def submit_handler(event):
+        pass
+
+    _bind_prompt_submit_keys(kb, submit_handler)
+
+    keys = _bound_key_tuples(kb)
+    assert (Keys.ControlM,) in keys  # prompt_toolkit's normal Enter / CR
+    assert (Keys.ControlJ,) not in keys  # Ctrl+Enter / LF is reserved for newline


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Fixes a CLI multiline input regression where Ctrl+Enter / c-j submits the prompt instead of inserting a newline.

After commit 5044e1cbf, _bind_prompt_submit_keys() binds both normal Enter (ControlM / CR) and c-j (ControlJ / LF) to the prompt submit handler. In many terminals, Ctrl+Enter is delivered as LF / c-j, and Hermes has historically used that chord for multiline input.

This PR preserves the intended CLI behavior:

    - normal Enter submits the prompt
    - Ctrl+Enter / c-j inserts a newline
    - Alt+Enter continues to insert a newline

The fix keeps _bind_prompt_submit_keys() limited to normal Enter and adds a regression test to make sure ControlJ is not accidentally rebound to submit in the future.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- cli.py
      - Changed _bind_prompt_submit_keys() so it only binds normal Enter / ControlM to prompt submission.
      - Preserved c-j / ControlJ for multiline newline insertion.
    - tests/cli/test_cli_prompt_keybindings.py
      - Added a regression test asserting that normal Enter is bound to submit and ControlJ is not bound by _bind_prompt_submit_keys().

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run the focused regression test:

       bash
       ./venv/bin/python -m pytest tests/cli/test_cli_prompt_keybindings.py -q -o 'addopts='
2.  Confirm the test passes:

       text
       1 passed
3.  Manually test the CLI prompt:
       - start hermes
       - type a first line
       - press Ctrl+Enter
       - confirm a newline is inserted instead of submitting the prompt
       - press normal Enter to submit

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x ] I've run `pytest tests/ -q` and all tests pass
- [x ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

 $ ./venv/bin/python -m pytest tests/cli/test_cli_prompt_keybindings.py -q -o 'addopts='
    .                                                                        [100%]
    1 passed in 2.64s


    Before this fix, Ctrl+Enter / c-j submitted the prompt. After this fix, it inserts a newline, preserving multiline input behavior.