### PR TITLE
feat(agent): add google-gemini-cli to fallback chain and vision auto-routing

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -101,6 +101,7 @@ OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
 from agent.credential_pool import load_pool
 from hermes_cli.config import get_hermes_home
+from hermes_cli.timeouts import get_provider_request_timeout
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, normalize_proxy_env_vars
 
@@ -260,6 +261,7 @@ def _get_aux_model_for_provider(provider_id: str) -> str:
 # profiles). New providers should set default_aux_model on their profile instead.
 _API_KEY_PROVIDER_AUX_MODELS_FALLBACK: Dict[str, str] = {
     "gemini": "gemini-3-flash-preview",
+    "google-gemini-cli": "gemini-2.5-flash",
     "zai": "glm-4.5-flash",
     "kimi-coding": "kimi-k2-turbo-preview",
     "stepfun": "step-3.5-flash",
@@ -2125,6 +2127,14 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
             return sync_client, model
     except ImportError:
         pass
+    try:
+        from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+        if isinstance(sync_client, GeminiCloudCodeClient):
+            # GeminiCloudCodeClient manages its own HTTP transport
+            # (httpx-based, not OpenAI SDK); return as-is.
+            return sync_client, model
+    except ImportError:
+        pass
 
     async_kwargs = {
         "api_key": sync_client.api_key,
@@ -2569,6 +2579,17 @@ def resolve_provider_client(
                 logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
                 return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                         else (client, final_model))
+        if provider == "google-gemini-cli":
+            from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+
+            client = GeminiCloudCodeClient(
+                api_key=api_key,
+                base_url=base_url,
+                timeout=get_provider_request_timeout(provider, final_model),
+            )
+            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                    else (client, final_model))
 
         # Provider-specific headers
         headers = {}
@@ -2702,6 +2723,20 @@ def resolve_provider_client(
             return resolve_provider_client("nous", model, async_mode)
         if provider == "openai-codex":
             return resolve_provider_client("openai-codex", model, async_mode)
+        if provider == "google-gemini-cli":
+            from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
+            from hermes_cli.auth import resolve_gemini_oauth_runtime_credentials
+
+            creds = resolve_gemini_oauth_runtime_credentials()
+            final_model = _normalize_resolved_model(model or _get_aux_model_for_provider(provider), provider)
+            client = GeminiCloudCodeClient(
+                api_key=explicit_api_key or creds.get("api_key") or "",
+                base_url=explicit_base_url or creds.get("base_url") or "cloudcode-pa://google",
+                timeout=get_provider_request_timeout(provider, final_model),
+            )
+            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+            return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                    else (client, final_model))
         # Other OAuth providers not directly supported
         logger.warning("resolve_provider_client: OAuth provider %s not "
                        "directly supported, try 'auto'", provider)
@@ -2759,6 +2794,7 @@ def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Di
 
 
 _VISION_AUTO_PROVIDER_ORDER = (
+    "google-gemini-cli",
     "openrouter",
     "nous",
 )
@@ -2786,6 +2822,8 @@ def _resolve_strict_vision_backend(
         return resolve_provider_client("openai-codex", model, is_vision=True)
     if provider == "anthropic":
         return _try_anthropic()
+    if provider == "google-gemini-cli":
+        return resolve_provider_client("google-gemini-cli", model, is_vision=True)
     if provider == "custom":
         return _try_custom_endpoint()
     return None, None

--- a/plugins/model-providers/gemini/__init__.py
+++ b/plugins/model-providers/gemini/__init__.py
@@ -66,6 +66,7 @@ google_gemini_cli = GeminiProfile(
     env_vars=(),  # OAuth — no API key
     base_url="cloudcode-pa://google",  # Cloud Code Assist internal scheme
     auth_type="oauth_external",
+    default_aux_model="gemini-2.5-flash",
 )
 
 register_provider(gemini)

--- a/run_agent.py
+++ b/run_agent.py
@@ -2857,7 +2857,7 @@ class AIAgent:
                 msg = (
                     "⚠ No auxiliary LLM provider configured — context "
                     "compression will drop middle turns without a summary. "
-                    "Run `hermes setup` or set OPENROUTER_API_KEY."
+                    "Run `hermes setup` or configure an auxiliary provider."
                 )
                 self._compression_warning = msg
                 self._emit_status(msg)
@@ -8075,6 +8075,8 @@ class AIAgent:
             elif _fb_is_azure:
                 # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
                 # support the Responses API. Stay on chat_completions.
+                fb_api_mode = "chat_completions"
+            elif fb_provider == "google-gemini-cli":
                 fb_api_mode = "chat_completions"
             elif self._is_direct_openai_url(fb_base_url):
                 fb_api_mode = "codex_responses"

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -349,9 +349,10 @@ class TestResolveVisionMainFirst:
         assert captured == {"is_agent_turn": True, "is_vision": False}
         assert "default_headers" not in mock_openai.call_args.kwargs
 
-    def test_main_unavailable_vision_falls_through_to_aggregators(self):
-        """Main provider fails → fall back to OpenRouter/Nous strict backends."""
-        fallback_client = MagicMock()
+    def test_main_unavailable_vision_falls_through_to_google_gemini_cli(self):
+        """Main provider fails → fall back to google-gemini-cli vision backend."""
+        gemini_client = MagicMock()
+
         with patch(
             "agent.auxiliary_client._read_main_provider", return_value="deepseek",
         ), patch(
@@ -359,9 +360,36 @@ class TestResolveVisionMainFirst:
         ), patch(
             "agent.auxiliary_client.resolve_provider_client",
             return_value=(None, None),
+        ) as mock_rpc, patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", None, None, None, None),
+        ):
+            # resolve_provider_client returns (None, None) for the main
+            # provider ("deepseek") but should return a real client when
+            # called again for "google-gemini-cli" from the strict backend.
+            mock_rpc.side_effect = [
+                (None, None),                      # deepseek main provider
+                (gemini_client, "gemini-2.5-flash"),  # google-gemini-cli strict backend
+            ]
+            from agent.auxiliary_client import resolve_vision_provider_client
+
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "google-gemini-cli"
+        assert client is gemini_client
+        assert model == "gemini-2.5-flash"
+
+    def test_opencode_go_main_vision_uses_main_provider(self):
+        """opencode-go (kimi-k2.6) has vision — main provider should be used directly."""
+        opencode_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="opencode-go",
         ), patch(
-            "agent.auxiliary_client._resolve_strict_vision_backend",
-            return_value=(fallback_client, "google/gemini-3-flash-preview"),
+            "agent.auxiliary_client._read_main_model", return_value="kimi-k2.6",
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(opencode_client, "kimi-k2.6"),
         ), patch(
             "agent.auxiliary_client._resolve_task_provider_model",
             return_value=("auto", None, None, None, None),
@@ -370,8 +398,9 @@ class TestResolveVisionMainFirst:
 
             provider, client, model = resolve_vision_provider_client()
 
-        assert client is fallback_client
-        assert provider in ("openrouter", "nous")
+        assert provider == "opencode-go"
+        assert client is opencode_client
+        assert model == "kimi-k2.6"
 
     def test_explicit_provider_override_still_wins(self):
         """Explicit config override bypasses main-first policy."""

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -271,6 +271,34 @@ class TestGeminiAgentInit:
             resolve_provider_client("gemini")
         mock_openai.assert_called_once()
 
+    def test_google_gemini_cli_resolve_provider_client_uses_cloudcode_client(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        from agent.google_oauth import GoogleCredentials, save_credentials
+        from hermes_constants import get_hermes_home
+
+        save_credentials(GoogleCredentials(
+            access_token="oauth-token",
+            refresh_token="refresh-token",
+            expires_ms=int((__import__("time").time() + 3600) * 1000),
+            project_id="proj-123",
+            email="brad@example.com",
+        ))
+        assert get_hermes_home().exists()
+
+        with patch("agent.gemini_cloudcode_adapter.GeminiCloudCodeClient") as mock_client, \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_client.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            client, model = resolve_provider_client("google-gemini-cli", "gemini-2.5-flash")
+
+        assert client is not None
+        assert model == "gemini-2.5-flash"
+        mock_client.assert_called_once()
+        mock_openai.assert_not_called()
+
 
 # ── models.dev Integration ──
 

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -186,6 +186,22 @@ class TestQwenProfile:
         assert "metadata" not in eb
 
 
+class TestGoogleGeminiCliProfile:
+    def test_profile_registered(self):
+        p = get_provider_profile("google-gemini-cli")
+        assert p is not None
+        assert p.name == "google-gemini-cli"
+        assert p.auth_type == "oauth_external"
+
+    def test_aliases_still_resolve_to_google_gemini_cli(self):
+        assert get_provider_profile("gemini-cli").name == "google-gemini-cli"
+        assert get_provider_profile("gemini-oauth").name == "google-gemini-cli"
+
+    def test_default_aux_model(self):
+        p = get_provider_profile("google-gemini-cli")
+        assert p.default_aux_model == "gemini-2.5-flash"
+
+
 class TestBaseProfile:
     def test_prepare_messages_passthrough(self):
         p = ProviderProfile(name="test")

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4174,6 +4174,23 @@ class TestFallbackAnthropicProvider:
         assert agent.api_mode == "chat_completions"
         assert agent.client is mock_client
 
+    def test_fallback_to_google_gemini_cli_sets_chat_completions(self, agent):
+        agent._fallback_activated = False
+        agent._fallback_model = {"provider": "google-gemini-cli", "model": "gemini-2.5-flash"}
+        agent._fallback_chain = [agent._fallback_model]
+        agent._fallback_index = 0
+
+        mock_client = MagicMock()
+        mock_client.base_url = "cloudcode-pa://google"
+        mock_client.api_key = "oauth-token"
+
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        assert agent.api_mode == "chat_completions"
+        assert agent.client is mock_client
+
 
 def test_aiagent_uses_copilot_acp_client():
     with (


### PR DESCRIPTION
## What

Wire Google Gemini CLI (OAuth) into the provider resolution and vision fallback chain. Users with Gemini OAuth active get free, vision-capable Gemini Flash as a fallback option.

## Why

Gemini OAuth provides free access to multimodal models. Currently the fallback chain skips it entirely — `resolve_provider_client()` returns `(None, None)` for `google-gemini-cli` and the vision auto-routing order has no entry for it. This PR closes both gaps.

## Changes

**`agent/auxiliary_client.py`**
- Add `google-gemini-cli` handling in `resolve_provider_client()` for both API-key and OAuth auth paths, constructing `GeminiCloudCodeClient`
- Add `google-gemini-cli` to `_VISION_AUTO_PROVIDER_ORDER` (first position, before OpenRouter/Nous)
- Add `google-gemini-cli` handler in `_resolve_strict_vision_backend()` so vision auto-fallback actually resolves it
- Remove `opencode-go` from `_PROVIDERS_WITHOUT_VISION` (kimi-k2.6 is multimodal)

**`run_agent.py`**
- Set `chat_completions` api_mode when `google-gemini-cli` activates as fallback provider

**Tests** (6 new tests across 4 files)
- Provider profile registration, aliases, default aux model
- OAuth client resolution (CloudCodeClient, not vanilla OpenAI)
- Fallback activation with correct api_mode
- Vision auto-routing: main-unavailable → google-gemini-cli fallback
- Vision auto-routing: opencode-go main provider uses kimi-k2.6 directly

## How to test

```bash
# Set up Gemini OAuth
hermes setup  # choose Google Gemini CLI

# Verify provider resolution
hermes chat -q "Describe this image: <url>"  # should use Gemini Flash for vision

# Run tests
pytest tests/agent/test_auxiliary_main_first.py tests/providers/test_provider_profiles.py tests/run_agent/test_run_agent.py tests/hermes_cli/test_gemini_provider.py -v
```

## Platforms tested

- macOS (Apple Silicon, Python 3.11)