### PR TITLE
chore(ui-tui): upgrade TypeScript to 6.0 and drop deprecated baseUrl

### DIFF
--- a/ui-tui/package-lock.json
+++ b/ui-tui/package-lock.json
@@ -35,7 +35,7 @@
         "globals": "^16",
         "prettier": "^3",
         "tsx": "^4.19.0",
-        "typescript": "^5.7.0",
+        "typescript": "~6.0.3",
         "vitest": "^4.1.3"
       }
     },
@@ -6732,9 +6732,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -44,7 +44,7 @@
     "globals": "^16",
     "prettier": "^3",
     "tsx": "^4.19.0",
-    "typescript": "^5.7.0",
+    "typescript": "~6.0.3",
     "vitest": "^4.1.3"
   }
 }

--- a/ui-tui/tsconfig.build.json
+++ b/ui-tui/tsconfig.build.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "types": ["node"],
     "paths": {
-      "@hermes/ink": ["src/types/hermes-ink.d.ts"]
+      "@hermes/ink": ["./src/types/hermes-ink.d.ts"]
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Companion to the `web/` TypeScript 6 upgrade (#REPLACE-WITH-PR1-NUMBER).
Same migration applied to `ui-tui/`: bump `typescript` `^5.7.0` →
`~6.0.3` and remove `baseUrl` from `tsconfig.build.json`.

Two TS6 quirks surfaced once `baseUrl` was gone:

1. **Bare `paths` entries fail TS5090.** Once `baseUrl` is removed,
   TS requires explicit `./`. Changed
   `["src/types/hermes-ink.d.ts"]` →
   `["./src/types/hermes-ink.d.ts"]`.
2. **`@types/node` auto-discovery stops** when `paths` is set without
   `baseUrl` — `process` and `NodeJS` go missing in `src/theme.ts`
   and `src/lib/wheelAccel.ts`. Added `"types": ["node"]` to
   `tsconfig.build.json`, matching the compiler's own suggestion in
   the error message. `tsconfig.json` is unaffected (no `paths`
   there).

## Related Issue

None directly. Companion to #REPLACE-WITH-PR1-NUMBER.

## Type of Change

- [x] ♻️ Refactor (no behavior change)

## Changes Made

- `ui-tui/package.json`: `typescript` `^5.7.0` → `~6.0.3`
- `ui-tui/tsconfig.build.json`: remove `baseUrl`, add
  `"types": ["node"]`, prefix `@hermes/ink` path with `./`
- `ui-tui/package-lock.json`: refreshed (only `typescript` pkg)

## How to Test

1. `cd ui-tui && npm install`
2. `npm run type-check` — clean
3. `npm run build` — tsc + babel compile, 117 files
4. `npm test` — 627 passed, identical to `main` (8 pre-existing
   platform-specific failures around POSIX `$PATH` / editor lookup
   on Windows; unrelated to this change)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`chore(ui-tui):`)
- [x] I searched for existing PRs
- [x] My PR contains **only** changes related to this fix/feature
- [ ] N/A — change is TS-only
- [ ] N/A — config-only change
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [ ] N/A
- [ ] N/A
- [ ] N/A
- [x] Cross-platform OK — TS-only
- [ ] N/A

## Screenshots / Logs
