### PR TITLE
feat(mcp): add diagnostics doctor command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6837,6 +6837,19 @@ class HermesCLI:
             # The auto-reload path (file watcher) calls _reload_mcp directly
             # without this confirmation.
             self._confirm_and_reload_mcp(cmd_original)
+        elif canonical == "mcp":
+            parts = cmd_original.split(maxsplit=1)
+            arg_text = parts[1].strip().lower() if len(parts) > 1 else ""
+            if arg_text in ("reload", "r"):
+                self._confirm_and_reload_mcp(cmd_original)
+            else:
+                from hermes_cli.mcp_config import _format_mcp_doctor_text
+                from tools.mcp_tool import get_mcp_diagnostics
+                refresh = arg_text in ("verbose", "v", "refresh", "doctor", "diagnose")
+                verbose = arg_text in ("verbose", "v")
+                with self._busy_command("Checking MCP diagnostics..."):
+                    diagnostics = get_mcp_diagnostics(refresh=refresh)
+                print(_format_mcp_doctor_text(diagnostics, verbose=verbose))
         elif canonical == "reload-skills":
             with self._busy_command(self._slow_command_status(cmd_original)):
                 self._reload_skills()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5611,6 +5611,21 @@ class GatewayRunner:
         if canonical == "insights":
             return await self._handle_insights_command(event)
 
+        if canonical == "mcp":
+            args_text = event.get_command_args().strip().lower()
+            if args_text in ("reload", "r"):
+                return await self._handle_reload_mcp_command(event)
+            try:
+                from hermes_cli.mcp_config import _format_mcp_doctor_text
+                from tools.mcp_tool import get_mcp_diagnostics
+                refresh = args_text in ("verbose", "v", "refresh", "doctor", "diagnose")
+                verbose = args_text in ("verbose", "v")
+                diagnostics = await asyncio.to_thread(get_mcp_diagnostics, refresh=refresh)
+                return _format_mcp_doctor_text(diagnostics, verbose=verbose)
+            except Exception as exc:
+                from tools.mcp_tool import _redact_mcp_diagnostic_text
+                return f"MCP diagnostics failed: {_redact_mcp_diagnostic_text(str(exc))}"
+
         if canonical == "reload-mcp":
             return await self._handle_reload_mcp_command(event)
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -169,6 +169,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("reload-mcp", "Reload MCP servers from config", "Tools & Skills",
                aliases=("reload_mcp",)),
