### PR TITLE
docs(qqbot): document inline approval buttons

### DIFF
--- a/website/docs/user-guide/messaging/qqbot.md
+++ b/website/docs/user-guide/messaging/qqbot.md
@@ -8,6 +8,7 @@ The QQ Bot adapter uses the [Official QQ Bot API](https://bot.q.qq.com/wiki/deve
 
 - Receive messages via a persistent **WebSocket** connection to the QQ Gateway
 - Send text and markdown replies via the **REST API**
+- Show inline keyboard buttons for command approvals and update prompts
 - Download and process images, voice messages, and file attachments
 - Transcribe voice messages using Tencent's built-in ASR or a configurable STT provider
 
@@ -82,6 +83,23 @@ platforms:
         apiKey: "your-stt-key"
         model: "glm-asr"
 ```
+
+## Inline Approvals and Update Prompts
+
+QQ Bot supports inline keyboards in private C2C chats and group chats. When Hermes needs a dangerous-command approval, QQ users get a three-button prompt:
+
+- **允许一次** — approve once
+- **始终允许** — always approve this command pattern
+- **拒绝** — deny
+
+The buttons are mutually exclusive. When a user clicks one, QQ sends an `INTERACTION_CREATE` event to the gateway, Hermes acknowledges the interaction, and the pending approval is resolved without requiring the user to type `/approve` or `/deny`.
+
+Gateway update prompts also use inline buttons:
+
+- **确认** — yes
+- **取消** — no
+
+QQ guild/channel chats do not support inline keyboards through this adapter. For dangerous-command approvals in guild chats, use the normal text commands (`/approve`, `/approve always`, or `/deny`) when prompted.
 
 ## Voice Messages (STT)
 


### PR DESCRIPTION
## What does this PR do?

Documents the QQ Bot inline-keyboard approval behavior currently implemented in `gateway/platforms/qqbot/adapter.py` and `gateway/platforms/qqbot/keyboards.py`.

QQBot now sends button-based dangerous-command approval prompts and update prompts in private C2C chats and group chats. Button clicks arrive as `INTERACTION_CREATE`, are acknowledged by the adapter, and route back to the pending approval or update prompt handler.

The docs page previously covered text, markdown, media, and voice/STT, but did not mention inline approvals or the guild/channel limitation.

## Related Issue

No GitHub issue filed. Docs drift found from local docs drift log for commit `de584cd1dd4ed82a335a9dcd367406316c9923e0` and verified against current `main` code.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docs/user-guide/messaging/qqbot.md`: add inline keyboard support to the overview.
- `website/docs/user-guide/messaging/qqbot.md`: document dangerous-command approval buttons, update prompt buttons, `INTERACTION_CREATE` routing, and the C2C/group-only support caveat.

## How to Test

1. Confirm the new terms are present: `rg -n "Inline Approvals|inline keyboard|INTERACTION_CREATE|/approve always|update prompts" website/docs/user-guide/messaging/qqbot.md`
2. Check diff whitespace: `git diff --check HEAD~1 HEAD`

## Checklist

### Code

- [ ] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [ ] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: Ubuntu/WSL

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I have updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

Docs-only change. Validation run:

- `rg -n "Inline Approvals|inline keyboard|INTERACTION_CREATE|/approve always|update prompts" website/docs/user-guide/messaging/qqbot.md`
- `git diff --check HEAD~1 HEAD`
