### PR TITLE
feat(voice): add Gemini STT and WhatsApp PTT support

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -93,7 +93,7 @@ def _kill_stale_bridge_by_pidfile(session_path: Path) -> None:
 
     The bridge writes ``bridge.pid`` into the session directory when it
     starts.  If the gateway crashed without a clean shutdown the old bridge
-    process becomes orphaned — this helper finds and kills it.
+    process becomes orphaned - this helper finds and kills it.
     """
     pid_file = session_path / "bridge.pid"
     if not pid_file.exists():
@@ -208,13 +208,13 @@ class WhatsAppAdapter(BasePlatformAdapter):
     - bridge_script: Path to the Node.js bridge script
     - bridge_port: Port for HTTP communication (default: 3000)
     - session_path: Path to store WhatsApp session data
-    - dm_policy: "open" | "allowlist" | "disabled" — how DMs are handled (default: "open")
+    - dm_policy: "open" | "allowlist" | "disabled" - how DMs are handled (default: "open")
     - allow_from: List of sender IDs allowed in DMs (when dm_policy="allowlist")
-    - group_policy: "open" | "allowlist" | "disabled" — which groups are processed (default: "open")
+    - group_policy: "open" | "allowlist" | "disabled" - which groups are processed (default: "open")
     - group_allow_from: List of group JIDs allowed (when group_policy="allowlist")
     """
     
-    # WhatsApp message limits — practical UX limit, not protocol max.
+    # WhatsApp message limits - practical UX limit, not protocol max.
     # WhatsApp allows ~65K but long messages are unreadable on mobile.
     MAX_MESSAGE_LENGTH = 4096
     DEFAULT_REPLY_PREFIX = "⚕ *Hermes Agent*\n────────────\n"
@@ -303,7 +303,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             return False
         if self._dm_policy == "allowlist":
             return sender_id in self._allow_from
-        # "open" — all DMs allowed
+        # "open" - all DMs allowed
         return True
 
     def _is_group_allowed(self, chat_id: str) -> bool:
@@ -312,7 +312,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             return False
         if self._group_policy == "allowlist":
             return chat_id in self._group_allow_from
-        # "open" — all groups allowed
+        # "open" - all groups allowed
         return True
 
     def _compile_mention_patterns(self):
@@ -600,7 +600,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                     except Exception:
                         continue
                 else:
-                    # Still not connected — warn but proceed (bridge may
+                    # Still not connected - warn but proceed (bridge may
                     # auto-reconnect later, e.g. after a code 515 restart).
                     print(f"[{self.name}] ⚠ WhatsApp not connected after 30s")
                     print(f"[{self.name}]   Bridge log: {self._bridge_log}")
@@ -756,8 +756,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
         result = re.sub(r"__(.+?)__", r"*\1*", result)
         # Strikethrough: ~~text~~ → ~text~
         result = re.sub(r"~~(.+?)~~", r"~\1~", result)
-        # Italic: *text* is already WhatsApp italic — leave as-is
-        # _text_ is already WhatsApp italic — leave as-is
+        # Italic: *text* is already WhatsApp italic - leave as-is
+        # _text_ is already WhatsApp italic - leave as-is
 
         # --- 4. Convert markdown headers to bold text ---
         # # Header → *Header*
