### PR TITLE
feat(gateway): opt-in Discord requester mention on approval prompts

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -821,6 +821,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
+                if plat == Platform.DISCORD and "mention_exec_approval" in platform_cfg:
+                    bridged["mention_exec_approval"] = platform_cfg["mention_exec_approval"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if "mention_patterns" in platform_cfg:

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3601,6 +3601,30 @@ class DiscordAdapter(BasePlatformAdapter):
             return 32 * 1024 * 1024
         return max(0, value)
 
+    def _discord_ping_exec_approval(self) -> bool:
+        """Return whether Discord exec-approval prompts should @mention the requester.
+
+        Default ``False`` (opt-in) to preserve existing behavior. When enabled,
+        the adapter prepends ``<@user_id> command approval needed`` and restricts
+        that message's ``AllowedMentions`` to the validated requester user ID.
+        Per-message ``AllowedMentions`` keeps the ping explicit while still
+        denying ``@everyone`` and role pings.
+        """
+
+        def _bool(raw: Any) -> bool:
+            if isinstance(raw, bool):
+                return raw
+            if raw is None:
+                return False
+            return str(raw).strip().lower() in ("true", "1", "yes", "on")
+
+        env_raw = os.getenv("DISCORD_MENTION_EXEC_APPROVAL")
+        if env_raw is not None:
+            return _bool(env_raw)
+
+        configured = self.config.extra.get("mention_exec_approval")
+        return _bool(configured)
+
     def _discord_free_response_channels(self) -> set:
         """Return Discord channel IDs where no bot mention is required.
 
@@ -4027,7 +4051,31 @@ class DiscordAdapter(BasePlatformAdapter):
                 allowed_role_ids=self._allowed_role_ids,
             )
 
-            msg = await channel.send(embed=embed, view=view)
+            mention_user_id: Optional[str] = None
+            if self._discord_ping_exec_approval() and metadata and metadata.get("requester_user_id"):
+                candidate = str(metadata["requester_user_id"]).strip()
+                if candidate.isdigit():
+                    mention_user_id = candidate
+                else:
+                    logger.warning(
+                        "[%s] Skipping Discord exec approval mention for invalid requester_user_id=%r",
+                        self.name,
+                        candidate,
+                    )
+
+            mention_text = f"<@{mention_user_id}> command approval needed" if mention_user_id else None
+            send_kwargs: Dict[str, Any] = {"embed": embed, "view": view}
+            if mention_text:
+                send_kwargs["content"] = mention_text
+                allowed_user = discord.Object(id=int(mention_user_id))
+                send_kwargs["allowed_mentions"] = discord.AllowedMentions(
+                    everyone=False,
+                    roles=False,
+                    users=[allowed_user],
+                    replied_user=False,
+                )
+
+            msg = await channel.send(**send_kwargs)
             return SendResult(success=True, message_id=str(msg.id))
 
         except Exception as e:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -671,6 +671,47 @@ logger = logging.getLogger(__name__)
 _AGENT_PENDING_SENTINEL = object()
 
 
+def _build_status_thread_metadata(
+    source: SessionSource,
+    progress_thread_id: Optional[str],
+    event_message_id: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Build routing metadata for status/progress sends."""
+    metadata: Dict[str, Any] = {}
+    if progress_thread_id:
+        metadata["thread_id"] = progress_thread_id
+
+    if (
+        progress_thread_id
+        and source.platform == Platform.TELEGRAM
+        and getattr(source, "chat_type", None) == "dm"
+    ):
+        metadata["telegram_dm_topic_reply_fallback"] = True
+        anchor = event_message_id or getattr(source, "message_id", None)
+        if anchor is not None:
+            metadata["telegram_reply_to_message_id"] = str(anchor)
+
+    if (
+        source.platform == Platform.FEISHU
+        and source.thread_id
+        and event_message_id
+    ):
+        metadata["reply_to_message_id"] = event_message_id
+
+    return metadata or None
+
+
+def _build_exec_approval_metadata(
+    source: SessionSource,
+    status_metadata: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Add approval-only metadata for adapters that render approval prompts."""
+    metadata = dict(status_metadata or {})
+    if source.platform == Platform.DISCORD and not source.is_bot and source.user_id:
+        metadata["requester_user_id"] = str(source.user_id)
+    return metadata or None
+
+
 def _resolve_runtime_agent_kwargs() -> dict:
     """Resolve provider credentials for gateway-created AIAgent instances.
 
@@ -15305,17 +15346,9 @@ class GatewayRunner:
         # Bridge sync status_callback → async adapter.send for context pressure
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
-        if source.platform == Platform.FEISHU and source.thread_id and event_message_id:
-            # Feishu topics only keep messages inside the topic when they are
-            # sent via the reply API with reply_in_thread=true. Status/interim,
-            # approval, and stream-consumer paths usually only receive metadata,
-            # so carry the triggering message id as a Feishu-specific fallback.
-            _status_thread_metadata: Optional[Dict[str, Any]] = {
-                "thread_id": _progress_thread_id,
-                "reply_to_message_id": event_message_id,
-            }
-        else:
-            _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
+        _status_thread_metadata = _build_status_thread_metadata(
+            source, _progress_thread_id, event_message_id
+        )
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
@@ -15821,7 +15854,9 @@ class GatewayRunner:
                                 command=cmd,
                                 session_key=_approval_session_key,
                                 description=desc,
-                                metadata=_status_thread_metadata,
+                                metadata=_build_exec_approval_metadata(
+                                    source, _status_thread_metadata
+                                ),
                             ),
                             _loop_for_step,
                             logger=logger,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -687,6 +687,9 @@ def _build_status_thread_metadata(
         and getattr(source, "chat_type", None) == "dm"
     ):
         metadata["telegram_dm_topic_reply_fallback"] = True
+        tid = str(progress_thread_id)
+        if tid and tid not in {"", "1"}:
+            metadata["direct_messages_topic_id"] = tid
         anchor = event_message_id or getattr(source, "message_id", None)
         if anchor is not None:
             metadata["telegram_reply_to_message_id"] = str(anchor)

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -121,13 +121,20 @@ def _ensure_discord_mock() -> None:
             self.color = color
             self.fields = []
             self.footer = None
+
         def add_field(self, *, name=None, value=None, inline=False, **_):
             self.fields.append({"name": name, "value": value, "inline": inline})
             return self
+
         def set_footer(self, *, text=None, icon_url=None, **_):
             self.footer = {"text": text, "icon_url": icon_url}
             return self
     discord_mod.Embed = _FakeEmbed
+
+    # AllowedMentions / Object: simple containers so tests can assert on
+    # the kwargs the adapter passes to ``channel.send``.
+    discord_mod.AllowedMentions = lambda **kwargs: SimpleNamespace(**kwargs)
+    discord_mod.Object = lambda id: SimpleNamespace(id=id)
 
     # ui.View / ui.Select / ui.Button: real classes (not MagicMock) so
     # tests that subclass ModelPickerView / iterate .children / clear

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -4,6 +4,8 @@ import os
 from unittest.mock import patch
 
 from gateway.config import (
+    DEFAULT_STREAMING_BUFFER_THRESHOLD,
+    DEFAULT_STREAMING_EDIT_INTERVAL,
     GatewayConfig,
     HomeChannel,
     Platform,
@@ -176,8 +178,8 @@ class TestStreamingConfig:
                 "fresh_final_after_seconds": "oops",
             }
         )
