### PR TITLE
feat(cli): recognise Shift+Enter as a newline key

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -60,6 +60,13 @@ try:
     _STEADY_CURSOR = CursorShape.BLOCK  # Non-blinking block cursor
 except (ImportError, AttributeError):
     _STEADY_CURSOR = None
+
+try:
+    from hermes_cli.pt_input_extras import install_shift_enter_alias
+    install_shift_enter_alias()
+    del install_shift_enter_alias
+except Exception:
+    pass
 import threading
 import queue
 

--- a/hermes_cli/pt_input_extras.py
+++ b/hermes_cli/pt_input_extras.py
@@ -1,0 +1,51 @@
+"""Augmentations to prompt_toolkit's input-parsing tables.
+
+Imported once at CLI startup. Each helper installs a small mapping into
+prompt_toolkit's `ANSI_SEQUENCES` so byte sequences emitted by modern
+keyboard protocols (Kitty / xterm `modifyOtherKeys`) decode to existing
+key tuples Hermes already binds.
+
+Kept in a standalone module — separate from `cli.py` — so the registrations
+can be unit-tested without importing the whole CLI runtime.
+"""
+
+from __future__ import annotations
+
+
+def install_shift_enter_alias() -> int:
+    """Map Shift+Enter byte sequences to the (Escape, ControlM) key tuple
+    that Alt+Enter produces, so the existing Alt+Enter newline handler
+    fires for terminals that emit a distinct Shift+Enter.
+
+    Sequences mapped:
+      - "\\x1b[13;2u"     — Kitty keyboard protocol / CSI-u, modifier=2 (Shift)
+      - "\\x1b[27;2;13~"  — xterm modifyOtherKeys=2, modifier=2 (Shift)
+      - "\\x1b[27;2;13u"  — alternate ordering some emitters use
+
+    The CSI-u sequence is not in stock prompt_toolkit. The modifyOtherKeys
+    variant `\\x1b[27;2;13~` IS in stock prompt_toolkit but mapped to plain
+    `Keys.ControlM` — i.e. Shift+Enter behaves identically to Enter, which
+    is the very bug this helper exists to fix. We therefore overwrite
+    those two specific keys (and `\\x1b[27;2;13u`) unconditionally; other
+    `\\x1b[27;...;13~` sequences (Ctrl+Enter, Alt+Enter via modifyOtherKeys
+    variants 5/6/etc.) are left untouched.
+
+    Default macOS Terminal and stock Windows Terminal still send the same
+    byte for Enter and Shift+Enter, so there is no fix for those terminals
+    at the application layer — the sequences above never reach Hermes.
+
+    Returns the number of sequences whose mapping was changed.
+    """
+    try:
+        from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+        from prompt_toolkit.keys import Keys
+    except Exception:
+        return 0
+
+    alt_enter = (Keys.Escape, Keys.ControlM)
+    changed = 0
+    for seq in ("\x1b[13;2u", "\x1b[27;2;13~", "\x1b[27;2;13u"):
+        if ANSI_SEQUENCES.get(seq) != alt_enter:
+            ANSI_SEQUENCES[seq] = alt_enter
+            changed += 1
+    return changed

