### PR TITLE
fix(mcp): unwrap platforms key in channels_list

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -802,7 +802,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
             return json.dumps({"count": len(targets), "channels": targets}, indent=2)
 
         channels = []
-        for plat, entries_list in directory.items():
+        for plat, entries_list in directory.get("platforms", {}).items():
             if platform and plat.lower() != platform.lower():
                 continue
             if isinstance(entries_list, list):

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -828,18 +828,45 @@ class TestE2EChannelsList:
         assert result["channels"][0]["target"] == "slack:C1234"
 
     def test_channels_with_directory(self, mcp_server_e2e, _event_loop, monkeypatch):
+        """Populated channel_directory.json should be unwrapped via the 'platforms' key.
+
+        Regression test for issue #21474: the writer wraps platforms under
+        {"updated_at": ..., "platforms": {...}} but the reader was iterating
+        directory.items() directly, so channels_list always returned 0.
+        """
         import mcp_serve
         monkeypatch.setattr(mcp_serve, "_load_channel_directory", lambda: {
-            "telegram": [
-                {"id": "123456", "name": "Alice", "type": "dm"},
-                {"id": "-100999", "name": "Dev Group", "type": "group"},
-            ],
+            "updated_at": "2026-05-07T12:00:00",
+            "platforms": {
+                "telegram": [
+                    {"id": "123456", "name": "Alice", "type": "dm"},
+                    {"id": "-100999", "name": "Dev Group", "type": "group"},
+                ],
+                "discord": [
+                    {"id": "789", "name": "general", "type": "text"},
+                ],
+            },
         })
-        # Need to recreate server to pick up the new mock
-        server, bridge = mcp_server_e2e
-        # The tool closure already captured the old mock, so test the function directly
-        directory = mcp_serve._load_channel_directory()
-        assert len(directory["telegram"]) == 2
+        server, _ = mcp_server_e2e
+        result = _run_tool(server, "channels_list")
+        assert result["count"] == 3
+        targets = {c["target"] for c in result["channels"]}
+        assert targets == {"telegram:123456", "telegram:-100999", "discord:789"}
+
+    def test_channels_with_directory_platform_filter(self, mcp_server_e2e, _event_loop, monkeypatch):
+        """Platform filter should work against the wrapped 'platforms' payload."""
+        import mcp_serve
+        monkeypatch.setattr(mcp_serve, "_load_channel_directory", lambda: {
+            "updated_at": "2026-05-07T12:00:00",
+            "platforms": {
+                "telegram": [{"id": "123456", "name": "Alice", "type": "dm"}],
+                "discord": [{"id": "789", "name": "general", "type": "text"}],
+            },
+        })
+        server, _ = mcp_server_e2e
+        result = _run_tool(server, "channels_list", {"platform": "discord"})
+        assert result["count"] == 1
+        assert result["channels"][0]["target"] == "discord:789"
 
 
 class TestE2EPermissions:


### PR DESCRIPTION
## Summary
`channels_list` now returns populated channels when `channel_directory.json` exists, instead of always returning `{"count": 0, "channels": []}`.

Root cause: writer wraps payload as `{"updated_at": ..., "platforms": {...}}` but `mcp_serve.channels_list` was iterating `directory.items()` directly, yielding `("updated_at", str)` and `("platforms", dict)` — neither passed the inner `isinstance(entries_list, list)` check, so the loop never ran. Every other reader in the codebase already unwraps via `directory.get("platforms", {})`.

## Changes
- `mcp_serve.py`: unwrap `"platforms"` in the `channels_list` iteration
- `tests/test_mcp_serve.py`: rewrite `test_channels_with_directory` to actually call the tool (previously sidestepped the bug by asserting against `_load_channel_directory()` directly); add `test_channels_with_directory_platform_filter`

## Validation
Both tests fail against the pre-fix code (`assert 0 == 3`, `assert 0 == 1`) and pass with the fix.

```
tests/test_mcp_serve.py::TestE2EChannelsList::test_channels_from_sessions                     PASSED
tests/test_mcp_serve.py::TestE2EChannelsList::test_channels_platform_filter                   PASSED
tests/test_mcp_serve.py::TestE2EChannelsList::test_channels_with_directory                    PASSED
tests/test_mcp_serve.py::TestE2EChannelsList::test_channels_with_directory_platform_filter    PASSED
```

Closes #21474

Reported and diagnosed by @chrisworksai with the one-line patch already in the issue; preserved as co-author.