### PR TITLE
fix: filter shell snapshot functions by block, not by line

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -371,7 +371,12 @@ class BaseEnvironment(ABC):
         _quoted_cwd_file = shlex.quote(self._cwd_file)
         bootstrap = (
             f"export -p > {_quoted_snap}\n"
-            f"declare -f | grep -vE '^_[^_]' >> {_quoted_snap}\n"
+            # Filter function definitions by name, not by line — the old
+            # `declare -f | grep` removed function name lines but leaked orphaned
+            # bodies into the snapshot, which bash then executed as compound commands
+            # (e.g. atuin hooks hanging in non-interactive shells).
+            f"declare -F | awk '{{print $3}}' | grep -vE '^_[^_]' | "
+            f"while IFS= read -r _f; do declare -f \"$_f\"; done >> {_quoted_snap}\n"
             f"alias -p >> {_quoted_snap}\n"
             f"echo 'shopt -s expand_aliases' >> {_quoted_snap}\n"
             f"echo 'set +e' >> {_quoted_snap}\n"


### PR DESCRIPTION
## Problem

`init_session()` builds a shell environment snapshot by running `declare -f | grep -vE '^_[^_]'` to filter out underscore-prefixed functions. But `grep` is line-based — it removes the function **name** line while leaving the function **body** (`{ ... }`) in the snapshot.

When bash later `source`s this file, the orphaned `{ ... }` blocks are executed as compound commands. If any of them call interactive tools (e.g. atuin's `_atuin_ai_question_mark` calling `atuin ai inline --hook`), the sourcing hangs indefinitely. This causes **every terminal tool call to time out**.

**Note:** Hermes running MiMo 2.5 Pro tracked this down and fixed it; happy to adjust as necessary.

## Root cause

The snapshot contained lines like:

```
...env vars...
{                                    ← orphaned body from filtered _atuin_ai_question_mark
    if [[ -z "$READLINE_LINE" ]]; then
        output=$(atuin ai inline --hook)   ← HANGS: no terminal attached
    fi
}
{                                    ← another orphaned body
    _atuin_ai_question_mark
    ...
}
shopt -s expand_aliases
...
```

## Fix

Replace line-based grep with block-aware filtering:

```bash
# Before (broken — leaks function bodies):
declare -f | grep -vE '^_[^_]' >> snapshot.sh

# After (filters by name, emits complete definitions only):
declare -F | awk '{print $3}' | grep -vE '^_[^_]' |   while IFS= read -r _f; do declare -f "$_f"; done >> snapshot.sh
```

`declare -F` lists function names only (no bodies). We filter names, then `declare -f "$name"` emits each complete, properly-headed definition. No orphaned bodies possible.

## Testing

Verified on macOS with atuin + starship shell integrations:
- Before fix: every `terminal_tool("echo test", timeout=5)` → timeout after 5s
- After fix: completes in ~0.3s
- Snapshot went from 146 lines (with orphaned bodies) to 98 lines (clean)
