### PR TITLE
fix: honor opencode-go max reasoning effort

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1998,7 +1998,7 @@ class GatewayRunner:
         """Load reasoning effort from config.yaml.
 
         Reads agent.reasoning_effort from config.yaml. Valid: "none",
-        "minimal", "low", "medium", "high", "xhigh". Returns None to use
+        "minimal", "low", "medium", "high", "xhigh", "max". Returns None to use
         default (medium).
         """
         from hermes_constants import parse_reasoning_effort
@@ -9409,7 +9409,7 @@ class GatewayRunner:
                 f"**Effort:** `{level}`\n"
                 f"**Scope:** {scope}\n"
                 f"**Display:** {display_state}\n\n"
-                "_Usage:_ `/reasoning <none|minimal|low|medium|high|xhigh|reset|show|hide> [--global]`"
+                "_Usage:_ `/reasoning <none|minimal|low|medium|high|xhigh|max|reset|show|hide> [--global]`"
             )
 
         # Display toggle (per-platform)
@@ -9438,12 +9438,12 @@ class GatewayRunner:
             return "🧠 ✓ Session reasoning override cleared; falling back to global config."
         if effort == "none":
             parsed = {"enabled": False}
-        elif effort in ("minimal", "low", "medium", "high", "xhigh"):
+        elif effort in ("minimal", "low", "medium", "high", "xhigh", "max"):
             parsed = {"enabled": True, "effort": effort}
         else:
             return (
                 f"⚠️ Unknown argument: `{effort or raw_args.lower()}`\n\n"
-                "**Valid levels:** none, minimal, low, medium, high, xhigh\n"
+                "**Valid levels:** none, minimal, low, medium, high, xhigh, max\n"
                 "**Display:** show, hide\n"
                 "**Persist:** add `--global` to save beyond this session"
             )

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -131,7 +131,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Configuration"),
     CommandDef("reasoning", "Manage reasoning effort and display", "Configuration",
                args_hint="[level|show|hide]",
-               subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "show", "hide", "on", "off")),
+               subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "max", "show", "hide", "on", "off")),
     CommandDef("fast", "Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode (Normal/Fast)", "Configuration",
                args_hint="[normal|fast|status]",
                subcommands=("normal", "fast", "status", "on", "off")),

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1001,7 +1001,7 @@ DEFAULT_CONFIG = {
                                        # no ceiling). High-reasoning models on large tasks
                                        # (e.g. gpt-5.5 xhigh, opus-4.6) need generous budgets;
                                        # raise if children time out before producing output.
-        "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
+        "reasoning_effort": "",  # reasoning effort for subagents: "max", "xhigh", "high", "medium",
                                  # "low", "minimal", "none" (empty = inherit parent's level)
         "max_concurrent_children": 3,  # max parallel children per batch; floor of 1 enforced, no ceiling
         # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3758,7 +3758,7 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
             str(effort).strip().lower() for effort in efforts if str(effort).strip()
         )
     )
-    canonical_order = ("minimal", "low", "medium", "high", "xhigh")
+    canonical_order = ("minimal", "low", "medium", "high", "xhigh", "max")
     ordered = [effort for effort in canonical_order if effort in deduped]
     ordered.extend(effort for effort in deduped if effort not in canonical_order)
     if not ordered:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -188,13 +188,13 @@ def get_subprocess_home() -> str | None:
     return None
 
 
-VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
+VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max")
 
 
 def parse_reasoning_effort(effort: str) -> dict | None:
     """Parse a reasoning effort level into a config dict.
 
-    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh".
+    Valid levels: "none", "minimal", "low", "medium", "high", "xhigh", "max".
     Returns None when the input is empty or unrecognized (caller uses default).
     Returns {"enabled": False} for "none".
     Returns {"enabled": True, "effort": <level>} for valid effort levels.

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -7,8 +7,36 @@ Both use per-model api_mode routing:
     (this profile)
 """
 
+from typing import Any
+
 from providers import register_provider
 from providers.base import ProviderProfile
