### PR TITLE
fix(gateway): route image input via session override, not config default

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7794,7 +7794,12 @@ class GatewayRunner:
             if image_paths:
                 # Decide routing: native (attach pixels) vs text (vision_analyze
                 # pre-run + prepend description).  See agent/image_routing.py.
-                _img_mode = self._decide_image_input_mode()
+                # Pass session_key so per-session ``/model`` overrides (e.g. a
+                # WeChat session switched to a text-only Xiaomi MiMo model) win
+                # over config.yaml's default — otherwise the routing decides
+                # against config-default capabilities and the actual API call
+                # uses the session-override model, producing 400s like #21119.
+                _img_mode = self._decide_image_input_mode(session_key=session_key)
                 if _img_mode == "native":
                     # Defer attachment to the run_conversation call site.
                     pending_native = getattr(self, "_pending_native_image_paths_by_session", None)
@@ -14377,15 +14382,23 @@ class GatewayRunner:
         ctx = copy_context()
         return await loop.run_in_executor(None, ctx.run, func, *args)
 
-    def _decide_image_input_mode(self) -> str:
+    def _decide_image_input_mode(self, session_key: Optional[str] = None) -> str:
         """Resolve the image-input routing for the currently active model.
 
         Returns ``"native"`` (attach pixels on the user turn) or ``"text"``
         (pre-analyze with vision_analyze and prepend the description). See
         agent/image_routing.py for the full decision table.
 
-        The active provider/model are read from config.yaml so the decision
-        tracks ``/model`` switches automatically on the next message.
+        Per-session ``/model`` overrides (stored in
+        ``self._session_model_overrides``) take precedence over config.yaml's
+        ``model.default`` when ``session_key`` is provided. This matters
+        because the actual API call dispatches on the session-active model;
+        if routing decided on the config default's capabilities, a session
+        switched to a text-only model would still get native ``image_url``
+        parts the endpoint rejects (e.g. Xiaomi MiMo's text-only variants
+        return ``400 unknown variant image_url, expected text`` — #21119).
+        Falling back to config.yaml here also keeps callers without a
+        session_key (admin paths, tests) working as before.
         """
         try:
             from agent.image_routing import decide_image_input_mode
@@ -14393,8 +14406,21 @@ class GatewayRunner:
             from hermes_cli.config import load_config
 
             cfg = load_config()
-            provider = _read_main_provider()
-            model = _read_main_model()
+            provider = ""
+            model = ""
+            if session_key:
+                override = self._session_model_overrides.get(session_key) or {}
+                if isinstance(override, dict):
+                    raw_provider = override.get("provider")
+                    raw_model = override.get("model")
+                    if isinstance(raw_provider, str):
+                        provider = raw_provider.strip().lower()
+                    if isinstance(raw_model, str):
+                        model = raw_model.strip()
+            if not provider:
+                provider = _read_main_provider()
+            if not model:
+                model = _read_main_model()
             return decide_image_input_mode(provider, model, cfg)
         except Exception as exc:
             logger.debug("image_routing: decision failed, falling back to text — %s", exc)

