### PR TITLE
fix(feishu): hydrate reply mentions before dropping group events

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -431,6 +431,12 @@ def _is_bot_sender(sender: Any) -> bool:
     return getattr(sender, "sender_type", "") in ("bot", "app")
 
 
+def _get_field(obj: Any, name: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
 def _sender_identity(sender: Any) -> frozenset:
     # Take any non-empty id variant — tenant sender_id_type decides which are populated.
     sid = getattr(sender, "sender_id", None)
@@ -1174,12 +1180,13 @@ def _unique_lines(lines: List[str]) -> List[str]:
 
 
 def _extract_mention_ids(mention: Any) -> tuple[str, str]:
-    # Returns (open_id, user_id). im.v1.message.get hands back id as a string
-    # plus id_type discriminator; event payloads hand back a nested UserId
-    # object carrying both fields.
-    mention_id = getattr(mention, "id", None)
+    # Returns (open_id, user_id). im.v1.message.get can hand back mention
+    # entries either as SDK objects or raw dictionaries; in both cases id may
+    # be a string plus id_type discriminator, while websocket event payloads
+    # can expose a nested UserId object carrying both fields.
+    mention_id = _get_field(mention, "id", None)
     if isinstance(mention_id, str):
-        id_type = str(getattr(mention, "id_type", "") or "").lower()
+        id_type = str(_get_field(mention, "id_type", "") or "").lower()
         if id_type == "open_id":
             return mention_id, ""
         if id_type == "user_id":
@@ -1188,8 +1195,8 @@ def _extract_mention_ids(mention: Any) -> tuple[str, str]:
     if mention_id is None:
         return "", ""
     return (
-        str(getattr(mention_id, "open_id", "") or ""),
-        str(getattr(mention_id, "user_id", "") or ""),
+        str(_get_field(mention_id, "open_id", "") or ""),
+        str(_get_field(mention_id, "user_id", "") or ""),
     )
 
 
@@ -1199,14 +1206,14 @@ def _build_mentions_map(
 ) -> Dict[str, FeishuMentionRef]:
     result: Dict[str, FeishuMentionRef] = {}
     for mention in mentions or []:
-        key = str(getattr(mention, "key", "") or "")
+        key = str(_get_field(mention, "key", "") or "")
         if not key:
             continue
         if key == "@_all":
             result[key] = FeishuMentionRef(is_all=True)
             continue
         open_id, user_id = _extract_mention_ids(mention)
-        name = str(getattr(mention, "name", "") or "").strip()
+        name = str(_get_field(mention, "name", "") or "").strip()
         result[key] = FeishuMentionRef(
             name=name,
             open_id=open_id,
@@ -1561,6 +1568,15 @@ class FeishuAdapter(BasePlatformAdapter):
             .register_p2_im_chat_member_bot_deleted_v1(self._on_bot_removed_from_chat)
             .register_p2_im_chat_access_event_bot_p2p_chat_entered_v1(self._on_p2p_chat_entered)
             .register_p2_im_message_recalled_v1(self._on_message_recalled)
+            # No-op handlers for events users commonly subscribe in the open-platform
+            # console but that Hermes doesn't act on. Without these, the lark SDK
+            # logs "processor not found" and the entire WebSocket event batch can be
+            # dropped — taking real im.message.receive_v1 events down with it.
+            .register_p2_im_chat_updated_v1(lambda data: None)
+            .register_p2_im_chat_disbanded_v1(lambda data: None)
+            .register_p2_im_chat_member_user_added_v1(lambda data: None)
+            .register_p2_im_chat_member_user_deleted_v1(lambda data: None)
+            .register_p2_im_chat_member_user_withdrawn_v1(lambda data: None)
             .register_p2_customized_event(
                 "drive.notice.comment_add_v1",
                 self._on_drive_comment_event,
@@ -2263,7 +2279,33 @@ class FeishuAdapter(BasePlatformAdapter):
 
         reason = self._admit(sender, message)
         if reason is not None:
-            logger.debug("[Feishu] dropping inbound event: %s", reason)
+            hydrated_message = await self._maybe_hydrate_rejected_mention(message, reason)
+            if hydrated_message is not None:
+                setattr(hydrated_message, "_feishu_hydrated_for_admission", True)
+                message = hydrated_message
+                reason = self._admit(sender, message)
+                logger.debug(
+                    "[Feishu] mention hydration retried admission: message_id=%s chat_id=%s result=%s mentions=%d",
+                    message_id,
+                    getattr(message, "chat_id", "") or "",
+                    "admitted" if reason is None else reason,
+                    len(getattr(message, "mentions", None) or []),
+                )
+        if reason is not None:
+            logger.debug(
+                "[Feishu] dropping inbound event: reason=%s message_id=%s chat_id=%s chat_type=%s is_reply=%s has_placeholder=%s mentions=%d",
+                reason,
+                message_id,
+                getattr(message, "chat_id", "") or "",
+                getattr(message, "chat_type", "") or "",
+                bool(
+                    getattr(message, "parent_id", None)
+                    or getattr(message, "upper_message_id", None)
+                    or getattr(message, "root_id", None)
+                ),
+                bool(_MENTION_PLACEHOLDER_RE.search(str(getattr(message, "content", "") or ""))),
+                len(getattr(message, "mentions", None) or []),
+            )
             return
 
         chat_type = getattr(message, "chat_type", "p2p")
@@ -2750,16 +2792,11 @@ class FeishuAdapter(BasePlatformAdapter):
             if text.startswith("/"):
                 inbound_type = MessageType.COMMAND
 
-        # Guard runs post-strip so a pure "@Bot" message (stripped to "") is dropped.
-        if inbound_type == MessageType.TEXT and not text and not media_urls:
-            logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
-            return
-
-        if inbound_type != MessageType.COMMAND:
-            hint = _build_mention_hint(mentions)
-            if hint:
-                text = f"{hint}\n\n{text}" if text else hint
-
+        # Guard runs post-strip so a pure "@Bot" normal group/DM message is
+        # ignored. Reply-only @mentions are different: in Feishu, replying to a
+        # specific message and @mentioning the bot is an explicit request to act
+        # on that parent/root message, even if the new message body contains no
+        # text beyond the mention placeholder.
         thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
@@ -2767,6 +2804,20 @@ class FeishuAdapter(BasePlatformAdapter):
             or getattr(message, "root_id", None)
             or None
         )
+        if inbound_type == MessageType.TEXT and not text and not media_urls:
+            if reply_to_message_id and any(m.is_self for m in mentions):
+                text = "[Reply mentioned the bot]"
+            elif any(m.is_self for m in mentions):
+                text = "[Bot mentioned]"
+            else:
+                logger.debug("[Feishu] Ignoring empty text message id=%s", message_id)
+                return
+
+        if inbound_type != MessageType.COMMAND:
+            hint = _build_mention_hint(mentions)
+            if hint:
+                text = f"{hint}\n\n{text}" if text else hint
+
         reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
 
         sender_primary = (
@@ -3704,6 +3755,97 @@ class FeishuAdapter(BasePlatformAdapter):
         placeholder = normalized.metadata.get("placeholder_text") if isinstance(normalized.metadata, dict) else None
         return str(placeholder).strip() or None
 
+    async def _maybe_hydrate_rejected_mention(self, message: Any, reason: RejectReason) -> Optional[Any]:
+        if reason != "group_policy_rejected" or not self._client:
+            return None
+        # Some Feishu websocket reply events omit chat_type even for group
+        # messages. If _admit already returned group_policy_rejected, the
+        # message was group-like enough to reach group admission, so only skip
+        # explicit p2p payloads here.
+        if getattr(message, "chat_type", None) == "p2p":
+            return None
+        raw_content = str(getattr(message, "content", "") or "")
+        if not self._message_may_contain_unresolved_mention(message, raw_content):
+            return None
+
+        message_id = str(getattr(message, "message_id", "") or "")
+        if not message_id:
+            return None
+        try:
+            request = self._build_get_message_request(message_id)
+            response = await asyncio.to_thread(self._client.im.v1.message.get, request)
+            if not response or getattr(response, "success", lambda: False)() is False:
+                code = getattr(response, "code", "unknown")
+                msg = getattr(response, "msg", "message lookup failed")
+                logger.debug(
+                    "[Feishu] Mention hydration lookup failed for message %s chat_id=%s is_reply=%s has_placeholder=%s: [%s] %s",
+                    message_id,
+                    getattr(message, "chat_id", "") or "",
+                    bool(
+                        getattr(message, "parent_id", None)
+                        or getattr(message, "upper_message_id", None)
+                        or getattr(message, "root_id", None)
+                    ),
+                    bool(_MENTION_PLACEHOLDER_RE.search(raw_content)),
+                    code,
+                    msg,
+                )
+                return None
+            items = getattr(getattr(response, "data", None), "items", None) or []
+            hydrated = items[0] if items else None
+            if not hydrated:
+                logger.debug(
+                    "[Feishu] Mention hydration returned no message: message_id=%s chat_id=%s is_reply=%s has_placeholder=%s",
+                    message_id,
+                    getattr(message, "chat_id", "") or "",
+                    bool(
+                        getattr(message, "parent_id", None)
+                        or getattr(message, "upper_message_id", None)
+                        or getattr(message, "root_id", None)
+                    ),
+                    bool(_MENTION_PLACEHOLDER_RE.search(raw_content)),
+                )
+                return None
+            if not getattr(hydrated, "chat_type", None):
+                setattr(hydrated, "chat_type", getattr(message, "chat_type", ""))
+            if not getattr(hydrated, "chat_id", None):
+                setattr(hydrated, "chat_id", getattr(message, "chat_id", ""))
+            if not getattr(hydrated, "message_id", None):
+                setattr(hydrated, "message_id", message_id)
+            if getattr(hydrated, "message_type", None) is None:
+                setattr(hydrated, "message_type", getattr(message, "message_type", ""))
+            if getattr(hydrated, "content", None) is None:
+                setattr(hydrated, "content", raw_content)
+            if getattr(hydrated, "parent_id", None) is None:
+                setattr(hydrated, "parent_id", getattr(message, "parent_id", None))
+            if getattr(hydrated, "root_id", None) is None:
+                setattr(hydrated, "root_id", getattr(message, "root_id", None))
+            return hydrated
+        except Exception:
+            logger.debug(
+                "[Feishu] Mention hydration lookup raised for message %s chat_id=%s is_reply=%s has_placeholder=%s",
+                message_id,
+                getattr(message, "chat_id", "") or "",
+                bool(
+                    getattr(message, "parent_id", None)
+                    or getattr(message, "upper_message_id", None)
+                    or getattr(message, "root_id", None)
+                ),
+                bool(_MENTION_PLACEHOLDER_RE.search(raw_content)),
+                exc_info=True,
+            )
+            return None
+
+    @staticmethod
+    def _message_may_contain_unresolved_mention(message: Any, raw_content: str) -> bool:
+        if "@_all" in raw_content or _MENTION_PLACEHOLDER_RE.search(raw_content):
+            return True
+        return bool(
+            getattr(message, "parent_id", None)
+            or getattr(message, "upper_message_id", None)
+            or getattr(message, "root_id", None)
+        )
+
     @staticmethod
     def _default_image_media_type(ext: str) -> str:
         normalized_ext = (ext or "").lower()
@@ -3727,6 +3869,14 @@ class FeishuAdapter(BasePlatformAdapter):
         self_ids = frozenset(v for v in (self._bot_open_id, self._bot_user_id) if v)
         is_bot = _is_bot_sender(sender)
         is_group = getattr(message, "chat_type", "p2p") != "p2p"
+        if not is_group and (
+            getattr(message, "parent_id", None)
+            or getattr(message, "upper_message_id", None)
+            or getattr(message, "root_id", None)
+            or getattr(message, "mentions", None)
+            or getattr(message, "_feishu_hydrated_for_admission", False)
+        ):
+            is_group = bool(getattr(message, "chat_id", ""))
         chat_id = getattr(message, "chat_id", "") or ""
         require_mention = is_group and self._require_mention_for(chat_id)
 
@@ -3830,12 +3980,13 @@ class FeishuAdapter(BasePlatformAdapter):
     def _message_mentions_bot(self, mentions: List[Any]) -> bool:
         # IDs trump names: when both sides have open_id (or both user_id),
         # match requires equal IDs. Name fallback only when either side
-        # lacks an ID.
+        # lacks an ID. Feishu websocket event payloads expose mention.id as
+        # a UserId-like object, while im/v1/message.get returns the same field
+        # as a string plus id_type. Use the shared extractor so both shapes are
+        # admitted consistently.
         for mention in mentions:
-            mention_id = getattr(mention, "id", None)
-            mention_open_id = (getattr(mention_id, "open_id", None) or "").strip()
-            mention_user_id = (getattr(mention_id, "user_id", None) or "").strip()
-            mention_name = (getattr(mention, "name", None) or "").strip()
+            mention_open_id, mention_user_id = _extract_mention_ids(mention)
+            mention_name = (_get_field(mention, "name", None) or "").strip()
 
             if mention_open_id and self._bot_open_id:
                 if mention_open_id == self._bot_open_id:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -614,6 +614,26 @@ class TestAdapterBehavior(unittest.TestCase):
                 calls.append("message_recalled")
                 return self
 
+            def register_p2_im_chat_updated_v1(self, _handler):
+                calls.append("chat_updated")
+                return self
+
+            def register_p2_im_chat_disbanded_v1(self, _handler):
+                calls.append("chat_disbanded")
+                return self
+
+            def register_p2_im_chat_member_user_added_v1(self, _handler):
+                calls.append("user_added")
+                return self
+
+            def register_p2_im_chat_member_user_deleted_v1(self, _handler):
+                calls.append("user_deleted")
+                return self
+
+            def register_p2_im_chat_member_user_withdrawn_v1(self, _handler):
+                calls.append("user_withdrawn")
+                return self
+
             def register_p2_customized_event(self, event_key, _handler):
                 calls.append(f"customized:{event_key}")
                 return self
@@ -645,6 +665,11 @@ class TestAdapterBehavior(unittest.TestCase):
                 "bot_deleted",
                 "p2p_chat_entered",
                 "message_recalled",
+                "chat_updated",
+                "chat_disbanded",
+                "user_added",
+                "user_deleted",
+                "user_withdrawn",
                 "customized:drive.notice.comment_add_v1",
                 "build",
             ],
@@ -789,6 +814,370 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertFalse(
             _admits_group(adapter, SimpleNamespace(mentions=[other_mention]), sender_id, "")
         )
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_group_message_with_string_open_id_mention_is_admitted(self):
+        """Regression: Feishu websocket and message.get can represent
+        mentions differently. ``im/v1/message.get`` returns mentions[].id as a
+        string with id_type=open_id; mention gating must treat that as a real
+        bot mention too.
+        """
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._bot_open_id = "ou_bot"
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        bot_mention = SimpleNamespace(
+            name="fy_bot",
+            id="ou_bot",
+            id_type="open_id",
+        )
+
+        self.assertTrue(
+            _admits_group(adapter, SimpleNamespace(mentions=[bot_mention]), sender_id, "")
+        )
+
+
+    def test_build_mentions_map_uses_dict_key_for_placeholder_resolution(self):
+        from gateway.platforms.feishu import _FeishuBotIdentity, _build_mentions_map
+
+        refs = _build_mentions_map(
+            [{"key": "@_user_1", "name": "fy_bot", "id": "ou_bot", "id_type": "open_id"}],
+            _FeishuBotIdentity(open_id="ou_bot", user_id="", name="fy_bot"),
+        )
+
+        self.assertIn("@_user_1", refs)
+        self.assertTrue(refs["@_user_1"].is_self)
+
+    def test_normalize_text_resolves_dict_mention_placeholder(self):
+        from gateway.platforms.feishu import _FeishuBotIdentity, _build_mentions_map, _normalize_feishu_text
+
+        mentions_map = _build_mentions_map(
+            [{"key": "@_user_1", "name": "fy_bot", "id": "ou_bot", "id_type": "open_id"}],
+            _FeishuBotIdentity(open_id="ou_bot", user_id="", name="fy_bot"),
+        )
+        normalized = _normalize_feishu_text("@_user_1 please help", mentions_map)
+
+        self.assertIn("@fy_bot", normalized)
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_group_message_mentions_bot_from_dict_payload(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._bot_open_id = "ou_bot"
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        message = SimpleNamespace(
+            chat_type="group",
+            chat_id="oc_chat",
+            mentions=[{"key": "@_user_1", "name": "fy_bot", "id": "ou_bot", "id_type": "open_id"}],
+        )
+
+        self.assertTrue(_admits_group(adapter, message, sender_id, "oc_chat"))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_group_reply_placeholder_fetches_mentions_before_rejecting(self):
+        """Feishu reply websocket events can carry only @_user_N in content.
+
+        Since the placeholder does not include the mentioned user's identity,
+        admission must hydrate the message via im/v1/message.get before dropping
+        it for require_mention.
+        """
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._bot_open_id = "ou_bot"
+        adapter._is_duplicate = Mock(return_value=False)
+        adapter._process_inbound_message = AsyncMock()
+        adapter._build_get_message_request = Mock(return_value=object())
+        fetched = SimpleNamespace(
+            message_id="om_reply",
+            chat_id="oc_chat",
+            chat_type="group",
+            message_type="text",
+            content=json.dumps({"text": "@_user_1 please help"}),
+            # The live lark_oapi message.get response exposed mentions as dicts;
+            # keep that shape in the test to prevent object-only regressions.
+            mentions=[{"key": "@_user_1", "name": "fy_bot", "id": "ou_bot", "id_type": "open_id"}],
+            parent_id="om_parent",
+            root_id="om_root",
+        )
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=SimpleNamespace(
+                        get=Mock(return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace(items=[fetched])))
+                    )
+                )
+            )
+        )
+        data = SimpleNamespace(
+            event=SimpleNamespace(
+                sender=SimpleNamespace(
+                    sender_type="user",
+                    sender_id=SimpleNamespace(open_id="ou_any", user_id=None, union_id=None),
+                ),
+                message=SimpleNamespace(
+                    message_id="om_reply",
+                    chat_id="oc_chat",
+                    chat_type="group",
+                    message_type="text",
+                    content=json.dumps({"text": "@_user_1 please help"}),
+                    mentions=[],
+                    parent_id="om_parent",
+                    root_id="om_root",
+                ),
+            )
+        )
+
+        asyncio.run(adapter._handle_message_event_data(data))
+
+        adapter._client.im.v1.message.get.assert_called_once()
+        adapter._process_inbound_message.assert_awaited_once()
+
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_group_reply_hydration_treats_rest_null_chat_type_as_group(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._bot_open_id = "ou_bot"
+        adapter._is_duplicate = Mock(return_value=False)
+        adapter._process_inbound_message = AsyncMock()
+        adapter._build_get_message_request = Mock(return_value=object())
+        fetched = SimpleNamespace(
+            message_id="om_reply",
+            chat_id="oc_chat",
+            chat_type=None,
+            message_type=None,
+            content=None,
+            body={"content": json.dumps({"text": "@_user_1"})},
+            msg_type="text",
+            mentions=[{"key": "@_user_1", "name": "fy_bot", "id": "ou_bot", "id_type": "open_id"}],
+            parent_id="om_parent",
+            root_id="om_parent",
+        )
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=SimpleNamespace(
+                        get=Mock(return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace(items=[fetched])))
+                    )
+                )
+            )
+        )
+        data = SimpleNamespace(
+            event=SimpleNamespace(
+                sender=SimpleNamespace(
+                    sender_type="user",
+                    sender_id=SimpleNamespace(open_id="ou_any", user_id=None, union_id=None),
+                ),
+                message=SimpleNamespace(
+                    message_id="om_reply",
+                    chat_id="oc_chat",
+                    chat_type="group",
+                    message_type="text",
+                    content=json.dumps({"text": "@_user_1"}),
+                    mentions=[],
+                    parent_id="om_parent",
+                    root_id="om_parent",
+                ),
+            )
+        )
+
+        asyncio.run(adapter._handle_message_event_data(data))
+
+        adapter._client.im.v1.message.get.assert_called_once()
+        adapter._process_inbound_message.assert_awaited_once()
+        hydrated = adapter._process_inbound_message.await_args.kwargs["message"]
+        self.assertEqual(getattr(hydrated, "chat_type"), "group")
+        self.assertEqual(getattr(hydrated, "message_type"), "text")
+        self.assertEqual(getattr(hydrated, "content"), json.dumps({"text": "@_user_1"}))
+
+
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_reply_only_bot_mention_dispatches_with_parent_context(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._bot_open_id = "ou_bot"
+        adapter._bot_name = "fy_bot"
+        adapter._is_duplicate = Mock(return_value=False)
+        adapter._download_feishu_message_resources = AsyncMock(return_value=([], []))
+        adapter._fetch_message_text = AsyncMock(return_value="parent text")
+        adapter.get_chat_info = AsyncMock(return_value={"name": "realestate", "type": "group"})
+        adapter._resolve_sender_profile = AsyncMock(return_value={
+            "user_id": "ou_sender",
+            "user_name": "Fan",
+            "user_id_alt": None,
+        })
+        adapter._handle_message_with_guards = AsyncMock()
+
+        hydrated = SimpleNamespace(
+            message_id="om_live",
+            chat_id="oc_group",
+            chat_type=None,
+            message_type="text",
+            content=json.dumps({"text": "@_user_1"}),
+            body={"content": json.dumps({"text": "@_user_1"})},
+            msg_type="text",
+            mentions=[{"key": "@_user_1", "name": "fy_bot", "id": "ou_bot", "id_type": "open_id"}],
+            parent_id="om_parent",
+            root_id="om_root",
+        )
+        adapter._build_get_message_request = Mock(return_value=object())
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=SimpleNamespace(
+                        get=Mock(
+                            return_value=SimpleNamespace(
+                                success=lambda: True,
+                                data=SimpleNamespace(items=[hydrated]),
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        raw_message = SimpleNamespace(
+            message_id="om_live",
+            chat_id="oc_group",
+            chat_type=None,
+            message_type="text",
+            content=json.dumps({"text": "@_user_1"}),
+            mentions=[],
+            parent_id="om_parent",
+            root_id="om_root",
+        )
+        sender = SimpleNamespace(
+            sender_type="user",
+            sender_id=SimpleNamespace(open_id="ou_sender", user_id=None, union_id=None),
+        )
+
+        asyncio.run(adapter._handle_message_event_data(SimpleNamespace(event=SimpleNamespace(sender=sender, message=raw_message))))
+        self.assertEqual(len(adapter._pending_text_batches), 1)
+        pending = next(iter(adapter._pending_text_batches.values()))
+        self.assertEqual(pending.text, "[Reply mentioned the bot]")
+        self.assertEqual(pending.reply_to_message_id, "om_parent")
+        self.assertEqual(pending.reply_to_text, "parent text")
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_group_reply_placeholder_with_missing_raw_chat_type_still_hydrates(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._bot_open_id = "ou_bot"
+        adapter._is_duplicate = Mock(return_value=False)
+        adapter._process_inbound_message = AsyncMock()
+        adapter._build_get_message_request = Mock(return_value=object())
+        fetched = SimpleNamespace(
+            message_id="om_reply",
+            chat_id="oc_chat",
+            chat_type=None,
+            message_type=None,
+            content=None,
+            body={"content": json.dumps({"text": "@_user_1"})},
+            msg_type="text",
+            mentions=[{"key": "@_user_1", "name": "fy_bot", "id": "ou_bot", "id_type": "open_id"}],
+            parent_id="om_parent",
+            root_id="om_parent",
+        )
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=SimpleNamespace(
+                        get=Mock(return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace(items=[fetched])))
+                    )
+                )
+            )
+        )
+        data = SimpleNamespace(
+            event=SimpleNamespace(
+                sender=SimpleNamespace(
+                    sender_type="user",
+                    sender_id=SimpleNamespace(open_id="ou_any", user_id=None, union_id=None),
+                ),
+                message=SimpleNamespace(
+                    message_id="om_reply",
+                    chat_id="oc_chat",
+                    chat_type=None,
+                    message_type="text",
+                    content=json.dumps({"text": "@_user_1"}),
+                    mentions=[],
+                    parent_id="om_parent",
+                    root_id="om_parent",
+                ),
+            )
+        )
+
+        asyncio.run(adapter._handle_message_event_data(data))
+
+        adapter._client.im.v1.message.get.assert_called_once()
+        adapter._process_inbound_message.assert_awaited_once()
+        hydrated = adapter._process_inbound_message.await_args.kwargs["message"]
+        self.assertIsNone(getattr(hydrated, "chat_type"))
+        self.assertTrue(adapter._mentions_self(hydrated))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_group_reply_placeholder_still_rejects_when_hydrated_mentions_do_not_target_bot(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._bot_open_id = "ou_bot"
+        adapter._is_duplicate = Mock(return_value=False)
+        adapter._process_inbound_message = AsyncMock()
+        adapter._build_get_message_request = Mock(return_value=object())
+        fetched = SimpleNamespace(
+            message_id="om_reply",
+            chat_id="oc_chat",
+            chat_type="group",
+            message_type="text",
+            content=json.dumps({"text": "@_user_1 please help"}),
+            mentions=[SimpleNamespace(key="@_user_1", name="Other", id="ou_other", id_type="open_id")],
+            parent_id="om_parent",
+            root_id="om_root",
+        )
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=SimpleNamespace(
+                        get=Mock(return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace(items=[fetched])))
+                    )
+                )
+            )
+        )
+        data = SimpleNamespace(
+            event=SimpleNamespace(
+                sender=SimpleNamespace(
+                    sender_type="user",
+                    sender_id=SimpleNamespace(open_id="ou_any", user_id=None, union_id=None),
+                ),
+                message=SimpleNamespace(
+                    message_id="om_reply",
+                    chat_id="oc_chat",
+                    chat_type="group",
+                    message_type="text",
+                    content=json.dumps({"text": "@_user_1 please help"}),
+                    mentions=[],
+                    parent_id="om_parent",
+                    root_id="om_root",
+                ),
+            )
+        )
+
+        asyncio.run(adapter._handle_message_event_data(data))
+
+        adapter._client.im.v1.message.get.assert_called_once()
+        adapter._process_inbound_message.assert_not_awaited()
 
     @patch.dict(
         os.environ,
@@ -4465,12 +4854,8 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         event = adapter._dispatch_inbound_event.call_args.args[0]
         self.assertEqual(event.text, "stop pinging @Hermes please")
 
-    def test_pure_self_mention_message_is_ignored(self):
-        """A message containing only '@Bot' (no body, no media) must not dispatch.
-
-        Regression guard: the rendered '@Hermes' slips past the pre-strip empty
-        guard; the post-strip guard must catch it.
-        """
+    def test_pure_self_mention_message_dispatches_as_bot_ping(self):
+        """A message containing only '@Bot' should still dispatch as an explicit bot ping."""
         adapter = self._build_adapter()
         bot_mention = SimpleNamespace(
             key="@_user_1",
@@ -4493,7 +4878,8 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
                 chat_type="group", message_id="m5",
             )
         )
