### PR TITLE
feat: inline image rendering in CLI via Kitty/iTerm2 graphics protocol

### DIFF
--- a/agent/inline_images.py
+++ b/agent/inline_images.py
@@ -111,6 +111,47 @@ def _get_jpeg_dimensions(data: bytes) -> Tuple[int, int]:
     return (800, 600)
 
 
+def _get_image_dimensions_from_data(data: bytes) -> Tuple[int, int]:
+    """Get image dimensions from raw bytes. Handles PNG natively, JPEG via SOF
+    marker parsing, and falls back to PIL for other formats."""
+    # PNG
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return _get_png_dimensions(data)
+
+    # JPEG
+    if data[:2] == b"\xff\xd8":
+        return _get_jpeg_dimensions(data)
+
+    # Try PIL/Pillow for GIF, WebP, BMP, etc.
+    try:
+        import io as _io
+        from PIL import Image
+        with Image.open(_io.BytesIO(data)) as img:
+            return img.size
+    except (ImportError, Exception):
+        pass
+
+    return (800, 600)  # fallback estimate
+
+
+def _ensure_png(data: bytes) -> bytes:
+    """Convert image data to PNG if it isn't already. Returns the original data
+    unchanged if it's already PNG or if PIL is not available for conversion."""
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return data
+
+    try:
+        import io as _io
+        from PIL import Image
+        with Image.open(_io.BytesIO(data)) as img:
+            buf = _io.BytesIO()
+            img.save(buf, format="PNG")
+            return buf.getvalue()
+    except (ImportError, Exception) as e:
+        logger.debug("Cannot convert image to PNG (PIL unavailable or failed): %s", e)
+        return data  # best-effort: send as-is
+
+
 # ── Terminal size helpers ──────────────────────────────────────────────
 
 
