### PR TITLE
feat(cli): add Eden AI as a built-in provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -468,3 +468,12 @@ IMAGE_TOOLS_DEBUG=false
 # GOOGLE_CHAT_ALLOW_ALL_USERS=false             # Set true to skip the allowlist
 # GOOGLE_CHAT_HOME_CHANNEL=                     # Default space (spaces/XXXX) for cron delivery
 # GOOGLE_CHAT_HOME_CHANNEL_NAME=                # Display name for the home channel
+
+# =============================================================================
+# LLM PROVIDER (Eden AI)
+# =============================================================================
+# Eden AI is a meta-gateway: one OpenAI-compatible endpoint, 349+ models across
+# 21+ underlying providers (Anthropic, OpenAI, Google, Cohere, Mistral, ...).
+# Get your key at: https://app.edenai.run/admin/account/settings
+# EDENAI_API_KEY=
+# EDENAI_BASE_URL=https://api.edenai.run/v3  # Override default base URL

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -275,6 +275,7 @@ _API_KEY_PROVIDER_AUX_MODELS_FALLBACK: Dict[str, str] = {
     "kilocode": "google/gemini-3-flash-preview",
     "ollama-cloud": "nemotron-3-nano:30b",
     "tencent-tokenhub": "hy3-preview",
+    "edenai": "google/gemini-2.5-flash-lite",
 }
 
 # Legacy alias — callers that haven't been updated to _get_aux_model_for_provider()

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -63,6 +63,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "mimo", "xiaomi-mimo",
     "tencent", "tokenhub", "tencent-cloud", "tencentmaas",
     "arcee-ai", "arceeai",
+    "edenai", "eden", "eden-ai", "eden_ai",
     "gmi-cloud", "gmicloud",
     "xai", "x-ai", "x.ai", "grok",
     "nvidia", "nim", "nvidia-nim", "nemotron",
@@ -375,6 +376,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.novita.ai": "novita",
     "tokenhub.tencentmaas.com": "tencent-tokenhub",
     "ollama.com": "ollama-cloud",
+    "api.edenai.run": "edenai",
 }
 
 # Auto-extend with hostnames derived from provider profiles.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -29,6 +29,7 @@ model:
   #   "arcee"        - Arcee AI Trinity models (requires: ARCEEAI_API_KEY)
   #   "ollama-cloud" - Ollama Cloud (requires: OLLAMA_API_KEY — https://ollama.com/settings)
   #   "kilocode"     - KiloCode gateway (requires: KILOCODE_API_KEY)
+  #   "edenai"       - Eden AI meta-gateway (requires: EDENAI_API_KEY)
   #   "ai-gateway"   - Vercel AI Gateway (requires: AI_GATEWAY_API_KEY)
   #   "azure-foundry" - Microsoft Foundry / Azure OpenAI (API key or Entra ID)
   #   "lmstudio"     - LM Studio local server (optional: LM_API_KEY, defaults to http://127.0.0.1:1234/v1)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -386,6 +386,16 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("OPENCODE_ZEN_API_KEY",),
         base_url_env_var="OPENCODE_ZEN_BASE_URL",
     ),
+    "edenai": ProviderConfig(
+        id="edenai",
+        name="Eden AI",
+        auth_type="api_key",
+        # Eden AI is a meta-gateway: 349+ models across 21+ underlying providers
+        # (Anthropic, OpenAI, Google, Cohere, Mistral, ...) under one OpenAI-shape API.
+        inference_base_url="https://api.edenai.run/v3",
+        api_key_env_vars=("EDENAI_API_KEY",),
+        base_url_env_var="EDENAI_BASE_URL",
+    ),
     "opencode-go": ProviderConfig(
         id="opencode-go",
         name="OpenCode Go",
@@ -1424,6 +1434,7 @@ def resolve_provider(
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
         "aigateway": "ai-gateway", "vercel": "ai-gateway", "vercel-ai-gateway": "ai-gateway",
         "opencode": "opencode-zen", "zen": "opencode-zen",
+        "eden": "edenai", "eden-ai": "edenai", "eden_ai": "edenai",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth", "google-gemini-cli": "google-gemini-cli", "gemini-cli": "google-gemini-cli", "gemini-oauth": "google-gemini-cli",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
         "mimo": "xiaomi", "xiaomi-mimo": "xiaomi",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2130,6 +2130,7 @@ def select_provider_and_model(args=None):
         "nvidia",
         "ollama-cloud",
         "tencent-tokenhub",
+        "edenai",
         "lmstudio",
     } or _is_profile_api_key_provider(selected_provider):
         _model_flow_api_key_provider(config, selected_provider, current_model)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -397,6 +397,19 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "google/gemini-3-pro-preview",
         "google/gemini-3-flash-preview",
     ],
