### PR TITLE
fix(tui): use skin verbs in status ticker

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -59,6 +59,28 @@ def test_write_json_returns_false_on_broken_pipe(monkeypatch):
     assert server.write_json({"ok": True}) is False
 
 
+def test_resolve_skin_includes_spinner_thinking_verbs(monkeypatch):
+    from hermes_cli.skin_engine import set_active_skin
+
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"display": {"skin": "ares"}},
+    )
+
+    try:
+        payload = server.resolve_skin()
+    finally:
+        set_active_skin("default")
+
+    verbs = payload["spinner"]["thinking_verbs"]
+
+    assert payload["name"] == "ares"
+    assert isinstance(verbs, list)
+    assert verbs
+    assert all(isinstance(verb, str) and verb for verb in verbs)
+
+
 def test_dispatch_rejects_non_object_request():
     resp = server.dispatch([])
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -755,6 +755,7 @@ def resolve_skin() -> dict:
 
         init_skin_from_config(_load_cfg())
         skin = get_active_skin()
+        spinner = skin.spinner if isinstance(skin.spinner, dict) else {}
         return {
             "name": skin.name,
             "colors": skin.colors,
@@ -763,6 +764,9 @@ def resolve_skin() -> dict:
             "banner_hero": skin.banner_hero,
             "tool_prefix": skin.tool_prefix,
             "help_header": (skin.branding or {}).get("help_header", ""),
+            "spinner": {
+                "thinking_verbs": spinner.get("thinking_verbs", []),
+            },
         }
     except Exception:
         return {}

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -4,7 +4,8 @@ import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
 import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
 import { turnController } from '../app/turnController.js'
 import { getTurnState, resetTurnState } from '../app/turnStore.js'
-import { patchUiState, resetUiState } from '../app/uiStore.js'
+import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
+import { VERBS } from '../content/verbs.js'
 import { estimateTokensRough } from '../lib/text.js'
 import type { Msg } from '../types.js'
 
