### PR TITLE
fix(mcp): plumb OAuth redirect host config

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -102,6 +102,7 @@ class TestHermesTokenStorage:
 
         client_path = tmp_path / "mcp-tokens" / "test-server.client.json"
         assert client_path.exists()
+        assert json.loads(client_path.read_text())["hermes_dynamic_client"] is True
 
     def test_remove_cleans_up(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -385,6 +386,24 @@ class TestCallbackHandlerIsolation:
         assert result["auth_code"] is None
         assert result["error"] == "access_denied"
 
+    def test_log_message_redacts_callback_code_and_state(self, caplog):
+        HandlerClass, _ = _make_callback_handler()
+        handler = object.__new__(HandlerClass)
+        caplog.set_level("DEBUG", logger="tools.mcp_oauth")
+
+        handler.log_message(
+            '"%s" %s %s',
+            "GET /callback?code=secret-code&state=secret-state&scope=read HTTP/1.1",
+            "200",
+            "-",
+        )
+
+        assert "code=[REDACTED]" in caplog.text
+        assert "state=[REDACTED]" in caplog.text
+        assert "scope=read" in caplog.text
+        assert "secret-code" not in caplog.text
+        assert "secret-state" not in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # Port sharing
@@ -588,6 +607,345 @@ def test_configure_callback_port_uses_explicit_port():
     assert cfg["_resolved_port"] == 54321
 
 
+# ---------------------------------------------------------------------------
+# redirect_host / redirect_port plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestRedirectHostPlumbing:
+    """``oauth.redirect_host`` and ``oauth.redirect_port`` plumb through to
+    the redirect_uri, the pre-registered client, and the listener bind."""
+
+    def test_default_redirect_host_is_loopback(self):
+        """Without redirect_host configured, the URL stays on 127.0.0.1."""
+        pytest.importorskip("mcp")
+        import tools.mcp_oauth as mod
+        from tools.mcp_oauth import _build_client_metadata, _configure_callback_port
+
+        cfg: dict = {}
+        _configure_callback_port(cfg)
+        md = _build_client_metadata(cfg)
+
+        port = cfg["_resolved_port"]
+        assert str(md.redirect_uris[0]).startswith(f"http://127.0.0.1:{port}/")
+        assert mod._oauth_bind_host == "127.0.0.1"
+
+    def test_redirect_host_localhost_in_uri_and_bind(self):
+        """``redirect_host: localhost`` shows up in URI and binds to localhost.
+
+        ``localhost`` resolves to a loopback address — the listener must
+        not silently broaden to ``0.0.0.0``.
+        """
+        pytest.importorskip("mcp")
+        import tools.mcp_oauth as mod
+        from tools.mcp_oauth import _build_client_metadata, _configure_callback_port
+
+        cfg = {"redirect_host": "localhost"}
+        _configure_callback_port(cfg)
+        md = _build_client_metadata(cfg)
+
+        port = cfg["_resolved_port"]
+        assert str(md.redirect_uris[0]) == f"http://localhost:{port}/callback"
+        assert mod._oauth_bind_host == "localhost"
+        assert mod._oauth_bind_host != "0.0.0.0"
+
+    def test_redirect_host_in_preregistered_client_info(self, tmp_path, monkeypatch):
+        """A pre-registered client_id stores redirect_uri using redirect_host."""
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth import (
+            HermesTokenStorage,
+            _build_client_metadata,
+            _configure_callback_port,
+            _maybe_preregister_client,
+        )
+
+        cfg = {
+            "client_id": "preregistered-id",
+            "redirect_host": "localhost",
+            "redirect_port": 0,
+        }
+        _configure_callback_port(cfg)
+        client_metadata = _build_client_metadata(cfg)
+        storage = HermesTokenStorage("hostcfg")
+        _maybe_preregister_client(storage, cfg, client_metadata)
+
+        client_path = tmp_path / "mcp-tokens" / "hostcfg.client.json"
+        assert client_path.exists()
+        data = json.loads(client_path.read_text())
+        port = cfg["_resolved_port"]
+        assert data["redirect_uris"] == [f"http://localhost:{port}/callback"]
+        assert data["hermes_preregistered_client"] is True
+
+    def test_removed_preregistered_client_secret_clears_cached_client_info(
+        self, tmp_path, monkeypatch
+    ):
+        """Removing client_id/client_secret from config must not reuse cached secrets."""
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth import (
+            HermesTokenStorage,
+            _build_client_metadata,
+            _configure_callback_port,
+            _invalidate_stale_dynamic_client_info,
+            _maybe_preregister_client,
+        )
+
+        cfg = {
+            "client_id": "old-confidential-client",
+            "client_secret": "removed-secret",
+            "redirect_host": "127.0.0.1",
+            "redirect_port": 54321,
+        }
+        _configure_callback_port(cfg)
+        storage = HermesTokenStorage("removed-secret")
+        _maybe_preregister_client(storage, cfg, _build_client_metadata(cfg))
+        client_path = tmp_path / "mcp-tokens" / "removed-secret.client.json"
+        assert json.loads(client_path.read_text())["client_secret"] == "removed-secret"
+
+        public_cfg = {"redirect_host": "127.0.0.1", "redirect_port": 54321}
+        _configure_callback_port(public_cfg)
+        _invalidate_stale_dynamic_client_info(
+            storage, public_cfg, _build_client_metadata(public_cfg)
+        )
+
+        assert not client_path.exists()
+
+    def test_confidential_cached_client_info_cleared_when_config_becomes_public(
+        self, tmp_path, monkeypatch
+    ):
+        """Legacy cached confidential client_info is stale for public-client config."""
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth import (
+            HermesTokenStorage,
+            _build_client_metadata,
+            _configure_callback_port,
+            _invalidate_stale_dynamic_client_info,
+        )
+
+        cfg = {"redirect_host": "127.0.0.1", "redirect_port": 54321}
+        _configure_callback_port(cfg)
+        storage = HermesTokenStorage("legacy-confidential")
+        client_path = tmp_path / "mcp-tokens" / "legacy-confidential.client.json"
+        client_path.parent.mkdir(parents=True)
+        client_path.write_text(json.dumps({
+            "client_id": "legacy-confidential-client",
+            "client_secret": "removed-secret",
+            "redirect_uris": ["http://127.0.0.1:54321/callback"],
+            "token_endpoint_auth_method": "client_secret_post",
+        }))
+
+        _invalidate_stale_dynamic_client_info(storage, cfg, _build_client_metadata(cfg))
+
+        assert not client_path.exists()
+
+    def test_legacy_unmarked_public_client_info_is_cleared_when_config_has_no_client_id(
+        self, tmp_path, monkeypatch
+    ):
+        """Unmarked legacy files may be removed pre-registered clients; re-register."""
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth import (
+            HermesTokenStorage,
+            _build_client_metadata,
+            _configure_callback_port,
+            _invalidate_stale_dynamic_client_info,
+        )
+
+        cfg = {"redirect_host": "127.0.0.1", "redirect_port": 54321}
+        _configure_callback_port(cfg)
+        storage = HermesTokenStorage("legacy-public")
+        client_path = tmp_path / "mcp-tokens" / "legacy-public.client.json"
+        client_path.parent.mkdir(parents=True)
+        client_path.write_text(json.dumps({
+            "client_id": "maybe-removed-preregistered-client",
+            "redirect_uris": ["http://127.0.0.1:54321/callback"],
+            "token_endpoint_auth_method": "none",
+        }))
+
+        _invalidate_stale_dynamic_client_info(storage, cfg, _build_client_metadata(cfg))
+
+        assert not client_path.exists()
+
+    def test_legacy_unmarked_confidential_client_info_with_refresh_is_cleared_when_public(
+        self, tmp_path, monkeypatch
+    ):
+        """A removed confidential secret must not survive just because tokens refresh."""
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth import (
+            HermesTokenStorage,
+            _build_client_metadata,
+            _configure_callback_port,
+            _invalidate_stale_dynamic_client_info,
+        )
+
+        cfg = {"redirect_host": "127.0.0.1", "redirect_port": 54321}
+        _configure_callback_port(cfg)
+        storage = HermesTokenStorage("legacy-confidential-refreshable")
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir(parents=True)
+        client_path = token_dir / "legacy-confidential-refreshable.client.json"
+        token_path = token_dir / "legacy-confidential-refreshable.json"
+        client_path.write_text(json.dumps({
+            "client_id": "legacy-confidential-client",
+            "client_secret": "removed-secret",
+            "redirect_uris": ["http://127.0.0.1:54321/callback"],
+            "token_endpoint_auth_method": "client_secret_post",
+        }))
+        token_path.write_text(json.dumps({
+            "access_token": "expired-access",
+            "refresh_token": "refresh-me",
+            "token_type": "Bearer",
+            "expires_in": 0,
+        }))
+
+        _invalidate_stale_dynamic_client_info(storage, cfg, _build_client_metadata(cfg))
+
+        assert not client_path.exists()
+
+    def test_legacy_unmarked_client_info_is_removed_when_redirect_changes_even_with_refresh(
+        self, tmp_path, monkeypatch
+    ):
+        """Legacy unmarked client_info is unsafe once redirect_uri changes."""
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth import (
+            HermesTokenStorage,
+            _build_client_metadata,
+            _configure_callback_port,
+            _invalidate_stale_dynamic_client_info,
+        )
+
+        cfg = {"redirect_host": "127.0.0.1", "redirect_port": 54321}
+        _configure_callback_port(cfg)
+        storage = HermesTokenStorage("legacy-refreshable")
+        token_dir = tmp_path / "mcp-tokens"
+        token_dir.mkdir(parents=True)
+        client_path = token_dir / "legacy-refreshable.client.json"
+        token_path = token_dir / "legacy-refreshable.json"
+        client_path.write_text(json.dumps({
+            "client_id": "legacy-dynamic-client",
+            "redirect_uris": ["http://127.0.0.1:49000/callback"],
+            "token_endpoint_auth_method": "none",
+        }))
+        token_path.write_text(json.dumps({
+            "access_token": "expired-access",
+            "refresh_token": "refresh-me",
+            "token_type": "Bearer",
+            "expires_in": 0,
+        }))
+
+        _invalidate_stale_dynamic_client_info(storage, cfg, _build_client_metadata(cfg))
+
+        assert not client_path.exists()
+
+    def test_matching_public_dynamic_client_info_is_kept(self, tmp_path, monkeypatch):
+        """A same-redirect public dynamic registration remains reusable."""
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth import (
+            HermesTokenStorage,
+            _build_client_metadata,
+            _configure_callback_port,
+            _invalidate_stale_dynamic_client_info,
+        )
+
+        cfg = {"redirect_host": "127.0.0.1", "redirect_port": 54321}
+        _configure_callback_port(cfg)
+        storage = HermesTokenStorage("public-dynamic")
+        client_path = tmp_path / "mcp-tokens" / "public-dynamic.client.json"
+        client_path.parent.mkdir(parents=True)
+        client_path.write_text(json.dumps({
+            "client_id": "dynamic-public-client",
+            "redirect_uris": ["http://127.0.0.1:54321/callback"],
+            "token_endpoint_auth_method": "none",
+            "hermes_dynamic_client": True,
+        }))
+
+        _invalidate_stale_dynamic_client_info(storage, cfg, _build_client_metadata(cfg))
+
+        assert client_path.exists()
+
+    def test_redirect_port_zero_picks_free_port(self):
+        """``redirect_port: 0`` keeps the auto-pick behavior."""
+        from tools.mcp_oauth import _configure_callback_port
+
+        cfg = {"redirect_port": 0}
+        port = _configure_callback_port(cfg)
+        assert 1024 < port < 65536
+        assert cfg["_resolved_port"] == port
+
+    def test_explicit_redirect_port_preserved_in_uri(self):
+        """An explicit ``redirect_port`` flows through to the URL."""
+        pytest.importorskip("mcp")
+        from tools.mcp_oauth import _build_client_metadata, _configure_callback_port
+
+        cfg = {"redirect_port": 54321, "redirect_host": "127.0.0.1"}
+        _configure_callback_port(cfg)
+        md = _build_client_metadata(cfg)
+
+        assert str(md.redirect_uris[0]) == "http://127.0.0.1:54321/callback"
+
+    def test_wait_for_callback_binds_to_configured_host(self, monkeypatch):
+        """``_wait_for_callback`` for ``localhost`` binds BOTH loopback
+        families on the same port and never broadens to ``0.0.0.0``.
+
+        Single ``"localhost"`` advertised in the redirect_uri can be
+        resolved by the browser to either ``127.0.0.1`` or ``::1``
+        depending on the OS resolver order. Listening on only one would
+        silently drop the callback whenever the browser picked the
+        other family. We verify the listener covers both — the single
+        ``("localhost", port)`` bind tuple from the previous design is
+        now a regression to guard against.
+        """
+        import tools.mcp_oauth as mod
+        import socket
+        import asyncio
+
+        captured: dict = {"addrs": [], "families": []}
+
+        class _FakeServer:
+            def __init__(self, addr, handler):
+                captured["addrs"].append(addr)
+                captured["families"].append(getattr(type(self), "address_family", socket.AF_INET))
+                captured["handler"] = handler
+
+            def handle_request(self):
+                pass
+
+            def server_close(self):
+                pass
+
+        async def instant_sleep(_seconds):
+            pass
+
+        monkeypatch.setattr(mod, "HTTPServer", _FakeServer)
+        monkeypatch.setattr(mod.asyncio, "sleep", instant_sleep)
+        monkeypatch.setattr(
+            mod.threading, "Thread", lambda target, daemon: MagicMock()
+        )
+
+        mod._oauth_port = 51234
+        mod._oauth_bind_host = "localhost"
+        try:
+            with pytest.raises(OAuthNonInteractiveError):
+                asyncio.run(mod._wait_for_callback())
+        finally:
+            mod._oauth_bind_host = "127.0.0.1"
+
+        assert ("127.0.0.1", 51234) in captured["addrs"]
+        assert ("::1", 51234) in captured["addrs"]
+        assert socket.AF_INET in captured["families"]
+        assert socket.AF_INET6 in captured["families"]
+        # No spurious bind to anything but the configured loopbacks.
+        for addr, _ in captured["addrs"]:
+            assert addr in {"127.0.0.1", "::1"}, (
+                f"unexpected bind host {addr!r} — listener must stay loopback-only"
+            )
+
+
 def test_build_oauth_auth_preserves_server_url_path():
     """server_url with path is forwarded to OAuthClientProvider unmodified.
 
@@ -609,6 +967,7 @@ def test_build_oauth_auth_preserves_server_url_path():
     with patch.object(mcp_oauth, "_OAUTH_AVAILABLE", True), \
          patch.object(mcp_oauth, "OAuthClientProvider", _FakeProvider), \
          patch.object(mcp_oauth, "_is_interactive", return_value=True), \
+         patch.object(mcp_oauth, "_invalidate_stale_dynamic_client_info"), \
          patch.object(mcp_oauth, "_maybe_preregister_client"), \
          patch.object(mcp_oauth, "HermesTokenStorage") as mock_storage_cls:
         mock_storage_cls.return_value = MagicMock(has_cached_tokens=lambda: True)
@@ -620,4 +979,974 @@ def test_build_oauth_auth_preserves_server_url_path():
 
     assert captured["server_url"] == "https://mcp.notion.com/mcp"
 
+
+# ---------------------------------------------------------------------------
+# redirect_host validation: reject non-loopback / malformed values
+# ---------------------------------------------------------------------------
+
+
+class TestRedirectHostValidation:
+    """``_validate_redirect_host`` (called from ``_configure_callback_port``)
+    must reject any value that would broaden the callback listener beyond
+    loopback or that smuggles a scheme/port/path into the host field."""
+
+    @pytest.mark.parametrize(
+        "bad_host",
+        ["0.0.0.0", "192.168.1.2", "example.com"],
+    )
+    def test_rejects_non_loopback_host(self, bad_host):
+        """Public, LAN, or all-interfaces hosts must be rejected.
+
+        ``0.0.0.0`` would make the callback reachable from any host on the
+        network, exposing the authorization-code redirect; LAN literals and
+        public hostnames similarly point the listener at a non-loopback
+        interface. All three must fail at config time.
+        """
+        from tools.mcp_oauth import _configure_callback_port
+
+        with pytest.raises(ValueError, match="loopback"):
+            _configure_callback_port({"redirect_host": bad_host})
+
+    @pytest.mark.parametrize(
+        "bad_host",
+        ["http://localhost", "localhost:3000", "localhost/callback"],
+    )
+    def test_rejects_malformed_host_with_scheme_port_or_path(self, bad_host):
+        """``redirect_host`` is a bare hostname; scheme/port/path are invalid.
+
+        ``redirect_port`` is its own field, the path is hardcoded to
+        ``/callback``, and the scheme is always ``http``. Accepting any of
+        these would either silently drop user intent or build a malformed
+        ``redirect_uri``.
+        """
+        from tools.mcp_oauth import _configure_callback_port
+
+        with pytest.raises(ValueError):
+            _configure_callback_port({"redirect_host": bad_host})
+
+
+# ---------------------------------------------------------------------------
+# IPv6 loopback support
+# ---------------------------------------------------------------------------
+
+
+class TestIPv6LoopbackRedirectHost:
+    """``redirect_host: ::1`` (or ``[::1]``) builds an RFC-3986-bracketed
+    redirect_uri and binds the listener to the bare IPv6 loopback."""
+
+    @pytest.mark.parametrize("raw_host", ["::1", "[::1]"])
+    def test_ipv6_loopback_in_uri_and_bind_host(self, raw_host):
+        pytest.importorskip("mcp")
+        import tools.mcp_oauth as mod
+        from tools.mcp_oauth import _build_client_metadata, _configure_callback_port
+
+        cfg = {"redirect_host": raw_host}
+        _configure_callback_port(cfg)
+        md = _build_client_metadata(cfg)
+
+        port = cfg["_resolved_port"]
+        # URI authority must bracket the IPv6 literal.
+        assert str(md.redirect_uris[0]) == f"http://[::1]:{port}/callback"
+        # HTTPServer bind tuple takes the bare address (no brackets).
+        assert mod._oauth_bind_host == "::1"
+        assert cfg["_resolved_bind_host"] == "::1"
+        assert cfg["_resolved_uri_host"] == "[::1]"
+
+    def test_auto_port_pick_uses_ipv6_for_ipv6_bind_host(self, monkeypatch):
+        """``redirect_port: 0`` with ``redirect_host: ::1`` must probe the
+        IPv6 loopback (AF_INET6, bind ``::1``) when picking a free port.
+
+        Probing IPv4 ``127.0.0.1`` and then binding IPv6 ``::1`` would only
+        prove the port is free on the IPv4 loopback — the IPv6 bind could
+        still race or collide. The address family of the probe must match
+        the family the callback server will use.
+        """
+        import socket as _socket
+        import tools.mcp_oauth as mod
+
+        captured: dict = {"families": [], "binds": []}
+
+        real_socket = _socket.socket
+
+        class _FakeSocket:
+            def __init__(self, family, kind):
+                captured["families"].append(family)
+                self._family = family
+                self._inner = real_socket(family, kind)
+
+            def setsockopt(self, *_a, **_k):
+                pass
+
+            def bind(self, addr):
+                captured["binds"].append(addr)
+                # Use a fixed port to avoid touching the network stack.
+                self._sockname = (addr[0], 51999)
+
+            def getsockname(self):
+                return self._sockname
+
+            def close(self):
+                self._inner.close()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                self._inner.close()
+                return False
+
+        monkeypatch.setattr(mod.socket, "socket", _FakeSocket)
+
+        cfg = {"redirect_host": "::1", "redirect_port": 0}
+        port = mod._configure_callback_port(cfg)
+
+        assert port == 51999
+        assert captured["families"] == [_socket.AF_INET6]
+        assert captured["binds"] == [("::1", 0)]
+        assert cfg["_resolved_bind_host"] == "::1"
+        assert mod._oauth_bind_host == "::1"
+
+    def test_explicit_port_skips_probe_for_ipv6_bind_host(self, monkeypatch):
+        """An explicit ``redirect_port`` must NOT probe a socket — the user
+        supplied the port intentionally, and probing IPv4 to validate an
+        IPv6 bind would be wrong anyway. Preserves explicit-port behavior.
+        """
+        import tools.mcp_oauth as mod
+
+        called = {"socket": 0}
+
+        def _boom(*a, **kw):
+            called["socket"] += 1
+            raise AssertionError(
+                "explicit redirect_port must not open a probe socket"
+            )
+
+        monkeypatch.setattr(mod.socket, "socket", _boom)
+
+        cfg = {"redirect_host": "::1", "redirect_port": 56789}
+        port = mod._configure_callback_port(cfg)
+
+        assert port == 56789
+        assert called["socket"] == 0
+        assert cfg["_resolved_bind_host"] == "::1"
+
+    def test_wait_for_callback_uses_ipv6_address_family_for_ipv6_bind(
+        self, monkeypatch
+    ):
+        """When ``_oauth_bind_host == "::1"``, ``_wait_for_callback`` must
+        instantiate an HTTPServer subclass with ``address_family =
+        socket.AF_INET6`` so the listener actually binds the IPv6 socket.
+
+        Without the AF_INET6 switch, ``HTTPServer`` defaults to AF_INET and
+        ``bind(("::1", port))`` raises ``OSError``, so the OAuth flow can't
+        receive the callback at all.
+        """
+        import asyncio
+        import socket as _socket
+        import tools.mcp_oauth as mod
+
+        captured: dict = {}
+
+        class _FakeServer:
+            # No address_family set — the IPv4 path would use the default
+            # (AF_INET); the IPv6 subclass overrides to AF_INET6.
+            def __init__(self, addr, handler):
+                captured["addr"] = addr
+                captured["server_cls"] = type(self)
+                captured["address_family"] = getattr(
+                    type(self), "address_family", None
+                )
+
+            def handle_request(self):
+                pass
+
+            def server_close(self):
+                pass
+
+        async def instant_sleep(_seconds):
+            pass
+
+        monkeypatch.setattr(mod, "HTTPServer", _FakeServer)
+        monkeypatch.setattr(mod.asyncio, "sleep", instant_sleep)
+        monkeypatch.setattr(
+            mod.threading, "Thread", lambda target, daemon: MagicMock()
+        )
+
+        mod._oauth_port = 51234
+        mod._oauth_bind_host = "::1"
+        try:
+            with pytest.raises(OAuthNonInteractiveError):
+                asyncio.run(mod._wait_for_callback())
+        finally:
+            mod._oauth_bind_host = "127.0.0.1"
+
+        # Bind tuple uses the bare ``::1``; an IPv6 subclass was selected.
+        assert captured["addr"] == ("::1", 51234)
+        assert captured["address_family"] == _socket.AF_INET6
+        # The class actually instantiated must be a subclass of our fake
+        # HTTPServer — i.e. the local _IPv6HTTPServer wrapper, not the
+        # plain HTTPServer reference.
+        assert captured["server_cls"] is not _FakeServer
+        assert issubclass(captured["server_cls"], _FakeServer)
+
+
+# ---------------------------------------------------------------------------
+# Dual-stack ``localhost``: listener and free-port probe must cover both
+# IPv4 ``127.0.0.1`` and IPv6 ``::1`` on the same port.
+# ---------------------------------------------------------------------------
+
+
+class TestLocalhostDualLoopback:
+    """``redirect_host: localhost`` advertises a single hostname whose
+    A/AAAA records resolve to either ``127.0.0.1`` or ``::1`` depending
+    on platform (and on Linux, on glibc resolver tuning + ``/etc/hosts``).
+    A browser following the OAuth redirect picks whichever the resolver
+    returned — and on macOS / Windows / many Linux distros that's IPv6
+    first. So the callback listener has to cover BOTH families on the
+    same port. Listening only on AF_INET (the previous default whenever
+    the bind_host had no colon) silently drops every IPv6-resolved
+    callback.
+    """
+
+    def test_auto_port_probes_both_loopback_families(self, monkeypatch):
+        """``redirect_port: 0`` with ``redirect_host: localhost`` probes
+        AF_INET 127.0.0.1 AND AF_INET6 ::1 simultaneously, returning a
+        port confirmed free on both. Probing only one family would let
+        the listener bind succeed on that family while colliding on the
+        other.
+        """
+        import socket as _socket
+        import tools.mcp_oauth as mod
+
+        captured: dict = {"sockets": []}
+        real_socket = _socket.socket
+
+        class _FakeSocket:
+            def __init__(self, family, kind):
+                captured["sockets"].append({"family": family, "binds": []})
+                self._idx = len(captured["sockets"]) - 1
+                self._inner = real_socket(family, kind)
+
+            def setsockopt(self, *_a, **_k):
+                pass
+
+            def bind(self, addr):
+                captured["sockets"][self._idx]["binds"].append(addr)
+                # Pretend the kernel handed us port 51999 every time so
+                # the multi-family-same-port assertion is checkable
+                # without touching the real network stack.
+                self._sockname = (addr[0], 51999)
+
+            def getsockname(self):
+                return self._sockname
+
+            def close(self):
+                self._inner.close()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                self._inner.close()
+                return False
+
+        monkeypatch.setattr(mod.socket, "socket", _FakeSocket)
+
+        cfg = {"redirect_host": "localhost", "redirect_port": 0}
+        port = mod._configure_callback_port(cfg)
+
+        assert port == 51999
+        # Two probe sockets: one AF_INET on 127.0.0.1:0, one AF_INET6 on
+        # ::1:51999 (the IPv6 verifier must bind the SAME port the IPv4
+        # head returned, otherwise it isn't actually verifying coverage).
+        families = [s["family"] for s in captured["sockets"]]
+        assert _socket.AF_INET in families, (
+            "localhost probe must include IPv4 loopback"
+        )
+        assert _socket.AF_INET6 in families, (
+            "localhost probe must include IPv6 loopback — without this "
+            "the IPv6 listener can collide on the chosen port"
+        )
+        # Must verify the SAME port on both families.
+        ipv4_binds = next(s["binds"] for s in captured["sockets"] if s["family"] == _socket.AF_INET)
+        ipv6_binds = next(s["binds"] for s in captured["sockets"] if s["family"] == _socket.AF_INET6)
+        assert ipv4_binds == [("127.0.0.1", 0)]
+        assert ipv6_binds == [("::1", 51999)]
+        assert cfg["_resolved_bind_host"] == "localhost"
+        assert cfg["_resolved_uri_host"] == "localhost"
+
+    def test_auto_port_retries_when_ipv6_collides_with_chosen_ipv4_port(
+        self, monkeypatch
+    ):
+        """If the port that came back free on IPv4 turns out to be in use
+        on IPv6, the probe must retry rather than return a port the
+        listener will fail to bind on the IPv6 family.
+
+        Previously ``_find_free_port`` only probed one family — so
+        ``localhost`` could return an IPv4-free port that the IPv6
+        listener then fails to claim, and the OAuth flow silently dropped
+        every IPv6-resolved callback.
+        """
+        import socket as _socket
+        import tools.mcp_oauth as mod
+
+        # First IPv4 attempt → port 60001. IPv6 bind on 60001 → EADDRINUSE.
+        # Retry: IPv4 → 60002. IPv6 bind on 60002 → success.
+        ipv4_ports = iter([60001, 60002])
+        ipv6_should_fail = iter([True, False])
+
+        class _FakeSocket:
+            def __init__(self, family, kind):
+                self._family = family
+
+            def setsockopt(self, *_a, **_k):
+                pass
+
+            def bind(self, addr):
+                if self._family == _socket.AF_INET:
+                    self._sockname = (addr[0], next(ipv4_ports))
+                else:
+                    if next(ipv6_should_fail):
+                        raise OSError(
+                            "[Errno 98] Address already in use"
+                        )
+                    self._sockname = (addr[0], addr[1])
+
+            def getsockname(self):
+                return self._sockname
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(mod.socket, "socket", _FakeSocket)
+
+        cfg = {"redirect_host": "localhost", "redirect_port": 0}
+        port = mod._configure_callback_port(cfg)
+
+        # On the second attempt the IPv4 head returned 60002 and the IPv6
+        # verify succeeded — that's the port we must surface.
+        assert port == 60002
+
+    def test_listener_starts_both_ipv4_and_ipv6_specs(self, monkeypatch):
+        """``_wait_for_callback`` for ``localhost`` instantiates one
+        HTTPServer per loopback family, sharing a single result dict, so
+        whichever family the browser hits writes into the same callback
+        result.
+        """
+        import asyncio
+        import socket as _socket
+        import tools.mcp_oauth as mod
+
+        captured: dict = {"calls": []}
+
+        class _FakeServer:
+            def __init__(self, addr, handler):
+                captured["calls"].append({
+                    "addr": addr,
+                    "address_family": getattr(
+                        type(self), "address_family", _socket.AF_INET
+                    ),
+                    "handler": handler,
+                })
+
+            def handle_request(self):
+                pass
+
+            def server_close(self):
+                pass
+
+        async def instant_sleep(_s):
+            pass
+
+        monkeypatch.setattr(mod, "HTTPServer", _FakeServer)
+        monkeypatch.setattr(mod.asyncio, "sleep", instant_sleep)
+        monkeypatch.setattr(
+            mod.threading, "Thread", lambda target, daemon: MagicMock()
+        )
+
+        mod._oauth_port = 51234
+        mod._oauth_bind_host = "localhost"
+        try:
+            with pytest.raises(OAuthNonInteractiveError):
+                asyncio.run(mod._wait_for_callback())
+        finally:
+            mod._oauth_bind_host = "127.0.0.1"
+
+        addrs = [c["addr"] for c in captured["calls"]]
+        families = [c["address_family"] for c in captured["calls"]]
+        assert ("127.0.0.1", 51234) in addrs
+        assert ("::1", 51234) in addrs
+        assert _socket.AF_INET in families
+        assert _socket.AF_INET6 in families
+        # Every listener must share the SAME handler class so callbacks on
+        # either family resolve to one shared result dict.
+        handler_classes = {c["handler"] for c in captured["calls"]}
+        assert len(handler_classes) == 1, (
+            "dual-listener setup must share a single handler class so the "
+            "browser's callback (whichever family it lands on) writes into "
+            "the same result the polling loop watches"
+        )
+
+    def test_localhost_explicit_port_fails_fast_when_ipv6_bind_fails(
+        self, monkeypatch
+    ):
+        """Explicit ``redirect_port`` with ``redirect_host: localhost``
+        must fail fast (before the polling timeout) if either loopback
+        family can't bind. Half-coverage would silently drop callbacks
+        on the missing family for the full 5-minute timeout.
+        """
+        import asyncio
+        import socket as _socket
+        import tools.mcp_oauth as mod
+
+        closed: list = []
+
+        class _IPv4FakeServer:
+            def __init__(self, addr, handler):
+                self.addr = addr
+
+            def handle_request(self):
+                pass
+
+            def server_close(self):
+                closed.append(self.addr)
+
+        def _server_factory(family):
+            if family == _socket.AF_INET:
+                return _IPv4FakeServer
+
+            class _IPv6FailServer:
+                def __init__(self, addr, handler):
+                    raise OSError("[Errno 98] Address already in use")
+
+            return _IPv6FailServer
+
+        # Patch the factory so AF_INET succeeds and AF_INET6 raises on
+        # construction (mimicking ``socket.bind`` failing inside
+        # ``HTTPServer.__init__``).
+        monkeypatch.setattr(mod, "_make_http_server_cls", _server_factory)
+
+        async def instant_sleep(_s):
+            raise AssertionError(
+                "fail-fast: must not reach the polling sleep when one "
+                "loopback family failed to bind"
+            )
+
+        monkeypatch.setattr(mod.asyncio, "sleep", instant_sleep)
+
+        mod._oauth_port = 51234
+        mod._oauth_bind_host = "localhost"
+        try:
+            with pytest.raises(OAuthNonInteractiveError, match="could not bind"):
+                asyncio.run(mod._wait_for_callback())
+        finally:
+            mod._oauth_bind_host = "127.0.0.1"
+
+        # The IPv4 server that bound successfully must be closed before
+        # we raise — otherwise we'd leak the loopback port.
+        assert closed == [("127.0.0.1", 51234)]
+
+
+# ---------------------------------------------------------------------------
+# MCPOAuthManager: rebuild provider when oauth_config changes
+# ---------------------------------------------------------------------------
+
+
+class TestManagerRebuildOnOAuthConfigChange:
+    """``MCPOAuthManager.get_or_build_provider`` must discard and rebuild
+    a cached provider when ``oauth_config`` changes for the same
+    ``server_name``/``server_url``. Otherwise a user editing
+    ``redirect_host``/``redirect_port`` in config.yaml would still see the
+    old listener bind / redirect_uri until the process restarts."""
+
+    def test_rebuilds_when_redirect_port_changes(self, tmp_path, monkeypatch):
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth_manager import MCPOAuthManager
+
+        url = "https://example.com/mcp"
+        mgr = MCPOAuthManager()
+        p1 = mgr.get_or_build_provider("srv", url, {"redirect_port": 51111})
+        p2 = mgr.get_or_build_provider("srv", url, {"redirect_port": 52222})
+
+        assert p1 is not None and p2 is not None
+        assert p1 is not p2, (
+            "config change must discard the cached provider so the new "
+            "redirect_port takes effect"
+        )
+        # New metadata reflects the new port — proves we didn't just hand
+        # back a fresh wrapper around stale state.
+        assert (
+            str(p2.context.client_metadata.redirect_uris[0])
+            == "http://127.0.0.1:52222/callback"
+        )
+
+    def test_rebuilds_when_redirect_host_changes(self, tmp_path, monkeypatch):
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth_manager import MCPOAuthManager
+
+        url = "https://example.com/mcp"
+        mgr = MCPOAuthManager()
+        p1 = mgr.get_or_build_provider(
+            "srv", url, {"redirect_host": "127.0.0.1", "redirect_port": 51111}
+        )
+        p2 = mgr.get_or_build_provider(
+            "srv", url, {"redirect_host": "localhost", "redirect_port": 51111}
+        )
+
+        assert p1 is not None and p2 is not None
+        assert p1 is not p2
+        assert (
+            str(p2.context.client_metadata.redirect_uris[0])
+            == "http://localhost:51111/callback"
+        )
+
+    def test_rebuilds_on_in_place_mutation_of_same_oauth_config_dict(
+        self, tmp_path, monkeypatch
+    ):
+        """In-place mutation of the caller's ``oauth_config`` dict must still
+        invalidate the cached provider.
+
+        If the manager stored the caller's dict by reference, comparing the
+        cached entry against the (now mutated) same object would always
+        evaluate equal and the manager would silently keep handing back the
+        stale provider. Snapshotting via ``_snapshot_oauth_config`` defeats
+        that aliasing.
+        """
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth_manager import MCPOAuthManager
+
+        url = "https://example.com/mcp"
+        shared_cfg = {"redirect_host": "127.0.0.1", "redirect_port": 51111}
+
+        mgr = MCPOAuthManager()
+        p1 = mgr.get_or_build_provider("srv", url, shared_cfg)
+
+        # Mutate the SAME dict the manager already saw — this is the case
+        # the snapshot has to defend against.
+        shared_cfg["redirect_port"] = 52222
+        p2 = mgr.get_or_build_provider("srv", url, shared_cfg)
+
+        assert p1 is not None and p2 is not None
+        assert p1 is not p2, (
+            "in-place mutation of the same oauth_config dict object must "
+            "still trigger rebuild — the manager must snapshot, not alias"
+        )
+        assert (
+            str(p2.context.client_metadata.redirect_uris[0])
+            == "http://127.0.0.1:52222/callback"
+        )
+
+    def test_none_vs_empty_dict_oauth_config_is_stable(
+        self, tmp_path, monkeypatch
+    ):
+        """``oauth_config=None`` and ``oauth_config={}`` are distinct stable
+        states (snapshotting must not coerce one to the other).
+
+        Caching a fresh entry with ``None`` then querying with ``{}`` should
+        behave deterministically — currently rebuild, since the manager
+        treats them as different inputs. The contract here is *stability*:
+        we don't silently flip them.
+        """
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth_manager import MCPOAuthManager, _snapshot_oauth_config
+
+        # Snapshot helper preserves the None/{} distinction.
+        assert _snapshot_oauth_config(None) is None
+        assert _snapshot_oauth_config({}) == {}
+        assert _snapshot_oauth_config({}) is not None
+
+        url = "https://example.com/mcp"
+        mgr = MCPOAuthManager()
+        p_none_a = mgr.get_or_build_provider("srv", url, None)
+        p_none_b = mgr.get_or_build_provider("srv", url, None)
+        # Two None calls in a row reuse the same cached provider.
+        assert p_none_a is p_none_b
+
+
+# ---------------------------------------------------------------------------
+# Per-provider callback handler isolation
+# ---------------------------------------------------------------------------
+
+
+class TestProviderLocalCallbackHandlerIsolation:
+    """Each provider's ``callback_handler`` must bind to ITS resolved
+    host/port, not whichever was last written to the module globals
+    ``_oauth_port`` / ``_oauth_bind_host``.
+
+    The cache in :class:`MCPOAuthManager` lazily builds providers, so a
+    later ``_configure_callback_port`` for provider B overwrites the
+    globals while provider A's advertised ``redirect_uri`` still points
+    at A's original values. Without provider-local closures, calling
+    A's ``callback_handler`` would bind B's host/port and the OAuth
+    server's redirect would never reach a live listener.
+    """
+
+    def test_handler_a_binds_a_host_port_after_b_is_built(
+        self, tmp_path, monkeypatch
+    ):
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        import asyncio
+        from tools import mcp_oauth as mod
+        from tools.mcp_oauth_manager import MCPOAuthManager
+
+        captured_addrs: list = []
+
+        class _RecordingServer:
+            def __init__(self, addr, handler):
+                captured_addrs.append(addr)
+
+            def handle_request(self):
+                pass
+
+            def server_close(self):
+                pass
+
+        async def instant_sleep(_seconds):
+            pass
+
+        monkeypatch.setattr(mod, "HTTPServer", _RecordingServer)
+        monkeypatch.setattr(mod.asyncio, "sleep", instant_sleep)
+        monkeypatch.setattr(
+            mod.threading, "Thread", lambda target, daemon: MagicMock()
+        )
+
+        mgr = MCPOAuthManager()
+        p_a = mgr.get_or_build_provider(
+            "srv-a",
+            "https://a.example.com/mcp",
+            {"redirect_host": "127.0.0.1", "redirect_port": 51111},
+        )
+        p_b = mgr.get_or_build_provider(
+            "srv-b",
+            "https://b.example.com/mcp",
+            {"redirect_host": "localhost", "redirect_port": 52222},
+        )
+
+        assert p_a is not None and p_b is not None
+
+        # After building B, the module globals point at B's host/port.
+        assert mod._oauth_port == 52222
+        assert mod._oauth_bind_host == "localhost"
+
+        handler_a = p_a.context.callback_handler
+        handler_b = p_b.context.callback_handler
+
+        # Calling A's handler must STILL bind A's original host/port even
+        # though the globals now reflect B's. This is the regression the
+        # provider-local closure prevents.
+        with pytest.raises(OAuthNonInteractiveError):
+            asyncio.run(handler_a())
+        addrs_after_a = list(captured_addrs)
+        assert addrs_after_a == [("127.0.0.1", 51111)], (
+            "provider A's callback_handler must bind A's original host/port "
+            "regardless of any later provider's _configure_callback_port"
+        )
+
+        with pytest.raises(OAuthNonInteractiveError):
+            asyncio.run(handler_b())
+        # Provider B used ``redirect_host: localhost`` so the listener
+        # must cover BOTH 127.0.0.1 and ::1 on B's port; preserves the
+        # closure isolation guarantee for the dual-listener path.
+        addrs_after_b = captured_addrs[len(addrs_after_a):]
+        assert ("127.0.0.1", 52222) in addrs_after_b
+        assert ("::1", 52222) in addrs_after_b
+
+
+class TestProviderLocalRedirectHandlerSshHint:
+    """Each provider's ``redirect_handler`` must print its SSH port-forward
+    hint using the host/port resolved for THAT provider — not the module
+    globals ``_oauth_port`` / ``_oauth_uri_host`` that a later
+    ``build_oauth_auth`` for a different server overwrites.
+
+    Covers two regressions: an IPv6 ``redirect_host`` must surface ``[::1]``
+    (never the hard-coded ``127.0.0.1``), and a second provider built after
+    the first must not retarget the first's hint.
+    """
+
+    def test_ipv6_redirect_host_hint_uses_bracketed_v6_not_v4(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("SSH_CLIENT", "1.2.3.4 1234 22")
+        monkeypatch.delenv("SSH_TTY", raising=False)
+
+        import asyncio
+        from tools import mcp_oauth as mod
+        from tools.mcp_oauth_manager import MCPOAuthManager
+
+        monkeypatch.setattr(mod, "_can_open_browser", lambda: False)
+
+        mgr = MCPOAuthManager()
+        provider = mgr.get_or_build_provider(
+            "srv-v6",
+            "https://v6.example.com/mcp",
+            {"redirect_host": "::1", "redirect_port": 49600},
+        )
+        assert provider is not None
+
+        asyncio.run(
+            provider.context.redirect_handler("https://example.com/auth")
+        )
+        err = capsys.readouterr().err
+
+        assert "Remote session detected" in err
+        # IPv6 loopback must appear in BOTH the callback URL and ssh -L spec,
+        # bracketed per RFC 3986 / OpenSSH's host:port parsing.
+        assert "http://[::1]:49600/callback" in err
+        assert "ssh -N -L '49600:[::1]:49600'" in err
+        # The old global-reading handler hard-coded 127.0.0.1 — it must not
+        # leak into a hint for a provider configured with an IPv6 host.
+        assert "127.0.0.1" not in err
+
+    def test_two_providers_keep_their_own_ports_in_ssh_hint(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("SSH_TTY", "/dev/pts/3")
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+
+        import asyncio
+        from tools import mcp_oauth as mod
+        from tools.mcp_oauth_manager import MCPOAuthManager
+
+        monkeypatch.setattr(mod, "_can_open_browser", lambda: False)
+
+        mgr = MCPOAuthManager()
+        p_a = mgr.get_or_build_provider(
+            "srv-a",
+            "https://a.example.com/mcp",
+            {"redirect_host": "127.0.0.1", "redirect_port": 51111},
+        )
+        p_b = mgr.get_or_build_provider(
+            "srv-b",
+            "https://b.example.com/mcp",
+            {"redirect_host": "127.0.0.1", "redirect_port": 52222},
+        )
+        assert p_a is not None and p_b is not None
+
+        # After building B, the module globals point at B's port.
+        assert mod._oauth_port == 52222
+
+        # A's handler must STILL advertise A's port — the provider-local
+        # closure shields it from B's later _configure_callback_port.
+        asyncio.run(p_a.context.redirect_handler("https://example.com/auth"))
+        err_a = capsys.readouterr().err
+        assert "51111" in err_a
+        assert "52222" not in err_a
+
+        asyncio.run(p_b.context.redirect_handler("https://example.com/auth"))
+        err_b = capsys.readouterr().err
+        assert "52222" in err_b
+        assert "51111" not in err_b
+
+
+# ---------------------------------------------------------------------------
+# Stale dynamic client_info invalidation when redirect host/port change
+# ---------------------------------------------------------------------------
+
+
+class TestStaleDynamicClientInfoInvalidation:
+    """When dynamic registration is in use (no pre-registered ``client_id``)
+    and the on-disk ``<server>.client.json`` redirect_uris no longer match
+    the configured redirect_host/redirect_port, the stale file must be
+    removed before provider construction so the SDK re-registers and does
+    not reuse the old ``client_id`` against the new ``redirect_uri``."""
+
+    def test_stale_client_info_removed_when_redirect_port_changes(
+        self, tmp_path, monkeypatch
+    ):
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth import build_oauth_auth
+
+        d = tmp_path / "mcp-tokens"
+        d.mkdir(parents=True)
+        client_path = d / "srv.client.json"
+        client_path.write_text(json.dumps({
+            "client_id": "stale-dyn-id",
+            "redirect_uris": ["http://127.0.0.1:11111/callback"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+        }))
+
+        # No pre-registered client_id — purely dynamic. New port differs
+        # from the stored value, so the stale file must be removed.
+        provider = build_oauth_auth(
+            "srv",
+            "https://example.com/mcp",
+            {"redirect_port": 22222},
+        )
+        assert provider is not None
+        assert not client_path.exists(), (
+            "stale dynamic client_info must be removed when redirect_port "
+            "changes and no tokens are cached — otherwise the SDK reuses the old "
+            "client_id with the new redirect_uri"
+        )
+
+    def test_stale_marked_dynamic_client_info_removed_even_when_tokens_cached(
+        self, tmp_path, monkeypatch
+    ):
+        """Redirect changes require re-registration even with cached refresh tokens."""
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth import build_oauth_auth
+
+        d = tmp_path / "mcp-tokens"
+        d.mkdir(parents=True)
+        client_path = d / "srv.client.json"
+        token_path = d / "srv.json"
+        client_path.write_text(json.dumps({
+            "client_id": "refreshable-dyn-id",
+            "redirect_uris": ["http://127.0.0.1:11111/callback"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+            "hermes_dynamic_client": True,
+        }))
+        token_path.write_text(json.dumps({
+            "access_token": "expired-access",
+            "refresh_token": "refresh-token",
+            "token_type": "Bearer",
+        }))
+
+        provider = build_oauth_auth(
+            "srv",
+            "https://example.com/mcp",
+            {"redirect_port": 22222},
+        )
+        assert provider is not None
+        assert not client_path.exists(), (
+            "stale dynamic client_info must be removed when redirect_port changes "
+            "even if a refresh token is cached; otherwise a later browser flow can "
+            "reuse an old client_id with the new redirect_uri"
+        )
+
+    def test_stale_marked_dynamic_client_info_removed_without_refresh_token(
+        self, tmp_path, monkeypatch
+    ):
+        """Access-token-only cache cannot refresh, so stale client_info is unsafe."""
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth import build_oauth_auth
+
+        d = tmp_path / "mcp-tokens"
+        d.mkdir(parents=True)
+        client_path = d / "srv.client.json"
+        token_path = d / "srv.json"
+        client_path.write_text(json.dumps({
+            "client_id": "nonrefreshable-dyn-id",
+            "redirect_uris": ["http://127.0.0.1:11111/callback"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+            "hermes_dynamic_client": True,
+        }))
+        token_path.write_text(json.dumps({
+            "access_token": "access-only",
+            "token_type": "Bearer",
+        }))
+
+        provider = build_oauth_auth(
+            "srv",
+            "https://example.com/mcp",
+            {"redirect_port": 22222},
+        )
+        assert provider is not None
+        assert not client_path.exists()
+
+    def test_stale_client_info_removed_when_redirect_host_changes(
+        self, tmp_path, monkeypatch
+    ):
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth import build_oauth_auth
+
+        d = tmp_path / "mcp-tokens"
+        d.mkdir(parents=True)
+        client_path = d / "srv.client.json"
+        client_path.write_text(json.dumps({
+            "client_id": "stale-dyn-id",
+            "redirect_uris": ["http://127.0.0.1:33333/callback"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+        }))
+
+        provider = build_oauth_auth(
+            "srv",
+            "https://example.com/mcp",
+            {"redirect_host": "localhost", "redirect_port": 33333},
+        )
+        assert provider is not None
+        assert not client_path.exists()
+
+    def test_matching_client_info_preserved(self, tmp_path, monkeypatch):
+        """A marked dynamic file with matching redirect_uris is reusable."""
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth import build_oauth_auth
+
+        d = tmp_path / "mcp-tokens"
+        d.mkdir(parents=True)
+        client_path = d / "srv.client.json"
+        client_path.write_text(json.dumps({
+            "client_id": "good-dyn-id",
+            "redirect_uris": ["http://127.0.0.1:44444/callback"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+            "hermes_dynamic_client": True,
+        }))
+
+        provider = build_oauth_auth(
+            "srv",
+            "https://example.com/mcp",
+            {"redirect_port": 44444},
+        )
+        assert provider is not None
+        assert client_path.exists()
+        data = json.loads(client_path.read_text())
+        assert data["client_id"] == "good-dyn-id"
+
+    def test_preregistered_client_id_overwrites_regardless(
+        self, tmp_path, monkeypatch
+    ):
+        """The pre-registered ``client_id`` path is unaffected by the
+        invalidation helper: ``_maybe_preregister_client`` always writes
+        the file with the current redirect_uri, replacing any prior content.
+        """
+        pytest.importorskip("mcp")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from tools.mcp_oauth import build_oauth_auth
+
+        d = tmp_path / "mcp-tokens"
+        d.mkdir(parents=True)
+        client_path = d / "srv.client.json"
+        client_path.write_text(json.dumps({
+            "client_id": "old-static-id",
+            "redirect_uris": ["http://127.0.0.1:11111/callback"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+        }))
+
+        provider = build_oauth_auth(
+            "srv",
+            "https://example.com/mcp",
+            {"client_id": "new-static-id", "redirect_port": 22222},
+        )
+        assert provider is not None
+        assert client_path.exists()
+        data = json.loads(client_path.read_text())
+        assert data["client_id"] == "new-static-id"
+        assert data["redirect_uris"] == ["http://127.0.0.1:22222/callback"]
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -28,6 +28,13 @@ Configuration in config.yaml::
           client_id: "pre-registered-id"        # skip dynamic registration
           client_secret: "secret"               # confidential clients only
           scope: "read write"                   # default: server-provided
+          redirect_host: "127.0.0.1"            # loopback host for redirect_uri
+                                                #   one of: localhost (binds
+                                                #   both 127.0.0.1 and ::1 so
+                                                #   dual-stack browsers reach
+                                                #   the listener regardless of
+                                                #   which family they pick),
+                                                #   127.0.0.1, ::1 (or [::1])
           redirect_port: 0                      # 0 = auto-pick free port
           client_name: "My Custom Client"       # default: "Hermes Agent"
 """
@@ -88,9 +95,16 @@ class OAuthNonInteractiveError(RuntimeError):
 # Module-level state
 # ---------------------------------------------------------------------------
 
-# Port used by the most recent build_oauth_auth() call.  Exposed so that
-# tests can verify the callback server and the redirect_uri share a port.
+# Port/host used by the most recent build_oauth_auth() call. Exposed so that
+# tests can verify the callback server and the redirect_uri share the same
+# listener settings. ``_oauth_bind_host`` is the bare HTTPServer bind address
+# (``::1``); ``_oauth_uri_host`` is the URI-authority form (``[::1]``) used in
+# the redirect_uri and SSH hint. These globals only back the legacy
+# ``_redirect_handler`` / ``_wait_for_callback`` entry points — provider
+# construction passes resolved values into per-provider closures instead.
 _oauth_port: int | None = None
+_oauth_bind_host: str = "127.0.0.1"
+_oauth_uri_host: str = "127.0.0.1"
 
 
 # ---------------------------------------------------------------------------
@@ -117,11 +131,176 @@ def _safe_filename(name: str) -> str:
     return re.sub(r"[^\w\-]", "_", name).strip("_")[:128] or "default"
 
 
-def _find_free_port() -> int:
-    """Find an available TCP port on localhost."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
+# Upper bound on probe retries when picking a port that must be free on
+# multiple loopback families simultaneously (only the ``localhost`` path
+# triggers a multi-family probe). 50 is generous: each retry is a single
+# bind/close pair on the loopback, so even a hostile host with a tight
+# port pool resolves quickly.
+_MAX_PORT_PROBE_ATTEMPTS = 50
+
+
+def _listener_specs(bind_host: str) -> list[tuple[int, str]]:
+    """Return ``(address_family, bind_address)`` pairs for the callback listener.
+
+    The OAuth ``redirect_uri`` advertises a single host string, but the
+    listener may need more than one socket behind it. ``localhost`` is the
+    only such case: a dual-stack OS resolves ``localhost`` to either
+    ``127.0.0.1`` or ``::1`` depending on platform/order/glibc-tuning, and
+    a browser following the OAuth redirect picks whichever the resolver
+    returned first. If we listened on only one family while the browser hit
+    the other, the callback would never arrive. So we expand ``localhost``
+    into BOTH loopback families and bind both. Literal addresses
+    (``127.0.0.1`` / ``::1``) keep their single-family behavior.
+    """
+    if bind_host == "localhost":
+        return [(socket.AF_INET, "127.0.0.1"), (socket.AF_INET6, "::1")]
+    if ":" in bind_host:
+        return [(socket.AF_INET6, bind_host)]
+    return [(socket.AF_INET, bind_host)]
+
+
+def _make_loopback_socket(family: int) -> socket.socket:
+    """Create a loopback probe socket; force IPV6_V6ONLY=1 on AF_INET6.
+
+    Without ``IPV6_V6ONLY`` the kernel may treat the IPv6 socket as
+    dual-stack — accepting IPv4-mapped addresses on the same port. That
+    would conflict with the AF_INET sibling we also want to bind for the
+    ``localhost`` path. Setting ``IPV6_V6ONLY=1`` keeps the two listeners
+    in separate accept queues so they coexist on the same port.
+
+    The socket option is best-effort: on platforms that don't expose it,
+    we fall back to default kernel behavior (which on macOS already
+    defaults to v6-only).
+    """
+    s = socket.socket(family, socket.SOCK_STREAM)
+    if family == socket.AF_INET6:
+        try:
+            s.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+        except (AttributeError, OSError):
+            pass
+    return s
+
+
+def _find_free_port(bind_host: str = "127.0.0.1") -> int:
+    """Find a TCP port free on every family the listener will bind.
+
+    For literal ``127.0.0.1`` / ``::1`` this is a single-family probe — the
+    address family of the probe socket must match the family the listener
+    will use, since "free on IPv4 127.0.0.1" tells you nothing about the
+    same port number's IPv6 in-use set (different sockets, different
+    namespaces).
+
+    For ``localhost`` we expand to both loopback families
+    (:func:`_listener_specs`) and only return a port we could
+    simultaneously bind on every spec; that simultaneous-bind step also
+    gives us a coarse race shield, since holding the head socket bound
+    while we probe the rest prevents a competing process from sniping the
+    port between probes within the same attempt. After all probes succeed
+    we close every socket and return the port — the listener's bind is
+    still racy against external processes (no different from the legacy
+    single-family probe), but the multi-family ordering is consistent.
+
+    Raises:
+        OSError: ``_MAX_PORT_PROBE_ATTEMPTS`` consecutive probes all
+            collided on at least one family. Surfaces a system-level
+            problem (port pool exhausted, IPv6 disabled, etc.) rather
+            than silently looping forever.
+    """
+    specs = _listener_specs(bind_host)
+    last_error: OSError | None = None
+    for _ in range(_MAX_PORT_PROBE_ATTEMPTS):
+        held: list[socket.socket] = []
+        try:
+            head_family, head_addr = specs[0]
+            head = _make_loopback_socket(head_family)
+            held.append(head)
+            head.bind((head_addr, 0))
+            port = head.getsockname()[1]
+
+            collision: OSError | None = None
+            for fam, addr in specs[1:]:
+                t = _make_loopback_socket(fam)
+                held.append(t)
+                try:
+                    t.bind((addr, port))
+                except OSError as exc:
+                    collision = exc
+                    break
+            if collision is None:
+                return port
+            last_error = collision
+        finally:
+            for s in held:
+                try:
+                    s.close()
+                except OSError:
+                    pass
+    raise OSError(
+        f"could not find a port free on all loopback families for "
+        f"redirect_host={bind_host!r} after {_MAX_PORT_PROBE_ATTEMPTS} "
+        f"attempts (last error: {last_error})"
+    )
+
+
+def _redact_oauth_callback_log_message(message: str) -> str:
+    """Redact OAuth callback secrets from HTTP request log lines."""
+    return re.sub(r"([?&](?:code|state)=)[^&\s\"']*", r"\1[REDACTED]", message)
+
+
+def _validate_redirect_host(host: Any) -> tuple[str, str]:
+    """Validate ``redirect_host`` and return ``(uri_host, bind_host)``.
+
+    The OAuth callback listener runs on the local machine; allowing the
+    user to point the listener at ``0.0.0.0`` or any non-loopback address
+    would expose the authorization-code endpoint to other hosts on the
+    network. Restrict ``redirect_host`` to the recognised loopback values
+    only:
+
+    - ``"localhost"`` — IPv4/IPv6 loopback resolver
+    - ``"127.0.0.1"`` — IPv4 loopback literal
+    - ``"::1"`` / ``"[::1]"`` — IPv6 loopback literal
+
+    The two return values differ only for IPv6: per RFC 3986 the URI
+    authority must bracket the address (``http://[::1]:PORT/...``) but the
+    ``HTTPServer`` bind tuple takes the bare address (``"::1"``).
+
+    Raises:
+        ValueError: ``host`` is non-string, empty, includes a scheme/path/
+            port, or is not one of the allowed loopback values.
+    """
+    if not isinstance(host, str):
+        raise ValueError(
+            f"redirect_host must be a string; got {type(host).__name__}"
+        )
+    raw = host.strip()
+    if not raw:
+        raise ValueError("redirect_host must be a non-empty string")
+    if "://" in raw or "/" in raw:
+        raise ValueError(
+            f"redirect_host must be a bare hostname (no scheme/path): {host!r}"
+        )
+
+    # IPv6 loopback: accept bare ``::1`` or bracketed ``[::1]``.
+    if raw == "::1" or raw == "[::1]":
+        return "[::1]", "::1"
+
+    # Anything else with a colon is either ``host:port`` (forbidden — the
+    # port goes in ``redirect_port``) or a non-loopback IPv6 literal like
+    # ``2001:db8::1``. Both are rejected so the only IPv6 we accept is
+    # the loopback handled above.
+    if ":" in raw or raw.startswith("[") or raw.endswith("]"):
+        raise ValueError(
+            f"redirect_host must be a loopback host "
+            f"(localhost, 127.0.0.1, ::1, [::1]); got {host!r}"
+        )
+
+    if raw in {"localhost", "127.0.0.1"}:
+        return raw, raw
+
+    raise ValueError(
+        f"redirect_host must be a loopback host "
+        f"(localhost, 127.0.0.1, ::1, [::1]); got {host!r}"
+    )
 
 
 def _is_interactive() -> bool:
@@ -302,7 +481,9 @@ class HermesTokenStorage:
             return None
 
     async def set_client_info(self, client_info: "OAuthClientInformationFull") -> None:
-        _write_json(self._client_info_path(), client_info.model_dump(mode="json", exclude_none=True))
+        payload = client_info.model_dump(mode="json", exclude_none=True)
+        payload["hermes_dynamic_client"] = True
+        _write_json(self._client_info_path(), payload)
         logger.debug("OAuth client info saved for %s", self._server_name)
 
     # -- oauth server metadata --------------------------------------------
@@ -378,7 +559,7 @@ def _make_callback_handler() -> tuple[type, dict]:
             self.wfile.write(body.encode())
 
         def log_message(self, fmt: str, *args: Any) -> None:
-            logger.debug("OAuth callback: %s", fmt % args)
+            logger.debug("OAuth callback: %s", _redact_oauth_callback_log_message(fmt % args))
 
     return _Handler, result
 
@@ -388,11 +569,39 @@ def _make_callback_handler() -> tuple[type, dict]:
 # ---------------------------------------------------------------------------
 
 
-async def _redirect_handler(authorization_url: str) -> None:
-    """Show the authorization URL to the user.
+def _format_ssh_tunnel_hint(uri_host: str, port: int) -> str:
+    """Build the SSH port-forward hint for a remote (SSH) OAuth session.
 
-    Opens the browser automatically when possible; always prints the URL
-    as a fallback for headless/SSH/gateway environments.
+    ``uri_host`` is the redirect host in *URI-authority* form: IPv6 literals
+    arrive bracketed (``[::1]``), ``localhost`` / ``127.0.0.1`` pass through
+    unchanged. That single form drops correctly into both the ``http://``
+    callback URL and the ``ssh -L`` forward spec — OpenSSH parses the bracket
+    form ``port:[::1]:port`` for IPv6 hosts, so we never have to special-case
+    the family here.
+    """
+    return (
+        f"  Remote session detected. The OAuth provider will redirect your browser to\n"
+        f"    http://{uri_host}:{port}/callback\n"
+        f"  which the callback listener on THIS machine is waiting on. If your browser\n"
+        f"  is on a different machine, forward the port first in a separate terminal:\n"
+        f"\n"
+        f"    ssh -N -L '{port}:{uri_host}:{port}' <user>@<this-host>\n"
+        f"\n"
+        f"  Then open the URL above. See: https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh\n"
+    )
+
+
+async def _redirect_handler_impl(
+    authorization_url: str, uri_host: str | None, port: int | None
+) -> None:
+    """Show the authorization URL to the user (shared redirect-handler body).
+
+    Opens the browser automatically when possible; always prints the URL as a
+    fallback for headless/SSH/gateway environments. On an SSH session a
+    port-forward hint is printed using the ``uri_host`` / ``port`` resolved
+    for the provider that owns this handler — never module globals — so the
+    hint stays correct for a configured ``redirect_host`` (e.g. ``[::1]``)
+    and for multi-provider setups where each provider has its own port.
     """
     msg = (
         f"\n  MCP OAuth: authorization required.\n"
@@ -401,22 +610,11 @@ async def _redirect_handler(authorization_url: str) -> None:
     )
     print(msg, file=sys.stderr)
 
-    # On a remote SSH session the OAuth provider redirects to
-    # http://127.0.0.1:<port>/callback, which reaches the callback server on
-    # the *remote* machine — not the user's local machine where the browser
-    # opened.  Print a port-forward hint so the user knows to tunnel first.
-    if _oauth_port and (os.getenv("SSH_CLIENT") or os.getenv("SSH_TTY")):
-        print(
-            f"  Remote session detected. The OAuth provider will redirect your browser to\n"
-            f"    http://127.0.0.1:{_oauth_port}/callback\n"
-            f"  which the callback listener on THIS machine is waiting on. If your browser\n"
-            f"  is on a different machine, forward the port first in a separate terminal:\n"
-            f"\n"
-            f"    ssh -N -L {_oauth_port}:127.0.0.1:{_oauth_port} <user>@<this-host>\n"
-            f"\n"
-            f"  Then open the URL above. See: https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh\n",
-            file=sys.stderr,
-        )
+    # On a remote SSH session the OAuth provider redirects to the callback
+    # server on the *remote* machine — not the user's local machine where the
+    # browser opened.  Print a port-forward hint so the user knows to tunnel.
+    if port and uri_host and (os.getenv("SSH_CLIENT") or os.getenv("SSH_TTY")):
+        print(_format_ssh_tunnel_hint(uri_host, port), file=sys.stderr)
 
     if _can_open_browser():
         try:
@@ -431,12 +629,175 @@ async def _redirect_handler(authorization_url: str) -> None:
         print("  (Headless environment detected — open the URL manually.)\n", file=sys.stderr)
 
 
-async def _wait_for_callback() -> tuple[str, str | None]:
-    """Wait for the OAuth callback to arrive on the local callback server.
+def _make_redirect_handler(uri_host: str, port: int):
+    """Return a per-provider redirect handler closure bound to ``(uri_host, port)``.
 
-    Uses the module-level ``_oauth_port`` which is set by ``build_oauth_auth``
-    before this is ever called.  Polls for the result without blocking the
-    event loop.
+    Mirrors :func:`_make_wait_for_callback`: provider construction uses this
+    so each provider's ``redirect_handler`` carries the redirect host/port
+    resolved for *that* provider. Without the closure the SSH hint would read
+    the module-global ``_oauth_port`` / ``_oauth_uri_host``, which a later
+    ``build_oauth_auth`` call for a different server overwrites — so the hint
+    could advertise the wrong port, or ``127.0.0.1`` for a provider actually
+    configured with ``redirect_host: ::1``.
+    """
+    async def redirect_handler(authorization_url: str) -> None:
+        await _redirect_handler_impl(authorization_url, uri_host, port)
+
+    return redirect_handler
+
+
+async def _redirect_handler(authorization_url: str) -> None:
+    """Legacy entry: read module-level globals set by ``build_oauth_auth``.
+
+    Retained for backward compatibility with the no-args ``redirect_handler``
+    signature the MCP SDK historically accepted, and with tests that drive the
+    handler via globals. New code paths build a provider-local closure via
+    :func:`_make_redirect_handler` instead.
+    """
+    await _redirect_handler_impl(authorization_url, _oauth_uri_host, _oauth_port)
+
+
+def _make_http_server_cls(family: int) -> type:
+    """Return an :class:`HTTPServer` subclass bound to ``family``.
+
+    The IPv6 subclass also forces ``IPV6_V6ONLY=1`` in ``server_bind`` so
+    the IPv4 sibling listener (used for ``redirect_host: localhost``) can
+    coexist on the same port. Without this, on Linux the IPv6 listener
+    might claim IPv4-mapped traffic on that port and the IPv4 bind would
+    fail with EADDRINUSE.
+    """
+    if family == socket.AF_INET:
+        return HTTPServer
+
+    class _IPv6HTTPServer(HTTPServer):
+        address_family = socket.AF_INET6
+
+        def server_bind(self) -> None:  # type: ignore[override]
+            try:
+                self.socket.setsockopt(
+                    socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1
+                )
+            except (AttributeError, OSError):
+                pass
+            super().server_bind()
+
+    return _IPv6HTTPServer
+
+
+async def _wait_for_callback_impl(
+    bind_host: str, port: int
+) -> tuple[str, str | None]:
+    """Wait for the OAuth callback bound to an explicit ``(bind_host, port)``.
+
+    Starts one listener per spec returned by :func:`_listener_specs`. For
+    literal addresses that's a single listener; for ``localhost`` it's two
+    (IPv4 + IPv6 loopback) so the callback is reachable regardless of which
+    family the browser resolves ``localhost`` to.
+
+    All listeners share one ``(handler_cls, result)`` pair from
+    :func:`_make_callback_handler`, so whichever family the browser hits
+    writes into the same result dict the polling loop watches.
+
+    Raises:
+        OAuthNonInteractiveError: If any required listener fails to bind
+            (fail-fast — partial coverage on ``localhost`` would silently
+            drop callbacks on the missing family) or if the callback times
+            out.
+        RuntimeError: If the OAuth server signalled an authorization error.
+    """
+    handler_cls, result = _make_callback_handler()
+    specs = _listener_specs(bind_host)
+
+    servers: list[HTTPServer] = []
+    bind_errors: list[tuple[str, OSError]] = []
+    for family, addr in specs:
+        cls = _make_http_server_cls(family)
+        try:
+            servers.append(cls((addr, port), handler_cls))
+        except OSError as exc:
+            bind_errors.append((addr, exc))
+
+    if bind_errors:
+        # Either nothing bound at all, or — for ``localhost`` — one of the
+        # two families failed. In both cases the listener can't be relied
+        # on to receive the callback, so close any partial listeners and
+        # surface the bind error promptly. (Requirement: explicit
+        # ``redirect_port`` with ``localhost`` must fail fast when either
+        # loopback family can't bind.)
+        for s in servers:
+            try:
+                s.server_close()
+            except OSError:
+                pass
+        details = "; ".join(f"{addr}: {exc}" for addr, exc in bind_errors)
+        raise OAuthNonInteractiveError(
+            f"OAuth callback could not bind {bind_host}:{port} "
+            f"({details}). Free the port or change redirect_port and retry."
+        )
+
+    threads: list[threading.Thread] = []
+    for server in servers:
+        t = threading.Thread(target=server.handle_request, daemon=True)
+        t.start()
+        threads.append(t)
+
+    timeout = 300.0
+    poll_interval = 0.5
+    elapsed = 0.0
+    try:
+        while elapsed < timeout:
+            if result["auth_code"] is not None or result["error"] is not None:
+                break
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+    finally:
+        # Close every listener — server_close on a thread-blocked accept
+        # unblocks the daemon thread, which then exits. Daemon threads
+        # also wouldn't keep the process alive, but we close anyway so
+        # the loopback port is released for the next flow.
+        for server in servers:
+            try:
+                server.server_close()
+            except OSError:
+                pass
+
+    if result["error"]:
+        raise RuntimeError(f"OAuth authorization failed: {result['error']}")
+    if result["auth_code"] is None:
+        raise OAuthNonInteractiveError(
+            "OAuth callback timed out — no authorization code received. "
+            "Ensure you completed the browser authorization flow."
+        )
+
+    return result["auth_code"], result["state"]
+
+
+def _make_wait_for_callback(bind_host: str, port: int):
+    """Return a per-provider callback handler closure bound to ``(bind_host, port)``.
+
+    Provider construction uses this so that each provider's
+    ``callback_handler`` carries its own resolved bind host/port. Without
+    the closure, all providers would share the module-global
+    ``_oauth_port`` / ``_oauth_bind_host`` and provider A could end up
+    binding the host/port that was last configured for provider B (the
+    cache in :class:`MCPOAuthManager` builds providers lazily, so a later
+    ``_configure_callback_port`` for provider B overwrites the globals
+    while provider A's advertised ``redirect_uri`` still points at A's
+    original values).
+    """
+    async def callback_handler() -> tuple[str, str | None]:
+        return await _wait_for_callback_impl(bind_host, port)
+
+    return callback_handler
+
+
+async def _wait_for_callback() -> tuple[str, str | None]:
+    """Legacy entry: read module-level globals set by ``build_oauth_auth``.
+
+    Retained for backward compatibility with tests that drive the callback
+    server via globals, and as the no-args signature the MCP SDK historically
+    accepted. New code paths build a provider-local closure via
+    :func:`_make_wait_for_callback` instead.
 
     Raises:
         OAuthNonInteractiveError: If the callback times out (no user present
@@ -450,46 +811,8 @@ async def _wait_for_callback() -> tuple[str, str | None]:
             "OAuth callback port not set — build_oauth_auth must be called "
             "before _wait_for_oauth_callback"
         )
-
-    # The callback server is already running (started in build_oauth_auth).
-    # We just need to poll for the result.
-    handler_cls, result = _make_callback_handler()
-
-    # Start a temporary server on the known port
-    try:
-        server = HTTPServer(("127.0.0.1", _oauth_port), handler_cls)
-    except OSError:
-        # Port already in use — the server from build_oauth_auth is running.
-        # Fall back to polling the server started by build_oauth_auth.
-        raise OAuthNonInteractiveError(
-            "OAuth callback timed out — could not bind callback port. "
-            "Complete the authorization in a browser first, then retry."
-        )
-
-    server_thread = threading.Thread(target=server.handle_request, daemon=True)
-    server_thread.start()
-
-    timeout = 300.0
-    poll_interval = 0.5
-    elapsed = 0.0
-    try:
-        while elapsed < timeout:
-            if result["auth_code"] is not None or result["error"] is not None:
-                break
-            await asyncio.sleep(poll_interval)
-            elapsed += poll_interval
-    finally:
-        server.server_close()
-
-    if result["error"]:
-        raise RuntimeError(f"OAuth authorization failed: {result['error']}")
-    if result["auth_code"] is None:
-        raise OAuthNonInteractiveError(
-            "OAuth callback timed out — no authorization code received. "
-            "Ensure you completed the browser authorization flow."
-        )
-
-    return result["auth_code"], result["state"]
+    bind_host = _oauth_bind_host or "127.0.0.1"
+    return await _wait_for_callback_impl(bind_host, _oauth_port)
 
 
 # ---------------------------------------------------------------------------
@@ -526,12 +849,45 @@ def _configure_callback_port(cfg: dict) -> int:
     flows); replacing it with a ContextVar is out of scope for this
     consolidation PR.
     """
-    global _oauth_port
+    global _oauth_port, _oauth_bind_host, _oauth_uri_host
+
+    # Validate redirect_host BEFORE auto-picking a port — the address
+    # family of the probe socket must match the family the callback
+    # listener will bind, or the port may be in-use on the bind family
+    # even though it's free on the probe family (e.g. picking a port
+    # via IPv4 127.0.0.1 and then binding ::1 on IPv6).
+    raw_host = cfg.get("redirect_host", "127.0.0.1")
+    uri_host, bind_host = _validate_redirect_host(raw_host)
+
     requested = int(cfg.get("redirect_port", 0))
-    port = _find_free_port() if requested == 0 else requested
+    port = _find_free_port(bind_host) if requested == 0 else requested
+
     cfg["_resolved_port"] = port
+    cfg["_resolved_uri_host"] = uri_host
+    cfg["_resolved_bind_host"] = bind_host
     _oauth_port = port  # legacy consumer: _wait_for_callback reads this
+    _oauth_bind_host = bind_host
+    _oauth_uri_host = uri_host  # legacy consumer: _redirect_handler reads this
     return port
+
+
+def _build_redirect_uri(cfg: dict) -> str:
+    """Build the OAuth ``redirect_uri`` from the resolved port + redirect_host.
+
+    Requires ``cfg['_resolved_port']`` to have been populated by
+    :func:`_configure_callback_port` first.
+    """
+    port = cfg.get("_resolved_port")
+    if port is None:
+        raise ValueError(
+            "_configure_callback_port() must be called before _build_redirect_uri()"
+        )
+    uri_host = cfg.get("_resolved_uri_host")
+    if uri_host is None:
+        # Defensive: re-validate if the caller skipped _configure_callback_port
+        # (shouldn't happen via the supported entry points).
+        uri_host, _ = _validate_redirect_host(cfg.get("redirect_host", "127.0.0.1"))
+    return f"http://{uri_host}:{port}/callback"
 
 
 def _build_client_metadata(cfg: dict) -> "OAuthClientMetadata":
@@ -540,14 +896,9 @@ def _build_client_metadata(cfg: dict) -> "OAuthClientMetadata":
     Requires ``cfg['_resolved_port']`` to have been populated by
     :func:`_configure_callback_port` first.
     """
-    port = cfg.get("_resolved_port")
-    if port is None:
-        raise ValueError(
-            "_configure_callback_port() must be called before _build_client_metadata()"
-        )
     client_name = cfg.get("client_name", "Hermes Agent")
     scope = cfg.get("scope")
-    redirect_uri = f"http://127.0.0.1:{port}/callback"
+    redirect_uri = _build_redirect_uri(cfg)
 
     metadata_kwargs: dict[str, Any] = {
         "client_name": client_name,
@@ -564,6 +915,114 @@ def _build_client_metadata(cfg: dict) -> "OAuthClientMetadata":
     return OAuthClientMetadata.model_validate(metadata_kwargs)
 
 
+def _stored_tokens_have_refresh_token(storage: "HermesTokenStorage") -> bool:
+    """Return True when stored tokens can plausibly refresh without browser auth."""
+    data = _read_json(storage._tokens_path())
+    if not isinstance(data, dict):
+        return False
+    return bool(data.get("refresh_token"))
+
+
+def _invalidate_stale_dynamic_client_info(
+    storage: "HermesTokenStorage",
+    cfg: dict,
+    client_metadata: "OAuthClientMetadata",
+) -> None:
+    """Drop on-disk client_info when it no longer matches cfg.
+
+    When the user edits ``redirect_host`` / ``redirect_port`` in
+    ``config.yaml``, ``<server>.client.json`` may still hold the previously
+    registered ``client_id`` paired with the old ``redirect_uri``. The MCP
+    SDK loads that file via ``storage.get_client_info()`` and would reuse
+    the old ``client_id`` against the new ``redirect_uri``, which OAuth
+    servers reject (or worse, accept while redirecting back to the stale
+    host/port).
+
+    Also handle the inverse of :func:`_maybe_preregister_client`: if the
+    config no longer has a pre-registered ``client_id``/``client_secret``
+    but the stored file was written by that path (or otherwise has a client
+    auth method that no longer matches the current metadata), delete it so
+    the SDK falls back to dynamic registration/public-client behavior. This
+    prevents a removed client secret from staying active via cached
+    ``client_info``. Legacy files written before Hermes added explicit
+    dynamic/pre-registered markers are removed once as a conservative
+    migration: they could be either dynamic registrations or removed
+    pre-registered clients, and re-registering is safer than silently
+    retaining a removed configured client_id. Redirect URI changes always
+    invalidate stored client_info, even when cached tokens include a refresh
+    token: if refresh is skipped or fails, reusing the old dynamic client_id
+    with the new redirect_uri makes the next browser flow fail against OAuth
+    servers that bind client registrations to exact redirect URIs.
+
+    The active pre-registered ``client_id`` path is intentionally skipped
+    here — :func:`_maybe_preregister_client` overwrites the file
+    unconditionally on that path, so deletion would be wasted I/O.
+    """
+    if cfg.get("client_id"):
+        return
+    path = storage._client_info_path()
+    if not path.exists():
+        return
+    existing = _read_json(path)
+    if existing is None:
+        return
+    stored_uris = [str(u) for u in (existing.get("redirect_uris") or [])]
+    new_uris = [str(u) for u in (client_metadata.redirect_uris or [])]
+    stored_auth_method = existing.get("token_endpoint_auth_method")
+    new_auth_method = client_metadata.token_endpoint_auth_method
+    is_dynamic_client = existing.get("hermes_dynamic_client") is True
+    has_refresh_token = _stored_tokens_have_refresh_token(storage)
+    legacy_confidential_client = (
+        not is_dynamic_client
+        and (
+            bool(existing.get("client_secret"))
+            or (
+                stored_auth_method is not None
+                and stored_auth_method != "none"
+                and stored_auth_method != new_auth_method
+            )
+        )
+    )
+
+    stale_reasons: list[str] = []
+    if set(stored_uris) != set(new_uris):
+        stale_reasons.append(f"redirect_uris {stored_uris} != {new_uris}")
+    if existing.get("hermes_preregistered_client") is True:
+        stale_reasons.append("stored client_info came from removed pre-registered config")
+    elif not is_dynamic_client:
+        if legacy_confidential_client:
+            stale_reasons.append(
+                "legacy unmarked confidential client_info could be removed pre-registered config"
+            )
+        elif has_refresh_token:
+            logger.debug(
+                "MCP OAuth '%s': keeping legacy unmarked client_info because "
+                "cached tokens include a refresh token",
+                storage._server_name,
+            )
+        else:
+            stale_reasons.append("legacy unmarked client_info could be removed pre-registered config")
+    elif stored_auth_method is not None and stored_auth_method != new_auth_method:
+        stale_reasons.append(
+            f"token_endpoint_auth_method {stored_auth_method!r} != {new_auth_method!r}"
+        )
+
+    if not stale_reasons:
+        return
+    try:
+        path.unlink()
+    except OSError as exc:
+        logger.warning(
+            "MCP OAuth '%s': failed to remove stale client_info at %s: %s",
+            storage._server_name, path, exc,
+        )
+        return
+    logger.info(
+        "MCP OAuth '%s': removed stale client_info (%s) so SDK will re-register",
+        storage._server_name, "; ".join(stale_reasons),
+    )
+
+
 def _maybe_preregister_client(
     storage: "HermesTokenStorage",
     cfg: dict,
@@ -573,8 +1032,7 @@ def _maybe_preregister_client(
     client_id = cfg.get("client_id")
     if not client_id:
         return
-    port = cfg["_resolved_port"]
-    redirect_uri = f"http://127.0.0.1:{port}/callback"
+    redirect_uri = _build_redirect_uri(cfg)
 
     info_dict: dict[str, Any] = {
         "client_id": client_id,
@@ -582,6 +1040,7 @@ def _maybe_preregister_client(
         "grant_types": client_metadata.grant_types,
         "response_types": client_metadata.response_types,
         "token_endpoint_auth_method": client_metadata.token_endpoint_auth_method,
+        "hermes_preregistered_client": True,
     }
     if cfg.get("client_secret"):
         info_dict["client_secret"] = cfg["client_secret"]
@@ -591,7 +1050,9 @@ def _maybe_preregister_client(
         info_dict["scope"] = cfg["scope"]
 
     client_info = OAuthClientInformationFull.model_validate(info_dict)
-    _write_json(storage._client_info_path(), client_info.model_dump(mode="json", exclude_none=True))
+    payload = client_info.model_dump(mode="json", exclude_none=True)
+    payload["hermes_preregistered_client"] = True
+    _write_json(storage._client_info_path(), payload)
     logger.debug("Pre-registered client_id=%s for '%s'", client_id, storage._server_name)
 
 
@@ -635,15 +1096,22 @@ def build_oauth_auth(
             server_name,
         )
 
-    _configure_callback_port(cfg)
+    port = _configure_callback_port(cfg)
     client_metadata = _build_client_metadata(cfg)
+    _invalidate_stale_dynamic_client_info(storage, cfg, client_metadata)
     _maybe_preregister_client(storage, cfg, client_metadata)
+
+    # Capture the resolved host/port in per-provider closures so a later
+    # ``build_oauth_auth`` call for a different server can't retarget this
+    # provider's callback listener or SSH hint via the module globals.
+    callback_handler = _make_wait_for_callback(cfg["_resolved_bind_host"], port)
+    redirect_handler = _make_redirect_handler(cfg["_resolved_uri_host"], port)
 
     return OAuthClientProvider(
         server_url=server_url,
         client_metadata=client_metadata,
         storage=storage,
-        redirect_handler=_redirect_handler,
-        callback_handler=_wait_for_callback,
+        redirect_handler=redirect_handler,
+        callback_handler=callback_handler,
         timeout=float(cfg.get("timeout", 300)),
     )

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -35,6 +35,7 @@ Design reference:
 from __future__ import annotations
 
 import asyncio
+import copy
 import logging
 import threading
 from dataclasses import dataclass, field
@@ -69,6 +70,13 @@ class _ProviderEntry:
     """
 
     server_url: str
+    # Defensive deep-copy snapshot of the caller's oauth_config dict.
+    # Storing the caller's reference would alias state: a later in-place
+    # mutation (e.g. config.yaml hot-reload mutating the same dict) would
+    # also retroactively change ``entry.oauth_config``, causing the
+    # change-detection branch in :meth:`MCPOAuthManager.get_or_build_provider`
+    # to compare equal and silently skip rebuild. Always snapshot via
+    # :func:`_snapshot_oauth_config` before assigning here.
     oauth_config: Optional[dict]
     provider: Optional[Any] = None
     last_mtime_ns: int = 0
@@ -331,6 +339,20 @@ def _make_hermes_provider_class() -> Optional[type]:
 _HERMES_PROVIDER_CLS: Optional[type] = _make_hermes_provider_class()
 
 
+def _snapshot_oauth_config(cfg: Optional[dict]) -> Optional[dict]:
+    """Return a deep-copy snapshot of an ``oauth_config`` dict.
+
+    The manager caches a per-server snapshot so subsequent change-detection
+    compares against a frozen baseline rather than the caller's live
+    reference. ``None`` is preserved (distinct from an empty dict) so the
+    "no oauth block configured" state stays distinguishable from an
+    explicit empty mapping.
+    """
+    if cfg is None:
+        return None
+    return copy.deepcopy(cfg)
+
+
 # ---------------------------------------------------------------------------
 # Manager
 # ---------------------------------------------------------------------------
@@ -359,11 +381,18 @@ class MCPOAuthManager:
         """Return a cached OAuth provider for ``server_name`` or build one.
 
         Idempotent: repeat calls with the same name return the same instance.
-        If ``server_url`` changes for a given name, the cached entry is
-        discarded and a fresh provider is built.
+        If ``server_url`` or ``oauth_config`` changes for a given name, the
+        cached entry is discarded and a fresh provider is built so changes
+        to ``redirect_host``/``redirect_port``/``client_id`` etc. take
+        effect in-process without restart.
 
         Returns None if the MCP SDK's OAuth support is unavailable.
         """
+        # Snapshot up front: subsequent comparisons and the cache entry
+        # both store an isolated copy, so a caller mutating the same dict
+        # in place between calls is still detected as a change.
+        config_snapshot = _snapshot_oauth_config(oauth_config)
+
         with self._entries_lock:
             entry = self._entries.get(server_name)
             if entry is not None and entry.server_url != server_url:
@@ -372,11 +401,17 @@ class MCPOAuthManager:
                     server_name, entry.server_url, server_url,
                 )
                 entry = None
+            elif entry is not None and entry.oauth_config != config_snapshot:
+                logger.info(
+                    "MCP OAuth '%s': oauth_config changed, discarding cache",
+                    server_name,
+                )
+                entry = None
 
             if entry is None:
                 entry = _ProviderEntry(
                     server_url=server_url,
-                    oauth_config=oauth_config,
+                    oauth_config=config_snapshot,
                 )
                 self._entries[server_name] = entry
 
@@ -411,10 +446,11 @@ class MCPOAuthManager:
             _OAUTH_AVAILABLE,
             _build_client_metadata,
             _configure_callback_port,
+            _invalidate_stale_dynamic_client_info,
             _is_interactive,
+            _make_redirect_handler,
+            _make_wait_for_callback,
             _maybe_preregister_client,
-            _redirect_handler,
-            _wait_for_callback,
         )
 
         if not _OAUTH_AVAILABLE:
@@ -431,17 +467,30 @@ class MCPOAuthManager:
                 server_name,
             )
 
-        _configure_callback_port(cfg)
+        port = _configure_callback_port(cfg)
         client_metadata = _build_client_metadata(cfg)
+        _invalidate_stale_dynamic_client_info(storage, cfg, client_metadata)
         _maybe_preregister_client(storage, cfg, client_metadata)
+
+        # Bind the callback + redirect handlers to the host/port resolved for
+        # THIS provider. Building a second provider for a different server
+        # would otherwise overwrite the module-level ``_oauth_port`` /
+        # ``_oauth_bind_host`` / ``_oauth_uri_host`` and silently retarget
+        # this listener, or print an SSH hint for the wrong host/port.
+        callback_handler = _make_wait_for_callback(
+            cfg["_resolved_bind_host"], port
+        )
+        redirect_handler = _make_redirect_handler(
+            cfg["_resolved_uri_host"], port
+        )
 
         return _HERMES_PROVIDER_CLS(
             server_name=server_name,
             server_url=entry.server_url,
             client_metadata=client_metadata,
             storage=storage,
-            redirect_handler=_redirect_handler,
-            callback_handler=_wait_for_callback,
+            redirect_handler=redirect_handler,
+            callback_handler=callback_handler,
             timeout=float(cfg.get("timeout", 300)),
         )
 


### PR DESCRIPTION
## What does this PR do?

Adds MCP OAuth redirect-host plumbing so configured loopback redirect hosts are reflected consistently in redirect URI generation and callback listener binding.

## Related Issue

N/A.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `oauth.redirect_host` plumbing for MCP OAuth redirect URIs.
- Restrict redirect hosts to loopback values only (`127.0.0.1`, `localhost`, `::1`, `[::1]`).
- Keep listener behavior aligned with the selected redirect host, including IPv6 loopback handling.
- Bind generated redirect URIs and callback listener behavior to the same validated config value.
- Add regression coverage for valid and invalid redirect-host configurations.

## How to Test

1. Run MCP OAuth redirect-host focused tests.
2. Verify loopback-only validation for IPv4, localhost, and IPv6 forms.
3. Verify generated redirect URIs and listener binding stay consistent.
4. Run a read-only Codex review of the final branch delta.

Verification performed during refresh:

- Focused MCP OAuth redirect-host tests passed locally.
- Read-only Codex review: `VERDICT: CLEAN`.
- Branch was rebased onto current `main` and updated with `--force-with-lease`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

Note: I ran focused/regression tests locally for the changed MCP OAuth redirect-host behavior and am relying on GitHub Actions for the full matrix.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

N/A. Relevant verification is in local focused test output, Codex review logs, and GitHub Actions checks.