@@ -197,11 +238,19 @@ def _render_kitty(image_path: str, max_cols: Optional[int] = None, max_rows: Opt
 def _render_kitty_from_data(
     data: bytes, max_cols: Optional[int] = None, max_rows: Optional[int] = None
 ) -> str:
-    """Render image from raw bytes via Kitty protocol (direct transmission)."""
-    try:
-        img_w, img_h = _get_png_dimensions(data)
-    except ValueError:
-        img_w, img_h = 800, 600
+    """Render image from raw bytes via Kitty protocol (direct transmission).
+
+    Converts non-PNG images to PNG (via PIL) so the f=100 format code is always
+    correct.  Falls back to sending raw data if PIL is unavailable — most modern
+    Kitty-compatible terminals auto-detect the format from the payload even when
+    f=100 is declared.
+    """
+    # Get dimensions from the *original* data (before any conversion) so we
+    # handle all formats correctly — JPEG via SOF parsing, PNG natively, etc.
+    img_w, img_h = _get_image_dimensions_from_data(data)
+
+    # Convert to PNG so f=100 is always truthful
+    data = _ensure_png(data)
 
     display_cols, display_rows = _calculate_display_cells(img_w, img_h, max_cols, max_rows)
     b64_data = base64.b64encode(data).decode()

--- a/agent/inline_images.py
+++ b/agent/inline_images.py
@@ -1,0 +1,380 @@
+"""
+Inline image rendering for terminals that support the Kitty or iTerm2 graphics protocol.
+
+Supports: Kitty, Ghostty, WezTerm (kitty protocol), iTerm2 (iterm2 protocol).
+
+Usage from CLI:
+    from agent.inline_images import try_render_inline
+    try_render_inline("/path/to/screenshot.png")  # renders if supported, no-op otherwise
+
+Config: display.inline_images in config.yaml
+    - "auto" (default): auto-detect terminal capability
+    - true: force enabled (kitty protocol)
+    - false: disabled
+"""
+
+import base64
+import json
+import logging
+import os
+import struct
+import sys
+from pathlib import Path
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ── Terminal capability detection ──────────────────────────────────────
+
+
+def detect_image_protocol() -> str:
+    """Detect which inline image protocol the terminal supports.
+
+    Returns: 'kitty', 'iterm2', or 'none'
+    """
+    term = os.environ.get("TERM", "").lower()
+    term_program = os.environ.get("TERM_PROGRAM", "").lower()
+    kitty_window = os.environ.get("KITTY_WINDOW_ID", "")
+
+    # Kitty protocol support
+    if kitty_window:
+        return "kitty"
+    if term_program in ("ghostty", "kitty"):
+        return "kitty"
+    if "ghostty" in term or "kitty" in term:
+        return "kitty"
+
+    # iTerm2 protocol support (also works in WezTerm, Hyper, etc.)
+    if term_program in ("iterm2", "iterm2.app", "wezterm", "hyper"):
+        return "iterm2"
+    if "iterm" in term_program:
+        return "iterm2"
+
+    # WezTerm also supports kitty protocol — check TERM
+    if "wezterm" in term:
+        return "kitty"
+
+    return "none"
+
+
+# ── PNG dimension reader (no PIL) ──────────────────────────────────────
+
+
+def _get_png_dimensions(data: bytes) -> Tuple[int, int]:
+    """Extract (width, height) from PNG header."""
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise ValueError("Not a valid PNG file")
+    return struct.unpack(">II", data[16:24])
+
+
+def _get_image_dimensions(path: Path) -> Tuple[int, int]:
+    """Get image dimensions. Handles PNG natively, tries PIL for others."""
+    data = path.read_bytes()
+
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return _get_png_dimensions(data)
+
+    # Try PIL/Pillow for JPEG etc.
+    try:
+        from PIL import Image
+
+        with Image.open(path) as img:
+            return img.size
+    except ImportError:
+        pass
+
+    # JPEG: try to parse SOF marker
+    if data[:2] == b"\xff\xd8":
+        return _get_jpeg_dimensions(data)
+
+    return (800, 600)  # fallback estimate
+
+
+def _get_jpeg_dimensions(data: bytes) -> Tuple[int, int]:
+    """Parse JPEG SOF marker for dimensions."""
+    i = 2
+    while i < len(data) - 1:
+        if data[i] != 0xFF:
+            break
+        marker = data[i + 1]
+        if marker in (0xC0, 0xC1, 0xC2):  # SOF markers
+            h = struct.unpack(">H", data[i + 5 : i + 7])[0]
+            w = struct.unpack(">H", data[i + 7 : i + 9])[0]
+            return (w, h)
+        if marker == 0xD9:  # EOI
+            break
+        if marker in (0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8, 0x01):
+            i += 2
+            continue
+        length = struct.unpack(">H", data[i + 2 : i + 4])[0]
+        i += 2 + length
+    return (800, 600)
+
+
+# ── Terminal size helpers ──────────────────────────────────────────────
+
+
+def _get_terminal_size_pixels() -> Tuple[int, int, int, int]:
+    """Return (cols, rows, pixel_width, pixel_height)."""
+    try:
+        cols, rows = os.get_terminal_size()
+    except OSError:
+        cols, rows = 80, 24
+
+    try:
+        import fcntl
+        import termios
+
+        result = fcntl.ioctl((getattr(sys, "__stdout__", None) or sys.stdout).fileno(), termios.TIOCGWINSZ, b"\x00" * 8)
+        _, _, xpixel, ypixel = struct.unpack("HHHH", result)
+        if xpixel > 0 and ypixel > 0:
+            return cols, rows, xpixel, ypixel
+    except Exception:
+        pass
+
+    # Estimate: typical cell ~8x16
+    return cols, rows, cols * 8, rows * 16
+
+
+def _calculate_display_cells(
+    img_w: int, img_h: int, max_cols: Optional[int] = None, max_rows: Optional[int] = None
+) -> Tuple[int, int]:
+    """Calculate display size in terminal cells, preserving aspect ratio."""
+    term_cols, term_rows, px_w, px_h = _get_terminal_size_pixels()
+
+    if max_cols is None:
+        max_cols = min(term_cols - 4, 120)
+    if max_rows is None:
+        max_rows = min(term_rows - 4, 30)
+
+    cell_w = px_w / term_cols if term_cols > 0 else 8
+    cell_h = px_h / term_rows if term_rows > 0 else 16
+
+    img_cols = img_w / cell_w
+    img_rows = img_h / cell_h
+
+    scale = min(1.0, max_cols / max(img_cols, 0.1), max_rows / max(img_rows, 0.1))
+
+    return max(1, int(img_cols * scale)), max(1, int(img_rows * scale))
+
+
+# ── Kitty graphics protocol renderer ──────────────────────────────────
+
+
+def _is_ssh_session() -> bool:
+    """Detect if we're running inside an SSH session."""
+    return bool(os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY"))
+
+
+def _render_kitty(image_path: str, max_cols: Optional[int] = None, max_rows: Optional[int] = None) -> str:
+    """Render image using Kitty graphics protocol.
+
+    Uses transmit-by-file-path (t=f) locally for speed, but falls back to
+    direct base64 data transmission (t=d) over SSH since the local terminal
+    can't access remote file paths.
+    """
+    path = Path(image_path).resolve()
+    if not path.exists():
+        return ""
+
+    # Over SSH, the terminal is on the local machine and can't read remote
+    # file paths.  Send the image data directly through the SSH pipe instead.
+    if _is_ssh_session():
+        data = path.read_bytes()
+        return _render_kitty_from_data(data, max_cols, max_rows)
+
+    try:
+        img_w, img_h = _get_image_dimensions(path)
+    except Exception:
+        img_w, img_h = 800, 600
+
+    display_cols, display_rows = _calculate_display_cells(img_w, img_h, max_cols, max_rows)
+    path_b64 = base64.b64encode(str(path).encode()).decode()
+
+    return f"\033_Ga=T,f=100,t=f,c={display_cols},r={display_rows};{path_b64}\033\\"
+
+
+def _render_kitty_from_data(
+    data: bytes, max_cols: Optional[int] = None, max_rows: Optional[int] = None
+) -> str:
+    """Render image from raw bytes via Kitty protocol (direct transmission)."""
+    try:
+        img_w, img_h = _get_png_dimensions(data)
+    except ValueError:
+        img_w, img_h = 800, 600
+
+    display_cols, display_rows = _calculate_display_cells(img_w, img_h, max_cols, max_rows)
+    b64_data = base64.b64encode(data).decode()
+
+    chunks = [b64_data[i : i + 4096] for i in range(0, len(b64_data), 4096)]
+
+    if len(chunks) == 1:
+        return f"\033_Ga=T,f=100,t=d,c={display_cols},r={display_rows};{chunks[0]}\033\\"
+
+    result = f"\033_Ga=T,f=100,t=d,c={display_cols},r={display_rows},m=1;{chunks[0]}\033\\"
+    for chunk in chunks[1:-1]:
+        result += f"\033_Gm=1;{chunk}\033\\"
+    result += f"\033_Gm=0;{chunks[-1]}\033\\"
+    return result
+
+
+# ── iTerm2 inline image protocol renderer ─────────────────────────────
+
+
+def _render_iterm2(image_path: str, max_cols: Optional[int] = None, max_rows: Optional[int] = None) -> str:
+    """Render image using iTerm2 inline image protocol."""
+    path = Path(image_path).resolve()
+    if not path.exists():
+        return ""
+
+    data = path.read_bytes()
+    b64_data = base64.b64encode(data).decode()
+
+    try:
+        img_w, img_h = _get_image_dimensions(path)
+    except Exception:
+        img_w, img_h = 800, 600
+
+    display_cols, _ = _calculate_display_cells(img_w, img_h, max_cols, max_rows)
+    name_b64 = base64.b64encode(path.name.encode()).decode()
+
+    return (
+        f"\033]1337;File=name={name_b64}"
+        f";size={len(data)}"
+        f";inline=1"
+        f";width={display_cols}"
+        f";preserveAspectRatio=1"
+        f":{b64_data}\a"
+    )
+
+
+# ── Public API ─────────────────────────────────────────────────────────
+
+# Cached protocol detection (avoid re-checking env vars every call)
+_cached_protocol: Optional[str] = None
+
+
+def _get_protocol(config_value: object = None) -> str:
+    """Resolve the inline image protocol from config + environment.
+
+    config_value: display.inline_images from config.yaml
+        - "auto" or None → auto-detect
+        - True / "true" → force kitty
+        - False / "false" → disabled
+        - "kitty" / "iterm2" → force specific protocol
+    """
+    global _cached_protocol
+
+    if config_value is False or config_value == "false":
+        return "none"
+
+    if config_value is True or config_value == "true":
+        if _cached_protocol is None:
+            _cached_protocol = detect_image_protocol()
+        return _cached_protocol if _cached_protocol != "none" else "kitty"
+
+    if isinstance(config_value, str) and config_value in ("kitty", "iterm2"):
+        return config_value
+
+    # auto or None
+    if _cached_protocol is None:
+        _cached_protocol = detect_image_protocol()
+    return _cached_protocol
+
+
+def try_render_inline(
+    image_path: str,
+    max_cols: Optional[int] = None,
+    max_rows: Optional[int] = None,
+    config_value: object = "auto",
+    label: Optional[str] = None,
+    indent: str = "  ",
+) -> bool:
+    """Attempt to render an image inline in the terminal.
+
+    Args:
+        image_path: Path to a PNG/JPEG image file
+        max_cols: Max display width in terminal columns (default: auto)
+        max_rows: Max display height in terminal rows (default: auto)
+        config_value: Value of display.inline_images from config
+        label: Optional text label to show below the image
+        indent: Indentation prefix for the image and label
+
+    Returns:
+        True if rendered inline, False if not supported or failed
+    """
+    protocol = _get_protocol(config_value)
+    if protocol == "none":
+        return False
+
+    path = Path(image_path)
+    if not path.exists():
+        logger.debug("Inline image: file not found: %s", image_path)
+        return False
+
+    # Check file is a supported image
+    suffix = path.suffix.lower()
+    if suffix not in (".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"):
+        logger.debug("Inline image: unsupported format: %s", suffix)
+        return False
+
+    try:
+        if protocol == "kitty":
+            output = _render_kitty(str(path), max_cols, max_rows)
+        elif protocol == "iterm2":
+            output = _render_iterm2(str(path), max_cols, max_rows)
+        else:
+            return False
+
+        if not output:
+            return False
+
+        # Write to the *real* stdout, bypassing prompt_toolkit's StdoutProxy.
+        # prompt_toolkit's patch_stdout replaces sys.stdout with a proxy that
+        # swallows raw escape sequences (it only understands ANSI color codes
+        # routed through print_formatted_text).  Kitty/iTerm2 graphics protocol
+        # uses APC/OSC sequences that the proxy silently discards.
+        # sys.__stdout__ is the original file object saved by Python at startup.
+        _real_out = getattr(sys, "__stdout__", None) or sys.stdout
+        _real_out.write(f"{indent}{output}\n")
+        if label:
+            _real_out.write(f"{indent}{label}\n")
+        _real_out.flush()
+        return True
+
+    except Exception as e:
+        logger.debug("Inline image rendering failed: %s", e)
+        return False
+
+
+def extract_image_path_from_tool_result(function_name: str, result: str) -> Optional[str]:
+    """Extract an image file path from a tool's JSON result string.
+
+    Supports: browser_vision, image_generate, vision_analyze.
+    Returns the path if found, None otherwise.
+    """
+    _IMAGE_TOOLS = {
+        "browser_vision",
+        "image_generate",
+        "vision_analyze",
+    }
+    if function_name not in _IMAGE_TOOLS:
+        return None
+
+    try:
+        data = json.loads(result)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+    # browser_vision returns {"analysis": "...", "screenshot_path": "/path/..."}
+    # image_generate returns {"image": "/path/..." or "https://..."}
+    # vision_analyze returns {"analysis": "...", "screenshot_path": "..."}
+
+    for key in ("screenshot_path", "image", "image_path"):
+        val = data.get(key)
+        if isinstance(val, str) and val and not val.startswith("http"):
+            path = Path(val)
+            if path.exists() and path.suffix.lower() in (".png", ".jpg", ".jpeg", ".gif", ".webp"):
+                return str(path)
+
+    return None

--- a/cli.py
+++ b/cli.py
@@ -1417,6 +1417,7 @@ def _cprint(text: str):
         current_loop = None
     except Exception:
         current_loop = None
+
     # Same thread as the app's loop → safe to print directly.
     if current_loop is loop and loop.is_running():
         _pt_print(_PT_ANSI(text))
@@ -1429,7 +1430,7 @@ def _cprint(text: str):
     def _schedule():
         try:
             run_in_terminal(lambda: _pt_print(_PT_ANSI(text)))
-        except Exception:
+        except Exception as _sch_err:
             try:
                 _pt_print(_PT_ANSI(text))
             except Exception:
@@ -8456,6 +8457,30 @@ class HermesCLI:
                     if is_error:
                         line = f"{line} [error]"
                     _cprint(f"  {line}")
+                except Exception:
+                    pass
+                # ── Inline image rendering for visual tool results ──
+                # When a tool like browser_vision or image_generate completes,
+                # render the screenshot/image inline if the terminal supports it.
+                try:
+                    tool_result = kwargs.get("result", "")
+                    if tool_result and function_name:
+                        from agent.inline_images import (
+                            extract_image_path_from_tool_result,
+                            try_render_inline,
+                        )
+                        img_path = extract_image_path_from_tool_result(
+                            function_name, tool_result
+                        )
+                        if img_path:
+                            inline_cfg = CLI_CONFIG.get("display", {}).get(
+                                "inline_images", "auto"
+                            )
+                            rendered = try_render_inline(
+                                img_path,
+                                config_value=inline_cfg,
+                                indent="  ┊ ",
+                            )
                 except Exception:
                     pass
                 # First-touch onboarding: on the first tool in this process

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -828,6 +828,7 @@ DEFAULT_CONFIG = {
         "persistent_output": True,
         "persistent_output_max_lines": 200,
         "inline_diffs": True,     # Show inline diff previews for write actions (write_file, patch, skill_manage)
+        "inline_images": "auto",  # Render images inline via Kitty/iTerm2 protocol (auto|true|false|kitty|iterm2)
         "show_cost": False,       # Show $ cost in the status bar (off by default)
         "skin": "default",
         # UI language for static user-facing messages (approval prompts, a

--- a/run_agent.py
+++ b/run_agent.py
@@ -10090,6 +10090,7 @@ class AIAgent:
                         self.tool_progress_callback(
                             "tool.completed", function_name, None, None,
                             duration=tool_duration, is_error=is_error,
+                            result=function_result,
                         )
                     except Exception as cb_err:
                         logging.debug(f"Tool progress callback error: {cb_err}")
@@ -10490,6 +10491,7 @@ class AIAgent:
                     self.tool_progress_callback(
                         "tool.completed", function_name, None, None,
                         duration=tool_duration, is_error=_is_error_result,
+                        result=function_result,
                     )
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")

--- a/tests/agent/test_inline_images.py
+++ b/tests/agent/test_inline_images.py
@@ -13,6 +13,8 @@ import pytest
 from agent.inline_images import (
     _calculate_display_cells,
     _get_png_dimensions,
+    _get_image_dimensions_from_data,
+    _ensure_png,
     detect_image_protocol,
     extract_image_path_from_tool_result,
     try_render_inline,
@@ -39,6 +41,24 @@ def _make_test_png(width=100, height=50) -> bytes:
     png += make_chunk(b'IDAT', compressed)
     png += make_chunk(b'IEND', b'')
     return png
+
+
+def _make_test_jpeg(width=100, height=50) -> bytes:
+    """Create a minimal valid JPEG file via PIL, or a hand-crafted stub."""
+    try:
+        import io as _io
+        from PIL import Image
+        img = Image.new("RGB", (width, height), color=(128, 128, 128))
+        buf = _io.BytesIO()
+        img.save(buf, format="JPEG")
+        return buf.getvalue()
+    except ImportError:
+        # Hand-craft a minimal JPEG with a SOF0 marker so _get_jpeg_dimensions works
+        sof = b"\xff\xc0"  # SOF0 marker
+        sof_len = struct.pack(">H", 11)  # length
+        sof_data = struct.pack(">BHHB", 8, height, width, 3)  # precision, h, w, components
+        sof_data += b"\x01\x11\x00\x02\x11\x00\x03\x11\x00"  # component specs
+        return b"\xff\xd8" + sof + sof_len + sof_data + b"\xff\xd9"
 
 
 class TestDetectProtocol:
@@ -166,3 +186,66 @@ class TestCalculateDisplayCells:
         cols, rows = _calculate_display_cells(10, 10, max_cols=80, max_rows=24)
         assert cols >= 1
         assert rows >= 1
+
+
+class TestImageDimensionsFromData:
+    """Tests for _get_image_dimensions_from_data — the format-agnostic dimension reader."""
+
+    def test_png_data(self):
+        png = _make_test_png(320, 200)
+        assert _get_image_dimensions_from_data(png) == (320, 200)
+
+    def test_jpeg_data(self):
+        jpeg = _make_test_jpeg(160, 120)
+        w, h = _get_image_dimensions_from_data(jpeg)
+        assert w == 160
+        assert h == 120
+
+    def test_unknown_format_fallback(self):
+        assert _get_image_dimensions_from_data(b"not an image at all") == (800, 600)
+
+
+class TestEnsurePng:
+    """Tests for _ensure_png — the non-PNG-to-PNG converter."""
+
+    def test_png_passthrough(self):
+        """PNG data should be returned unchanged."""
+        png = _make_test_png(10, 10)
+        result = _ensure_png(png)
+        assert result is png  # exact same object, no conversion
+
+    def test_jpeg_converted_to_png(self):
+        """JPEG data should be converted to valid PNG (if PIL is available)."""
+        jpeg = _make_test_jpeg(20, 15)
+        result = _ensure_png(jpeg)
+        try:
+            import PIL  # noqa: F401
+            # PIL available — should have been converted
+            assert result[:8] == b"\x89PNG\r\n\x1a\n", "JPEG should be converted to PNG"
+            # Verify dimensions are preserved
+            w, h = _get_png_dimensions(result)
+            assert w == 20
+            assert h == 15
+        except ImportError:
+            # No PIL — data returned as-is
+            assert result == jpeg
+
+    def test_unknown_format_passthrough(self):
+        """Unknown format should be returned as-is (best-effort)."""
+        data = b"definitely not an image"
+        result = _ensure_png(data)
+        assert result == data
+
+
+class TestKittySSHJpeg:
+    """Regression test: JPEG images over SSH should get correct dimensions and valid protocol output."""
+
+    def test_jpeg_over_ssh_renders(self):
+        """Simulate SSH rendering of a JPEG — should produce valid Kitty escape sequences."""
+        from agent.inline_images import _render_kitty_from_data
+        jpeg = _make_test_jpeg(200, 100)
+        output = _render_kitty_from_data(jpeg, max_cols=80, max_rows=24)
+        # Must contain kitty graphics protocol escape
+        assert "\033_G" in output
+        # f=100 is declared (PNG format) — the data should have been converted to PNG
+        assert "f=100" in output

--- a/tests/agent/test_inline_images.py
+++ b/tests/agent/test_inline_images.py
@@ -1,0 +1,168 @@
+"""Tests for agent/inline_images.py"""
+import json
+import os
+import struct
+import sys
+import tempfile
+import zlib
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.inline_images import (
+    _calculate_display_cells,
+    _get_png_dimensions,
+    detect_image_protocol,
+    extract_image_path_from_tool_result,
+    try_render_inline,
+    _cached_protocol,
+)
+
+
+def _make_test_png(width=100, height=50) -> bytes:
+    """Create a minimal valid PNG file."""
+    def make_chunk(chunk_type, data):
+        c = chunk_type + data
+        return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+
+    ihdr_data = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    raw = bytearray()
+    for y in range(height):
+        raw.append(0)
+        for x in range(width):
+            raw.extend([128, 128, 128])
+    compressed = zlib.compress(bytes(raw), 1)
+
+    png = b'\x89PNG\r\n\x1a\n'
+    png += make_chunk(b'IHDR', ihdr_data)
+    png += make_chunk(b'IDAT', compressed)
+    png += make_chunk(b'IEND', b'')
+    return png
+
+
+class TestDetectProtocol:
+    def test_kitty_window_id(self):
+        with patch.dict(os.environ, {"KITTY_WINDOW_ID": "1", "TERM": "", "TERM_PROGRAM": ""}):
+            import agent.inline_images as m
+            m._cached_protocol = None
+            assert detect_image_protocol() == "kitty"
+
+    def test_ghostty_term(self):
+        with patch.dict(os.environ, {"TERM": "xterm-ghostty", "TERM_PROGRAM": "", "KITTY_WINDOW_ID": ""}, clear=False):
+            import agent.inline_images as m
+            m._cached_protocol = None
+            assert detect_image_protocol() == "kitty"
+
+    def test_ghostty_term_program(self):
+        with patch.dict(os.environ, {"TERM_PROGRAM": "ghostty", "TERM": "", "KITTY_WINDOW_ID": ""}, clear=False):
+            import agent.inline_images as m
+            m._cached_protocol = None
+            assert detect_image_protocol() == "kitty"
+
+    def test_iterm2(self):
+        with patch.dict(os.environ, {"TERM_PROGRAM": "iTerm2", "TERM": "", "KITTY_WINDOW_ID": ""}, clear=False):
+            import agent.inline_images as m
+            m._cached_protocol = None
+            assert detect_image_protocol() == "iterm2"
+
+    def test_none(self):
+        with patch.dict(os.environ, {"TERM": "xterm-256color", "TERM_PROGRAM": "", "KITTY_WINDOW_ID": ""}, clear=False):
+            import agent.inline_images as m
+            m._cached_protocol = None
+            assert detect_image_protocol() == "none"
+
+
+class TestPNGDimensions:
+    def test_valid_png(self):
+        png = _make_test_png(320, 200)
+        assert _get_png_dimensions(png) == (320, 200)
+
+    def test_invalid_data(self):
+        with pytest.raises(ValueError):
+            _get_png_dimensions(b"not a png")
+
+
+class TestExtractImagePath:
+    def test_browser_vision(self):
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            f.write(_make_test_png())
+            f.flush()
+            result = json.dumps({"analysis": "a webpage", "screenshot_path": f.name})
+            path = extract_image_path_from_tool_result("browser_vision", result)
+            assert path == f.name
+            os.unlink(f.name)
+
+    def test_image_generate(self):
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            f.write(_make_test_png())
+            f.flush()
+            result = json.dumps({"image": f.name})
+            path = extract_image_path_from_tool_result("image_generate", result)
+            assert path == f.name
+            os.unlink(f.name)
+
+    def test_url_ignored(self):
+        result = json.dumps({"image": "https://example.com/image.png"})
+        path = extract_image_path_from_tool_result("image_generate", result)
+        assert path is None
+
+    def test_unrelated_tool(self):
+        result = json.dumps({"screenshot_path": "/tmp/test.png"})
+        path = extract_image_path_from_tool_result("terminal", result)
+        assert path is None
+
+    def test_invalid_json(self):
+        path = extract_image_path_from_tool_result("browser_vision", "not json")
+        assert path is None
+
+
+class TestTryRenderInline:
+    def test_disabled_by_config(self):
+        result = try_render_inline("/tmp/test.png", config_value=False)
+        assert result is False
+
+    def test_nonexistent_file(self):
+        result = try_render_inline("/tmp/nonexistent_image_12345.png", config_value="kitty")
+        assert result is False
+
+    def test_unsupported_format(self):
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"not an image")
+            f.flush()
+            result = try_render_inline(f.name, config_value="kitty")
+            assert result is False
+            os.unlink(f.name)
+
+    def test_kitty_renders(self, capsys):
+        """Test that kitty protocol produces escape sequences."""
+        png = _make_test_png(100, 50)
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            f.write(png)
+            f.flush()
+            # try_render_inline writes to sys.__stdout__ (bypassing prompt_toolkit),
+            # so redirect __stdout__ to a StringIO for capture in tests.
+            import io
+            buf = io.StringIO()
+            old_real = getattr(sys, "__stdout__", sys.stdout)
+            sys.__stdout__ = buf
+            try:
+                result = try_render_inline(f.name, config_value="kitty", indent="")
+            finally:
+                sys.__stdout__ = old_real
+            if result:
+                # Should contain kitty escape sequence
+                assert "\033_G" in buf.getvalue()
+            os.unlink(f.name)
+
+
+class TestCalculateDisplayCells:
+    def test_basic(self):
+        cols, rows = _calculate_display_cells(800, 600, max_cols=80, max_rows=24)
+        assert 1 <= cols <= 80
+        assert 1 <= rows <= 24
+
+    def test_tiny_image(self):
+        cols, rows = _calculate_display_cells(10, 10, max_cols=80, max_rows=24)
+        assert cols >= 1
+        assert rows >= 1


### PR DESCRIPTION
## Summary

Adds terminal inline image support so visual tool results (`browser_vision`, `image_generate`, `vision_analyze`) render directly in the terminal scrollback instead of just returning a file path.

## Problem

When using tools like `browser_vision`, the CLI returns a screenshot path but the user has to open it manually. Terminals like Kitty, Ghostty, and iTerm2 support inline image protocols that can display images directly in the scrollback.

Additionally, over SSH sessions the Kitty `t=f` (transmit-by-file-path) mode silently fails because the local terminal emulator can't access file paths on the remote machine.

## Solution

- **New module: `agent/inline_images.py`** — protocol detection, rendering, and image path extraction
- **Auto-detects** Kitty vs iTerm2 protocol from `TERM`/`TERM_PROGRAM` env vars
- **SSH-aware**: uses `t=d` (direct base64 data transmission) over SSH instead of `t=f` (file path), since the local terminal can't read remote paths. This is the same approach used by yazi.
- **Chunked transfer**: 4096-byte base64 chunks for large images per Kitty spec
- **Zero new dependencies**: PNG dimensions parsed natively; JPEG SOF marker fallback; PIL used only if available
- Writes to `sys.__stdout__` to bypass prompt_toolkit's `StdoutProxy` which swallows APC/OSC sequences
- Configurable: `display.inline_images: auto|true|false|kitty|iterm2`

## Changes

| File | Change |
|------|--------|
| `agent/inline_images.py` | New — protocol detection, Kitty + iTerm2 renderers, image path extraction |
| `cli.py` | Hook into `_on_tool_progress()` tool.completed callback to render images |
| `run_agent.py` | Pass `result=` to `tool_progress_callback` (both parallel + sequential paths) |
| `hermes_cli/config.py` | Add `inline_images` default to `DEFAULT_CONFIG` |
| `tests/agent/test_inline_images.py` | Unit tests for detection, rendering, and extraction |

## Testing

- Tested with Ghostty (`TERM=xterm-ghostty`) over SSH — images render correctly in scrollback
- Verified `t=d` chunked base64 works transparently through SSH pipe
- Unit tests cover protocol detection, PNG dimension parsing, display cell calculation, and tool result extraction
