### PR TITLE
fix(installer): set UV_NO_CONFIG=1 to avoid permission denied under sudo -u

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,6 +28,10 @@ if [ -n "${PYTHONHOME:-}" ]; then
     unset PYTHONHOME
 fi
 
+# Prevent uv from discovering config files (uv.toml, pyproject.toml) from the
+# wrong user's home directory when running under sudo -u <user>.  See #21269.
+export UV_NO_CONFIG=1
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -78,6 +78,7 @@ AUTHOR_MAP = {
     "dengtaoyuan@dengtaoyuandeMac-mini.local": "dengtaoyuan450-a11y",
     "ysfalweshcan@gmail.com": "Junass1",
     "bartokmagic@proton.me": "Bartok9",
+    "androidhtml@yandex.com": "hllqkb",
     "25840394+Bongulielmi@users.noreply.github.com": "Bongulielmi",
     "jonathan.troyer@overmatch.com": "JTroyerOvermatch",
     "harryykyle1@gmail.com": "hharry11",

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -29,6 +29,10 @@ NC='\033[0m'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Prevent uv from discovering config files (uv.toml, pyproject.toml) from the
+# wrong user's home directory when running under sudo -u <user>.  See #21269.
+export UV_NO_CONFIG=1
+
 PYTHON_VERSION="3.11"
 
 is_termux() {


### PR DESCRIPTION
Salvages #21288 (@hllqkb) onto current main. Fixes #21269.

Installer no longer fails when run via `sudo -u <user>` — uv was reading `/root/uv.toml` because it resolves config paths against the process owner's HOME, not the effective user's. Setting `UV_NO_CONFIG=1` at the top of both scripts disables config discovery across every uv subcommand (`python install`, `python find`, `venv`, `pip install`, `sync`) without affecting pyproject.toml dependency reading.

## Changes
- scripts/install.sh, setup-hermes.sh: export UV_NO_CONFIG=1 early, next to the existing PYTHONPATH/PYTHONHOME scrubs
- scripts/release.py: AUTHOR_MAP entry for hllqkb

Co-authored-by: hllqkb <androidhtml@yandex.com>