### PR TITLE
fix(tui_gateway): event-driven delivery for notify_on_complete + watch_patterns

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -431,6 +431,7 @@ AUTHOR_MAP = {
     "hcn518@gmail.com": "pedh",
     "haileymarshall005@gmail.com": "haileymarshall",
     "bennet.yr.wang@gmail.com": "BennetYrWang",
+    "liftaris@gmail.com": "liftaris",
     "greer.guthrie@gmail.com": "g-guthrie",
     "kennyx102@gmail.com": "bobashopcashier",
     "77253505+bobashopcashier@users.noreply.github.com": "bobashopcashier",

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4649,3 +4649,495 @@ def test_config_show_displays_nested_max_turns(monkeypatch):
     )
 
     assert ["Max Turns", "120"] in agent_rows
+
+
+# ── Background-process notification delivery ─────────────────────────
+#
+# Covers the tui_gateway completion_queue consumer: the router thread drains
+# process_registry.completion_queue and dispatches each event to a worker
+# from _notify_pool that waits on session['idle'] before synthesizing a
+# prompt.submit.  The design is entirely event-driven (Event.wait +
+# queue.get) with no polling.
+#
+# Tests below intentionally bypass the router thread and call the dispatcher
+# directly where possible — routing is trivial (a queue.get in a loop), the
+# interesting contract lives in _dispatch_process_notification.
+
+import queue as _queue_mod
+
+
+def _drain_process_completion_queue(process_registry):
+    while True:
+        try:
+            process_registry.completion_queue.get_nowait()
+        except _queue_mod.Empty:
+            break
+
+
+class _StubProcessRegistry:
+    """Minimal stand-in for tools.process_registry.process_registry."""
+
+    def __init__(self, session_key: str = "session-key"):
+        self._consumed: set[str] = set()
+        self._session_key = session_key
+
+    def get(self, session_id):
+        return types.SimpleNamespace(session_key=self._session_key)
+
+    def is_completion_consumed(self, session_id):
+        return session_id in self._consumed
+
+    def mark_consumed(self, session_id):
+        self._consumed.add(session_id)
+
+
+def _install_stub_registry(monkeypatch, stub):
+    import tools.process_registry as _pr
+
+    monkeypatch.setattr(_pr, "process_registry", stub)
+    return stub
+
+
+def _make_session(sid: str, session_key: str, *, running: bool = False) -> dict:
+    """Construct the minimum session dict the dispatcher reads."""
+    idle = threading.Event()
+    if not running:
+        idle.set()
+    return {
+        "session_key": session_key,
+        "running": running,
+        "idle": idle,
+        "history_lock": threading.Lock(),
+    }
+
+
+def test_notification_fires_after_idle_set_without_polling(monkeypatch):
+    """Core event-driven contract: the dispatcher waits on idle, not a sleep loop."""
+    stub = _install_stub_registry(monkeypatch, _StubProcessRegistry())
+    dispatched: list[dict] = []
+    monkeypatch.setattr(
+        server,
+        "handle_request",
+        lambda req: dispatched.append(req) or {"result": {}},
+    )
+
+    # time.sleep in the server module should never be called from the
+    # notification path — any call would indicate accidental polling.
+    original_sleep = time.sleep
+
+    def _forbidden_sleep(*args, **kwargs):
+        raise AssertionError("time.sleep called from notification dispatch")
+
+    monkeypatch.setattr(server.time, "sleep", _forbidden_sleep)
+
+    server._sessions.clear()
+    session = _make_session("sid", stub._session_key, running=True)
+    server._sessions["sid"] = session
+    try:
+        worker = threading.Thread(
+            target=server._dispatch_process_notification,
+            args=(
+                {
+                    "type": "completion",
+                    "session_id": "proc_evt",
+                    "command": "python -c 'print(42)'",
+                    "exit_code": 0,
+                    "output": "42\n",
+                },
+            ),
+            daemon=True,
+        )
+        worker.start()
+
+        # Worker should be blocked on idle.wait() — no dispatch yet.
+        worker.join(timeout=0.1)
+        assert worker.is_alive()
+        assert dispatched == []
+
+        # Flip the edge. Worker must wake and dispatch.
+        server._set_session_running(session, False)
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
+        assert len(dispatched) == 1
+        assert dispatched[0]["method"] == "prompt.submit"
+        assert dispatched[0]["params"]["session_id"] == "sid"
+        assert dispatched[0]["params"]["text"].startswith(
+            "[SYSTEM: Background process proc_evt completed"
+        )
+    finally:
+        monkeypatch.setattr(server.time, "sleep", original_sleep)
+        server._sessions.clear()
+
+
+def test_notification_dropped_when_session_closed_mid_wait(monkeypatch):
+    """Session teardown during idle.wait must not crash; dispatcher drops silently."""
+    stub = _install_stub_registry(monkeypatch, _StubProcessRegistry())
+    dispatched: list[dict] = []
+    monkeypatch.setattr(
+        server,
+        "handle_request",
+        lambda req: dispatched.append(req) or {"result": {}},
+    )
+
+    server._sessions.clear()
+    session = _make_session("sid", stub._session_key, running=True)
+    server._sessions["sid"] = session
+    try:
+        worker = threading.Thread(
+            target=server._dispatch_process_notification,
+            args=(
+                {
+                    "type": "completion",
+                    "session_id": "proc_teardown",
+                    "command": "x",
+                    "exit_code": 0,
+                    "output": "",
+                },
+            ),
+            daemon=True,
+        )
+        worker.start()
+
+        # Close the session while the worker is blocked on idle.wait().
+        server._sessions.pop("sid", None)
+        server._set_session_running(session, False)  # release the wait
+
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
+        # Post-wait recheck sees _sessions.get("sid") is not session → drop.
+        assert dispatched == []
+    finally:
+        server._sessions.clear()
+
+
+def test_concurrent_sessions_dispatch_in_parallel(monkeypatch):
+    """Two sessions with simultaneous completions: busy A must not block idle B.
+
+    HoL (head-of-line) blocking was the core weakness of the single-worker
+    polling design.  Per-event dispatcher threads make this impossible.
+    """
+
+    class _Routing:
+        """Unified process_registry stand-in that routes by process sid."""
+
+        def __init__(self):
+            self._consumed: set[str] = set()
+
+        def get(self, session_id):
+            if session_id.endswith("_a"):
+                return types.SimpleNamespace(session_key="key-A")
+            if session_id.endswith("_b"):
+                return types.SimpleNamespace(session_key="key-B")
+            return types.SimpleNamespace(session_key="")
+
+        def is_completion_consumed(self, session_id):
+            return session_id in self._consumed
+
+    routing = _Routing()
+    _install_stub_registry(monkeypatch, routing)
+
+    dispatched: list[str] = []
+    dispatched_lock = threading.Lock()
+
+    def _fake_handle(req):
+        with dispatched_lock:
+            dispatched.append(req["params"]["session_id"])
+        return {"result": {}}
+
+    monkeypatch.setattr(server, "handle_request", _fake_handle)
+
+    server._sessions.clear()
+    # Session A is busy; B is idle.
+    session_a = _make_session("sid-A", "key-A", running=True)
+    session_b = _make_session("sid-B", "key-B", running=False)
+    server._sessions["sid-A"] = session_a
+    server._sessions["sid-B"] = session_b
+    try:
+        # Fire both events.
+        worker_a = threading.Thread(
+            target=server._dispatch_process_notification,
+            args=(
+                {
+                    "type": "completion",
+                    "session_id": "proc_a",
+                    "command": "ca",
+                    "exit_code": 0,
+                    "output": "",
+                },
+            ),
+            daemon=True,
+        )
+        worker_b = threading.Thread(
+            target=server._dispatch_process_notification,
+            args=(
+                {
+                    "type": "completion",
+                    "session_id": "proc_b",
+                    "command": "cb",
+                    "exit_code": 0,
+                    "output": "",
+                },
+            ),
+            daemon=True,
+        )
+        worker_a.start()
+        worker_b.start()
+
+        # B is idle — should dispatch immediately and exit without waiting for A.
+        worker_b.join(timeout=2.0)
+        assert not worker_b.is_alive(), (
+            "session B's dispatcher HoL-blocked on session A"
+        )
+        with dispatched_lock:
+            assert dispatched == ["sid-B"]
+        # A is still busy.
+        assert worker_a.is_alive()
+
+        # Release A.
+        server._set_session_running(session_a, False)
+        worker_a.join(timeout=2.0)
+        assert not worker_a.is_alive()
+        with dispatched_lock:
+            assert sorted(dispatched) == ["sid-A", "sid-B"]
+    finally:
+        server._sessions.clear()
+
+
+def test_notification_dropped_when_session_key_unresolvable(monkeypatch):
+    """Events for a session_key that no TUI session owns: drop cleanly."""
+    stub = _install_stub_registry(monkeypatch, _StubProcessRegistry(session_key="ghost"))
+    dispatched: list[dict] = []
+    monkeypatch.setattr(
+        server,
+        "handle_request",
+        lambda req: dispatched.append(req) or {"result": {}},
+    )
+
+    server._sessions.clear()
+    try:
+        server._dispatch_process_notification(
+            {
+                "type": "completion",
+                "session_id": "proc_orphan",
+                "command": "x",
+                "exit_code": 0,
+                "output": "",
+            }
+        )
+        assert dispatched == []
+    finally:
+        server._sessions.clear()
+
+
+def test_notification_skipped_when_completion_already_consumed(monkeypatch):
+    """Double-check path: if the agent consumed the completion via wait/poll
+    before the dispatcher fires, don't send a redundant synthetic turn.
+    """
+    stub = _install_stub_registry(monkeypatch, _StubProcessRegistry())
+    stub.mark_consumed("proc_consumed")
+    dispatched: list[dict] = []
+    monkeypatch.setattr(
+        server,
+        "handle_request",
+        lambda req: dispatched.append(req) or {"result": {}},
+    )
+
+    server._sessions.clear()
+    server._sessions["sid"] = _make_session("sid", stub._session_key)
+    try:
+        server._dispatch_process_notification(
+            {
+                "type": "completion",
+                "session_id": "proc_consumed",
+                "command": "x",
+                "exit_code": 0,
+                "output": "",
+            }
+        )
+        assert dispatched == []
+    finally:
+        server._sessions.clear()
+
+
+def test_idle_timeout_drops_notification_and_warns(monkeypatch, caplog):
+    """A turn that never ends (5min+) must not hang the dispatcher forever."""
+    stub = _install_stub_registry(monkeypatch, _StubProcessRegistry())
+    dispatched: list[dict] = []
+    monkeypatch.setattr(
+        server,
+        "handle_request",
+        lambda req: dispatched.append(req) or {"result": {}},
+    )
+    # Collapse the 5-minute timeout to something testable.
+    monkeypatch.setattr(server, "_NOTIFY_IDLE_TIMEOUT_SECONDS", 0.05)
+
+    server._sessions.clear()
+    server._sessions["sid"] = _make_session("sid", stub._session_key, running=True)
+    try:
+        with caplog.at_level("WARNING", logger=server.logger.name):
+            server._dispatch_process_notification(
+                {
+                    "type": "completion",
+                    "session_id": "proc_timeout",
+                    "command": "x",
+                    "exit_code": 0,
+                    "output": "",
+                }
+            )
+        assert dispatched == []
+        assert any("busy" in rec.getMessage() for rec in caplog.records)
+    finally:
+        server._sessions.clear()
+
+
+def test_formatter_renders_completion_watch_and_disabled_events():
+    """Event formatter parity with gateway/cli text shapes."""
+    # Completion
+    out = server._format_process_notification(
+        {
+            "type": "completion",
+            "session_id": "p1",
+            "command": "echo hi",
+            "exit_code": 0,
+            "output": "hi\n",
+        }
+    )
+    assert "Background process p1 completed" in out
+    assert "exit code 0" in out
+    assert "hi\n" in out
+
+    # Watch match
+    out = server._format_process_notification(
+        {
+            "type": "watch_match",
+            "session_id": "p2",
+            "command": "tail -f log",
+            "pattern": "ERROR",
+            "output": "ERROR: boom",
+            "suppressed": 3,
+        }
+    )
+    assert 'matched watch pattern "ERROR"' in out
+    assert "3 earlier matches were suppressed" in out
+
+    # Watch disabled
+    out = server._format_process_notification(
+        {"type": "watch_disabled", "message": "watch disabled"}
+    )
+    assert out == "[SYSTEM: watch disabled]"
+
+    # Watch overflow released (global breaker)
+    out = server._format_process_notification(
+        {"type": "watch_overflow_released", "message": "resumed"}
+    )
+    assert out == "[SYSTEM: resumed]"
+
+    # Unknown type with no message: no synthetic prompt
+    assert server._format_process_notification({"type": "watch_disabled"}) is None
+
+
+def test_dispatch_uses_synthetic_request_id(monkeypatch):
+    """Request IDs are stable-prefixed so they can be filtered from logs."""
+    stub = _install_stub_registry(monkeypatch, _StubProcessRegistry())
+    dispatched: list[dict] = []
+    monkeypatch.setattr(
+        server,
+        "handle_request",
+        lambda req: dispatched.append(req) or {"result": {}},
+    )
+
+    server._sessions.clear()
+    server._sessions["sid"] = _make_session("sid", stub._session_key)
+    try:
+        server._dispatch_process_notification(
+            {
+                "type": "completion",
+                "session_id": "proc_id",
+                "command": "x",
+                "exit_code": 0,
+                "output": "",
+            }
+        )
+        assert len(dispatched) == 1
+        assert dispatched[0]["id"].startswith("process-notify-")
+        assert dispatched[0]["method"] == "prompt.submit"
+    finally:
+        server._sessions.clear()
+
+
+def test_set_session_running_keeps_running_and_idle_in_sync():
+    """The helper is the single source of truth for the running/idle invariant."""
+    session = _make_session("sid", "key", running=False)
+    assert session["running"] is False
+    assert session["idle"].is_set()
+
+    server._set_session_running(session, True)
+    assert session["running"] is True
+    assert not session["idle"].is_set()
+
+    server._set_session_running(session, False)
+    assert session["running"] is False
+    assert session["idle"].is_set()
+
+    # Missing idle must not crash — legacy session compatibility.
+    session_no_idle = {"running": False, "history_lock": threading.Lock()}
+    server._set_session_running(session_no_idle, True)
+    assert session_no_idle["running"] is True
+    server._set_session_running(session_no_idle, False)
+    assert session_no_idle["running"] is False
+
+
+def test_router_and_dispatch_end_to_end(monkeypatch):
+    """Integration: enqueue on completion_queue, observe prompt.submit."""
+    from tools.process_registry import process_registry
+
+    _drain_process_completion_queue(process_registry)
+    server._sessions.clear()
+
+    dispatched: list[dict] = []
+    dispatched_evt = threading.Event()
+
+    def _fake_handle(req):
+        dispatched.append(req)
+        dispatched_evt.set()
+        return {"result": {}}
+
+    monkeypatch.setattr(server, "handle_request", _fake_handle)
+
+    idle = threading.Event()
+    idle.set()
+    server._sessions["sid"] = {
+        "session_key": "end-to-end",
+        "running": False,
+        "idle": idle,
+        "history_lock": threading.Lock(),
+    }
+
+    original_get = process_registry.get
+
+    def _fake_get(session_id):
+        if session_id == "proc_e2e":
+            return types.SimpleNamespace(session_key="end-to-end")
+        return original_get(session_id)
+
+    monkeypatch.setattr(process_registry, "get", _fake_get)
+
+    try:
+        # Start the router if it isn't running (no TUI session has initialised
+        # it in this test process).
+        server._ensure_notification_router()
+        process_registry.completion_queue.put(
+            {
+                "type": "completion",
+                "session_id": "proc_e2e",
+                "command": "python -c 'print(1)'",
+                "exit_code": 0,
+                "output": "1\n",
+            }
+        )
+        assert dispatched_evt.wait(timeout=3.0), "router+dispatch never completed"
+        assert len(dispatched) == 1
+        assert "proc_e2e completed" in dispatched[0]["params"]["text"]
+    finally:
+        _drain_process_completion_queue(process_registry)
+        server._sessions.clear()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4712,7 +4712,12 @@ def _make_session(sid: str, session_key: str, *, running: bool = False) -> dict:
 
 
 def test_notification_fires_after_idle_set_without_polling(monkeypatch):
