### PR TITLE
fix(auxiliary): sanitize Codex memory flush requests

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -563,54 +563,6 @@ def _pool_runtime_base_url(entry: Any, fallback: str = "") -> str:
 # calls to the Codex Responses API so callers don't need any changes.
 
 
-def _convert_content_for_responses(content: Any) -> Any:
-    """Convert chat.completions content to Responses API format.
-
-    chat.completions uses:
-      {"type": "text", "text": "..."}
-      {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
-
-    Responses API uses:
-      {"type": "input_text", "text": "..."}
-      {"type": "input_image", "image_url": "data:image/png;base64,..."}
-
-    If content is a plain string, it's returned as-is (the Responses API
-    accepts strings directly for text-only messages).
-    """
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, list):
-        return str(content) if content else ""
-
-    converted: List[Dict[str, Any]] = []
-    for part in content:
-        if not isinstance(part, dict):
-            continue
-        ptype = part.get("type", "")
-        if ptype == "text":
-            converted.append({"type": "input_text", "text": part.get("text", "")})
-        elif ptype == "image_url":
-            # chat.completions nests the URL: {"image_url": {"url": "..."}}
-            image_data = part.get("image_url", {})
-            url = image_data.get("url", "") if isinstance(image_data, dict) else str(image_data)
-            entry: Dict[str, Any] = {"type": "input_image", "image_url": url}
-            # Preserve detail if specified
-            detail = image_data.get("detail") if isinstance(image_data, dict) else None
-            if detail:
-                entry["detail"] = detail
-            converted.append(entry)
-        elif ptype in {"input_text", "input_image"}:
-            # Already in Responses format — pass through
-            converted.append(part)
-        else:
-            # Unknown content type — try to preserve as text
-            text = part.get("text", "")
-            if text:
-                converted.append({"type": "input_text", "text": text})
-
-    return converted or ""
-
-
 class _CodexCompletionsAdapter:
     """Drop-in shim that accepts chat.completions.create() kwargs and
     routes them through the Codex Responses streaming API."""
@@ -623,22 +575,24 @@ class _CodexCompletionsAdapter:
         messages = kwargs.get("messages", [])
         model = kwargs.get("model", self._model)
 
-        # Separate system/instructions from conversation messages.
-        # Convert chat.completions multimodal content blocks to Responses
-        # API format (input_text / input_image instead of text / image_url).
+        # Separate system/instructions from conversation messages, then use
+        # the shared Codex conversion path for input. Passing chat-style
+        # {"role": "tool"} messages directly to Responses 400s with
+        # "Invalid value: 'tool'"; the shared adapter converts them into
+        # function_call_output items and also preserves assistant tool calls.
         instructions = "You are a helpful assistant."
-        input_msgs: List[Dict[str, Any]] = []
+        input_source: List[Dict[str, Any]] = []
         for msg in messages:
             role = msg.get("role", "user")
             content = msg.get("content") or ""
             if role == "system":
                 instructions = content if isinstance(content, str) else str(content)
             else:
-                input_msgs.append({
-                    "role": role,
-                    "content": _convert_content_for_responses(content),
-                })
+                input_source.append(msg)
 