@@ -942,6 +942,17 @@ class WhatsAppAdapter(BasePlatformAdapter):
         """Send a local image file natively via bridge."""
         return await self._send_media_to_bridge(chat_id, image_path, "image", caption)
 
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send audio as WhatsApp voice note (PTT) via bridge. Bridge auto-sets ptt:true for ogg/opus."""
+        return await self._send_media_to_bridge(chat_id, audio_path, "audio", caption)
+
     async def send_video(
         self,
         chat_id: str,
@@ -950,7 +961,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         **kwargs,
     ) -> SendResult:
-        """Send a video natively via bridge — plays inline in WhatsApp."""
+        """Send a video natively via bridge - plays inline in WhatsApp."""
         return await self._send_media_to_bridge(chat_id, video_path, "video", caption)
 
     async def send_voice(
@@ -989,7 +1000,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
         try:
             import aiohttp
 
-            # Must wrap in `async with` — a bare `await session.post(...)`
+            # Must wrap in `async with` - a bare `await session.post(...)`
             # leaves the response object alive until GC, holding its TCP
             # socket in CLOSE_WAIT. See #18451.
             async with self._http_session.post(
@@ -1110,7 +1121,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         cached_urls.append(url)
                         media_types.append("image/jpeg")
                 elif msg_type == MessageType.PHOTO and os.path.isabs(url):
-                    # Local file path — bridge already downloaded the image
+                    # Local file path - bridge already downloaded the image
                     cached_urls.append(url)
                     media_types.append("image/jpeg")
                     print(f"[{self.name}] Using bridge-cached image: {url}", flush=True)
@@ -1125,12 +1136,12 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         cached_urls.append(url)
                         media_types.append("audio/ogg")
                 elif msg_type == MessageType.VOICE and os.path.isabs(url):
-                    # Local file path — bridge already downloaded the audio
+                    # Local file path - bridge already downloaded the audio
                     cached_urls.append(url)
                     media_types.append("audio/ogg")
                     print(f"[{self.name}] Using bridge-cached audio: {url}", flush=True)
                 elif msg_type == MessageType.DOCUMENT and os.path.isabs(url):
-                    # Local file path — bridge already downloaded the document
+                    # Local file path - bridge already downloaded the document
                     cached_urls.append(url)
                     ext = Path(url).suffix.lower()
                     mime = SUPPORTED_DOCUMENT_TYPES.get(ext, "application/octet-stream")

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,15 +2,17 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with six providers:
+Provides speech-to-text transcription with seven providers:
 
-  - **local** (default, free) — faster-whisper running locally, no API key needed.
+  - **local** (default, free) - faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
-  - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
-  - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
-  - **mistral** — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
-  - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
+  - **groq** (free tier) - Groq Whisper API, requires ``GROQ_API_KEY``.
+  - **openai** (paid) - OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
+  - **mistral** - Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
+  - **xai** - xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
+  - **gemini** - Google Gemini generateContent (inline audio). Requires
+    ``GEMINI_STT_API_KEY`` (also accepts ``GEMINI_API_KEY`` / ``GOOGLE_API_KEY``).
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -26,12 +28,17 @@ Usage::
         print(result["transcript"])
 """
 
+import base64
+import json
 import logging
+import mimetypes
 import os
 import shlex
 import shutil
 import subprocess
 import tempfile
+import urllib.error
+import urllib.request
 from pathlib import Path
 from typing import Optional, Dict, Any
 from urllib.parse import urljoin
@@ -57,7 +64,7 @@ def get_env_value(name, default=None):
     return default if value is None else value
 
 # ---------------------------------------------------------------------------
-# Optional imports — graceful degradation
+# Optional imports - graceful degradation
 # ---------------------------------------------------------------------------
 
 import importlib.util as _ilu
@@ -84,6 +91,15 @@ DEFAULT_LOCAL_STT_LANGUAGE = "en"
 DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
+DEFAULT_GEMINI_STT_MODEL = os.getenv("GEMINI_STT_MODEL", "gemini-3-flash-preview")
+GEMINI_STT_BASE_URL = os.getenv(
+    "GEMINI_STT_BASE_URL", "https://generativelanguage.googleapis.com/v1beta"
+)
+GEMINI_STT_PROMPT = (
+    "Transcribe the following audio verbatim. Return only the transcript, no "
+    "preamble, in the audio's original language. If the audio is in Portuguese, "
+    "return Portuguese text."
+)
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
@@ -100,7 +116,7 @@ MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 OPENAI_MODELS = {"whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe"}
 GROQ_MODELS = {"whisper-large-v3", "whisper-large-v3-turbo", "distil-whisper-large-v3-en"}
 
-# Singleton for the local model — loaded once, reused across calls
+# Singleton for the local model - loaded once, reused across calls
 _local_model: Optional[object] = None
 _local_model_name: Optional[str] = None
 
@@ -201,7 +217,7 @@ def _get_provider(stt_config: dict) -> str:
     """Determine which STT provider to use.
 
     When ``stt.provider`` is explicitly set in config, that choice is
-    honoured — no silent cloud fallback.  When no provider is configured,
+    honoured - no silent cloud fallback.  When no provider is configured,
     auto-detect tries: local > groq (free) > openai (paid).
     """
     if not is_stt_enabled(stt_config):
@@ -268,9 +284,18 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
-        return provider  # Unknown — let it fail downstream
+        if provider == "gemini":
+            if _resolve_gemini_api_key():
+                return "gemini"
+            logger.warning(
+                "STT provider 'gemini' configured but GEMINI_STT_API_KEY "
+                "(or GEMINI_API_KEY / GOOGLE_API_KEY) is not set"
+            )
+            return "none"
 
