### PR TITLE
fix(feishu): hydrate mentions via REST before dropping ambiguous reply messages

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2411,6 +2411,17 @@ class FeishuAdapter(BasePlatformAdapter):
             return
 
         reason = self._admit(sender, message)
+        if reason in (
+            "group_policy_rejected",
+            "bot_not_mentioned",
+        ) and self._should_attempt_mention_hydration(message):
+            # Feishu reply events can omit message.mentions for the bot @-mention
+            # (raw content shows only "@_user_1"); fetch the canonical message via
+            # REST and re-admit before dropping. See GH #21366. The same missing
+            # mentions shape can also trip allow_bots="mentions" before the
+            # group require_mention gate, yielding bot_not_mentioned.
+            if await self._hydrate_message_mentions(message):
+                reason = self._admit(sender, message)
         if reason is not None:
             logger.debug("[Feishu] dropping inbound event: %s", reason)
             return
@@ -4105,6 +4116,88 @@ class FeishuAdapter(BasePlatformAdapter):
             bot=self._bot_identity(),
         )
         return self._post_mentions_bot(normalized.mentions)
+
+    def _should_attempt_mention_hydration(self, message: Any) -> bool:
+        """Return True when an admission rejection deserves a REST hydration retry.
+
+        Feishu's websocket events for replies can omit ``message.mentions`` and
+        deliver raw content like ``{"text":"@_user_1"}`` even when the canonical
+        message (``GET im/v1/messages/{id}``) has a populated ``mentions[]``
+        entry for the bot. The two ambiguity signals worth one extra REST call:
+
+          * a Feishu user-mention placeholder (``@_user_``) in raw content, or
+          * any reply/thread linkage field (``parent_id``/``root_id``/...).
+        """
+        if getattr(message, "chat_type", "p2p") == "p2p":
+            return False
+        if not self._client or not getattr(message, "message_id", None):
+            return False
+        raw_content = getattr(message, "content", "") or ""
+        if "@_user_" in raw_content:
+            return True
+        for attr in ("parent_id", "root_id", "thread_id", "upper_message_id"):
+            if getattr(message, attr, None):
+                return True
+        return False
+
+    async def _hydrate_message_mentions(self, message: Any) -> bool:
+        """Fetch the canonical message and merge ``mentions``/reply linkage in-place.
+
+        Returns True when at least one mention entry was merged from the REST
+        payload onto ``message`` (caller should re-run ``_admit``). Failures
+        are logged at DEBUG and treated as no-op.
+        """
+        message_id = getattr(message, "message_id", None)
+        if not message_id or not self._client:
+            return False
+        try:
+            request = self._build_get_message_request(message_id)
+            response = await asyncio.to_thread(self._client.im.v1.message.get, request)
+            if not response or getattr(response, "success", lambda: False)() is False:
+                logger.debug(
+                    "[Feishu] Mention hydration GET failed for %s: code=%s msg=%s",
+                    message_id,
+                    getattr(response, "code", "unknown"),
+                    getattr(response, "msg", ""),
+                )
+                return False
+            items = getattr(getattr(response, "data", None), "items", None) or []
+            hydrated = items[0] if items else None
+            if hydrated is None:
+                return False
+            hydrated_mentions = getattr(hydrated, "mentions", None) or []
+            merged = False
+            if hydrated_mentions and not getattr(message, "mentions", None):
+                try:
+                    setattr(message, "mentions", list(hydrated_mentions))
+                    merged = True
+                except Exception:
+                    logger.debug(
+                        "[Feishu] Could not assign hydrated mentions onto message %s",
+                        message_id,
+                        exc_info=True,
+                    )
+            for attr in ("parent_id", "root_id", "thread_id", "upper_message_id"):
+                if not getattr(message, attr, None):
+                    value = getattr(hydrated, attr, None)
+                    if value:
+                        try:
+                            setattr(message, attr, value)
+                        except Exception:
+                            pass
+            if merged:
+                logger.info(
+                    "[Feishu] Hydrated mentions via REST for ambiguous reply event %s",
+                    message_id,
+                )
+            return merged
+        except Exception:
+            logger.debug(
+                "[Feishu] Mention hydration raised for %s",
+                message_id,
+                exc_info=True,
+            )
+            return False
 
     def _message_mentions_bot(self, mentions: List[Any]) -> bool:
         # IDs trump names: when both sides have open_id (or both user_id),

--- a/tests/gateway/test_feishu_bot_admission.py
+++ b/tests/gateway/test_feishu_bot_admission.py
@@ -772,3 +772,274 @@ def test_handle_message_event_data_forwards_sender_when_admitted():
     assert captured.get("sender_id") is sender.sender_id
     assert captured.get("is_bot") is True
     assert captured.get("message_id") == "om_bot_ok"
+
+
+# --- REST mention hydration on ambiguous reply events (GH #21366) ----------
+
+
+def _hydration_message(**overrides):
+    """Reply-shaped Feishu websocket message: raw @_user_1 placeholder, no SDK mentions."""
+    base = dict(
+        message_id="om_reply_21366",
+        chat_id="oc_group",
+        chat_type="group",
+        message_type="text",
+        # The websocket event omits the bot open_id from message.mentions
+        # and only carries the raw placeholder in content.
+        content='{"text":"@_user_1 hello"}',
+        mentions=None,
+        parent_id="om_parent",
+        root_id="om_root",
+        thread_id=None,
+        upper_message_id=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_should_attempt_mention_hydration_signals():
+    adapter = make_adapter_skeleton(bot_open_id="ou_self")
+    adapter._client = object()  # truthy stand-in for the lark client
+    # Group + placeholder placeholder triggers hydration.
+    msg = _hydration_message(parent_id=None, root_id=None, content='{"text":"@_user_1"}')
+    assert adapter._should_attempt_mention_hydration(msg) is True
+    # Group + reply linkage (no placeholder) also triggers hydration.
+    msg = _hydration_message(content='{"text":"hi"}')
+    assert adapter._should_attempt_mention_hydration(msg) is True
+    # P2P never hydrates — there is no group mention gate to fail.
+    msg = _hydration_message(chat_type="p2p")
+    assert adapter._should_attempt_mention_hydration(msg) is False
+    # Plain group message (no signals) does not trigger hydration.
+    msg = _hydration_message(parent_id=None, root_id=None, content='{"text":"hello"}')
+    assert adapter._should_attempt_mention_hydration(msg) is False
+    # Without a client, never hydrate (defensive — no REST path available).
+    adapter._client = None
+    msg = _hydration_message()
+    assert adapter._should_attempt_mention_hydration(msg) is False
+
+
+def test_handle_message_event_data_hydrates_mentions_for_reply_with_raw_placeholder():
+    """Reproduces #21366: a Feishu reply @-mentioning the bot is dropped
+    when ``message.mentions`` is empty, but should be admitted after the
+    adapter falls back to GET im/v1/messages and merges the canonical
+    mentions[] entry for the bot's open_id."""
+    import asyncio
+
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_bot",
+        require_mention=True,
+        group_policy="open",
+    )
+    install_dedup_state(adapter)
+
+    # Hydrated mention shape mirrors the SDK objects (id has open_id/user_id).
+    bot_mention = SimpleNamespace(
+        key="@_user_1",
+        name="hermes_bot",
+        id=SimpleNamespace(open_id="ou_bot", user_id="u_bot", union_id=None),
+    )
+    hydrated_msg = SimpleNamespace(
+        mentions=[bot_mention],
+        parent_id="om_parent",
+        root_id="om_root",
+        thread_id=None,
+        upper_message_id=None,
+    )
+    response = SimpleNamespace(
+        success=lambda: True,
+        data=SimpleNamespace(items=[hydrated_msg]),
+        code=0,
+        msg="ok",
+    )
+
+    get_calls = []
+
+    def _fake_get(request):
+        get_calls.append(getattr(request, "message_id", None))
+        return response
+
+    adapter._client = SimpleNamespace(
+        im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(get=_fake_get))),
+    )
+
+    captured = {}
+
+    async def _fake_process_inbound_message(**kwargs):
+        captured.update(kwargs)
+
+    adapter._process_inbound_message = _fake_process_inbound_message
+
+    message = _hydration_message()
+    sender = make_sender(sender_type="user", open_id="ou_human")
+    data = SimpleNamespace(event=SimpleNamespace(sender=sender, message=message))
+
+    # Without the fix the first _admit returns "group_policy_rejected"
+    # and the message is silently dropped.
+    asyncio.run(adapter._handle_message_event_data(data))
+
+    assert get_calls == ["om_reply_21366"], (
+        "Expected one REST hydration call for the ambiguous reply event"
+    )
+    assert captured.get("message_id") == "om_reply_21366", (
+        "Expected the reply to be admitted into the agent pipeline after hydration"
+    )
+    # The hydrated mentions should now be on the message so downstream
+    # processing sees a fully populated event.
+    assert getattr(message, "mentions", None) == [bot_mention]
+
+
+def test_handle_message_event_data_hydrates_bot_not_mentioned_rejection():
+    """allow_bots=mentions can reject before the group require_mention gate.
+
+    Missing websocket mentions can surface as ``bot_not_mentioned`` for bot
+    senders when group ``require_mention`` is disabled. Hydration should cover
+    that ambiguous reply shape too, then re-admit once REST supplies the bot
+    mention.
+    """
+    import asyncio
+
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_bot",
+        allow_bots="mentions",
+        require_mention=False,
+        group_policy="open",
+    )
+    install_dedup_state(adapter)
+
+    bot_mention = SimpleNamespace(
+        key="@_user_1",
+        name="hermes_bot",
+        id=SimpleNamespace(open_id="ou_bot", user_id="u_bot", union_id=None),
+    )
+    response = SimpleNamespace(
+        success=lambda: True,
+        data=SimpleNamespace(items=[SimpleNamespace(mentions=[bot_mention])]),
+        code=0,
+        msg="ok",
+    )
+    get_calls = []
+
+    def _fake_get(request):
+        get_calls.append(getattr(request, "message_id", None))
+        return response
+
+    adapter._client = SimpleNamespace(
+        im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(get=_fake_get))),
+    )
+
+    captured = {}
+
+    async def _fake_process_inbound_message(**kwargs):
+        captured.update(kwargs)
+
+    adapter._process_inbound_message = _fake_process_inbound_message
+
+    message = _hydration_message(message_id="om_bot_not_mentioned")
+    sender = make_sender(sender_type="bot", open_id="ou_peer_bot")
+    data = SimpleNamespace(event=SimpleNamespace(sender=sender, message=message))
+
+    assert adapter._admit(sender, message) == "bot_not_mentioned"
+    asyncio.run(adapter._handle_message_event_data(data))
+
+    assert get_calls == ["om_bot_not_mentioned"]
+    assert captured.get("message_id") == "om_bot_not_mentioned"
+    assert captured.get("is_bot") is True
+    assert getattr(message, "mentions", None) == [bot_mention]
+
+
+def test_handle_message_event_data_still_drops_when_hydration_finds_no_bot_mention():
+    """If REST hydration returns mentions that don't include the bot, the
+    admission gate must still reject the message (no false-positive admits)."""
+    import asyncio
+
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_bot",
+        require_mention=True,
+        group_policy="open",
+    )
+    install_dedup_state(adapter)
+
+    other_mention = SimpleNamespace(
+        key="@_user_1",
+        name="someone_else",
+        id=SimpleNamespace(open_id="ou_other", user_id="u_other", union_id=None),
+    )
+    hydrated_msg = SimpleNamespace(
+        mentions=[other_mention],
+        parent_id="om_parent",
+        root_id=None,
+        thread_id=None,
+        upper_message_id=None,
+    )
+    response = SimpleNamespace(
+        success=lambda: True,
+        data=SimpleNamespace(items=[hydrated_msg]),
+        code=0,
+        msg="ok",
+    )
+    adapter._client = SimpleNamespace(
+        im=SimpleNamespace(
+            v1=SimpleNamespace(message=SimpleNamespace(get=lambda _r: response)),
+        ),
+    )
+
+    processed = []
+
+    async def _fake_process_inbound_message(**kwargs):
+        processed.append(kwargs)
+
+    adapter._process_inbound_message = _fake_process_inbound_message
+
+    message = _hydration_message()
+    sender = make_sender(sender_type="user", open_id="ou_human")
+    data = SimpleNamespace(event=SimpleNamespace(sender=sender, message=message))
+
+    asyncio.run(adapter._handle_message_event_data(data))
+
+    assert processed == [], "Message must remain rejected when hydration shows no bot mention"
+
+
+def test_handle_message_event_data_skips_hydration_without_signals():
+    """A plain group message with no mention placeholder and no reply linkage
+    must not pay the REST cost — it's just a normal off-topic group post."""
+    import asyncio
+
+    adapter = make_adapter_skeleton(
+        bot_open_id="ou_bot",
+        require_mention=True,
+        group_policy="open",
+    )
+    install_dedup_state(adapter)
+
+    get_calls = []
+
+    def _fake_get(request):  # pragma: no cover — must not be invoked
+        get_calls.append(getattr(request, "message_id", None))
+        return SimpleNamespace(success=lambda: True, data=None)
+
+    adapter._client = SimpleNamespace(
+        im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(get=_fake_get))),
+    )
+
+    processed = []
+
+    async def _fake_process_inbound_message(**kwargs):
+        processed.append(kwargs)
+
+    adapter._process_inbound_message = _fake_process_inbound_message
+
+    message = _hydration_message(
+        message_id="om_no_signals",
+        content='{"text":"random group chatter"}',
+        parent_id=None,
+        root_id=None,
+        thread_id=None,
+        upper_message_id=None,
+    )
+    sender = make_sender(sender_type="user", open_id="ou_human")
+    data = SimpleNamespace(event=SimpleNamespace(sender=sender, message=message))
+
+    asyncio.run(adapter._handle_message_event_data(data))
+
+    assert get_calls == [], "Hydration must not run when there are no ambiguity signals"
+    assert processed == [], "Plain group chatter without @-mention stays rejected"


### PR DESCRIPTION
## What does this PR do?

When `_admit()` rejects a Feishu group message for `require_mention` failure, and the message carries ambiguity signals (raw `@_user_` placeholder, or any of `parent_id` / `root_id` / `thread_id` / `upper_message_id`), this PR fetches the canonical message via `GET im/v1/messages/{message_id}` and re-admits before dropping it.

The bug: Feishu websocket events for *replies* deliver content like `{"text":"@_user_1"}` with `message.mentions` empty, even though the REST `im/v1/messages/{id}` payload for the same message has a `mentions[]` entry containing the bot's `open_id`. With `FEISHU_REQUIRE_MENTION=true`, the admission gate runs against the SDK-normalized `mentions` field only, so it silently drops legitimate `@bot` replies in groups while admitting equivalent standalone messages.

The fix hydrates **only on ambiguous events** and **only after** the cheap path has already returned reject — so plain group chatter takes no extra REST call. Hydration that finds no bot mention still rejects the message (no false-positive admits). One REST call per inbound rejected ambiguous event, naturally deduped by the existing `_is_duplicate(message_id)` guard.

The hydration trigger covers two reject reasons: `group_policy_rejected` (the primary user-reported case under `require_mention=true`) and `bot_not_mentioned` (the bot-sender path under `allow_bots="mentions"` — same missing-mentions ambiguity, different gate).

