### PR TITLE
feat: add Crawl4AI as self-hosted extract backend

### DIFF
--- a/tests/tools/test_crawl4ai_backend.py
+++ b/tests/tools/test_crawl4ai_backend.py
@@ -1,0 +1,219 @@
+"""Tests for the Crawl4AI backend.
+
+Covers:
+- Response normalization (dict vs string markdown)
+- Error handling (network failures, invalid responses)
+- Batch extraction with missing results
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestCrawl4AiExtractSingle:
+    """crawl4ai_extract_single parses /md responses correctly."""
+
+    def test_successful_single_extraction(self):
+        from tools.crawl4ai_backend import crawl4ai_extract_single
+
+        mock_response = {
+            "markdown": "# Test Title\n\nSome content here.",
+            "success": True,
+        }
+
+        with patch("tools.crawl4ai_backend._crawl4ai_request", return_value=mock_response):
+            result = crawl4ai_extract_single("https://example.com")
+
+        assert result["success"] is True
+        assert result["data"]["markdown"] == "# Test Title\n\nSome content here."
+        assert result["data"]["metadata"]["title"] == "Test Title"
+        assert result["data"]["metadata"]["sourceURL"] == "https://example.com"
+
+    def test_empty_markdown(self):
+        from tools.crawl4ai_backend import crawl4ai_extract_single
+
+        mock_response = {
+            "markdown": "",
+            "success": True,
+        }
+
+        with patch("tools.crawl4ai_backend._crawl4ai_request", return_value=mock_response):
+            result = crawl4ai_extract_single("https://example.com")
+
+        assert result["success"] is True
+        assert result["data"]["markdown"] == ""
+        assert result["data"]["metadata"]["title"] == ""
+
+    def test_request_failure(self):
+        from tools.crawl4ai_backend import crawl4ai_extract_single
+
+        with patch(
+            "tools.crawl4ai_backend._crawl4ai_request",
+            side_effect=Exception("Connection refused"),
+        ):
+            result = crawl4ai_extract_single("https://example.com")
+
+        assert result["success"] is False
+        assert "Connection refused" in result["error"]
+
+
+class TestCrawl4AiExtractBatch:
+    """crawl4ai_extract_batch handles /crawl responses with multiple results."""
+
+    def test_successful_batch_extraction(self):
+        from tools.crawl4ai_backend import crawl4ai_extract_batch
+
+        mock_response = {
+            "results": [
+                {
+                    "url": "https://example.com",
+                    "success": True,
+                    "markdown": {
+                        "raw_markdown": "# Example\nContent",
+                        "markdown_with_citations": "# Example\nContent [1]",
+                    },
+                    "metadata": {"title": "Example Page"},
+                },
+                {
+                    "url": "https://test.com",
+                    "success": True,
+                    "markdown": {
+                        "raw_markdown": "# Test\nMore content",
+                    },
+                    "metadata": {"title": "Test Page"},
+                },
+            ]
+        }
+
+        with patch("tools.crawl4ai_backend._crawl4ai_request", return_value=mock_response):
+            results = crawl4ai_extract_batch(["https://example.com", "https://test.com"])
+
+        assert len(results) == 2
+        assert results[0]["url"] == "https://example.com"
+        assert results[0]["title"] == "Example Page"
+        assert results[0]["content"] == "# Example\nContent"
+        assert results[1]["url"] == "https://test.com"
+        assert results[1]["title"] == "Test Page"
+
+    def test_markdown_as_string(self):
+        """Some Crawl4AI versions return markdown as a string instead of dict."""
+        from tools.crawl4ai_backend import crawl4ai_extract_batch
+
+        mock_response = {
+            "results": [
+                {
+                    "url": "https://example.com",
+                    "success": True,
+                    "markdown": "Plain string markdown",
+                    "metadata": {"title": "Example"},
+                }
+            ]
+        }
+
+        with patch("tools.crawl4ai_backend._crawl4ai_request", return_value=mock_response):
+            results = crawl4ai_extract_batch(["https://example.com"])
+
+        assert results[0]["content"] == "Plain string markdown"
+
+    def test_fallback_to_html(self):
+        """When markdown is empty, falls back to cleaned_html or html."""
+        from tools.crawl4ai_backend import crawl4ai_extract_batch
+
+        mock_response = {
+            "results": [
+                {
+                    "url": "https://example.com",
+                    "success": True,
+                    "markdown": {"raw_markdown": "", "markdown_with_citations": ""},
+                    "cleaned_html": "<h1>Title</h1><p>Content</p>",
+                    "html": "<html><body>Original</body></html>",
+                    "metadata": {},
+                }
+            ]
+        }
+
+        with patch("tools.crawl4ai_backend._crawl4ai_request", return_value=mock_response):
+            results = crawl4ai_extract_batch(["https://example.com"])
+
+        assert results[0]["content"] == "<h1>Title</h1><p>Content</p>"
+
+    def test_failed_url(self):
+        """URLs that fail return error entries."""
+        from tools.crawl4ai_backend import crawl4ai_extract_batch
+
+        mock_response = {
+            "results": [
+                {
+                    "url": "https://fail.com",
+                    "success": False,
+                    "error_message": "Timeout after 30s",
+                }
+            ]
+        }
+
+        with patch("tools.crawl4ai_backend._crawl4ai_request", return_value=mock_response):
+            results = crawl4ai_extract_batch(["https://fail.com"])
+
+        assert results[0]["error"] == "Timeout after 30s"
+        assert results[0]["content"] == ""
+
+    def test_missing_result(self):
+        """URLs not returned in results get error entries."""
+        from tools.crawl4ai_backend import crawl4ai_extract_batch
+
+        mock_response = {
+            "results": [
+                {
+                    "url": "https://present.com",
+                    "success": True,
+                    "markdown": {"raw_markdown": "Content"},
+                    "metadata": {"title": "Present"},
+                }
+                # https://missing.com is not in results
+            ]
+        }
+
+        with patch("tools.crawl4ai_backend._crawl4ai_request", return_value=mock_response):
+            results = crawl4ai_extract_batch(["https://present.com", "https://missing.com"])
+
+        assert len(results) == 2
+        assert results[0]["url"] == "https://present.com"
+        assert results[1]["url"] == "https://missing.com"
+        assert results[1]["error"] == "No response from Crawl4AI"
+
+    def test_batch_request_failure(self):
+        """When the entire batch request fails, all URLs get error entries."""
+        from tools.crawl4ai_backend import crawl4ai_extract_batch
+
+        with patch(
+            "tools.crawl4ai_backend._crawl4ai_request",
+            side_effect=Exception("Service unavailable"),
+        ):
+            results = crawl4ai_extract_batch(["https://a.com", "https://b.com"])
+
+        assert len(results) == 2
+        assert results[0]["error"] == "Service unavailable"
+        assert results[1]["error"] == "Service unavailable"
+
+
+class TestCheckCrawl4AiAvailable:
+    """check_crawl4ai_available probes the /health endpoint."""
+
+    def test_available(self):
+        from tools.crawl4ai_backend import check_crawl4ai_available
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch("httpx.get", return_value=mock_response):
+            assert check_crawl4ai_available() is True
+
+    def test_unavailable(self):
+        from tools.crawl4ai_backend import check_crawl4ai_available
+
+        with patch("httpx.get", side_effect=Exception("Connection refused")):
+            assert check_crawl4ai_available() is False

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -137,6 +137,25 @@ class TestPerCapabilityBackendSelection:
         assert web_tools._get_search_backend() == "tavily"
         assert web_tools._get_extract_backend() == "tavily"
 
+    def test_extract_backend_crawl4ai(self, monkeypatch):
+        """Crawl4AI can be selected as extract_backend."""
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
+            "backend": "firecrawl",
+            "extract_backend": "crawl4ai",
+        })
+        monkeypatch.setenv("CRAWL4AI_URL", "http://localhost:11235")
+        assert web_tools._get_extract_backend() == "crawl4ai"
+
+    def test_crawl4ai_fallback_when_no_other_keys(self, monkeypatch):
+        """Crawl4AI is used as fallback when no other backends are configured."""
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+        monkeypatch.setenv("CRAWL4AI_URL", "http://localhost:11235")
+        assert web_tools._get_backend() == "crawl4ai"
+
 
 # ---------------------------------------------------------------------------
 # Config key presence in DEFAULT_CONFIG

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -386,7 +386,8 @@ class TestBackendSelection:
     def test_fallback_no_keys_defaults_to_firecrawl(self):
         """No keys, no config → 'firecrawl' (will fail at client init)."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}):
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch.dict(os.environ, {}, clear=True):
             assert _get_backend() == "firecrawl"
 
     def test_invalid_config_falls_through_to_fallback(self):

