### PR TITLE
docs(web): fix SearXNG env configuration

### DIFF
--- a/tools/web_providers/searxng.py
+++ b/tools/web_providers/searxng.py
@@ -5,10 +5,11 @@ It implements ``WebSearchProvider`` only — there is no extract capability.
 
 Configuration::
 
-    # ~/.hermes/config.yaml  (SEARXNG_URL is a URL, not a secret — use config.yaml not .env)
-    SEARXNG_URL: http://localhost:8080
+    # ~/.hermes/.env
+    SEARXNG_URL=http://localhost:8080
 
     # Use SearXNG for search, pair with any extract provider:
+    # ~/.hermes/config.yaml
     web:
       search_backend: "searxng"
       extract_backend: "firecrawl"

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -148,8 +148,15 @@ You should see something like `10 results`. If you get a `403 Forbidden`, JSON f
 **7. Configure Hermes:**
 
 ```bash
-# ~/.hermes/config.yaml
-SEARXNG_URL: http://localhost:8888
+# ~/.hermes/.env
+SEARXNG_URL=http://localhost:8888
+```
+
+Then select SearXNG as the search backend in `~/.hermes/config.yaml`:
+
+```yaml
+web:
+  search_backend: "searxng"
 ```
 
 Or set via `hermes tools` → Web Search & Extract → SearXNG.
@@ -161,8 +168,8 @@ Or set via `hermes tools` → Web Search & Extract → SearXNG.
 Public SearXNG instances are listed at [searx.space](https://searx.space/). Filter by instances that have **JSON format enabled** (shown in the table).
 
 ```bash
-# ~/.hermes/config.yaml
-SEARXNG_URL: https://searx.example.com
+# ~/.hermes/.env
+SEARXNG_URL=https://searx.example.com
 ```
 
 :::caution Public instances


### PR DESCRIPTION
## What does this PR do?

Corrects the SearXNG web search documentation so `SEARXNG_URL` is configured in `~/.hermes/.env`, matching the runtime code path that reads `os.getenv("SEARXNG_URL")`.

The docs previously showed `SEARXNG_URL:` as a top-level `config.yaml` key, which does not match the provider implementation or backend availability check. This also updates the SearXNG provider docstring so source comments and public docs agree.

## Related Issue

No GitHub issue filed. Surfaced from a Discord support report about the SearXNG setup docs.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docs/user-guide/features/web-search.md`: moves SearXNG URL examples from `config.yaml` syntax to `.env` syntax and adds the matching `web.search_backend: "searxng"` config example.
- `tools/web_providers/searxng.py`: updates the provider docstring to document `.env` for `SEARXNG_URL` and `config.yaml` for backend selection.

## How to Test

1. Confirm the docs no longer contain `SEARXNG_URL:` as a `config.yaml` example:
   `rg -n "SEARXNG_URL:|SEARXNG_URL is a URL|config.yaml.*SEARXNG_URL" website/docs/user-guide/features/web-search.md tools/web_providers/searxng.py`
2. Compile the touched Python source:
   `python3 -m py_compile tools/web_providers/searxng.py`
3. Check whitespace in the diff:
   `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL / Ubuntu

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — updated web search docs and SearXNG provider docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A, docs/comment-only change
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool behavior changed

## Screenshots / Logs

```bash
$ python3 -m py_compile tools/web_providers/searxng.py
# passed

$ rg -n "SEARXNG_URL:|SEARXNG_URL is a URL|config.yaml.*SEARXNG_URL" website/docs/user-guide/features/web-search.md tools/web_providers/searxng.py
# no matches

$ git diff --check
# passed
```
