### PR TITLE
fix(gateway): detect Telegram polling-pool wedges via correct pool

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -8,6 +8,7 @@ Uses python-telegram-bot library for:
 """
 
 import asyncio
+import time as _time
 import json
 import logging
 import os
@@ -269,6 +270,10 @@ class TelegramAdapter(BasePlatformAdapter):
     MEDIA_GROUP_WAIT_SECONDS = 0.8
     _GENERAL_TOPIC_THREAD_ID = "1"
 
+    # Two-strike escalation window for polling-pool probe failures (issue #5729).
+    # Two failures within this many seconds escalate to fatal-retryable.
+    _PROBE_STRIKE_WINDOW: float = 300.0  # 5 minutes
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.TELEGRAM)
         self._app: Optional[Application] = None
@@ -294,6 +299,19 @@ class TelegramAdapter(BasePlatformAdapter):
         self._polling_conflict_count: int = 0
         self._polling_network_error_count: int = 0
         self._polling_error_callback_ref = None
+        # Serializes the polling-pool probe and `_drain_polling_connections`
+        # so the probe never hits a half-torn-down `_request[0]` (issue #5729).
+        self._probe_drain_lock: asyncio.Lock = asyncio.Lock()
+        # Two-strike escalation: monotonic timestamps of recent probe
+        # failures. Pruned to the last `_PROBE_STRIKE_WINDOW` seconds on each
+        # failure. Two failures within the window mean the reconnect ladder
+        # didn't actually fix the wedge — escalate so the supervisor
+        # restarts the process from a clean interpreter.
+        self._probe_failure_history: List[float] = []
+        # Track the most recently scheduled probe task so `disconnect()` can
+        # cancel it cleanly instead of leaking a 60s-sleeping task into
+        # asyncio's "Task was destroyed but it is pending" warnings.
+        self._latest_probe_task: Optional[asyncio.Task] = None
         # DM Topics: map of topic_name -> message_thread_id (populated at startup)
         self._dm_topics: Dict[str, int] = {}
         # DM Topics config from extra.dm_topics
@@ -459,23 +477,26 @@ class TelegramAdapter(BasePlatformAdapter):
             polling_req = self._app.bot._request[0]  # noqa: SLF001
         except Exception:
             return
-        try:
-            await polling_req.shutdown()
-        except Exception:
-            logger.debug(
-                "[%s] Polling request shutdown failed (non-fatal)",
-                self.name, exc_info=True,
-            )
-        try:
-            await polling_req.initialize()
-            logger.debug(
-                "[%s] Polling request pool drained before reconnect", self.name
-            )
-        except Exception:
-            logger.debug(
-                "[%s] Polling request re-initialize failed (non-fatal)",
-                self.name, exc_info=True,
-            )
+        # Serialize against the polling-pool probe so the probe never hits a
+        # half-torn-down pool (issue #5729).
+        async with self._probe_drain_lock:
+            try:
+                await polling_req.shutdown()
+            except Exception:
+                logger.debug(
+                    "[%s] Polling request shutdown failed (non-fatal)",
+                    self.name, exc_info=True,
+                )
+            try:
+                await polling_req.initialize()
+                logger.debug(
+                    "[%s] Polling request pool drained before reconnect", self.name
+                )
+            except Exception:
+                logger.debug(
+                    "[%s] Polling request re-initialize failed (non-fatal)",
+                    self.name, exc_info=True,
+                )
 
     async def _handle_polling_network_error(self, error: Exception) -> None:
         """Reconnect polling after a transient network interruption.
@@ -542,10 +563,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # in that state, so the reconnect ladder won't advance on its
             # own. Schedule a deferred probe to detect the wedge and
             # re-enter the ladder if needed.
-            if not self.has_fatal_error:
-                probe = asyncio.ensure_future(self._verify_polling_after_reconnect())
-                self._background_tasks.add(probe)
-                probe.add_done_callback(self._background_tasks.discard)
+            self._schedule_polling_pool_probe()
         except Exception as retry_err:
             logger.warning("[%s] Telegram polling reconnect failed: %s", self.name, retry_err)
             # start_polling failed — polling is dead and no further error
@@ -557,26 +575,71 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._background_tasks.add(task)
                 task.add_done_callback(self._background_tasks.discard)
 
-    async def _verify_polling_after_reconnect(self) -> None:
-        """Heartbeat probe scheduled after a successful reconnect.
+    def _schedule_polling_pool_probe(self, trigger: str = "reconnect") -> None:
+        """Schedule a polling-pool wedge-detection probe.
+
+        Called from two paths:
+          * After a successful cold-boot ``start_polling`` in :meth:`connect`
+            (``trigger="cold_boot"``), so silent cold-boot wedges (DNS / TCP
+            transient that doesn't raise) are detected at all — the error
+            callback can't see them.
+          * After a successful reconnect ``start_polling`` in
+            :meth:`_handle_polling_network_error` (``trigger="reconnect"``),
+            so PTB ``Updater`` states with ``running=True`` but a wedged
+            consumer task are caught.
+
+        The trigger label is forwarded into the wedge-detection log so
+        operators can tell cold-boot vs post-reconnect wedges apart in
+        production.
+
+        The probe routes through ``Bot._request[0]`` (the polling pool); see
+        :meth:`_verify_polling_after_reconnect` for the dispatch rationale.
+        """
+        if self.has_fatal_error:
+            return
+        probe = asyncio.ensure_future(self._verify_polling_after_reconnect(trigger=trigger))
+        self._background_tasks.add(probe)
+        probe.add_done_callback(self._background_tasks.discard)
+        self._latest_probe_task = probe
+
+    async def _verify_polling_after_reconnect(self, trigger: str = "reconnect") -> None:
+        """Heartbeat probe that exercises the polling pool specifically.
 
         PTB's Updater can survive a botched stop()+start_polling() cycle
         with `running=True` but a wedged consumer task. No error callback
-        fires, so the reconnect ladder doesn't advance on its own. This
-        probe detects the wedge by:
+        fires, so the reconnect ladder doesn't advance on its own. The
+        same wedge can also occur on cold-boot if DNS / TCP transiently
+        fails on the polling pool but the long-poll task is created
+        anyway — no exception is raised, the long-poll just never makes
+        progress (issue #5729).
 
-        1. Sleeping HEARTBEAT_PROBE_DELAY so a healthy long-poll has time
-           to complete at least one cycle.
+        This probe detects the wedge by:
+
+        1. Sleeping HEARTBEAT_PROBE_DELAY so a healthy long-poll has
+           time to complete at least one cycle.
         2. Verifying `Updater.running` is still True.
-        3. Probing the bot endpoint with a tight asyncio timeout. A
-           wedged httpx pool fails this probe; a healthy one returns
-           well under the timeout.
+        3. Probing the *polling* connection pool (`Bot._request[0]`)
+           with a non-destructive `getMe` call against the bot's base
+           URL.
+
+        Critical: the probe must route through `_request[0]`, not the
+        general pool `_request[1]` that `bot.get_me()` uses. PTB v22
+        `_bot.py:717` dispatches `getUpdates` to `_request[0]` and
+        everything else to `_request[1]`. A wedged polling pool with a
+        healthy general pool — exactly the rblakemesser/#5729 failure
+        mode — would falsely pass a `bot.get_me()` heartbeat. We
+        therefore bypass `Bot._do_post`'s endpoint dispatch and call
+        `BaseRequest.post` directly on `_request[0]` against `getMe`,
+        which exercises the same connection pool the long-poll uses
+        without invoking Telegram's destructive `getUpdates` semantics
+        (`offset=-1` "forgets" the queue; concurrent `getUpdates` is
+        forbidden).
 
         On any failure, re-enter the reconnect ladder so the existing
         MAX_NETWORK_RETRIES path can ultimately escalate to fatal-error.
         """
         HEARTBEAT_PROBE_DELAY = 60
-        PROBE_TIMEOUT = 10
+        PROBE_TIMEOUT = 65  # must exceed long-poll contention window
 
         await asyncio.sleep(HEARTBEAT_PROBE_DELAY)
 
@@ -584,22 +647,85 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         if not (self._app and self._app.updater and self._app.updater.running):
             logger.warning(
-                "[%s] Updater not running %ds after reconnect — treating as wedged",
-                self.name, HEARTBEAT_PROBE_DELAY,
+                "[%s] Updater not running %ds after %s probe scheduled — treating as wedged",
+                self.name, HEARTBEAT_PROBE_DELAY, trigger,
             )
             await self._handle_polling_network_error(
-                RuntimeError("Updater not running after reconnect heartbeat")
+                RuntimeError(f"Updater not running after {trigger} heartbeat")
+            )
+            return
+
+        # Shape-check `bot._request` before probing. PTB-internal layout can
+        # be replaced by a caller-supplied HTTPXRequest (via
+        # ApplicationBuilder.request() / get_updates_request()) or could shift
+        # in a future PTB version. On shape mismatch, log-and-skip — never
+        # crash, never falsely declare wedge. The cost of skipping is losing
+        # this layer of protection; the cost of a false-positive is an
+        # unnecessary supervisor restart.
+        request_attr = getattr(self._app.bot, "_request", None)
+        try:
+            pool = request_attr[0]
+        except (TypeError, IndexError, KeyError):
+            pool = None
+        if pool is None or not callable(getattr(pool, "post", None)):
+            logger.warning(
+                "[%s] Polling pool probe skipped: bot._request shape unrecognized "
+                "(type=%s). Wedge detection on this connection unavailable.",
+                self.name, type(request_attr).__name__,
             )
             return
 
         try:
-            await asyncio.wait_for(self._app.bot.get_me(), PROBE_TIMEOUT)
+            # Bypass Bot._do_post so the call routes through the polling pool
+            # (`_request[0]`), not the general pool (`_request[1]`). See the
+            # docstring above for the dispatch rationale.
+            # Serialize against `_drain_polling_connections` so the probe
+            # never hits a half-torn-down pool.
+            base = self._app.bot.base_url
+            async with self._probe_drain_lock:
+                await asyncio.wait_for(pool.post(f"{base}/getMe"), PROBE_TIMEOUT)
+            # Probe succeeded — reset the strike history so a single isolated
+            # failure plus a much later one doesn't escalate.
+            self._probe_failure_history.clear()
         except Exception as probe_err:
+            # Don't log probe_err repr — HTTPX exceptions can include the
+            # URL, which embeds the bot token. Log type + class only.
             logger.warning(
-                "[%s] Polling heartbeat probe failed %ds after reconnect: %s",
-                self.name, HEARTBEAT_PROBE_DELAY, probe_err,
+                "[%s] Polling pool wedge detected by %s probe (exception=%s)",
+                self.name, trigger, type(probe_err).__name__,
             )
+            if self._record_probe_failure_and_should_escalate():
+                # Two failures within the window — the reconnect ladder
+                # already had a chance and didn't fix it. Escalate so the
+                # supervisor restarts the process from a clean interpreter.
+                message = (
+                    "Telegram polling pool wedged twice within "
+                    f"{int(self._PROBE_STRIKE_WINDOW)}s — escalating to "
+                    "supervisor restart."
+                )
+                logger.error("[%s] %s", self.name, message)
+                self._set_fatal_error(
+                    "telegram_network_error", message, retryable=True,
+                )
+                await self._notify_fatal_error()
+                return
             await self._handle_polling_network_error(probe_err)
+
+    def _record_probe_failure_and_should_escalate(self) -> bool:
+        """Record a probe failure timestamp and return True if 2nd within window.
+
+        Two-strike escalation per issue #5729 council ruling: a single probe
+        failure exercises the existing reconnect ladder; a second within the
+        window means that ladder didn't actually fix the wedge.
+        """
+        now = _time.monotonic()
+        cutoff = now - self._PROBE_STRIKE_WINDOW
+        # Prune timestamps older than the window.
+        self._probe_failure_history = [
+            t for t in self._probe_failure_history if t >= cutoff
+        ]
+        self._probe_failure_history.append(now)
+        return len(self._probe_failure_history) >= 2
 
     async def _handle_polling_conflict(self, error: Exception) -> None:
         if self.has_fatal_error and self.fatal_error_code == "telegram_polling_conflict":
@@ -1101,7 +1227,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     drop_pending_updates=True,
                     error_callback=_polling_error_callback,
                 )
-            
+                # Schedule a polling-pool wedge probe. The error callback can't
+                # see a silent cold-boot wedge (the long-poll task is running
+                # but never makes progress and never raises), so an explicit
+                # probe is the only signal — see issue #5729.
+                self._schedule_polling_pool_probe(trigger="cold_boot")
+
             # Register bot commands so Telegram shows a hint menu when users type /
             # List is derived from the central COMMAND_REGISTRY — adding a new
             # gateway command there automatically adds it to the Telegram menu.
@@ -1154,6 +1285,17 @@ class TelegramAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         """Stop polling/webhook, cancel pending album flushes, and disconnect."""
+        # Cancel any pending polling-pool wedge probe so its 60s heartbeat
+        # sleep doesn't keep the event loop alive past intended shutdown.
+        probe = self._latest_probe_task
+        if probe is not None and not probe.done():
+            probe.cancel()
+            try:
+                await probe
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._latest_probe_task = None
+
         pending_media_group_tasks = list(self._media_group_tasks.values())
         for task in pending_media_group_tasks:
             task.cancel()

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -597,6 +597,14 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if self.has_fatal_error:
             return
+        # Cancel any previously scheduled probe to maintain at most one in
+        # flight per adapter. Without this, multiple sleeping probes can
+        # accumulate (cold_boot then later reconnect) and `disconnect()`
+        # cancels only `_latest_probe_task`; older probes wake on a
+        # torn-down adapter and recurse into `_handle_polling_network_error`.
+        prev = self._latest_probe_task
+        if prev is not None and not prev.done():
+            prev.cancel()
         probe = asyncio.ensure_future(self._verify_polling_after_reconnect(trigger=trigger))
         self._background_tasks.add(probe)
         probe.add_done_callback(self._background_tasks.discard)
@@ -645,7 +653,15 @@ class TelegramAdapter(BasePlatformAdapter):
 
         if self.has_fatal_error:
             return
-        if not (self._app and self._app.updater and self._app.updater.running):
+        # Bail if the adapter has been torn down while we slept. `disconnect()`
+        # cancels the latest probe directly, but a previously scheduled probe
+        # whose cancellation raced with disconnect can still wake here with
+        # `_app=None` — without this guard, the wedge-detection branch below
+        # would falsely fire and call `_handle_polling_network_error` against
+        # a torn-down adapter.
+        if self._app is None:
+            return
+        if not (self._app.updater and self._app.updater.running):
             logger.warning(
                 "[%s] Updater not running %ds after %s probe scheduled — treating as wedged",
                 self.name, HEARTBEAT_PROBE_DELAY, trigger,
@@ -680,8 +696,11 @@ class TelegramAdapter(BasePlatformAdapter):
             # (`_request[0]`), not the general pool (`_request[1]`). See the
             # docstring above for the dispatch rationale.
             # Serialize against `_drain_polling_connections` so the probe
-            # never hits a half-torn-down pool.
-            base = self._app.bot.base_url
+            # never hits a half-torn-down pool. Strip any trailing slash on
+            # `base_url` — the default config has none, but callable /
+            # format-map / `local_mode=True` configs can produce one and
+            # `f"{base}/getMe"` would yield a `//getMe`.
+            base = str(self._app.bot.base_url).rstrip("/")
             async with self._probe_drain_lock:
                 await asyncio.wait_for(pool.post(f"{base}/getMe"), PROBE_TIMEOUT)
             # Probe succeeded — reset the strike history so a single isolated

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -303,15 +303,21 @@ async def test_drain_helper_noop_without_app():
 async def test_heartbeat_probe_no_op_when_polling_healthy():
     """
     Probe scheduled after a successful reconnect: Updater.running=True and
-    bot.get_me() returns quickly → recovery confirmed, no further action.
+    the polling pool probe (`_request[0].post(...)`) returns quickly →
+    recovery confirmed, no further action. See issue #5729 for why the
+    probe must route through `_request[0]` (polling pool) rather than
+    `bot.get_me()` which routes through `_request[1]` (general pool).
     """
     adapter = _make_adapter()
 
     mock_updater = MagicMock()
     mock_updater.running = True
 
+    pool0_post = AsyncMock(return_value={"id": 1, "is_bot": True})
     mock_app = MagicMock()
     mock_app.updater = mock_updater
+    mock_app.bot._request = (MagicMock(post=pool0_post), MagicMock())
+    mock_app.bot.base_url = "https://api.telegram.org/bot<REDACTED>"
     mock_app.bot.get_me = AsyncMock(return_value=MagicMock())
     adapter._app = mock_app
 
@@ -320,7 +326,10 @@ async def test_heartbeat_probe_no_op_when_polling_healthy():
     with patch("asyncio.sleep", new_callable=AsyncMock):
         await adapter._verify_polling_after_reconnect()
 
-    mock_app.bot.get_me.assert_awaited_once()
+    pool0_post.assert_awaited_once()
+    # The new probe must NOT route through bot.get_me() — that exercises
+    # the wrong pool (`_request[1]`). See #5729.
+    mock_app.bot.get_me.assert_not_called()
     adapter._handle_polling_network_error.assert_not_awaited()
 
 
@@ -353,10 +362,10 @@ async def test_heartbeat_probe_reenters_ladder_when_updater_not_running():
 
 
 @pytest.mark.asyncio
-async def test_heartbeat_probe_reenters_ladder_when_get_me_times_out():
+async def test_heartbeat_probe_reenters_ladder_when_polling_pool_times_out():
     """
-    If bot.get_me() hangs longer than PROBE_TIMEOUT, treat as wedged.
-    Simulates the connection-pool wedge that motivated this fix.
+    If `_request[0].post(...)` hangs longer than PROBE_TIMEOUT, treat as wedged.
+    Simulates the polling-pool connection wedge that motivated #5729.
     """
     adapter = _make_adapter()
 
@@ -366,9 +375,11 @@ async def test_heartbeat_probe_reenters_ladder_when_get_me_times_out():
     async def hang_forever(*args, **kwargs):
         await asyncio.sleep(3600)
 
+    pool0_post = AsyncMock(side_effect=hang_forever)
     mock_app = MagicMock()
     mock_app.updater = mock_updater
-    mock_app.bot.get_me = AsyncMock(side_effect=hang_forever)
+    mock_app.bot._request = (MagicMock(post=pool0_post), MagicMock())
+    mock_app.bot.base_url = "https://api.telegram.org/bot<REDACTED>"
     adapter._app = mock_app
 
     adapter._handle_polling_network_error = AsyncMock()
@@ -386,19 +397,22 @@ async def test_heartbeat_probe_reenters_ladder_when_get_me_times_out():
 
 
 @pytest.mark.asyncio
-async def test_heartbeat_probe_reenters_ladder_on_get_me_network_error():
+async def test_heartbeat_probe_reenters_ladder_on_polling_pool_network_error():
     """
-    Any exception raised by bot.get_me() (NetworkError, ConnectionError, etc.)
-    should re-enter the reconnect ladder with the original exception.
+    Any exception raised by the polling-pool probe (NetworkError,
+    ConnectionError, etc.) should re-enter the reconnect ladder with the
+    original exception.
     """
     adapter = _make_adapter()
 
     mock_updater = MagicMock()
     mock_updater.running = True
 
+    pool0_post = AsyncMock(side_effect=ConnectionError("pool wedged"))
     mock_app = MagicMock()
     mock_app.updater = mock_updater
-    mock_app.bot.get_me = AsyncMock(side_effect=ConnectionError("pool wedged"))
+    mock_app.bot._request = (MagicMock(post=pool0_post), MagicMock())
+    mock_app.bot.base_url = "https://api.telegram.org/bot<REDACTED>"
     adapter._app = mock_app
 
     adapter._handle_polling_network_error = AsyncMock()

--- a/tests/gateway/test_telegram_polling_pool_wedge.py
+++ b/tests/gateway/test_telegram_polling_pool_wedge.py
@@ -1,0 +1,645 @@
+"""
+Tests for Telegram polling-pool wedge detection.
+
+Issue #5729: cold-boot or post-reconnect resolver/network wedge leaves the
+long-poll's `_request[0]` connection pool unable to make progress while the
+general `_request[1]` pool stays healthy. The pre-existing heartbeat probe
+called `bot.get_me()` which routes through `_request[1]` — so a wedged
+polling pool falsely passed the probe ("getMe worked but messages weren't
+handled" — rblakemesser field report 2026-05-07).
+
+These tests pin the corrected probe behaviour:
+
+  1. The probe routes through `_request[0]` (the polling pool), not the
+     general pool. A wedged `_request[0]` is detected even when `_request[1]`
+     and `bot.get_me()` are healthy.
+  2. The probe is scheduled after cold-boot `start_polling`, not only after
+     error-driven reconnects (so silent cold-boot wedges that produce no
+     exception are detected at all).
+  3. A `bot._request` shape mismatch (custom `HTTPXRequest` injection / PTB
+     drift) downgrades to a logged warning and skips the probe — no crash.
+  4. The probe and `_drain_polling_connections` mutually exclude via a shared
+     `asyncio.Lock` so the probe never hits a half-torn-down pool.
+  5. Two probe failures within a 5-minute window escalate to a fatal-retryable
+     state so the supervisor restarts the gateway.
+  6. A pending probe task is cancelled by `disconnect()`.
+  7. The probe does not advance the long-poll's update offset.
+  8. Probe-related logs do not contain `bot.base_url` (which embeds the bot
+     token in the Telegram URL format).
+
+Council adversarial review session: a8c9534fee5e (2026-05-07).
+Local probe primitive validation: 2026-05-07 (separate Bot, getMe via
+_request[0], 357.7ms — well under the proposed 65s timeout).
+"""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+    telegram_mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    telegram_mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    telegram_mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+    sys.modules.setdefault("telegram.error", telegram_mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_auto_discovery(monkeypatch):
+    """Disable DoH auto-discovery so connect() uses the plain builder chain."""
+    async def _noop():
+        return []
+    monkeypatch.setattr("gateway.platforms.telegram.discover_fallback_ips", _noop)
+    monkeypatch.setattr("gateway.platforms.telegram.HTTPXRequest", lambda **kwargs: MagicMock())
+
+
+def _make_adapter() -> TelegramAdapter:
+    return TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+
+def _wire_adapter_with_pools(
+    adapter: TelegramAdapter,
+    *,
+    pool0_post: AsyncMock,
+    pool1_post: AsyncMock,
+    base_url: str = "https://api.telegram.org/bot<REDACTED>",
+    updater_running: bool = True,
+) -> MagicMock:
+    """Attach a mock _app whose bot._request is a 2-tuple of distinct pools."""
+    pool0 = MagicMock()
+    pool0.post = pool0_post
+    pool1 = MagicMock()
+    pool1.post = pool1_post
+
+    mock_bot = MagicMock()
+    mock_bot._request = (pool0, pool1)
+    mock_bot.base_url = base_url
+    # get_me must be present so a regression to the old probe primitive is
+    # observable (we assert it is NOT called by the new probe).
+    mock_bot.get_me = AsyncMock(return_value=MagicMock(id=1, is_bot=True))
+
+    mock_updater = MagicMock()
+    mock_updater.running = updater_running
+    mock_updater.stop = AsyncMock()
+    mock_updater.start_polling = AsyncMock()
+
+    mock_app = MagicMock()
+    mock_app.bot = mock_bot
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+    adapter._bot = mock_bot
+    return mock_app
+
+
+# -----------------------------------------------------------------------------
+# Iteration 1 — probe routes through _request[0], not _request[1]
+# -----------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_probe_routes_through_polling_pool_not_general_pool():
+    """
+    The corrected heartbeat probe must call `_request[0].post` (polling pool),
+    not `bot.get_me()` (which routes through `_request[1]`, the general pool).
+
+    A wedged polling pool with a healthy general pool — exactly the
+    rblakemesser failure mode — must be detected.
+    """
+    adapter = _make_adapter()
+
+    # _request[0]: wedged — never resolves. Use an Event that's never set so
+    # the hang survives test-wide asyncio.sleep patches.
+    never_set = asyncio.Event()
+
+    async def _hang(*args, **kwargs):
+        await never_set.wait()
+
+    pool0_post = AsyncMock(side_effect=_hang)
+    # _request[1]: healthy — returns immediately
+    pool1_post = AsyncMock(return_value={"id": 1, "is_bot": True})
+
+    _wire_adapter_with_pools(
+        adapter,
+        pool0_post=pool0_post,
+        pool1_post=pool1_post,
+    )
+
+    # Skip the 60s heartbeat sleep but keep the probe's wait_for honoring real
+    # timeouts so the wedge is detected.
+    real_wait_for = asyncio.wait_for
+
+    async def _fast_sleep(seconds):
+        return None
+
+    with patch("asyncio.sleep", new=_fast_sleep), \
+         patch.object(adapter, "_handle_polling_network_error",
+                      new_callable=AsyncMock) as mock_handler:
+        # Make the probe's wait_for use a tiny timeout so the test runs fast,
+        # but only when called from the probe (preserve the real timeout for
+        # any nested wait_fors).
+        async def _short_wait_for(coro, timeout):
+            return await real_wait_for(coro, timeout=0.05)
+        with patch("gateway.platforms.telegram.asyncio.wait_for",
+                   side_effect=_short_wait_for):
+            await adapter._verify_polling_after_reconnect()
+
+    # The new probe must hit the polling pool.
+    assert pool0_post.await_count == 1, (
+        "Probe must call _request[0].post exactly once "
+        f"(got {pool0_post.await_count} calls)"
+    )
+    # The new probe must NOT use bot.get_me (which routes through _request[1]).
+    assert adapter._bot.get_me.await_count == 0, (
+        "Probe must not call bot.get_me() — that routes through the wrong pool. "
+        f"get_me was called {adapter._bot.get_me.await_count} times."
+    )
+    # And on wedge detection it must re-enter the reconnect ladder.
+    assert mock_handler.await_count == 1, (
+        "Wedge detection must re-enter _handle_polling_network_error "
+        f"(was called {mock_handler.await_count} times)"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Iteration 2 — probe scheduled on cold-boot (not just error-driven reconnects)
+# -----------------------------------------------------------------------------
+
+def _wire_cold_boot_mocks(monkeypatch):
+    """Build the minimal mocks needed for connect() to reach start_polling."""
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+
+def _make_cold_boot_app(monkeypatch) -> SimpleNamespace:
+    """Construct a minimal Application mock that lets connect() succeed."""
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(
+        set_my_commands=AsyncMock(),
+        delete_webhook=AsyncMock(),
+        _request=(MagicMock(post=AsyncMock()), MagicMock(post=AsyncMock())),
+        base_url="https://api.telegram.org/bot<REDACTED>",
+        get_me=AsyncMock(return_value=MagicMock(id=1, is_bot=True)),
+    )
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_cold_boot_schedules_polling_pool_probe(monkeypatch):
+    """
+    After a successful cold-boot start_polling(), a polling-pool wedge probe
+    must be scheduled. Without this, a long-poll that starts wedged (cold-boot
+    DNS / TCP race that doesn't raise an exception) is invisible to the
+    error-callback path and the gateway sits silent until manual restart
+    (issue #5729, rblakemesser field report 2026-05-07).
+    """
+    adapter = _make_adapter()
+    _wire_cold_boot_mocks(monkeypatch)
+    _make_cold_boot_app(monkeypatch)
+
+    # Stub the scheduling helper directly. Asserting on it (a regular Mock)
+    # avoids the await-ordering subtleties of AsyncMock + ensure_future.
+    adapter._schedule_polling_pool_probe = MagicMock()
+
+    ok = await adapter.connect()
+    assert ok is True, (
+        f"connect() must succeed under the standard cold-boot mocks "
+        f"(fatal={adapter.fatal_error_code})"
+    )
+
+    assert adapter._schedule_polling_pool_probe.call_count >= 1, (
+        "Cold-boot start_polling must call _schedule_polling_pool_probe(); "
+        f"got {adapter._schedule_polling_pool_probe.call_count} calls."
+    )
+
+
+# -----------------------------------------------------------------------------
+# Iteration 3 — shape-check fallback for bot._request mismatch
+# -----------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_probe_skips_when_request_shape_mismatch(caplog):
+    """
+    `bot._request` is PTB-internal API. A custom HTTPXRequest injection
+    via ApplicationBuilder.request() / get_updates_request() can replace the
+    tuple, and a PTB minor bump may rename or restructure it. The probe must
+    log a warning and skip — never crash, never falsely declare wedge.
+    """
+    import logging
+    adapter = _make_adapter()
+
+    # _request is a non-conforming object: not a sequence with .post on [0].
+    mock_bot = MagicMock()
+    mock_bot._request = object()  # No __getitem__, no .post
+    mock_bot.base_url = "https://api.telegram.org/bot<REDACTED>"
+    mock_bot.get_me = AsyncMock(return_value=MagicMock(id=1, is_bot=True))
+
+    mock_updater = MagicMock()
+    mock_updater.running = True
+
+    mock_app = MagicMock()
+    mock_app.bot = mock_bot
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+    adapter._bot = mock_bot
+
+    with patch("asyncio.sleep", new_callable=AsyncMock), \
+         patch.object(adapter, "_handle_polling_network_error",
+                      new_callable=AsyncMock) as mock_handler, \
+         caplog.at_level(logging.WARNING, logger="gateway.platforms.telegram"):
+        # Must not raise.
+        await adapter._verify_polling_after_reconnect()
+
+    # Skip semantics: no false-positive wedge declaration on shape mismatch.
+    assert mock_handler.await_count == 0, (
+        "Shape mismatch must not be treated as a wedge "
+        f"(handler called {mock_handler.await_count} times)"
+    )
+    # Operator-visible signal so the missing protection is not silent.
+    assert any(
+        "polling pool probe skipped" in rec.message.lower()
+        or "request shape" in rec.message.lower()
+        or "_request" in rec.message
+        for rec in caplog.records
+    ), (
+        "Expected a WARNING log on shape mismatch; got: "
+        f"{[rec.message for rec in caplog.records]}"
+    )
+    # Token must not leak in any log line.
+    for rec in caplog.records:
+        assert "<REDACTED>" not in rec.getMessage() or "base_url" not in rec.getMessage(), \
+            "Probe must not log bot.base_url (contains the token)"
+
+
+# -----------------------------------------------------------------------------
+# Iteration 4 — probe and drain mutually exclude via shared asyncio.Lock
+# -----------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_probe_and_drain_mutually_exclude():
+    """
+    `_drain_polling_connections` resets `_request[0]` (calls shutdown + init).
+    During that window, probing the same pool would hit a half-torn-down
+    object. The probe and drain must serialize via a shared `asyncio.Lock`
+    so the probe never fires concurrent with drain.
+    """
+    adapter = _make_adapter()
+
+    # Build an _app with a working _request[0] so the probe would otherwise
+    # succeed quickly.
+    pool0_post = AsyncMock(return_value={"id": 1, "is_bot": True})
+    pool1_post = AsyncMock(return_value={"id": 1, "is_bot": True})
+    _wire_adapter_with_pools(
+        adapter,
+        pool0_post=pool0_post,
+        pool1_post=pool1_post,
+    )
+
+    # Hold the shared lock as if drain were in its critical section.
+    assert hasattr(adapter, "_probe_drain_lock"), (
+        "Adapter must expose a shared asyncio.Lock _probe_drain_lock for "
+        "probe/drain mutual exclusion"
+    )
+    assert isinstance(adapter._probe_drain_lock, asyncio.Lock)
+
+    drain_held = adapter._probe_drain_lock
+    await drain_held.acquire()
+    try:
+        # Skip the heartbeat sleep so the probe reaches the lock acquisition.
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            probe_task = asyncio.create_task(adapter._verify_polling_after_reconnect())
+
+            # Yield several event-loop ticks. The probe must block on the
+            # lock and not have called pool0.post() yet.
+            for _ in range(20):
+                await asyncio.sleep(0)
+
+            assert pool0_post.await_count == 0, (
+                "Probe must wait on _probe_drain_lock; called pool0.post "
+                f"{pool0_post.await_count} times while drain held the lock"
+            )
+
+            # Release the lock — probe should now proceed.
+            drain_held.release()
+
+            # Wait briefly for the probe to complete its post.
+            await asyncio.wait_for(probe_task, timeout=2.0)
+
+        assert pool0_post.await_count == 1, (
+            "Probe must call pool0.post exactly once after lock released; "
+            f"got {pool0_post.await_count}"
+        )
+    finally:
+        if drain_held.locked():
+            try:
+                drain_held.release()
+            except RuntimeError:
+                pass
+
+
+@pytest.mark.asyncio
+async def test_drain_acquires_shared_probe_drain_lock():
+    """
+    Symmetric assertion: `_drain_polling_connections` must acquire the same
+    `_probe_drain_lock` so a probe in flight blocks drain too. Otherwise the
+    invariant ("probe never hits a half-torn-down pool") doesn't hold.
+    """
+    adapter = _make_adapter()
+
+    # Wire a minimal _request[0] with shutdown + initialize that we can
+    # observe.
+    polling_req = MagicMock()
+    polling_req.shutdown = AsyncMock()
+    polling_req.initialize = AsyncMock()
+    mock_bot = MagicMock()
+    mock_bot._request = (polling_req, MagicMock())
+
+    mock_app = MagicMock()
+    mock_app.bot = mock_bot
+    adapter._app = mock_app
+    adapter._bot = mock_bot
+
+    # Hold the lock from outside, run drain in parallel, observe blocked.
+    held = adapter._probe_drain_lock
+    await held.acquire()
+    try:
+        drain_task = asyncio.create_task(adapter._drain_polling_connections())
+        for _ in range(20):
+            await asyncio.sleep(0)
+        assert polling_req.shutdown.await_count == 0, (
+            "Drain must wait on _probe_drain_lock; called shutdown "
+            f"{polling_req.shutdown.await_count} times while it was held"
+        )
+        held.release()
+        await asyncio.wait_for(drain_task, timeout=2.0)
+        assert polling_req.shutdown.await_count == 1
+        assert polling_req.initialize.await_count == 1
+    finally:
+        if held.locked():
+            try:
+                held.release()
+            except RuntimeError:
+                pass
+
+
+# -----------------------------------------------------------------------------
+# Iteration 5 — two-strike escalation within 5min window
+# -----------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_two_probe_failures_within_window_escalate_to_fatal():
+    """
+    A single probe failure re-enters the existing reconnect ladder. But two
+    failures within 5 minutes mean the previous reconnect's drain+restart
+    didn't actually fix the wedge — the slow ladder will just keep trying
+    and failing. Escalate to fatal-retryable so the supervisor restarts the
+    process (a fresh interpreter clears any stale resolver / connection
+    state).
+    """
+    adapter = _make_adapter()
+
+    never_set = asyncio.Event()
+
+    async def _hang(*args, **kwargs):
+        await never_set.wait()
+
+    pool0_post = AsyncMock(side_effect=_hang)
+    pool1_post = AsyncMock(return_value={"id": 1, "is_bot": True})
+    _wire_adapter_with_pools(
+        adapter, pool0_post=pool0_post, pool1_post=pool1_post,
+    )
+
+    real_wait_for = asyncio.wait_for
+
+    async def _short_wait_for(coro, timeout):
+        return await real_wait_for(coro, timeout=0.05)
+
+    fatal_calls = []
+
+    def _capture_fatal(code, message, *, retryable):
+        fatal_calls.append((code, retryable, message))
+
+    with patch("asyncio.sleep", new_callable=AsyncMock), \
+         patch("gateway.platforms.telegram.asyncio.wait_for",
+               side_effect=_short_wait_for), \
+         patch.object(adapter, "_handle_polling_network_error",
+                      new_callable=AsyncMock), \
+         patch.object(adapter, "_set_fatal_error", side_effect=_capture_fatal), \
+         patch.object(adapter, "_notify_fatal_error", new_callable=AsyncMock):
+        # First probe failure — handler called, no fatal yet.
+        await adapter._verify_polling_after_reconnect()
+        assert fatal_calls == [], (
+            "Single probe failure must not escalate to fatal "
+            f"(got {fatal_calls})"
+        )
+
+        # Second probe failure within the same window — must escalate.
+        await adapter._verify_polling_after_reconnect()
+
+    assert len(fatal_calls) == 1, (
+        "Two probe failures within the 5-minute window must escalate "
+        f"exactly once (got {len(fatal_calls)} fatal calls: {fatal_calls})"
+    )
+    code, retryable, _ = fatal_calls[0]
+    assert code == "telegram_network_error" or "telegram" in code, (
+        f"Fatal error code must reference telegram (got {code!r})"
+    )
+    assert retryable is True, (
+        "Escalation must be retryable so the supervisor restarts the process"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Iteration 6 — probe task cancellation on disconnect()
+# -----------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_disconnect_cancels_pending_probe_task():
+    """
+    A probe task in flight at shutdown must be cancelled by disconnect().
+    Otherwise asyncio emits "Task was destroyed but it is pending" warnings
+    and the long sleep can keep the event loop alive past intended shutdown.
+    """
+    adapter = _make_adapter()
+
+    # Build minimal _app/_bot so disconnect() doesn't blow up partway through.
+    mock_updater = MagicMock()
+    mock_updater.running = False  # so disconnect doesn't call stop()
+    mock_app = MagicMock()
+    mock_app.running = False
+    mock_app.updater = mock_updater
+    mock_app.stop = AsyncMock()
+    mock_app.shutdown = AsyncMock()
+    adapter._app = mock_app
+    adapter._bot = MagicMock()
+
+    # Schedule a probe — its 60s heartbeat sleep keeps it pending.
+    adapter._schedule_polling_pool_probe()
+    assert hasattr(adapter, "_latest_probe_task"), (
+        "_schedule_polling_pool_probe must record the latest probe task on "
+        "the adapter (e.g. self._latest_probe_task) so disconnect() can "
+        "cancel it"
+    )
+    probe_task = adapter._latest_probe_task
+    assert probe_task is not None and not probe_task.done()
+
+    await adapter.disconnect()
+
+    # Yield to let the cancellation propagate.
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    assert probe_task.done(), (
+        "Pending probe task must be done (cancelled or finished) after "
+        "disconnect()"
+    )
+    assert probe_task.cancelled() or probe_task.exception() is not None, (
+        "Probe task should have been cancelled by disconnect (got: "
+        f"cancelled={probe_task.cancelled()}, "
+        f"exception={probe_task.exception() if probe_task.done() and not probe_task.cancelled() else 'n/a'})"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Iteration 7 — long-poll offset preservation across the probe
+# -----------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_probe_does_not_advance_long_poll_offset():
+    """
+    The probe must not interfere with the long-poll's update offset
+    bookkeeping. PTB's ``Updater`` tracks ``last_update_id`` internally and
+    advances it as updates are consumed via ``getUpdates``. The probe calls
+    ``getMe`` (not ``getUpdates``), so the offset must be untouched. This
+    test pins that invariant — a regression toward any ``getUpdates``-based
+    probe (forbidden by the council ruling on session a8c9534fee5e) would
+    trip this test.
+    """
+    adapter = _make_adapter()
+
+    pool0_post = AsyncMock(return_value={"id": 1, "is_bot": True})
+    pool1_post = AsyncMock(return_value={"id": 1, "is_bot": True})
+    mock_app = _wire_adapter_with_pools(
+        adapter, pool0_post=pool0_post, pool1_post=pool1_post,
+    )
+    # Simulate the long-poll's offset bookkeeping. PTB stores this on its
+    # internal ``_last_update_id`` (private API; the test intent is the
+    # invariant, not the attribute name).
+    mock_app.updater._last_update_id = 4242
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._verify_polling_after_reconnect()
+
+    assert mock_app.updater._last_update_id == 4242, (
+        "Probe must not advance the long-poll's update offset "
+        f"(was 4242, became {mock_app.updater._last_update_id})"
+    )
+    pool0_post.assert_awaited_once()
+    # Verify the probe URL is /getMe — never any flavor of getUpdates.
+    call_url = pool0_post.await_args.args[0]
+    assert "/getMe" in call_url, (
+        f"Probe must call /getMe; got URL: {call_url!r}"
+    )
+    assert "getUpdates" not in call_url, (
+        "Probe must NEVER use getUpdates — Telegram's API contract makes "
+        f"that destructive (offset=-1 forgets queue). Got: {call_url!r}"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Iteration 8 — log distinguishes cold_boot vs reconnect trigger
+# -----------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_wedge_log_distinguishes_cold_boot_vs_reconnect_trigger(caplog):
+    """
+    Operators triaging a production wedge need to tell at a glance whether
+    the probe fired from cold-boot (DNS / TCP failure at startup that didn't
+    raise) or from a post-reconnect heartbeat. The log must include the
+    trigger label.
+    """
+    import logging
+
+    adapter = _make_adapter()
+
+    never_set = asyncio.Event()
+
+    async def _hang(*args, **kwargs):
+        await never_set.wait()
+
+    pool0_post = AsyncMock(side_effect=_hang)
+    pool1_post = AsyncMock(return_value={"id": 1, "is_bot": True})
+    _wire_adapter_with_pools(
+        adapter, pool0_post=pool0_post, pool1_post=pool1_post,
+    )
+
+    real_wait_for = asyncio.wait_for
+
+    async def _short_wait_for(coro, timeout):
+        return await real_wait_for(coro, timeout=0.05)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock), \
+         patch("gateway.platforms.telegram.asyncio.wait_for",
+               side_effect=_short_wait_for), \
+         patch.object(adapter, "_handle_polling_network_error",
+                      new_callable=AsyncMock), \
+         caplog.at_level(logging.WARNING, logger="gateway.platforms.telegram"):
+        await adapter._verify_polling_after_reconnect(trigger="cold_boot")
+
+    cold_boot_messages = [
+        rec.getMessage() for rec in caplog.records
+        if "cold_boot" in rec.getMessage().lower()
+        and "wedge detected" in rec.getMessage().lower()
+    ]
+    assert cold_boot_messages, (
+        "Expected at least one WARNING containing both 'cold_boot' and "
+        f"'wedge detected'. Got: {[rec.getMessage() for rec in caplog.records]}"
+    )

--- a/tests/gateway/test_telegram_polling_pool_wedge.py
+++ b/tests/gateway/test_telegram_polling_pool_wedge.py
@@ -272,14 +272,24 @@ async def test_probe_skips_when_request_shape_mismatch(caplog):
     via ApplicationBuilder.request() / get_updates_request() can replace the
     tuple, and a PTB minor bump may rename or restructure it. The probe must
     log a warning and skip — never crash, never falsely declare wedge.
+
+    Also pins token redaction: with a realistic-looking token in `base_url`,
+    no log line in any probe path may contain the token literal.
     """
     import logging
     adapter = _make_adapter()
 
+    # Token sentinel — chosen to NOT match GitHub's secret-scanning regex
+    # for Telegram bot tokens (which expects the standard
+    # `<digits>:<35-char-base64ish>` format). Test logic only needs a
+    # distinctive string to assert is absent from logs; it does not need
+    # to look like a real token.
+    test_token = "TEST-FAKE-TOKEN-FOR-CI-DO-NOT-SCAN"
+
     # _request is a non-conforming object: not a sequence with .post on [0].
     mock_bot = MagicMock()
     mock_bot._request = object()  # No __getitem__, no .post
-    mock_bot.base_url = "https://api.telegram.org/bot<REDACTED>"
+    mock_bot.base_url = f"https://api.telegram.org/bot{test_token}"
     mock_bot.get_me = AsyncMock(return_value=MagicMock(id=1, is_bot=True))
 
     mock_updater = MagicMock()
@@ -313,10 +323,14 @@ async def test_probe_skips_when_request_shape_mismatch(caplog):
         "Expected a WARNING log on shape mismatch; got: "
         f"{[rec.message for rec in caplog.records]}"
     )
-    # Token must not leak in any log line.
+    # Token must not leak in ANY captured log line, regardless of message
+    # context. Strong assertion — checks for the literal token, not a
+    # weaker keyword combination.
     for rec in caplog.records:
-        assert "<REDACTED>" not in rec.getMessage() or "base_url" not in rec.getMessage(), \
-            "Probe must not log bot.base_url (contains the token)"
+        msg = rec.getMessage()
+        assert test_token not in msg, (
+            f"Probe log leaks bot token (sentinel {test_token!r}): {msg!r}"
+        )
 
 
 # -----------------------------------------------------------------------------
@@ -352,15 +366,28 @@ async def test_probe_and_drain_mutually_exclude():
 
     drain_held = adapter._probe_drain_lock
     await drain_held.acquire()
+    # Capture real asyncio.sleep BEFORE patching, so our test's scheduling
+    # yields actually advance the event loop. Patching asyncio.sleep with
+    # `new_callable=AsyncMock` would make `await asyncio.sleep(0)` skip the
+    # yield entirely — the probe task would never get CPU and the
+    # `pool0_post.await_count == 0` assertion could pass for the wrong
+    # reason (Codex review on PR #21548).
+    real_sleep = asyncio.sleep
+
+    async def _heartbeat_yield(seconds):
+        # Skip the long heartbeat but yield to the loop once.
+        await real_sleep(0)
+
     try:
-        # Skip the heartbeat sleep so the probe reaches the lock acquisition.
-        with patch("asyncio.sleep", new_callable=AsyncMock):
+        with patch("gateway.platforms.telegram.asyncio.sleep",
+                   side_effect=_heartbeat_yield):
             probe_task = asyncio.create_task(adapter._verify_polling_after_reconnect())
 
-            # Yield several event-loop ticks. The probe must block on the
-            # lock and not have called pool0.post() yet.
+            # Yield several real event-loop ticks. The probe must reach
+            # `async with self._probe_drain_lock` and block there — not
+            # call pool0.post.
             for _ in range(20):
-                await asyncio.sleep(0)
+                await real_sleep(0)
 
             assert pool0_post.await_count == 0, (
                 "Probe must wait on _probe_drain_lock; called pool0.post "

--- a/tests/gateway/test_telegram_polling_pool_wedge.py
+++ b/tests/gateway/test_telegram_polling_pool_wedge.py
@@ -643,3 +643,108 @@ async def test_wedge_log_distinguishes_cold_boot_vs_reconnect_trigger(caplog):
         "Expected at least one WARNING containing both 'cold_boot' and "
         f"'wedge detected'. Got: {[rec.getMessage() for rec in caplog.records]}"
     )
+
+
+# -----------------------------------------------------------------------------
+# Iteration 9 — schedule cancels prior pending probe (PR #21548 review)
+# -----------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_schedule_cancels_previously_pending_probe():
+    """
+    `_schedule_polling_pool_probe` is called from both cold-boot and
+    reconnect paths. Without cancelling a prior pending probe, multiple
+    60s-sleeping probes can accumulate; `disconnect()` cancels only the
+    most recent (`_latest_probe_task`), so older probes wake on a torn-down
+    adapter and call `_handle_polling_network_error` against `_app=None`,
+    leaking into a recursive reconnect failure.
+
+    Invariant: at most one probe in flight per adapter.
+    """
+    adapter = _make_adapter()
+    adapter._app = MagicMock()  # any truthy value so probes don't bail early
+
+    # First schedule (e.g. cold_boot)
+    adapter._schedule_polling_pool_probe(trigger="cold_boot")
+    first = adapter._latest_probe_task
+    assert first is not None and not first.done()
+
+    # Second schedule (e.g. reconnect after a transient blip)
+    adapter._schedule_polling_pool_probe(trigger="reconnect")
+    second = adapter._latest_probe_task
+    assert second is not None and not second.done()
+    assert second is not first, "Second schedule must produce a distinct task"
+
+    # The first probe must have been cancelled — at most one in flight.
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert first.cancelled() or first.done(), (
+        "Previous probe must be cancelled when a new one is scheduled "
+        f"(state: cancelled={first.cancelled()}, done={first.done()})"
+    )
+
+    # Cleanup
+    second.cancel()
+    try:
+        await second
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_probe_bails_when_app_torn_down_after_sleep():
+    """
+    If the adapter is disconnected (`self._app = None`) while a probe is
+    sleeping its 60s heartbeat, the probe must bail silently after waking —
+    not call `_handle_polling_network_error` against a torn-down adapter.
+    """
+    adapter = _make_adapter()
+    adapter._app = None  # simulates a disconnect that already happened
+
+    with patch("asyncio.sleep", new_callable=AsyncMock), \
+         patch.object(adapter, "_handle_polling_network_error",
+                      new_callable=AsyncMock) as mock_handler:
+        await adapter._verify_polling_after_reconnect()
+
+    assert mock_handler.await_count == 0, (
+        "Probe must not call _handle_polling_network_error after "
+        f"disconnect (called {mock_handler.await_count} times)"
+    )
+
+
+# -----------------------------------------------------------------------------
+# Iteration 10 — URL normalization for trailing-slash base_url (PR #21548 review)
+# -----------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_probe_url_normalizes_trailing_slash_in_base_url():
+    """
+    PTB's `Bot.base_url` is built via `_parse_base_url(base_url, token)`.
+    For default config it has no trailing slash, but custom configs
+    (callable `base_url`, `format_map`-based, `local_mode=True` self-hosted
+    Bot API servers) can produce one. `f"{base}/getMe"` then yields
+    `.../bot<TOKEN>//getMe` — most servers normalize, but it's avoidable.
+    """
+    adapter = _make_adapter()
+
+    pool0_post = AsyncMock(return_value={"id": 1, "is_bot": True})
+    pool1_post = AsyncMock(return_value={"id": 1, "is_bot": True})
+    _wire_adapter_with_pools(
+        adapter,
+        pool0_post=pool0_post,
+        pool1_post=pool1_post,
+        # Trailing slash — the case Copilot flagged on PR #21548.
+        base_url="https://api.telegram.org/bot<REDACTED>/",
+    )
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._verify_polling_after_reconnect()
+
+    pool0_post.assert_awaited_once()
+    call_url = pool0_post.await_args.args[0]
+    assert "//getMe" not in call_url, (
+        f"Probe URL must not contain double slash; got: {call_url!r}"
+    )
+    assert call_url.endswith("/getMe"), (
+        f"Probe URL must end in '/getMe' (single slash); got: {call_url!r}"
+    )


### PR DESCRIPTION
## Summary

Fixes #5729 — Telegram silent wedges where `getMe`, `getWebhookInfo`, and `curl` all
work but messages are not handled until manual `hermes gateway restart`.

The existing `_verify_polling_after_reconnect` heartbeat probe at
`gateway/platforms/telegram.py:596` calls `bot.get_me()`. Per PTB v22
[`_bot.py:717`](https://github.com/python-telegram-bot/python-telegram-bot/blob/v22.0/telegram/_bot.py#L717):

```python
request = self._request[0] if endpoint == "getUpdates" else self._request[1]
```

`bot.get_me()` routes through the **general** pool (`_request[1]`); the long-poll
runs on the **polling** pool (`_request[0]`). `_drain_polling_connections` only
resets `_request[0]`. After a botched drain+reconnect — or a cold-boot wedge
where the polling pool's first `getUpdates` hits a stale DNS/TCP race that doesn't
raise — `_request[1]` stays healthy and `bot.get_me()` returns instantly while
`_request[0]` is wedged. The probe falsely passes; the gateway sits silent.

This matches @rblakemesser's 2026-05-07 field report on #5729 exactly:

> at diagnosis time: `curl https://api.telegram.org/` worked. `getMe` worked.
> `getWebhookInfo` showed no webhook and `pending_update_count=0`. launchd still
> reported the gateway running.

## Changes

**Two surgical changes (Change 2 depends on Change 1).** Shipping Change 2
without Change 1 is strictly worse than the status quo because it would
schedule a probe of the wrong pool.

### 1. Replace the probe primitive

Bypass `Bot._do_post`'s endpoint dispatch and call `BaseRequest.post` directly
on `_request[0]` against `getMe` — same connection pool the long-poll uses,
non-destructive Telegram-side semantics:

```python
pool = self._app.bot._request[0]
async with self._probe_drain_lock:
    await asyncio.wait_for(pool.post(f"{base}/getMe"), PROBE_TIMEOUT)
```

Using any flavor of `getUpdates` would be destructive per Telegram's API
contract — [`offset=-1` "forgets" the queue](https://core.telegram.org/bots/api#getupdates)
and concurrent `getUpdates` calls on the same pool are forbidden.

`PROBE_TIMEOUT` raised from 10s to 65s to exceed the long-poll contention
window (the polling pool may be busy with an in-flight `getUpdates` long-poll).

### 2. Schedule the probe after cold-boot `start_polling`

Previously, `_verify_polling_after_reconnect` was only triggered from
`_handle_polling_network_error`. The cold-boot `connect()` path called
`start_polling()` and fell through to `_mark_connected()` with no
post-start probe.

A wedge that starts at cold boot produces no exception (the long-poll task is
running, just not making progress) → no error callback → no heartbeat
scheduled → silent failure. The cold-boot probe is the only signal for that
class.

### Supporting hardening

- **Shared `asyncio.Lock`** between the probe and `_drain_polling_connections`
  so the probe never hits a half-torn-down pool.
- **Startup shape-check** on `bot._request` (PTB-internal API). Custom
  `HTTPXRequest` injection via `ApplicationBuilder.request()` /
  `get_updates_request()` can replace the tuple, and a PTB minor bump may
  rename or restructure it. On shape mismatch the probe logs a warning and
  skips — never crashes, never falsely declares wedge.
- **Two-strike escalation**: two probe failures within 5 minutes → fatal
  retryable, supervisor restarts the process. The slow ladder couldn't fix
  what the first reconnect missed; a fresh interpreter clears any stale
  resolver / connection state.
- **`trigger=` parameter** on the probe so logs distinguish `cold_boot` vs
  `reconnect` for operator triage.
- **Token redaction in logs**: `bot.base_url` literally contains the bot
  token (Telegram's URL format is `https://api.telegram.org/bot<TOKEN>/`).
  Probe-related logs use the exception class name and trigger, never the
  full URL or `repr(probe_err)`.
- **Probe task cancellation on `disconnect()`** to avoid `Task was destroyed
  but it is pending` warnings during shutdown.

## Adjacent in-flight work (distinct surfaces)

- #10947 (merged): cold-boot retry budget bumped 3 → 8 with backoff cap 15s.
  Mode-1 fix; this PR is the mode-2 fix on top.
- #7023 (open): `gateway_health.json` substrate. Composes well — a follow-up
  can add `last_polling_pool_probe_ok_at` once #7023 lands.
- #17984 (open): degraded-mode on startup retry exhaustion. Different surface
  (this PR addresses the post-reconnect / cold-boot wedge that does not
  exhaust startup retries).
- #17216 (open): removes the 20-attempt cap. Different surface
  (rblakemesser's incident did not hit `Giving up after 20 attempts`).

## Test plan

```
pytest tests/gateway/test_telegram_polling_pool_wedge.py
pytest tests/gateway/test_telegram_network_reconnect.py
pytest tests/gateway/test_telegram*.py
```

Result: 368 telegram tests pass.

**New tests** (`tests/gateway/test_telegram_polling_pool_wedge.py`):
- `test_probe_routes_through_polling_pool_not_general_pool` — wedged
  `_request[0]` with healthy `_request[1]` is detected; `bot.get_me()` is
  not called.
- `test_cold_boot_schedules_polling_pool_probe` — probe scheduled by
  `connect()` after `start_polling`, not just by `_handle_polling_network_error`.
- `test_probe_skips_when_request_shape_mismatch` — non-tuple `bot._request`
  → log warning + skip, no crash, no false-positive wedge.
- `test_probe_and_drain_mutually_exclude` — concurrent probe blocks while
  drain holds `_probe_drain_lock`.
- `test_drain_acquires_shared_probe_drain_lock` — symmetric.
- `test_two_probe_failures_within_window_escalate_to_fatal` — two failures
  in 5min → `_set_fatal_error("telegram_network_error", retryable=True)`.
- `test_disconnect_cancels_pending_probe_task` — pending probe cancelled,
  not leaked.
- `test_probe_does_not_advance_long_poll_offset` — probe leaves `Updater`'s
  `_last_update_id` untouched (regression guard against any future
  `getUpdates`-flavored probe).
- `test_wedge_log_distinguishes_cold_boot_vs_reconnect_trigger` — operator
  triage signal.

**Updated tests** (`tests/gateway/test_telegram_network_reconnect.py`):
- `test_heartbeat_probe_no_op_when_polling_healthy` — asserts probe routes
  through `_request[0]`, not `bot.get_me()`.
- `test_heartbeat_probe_reenters_ladder_when_polling_pool_times_out` —
  renamed from `_get_me_times_out` and updated for new probe.
- `test_heartbeat_probe_reenters_ladder_on_polling_pool_network_error` —
  renamed from `_get_me_network_error` and updated.

## Manual smoke test (recommended for reviewers)

1. Start gateway with Telegram polling configured.
2. Block DNS for `api.telegram.org` for 60s during cold boot:
   ```
   # macOS:    sudo pfctl -t blocklist -T add api.telegram.org
   # Linux:    sudo iptables -A OUTPUT -d api.telegram.org -j REJECT
   # restore after 60s
   ```
3. Without this PR: polling logs "started", no message handling, manual
   restart required to recover.
4. With this PR: post-connect probe at T+60s detects the wedge via
   `_request[0]` failure, re-enters the existing reconnect ladder.
5. Send a Telegram message at T+90s — confirm it's handled.

## Residual blind spot

**Flood-wait masking.** If Telegram is rate-limiting the bot, `getMe` via
`_request[0]` returns success (different rate-limit bucket from `getUpdates`).
The probe says healthy; the polling pool is throttled, not wedged. Same
false-positive shape as the previous `bot.get_me()` probe — just narrower.
A future PR could inspect rate-limit response headers; out of scope here.

## Rollback

- Both changes are additive. Revert is a single PR revert, no migration,
  no schema change.
- The shape-check (`bot._request` validation) makes the probe self-disable
  on PTB version drift — built-in escape hatch without requiring a code
  change.

## References

- PTB v22 pool routing: `_bot.py:717`
- Telegram API contract on `getUpdates`: https://core.telegram.org/bots/api#getupdates
- Field reports: @alt-glitch (2026-04-30), @rblakemesser (2026-05-07)