+    # Eden AI: meta-gateway. The live /v3/models catalog (349+ models) is
+    # used at runtime; this curated list is the offline fallback only.
+    # Anthropic ids use the hyphen form Eden AI stores (dot form returns 400).
+    "edenai": [
+        "anthropic/claude-opus-4-6",
+        "anthropic/claude-sonnet-4-6",
+        "anthropic/claude-haiku-4-5",
+        "openai/gpt-4o",
+        "openai/gpt-4o-mini",
+        "google/gemini-2.0-flash",
+        "mistral/mistral-large-latest",
+        "cohere/command-r-plus",
+    ],
     # Alibaba DashScope Coding platform (coding-intl) — default endpoint.
     # Supports Qwen models + third-party providers (GLM, Kimi, MiniMax).
     # Users with classic DashScope keys should override DASHSCOPE_BASE_URL
@@ -953,6 +966,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("kilocode",       "Kilo Code",                "Kilo Code (Kilo Gateway API)"),
     ProviderEntry("opencode-zen",   "OpenCode Zen",             "OpenCode Zen (35+ curated models, pay-as-you-go)"),
     ProviderEntry("opencode-go",    "OpenCode Go",              "OpenCode Go (open models, $10/month subscription)"),
+    ProviderEntry("edenai",         "Eden AI",                  "Eden AI (drop-in for OpenAI; 349 models across 21 underlying providers)"),
     ProviderEntry("bedrock",        "AWS Bedrock",              "AWS Bedrock (Claude, Nova, Llama, DeepSeek — IAM or API key)"),
     ProviderEntry("azure-foundry",  "Azure Foundry",            "Azure Foundry (OpenAI-style or Anthropic-style endpoint — your Azure AI deployment)"),
     ProviderEntry("ai-gateway",     "Vercel AI Gateway",        "Vercel AI Gateway"),
@@ -1029,6 +1043,9 @@ _PROVIDER_ALIASES = {
     "aliyun": "alibaba",
     "qwen": "alibaba",
     "alibaba-cloud": "alibaba",
+    "eden": "edenai",
+    "eden-ai": "edenai",
+    "eden_ai": "edenai",
     "qwen-portal": "qwen-oauth",
     "gemini-cli": "google-gemini-cli",
     "gemini-oauth": "google-gemini-cli",
@@ -1293,6 +1310,28 @@ def ai_gateway_model_ids(*, force_refresh: bool = False) -> list[str]:
     return [mid for mid, _ in fetch_ai_gateway_models(force_refresh=force_refresh)]
 
 
+def fetch_edenai_models() -> list[tuple[str, str]]:
+    """Return Eden AI's catalog as (model_id, description) tuples.
+
+    Eden AI is a meta-gateway exposing 349+ models across 21 underlying
+    providers. Live `/v3/models` is the source of truth when an API key is
+    configured; otherwise we fall back to the curated headline list in
+    ``_PROVIDER_MODELS["edenai"]``. Description is empty — Eden AI's catalog
+    doesn't expose the same per-model annotation OpenRouter does.
+    """
+    try:
+        from hermes_cli.auth import resolve_api_key_provider_credentials
+
+        creds = resolve_api_key_provider_credentials("edenai")
+        api_key = str(creds.get("api_key") or "").strip()
+        base_url = str(creds.get("base_url") or "").strip()
+        if api_key and base_url:
+            live = fetch_api_models(api_key, base_url)
+            if live:
+                return [(mid, "") for mid in live]
+    except Exception:
+        pass
+    return [(mid, "") for mid in _PROVIDER_MODELS.get("edenai", [])]
 
 
 # ---------------------------------------------------------------------------
@@ -2245,6 +2284,19 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             from hermes_cli.auth import resolve_api_key_provider_credentials
 
             creds = resolve_api_key_provider_credentials("gmi")
+            api_key = str(creds.get("api_key") or "").strip()
+            base_url = str(creds.get("base_url") or "").strip()
+            if api_key and base_url:
+                live = fetch_api_models(api_key, base_url)
+                if live:
+                    return live
+        except Exception:
+            pass
+    if normalized == "edenai":
+        try:
+            from hermes_cli.auth import resolve_api_key_provider_credentials
+
+            creds = resolve_api_key_provider_credentials("edenai")
             api_key = str(creds.get("api_key") or "").strip()
             base_url = str(creds.get("base_url") or "").strip()
             if api_key and base_url:

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -167,6 +167,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         is_aggregator=True,
         base_url_env_var="NOVITA_BASE_URL",
     ),
