### PR TITLE
feat(honcho): support per-LID peer routing

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -297,6 +297,34 @@ class HonchoMemoryProvider(MemoryProvider):
                 logger.debug("Honcho not configured — plugin inactive")
                 return
 
+            # Optional per-sender routing.
+            # peerByLid routes multi-user WhatsApp chats to the correct
+            # Honcho peer. We scan the gateway user_id (the sender's LID,
+            # e.g. "1234567890@lid") for any known LID and override the
+            # configured peer_name when a match is found. The map lives in
+            # honcho.json, e.g. {"1234567890": "alice", "9876543210": "bob"}
+            # This override wins over both the default peer_name and the
+            # upstream runtime_user_peer_name path because routing
+            # identity is per-message, not per-deployment. Load-bearing
+            # for auto-renamed sessions where the LID is no longer
+            # present in the session key.
+            #
+            # We also rewrite kwargs["user_id"] so the upstream
+            # runtime_user_peer_name plumbing (passed into the session
+            # manager below) sees the resolved peer instead of the raw
+            # LID. Defense in depth alongside the session.py patch.
+            _gw_user_id = kwargs.get("user_id")
+            if _gw_user_id and getattr(cfg, "peer_by_lid", None):
+                for _lid, _peer in cfg.peer_by_lid.items():
+                    if _lid and str(_lid) in str(_gw_user_id):
+                        cfg.peer_name = _peer
+                        kwargs["user_id"] = _peer
+                        logger.info(
+                            "peerByLid routed user_id=%s -> peer=%s",
+                            _gw_user_id, _peer,
+                        )
+                        break
+
             self._config = cfg
 
             # ----- B1: recall_mode from config -----

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -251,6 +251,10 @@ class HonchoClientConfig:
     # Identity
     peer_name: str | None = None
     ai_peer: str = "hermes"
+    # Map of WhatsApp LID -> Honcho peer name.
+    # Populated from honcho.json root or host block as "peerByLid".
+    # Used for deployments where one gateway account serves multiple peers.
+    peer_by_lid: dict = field(default_factory=dict)
     # When True, ``peer_name`` wins over any gateway-supplied runtime
     # identity (Telegram UID, Discord ID, …) when resolving the user peer.
     # This keeps memory unified across platforms for single-user deployments
@@ -452,6 +456,8 @@ class HonchoClientConfig:
             timeout=timeout,
             peer_name=host_block.get("peerName") or raw.get("peerName"),
             ai_peer=ai_peer,
+            # 
+            peer_by_lid=(host_block.get("peerByLid") or raw.get("peerByLid") or {}),
             pin_peer_name=_resolve_bool(
                 host_block.get("pinPeerName"),
                 raw.get("pinPeerName"),

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -267,6 +267,20 @@ class HonchoSessionManager:
         """Sanitize an ID to match Honcho's pattern: ^[a-zA-Z0-9_-]+"""
         return re.sub(r'[^a-zA-Z0-9_-]', '-', id_str)
 
+    def _resolve_user_peer_for_key(self, key: str) -> str | None:
+        """Map a WhatsApp LID in a session key to a peer name.
+
+        When the session key contains a known LID (from peer_by_lid in
+        honcho.json), return the mapped peer. Returns None when no mapping
+        matches, so the caller falls back to the default behavior.
+        """
+        if not self._config or not getattr(self._config, "peer_by_lid", None):
+            return None
+        for lid, peer in self._config.peer_by_lid.items():
+            if lid and str(lid) in key:
+                return self._sanitize_id(peer)
+        return None
+
     def get_or_create(self, key: str) -> HonchoSession:
         """
         Get an existing session or create a new one.
@@ -283,25 +297,36 @@ class HonchoSessionManager:
                 return self._cache[key]
 
         # Determine peer IDs — no lock needed (read-only, no shared state mutation).
-        # Gateway sessions normally use the runtime user identity (the
-        # platform-native ID: Telegram UID, Discord snowflake, Slack user,
-        # etc.) so multi-user bots scope memory per user.  For a single-user
-        # deployment the config-supplied ``peer_name`` is an unambiguous
-        # identity and we should keep it unified across platforms — see
-        # #14984.  Opt into that with ``hosts.<host>.pinPeerName: true`` in
-        # ``honcho.json`` (or root-level ``pinPeerName: true``).
+        # Per-LID peer override wins over everything else. The session key
+        # usually carries the chat LID (e.g. "whatsapp:dm:1234567890@lid"),
+        # which lets multi-user deployments route each sender to the right peer.
+        # More specific than runtime_user_peer_name, which is set by the
+        # gateway from the sender id and may not match the multi-tenant
+        # WhatsApp DM case.
+        #
+        # After LID, gateway sessions normally use the runtime user identity
+        # (the platform-native ID: Telegram UID, Discord snowflake, Slack
+        # user, etc.) so multi-user bots scope memory per user.  For a
+        # single-user deployment the config-supplied ``peer_name`` is an
+        # unambiguous identity and we should keep it unified across
+        # platforms — see #14984.  Opt into that with
+        # ``hosts.<host>.pinPeerName: true`` in ``honcho.json`` (or
+        # root-level ``pinPeerName: true``).
         # `is True` (not `bool(...)`) is deliberate: several multi-user tests
         # pass a ``MagicMock`` for ``config`` where ``mock.pin_peer_name``
         # silently returns another MagicMock — truthy by default.  Requiring
         # strict ``True`` keeps pinning as opt-in even for callers that
         # haven't updated their mocks yet; real configs built via
         # ``from_global_config`` always produce a proper boolean.
+        lid_peer = self._resolve_user_peer_for_key(key)
         pin_peer_name = (
             self._config is not None
             and bool(getattr(self._config, "peer_name", None))
             and getattr(self._config, "pin_peer_name", False) is True
         )
-        if self._runtime_user_peer_name and not pin_peer_name:
+        if lid_peer:
+            user_peer_id = lid_peer
+        elif self._runtime_user_peer_name and not pin_peer_name:
             user_peer_id = self._sanitize_id(self._runtime_user_peer_name)
         elif self._config and self._config.peer_name:
             user_peer_id = self._sanitize_id(self._config.peer_name)


### PR DESCRIPTION
# Add per-LID peer routing for Honcho memory

## Problem

In multi-user WhatsApp deployments, one gateway account can receive messages from multiple senders. The Honcho memory plugin currently resolves identity from a default peer or gateway runtime identity, which is not enough when a deployment needs to map sender LIDs to stable Honcho peer names.

## Fix

Add optional `peerByLid` support:

1. `plugins/memory/honcho/client.py`: add a `peer_by_lid` config field loaded from `honcho.json`.
2. `plugins/memory/honcho/session.py`: resolve a known LID from the session key before falling back to existing peer resolution.
3. `plugins/memory/honcho/__init__.py`: when `user_id` contains a known LID, rewrite it to the configured peer name before session manager initialization.

Example configuration:

```json
{
  "hosts": {
    "your-host": {
      "peerByLid": {
        "1234567890": "alice",
        "9876543210": "bob"
      }
    }
  }
}
```

The change is opt-in. Without `peerByLid`, the existing fallback behavior is unchanged.

## Files touched

- `plugins/memory/honcho/client.py`
- `plugins/memory/honcho/session.py`
- `plugins/memory/honcho/__init__.py`

## Verification

- Syntax checked with `python3 -m py_compile` on the three touched files.
- Suggested follow-up: add unit tests for two configured LIDs and the empty-config fallback.