-        assert restored.edit_interval == 0.8
-        assert restored.buffer_threshold == 24
+        assert restored.edit_interval == DEFAULT_STREAMING_EDIT_INTERVAL
+        assert restored.buffer_threshold == DEFAULT_STREAMING_BUFFER_THRESHOLD
         assert restored.fresh_final_after_seconds == 60.0
 
 
@@ -428,6 +430,57 @@ class TestLoadGatewayConfig:
 
         assert os.getenv("DISCORD_HISTORY_BACKFILL") == "true"
         assert os.getenv("DISCORD_HISTORY_BACKFILL_LIMIT") == "17"
+
+    def test_bridges_discord_mention_exec_approval_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  mention_exec_approval: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_MENTION_EXEC_APPROVAL", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].extra["mention_exec_approval"] is True
+        assert "DISCORD_MENTION_EXEC_APPROVAL" not in os.environ
+
+    def test_env_var_takes_precedence_over_discord_mention_exec_approval(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  mention_exec_approval: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("DISCORD_MENTION_EXEC_APPROVAL", "")
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].extra["mention_exec_approval"] is True
+        assert os.environ["DISCORD_MENTION_EXEC_APPROVAL"] == ""
+
+    def test_discord_mention_exec_approval_yaml_reload_not_stuck_in_env(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_MENTION_EXEC_APPROVAL", raising=False)
+
+        config_path.write_text("discord:\n  mention_exec_approval: true\n", encoding="utf-8")
+        config = load_gateway_config()
+        assert config.platforms[Platform.DISCORD].extra["mention_exec_approval"] is True
+        assert "DISCORD_MENTION_EXEC_APPROVAL" not in os.environ
+
+        config_path.write_text("discord:\n  mention_exec_approval: false\n", encoding="utf-8")
+        config = load_gateway_config()
+        assert config.platforms[Platform.DISCORD].extra["mention_exec_approval"] is False
+        assert "DISCORD_MENTION_EXEC_APPROVAL" not in os.environ
 
     def test_bridges_telegram_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -24,6 +24,8 @@ def _ensure_discord_mock():
     discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
     discord_mod.Interaction = object
     discord_mod.Embed = MagicMock
+    discord_mod.AllowedMentions = lambda **kwargs: SimpleNamespace(**kwargs)
+    discord_mod.Object = lambda id: SimpleNamespace(id=id)
     discord_mod.app_commands = SimpleNamespace(
         describe=lambda **kwargs: (lambda fn: fn),
         choices=lambda **kwargs: (lambda fn: fn),
@@ -445,3 +447,150 @@ async def test_typing_stop_cleans_up():
 
     await adapter.stop_typing("12345")
     assert "12345" not in adapter._typing_tasks
+
+
+# ---------------------------------------------------------------------------
+# discord.mention_exec_approval — opt-in requester ping on approval prompts
+# ---------------------------------------------------------------------------
+
+
+def test_discord_ping_exec_approval_defaults_false(monkeypatch):
+    monkeypatch.delenv("DISCORD_MENTION_EXEC_APPROVAL", raising=False)
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    assert adapter._discord_ping_exec_approval() is False
+
+
+def test_discord_ping_exec_approval_env_true(monkeypatch):
+    monkeypatch.setenv("DISCORD_MENTION_EXEC_APPROVAL", "true")
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    assert adapter._discord_ping_exec_approval() is True
+
+
+def test_discord_ping_exec_approval_env_overrides_config(monkeypatch):
+    monkeypatch.setenv("DISCORD_MENTION_EXEC_APPROVAL", "false")
+    adapter = DiscordAdapter(
+        PlatformConfig(enabled=True, token="***", extra={"mention_exec_approval": True})
+    )
+    assert adapter._discord_ping_exec_approval() is False
+
+
+def test_discord_ping_exec_approval_string_values(monkeypatch):
+    monkeypatch.delenv("DISCORD_MENTION_EXEC_APPROVAL", raising=False)
+    for raw, expected in (
+        ("true", True), ("True", True), (" yes ", True), ("1", True), ("on", True),
+        ("false", False), ("0", False), ("off", False), ("", False), (" false ", False),
+        ("maybe", False),
+    ):
+        adapter = DiscordAdapter(
+            PlatformConfig(enabled=True, token="***", extra={"mention_exec_approval": raw})
+        )
+        assert adapter._discord_ping_exec_approval() is expected, raw
+
+
+def test_discord_ping_exec_approval_env_string_values(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    for raw, expected in (
+        ("true", True), ("YES", True), (" on ", True), ("1", True),
+        ("false", False), (" false ", False), ("", False), ("maybe", False),
+    ):
+        monkeypatch.setenv("DISCORD_MENTION_EXEC_APPROVAL", raw)
+        assert adapter._discord_ping_exec_approval() is expected, raw
+
+
+@pytest.mark.asyncio
+async def test_send_exec_approval_pings_requester_when_enabled(monkeypatch):
+    adapter = DiscordAdapter(
+        PlatformConfig(enabled=True, token="***", extra={"mention_exec_approval": True})
+    )
+    monkeypatch.setattr(
+        "gateway.platforms.discord.ExecApprovalView",
+        lambda *a, **kw: SimpleNamespace(session_key=kw.get("session_key")),
+        raising=False,
+    )
+
+    sent = {}
+
+    async def fake_send(**kwargs):
+        sent.update(kwargs)
+        return SimpleNamespace(id=789)
+
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send_exec_approval(
+        "555", "rm -rf /", "sess",
+        metadata={"thread_id": "555", "requester_user_id": "42"},
+    )
+    assert result.success is True
+    assert sent.get("content") == "<@42> command approval needed"
+    am = sent.get("allowed_mentions")
+    assert am is not None
+    assert am.everyone is False and am.roles is False
+    assert am.replied_user is False
+    assert [u.id for u in am.users] == [42]
+
+
+@pytest.mark.asyncio
+async def test_send_exec_approval_no_ping_when_disabled(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    monkeypatch.delenv("DISCORD_MENTION_EXEC_APPROVAL", raising=False)
+    monkeypatch.setattr(
+        "gateway.platforms.discord.ExecApprovalView",
+        lambda *a, **kw: SimpleNamespace(session_key=kw.get("session_key")),
+        raising=False,
+    )
+
+    sent = {}
+
+    async def fake_send(**kwargs):
+        sent.update(kwargs)
+        return SimpleNamespace(id=1)
+
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    await adapter.send_exec_approval(
+        "555", "ls", "sess",
+        metadata={"thread_id": "555", "requester_user_id": "42"},
+    )
+    assert "content" not in sent
+    assert "allowed_mentions" not in sent
+
+
+@pytest.mark.asyncio
+async def test_send_exec_approval_rejects_invalid_user_id(monkeypatch, caplog):
+    adapter = DiscordAdapter(
+        PlatformConfig(enabled=True, token="***", extra={"mention_exec_approval": True})
+    )
+    monkeypatch.setattr(
+        "gateway.platforms.discord.ExecApprovalView",
+        lambda *a, **kw: SimpleNamespace(session_key=kw.get("session_key")),
+        raising=False,
+    )
+
+    sent = {}
+
+    async def fake_send(**kwargs):
+        sent.update(kwargs)
+        return SimpleNamespace(id=1)
+
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    with caplog.at_level("WARNING"):
+        await adapter.send_exec_approval(
+            "555", "ls", "sess",
+            metadata={"thread_id": "555", "requester_user_id": "<@everyone>"},
+        )
+    assert "content" not in sent
+    assert "allowed_mentions" not in sent
+    assert any("invalid requester_user_id" in r.message for r in caplog.records)

--- a/tests/gateway/test_status_thread_metadata.py
+++ b/tests/gateway/test_status_thread_metadata.py
@@ -1,0 +1,114 @@
+"""Tests for ``gateway.run._build_status_thread_metadata``.
+
+Covers status routing metadata plus approval-only requester metadata.
+"""
+
+from gateway.run import _build_exec_approval_metadata, _build_status_thread_metadata
+from gateway.session import SessionSource
+from gateway.config import Platform
+
+
+def _src(**kwargs) -> SessionSource:
+    defaults = dict(
+        platform=Platform.DISCORD,
+        chat_id="555",
+        user_id="42",
+        user_name="ada",
+        thread_id=None,
+        is_bot=False,
+    )
+    defaults.update(kwargs)
+    return SessionSource(**defaults)
+
+
+def test_no_metadata_when_no_thread_or_special_platform():
+    src = _src(platform=Platform.SLACK, user_id=None, user_name=None)
+    assert _build_status_thread_metadata(src, None) is None
+
+
+def test_thread_id_only_for_non_discord_non_feishu():
+    src = _src(platform=Platform.SLACK, user_id="999", user_name="bob")
+    md = _build_status_thread_metadata(src, "thread-abc")
+    assert md == {"thread_id": "thread-abc"}
+
+
+def test_telegram_dm_topic_fallback_metadata_preserved():
+    src = _src(
+        platform=Platform.TELEGRAM,
+        chat_id="555",
+        user_id="42",
+        user_name="ada",
+        chat_type="dm",
+        message_id="msg-source",
+    )
+    md = _build_status_thread_metadata(src, "topic-42", event_message_id="msg-event")
+    assert md == {
+        "thread_id": "topic-42",
+        "telegram_dm_topic_reply_fallback": True,
+        "telegram_reply_to_message_id": "msg-event",
+    }
+
+
+def test_telegram_dm_topic_fallback_uses_source_message_when_event_missing():
+    src = _src(
+        platform=Platform.TELEGRAM,
+        chat_id="555",
+        user_id="42",
+        user_name="ada",
+        chat_type="dm",
+        message_id="msg-source",
+    )
+    md = _build_status_thread_metadata(src, "topic-42")
+    assert md == {
+        "thread_id": "topic-42",
+        "telegram_dm_topic_reply_fallback": True,
+        "telegram_reply_to_message_id": "msg-source",
+    }
+
+
+def test_telegram_non_dm_uses_thread_id_only():
+    src = _src(platform=Platform.TELEGRAM, chat_type="group", message_id="msg-source")
+    md = _build_status_thread_metadata(src, "topic-42", event_message_id="msg-event")
+    assert md == {"thread_id": "topic-42"}
+
+
+def test_discord_status_metadata_uses_thread_id_only():
+    src = _src(platform=Platform.DISCORD, user_id="42", user_name="ada")
+    md = _build_status_thread_metadata(src, "555")
+    assert md == {"thread_id": "555"}
+
+
+def test_discord_approval_metadata_includes_requester_id():
+    src = _src(platform=Platform.DISCORD, user_id="42", user_name="ada")
+    md = _build_exec_approval_metadata(src, {"thread_id": "555"})
+    assert md == {"thread_id": "555", "requester_user_id": "42"}
+
+
+def test_discord_approval_metadata_present_even_without_thread():
+    src = _src(platform=Platform.DISCORD, user_id="42", user_name="ada")
+    md = _build_exec_approval_metadata(src, None)
+    assert md == {"requester_user_id": "42"}
+
+
+def test_discord_approval_metadata_skips_missing_user_id():
+    src = _src(platform=Platform.DISCORD, user_id=None, user_name="ada")
+    md = _build_exec_approval_metadata(src, {"thread_id": "555"})
+    assert md == {"thread_id": "555"}
+
+
+def test_discord_approval_metadata_skips_bot_source():
+    src = _src(platform=Platform.DISCORD, user_id="42", user_name="webhook", is_bot=True)
+    md = _build_exec_approval_metadata(src, {"thread_id": "555"})
+    assert md == {"thread_id": "555"}
+
+
+def test_feishu_reply_to_message_id_only_with_thread_id():
+    src = _src(platform=Platform.FEISHU, thread_id="topic-x", user_id=None, user_name=None)
+    md = _build_status_thread_metadata(src, "topic-x", event_message_id="msg-1")
+    assert md == {"thread_id": "topic-x", "reply_to_message_id": "msg-1"}
+
+
+def test_feishu_no_reply_to_when_thread_id_missing():
+    src = _src(platform=Platform.FEISHU, thread_id=None, user_id=None, user_name=None)
+    md = _build_status_thread_metadata(src, None, event_message_id="msg-1")
+    assert md is None

--- a/tests/gateway/test_status_thread_metadata.py
+++ b/tests/gateway/test_status_thread_metadata.py
@@ -45,6 +45,7 @@ def test_telegram_dm_topic_fallback_metadata_preserved():
     assert md == {
         "thread_id": "topic-42",
         "telegram_dm_topic_reply_fallback": True,
+        "direct_messages_topic_id": "topic-42",
         "telegram_reply_to_message_id": "msg-event",
     }
 
@@ -62,6 +63,7 @@ def test_telegram_dm_topic_fallback_uses_source_message_when_event_missing():
     assert md == {
         "thread_id": "topic-42",
         "telegram_dm_topic_reply_fallback": True,
+        "direct_messages_topic_id": "topic-42",
         "telegram_reply_to_message_id": "msg-source",
     }
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -263,6 +263,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `DISCORD_HOME_CHANNEL_NAME` | Display name for the Discord home channel |
 | `DISCORD_COMMAND_SYNC_POLICY` | Discord slash-command startup sync policy: `safe` (diff and reconcile), `bulk` (legacy `tree.sync()`), or `off` |
 | `DISCORD_REQUIRE_MENTION` | Require an @mention before responding in server channels |
+| `DISCORD_MENTION_EXEC_APPROVAL` | Ping the requester on dangerous-command approval prompts (default: `false`). See [`discord.mention_exec_approval`](../user-guide/messaging/discord.md#discordmention_exec_approval). |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where mention is not required |
 | `DISCORD_AUTO_THREAD` | Auto-thread long replies when supported |
 | `DISCORD_ALLOW_ANY_ATTACHMENT` | When `true`, accept attachments of any file type (not just the built-in PDF/text/zip/office allowlist). Unknown types are cached and surfaced to the agent as a local path so it can inspect them via `terminal` / `read_file` / `ffprobe`. Default `false`. |

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -280,6 +280,7 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_THREAD_REQUIRE_MENTION` | No | `false` | When `true`, the in-thread mention shortcut is disabled — threads are gated the same as channels, requiring `@mention` even after the bot has already participated. Use this when multiple bots share a thread and you want each to fire only on explicit `@mention`. |
 | `DISCORD_FREE_RESPONSE_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds without requiring an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `true`. |
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
+| `DISCORD_MENTION_EXEC_APPROVAL` | No | `false` | When `true`, dangerous-command approval prompts prepend `<@user_id> command approval needed` so the original requester gets a notification and won't miss the prompt. The approval message scopes `AllowedMentions` to that single validated user — `@everyone` and role pings remain denied even when `discord.allow_mentions.users` is `false`. |
 | `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
 | `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
 | `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
@@ -308,6 +309,7 @@ The `discord` section in `~/.hermes/config.yaml` mirrors the env vars above. Con
 discord:
   require_mention: true           # Require @mention in server channels
   thread_require_mention: false   # If true, require @mention in threads too (multi-bot threads)
+  mention_exec_approval: false    # Ping the requester on dangerous-command approvals
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
@@ -345,6 +347,16 @@ discord:
   require_mention: true
   thread_require_mention: true    # multi-bot setup
 ```
+
+#### `discord.mention_exec_approval`
+
+**Type:** boolean — **Default:** `false`
+
+When enabled, dangerous-command approval prompts prepend `<@user_id> command approval needed` so the original requester gets a Discord notification while the agent is blocked.
+
+The approval message restricts `AllowedMentions` to a single validated requester user ID, so this intentional ping still works if `discord.allow_mentions.users` is `false` globally. `@everyone` and role pings remain denied.
+
+The user ID is validated to be digit-only before mentioning. If invalid requester metadata arrives, the adapter logs a warning and sends the embed with no mention prefix.
 
 #### `discord.free_response_channels`
 


### PR DESCRIPTION
## Summary

Adds an opt-in Discord setting, `discord.mention_exec_approval` / `DISCORD_MENTION_EXEC_APPROVAL`, default `false`.

When enabled, dangerous-command approval prompts on Discord prepend `<@user_id> command approval needed` so the original requester gets notified while the agent is blocked waiting for approval.

The mention is constrained to a digit-only requester ID and the outgoing approval message uses per-message `AllowedMentions` restricted to that single user. `@everyone`, `@here`, role pings, and replied-user pings remain disabled.

## Configuration

```yaml
discord:
  mention_exec_approval: true
```

```bash
DISCORD_MENTION_EXEC_APPROVAL=true
```

If both are present, the environment variable wins. Blank or invalid env values stay disabled.

## Implementation

- Reads the YAML setting into Discord platform `extra`; does not seed process env from YAML, so gateway config reloads cannot get stuck behind a self-written env var.
- Adds approval-only metadata containing `requester_user_id` for Discord human requesters.
- Keeps normal status/progress metadata generic (`thread_id`, Telegram DM topic fallback, Feishu reply metadata).
- `send_exec_approval()` adds mention content only when the setting is enabled and the requester ID is digit-only.

## Verification

- `ulimit -n 4096 && ./scripts/run_tests.sh tests/gateway/test_config.py tests/gateway/test_discord_send.py tests/gateway/test_status_thread_metadata.py -q` — 87 passed
- `ulimit -n 4096 && ./scripts/run_tests.sh tests/gateway/test_tts_media_routing.py -q` — 6 passed
- `git diff --check upstream/main...HEAD`
- conflict-marker scan over changed files

Full `tests/gateway -q` was also attempted locally: the PR-relevant suites passed, while the run still had unrelated existing/baseline failures around `Platform.GOOGLE_CHAT` plugin enum registration plus two parallel timing failures that passed when rerun in isolation.

## Risk

Low: default off, requester IDs are validated before mention construction, and the mention allowlist is scoped per approval message.