### PR TITLE
fix(gateway): catch SystemError from os.kill on Windows process probes

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -505,8 +505,10 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         if not stale:
             try:
                 os.kill(existing_pid, 0)
-            except (ProcessLookupError, PermissionError, OSError):
-                # Windows raises OSError with WinError 87 for invalid pid check
+            except (ProcessLookupError, PermissionError, OSError, SystemError):
+                # Windows raises OSError with WinError 87 for invalid pid check;
+                # signal 0 is unsupported on Windows so os.kill can also raise
+                # SystemError ("returned a result with an exception set").
                 stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
@@ -838,6 +840,12 @@ def get_running_pid(
         except OSError:
             # Windows raises OSError with WinError 87 for an invalid pid
             # (process is definitely gone). Treat as "process doesn't exist".
+            continue
+        except SystemError:
+            # Windows: signal 0 is unsupported, so os.kill can surface as
+            # SystemError ("returned a result with an exception set") instead
+            # of OSError. Treat the same as a definitively-gone process so
+            # `hermes gateway` doesn't crash on startup (#21432).
             continue
 
         recorded_start = record.get("start_time")

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -75,6 +75,40 @@ class TestGatewayPidState:
         assert status.get_running_pid() is None
         assert not pid_path.exists()
 
+    def test_get_running_pid_handles_systemerror_from_oskill_on_windows(self, tmp_path, monkeypatch):
+        """Regression for #21432: on Windows, ``os.kill(pid, 0)`` can raise
+        ``SystemError`` ("returned a result with an exception set") because
+        signal 0 isn't supported. The ``except OSError`` branch alone doesn't
+        catch this, and the user-visible result was an immediate crash of
+        ``hermes gateway`` after ``hermes update``.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        dead_pid = 999999
+        pid_path.write_text(json.dumps({
+            "pid": dead_pid,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            "start_time": 111,
+        }))
+
+        # Force the runtime-lock check to return True so the os.kill probe
+        # path is actually exercised — without this, get_running_pid takes
+        # the early-return branch before ever calling os.kill.
+        monkeypatch.setattr(status, "is_gateway_runtime_lock_active", lambda lock_path=None: True)
+
+        def _systemerror_kill(pid, sig):
+            raise SystemError(
+                "<built-in function kill> returned a result with an exception set"
+            )
+
+        monkeypatch.setattr(status.os, "kill", _systemerror_kill)
+
+        # Must not propagate SystemError; treat the probe as "process gone"
+        # and fall through to the cleanup path.
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+
     def test_get_running_pid_accepts_gateway_metadata_when_cmdline_unavailable(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         pid_path = tmp_path / "gateway.pid"
@@ -435,6 +469,39 @@ class TestScopedLocks:
 
         acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
 
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "telegram"
+
+    def test_acquire_scoped_lock_treats_systemerror_as_stale(self, tmp_path, monkeypatch):
+        """Regression for #21432: the scope-lock liveness probe must also
+        absorb ``SystemError`` from ``os.kill(pid, 0)`` on Windows; otherwise
+        gateway lock-acquisition crashes on the same platform path that
+        broke ``hermes gateway`` startup.
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+        }))
+
+        def fake_kill(pid, sig):
+            raise SystemError(
+                "<built-in function kill> returned a result with an exception set"
+            )
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        acquired, existing = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", metadata={"platform": "telegram"}
+        )
+
+        # Must treat the prior holder as stale rather than propagate
+        # SystemError up through start_gateway().
         assert acquired is True
         payload = json.loads(lock_path.read_text())
         assert payload["pid"] == os.getpid()


### PR DESCRIPTION
## What does this PR do?

After `hermes update` on Windows 11, `hermes gateway` crashes immediately because `os.kill(pid, 0)` raises `SystemError` ("returned a result with an exception set") rather than `OSError` — signal 0 isn't a supported signal value on Windows, and CPython doesn't always normalise the C-level failure into `OSError`. The existing `except OSError` clause was added specifically for "WinError 87" but doesn't cover this related failure mode, so the exception escapes the existence-probe and crashes startup.

This PR widens the `except` clauses at the two `os.kill(pid, 0)` existence-probe sites in `gateway/status.py` to also catch `SystemError`. The body is identical to the existing `OSError` body — the user-visible meaning at a probe site is "couldn't determine liveness via signal 0; treat as gone." `terminate_pid` (which sends real signals, not signal-0 probes) is intentionally left alone — failures there must propagate.

## Related Issue

Addresses #21432

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/status.py:507` (`acquire_scoped_lock` liveness probe) — append `SystemError` to the existing `(ProcessLookupError, PermissionError, OSError)` exception tuple. Body is identical (mark prior holder stale).
- `gateway/status.py:828` (`get_running_pid` liveness probe) — add a parallel `except SystemError: continue` next to the existing `OSError` handler. Matches the style of other distinct-body handlers in that block.
- `gateway/status.py:91, :100` (`terminate_pid` real-signal sends) — **intentionally untouched**. These send `SIGTERM`/`SIGKILL`, not signal-0 probes; failures must propagate.
- `tests/gateway/test_status.py` — two regression tests that monkeypatch `os.kill` to raise `SystemError` and assert the probes degrade correctly.

## How to Test

1. `python -m pytest tests/gateway/test_status.py -q` → 44 passed.
2. To confirm the tests catch the regression: `git stash` the `gateway/status.py` changes, re-run pytest. The two new tests fail (`SystemError` propagates out of `get_running_pid` / `acquire_scoped_lock`). `git stash pop` restores.
3. The bug is Windows-specific; the regression tests simulate the exception via `monkeypatch.setattr(os, "kill", _raise_systemerror)` rather than triggering it at the OS level. The reporter's traceback confirms the exception type.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0); bug reproduction is Windows-specific and verified by mock

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ python -m pytest tests/gateway/test_status.py -q
............................................
44 passed in 2.58s
```

Reporter's failing traceback (Windows 11, Python 3.12.8):

```
File "...gateway/run.py", line 15063, in start_gateway
    existing_pid = get_running_pid()
File "...gateway/status.py", line 828, in get_running_pid
    os.kill(pid, 0)
SystemError: <built-in function kill> returned a result with an exception set
```

## Notes

Minimal diff: no refactor of `get_running_pid` or surrounding helpers, no whitespace cleanup, no behavioural change on POSIX (where `os.kill(pid, 0)` raises `ProcessLookupError` / `PermissionError` as before). `SystemError` joins `OSError` on the same control-flow path because the user-visible meaning at a probe site is identical.
