### PR TITLE
fix(auxiliary): bump aux-call timeout for local endpoints (#21566)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -100,6 +100,7 @@ class _OpenAIProxy:
 OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
 from agent.credential_pool import load_pool
+from agent.model_metadata import is_local_endpoint
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, normalize_proxy_env_vars
@@ -4648,13 +4649,8 @@ def _resolve_default_timeout(default: float, base_url: Optional[str]) -> float:
     Only triggers when *default* is the implicit ``_DEFAULT_AUX_TIMEOUT``
     (so explicit caller defaults are respected) and *base_url* is local.
     """
-    if base_url and default == _DEFAULT_AUX_TIMEOUT:
-        try:
-            from agent.model_metadata import is_local_endpoint
-            if is_local_endpoint(base_url):
-                return _local_aux_default_timeout()
-        except ImportError:
-            pass
+    if base_url and default == _DEFAULT_AUX_TIMEOUT and is_local_endpoint(base_url):
+        return _local_aux_default_timeout()
     return default
 
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4630,10 +4630,51 @@ def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
     return task_config
 
 
-def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float:
-    """Read timeout from auxiliary.{task}.timeout in config, falling back to *default*."""
+def _local_aux_default_timeout() -> float:
+    """Default auxiliary timeout for local providers (Ollama, llama.cpp, vLLM).
+
+    Mirrors ``HERMES_API_TIMEOUT`` (default 1800s) used by ``run_agent.py``
+    for the main loop's local-endpoint stream/stale timeout bumps.
+    """
+    try:
+        return float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
+    except (ValueError, TypeError):
+        return 1800.0
+
+
+def _resolve_default_timeout(default: float, base_url: Optional[str]) -> float:
+    """Apply the local-endpoint bump to *default* when applicable.
+
+    Only triggers when *default* is the implicit ``_DEFAULT_AUX_TIMEOUT``
+    (so explicit caller defaults are respected) and *base_url* is local.
+    """
+    if base_url and default == _DEFAULT_AUX_TIMEOUT:
+        try:
+            from agent.model_metadata import is_local_endpoint
+            if is_local_endpoint(base_url):
+                return _local_aux_default_timeout()
+        except ImportError:
+            pass
+    return default
+
+
+def _get_task_timeout(
+    task: str,
+    default: float = _DEFAULT_AUX_TIMEOUT,
+    base_url: Optional[str] = None,
+) -> float:
+    """Read timeout from ``auxiliary.{task}.timeout`` in config, falling back to *default*.
+
+    When ``base_url`` is supplied and points to a local endpoint (Ollama,
+    llama.cpp, vLLM, etc.) AND neither the caller nor the config has set an
+    explicit value, the default is bumped to ``HERMES_API_TIMEOUT`` (1800s
+    by default). This mirrors the local-endpoint timeout behavior the main
+    agent loop already applies in ``run_agent.py`` and prevents the 30s
+    auxiliary default from triggering ReadTimeout → retry → inference-server
+    queue saturation on slow local prefill (#21566).
+    """
     if not task:
-        return default
+        return _resolve_default_timeout(default, base_url)
     task_config = _get_auxiliary_task_config(task)
     raw = task_config.get("timeout")
     if raw is not None:
@@ -4641,7 +4682,7 @@ def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float
             return float(raw)
         except (ValueError, TypeError):
             pass
-    return default
+    return _resolve_default_timeout(default, base_url)
 
 
 def _get_task_extra_body(task: str) -> Dict[str, Any]:
@@ -4943,10 +4984,14 @@ def call_llm(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
-    effective_timeout = timeout if timeout is not None else _get_task_timeout(task)
-
     # Log what we're about to do — makes auxiliary operations visible
     _base_info = str(getattr(client, "base_url", resolved_base_url) or "")
+    effective_timeout = (
+        timeout
+        if timeout is not None
+        else _get_task_timeout(task, base_url=_base_info or resolved_base_url)
+    )
+
     if task:
         logger.info("Auxiliary %s: using %s (%s)%s",
                      task, resolved_provider or "auto", final_model or "default",
@@ -5393,12 +5438,16 @@ async def async_call_llm(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
-    effective_timeout = timeout if timeout is not None else _get_task_timeout(task)
-
     # Pass the client's actual base_url (not just resolved_base_url) so
     # endpoint-specific temperature overrides can distinguish
     # api.moonshot.ai vs api.kimi.com/coding even on auto-detected routes.
     _client_base = str(getattr(client, "base_url", "") or "")
+    effective_timeout = (
+        timeout
+        if timeout is not None
+        else _get_task_timeout(task, base_url=_client_base or resolved_base_url)
+    )
+
     kwargs = _build_call_kwargs(
         resolved_provider, final_model, messages,
         temperature=temperature, max_tokens=max_tokens,

--- a/tests/agent/test_auxiliary_local_endpoint_timeout.py
+++ b/tests/agent/test_auxiliary_local_endpoint_timeout.py
@@ -8,8 +8,6 @@ auto-bumps timeouts for local endpoints; auxiliary calls should do the
 same when neither the caller nor config has set an explicit value.
 """
 
-import os
-
 import pytest
 from unittest.mock import patch
 

--- a/tests/agent/test_auxiliary_local_endpoint_timeout.py
+++ b/tests/agent/test_auxiliary_local_endpoint_timeout.py
@@ -1,0 +1,135 @@
+"""Tests for local-endpoint timeout auto-bump in agent.auxiliary_client.
+
+When an auxiliary call (session_search, skills_hub, title_generation,
+vision, etc.) routes to a local LLM provider (Ollama, llama.cpp, vLLM),
+the 30s default timeout causes ReadTimeout → retry → inference-server
+queue saturation on slow prefill (#21566). The main agent loop already
+auto-bumps timeouts for local endpoints; auxiliary calls should do the
+same when neither the caller nor config has set an explicit value.
+"""
+
+import os
+
+import pytest
+from unittest.mock import patch
+
+from agent.auxiliary_client import (
+    _DEFAULT_AUX_TIMEOUT,
+    _get_task_timeout,
+    _local_aux_default_timeout,
+)
+
+
+class TestGetTaskTimeoutLocalBump:
+    """``_get_task_timeout`` should auto-bump to local default for local URLs."""
+
+    @pytest.mark.parametrize("base_url", [
+        "http://localhost:11434",
+        "http://127.0.0.1:8080",
+        "http://0.0.0.0:5000",
+        "http://192.168.1.100:8000",
+        "http://10.0.0.5:1234",
+        "http://host.docker.internal:11434",
+    ])
+    def test_local_endpoint_no_config_override_bumps(self, base_url, monkeypatch):
+        """Local URL + no caller/config override → bumped to local default (1800s)."""
+        monkeypatch.delenv("HERMES_API_TIMEOUT", raising=False)
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={}):
+            result = _get_task_timeout("session_search", base_url=base_url)
+        assert result == 1800.0
+
+    def test_local_endpoint_respects_explicit_config(self, monkeypatch):
+        """Explicit ``auxiliary.<task>.timeout`` wins over local-endpoint bump."""
+        monkeypatch.delenv("HERMES_API_TIMEOUT", raising=False)
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"timeout": 60},
+        ):
+            result = _get_task_timeout("session_search", base_url="http://localhost:11434")
+        assert result == 60.0
+
+    def test_local_endpoint_respects_caller_default(self, monkeypatch):
+        """Non-default ``default=`` arg means caller is overriding — no bump."""
+        monkeypatch.delenv("HERMES_API_TIMEOUT", raising=False)
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={}):
+            result = _get_task_timeout(
+                "session_search", default=120.0, base_url="http://localhost:11434",
+            )
+        assert result == 120.0
+
+    @pytest.mark.parametrize("base_url", [
+        "https://api.openai.com",
+        "https://openrouter.ai/api",
+        "https://api.anthropic.com",
+        "https://api.moonshot.ai",
+    ])
+    def test_remote_endpoint_keeps_default(self, base_url, monkeypatch):
+        """Remote URL → keep 30s default."""
+        monkeypatch.delenv("HERMES_API_TIMEOUT", raising=False)
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={}):
+            result = _get_task_timeout("session_search", base_url=base_url)
+        assert result == _DEFAULT_AUX_TIMEOUT
+
+    def test_no_base_url_keeps_default(self, monkeypatch):
+        """No base_url (None or empty) → keep 30s default (no bump applied)."""
+        monkeypatch.delenv("HERMES_API_TIMEOUT", raising=False)
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={}):
+            assert _get_task_timeout("session_search") == _DEFAULT_AUX_TIMEOUT
+            assert _get_task_timeout("session_search", base_url=None) == _DEFAULT_AUX_TIMEOUT
+            assert _get_task_timeout("session_search", base_url="") == _DEFAULT_AUX_TIMEOUT
+
+    def test_empty_task_with_local_base_url_still_bumps(self, monkeypatch):
+        """Empty task (used by ad-hoc call_llm) + local URL → still bump."""
+        monkeypatch.delenv("HERMES_API_TIMEOUT", raising=False)
+        result = _get_task_timeout("", base_url="http://localhost:11434")
+        assert result == 1800.0
+
+    def test_empty_task_with_remote_base_url_keeps_default(self):
+        """Empty task + remote URL → 30s default (no bump)."""
+        result = _get_task_timeout("", base_url="https://api.openai.com")
+        assert result == _DEFAULT_AUX_TIMEOUT
+
+    def test_hermes_api_timeout_env_overrides_local_default(self, monkeypatch):
+        """Local-endpoint default reads ``HERMES_API_TIMEOUT`` like run_agent.py does."""
+        monkeypatch.setenv("HERMES_API_TIMEOUT", "900")
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={}):
+            result = _get_task_timeout("session_search", base_url="http://localhost:11434")
+        assert result == 900.0
+
+    def test_hermes_api_timeout_invalid_falls_back_to_1800(self, monkeypatch):
+        """Garbage ``HERMES_API_TIMEOUT`` falls back to 1800s, never crashes."""
+        monkeypatch.setenv("HERMES_API_TIMEOUT", "not-a-number")
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={}):
+            result = _get_task_timeout("session_search", base_url="http://localhost:11434")
+        assert result == 1800.0
+
+
+class TestLocalAuxDefaultTimeout:
+    """``_local_aux_default_timeout`` reads HERMES_API_TIMEOUT with safe fallback."""
+
+    def test_default_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv("HERMES_API_TIMEOUT", raising=False)
+        assert _local_aux_default_timeout() == 1800.0
+
+    def test_reads_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_API_TIMEOUT", "600")
+        assert _local_aux_default_timeout() == 600.0
+
+    def test_invalid_env_falls_back(self, monkeypatch):
+        monkeypatch.setenv("HERMES_API_TIMEOUT", "")
+        assert _local_aux_default_timeout() == 1800.0
+        monkeypatch.setenv("HERMES_API_TIMEOUT", "garbage")
+        assert _local_aux_default_timeout() == 1800.0
+
+
+class TestRegressionBaseline:
+    """Confirms the bug exists without the base_url argument (old signature).
+
+    Without ``base_url`` passed in, the function returns the unbumped 30s
+    default — proving the local-endpoint awareness only kicks in when
+    callers thread the URL through.
+    """
+
+    def test_old_signature_returns_30s_for_local_workload(self):
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={}):
+            assert _get_task_timeout("session_search") == 30.0


### PR DESCRIPTION
## Summary

Auxiliary tasks (`session_search`, `skills_hub`, `title_generation`, vision, etc.) used a fixed 30s default timeout regardless of provider. When those calls route to a local LLM (Ollama, llama.cpp, vLLM) on a slow or large-context request, the 30s default fires before prefill completes and the per-task retry layer issues a fresh request while the original is still being processed — saturating the inference server's queue (#21566).

## The bug

`agent/auxiliary_client.py::_get_task_timeout()` resolves to `_DEFAULT_AUX_TIMEOUT` (30s) whenever the caller did not pass `timeout=` and the user did not set `auxiliary.<task>.timeout` in config. There is no awareness of whether the endpoint is a slow local provider that needs minutes for prefill.

The main agent loop already auto-bumps timeouts for local endpoints in three places:

- `run_agent.py:7111` — streaming read timeout raised to `HERMES_API_TIMEOUT` (1800s) when local.
- `run_agent.py:7670` — streaming stale timeout disabled (`inf`) when local.
- `run_agent.py:2940` — non-streaming stale timeout disabled when local.

`auxiliary_client.py` had no equivalent, so every aux task regressed back to 30s.

Repro from #21566 (paraphrased):
1. Configure Hermes against a local vLLM/llama.cpp endpoint where large-context responses take >30s.
2. Trigger `session_search` (or any auxiliary task with a non-trivial prompt).
3. `httpcore.ReadTimeout` after 30s → tool retries → original request still processing on the inference server → queue saturation.