-    # --- Auto-detect (no explicit provider): local > groq > openai > mistral > xai -
+        return provider  # Unknown - let it fail downstream
+
+    # --- Auto-detect (no explicit provider): local > groq > openai > mistral > xai > gemini -
 
     if _HAS_FASTER_WHISPER:
         return "local"
@@ -288,6 +313,9 @@ def _get_provider(stt_config: dict) -> str:
     if get_env_value("XAI_API_KEY"):
         logger.info("No local STT available, using xAI Grok STT API")
         return "xai"
+    if _resolve_gemini_api_key():
+        logger.info("No local STT available, using Gemini API")
+        return "gemini"
     return "none"
 
 # ---------------------------------------------------------------------------
@@ -330,11 +358,11 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
 # Substrings that identify a missing/unloadable CUDA runtime library.  When
 # ctranslate2 (the backend for faster-whisper) cannot dlopen one of these, the
 # "auto" device picker has already committed to CUDA and the model can no
-# longer be used — we fall back to CPU and reload.
+# longer be used - we fall back to CPU and reload.
 #
 # Deliberately narrow: we match on library-name tokens and dlopen phrasing so
 # we DO NOT accidentally catch legitimate runtime failures like "CUDA out of
-# memory" — those should surface to the user, not silently fall back to CPU
+# memory" - those should surface to the user, not silently fall back to CPU
 # (a 32GB audio clip on CPU at int8 isn't useful either).
 _CUDA_LIB_ERROR_MARKERS = (
     "libcublas",
@@ -365,7 +393,7 @@ def _load_local_whisper_model(model_name: str):
 
     faster-whisper's ``device="auto"`` picks CUDA when the ctranslate2 wheel
     ships CUDA shared libs, even on hosts where the NVIDIA runtime
-    (``libcublas.so.12`` / ``libcudnn*``) isn't installed — common on WSL2
+    (``libcublas.so.12`` / ``libcudnn*``) isn't installed - common on WSL2
     without CUDA-on-WSL, headless servers, and CPU-only developer machines.
     On those hosts the load itself sometimes succeeds and the dlopen failure
     only surfaces at first ``transcribe()`` call.
@@ -380,7 +408,7 @@ def _load_local_whisper_model(model_name: str):
         if not _looks_like_cuda_lib_error(exc):
             raise
         logger.warning(
-            "faster-whisper CUDA load failed (%s) — falling back to CPU (int8). "
+            "faster-whisper CUDA load failed (%s) - falling back to CPU (int8). "
             "Install the NVIDIA CUDA runtime (libcublas/libcudnn) to use GPU.",
             exc,
         )
@@ -423,7 +451,7 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
             if not _looks_like_cuda_lib_error(exc):
                 raise
             logger.warning(
-                "faster-whisper CUDA runtime failed mid-transcribe (%s) — "
+                "faster-whisper CUDA runtime failed mid-transcribe (%s) - "
                 "evicting cached model and retrying on CPU (int8).",
                 exc,
             )
@@ -535,7 +563,7 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
         return {"success": False, "transcript": "", "error": f"Local transcription failed: {e}"}
 
 # ---------------------------------------------------------------------------
-# Provider: groq (Whisper API — free tier)
+# Provider: groq (Whisper API - free tier)
 # ---------------------------------------------------------------------------
 
 
@@ -680,6 +708,159 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
     except Exception as e:
         logger.error("Mistral transcription failed: %s", e, exc_info=True)
         return {"success": False, "transcript": "", "error": f"Mistral transcription failed: {type(e).__name__}"}
+
+# ---------------------------------------------------------------------------
+# Provider: gemini (Google Generative Language API - inline audio)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_gemini_api_key() -> Optional[str]:
+    """Resolve the Gemini API key from the canonical envs, in order of preference."""
+    for name in ("GEMINI_STT_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"):
+        value = os.getenv(name)
+        if value:
+            return value
+    return None
+
+
+def _guess_gemini_mime_type(file_path: str) -> str:
+    """Return a mime type the Gemini API accepts for a given audio file."""
+    suffix = Path(file_path).suffix.lower()
+    if suffix in (".ogg", ".opus"):
+        return "audio/ogg; codecs=opus"
+    if suffix == ".mp3":
+        return "audio/mpeg"
+    if suffix in (".m4a", ".mp4", ".aac"):
+        return "audio/mp4"
+    if suffix == ".wav":
+        return "audio/wav"
+    if suffix == ".flac":
+        return "audio/flac"
+    if suffix == ".webm":
+        return "audio/webm"
+    guessed, _ = mimetypes.guess_type(file_path)
+    return guessed or "audio/ogg; codecs=opus"
+
+
+def _transcribe_gemini(file_path: str, config: Optional[dict] = None) -> Dict[str, Any]:
+    """Transcribe using Google Gemini generateContent with inline audio.
+
+    Calls ``POST {base}/models/{model}:generateContent?key={key}`` with the audio
+    bytes base64-encoded inline. Returns the standard transcription result dict.
+    """
+    api_key = _resolve_gemini_api_key()
+    if not api_key:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": (
+                "GEMINI_STT_API_KEY not set (also accepts GEMINI_API_KEY or "
+                "GOOGLE_API_KEY)"
+            ),
+        }
+
+    cfg = config or {}
+    model_name = (
+        cfg.get("model")
+        or os.getenv("GEMINI_STT_MODEL")
+        or DEFAULT_GEMINI_STT_MODEL
+    )
+    try:
+        timeout = float(cfg.get("timeout", 60))
+    except (TypeError, ValueError):
+        timeout = 60.0
+
+    try:
+        with open(file_path, "rb") as audio_file:
+            audio_bytes = audio_file.read()
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except OSError as e:
+        return {"success": False, "transcript": "", "error": f"Failed to read audio file: {e}"}
+
+    mime_type = _guess_gemini_mime_type(file_path)
+    b64_audio = base64.b64encode(audio_bytes).decode("ascii")
+
+    payload = {
+        "contents": [
+            {
+                "parts": [
+                    {"text": GEMINI_STT_PROMPT},
+                    {"inline_data": {"mime_type": mime_type, "data": b64_audio}},
+                ]
+            }
+        ]
+    }
+
+    url = (
+        f"{GEMINI_STT_BASE_URL.rstrip('/')}/models/{model_name}:generateContent"
+        f"?key={api_key}"
+    )
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        detail = ""
+        try:
+            detail = e.read().decode("utf-8", errors="replace")[:500]
+        except Exception:
+            pass
+        logger.error("Gemini STT HTTP %s: %s", e.code, detail)
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Gemini API error {e.code}: {detail or e.reason}",
+        }
+    except urllib.error.URLError as e:
+        return {"success": False, "transcript": "", "error": f"Connection error: {e.reason}"}
+    except TimeoutError as e:
+        return {"success": False, "transcript": "", "error": f"Request timeout: {e}"}
+    except Exception as e:
+        logger.error("Gemini transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Transcription failed: {e}"}
+
+    try:
+        data = json.loads(body)
+    except json.JSONDecodeError as e:
+        return {"success": False, "transcript": "", "error": f"Invalid Gemini JSON: {e}"}
+
+    try:
+        parts = data["candidates"][0]["content"]["parts"]
+    except (KeyError, IndexError, TypeError):
+        prompt_feedback = data.get("promptFeedback") if isinstance(data, dict) else None
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Gemini response missing transcript (feedback={prompt_feedback})",
+        }
+
+    transcript_text = ""
+    for part in parts:
+        if isinstance(part, dict) and isinstance(part.get("text"), str):
+            transcript_text += part["text"]
+    transcript_text = transcript_text.strip()
+
+    if not transcript_text:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "Gemini returned an empty transcript",
+        }
+
+    logger.info(
+        "Transcribed %s via Gemini API (%s, %d chars)",
+        Path(file_path).name,
+        model_name,
+        len(transcript_text),
+    )
+    return {"success": True, "transcript": transcript_text, "provider": "gemini"}
 
 
 # ---------------------------------------------------------------------------
