### PR TITLE
run_agent: merge profile.default_headers on OpenRouter path (don't replace)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1447,7 +1447,19 @@ class AIAgent:
                 effective_base = base_url
                 if base_url_host_matches(effective_base, "openrouter.ai"):
                     from agent.auxiliary_client import build_or_headers
-                    client_kwargs["default_headers"] = build_or_headers()
+                    # Merge profile.default_headers on top of Hermes's OR base
+                    # headers so per-profile attribution (HTTP-Referer /
+                    # X-Title) overrides the library default. Profile wins on
+                    # conflict.
+                    _or_headers = build_or_headers()
+                    try:
+                        from providers import get_provider_profile as _gpf_or
+                        _ph_or = _gpf_or(self.provider)
+                        if _ph_or and _ph_or.default_headers:
+                            _or_headers.update(_ph_or.default_headers)
+                    except Exception:
+                        pass
+                    client_kwargs["default_headers"] = _or_headers
                 elif base_url_host_matches(effective_base, "api.routermint.com"):
                     client_kwargs["default_headers"] = _routermint_headers()
                 elif base_url_host_matches(effective_base, "api.githubcopilot.com"):
@@ -6459,7 +6471,18 @@ class AIAgent:
         from agent.auxiliary_client import _AI_GATEWAY_HEADERS, build_or_headers
 
         if base_url_host_matches(base_url, "openrouter.ai"):
-            self._client_kwargs["default_headers"] = build_or_headers()
+            # Merge profile.default_headers on top of Hermes's OR base headers
+            # so per-profile attribution (HTTP-Referer / X-Title) overrides
+            # the library default. Profile wins on conflict.
+            _or_headers = build_or_headers()
+            try:
+                from providers import get_provider_profile as _gpf_or
+                _ph_or = _gpf_or(self.provider)
+                if _ph_or and _ph_or.default_headers:
+                    _or_headers.update(_ph_or.default_headers)
+            except Exception:
+                pass
+            self._client_kwargs["default_headers"] = _or_headers
         elif base_url_host_matches(base_url, "ai-gateway.vercel.sh"):
             self._client_kwargs["default_headers"] = dict(_AI_GATEWAY_HEADERS)
         elif base_url_host_matches(base_url, "api.routermint.com"):

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -129,3 +129,58 @@ def test_openrouter_headers_no_cache_when_disabled(mock_openai):
     assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
     assert "X-OpenRouter-Cache" not in headers
     assert "X-OpenRouter-Cache-TTL" not in headers
+
+
+@patch("run_agent.OpenAI")
+def test_openrouter_merges_profile_default_headers(mock_openai):
+    """Profile.default_headers must merge into the OR base headers and win
+    on conflict. Regression test for the silent-drop bug where the OR
+    branch unconditionally replaced default_headers.
+    """
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    fake_profile = MagicMock()
+    fake_profile.default_headers = {
+        "HTTP-Referer": "openzeke",
+        "X-Title": "cardstream:klinker",
+    }
+    with patch("providers.get_provider_profile", return_value=fake_profile):
+        agent._apply_client_headers_for_base_url("https://openrouter.ai/api/v1")
+
+    headers = agent._client_kwargs["default_headers"]
+    # Profile wins on conflict.
+    assert headers["HTTP-Referer"] == "openzeke"
+    assert headers["X-Title"] == "cardstream:klinker"
+    # Non-conflicting OR base headers survive.
+    assert headers["X-OpenRouter-Categories"] == "productivity,cli-agent"
+
+
+@patch("run_agent.OpenAI")
+def test_openrouter_no_profile_headers_unchanged(mock_openai):
+    """When the profile sets no default_headers, the OR branch must
+    return exactly build_or_headers() — no regression for existing
+    users.
+    """
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._apply_client_headers_for_base_url("https://openrouter.ai/api/v1")
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
+    assert headers["X-Title"] == "Hermes Agent"


### PR DESCRIPTION
## Summary

Fixes https://github.com/NousResearch/hermes-agent/issues/21588.

`AIAgent._apply_client_headers_for_base_url` and the parallel
construction site at `run_agent.py:1448` previously replaced
`default_headers` with `build_or_headers()` whenever `base_url` matched
`openrouter.ai`, silently dropping any caller-supplied
`profile.default_headers`. This PR merges the two: Hermes's OR base
headers are layered first, then `profile.default_headers` is `update()`d
on top so caller intent wins on conflict.

The change is strictly additive — when no profile headers are set,
behaviour is unchanged and existing tests pass without modification.

## Why this matters

The keys most likely to be overridden in `profile.default_headers` are
`HTTP-Referer` and `X-Title`. Those are also the canonical OpenRouter
attribution keys (HTTP-Referer maps to "App URL" and X-Title to "App
name" in OpenRouter's dashboard / per-key spend rollups). Users running
multi-tenant or per-venture deployments need to be able to set those
per profile and have them flow through. Today they can't on the OR
path.

The `else` branch in the same function (lines 6285-6298) already falls
back to `profile.default_headers` when no URL-specific headers apply,
so the OR-path merge brings the OR branch in line with that pattern
(actually less aggressive — the OR base layer is preserved, only
conflicting keys get overridden).

## Order of precedence

```python
merged = build_or_headers()       # Hermes OR base
merged.update(profile_headers)    # profile wins on conflict
```

Profile wins. Rationale:
- Caller intent over library default.
- Only the attribution-relevant keys (`HTTP-Referer`, `X-Title`)
  actually conflict; cache headers (`X-OpenRouter-Cache*`) and
  cosmetic hints (`X-OpenRouter-Categories`) survive untouched in
  realistic profiles.

## Changes

- `run_agent.py` — patched two sites (lines ~1448 and ~6266) to merge
  `provider_profile.default_headers` into `build_or_headers()` for
  the OpenRouter path.
- `tests/run_agent/test_provider_attribution_headers.py` — two new
  test cases:
  - `test_openrouter_merges_profile_default_headers` — verifies merge
    + profile-wins-on-conflict semantics.
  - `test_openrouter_no_profile_headers_unchanged` — regression guard
    for users who don't set profile headers.

No changes to public API. No changes to `agent/auxiliary_client.py`
(the auxiliary client construction sites at lines 1285/1292/2071 are
not on the primary user-facing request path and are intentionally left
alone).

## Test plan

- [x] `pytest tests/run_agent/test_provider_attribution_headers.py -v`
      — all six tests pass (4 existing + 2 new).
- [x] `pytest tests/run_agent/ tests/agent/test_openrouter_response_cache.py`
      — no regressions in adjacent header / OR cache tests.
- [ ] Manual smoke test: launch `hermes-agent` against OpenRouter with
      a profile that sets `HTTP-Referer` / `X-Title`, capture the
      outgoing request, confirm the profile values appear.
- [ ] Manual smoke test: launch `hermes-agent` against OpenRouter with
      *no* profile headers set, confirm
      `HTTP-Referer: https://hermes-agent.nousresearch.com` and
      `X-Title: Hermes Agent` still flow through (regression check).

## Notes for reviewers

- Scope is OpenRouter only. The same replace pattern exists for five
  other hosts (ai-gateway.vercel.sh, routermint, copilot, kimi,
  qwen-portal, chatgpt) — happy to extend if maintainers prefer a
  one-shot fix; left out to keep this PR small and easy to review.
- The provider-profile lookup at the patched sites uses the same
  pattern (`from providers import get_provider_profile`) as the
  existing else-branch at lines 6285-6298, so this introduces no new
  import surface.
- No new dependencies. No changes to `pyproject.toml`.