## The fix

Thread the resolved client `base_url` through `_get_task_timeout()`. When neither the caller nor `auxiliary.<task>.timeout` sets an explicit value AND the resolved URL is local, return `HERMES_API_TIMEOUT` (1800s by default) instead of 30s. Explicit caller and config values keep winning, so users who already tuned `auxiliary.session_search.timeout` see no change.

The local-endpoint check uses `agent.model_metadata.is_local_endpoint`, which already recognises loopback, RFC-1918, container DNS (`host.docker.internal`, `host.containers.internal`, `host.lima.internal`), and Tailscale CGNAT — so remote-but-trusted Ollama boxes reached over Tailscale get the same bump as localhost.

Both call sites in `auxiliary_client.py` (sync `call_llm` and async `async_call_llm`) now compute the client's actual `base_url` before resolving the timeout, then pass it into `_get_task_timeout(task, base_url=...)`.

## Test plan

- [x] Focused regression test: `tests/agent/test_auxiliary_local_endpoint_timeout.py` — 21 cases.
  - Local URLs (`localhost`, `127.0.0.1`, RFC-1918, `host.docker.internal`) bump from 30s → 1800s.
  - Explicit `auxiliary.<task>.timeout` config wins over local bump (60s preserved).
  - Explicit caller `default=` arg wins over local bump (120s preserved).
  - Remote URLs (`api.openai.com`, `openrouter.ai`, `api.anthropic.com`, `api.moonshot.ai`) keep 30s.
  - Empty / missing `base_url` keeps 30s (so existing call paths without URL knowledge are unchanged).
  - Empty `task` (ad-hoc `call_llm`) still bumps when local URL is supplied.
  - `HERMES_API_TIMEOUT` env var honoured for the local default; invalid values fall back to 1800s.
- [x] Adjacent suite: `tests/agent/test_auxiliary_client.py` (138 tests) and seven other `test_auxiliary_*` / `test_local_stream_timeout` / `test_minimax_auxiliary_url` / `test_model_metadata_local_ctx` files — all pass.
- [x] Regression guard: `TestRegressionBaseline::test_old_signature_returns_30s_for_local_workload` proves the bug exists when the URL isn't threaded through (legacy 30s behavior); the new tests prove it's fixed when callers pass the URL.

## Related

- Fixes #21566
- Mirrors local-endpoint timeout pattern from `run_agent.py::_compute_non_stream_stale_timeout` and the streaming read-timeout auto-bump.

> Sibling code paths that may need the same fix: any other module that calls into `auxiliary_client._get_task_timeout` directly (none found in `git grep`), or future aux call paths that don't go through `call_llm` / `async_call_llm`. Intentionally left out of this PR's scope to keep the diff focused — happy to widen if preferred.