### PR TITLE
fix(gateway,telegram): wire clarify_callback through gateway agent and Telegram adapter

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -305,6 +305,10 @@ class TelegramAdapter(BasePlatformAdapter):
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
+        # Clarify button state: clarify_id → {event, choice, choices, question}.
+        # The agent thread parks on the threading.Event; the inline-button
+        # callback writes the chosen string and sets the event.
+        self._clarify_state: Dict[str, Dict[str, Any]] = {}
 
     def _is_callback_user_authorized(
         self,
@@ -1508,6 +1512,55 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_update_prompt failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    async def send_clarify_prompt(
+        self, chat_id: str, question: str, choices: List[str],
+        clarify_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a clarify question with inline-keyboard choice buttons.
+
+        Used by the gateway clarify_callback bridge to deliver an interactive
+        question from the ``clarify`` tool to the user. Each choice becomes
+        an inline button with callback data ``clarify:<id>:<idx>``. A trailing
+        Skip button (``clarify:<id>:skip``) lets the user dismiss the prompt
+        without picking an option — the agent thread is unblocked with an
+        empty response.
+        """
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            buttons: List[List[InlineKeyboardButton]] = []
+            for idx, choice in enumerate(choices or []):
+                label = str(choice)
+                if len(label) > 60:
+                    label = label[:57] + "..."
+                buttons.append([
+                    InlineKeyboardButton(
+                        label,
+                        callback_data=f"clarify:{clarify_id}:{idx}",
+                    )
+                ])
+            buttons.append([
+                InlineKeyboardButton(
+                    "✗ Skip",
+                    callback_data=f"clarify:{clarify_id}:skip",
+                )
+            ])
+            keyboard = InlineKeyboardMarkup(buttons)
+            thread_id = self._metadata_thread_id(metadata)
+            message_thread_id = self._message_thread_id_for_send(thread_id)
+            msg = await self._bot.send_message(
+                chat_id=int(chat_id),
+                text=question,
+                reply_markup=keyboard,
+                message_thread_id=message_thread_id,
+                **self._link_preview_kwargs(),
+            )
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_clarify_prompt failed: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
@@ -2060,6 +2113,68 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._bot.send_message(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Clarify callbacks (clarify:id:idx | clarify:id:skip) ---
+        if data.startswith("clarify:"):
+            parts = data.split(":", 2)
+            if len(parts) == 3:
+                caller_id = str(getattr(query.from_user, "id", ""))
+                if not self._is_callback_user_authorized(
+                    caller_id,
+                    chat_id=query_chat_id,
+                    chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                    user_name=query_user_name,
+                ):
+                    await query.answer(text="⛔ You are not authorized to answer this prompt.")
+                    return
+
+                clarify_id = parts[1]
+                choice_key = parts[2]
+                state = self._clarify_state.get(clarify_id)
+                if not state:
+                    await query.answer(text="This question is no longer active.")
+                    return
+                if choice_key == "skip":
+                    user_choice = ""
+                else:
+                    try:
+                        idx = int(choice_key)
+                    except ValueError:
+                        await query.answer(text="Invalid choice.")
+                        return
+                    state_choices = state.get("choices", []) or []
+                    if 0 <= idx < len(state_choices):
+                        user_choice = str(state_choices[idx])
+                    else:
+                        await query.answer(text="Invalid choice.")
+                        return
+
+                # Resolve the agent thread waiting on the Event.
+                state["choice"] = user_choice
+                event = state.get("event")
+                if event is not None:
+                    try:
+                        event.set()
+                    except Exception:
+                        pass
+
+                user_display = getattr(query.from_user, "first_name", "User")
+                label = f"Selected: {user_choice}" if user_choice else "Skipped"
+                await query.answer(text=label)
+                try:
+                    await query.edit_message_text(
+                        text=f"{state.get('question', '')}\n\n*{label}* by {user_display}",
+                        parse_mode=ParseMode.MARKDOWN,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass  # non-fatal if edit fails
+                logger.info(
+                    "[%s] clarify resolved: %s key=%s choice=%r",
+                    self.name, clarify_id, choice_key, user_choice,
+                )
             return
 
         # --- Update prompt callbacks ---

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13548,6 +13548,50 @@ class GatewayRunner:
             except Exception as _e:
                 logger.debug("status_callback error (%s): %s", event_type, _e)
 
+        # Bridge sync clarify_callback → async adapter.send_clarify_prompt.
+        # The agent thread parks on a threading.Event; the platform's inline-
+        # button callback resolves it (see TelegramAdapter._handle_callback_query
+        # "clarify:" branch). Adapters without send_clarify_prompt return "" so
+        # the agent falls back to its own judgement.
+        def _clarify_callback_sync(question: str, choices=None) -> str:
+            if not _status_adapter or not _run_still_current():
+                return ""
+            send_prompt = getattr(_status_adapter, "send_clarify_prompt", None)
+            clarify_state = getattr(_status_adapter, "_clarify_state", None)
+            if not callable(send_prompt) or clarify_state is None:
+                return ""
+            import uuid as _uuid
+            clarify_id = _uuid.uuid4().hex
+            event = threading.Event()
+            clarify_state[clarify_id] = {
+                "event": event,
+                "choice": None,
+                "choices": list(choices or []),
+                "question": question,
+            }
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    send_prompt(
+                        chat_id=_status_chat_id,
+                        question=question,
+                        choices=list(choices or []),
+                        clarify_id=clarify_id,
+                        metadata=_status_thread_metadata,
+                    ),
+                    _loop_for_step,
+                ).result(timeout=10)
+            except Exception as _e:
+                logger.error("clarify_callback send error: %s", _e)
+                clarify_state.pop(clarify_id, None)
+                return ""
+            logger.info(
+                "clarify pending stored: %s choices=%s", clarify_id, choices,
+            )
+            # Wait for the user — bounded so the agent never hangs forever.
+            event.wait(timeout=120)
+            state = clarify_state.pop(clarify_id, {"choice": ""})
+            return state.get("choice") or ""
+
         def run_sync():
             # The conditional re-assignment of `message` further below
             # (prepending model-switch notes) makes Python treat it as a
@@ -13785,6 +13829,7 @@ class GatewayRunner:
             agent.stream_delta_callback = _stream_delta_cb
             agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
             agent.status_callback = _status_callback_sync
+            agent.clarify_callback = _clarify_callback_sync
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}

--- a/tests/gateway/test_runner_clarify_callback.py
+++ b/tests/gateway/test_runner_clarify_callback.py
@@ -1,0 +1,163 @@
+"""End-to-end logic test for gateway clarify_callback wiring.
+
+Issue #21032: ``AIAgent.clarify_callback`` was never set on the messaging
+gateway path. This test verifies:
+
+1. The gateway code in ``gateway/run.py`` actually assigns
+   ``agent.clarify_callback`` next to ``agent.status_callback`` (regression
+   guard against future deletions).
+2. The clarify-callback contract — a sync function that posts an async
+   ``send_clarify_prompt`` coroutine to the adapter and blocks on a
+   ``threading.Event`` until the platform resolves it — works correctly
+   when reproduced against a mock adapter.
+"""
+
+import asyncio
+import re
+import sys
+import threading
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_repo = Path(__file__).resolve().parents[2]
+if str(_repo) not in sys.path:
+    sys.path.insert(0, str(_repo))
+
+
+# ---------------------------------------------------------------------------
+# Static guard: the wiring line must remain in gateway/run.py.
+# ---------------------------------------------------------------------------
+
+def test_run_py_wires_clarify_callback_on_agent():
+    """gateway/run.py must assign agent.clarify_callback for every turn."""
+    src = (_repo / "gateway" / "run.py").read_text(encoding="utf-8")
+    # Wired right after status_callback, on the per-turn assignment block
+    pattern = re.compile(
+        r"agent\.status_callback\s*=\s*_status_callback_sync\s*\n"
+        r"\s*agent\.clarify_callback\s*=\s*_clarify_callback_sync",
+    )
+    assert pattern.search(src), (
+        "agent.clarify_callback wiring missing in gateway/run.py — "
+        "issue #21032 regression"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behavioural test: reproduce the closure's contract against a mock adapter.
+# This exercises the same logic the gateway uses (post coroutine, park on
+# Event, return choice) without standing up a full GatewayRunner.
+# ---------------------------------------------------------------------------
+
+class _FakeAdapter:
+    """Stand-in for an adapter that supports send_clarify_prompt."""
+
+    def __init__(self):
+        self._clarify_state = {}
+        self.calls = []
+
+    async def send_clarify_prompt(self, *, chat_id, question, choices, clarify_id, metadata=None):
+        self.calls.append({
+            "chat_id": chat_id, "question": question,
+            "choices": list(choices), "clarify_id": clarify_id,
+            "metadata": metadata,
+        })
+        # Return a SendResult-shaped object — only success matters here.
+        return MagicMock(success=True, message_id="1")
+
+
+def _build_clarify_callback(adapter, *, loop, chat_id="12345",
+                            thread_metadata=None,
+                            run_still_current=lambda: True):
+    """Reproduces the closure built inside gateway.run.GatewayRunner._run_agent."""
+    import logging
+    logger = logging.getLogger(__name__)
+
+    def _clarify_callback_sync(question, choices=None):
+        if not adapter or not run_still_current():
+            return ""
+        send_prompt = getattr(adapter, "send_clarify_prompt", None)
+        clarify_state = getattr(adapter, "_clarify_state", None)
+        if not callable(send_prompt) or clarify_state is None:
+            return ""
+        import uuid
+        clarify_id = uuid.uuid4().hex
+        event = threading.Event()
+        clarify_state[clarify_id] = {
+            "event": event, "choice": None,
+            "choices": list(choices or []), "question": question,
+        }
+        try:
+            asyncio.run_coroutine_threadsafe(
+                send_prompt(
+                    chat_id=chat_id, question=question,
+                    choices=list(choices or []),
+                    clarify_id=clarify_id, metadata=thread_metadata,
+                ),
+                loop,
+            ).result(timeout=5)
+        except Exception as exc:
+            logger.error("clarify_callback send error: %s", exc)
+            clarify_state.pop(clarify_id, None)
+            return ""
+        event.wait(timeout=5)
+        state = clarify_state.pop(clarify_id, {"choice": ""})
+        return state.get("choice") or ""
+
+    return _clarify_callback_sync
+
+
+def test_clarify_callback_posts_coroutine_and_blocks_until_resolved():
+    """Mirror the gateway contract: post async send, park, return user's choice."""
+    adapter = _FakeAdapter()
+
+    # Run the asyncio loop in a background thread (matches gateway shape).
+    loop = asyncio.new_event_loop()
+    loop_thread = threading.Thread(target=loop.run_forever, daemon=True)
+    loop_thread.start()
+    try:
+        cb = _build_clarify_callback(adapter, loop=loop)
+
+        # Resolver thread acts as the inline-button click — once the
+        # callback posts state, find the clarify_id and resolve it.
+        resolved_with = {}
+
+        def _resolver():
+            for _ in range(50):
+                if adapter._clarify_state:
+                    cid, state = next(iter(adapter._clarify_state.items()))
+                    state["choice"] = "green"
+                    state["event"].set()
+                    resolved_with["id"] = cid
+                    return
+                time.sleep(0.05)
+
+        threading.Thread(target=_resolver, daemon=True).start()
+
+        result = cb("Pick a colour:", ["red", "green", "blue"])
+
+        assert result == "green"
+        assert resolved_with.get("id") is not None
+        assert len(adapter.calls) == 1
+        call = adapter.calls[0]
+        assert call["question"] == "Pick a colour:"
+        assert call["choices"] == ["red", "green", "blue"]
+        # State should be cleaned up
+        assert adapter._clarify_state == {}
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=2)
+
+
+def test_clarify_callback_returns_empty_when_adapter_lacks_method():
+    """Adapters without send_clarify_prompt must not raise — return "" so the
+    agent falls back to its own judgement."""
+    bare_adapter = MagicMock(spec=[])  # has nothing
+    loop = asyncio.new_event_loop()
+    try:
+        cb = _build_clarify_callback(bare_adapter, loop=loop)
+        assert cb("Q?", ["a"]) == ""
+    finally:
+        loop.close()

--- a/tests/gateway/test_telegram_clarify_buttons.py
+++ b/tests/gateway/test_telegram_clarify_buttons.py
@@ -1,0 +1,317 @@
+"""Tests for Telegram clarify-tool inline keyboard wiring.
+
+Covers issue #21032 — the messaging gateway never wired ``clarify_callback``
+into the AIAgent, so the clarify tool always returned
+``"Clarify tool is not available in this execution context."`` for users on
+Telegram. These tests exercise the adapter primitives that the wiring relies
+on; the wiring itself is exercised in
+``tests/gateway/test_runner_clarify_callback.py``.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+def _ensure_telegram_mock():
+    """Wire up the minimal mocks required to import TelegramAdapter."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter
+from gateway.config import PlatformConfig
+
+
+def _make_adapter():
+    config = PlatformConfig(enabled=True, token="test-token", extra={})
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+# ===========================================================================
+# send_clarify_prompt — inline keyboard buttons
+# ===========================================================================
+
+class TestTelegramClarifyPrompt:
+    @pytest.mark.asyncio
+    async def test_sends_inline_keyboard_with_choices(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 77
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        result = await adapter.send_clarify_prompt(
+            chat_id="12345",
+            question="Pick a colour:",
+            choices=["red", "green", "blue"],
+            clarify_id="abcd1234",
+        )
+
+        assert result.success is True
+        assert result.message_id == "77"
+
+        adapter._bot.send_message.assert_called_once()
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert kwargs["chat_id"] == 12345
+        assert kwargs["text"] == "Pick a colour:"
+        assert kwargs["reply_markup"] is not None  # InlineKeyboardMarkup
+
+    @pytest.mark.asyncio
+    async def test_sends_skip_button_for_open_ended(self):
+        """Open-ended questions still get a Skip button so the user can dismiss."""
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 1
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        await adapter.send_clarify_prompt(
+            chat_id="12345",
+            question="Anything else?",
+            choices=[],
+            clarify_id="open1",
+        )
+
+        kwargs = adapter._bot.send_message.call_args[1]
+        # Skip button is always appended
+        assert kwargs["reply_markup"] is not None
+
+    @pytest.mark.asyncio
+    async def test_sends_in_thread(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 1
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        await adapter.send_clarify_prompt(
+            chat_id="12345",
+            question="Q?",
+            choices=["a"],
+            clarify_id="t1",
+            metadata={"thread_id": "5550"},
+        )
+
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert kwargs.get("message_thread_id") == 5550
+
+    @pytest.mark.asyncio
+    async def test_not_connected(self):
+        adapter = _make_adapter()
+        adapter._bot = None
+        result = await adapter.send_clarify_prompt(
+            chat_id="12345", question="Q?", choices=["a"], clarify_id="x",
+        )
+        assert result.success is False
+
+
+# ===========================================================================
+# _handle_callback_query — clarify button clicks
+# ===========================================================================
+
+class TestTelegramClarifyCallback:
+    @pytest.mark.asyncio
+    async def test_choice_resolves_event_and_writes_choice(self):
+        adapter = _make_adapter()
+        import threading
+        ev = threading.Event()
+        adapter._clarify_state["xyz"] = {
+            "event": ev, "choice": None,
+            "choices": ["red", "green", "blue"],
+            "question": "Pick a colour:",
+        }
+
+        query = AsyncMock()
+        query.data = "clarify:xyz:1"  # green
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Norbert"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        await adapter._handle_callback_query(update, context)
+
+        assert ev.is_set()
+        assert adapter._clarify_state["xyz"]["choice"] == "green"
+        query.answer.assert_called_once()
+        query.edit_message_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_cannot_resolve_choice(self):
+        adapter = _make_adapter()
+        adapter._is_callback_user_authorized = MagicMock(return_value=False)
+        import threading
+        ev = threading.Event()
+        adapter._clarify_state["locked"] = {
+            "event": ev, "choice": None,
+            "choices": ["red", "green"],
+            "question": "Pick a colour:",
+        }
+
+        query = AsyncMock()
+        query.data = "clarify:locked:1"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_thread_id = 777
+        query.message.chat = MagicMock()
+        query.message.chat.type = "supergroup"
+        query.from_user = MagicMock()
+        query.from_user.id = 999
+        query.from_user.first_name = "Mallory"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        await adapter._handle_callback_query(update, context)
+
+        adapter._is_callback_user_authorized.assert_called_once_with(
+            "999",
+            chat_id=12345,
+            chat_type="supergroup",
+            thread_id="777",
+            user_name="Mallory",
+        )
+        assert not ev.is_set()
+        assert adapter._clarify_state["locked"]["choice"] is None
+        query.answer.assert_called_once()
+        assert "not authorized" in query.answer.call_args[1]["text"].lower()
+        query.edit_message_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skip_resolves_with_empty_string(self):
+        adapter = _make_adapter()
+        import threading
+        ev = threading.Event()
+        adapter._clarify_state["zzz"] = {
+            "event": ev, "choice": None,
+            "choices": ["a", "b"], "question": "Pick:",
+        }
+
+        query = AsyncMock()
+        query.data = "clarify:zzz:skip"
+        query.message = MagicMock()
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Alice"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        await adapter._handle_callback_query(update, context)
+
+        assert ev.is_set()
+        assert adapter._clarify_state["zzz"]["choice"] == ""
+
+    @pytest.mark.asyncio
+    async def test_unknown_clarify_id_acks_gracefully(self):
+        adapter = _make_adapter()
+        # No state for "missing" — already resolved or expired
+
+        query = AsyncMock()
+        query.data = "clarify:missing:0"
+        query.from_user = MagicMock()
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        await adapter._handle_callback_query(update, context)
+
+        query.answer.assert_called_once()
+        ack_text = query.answer.call_args[1]["text"]
+        assert "no longer active" in ack_text.lower()
+        query.edit_message_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_index_rejected(self):
+        adapter = _make_adapter()
+        import threading
+        ev = threading.Event()
+        adapter._clarify_state["foo"] = {
+            "event": ev, "choice": None,
+            "choices": ["only"], "question": "Q?",
+        }
+
+        query = AsyncMock()
+        query.data = "clarify:foo:99"  # out of range
+        query.from_user = MagicMock()
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        await adapter._handle_callback_query(update, context)
+
+        # State must NOT be resolved on a bad index
+        assert not ev.is_set()
+        assert adapter._clarify_state["foo"]["choice"] is None
+        query.answer.assert_called_once()
+        assert "invalid" in query.answer.call_args[1]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_does_not_clobber_existing_callbacks(self):
+        """clarify: prefix must not match the ea:/sc:/update_prompt: branches."""
+        adapter = _make_adapter()
+        adapter._approval_state[1] = "session-x"
+
+        query = AsyncMock()
+        query.data = "ea:once:1"  # exec-approval, NOT clarify
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.from_user = MagicMock()
+        query.from_user.first_name = "Alice"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as m:
+            await adapter._handle_callback_query(update, context)
+
+        m.assert_called_once()  # ea: still routes to approval


### PR DESCRIPTION
## What does this PR do?

After upgrade, every clarify call from the agent in gateway/Telegram mode returned `{"error": "Clarify tool is not available in this execution context."}`. Inline keyboard buttons never appeared. The tool worked in CLI and TUI — gateway-only regression.

Root cause: `AIAgent` requires `clarify_callback` to wire the tool to the platform. CLI (`hermes_cli/main.py`) and TUI (`tui_gateway/server.py`) both pass it during agent construction. The messaging gateway path in `gateway/run.py` was never assigning it, so `agent.clarify_callback` stayed `None` and `tools/clarify_tool.py:57` returned the not-available error. Additionally, the Telegram adapter had none of the primitives needed to actually display the choices (no `_clarify_state`, no `send_clarify_prompt`, no `clarify:` callback handler).

This PR:

1. Wires `agent.clarify_callback` on the messaging gateway path, right next to the existing `agent.status_callback = _status_callback_sync` line. The bridge closure (`_clarify_callback_sync`) posts an async `send_clarify_prompt` coroutine on the running loop and parks on a `threading.Event` (120s timeout, matching CLI behaviour).
2. Adds `send_clarify_prompt`, `_clarify_state`, and the `clarify:id:idx|skip` callback handler on `TelegramAdapter`.
3. Authorizes clarify callbacks via the existing `_is_callback_user_authorized` helper so unauthorized users in shared chats can't steer the waiting agent turn (security: same gate that already protects slash-confirm and update-prompt callbacks).
4. Other gateway adapters (Slack, Discord, Matrix, Feishu, …) lack `send_clarify_prompt`/`_clarify_state`. The bridge detects this and returns `""` so the clarify tool produces an empty user response on those platforms instead of crashing — same UX as before this PR for those adapters. Wiring them up is follow-up work.

## Related Issue

Closes #21032

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py` — added `_clarify_callback_sync` bridge closure (sync→async via `run_coroutine_threadsafe`, 120s wait, threading.Event resolution); assigned `agent.clarify_callback = _clarify_callback_sync` next to the existing `agent.status_callback = _status_callback_sync`.
- `gateway/platforms/telegram.py` — added `_clarify_state: Dict[str, Dict[str, Any]]` initializer; added `send_clarify_prompt(...)` method (inline keyboard with one button per choice + a Skip row, uses existing `_metadata_thread_id`/`_message_thread_id_for_send` helpers, button labels truncated to 60 chars, `parse_mode=None` for the agent-supplied question); added the `clarify:id:idx|skip` branch to `_handle_callback_query` with an `_is_callback_user_authorized` guard up front, before any state lookup.
- `tests/gateway/test_telegram_clarify_buttons.py` — new file. Adapter-side tests for `send_clarify_prompt` (4 tests covering inline keyboard with choices, skip-only for open-ended, thread routing, not-connected guard) and the callback handler (5 tests including the authorization guard, choice resolution, skip behaviour, unknown id graceful response, invalid index rejection without resolving the event, no-clobber on `ea:`/`update_prompt:` routes).
- `tests/gateway/test_runner_clarify_callback.py` — new file. End-to-end tests for the gateway closure: posts a coroutine on a real asyncio loop in a background thread, asserts blocking + resolution + cleanup; verifies graceful `""` return when the adapter lacks `send_clarify_prompt`; static guard on the wiring line in `gateway/run.py`.

## How to Test

1. `python -m pytest tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_runner_clarify_callback.py -q` → 13 passed.
2. Surrounding telegram suite stays green: `python -m pytest tests/gateway/test_telegram_format.py tests/gateway/test_telegram_topic_*.py tests/gateway/test_telegram_caption*.py tests/gateway/test_telegram_approval*.py tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_runner_clarify_callback.py -q` → 161 passed.
3. To exercise the bug manually: configure a Telegram gateway, send a message that triggers the `clarify` tool. Without this PR, the agent receives the not-available error and proceeds without disambiguation. With this PR, an inline keyboard appears in Telegram; tapping a button resolves the agent's wait.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test suites and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0); end-to-end against a live Telegram bot was not exercised (unit-level only, via real asyncio loop in a background thread + mocked adapter `send_message`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ python -m pytest tests/gateway/test_telegram_clarify_buttons.py tests/gateway/test_runner_clarify_callback.py -q
.............
13 passed in 0.91s
```

## Notes

- **Telegram-only in this PR.** Other gateway adapters (Slack, Discord, Matrix, Feishu, ...) still lack `send_clarify_prompt`/`_clarify_state`. The bridge detects that and returns `""` for those (graceful degradation, same UX as before this PR). Wiring them up is follow-up work.
- The `_is_callback_user_authorized` guard runs *before* any state lookup or mutation, so unauthorized users get a "not authorized" answer with no observable effect on the waiting agent turn. Pattern matches the existing slash-confirm and update-prompt callback flows.
- Wait timeout (120s) matches CLI clarify behaviour (`CLI_CONFIG["clarify"]["timeout"]`).
- Button labels are truncated to 60 chars (Telegram inline-button label limit defensive guard).
- `parse_mode=None` for the agent-supplied question text — agent prompts aren't trusted Markdown.
