### PR TITLE
fix(gateway): hydrate Feishu reply mentions via REST before admission rejection

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -423,6 +423,7 @@ RejectReason = Literal[
     "bots_disabled",
     "bot_not_mentioned",
     "group_policy_rejected",
+    "mention_required",
 ]
 
 
@@ -2262,6 +2263,14 @@ class FeishuAdapter(BasePlatformAdapter):
             return
 
         reason = self._admit(sender, message)
+        if reason == "mention_required" and self._might_mention_self(message):
+            hydrated = await self._hydrate_mentions_for_admit(message_id)
+            if hydrated and self._message_mentions_bot(hydrated):
+                logger.debug(
+                    "[Feishu] Admission recovered via REST hydration: %s",
+                    message_id,
+                )
+                reason = None
         if reason is not None:
             logger.debug("[Feishu] dropping inbound event: %s", reason)
             return
@@ -3656,6 +3665,31 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.debug("[Feishu] Failed to fetch bot names for %s", bot_ids, exc_info=True)
             return None
 
+    async def _hydrate_mentions_for_admit(self, message_id: str) -> Optional[list]:
+        """Fetch message via REST to obtain ``mentions[]`` for admission gating.
+
+        Returns the hydrated mentions list or ``None`` on failure.
+        """
+        if not self._client or not message_id:
+            return None
+        try:
+            request = self._build_get_message_request(message_id)
+            response = await asyncio.to_thread(self._client.im.v1.message.get, request)
+            if not response or getattr(response, "success", lambda: False)() is False:
+                return None
+            items = getattr(getattr(response, "data", None), "items", None) or []
+            msg = items[0] if items else None
+            if not msg:
+                return None
+            return getattr(msg, "mentions", None) or []
+        except Exception:
+            logger.debug(
+                "[Feishu] Failed to hydrate mentions for admission %s",
+                message_id,
+                exc_info=True,
+            )
+            return None
+
     async def _fetch_message_text(self, message_id: str) -> Optional[str]:
         if not self._client or not message_id:
             return None
@@ -3755,7 +3789,7 @@ class FeishuAdapter(BasePlatformAdapter):
         ):
             return "group_policy_rejected"
         if require_mention and not self._mentions_self(message):
-            return "group_policy_rejected"
+            return "mention_required"
         return None
 
     def _require_mention_for(self, chat_id: str) -> bool:
@@ -3810,6 +3844,21 @@ class FeishuAdapter(BasePlatformAdapter):
         return bool(sender_ids and (sender_ids & self._allowed_group_users))
 
     # --- Mention detection ----------------------------------------------------
+
+    def _might_mention_self(self, message: Any) -> bool:
+        """Check if message *might* mention the bot but lacks mapped mentions.
+
+        Feishu reply messages via websocket may omit ``message.mentions`` even
+        when the user explicitly @mentioned the bot.  This heuristic detects
+        ambiguous cases worth hydrating via REST before admission rejection.
+        """
+        raw_content = getattr(message, "content", "") or ""
+        if _MENTION_RE.search(raw_content):
+            return True
+        for attr in ("parent_id", "root_id", "thread_id", "upper_message_id"):
+            if getattr(message, attr, None):
+                return True
+        return False
 
     def _mentions_self(self, message: Any) -> bool:
         # @_all is Feishu's @everyone placeholder.

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -445,7 +445,7 @@ def test_admit_per_group_require_mention_overrides_global():
     assert adapter._admit(sender, make_message(chat_id="oc_free", chat_type="group")) is None
     assert (
         adapter._admit(sender, make_message(chat_id="oc_other", chat_type="group"))
-        == "group_policy_rejected"
+        == "mention_required"
     )
 
 
@@ -743,3 +743,171 @@ def test_handle_message_event_data_forwards_sender_when_admitted():
     assert captured.get("sender_id") is sender.sender_id
     assert captured.get("is_bot") is True
     assert captured.get("message_id") == "om_bot_ok"