@@ -157,6 +158,29 @@ describe('createGatewayEventHandler', () => {
     onEvent({ payload: undefined, type: 'review.summary' } as any)
 
     expect(ctx.system.sys).not.toHaveBeenCalled()
+  })
+
+  it('applies skin.changed spinner thinking verbs to the status ticker', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({
+      payload: { spinner: { thinking_verbs: ['forging', 'plotting impact'] } },
+      type: 'skin.changed'
+    } as any)
+
+    expect(getUiState().tickerVerbs).toEqual(['forging', 'plotting impact'])
+  })
+
+  it('falls back to default status ticker verbs for empty skin.changed verb lists', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    patchUiState({ tickerVerbs: ['customizing'] })
+
+    onEvent({ payload: { spinner: { thinking_verbs: [] } }, type: 'skin.changed' } as any)
+
+    expect(getUiState().tickerVerbs).toEqual(VERBS)
   })
 
   it('clears the visible todo list when the todo tool returns an empty list', () => {

--- a/ui-tui/src/__tests__/statusBarTicker.test.ts
+++ b/ui-tui/src/__tests__/statusBarTicker.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
-import { padVerb, VERB_PAD_LEN } from '../components/appChrome.js'
+import { getVerbPadLen, padVerb, VERB_PAD_LEN } from '../components/appChrome.js'
 import { VERBS } from '../content/verbs.js'
+import { normalizeTickerVerbs } from '../lib/tickerVerbs.js'
 
 describe('FaceTicker verb padding', () => {
   it('pads every verb to the same width', () => {
@@ -14,5 +15,29 @@ describe('FaceTicker verb padding', () => {
     for (const verb of VERBS) {
       expect(padVerb(verb).startsWith(`${verb}…`)).toBe(true)
     }
+  })
+
+  it('pads custom skin verbs to the active verb-list width', () => {
+    const customVerbs = ['forging', 'sizing the field', 'go']
+    const padLen = getVerbPadLen(customVerbs)
+
+    expect(padLen).toBeGreaterThan(VERB_PAD_LEN)
+
+    for (const verb of customVerbs) {
+      expect(padVerb(verb, padLen)).toHaveLength(padLen)
+      expect(padVerb(verb, padLen).startsWith(`${verb}…`)).toBe(true)
+    }
+  })
+})
+
+describe('FaceTicker skin verb normalization', () => {
+  it('uses a non-empty string list from the active skin', () => {
+    expect(normalizeTickerVerbs([' forging ', '', 42, 'plotting'])).toEqual(['forging', 'plotting'])
+  })
+
+  it('falls back to default verbs for missing, empty, or invalid skin verb lists', () => {
+    expect(normalizeTickerVerbs(undefined)).toEqual(VERBS)
+    expect(normalizeTickerVerbs([])).toEqual(VERBS)
+    expect(normalizeTickerVerbs([null, 123, false])).toEqual(VERBS)
   })
 })

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -12,6 +12,7 @@ import type {
 import { rpcErrorMessage } from '../lib/rpc.js'
 import { topLevelSubagents } from '../lib/subagentTree.js'
 import { formatToolCall, stripAnsi } from '../lib/text.js'
+import { normalizeTickerVerbs } from '../lib/tickerVerbs.js'
 import { fromSkin } from '../theme.js'
 import type { Msg, SubagentProgress } from '../types.js'
 
@@ -34,7 +35,8 @@ const applySkin = (s: GatewaySkin) =>
       s.banner_hero ?? '',
       s.tool_prefix ?? '',
       s.help_header ?? ''
-    )
+    ),
+    tickerVerbs: normalizeTickerVerbs(s.spinner?.thinking_verbs)
   })
 
 const dropBgTask = (taskId: string) =>

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -114,6 +114,7 @@ export interface UiState {
   statusBar: StatusBarMode
   streaming: boolean
   theme: Theme
+  tickerVerbs: string[]
   usage: Usage
 }
 

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -1,6 +1,7 @@
 import { atom, computed } from 'nanostores'
 
 import { MOUSE_TRACKING } from '../config/env.js'
+import { VERBS } from '../content/verbs.js'
 import { ZERO } from '../domain/usage.js'
 import { DEFAULT_THEME } from '../theme.js'
 
@@ -25,6 +26,7 @@ const buildUiState = (): UiState => ({
   statusBar: 'top',
   streaming: true,
   theme: DEFAULT_THEME,
+  tickerVerbs: VERBS,
   usage: ZERO
 })
 

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -13,6 +13,7 @@ import { fmtDuration } from '../domain/messages.js'
 import { stickyPromptFromViewport } from '../domain/viewport.js'
 import { buildSubagentTree, treeTotals, widthByDepth } from '../lib/subagentTree.js'
 import { fmtK } from '../lib/text.js'
+import { DEFAULT_VERB_PAD_LEN, getVerbPadLen, padVerb } from '../lib/tickerVerbs.js'
 import { useScrollbarSnapshot, useViewportSnapshot } from '../lib/viewportStore.js'
 import type { Theme } from '../theme.js'
 import type { Msg, Usage } from '../types.js'
@@ -22,8 +23,8 @@ const HEART_COLORS = ['#ff5fa2', '#ff4d6d']
 
 // Keep verb segment width stable so status-bar content to the right doesn't
 // jitter when the ticker rotates between short/long verbs.
-export const VERB_PAD_LEN = VERBS.reduce((max, v) => Math.max(max, v.length), 0) + 1 // + ellipsis
-export const padVerb = (verb: string) => `${verb}…`.padEnd(VERB_PAD_LEN, ' ')
+export const VERB_PAD_LEN = DEFAULT_VERB_PAD_LEN
+export { getVerbPadLen, padVerb }
 
 // Compact alternates for the `emoji` and `ascii` indicator styles.
 // Each entry is a fixed-width (display-width) glyph.
@@ -79,8 +80,9 @@ function FaceTicker({ color, startedAt }: { color: string; startedAt?: null | nu
   const ui = useStore($uiState)
   const style = ui.indicatorStyle
   const [tick, setTick] = useState(() => Math.floor(Math.random() * 1000))
-  const [verbTick, setVerbTick] = useState(() => Math.floor(Math.random() * VERBS.length))
+  const [verbTick, setVerbTick] = useState(() => Math.floor(Math.random() * Math.max(1, ui.tickerVerbs.length)))
   const [now, setNow] = useState(() => Date.now())
+  const activeVerbs = ui.tickerVerbs.length ? ui.tickerVerbs : VERBS
 
   // Pre-compute cadence + verb-visibility for the active style so an
   // `/indicator` switch re-arms the interval (and skips the verb timer
@@ -106,8 +108,9 @@ function FaceTicker({ color, startedAt }: { color: string; startedAt?: null | nu
   }, [intervalMs, showVerb])
 
   const { frame } = renderIndicator(style, tick)
-  const verb = VERBS[verbTick % VERBS.length] ?? ''
-  const verbSegment = showVerb ? ` ${padVerb(verb)}` : ''
+  const verbPadLen = useMemo(() => getVerbPadLen(activeVerbs), [activeVerbs])
+  const verb = activeVerbs[verbTick % activeVerbs.length] ?? ''
+  const verbSegment = showVerb ? ` ${padVerb(verb, verbPadLen)}` : ''
   // Leading space keeps a gap between the frame and the duration when the
   // verb segment is hidden (e.g. `unicode` spinner style).  When the verb
   // IS shown, its trailing padding already provides the gap, so the extra

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -6,6 +6,9 @@ export interface GatewaySkin {
   branding?: Record<string, string>
   colors?: Record<string, string>
   help_header?: string
+  spinner?: {
+    thinking_verbs?: unknown
+  }
   tool_prefix?: string
 }
 

--- a/ui-tui/src/lib/tickerVerbs.ts
+++ b/ui-tui/src/lib/tickerVerbs.ts
@@ -1,0 +1,21 @@
+import { VERBS } from '../content/verbs.js'
+
+export const getVerbPadLen = (verbs: readonly string[] = VERBS) =>
+  verbs.reduce((max, verb) => Math.max(max, verb.length), 0) + 1 // + ellipsis
+
+export const DEFAULT_VERB_PAD_LEN = getVerbPadLen(VERBS)
+
+export const padVerb = (verb: string, padLen = DEFAULT_VERB_PAD_LEN) => `${verb}…`.padEnd(padLen, ' ')
+
+export const normalizeTickerVerbs = (raw: unknown): string[] => {
+  if (!Array.isArray(raw)) {
+    return VERBS
+  }
+
+  const verbs = raw
+    .filter((value): value is string => typeof value === 'string')
+    .map(value => value.trim())
+    .filter(Boolean)
+
+  return verbs.length ? verbs : VERBS
+}

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -119,15 +119,14 @@ export HERMES_TUI_THEME=light
 
 ## Busy indicator styles
 
-The status-bar FaceTicker is pluggable — the default rotates Hermes' kawaii face palette every 2.5 seconds during agent work. Pick a different style (or `none` for a minimal dot) via config:
+The status-bar FaceTicker is pluggable — the default rotates Hermes' kawaii face palette every 2.5 seconds during agent work. Pick a different style via config or `/indicator <style>`:
 
 ```yaml
 display:
-  busy_indicator:
-    style: kawaii     # kawaii | minimal | dots | wings | none
+  tui_status_indicator: kaomoji   # kaomoji | emoji | ascii | unicode
 ```
 
-Styles ship with matched glyph widths so the rest of the status bar doesn't jitter on rotation.
+`kaomoji`, `emoji`, and `ascii` show rotating verb text; `unicode` stays minimal and hides the verbs. When the active skin defines a non-empty `spinner.thinking_verbs` list, the TUI uses it and pads against that active list so the rest of the status bar doesn't jitter on rotation.
 
 ## Auto-resume
 


### PR DESCRIPTION
## What does this PR do?

Makes the TUI status ticker use the active skin's `spinner.thinking_verbs` instead of always rotating the hardcoded default verb list.

The Python skin engine already lets skins define spinner verbs, and the classic CLI uses those verbs through `KawaiiSpinner.get_thinking_verbs()`. The Ink TUI had a separate `FaceTicker` path that only read `ui-tui/src/content/verbs.ts`, so skins could appear active while their thinking/status verbs were ignored.

This passes the skin spinner verb list through the TUI gateway payload, normalizes it in the frontend with a default fallback, and pads the status ticker against the active verb list so longer skin verbs do not make the rest of the status bar jitter. The `unicode` indicator style remains minimal and verb-less.

## Related Issue

Refs #17977
Refs #7307

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tui_gateway/server.py`
  - Includes `spinner.thinking_verbs` in the resolved skin payload sent to the TUI.
- `ui-tui/src/app/createGatewayEventHandler.ts`, `ui-tui/src/app/uiStore.ts`, `ui-tui/src/app/interfaces.ts`, `ui-tui/src/gatewayTypes.ts`
  - Adds typed UI state for active ticker verbs and applies skin verb updates on `skin.changed`.
- `ui-tui/src/components/appChrome.tsx`, `ui-tui/src/lib/tickerVerbs.ts`
  - Uses skin-provided verbs when available, falls back to defaults, and pads against the active verb list.
- `tests/test_tui_gateway_server.py`, `ui-tui/src/__tests__/createGatewayEventHandler.test.ts`, `ui-tui/src/__tests__/statusBarTicker.test.ts`
  - Adds regression coverage for gateway payload, frontend skin event handling, fallback behavior, and custom verb padding.
- `website/docs/user-guide/tui.md`
  - Corrects the documented TUI indicator config key and notes the skin-aware verb behavior.

## How to Test

```bash
pytest tests/ -v
scripts/run_tests.sh
npm --prefix ui-tui test -- src/__tests__/statusBarTicker.test.ts src/__tests__/createGatewayEventHandler.test.ts
npm --prefix ui-tui run type-check
npm --prefix ui-tui run build
scripts/run_tests.sh tests/test_tui_gateway_server.py::test_resolve_skin_includes_spinner_thinking_verbs
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full test suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux
