### PR TITLE
fix(mcp): isolate OAuth callback result state

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -22,6 +22,7 @@ from tools.mcp_oauth import (
     _is_interactive,
     _wait_for_callback,
     _make_callback_handler,
+    _make_redirect_handler,
     _redirect_handler,
 )
 
@@ -301,6 +302,24 @@ class TestRedirectHandlerSshHint:
         err = capsys.readouterr().err
         assert "ssh -N -L" not in err
 
+    def test_bound_redirect_handler_uses_captured_port_for_ssh_hint(self, monkeypatch, capsys):
+        import tools.mcp_oauth as mco
+
+        monkeypatch.setattr(mco, "_oauth_port", 49299)
+        monkeypatch.setenv("SSH_CLIENT", "1.2.3.4 1234 22")
+        monkeypatch.setattr(mco, "_can_open_browser", lambda: False)
+        mco._oauth_active_flow_claims.clear()
+        mco._oauth_results_by_port.clear()
+        mco._oauth_pending_ports.clear()
+
+        handler = _make_redirect_handler(49203, ("server-a", "https://example.com/mcp"))
+        self._run(handler("https://example.com/auth"))
+
+        err = capsys.readouterr().err
+        assert "49203" in err
+        assert "49299" not in err
+        assert "ssh -N -L 49203:127.0.0.1:49203" in err
+
 
 # ---------------------------------------------------------------------------
 # Path traversal protection
@@ -466,6 +485,10 @@ class TestWaitForCallbackNoBlocking:
         import asyncio
 
         mod._oauth_port = _find_free_port()
+        mod._oauth_result = None
+        mod._oauth_result_active = False
+        mod._oauth_result_port = None
+        mod._oauth_results_by_port.clear()
 
         async def instant_sleep(_seconds):
             pass
@@ -474,6 +497,404 @@ class TestWaitForCallbackNoBlocking:
             with patch("builtins.input", side_effect=AssertionError("input() must not be called")):
                 with pytest.raises(OAuthNonInteractiveError, match="callback timed out"):
                     asyncio.run(_wait_for_callback())
