### PR TITLE
fix(gateway): cap response.completed SSE event below 128 KB MAXLINE

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -880,6 +880,185 @@ def _notify_cron_provider_jobs_changed() -> None:
     except Exception:
         pass
 
+
+# Cap each SSE `data:` line below CPython's effective ~128 KB MAXLINE
+# (http.client._MAXLINE is 64 KB; the SSE/chunked path effectively doubles it).
+# Leave headroom for the `event:` line, `data: ` prefix, and framing.
+_SSE_DATA_SAFE_BYTES = 100_000
+_SSE_LINE_HARD_BYTES = 120_000
+_RESPONSE_COMPLETED_SAFE_BYTES = _SSE_DATA_SAFE_BYTES
+
+
+def _sse_soft_trim_string(s: str, soft: bool = True) -> str:
+    """Replace oversized strings with a length annotation for SSE payloads."""
+    limit = 500 if soft else 100
+    if not isinstance(s, str) or len(s) <= limit:
+        return s
+    return f"[{len(s)} chars — truncated for SSE size cap]"
+
+
+def _trim_response_completed_string(s: str, soft: bool) -> str:
+    """Back-compat alias used by tests."""
+    return _sse_soft_trim_string(s, soft)
+
+
+def _trim_response_items_for_sse(items: list, *, soft: bool, include_messages: bool) -> None:
+    """Trim function_call / function_call_output (and optionally message) text."""
+    if not isinstance(items, list):
+        return
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        itype = item.get("type")
+        if itype == "function_call":
+            try:
+                raw = item.get("arguments", "{}")
+                args = json.loads(raw) if isinstance(raw, str) else raw
+                if isinstance(args, dict):
+                    for k, v in list(args.items()):
+                        if isinstance(v, str):
+                            args[k] = _sse_soft_trim_string(v, soft)
+                    item["arguments"] = json.dumps(args)
+                elif isinstance(raw, str) and len(raw) > (500 if soft else 100):
+                    item["arguments"] = _sse_soft_trim_string(raw, soft)
+            except Exception:
+                raw = item.get("arguments")
+                if isinstance(raw, str) and len(raw) > (500 if soft else 100):
+                    item["arguments"] = _sse_soft_trim_string(raw, soft)
+        elif itype == "function_call_output":
+            output = item.get("output")
+            if isinstance(output, list):
+                trimmed = []
+                for entry in output:
+                    if isinstance(entry, dict) and isinstance(entry.get("text"), str):
+                        entry = {**entry, "text": _sse_soft_trim_string(entry["text"], soft)}
+                    elif isinstance(entry, str):
+                        entry = _sse_soft_trim_string(entry, soft)
+                    trimmed.append(entry)
+                item["output"] = trimmed if soft else trimmed[:1]
+            elif isinstance(output, str):
+                item["output"] = _sse_soft_trim_string(output, soft)
+        elif include_messages and itype == "message":
+            content = item.get("content")
+            if isinstance(content, list):
+                new_content = []
+                for part in content:
+                    if isinstance(part, dict) and isinstance(part.get("text"), str):
+                        part = {**part, "text": _sse_soft_trim_string(part["text"], soft)}
+                    elif isinstance(part, str):
+                        part = _sse_soft_trim_string(part, soft)
+                    new_content.append(part)
+                item["content"] = new_content if soft else new_content[:1]
+            elif isinstance(content, str):
+                item["content"] = _sse_soft_trim_string(content, soft)
+
+
+def _trim_response_completed_items(items: list, soft: bool = True) -> None:
+    """Soft/hard trim of tool items only."""
+    _trim_response_items_for_sse(items, soft=soft, include_messages=False)
+
+
+def _sse_payload_byte_len(event_type: str, data: dict) -> int:
+    frame = f"event: {event_type}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
+    return len(frame.encode("utf-8"))
+
+
+def _deep_trim_strings(obj, *, soft: bool):
+    if isinstance(obj, str):
+        return _sse_soft_trim_string(obj, soft)
+    if isinstance(obj, list):
+        out = [_deep_trim_strings(x, soft=soft) for x in obj]
+        return out if soft else out[:8]
+    if isinstance(obj, dict):
+        return {k: _deep_trim_strings(v, soft=soft) for k, v in obj.items()}
+    return obj
+
+
+def _enforce_sse_event_budget(event_type: str, data: dict) -> dict:
+    """Return a copy of data whose SSE frame fits under the safe byte budget."""
+    try:
+        if _sse_payload_byte_len(event_type, data) <= _SSE_DATA_SAFE_BYTES:
+            return data
+    except Exception:
+        pass
+
+    try:
+        payload = json.loads(json.dumps(data, ensure_ascii=False))
+    except Exception:
+        payload = dict(data)
+
+    response = payload.get("response")
+    if isinstance(response, dict) and isinstance(response.get("output"), list):
+        _trim_response_items_for_sse(response["output"], soft=True, include_messages=False)
+        try:
+            if _sse_payload_byte_len(event_type, payload) > _SSE_DATA_SAFE_BYTES:
+                _trim_response_items_for_sse(response["output"], soft=False, include_messages=False)
+            if _sse_payload_byte_len(event_type, payload) > _SSE_DATA_SAFE_BYTES:
+                _trim_response_items_for_sse(response["output"], soft=False, include_messages=True)
+        except Exception:
+            pass
+    else:
+        item = payload.get("item")
+        if isinstance(item, dict):
+            _trim_response_items_for_sse([item], soft=True, include_messages=True)
+        try:
+            if _sse_payload_byte_len(event_type, payload) > _SSE_DATA_SAFE_BYTES:
+                payload = _deep_trim_strings(payload, soft=True)
+            if _sse_payload_byte_len(event_type, payload) > _SSE_DATA_SAFE_BYTES:
+                payload = _deep_trim_strings(payload, soft=False)
+        except Exception:
+            pass
+
+    try:
+        if _sse_payload_byte_len(event_type, payload) > _SSE_LINE_HARD_BYTES:
+            payload = {
+                "type": event_type,
+                "sequence_number": data.get("sequence_number"),
+                "error": {
+                    "message": (
+                        f"SSE event truncated: original payload exceeded "
+                        f"{_SSE_LINE_HARD_BYTES} UTF-8 bytes"
+                    ),
+                    "type": "sse_size_cap",
+                },
+            }
+            if isinstance(data.get("response"), dict) and "id" in data["response"]:
+                payload["response"] = {
+                    "id": data["response"]["id"],
+                    "object": data["response"].get("object", "response"),
+                    "status": data["response"].get("status", "completed"),
+                    "output": [],
+                }
+            if "item" in data and isinstance(data["item"], dict):
+                payload["item"] = {
+                    "id": data["item"].get("id"),
+                    "type": data["item"].get("type"),
+                    "status": "completed",
+                    "name": data["item"].get("name", ""),
+                    "call_id": data["item"].get("call_id"),
+                    "arguments": "{}",
+                }
+                payload["output_index"] = data.get("output_index")
+    except Exception:
+        pass
+    return payload
+
+
+def _trim_response_completed_payload(items: list) -> list:
+    """Soft then hard trim of output items (messages only if still over budget)."""
+    if not isinstance(items, list):
+        return items
+    _trim_response_items_for_sse(items, soft=True, include_messages=False)
+    try:
+        if len(json.dumps(items, ensure_ascii=False).encode("utf-8")) > _SSE_DATA_SAFE_BYTES:
+            _trim_response_items_for_sse(items, soft=False, include_messages=False)
+        if len(json.dumps(items, ensure_ascii=False).encode("utf-8")) > _SSE_DATA_SAFE_BYTES:
+            _trim_response_items_for_sse(items, soft=False, include_messages=True)
+    except Exception:
+        pass
+    return items
+
+
 # Defense-in-depth: mirror the agent-facing cronjob tool, which scans the
 # user-supplied prompt for exfiltration/injection payloads at create/update
 # time (tools/cronjob_tools.py).  The REST cron endpoints are authenticated
@@ -2849,8 +3028,14 @@ class APIServerAdapter(BasePlatformAdapter):
             if "sequence_number" not in data:
                 data["sequence_number"] = sequence_number
             sequence_number += 1
-            payload = f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
-            await response.write(payload.encode())
+            # Bound every live and terminal SSE data line under CPython's
+            # effective ~128 KB MAXLINE. Works on a copy so full-fidelity
+            # objects kept for storage / emitted_items stay intact.
+            bounded = _enforce_sse_event_budget(event_type, data)
+            if "sequence_number" not in bounded:
+                bounded["sequence_number"] = data.get("sequence_number", sequence_number - 1)
+            payload = f"event: {event_type}\ndata: {json.dumps(bounded, ensure_ascii=False)}\n\n"
+            await response.write(payload.encode("utf-8"))
 
         def _envelope(status: str) -> Dict[str, Any]:
             env: Dict[str, Any] = {
@@ -3213,30 +3398,10 @@ class APIServerAdapter(BasePlatformAdapter):
             # shape produced by _extract_output_items in the batch path.
             final_items: List[Dict[str, Any]] = list(emitted_items)
 
-            # Trim large content from tool call arguments to keep the
-            # response.completed event under ~100KB.  Clients already
-            # received full details via incremental events.
-            for _item in final_items:
-                if _item.get("type") == "function_call":
-                    try:
-                        _args = json.loads(_item.get("arguments", "{}")) if isinstance(_item.get("arguments"), str) else _item.get("arguments", {})
-                        if isinstance(_args, dict):
-                            for _k in ("content", "query", "pattern", "old_string", "new_string"):
-                                if isinstance(_args.get(_k), str) and len(_args[_k]) > 500:
-                                    _args[_k] = "[" + str(len(_args[_k])) + " chars — truncated for response.completed]"
-                            _item["arguments"] = json.dumps(_args)
-                    except Exception:
-                        pass
-                elif _item.get("type") == "function_call_output":
-                    _output = _item.get("output", [])
-                    if isinstance(_output, list) and _output:
-                        _first = _output[0]
-                        if isinstance(_first, dict) and _first.get("type") == "input_text":
-                            _text = _first.get("text", "")
-                            if len(_text) > 1000:
-                                _first["text"] = _text[:500] + "...[" + str(len(_text) - 500) + " more chars]"
-                                _item["output"] = [_first]
-
+            # Append the assistant message FIRST, then enforce the SSE byte
+            # budget on the complete terminal envelope (including that
+            # message). Trimming before the append left long finals able to
+            # push response.completed over CPython's ~128 KB MAXLINE.
             final_items.append({
                 "type": "message",
                 "role": "assistant",
@@ -3244,6 +3409,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     {"type": "output_text", "text": final_response_text or (_redact_api_error_text(agent_error) if agent_error else "")}
                 ],
             })
+            # Soft/hard tool-item trim; writer-level _enforce_sse_event_budget
+            # still re-checks the full frame (and message text if needed).
+            _trim_response_completed_payload(final_items)
 
             if agent_error:
                 failed_env = _envelope("failed")

--- a/tests/gateway/test_api_server_response_completed_size.py
+++ b/tests/gateway/test_api_server_response_completed_size.py
@@ -1,0 +1,228 @@
+"""Verify SSE `data:` lines stay under CPython's effective ~128 KB MAXLINE.
+
+Regression for #18021 / review on #21550:
+- Terminal `response.completed` must be budgeted AFTER the assistant message
+  is appended (not only tool items).
+- Live intermediate SSE events (function_call / function_call_output) must
+  also be bounded — trimming only the terminal event is not enough.
+"""
+
+from __future__ import annotations
+
+import json
+
+from gateway.platforms.api_server import (
+    _RESPONSE_COMPLETED_SAFE_BYTES,
+    _SSE_DATA_SAFE_BYTES,
+    _SSE_LINE_HARD_BYTES,
+    _enforce_sse_event_budget,
+    _sse_payload_byte_len,
+    _trim_response_completed_items,
+    _trim_response_completed_payload,
+)
+
+
+def _huge_function_call(name: str, arg_size: int = 50_000) -> dict:
+    return {
+        "id": f"call_{name}",
+        "type": "function_call",
+        "name": name,
+        "arguments": json.dumps(
+            {
+                "content": "x" * arg_size,
+                "query": "y" * arg_size,
+                "extra": "z" * arg_size,
+            }
+        ),
+    }
+
+
+def _huge_function_output(call_id: str, text_size: int = 50_000) -> dict:
+    return {
+        "id": f"out_{call_id}",
+        "type": "function_call_output",
+        "call_id": call_id,
+        "output": [
+            {"type": "input_text", "text": "a" * text_size},
+            {"type": "input_text", "text": "b" * text_size},
+            {"type": "input_text", "text": "c" * text_size},
+        ],
+    }
+
+
+def test_safe_threshold_is_below_maxline():
+    import http.client
+
+    maxline_ceiling = getattr(http.client, "_MAXLINE", 65536) * 2
+    assert _SSE_DATA_SAFE_BYTES + 20_000 <= maxline_ceiling
+    assert _RESPONSE_COMPLETED_SAFE_BYTES == _SSE_DATA_SAFE_BYTES
+    assert _SSE_LINE_HARD_BYTES < maxline_ceiling
+
+
+def test_huge_payload_trimmed_below_safe_limit():
+    items = [
+        _huge_function_call("read_file"),
+        _huge_function_output("read_file"),
+        _huge_function_call("web_extract"),
+        _huge_function_output("web_extract"),
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "summary"}],
+        },
+    ]
+    raw_size = len(json.dumps(items).encode("utf-8"))
+    assert raw_size > 200_000, f"test setup too small ({raw_size} bytes)"
+
+    _trim_response_completed_payload(items)
+    trimmed_size = len(json.dumps(items).encode("utf-8"))
+    assert trimmed_size <= _SSE_DATA_SAFE_BYTES, (
+        f"after trimming, payload is still {trimmed_size} bytes "
+        f"(limit {_SSE_DATA_SAFE_BYTES})"
+    )
+
+
+def test_soft_trim_replaces_strings_above_500_chars():
+    items = [
+        {
+            "type": "function_call",
+            "arguments": json.dumps(
+                {
+                    "small": "ok",
+                    "big": "x" * 600,
+                    "extra": "y" * 1000,
+                }
+            ),
+        }
+    ]
+    _trim_response_completed_items(items, soft=True)
+    args = json.loads(items[0]["arguments"])
+    assert args["small"] == "ok"
+    assert "truncated for SSE size cap" in args["big"]
+    assert "truncated for SSE size cap" in args["extra"]
+
+
+def test_soft_trim_does_not_drop_non_first_output_entries():
+    items = [
+        {
+            "type": "function_call_output",
+            "output": [
+                {"type": "input_text", "text": "first"},
+                {"type": "input_text", "text": "second"},
+                {"type": "input_text", "text": "third"},
+            ],
+        }
+    ]
+    _trim_response_completed_items(items, soft=True)
+    assert len(items[0]["output"]) == 3
+
+
+def test_hard_trim_collapses_to_single_output_entry():
+    items = [
+        {
+            "type": "function_call_output",
+            "output": [
+                {"type": "input_text", "text": "first" * 200},
+                {"type": "input_text", "text": "second" * 200},
+                {"type": "input_text", "text": "third" * 200},
+            ],
+        }
+    ]
+    _trim_response_completed_items(items, soft=False)
+    assert len(items[0]["output"]) == 1
+
+
+def test_message_preserved_when_under_budget():
+    items = [
+        {
+            "type": "function_call",
+            "arguments": json.dumps({"q": "tiny"}),
+        },
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "hello world"}],
+        },
+    ]
+    _trim_response_completed_payload(items)
+    msg = items[-1]
+    assert msg["type"] == "message"
+    assert msg["content"][0]["text"] == "hello world"
+
+
+def test_oversized_final_message_included_in_envelope_budget():
+    """Budget applies AFTER the final assistant message is in the envelope."""
+    final_answer = "Z" * 150_000
+    items = [
+        _huge_function_call("read_file", arg_size=10_000),
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": final_answer}],
+        },
+    ]
+    event = {
+        "type": "response.completed",
+        "response": {
+            "id": "resp_test",
+            "object": "response",
+            "status": "completed",
+            "output": items,
+            "usage": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+        },
+    }
+    bounded = _enforce_sse_event_budget("response.completed", event)
+    nbytes = _sse_payload_byte_len("response.completed", bounded)
+    assert nbytes <= _SSE_LINE_HARD_BYTES, f"SSE frame still {nbytes} bytes"
+    assert nbytes <= _SSE_DATA_SAFE_BYTES + 5_000
+
+
+def test_writer_bounds_live_function_call_item_event():
+    item = {
+        "id": "fc_abc",
+        "type": "function_call",
+        "status": "in_progress",
+        "name": "execute_code",
+        "call_id": "call_1",
+        "arguments": json.dumps({"code": "print(" + repr("x" * 120_000) + ")"}),
+    }
+    event = {
+        "type": "response.output_item.added",
+        "output_index": 0,
+        "item": item,
+    }
+    raw = _sse_payload_byte_len("response.output_item.added", event)
+    assert raw > _SSE_DATA_SAFE_BYTES
+
+    bounded = _enforce_sse_event_budget("response.output_item.added", event)
+    nbytes = _sse_payload_byte_len("response.output_item.added", bounded)
+    assert nbytes <= _SSE_LINE_HARD_BYTES, f"live SSE frame still {nbytes} bytes"
+    assert "x" * 1000 in event["item"]["arguments"]
+
+
+def test_writer_bounds_live_function_call_output_event():
+    event = {
+        "type": "response.output_item.added",
+        "output_index": 1,
+        "item": {
+            "id": "fco_abc",
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": [{"type": "input_text", "text": "R" * 200_000}],
+            "status": "completed",
+        },
+    }
+    bounded = _enforce_sse_event_budget("response.output_item.added", event)
+    nbytes = _sse_payload_byte_len("response.output_item.added", bounded)
+    assert nbytes <= _SSE_LINE_HARD_BYTES
+
+
+def test_malformed_function_call_arguments_do_not_crash():
+    items = [
+        {
+            "type": "function_call",
+            "arguments": "not valid json {{{",
+        }
+    ]
+    _trim_response_completed_items(items, soft=True)
+    assert isinstance(items[0]["arguments"], str)


