### PR TITLE
fix(sessions): show latest user prompt in previews

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1002,10 +1002,10 @@ class SessionDB:
         project_compression_tips: bool = True,
         order_by_last_active: bool = False,
     ) -> List[Dict[str, Any]]:
-        """List sessions with preview (first user message) and last active timestamp.
+        """List sessions with preview (latest user message) and last active timestamp.
 
         Returns dicts with keys: id, source, model, title, started_at, ended_at,
-        message_count, preview (first 60 chars of first user message),
+        message_count, preview (first 60 chars of latest user message),
         last_active (timestamp of last message).
 
         Uses a single query with correlated subqueries instead of N+2 queries.
@@ -1093,7 +1093,7 @@ class SessionDB:
                         (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
                          FROM messages m
                          WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                         ORDER BY m.timestamp, m.id LIMIT 1),
+                         ORDER BY m.timestamp DESC, m.id DESC LIMIT 1),
                         ''
                     ) AS _preview_raw,
                     COALESCE(
@@ -1116,7 +1116,7 @@ class SessionDB:
                         (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
                          FROM messages m
                          WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                         ORDER BY m.timestamp, m.id LIMIT 1),
+                         ORDER BY m.timestamp DESC, m.id DESC LIMIT 1),
                         ''
                     ) AS _preview_raw,
                     COALESCE(
@@ -1193,7 +1193,7 @@ class SessionDB:
                     (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
                      FROM messages m
                      WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                     ORDER BY m.timestamp, m.id LIMIT 1),
+                     ORDER BY m.timestamp DESC, m.id DESC LIMIT 1),
                     ''
                 ) AS _preview_raw,
                 COALESCE(
@@ -2521,7 +2521,7 @@ class SessionDB:
                             (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
                              FROM messages m
                              WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                             ORDER BY m.timestamp, m.id LIMIT 1),
+                             ORDER BY m.timestamp DESC, m.id DESC LIMIT 1),
                             ''
                         ) AS _preview_raw,
                         COALESCE(
@@ -2550,7 +2550,7 @@ class SessionDB:
                             (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
                              FROM messages m
                              WHERE m.session_id = s.id AND m.role = 'user' AND m.content IS NOT NULL
-                             ORDER BY m.timestamp, m.id LIMIT 1),
+                             ORDER BY m.timestamp DESC, m.id DESC LIMIT 1),
                             ''
                         ) AS _preview_raw,
                         COALESCE(

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2014,14 +2014,16 @@ class TestTitleSqlWildcards:
 class TestListSessionsRich:
     """Tests for enhanced session listing with preview and last_active."""
 
-    def test_preview_from_first_user_message(self, db):
+    def test_preview_from_latest_user_message(self, db):
         db.create_session("s1", "cli")
         db.append_message("s1", "system", "You are a helpful assistant.")
         db.append_message("s1", "user", "Help me refactor the auth module please")
         db.append_message("s1", "assistant", "Sure, let me look at it.")
+        db.append_message("s1", "user", "Now switch Kimi from OpenRouter to Ollama Cloud")
         sessions = db.list_sessions_rich()
         assert len(sessions) == 1
-        assert "Help me refactor the auth module" in sessions[0]["preview"]
+        assert "Now switch Kimi" in sessions[0]["preview"]
+        assert "Help me refactor" not in sessions[0]["preview"]
 
     def test_preview_truncated_at_60(self, db):
         db.create_session("s1", "cli")


### PR DESCRIPTION
## Summary
- make rich session-list previews use the latest user prompt instead of the opening prompt
- apply the same ordering to single-session rich rows and Telegram unlinked-session lists
- update regression coverage to prove long-running sessions surface their current topic

## Root cause
`SessionDB.list_sessions_rich()` built `preview` from the first user message via `ORDER BY m.timestamp, m.id LIMIT 1`. Long-running or repurposed sessions therefore kept an old preview even when `last_active` correctly moved them to the top, which made the relevant session look missing in resume/session lists.

## Related reconnaissance
There is an older open broader feature PR, #9000, that makes preview selection configurable. This PR is the minimal bugfix variant: no config surface, no CLI plumbing, just deterministic latest-prompt previews in the existing rich-list queries.

## Test plan
- `python -m pytest tests/test_hermes_state.py::TestListSessionsRich -q -o addopts=`
- `python -m pytest tests/test_hermes_state.py -q -o addopts=`
- `python -m py_compile hermes_state.py`
- Static added-line scan: 0 findings
