### PR TITLE
docs: replace ASCII diagrams and clarify fallback config

### DIFF
--- a/website/docs/guides/cron-script-only.md
+++ b/website/docs/guides/cron-script-only.md
@@ -10,21 +10,11 @@ Sometimes you already know exactly what message you want to send. You don't need
 
 Hermes calls this **no-agent mode**. It's the cron system minus the LLM.
 
-<!-- ascii-guard-ignore -->
+```mermaid
+flowchart LR
+    tick["scheduler tick<br/>(every N minutes)"] -->|every| script["run script<br/>(bash or python)"]
+    script -->|stdout| router["delivery router<br/>(telegram / discord / ...)"]
 ```
-   ┌──────────────────┐          ┌──────────────────┐
-   │ scheduler tick   │  every   │ run script       │
-   │ (every N minutes)│ ──────▶ │ (bash or python) │
-   └──────────────────┘          └──────────────────┘
-                                          │
-                                          │ stdout
-                                          ▼
-                                 ┌──────────────────┐
-                                 │ delivery router  │
-                                 │ (telegram/disc…) │
-                                 └──────────────────┘
-```
-<!-- ascii-guard-ignore-end -->
 
 - **No LLM call.** Zero tokens, zero agent loop, zero model spend.
 - **Script is the job.** The script decides whether to alert. Emit output → message gets sent. Emit nothing → silent tick.

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1587,7 +1587,7 @@ When activated, the fallback swaps the model and provider mid-session without lo
 Supported providers: `openrouter`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `ai-gateway`, `azure-foundry`, `opencode-zen`, `opencode-go`, `commandcode`, `commandcode-anthropic`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `actual`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
 
 :::tip
-Fallback is configured exclusively through `config.yaml` — or interactively via `hermes fallback`. For full details on when it triggers, how the chain advances, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/user-guide/features/fallback-providers).
+Fallback is configured exclusively through `config.yaml` — or interactively via `hermes fallback`; there are no environment variables for fallback routing. The legacy single-entry `fallback_model` dictionary remains supported for backward compatibility, but new configurations should use the ordered `fallback_providers` list. For full details on when fallback triggers, how the chain advances, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/user-guide/features/fallback-providers).
 :::
 
 ---

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1558,7 +1558,7 @@ When activated, the fallback swaps the model and provider mid-session without lo
 Supported providers: `openrouter`, `nous`, `novita`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `ai-gateway`, `azure-foundry`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `actual`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
 
 :::tip
-Fallback is configured exclusively through `config.yaml` — or interactively via `hermes fallback`. For full details on when it triggers, how the chain advances, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/user-guide/features/fallback-providers).
+Fallback is configured exclusively through `config.yaml` — or interactively via `hermes fallback`; there are no environment variables for fallback routing. The legacy single-entry `fallback_model` dictionary remains supported for backward compatibility, but new configurations should use the ordered `fallback_providers` list. For full details on when fallback triggers, how the chain advances, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/user-guide/features/fallback-providers).
 :::
 
 ---

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -627,27 +627,17 @@ And the two auxiliary LLM slots:
 
 The GUI is strictly a **read-through-the-DB + write-through-kanban_db** layer with no domain logic of its own:
 
-<!-- ascii-guard-ignore -->
+```mermaid
+flowchart TD
+  UI["React SPA plugin<br/>HTML5 drag-and-drop"]
+  API["FastAPI router + WebSocket tail<br/>plugins/kanban/dashboard/plugin_api.py"]
+  DB["~/.hermes/kanban.db<br/>WAL persistence"]
+
+  UI -->|REST over fetchJSON| API
+  API -->|writes call kanban_db.*<br/>same code path CLI /kanban verbs use| DB
+  DB -->|persist task_events rows| API
+  API -->|WebSocket streams task_events| UI
 ```
-┌────────────────────────┐      WebSocket (tails task_events)
-│   React SPA (plugin)   │ ◀──────────────────────────────────┐
-│   HTML5 drag-and-drop  │                                    │
-└──────────┬─────────────┘                                    │
-           │ REST over fetchJSON                              │
-           ▼                                                  │
-┌────────────────────────┐     writes call kanban_db.*        │
-│  FastAPI router        │     directly — same code path      │
-│  plugins/kanban/       │     the CLI /kanban verbs use      │
-│  dashboard/plugin_api.py                                    │
-└──────────┬─────────────┘                                    │
-           │                                                  │
-           ▼                                                  │
-┌────────────────────────┐                                    │
-│  ~/.hermes/kanban.db   │ ───── append task_events ──────────┘
-│  (WAL, shared)         │
-└────────────────────────┘
-```
-<!-- ascii-guard-ignore-end -->
 
 ### REST surface
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -596,27 +596,17 @@ And the two auxiliary LLM slots:
 
 The GUI is strictly a **read-through-the-DB + write-through-kanban_db** layer with no domain logic of its own:
 
-<!-- ascii-guard-ignore -->
+```mermaid
+flowchart TD
+  UI["React SPA plugin<br/>HTML5 drag-and-drop"]
+  API["FastAPI router + WebSocket tail<br/>plugins/kanban/dashboard/plugin_api.py"]
+  DB["~/.hermes/kanban.db<br/>WAL persistence"]
+
+  UI -->|REST over fetchJSON| API
+  API -->|writes call kanban_db.*<br/>same code path CLI /kanban verbs use| DB
+  DB -->|persist task_events rows| API
+  API -->|WebSocket streams task_events| UI
 ```
-┌────────────────────────┐      WebSocket (tails task_events)
-│   React SPA (plugin)   │ ◀──────────────────────────────────┐
-│   HTML5 drag-and-drop  │                                    │
-└──────────┬─────────────┘                                    │
-           │ REST over fetchJSON                              │
-           ▼                                                  │
-┌────────────────────────┐     writes call kanban_db.*        │
-│  FastAPI router        │     directly — same code path      │
-│  plugins/kanban/       │     the CLI /kanban verbs use      │
-│  dashboard/plugin_api.py                                    │
-└──────────┬─────────────┘                                    │
-           │                                                  │
-           ▼                                                  │
-┌────────────────────────┐                                    │
-│  ~/.hermes/kanban.db   │ ───── append task_events ──────────┘
-│  (WAL, shared)         │
-└────────────────────────┘
-```
-<!-- ascii-guard-ignore-end -->
 
 ### REST surface
 


### PR DESCRIPTION
## Why change

Replace remaining docs ASCII diagrams with supported Mermaid and clarify fallback configuration without losing legacy compatibility guidance.

## Files changed

- `cron-script-only.md`: replace the no-agent execution diagram with Mermaid.
- `kanban.md`: replace the GUI architecture diagram with Mermaid and show the actual DB persistence -> FastAPI/WebSocket tail -> React UI boundary.
- `providers.md`: clarify that fallback routing has no environment variables, preserve legacy `fallback_model` compatibility, and recommend `fallback_providers` for new configuration.

## Verification run

- full Docusaurus build — passed for English and zh-Hans
- full ASCII guard — passed
- touched-file ASCII guard — passed
- `git diff --check` — passed

## Risk level

Low. Docs-only changes; no runtime code or dependency changes.