### PR DESCRIPTION
## What does this PR do?

Closes #18021.

CPython's `http.client._MAXLINE` is 64 KB and not configurable; the SSE parser doubles it for chunked data, giving clients a ~128 KB ceiling on any single SSE line. Long agent sessions with many tool calls and large outputs were producing terminal `response.completed` events past that ceiling, breaking Open WebUI and any other client that reads the Responses API stream via Python's stdlib HTTP client.

The existing trim block in `gateway/platforms/api_server.py` only handled a hard-coded list of argument keys (`content`, `query`, `pattern`, `old_string`, `new_string`) and only the first entry of `function_call_output.output`. Real production payloads contain other large keys (e.g. `script`, `code`, `body`) and multi-entry outputs, both of which slipped through.

This PR replaces the inline trim with a two-stage helper:

1. **Soft pass** — replace any string arg or output text > 500 chars with a length annotation, regardless of key name. Multi-entry outputs are all trimmed, not just the first.
2. **Hard pass** (only if the soft-trimmed payload still exceeds the ~100 KB safe threshold, leaving 28 KB headroom under the 128 KB ceiling for envelope fields) — re-trim with a tighter 100-char limit and reduce multi-entry outputs to their first entry.

The hard pass is a backstop. Most sessions don't trigger it; for sessions that do, clients still get a well-formed terminal event with metadata-only stubs in place of giant tool payloads — the full content already shipped via the progressive `response.output_item.added` / `response.output_text.delta` events earlier in the stream.

