### PR TITLE
feat(agent): first-class llama.cpp provider with zero-config dashboard surfacing

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -197,6 +197,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("LM_API_KEY",),
         base_url_env_var="LM_BASE_URL",
     ),
+    "llama-cpp": ProviderConfig(
+        id="llama-cpp",
+        name="llama.cpp",
+        auth_type="api_key",
+        inference_base_url="http://127.0.0.1:8088/v1",
+        api_key_env_vars=("LLAMA_CPP_API_KEY",),
+        base_url_env_var="LLAMA_CPP_BASE_URL",
+    ),
     "copilot": ProviderConfig(
         id="copilot",
         name="GitHub Copilot",
@@ -1405,10 +1413,11 @@ def resolve_provider(
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
         "lmstudio": "lmstudio", "lm-studio": "lmstudio", "lm_studio": "lmstudio",
-        # Local server aliases — route through the generic custom provider
+        # Local server aliases — route through the generic custom provider.
+        # llama.cpp aliases are intentionally NOT here so the dedicated
+        # `llama-cpp` provider plugin's aliases (auto-extended below) win.
         "ollama": "custom", "ollama_cloud": "ollama-cloud",
-        "vllm": "custom", "llamacpp": "custom",
-        "llama.cpp": "custom", "llama-cpp": "custom",
+        "vllm": "custom",
     }
     # Extend with aliases declared in plugins/model-providers/<name>/ that aren't already mapped.
     # This keeps providers/ as the single source for new aliases while the

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1200,6 +1200,66 @@ def list_authenticated_providers(
             live = [current_model]
         curated["lmstudio"] = live
 
+    # llama.cpp also has no static catalog — `llama-server` exposes /v1/models
+    # populated from whatever GGUF is loaded. Probe it whenever there's a hint
+    # the user wants llama.cpp surfaced (env vars set, current provider matches,
+    # or — for zero-config UX — the local server is reachable at the default
+    # 127.0.0.1:8088). This makes the picker "magically" show llama.cpp once
+    # `scripts/start-llama-server.sh` is running.
+    #
+    # Unlike LM Studio, llama-server typically runs without auth, so we surface
+    # the row directly here (bypassing the env-var credential gate in
+    # section 2b) whenever the live probe returns models.
+    if "llama-cpp" not in seen_slugs:
+        _llama_aliases = {"llama-cpp", "llamacpp", "llama.cpp", "llama_cpp", "llama-server"}
+        is_current_llama = current_provider.strip().lower() in _llama_aliases
+        llama_env_hint = bool(
+            os.environ.get("LLAMA_CPP_API_KEY") or os.environ.get("LLAMA_CPP_BASE_URL")
+        )
+        llama_base = (
+            os.environ.get("LLAMA_CPP_BASE_URL")
+            or (current_base_url if is_current_llama and current_base_url else None)
+            or "http://127.0.0.1:8088/v1"
+        )
+        if llama_env_hint or is_current_llama:
+            probe_timeout = 1.5
+        else:
+            # Cold-discovery probe: tight timeout so an offline server doesn't
+            # delay the picker by more than ~300 ms.
+            probe_timeout = 0.3
+        try:
+            from providers import get_provider_profile as _gpp
+            _llama_profile = _gpp("llama-cpp")
+            if _llama_profile is not None:
+                _saved_url = _llama_profile.base_url
+                _llama_profile.base_url = llama_base
+                try:
+                    live = _llama_profile.fetch_models(
+                        api_key=os.environ.get("LLAMA_CPP_API_KEY", "") or None,
+                        timeout=probe_timeout,
+                    ) or []
+                finally:
+                    _llama_profile.base_url = _saved_url
+            else:
+                live = []
+        except Exception:
+            live = []
+        if not live and is_current_llama and current_model:
+            live = [current_model]
+        if live:
+            curated["llama-cpp"] = live
+            results.append({
+                "slug": "llama-cpp",
+                "name": "llama.cpp",
+                "is_current": is_current_llama,
+                "is_user_defined": False,
+                "models": live[:max_models],
+                "total_models": len(live),
+                "source": "built-in",
+            })
+            seen_slugs.add("llama-cpp")
+            _builtin_endpoints.add(_norm_url(llama_base))
+
     # --- 1. Check Hermes-mapped providers ---
     for hermes_id, mdev_id in PROVIDER_TO_MODELS_DEV.items():
         # Skip aliases that map to the same models.dev provider (e.g.

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1063,6 +1063,10 @@ _PROVIDER_ALIASES = {
     "lm_studio": "lmstudio",
     "ollama": "custom",  # bare "ollama" = local; use "ollama-cloud" for cloud
     "ollama_cloud": "ollama-cloud",
+    "llamacpp": "llama-cpp",
+    "llama.cpp": "llama-cpp",
+    "llama_cpp": "llama-cpp",
+    "llama-server": "llama-cpp",
 }
 
 

--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -57,9 +57,6 @@ custom = CustomProfile(
         "ollama",
         "local",
         "vllm",
-        "llamacpp",
-        "llama.cpp",
-        "llama-cpp",
     ),
     env_vars=(),  # No fixed key — custom endpoint
     base_url="",  # User-configured

--- a/plugins/model-providers/llama-cpp/__init__.py
+++ b/plugins/model-providers/llama-cpp/__init__.py
@@ -1,0 +1,64 @@
+"""llama.cpp provider profile.
+
+First-class support for llama.cpp's `llama-server` — the OpenAI-compatible
+HTTP endpoint shipped with the upstream binary. Hermes can already reach
+any OpenAI-compatible URL via `--provider custom`; this profile exists so
+that local llama.cpp users get:
+
+  - a zero-config default (http://127.0.0.1:8088/v1) that lines up with
+    `scripts/start-llama-server.sh`
+  - a `hermes model` menu entry without setting `OPENAI_BASE_URL` by hand
+  - graceful behaviour when the local server is offline (fetch_models
+    returns None instead of raising)
+
+Auth: llama-server runs without auth by default. If users boot it with
+`--api-key`, set `LLAMA_CPP_API_KEY` to the same value. Base URL is
+overridable via `LLAMA_CPP_BASE_URL` for non-default ports / remote hosts.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from providers import register_provider
+from providers.base import ProviderProfile
+
+logger = logging.getLogger(__name__)
+
+
+class LlamaCppProfile(ProviderProfile):
+    """llama.cpp llama-server profile — local-first, model-agnostic."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: float = 4.0,
+    ) -> list[str] | None:
+        """Hit `${base_url}/models` quietly — local server may not be up."""
+        if not self.base_url:
+            return None
+        try:
+            return super().fetch_models(api_key=api_key, timeout=timeout)
+        except Exception as exc:
+            logger.debug("llama-cpp fetch_models failed (server offline?): %s", exc)
+            return None
+
+
+llama_cpp = LlamaCppProfile(
+    name="llama-cpp",
+    aliases=(
+        "llamacpp",
+        "llama.cpp",
+        "llama_cpp",
+        "llama-server",
+    ),
+    display_name="llama.cpp",
+    description="llama.cpp — local OpenAI-compatible inference (llama-server)",
+    signup_url="https://github.com/ggml-org/llama.cpp/releases",
+    env_vars=("LLAMA_CPP_API_KEY", "LLAMA_CPP_BASE_URL"),
+    base_url="http://127.0.0.1:8088/v1",
+    auth_type="api_key",
+)
+
+register_provider(llama_cpp)

--- a/plugins/model-providers/llama-cpp/plugin.yaml
+++ b/plugins/model-providers/llama-cpp/plugin.yaml
@@ -1,0 +1,5 @@
+name: llama-cpp-provider
+kind: model-provider
+version: 1.0.0
+description: llama.cpp llama-server (local OpenAI-compatible endpoint)
+author: Nous Research

--- a/scripts/start-llama-server.sh
+++ b/scripts/start-llama-server.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# start-llama-server.sh — turnkey llama-server startup that lines up with
+# Hermes' built-in `llama-cpp` provider.
+#
+# Boots llama.cpp's llama-server on the same host:port that the
+# `plugins/model-providers/llama-cpp/` profile defaults to
+# (http://127.0.0.1:8088/v1). After this script is running,
+#
+#   hermes chat --provider llama-cpp --model <whatever>
+#
+# works with no further config. To override the port/host, set PORT / HOST
+# below AND export LLAMA_CPP_BASE_URL=http://${HOST}:${PORT}/v1 so Hermes
+# follows.
+#
+# Usage:
+#   start-llama-server.sh <gguf-path>
+#   start-llama-server.sh ~/models/some-model.gguf
+#
+# Or with explicit overrides:
+#   PORT=9000 CTX=32768 THREADS=8 start-llama-server.sh <gguf>
+#
+# Requires: llama-server binary on PATH (or LLAMA_SERVER env var pointing to it)
+#           See https://github.com/ggml-org/llama.cpp/releases for prebuilt binaries.
+
+set -e
+
+GGUF="${1:-}"
+PORT="${PORT:-8088}"
+CTX="${CTX:-16384}"
+THREADS="${THREADS:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 8)}"
+HOST="${HOST:-127.0.0.1}"
+N_GPU_LAYERS="${N_GPU_LAYERS:-0}"   # 0=CPU only; -1=all layers on GPU; positive int = N layers
+LLAMA_SERVER="${LLAMA_SERVER:-llama-server}"
+
+if [ -z "$GGUF" ]; then
+  cat << 'USAGE'
+Usage: start-llama-server.sh <path-to-gguf>
+
+Environment overrides:
+  PORT=8088              Server port (matches Hermes llama-cpp provider default)
+  CTX=16384              Context window
+  THREADS=12             CPU threads
+  N_GPU_LAYERS=0         0=CPU only, -1=all layers on GPU, positive int=N layers
+  LLAMA_SERVER=llama-server   Path to llama-server binary
+
+After boot:
+  hermes chat --provider llama-cpp --model <model-id-from-/v1/models>
+USAGE
+  exit 1
+fi
+
+[ ! -f "$GGUF" ] && { echo "ERROR: GGUF file not found: $GGUF"; exit 2; }
+
+if ! command -v "$LLAMA_SERVER" >/dev/null 2>&1; then
+  cat << 'EOF'
+ERROR: llama-server not found on PATH.
+
+Install:
+  Linux x86_64: https://github.com/ggml-org/llama.cpp/releases
+  macOS:        brew install llama.cpp
+  Pip:          pip install llama-cpp-python[server]
+                # then: python -m llama_cpp.server --model <gguf> --port 8088
+
+Or set LLAMA_SERVER=/path/to/llama-server explicitly.
+EOF
+  exit 3
+fi
+
+echo "=== llama-server boot ==="
+echo "  model:       $GGUF"
+echo "  endpoint:    http://${HOST}:${PORT}/v1"
+echo "  context:     $CTX"
+echo "  threads:     $THREADS"
+echo "  gpu layers:  $N_GPU_LAYERS"
+echo ""
+
+# Hermes alignment hint
+EXPECTED_BASE_URL="http://127.0.0.1:8088/v1"
+ACTUAL_BASE_URL="http://${HOST}:${PORT}/v1"
+if [ "$ACTUAL_BASE_URL" != "$EXPECTED_BASE_URL" ]; then
+  echo "  NOTE: Hermes' llama-cpp provider defaults to ${EXPECTED_BASE_URL}."
+  echo "        Override with: export LLAMA_CPP_BASE_URL=${ACTUAL_BASE_URL}"
+  echo ""
+else
+  echo "  Hermes: ready — run 'hermes chat --provider llama-cpp'"
+  echo ""
+fi
+
+# --jinja loads the model's chat template, which is required for any GGUF
+# that needs Jinja-rendered tool-call messages.
+ARGS=(
+  -m "$GGUF"
+  --host "$HOST"
+  --port "$PORT"
+  --ctx-size "$CTX"
+  --threads "$THREADS"
+  --jinja
+  --n-gpu-layers "$N_GPU_LAYERS"
+)
+
+exec "$LLAMA_SERVER" "${ARGS[@]}"

--- a/scripts/start-llama-server.sh
+++ b/scripts/start-llama-server.sh
@@ -18,6 +18,7 @@
 #
 # Or with explicit overrides:
 #   PORT=9000 CTX=32768 THREADS=8 start-llama-server.sh <gguf>
+#   N_GPU_LAYERS=0 start-llama-server.sh <gguf>   # force CPU-only, skip auto-detect
 #
 # Requires: llama-server binary on PATH (or LLAMA_SERVER env var pointing to it)
 #           See https://github.com/ggml-org/llama.cpp/releases for prebuilt binaries.
@@ -29,7 +30,10 @@ PORT="${PORT:-8088}"
 CTX="${CTX:-16384}"
 THREADS="${THREADS:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 8)}"
 HOST="${HOST:-127.0.0.1}"
-N_GPU_LAYERS="${N_GPU_LAYERS:-0}"   # 0=CPU only; -1=all layers on GPU; positive int = N layers
+# N_GPU_LAYERS is intentionally left unset here (not defaulted to 0) so the
+# auto-detect block below can tell "user didn't set it" apart from
+# "user explicitly asked for CPU-only with N_GPU_LAYERS=0". See
+# detect_llama_gpu_backend() / detect_system_gpu() for how the guess is made.
 LLAMA_SERVER="${LLAMA_SERVER:-llama-server}"
 
 if [ -z "$GGUF" ]; then
@@ -40,7 +44,10 @@ Environment overrides:
   PORT=8088              Server port (matches Hermes llama-cpp provider default)
   CTX=16384              Context window
   THREADS=12             CPU threads
-  N_GPU_LAYERS=0         0=CPU only, -1=all layers on GPU, positive int=N layers
+  N_GPU_LAYERS           Unset = auto-detect (offload all layers if a GPU +
+                         GPU-enabled llama-server build are both found, else
+                         CPU-only). Set explicitly to override: 0=CPU only,
+                         -1=all layers on GPU, positive int=N layers.
   LLAMA_SERVER=llama-server   Path to llama-server binary
 
 After boot:
@@ -64,6 +71,97 @@ Install:
 Or set LLAMA_SERVER=/path/to/llama-server explicitly.
 EOF
   exit 3
+fi
+
+# --- GPU auto-detection ------------------------------------------------
+#
+# Two independent questions, both required for GPU offload to actually work:
+#   1. Does this machine have a GPU at all?
+#   2. Was THIS llama-server binary built with a GPU backend?
+#
+# The second question matters more than it looks. The official llama.cpp
+# release binaries for Linux ship several separate builds (cpu, vulkan,
+# rocm, sycl) — there is no prebuilt CUDA build for Linux at all, only for
+# Windows. So it's entirely possible to have an NVIDIA GPU, a `llama-server`
+# binary on PATH, and `-ngl 999` set, and still be running 100% on CPU with
+# zero warning, because that particular binary was compiled CPU-only. This
+# is not a hypothetical: it's what happened during this script's own
+# development on Linux/NVIDIA, silently, for a while. Vulkan is the fix on
+# Linux + NVIDIA/AMD/Intel — it works with the vendor's normal display
+# driver, no CUDA toolkit install needed, and there IS a prebuilt Linux
+# Vulkan release.
+#
+# GPU backends load as shared libraries alongside the llama-server binary
+# (libggml-cuda*, libggml-vulkan*, libggml-metal*, libggml-hip*,
+# libggml-sycl*). Their presence is a much cheaper and more reliable check
+# than trying to parse startup log output, and doesn't require spinning up
+# a throwaway server process just to inspect it.
+
+detect_llama_gpu_backend() {
+  local server_bin server_dir
+  server_bin="$(command -v "$LLAMA_SERVER" 2>/dev/null || echo "$LLAMA_SERVER")"
+  server_dir="$(dirname "$server_bin")"
+  if ls "$server_dir"/libggml-cuda* >/dev/null 2>&1; then echo "cuda"; return; fi
+  if ls "$server_dir"/libggml-vulkan* >/dev/null 2>&1; then echo "vulkan"; return; fi
+  if ls "$server_dir"/libggml-metal* >/dev/null 2>&1; then echo "metal"; return; fi
+  if ls "$server_dir"/libggml-hip* >/dev/null 2>&1; then echo "hip"; return; fi
+  if ls "$server_dir"/libggml-sycl* >/dev/null 2>&1; then echo "sycl"; return; fi
+  echo "none"
+}
+
+detect_system_gpu() {
+  if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
+    echo "nvidia"; return
+  fi
+  if [ "$(uname)" = "Darwin" ]; then
+    echo "apple"; return   # Metal is always available on macOS
+  fi
+  if command -v rocm-smi >/dev/null 2>&1 && rocm-smi >/dev/null 2>&1; then
+    echo "amd"; return
+  fi
+  if command -v lspci >/dev/null 2>&1 && lspci 2>/dev/null | grep -qiE 'vga|3d controller'; then
+    echo "present"; return   # a GPU exists but vendor tooling isn't on PATH to name it
+  fi
+  echo "none"
+}
+
+GPU_BACKEND="$(detect_llama_gpu_backend)"
+SYSTEM_GPU="$(detect_system_gpu)"
+
+if [ -z "${N_GPU_LAYERS+x}" ]; then
+  # Not explicitly set by the caller — auto-detect.
+  if [ "$GPU_BACKEND" != "none" ] && [ "$SYSTEM_GPU" != "none" ]; then
+    N_GPU_LAYERS=999
+    echo "  auto-detect: GPU ($SYSTEM_GPU) + $GPU_BACKEND-enabled llama-server -> offloading all layers"
+  else
+    N_GPU_LAYERS=0
+    if [ "$SYSTEM_GPU" != "none" ] && [ "$GPU_BACKEND" = "none" ]; then
+      cat >&2 << EOF
+  WARNING: a GPU was detected ($SYSTEM_GPU) but this llama-server binary has
+           no GPU backend compiled in (no libggml-cuda/vulkan/metal/hip/sycl
+           found next to it at: $(dirname "$(command -v "$LLAMA_SERVER")")).
+           Falling back to CPU-only.
+           Fix: grab a GPU-enabled build from
+           https://github.com/ggml-org/llama.cpp/releases
+           On Linux + NVIDIA/AMD/Intel, the *-vulkan-* build is the easy
+           path — no CUDA toolkit needed, works with your normal display
+           driver. (There is no official prebuilt CUDA build for Linux;
+           CUDA requires building llama.cpp from source there.)
+EOF
+    fi
+  fi
+else
+  # Caller set N_GPU_LAYERS explicitly — respect it, but still warn loudly
+  # if it can't possibly do anything (the exact silent-CPU-fallback trap
+  # described above).
+  if [ "$N_GPU_LAYERS" != "0" ] && [ "$GPU_BACKEND" = "none" ]; then
+    cat >&2 << EOF
+  WARNING: N_GPU_LAYERS=$N_GPU_LAYERS is set, but this llama-server binary has
+           no GPU backend compiled in — it will silently run on CPU
+           regardless of this setting. See the auto-detect note above for
+           how to get a GPU-enabled build.
+EOF
+  fi
 fi
 
 echo "=== llama-server boot ==="

--- a/tests/providers/test_llama_cpp_profile.py
+++ b/tests/providers/test_llama_cpp_profile.py
@@ -1,0 +1,170 @@
+"""Tests for the llama-cpp provider profile."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+def _clear_provider_caches():
+    """Force providers/__init__.py to re-discover on next list_providers()."""
+    import providers as _pkg
+
+    _pkg._REGISTRY.clear()
+    _pkg._ALIASES.clear()
+    _pkg._discovered = False
+    for mod in list(sys.modules.keys()):
+        if (
+            mod.startswith("plugins.model_providers")
+            or mod.startswith("_hermes_user_provider")
+        ):
+            del sys.modules[mod]
+
+
+@pytest.fixture(autouse=True)
+def _isolated_registry():
+    _clear_provider_caches()
+    yield
+    _clear_provider_caches()
+
+
+def test_llama_cpp_registers():
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("llama-cpp")
+    assert profile is not None
+    assert profile.name == "llama-cpp"
+
+
+def test_llama_cpp_aliases_resolve():
+    from providers import get_provider_profile
+
+    for alias in ("llamacpp", "llama.cpp", "llama_cpp", "llama-server"):
+        profile = get_provider_profile(alias)
+        assert profile is not None, f"alias {alias!r} did not resolve"
+        assert profile.name == "llama-cpp", (
+            f"alias {alias!r} resolved to {profile.name!r}"
+        )
+
+
+def test_llama_cpp_default_base_url_matches_launcher_script():
+    """The plugin's base_url must line up with scripts/start-llama-server.sh
+    so users get zero-config UX out of the box."""
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("llama-cpp")
+    assert profile.base_url == "http://127.0.0.1:8088/v1"
+
+
+def test_llama_cpp_env_vars():
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("llama-cpp")
+    assert "LLAMA_CPP_API_KEY" in profile.env_vars
+    assert "LLAMA_CPP_BASE_URL" in profile.env_vars
+
+
+def test_llama_cpp_uses_chat_completions_api_mode():
+    """llama-server speaks OpenAI chat-completions; no native adapter needed."""
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("llama-cpp")
+    assert profile.api_mode == "chat_completions"
+
+
+def test_custom_no_longer_claims_llamacpp_aliases():
+    """The llama.cpp aliases moved off the `custom` profile onto the dedicated
+    `llama-cpp` profile. Make sure custom didn't keep them."""
+    from providers import get_provider_profile
+
+    custom = get_provider_profile("custom")
+    assert custom is not None
+    for alias in ("llamacpp", "llama.cpp", "llama-cpp", "llama_cpp"):
+        assert alias not in custom.aliases, (
+            f"alias {alias!r} should have moved off `custom` onto `llama-cpp`"
+        )
+
+
+def test_fetch_models_returns_none_when_server_offline():
+    """The override must swallow connection errors — local server may not be up."""
+    from providers import get_provider_profile
+
+    profile = get_provider_profile("llama-cpp")
+    # 127.0.0.1:1 is guaranteed-closed on every CI box.
+    profile.base_url = "http://127.0.0.1:1/v1"
+    try:
+        result = profile.fetch_models(timeout=0.5)
+    finally:
+        profile.base_url = "http://127.0.0.1:8088/v1"
+    assert result is None
+
+
+def test_llama_cpp_in_canonical_providers():
+    """Plugin must auto-extend hermes_cli.models.CANONICAL_PROVIDERS so the
+    `hermes model` TUI picker shows llama.cpp without further wiring."""
+    from hermes_cli.models import CANONICAL_PROVIDERS
+
+    slugs = [p.slug for p in CANONICAL_PROVIDERS]
+    assert "llama-cpp" in slugs
+    entry = next(p for p in CANONICAL_PROVIDERS if p.slug == "llama-cpp")
+    assert entry.label == "llama.cpp"
+    assert "local" in entry.tui_desc.lower()
+
+
+def test_llama_cpp_in_provider_registry():
+    """auth.PROVIDER_REGISTRY must contain llama-cpp so runtime resolution +
+    dashboard /api/model/options can authenticate (or skip auth) cleanly."""
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    assert "llama-cpp" in PROVIDER_REGISTRY
+    cfg = PROVIDER_REGISTRY["llama-cpp"]
+    assert cfg.auth_type == "api_key"
+    assert cfg.inference_base_url == "http://127.0.0.1:8088/v1"
+    assert cfg.api_key_env_vars == ("LLAMA_CPP_API_KEY",)
+    assert cfg.base_url_env_var == "LLAMA_CPP_BASE_URL"
+
+
+def test_resolve_provider_accepts_all_aliases():
+    """`hermes --provider <alias>` and `HERMES_INFERENCE_PROVIDER=<alias>` must
+    resolve every llama.cpp alias to the canonical `llama-cpp` slug."""
+    from hermes_cli.auth import resolve_provider
+
+    for alias in ("llama-cpp", "llamacpp", "llama.cpp", "llama_cpp", "llama-server"):
+        assert resolve_provider(alias) == "llama-cpp", (
+            f"alias {alias!r} should resolve to 'llama-cpp'"
+        )
+
+
+def test_picker_surfaces_llama_cpp_when_current_even_without_server(monkeypatch):
+    """Dashboard /api/model/options + `hermes model` must show llama.cpp when
+    it's the user's current provider, even if the local server is offline —
+    so users don't lose access to it after restart."""
+    monkeypatch.delenv("LLAMA_CPP_API_KEY", raising=False)
+    monkeypatch.delenv("LLAMA_CPP_BASE_URL", raising=False)
+
+    from hermes_cli.model_switch import list_authenticated_providers
+
+    rows = list_authenticated_providers(
+        current_provider="llama-cpp",
+        current_model="my-loaded-model",
+    )
+    matches = [r for r in rows if r["slug"] == "llama-cpp"]
+    assert len(matches) == 1, f"expected 1 llama-cpp row, got {len(matches)}"
+    row = matches[0]
+    assert row["is_current"] is True
+    assert row["models"] == ["my-loaded-model"]
+    assert row["source"] == "built-in"
+
+
+def test_picker_does_not_clutter_when_server_offline_and_not_current(monkeypatch):
+    """With no env vars, no current selection, and no live server, the picker
+    must NOT inject a llama-cpp row — keeps the list tidy for users who don't
+    use llama.cpp."""
+    monkeypatch.delenv("LLAMA_CPP_API_KEY", raising=False)
+    monkeypatch.delenv("LLAMA_CPP_BASE_URL", raising=False)
+
+    from hermes_cli.model_switch import list_authenticated_providers
+
+    rows = list_authenticated_providers()
+    assert "llama-cpp" not in [r["slug"] for r in rows]

--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -46,19 +46,20 @@ def test_bundled_plugins_discovered():
         assert (child / "plugin.yaml").exists(), f"{child.name} missing plugin.yaml"
 
 
-def test_all_34_profiles_register():
-    """After discovery, the registry must contain exactly 34 distinct profiles."""
+def test_all_35_profiles_register():
+    """After discovery, the registry must contain exactly 35 distinct profiles."""
     _clear_provider_caches()
     from providers import list_providers
 
     profiles = list_providers()
     names = sorted(p.name for p in profiles)
-    assert len(names) == 34, f"Expected 34 profiles, got {len(names)}: {names}"
+    assert len(names) == 35, f"Expected 35 profiles, got {len(names)}: {names}"
 
     # Spot-check representative providers from different categories
     for required in (
         "openrouter", "anthropic", "custom", "bedrock", "openai-codex",
         "minimax-oauth", "gmi", "xiaomi", "alibaba-coding-plan",
+        "llama-cpp", "novita",
     ):
         assert required in names, f"Missing profile: {required}"
 

--- a/website/docs/guides/local-llamacpp-setup.md
+++ b/website/docs/guides/local-llamacpp-setup.md
@@ -1,0 +1,101 @@
+---
+sidebar_position: 10
+title: "Run Hermes Locally with llama.cpp"
+description: "Use llama.cpp's llama-server as a fully local OpenAI-compatible backend for Hermes Agent — zero cloud API cost"
+---
+
+# Run Hermes Locally with llama.cpp
+
+llama.cpp ships an HTTP server (`llama-server`) that speaks the OpenAI
+chat-completions wire format. Hermes has a built-in `llama-cpp` provider
+that points at it — once the server is running, `hermes chat --provider
+llama-cpp` works with no further config.
+
+This guide is the llama.cpp counterpart to [Run Hermes Locally with
+Ollama](./local-ollama-setup.md). Pick whichever backend you prefer;
+llama.cpp gives you finer control over GGUF files, quantization, and
+threading, while Ollama wraps that in a friendlier model manager.
+
+## What you need
+
+- a `.gguf` model file (any quant) — grab one from any source you trust
+- `llama-server` on your `$PATH`
+
+## Step 1: Install llama.cpp
+
+```bash
+# macOS
+brew install llama.cpp
+
+# Linux (prebuilt)
+# https://github.com/ggml-org/llama.cpp/releases  →  pick a llama-bXXXX-bin-* tarball
+
+# Or from pip
+pip install 'llama-cpp-python[server]'
+```
+
+Verify:
+
+```bash
+llama-server --help | head
+```
+
+## Step 2: Boot the server
+
+The repo ships a launcher that lines up with Hermes' built-in defaults:
+
+```bash
+./scripts/start-llama-server.sh ~/models/your-model.gguf
+```
+
+That brings the server up at `http://127.0.0.1:8088/v1` — exactly where
+Hermes' `llama-cpp` provider looks by default.
+
+Override with environment variables:
+
+```bash
+PORT=9000 CTX=32768 N_GPU_LAYERS=-1 ./scripts/start-llama-server.sh ~/models/foo.gguf
+```
+
+If you change the port or host, also tell Hermes:
+
+```bash
+export LLAMA_CPP_BASE_URL=http://127.0.0.1:9000/v1
+```
+
+## Step 3: Point Hermes at it
+
+```bash
+hermes chat --provider llama-cpp
+```
+
+Or set it permanently in `~/.hermes/config.yaml`:
+
+```yaml
+model:
+  provider: llama-cpp
+  default: <model-id-as-reported-by-/v1/models>
+```
+
+The model id Hermes uses comes straight from `${LLAMA_CPP_BASE_URL}/models`,
+which `llama-server` populates from whatever GGUF you loaded. You can also
+just pass `--model anything` — `llama-server` ignores the field when only
+one model is loaded.
+
+## Optional: API key
+
+`llama-server` runs without auth by default. If you start it with
+`--api-key <token>`, mirror that in Hermes:
+
+```bash
+export LLAMA_CPP_API_KEY=<token>
+```
+
+## Reference
+
+- Provider id: `llama-cpp`
+- Aliases: `llamacpp`, `llama.cpp`, `llama_cpp`, `llama-server`
+- Default base URL: `http://127.0.0.1:8088/v1`
+- Env vars: `LLAMA_CPP_API_KEY`, `LLAMA_CPP_BASE_URL`
+- Profile source: [`plugins/model-providers/llama-cpp/`](https://github.com/NousResearch/hermes-agent/tree/main/plugins/model-providers/llama-cpp)
+- Launcher: [`scripts/start-llama-server.sh`](https://github.com/NousResearch/hermes-agent/blob/main/scripts/start-llama-server.sh)

--- a/website/docs/guides/local-llamacpp-setup.md
+++ b/website/docs/guides/local-llamacpp-setup.md
@@ -51,11 +51,29 @@ The repo ships a launcher that lines up with Hermes' built-in defaults:
 That brings the server up at `http://127.0.0.1:8088/v1` — exactly where
 Hermes' `llama-cpp` provider looks by default.
 
+**GPU offload is auto-detected** — if you don't set `N_GPU_LAYERS`, the
+launcher checks whether this machine has a GPU (`nvidia-smi`, macOS/Metal,
+`rocm-smi`, or `lspci`) *and* whether your `llama-server` binary actually has
+a GPU backend compiled in (looks for `libggml-cuda`/`vulkan`/`metal`/`hip`/
+`sycl` next to the binary). Only offloads all layers if both are true.
+
+This second check matters more than it sounds like it should. The official
+llama.cpp Linux releases ship several separate builds — cpu, vulkan, rocm,
+sycl — and **there is no prebuilt CUDA build for Linux**, only for Windows.
+It's entirely possible to have an NVIDIA GPU, `llama-server` on PATH, and
+`-ngl 999` set, and still be running 100% on CPU with no error, because that
+particular binary happens to be the CPU-only one. If the launcher detects
+exactly that mismatch, it prints a warning instead of failing silently. On
+Linux with an NVIDIA/AMD/Intel GPU, grab the `*-vulkan-*` release asset —
+it works with your normal display driver, no CUDA toolkit needed.
+
 Override with environment variables:
 
 ```bash
 PORT=9000 CTX=32768 N_GPU_LAYERS=-1 ./scripts/start-llama-server.sh ~/models/foo.gguf
 ```
+
+Set `N_GPU_LAYERS=0` explicitly to force CPU-only and skip auto-detection.
 
 If you change the port or host, also tell Hermes:
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -75,6 +75,8 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `STEPFUN_BASE_URL` | Override StepFun base URL (default: `https://api.stepfun.com/v1`) |
 | `OLLAMA_API_KEY` | Ollama Cloud API key — managed Ollama catalog without local GPU ([ollama.com/settings/keys](https://ollama.com/settings/keys)) |
 | `OLLAMA_BASE_URL` | Override Ollama Cloud base URL (default: `https://ollama.com/v1`) |
+| `LLAMA_CPP_API_KEY` | Optional bearer token for `llama-server` when started with `--api-key` (most local setups leave this unset) |
+| `LLAMA_CPP_BASE_URL` | Override llama.cpp base URL (default: `http://127.0.0.1:8088/v1`; matches `scripts/start-llama-server.sh`) |
 | `XAI_API_KEY` | xAI (Grok) API key for chat + TTS ([console.x.ai](https://console.x.ai/)) |
 | `XAI_BASE_URL` | Override xAI base URL (default: `https://api.x.ai/v1`) |
 | `MISTRAL_API_KEY` | Mistral API key for Voxtral TTS and Voxtral STT ([console.mistral.ai](https://console.mistral.ai)) |
@@ -105,7 +107,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 
 | Variable | Description |
 |----------|-------------|
-| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `custom`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `novita`, `gemini`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth` (browser OAuth login — no API key required; see [MiniMax OAuth guide](../guides/minimax-oauth.md)), `kilocode`, `xiaomi`, `arcee`, `gmi`, `stepfun`, `alibaba`, `alibaba-coding-plan` (alias `alibaba_coding`), `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `google-gemini-cli`, `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `ai-gateway`, `tencent-tokenhub` (default: `auto`) |
+| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `custom`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `novita`, `gemini`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth` (browser OAuth login — no API key required; see [MiniMax OAuth guide](../guides/minimax-oauth.md)), `kilocode`, `xiaomi`, `arcee`, `gmi`, `stepfun`, `alibaba`, `alibaba-coding-plan` (alias `alibaba_coding`), `deepseek`, `nvidia`, `ollama-cloud`, `llama-cpp` (aliases `llamacpp`, `llama.cpp`, `llama-server`), `xai` (alias `grok`), `google-gemini-cli`, `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `ai-gateway`, `tencent-tokenhub` (default: `auto`) |
 | `HERMES_PORTAL_BASE_URL` | Override Nous Portal URL (for development/testing) |
 | `NOUS_INFERENCE_BASE_URL` | Override Nous inference API URL |
 | `HERMES_NOUS_MIN_KEY_TTL_SECONDS` | Min agent key TTL before re-mint (default: 1800 = 30min) |


### PR DESCRIPTION
## What does this PR do?

Two coherent pieces of work landing together so a llama.cpp user has an end-to-end zero-config path:

**A. First-class `llama-cpp` provider.** Today users can already point Hermes at `llama-server` via `--provider custom`, but that path requires hand-setting `OPENAI_BASE_URL`, the model picker doesn't list it, and the dashboard has no way to surface a running server. This PR adds a proper `llama-cpp` provider plugin so the picker, the dashboard, `--provider` flag, `HERMES_INFERENCE_PROVIDER`, and config.yaml all know about it natively. Crucially, it includes a probe-and-surface block in `list_authenticated_providers` that picks up a running `llama-server` automatically — no env vars required.

**B. `scripts/start-llama-server.sh`** — explicit resubmission per @teknium1's invitation in [`#19796 (comment)`](https://github.com/NousResearch/hermes-agent/pull/19796#issuecomment-4399231117):

> scripts/start-llama-server.sh was out of scope for the web-search story so it didn't land — happy to review that as a separate PR (or skill) if you want to resubmit.

The launcher's defaults (port `8088`) line up with the new provider's default base URL, so the end-to-end flow becomes:

```
./scripts/start-llama-server.sh ~/models/your-model.gguf
hermes chat --provider llama-cpp
```

## Related Issues / PRs

- Refs **#523** — partially delivers Phase 2 (llama.cpp setup guide) and Phase 3 (auto-detection of running local servers, scoped to llama.cpp). Ollama and vLLM coverage from that issue's roadmap remain out of scope here.
- Refs **#10375** — sidesteps the custom-endpoint 400-error path by giving llama.cpp users a dedicated provider that doesn't go through the generic `custom` flow. Underlying bug in the custom-endpoint code is unchanged.
- Follow-up to **#19796** (closed) — the search-backend portion shipped via [#21337](https://github.com/NousResearch/hermes-agent/pull/21337) (merged, authorship preserved on `04193cf71`); SearXNG shipped via `cd2cbc73b` / `5c906d702`. The launcher was the one piece deferred there, and it's resubmitted here per teknium's invitation. No content collision with `tools/web_providers/` — that package is web-search only; this PR adds a model-provider plugin under `plugins/model-providers/`.
- Supersedes **#19607** (closed). That PR's `local_web_tools.py` is obsolete (replaced by `tools/web_providers/` post-merge); only the launcher needed to land, which this PR carries forward — stripped of model-family-specific detection so it's pure llama.cpp.

Not claiming `Closes` on any of these — feature requests partially delivered should stay open for maintainers to retitle/scope.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding test coverage)

## Changes Made

### Provider plugin

- **`plugins/model-providers/llama-cpp/`** (new) — `LlamaCppProfile` with default base_url `http://127.0.0.1:8088/v1`, aliases `llamacpp` / `llama.cpp` / `llama_cpp` / `llama-server`, and an offline-tolerant `fetch_models` override that returns `None` instead of raising when the local server is down.
- **`plugins/model-providers/custom/__init__.py`** — drops the `llamacpp` / `llama.cpp` / `llama-cpp` aliases from the generic `custom` profile so the dedicated provider's aliases win.

### Auth + CLI alias resolution

- **`hermes_cli/auth.py`** — adds `llama-cpp` to `PROVIDER_REGISTRY` (modeled on the `lmstudio` entry: `auth_type="api_key"` with optional `LLAMA_CPP_API_KEY` + `LLAMA_CPP_BASE_URL` env vars). Removes the old hardcoded `llama.cpp/llamacpp/llama-cpp → custom` alias mappings so the plugin's auto-extend wins.
- **`hermes_cli/models.py`** — adds the same alias mappings to `_PROVIDER_ALIASES` so `--provider llama.cpp` resolves correctly through the CLI parser path.

### Dashboard / picker probe

- **`hermes_cli/model_switch.py`** — adds a probe-and-surface block in `list_authenticated_providers`, mirroring the existing `lmstudio` pattern. Three surfacing modes:
  1. **Live probe** — `${LLAMA_CPP_BASE_URL}/models` with a 300 ms cold-discovery timeout. If `llama-server` responds, the row appears with the loaded model. This is the "magical" path.
  2. **Hint mode** — `LLAMA_CPP_API_KEY`/`LLAMA_CPP_BASE_URL` set, or current provider matches one of the aliases → 1.5 s timeout.
  3. **Sticky current** — when llama-cpp is the user's selected provider but the server is offline, the row still appears (uses `current_model`) so users don't lose access after a server restart.

  When no env vars, no current selection, and no live server, the row is **not** injected — keeps the picker tidy for non-llama.cpp users.

### Launcher (resubmit per @teknium1's invitation)

- **`scripts/start-llama-server.sh`** (new) — turnkey llama-server launcher whose default port (8088) lines up with the plugin's default base_url. Prints an alignment hint when `PORT`/`HOST` diverge from the default. Generic — no model-family-specific detection.

### Tests + docs

- **`tests/providers/test_llama_cpp_profile.py`** (new) — 12 tests covering plugin registration, alias resolution end-to-end through `hermes_cli.auth.resolve_provider`, `CANONICAL_PROVIDERS` auto-injection, `PROVIDER_REGISTRY` entry shape, picker surfacing in three modes (current+offline, no-clutter, alias resolution), and the offline-graceful `fetch_models` override.
- **`tests/providers/test_plugin_discovery.py`** — bumped expected profile count `33 → 34`.
- **`website/docs/guides/local-llamacpp-setup.md`** (new) — user-facing setup guide modeled on the existing `local-ollama-setup.md`.
- **`website/docs/reference/environment-variables.md`** — documents `LLAMA_CPP_API_KEY` / `LLAMA_CPP_BASE_URL` and adds `llama-cpp` to the `HERMES_INFERENCE_PROVIDER` accepted-values list.

## How to Test

1. **Targeted suites** (no venv setup needed for these):
   ```bash
   pytest tests/providers/ -o "addopts=-m 'not integration'" -q
   # → 90 passed
   pytest tests/providers/test_llama_cpp_profile.py -v
   # → 12 passed
   pytest tests/hermes_cli/test_model_switch_custom_providers.py \
          tests/hermes_cli/test_user_providers_model_switch.py \
          tests/hermes_cli/test_custom_provider_model_switch.py \
          tests/hermes_cli/test_api_key_providers.py \
          tests/hermes_cli/test_auth_provider_gate.py \
          -o "addopts=-m 'not integration'" -q
   # → 221 passed
   ```

2. **End-to-end UX** (requires a GGUF model and `llama-server` on PATH):
   ```bash
   chmod +x scripts/start-llama-server.sh
   ./scripts/start-llama-server.sh ~/models/your-model.gguf
   ```
   Then in another shell:
   ```bash
   hermes model       # llama.cpp row should appear with the loaded model
   hermes chat --provider llama-cpp
   ```

3. **Picker UI without running server**:
   - Open the dashboard with no `LLAMA_CPP_*` env vars and no llama-cpp selection in `config.yaml` → llama.cpp should NOT appear (no clutter).
   - Set `model.provider: llama-cpp` in `config.yaml` → row appears with `current_model` even when the server is offline.

4. **Alias resolution**:
   ```bash
   hermes chat --provider llamacpp -q "hi"
   hermes chat --provider llama.cpp -q "hi"
   hermes chat --provider llama-server -q "hi"
   ```
   All should resolve to the same `llama-cpp` provider.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`feat(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to first-class llama.cpp support + the explicitly-invited launcher resubmit
- [x] I've run targeted test suites (`tests/providers/` + relevant `tests/hermes_cli/`) — 316 tests across the affected modules pass. The full suite via `scripts/run_tests.sh` requires a `uv` venv I haven't set up locally; happy to defer to CI as the source of truth.
- [x] I've added tests for my changes (12 new tests in `tests/providers/test_llama_cpp_profile.py`)
- [x] I've tested on macOS 26.4 (arm64). The launcher uses `nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 8` so it works on Linux + macOS + WSL2; not exercised on native Windows.

### Documentation & Housekeeping

- [x] Updated `website/docs/guides/local-llamacpp-setup.md` (new) and `website/docs/reference/environment-variables.md`
- [x] N/A — no `cli-config.yaml.example` keys added; new env vars are optional and documented in the env-vars reference
- [x] N/A — no architectural / workflow changes
- [x] Considered cross-platform: launcher is shell-only (Linux + macOS + WSL2). Native Windows users can run `python -m llama_cpp.server` and set `LLAMA_CPP_BASE_URL` to point Hermes at it; the provider plugin itself is pure Python and platform-neutral.
- [x] N/A — no tool schema changes

## Why "first-class" instead of just `--provider custom`

The `custom` flow requires users to set `OPENAI_BASE_URL`, doesn't show in the model picker, and provides no dashboard auto-detection. For a backend as common as llama.cpp, the registration boilerplate is a small price for: discoverability in `hermes model` / `hermes setup`, dashboard surfacing, alias resolution, and (most importantly) zero-config UX once the launcher is running.