### PR TITLE
fix(auth): send Nous refresh token via header

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2578,10 +2578,10 @@ def _refresh_access_token(
 ) -> Dict[str, Any]:
     response = client.post(
         f"{portal_base_url}/api/oauth/token",
+        headers={"x-nous-refresh-token": refresh_token},
         data={
             "grant_type": "refresh_token",
             "client_id": client_id,
-            "refresh_token": refresh_token,
         },
     )
 

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -878,6 +878,7 @@ def test_refresh_token_exchange_sends_refresh_token_header():
     )
 
     assert payload["access_token"] == "access-2"
+    assert payload["refresh_token"] == "refresh-2"
     assert client.kwargs is not None
     assert client.kwargs["headers"]["x-nous-refresh-token"] == "refresh-1"
     assert client.kwargs["data"] == {

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -1,7 +1,6 @@
 """Regression tests for Nous OAuth refresh + agent-key mint interactions."""
 
 import json
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -846,6 +845,45 @@ def test_refresh_token_reuse_detection_surfaces_actionable_message():
     # Must still be classified as invalid_grant + relogin_required.
     assert exc_info.value.code == "invalid_grant"
     assert exc_info.value.relogin_required is True
+
+
+def test_refresh_token_exchange_sends_refresh_token_header():
+    """Nous refresh tokens must be sent in a header so sandbox proxies can
+    substitute placeholder credentials without parsing form bodies.
+    """
+    from hermes_cli.auth import _refresh_access_token
+
+    class _FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"access_token": "access-2", "refresh_token": "refresh-2"}
+
+    class _FakeClient:
+        def __init__(self):
+            self.kwargs = None
+
+        def post(self, *args, **kwargs):
+            del args
+            self.kwargs = kwargs
+            return _FakeResponse()
+
+    client = _FakeClient()
+
+    payload = _refresh_access_token(
+        client=client,
+        portal_base_url="https://portal.nousresearch.com",
+        client_id="hermes-cli",
+        refresh_token="refresh-1",
+    )
+
+    assert payload["access_token"] == "access-2"
+    assert client.kwargs is not None
+    assert client.kwargs["headers"]["x-nous-refresh-token"] == "refresh-1"
+    assert client.kwargs["data"] == {
+        "grant_type": "refresh_token",
+        "client_id": "hermes-cli",
+    }
 
 
 def test_refresh_non_reuse_error_keeps_original_description():


### PR DESCRIPTION
## Summary
- send Nous Portal OAuth refresh tokens via the `x-nous-refresh-token` header
- keep `grant_type` and `client_id` in the form body
- add a regression test that verifies the refresh token is not sent in form data

## Why
NemoClaw/OpenShell credential placeholder substitution can safely rewrite headers, but not `application/x-www-form-urlencoded` request bodies. The Nous account service now accepts refresh tokens through `x-nous-refresh-token`, so Hermes can use that path without exposing raw refresh tokens to sandbox-side body rewriting.

## Tests
- `.venv/bin/python -m pytest tests/hermes_cli/test_auth_nous_provider.py -q`
- `.venv/bin/python -m py_compile hermes_cli/auth.py tests/hermes_cli/test_auth_nous_provider.py`
- `ruff check hermes_cli/auth.py tests/hermes_cli/test_auth_nous_provider.py`
- `git diff --check`