+    "edenai": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        base_url_env_var="EDENAI_BASE_URL",
+    ),
     "xai": HermesOverlay(
         transport="codex_responses",
         base_url_override="https://api.x.ai/v1",
@@ -293,6 +298,11 @@ ALIASES: Dict[str, str] = {
     # opencode (models.dev ID for OpenCode Zen)
     "opencode-zen": "opencode",
     "zen": "opencode",
+
+    # edenai
+    "eden": "edenai",
+    "eden-ai": "edenai",
+    "eden_ai": "edenai",
 
     # opencode-go
     "go": "opencode-go",

--- a/tests/hermes_cli/test_edenai_provider.py
+++ b/tests/hermes_cli/test_edenai_provider.py
@@ -1,0 +1,264 @@
+"""Tests for Eden AI provider support."""
+
+import types
+
+import pytest
+
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    resolve_provider,
+    get_api_key_provider_status,
+    resolve_api_key_provider_credentials,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_provider_env(monkeypatch):
+    """Clear every provider's env vars + auth store before each test.
+
+    Reads ``PROVIDER_REGISTRY`` dynamically so the list stays current as new
+    providers land — no hardcoded constant to maintain. Extras list covers
+    env vars that intentionally live outside ``PROVIDER_REGISTRY``: OpenRouter
+    (Hermes' default-fallback, special-cased in ``auth.py``), the GitHub /
+    Copilot tokens (resolved through external auth flows), and HF_TOKEN.
+    """
+    for pcfg in PROVIDER_REGISTRY.values():
+        for env in pcfg.api_key_env_vars:
+            monkeypatch.delenv(env, raising=False)
+        if pcfg.base_url_env_var:
+            monkeypatch.delenv(pcfg.base_url_env_var, raising=False)
+    for env in (
+        "OPENROUTER_API_KEY",
+        "COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN",
+        "HF_TOKEN",
+    ):
+        monkeypatch.delenv(env, raising=False)
+    monkeypatch.setattr("hermes_cli.auth._load_auth_store", lambda: {})
+
+
+# =============================================================================
+# Provider Registry
+# =============================================================================
+
+
+class TestEdenAIProviderRegistry:
+    def test_registered(self):
+        assert "edenai" in PROVIDER_REGISTRY
+
+    def test_name(self):
+        assert PROVIDER_REGISTRY["edenai"].name == "Eden AI"
+
+    def test_auth_type(self):
+        assert PROVIDER_REGISTRY["edenai"].auth_type == "api_key"
+
+    def test_inference_base_url(self):
+        assert PROVIDER_REGISTRY["edenai"].inference_base_url == "https://api.edenai.run/v3"
+
+    def test_api_key_env_vars(self):
+        assert PROVIDER_REGISTRY["edenai"].api_key_env_vars == ("EDENAI_API_KEY",)
+
+    def test_base_url_env_var(self):
+        assert PROVIDER_REGISTRY["edenai"].base_url_env_var == "EDENAI_BASE_URL"
+
+
+# =============================================================================
+# Aliases (auth.py + models.py + providers.py)
+# =============================================================================
+
+
+class TestEdenAIAliases:
+    @pytest.mark.parametrize("alias", ["edenai", "eden", "eden-ai", "eden_ai"])
+    def test_alias_resolves_in_auth(self, alias, monkeypatch):
+        monkeypatch.setenv("EDENAI_API_KEY", "eden-test-12345")
+        assert resolve_provider(alias) == "edenai"
+
+    def test_normalize_provider_models_py(self):
+        from hermes_cli.models import normalize_provider
+        assert normalize_provider("eden") == "edenai"
+        assert normalize_provider("eden-ai") == "edenai"
+
+    def test_normalize_provider_providers_py(self):
+        from hermes_cli.providers import normalize_provider
+        assert normalize_provider("eden") == "edenai"
+        assert normalize_provider("eden-ai") == "edenai"
+
+
+# =============================================================================
+# Credentials
+# =============================================================================
+
+
+class TestEdenAICredentials:
+    # Env-clear is handled by the module-level ``_clear_provider_env`` autouse
+    # fixture at the top of this file — no per-class duplication needed.
+
+    def test_status_configured(self, monkeypatch):
+        monkeypatch.setenv("EDENAI_API_KEY", "eden-test")
+        status = get_api_key_provider_status("edenai")
+        assert status["configured"]
+
+    def test_status_not_configured(self):
+        status = get_api_key_provider_status("edenai")
+        assert not status["configured"]
+
+    def test_status_isolated_from_other_provider_keys(self, monkeypatch):
+        """An unrelated provider's API key must not flip Eden AI to ``configured``.
+
+        Verified with ``ANTHROPIC_API_KEY`` rather than ``OPENROUTER_API_KEY``
+        because OpenRouter is Hermes' default-fallback provider — its priority
+        behaviour is host-internal logic, not an Eden AI concern.
+        """
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        status = get_api_key_provider_status("edenai")
+        assert not status["configured"]
+
+    def test_auto_detects_when_only_edenai_env_set(self, monkeypatch):
+        monkeypatch.setenv("EDENAI_API_KEY", "eden-key")
+        assert resolve_provider("auto") == "edenai"
+
+    def test_resolve_credentials(self, monkeypatch):
+        monkeypatch.setenv("EDENAI_API_KEY", "eden-direct-key")
+        creds = resolve_api_key_provider_credentials("edenai")
+        assert creds["api_key"] == "eden-direct-key"
+        assert creds["base_url"] == "https://api.edenai.run/v3"
+        assert creds["source"] == "EDENAI_API_KEY"
+
+    def test_custom_base_url_override(self, monkeypatch):
+        monkeypatch.setenv("EDENAI_API_KEY", "eden-x")
+        monkeypatch.setenv("EDENAI_BASE_URL", "https://custom.edenai.example/v3")
+        creds = resolve_api_key_provider_credentials("edenai")
+        assert creds["base_url"] == "https://custom.edenai.example/v3"
+
+    def test_runtime_uses_chat_completions(self, monkeypatch):
+        monkeypatch.setenv("EDENAI_API_KEY", "rt-key")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="edenai")
+        assert result["provider"] == "edenai"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "rt-key"
+        assert result["base_url"] == "https://api.edenai.run/v3"
+
+
+# =============================================================================
+# Model catalog — static fallback + live /v3/models probe
+# =============================================================================
+
+
+class TestEdenAIModelCatalog:
+    def test_static_model_list(self):
+        """A static fallback exists so the picker shows something when offline."""
+        from hermes_cli.models import _PROVIDER_MODELS
+        assert "edenai" in _PROVIDER_MODELS
+        assert len(_PROVIDER_MODELS["edenai"]) >= 1
+
+    def test_canonical_provider_entry(self):
+        from hermes_cli.models import CANONICAL_PROVIDERS
+        slugs = [p.slug for p in CANONICAL_PROVIDERS]
+        assert "edenai" in slugs
+
+    def test_label(self):
+        from hermes_cli.models import _PROVIDER_LABELS
+        assert _PROVIDER_LABELS["edenai"] == "Eden AI"
+
+    def test_static_anthropic_ids_use_hyphen_form(self):
+        """Eden AI's catalog stores anthropic/claude-opus-4-6 (hyphen), not the
+        dot form Anthropic / OpenRouter use. The static fallback must match
+        so users hit a working default if the live probe fails."""
+        from hermes_cli.models import _PROVIDER_MODELS
+        anthropic_picks = [m for m in _PROVIDER_MODELS["edenai"] if m.startswith("anthropic/")]
+        assert anthropic_picks
+        for m in anthropic_picks:
+            tail = m.split("/", 1)[1]
+            assert "." not in tail, f"Eden AI anthropic id must be hyphen-form: {m!r}"
+
+    def test_fetch_edenai_models_callable(self):
+        """The live-probe helper exists and returns a list of (id, desc) tuples."""
+        from hermes_cli.models import fetch_edenai_models
+        # Network call is OK to skip in unit tests; we only assert the
+        # function is wired and returns the expected shape on cache or fallback.
+        result = fetch_edenai_models()
+        assert isinstance(result, list)
+        if result:
+            mid, desc = result[0]
+            assert isinstance(mid, str) and mid
+            assert isinstance(desc, str)
+
+
+# =============================================================================
+# Model normalisation — Eden AI uses vendor/model format, no prefix-strip
+# =============================================================================
+
+
+class TestEdenAINormalization:
+    def test_NOT_in_matching_prefix_strip_set(self):
+        """Eden AI sends ids in vendor/model form (e.g. anthropic/claude-opus-4-6).
+        Stripping the 'edenai/' prefix from a user input would mangle that, so
+        we deliberately keep edenai out of the prefix-strip set."""
+        from hermes_cli.model_normalize import _MATCHING_PREFIX_STRIP_PROVIDERS
+        assert "edenai" not in _MATCHING_PREFIX_STRIP_PROVIDERS
+
+    def test_vendor_prefix_preserved(self):
+        from hermes_cli.model_normalize import normalize_model_for_provider
+        # User says "anthropic/claude-opus-4-6" + provider "edenai".
+        # We must keep the vendor prefix intact — Eden AI requires it.
+        assert (
+            normalize_model_for_provider("anthropic/claude-opus-4-6", "edenai")
+            == "anthropic/claude-opus-4-6"
+        )
+
+
+# =============================================================================
+# URL mapping (model_metadata + trajectory_compressor)
+# =============================================================================
+
+
+class TestEdenAIURLMapping:
+    def test_url_to_provider(self):
+        from agent.model_metadata import _URL_TO_PROVIDER
+        assert _URL_TO_PROVIDER.get("api.edenai.run") == "edenai"
+
+    def test_provider_prefixes(self):
+        from agent.model_metadata import _PROVIDER_PREFIXES
+        assert "edenai" in _PROVIDER_PREFIXES
+        assert "eden" in _PROVIDER_PREFIXES
+        assert "eden-ai" in _PROVIDER_PREFIXES
+
+    def test_trajectory_compressor_detects_edenai(self):
+        import trajectory_compressor as tc
+        comp = tc.TrajectoryCompressor.__new__(tc.TrajectoryCompressor)
+        comp.config = types.SimpleNamespace(base_url="https://api.edenai.run/v3")
+        assert comp._detect_provider() == "edenai"
+
+
+# =============================================================================
+# providers.py overlay — is_aggregator drives picker /models probing
+# =============================================================================
+
+
+class TestEdenAIProvidersModule:
+    def test_overlay_exists(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+        assert "edenai" in HERMES_OVERLAYS
+        overlay = HERMES_OVERLAYS["edenai"]
+        assert overlay.transport == "openai_chat"
+        assert overlay.base_url_env_var == "EDENAI_BASE_URL"
+
+    def test_overlay_marks_aggregator(self):
+        """Eden AI fronts 349 models — the picker probes /v3/models for the live catalog."""
+        from hermes_cli.providers import HERMES_OVERLAYS
+        assert HERMES_OVERLAYS["edenai"].is_aggregator is True
+
+
+# =============================================================================
+# Auxiliary client — Eden AI exposes cheap GPT-4o-mini for side tasks
+# =============================================================================
+
+
+class TestEdenAIAuxiliary:
+    def test_aux_model_registered(self):
+        """Eden AI registers an OpenAI-side cheap model for summary / vision /
+        memory side tasks. Without this entry, side tasks fall back to the
+        user's main model — expensive when the main is Claude Opus."""
+        from agent.auxiliary_client import _API_KEY_PROVIDER_AUX_MODELS
+        assert "edenai" in _API_KEY_PROVIDER_AUX_MODELS
+        assert _API_KEY_PROVIDER_AUX_MODELS["edenai"]  # non-empty

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -454,6 +454,8 @@ class TrajectoryCompressor:
             return "kimi-coding"
         if base_url_host_matches(url, "arcee.ai"):
             return "arcee"
+        if base_url_host_matches(url, "edenai.run"):
+            return "edenai"
         if base_url_host_matches(url, "minimaxi.com"):
             return "minimax-cn"
         if base_url_host_matches(url, "minimax.io"):

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -22,6 +22,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **NovitaAI** | `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud) |
 | **AI Gateway** | `AI_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `ai-gateway`) |
+| **Eden AI** | `EDENAI_API_KEY` in `~/.hermes/.env` (provider: `edenai`) |
 | **z.ai / GLM** | `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`) |
 | **Kimi / Moonshot** | `KIMI_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding`) |
 | **Kimi / Moonshot (China)** | `KIMI_CN_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding-cn`; aliases: `kimi-cn`, `moonshot-cn`) |