+    CommandDef("mcp", "Show MCP diagnostics or reload MCP servers", "Tools & Skills",
+               args_hint="[verbose|doctor|reload]", subcommands=("verbose", "doctor", "diagnose", "reload")),
     CommandDef("reload-skills", "Re-scan ~/.hermes/skills/ for newly installed or removed skills",
                "Tools & Skills", aliases=("reload_skills",)),
     CommandDef("browser", "Connect browser tools to your live Chrome via CDP", "Tools & Skills",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10068,6 +10068,20 @@ Examples:
     mcp_test_p = mcp_sub.add_parser("test", help="Test MCP server connection")
     mcp_test_p.add_argument("name", help="Server name to test")
 
+    mcp_doctor_p = mcp_sub.add_parser(
+        "doctor",
+        aliases=["diagnose"],
+        help="Diagnose configured MCP servers",
+    )
+    mcp_doctor_p.add_argument("name", nargs="?", help="Optional server name to diagnose")
+    mcp_doctor_p.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Actively probe disconnected servers and re-run tools/list",
+    )
+    mcp_doctor_p.add_argument("--json", action="store_true", help="Print diagnostics as JSON")
+    mcp_doctor_p.add_argument("-v", "--verbose", action="store_true", help="Include extra runtime metrics")
+
     mcp_cfg_p = mcp_sub.add_parser(
         "configure", aliases=["config"], help="Toggle tool selection"
     )

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -9,6 +9,7 @@ configuration in ~/.hermes/config.yaml under the ``mcp_servers`` key.
 """
 
 import asyncio
+import json
 import logging
 import os
 import re
@@ -583,6 +584,67 @@ def _interpolate_value(value: str) -> str:
     return re.sub(r"\$\{(\w+)\}", _replace, value)
 
 
+def _format_mcp_doctor_text(diagnostics: List[dict], *, verbose: bool = False) -> str:
+    """Render MCP diagnostics as operator-friendly text."""
+    if not diagnostics:
+        return "No MCP servers configured. Add one with `hermes mcp add <name> --url <endpoint>`."
+    lines = ["MCP diagnostics:"]
+    for item in diagnostics:
+        name = item.get("name", "?")
+        if not item.get("configured", True):
+            status = "not configured"
+        elif not item.get("enabled", True):
+            status = "disabled"
+        elif item.get("connected") and item.get("tool_count", 0) > 0:
+            status = "connected"
+        elif item.get("connected"):
+            status = "zero tools"
+        elif item.get("needs_auth"):
+            status = "needs auth"
+        elif item.get("tools_list_failed"):
+            status = "tools/list failed"
+        elif item.get("process_or_http_failure"):
+            status = "process/http failure"
+        else:
+            status = "not connected"
+        lines.append(f"- {name}: {status}")
+        lines.append(f"  transport: {item.get('transport', '?')}")
+        lines.append(
+            "  tools: "
+            f"{item.get('tool_count', 0)} "
+            f"(registered={item.get('registered_tool_count', 0)}, raw={item.get('raw_tool_count', 0)})"
+        )
+        lines.append(
+            "  flags: "
+            f"attempted={bool(item.get('attempted'))}, "
+            f"connected={bool(item.get('connected'))}, "
+            f"needs_auth={bool(item.get('needs_auth'))}, "
+            f"tools_list_failed={bool(item.get('tools_list_failed'))}, "
+            f"process_or_http_failure={bool(item.get('process_or_http_failure'))}"
+        )
+        if item.get("last_error"):
+            lines.append(f"  error: {item['last_error']}")
+        if verbose and item.get("sampling"):
+            lines.append(f"  sampling: {item['sampling']}")
+        lines.append(f"  next: {item.get('next_action', 'No action needed.')}")
+    return "\n".join(lines)
+
+
+def cmd_mcp_doctor(args):
+    """Run MCP diagnostics for one or all configured servers."""
+    from tools.mcp_tool import get_mcp_diagnostics
+
+    name = getattr(args, "name", None)
+    refresh = bool(getattr(args, "refresh", False))
+    diagnostics = get_mcp_diagnostics(name=name, refresh=refresh)
+    if getattr(args, "json", False):
+        print(json.dumps(diagnostics, indent=2, ensure_ascii=False))
+        return
+    print()
+    print(_format_mcp_doctor_text(diagnostics, verbose=getattr(args, "verbose", False)))
+    print()
+
+
 # ─── hermes mcp login ────────────────────────────────────────────────────────
 
 def cmd_mcp_login(args):
@@ -757,6 +819,8 @@ def mcp_command(args):
         "list": cmd_mcp_list,
         "ls": cmd_mcp_list,
         "test": cmd_mcp_test,
+        "doctor": cmd_mcp_doctor,
+        "diagnose": cmd_mcp_doctor,
         "configure": cmd_mcp_configure,
         "config": cmd_mcp_configure,
         "login": cmd_mcp_login,
@@ -776,6 +840,7 @@ def mcp_command(args):
         _info("hermes mcp remove <name>                      Remove a server")
         _info("hermes mcp list                               List servers")
         _info("hermes mcp test <name>                        Test connection")
+        _info("hermes mcp doctor [name] [--refresh] [--json] Diagnose MCP servers")
         _info("hermes mcp configure <name>                   Toggle tools")
         _info("hermes mcp login <name>                       Re-authenticate OAuth")
         print()

--- a/tests/cli/test_mcp_doctor.py
+++ b/tests/cli/test_mcp_doctor.py
@@ -1,0 +1,88 @@
+"""Tests for `hermes mcp doctor` CLI diagnostics rendering."""
+
+import argparse
+import json
+
+
+def _args(**kwargs):
+    defaults = {
+        "mcp_action": "doctor",
+        "name": None,
+        "refresh": False,
+        "json": False,
+        "verbose": False,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def test_mcp_doctor_prints_json(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "tools.mcp_tool.get_mcp_diagnostics",
+        lambda name=None, refresh=False: [{
+            "name": name or "srv",
+            "configured": True,
+            "enabled": True,
+            "attempted": refresh,
+            "connected": False,
+            "transport": "stdio → npx",
+            "tool_count": 0,
+            "registered_tool_count": 0,
+            "raw_tool_count": 0,
+            "needs_auth": False,
+            "tools_list_failed": False,
+            "process_or_http_failure": False,
+            "last_error": "",
+            "next_action": "Run refresh.",
+        }],
+    )
+    from hermes_cli.mcp_config import cmd_mcp_doctor
+
+    cmd_mcp_doctor(_args(name="srv", refresh=True, json=True))
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data[0]["name"] == "srv"
+    assert data[0]["attempted"] is True
+
+
+def test_mcp_doctor_text_includes_status_and_next(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "tools.mcp_tool.get_mcp_diagnostics",
+        lambda name=None, refresh=False: [{
+            "name": "remote",
+            "configured": True,
+            "enabled": True,
+            "attempted": True,
+            "connected": False,
+            "transport": "http → https://example.com/mcp",
+            "tool_count": 0,
+            "registered_tool_count": 0,
+            "raw_tool_count": 0,
+            "needs_auth": True,
+            "tools_list_failed": False,
+            "process_or_http_failure": False,
+            "last_error": "401 Unauthorized",
+            "next_action": "Check auth headers/env vars for `remote`.",
+        }],
+    )
+    from hermes_cli.mcp_config import cmd_mcp_doctor
+
+    cmd_mcp_doctor(_args())
+    out = capsys.readouterr().out
+    assert "MCP diagnostics" in out
+    assert "remote: needs auth" in out
+    assert "401 Unauthorized" in out
+    assert "Check auth" in out
+
+
+def test_mcp_dispatcher_routes_doctor(monkeypatch, capsys):
+    called = {}
+    monkeypatch.setattr(
+        "hermes_cli.mcp_config.cmd_mcp_doctor",
+        lambda args: called.setdefault("action", args.mcp_action),
+    )
+    from hermes_cli.mcp_config import mcp_command
+
+    mcp_command(_args(mcp_action="doctor"))
+
+    assert called["action"] == "doctor"

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -108,6 +108,7 @@ class TestResolveCommand:
         assert resolve_command("set-home").name == "sethome"
         assert resolve_command("reload_mcp").name == "reload-mcp"
         assert resolve_command("tasks").name == "agents"
+        assert resolve_command("mcp").name == "mcp"
 
     def test_topic_is_gateway_command(self):
         topic = resolve_command("topic")

--- a/tests/tools/test_mcp_diagnostics.py
+++ b/tests/tools/test_mcp_diagnostics.py
@@ -1,0 +1,131 @@
+"""Tests for MCP diagnostics helpers."""
+
+import types
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: tmp_path / "config.yaml")
+    return tmp_path
+
+
+def _seed_config(tmp_path, servers):
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"mcp_servers": servers, "_config_version": 9}),
+        encoding="utf-8",
+    )
+
+
+def test_diagnostics_reports_configured_disconnected_server(tmp_path):
+    _seed_config(tmp_path, {
+        "firecrawl": {"url": "https://api.example.com/mcp?api_key=secret-token"},
+    })
+    from tools.mcp_tool import get_mcp_diagnostics
+
+    result = get_mcp_diagnostics()
+
+    assert len(result) == 1
+    entry = result[0]
+    assert entry["name"] == "firecrawl"
+    assert entry["configured"] is True
+    assert entry["attempted"] is False
+    assert entry["connected"] is False
+    assert entry["tool_count"] == 0
+    assert "secret-token" not in entry["transport"]
+    assert "[REDACTED]" in entry["transport"]
+    assert "hermes mcp doctor firecrawl --refresh" in entry["next_action"]
+
+
+def test_diagnostics_hides_stdio_args_that_may_contain_secrets(tmp_path):
+    _seed_config(tmp_path, {
+        "secret_stdio": {
+            "command": "npx",
+            "args": ["server", "--token", "plain-secret-value", "--project", "public-id"],
+        },
+    })
+    from tools.mcp_tool import get_mcp_diagnostics
+
+    entry = get_mcp_diagnostics(name="secret_stdio")[0]
+    assert "plain-secret-value" not in entry["transport"]
+    assert "public-id" not in entry["transport"]
+    assert "--token" not in entry["transport"]
+    assert "5 args hidden" in entry["transport"]
+
+
+def test_diagnostics_redacts_sensitive_flag_values_in_errors(tmp_path, monkeypatch):
+    _seed_config(tmp_path, {"remote": {"url": "https://example.com/mcp"}})
+    from tools import mcp_tool
+
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    monkeypatch.setattr(mcp_tool, "_ensure_mcp_loop", lambda: None)
+
+    def _raise_secret_arg(coro, *args, **kwargs):
+        coro.close()
+        raise RuntimeError("process failed --token plain-secret-value")
+
+    monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", _raise_secret_arg)
+
+    entry = mcp_tool.get_mcp_diagnostics(name="remote", refresh=True)[0]
+    assert "plain-secret-value" not in entry["last_error"]
+    assert "[REDACTED]" in entry["last_error"]
+
+
+def test_diagnostics_reports_active_connected_server(tmp_path, monkeypatch):
+    _seed_config(tmp_path, {"obsidian": {"command": "uvx", "args": ["server"]}})
+    from tools import mcp_tool
+
+    fake_server = types.SimpleNamespace(
+        session=object(),
+        _registered_tool_names=["mcp_obsidian_read", "mcp_obsidian_write"],
+        _tools=[object(), object()],
+        _sampling=None,
+        _error=None,
+    )
+    with mcp_tool._lock:
+        mcp_tool._servers["obsidian"] = fake_server
+    try:
+        result = mcp_tool.get_mcp_diagnostics()
+    finally:
+        with mcp_tool._lock:
+            mcp_tool._servers.pop("obsidian", None)
+
+    assert result[0]["connected"] is True
+    assert result[0]["tool_count"] == 2
+    assert result[0]["next_action"] == "No action needed."
+
+
+def test_diagnostics_classifies_auth_failure_on_refresh(tmp_path, monkeypatch):
+    _seed_config(tmp_path, {"remote": {"url": "https://example.com/mcp", "headers": {"Authorization": "Bearer ${TOKEN}"}}})
+    from tools import mcp_tool
+
+    monkeypatch.setattr(mcp_tool, "_MCP_AVAILABLE", True)
+    monkeypatch.setattr(mcp_tool, "_ensure_mcp_loop", lambda: None)
+    def _raise_auth(coro, *args, **kwargs):
+        coro.close()
+        raise RuntimeError("401 Unauthorized token=super-secret")
+
+    monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", _raise_auth)
+
+    result = mcp_tool.get_mcp_diagnostics(name="remote", refresh=True)
+    entry = result[0]
+    assert entry["attempted"] is True
+    assert entry["needs_auth"] is True
+    assert entry["process_or_http_failure"] is False
+    assert "super-secret" not in entry["last_error"]
+    assert "[REDACTED]" in entry["last_error"]
+
+
+def test_diagnostics_unknown_name():
+    from tools.mcp_tool import get_mcp_diagnostics
+
+    result = get_mcp_diagnostics(name="missing")
+
+    assert result[0]["configured"] is False
+    assert result[0]["connected"] is False
+    assert "not found" in result[0]["last_error"]

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -270,11 +270,8 @@ _CREDENTIAL_PATTERN = re.compile(
     r"ghp_[A-Za-z0-9_]{1,255}"           # GitHub PAT
     r"|sk-[A-Za-z0-9_]{1,255}"           # OpenAI-style key
     r"|Bearer\s+\S+"                      # Bearer token
-    r"|token=[^\s&,;\"']{1,255}"         # token=...
-    r"|key=[^\s&,;\"']{1,255}"           # key=...
-    r"|API_KEY=[^\s&,;\"']{1,255}"       # API_KEY=...
-    r"|password=[^\s&,;\"']{1,255}"      # password=...
-    r"|secret=[^\s&,;\"']{1,255}"        # secret=...
+    r"|(?:api[_-]?key|access[_-]?token|token|key|password|secret)=[^\s&,;\"']{1,255}"  # key=value secrets
+    r"|--(?:api[_-]?key|access[_-]?token|token|key|password|secret)\s+[^\s&,;\"']{1,255}"  # --key value secrets
     r")",
     re.IGNORECASE,
 )
@@ -3174,6 +3171,203 @@ def discover_mcp_tools() -> List[str]:
         logger.info(summary)
 
     return tool_names
+
+
+def _redact_mcp_diagnostic_text(text: str) -> str:
+    """Redact secrets in MCP diagnostic strings, including query params."""
+    if not text:
+        return ""
+    raw = str(text)
+    try:
+        from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+        split = urlsplit(raw)
+        if split.scheme and split.netloc:
+            sensitive = {"key", "token", "secret", "password", "api_key", "apikey", "access_token"}
+            query_parts = []
+            for key, value in parse_qsl(split.query, keep_blank_values=True):
+                lowered = key.lower()
+                if any(marker in lowered for marker in sensitive):
+                    query_parts.append(f"{key}=[REDACTED]")
+                else:
+                    query_parts.append(urlencode({key: _sanitize_error(value)}))
+            return urlunsplit((
+                split.scheme,
+                split.netloc,
+                _sanitize_error(split.path),
+                "&".join(query_parts),
+                _sanitize_error(split.fragment),
+            ))
+    except Exception:
+        pass
+    return _sanitize_error(raw)
+
+
+def _mcp_transport_label(cfg: dict) -> str:
+    if "url" in cfg:
+        transport = cfg.get("transport") or "http"
+        return f"{transport} → {_redact_mcp_diagnostic_text(str(cfg.get('url') or ''))}"
+    command = str(cfg.get("command") or "?")
+    args = cfg.get("args") or []
+    arg_count = len(args) if isinstance(args, list) else 0
+    suffix = f" ({arg_count} arg{'s' if arg_count != 1 else ''} hidden)" if arg_count else ""
+    return _redact_mcp_diagnostic_text(f"stdio → {command}{suffix}")
+
+
+def _mcp_error_needs_auth(text: str) -> bool:
+    lowered = (text or "").lower()
+    return any(marker in lowered for marker in (
+        "401", "unauthorized", "forbidden", "oauth", "auth", "token", "api key",
+    ))
+
+
+def _mcp_next_action(entry: dict) -> str:
+    name = entry.get("name", "<name>")
+    if not entry.get("configured"):
+        return "Add it with `hermes mcp add <name> --url <endpoint>` or `--command <cmd>`."
+    if not entry.get("enabled", True):
+        return f"Enable `mcp_servers.{name}.enabled` in config.yaml, then run `/reload-mcp`."
+    if entry.get("connected") and entry.get("tool_count", 0) > 0:
+        return "No action needed."
+    if entry.get("needs_auth"):
+        if entry.get("auth_type") == "oauth":
+            return f"Run `hermes mcp login {name}`, then `/reload-mcp`."
+        return f"Check auth headers/env vars for `{name}`, then run `hermes mcp doctor {name} --refresh`."
+    if entry.get("tools_list_failed"):
+        return f"Inspect server logs and run `hermes mcp test {name}`."
+    if entry.get("connected") and entry.get("tool_count", 0) == 0:
+        return f"Server connected but exposed zero tools; run `hermes mcp configure {name}` after confirming the server supports tools/list."
+    if entry.get("attempted"):
+        return f"Fix the transport/process failure, then run `hermes mcp doctor {name} --refresh`."
+    return f"Run `hermes mcp doctor {name} --refresh` to probe it."
+
+
+def get_mcp_diagnostics(name: Optional[str] = None, refresh: bool = False) -> List[dict]:
+    """Return operator-friendly diagnostics for configured MCP servers.
+
+    The default path is read-only against current in-process state. With
+    ``refresh=True``, Hermes actively probes disconnected enabled servers and
+    re-runs ``tools/list`` for connected servers. All user-facing strings are
+    redacted before returning.
+    """
+    configured = _load_mcp_config()
+    if name:
+        configured = {name: configured[name]} if name in configured else {}
+    with _lock:
+        active_servers = dict(_servers)
+
+    diagnostics: List[dict] = []
+    for server_name, cfg in configured.items():
+        enabled = _parse_boolish(cfg.get("enabled", True), default=True)
+        server = active_servers.get(server_name)
+        connected = bool(server and server.session is not None)
+        registered_tool_count = 0
+        raw_tool_count = 0
+        sampling = None
+        last_error = ""
+        if server is not None:
+            registered_tool_count = len(getattr(server, "_registered_tool_names", []) or [])
+            raw_tool_count = len(getattr(server, "_tools", []) or [])
+            if getattr(server, "_sampling", None):
+                sampling = dict(server._sampling.metrics)
+            if getattr(server, "_error", None):
+                last_error = _format_connect_error(server._error)
+
+        auth_type = str(cfg.get("auth") or ("header" if cfg.get("headers") else "none"))
+        entry = {
+            "name": server_name,
+            "configured": True,
+            "enabled": enabled,
+            "attempted": bool(refresh or connected or last_error),
+            "connected": connected,
+            "transport": _mcp_transport_label(cfg),
+            "tool_count": registered_tool_count or raw_tool_count,
+            "registered_tool_count": registered_tool_count,
+            "raw_tool_count": raw_tool_count,
+            "needs_auth": False,
+            "tools_list_failed": False,
+            "process_or_http_failure": False,
+            "last_error": _redact_mcp_diagnostic_text(last_error),
+            "auth_type": auth_type,
+        }
+        if sampling:
+            entry["sampling"] = sampling
+
+        if not enabled:
+            entry["next_action"] = _mcp_next_action(entry)
+            diagnostics.append(entry)
+            continue
+
+        if refresh and connected and server is not None and server.session is not None:
+            entry["attempted"] = True
+            async def _list_tools(_server=server):
+                async with _server._rpc_lock:
+                    return await _server.session.list_tools()
+            try:
+                tools_result = _run_on_mcp_loop(_list_tools(), timeout=float(cfg.get("timeout", _DEFAULT_TOOL_TIMEOUT)))
+                tools = tools_result.tools if hasattr(tools_result, "tools") else []
+                entry["raw_tool_count"] = len(tools)
+                entry["tool_count"] = registered_tool_count or len(tools)
+            except Exception as exc:
+                msg = _format_connect_error(exc)
+                entry["tools_list_failed"] = True
+                entry["last_error"] = _redact_mcp_diagnostic_text(msg)
+                entry["needs_auth"] = _mcp_error_needs_auth(msg)
+
+        elif refresh and not connected:
+            entry["attempted"] = True
+            if not _MCP_AVAILABLE:
+                entry["last_error"] = "MCP SDK not installed"
+                entry["process_or_http_failure"] = True
+            else:
+                _ensure_mcp_loop()
+                async def _probe_once():
+                    probe = await asyncio.wait_for(
+                        _connect_server(server_name, cfg),
+                        timeout=float(cfg.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)) + 5,
+                    )
+                    try:
+                        tools = list(getattr(probe, "_tools", []) or [])
+                        return len(tools), len(getattr(probe, "_registered_tool_names", []) or [])
+                    finally:
+                        await probe.shutdown()
+                try:
+                    raw_count, reg_count = _run_on_mcp_loop(_probe_once(), timeout=float(cfg.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)) + 15)
+                    entry["connected"] = True
+                    entry["raw_tool_count"] = raw_count
+                    entry["registered_tool_count"] = reg_count
+                    entry["tool_count"] = reg_count or raw_count
+                    entry["last_error"] = ""
+                except Exception as exc:
+                    msg = _format_connect_error(exc)
+                    entry["last_error"] = _redact_mcp_diagnostic_text(msg)
+                    entry["needs_auth"] = _mcp_error_needs_auth(msg)
+                    entry["process_or_http_failure"] = not entry["needs_auth"]
+
+        if entry["last_error"] and not entry["needs_auth"]:
+            entry["needs_auth"] = _mcp_error_needs_auth(entry["last_error"])
+        entry["next_action"] = _mcp_next_action(entry)
+        diagnostics.append(entry)
+
+    if name and not diagnostics:
+        diagnostics.append({
+            "name": name,
+            "configured": False,
+            "enabled": False,
+            "attempted": False,
+            "connected": False,
+            "transport": "not configured",
+            "tool_count": 0,
+            "registered_tool_count": 0,
+            "raw_tool_count": 0,
+            "needs_auth": False,
+            "tools_list_failed": False,
+            "process_or_http_failure": False,
+            "last_error": "Server not found in mcp_servers config",
+            "auth_type": "none",
+            "next_action": "Add it with `hermes mcp add <name> --url <endpoint>` or `--command <cmd>`."
+        })
+    return diagnostics
 
 
 def get_mcp_status() -> List[dict]:


### PR DESCRIPTION
## Summary
- Add MCP diagnostics API for configured servers, including connected/tool counts, auth and transport failure classification, and next-action guidance.
- Add `hermes mcp doctor [name] [--refresh] [--json]` plus `diagnose` alias.
- Add `/mcp`, `/mcp verbose`, `/mcp doctor`, `/mcp diagnose`, and `/mcp reload` command surfaces for CLI/gateway sessions.
- Redact secret-like values from MCP diagnostics, including URL query credentials, `key=value`, `--token value`, and stdio args.

## Test Plan
- `python -m pytest -o 'addopts=' tests/tools/test_mcp_diagnostics.py tests/cli/test_mcp_doctor.py tests/hermes_cli/test_commands.py tests/hermes_cli/test_mcp_config.py tests/tools/test_mcp_tool.py -q` → 366 passed
- `python -m py_compile tools/mcp_tool.py hermes_cli/mcp_config.py hermes_cli/commands.py cli.py gateway/run.py`
- `git diff --check`
- `hermes mcp doctor --json` validates as JSON locally

## Safety
- Independent pre-commit review passed with no security concerns or logic errors.
- Avoids exposing stdio args in diagnostics; shows only command plus hidden arg count.