+
+
+class TestSharedCallbackResultCleanup:
+    """``_oauth_result`` must not leak across login attempts.
+
+    If a prior flow exited (success, error, or timeout) and left a stale
+    auth_code/state/error in the shared slot, a subsequent
+    ``_wait_for_callback`` would wrongly accept it without ever seeing a
+    real browser callback.
+    """
+
+    def _instant_sleep_patch(self):
+        async def instant_sleep(_seconds):
+            pass
+        import tools.mcp_oauth as mod
+        return patch.object(mod.asyncio, "sleep", instant_sleep)
+
+    def test_timeout_clears_shared_result(self):
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        mod._oauth_port = _find_free_port()
+        mod._oauth_result = None
+        mod._oauth_result_active = False
+        mod._oauth_result_port = None
+        mod._oauth_results_by_port.clear()
+
+        with self._instant_sleep_patch():
+            with pytest.raises(OAuthNonInteractiveError):
+                asyncio.run(_wait_for_callback())
+
+        assert mod._oauth_result is None, (
+            "timed-out callback must clear _oauth_result so the next login "
+            "attempt cannot reuse stale state"
+        )
+
+    def test_error_clears_shared_result(self):
+        """When the owner-waiter's callback returns ?error=…, the shared
+        slot must be cleared so the next attempt starts fresh."""
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        mod._oauth_port = _find_free_port()
+        mod._oauth_result = None
+        mod._oauth_result_active = False
+        mod._oauth_result_port = None
+        mod._oauth_results_by_port.clear()
+
+        async def push_error_then_sleep(_seconds):
+            if mod._oauth_result is not None and mod._oauth_result["error"] is None:
+                mod._oauth_result["error"] = "server_error"
+
+        with patch.object(mod.asyncio, "sleep", push_error_then_sleep):
+            with pytest.raises(RuntimeError, match="server_error"):
+                asyncio.run(_wait_for_callback())
+
+        assert mod._oauth_result is None, (
+            "errored callback must clear _oauth_result so the next login "
+            "attempt does not raise the prior flow's error"
+        )
+
+    def test_success_clears_shared_result(self):
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        mod._oauth_port = _find_free_port()
+        mod._oauth_result = None
+        mod._oauth_result_active = False
+        mod._oauth_result_port = None
+        mod._oauth_results_by_port.clear()
+
+        async def push_code_then_sleep(_seconds):
+            if mod._oauth_result is not None and mod._oauth_result["auth_code"] is None:
+                mod._oauth_result["auth_code"] = "fresh-code"
+                mod._oauth_result["state"] = "fresh-state"
+
+        with patch.object(mod.asyncio, "sleep", push_code_then_sleep):
+            code, state = asyncio.run(_wait_for_callback())
+
+        assert code == "fresh-code"
+        assert state == "fresh-state"
+        assert mod._oauth_result is None, (
+            "successful callback must clear _oauth_result so the next login "
+            "attempt does not reuse the previous code"
+        )
+
+    def test_owner_bind_failure_raises_noninteractive_error(self):
+        """Owner-branch bind failure must surface immediately.
+
+        The owner waiter is the only candidate to populate the shared
+        result dict, so a bind failure that is silently downgraded to
+        "fall through to polling" leaves the waiter blocked until the
+        5-minute timeout. Surface the failure as
+        ``OAuthNonInteractiveError`` (the existing user-friendly
+        callback-port message) and chain the underlying ``OSError`` via
+        ``__cause__`` so debugging info is preserved without leaking the
+        raw errno through the public API.
+        """
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        mod._oauth_port = _find_free_port()
+        mod._oauth_result = None
+        mod._oauth_result_active = False
+        mod._oauth_result_port = None
+        mod._oauth_results_by_port.clear()
+
+        underlying = OSError("address already in use")
+        with patch.object(mod, "HTTPServer", side_effect=underlying):
+            with pytest.raises(OAuthNonInteractiveError) as excinfo:
+                asyncio.run(_wait_for_callback())
+
+        assert isinstance(excinfo.value.__cause__, OSError)
+        assert excinfo.value.__cause__ is underlying
+
+        # Owner must roll back the shared slot it installed so the next
+        # waiter doesn't poll a never-filled buffer.
+        assert mod._oauth_result is None
+
+    def test_build_oauth_auth_clears_stale_result(self, tmp_path, monkeypatch):
+        """``build_oauth_auth`` must drop any stale shared result before the
+        new flow begins, even if the previous flow leaked state."""
+        try:
+            from mcp.client.auth import OAuthClientProvider  # noqa: F401
+        except ImportError:
+            pytest.skip("MCP SDK auth not available")
+
+        import tools.mcp_oauth as mod
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Simulate stale state from a crashed previous flow.
+        mod._oauth_result = {
+            "auth_code": "stale-code",
+            "state": "stale-state",
+            "error": None,
+        }
+        mod._oauth_result_active = False
+        mod._oauth_results_by_port[mod._callback_result_key(12345)] = {
+            "auth_code": "stale-map-code",
+            "state": "stale-map-state",
+            "error": None,
+        }
+
+        build_oauth_auth("fresh-flow", "https://example.com/mcp")
+
+        assert mod._oauth_result is None
+        assert mod._oauth_result_active is False
+        assert mod._oauth_results_by_port == {}
+
+    def test_concurrent_waiter_reuses_shared_result(self):
+        """A second waiter on the same flow shares the first's result dict.
+
+        It must not try to bind a fresh server (port is already taken) and
+        must observe the auth_code the first waiter's handler captured.
+        """
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        mod._oauth_port = _find_free_port()
+        mod._oauth_result = None
+        mod._oauth_result_active = False
+        mod._oauth_result_port = None
+        mod._oauth_results_by_port.clear()
+
+        # First waiter installs the shared slot. Push a code so it returns
+        # quickly; we capture the dict identity before cleanup runs.
+        captured = {}
+
+        async def push_and_capture(_seconds):
+            if mod._oauth_result is not None and mod._oauth_result["auth_code"] is None:
+                captured["slot"] = mod._oauth_result
+                mod._oauth_result["auth_code"] = "shared-code"
+
+        with patch.object(mod.asyncio, "sleep", push_and_capture):
+            code1, _ = asyncio.run(_wait_for_callback())
+
+        assert code1 == "shared-code"
+        assert mod._oauth_result is None  # cleared by owner on exit
+
+        # Now seed a fresh shared slot as if a sibling waiter had set it
+        # up first. The new waiter should NOT own it and should NOT clear
+        # it on its own exit (only the installer cleans up). It should,
+        # however, observe the code already in the dict.
+        sibling_slot = {"auth_code": "sibling-code", "state": "sibling-state", "error": None}
+        mod._oauth_result = sibling_slot
+        mod._oauth_result_active = True
+        mod._oauth_result_port = mod._oauth_port
+        sibling_key = mod._callback_result_key(mod._oauth_port)
+        mod._oauth_results_by_port[sibling_key] = sibling_slot
+
+        async def noop(_seconds):
+            pass
+
+        with patch.object(mod.asyncio, "sleep", noop):
+            code2, state2 = asyncio.run(_wait_for_callback())
+
+        assert code2 == "sibling-code"
+        assert state2 == "sibling-state"
+        # Non-owner does not clear the slot — sibling waiter still owns it.
+        assert mod._oauth_result is sibling_slot
+        # Cleanup for the next test.
+        mod._oauth_result = None
+        mod._oauth_result_active = False
+        mod._oauth_result_port = None
+        mod._oauth_results_by_port.clear()
+
+    def test_provider_build_does_not_clear_active_shared_result(self, tmp_path, monkeypatch):
+        """Provider construction must not erase a live listener's result slot."""
+        try:
+            from mcp.client.auth import OAuthClientProvider  # noqa: F401
+        except ImportError:
+            pytest.skip("MCP SDK auth not available")
+
+        import tools.mcp_oauth as mod
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        active_slot = {"auth_code": None, "state": None, "error": None}
+        active_port = 12345
+        mod._oauth_result = active_slot
+        mod._oauth_result_active = True
+        mod._oauth_result_port = active_port
+        active_key = mod._callback_result_key(active_port)
+        mod._oauth_results_by_port[active_key] = active_slot
+
+        build_oauth_auth("fresh-flow", "https://example.com/mcp")
+
+        assert mod._oauth_result is active_slot
+        assert mod._oauth_result_active is True
+        assert mod._oauth_results_by_port[active_key] is active_slot
+        mod._oauth_result = None
+        mod._oauth_result_active = False
+        mod._oauth_result_port = None
+        mod._oauth_results_by_port.clear()
+
+    def test_reset_preserves_claim_before_listener_publish(self):
+        """Provider reset must not drop a claim made before listener publish.
+
+        OAuthClientProvider invokes the redirect handler (which shows the auth
+        URL) before it invokes the callback waiter (which publishes
+        _oauth_results_by_port and flips _oauth_result_active). In that gap the
+        active-flow claim is the only guard preventing a different flow on the
+        same explicit callback port from emitting a competing URL.
+        """
+        import tools.mcp_oauth as mod
+
+        port = _find_free_port()
+        flow_a = ("server-a", "https://a.example/mcp", (("client_id", '"a"'),))
+        flow_b = ("server-b", "https://b.example/mcp", (("client_id", '"b"'),))
+        flow_a_key = mod._callback_result_key(port, flow_a)
+        stale_key = mod._callback_result_key(port + 1, flow_a)
+
+        mod._oauth_result = {"auth_code": "stale", "state": None, "error": None}
+        mod._oauth_result_active = False
+        mod._oauth_result_port = port + 1
+        mod._oauth_results_by_port.clear()
+        mod._oauth_results_by_port[stale_key] = mod._oauth_result
+        mod._oauth_pending_ports.clear()
+        mod._oauth_active_flow_claims.clear()
+        mod._oauth_active_flow_claims.add(flow_a_key)
+
+        mod._reset_shared_callback_result()
+
+        assert mod._oauth_result is None
+        assert mod._oauth_result_port is None
+        assert mod._oauth_results_by_port == {}
+        assert flow_a_key in mod._oauth_active_flow_claims
+        with pytest.raises(
+            OAuthNonInteractiveError,
+            match="already in use by another active OAuth flow",
+        ):
+            mod._claim_callback_flow(port, flow_b)
+
+        mod._oauth_active_flow_claims.clear()
+
+    def test_bind_failure_does_not_publish_unbacked_shared_result(self):
+        """A failed owner bind must not expose a result dict for siblings to poll."""
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        mod._oauth_port = _find_free_port()
+        mod._oauth_result = None
+        mod._oauth_result_active = False
+        mod._oauth_result_port = None
+        mod._oauth_results_by_port.clear()
+
+        with patch.object(mod, "HTTPServer", side_effect=OSError("address already in use")):
+            with pytest.raises(OAuthNonInteractiveError):
+                asyncio.run(_wait_for_callback())
+
+        assert mod._oauth_result is None
+        assert mod._oauth_result_active is False
+        assert mod._oauth_result_port is None
+        assert mod._oauth_results_by_port == {}
+
+    def test_active_slot_reuse_is_scoped_to_callback_port(self):
+        """A new flow on a different port must not poll another flow's result."""
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        active_slot = {"auth_code": "flow-a-code", "state": "flow-a-state", "error": None}
+        flow_a_port = _find_free_port()
+        flow_b_port = _find_free_port()
+        while flow_b_port == flow_a_port:
+            flow_b_port = _find_free_port()
+
+        mod._oauth_port = flow_b_port
+        mod._oauth_result = active_slot
+        mod._oauth_result_active = True
+        mod._oauth_result_port = flow_a_port
+        mod._oauth_results_by_port.clear()
+        flow_a_key = mod._callback_result_key(flow_a_port)
+        flow_b_key = mod._callback_result_key(flow_b_port)
+        mod._oauth_results_by_port[flow_a_key] = active_slot
+
+        async def push_flow_b_code(_seconds):
+            flow_b_slot = mod._oauth_results_by_port.get(flow_b_key)
+            if flow_b_slot is not None and flow_b_slot["auth_code"] is None:
+                flow_b_slot["auth_code"] = "flow-b-code"
+                flow_b_slot["state"] = "flow-b-state"
+
+        with patch.object(mod.asyncio, "sleep", push_flow_b_code):
+            code, state = asyncio.run(_wait_for_callback())
+
+        assert (code, state) == ("flow-b-code", "flow-b-state")
+        assert mod._oauth_results_by_port[flow_a_key] is active_slot
+        mod._oauth_result = None
+        mod._oauth_result_active = False
+        mod._oauth_result_port = None
+        mod._oauth_results_by_port.clear()
+
+    def test_different_flow_on_active_same_port_is_rejected(self):
+        """Two different OAuth flows sharing a live port must fail closed.
+
+        The callback server is bound to one handler/result buffer. Until Hermes
+        has a state-aware demux listener, a second flow on the same explicit
+        port would either fail to bind or risk consuming the wrong code/state.
+        """
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        port = _find_free_port()
+        flow_a = ("server-a", "https://a.example/mcp", (("client_id", '"a"'),))
+        flow_b = ("server-b", "https://b.example/mcp", (("client_id", '"b"'),))
+        flow_a_slot = {"auth_code": "flow-a-code", "state": "flow-a-state", "error": None}
+        flow_a_key = mod._callback_result_key(port, flow_a)
+
+        mod._oauth_port = port
+        mod._oauth_result = flow_a_slot
+        mod._oauth_result_active = True
+        mod._oauth_result_port = port
+        mod._oauth_results_by_port.clear()
+        mod._oauth_pending_ports.clear()
+        mod._oauth_active_flow_claims.clear()
+        mod._oauth_results_by_port[flow_a_key] = flow_a_slot
+
+        with pytest.raises(
+            OAuthNonInteractiveError,
+            match="already in use by another active OAuth flow",
+        ):
+            asyncio.run(_wait_for_callback(port=port, flow_key=flow_b))
+
+        assert mod._oauth_results_by_port[flow_a_key] is flow_a_slot
+        mod._oauth_result = None
+        mod._oauth_result_active = False
+        mod._oauth_result_port = None
+        mod._oauth_results_by_port.clear()
+        mod._oauth_pending_ports.clear()
+        mod._oauth_active_flow_claims.clear()
+
+    def test_sibling_waiters_for_same_flow_reuse_same_port_result(self):
+        """Sibling waiters for the same flow still reuse listener/result."""
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        port = _find_free_port()
+        flow_key = ("same-server", "https://same.example/mcp", (("client_id", '"same"'),))
+        slot = {"auth_code": "same-flow-code", "state": "same-flow-state", "error": None}
+        slot_key = mod._callback_result_key(port, flow_key)
+
+        mod._oauth_port = port
+        mod._oauth_result = slot
+        mod._oauth_result_active = True
+        mod._oauth_result_port = port
+        mod._oauth_results_by_port.clear()
+        mod._oauth_results_by_port[slot_key] = slot
+
+        async def noop(_seconds):
+            pass
+
+        with patch.object(mod.asyncio, "sleep", noop):
+            code, state = asyncio.run(_wait_for_callback(port=port, flow_key=flow_key))
+
+        assert (code, state) == ("same-flow-code", "same-flow-state")
+        assert mod._oauth_results_by_port[slot_key] is slot
+        mod._oauth_result = None
+        mod._oauth_result_active = False
+        mod._oauth_result_port = None
+        mod._oauth_results_by_port.clear()
 
 
 class TestBuildOAuthAuthNonInteractive:
