### PR TITLE
fix: register BlueBubbles loopback webhook with 127.0.0.1

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -223,8 +223,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     def _webhook_url(self) -> str:
         """Compute the external webhook URL for BlueBubbles registration."""
         host = self.webhook_host
-        if host in ("0.0.0.0", "127.0.0.1", "localhost", "::"):
-            host = "localhost"
+        if host in ("0.0.0.0", "localhost", "::"):
+            host = DEFAULT_WEBHOOK_HOST
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 
     @property

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -418,19 +418,23 @@ class TestBlueBubblesAttachmentDownload:
 
 
 class TestBlueBubblesWebhookUrl:
-    """_webhook_url property normalises local hosts to 'localhost'."""
+    """_webhook_url property normalises bind-all/localhost hosts to 127.0.0.1."""
 
     def test_default_host(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
-        assert "localhost" in adapter._webhook_url
+        # Default webhook_host is 0.0.0.0 → normalized to 127.0.0.1 for registration.
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url
 
-    @pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1", "localhost", "::"])
-    def test_local_hosts_normalized(self, monkeypatch, host):
+    @pytest.mark.parametrize("host", ["0.0.0.0", "localhost", "::"])
+    def test_bind_all_and_localhost_hosts_normalized(self, monkeypatch, host):
         adapter = _make_adapter(monkeypatch, webhook_host=host)
-        assert adapter._webhook_url.startswith("http://localhost:")
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
+
+    def test_loopback_host_preserved(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, webhook_host="127.0.0.1")
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
 
     def test_custom_host_preserved(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, webhook_host="192.168.1.50")


### PR DESCRIPTION
## Summary
- Preserve `127.0.0.1` for BlueBubbles local webhook registration instead of normalizing loopback URLs to `localhost`
- Normalize bind-all/localhost webhook hosts to `127.0.0.1` for a stable local callback URL
- Update BlueBubbles webhook URL tests for the new loopback behavior

## Test Plan
- [x] `python -m pytest tests/gateway/test_bluebubbles.py -o 'addopts=' -q`
- [x] `python -m py_compile gateway/platforms/bluebubbles.py`