--- a/tests/gateway/test_image_routing_session_override.py
+++ b/tests/gateway/test_image_routing_session_override.py
@@ -1,0 +1,126 @@
+"""Regression test for #21119 — gateway image routing must consult session
+overrides, not just config.yaml.
+
+When a user runs ``/model mimo-v2-pro`` (text-only Xiaomi MiMo) on a WeChat
+session whose config.yaml default is the vision-capable ``mimo-v2.5``, the
+gateway used to make its image-input routing decision against the config
+default (vision-capable -> ``native``), then send the inline ``image_url``
+content parts to the session-active text-only endpoint, which rejected
+them with::
+
+    400 unknown variant image_url, expected text
+
+The fix routes the decision through the session's actual override-resolved
+provider/model so non-vision sessions correctly fall back to ``text`` mode
+(vision_analyze pre-analysis + prepended description).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from gateway.run import GatewayRunner
+
+
+def _make_runner() -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._session_model_overrides = {}
+    return runner
+
+
+def test_session_override_to_text_only_xiaomi_routes_text():
+    """Session was switched to text-only Xiaomi MiMo — must route ``text``.
+
+    Without the fix, ``_decide_image_input_mode`` reads provider/model from
+    config.yaml (vision-capable mimo-v2.5) and returns ``native``, which
+    then sends ``image_url`` parts that the actual session-active endpoint
+    (mimo-v2-pro, text-only) rejects with HTTP 400.
+    """
+    runner = _make_runner()
+    session_key = "weixin:user-42"
+    runner._session_model_overrides[session_key] = {
+        "provider": "xiaomi",
+        "model": "mimo-v2-pro",  # text-only per models.dev modalities
+    }
+
+    # Stub config.yaml to assert the override path beats the config path:
+    # config says vision-capable mimo-v2.5, override says text-only mimo-v2-pro.
+    with patch("hermes_cli.config.load_config", return_value={
+        "model": {"provider": "xiaomi", "default": "mimo-v2.5"},
+    }):
+        # Force a deterministic capability lookup: caps say mimo-v2-pro is
+        # NOT vision-capable, mimo-v2.5 IS. The fix must consult the override
+        # so the decision is "text", not "native".
+        def fake_caps(provider: str, model: str):
+            class _Caps:
+                def __init__(self, supports_vision: bool) -> None:
+                    self.supports_vision = supports_vision
+            if model == "mimo-v2-pro":
+                return _Caps(False)
+            if model == "mimo-v2.5":
+                return _Caps(True)
+            return None
+
+        with patch("agent.models_dev.get_model_capabilities", side_effect=fake_caps):
+            mode = runner._decide_image_input_mode(session_key=session_key)
+
+    assert mode == "text", (
+        "Session override to text-only model must force text routing — "
+        "otherwise inline image_url parts get rejected by the API (#21119)."
+    )
+
+
+def test_no_session_override_falls_back_to_config_yaml():
+    """Without an override, config.yaml's main provider/model is used."""
+    runner = _make_runner()
+    # Empty overrides dict; pass session_key that is not present.
+    session_key = "weixin:user-7"
+
+    with patch("hermes_cli.config.load_config", return_value={
+        "model": {"provider": "xiaomi", "default": "mimo-v2.5"},
+    }):
+        def fake_caps(provider: str, model: str):
+            class _Caps:
+                def __init__(self, supports_vision: bool) -> None:
+                    self.supports_vision = supports_vision
+            if model == "mimo-v2.5":
+                return _Caps(True)
+            return None
+
+        with patch("agent.models_dev.get_model_capabilities", side_effect=fake_caps):
+            mode = runner._decide_image_input_mode(session_key=session_key)
+
+    assert mode == "native", (
+        "Without a session override, config.yaml's vision-capable model "
+        "should still route native."
+    )
+
+
+def test_no_session_key_argument_preserves_legacy_behavior():
+    """Calling without session_key reads config.yaml — backward compatible."""
+    runner = _make_runner()
+    runner._session_model_overrides["weixin:user-1"] = {
+        "provider": "xiaomi",
+        "model": "mimo-v2-pro",
+    }
+
+    with patch("hermes_cli.config.load_config", return_value={
+        "model": {"provider": "xiaomi", "default": "mimo-v2.5"},
+    }):
+        def fake_caps(provider: str, model: str):
+            class _Caps:
+                def __init__(self, supports_vision: bool) -> None:
+                    self.supports_vision = supports_vision
+            if model == "mimo-v2.5":
+                return _Caps(True)
+            if model == "mimo-v2-pro":
+                return _Caps(False)
+            return None
+
+        with patch("agent.models_dev.get_model_capabilities", side_effect=fake_caps):
+            mode = runner._decide_image_input_mode()  # no session_key
+
+    assert mode == "native", (
+        "Without session_key, the function must consult config.yaml only — "
+        "this preserves call sites that pre-date the override-aware signature."
+    )