@@ -588,6 +1009,216 @@ def test_configure_callback_port_uses_explicit_port():
     assert cfg["_resolved_port"] == 54321
 
 
+def test_manager_build_provider_clears_stale_result(tmp_path, monkeypatch):
+    """The manager's provider-construction path must also reset the shared
+    ``_oauth_result`` slot.
+
+    ``build_oauth_auth`` already drops stale callback state before the new
+    flow begins; ``MCPOAuthManager._build_provider`` bypasses
+    ``build_oauth_auth`` entirely and constructs the provider directly,
+    so without an explicit reset a crashed prior flow's auth_code/state/
+    error could leak into the next ``_wait_for_callback``.
+    """
+    pytest.importorskip("mcp")
+
+    import tools.mcp_oauth as mod
+    from tools.mcp_oauth_manager import MCPOAuthManager
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    mod._oauth_result = {
+        "auth_code": "stale-code",
+        "state": "stale-state",
+        "error": None,
+    }
+
+    manager = MCPOAuthManager()
+    provider = manager.get_or_build_provider(
+        "manager-fresh-flow",
+        "https://example.com/mcp",
+        None,
+    )
+
+    assert provider is not None
+    assert mod._oauth_result is None
+
+
+class TestConcurrentBindRace:
+    """Regression for the bind/publish race in ``_wait_for_callback``.
+
+    After one waiter's ``HTTPServer`` bind succeeds but before it publishes
+    ``_oauth_results_by_port``, a concurrent waiter used to bind the same
+    port, fail (port taken), see no published result, and raise
+    ``OAuthNonInteractiveError`` — even though the first waiter was about to
+    publish a live listener. The fix reserves an in-progress marker
+    (``_oauth_pending_ports``) atomically with the decision to bind, so a
+    concurrent waiter waits for that bind to resolve instead of racing it.
+    """
+
+    def _reset(self, mod, port):
+        mod._oauth_port = port
+        mod._oauth_result = None
+        mod._oauth_result_active = False
+        mod._oauth_result_port = None
+        mod._oauth_results_by_port.clear()
+        mod._oauth_pending_ports.clear()
+        mod._oauth_active_flow_claims.clear()
+
+    def test_waiter_waits_for_pending_binder_then_reuses_listener(self):
+        """A waiter that finds the port mid-bind must wait for the binding
+        sibling to publish, then reuse its listener — not bind and raise."""
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        port = _find_free_port()
+        self._reset(mod, port)
+        # Simulate a sibling that has committed to binding this flow: the
+        # in-progress marker is set but no result is published yet.
+        slot_key = mod._callback_result_key(port)
+        mod._oauth_pending_ports.add(slot_key)
+
+        published = {"auth_code": "raced-code", "state": "raced-state", "error": None}
+
+        async def publish_during_poll(_seconds):
+            # The binding sibling finishes: it publishes a live listener and
+            # drops the in-progress marker.
+            if slot_key in mod._oauth_pending_ports:
+                mod._oauth_results_by_port[slot_key] = published
+                mod._oauth_pending_ports.discard(slot_key)
+
+        with patch.object(mod.asyncio, "sleep", publish_during_poll):
+            code, state = asyncio.run(_wait_for_callback())
+
+        assert (code, state) == ("raced-code", "raced-state")
+        # The waiting sibling never owned the slot; it must leave it intact.
+        assert mod._oauth_results_by_port[slot_key] is published
+        self._reset(mod, port)
+
+    def test_waiter_raises_when_pending_binder_fails_to_bind(self):
+        """If the binding sibling abandons its bind (marker dropped, nothing
+        published), the waiting sibling surfaces the bind failure."""
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        port = _find_free_port()
+        self._reset(mod, port)
+        slot_key = mod._callback_result_key(port)
+        mod._oauth_pending_ports.add(slot_key)
+
+        async def binder_fails_during_poll(_seconds):
+            mod._oauth_pending_ports.discard(slot_key)
+
+        with patch.object(mod.asyncio, "sleep", binder_fails_during_poll):
+            with pytest.raises(OAuthNonInteractiveError, match="failed to bind"):
+                asyncio.run(_wait_for_callback())
+
+        self._reset(mod, port)
+
+    def test_binder_clears_in_progress_marker_on_success(self):
+        """The waiter that binds must publish a listener and drop its
+        in-progress marker so siblings switch from waiting to reusing."""
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        port = _find_free_port()
+        self._reset(mod, port)
+
+        async def push_code_then_sleep(_seconds):
+            if mod._oauth_result is not None and mod._oauth_result["auth_code"] is None:
+                # While the listener is live, the marker must already be gone.
+                assert mod._callback_result_key(port) not in mod._oauth_pending_ports
+                mod._oauth_result["auth_code"] = "ok-code"
+
+        with patch.object(mod.asyncio, "sleep", push_code_then_sleep):
+            code, _ = asyncio.run(_wait_for_callback())
+
+        assert code == "ok-code"
+        assert mod._oauth_pending_ports == set()
+        self._reset(mod, port)
+
+    def test_binder_clears_in_progress_marker_on_bind_failure(self):
+        """A failed bind must drop the in-progress marker so a waiting
+        sibling stops waiting instead of hanging until the pending timeout."""
+        import tools.mcp_oauth as mod
+        import asyncio
+
+        port = _find_free_port()
+        self._reset(mod, port)
+
+        with patch.object(mod, "HTTPServer", side_effect=OSError("address already in use")):
+            with pytest.raises(OAuthNonInteractiveError):
+                asyncio.run(_wait_for_callback())
+
+        assert mod._oauth_pending_ports == set()
+        assert mod._oauth_results_by_port == {}
+        self._reset(mod, port)
+
+
+class TestCallbackLogRedaction:
+    """``log_message`` must not leak OAuth secrets into the debug log.
+
+    ``BaseHTTPRequestHandler`` log lines embed the raw request line, which
+    for the callback is ``GET /callback?code=...&state=...``. Logging that
+    verbatim leaks the authorization code and CSRF state.
+    """
+
+    def test_log_message_redacts_code_and_state(self, caplog):
+        import logging
+
+        HandlerClass, _ = _make_callback_handler()
+        handler = HandlerClass.__new__(HandlerClass)
+
+        with caplog.at_level(logging.DEBUG, logger="tools.mcp_oauth"):
+            handler.log_message(
+                '"%s" %s %s',
+                "GET /callback?code=secret-auth-code&state=secret-csrf HTTP/1.1",
+                "200",
+                "-",
+            )
+
+        assert "secret-auth-code" not in caplog.text
+        assert "secret-csrf" not in caplog.text
+        assert "code=REDACTED" in caplog.text
+        assert "state=REDACTED" in caplog.text
+
+    def test_log_message_redacts_error(self, caplog):
+        import logging
+
+        HandlerClass, _ = _make_callback_handler()
+        handler = HandlerClass.__new__(HandlerClass)
+
+        with caplog.at_level(logging.DEBUG, logger="tools.mcp_oauth"):
+            handler.log_message(
+                '"%s" %s %s',
+                "GET /callback?error=access_denied_with_detail HTTP/1.1",
+                "200",
+                "-",
+            )
+
+        assert "access_denied_with_detail" not in caplog.text
+        assert "error=REDACTED" in caplog.text
+
+    def test_redact_helper_preserves_non_secret_text(self):
+        from tools.mcp_oauth import _redact_callback_log
+
+        msg = '"GET /callback?code=abc123&state=xyz789&scope=channels:read HTTP/1.1" 200 -'
+        out = _redact_callback_log(msg)
+
+        assert "abc123" not in out
+        assert "xyz789" not in out
+        assert "code=REDACTED" in out
+        assert "state=REDACTED" in out
+        # Non-secret query params and the rest of the line are untouched.
+        assert "scope=channels:read" in out
+        assert out.endswith('HTTP/1.1" 200 -')
+
+    def test_redact_helper_noop_without_secrets(self):
+        from tools.mcp_oauth import _redact_callback_log
+
+        msg = '"GET /favicon.ico HTTP/1.1" 404 -'
+        assert _redact_callback_log(msg) == msg
+
+
 def test_build_oauth_auth_preserves_server_url_path():
     """server_url with path is forwarded to OAuthClientProvider unmodified.
 
@@ -619,5 +1250,32 @@ def test_build_oauth_auth_preserves_server_url_path():
         )
 
     assert captured["server_url"] == "https://mcp.notion.com/mcp"
+
+
+def test_redirect_handler_rejects_same_port_other_flow_before_emitting_url(monkeypatch):
+    """Conflicting flows must fail before the second authorization URL is shown."""
+    import asyncio
+    import tools.mcp_oauth as mod
+
+    port = _find_free_port()
+    flow_a = ("server-a", "https://example.com/a", ())
+    flow_b = ("server-b", "https://example.com/b", ())
+    mod._oauth_active_flow_claims.clear()
+    mod._oauth_results_by_port.clear()
+    mod._oauth_pending_ports.clear()
+
+    emitted: list[str] = []
+
+    async def fake_redirect(url, callback_port=None):
+        emitted.append(url)
+
+    monkeypatch.setattr(mod, "_redirect_handler", fake_redirect)
+
+    asyncio.run(mod._make_redirect_handler(port, flow_a)("https://auth.example/a"))
+    with pytest.raises(OAuthNonInteractiveError, match="already in use"):
+        asyncio.run(mod._make_redirect_handler(port, flow_b)("https://auth.example/b"))
+
+    assert emitted == ["https://auth.example/a"]
+    mod._oauth_active_flow_claims.clear()
 
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -92,6 +92,37 @@ class OAuthNonInteractiveError(RuntimeError):
 # tests can verify the callback server and the redirect_uri share a port.
 _oauth_port: int | None = None
 
+# Shared callback result for live OAuth flows. ``_wait_for_callback`` may be
+# invoked more than once per flow (e.g. SDK retries, or a second concurrent
+# waiter sharing the already-bound port). Storing the handler's result dict by
+# (callback port, flow identity) lets sibling waiters poll the same buffer
+# instead of binding a fresh server, without letting distinct servers/providers
+# on the same port consume each other's code/state.
+#
+# MUST be reset to None on completion, failure, or timeout so a subsequent
+# login attempt cannot inherit stale auth_code/state/error from a prior
+# flow. ``build_oauth_auth`` also resets inactive slots defensively at flow
+# start.
+_oauth_result: dict[str, Any] | None = None
+_oauth_result_active = False
+_oauth_result_port: int | None = None
+_oauth_flow_key: tuple[Any, ...] = ("legacy",)
+_oauth_results_by_port: dict[tuple[int, tuple[Any, ...]], dict[str, Any]] = {}
+# Flows that have reached the user-visible redirect step but may not have
+# entered ``_wait_for_callback`` yet. The MCP SDK emits the authorization URL
+# before opening the callback listener, so checking for cross-flow port reuse
+# only inside ``_wait_for_callback`` is too late: a browser could already hit a
+# listener owned by another flow. Claiming here lets the redirect handler fail
+# before the URL is shown for a conflicting flow.
+_oauth_active_flow_claims: set[tuple[int, tuple[Any, ...]]] = set()
+# Ports for which a waiter has decided to bind a listener but has not yet
+# finished (the bind may still succeed and publish, or fail). This is an
+# explicit "in-progress" marker -- NOT a result buffer. A concurrent waiter
+# that sees a pending port must wait for the binding waiter to resolve
+# instead of racing its own bind (which would lose and spuriously raise).
+_oauth_pending_ports: set[tuple[int, tuple[Any, ...]]] = set()
+_oauth_result_lock = threading.Lock()
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -344,6 +375,29 @@ class HermesTokenStorage:
 # ---------------------------------------------------------------------------
 
 
+# Query parameters that carry OAuth secrets and must never reach the logs.
+# ``code``/``state`` are the authorization code and CSRF token; ``error``
+# can echo provider-side detail. ``BaseHTTPRequestHandler`` log lines embed
+# the raw request line (e.g. ``"GET /callback?code=...&state=..."``), so the
+# formatted message is scrubbed before it is handed to the logger.
+_SENSITIVE_CALLBACK_QUERY_RE = re.compile(
+    r"\b(code|state|error)=[^&\s\"']*",
+    re.IGNORECASE,
+)
+
+
+def _redact_callback_log(message: str) -> str:
+    """Redact OAuth secrets from a callback HTTP-server log line.
+
+    Replaces the value of any ``code``/``state``/``error`` query parameter
+    with ``REDACTED`` so the authorization code and CSRF state never land in
+    debug logs (which may be shipped off-box or shared in bug reports).
+    """
+    return _SENSITIVE_CALLBACK_QUERY_RE.sub(
+        lambda m: f"{m.group(1)}=REDACTED", message
+    )
+
+
 def _make_callback_handler() -> tuple[type, dict]:
     """Create a per-flow callback HTTP handler class with its own result dict.
 
