### PR TITLE
docs(mcp): document SSE transport config

### DIFF
--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -22,7 +22,8 @@ mcp_servers:
     env: {}
 
     # OR
-    url: "..."          # HTTP servers
+    url: "..."          # Streamable HTTP or SSE servers
+    transport: sse      # optional; use only for SSE MCP servers
     headers: {}
 
     # Optional HTTP/SSE TLS settings:
@@ -48,17 +49,18 @@ mcp_servers:
 | `command` | string | stdio | Executable to launch |
 | `args` | list | stdio | Arguments for the subprocess |
 | `env` | mapping | stdio | Environment passed to the subprocess |
-| `url` | string | HTTP | Remote MCP endpoint |
-| `headers` | mapping | HTTP | Headers for remote server requests |
-| `ssl_verify` | bool or string | HTTP | TLS verification. `true` (default) uses system CAs, `false` disables verification (insecure), or a string path to a custom CA bundle (PEM) |
-| `client_cert` | string or list | HTTP | mTLS client certificate. String = path to a PEM file containing cert + key. List `[cert, key]` = separate files. List `[cert, key, password]` = encrypted key |
-| `client_key` | string | HTTP | Path to the client private key, when `client_cert` is a string and the key is in a separate file |
+| `url` | string | HTTP/SSE | Remote MCP endpoint |
+| `transport` | string | HTTP/SSE | Set to `sse` for SSE MCP servers. Omit for default Streamable HTTP. |
+| `headers` | mapping | HTTP/SSE | Headers for remote server requests |
+| `ssl_verify` | bool or string | HTTP/SSE | TLS verification. `true` (default) uses system CAs, `false` disables verification (insecure), or a string path to a custom CA bundle (PEM) |
+| `client_cert` | string or list | HTTP/SSE | mTLS client certificate. String = path to a PEM file containing cert + key. List `[cert, key]` = separate files. List `[cert, key, password]` = encrypted key |
+| `client_key` | string | HTTP/SSE | Path to the client private key, when `client_cert` is a string and the key is in a separate file |
 | `enabled` | bool | both | Skip the server entirely when false |
 | `timeout` | number | both | Tool call timeout in seconds (default: `300`) |
 | `connect_timeout` | number | both | Initial connection timeout in seconds (default: `60`) |
 | `supports_parallel_tool_calls` | bool | both | Allow tools from this server to run concurrently |
 | `tools` | mapping | both | Filtering and utility-tool policy |
-| `auth` | string | HTTP | Authentication method. Set to `oauth` to enable OAuth 2.1 with PKCE |
+| `auth` | string | HTTP/SSE | Authentication method. Set to `oauth` to enable OAuth 2.1 with PKCE |
 | `sampling` | mapping | both | Server-initiated LLM request policy (see MCP guide) |
 
 ## `tools` policy keys
@@ -187,6 +189,17 @@ mcp_servers:
       exclude: [delete_customer, refund_payment]
 ```
 
+### SSE transport server
+
+```yaml
+mcp_servers:
+  legacy_sse:
+    url: "https://mcp.example.com/sse"
+    transport: sse
+    headers:
+      Authorization: "Bearer ***"
+```
+
 ### Resource-only docs server
 
 ```yaml
@@ -274,7 +287,7 @@ Keep this in mind when writing `include` / `exclude` filters — use the **origi
 
 ## OAuth 2.1 authentication
 
-For HTTP servers that require OAuth, set `auth: oauth` on the server entry:
+For URL-based servers that require OAuth, set `auth: oauth` on the server entry:
 
 ```yaml
 mcp_servers:
@@ -288,4 +301,4 @@ Behavior:
 - On first connect, a browser window opens for authorization
 - Tokens are persisted to `~/.hermes/mcp-tokens/<server>.json` and reused across sessions
 - Token refresh is automatic; re-authorization only happens when refresh fails
-- Only applies to HTTP/StreamableHTTP transport (`url`-based servers)
+- Applies to URL-based Streamable HTTP servers and URL-based SSE servers (`transport: sse`)

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -13,7 +13,7 @@ If you have ever wanted Hermes to use a tool that already exists somewhere else,
 ## What MCP gives you
 
 - Access to external tool ecosystems without writing a native Hermes tool first
-- Local stdio servers and remote HTTP MCP servers in the same config
+- Local stdio servers and remote HTTP/SSE MCP servers in the same config
 - Automatic tool discovery and registration at startup
 - Utility wrappers for MCP resources and prompts when supported by the server
 - Per-server filtering so you can expose only the MCP tools you actually want Hermes to see
@@ -192,9 +192,10 @@ Use stdio servers when:
 - you want low-latency access to local resources
 - you are following MCP server docs that show `command`, `args`, and `env`
 
-### HTTP servers
+### HTTP and SSE servers
 
-HTTP MCP servers are remote endpoints Hermes connects to directly.
+HTTP MCP servers are remote endpoints Hermes connects to directly. By default,
+Hermes uses MCP's Streamable HTTP transport for `url`-based servers.
 
 ```yaml
 mcp_servers:
