### PR TITLE
fix(doctor): validate Gemini keys with Google auth

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -54,6 +54,9 @@ _PROVIDER_ENV_HINTS = (
     "OPENCODE_GO_API_KEY",
     "XIAOMI_API_KEY",
     "TOKENHUB_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "GEMINI_BASE_URL",
 )
 
 
@@ -190,6 +193,34 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
 
 
 _APIKEY_PROVIDERS_CACHE: list | None = None
+
+_GEMINI_DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+
+
+def _gemini_doctor_error_detail(resp) -> str:
+    try:
+        data = resp.json()
+        if isinstance(data, dict):
+            error = data.get("error")
+            if isinstance(error, dict):
+                message = str(error.get("message") or "").strip()
+                status = str(error.get("status") or "").strip()
+                return message or status
+    except Exception:
+        pass
+    return str(getattr(resp, "text", "") or "").strip()
+
+
+def _gemini_doctor_auth_failed(resp) -> bool:
+    if resp.status_code in (401, 403):
+        return True
+    if resp.status_code != 400:
+        return False
+    detail = _gemini_doctor_error_detail(resp).lower()
+    return any(
+        marker in detail
+        for marker in ("api key", "apikey", "credential", "auth", "permission")
+    )
 
 
 def _build_apikey_providers_list() -> list:
@@ -1213,6 +1244,29 @@ def run_doctor(args):
                     _base = _to_openai_base_url(_base)
                 if base_url_host_matches(_base, "api.kimi.com") and _base.rstrip("/").endswith("/coding"):
                     _base = _base.rstrip("/") + "/v1"
+                if _pname == "gemini":
+                    _base = os.getenv("GEMINI_BASE_URL", "") or _base or _GEMINI_DEFAULT_BASE_URL
+                    _url = _base.rstrip("/") + "/models"
+                    _resp = httpx.get(
+                        _url,
+                        headers={
+                            "x-goog-api-key": _key,
+                            "User-Agent": _HERMES_USER_AGENT,
+                        },
+                        timeout=10,
+                    )
+                    if _resp.status_code == 200:
+                        print(f"\r  {color('✓', Colors.GREEN)} {_label}                          ")
+                    elif _gemini_doctor_auth_failed(_resp):
+                        print(f"\r  {color('✗', Colors.RED)} {_label} {color('(authentication failed)', Colors.DIM)}           ")
+                        issues.append("Check GOOGLE_API_KEY or GEMINI_API_KEY in .env")
+                    else:
+                        _detail = _gemini_doctor_error_detail(_resp)
+                        _msg = f"HTTP {_resp.status_code}"
+                        if _detail:
+                            _msg = f"{_msg}: {_detail[:120]}"
+                        print(f"\r  {color('⚠', Colors.YELLOW)} {_label} {color(f'({_msg})', Colors.DIM)}           ")
+                    continue
                 _url = (_base.rstrip("/") + "/models") if _base else _default_url
                 _headers = {
                     "Authorization": f"Bearer {_key}",

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -46,6 +46,10 @@ class TestProviderEnvDetection:
         content = "KIMI_CN_API_KEY=sk-test\n"
         assert _has_provider_env_config(content)
 
+    def test_detects_gemini_api_key(self):
+        content = "GOOGLE_API_KEY=sk-test\n"
+        assert _has_provider_env_config(content)
+
     def test_returns_false_when_no_provider_settings(self):
         content = "TERMINAL_ENV=local\n"
         assert not _has_provider_env_config(content)
@@ -704,6 +708,137 @@ def test_run_doctor_dashscope_retries_china_endpoint_after_intl_unauthorized(mon
         url == "https://dashscope.aliyuncs.com/compatible-mode/v1/models"
         for url, _, _ in calls
     )
+
+
+def test_run_doctor_gemini_uses_google_api_key_auth(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    (home / ".env").write_text("GOOGLE_API_KEY=gemini-key\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(
+        doctor_mod,
+        "_APIKEY_PROVIDERS_CACHE",
+        [
+            (
+                "gemini",
+                ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+                "https://generativelanguage.googleapis.com/v1beta/models",
+                None,
+                True,
+            )
+        ],
+    )
+    monkeypatch.setenv("GOOGLE_API_KEY", "gemini-key")
+    monkeypatch.setenv("GEMINI_BASE_URL", "https://generativelanguage.googleapis.com/v1beta")
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except ImportError:
+        pass
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers, timeout))
+        return types.SimpleNamespace(status_code=200)
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "gemini" in out
+    assert len(calls) == 1
+    assert calls[0][0] == "https://generativelanguage.googleapis.com/v1beta/models"
+    assert calls[0][2] == 10
+    headers = calls[0][1]
+    assert headers["x-goog-api-key"] == "gemini-key"
+    assert "Authorization" not in headers
+    assert "invalid API key" not in out
+
+
+def test_run_doctor_gemini_auth_failure_reports_google_key_issue(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    (home / ".env").write_text("GOOGLE_API_KEY=bad-key\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(
+        doctor_mod,
+        "_APIKEY_PROVIDERS_CACHE",
+        [
+            (
+                "gemini",
+                ("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+                "https://generativelanguage.googleapis.com/v1beta/models",
+                None,
+                True,
+            )
+        ],
+    )
+    monkeypatch.setenv("GOOGLE_API_KEY", "bad-key")
+    monkeypatch.delenv("GEMINI_BASE_URL", raising=False)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except ImportError:
+        pass
+
+    class FakeResponse:
+        status_code = 403
+        text = ""
+
+        def json(self):
+            return {"error": {"status": "PERMISSION_DENIED", "message": "API key not valid"}}
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers, timeout))
+        return FakeResponse()
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert calls[0][0] == "https://generativelanguage.googleapis.com/v1beta/models"
+    assert "Authorization" not in calls[0][1]
+    assert "authentication failed" in out
+    assert "Check GOOGLE_API_KEY or GEMINI_API_KEY in .env" in out
 
 
 @pytest.mark.parametrize("base_url", [None, "https://opencode.ai/zen/go/v1"])