-        adapter._dispatch_inbound_event.assert_not_called()
+        event = adapter._dispatch_inbound_event.call_args.args[0]
+        self.assertEqual(event.text, "[Bot mentioned]")
 
 
 class TestFeishuFetchMessageText(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Hydrate ambiguous Feishu reply @mentions via `message.get` before rejecting group events at the mention gate.
- Support dict-shaped mention payloads returned by Feishu REST (`id`, `id_type`, `key`, `name`) throughout mention admission and text normalization.
- Preserve reply-only and pure `@bot` messages as explicit bot pings instead of dropping them after self-mention stripping. This intentionally matches Discord and other channel behavior so users are not confused by Feishu sometimes ignoring an otherwise valid `@bot` ping.
- Add regressions for live Feishu reply shapes, missing `chat_type`, dict mentions, reply-only `@bot`, and pure `@bot` dispatch.

Fixes #21366.

## Test plan
- `python -m pytest tests/gateway/test_feishu.py::TestAdapterBehavior::test_reply_only_bot_mention_dispatches_with_parent_context tests/gateway/test_feishu.py::TestFeishuProcessInboundMessage::test_pure_self_mention_message_dispatches_as_bot_ping -q`
- `python -m pytest tests/gateway/test_feishu.py -q`

## Disclosure
Generated by an AI agent; validated with targeted and full Feishu adapter tests.