@@ -204,12 +205,24 @@ mcp_servers:
       Authorization: "Bearer ***"
 ```
 
-Use HTTP servers when:
+Some older or service-specific MCP servers still expose the SSE transport
+instead. For those, keep the `url` config but add `transport: sse`:
+
+```yaml
+mcp_servers:
+  sse_api:
+    url: "https://mcp.example.com/sse"
+    transport: sse
+    headers:
+      Authorization: "Bearer ***"
+```
+
+Use URL-based servers when:
 - the MCP server is hosted elsewhere
 - your organization exposes internal MCP endpoints
 - you do not want Hermes spawning a local subprocess for that integration
 
-### OAuth-authenticated HTTP servers
+### OAuth-authenticated URL-based servers
 
 Most hosted MCP servers (Linear, Sentry, Atlassian, Asana, Figma, Stripe, …) require OAuth 2.1 instead of a static bearer token. Set `auth: oauth` and Hermes handles discovery, dynamic client registration, PKCE, token exchange, refresh, and step-up auth via the MCP Python SDK.
 
@@ -291,10 +304,12 @@ Hermes reads MCP config from `~/.hermes/config.yaml` under `mcp_servers`.
 | `command` | string | Executable for a stdio MCP server |
 | `args` | list | Arguments for the stdio server |
 | `env` | mapping | Environment variables passed to the stdio server |
-| `url` | string | HTTP MCP endpoint |
-| `headers` | mapping | HTTP headers for remote servers |
+| `url` | string | Remote MCP endpoint |
+| `transport` | string | `sse` for URL-based servers that use the SSE transport instead of Streamable HTTP |
+| `headers` | mapping | HTTP/SSE headers for remote servers |
 | `client_cert` | string \| list | Client certificate for mTLS — a combined PEM path, or `[cert, key]` / `[cert, key, password]` |
 | `client_key` | string | Client private-key PEM path (when separate from `client_cert`) |
+| `auth` | string | `oauth` for URL-based servers that require OAuth 2.1 PKCE |
 | `timeout` | number | Tool call timeout |
 | `connect_timeout` | number | Initial connection timeout |
 | `enabled` | bool | If `false`, Hermes skips the server entirely |
@@ -771,7 +786,7 @@ The gateway does NOT need to be running for read operations (listing conversatio
 
 ### Current limits
 
-- The embedded `hermes mcp serve` exposes a **stdio-only** MCP server today. If you need an HTTP MCP server, run a separate adapter — or, much more commonly, use the MCP **client** side of Hermes, which already speaks both stdio and HTTP (`url` + `headers` in `mcp_servers.yaml` / `config.yaml`; see [HTTP servers](#http-servers) above).
+- The embedded `hermes mcp serve` exposes a **stdio-only** MCP server today. If you need an HTTP/SSE MCP server, run a separate adapter — or, much more commonly, use the MCP **client** side of Hermes, which already speaks stdio, Streamable HTTP, and SSE (`url`, optional `transport: sse`, and `headers` in `mcp_servers.yaml` / `config.yaml`; see [HTTP and SSE servers](#http-and-sse-servers) above).
 - Event polling at ~200ms intervals via mtime-optimized DB polling (skips work when files are unchanged)
 - No `claude/channel` push notification protocol yet
 - Text-only sends (no media/attachment sending through `messages_send`)


### PR DESCRIPTION
## What does this PR do?

Documents the current MCP SSE transport behavior implemented in `tools/mcp_tool.py`.

Current code supports URL-based SSE MCP servers with `transport: sse`, forwards `auth: oauth` into the SSE client, and treats Streamable HTTP as the default for `url`-based servers. The docs previously described only remote HTTP MCP servers and the config reference said OAuth only applied to HTTP/StreamableHTTP.

## Related Issue

No GitHub issue filed. Docs drift found from local docs drift log for commit `dd2dc2bddf43d72e24e61fd306206c696298df47` and verified against current `main` code.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docs/user-guide/features/mcp.md`: describe HTTP and SSE URL-based MCP servers, show a `transport: sse` example, and add `transport` / `auth` to the common keys table.
- `website/docs/reference/mcp-config-reference.md`: add `transport: sse` to the root config shape, server key table, example configs, and OAuth applicability notes.

## How to Test

1. Confirm SSE/OAuth docs terms are present: `rg -n "transport: sse|HTTP/SSE|URL-based servers|Streamable HTTP or SSE|OAuth 2.1" website/docs/user-guide/features/mcp.md website/docs/reference/mcp-config-reference.md`
2. Confirm stale OAuth wording is gone: `rg -n "Only applies to HTTP/StreamableHTTP|For HTTP servers" website/docs/user-guide/features/mcp.md website/docs/reference/mcp-config-reference.md`
3. Check diff whitespace: `git diff --check`

## Checklist

### Code

- [ ] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [ ] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: Ubuntu/WSL

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I have updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A.

## Screenshots / Logs

Docs-only change. Validation run:

- `rg -n "transport: sse|HTTP/SSE|URL-based servers|Streamable HTTP or SSE|OAuth 2.1" website/docs/user-guide/features/mcp.md website/docs/reference/mcp-config-reference.md`
- `rg -n "Only applies to HTTP/StreamableHTTP|For HTTP servers" website/docs/user-guide/features/mcp.md website/docs/reference/mcp-config-reference.md` returned no stale matches
- `git diff --check`