### PR DESCRIPTION
## What does this PR do?

Fixes a false-positive in `hermes doctor` where valid Google AI Studio / Gemini API keys were reported as invalid.

The doctor API connectivity check dynamically includes the `gemini` API-key provider, but previously sent the key as an OpenAI-compatible bearer token. Google AI Studio Gemini API keys require Google-style API-key auth, so this PR adds a narrow Gemini-specific doctor health check that probes `/models` with `x-goog-api-key`.

It also updates the `.env` provider-config detector so `GOOGLE_API_KEY`, `GEMINI_API_KEY`, and `GEMINI_BASE_URL` count as configured provider settings.

This differs from #20204 by fixing the existing dynamic `gemini` provider health-check path directly, so doctor no longer emits the old bearer-auth `gemini (invalid API key)` result.

## Related Issue

Fixes #21058
Fixes #21481

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/doctor.py`: add a Gemini-specific API connectivity path that uses `x-goog-api-key` against `{base}/models` instead of `Authorization: Bearer`.
- `hermes_cli/doctor.py`: support `GEMINI_BASE_URL` for the doctor Gemini probe, defaulting to `https://generativelanguage.googleapis.com/v1beta`.
- `hermes_cli/doctor.py`: report Gemini auth failures with a Google-key-specific issue message.
- `hermes_cli/doctor.py`: recognize `GOOGLE_API_KEY`, `GEMINI_API_KEY`, and `GEMINI_BASE_URL` as provider configuration in `.env` detection.
- `tests/hermes_cli/test_doctor.py`: add regression coverage for Gemini env detection, Google-style auth, and auth-failure reporting.

## How to Test

1. Configure a working Google AI Studio key as `GOOGLE_API_KEY` and use Gemini as the provider.
2. Run `hermes chat -Q -q "Reply with exactly: hermes-ok" --max-turns 3` and confirm it returns `hermes-ok`.
3. Run `hermes doctor` and confirm API Connectivity reports `✓ gemini` instead of `gemini (invalid API key)`.
4. Run `scripts/run_tests.sh tests/hermes_cli/test_doctor.py -v`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Fedora 43 / Linux, Python 3.11.14 in repo venv

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Before:

```text
◆ API Connectivity
  Checking gemini API...
  ✗ gemini (invalid API key)
```

After running the patched command with a real Google AI Studio key:

```text
◆ Configuration Files
  ✓ ~/.hermes/.env file exists
  ✓ API key or custom endpoint configured

◆ API Connectivity
  ⚠ OpenRouter API (not configured)
  Checking gemini API...
  ✓ gemini
```

Test run:

```text
scripts/run_tests.sh tests/hermes_cli/test_doctor.py -v
41 passed in 4.18s
```