--- a/tools/crawl4ai_backend.py
+++ b/tools/crawl4ai_backend.py
@@ -1,0 +1,185 @@
+"""Crawl4AI backend for Hermes web tools.
+
+Provides extract capabilities via a local Crawl4AI service.
+Uses the /md endpoint for single-URL markdown extraction
+and /crawl endpoint for batch operations.
+
+Environment variable:
+    CRAWL4AI_URL=http://localhost:11235
+"""
+
+import os
+import logging
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_CRAWL4AI_BASE_URL = os.getenv("CRAWL4AI_URL", "http://localhost:11235")
+
+
+def _crawl4ai_request(endpoint: str, payload: dict, timeout: float = 60.0) -> dict:
+    """Send a POST request to the Crawl4AI API."""
+    url = f"{_CRAWL4AI_BASE_URL}/{endpoint.lstrip('/')}"
+    logger.info("Crawl4AI %s request to %s", endpoint, url)
+    response = httpx.post(url, json=payload, timeout=timeout)
+    response.raise_for_status()
+    return response.json()
+
+
+def check_crawl4ai_available() -> bool:
+    """Return True when the Crawl4AI service is reachable."""
+    try:
+        resp = httpx.get(f"{_CRAWL4AI_BASE_URL}/health", timeout=5)
+        return resp.status_code == 200
+    except Exception:
+        return False
+
+
+def crawl4ai_extract_single(url: str, format: str = "markdown") -> Dict[str, Any]:
+    """Extract a single URL using Crawl4AI /md endpoint.
+    
+    Returns a dict matching Firecrawl's scrape response shape:
+    {success, data: {markdown, html, metadata}}
+    """
+    try:
+        # Use /md endpoint for clean markdown extraction
+        filter_type = "fit" if format == "markdown" else "raw"
+        response = _crawl4ai_request("/md", {
+            "url": url,
+            "f": filter_type,
+        }, timeout=60.0)
+        
+        markdown = response.get("markdown", "")
+        success = response.get("success", False)
+        
+        return {
+            "success": success,
+            "data": {
+                "markdown": markdown,
+                "html": "",  # /md doesn't return HTML
+                "metadata": {
+                    "title": _extract_title_from_markdown(markdown),
+                    "sourceURL": url,
+                    "url": url,
+                },
+            },
+        }
+    except Exception as e:
+        logger.warning("Crawl4AI extract failed for %s: %s", url, e)
+        return {
+            "success": False,
+            "data": {},
+            "error": str(e),
+        }
+
+
+def crawl4ai_extract_batch(urls: List[str], format: str = "markdown") -> List[Dict[str, Any]]:
+    """Extract multiple URLs using Crawl4AI /crawl endpoint.
+    
+    Returns a list of dicts matching the standard document format:
+    [{url, title, content, raw_content, metadata, error}]
+    """
+    documents: List[Dict[str, Any]] = []
+    
+    try:
+        response = _crawl4ai_request("/crawl", {
+            "urls": urls,
+            "crawler_config": {
+                "cache_mode": "bypass",
+                "headless": True,
+            },
+        }, timeout=120.0)
+        
+        results = response.get("results", [])
+        
+        for result in results:
+            url = result.get("url", "")
+            success = result.get("success", False)
+            error = result.get("error_message", "")
+            
+            if not success and error:
+                documents.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": error,
+                    "metadata": {"sourceURL": url},
+                })
+                continue
+            
+            # Try to get markdown first, then cleaned_html, then html
+            content = ""
+            markdown_data = result.get("markdown")
+            if isinstance(markdown_data, dict):
+                # Crawl4AI returns markdown as dict with raw_markdown, markdown_with_citations, etc.
+                content = markdown_data.get("raw_markdown", "") or markdown_data.get("markdown_with_citations", "")
+            elif isinstance(markdown_data, str) and markdown_data:
+                content = markdown_data
+            
+            # Fallback chain if markdown is empty
+            if not content:
+                if result.get("fit_markdown"):
+                    content = result["fit_markdown"]
+                elif result.get("cleaned_html"):
+                    content = result["cleaned_html"]
+                elif result.get("html"):
+                    content = result["html"]
+            
+            metadata = result.get("metadata", {}) or {}
+            title = ""
+            if isinstance(metadata, dict):
+                title = metadata.get("title", "") or ""
+            
+            documents.append({
+                "url": url,
+                "title": title or "",
+                "content": content or "",
+                "raw_content": content or "",
+                "metadata": {
+                    "sourceURL": url,
+                    "title": title or "",
+                },
+            })
+        
+        # Handle missing results (URLs that didn't return)
+        returned_urls = {r.get("url") for r in results}
+        for url in urls:
+            if url not in returned_urls:
+                documents.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": "No response from Crawl4AI",
+                    "metadata": {"sourceURL": url},
+                })
+                
+    except Exception as e:
+        logger.warning("Crawl4AI batch extract failed: %s", e)
+        # Return error for all URLs
+        for url in urls:
+            documents.append({
+                "url": url,
+                "title": "",
+                "content": "",
+                "raw_content": "",
+                "error": str(e),
+                "metadata": {"sourceURL": url},
+            })
+    
+    return documents
+
+
+def _extract_title_from_markdown(markdown: str) -> str:
+    """Extract title from markdown content (first H1)."""
+    if not markdown:
+        return ""
+    lines = markdown.strip().split("\n")
+    for line in lines[:10]:  # Check first 10 lines
+        line = line.strip()
+        if line.startswith("# "):
+            return line[2:].strip()
+    return ""

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -13,6 +13,7 @@ Available tools:
 - web_crawl_tool: Crawl websites with specific instructions
 
 Backend compatibility:
+- Crawl4AI: https://github.com/unclecode/crawl4ai (extract; self-hosted via CRAWL4AI_URL)
 - Exa: https://exa.ai (search, extract)
 - Firecrawl: https://docs.firecrawl.dev/introduction (search, extract, crawl; direct or derived firecrawl-gateway.<domain> for Nous Subscribers)
 - Parallel: https://docs.parallel.ai (search, extract)
@@ -126,13 +127,13 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "crawl4ai"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
     # available backend. Firecrawl also counts as available when the managed
     # tool gateway is configured for Nous subscribers.
-    # Free-tier backends (searxng / brave-free / ddgs) trail the paid ones so
+    # Free-tier backends (searxng / brave-free / ddgs / crawl4ai) trail the paid ones so
     # existing paid setups are unaffected.
     backend_candidates = (
         ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL") or _is_tool_gateway_ready()),
@@ -142,6 +143,7 @@ def _get_backend() -> str:
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
+        ("crawl4ai", _has_env("CRAWL4AI_URL")),
     )
     for backend, available in backend_candidates:
         if available:
@@ -204,6 +206,8 @@ def _is_backend_available(backend: str) -> bool:
         return _has_env("BRAVE_SEARCH_API_KEY")
     if backend == "ddgs":
         return _ddgs_package_importable()