@@ -378,7 +432,9 @@ def _make_callback_handler() -> tuple[type, dict]:
             self.wfile.write(body.encode())
 
         def log_message(self, fmt: str, *args: Any) -> None:
-            logger.debug("OAuth callback: %s", fmt % args)
+            # The request line embedded here contains the callback query
+            # string (?code=...&state=...); redact secrets before logging.
+            logger.debug("OAuth callback: %s", _redact_callback_log(fmt % args))
 
     return _Handler, result
 
@@ -388,7 +444,7 @@ def _make_callback_handler() -> tuple[type, dict]:
 # ---------------------------------------------------------------------------
 
 
-async def _redirect_handler(authorization_url: str) -> None:
+async def _redirect_handler(authorization_url: str, callback_port: int | None = None) -> None:
     """Show the authorization URL to the user.
 
     Opens the browser automatically when possible; always prints the URL
@@ -405,14 +461,15 @@ async def _redirect_handler(authorization_url: str) -> None:
     # http://127.0.0.1:<port>/callback, which reaches the callback server on
     # the *remote* machine — not the user's local machine where the browser
     # opened.  Print a port-forward hint so the user knows to tunnel first.
-    if _oauth_port and (os.getenv("SSH_CLIENT") or os.getenv("SSH_TTY")):
+    callback_port = callback_port or _oauth_port
+    if callback_port and (os.getenv("SSH_CLIENT") or os.getenv("SSH_TTY")):
         print(
             f"  Remote session detected. The OAuth provider will redirect your browser to\n"
-            f"    http://127.0.0.1:{_oauth_port}/callback\n"
+            f"    http://127.0.0.1:{callback_port}/callback\n"
             f"  which the callback listener on THIS machine is waiting on. If your browser\n"
             f"  is on a different machine, forward the port first in a separate terminal:\n"
             f"\n"
-            f"    ssh -N -L {_oauth_port}:127.0.0.1:{_oauth_port} <user>@<this-host>\n"
+            f"    ssh -N -L {callback_port}:127.0.0.1:{callback_port} <user>@<this-host>\n"
             f"\n"
             f"  Then open the URL above. See: https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh\n",
             file=sys.stderr,
@@ -431,7 +488,96 @@ async def _redirect_handler(authorization_url: str) -> None:
         print("  (Headless environment detected — open the URL manually.)\n", file=sys.stderr)
 
 
-async def _wait_for_callback() -> tuple[str, str | None]:
+def _claim_callback_flow(
+    port: int,
+    flow_key: tuple[Any, ...] | None = None,
+) -> tuple[int, tuple[Any, ...]]:
+    """Reserve a callback port for one OAuth flow before URL emission.
+
+    ``OAuthClientProvider`` calls ``redirect_handler`` before it calls the
+    callback waiter. If two distinct flows share a configured callback port,
+    allowing the second URL to be shown risks the user's browser redirecting to
+    the first flow's listener and writing the second code/state into the first
+    result buffer. This guard is therefore shared by the redirect handler and
+    callback waiter and runs before any conflicting authorization URL is shown.
+    """
+    slot_key = _callback_result_key(port, flow_key)
+    with _oauth_result_lock:
+        same_port_other_flow_active = any(
+            key[0] == port and key != slot_key
+            for key in (
+                *_oauth_active_flow_claims,
+                *_oauth_results_by_port.keys(),
+                *_oauth_pending_ports,
+            )
+        )
+        if same_port_other_flow_active:
+            raise OAuthNonInteractiveError(
+                f"OAuth callback port 127.0.0.1:{port} is already in use by "
+                "another active OAuth flow. Set 'oauth.redirect_port: 0' or "
+                "configure unique callback ports for concurrent MCP logins."
+            )
+        _oauth_active_flow_claims.add(slot_key)
+    return slot_key
+
+
+def _make_redirect_handler(port: int, flow_key: tuple[Any, ...]):
+    """Return a redirect handler that claims this flow before showing its URL."""
+
+    async def _bound_redirect_handler(authorization_url: str) -> None:
+        _claim_callback_flow(port, flow_key)
+        await _redirect_handler(authorization_url, callback_port=port)
+
+    return _bound_redirect_handler
+
+
+def _callback_result_key(
+    port: int,
+    flow_key: tuple[Any, ...] | None = None,
+) -> tuple[int, tuple[Any, ...]]:
+    """Return the isolation key for an OAuth callback result buffer."""
+    return (port, flow_key or _oauth_flow_key)
+
+
+def _flow_key_for_config(
+    server_name: str,
+    server_url: str,
+    cfg: dict[str, Any],
+) -> tuple[Any, ...]:
+    """Build a stable in-process identity for one OAuth login flow.
+
+    The callback server is keyed by port *and* this flow identity. That lets
+    sibling waiters for the same provider reuse the listener/result, while
+    distinct MCP servers/providers that intentionally share a redirect_port do
+    not consume each other's authorization code/state.
+    """
+    cfg_items: list[tuple[str, str]] = []
+    for key, value in sorted(cfg.items()):
+        if key.startswith("_") or key == "timeout":
+            continue
+        try:
+            encoded = json.dumps(value, sort_keys=True, default=str)
+        except TypeError:
+            encoded = repr(value)
+        cfg_items.append((key, encoded))
+    return (server_name, server_url, tuple(cfg_items))
+
+
+def _make_wait_for_callback(
+    port: int,
+    flow_key: tuple[Any, ...],
+):
+    """Return a provider callback handler bound to one flow identity."""
+    async def _bound_wait_for_callback() -> tuple[str, str | None]:
+        return await _wait_for_callback(port=port, flow_key=flow_key)
+
+    return _bound_wait_for_callback
+
+
+async def _wait_for_callback(
+    port: int | None = None,
+    flow_key: tuple[Any, ...] | None = None,
+) -> tuple[str, str | None]:
     """Wait for the OAuth callback to arrive on the local callback server.
 
     Uses the module-level ``_oauth_port`` which is set by ``build_oauth_auth``