--- a/tests/gateway/test_native_image_buffer_isolation.py
+++ b/tests/gateway/test_native_image_buffer_isolation.py
@@ -14,7 +14,7 @@ def _make_runner() -> GatewayRunner:
     runner.adapters = {}
     runner._model = "openai/gpt-4.1-mini"
     runner._base_url = None
-    runner._decide_image_input_mode = lambda: "native"
+    runner._decide_image_input_mode = lambda session_key=None: "native"
     return runner
 
 


### PR DESCRIPTION
## What does this PR do?

When a WeChat session is `/model`-switched to a text-only Xiaomi MiMo variant, the gateway's image-routing decision was still being made against `config.yaml`'s default model (vision-capable), but the actual API call dispatched on the session-override model (text-only). The result: HTTP 400 from MiMo —

```
{"error":{"message":"Failed to deserialize the JSON body into the target type:
 messages[0]: unknown variant image_url, expected text",
 "type":"invalid_request_error","code":"invalid_request_error"}}
```

— because the routing decision picked `native` (inline `image_url` parts) but dispatch sent to a backend that only accepts `text` parts. CLI mode wasn't affected because `self.provider`/`self.model` track the live session state directly.

This PR aligns the routing decision with the dispatch target: `_decide_image_input_mode` now optionally accepts a `session_key` and consults `_session_model_overrides[session_key]` first (per-field), falling back to `config.yaml`-derived provider/model when the override is absent or partial. Backwards compatible — callers without a session context (admin paths, tests) keep the legacy behaviour.

The fix is generic, not Xiaomi-specific. The same divergence affects any provider whose multimodal capability differs from a session-override target.

## Related Issue

Addresses #21119

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py:_decide_image_input_mode` — added optional `session_key` kwarg; resolves provider/model from `_session_model_overrides[session_key]` first (per-field), falling back to `_read_main_provider`/`_read_main_model`. Pre-existing callers without `session_key` keep the legacy `config.yaml`-only behaviour.
- `gateway/run.py` inbound-image call site — pass the active `session_key` into `_decide_image_input_mode`.
- `tests/gateway/test_image_routing_session_override.py` — three regression tests: override-to-text-only routes `text`, no-override falls back to `config.yaml`, no-`session_key` preserves legacy behaviour.
- `tests/gateway/test_native_image_buffer_isolation.py` — 1-line lambda signature update for the new optional kwarg.

## How to Test

1. `python -m pytest tests/agent/test_image_routing.py tests/gateway/test_native_image_buffer_isolation.py tests/gateway/test_image_routing_session_override.py -q` → 36 passed.
2. To confirm the test catches the regression: `git stash` the `gateway/run.py` changes, re-run pytest. The override-to-text-only test fails with `TypeError: unexpected keyword argument 'session_key'`. `git stash pop` restores.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ python -m pytest tests/agent/test_image_routing.py tests/gateway/test_native_image_buffer_isolation.py tests/gateway/test_image_routing_session_override.py -q
....................................
36 passed
```

Reporter's failure (WeChat session, MiMo, vision-capable config default + text-only override):

```
Error code: 400 - {'error': {'message': "Failed to deserialize the JSON body into the target type:
 messages[0]: unknown variant image_url, expected text",
 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_request_error'}}
```

## Notes

- The fix is intentionally narrow: it only re-derives provider/model from the override when a `session_key` is supplied. Callers without a session context (admin paths, tests) keep the legacy `config.yaml`-only behaviour.
- If a provider/model field is missing from the override dict, that field individually falls back to `config.yaml` — partial overrides still work.
- The reporter attributes the failure to Xiaomi MiMo specifically, but the underlying divergence (routing reads config, dispatch reads override) affects any provider whose multimodal capability differs from a session-override target. The fix corrects the divergence generically rather than special-casing Xiaomi.
- The reporter's "CLI works" observation is consistent with this analysis: CLI's `self.provider`/`self.model` always reflect the live session, so CLI never had the divergence.