@@ -850,9 +1031,15 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         return _transcribe_mistral(file_path, model_name)
 
     if provider == "xai":
-        # xAI Grok STT doesn't use a model parameter — pass through for logging
+        # xAI Grok STT doesn't use a model parameter - pass through for logging
         model_name = model or "grok-stt"
         return _transcribe_xai(file_path, model_name)
+
+    if provider == "gemini":
+        gemini_cfg = dict(stt_config.get("gemini", {}))
+        if model:
+            gemini_cfg["model"] = model
+        return _transcribe_gemini(file_path, gemini_cfg)
 
     # No provider available
     return {
@@ -862,7 +1049,8 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
-            "Voxtral Transcribe, set XAI_API_KEY for xAI Grok STT, or set VOICE_TOOLS_OPENAI_KEY "
+            "Voxtral Transcribe, set XAI_API_KEY for xAI Grok STT, set "
+            "GEMINI_STT_API_KEY for Google Gemini, or set VOICE_TOOLS_OPENAI_KEY "
             "or OPENAI_API_KEY for the OpenAI Whisper API."
         ),
     }

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -146,13 +146,20 @@ DEFAULT_XAI_LANGUAGE = "en"
 DEFAULT_XAI_SAMPLE_RATE = 24000
 DEFAULT_XAI_BIT_RATE = 128000
 DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1"
