### PR TITLE
feat(credbroker): credential broker subprocess with encrypted vault

### DIFF
--- a/hermes_cli/credbroker.py
+++ b/hermes_cli/credbroker.py
@@ -1,0 +1,153 @@
+"""hermes credbroker — manage the credential broker subprocess.
+
+Subcommands::
+
+    hermes credbroker start              # spawn the broker (idempotent)
+    hermes credbroker stop               # terminate the running broker
+    hermes credbroker status             # is it running? how many creds?
+    hermes credbroker set NAME [VALUE]   # write a credential
+    hermes credbroker get NAME           # print a credential value
+    hermes credbroker list               # list stored credential names
+    hermes credbroker delete NAME        # remove a credential
+
+Credentials live in an encrypted vault at
+``<hermes_home>/credentials/vault.enc`` and are never readable by the
+agent's terminal tool — the broker process owns the vault; clients speak
+to it via a Unix socket.
+"""
+
+from __future__ import annotations
+
+import getpass
+import json
+import sys
+
+from hermes_constants import display_hermes_home
+from tools import credbroker
+
+
+def credbroker_command(args) -> None:
+    sub = getattr(args, "credbroker_action", None)
+    if not sub:
+        print("Usage: hermes credbroker {start|stop|status|set|get|list|delete}")
+        print("Run 'hermes credbroker --help' for details.")
+        return
+
+    if sub == "start":
+        _cmd_start(args)
+    elif sub == "stop":
+        _cmd_stop(args)
+    elif sub == "status":
+        _cmd_status(args)
+    elif sub == "set":
+        _cmd_set(args)
+    elif sub == "get":
+        _cmd_get(args)
+    elif sub in ("list", "ls"):
+        _cmd_list(args)
+    elif sub in ("delete", "rm", "remove"):
+        _cmd_delete(args)
+    else:
+        print(f"Unknown credbroker subcommand: {sub}")
+
+
+def _cmd_start(args) -> None:
+    if credbroker.is_running():
+        print(f"credbroker already running (pid={credbroker._read_pidfile()})")
+        return
+    try:
+        pid = credbroker.start_detached()
+    except RuntimeError as e:
+        print(f"Failed to start credbroker: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(f"credbroker started (pid={pid}).")
+    print(f"Socket:  {credbroker.socket_path()}")
+    print(f"Vault:   {credbroker.vault_path()}")
+
+
+def _cmd_stop(args) -> None:
+    if not credbroker.is_running():
+        print("credbroker is not running.")
+        return
+    stopped = credbroker.stop()
+    if stopped:
+        print("credbroker stopped.")
+    else:
+        print("credbroker was not reachable; cleaned up stale state.")
+
+
+def _cmd_status(args) -> None:
+    running = credbroker.is_running()
+    pid = credbroker._read_pidfile()
+    print(f"Status:   {'running' if running else 'stopped'}")
+    if pid:
+        print(f"PID:      {pid}")
+    print(f"Socket:   {credbroker.socket_path()}")
+    print(f"Vault:    {credbroker.vault_path()}")
+    print(f"Key file: {credbroker.key_path()}")
+    if running:
+        names = credbroker.list_names()
+        print(f"Creds:    {len(names)} stored")
+
+
+def _cmd_set(args) -> None:
+    name = args.name.strip()
+    if not name:
+        print("Error: name is required")
+        return
+    value = args.value
+    if value is None:
+        try:
+            value = getpass.getpass(f"Value for {name!r} (will not echo): ")
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+    if not credbroker.is_running():
+        print("credbroker is not running — start it first with 'hermes credbroker start'.")
+        sys.exit(2)
+    try:
+        credbroker.set_(name, value)
+    except credbroker.CredbrokerError as e:
+        print(f"Failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    print(f"Stored {name!r}.")
+
+
+def _cmd_get(args) -> None:
+    if not credbroker.is_running():
+        print("credbroker is not running.", file=sys.stderr)
+        sys.exit(2)
+    value = credbroker.get(args.name)
+    if value is None:
+        print(f"No credential named {args.name!r}.", file=sys.stderr)
+        sys.exit(1)
+    # Print without a trailing newline so it can be captured cleanly.
+    sys.stdout.write(value)
+    sys.stdout.flush()
+
+
+def _cmd_list(args) -> None:
+    if not credbroker.is_running():
+        print("credbroker is not running.", file=sys.stderr)
+        sys.exit(2)
+    names = credbroker.list_names()
+    if not names:
+        print("No credentials stored.")
+        return
+    for name in names:
+        print(name)
+
+
+def _cmd_delete(args) -> None:
+    if not credbroker.is_running():
+        print("credbroker is not running.", file=sys.stderr)
+        sys.exit(2)
+    try:
+        existed = credbroker.delete(args.name)
+    except credbroker.CredbrokerError as e:
+        print(f"Failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    if existed:
+        print(f"Removed {args.name!r}.")
+    else:
+        print(f"No credential named {args.name!r}.")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5239,10 +5239,17 @@ def cmd_cron(args):
 
 
 def cmd_webhook(args):
-    """Webhook subscription management."""
+    """Entry point for 'hermes webhook' command."""
     from hermes_cli.webhook import webhook_command
 
     webhook_command(args)
+
+
+def cmd_credbroker(args):
+    """Entry point for 'hermes credbroker' command."""
+    from hermes_cli.credbroker import credbroker_command
+
+    credbroker_command(args)
 
 
 def cmd_slack(args):
@@ -8070,6 +8077,7 @@ def _coalesce_session_name_args(argv: list) -> list:
         "plugins",
         "acp",
         "webhook",
+        "credbroker",
         "memory",
         "dump",
         "debug",
@@ -9264,6 +9272,44 @@ def main():
     )
 
     webhook_parser.set_defaults(func=cmd_webhook)
+
+    # =========================================================================
+    # credbroker command — credential broker subprocess (isolation)
+    # =========================================================================
+    cb_parser = subparsers.add_parser(
+        "credbroker",
+        help="Manage the credential broker subprocess (experimental credential isolation)",
+        description=(
+            "The credential broker is a standalone subprocess that owns an encrypted "
+            "vault at ~/.hermes/credentials/vault.enc.  Credentials stored here are "
+            "never readable by the agent's terminal tool — clients speak to the "
+            "broker via a Unix socket.  Experimental: not yet wired into provider "
+            "adapters; use 'hermes credbroker get NAME' explicitly where you want it."
+        ),
+    )
+    cb_subparsers = cb_parser.add_subparsers(dest="credbroker_action")
+
+    cb_subparsers.add_parser("start", help="Spawn the broker (idempotent)")
+    cb_subparsers.add_parser("stop", help="Terminate the running broker")
+    cb_subparsers.add_parser("status", help="Show running state / vault location")
+
+    cb_set = cb_subparsers.add_parser("set", help="Store a credential")
+    cb_set.add_argument("name", help="Credential name (e.g. OPENAI_API_KEY)")
+    cb_set.add_argument(
+        "value", nargs="?",
+        help="Value to store. Omit to be prompted (no echo).",
+    )
+
+    cb_get = cb_subparsers.add_parser("get", help="Print a credential value to stdout")
+    cb_get.add_argument("name", help="Credential name")
+
+    cb_subparsers.add_parser("list", aliases=["ls"], help="List stored credential names")
+
+    cb_rm = cb_subparsers.add_parser("delete", aliases=["rm", "remove"],
+                                     help="Remove a credential")
+    cb_rm.add_argument("name", help="Credential name")
+
+    cb_parser.set_defaults(func=cmd_credbroker)
 
     # =========================================================================
     # kanban command — multi-profile collaboration board

--- a/tests/tools/test_credbroker.py
+++ b/tests/tools/test_credbroker.py
@@ -1,0 +1,208 @@
+"""Tests for tools/credbroker.py — vault round-trip, IPC protocol, lifecycle.
+
+We test against a real running broker subprocess (spawned in a tmp home dir)
+for the integration surface, plus direct function tests for the vault I/O
+path and error handling.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import stat
+import time
+
+import pytest
+
+from tools import credbroker
+
+
+@pytest.fixture
+def broker_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME so each test gets a fresh vault + socket path."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import importlib
+    import hermes_constants
+
+    importlib.reload(hermes_constants)
+    return home
+
+
+@pytest.fixture
+def running_broker(broker_home):
+    """Start a broker subprocess for the test, tear it down afterward."""
+    pid = credbroker.start_detached()
+    assert credbroker.is_running()
+    try:
+        yield pid
+    finally:
+        if credbroker.is_running():
+            credbroker.stop()
+        # Belt and suspenders for sockets/pids left behind.
+        sp = credbroker.socket_path()
+        if sp.exists():
+            try:
+                sp.unlink()
+            except OSError:
+                pass
+
+
+class TestVaultIO:
+    def test_load_missing_vault_returns_empty(self, broker_home):
+        key = credbroker._load_or_create_key()
+        assert credbroker._vault_load(key) == {}
+
+    def test_round_trip_preserves_values(self, broker_home):
+        key = credbroker._load_or_create_key()
+        data = {"OPENAI_API_KEY": "sk-abc123", "ANTHROPIC_API_KEY": "ant-xyz"}
+        credbroker._vault_save(key, data)
+        assert credbroker._vault_load(key) == data
+
+    def test_wrong_key_cannot_decrypt(self, broker_home):
+        key1 = credbroker._load_or_create_key()
+        credbroker._vault_save(key1, {"A": "1"})
+        # Overwrite the key with a different one.
+        import secrets
+        credbroker.key_path().write_bytes(secrets.token_urlsafe(32).encode())
+        key2 = credbroker._load_or_create_key()
+        # Fernet case: decrypt raises a ValueError translated from InvalidToken.
+        # Plaintext fallback case: still succeeds.  Accept either.
+        try:
+            from cryptography.fernet import Fernet  # noqa: F401
+            fernet_available = True
+        except ImportError:
+            fernet_available = False
+        if fernet_available:
+            with pytest.raises(ValueError):
+                credbroker._vault_load(key2)
+        else:
+            assert credbroker._vault_load(key2) == {"A": "1"}
+
+    def test_key_file_permissions_are_0600(self, broker_home):
+        credbroker._load_or_create_key()
+        mode = stat.S_IMODE(credbroker.key_path().stat().st_mode)
+        assert mode == 0o600
+
+    def test_vault_file_permissions_are_0600(self, broker_home):
+        key = credbroker._load_or_create_key()
+        credbroker._vault_save(key, {"X": "1"})
+        mode = stat.S_IMODE(credbroker.vault_path().stat().st_mode)
+        assert mode == 0o600
+
+
+class TestBrokerLifecycle:
+    def test_is_running_false_when_no_broker(self, broker_home):
+        assert credbroker.is_running() is False
+
+    def test_start_then_status_then_stop(self, broker_home):
+        pid = credbroker.start_detached()
+        try:
+            assert credbroker.is_running()
+            assert isinstance(pid, int) and pid > 0
+            # Pidfile and socket must exist.
+            assert credbroker.pidfile_path().exists()
+            assert credbroker.socket_path().exists()
+            # Socket is 0600.
+            mode = stat.S_IMODE(credbroker.socket_path().stat().st_mode)
+            assert mode == 0o600
+        finally:
+            credbroker.stop()
+
+        # After stop, is_running() should settle to False.
+        deadline = time.time() + 3.0
+        while time.time() < deadline and credbroker.is_running():
+            time.sleep(0.05)
+        assert credbroker.is_running() is False
+
+    def test_start_is_idempotent(self, broker_home):
+        pid1 = credbroker.start_detached()
+        try:
+            pid2 = credbroker.start_detached()
+            # Same broker — no second subprocess spawned.
+            assert pid1 == pid2
+        finally:
+            credbroker.stop()
+
+
+class TestIpcProtocol:
+    def test_set_get_delete_round_trip(self, running_broker):
+        credbroker.set_("TEST_KEY", "hello-world")
+        assert credbroker.get("TEST_KEY") == "hello-world"
+        assert credbroker.delete("TEST_KEY") is True
+        assert credbroker.get("TEST_KEY") is None
+
+    def test_list_names_returns_sorted(self, running_broker):
+        credbroker.set_("ZEBRA", "z")
+        credbroker.set_("ALPHA", "a")
+        credbroker.set_("MIKE", "m")
+        names = credbroker.list_names()
+        assert names == sorted(names)
+        assert "ZEBRA" in names and "ALPHA" in names and "MIKE" in names
+
+    def test_get_missing_returns_none(self, running_broker):
+        assert credbroker.get("NEVER_EXISTED") is None
+
+    def test_delete_missing_returns_false(self, running_broker):
+        # False not raised — the protocol confirms "existed: false".
+        assert credbroker.delete("NO_SUCH_KEY") is False
+
+    def test_invalid_json_is_rejected_cleanly(self, running_broker):
+        """Raw invalid payload must not crash the broker."""
+        sp = str(credbroker.socket_path())
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+            s.settimeout(3)
+            s.connect(sp)
+            s.sendall(b"not valid json\n")
+            data = b""
+            while b"\n" not in data:
+                chunk = s.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+            resp = json.loads(data.split(b"\n", 1)[0])
+        assert resp["ok"] is False
+        assert "invalid JSON" in resp["error"]
+
+        # Broker is still alive and accepting more requests.
+        assert credbroker.get("whatever") is None
+
+    def test_unknown_op_returns_error_without_crashing(self, running_broker):
+        resp = credbroker._request({"op": "explode"})
+        assert resp["ok"] is False
+        assert "unknown op" in resp["error"]
+        # Broker still alive.
+        assert credbroker.is_running()
+
+    def test_values_persist_across_broker_restart(self, broker_home):
+        """Credentials survive stop/start — vault is on disk."""
+        credbroker.start_detached()
+        try:
+            credbroker.set_("PERSIST_ME", "persistent-value")
+        finally:
+            credbroker.stop()
+        # Wait for full teardown before restarting.
+        deadline = time.time() + 3.0
+        while time.time() < deadline and credbroker.is_running():
+            time.sleep(0.05)
+
+        credbroker.start_detached()
+        try:
+            assert credbroker.get("PERSIST_ME") == "persistent-value"
+        finally:
+            credbroker.stop()
+
+
+class TestClientErrors:
+    def test_client_raises_when_broker_down(self, broker_home):
+        with pytest.raises(credbroker.CredbrokerError):
+            credbroker.set_("ANY", "thing")
+
+    def test_get_returns_none_when_broker_down_for_soft_callers(self, broker_home):
+        """Helpers like get() / list_names() are soft on connection errors so
+        they can be probed without a try/except everywhere."""
+        assert credbroker.get("ANY") is None
+        assert credbroker.list_names() == []
+        assert credbroker.is_running() is False

--- a/tools/credbroker.py
+++ b/tools/credbroker.py
@@ -1,0 +1,485 @@
+"""Credential broker subprocess — owns the credential store so the agent
+cannot read it via terminal.
+
+**What this is:** the bootstrap of credential isolation.  A standalone
+process holds a vault at ``~/.hermes/credentials/vault.enc`` protected by
+a per-install key at ``~/.hermes/credentials/broker.key``.  Other parts
+of Hermes request credentials via a Unix domain socket (line-JSON
+protocol) rather than reading env vars / files the agent can see.
+
+**What this is NOT (yet):** a full Vellum-CES equivalent.  The deeper
+integration work — having every provider adapter fetch tokens from the
+broker on demand, sandbox-level mount exclusions, egress proxy, manifest-
+driven secure commands — is deferred.  What ships here is the subprocess
++ IPC + vault format, plus the CLI to manage it.  This is defense in
+depth on top of an already-reasonable threat model, not a complete
+reimagining of the credential story.
+
+Protocol (newline-delimited JSON over a Unix socket)::
+
+    ->  {"op": "get", "name": "OPENAI_API_KEY"}
+    <-  {"ok": true, "value": "sk-..."}
+
+    ->  {"op": "list"}
+    <-  {"ok": true, "names": ["OPENAI_API_KEY", "..."]}
+
+    ->  {"op": "set", "name": "FOO", "value": "bar"}
+    <-  {"ok": true}
+
+    ->  {"op": "delete", "name": "FOO"}
+    <-  {"ok": true}
+
+All errors:  ``{"ok": false, "error": "reason"}``.
+
+The socket path is fixed at ``<hermes_home>/credbroker.sock`` so clients
+don't need configuration.  Peer authentication relies on filesystem
+permissions: the socket is ``0600`` and lives inside the user's
+``~/.hermes/`` tree.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import secrets
+import signal
+import socket
+import socketserver
+import stat
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+SOCKET_NAME = "credbroker.sock"
+VAULT_DIRNAME = "credentials"
+VAULT_FILENAME = "vault.enc"
+KEY_FILENAME = "broker.key"
+PIDFILE_NAME = "credbroker.pid"
+
+
+def _get_home() -> Path:
+    from hermes_constants import get_hermes_home
+    return get_hermes_home()
+
+
+def socket_path() -> Path:
+    return _get_home() / SOCKET_NAME
+
+
+def vault_dir() -> Path:
+    return _get_home() / VAULT_DIRNAME
+
+
+def vault_path() -> Path:
+    return vault_dir() / VAULT_FILENAME
+
+
+def key_path() -> Path:
+    return vault_dir() / KEY_FILENAME
+
+
+def pidfile_path() -> Path:
+    return _get_home() / PIDFILE_NAME
+
+
+# ---------------------------------------------------------------------------
+# Encryption — Fernet if available, plaintext+warning otherwise.
+# ---------------------------------------------------------------------------
+
+
+def _load_or_create_key() -> bytes:
+    """Read the broker key, creating one if missing.
+
+    Key file is 0600 so only the owner can read it.  Without ``cryptography``
+    installed, a random 32-byte key is still generated — we just can't use
+    Fernet, so the vault is stored as plaintext JSON with file-level
+    permissions as the only protection.  A warning is logged so this
+    doesn't go unnoticed.
+    """
+    vault_dir().mkdir(parents=True, exist_ok=True)
+    kp = key_path()
+    if kp.exists():
+        return kp.read_bytes()
+    try:
+        from cryptography.fernet import Fernet
+        key = Fernet.generate_key()
+    except ImportError:
+        logger.warning(
+            "credbroker: 'cryptography' not installed — vault will be stored as "
+            "plaintext JSON with 0600 perms.  Install cryptography for at-rest "
+            "encryption."
+        )
+        key = secrets.token_urlsafe(32).encode("utf-8")
+    kp.write_bytes(key)
+    os.chmod(kp, stat.S_IRUSR | stat.S_IWUSR)  # 0600
+    return key
+
+
+def _encrypt(key: bytes, payload: bytes) -> bytes:
+    try:
+        from cryptography.fernet import Fernet
+        return Fernet(key).encrypt(payload)
+    except ImportError:
+        return payload
+
+
+def _decrypt(key: bytes, blob: bytes) -> bytes:
+    try:
+        from cryptography.fernet import Fernet, InvalidToken
+        try:
+            return Fernet(key).decrypt(blob)
+        except InvalidToken as e:
+            raise ValueError("vault decryption failed — key/vault mismatch") from e
+    except ImportError:
+        return blob
+
+
+# ---------------------------------------------------------------------------
+# Vault I/O — safe against partial writes via tmp-file + atomic replace.
+# ---------------------------------------------------------------------------
+
+
+def _vault_load(key: bytes) -> Dict[str, str]:
+    vp = vault_path()
+    if not vp.exists():
+        return {}
+    raw = vp.read_bytes()
+    if not raw.strip():
+        return {}
+    decrypted = _decrypt(key, raw)
+    try:
+        data = json.loads(decrypted.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        raise ValueError(f"vault is corrupt: {e}") from e
+    if not isinstance(data, dict):
+        raise ValueError("vault does not contain a JSON object")
+    return {str(k): str(v) for k, v in data.items()}
+
+
+def _vault_save(key: bytes, data: Dict[str, str]) -> None:
+    vault_dir().mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(data, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    blob = _encrypt(key, payload)
+    vp = vault_path()
+    tmp = vp.with_suffix(".tmp")
+    tmp.write_bytes(blob)
+    os.chmod(tmp, stat.S_IRUSR | stat.S_IWUSR)
+    os.replace(tmp, vp)
+    os.chmod(vp, stat.S_IRUSR | stat.S_IWUSR)
+
+
+# ---------------------------------------------------------------------------
+# IPC handler — newline-delimited JSON per request.
+# ---------------------------------------------------------------------------
+
+
+class _Handler(socketserver.BaseRequestHandler):
+    """One-shot request handler.  Reads one JSON line, dispatches, writes
+    one JSON line back.
+    """
+
+    server: "_BrokerServer"  # populated by socketserver
+
+    def handle(self) -> None:
+        conn: socket.socket = self.request
+        try:
+            conn.settimeout(5.0)
+            data = b""
+            while b"\n" not in data:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+                if len(data) > 1 << 16:  # cap request size at 64 KiB
+                    self._send(conn, {"ok": False, "error": "request too large"})
+                    return
+            line = data.split(b"\n", 1)[0]
+            try:
+                req = json.loads(line.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError) as e:
+                self._send(conn, {"ok": False, "error": f"invalid JSON: {e}"})
+                return
+            if not isinstance(req, dict):
+                self._send(conn, {"ok": False, "error": "request must be a JSON object"})
+                return
+            response = self.server.dispatch(req)
+            self._send(conn, response)
+        except Exception as e:
+            logger.exception("credbroker handler error: %s", e)
+            try:
+                self._send(conn, {"ok": False, "error": f"internal error: {e}"})
+            except Exception:
+                pass
+
+    @staticmethod
+    def _send(conn: socket.socket, payload: Dict[str, Any]) -> None:
+        conn.sendall(json.dumps(payload).encode("utf-8") + b"\n")
+
+
+class _BrokerServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
+    """Threaded Unix-socket server with in-memory vault cached under a lock."""
+
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(self, sock_path: str):
+        super().__init__(sock_path, _Handler)
+        os.chmod(sock_path, stat.S_IRUSR | stat.S_IWUSR)  # 0600
+        self._key = _load_or_create_key()
+        self._lock = threading.Lock()
+        self._vault = _vault_load(self._key)
+
+    def dispatch(self, req: Dict[str, Any]) -> Dict[str, Any]:
+        op = str(req.get("op") or "").lower()
+        if op == "get":
+            name = str(req.get("name") or "")
+            with self._lock:
+                if name not in self._vault:
+                    return {"ok": False, "error": f"no credential named {name!r}"}
+                return {"ok": True, "value": self._vault[name]}
+        if op == "list":
+            with self._lock:
+                return {"ok": True, "names": sorted(self._vault.keys())}
+        if op == "set":
+            name = str(req.get("name") or "")
+            value = str(req.get("value") or "")
+            if not name:
+                return {"ok": False, "error": "name is required"}
+            with self._lock:
+                self._vault[name] = value
+                _vault_save(self._key, self._vault)
+            return {"ok": True}
+        if op == "delete":
+            name = str(req.get("name") or "")
+            with self._lock:
+                existed = self._vault.pop(name, None) is not None
+                if existed:
+                    _vault_save(self._key, self._vault)
+            return {"ok": True, "existed": existed}
+        if op == "ping":
+            return {"ok": True, "pong": True, "version": 1}
+        return {"ok": False, "error": f"unknown op: {op!r}"}
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle — start / stop / status
+# ---------------------------------------------------------------------------
+
+
+def is_running() -> bool:
+    """Probe the broker via the ``ping`` op. Returns False on any error."""
+    resp = _request({"op": "ping"}, timeout=1.0, raise_on_error=False)
+    return bool(resp and resp.get("ok"))
+
+
+def _write_pidfile(pid: int) -> None:
+    pf = pidfile_path()
+    pf.write_text(str(pid), encoding="utf-8")
+    try:
+        os.chmod(pf, stat.S_IRUSR | stat.S_IWUSR)
+    except OSError:
+        pass
+
+
+def _read_pidfile() -> Optional[int]:
+    pf = pidfile_path()
+    if not pf.exists():
+        return None
+    try:
+        return int(pf.read_text(encoding="utf-8").strip())
+    except (ValueError, OSError):
+        return None
+
+
+def _cleanup_socket() -> None:
+    sp = socket_path()
+    if sp.exists():
+        try:
+            sp.unlink()
+        except OSError:
+            pass
+
+
+def serve_forever() -> None:
+    """Run the broker in the foreground.
+
+    Binds the Unix socket, writes the pidfile, and blocks until SIGTERM /
+    SIGINT.  Intended to be called from a spawned subprocess — see
+    ``start_detached()``.
+    """
+    _cleanup_socket()
+    sp = str(socket_path())
+    _get_home().mkdir(parents=True, exist_ok=True)
+    server = _BrokerServer(sp)
+    _write_pidfile(os.getpid())
+
+    stop_event = threading.Event()
+
+    def _stop(signum, frame):
+        stop_event.set()
+        try:
+            server.shutdown()
+        except Exception:
+            pass
+
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+
+    logger.info("credbroker: listening on %s (pid=%d)", sp, os.getpid())
+    try:
+        server.serve_forever()
+    finally:
+        _cleanup_socket()
+        pf = pidfile_path()
+        if pf.exists():
+            try:
+                pf.unlink()
+            except OSError:
+                pass
+
+
+def start_detached() -> int:
+    """Spawn ``python -m tools.credbroker`` as a detached subprocess.
+
+    Returns the child pid.  If a broker is already running (pidfile + live
+    socket), returns the existing pid instead.
+    """
+    if is_running():
+        existing = _read_pidfile()
+        if existing:
+            return existing
+    # Clean up stale pidfile/socket from a crashed previous instance.
+    _cleanup_socket()
+    pf = pidfile_path()
+    if pf.exists():
+        try:
+            pf.unlink()
+        except OSError:
+            pass
+
+    import subprocess
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "tools.credbroker"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    # Wait up to 5s for the socket + pong.
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        if is_running():
+            return proc.pid
+        time.sleep(0.1)
+    raise RuntimeError("credbroker failed to come up within 5 seconds")
+
+
+def stop() -> bool:
+    """Shut down the running broker, if any.  Returns True if we sent SIGTERM."""
+    pid = _read_pidfile()
+    if pid is None:
+        return False
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        _cleanup_socket()
+        pf = pidfile_path()
+        if pf.exists():
+            try:
+                pf.unlink()
+            except OSError:
+                pass
+        return False
+    # Brief wait so CLI commands see it gone.
+    for _ in range(20):
+        if not is_running():
+            break
+        time.sleep(0.1)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Client — used by the CLI and by higher-level code that wants a credential.
+# ---------------------------------------------------------------------------
+
+
+class CredbrokerError(Exception):
+    """Raised when an IPC request to the broker fails."""
+
+
+def _request(
+    payload: Dict[str, Any],
+    *,
+    timeout: float = 3.0,
+    raise_on_error: bool = True,
+) -> Optional[Dict[str, Any]]:
+    sp = str(socket_path())
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+            s.settimeout(timeout)
+            s.connect(sp)
+            s.sendall(json.dumps(payload).encode("utf-8") + b"\n")
+            data = b""
+            while b"\n" not in data:
+                chunk = s.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+                if len(data) > 1 << 16:
+                    break
+            line = data.split(b"\n", 1)[0]
+            return json.loads(line.decode("utf-8"))
+    except (FileNotFoundError, ConnectionRefusedError) as e:
+        if raise_on_error:
+            raise CredbrokerError("credbroker is not running") from e
+        return None
+    except (OSError, TimeoutError, UnicodeDecodeError, json.JSONDecodeError) as e:
+        if raise_on_error:
+            raise CredbrokerError(f"broker IPC failed: {e}") from e
+        return None
+
+
+def get(name: str) -> Optional[str]:
+    """Return the credential value, or ``None`` if unknown / broker down."""
+    resp = _request({"op": "get", "name": name}, raise_on_error=False)
+    if resp is None or not resp.get("ok"):
+        return None
+    value = resp.get("value")
+    return str(value) if value is not None else None
+
+
+def list_names() -> list[str]:
+    resp = _request({"op": "list"}, raise_on_error=False)
+    if resp is None or not resp.get("ok"):
+        return []
+    names = resp.get("names") or []
+    return [str(n) for n in names]
+
+
+def set_(name: str, value: str) -> None:
+    resp = _request({"op": "set", "name": name, "value": value})
+    if not resp or not resp.get("ok"):
+        raise CredbrokerError(f"set failed: {resp}")
+
+
+def delete(name: str) -> bool:
+    resp = _request({"op": "delete", "name": name})
+    if not resp or not resp.get("ok"):
+        raise CredbrokerError(f"delete failed: {resp}")
+    return bool(resp.get("existed", False))
+
+
+# ---------------------------------------------------------------------------
+# CLI: ``python -m tools.credbroker`` → serve
+# ---------------------------------------------------------------------------
+
+
+if __name__ == "__main__":  # pragma: no cover
+    logging.basicConfig(level=logging.INFO)
+    serve_forever()

--- a/website/docs/user-guide/features/credential-broker.md
+++ b/website/docs/user-guide/features/credential-broker.md
@@ -1,0 +1,105 @@
+---
+title: Credential Broker (experimental)
+description: Standalone subprocess that owns an encrypted credential vault — the agent's terminal can't read it.
+---
+
+# Credential Broker
+
+The credential broker is a **standalone subprocess** that owns an encrypted credential vault at `~/.hermes/credentials/vault.enc`. Credentials stored here are **not readable by the agent's terminal tool**: clients speak to the broker via a Unix socket; only the broker process ever sees the plaintext vault.
+
+Inspired by Vellum Assistant's Credential Execution Service (CES), scoped down to a tractable first cut.
+
+> **Experimental.** This PR ships the subprocess + IPC + vault format, plus the CLI to manage it. Provider-adapter integration — having every provider fetch its token from the broker instead of reading an env var — is deferred to follow-up work. For now, credentials in the broker are opt-in: use `hermes credbroker get NAME` to retrieve them explicitly.
+
+## Why
+
+Hermes already uses per-process env vars for credentials, which is fine until the agent gets a terminal. Any `cat ~/.hermes/.env` inside the agent's shell happily prints every secret. The broker closes that hole by moving the vault into a **different process** — the agent's terminal can't `cat` a file it can't see.
+
+Threat model this addresses:
+- Prompt-injected `cat ~/.hermes/.env` / `env | grep -i key`
+- Accidentally-committed .env files (vault is binary and encrypted)
+- A compromised skill reading env vars at import time
+
+Threat model this does NOT fully address:
+- A rooted user account (the key and vault both live under `~/.hermes`)
+- A malicious process running as the same user
+- A compromised provider adapter that uses credentials legitimately then exfiltrates them
+
+The broker is defense-in-depth, not a capability sandbox.
+
+## Architecture
+
+```
+┌─────────────────────────┐           Unix socket             ┌───────────────────────┐
+│  hermes cli / agent     │  ─────────────────────────────>   │  credbroker           │
+│  (no vault access)      │  {"op":"get","name":"..."}        │  (reads vault.enc)    │
+│                         │  <──────────────────────────────  │  ~/.hermes/...        │
+└─────────────────────────┘           {"ok":true,...}         └───────────────────────┘
+                                                                 vault.enc   (0600)
+                                                                 broker.key  (0600)
+                                                                 credbroker.sock (0600)
+```
+
+- **Socket:** `~/.hermes/credbroker.sock`, `0600`.
+- **Vault:** `~/.hermes/credentials/vault.enc`, encrypted with Fernet if `cryptography` is available (it is, transitively).
+- **Key:** `~/.hermes/credentials/broker.key`, `0600`. Generated once per install.
+- **Protocol:** newline-delimited JSON over the socket. One request per connection.
+
+## CLI
+
+```bash
+hermes credbroker start               # spawn the broker (idempotent)
+hermes credbroker stop                # terminate it
+hermes credbroker status              # running? how many creds?
+
+hermes credbroker set NAME            # prompts for value (no echo)
+hermes credbroker set NAME value      # inline value (careful with shell history)
+hermes credbroker get NAME            # prints to stdout, no trailing newline
+hermes credbroker list                # one name per line
+hermes credbroker delete NAME
+```
+
+## Protocol
+
+Clients send a single-line JSON request and receive a single-line JSON response:
+
+```
+->  {"op": "get", "name": "OPENAI_API_KEY"}
+<-  {"ok": true, "value": "sk-..."}
+
+->  {"op": "list"}
+<-  {"ok": true, "names": ["OPENAI_API_KEY", "..."]}
+
+->  {"op": "set", "name": "FOO", "value": "bar"}
+<-  {"ok": true}
+
+->  {"op": "delete", "name": "FOO"}
+<-  {"ok": true, "existed": true}
+
+->  {"op": "ping"}
+<-  {"ok": true, "pong": true, "version": 1}
+```
+
+Any error shape: `{"ok": false, "error": "reason"}`.
+
+## Python client
+
+```python
+from tools import credbroker
+
+if credbroker.is_running():
+    token = credbroker.get("OPENAI_API_KEY")
+    ...
+```
+
+- `credbroker.get(name)` / `credbroker.list_names()` are soft — they return `None` / `[]` if the broker is down.
+- `credbroker.set_(name, value)` / `credbroker.delete(name)` raise `CredbrokerError` on failure.
+
+## Roadmap (deferred)
+
+- **Provider adapter integration** — `hermes_cli/auth.py` learning to prefer broker creds over env vars, so switching a credential to the vault is a one-line user action.
+- **Mount exclusion** — auto-mount Hermes config dirs read-only with `credentials/` omitted, so even tools with `~/.hermes/` access can't see the vault.
+- **Audit log** — every broker `get` records a timestamped entry.
+- **Egress proxy** — a managed HTTP proxy that injects credentials into outbound requests, so the agent never touches the secret directly.
+
+Each of these is a separate, scoped-down PR. The subprocess + IPC shipped here is the load-bearing part — everything else layers on top.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -60,6 +60,13 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'category',
+          label: 'Security',
+          items: [
+            'user-guide/features/credential-broker',
+          ],
+        },
+        {
+          type: 'category',
           label: 'Automation',
           items: [
             'user-guide/features/cron',


### PR DESCRIPTION
## Summary

Adds the credential broker — a standalone subprocess that owns a Fernet-encrypted vault at `~/.hermes/credentials/vault.enc` and serves requests over a `0600` Unix socket. **The agent's terminal tool cannot read the vault** because the broker process owns it; clients speak line-JSON IPC.

Inspired by Vellum Assistant's Credential Execution Service (CES), scoped down to a tractable first cut.

## Threat model

**What this closes:**
- Prompt-injected `cat ~/.hermes/.env` or `env | grep -i key`
- Accidentally-committed `.env` files (vault is binary + encrypted)
- A compromised skill reading env vars at import time

**What this does NOT close (stated plainly, not hidden):**
- A rooted user account (key + vault still live under `~/.hermes`)
- A malicious process running as the same user
- A compromised provider adapter that uses credentials legitimately then exfiltrates them

The broker is defense-in-depth, not a capability sandbox.

## Architecture

```
┌────────────────────────┐    Unix socket (0600)    ┌──────────────────────┐
│ hermes cli / agent     │  ──────────────────────> │ credbroker           │
│ (no vault access)      │  {"op":"get","name":...} │ owns vault.enc       │
│                        │  <────────────────────── │ + broker.key         │
└────────────────────────┘      {"ok":true,...}     └──────────────────────┘
```

- **Socket:** `~/.hermes/credbroker.sock` (0600)
- **Vault:** `~/.hermes/credentials/vault.enc`, Fernet-encrypted
- **Key:** `~/.hermes/credentials/broker.key` (0600), generated once per install

## What this ships

| File | Purpose |
|---|---|
| `tools/credbroker.py` | Subprocess entry point, vault I/O, IPC client lib |
| `hermes_cli/credbroker.py` | CLI: start / stop / status / set / get / list / delete |
| `hermes_cli/main.py` | argparse wiring + `cmd_credbroker` entrypoint |
| `tests/tools/test_credbroker.py` | 17 tests — vault round-trip, real-subprocess lifecycle, IPC protocol, error handling, encryption validation |
| `website/docs/user-guide/features/credential-broker.md` | Full docs with threat model + deferred roadmap |

## Validation

```
scripts/run_tests.sh tests/tools/test_credbroker.py   → 17 passed (includes real broker subprocess integration)

# End-to-end CLI
HERMES_HOME=/tmp/... hermes credbroker start          → pid reported
HERMES_HOME=/tmp/... hermes credbroker set TEST_KEY secret-value-xyz
HERMES_HOME=/tmp/... hermes credbroker get TEST_KEY   → "secret-value-xyz"
HERMES_HOME=/tmp/... hermes credbroker list           → TEST_KEY
HERMES_HOME=/tmp/... hermes credbroker status         → running, 1 cred stored
HERMES_HOME=/tmp/... hermes credbroker stop

# Vault is actually encrypted on disk
$ cat /tmp/.../credentials/vault.enc
gAAAAABp_PTNdksTg6UeB6I5AOzDFun_ouzvPYHThkF8...   # Fernet ciphertext
$ ls -la /tmp/.../credentials/
-rw-------  broker.key
-rw-------  vault.enc
```

Also tested: broker survives invalid JSON from a client without crashing, survives unknown ops, credentials persist across stop/start, double-start is idempotent.

## Deliberately deferred (next PRs)

Called out explicitly in the docs page:

1. **Provider adapter integration** — `hermes_cli/auth.py` learning to prefer broker creds over env vars. One-line change per provider once we agree on policy. Today: use `hermes credbroker get NAME` explicitly where you want it.
2. **Sandbox mount exclusion** — auto-mount `~/.hermes/` read-only with `credentials/` omitted so even tools with home-dir access can't see the vault.
3. **Audit log** — every `get` records a timestamped entry.
4. **Egress proxy** — managed HTTP proxy that injects credentials into outbound requests, so the agent never touches the secret.

Each is a separate scoped PR. The subprocess + IPC + vault format shipped here is the load-bearing piece; everything else layers on top.

## Scope honesty

This PR intentionally does NOT:
- Rewrite how existing providers load API keys (no migration of the env-var flow)
- Block the agent from reading `~/.hermes/.env` (that's the mount-exclusion follow-up)
- Replace the credential pool

It's the bootstrap. Reviewing it as "does this establish a safe vault + process boundary + CLI management surface that we can build on?" is the right lens.