+    if backend == "crawl4ai":
+        return _has_env("CRAWL4AI_URL")
     return False
 
 
@@ -291,6 +295,7 @@ def _web_requires_env() -> list[str]:
         "TAVILY_API_KEY",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
+        "CRAWL4AI_URL",
     ]
     if managed_nous_tools_enabled():
         requires.extend(
@@ -1393,13 +1398,17 @@ async def web_extract_tool(
                     "include_images": False,
                 })
                 results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
+            elif backend == "crawl4ai":
+                logger.info("Crawl4AI extract: %d URL(s)", len(safe_urls))
+                from tools.crawl4ai_backend import crawl4ai_extract_batch
+                results = crawl4ai_extract_batch(safe_urls, format=format or "markdown")
             elif backend in ("searxng", "brave-free", "ddgs"):
                 # These backends are search-only — they cannot extract URL content
                 _label = {"searxng": "SearXNG", "brave-free": "Brave Search (free tier)", "ddgs": "DuckDuckGo (ddgs)"}[backend]
                 return json.dumps({
                     "success": False,
                     "error": f"{_label} is a search-only backend and cannot extract URL content. "
-                             "Set web.extract_backend to firecrawl, tavily, exa, or parallel.",
+                             "Set web.extract_backend to firecrawl, tavily, exa, parallel, or crawl4ai.",
                 }, ensure_ascii=False)
             else:
                 # ── Firecrawl extraction ──