## Related Issue

Addresses #21366

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/feishu.py` — two new helpers: `_should_attempt_mention_hydration` (signal detection: chat_type≠p2p, raw `@_user_` placeholder, or any reply/thread linkage field set), and `_hydrate_message_mentions` (single REST call via the existing `_build_get_message_request` + `im.v1.message.get` path; merges `mentions[]` and reply linkage onto the SDK message in place via defensive `setattr`).
- `gateway/platforms/feishu.py:_handle_message_event_data` — when `_admit` rejects with `group_policy_rejected` or `bot_not_mentioned` and the ambiguity helper returns true, hydrate once and re-run `_admit`.
- `tests/gateway/test_feishu_bot_admission.py` — five regression tests covering the signal matrix, the `group_policy_rejected` admit-after-hydrate path, the `bot_not_mentioned` admit-after-hydrate path, the still-rejects-when-hydrated-mentions-don't-name-bot path, and the no-signals-skips-hydration cost guard.

## How to Test

1. `python -m pytest tests/gateway/test_feishu.py tests/gateway/test_feishu_bot_admission.py tests/gateway/test_feishu_bot_auth_bypass.py -q` → 225 passed, 43 skipped, 1 known pre-existing failure (`test_hydrate_bot_identity_populates_self_ids_from_bot_v3_info` — `KeyError: 'uri'`, reproduces on clean `origin/main`, untouched by this PR).
2. The new regression `test_handle_message_event_data_hydrates_mentions_for_reply_with_raw_placeholder` reproduces the exact websocket shape from the issue (reply event, raw `@_user_1`, no SDK mentions, parent_id set) and asserts the message reaches `_process_inbound_message` only after REST hydration merges the bot's `open_id` into `mentions[]`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted Feishu suites and all relevant tests pass (1 known pre-existing failure flagged above is unrelated to this PR)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ python -m pytest tests/gateway/test_feishu.py tests/gateway/test_feishu_bot_admission.py tests/gateway/test_feishu_bot_auth_bypass.py -q
...
225 passed, 43 skipped, 1 failed in 1.49s
(1 failure is pre-existing on main: test_hydrate_bot_identity_populates_self_ids_from_bot_v3_info — KeyError: 'uri')
```

## Notes

- **Feishu-only on purpose.** The reporter mentions a cross-platform "common adapter guideline/helper" for layered mention detection (SDK → raw syntax → REST hydration). That broader scope is intentionally not addressed here — Discord / Telegram / Signal already handle their own raw-content mention syntax via existing per-adapter logic, and the Feishu placeholder shape (`@_user_N` opaque to raw regex) requires REST specifically. Other platforms can adopt the same pattern in separate PRs as needed.
- The fix uses `setattr` on the SDK message object to merge hydrated `mentions[]` and reply linkage. lark-oapi event objects accept attribute assignment; each `setattr` is wrapped in defensive `try/except` and treats failures as no-op (admission stays rejected).
- `group_policy_rejected` is currently overloaded (covers both group-policy-disallowed and require-mention-failed cases). Splitting reject reasons (e.g., `group_not_allowed` vs `mention_required`) would make the hydration trigger more precise; out-of-scope here, callable as future cleanup.
- No live Feishu credentials available; the regression tests mock the SDK client. Websocket event shape matches the issue body verbatim.