-DEFAULT_GEMINI_TTS_MODEL = "gemini-2.5-flash-preview-tts"
-DEFAULT_GEMINI_TTS_VOICE = "Kore"
-DEFAULT_GEMINI_TTS_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+DEFAULT_GEMINI_TTS_MODEL = os.getenv("GEMINI_TTS_MODEL", "gemini-3.1-flash-tts-preview")
+DEFAULT_GEMINI_TTS_VOICE = os.getenv("GEMINI_TTS_VOICE", "Kore")
+DEFAULT_GEMINI_TTS_BASE_URL = os.getenv(
+    "GEMINI_TTS_BASE_URL", "https://generativelanguage.googleapis.com/v1beta"
+)
 # PCM output specs for Gemini TTS (fixed by the API)
 GEMINI_TTS_SAMPLE_RATE = 24000
 GEMINI_TTS_CHANNELS = 1
 GEMINI_TTS_SAMPLE_WIDTH = 2  # 16-bit PCM (L16)
+# Full prebuilt voice list (30 voices, all multilingual incl. pt-BR):
+# Zephyr, Puck, Charon, Kore, Fenrir, Leda, Orus, Aoede, Callirrhoe, Autonoe,
+# Enceladus, Iapetus, Umbriel, Algieba, Despina, Erinome, Algenib, Rasalgethi,
+# Laomedeia, Achernar, Alnilam, Schedar, Gacrux, Pulcherrima, Achird,
+# Zubenelgenubi, Vindemiatrix, Sadachbia, Sadaltager, Sulafat.
 
 def _get_default_output_dir() -> str:
     from hermes_constants import get_hermes_dir