@@ -445,51 +591,171 @@ async def _wait_for_callback() -> tuple[str, str | None]:
             that ``build_oauth_auth`` was skipped — the asserting form below
             was a silent bug when running Python with ``-O``/``-OO``.
     """
-    if _oauth_port is None:
+    if port is None:
+        port = _oauth_port
+    if port is None:
         raise RuntimeError(
             "OAuth callback port not set — build_oauth_auth must be called "
             "before _wait_for_oauth_callback"
         )
 
-    # The callback server is already running (started in build_oauth_auth).
-    # We just need to poll for the result.
-    handler_cls, result = _make_callback_handler()
-
-    # Start a temporary server on the known port
-    try:
-        server = HTTPServer(("127.0.0.1", _oauth_port), handler_cls)
-    except OSError:
-        # Port already in use — the server from build_oauth_auth is running.
-        # Fall back to polling the server started by build_oauth_auth.
-        raise OAuthNonInteractiveError(
-            "OAuth callback timed out — could not bind callback port. "
-            "Complete the authorization in a browser first, then retry."
+    # Reuse the shared result buffer only after a sibling waiter has
+    # successfully bound and published a listener for this exact port. Do not
+    # publish a fresh result before HTTPServer succeeds: a concurrent waiter
+    # could otherwise poll an unbacked buffer if the bind fails.
+    global _oauth_result, _oauth_result_active, _oauth_result_port
+    slot_key = _claim_callback_flow(port, flow_key)
+    waiting_for_pending = False
+    with _oauth_result_lock:
+        existing_result = _oauth_results_by_port.get(slot_key)
+        same_port_other_flow_active = any(
+            key[0] == port and key != slot_key
+            for key in (*_oauth_results_by_port.keys(), *_oauth_pending_ports)
         )
+        if existing_result is not None:
+            # A sibling already bound and published a live listener for this
+            # exact flow. Reuse that listener/result so SDK retries do not
+            # race a second bind.
+            handler_cls = None
+            result = existing_result
+            owns_shared_slot = False
+        elif slot_key in _oauth_pending_ports:
+            # A sibling has committed to binding this exact port/flow but has
+            # not yet finished. Binding ourselves would lose the race and
+            # raise spuriously even though that sibling is about to publish a
+            # listener. Wait below for its bind to resolve instead.
+            handler_cls = None
+            result = None
+            owns_shared_slot = False
+            waiting_for_pending = True
+        elif same_port_other_flow_active:
+            # One HTTPServer can only hand its callback to the result buffer it
+            # was created with. Without a state-aware demux layer, a different
+            # flow on the same callback port would either fail a second bind or
+            # risk consuming the wrong code/state. Fail early and tell the user
+            # to let Hermes choose unique callback ports for concurrent flows.
+            raise OAuthNonInteractiveError(
+                f"OAuth callback port 127.0.0.1:{port} is already in use by "
+                "another active OAuth flow. Set 'oauth.redirect_port: 0' or "
+                "configure unique callback ports for concurrent MCP logins."
+            )
+        else:
+            handler_cls, result = _make_callback_handler()
+            owns_shared_slot = True
+            # Reserve the in-progress marker while still holding the lock so
+            # concurrent waiters observe it atomically with our decision to
+            # bind. This is not a result buffer -- nothing polls it.
+            _oauth_pending_ports.add(slot_key)
 
-    server_thread = threading.Thread(target=server.handle_request, daemon=True)
-    server_thread.start()
+    server: HTTPServer | None = None
+    if handler_cls is not None:
+        try:
+            server = HTTPServer(("127.0.0.1", port), handler_cls)
+        except OSError as exc:
+            with _oauth_result_lock:
+                # Bind failed: drop the in-progress marker so a waiting
+                # sibling stops waiting, and fall back to any listener a
+                # sibling may already have published for this port.
+                _oauth_pending_ports.discard(slot_key)
+                existing_result = _oauth_results_by_port.get(slot_key)
+            if existing_result is not None:
+                result = existing_result
+                owns_shared_slot = False
+            else:
+                # We could not bind and no sibling has published a live
+                # listener for this port, so nothing will populate a result
+                # buffer. Surface the failure immediately rather than polling
+                # until timeout.
+                with _oauth_result_lock:
+                    _oauth_active_flow_claims.discard(slot_key)
+                raise OAuthNonInteractiveError(
+                    f"OAuth callback server failed to bind on 127.0.0.1:{port}. "
+                    "The configured callback port may already be in use; set "
+                    "'oauth.redirect_port: 0' in config.yaml to auto-pick a free port."
+                ) from exc
+        else:
+            with _oauth_result_lock:
+                # The in-progress marker guarantees we are the sole binder
+                # for this port, so the published slot below cannot collide
+                # with a sibling. Publish the live buffer and drop the
+                # marker atomically so siblings switch from waiting to
+                # reusing the listener.
+                _oauth_results_by_port[slot_key] = result
+                _oauth_result = result
+                _oauth_result_active = True
+                _oauth_result_port = port
+                _oauth_pending_ports.discard(slot_key)
+            threading.Thread(target=server.handle_request, daemon=True).start()
 
-    timeout = 300.0
-    poll_interval = 0.5
-    elapsed = 0.0
+    if waiting_for_pending:
+        # Poll for the binding sibling to either publish a listener or
+        # abandon its bind. Binding a local socket is fast, so this resolves
+        # quickly; the bound below is a safety net, not the expected path.
+        pending_timeout = 10.0
+        pending_poll = 0.05
+        pending_elapsed = 0.0
+        while True:
+            with _oauth_result_lock:
+                result = _oauth_results_by_port.get(slot_key)
+                still_pending = slot_key in _oauth_pending_ports
+            if result is not None:
+                break
+            if not still_pending:
+                # The binding sibling failed to bind and published nothing.
+                with _oauth_result_lock:
+                    _oauth_active_flow_claims.discard(slot_key)
+                raise OAuthNonInteractiveError(
+                    f"OAuth callback server failed to bind on 127.0.0.1:{port}. "
+                    "The configured callback port may already be in use; set "
+                    "'oauth.redirect_port: 0' in config.yaml to auto-pick a free port."
+                )
+            if pending_elapsed >= pending_timeout:
+                with _oauth_result_lock:
+                    _oauth_active_flow_claims.discard(slot_key)
+                raise OAuthNonInteractiveError(
+                    f"OAuth callback listener did not come up on 127.0.0.1:{port}."
+                )
+            await asyncio.sleep(pending_poll)
+            pending_elapsed += pending_poll
+
     try:
+        timeout = 300.0
+        poll_interval = 0.5
+        elapsed = 0.0
         while elapsed < timeout:
             if result["auth_code"] is not None or result["error"] is not None:
                 break
             await asyncio.sleep(poll_interval)
             elapsed += poll_interval
+
+        if result["error"]:
+            raise RuntimeError(f"OAuth authorization failed: {result['error']}")
+        if result["auth_code"] is None:
+            raise OAuthNonInteractiveError(
+                "OAuth callback timed out — no authorization code received. "
+                "Ensure you completed the browser authorization flow."
+            )
+
+        return result["auth_code"], result["state"]
     finally:
-        server.server_close()
-
-    if result["error"]:
-        raise RuntimeError(f"OAuth authorization failed: {result['error']}")
-    if result["auth_code"] is None:
-        raise OAuthNonInteractiveError(
-            "OAuth callback timed out — no authorization code received. "
-            "Ensure you completed the browser authorization flow."
-        )
-
-    return result["auth_code"], result["state"]
+        if server is not None:
+            server.server_close()
+        # Clear the shared slot on any exit (success, error, timeout) so a
+        # subsequent login attempt cannot inherit stale auth_code/state/error.
+        # Only the waiter that installed the slot clears it, to avoid a
+        # concurrent sibling waiter wiping out a result it still needs.
+        if owns_shared_slot:
+            with _oauth_result_lock:
+                if _oauth_results_by_port.get(slot_key) is result:
+                    _oauth_results_by_port.pop(slot_key, None)
+                _oauth_active_flow_claims.discard(slot_key)
+                if _oauth_result is result:
+                    _oauth_result = None
+                    _oauth_result_active = bool(_oauth_results_by_port)
+                    next_key = next(iter(_oauth_results_by_port), None)
+                    _oauth_result_port = next_key[0] if next_key is not None else None
+                    if next_key is not None:
+                        _oauth_result = _oauth_results_by_port[next_key]
 
 
 # ---------------------------------------------------------------------------
@@ -513,6 +779,30 @@ def remove_oauth_tokens(server_name: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _reset_shared_callback_result() -> None:
+    """Drop stale ``_oauth_result`` before a new provider is constructed.
+
+    Active callback listeners own the shared slot until their waiter exits.
+    Provider construction must not clear that live buffer, because sibling
+    waiters may still need to reuse it instead of racing a second bind on the
+    same port. Stale, inactive slots left by tests or unexpected paths are safe
+    to discard.
+    """
+    global _oauth_result, _oauth_result_active, _oauth_result_port
+    with _oauth_result_lock:
+        if not _oauth_result_active:
+            _oauth_result = None
+            _oauth_result_port = None
+            _oauth_results_by_port.clear()
+            # Do not clear _oauth_active_flow_claims here. A redirect handler
+            # claims its (port, flow) before the provider publishes its
+            # callback listener, so _oauth_result_active can still be false in
+            # that handoff window. Clearing claims during unrelated provider
+            # construction would let a different flow on the same port emit a
+            # competing auth URL instead of failing closed. The waiter that owns
+            # a claim releases it in _wait_for_callback() cleanup/error paths.
+
+
 def _configure_callback_port(cfg: dict) -> int:
     """Pick or validate the OAuth callback port.
 