+        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+        input_msgs = _chat_messages_to_responses_input(input_source)
         resp_kwargs: Dict[str, Any] = {
             "model": model,
             "instructions": instructions,
@@ -3998,14 +3952,21 @@ def _build_call_kwargs(
         if _forbids_sampling_params(model):
             temperature = None
 
-    if temperature is not None:
+    is_codex_backend = (
+        provider == "openai-codex"
+        or base_url_host_matches(base_url, "chatgpt.com")
+    )
+
+    if temperature is not None and not is_codex_backend:
         kwargs["temperature"] = temperature
 
-    if max_tokens is not None:
-        # Codex adapter handles max_tokens internally; OpenRouter/Nous use max_tokens.
-        # Direct OpenAI api.openai.com with newer models needs max_completion_tokens.
-        # ZAI vision models (glm-4v-flash, glm-4v-plus, etc.) reject max_tokens with
-        # error code 1210 ("API 调用参数有误") on multimodal requests — skip it.
+    if max_tokens is not None and not is_codex_backend:
+        # Codex's chatgpt.com Responses endpoint rejects both max_tokens and
+        # max_completion_tokens for auxiliary calls. OpenRouter/Nous use
+        # max_tokens. Direct OpenAI api.openai.com with newer models needs
+        # max_completion_tokens. ZAI vision models (glm-4v-flash,
+        # glm-4v-plus, etc.) reject max_tokens with error code 1210
+        # ("API 调用参数有误") on multimodal requests — skip it.
         _model_lower = (model or "").lower()
         _skip_max_tokens = (
             provider == "zai"

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -354,17 +354,28 @@ def _chat_messages_to_responses_input(messages: List[Dict[str, Any]]) -> List[Di
                 tool_calls = msg.get("tool_calls")
                 if isinstance(tool_calls, list):
                     for tc in tool_calls:
-                        if not isinstance(tc, dict):
-                            continue
-                        fn = tc.get("function", {})
-                        fn_name = fn.get("name")
+                        if isinstance(tc, dict):
+                            fn = tc.get("function", {})
+                            raw_tool_id = tc.get("id")
+                            call_id = tc.get("call_id")
+                        else:
+                            fn = getattr(tc, "function", {})
+                            raw_tool_id = getattr(tc, "id", None)
+                            call_id = getattr(tc, "call_id", None)
+
+                        if isinstance(fn, dict):
+                            fn_name = fn.get("name")
+                            arguments = fn.get("arguments", "{}")
+                        else:
+                            fn_name = getattr(fn, "name", None)
+                            arguments = getattr(fn, "arguments", "{}")
+
                         if not isinstance(fn_name, str) or not fn_name.strip():
                             continue
 
                         embedded_call_id, embedded_response_item_id = _split_responses_tool_id(
-                            tc.get("id")
+                            raw_tool_id
                         )
-                        call_id = tc.get("call_id")
                         if not isinstance(call_id, str) or not call_id.strip():
                             call_id = embedded_call_id
                         if not isinstance(call_id, str) or not call_id.strip():
@@ -375,11 +386,10 @@ def _chat_messages_to_responses_input(messages: List[Dict[str, Any]]) -> List[Di
                             ):
                                 call_id = f"call_{embedded_response_item_id[len('fc_'):]}"
                             else:
-                                _raw_args = str(fn.get("arguments", "{}"))
+                                _raw_args = str(arguments)
                                 call_id = _deterministic_call_id(fn_name, _raw_args, len(items))
                         call_id = call_id.strip()
 
-                        arguments = fn.get("arguments", "{}")
                         if isinstance(arguments, dict):
                             arguments = json.dumps(arguments, ensure_ascii=False)
                         elif not isinstance(arguments, str):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -347,6 +347,34 @@ class TestBuildCodexClient:
         assert function_output["call_id"] == "call_abc123"
         assert function_output["output"] == "file contents"
 
+    def test_codex_adapter_converts_object_tool_calls_to_responses_items(self):
+        from types import SimpleNamespace
+        from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [SimpleNamespace(
+                    id="call_obj123",
+                    type="function",
+                    function=SimpleNamespace(name="read_file", arguments="{}"),
+                )],
+            },
+            {"role": "tool", "tool_call_id": "call_obj123", "content": "file contents"},
+        ]
+
+        items = _chat_messages_to_responses_input(messages)
+
+        function_call = next(item for item in items if item.get("type") == "function_call")
+        assert function_call["call_id"] == "call_obj123"
+        assert function_call["name"] == "read_file"
+        function_output = next(
+            item for item in items if item.get("type") == "function_call_output"
+        )
+        assert function_output["call_id"] == "call_obj123"
+        assert function_output["output"] == "file contents"
+
     def test_pool_without_selected_entry_falls_back_to_auth_store(self):
         with (
             patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -277,6 +277,76 @@ class TestAnthropicOAuthFlag:
 
 
 class TestBuildCodexClient:
+    def test_codex_backend_omits_unsupported_sampling_kwargs(self):
+        kwargs = _build_call_kwargs(
+            "auto",
+            "gpt-5.5",
+            [{"role": "user", "content": "remember this"}],
+            temperature=0.3,
+            max_tokens=5120,
+            timeout=30,
+            base_url="https://chatgpt.com/backend-api/codex/",
+        )
+
+        assert "temperature" not in kwargs
+        assert "max_tokens" not in kwargs
+        assert "max_completion_tokens" not in kwargs
+
+    def test_codex_adapter_converts_tool_messages_to_responses_items(self):
+        from types import SimpleNamespace
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        captured = {}
+
+        class _FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter([])
+
+            def get_final_response(self):
+                return SimpleNamespace(
+                    output=[SimpleNamespace(
+                        type="message",
+                        role="assistant",
+                        content=[SimpleNamespace(type="output_text", text="ok")],
+                    )],
+                    usage=None,
+                )
+
+        class _FakeResponses:
+            def stream(self, **kwargs):
+                captured.update(kwargs)
+                return _FakeStream()
+
+        fake_client = SimpleNamespace(responses=_FakeResponses())
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.2-codex")
+        adapter.create(
+            messages=[
+                {"role": "system", "content": "You are Hermes."},
+                {"role": "assistant", "content": "", "tool_calls": [{
+                    "id": "call_abc123",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }]},
+                {"role": "tool", "tool_call_id": "call_abc123", "content": "file contents"},
+                {"role": "user", "content": "remember this"},
+            ],
+        )
+
+        assert captured["instructions"] == "You are Hermes."
+        assert all(item.get("role") != "tool" for item in captured["input"])
+        assert any(item.get("type") == "function_call" for item in captured["input"])
+        function_output = next(
+            item for item in captured["input"] if item.get("type") == "function_call_output"
+        )
+        assert function_output["call_id"] == "call_abc123"
+        assert function_output["output"] == "file contents"
+
     def test_pool_without_selected_entry_falls_back_to_auth_store(self):
         with (
             patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)),


### PR DESCRIPTION
## Summary
- route Codex auxiliary chat-style history through the shared Responses input converter so `role="tool"` messages become `function_call_output` items
- strip unsupported `temperature`, `max_tokens`, and `max_completion_tokens` kwargs for chatgpt.com Codex auxiliary calls
- preserve assistant tool calls when callers replay object-shaped / SDK-shaped tool call objects, not just dict-shaped tool calls
- remove a duplicate test import caught during review

## Test Plan
- `/home/methodician/projects/hermes-agent/venv/bin/python -m pytest -q tests/agent/test_auxiliary_client.py -q`
- `/home/methodician/projects/hermes-agent/venv/bin/python -m pytest -q tests/run_agent/test_provider_parity.py tests/run_agent/test_run_agent_codex_responses.py -q`
- `git diff --check`
- `/home/methodician/projects/hermes-agent/venv/bin/python -m ruff check --select F811 tests/agent/test_auxiliary_client.py`

## Notes
Prepared in an isolated worktree based on current `upstream/main`; no local gateway or live Hermes process was restarted or modified.