+
+
+class OpenCodeGoProfile(ProviderProfile):
+    """OpenCode Go subscription profile."""
+
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, **context
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        model = str(context.get("model") or "").strip().lower()
+        if not model.startswith("deepseek-v4-"):
+            return {}, {}
+
+        if reasoning_config and isinstance(reasoning_config, dict):
+            if reasoning_config.get("enabled") is False:
+                return {}, {}
+            effort = str(reasoning_config.get("effort") or "medium").strip().lower()
+        else:
+            effort = "medium"
+
+        if effort == "minimal":
+            effort = "low"
+        elif effort not in {"low", "medium", "high", "xhigh", "max"}:
+            effort = "medium"
+
+        return {}, {"reasoning_effort": effort}
+
 
 opencode_zen = ProviderProfile(
     name="opencode-zen",
@@ -18,7 +46,7 @@ opencode_zen = ProviderProfile(
     default_aux_model="gemini-3-flash",
 )
 
-opencode_go = ProviderProfile(
+opencode_go = OpenCodeGoProfile(
     name="opencode-go",
     aliases=("opencode_go", "go", "opencode-go-sub"),
     env_vars=("OPENCODE_GO_API_KEY",),

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -80,6 +80,7 @@ class TestReasoningCommand:
     def test_parse_reasoning_command_args_accepts_ascii_and_smart_global_flags(self):
         assert gateway_run.GatewayRunner._parse_reasoning_command_args("high --global") == ("high", True)
         assert gateway_run.GatewayRunner._parse_reasoning_command_args("—global xhigh") == ("xhigh", True)
+        assert gateway_run.GatewayRunner._parse_reasoning_command_args("--global max") == ("max", True)
 
     @pytest.mark.asyncio
     async def test_reasoning_command_reloads_current_state_from_config(self, tmp_path, monkeypatch):

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -88,6 +88,44 @@ class TestKimiProfile:
         assert tl["reasoning_effort"] == "medium"
 
 
+class TestOpenCodeGoProfile:
+    def test_deepseek_v4_reasoning_effort_top_level(self):
+        p = get_provider_profile("opencode-go")
+        eb, tl = p.build_api_kwargs_extras(
+            model="deepseek-v4-pro",
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+        assert eb == {}
+        assert tl["reasoning_effort"] == "max"
+
+    def test_deepseek_v4_minimal_clamps_to_low(self):
+        p = get_provider_profile("go")
+        eb, tl = p.build_api_kwargs_extras(
+            model="deepseek-v4-flash",
+            reasoning_config={"enabled": True, "effort": "minimal"},
+        )
+        assert eb == {}
+        assert tl["reasoning_effort"] == "low"
+
+    def test_deepseek_v4_omits_reasoning_when_disabled(self):
+        p = get_provider_profile("opencode-go")
+        eb, tl = p.build_api_kwargs_extras(
+            model="deepseek-v4-pro",
+            reasoning_config={"enabled": False},
+        )
+        assert eb == {}
+        assert tl == {}
+
+    def test_non_deepseek_v4_has_no_reasoning_effort(self):
+        p = get_provider_profile("opencode-go")
+        eb, tl = p.build_api_kwargs_extras(
+            model="qwen3.6-plus",
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+        assert eb == {}
+        assert tl == {}
+
+
 class TestOpenRouterProfile:
     def test_extra_body_with_prefs(self):
         p = get_provider_profile("openrouter")

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -122,6 +122,49 @@ class TestKimiParity:
         assert kw.get("reasoning_effort") == "medium"
 
 
+class TestOpenCodeGoParity:
+    def test_deepseek_v4_reasoning_effort_top_level(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("opencode-go"),
+            reasoning_config={"enabled": True, "effort": "max"},
+            supports_reasoning=True,
+        )
+        assert kw["reasoning_effort"] == "max"
+        assert "reasoning" not in kw.get("extra_body", {})
+
+    def test_deepseek_v4_reasoning_effort_default_medium(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("opencode-go"),
+        )
+        assert kw["reasoning_effort"] == "medium"
+
+    def test_deepseek_v4_reasoning_effort_omitted_when_disabled(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("opencode-go"),
+            reasoning_config={"enabled": False},
+        )
+        assert "reasoning_effort" not in kw
+
+    def test_non_deepseek_v4_has_no_reasoning_effort(self, transport):
+        kw = transport.build_kwargs(
+            model="qwen3.6-plus",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("opencode-go"),
+            reasoning_config={"enabled": True, "effort": "max"},
+        )
+        assert "reasoning_effort" not in kw
+
+
 class TestOpenRouterParity:
     """OpenRouter: provider preferences, reasoning in extra_body."""
 


### PR DESCRIPTION
## Summary
- accept `max` as a reasoning effort level in config and gateway command handling
- have the `opencode-go` provider profile send `deepseek-v4-*` reasoning effort as a top-level Chat Completions `reasoning_effort` parameter
- keep non-DeepSeek OpenCode Go models unchanged and avoid generic `extra_body.reasoning` for the DeepSeek V4 profile path

## Tests
- `uv run --frozen --extra dev pytest tests/providers/test_provider_profiles.py::TestOpenCodeGoProfile tests/providers/test_transport_parity.py::TestOpenCodeGoParity tests/gateway/test_reasoning_command.py::TestReasoningCommand::test_parse_reasoning_command_args_accepts_ascii_and_smart_global_flags`
- `uv run --frozen --extra dev pytest tests/providers/test_provider_profiles.py tests/providers/test_transport_parity.py tests/gateway/test_reasoning_command.py`
- `git diff --check`