@@ -521,10 +811,8 @@ def _configure_callback_port(cfg: dict) -> int:
     resolved port.
 
     NOTE: also sets the legacy module-level ``_oauth_port`` so existing
-    calls to ``_wait_for_callback`` keep working. The legacy global is
-    the root cause of issue #5344 (port collision on concurrent OAuth
-    flows); replacing it with a ContextVar is out of scope for this
-    consolidation PR.
+    direct calls to ``_wait_for_callback`` keep working. Provider callbacks
+    are bound to their resolved port/flow identity via ``_make_wait_for_callback``.
     """
     global _oauth_port
     requested = int(cfg.get("redirect_port", 0))
@@ -532,6 +820,20 @@ def _configure_callback_port(cfg: dict) -> int:
     cfg["_resolved_port"] = port
     _oauth_port = port  # legacy consumer: _wait_for_callback reads this
     return port
+
+
+def _configure_callback_flow(
+    server_name: str,
+    server_url: str,
+    cfg: dict[str, Any],
+) -> tuple[int, tuple[Any, ...]]:
+    """Resolve callback port and flow identity for provider construction."""
+    global _oauth_flow_key
+    port = _configure_callback_port(cfg)
+    flow_key = _flow_key_for_config(server_name, server_url, cfg)
+    _oauth_flow_key = flow_key  # legacy consumer: direct _wait_for_callback()
+    cfg["_flow_key"] = flow_key
+    return port, flow_key
 
 
 def _build_client_metadata(cfg: dict) -> "OAuthClientMetadata":
@@ -626,6 +928,11 @@ def build_oauth_auth(
     cfg = dict(oauth_config or {})  # copy — we mutate _resolved_port
     storage = HermesTokenStorage(server_name)
 
+    # Defensive reset: if a previous flow exited via an unexpected path
+    # (e.g. test harness) and left stale callback state behind, drop it
+    # before the new flow's _wait_for_callback can latch onto it.
+    _reset_shared_callback_result()
+
     if not _is_interactive() and not storage.has_cached_tokens():
         logger.warning(
             "MCP OAuth for '%s': non-interactive environment and no cached tokens "
@@ -635,7 +942,7 @@ def build_oauth_auth(
             server_name,
         )
 
-    _configure_callback_port(cfg)
+    port, flow_key = _configure_callback_flow(server_name, server_url, cfg)
     client_metadata = _build_client_metadata(cfg)
     _maybe_preregister_client(storage, cfg, client_metadata)
 
@@ -643,7 +950,7 @@ def build_oauth_auth(
         server_url=server_url,
         client_metadata=client_metadata,
         storage=storage,
-        redirect_handler=_redirect_handler,
-        callback_handler=_wait_for_callback,
+        redirect_handler=_make_redirect_handler(port, flow_key),
+        callback_handler=_make_wait_for_callback(port, flow_key),
         timeout=float(cfg.get("timeout", 300)),
     )

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -410,11 +410,12 @@ class MCPOAuthManager:
             HermesTokenStorage,
             _OAUTH_AVAILABLE,
             _build_client_metadata,
-            _configure_callback_port,
+            _configure_callback_flow,
             _is_interactive,
             _maybe_preregister_client,
-            _redirect_handler,
-            _wait_for_callback,
+            _make_redirect_handler,
+            _reset_shared_callback_result,
+            _make_wait_for_callback,
         )
 
         if not _OAUTH_AVAILABLE:
@@ -422,6 +423,13 @@ class MCPOAuthManager:
 
         cfg = dict(entry.oauth_config or {})
         storage = HermesTokenStorage(server_name)
+
+        # Mirror ``build_oauth_auth``: drop any stale shared callback result
+        # before the new flow begins. The manager path bypasses
+        # ``build_oauth_auth`` entirely, so without this a crashed prior
+        # flow's auth_code/state/error could leak into the next
+        # ``_wait_for_callback``.
+        _reset_shared_callback_result()
 
         if not _is_interactive() and not storage.has_cached_tokens():
             logger.warning(
@@ -431,7 +439,7 @@ class MCPOAuthManager:
                 server_name,
             )
 
-        _configure_callback_port(cfg)
+        port, flow_key = _configure_callback_flow(server_name, entry.server_url, cfg)
         client_metadata = _build_client_metadata(cfg)
         _maybe_preregister_client(storage, cfg, client_metadata)
 
@@ -440,8 +448,8 @@ class MCPOAuthManager:
             server_url=entry.server_url,
             client_metadata=client_metadata,
             storage=storage,
-            redirect_handler=_redirect_handler,
-            callback_handler=_wait_for_callback,
+            redirect_handler=_make_redirect_handler(port, flow_key),
+            callback_handler=_make_wait_for_callback(port, flow_key),
             timeout=float(cfg.get("timeout", 300)),
         )
 


### PR DESCRIPTION
## What does this PR do?

Isolates MCP OAuth callback result state between authorization flows so stale callback codes, states, or errors cannot leak from one OAuth attempt into a later attempt.

## Related Issue

N/A.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Reset shared MCP OAuth callback result state before starting new authorization flows.
- Clear callback code/state/error after success, OAuth error, timeout, and bind-failure paths.
- Apply stale-state cleanup consistently across the relevant OAuth flow paths.
- Fix SSH OAuth user-facing callback-port guidance to report the actual bound callback port.
- Add regression coverage for stale callback state and callback-port guidance.

## How to Test

1. Run MCP OAuth focused tests.
2. Verify repeated OAuth flows cannot reuse stale callback state.
3. Verify SSH callback-port guidance uses the actual listener port.
4. Run a read-only Codex review of the final branch delta.

Verification performed during refresh:

- `uv run --extra dev pytest ...` focused MCP OAuth tests: 64 passed.
- Read-only Codex review: first BLOCKED → fixes applied → fresh final review `VERDICT: CLEAN`.
- Branch was rebased onto current `main` and updated with `--force-with-lease`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

Note: I ran focused/regression tests locally for the changed MCP OAuth behavior and am relying on GitHub Actions for the full matrix.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

N/A. Relevant verification is in local focused test output, Codex review logs, and GitHub Actions checks.