--- a/tests/cli/test_cli_shift_enter_newline.py
+++ b/tests/cli/test_cli_shift_enter_newline.py
@@ -1,0 +1,88 @@
+"""Verify Shift+Enter byte sequences parse to the same key tuple Alt+Enter
+produces, so the existing Alt+Enter newline handler in `cli.py` fires for
+terminals that emit a distinct Shift+Enter under the Kitty keyboard protocol
+or xterm modifyOtherKeys mode.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+from prompt_toolkit.input.vt100_parser import Vt100Parser
+from prompt_toolkit.keys import Keys
+
+from hermes_cli.pt_input_extras import install_shift_enter_alias
+
+
+SHIFT_ENTER_SEQUENCES = (
+    "\x1b[13;2u",      # Kitty / CSI-u, modifier=2 (Shift)
+    "\x1b[27;2;13~",   # xterm modifyOtherKeys=2
+    "\x1b[27;2;13u",
+)
+
+
+@pytest.fixture(autouse=True)
+def _ensure_alias_installed():
+    """Make every test idempotent — install the alias once per test run."""
+    install_shift_enter_alias()
+
+
+def _parse(byte_seq: str):
+    out = []
+    parser = Vt100Parser(out.append)
+    for ch in byte_seq:
+        parser.feed(ch)
+    parser.flush()
+    return [kp.key for kp in out]
+
+
+def test_install_registers_all_three_sequences():
+    for seq in SHIFT_ENTER_SEQUENCES:
+        assert seq in ANSI_SEQUENCES, f"missing mapping for {seq!r}"
+        assert ANSI_SEQUENCES[seq] == (Keys.Escape, Keys.ControlM)
+
+
+def test_install_overwrites_stock_modifyotherkeys_shift_enter():
+    """Stock prompt_toolkit maps `\\x1b[27;2;13~` to plain Keys.ControlM —
+    i.e. it drops the Shift modifier and treats Shift+Enter like Enter,
+    which is the bug this helper exists to fix. The install must overwrite
+    that entry."""
+    seq = "\x1b[27;2;13~"
+    ANSI_SEQUENCES[seq] = Keys.ControlM
+    install_shift_enter_alias()
+    assert ANSI_SEQUENCES[seq] == (Keys.Escape, Keys.ControlM)
+
+
+def test_install_returns_zero_when_already_correct():
+    """Idempotency — running install twice should not report a second change."""
+    install_shift_enter_alias()
+    assert install_shift_enter_alias() == 0
+
+
+def test_csi_u_shift_enter_parses_as_alt_enter():
+    """Kitty keyboard protocol Shift+Enter must parse to the same key tuple
+    Alt+Enter produces, so the existing handler is reused."""
+    alt_enter = _parse("\x1b\r")
+    shift_enter = _parse("\x1b[13;2u")
+    assert shift_enter == alt_enter, (
+        f"Shift+Enter via CSI-u should parse identically to Alt+Enter; "
+        f"got {shift_enter!r} vs {alt_enter!r}"
+    )
+
+
+def test_modify_other_keys_shift_enter_parses_as_alt_enter():
+    """xterm modifyOtherKeys=2 Shift+Enter must parse identically to Alt+Enter."""
+    alt_enter = _parse("\x1b\r")
+    shift_enter = _parse("\x1b[27;2;13~")
+    assert shift_enter == alt_enter
+
+
+def test_plain_enter_remains_distinct_from_alt_enter():
+    """Plain Enter must keep emitting a single key (submit), not a two-key
+    Alt+Enter tuple — otherwise we would have broken submit."""
+    enter = _parse("\r")
+    alt_enter = _parse("\x1b\r")
+    assert enter != alt_enter
+    assert len(enter) == 1
+    assert len(alt_enter) == 2

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -204,7 +204,7 @@ Type `/` to see an autocomplete dropdown of all commands:
 
 ### Multi-line input
 
-Press `Alt+Enter` or `Ctrl+J` to add a new line. Great for pasting code or writing detailed prompts.
+Press `Alt+Enter`, `Ctrl+J`, or `Shift+Enter` to add a new line. `Shift+Enter` requires a terminal that sends it as a distinct sequence (Kitty / foot / WezTerm / Ghostty by default; iTerm2 / Alacritty / VS Code terminal once the Kitty keyboard protocol is enabled). `Alt+Enter` and `Ctrl+J` work in every terminal.
 
 ### Interrupt the agent
 

--- a/website/docs/guides/tips.md
+++ b/website/docs/guides/tips.md
@@ -36,7 +36,7 @@ Before writing a long prompt explaining how to do something, check if there's al
 
 ### Multi-Line Input
 
-Press **Alt+Enter** (or **Ctrl+J**) to insert a newline without sending. This lets you compose multi-line prompts, paste code blocks, or structure complex requests before hitting Enter to send.
+Press **Alt+Enter**, **Ctrl+J**, or **Shift+Enter** to insert a newline without sending. `Shift+Enter` only works when the terminal sends it as a distinct keystroke (Kitty / foot / WezTerm / Ghostty by default; iTerm2 / Alacritty / VS Code terminal once the Kitty keyboard protocol is enabled). The other two work in every terminal.
 
 ### Paste Detection
 

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -92,7 +92,7 @@ When resuming a previous session (`hermes -c` or `hermes --resume <id>`), a "Pre
 | Key | Action |
 |-----|--------|
 | `Enter` | Send message |
-| `Alt+Enter` or `Ctrl+J` | New line (multi-line input) |
+| `Alt+Enter`, `Ctrl+J`, or `Shift+Enter` | New line (multi-line input). `Shift+Enter` requires a terminal that distinguishes it from `Enter` — see below. |
 | `Alt+V` | Paste an image from the clipboard when supported by the terminal |
 | `Ctrl+V` | Paste text and opportunistically attach clipboard images |
 | `Ctrl+B` | Start/stop voice recording when voice mode is enabled (`voice.record_key`, default: `ctrl+b`) |
@@ -204,7 +204,7 @@ personalities:
 
 There are two ways to enter multi-line messages:
 
-1. **`Alt+Enter` or `Ctrl+J`** — inserts a new line
+1. **`Alt+Enter`, `Ctrl+J`, or `Shift+Enter`** — inserts a new line
 2. **Backslash continuation** — end a line with `\` to continue:
 
 ```
@@ -214,8 +214,20 @@ There are two ways to enter multi-line messages:
 ```
 
 :::info
-Pasting multi-line text is supported — use `Alt+Enter` or `Ctrl+J` to insert newlines, or simply paste content directly.
+Pasting multi-line text is supported — use any of the newline keys above, or simply paste content directly.
 :::
+
+### Shift+Enter compatibility
+
+Most terminals send the same byte sequence for `Enter` and `Shift+Enter` by default, so applications cannot distinguish them. Hermes recognises `Shift+Enter` only when the terminal sends a distinct sequence via the [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) or xterm's `modifyOtherKeys` mode.
+
+| Terminal | Status |
+|---|---|
+| Kitty, foot, WezTerm, Ghostty | Distinct `Shift+Enter` enabled by default |
+| iTerm2 (recent), Alacritty, VS Code terminal, Warp | Supported once the Kitty protocol is enabled in settings |
+| macOS Terminal.app, stock Windows Terminal | Not supported — `Shift+Enter` is indistinguishable from `Enter` |
+
+Where the terminal cannot distinguish them, `Alt+Enter` and `Ctrl+J` continue to work everywhere.
 
 ## Interrupting the Agent
 


### PR DESCRIPTION
## What does this PR do?

Closes #5346.

Most terminals send the same byte sequence for `Enter` and `Shift+Enter` by default, so applications can't tell them apart — that's a terminal protocol limitation, not something Hermes can paper over. But terminals that implement the [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) (Kitty / foot / WezTerm / Ghostty by default; iTerm2 / Alacritty / VS Code terminal / Warp once the protocol is enabled) do emit a distinct sequence for `Shift+Enter`:

- `\x1b[13;2u` — Kitty / CSI-u, modifier=2
- `\x1b[27;2;13~` — xterm `modifyOtherKeys=2`

Stock prompt_toolkit doesn't have the CSI-u sequence in its `ANSI_SEQUENCES` table at all, and it maps the modifyOtherKeys variant to plain `Keys.ControlM` (Enter) — i.e. it strips the Shift modifier, which is the bug users actually hit on iTerm2 and friends.

This PR registers/overwrites those sequences in `ANSI_SEQUENCES` so they decode to `(Keys.Escape, Keys.ControlM)` — the same key tuple `Alt+Enter` produces. The existing Alt+Enter handler (`@kb.add('escape', 'enter')` in [cli.py:10570](https://github.com/NousResearch/hermes-agent/blob/main/cli.py#L10570)) then fires unchanged, so there's no new keybinding to register and no behavioral change for terminals that don't emit the distinct sequences.

## Related Issue

Closes #5346.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding test coverage)

## Changes Made

- **`hermes_cli/pt_input_extras.py`** (new) — `install_shift_enter_alias()` helper. Lives outside `cli.py` so the helper is importable in tests without dragging in the full CLI runtime (which depends on `fire`, `rich`, `agent.usage_pricing`, etc.).
- **`cli.py`** — calls `install_shift_enter_alias()` once at module import, right after the prompt_toolkit imports. Wrapped in `try/except` so prompt_toolkit version drift can't break CLI startup.
- **`tests/cli/test_cli_shift_enter_newline.py`** (new) — 6 tests:
  - all three byte sequences register correctly
  - stock prompt_toolkit's broken `modifyOtherKeys` mapping is overwritten
  - second call returns 0 (idempotency)
  - parser equivalence: CSI-u Shift+Enter parses identically to Alt+Enter
  - parser equivalence: modifyOtherKeys Shift+Enter parses identically to Alt+Enter
  - plain Enter remains a single-key submit, distinct from the two-key Alt+Enter / Shift+Enter tuple (regression guard)
- **`website/docs/user-guide/cli.md`** — keybinding table updated; new "Shift+Enter compatibility" subsection with a per-terminal status table.
- **`website/docs/getting-started/quickstart.md`**, **`website/docs/guides/tips.md`** — short mentions pointing at the full compatibility note in `cli.md`.

## How to Test

```bash
pytest tests/cli/test_cli_shift_enter_newline.py -o "addopts=-m 'not integration'" -v
# → 6 passed
```

End-to-end on a Kitty-protocol-capable terminal (kitty / WezTerm / Ghostty / iTerm2 with Kitty keyboard protocol enabled):

1. Run `hermes chat`.
2. Press `Shift+Enter`. A newline should be inserted; the prompt should not submit.
3. Press `Enter`. The message should submit.

On terminals that don't distinguish the keystroke (default macOS Terminal, stock Windows Terminal), `Shift+Enter` continues to behave as `Enter` — no change. `Alt+Enter` and `Ctrl+J` still work everywhere.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`feat(cli):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to the Shift+Enter keybinding
- [x] I've run `pytest tests/cli/test_cli_shift_enter_newline.py` and all tests pass
- [x] I've added tests for my changes (6 new tests covering registration, idempotency, parser equivalence, and a regression guard for plain Enter)
- [x] Tested on macOS 26.4 (arm64). The patch is platform-independent — it lives entirely in prompt_toolkit's ANSI sequence table.

### Documentation & Housekeeping

- [x] Updated `website/docs/user-guide/cli.md`, `website/docs/getting-started/quickstart.md`, `website/docs/guides/tips.md`
- [x] N/A — no `cli-config.yaml.example` keys added
- [x] N/A — no architectural / workflow changes
- [x] Considered cross-platform: prompt_toolkit's `ANSI_SEQUENCES` table is shared across all platforms. The patch has no platform-specific code.
- [x] N/A — no tool schema changes

## Notes for reviewers

The helper is intentionally placed in a separate module (`hermes_cli/pt_input_extras.py`) rather than inlined in `cli.py` because importing `cli.py` requires `fire`, `rich`, full agent stack, etc. — the standalone module lets the tests exercise just the patching logic against a freshly-installed prompt_toolkit, which is what CI can rely on.

Three sequences are registered (CSI-u, modifyOtherKeys variant 1 and 2) to cover the small variation between emitters. Other `\x1b[27;...;13~` sequences (Ctrl+Enter, Alt+Enter via modifyOtherKeys, etc.) are deliberately left untouched.