### PR DESCRIPTION
## What changed

Eden AI is a meta-gateway exposing 349 models across 21 underlying providers (Anthropic, OpenAI, Google, Cohere, Mistral, ...) behind a single OpenAI-compatible `/chat/completions` endpoint at `https://api.edenai.run/v3`. This PR promotes it to a first-class built-in provider, so users can run

```
hermes chat --provider edenai --model anthropic/claude-opus-4-6
```

and reach any backend with one `EDENAI_API_KEY` — the same way OpenRouter and Vercel AI Gateway already work. Until now the only path was the `custom_providers` escape hatch.

## Why

Eden AI is OpenAI-compatible end-to-end. Validated live against `api.edenai.run/v3`: chat, multi-turn, `--resume`, tool calls (10-call agent loop), streaming, long context (25K input tokens, exact recall), JSON mode, aggregator routing to `anthropic/claude-opus-4-6`, `openai/gpt-4o`, `google/gemini-2.5-pro`. Promoting to built-in eliminates per-user `custom_providers` config and gives an immediate 21-backend / 349-model catalog through one key.

## How to test

```bash
export EDENAI_API_KEY=<your-key>

# unit
pytest tests/hermes_cli/test_edenai_provider.py -q          # 32/32

# smoke — chat
hermes chat -q "Say hello" --provider edenai --model anthropic/claude-opus-4-6

# smoke — aggregator routing to a non-Anthropic backend
hermes chat -q "Say hello" --provider edenai --model openai/gpt-4o
hermes chat -q "Say hello" --provider edenai --model google/gemini-2.5-pro

# multi-turn (capture session id from turn 1, then resume)
hermes chat -q "My name is X. Acknowledge." --provider edenai --model anthropic/claude-opus-4-6
hermes --resume <SESSION_ID> chat -q "What is my name?"
```

## Known caveat (server-side, not blocking)

Eden AI's catalog stores Anthropic ids with hyphens (`anthropic/claude-opus-4-6`) where Anthropic and OpenRouter use dots (`anthropic/claude-opus-4.6`). The curated default model list in this PR ships the hyphen form so users hit a working model out of the box. A request-time `.` → `-` normalisation on Eden AI's gateway would fix this for every OpenAI-compatible client and is the right long-term fix; not bundled here.

## Platforms tested

- Linux x86_64 (Ubuntu 24.04, Python 3.11)

## Out of scope

- No edits to `hermes_cli/model_switch.py`. The picker shows the curated 5–10 headline models from `_PROVIDER_MODELS["edenai"]`, consistent with how every other aggregator (OpenRouter, Vercel, Hugging Face) currently behaves. The full 349-model live catalog still drives runtime model resolution via `provider_model_ids("edenai")`.
- No changes to streaming parser, tool-call adapter, runtime resolver, or `run_agent.py`.