-    """Core event-driven contract: the dispatcher waits on idle, not a sleep loop."""
+    """Core event-driven contract: the dispatcher waits on idle, not a sleep loop.
+
+    Proof by blocking behavior: the worker thread must remain alive (blocked
+    on ``idle.wait()``) while the session is busy, and dispatch within a few
+    ms of ``idle.set()``.
+    """
     stub = _install_stub_registry(monkeypatch, _StubProcessRegistry())
     dispatched: list[dict] = []
     monkeypatch.setattr(
@@ -4720,15 +4725,6 @@ def test_notification_fires_after_idle_set_without_polling(monkeypatch):
         "handle_request",
         lambda req: dispatched.append(req) or {"result": {}},
     )
-
-    # time.sleep in the server module should never be called from the
-    # notification path — any call would indicate accidental polling.
-    original_sleep = time.sleep
-
-    def _forbidden_sleep(*args, **kwargs):
-        raise AssertionError("time.sleep called from notification dispatch")
-
-    monkeypatch.setattr(server.time, "sleep", _forbidden_sleep)
 
     server._sessions.clear()
     session = _make_session("sid", stub._session_key, running=True)
@@ -4765,7 +4761,6 @@ def test_notification_fires_after_idle_set_without_polling(monkeypatch):
             "[SYSTEM: Background process proc_evt completed"
         )
     finally:
-        monkeypatch.setattr(server.time, "sleep", original_sleep)
         server._sessions.clear()
 
 
@@ -4905,7 +4900,7 @@ def test_concurrent_sessions_dispatch_in_parallel(monkeypatch):
 
 def test_notification_dropped_when_session_key_unresolvable(monkeypatch):
     """Events for a session_key that no TUI session owns: drop cleanly."""
-    stub = _install_stub_registry(monkeypatch, _StubProcessRegistry(session_key="ghost"))
+    _install_stub_registry(monkeypatch, _StubProcessRegistry(session_key="ghost"))
     dispatched: list[dict] = []
     monkeypatch.setattr(
         server,
@@ -5002,6 +4997,7 @@ def test_formatter_renders_completion_watch_and_disabled_events():
             "output": "hi\n",
         }
     )
+    assert out is not None
     assert "Background process p1 completed" in out
     assert "exit code 0" in out
     assert "hi\n" in out
@@ -5017,6 +5013,7 @@ def test_formatter_renders_completion_watch_and_disabled_events():
             "suppressed": 3,
         }
     )
+    assert out is not None
     assert 'matched watch pattern "ERROR"' in out
     assert "3 earlier matches were suppressed" in out
 
@@ -5026,13 +5023,7 @@ def test_formatter_renders_completion_watch_and_disabled_events():
     )
     assert out == "[SYSTEM: watch disabled]"
 
-    # Watch overflow released (global breaker)
-    out = server._format_process_notification(
-        {"type": "watch_overflow_released", "message": "resumed"}
-    )
-    assert out == "[SYSTEM: resumed]"
-
-    # Unknown type with no message: no synthetic prompt
+    # Watch-disabled with no message: no synthetic prompt
     assert server._format_process_notification({"type": "watch_disabled"}) is None
 
 
@@ -5140,4 +5131,59 @@ def test_router_and_dispatch_end_to_end(monkeypatch):
         assert "proc_e2e completed" in dispatched[0]["params"]["text"]
     finally:
         _drain_process_completion_queue(process_registry)
+        server._sessions.clear()
+
+
+def test_dispatch_retries_after_4009_until_idle(monkeypatch):
+    """A goal-continuation / user prompt can reclaim the slot between
+    ``idle.set()`` and the dispatcher's ``prompt.submit``.  The dispatcher
+    must re-wait on the next idle edge and retry, not drop the event.
+    """
+    _install_stub_registry(monkeypatch, _StubProcessRegistry())
+    session = _make_session("sid", "session-key", running=False)
+    calls: list[dict] = []
+
+    def _fake_handle(req):
+        calls.append(req)
+        # First attempt: pretend a goal-continuation grabbed the slot.
+        if len(calls) == 1:
+            server._set_session_running(session, True)
+            return {"error": {"code": 4009, "message": "session busy"}}
+        return {"result": {}}
+
+    monkeypatch.setattr(server, "handle_request", _fake_handle)
+
+    server._sessions.clear()
+    server._sessions["sid"] = session
+    try:
+        worker = threading.Thread(
+            target=server._dispatch_process_notification,
+            args=(
+                {
+                    "type": "completion",
+                    "session_id": "proc_race",
+                    "command": "x",
+                    "exit_code": 0,
+                    "output": "",
+                },
+            ),
+            daemon=True,
+        )
+        worker.start()
+
+        # First call fires immediately (idle was set), gets 4009,
+        # dispatcher re-waits on idle.
+        deadline = time.monotonic() + 2.0
+        while len(calls) < 1 and time.monotonic() < deadline:
+            worker.join(timeout=0.01)
+        assert len(calls) == 1
+        assert worker.is_alive(), "dispatcher dropped instead of re-waiting on idle"
+
+        # Release the slot.  Second attempt succeeds and the worker exits.
+        server._set_session_running(session, False)
+        worker.join(timeout=2.0)
+        assert not worker.is_alive()
+        assert len(calls) == 2
+        assert calls[1]["method"] == "prompt.submit"
+    finally:
         server._sessions.clear()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -183,9 +183,12 @@ atexit.register(lambda: _pool.shutdown(wait=False, cancel_futures=True))
 # a ``prompt.submit`` that mirrors how real user turns are handled.
 #
 # All waits are on ``threading.Event`` / blocking ``queue.get()`` — no polling.