@@ -1087,6 +1094,25 @@ def _wrap_pcm_as_wav(
     return riff_header + fmt_chunk + data_chunk_header + pcm_bytes
 
 
+def _resolve_gemini_tts_api_key() -> Optional[str]:
+    """Resolve the Gemini TTS API key, in order of preference.
+
+    Mirrors the STT resolver in transcription_tools. The paid Gemini key can
+    be reused for TTS via GEMINI_STT_API_KEY when a dedicated GEMINI_TTS_API_KEY
+    is not provisioned.
+    """
+    for name in (
+        "GEMINI_TTS_API_KEY",
+        "GEMINI_STT_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+    ):
+        value = get_env_value(name)
+        if value:
+            return value.strip() or None
+    return None
+
+
 def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
     """Generate audio using Google Gemini TTS.
 
@@ -1094,6 +1120,9 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     raw 24kHz mono 16-bit PCM (L16) as base64. We wrap it with a WAV RIFF
     header to produce a playable file, then ffmpeg-convert to MP3 / Opus if
     the caller requested those formats (same pattern as NeuTTS).
+
+    For WhatsApp voice-note delivery we emit 32 kbps mono OGG Opus so the
+    bridge sends a PTT voice bubble.
 
     Args:
         text: Text to convert (prompt-style; supports inline direction like
@@ -1106,20 +1135,35 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     """
     import requests
 
-    api_key = (get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY") or "").strip()
+    api_key = _resolve_gemini_tts_api_key()
     if not api_key:
         raise ValueError(
-            "GEMINI_API_KEY not set. Get one at https://aistudio.google.com/app/apikey"
+            "Gemini TTS API key not set. Accepted envs (in order): "
+            "GEMINI_TTS_API_KEY, GEMINI_STT_API_KEY, GEMINI_API_KEY, GOOGLE_API_KEY. "
+            "Get one at https://aistudio.google.com/app/apikey"
         )
 
     gemini_config = tts_config.get("gemini", {})
-    model = str(gemini_config.get("model", DEFAULT_GEMINI_TTS_MODEL)).strip() or DEFAULT_GEMINI_TTS_MODEL
-    voice = str(gemini_config.get("voice", DEFAULT_GEMINI_TTS_VOICE)).strip() or DEFAULT_GEMINI_TTS_VOICE
+    model = str(
+        gemini_config.get("model")
+        or os.getenv("GEMINI_TTS_MODEL")
+        or DEFAULT_GEMINI_TTS_MODEL
+    ).strip() or DEFAULT_GEMINI_TTS_MODEL
+    voice = str(
+        gemini_config.get("voice")
+        or os.getenv("GEMINI_TTS_VOICE")
+        or DEFAULT_GEMINI_TTS_VOICE
+    ).strip() or DEFAULT_GEMINI_TTS_VOICE
     base_url = str(
         gemini_config.get("base_url")
+        or get_env_value("GEMINI_TTS_BASE_URL")
         or get_env_value("GEMINI_BASE_URL")
         or DEFAULT_GEMINI_TTS_BASE_URL
     ).strip().rstrip("/")
+    try:
+        timeout = float(gemini_config.get("timeout", 60))
+    except (TypeError, ValueError):
+        timeout = 60.0
 
     payload: Dict[str, Any] = {
         "contents": [{"parts": [{"text": text}]}],
@@ -1139,7 +1183,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         params={"key": api_key},
         headers={"Content-Type": "application/json"},
         json=payload,
-        timeout=60,
+        timeout=timeout,
     )
     if response.status_code != 200:
         # Surface the API error message when present
@@ -1187,13 +1231,16 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     try:
         ffmpeg = shutil.which("ffmpeg")
         if ffmpeg:
-            # For .ogg output, force libopus encoding (Telegram voice bubbles
-            # require Opus specifically; ffmpeg's default for .ogg is Vorbis).
+            # For .ogg output, force libopus encoding at 32 kbps mono so
+            # WhatsApp / Telegram recognise it as a PTT voice note
+            # (ffmpeg's default for .ogg is Vorbis, which the bridge treats
+            # as a regular audio attachment rather than a voice bubble).
             if output_path.lower().endswith(".ogg"):
                 cmd = [
                     ffmpeg, "-i", wav_path,
-                    "-acodec", "libopus", "-ac", "1",
-                    "-b:a", "64k", "-vbr", "off",
+                    "-c:a", "libopus", "-ac", "1",
+                    "-b:a", "32k", "-vbr", "off",
+                    "-application", "voip",
                     "-y", "-loglevel", "error",
                     output_path,
                 ]
@@ -1265,7 +1312,7 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
     model = neutts_config.get("model", "neuphonic/neutts-air-q4-gguf")
     device = neutts_config.get("device", "cpu")
 
-    # NeuTTS outputs WAV natively — use a .wav path for generation,
+    # NeuTTS outputs WAV natively - use a .wav path for generation,
     # let the caller convert to the final format afterward.
     wav_path = output_path
     if not output_path.endswith(".wav"):
@@ -1297,7 +1344,7 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
             subprocess.run(conv_cmd, check=True, timeout=30)
             os.remove(wav_path)
         else:
-            # No ffmpeg — just rename the WAV to the expected path
+            # No ffmpeg - just rename the WAV to the expected path
             os.rename(wav_path, output_path)
 
     return output_path
@@ -1379,7 +1426,7 @@ def _resolve_piper_voice_path(voice: str, download_dir: Path) -> str:
 
     if not cached.exists():
         raise RuntimeError(
-            f"Piper voice download completed but {cached} is missing — "
+            f"Piper voice download completed but {cached} is missing - "
             f"check voice name (see: https://github.com/OHF-Voice/piper1-gpl/"
             f"blob/main/docs/VOICES.md)"
         )
@@ -1412,7 +1459,7 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
         logger.info("[Piper] Voice loaded")
     voice = _piper_voice_cache[cache_key]
 
-    # Optional synthesis knobs — only pass a SynthesisConfig when at least
+    # Optional synthesis knobs - only pass a SynthesisConfig when at least
     # one advanced knob is configured, so we don't depend on a newer Piper
     # version than the user's installed one unless we need to.
     syn_config = None
@@ -1433,7 +1480,7 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
         except ImportError:
             logger.warning(
                 "[Piper] SynthesisConfig not available in this piper-tts "
-                "version — advanced knobs ignored"
+                "version - advanced knobs ignored"
             )
 
     # Piper outputs WAV. Caller handles downstream MP3/Opus conversion.
@@ -1458,7 +1505,7 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
             except OSError:
                 pass
         else:
-            # No ffmpeg — keep WAV and return that path
+            # No ffmpeg - keep WAV and return that path
             os.rename(wav_path, output_path)
 
     return output_path
@@ -1521,7 +1568,7 @@ def _generate_kittentts(text: str, output_path: str, tts_config: Dict[str, Any])
             subprocess.run(conv_cmd, check=True, timeout=30)
             os.remove(wav_path)
         else:
-            # No ffmpeg — rename the WAV to the expected path
+            # No ffmpeg - rename the WAV to the expected path
             os.rename(wav_path, output_path)
 
     return output_path
@@ -1579,7 +1626,7 @@ def text_to_speech_tool(
     # and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = platform in ("telegram", "whatsapp")
 
     # Determine output path
     if output_path:
@@ -1738,7 +1785,7 @@ def text_to_speech_tool(
             }, ensure_ascii=False)
 
         # Try Opus conversion for Telegram compatibility
-        # Edge TTS outputs MP3, NeuTTS/KittenTTS output WAV — all need ffmpeg conversion
+        # Edge TTS outputs MP3, NeuTTS/KittenTTS output WAV - all need ffmpeg conversion
         voice_compatible = False
         if command_provider_config is not None:
             # Command providers are documents by default. Voice-bubble
@@ -1829,7 +1876,7 @@ def check_tts_requirements() -> bool:
         return True
     if get_env_value("XAI_API_KEY"):
         return True
-    if get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY"):
+    if _resolve_gemini_tts_api_key():
         return True
     try:
         _import_mistral_client()
@@ -2156,7 +2203,7 @@ from tools.registry import registry, tool_error
 
 TTS_SCHEMA = {
     "name": "text_to_speech",
-    "description": "Convert text to speech audio. Returns a MEDIA: path that the platform delivers as native audio. Compatible providers render as a voice bubble on Telegram; otherwise audio is sent as a regular attachment. In CLI mode, saves to ~/voice-memos/. Voice and provider are user-configured (built-in providers like edge/openai or custom command providers under tts.providers.<name>), not model-selected.",
+    "description": "Convert text to speech and deliver as a native voice note on WhatsApp/Telegram. CRITICAL: to actually deliver, you MUST append the returned media_tag field VERBATIM at the end of your reply. Do NOT paraphrase. Do NOT show the file path as text. The tag looks like [[audio_as_voice]] then MEDIA:/path/to/file.ogg and is stripped by the adapter before the user sees it. Format: your textual message, blank line, media_tag exactly as returned. Voice and provider are user-configured.",
     "parameters": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
# Add Gemini STT, Gemini TTS options, and WhatsApp PTT delivery

## Problem

Hermes has WhatsApp and voice-related surfaces, but the end-to-end path for Gemini speech-to-text, configurable Gemini text-to-speech, and native WhatsApp push-to-talk delivery is incomplete.

## Fix

Add three coordinated pieces:

1. `tools/transcription_tools.py`: add Gemini as a first-class STT provider using the Google Generative Language API.
2. `tools/tts_tool.py`: expose Gemini TTS model, voice, and output codec configuration, including OGG Opus output.
3. `gateway/platforms/whatsapp.py`: add a `send_voice` override that can deliver supported audio as WhatsApp PTT and fall back to the generic audio path when needed.

The change is opt-in. Existing STT, TTS, and `send_audio` behavior is unchanged when Gemini configuration is absent.

## Configuration

```bash
GEMINI_STT_API_KEY=...
GEMINI_STT_MODEL=gemini-3-flash
GEMINI_TTS_API_KEY=...
GEMINI_TTS_MODEL=gemini-3.1-flash-tts-preview
GEMINI_TTS_VOICE=Kore
```

## Files touched

- `tools/transcription_tools.py`
- `tools/tts_tool.py`
- `gateway/platforms/whatsapp.py`

## Verification

- Syntax checked with `python3 -m py_compile` on the three touched files.
- Suggested follow-up: add fixture-based STT and TTS tests plus a WhatsApp adapter test for `send_voice`.
