### PR TITLE
chore(web,ui-tui): upgrade TypeScript to 6.0, drop deprecated baseUrl in web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21447,7 +21447,7 @@
         "globals": "^16",
         "prettier": "^3",
         "tsx": "^4.19.0",
-        "typescript": "^5.7.0",
+        "typescript": "~6.0.3",
         "vitest": "^4.1.3"
       }
     },
@@ -22026,6 +22026,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "ui-tui/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "ui-tui/node_modules/undici-types": {
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
@@ -22163,7 +22177,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
         "three": "^0.180.0",
-        "typescript": "~5.9.3",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.56.1",
         "vite": "^7.3.1"
       }
@@ -22223,6 +22237,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "web/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     }
   }

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -40,7 +40,7 @@
     "globals": "^16",
     "prettier": "^3",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0",
+    "typescript": "~6.0.3",
     "vitest": "^4.1.3"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -45,7 +45,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
     "three": "^0.180.0",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.56.1",
     "vite": "^7.3.1"
   }

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -17,7 +17,6 @@
     "jsx": "react-jsx",
 
     /* Path aliases */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
## What does this PR do?

Upgrades the **`web/`** and **`ui-tui/`** workspaces to TypeScript `~6.0.3`, matching `apps/desktop` and `apps/shared` which already moved to `^6.0.3`, and removes the now-deprecated `baseUrl` from `web/`'s live tsconfig.

> **Rebased & combined (supersedes #21518 + #21519).** Since these were first opened, the repo moved to **npm workspaces with a single root `package-lock.json`**, and the per-package `web/package-lock.json` / `ui-tui/package-lock.json` that the two original PRs edited were deleted upstream. A split no longer makes sense â€” both would self-conflict on the root lockfile â€” so the `ui-tui` bump is folded in here and **#21519 is closed in favor of this PR**.

The `@/*` path alias in `web/` keeps working â€” TS 5.0+ resolves `paths` without `baseUrl` ([docs](https://www.typescriptlang.org/tsconfig#paths)) â€” and Vite mirrors it in `vite.config.ts`.

## Type of Change

- [x] Refactor (no behavior change)

## Changes Made

- `web/package.json`: `typescript` `~5.9.3` -> `~6.0.3`
- `web/tsconfig.app.json`: remove `baseUrl` (this config is referenced by `web/tsconfig.json`'s project refs; its `@/*` path already uses the `./` prefix TS6 requires)
- `ui-tui/package.json`: `typescript` `^5.7.0` -> `~6.0.3`
- `package-lock.json`: add the two workspaces' nested `typescript@6.0.3` entries (diff kept to typescript only â€” no unrelated lockfile churn)

`ui-tui`'s live `tsconfig.json` has no `baseUrl`, so there is nothing to drop there. (Its `tsconfig.build.json` still carries one but has been orphaned since the esbuild build switch in `42627b4ea`; left untouched here â€” worth deleting in a separate cleanup.)

## How to Test

1. `npm install` (root)
2. **web** â€” `npm run build -w web`: `tsc -b` clean, `vite build` produces the bundle. âœ…
3. **ui-tui** â€” `npm run build -w ui-tui` (esbuild/babel): clean. âœ…
4. `npm test -w ui-tui`: `653 passed`, same `8` pre-existing Windows-platform failures as `main` (POSIX `$PATH` / editor lookup); unaffected by this change (vitest transforms with esbuild, not tsc).

### Note â€” pre-existing, not introduced here

`npm run type-check -w ui-tui` reports errors in `packages/hermes-ink/src/utils/execFileNoThrow.ts` (a union-typed `stdio` collapses `spawn`'s overloads to `never`). This **fails the same way on `main`** under the current `typescript@5.7` pin (in fact with more errors), driven by `@types/node@25` â€” it is unrelated to this TS6 bump and out of scope.

## Checklist

- [x] Conventional Commits (`chore(web,ui-tui):`)
- [x] PR contains only the TS-upgrade change
- [x] Tested on Windows 11
- [x] Cross-platform OK â€” TS-only