-_notify_pool_workers = max(
-    2, int(os.environ.get("HERMES_TUI_NOTIFY_POOL_WORKERS") or "16")
-)
+try:
+    _notify_pool_workers = max(
+        2, int(os.environ.get("HERMES_TUI_NOTIFY_POOL_WORKERS") or "16")
+    )
+except (ValueError, TypeError):
+    _notify_pool_workers = 16
 _notify_pool = concurrent.futures.ThreadPoolExecutor(
     max_workers=_notify_pool_workers,
     thread_name_prefix="tui-notify",
@@ -196,9 +199,12 @@ _notify_router_lock = threading.Lock()
 # Bound on how long a dispatcher waits for a busy session to go idle before
 # giving up.  5 minutes is well past any reasonable single-turn duration; a
 # turn that runs that long has a real problem and the notification is stale.
-_NOTIFY_IDLE_TIMEOUT_SECONDS = float(
-    os.environ.get("HERMES_TUI_NOTIFY_IDLE_TIMEOUT") or "300"
-)
+try:
+    _NOTIFY_IDLE_TIMEOUT_SECONDS = float(
+        os.environ.get("HERMES_TUI_NOTIFY_IDLE_TIMEOUT") or "300"
+    )
+except (ValueError, TypeError):
+    _NOTIFY_IDLE_TIMEOUT_SECONDS = 300.0
 
 # Reserve real stdout for JSON-RPC only; redirect Python's stdout to stderr
 # so stray print() from libraries/tools becomes harmless gateway.stderr instead
@@ -769,10 +775,6 @@ def _format_process_notification(evt: dict) -> str | None:
         msg = evt.get("message", "")
         return f"[SYSTEM: {msg}]" if msg else None
 
-    if evt_type == "watch_overflow_released":
-        msg = evt.get("message", "")
-        return f"[SYSTEM: {msg}]" if msg else None
-
     if evt_type == "watch_match":
         pattern = evt.get("pattern", "?")
         output = evt.get("output", "")
@@ -832,8 +834,13 @@ def _dispatch_process_notification(evt: dict) -> None:
     Runs in a short-lived worker thread from ``_notify_pool``.  Blocks on
     ``session['idle']`` — no polling.  Drops the event if:
       - the session has already been closed
-      - the agent is still busy after ``_NOTIFY_IDLE_TIMEOUT_SECONDS``
+      - the overall deadline (``_NOTIFY_IDLE_TIMEOUT_SECONDS``) elapses
       - the completion was already consumed via ``wait/poll/log``
+
+    ``prompt.submit`` can race with a goal-continuation turn or a user
+    prompt that re-claims the slot between ``idle.set()`` and our
+    dispatch; on a 4009 "session busy" response we re-wait on ``idle``
+    and retry, bounded by the same overall deadline.
     """
     evt_type = evt.get("type", "completion")
     pid = str(evt.get("session_id") or "")
@@ -859,51 +866,70 @@ def _dispatch_process_notification(evt: dict) -> None:
         return
     sid, session = match
 
-    # Wait for the agent to finish its current turn.  ``idle`` is set at
-    # session creation and flipped around every ``prompt.submit`` turn.
-    # Absent (legacy session or race): assume idle to preserve delivery.
-    idle = session.get("idle")
-    if idle is not None:
-        if not idle.wait(timeout=_NOTIFY_IDLE_TIMEOUT_SECONDS):
-            logger.warning(
-                "Dropping process notification for %s: session %s busy for >%ss",
-                pid or "unknown",
-                sid,
-                _NOTIFY_IDLE_TIMEOUT_SECONDS,
-            )
-            return
-
-    # Re-check everything after the wait — the session may have been closed,
-    # or an explicit wait/poll/log may have consumed the completion while we
-    # were sleeping.
-    if _sessions.get(sid) is not session:
-        return
-    if evt_type == "completion" and pid:
-        try:
-            from tools.process_registry import process_registry
-
-            if process_registry.is_completion_consumed(pid):
-                return
-        except Exception:
-            pass
-
     text = _format_process_notification(evt)
     if not text:
         return
 
-    resp = handle_request(
-        {
-            "id": f"process-notify-{uuid.uuid4().hex[:8]}",
-            "method": "prompt.submit",
-            "params": {"session_id": sid, "text": text},
-        }
-    )
-    if resp and resp.get("error"):
+    idle = session.get("idle")
+    deadline = time.monotonic() + _NOTIFY_IDLE_TIMEOUT_SECONDS
+
+    while True:
+        # Wait for the agent to finish its current turn.  ``idle`` is set
+        # at session creation and flipped around every ``prompt.submit``
+        # turn.  Absent (legacy session): assume idle to preserve delivery.
+        if idle is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0 or not idle.wait(timeout=remaining):
+                logger.warning(
+                    "Dropping process notification for %s: session %s busy for >%ss",
+                    pid or "unknown",
+                    sid,
+                    _NOTIFY_IDLE_TIMEOUT_SECONDS,
+                )
+                return
+
+        # Re-check everything after the wait — the session may have been
+        # closed, or an explicit wait/poll/log may have consumed the
+        # completion while we were sleeping.
+        if _sessions.get(sid) is not session:
+            return
+        if evt_type == "completion" and pid:
+            try:
+                from tools.process_registry import process_registry
+
+                if process_registry.is_completion_consumed(pid):
+                    return
+            except Exception:
+                pass
+
+        resp = handle_request(
+            {
+                "id": f"process-notify-{uuid.uuid4().hex[:8]}",
+                "method": "prompt.submit",
+                "params": {"session_id": sid, "text": text},
+            }
+        )
+        err = (resp or {}).get("error")
+        if not err:
+            return
+        # Lost the race to a goal-continuation turn or a real user prompt.
+        # Re-wait on the next idle edge, bounded by the overall deadline.
+        # Without an ``idle`` Event we have nothing to wait on, so bail
+        # rather than busy-spin.
+        if err.get("code") == 4009 and idle is not None:
+            logger.debug(
+                "Process notification for %s deferred: session %s busy, "
+                "re-waiting on idle",
+                pid or "unknown",
+                sid,
+            )
+            continue
         logger.warning(
             "Process notification dispatch failed for %s: %s",
             pid or "unknown",
-            resp.get("error", {}).get("message", resp["error"]),
+            err.get("message", err),
         )
+        return
 
 
 def _process_notification_router() -> None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -168,6 +168,38 @@ _pool = concurrent.futures.ThreadPoolExecutor(
 )
 atexit.register(lambda: _pool.shutdown(wait=False, cancel_futures=True))
 
+# Background-process completion delivery (notify_on_complete / watch_patterns).
+#
+# Producer: ``tools.process_registry`` enqueues `completion`, `watch_match`, and
+# `watch_disabled` events onto ``process_registry.completion_queue`` whenever a
+# background process exits or a watch pattern fires.  The CLI and messaging
+# gateway each drain this queue between agent turns (cli.py, gateway/run.py).
+# This TUI gateway historically had no consumer — events landed silently.
+#
+# Design: one router thread blocks on the queue with no timeout.  For each
+# event it spawns a short-lived dispatcher thread via ``_notify_pool`` (the
+# same per-request-thread idiom used elsewhere in this module).  Each
+# dispatcher waits for its owning session's ``idle`` Event, then synthesizes
+# a ``prompt.submit`` that mirrors how real user turns are handled.
+#
+# All waits are on ``threading.Event`` / blocking ``queue.get()`` — no polling.
+_notify_pool_workers = max(
+    2, int(os.environ.get("HERMES_TUI_NOTIFY_POOL_WORKERS") or "16")
+)
+_notify_pool = concurrent.futures.ThreadPoolExecutor(
+    max_workers=_notify_pool_workers,
+    thread_name_prefix="tui-notify",
+)
+atexit.register(lambda: _notify_pool.shutdown(wait=False, cancel_futures=True))
+_notify_router_thread: threading.Thread | None = None
+_notify_router_lock = threading.Lock()
+# Bound on how long a dispatcher waits for a busy session to go idle before
+# giving up.  5 minutes is well past any reasonable single-turn duration; a
+# turn that runs that long has a real problem and the notification is stale.
+_NOTIFY_IDLE_TIMEOUT_SECONDS = float(
+    os.environ.get("HERMES_TUI_NOTIFY_IDLE_TIMEOUT") or "300"
+)
+
 # Reserve real stdout for JSON-RPC only; redirect Python's stdout to stderr
 # so stray print() from libraries/tools becomes harmless gateway.stderr instead
 # of corrupting the JSON protocol.
@@ -715,6 +747,227 @@ def _enable_gateway_prompts() -> None:
     os.environ["HERMES_GATEWAY_SESSION"] = "1"
     os.environ["HERMES_EXEC_ASK"] = "1"
     os.environ["HERMES_INTERACTIVE"] = "1"
+
+
+# ── Background-process notification delivery ────────────────────────
+#
+# Completion events and watch matches for background processes flow through
+# ``tools.process_registry.completion_queue``.  A router thread blocks on the
+# queue, and each event is dispatched in a short-lived worker that waits on
+# the owning session's ``idle`` Event before synthesizing a ``prompt.submit``.
+# Entirely event-driven — see the module-top ``_notify_pool`` block for the
+# design rationale.
+
+
+def _format_process_notification(evt: dict) -> str | None:
+    """Render a queued background-process event as an agent-facing prompt."""
+    evt_type = evt.get("type", "completion")
+    pid = evt.get("session_id", "unknown")
+    cmd = evt.get("command", "unknown")
+
+    if evt_type == "watch_disabled":
+        msg = evt.get("message", "")
+        return f"[SYSTEM: {msg}]" if msg else None
+
+    if evt_type == "watch_overflow_released":
+        msg = evt.get("message", "")
+        return f"[SYSTEM: {msg}]" if msg else None
+
+    if evt_type == "watch_match":
+        pattern = evt.get("pattern", "?")
+        output = evt.get("output", "")
+        suppressed = evt.get("suppressed", 0)
+        text = (
+            f"[SYSTEM: Background process {pid} matched "
+            f'watch pattern "{pattern}".\n'
+            f"Command: {cmd}\n"
+            f"Matched output:\n{output}"
+        )
+        if suppressed:
+            text += f"\n({suppressed} earlier matches were suppressed by rate limit)"
+        return text + "]"
+
+    # Default: completion
+    exit_code = evt.get("exit_code", "?")
+    output = evt.get("output", "")
+    return (
+        f"[SYSTEM: Background process {pid} completed "
+        f"(exit code {exit_code}).\n"
+        f"Command: {cmd}\n"
+        f"Output:\n{output}]"
+    )
+
+
+def _session_for_process_event(evt: dict) -> tuple[str, dict] | None:
+    """Resolve the TUI session that owns a given process event.
+
+    Events of type ``completion`` carry no ``session_key`` directly
+    (see tools/process_registry.py::_move_to_finished), so we fall back
+    to looking up the owning ``ProcessSession`` in the registry.  Watch
+    events include ``session_key`` on the event itself.
+    """
+    key = str(evt.get("session_key") or "")
+    pid = str(evt.get("session_id") or "")
+    if not key and pid:
+        try:
+            from tools.process_registry import process_registry
+
+            proc = process_registry.get(pid)
+            key = str(getattr(proc, "session_key", "") or "")
+        except Exception:
+            return None
+    if not key:
+        return None
+
+    # list(...) — ``_sessions`` is mutated concurrently from other threads.
+    for sid, session in list(_sessions.items()):
+        if session.get("session_key") == key:
+            return sid, session
+    return None
+
+
+def _dispatch_process_notification(evt: dict) -> None:
+    """Deliver one queued background-process event to its owning TUI session.
+
+    Runs in a short-lived worker thread from ``_notify_pool``.  Blocks on
+    ``session['idle']`` — no polling.  Drops the event if:
+      - the session has already been closed
+      - the agent is still busy after ``_NOTIFY_IDLE_TIMEOUT_SECONDS``
+      - the completion was already consumed via ``wait/poll/log``
+    """
+    evt_type = evt.get("type", "completion")
+    pid = str(evt.get("session_id") or "")
+
+    # Early short-circuit: consumed-completion events are redundant because
+    # the agent already saw the output via a direct tool result.  Watch
+    # events can't be consumed this way, so only check for completions.
+    if evt_type == "completion" and pid:
+        try:
+            from tools.process_registry import process_registry
+
+            if process_registry.is_completion_consumed(pid):
+                return
+        except Exception:
+            pass
+
+    match = _session_for_process_event(evt)
+    if match is None:
+        logger.debug(
+            "Dropping process notification with no matching TUI session: %s",
+            pid or "unknown",
+        )
+        return
+    sid, session = match
+
+    # Wait for the agent to finish its current turn.  ``idle`` is set at
+    # session creation and flipped around every ``prompt.submit`` turn.
+    # Absent (legacy session or race): assume idle to preserve delivery.
+    idle = session.get("idle")
+    if idle is not None:
+        if not idle.wait(timeout=_NOTIFY_IDLE_TIMEOUT_SECONDS):
+            logger.warning(
+                "Dropping process notification for %s: session %s busy for >%ss",
+                pid or "unknown",
+                sid,
+                _NOTIFY_IDLE_TIMEOUT_SECONDS,
+            )
+            return
+
+    # Re-check everything after the wait — the session may have been closed,
+    # or an explicit wait/poll/log may have consumed the completion while we
+    # were sleeping.
+    if _sessions.get(sid) is not session:
+        return
+    if evt_type == "completion" and pid:
+        try:
+            from tools.process_registry import process_registry
+
+            if process_registry.is_completion_consumed(pid):
+                return
+        except Exception:
+            pass
+
+    text = _format_process_notification(evt)
+    if not text:
+        return
+
+    resp = handle_request(
+        {
+            "id": f"process-notify-{uuid.uuid4().hex[:8]}",
+            "method": "prompt.submit",
+            "params": {"session_id": sid, "text": text},
+        }
+    )
+    if resp and resp.get("error"):
+        logger.warning(
+            "Process notification dispatch failed for %s: %s",
+            pid or "unknown",
+            resp.get("error", {}).get("message", resp["error"]),
+        )
+
+
+def _process_notification_router() -> None:
+    """Block on completion_queue and hand each event to a dispatcher.
+
+    One thread total, started lazily by ``_ensure_notification_router``.
+    No polling — ``queue.get()`` blocks on the queue's internal condition
+    variable until the producer side calls ``.put()``.
+    """
+    from tools.process_registry import process_registry
+
+    while True:
+        try:
+            evt = process_registry.completion_queue.get()
+        except Exception as exc:
+            # A queue.get() from a healthy Queue shouldn't raise.  If it does
+            # (interpreter shutdown, for instance), retry once then bail.
+            logger.debug("notification router queue error: %s", exc)
+            return
+        if not isinstance(evt, dict):
+            continue
+        try:
+            _notify_pool.submit(_dispatch_process_notification, evt)
+        except RuntimeError:
+            # Pool shut down during atexit.  Nothing to deliver.
+            return
+        except Exception as exc:
+            logger.warning("notification dispatch submit error: %s", exc)
+
+
+def _ensure_notification_router() -> None:
+    """Start the notification router thread if not already running.
+
+    Idempotent; called from ``_init_session`` and the ``session.create`` RPC
+    handler so the router only spins up once a TUI session actually exists.
+    """
+    global _notify_router_thread
+    with _notify_router_lock:
+        if _notify_router_thread is not None and _notify_router_thread.is_alive():
+            return
+        _notify_router_thread = threading.Thread(
+            target=_process_notification_router,
+            name="tui-notify-router",
+            daemon=True,
+        )
+        _notify_router_thread.start()
+
+
+def _set_session_running(session: dict, running: bool) -> None:
+    """Flip a session's ``running`` flag and mirror it onto ``idle``.
+
+    ``idle`` is the threading.Event the notification dispatcher waits on to
+    fire between turns.  Keeping the two in sync at every transition site is
+    what turns notification delivery from polling into an event edge.
+    Callers must already hold ``session['history_lock']``.
+    """
+    session["running"] = running
+    idle = session.get("idle")
+    if idle is None:
+        return
+    if running:
+        idle.clear()
+    else:
+        idle.set()
 
 
 # ── Blocking prompt factory ──────────────────────────────────────────
@@ -1840,7 +2093,7 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
     session["attached_images"] = []
     session["edit_snapshots"] = {}
     session["image_counter"] = 0
-    session["running"] = False
+    _set_session_running(session, False)
     session["show_reasoning"] = _load_show_reasoning()
     session["tool_progress_mode"] = _load_tool_progress_mode()
     session["tool_started_at"] = {}
@@ -1907,12 +2160,15 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
 
 
 def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
+    idle = threading.Event()
+    idle.set()
     _sessions[sid] = {
         "agent": agent,
         "session_key": key,
         "history": history,
         "history_lock": threading.Lock(),
         "history_version": 0,
+        "idle": idle,
         "running": False,
         "attached_images": [],
         "image_counter": 0,
@@ -1955,6 +2211,7 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
         pass
     _wire_callbacks(sid)
     _notify_session_boundary("on_session_reset", key)
+    _ensure_notification_router()
     _emit("session.info", sid, _session_info(agent))
 
 
@@ -2094,6 +2351,8 @@ def _(rid, params: dict) -> dict:
     _enable_gateway_prompts()
 
     ready = threading.Event()
+    idle = threading.Event()
+    idle.set()
 
     _sessions[sid] = {
         "agent": None,
@@ -2105,6 +2364,7 @@ def _(rid, params: dict) -> dict:
         "history": [],
         "history_lock": threading.Lock(),
         "history_version": 0,
+        "idle": idle,
         "image_counter": 0,
         "pending_title": None,
         "running": False,
@@ -2115,6 +2375,7 @@ def _(rid, params: dict) -> dict:
         "tool_started_at": {},
         "transport": current_transport() or _stdio_transport,
     }
+    _ensure_notification_router()
 
     # Return the lightweight session immediately so Ink can paint the composer
     # + skeleton panel, then build the real AIAgent just after this response is
@@ -3001,7 +3262,7 @@ def _(rid, params: dict) -> dict:
     with session["history_lock"]:
         if session.get("running"):
             return _err(rid, 4009, "session busy")
-        session["running"] = True
+        _set_session_running(session, True)
 
     _start_agent_build(sid, session)
 
@@ -3018,7 +3279,7 @@ def _(rid, params: dict) -> dict:
                 },
             )
             with session["history_lock"]:
-                session["running"] = False
+                _set_session_running(session, False)
             return
         _run_prompt_submit(rid, sid, session, text)
 
@@ -3357,7 +3618,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 pass
             _clear_session_context(session_tokens)
             with session["history_lock"]:
-                session["running"] = False
+                _set_session_running(session, False)
 
         # Chain a goal-continuation turn if the judge said so. We do
         # this AFTER the finally releases session["running"], so the
@@ -3371,7 +3632,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     # User already sent something — their turn wins,
                     # the judge will re-run on the next turn anyway.
                     return
-                session["running"] = True
+                _set_session_running(session, True)
             try:
                 _emit("message.start", sid)
                 _run_prompt_submit(rid, sid, session, goal_followup)
@@ -3382,7 +3643,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     file=sys.stderr,
                 )
                 with session["history_lock"]:
-                    session["running"] = False
+                    _set_session_running(session, False)
 
     threading.Thread(target=run, daemon=True).start()
 


### PR DESCRIPTION
## What does this PR do?

Makes `terminal(background=true, notify_on_complete=true)` and `watch_patterns` deliver their notifications to TUI sessions. Currently they work everywhere except the TUI: events produced by `tools.process_registry.completion_queue` are drained by `cli.py` and `gateway/run.py` between agent turns, but `tui_gateway/server.py` has no consumer — events pile up in the queue and the agent never takes a follow-up turn on them.

The fix adds a router thread that blocks on `completion_queue.get()` and hands each event to a short-lived worker from a bounded `ThreadPoolExecutor`. Workers wait on a new per-session `threading.Event` (`idle`) before synthesizing a `prompt.submit` that re-enters the normal turn dispatch. `idle` is seeded at session construction and mirrored onto the existing `running` flag at every transition via a single `_set_session_running()` helper. If a goal-continuation turn or a real user prompt wins the race to the slot (4009 `session busy`), the dispatcher re-waits on the next `idle` edge and retries, bounded by the same overall 300s deadline. Entirely event-driven — every wait is on a `threading.Event` or a blocking `queue.get()`, no polling.

Message text matches `gateway/run.py::_format_gateway_process_notification` and `cli.py::_format_process_notification`, so the agent sees the same prompt regardless of transport.

Builds on and credits #15329 by @MestreY0d4-Uninter, whose PR established the right high-level shape but was closed for lack of maintainer signal with an explicit invitation to rebuild. This rebuild swaps the 100ms `session["running"]` polling for edge-triggered `threading.Event`, swaps the single serial worker for a bounded per-event pool (so a busy session can no longer head-of-line-block an idle sibling), and adds a 300s idle-timeout circuit breaker.

## Related Issue

Fixes #15248

(Does not attempt #10760 — that's the API server / WebUI variant with a different root cause. Happy to file a follow-up once this lands.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py` (+293 / -6):
  - Module-top: `_notify_pool` ThreadPoolExecutor, `_notify_router_thread` singleton, `_NOTIFY_IDLE_TIMEOUT_SECONDS` (all three env-configurable)
  - New helpers: `_format_process_notification`, `_session_for_process_event`, `_dispatch_process_notification`, `_process_notification_router`, `_ensure_notification_router`, `_set_session_running`
  - `session["idle"]` seeded in `session.create` and `_init_session`
  - 6 `running` transition sites now route through `_set_session_running(session, ...)`
  - Router started lazily on first session init
- `tests/test_tui_gateway_server.py` (+536): 11 new tests

## How to Test

### Manual

```
hermes --tui
# in the TUI composer:
> run `sleep 3 && echo done` in the background with notify_on_complete=true
```

**Before:** process completes, nothing happens, user has to manually ask.
**After:** ~3s later a `[SYSTEM: Background process proc_... completed (exit code 0). ...]` prompt appears and the agent takes a new turn on it.

### Automated

```
./scripts/run_tests.sh tests/test_tui_gateway_server.py tests/tools/test_notify_on_complete.py tests/tools/test_watch_patterns.py
# 235 passed in 1.53s
```

New tests cover: event-edge contract (dispatcher provably blocked on `idle.wait()` until the edge fires), 4009-busy retry, session-close-during-wait, concurrent-sessions-no-HoL, orphaned events, already-consumed short-circuit, idle timeout, formatter parity, synthetic request ID, the `_set_session_running` invariant, and an integration test that puts a real event onto `completion_queue` and observes the synthesized prompt.

### Platforms tested

- Linux (Manjaro, Python 3.11)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(tui_gateway): …`)
- [x] I searched for existing PRs — #15329 is the prior attempt, closed by its author inviting this rebuild
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `./scripts/run_tests.sh` and the target suites pass (235/235)
- [x] I've added tests for my changes (11 new)
- [x] I've tested on my platform: Linux (Manjaro, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing config or schema changes; behavior matches existing CLI/gateway paths)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (new env vars are opt-in tuning knobs, sensible defaults)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — threading primitives and `queue.Queue` are portable; no Unix-only syscalls introduced
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool surface changes; only completes an existing contract)

## Screenshots / Logs

Can attach a before/after `~/.hermes/logs/agent.log` snippet on request.
