### PR TITLE
fix: clear stale config context_length override on model switch

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2445,6 +2445,11 @@ class AIAgent:
         # ── LM Studio: preload before probing context length ──
         self._ensure_lmstudio_runtime_loaded()
 
+        # ── Clear stale config context_length override so the new model's
+        #     actual context window is resolved instead of inheriting the
+        #     override from the previous model.
+        self._config_context_length = None
+
         # ── Update context compressor ──
         if hasattr(self, "context_compressor") and self.context_compressor:
             from agent.model_metadata import get_model_context_length
@@ -2463,7 +2468,7 @@ class AIAgent:
                 base_url=self.base_url,
                 api_key=self.api_key,
                 provider=self.provider,
-                config_context_length=getattr(self, "_config_context_length", None),
+                config_context_length=None,
                 custom_providers=_sm_custom_providers,
             )
             self.context_compressor.update_model(


### PR DESCRIPTION
## Problem

When switching models with `/model`, Hermes changes the model correctly but keeps the context window size of the previous model instead of auto-detecting the new model's actual context window.

## Root Cause

`AIAgent._config_context_length` is set once during agent init from `model.context_length` in config.yaml. This value is NEVER cleared or updated when `switch_model()` is called. Since `get_model_context_length()` checks this value at resolution step 0 and returns it immediately, the new model inherits the old override instead of going through the full resolution chain (provider metadata, models.dev, live /models probe, etc.).

The stale value is passed here:
- `run_agent.py://aiagent.switch_model()` via `config_context_length=getattr(self, "_config_context_length", None)`
- `cli.py::_handle_model_switch()` and `_apply_model_switch_result()` via the same pattern

## Fix

Clear `self._config_context_length = None` before resolving the new model's context length in `switch_model()`. This allows `get_model_context_length()` to skip the stale step-0 override and properly auto-detect the context window for the newly selected model.

## Changes

- `run_agent.py`: Set `self._config_context_length = None` before the context compressor update in `switch_model()`
- `run_agent.py`: Pass `config_context_length=None` explicitly to `get_model_context_length` (belt-and-suspenders)

## Testing

1. Set `model.context_length: 128000` in config.yaml for model A
2. Start Hermes with model A — verify 128K context window
3. Switch to model B with `/model` — verify the context window now reflects model B's actual context window (e.g. 200K) instead of sticking to 128K
4. Switch back to model A — verify context window is auto-detected correctly