### PR DESCRIPTION
## Summary

Add [Crawl4AI](https://github.com/unclecode/crawl4ai) as a self-hosted extract backend for Hermes Agent's `web_extract` tool.

## Motivation

Users running resource-constrained servers (like the author: 3.8G RAM, 4 cores, 49G disk) need a free, self-hosted alternative to paid extract services like Firecrawl, Tavily, or Exa. Crawl4AI runs locally via Docker and provides high-quality markdown extraction.

## Changes

### New files
- `tools/crawl4ai_backend.py` — HTTP client for Crawl4AI's `/md` and `/crawl` endpoints
- `tests/tools/test_crawl4ai_backend.py` — 11 unit tests covering response normalization, error handling, batch extraction, and edge cases

### Modified files
- `tools/web_tools.py` — integrate Crawl4AI into backend selection logic and extract dispatch
- `tests/tools/test_web_providers.py` — add 2 tests for Crawl4AI backend selection
- `tests/tools/test_web_tools_config.py` — fix test isolation (mock env vars) to prevent Crawl4AI_URL from leaking across tests

### Backend priority
Crawl4AI is placed **last** in the fallback chain:
1. firecrawl (paid/managed)
2. parallel (paid)
3. tavily (paid)
4. exa (paid)
5. searxng (free, search-only)
6. **crawl4ai** (free, self-hosted)

This ensures existing paid setups are unaffected.

### Response normalization
Crawl4AI returns various markdown formats (`raw_markdown`, `markdown_with_citations`, `fit_markdown`, `cleaned_html`, `html`). The backend implements a fallback chain to extract the best available content.

### Bug fix
Fixed a bug where `crawl4ai_backend.py` didn't fall back to `cleaned_html` when both `raw_markdown` and `markdown_with_citations` were empty.

## Testing

- 74 tests passing (12 web_providers + 49 web_tools_config + 11 crawl4ai_backend + 2 new)
- Tested against live Crawl4AI v0.8.6 at `http://localhost:11235`

## Documentation

See `skills/hermes-agent/references/crawl4ai-integration.md` for setup instructions.

## Checklist

- [x] Tests added/updated
- [x] Bug fix included
- [x] No breaking changes to existing backends
- [x] Self-hosted / free tier friendly

---

**Note on CI Tests failure:** The Tests job shows failures in `test_bedrock_1m_context`, `test_cron_scheduler_mcp_init`, `test_gateway_restart_drain`, etc. These same failures exist on upstream/main (verified on commit `a313186`). This PR only modifies `tools/crawl4ai_backend.py` and `tools/web_tools.py` — none of the failing test files are touched. The Crawl4AI-specific tests (`test_crawl4ai_backend.py`) all pass.