+
+
+# --- _might_mention_self ---------------------------------------------------
+
+
+def test_might_mention_self_detects_at_user_placeholder():
+    adapter = make_adapter_skeleton()
+    msg = make_message()
+    msg.content = '{"text":"@_user_1 hello"}'
+    assert adapter._might_mention_self(msg) is True
+
+
+def test_might_mention_self_detects_parent_id():
+    adapter = make_adapter_skeleton()
+    msg = make_message()
+    msg.parent_id = "om_parent"
+    assert adapter._might_mention_self(msg) is True
+
+
+def test_might_mention_self_detects_root_id():
+    adapter = make_adapter_skeleton()
+    msg = make_message()
+    msg.root_id = "om_root"
+    assert adapter._might_mention_self(msg) is True
+
+
+def test_might_mention_self_false_for_plain_message():
+    adapter = make_adapter_skeleton()
+    msg = make_message()
+    assert adapter._might_mention_self(msg) is False
+
+
+# --- _admit returns mention_required ---------------------------------------
+
+
+def test_admit_returns_mention_required_not_group_policy_rejected():
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self", require_mention=True, group_policy="open",
+    )
+    stub_mention(adapter, False)
+    sender = make_sender(sender_type="user", open_id="ou_human")
+    msg = make_message(chat_type="group")
+    assert adapter._admit(sender, msg) == "mention_required"
+
+
+def test_admit_returns_none_when_mention_present():
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self", require_mention=True, group_policy="open",
+    )
+    stub_mention(adapter, True)
+    sender = make_sender(sender_type="user", open_id="ou_human")
+    msg = make_message(chat_type="group")
+    assert adapter._admit(sender, msg) is None
+
+
+# --- Hydration recovery in _handle_message_event_data ----------------------
+
+
+def test_handle_message_event_data_recovers_admission_via_hydration():
+    import asyncio
+
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self", require_mention=True, group_policy="open",
+    )
+    install_dedup_state(adapter)
+    processed = []
+
+    # _mentions_self returns False (no mentions on websocket message)
+    adapter._mentions_self = lambda _msg: False
+    # _might_mention_self returns True (has @_user_1 placeholder)
+    adapter._might_mention_self = lambda _msg: True
+
+    async def _fake_hydrate(message_id):
+        # Simulate REST returning a mention for the bot
+        return [SimpleNamespace(id=SimpleNamespace(open_id="ou_self", user_id=None), name="bot")]
+
+    async def _fake_process(**kwargs):
+        processed.append(kwargs)
+
+    adapter._hydrate_mentions_for_admit = _fake_hydrate
+    adapter._process_inbound_message = _fake_process
+
+    msg = make_message(
+        message_id="om_hydrate", chat_type="group",
+    )
+    msg.content = '{"text":"@_user_1"}'
+    data = SimpleNamespace(
+        event=SimpleNamespace(
+            sender=make_sender(sender_type="user", open_id="ou_human"),
+            message=msg,
+        )
+    )
+
+    asyncio.run(adapter._handle_message_event_data(data))
+    assert len(processed) == 1
+    assert processed[0]["message_id"] == "om_hydrate"
+
+
+def test_handle_message_event_data_still_drops_when_hydration_fails():
+    import asyncio
+
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self", require_mention=True, group_policy="open",
+    )
+    install_dedup_state(adapter)
+    processed = []
+
+    adapter._mentions_self = lambda _msg: False
+    adapter._might_mention_self = lambda _msg: True
+
+    async def _fake_hydrate_fail(message_id):
+        return None  # REST call failed
+
+    async def _fake_process(**kwargs):
+        processed.append(kwargs)
+
+    adapter._hydrate_mentions_for_admit = _fake_hydrate_fail
+    adapter._process_inbound_message = _fake_process
+
+    msg = make_message(
+        message_id="om_no_hydrate", chat_type="group",
+    )
+    msg.content = '{"text":"@_user_1"}'
+    data = SimpleNamespace(
+        event=SimpleNamespace(
+            sender=make_sender(sender_type="user", open_id="ou_human"),
+            message=msg,
+        )
+    )
+
+    asyncio.run(adapter._handle_message_event_data(data))
+    assert processed == []
+
+
+def test_handle_message_event_data_skips_hydration_when_not_ambiguous():
+    import asyncio
+
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_self", require_mention=True, group_policy="open",
+    )
+    install_dedup_state(adapter)
+    processed = []
+    hydration_called = []
+
+    adapter._mentions_self = lambda _msg: False
+    adapter._might_mention_self = lambda _msg: False  # not ambiguous
+
+    async def _fake_hydrate(message_id):
+        hydration_called.append(message_id)
+        return None
+
+    async def _fake_process(**kwargs):
+        processed.append(kwargs)
+
+    adapter._hydrate_mentions_for_admit = _fake_hydrate
+    adapter._process_inbound_message = _fake_process
+
+    msg = make_message(message_id="om_plain", chat_type="group")
+    data = SimpleNamespace(
+        event=SimpleNamespace(
+            sender=make_sender(sender_type="user", open_id="ou_human"),
+            message=msg,
+        )
+    )
+
+    asyncio.run(adapter._handle_message_event_data(data))
+    assert processed == []
+    assert hydration_called == []  # hydration not attempted


### PR DESCRIPTION
## What does this PR do?

Fixes silent admission rejection of Feishu reply messages that explicitly @mention the bot when `FEISHU_REQUIRE_MENTION=true`.


### Root Cause

Hermes' group-message admission gate (`_admit`) relies on `message.mentions` to detect bot @mentions. For Feishu **reply messages**, the websocket event may omit `mentions` even when the user explicitly @mentioned the bot — the mention mapping only appears in the REST `im/v1/messages/{id}` response.

This caused reply @mentions to be silently dropped before reaching the agent pipeline.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A