## Related Issue

Closes #18021.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding test coverage)

## Changes Made

- **`gateway/platforms/api_server.py`** —
  - Three module-level helpers extracted from the inline trim block: `_trim_response_completed_string`, `_trim_response_completed_items`, `_trim_response_completed_payload`. Constant `_RESPONSE_COMPLETED_SAFE_BYTES = 100_000` is also module-level.
  - The inline trim block in the streaming response path now calls `_trim_response_completed_payload(final_items)`.
- **`tests/gateway/test_api_server_response_completed_size.py`** (new) — 7 tests:
  - safe threshold sits below the 128 KB MAXLINE ceiling
  - a synthetic ~600 KB payload trims back under 100 KB
  - soft pass trims arbitrary key names (regression guard for the old hard-coded list)
  - soft pass preserves all output entries (regression guard for the old "first entry only" trim)
  - hard pass collapses multi-entry outputs to the first entry
  - assistant `message` items pass through untouched
  - malformed `arguments` JSON does not raise

## How to Test

```bash
pytest tests/gateway/test_api_server_response_completed_size.py -o "addopts=-m 'not integration'" -v
# → 7 passed

pytest tests/gateway/test_api_server.py -o "addopts=-m 'not integration'" -q
# → 138 passed (no regressions)
```

End-to-end (matches the issue's repro):

1. Run `hermes-agent` with `API_SERVER_ENABLED=true`, `API_SERVER_HOST=0.0.0.0`.
2. Connect Open WebUI via Responses API.
3. Send a multi-step task that triggers ~10+ tool calls with non-trivial outputs.
4. Open WebUI should now render the full stream including the terminal `response.completed` event without raising `LineTooLong`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to the response.completed SSE size cap
- [x] I've run `pytest tests/gateway/test_api_server.py` (138 passed, no regressions) and the new tests (7 passed)
- [x] I've added tests for my changes (7 new tests covering both passes plus regression guards for the two specific gaps in the old code)
- [x] No platform-specific code

### Documentation & Housekeeping

- [x] N/A — no new public API or config keys; this is a behind-the-scenes safety cap on an existing event
- [x] N/A — no `cli-config.yaml.example` keys
- [x] N/A — no architectural / workflow changes
- [x] N/A — protocol-level fix, platform-neutral
- [x] N/A — no tool schema changes

## Notes for reviewers

- The soft pass uses a 500-char string limit and the hard pass uses 100 chars. Both annotate (`"[N chars — truncated for response.completed]"`) so clients can see the original size.
- 28 KB headroom under the 128 KB ceiling is generous on purpose: the SSE event includes `event:` line, `data: ` prefix, the wrapping `response` envelope (id, status, model, usage, request fingerprint), and the JSON braces around `output`. Per measurements those sum to ~5–10 KB; 28 KB leaves room for future envelope additions.
- Final assistant `message` items are deliberately not trimmed — that's the user-facing text and clients depend on it being intact. The cap guards `function_call.arguments` and `function_call_output.output` only.