### PR TITLE
fix: recreate stale Discord slash command shapes

### DIFF
--- a/contributors/emails/mwnickerson@icloud.com
+++ b/contributors/emails/mwnickerson@icloud.com
@@ -1,0 +1,2 @@
+mwnickerson
+# PR #21530 salvage

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2708,6 +2708,34 @@ class DiscordAdapter(BasePlatformAdapter):
             "options": canonical["options"],
         }
 
+    @staticmethod
+    def _requires_app_command_recreate(
+        current_payload: Dict[str, Any], desired_payload: Dict[str, Any]
+    ) -> bool:
+        """Return whether a command shape transition requires delete+create.
+
+        Discord rejects in-place edits that switch between nested command
+        options (subcommands or groups) and flat arguments. This occurs when
+        migrating the legacy nested ``/skill`` command to its current flat,
+        autocomplete-based form.
+        """
+
+        def _option_shape(payload: Dict[str, Any]) -> tuple[int, ...]:
+            return tuple(
+                int(item.get("type", 0) or 0)
+                for item in payload.get("options", []) or []
+                if isinstance(item, dict)
+            )
+
+        current_shape = _option_shape(current_payload)
+        desired_shape = _option_shape(desired_payload)
+        if current_shape == desired_shape:
+            return False
+
+        current_has_subcommands = any(option_type in (1, 2) for option_type in current_shape)
+        desired_has_subcommands = any(option_type in (1, 2) for option_type in desired_shape)
+        return current_has_subcommands != desired_has_subcommands
+
     async def _safe_sync_slash_commands(self) -> Dict[str, int]:
         """Diff existing global commands and only mutate the commands that changed."""
         if not self._client:
@@ -2782,7 +2810,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 unchanged += 1
                 continue
 
-            if self._patchable_app_command_payload(current_existing_payload) == self._patchable_app_command_payload(desired):
+            if (
+                self._patchable_app_command_payload(current_existing_payload)
+                == self._patchable_app_command_payload(desired)
+                or self._requires_app_command_recreate(current_existing_payload, desired)
+            ):
                 await mutate(http.delete_global_command, app_id, current.id)
                 await mutate(http.upsert_global_command, app_id, desired)
                 recreated += 1

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -81,6 +81,7 @@ from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
 class FakeTree:
     def __init__(self):
         self.commands = {}
+        self.fetched_commands = []
 
     def command(self, *, name, description):
         def decorator(fn):
@@ -93,7 +94,13 @@ class FakeTree:
         self.commands[cmd.name] = cmd
 
     def get_commands(self):
-        return [SimpleNamespace(name=n) for n in self.commands]
+        return [
+            command if hasattr(command, "to_dict") else SimpleNamespace(name=name)
+            for name, command in self.commands.items()
+        ]
+
+    async def fetch_commands(self):
+        return list(self.fetched_commands)
 
 
 @pytest.fixture
@@ -1145,3 +1152,76 @@ def test_register_skill_command_autocomplete_filters_by_name_and_description(ada
     # (covered in other tests). The autocomplete filter itself is exercised
     # via direct function call in the real-discord integration path.
     assert skill_cmd.callback is not None
+
+
+@pytest.mark.asyncio
+async def test_safe_sync_recreates_stale_nested_skill_command(adapter):
+    """A legacy nested /skill command is recreated as the current flat form."""
+    desired = {
+        "type": 1,
+        "name": "skill",
+        "description": "Run a Hermes skill",
+        "options": [
+            {
+                "type": 3,
+                "name": "name",
+                "description": "Which skill to run",
+                "required": True,
+                "autocomplete": True,
+            },
+            {
+                "type": 3,
+                "name": "args",
+                "description": "Optional arguments for the skill",
+                "required": False,
+            },
+        ],
+    }
+    adapter._client.tree.commands["skill"] = SimpleNamespace(to_dict=lambda _tree: desired)
+    adapter._client.tree.fetched_commands = [
+        SimpleNamespace(
+            id=777,
+            name="skill",
+            type=1,
+            to_dict=lambda: {
+                "type": 1,
+                "name": "skill",
+                "description": "Run a Hermes skill",
+                "options": [
+                    {
+                        "type": 2,
+                        "name": "media",
+                        "description": "Media skills",
+                        "options": [
+                            {
+                                "type": 1,
+                                "name": "gif-search",
+                                "description": "Search GIFs",
+                                "options": [],
+                            }
+                        ],
+                    }
+                ],
+            },
+            nsfw=False,
+            guild_only=False,
+            default_member_permissions=None,
+        )
+    ]
+    http = SimpleNamespace(
+        delete_global_command=AsyncMock(),
+        upsert_global_command=AsyncMock(),
+        edit_global_command=AsyncMock(),
+    )
+    adapter._client.http = http
+    adapter._client.application_id = 4242
+    adapter._sleep_between_command_sync_mutations = AsyncMock()
+
+    summary = await adapter._safe_sync_slash_commands()
+
+    assert summary["recreated"] == 1
+    assert summary["updated"] == 0
+    http.delete_global_command.assert_awaited_once_with(4242, 777)
+    http.upsert_global_command.assert_awaited_once_with(4242, desired)
+    http.edit_global_command.assert_not_awaited()
+    adapter._sleep_between_command_sync_mutations.assert_awaited_once_with()


### PR DESCRIPTION
## Summary
- Recreate stale Discord global slash commands when their option structure changes between nested subcommands/groups and flat arguments.
- Preserve safe-sync mutation throttling while avoiding invalid in-place edits for stale command shapes.
- Add a regression test for migrating a legacy nested `/skill` command to the flat autocomplete `/skill` form.

## Why
After updates, Discord can keep serving stale global command definitions. A production example is an older nested `/skill <category> <name>` command lingering remotely after Hermes moved to a flat autocomplete `/skill` command. Editing that shape in place can fail repeatedly during slash sync; delete + recreate is safer for this transition.

This supersedes #21520, which was opened from a locally misconfigured commit identity.

## Test plan
- `venv/bin/python -m pytest tests/gateway/test_discord_slash_commands.py -q -o 'addopts='`
