### PR TITLE
fix(gateway): exit cleanly when another instance detected to avoid launchd restart loop

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15142,18 +15142,12 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 pass
         else:
             hermes_home = str(get_hermes_home())
-            logger.error(
+            logger.warning(
                 "Another gateway instance is already running (PID %d, HERMES_HOME=%s). "
-                "Use 'hermes gateway restart' to replace it, or 'hermes gateway stop' first.",
+                "Exiting cleanly to avoid restart loop.",
                 existing_pid, hermes_home,
             )
-            print(
-                f"\n❌ Gateway already running (PID {existing_pid}).\n"
-                f"   Use 'hermes gateway restart' to replace it,\n"
-                f"   or 'hermes gateway stop' to kill it first.\n"
-                f"   Or use 'hermes gateway run --replace' to auto-replace.\n"
-            )
-            return False
+            return True
 
     # Sync bundled skills on gateway start (fast -- skips unchanged)
     try:
@@ -15288,24 +15282,26 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     from gateway.status import write_pid_file, remove_pid_file, get_running_pid
     _current_pid = get_running_pid()
     if _current_pid is not None and _current_pid != os.getpid():
-        logger.error(
+        logger.warning(
             "Another gateway instance (PID %d) started during our startup. "
-            "Exiting to avoid double-running.", _current_pid
+            "Exiting cleanly (another instance wins).", _current_pid
         )
-        return False
+        return True
     if not acquire_gateway_runtime_lock():
-        logger.error(
-            "Gateway runtime lock is already held by another instance. Exiting."
+        logger.warning(
+            "Gateway runtime lock is already held by another instance. "
+            "Exiting cleanly (another instance wins)."
         )
-        return False
+        return True
     try:
         write_pid_file()
     except FileExistsError:
         release_gateway_runtime_lock()
-        logger.error(
-            "PID file race lost to another gateway instance. Exiting."
+        logger.warning(
+            "PID file race lost to another gateway instance. "
+            "Exiting cleanly (another instance wins)."
         )
-        return False
+        return True
     atexit.register(remove_pid_file)
     atexit.register(release_gateway_runtime_lock)
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -467,3 +467,138 @@ class TestStopProfileGateway:
         assert gateway.stop_profile_gateway() is True
         assert calls["kill"] == 21
         assert calls["remove"] == 0
+
+
+# ---------------------------------------------------------------------------
+# start_gateway — duplicate-instance guard exits cleanly (issue #21549)
+# ---------------------------------------------------------------------------
+
+class TestStartGatewayDuplicateInstanceGuard:
+    """Verify that start_gateway returns True (exit 0) when another instance
+    is already running, so launchd/systemd don't trigger a restart loop."""
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_another_instance_detected(self, monkeypatch, caplog):
+        """When get_running_pid returns a different PID, start_gateway should
+        return True (clean exit) instead of False (which triggers sys.exit(1)
+        and launchd restart loops)."""
+        import logging
+
+        # Mock get_running_pid to simulate another instance
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda pid_path=None, cleanup_stale=True: 12345,
+        )
+        # Mock acquire_gateway_runtime_lock to not actually lock
+        monkeypatch.setattr(
+            "gateway.status.acquire_gateway_runtime_lock",
+            lambda: False,
+        )
+        # Mock write_pid_file to not actually write
+        monkeypatch.setattr(
+            "gateway.status.write_pid_file",
+            lambda: None,
+        )
+        # Mock release_gateway_runtime_lock
+        monkeypatch.setattr(
+            "gateway.status.release_gateway_runtime_lock",
+            lambda: None,
+        )
+        # Mock remove_pid_file
+        monkeypatch.setattr(
+            "gateway.status.remove_pid_file",
+            lambda: None,
+        )
+
+        from gateway.run import start_gateway
+
+        with caplog.at_level(logging.WARNING, logger="gateway.run"):
+            result = await start_gateway()
+
+        # Must return True (clean exit), not False (which triggers sys.exit(1))
+        assert result is True
+        # Should log a warning about exiting cleanly
+        assert "Exiting cleanly" in caplog.text
+        assert "Another gateway instance" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_runtime_lock_held(self, monkeypatch, caplog):
+        """When the runtime lock is held by another instance, start_gateway
+        should return True (clean exit)."""
+        import logging
+
+        # Mock get_running_pid to return None (no PID file)
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda pid_path=None, cleanup_stale=True: None,
+        )
+        # Mock acquire_gateway_runtime_lock to return False (lock held)
+        monkeypatch.setattr(
+            "gateway.status.acquire_gateway_runtime_lock",
+            lambda: False,
+        )
+        # Mock write_pid_file
+        monkeypatch.setattr(
+            "gateway.status.write_pid_file",
+            lambda: None,
+        )
+        # Mock release_gateway_runtime_lock
+        monkeypatch.setattr(
+            "gateway.status.release_gateway_runtime_lock",
+            lambda: None,
+        )
+        # Mock remove_pid_file
+        monkeypatch.setattr(
+            "gateway.status.remove_pid_file",
+            lambda: None,
+        )
+
+        from gateway.run import start_gateway
+
+        with caplog.at_level(logging.WARNING, logger="gateway.run"):
+            result = await start_gateway()
+
+        assert result is True
+        assert "Exiting cleanly" in caplog.text
+        assert "runtime lock" in caplog.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_pid_file_race_lost(self, monkeypatch, caplog):
+        """When write_pid_file raises FileExistsError, start_gateway should
+        return True (clean exit)."""
+        import logging
+
+        # Mock get_running_pid to return None
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda pid_path=None, cleanup_stale=True: None,
+        )
+        # Mock acquire_gateway_runtime_lock to return True (we got the lock)
+        monkeypatch.setattr(
+            "gateway.status.acquire_gateway_runtime_lock",
+            lambda: True,
+        )
+        # Mock write_pid_file to raise FileExistsError (race lost)
+        monkeypatch.setattr(
+            "gateway.status.write_pid_file",
+            lambda: (_ for _ in ()).throw(FileExistsError("PID file exists")),
+        )
+        # Mock release_gateway_runtime_lock
+        monkeypatch.setattr(
+            "gateway.status.release_gateway_runtime_lock",
+            lambda: None,
+        )
+        # Mock remove_pid_file
+        monkeypatch.setattr(
+            "gateway.status.remove_pid_file",
+            lambda: None,
+        )
+
+        from gateway.run import start_gateway
+
+        with caplog.at_level(logging.WARNING, logger="gateway.run"):
+            result = await start_gateway()
+
+        assert result is True
+        assert "Exiting cleanly" in caplog.text
+        assert "PID file race" in caplog.text


### PR DESCRIPTION
## What does this PR do?

When `launchd` (macOS) spawns two gateway instances simultaneously (e.g., during display wake or `KeepAlive` restart), the second instance detects the first via PID file and exits with code 1 (`return False` → `sys.exit(1)`). With `KeepAlive.SuccessfulExit=false`, launchd interprets exit code 1 as a failure and **immediately restarts** — creating an infinite restart loop that spams logs and drains CPU.


### Root Cause

`start_gateway()` has multiple duplicate-instance guard paths that `return False` when another instance is detected:
1. First check: `get_running_pid()` finds an existing instance (line ~15145)
2. Second check: PID file race during startup (line ~15289)
3. Runtime lock check: `acquire_gateway_runtime_lock()` fails (line ~15297)
4. PID file write race: `write_pid_file()` raises `FileExistsError` (line ~15303)

All four paths call `return False`, which causes `sys.exit(1)` in the caller. This is correct behavior for actual failures (no platforms connected, etc.), but **wrong** for "another instance is already running" — that's a clean exit, not a failure.

## Related Issue

Fixes #21549

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A