### PR TITLE
feat(memory): support self-hosted Mem0 REST backend

### DIFF
--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -2,10 +2,20 @@
 
 Server-side LLM fact extraction with semantic search, reranking, and automatic deduplication.
 
+The provider supports two backends:
+
+- `platform` (default): Mem0 Platform through the `mem0ai` SDK.
+- `local_rest`: a self-hosted Mem0 server through its REST API.
+
 ## Requirements
 
+Platform mode:
 - `pip install mem0ai`
 - Mem0 API key from [app.mem0.ai](https://app.mem0.ai)
+
+Local REST mode:
+- A self-hosted Mem0 API reachable at `MEM0_BASE_URL` (for example `http://localhost:8888`)
+- `MEM0_API_KEY` set to the local `X-API-Key` value
 
 ## Setup
 
@@ -14,9 +24,23 @@ hermes memory setup    # select "mem0"
 ```
 
 Or manually:
+
 ```bash
 hermes config set memory.provider mem0
-echo "MEM0_API_KEY=your-key" >> ~/.hermes/.env
+```
+
+Platform mode:
+
+```bash
+echo "MEM0_API_KEY=your-platform-key" >> ~/.hermes/.env
+```
+
+Local REST mode:
+
+```bash
+echo "MEM0_BACKEND=local_rest" >> ~/.hermes/.env
+echo "MEM0_BASE_URL=http://localhost:8888" >> ~/.hermes/.env
+echo "MEM0_API_KEY=your-local-x-api-key" >> ~/.hermes/.env
 ```
 
 ## Config
@@ -25,14 +49,29 @@ Config file: `$HERMES_HOME/mem0.json`
 
 | Key | Default | Description |
 |-----|---------|-------------|
+| `backend` | `platform` | `platform` or `local_rest` |
+| `base_url` | `http://localhost:8888` | Local REST URL when `backend=local_rest` |
 | `user_id` | `hermes-user` | User identifier on Mem0 |
 | `agent_id` | `hermes` | Agent identifier |
-| `rerank` | `true` | Enable reranking for recall |
+| `rerank` | `true` | Enable reranking for platform recall. Ignored by `local_rest` because the self-hosted REST API does not consistently expose a rerank parameter. |
+
+## Local REST endpoint mapping
+
+When `backend=local_rest`, Hermes calls:
+
+| Hermes action | REST call |
+|---------------|-----------|
+| `mem0_profile` | `GET /memories?user_id=...` |
+| `mem0_search` and prefetch | `POST /search` with `query`, `filters`, and `top_k` |
+| `mem0_conclude` | `POST /memories` with `messages`, `user_id`, `agent_id`, and `infer=false` |
+| turn sync | `POST /memories` with the user and assistant messages |
+
+Local REST requests authenticate with the `X-API-Key` header.
 
 ## Tools
 
 | Tool | Description |
 |------|-------------|
 | `mem0_profile` | All stored memories about the user |
-| `mem0_search` | Semantic search with optional reranking |
+| `mem0_search` | Semantic search with optional reranking in platform mode |
 | `mem0_conclude` | Store a fact verbatim (no LLM extraction) |

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -1,12 +1,14 @@
 """Mem0 memory plugin — MemoryProvider interface.
 
 Server-side LLM fact extraction, semantic search with reranking, and
-automatic deduplication via the Mem0 Platform API.
+automatic deduplication via the Mem0 Platform API or a self-hosted Mem0 REST API.
 
 Original PR #2933 by kartik-mem0, adapted to MemoryProvider ABC.
 
 Config via environment variables:
-  MEM0_API_KEY       — Mem0 Platform API key (required)
+  MEM0_BACKEND       — platform or local_rest (default: platform)
+  MEM0_API_KEY       — Mem0 Platform API key, or local X-API-Key when local_rest
+  MEM0_BASE_URL      — local REST base URL when local_rest (default: http://localhost:8888)
   MEM0_USER_ID       — User identifier (default: hermes-user)
   MEM0_AGENT_ID      — Agent identifier (default: hermes)
 
@@ -20,6 +22,9 @@ import logging
 import os
 import threading
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
 from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
@@ -47,7 +52,9 @@ def _load_config() -> dict:
     from hermes_constants import get_hermes_home
 
     config = {
+        "backend": os.environ.get("MEM0_BACKEND", "platform"),
         "api_key": os.environ.get("MEM0_API_KEY", ""),
+        "base_url": os.environ.get("MEM0_BASE_URL", "http://localhost:8888"),
         "user_id": os.environ.get("MEM0_USER_ID", "hermes-user"),
         "agent_id": os.environ.get("MEM0_AGENT_ID", "hermes"),
         "rerank": True,
@@ -117,13 +124,15 @@ CONCLUDE_SCHEMA = {
 # ---------------------------------------------------------------------------
 
 class Mem0MemoryProvider(MemoryProvider):
-    """Mem0 Platform memory with server-side extraction and semantic search."""
+    """Mem0 memory using either the Platform SDK or self-hosted REST API."""
 
     def __init__(self):
         self._config = None
         self._client = None
         self._client_lock = threading.Lock()
         self._api_key = ""
+        self._backend = "platform"
+        self._base_url = "http://localhost:8888"
         self._user_id = "hermes-user"
         self._agent_id = "hermes"
         self._rerank = True
@@ -160,14 +169,48 @@ class Mem0MemoryProvider(MemoryProvider):
 
     def get_config_schema(self):
         return [
-            {"key": "api_key", "description": "Mem0 Platform API key", "secret": True, "required": True, "env_var": "MEM0_API_KEY", "url": "https://app.mem0.ai"},
+            {"key": "backend", "description": "Mem0 backend", "default": "platform", "choices": ["platform", "local_rest"]},
+            {"key": "api_key", "description": "Mem0 API key / local X-API-Key", "secret": True, "required": True, "env_var": "MEM0_API_KEY", "url": "https://app.mem0.ai"},
+            {"key": "base_url", "description": "Local REST base URL", "default": "http://localhost:8888", "when": {"backend": "local_rest"}, "env_var": "MEM0_BASE_URL"},
             {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
             {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
             {"key": "rerank", "description": "Enable reranking for recall", "default": "true", "choices": ["true", "false"]},
         ]
 
+    def _local_headers(self) -> Dict[str, str]:
+        """Build headers for the self-hosted REST API without logging secrets."""
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["X-API-Key"] = self._api_key
+        return headers
+
+    def _local_request(self, method: str, path: str, body: dict | None = None, query: dict | None = None) -> Any:
+        """Call the local self-hosted Mem0 REST API.
+
+        Hermes' original mem0 plugin uses the cloud SDK.  A local Mem0 server exposes
+        compatible operations over HTTP instead, so this adapter keeps persistent
+        memory local while preserving the MemoryProvider interface.
+        """
+        url = f"{self._base_url.rstrip('/')}{path}"
+        clean_query = {k: v for k, v in (query or {}).items() if v is not None}
+        if clean_query:
+            url += "?" + urllib.parse.urlencode(clean_query)
+        data = None if body is None else json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(url, data=data, headers=self._local_headers(), method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                raw = resp.read().decode("utf-8")
+                return json.loads(raw) if raw else {"ok": True}
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"Local Mem0 HTTP {exc.code}: {detail}") from exc
+        except Exception as exc:
+            raise RuntimeError(f"Local Mem0 request failed: {exc}") from exc
+
     def _get_client(self):
         """Thread-safe client accessor with lazy initialization."""
+        if self._backend == "local_rest":
+            return None
         with self._client_lock:
             if self._client is not None:
                 return self._client
@@ -204,6 +247,8 @@ class Mem0MemoryProvider(MemoryProvider):
     def initialize(self, session_id: str, **kwargs) -> None:
         self._config = _load_config()
         self._api_key = self._config.get("api_key", "")
+        self._backend = self._config.get("backend", "platform")
+        self._base_url = self._config.get("base_url", "http://localhost:8888")
         # Prefer gateway-provided user_id for per-user memory scoping;
         # fall back to config/env default for CLI (single-user) sessions.
         self._user_id = kwargs.get("user_id") or self._config.get("user_id", "hermes-user")
@@ -251,13 +296,24 @@ class Mem0MemoryProvider(MemoryProvider):
 
         def _run():
             try:
-                client = self._get_client()
-                results = self._unwrap_results(client.search(
-                    query=query,
-                    filters=self._read_filters(),
-                    rerank=self._rerank,
-                    top_k=5,
-                ))
+                if self._backend == "local_rest":
+                    results = self._unwrap_results(self._local_request(
+                        "POST",
+                        "/search",
+                        {
+                            "query": query,
+                            "filters": self._read_filters(),
+                            "top_k": 5,
+                        },
+                    ))
+                else:
+                    client = self._get_client()
+                    results = self._unwrap_results(client.search(
+                        query=query,
+                        filters=self._read_filters(),
+                        rerank=self._rerank,
+                        top_k=5,
+                    ))
                 if results:
                     lines = [r.get("memory", "") for r in results if r.get("memory")]
                     with self._prefetch_lock:
@@ -277,12 +333,19 @@ class Mem0MemoryProvider(MemoryProvider):
 
         def _sync():
             try:
-                client = self._get_client()
                 messages = [
                     {"role": "user", "content": user_content},
                     {"role": "assistant", "content": assistant_content},
                 ]
-                client.add(messages, **self._write_filters())
+                if self._backend == "local_rest":
+                    self._local_request(
+                        "POST",
+                        "/memories",
+                        {"messages": messages, **self._write_filters()},
+                    )
+                else:
+                    client = self._get_client()
+                    client.add(messages, **self._write_filters())
                 self._record_success()
             except Exception as e:
                 self._record_failure()
@@ -311,7 +374,14 @@ class Mem0MemoryProvider(MemoryProvider):
 
         if tool_name == "mem0_profile":
             try:
-                memories = self._unwrap_results(client.get_all(filters=self._read_filters()))
+                if self._backend == "local_rest":
+                    memories = self._unwrap_results(self._local_request(
+                        "GET",
+                        "/memories",
+                        query=self._read_filters(),
+                    ))
+                else:
+                    memories = self._unwrap_results(client.get_all(filters=self._read_filters()))
                 self._record_success()
                 if not memories:
                     return json.dumps({"result": "No memories stored yet."})
@@ -328,12 +398,23 @@ class Mem0MemoryProvider(MemoryProvider):
             rerank = args.get("rerank", False)
             top_k = min(int(args.get("top_k", 10)), 50)
             try:
-                results = self._unwrap_results(client.search(
-                    query=query,
-                    filters=self._read_filters(),
-                    rerank=rerank,
-                    top_k=top_k,
-                ))
+                if self._backend == "local_rest":
+                    results = self._unwrap_results(self._local_request(
+                        "POST",
+                        "/search",
+                        {
+                            "query": query,
+                            "filters": self._read_filters(),
+                            "top_k": top_k,
+                        },
+                    ))
+                else:
+                    results = self._unwrap_results(client.search(
+                        query=query,
+                        filters=self._read_filters(),
+                        rerank=rerank,
+                        top_k=top_k,
+                    ))
                 self._record_success()
                 if not results:
                     return json.dumps({"result": "No relevant memories found."})
@@ -348,11 +429,22 @@ class Mem0MemoryProvider(MemoryProvider):
             if not conclusion:
                 return tool_error("Missing required parameter: conclusion")
             try:
-                client.add(
-                    [{"role": "user", "content": conclusion}],
-                    **self._write_filters(),
-                    infer=False,
-                )
+                if self._backend == "local_rest":
+                    self._local_request(
+                        "POST",
+                        "/memories",
+                        {
+                            "messages": [{"role": "user", "content": conclusion}],
+                            **self._write_filters(),
+                            "infer": False,
+                        },
+                    )
+                else:
+                    client.add(
+                        [{"role": "user", "content": conclusion}],
+                        **self._write_filters(),
+                        infer=False,
+                    )
                 self._record_success()
                 return json.dumps({"result": "Fact stored."})
             except Exception as e:

--- a/tests/plugins/memory/test_mem0_v2.py
+++ b/tests/plugins/memory/test_mem0_v2.py
@@ -12,6 +12,13 @@ import pytest
 from plugins.memory.mem0 import Mem0MemoryProvider
 
 
+@pytest.fixture(autouse=True)
+def clean_mem0_env(monkeypatch):
+    """Keep developer shell/profile Mem0 settings from changing unit-test mode."""
+    for key in ("MEM0_BACKEND", "MEM0_API_KEY", "MEM0_BASE_URL", "MEM0_USER_ID", "MEM0_AGENT_ID"):
+        monkeypatch.delenv(key, raising=False)
+
+
 class FakeClientV2:
     """Fake Mem0 client that returns v2-style dict responses and captures call kwargs."""
 
@@ -215,6 +222,134 @@ def test_save_config_sets_owner_only_permissions(tmp_path):
     assert config_file.exists()
     mode = stat.S_IMODE(config_file.stat().st_mode)
     assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
+
+
+class TestMem0LocalRest:
+    """Self-hosted Mem0 REST backend maps provider calls to HTTP-compatible requests."""
+
+    def _make_provider(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("MEM0_BACKEND", "local_rest")
+        monkeypatch.setenv("MEM0_API_KEY", "local-key")
+        monkeypatch.setenv("MEM0_BASE_URL", "http://localhost:8888/")
+        monkeypatch.setenv("MEM0_USER_ID", "u123")
+        monkeypatch.setenv("MEM0_AGENT_ID", "hermes")
+        provider = Mem0MemoryProvider()
+        provider.initialize("test-session")
+        calls = []
+
+        def fake_local_request(method, path, body=None, query=None):
+            calls.append({"method": method, "path": path, "body": body, "query": query})
+            if path == "/search":
+                return {"results": [{"memory": "local result", "score": 0.7}]}
+            if method == "GET" and path == "/memories":
+                return {"results": [{"memory": "profile memory"}]}
+            return {"ok": True}
+
+        monkeypatch.setattr(provider, "_local_request", fake_local_request)
+        return provider, calls
+
+    def test_initialize_reads_local_rest_config(self, monkeypatch, tmp_path):
+        provider, _ = self._make_provider(monkeypatch, tmp_path)
+
+        assert provider._backend == "local_rest"
+        assert provider._base_url == "http://localhost:8888/"
+        assert provider._user_id == "u123"
+        assert provider._agent_id == "hermes"
+
+    def test_local_rest_does_not_require_cloud_client(self, monkeypatch, tmp_path):
+        provider, _ = self._make_provider(monkeypatch, tmp_path)
+
+        assert provider._get_client() is None
+
+    def test_local_rest_search_posts_filters_body_without_rerank(self, monkeypatch, tmp_path):
+        provider, calls = self._make_provider(monkeypatch, tmp_path)
+
+        result = json.loads(provider.handle_tool_call(
+            "mem0_search", {"query": "hello", "top_k": 3, "rerank": True}
+        ))
+
+        assert result["count"] == 1
+        assert calls[-1] == {
+            "method": "POST",
+            "path": "/search",
+            "body": {"query": "hello", "filters": {"user_id": "u123"}, "top_k": 3},
+            "query": None,
+        }
+        assert "rerank" not in calls[-1]["body"]
+
+    def test_local_rest_profile_gets_memories_with_user_query(self, monkeypatch, tmp_path):
+        provider, calls = self._make_provider(monkeypatch, tmp_path)
+
+        result = json.loads(provider.handle_tool_call("mem0_profile", {}))
+
+        assert result["count"] == 1
+        assert "profile memory" in result["result"]
+        assert calls[-1] == {
+            "method": "GET",
+            "path": "/memories",
+            "body": None,
+            "query": {"user_id": "u123"},
+        }
+
+    def test_local_rest_conclude_posts_verbatim_memory(self, monkeypatch, tmp_path):
+        provider, calls = self._make_provider(monkeypatch, tmp_path)
+
+        result = json.loads(provider.handle_tool_call(
+            "mem0_conclude", {"conclusion": "user likes local memory"}
+        ))
+
+        assert result["result"] == "Fact stored."
+        assert calls[-1] == {
+            "method": "POST",
+            "path": "/memories",
+            "body": {
+                "messages": [{"role": "user", "content": "user likes local memory"}],
+                "user_id": "u123",
+                "agent_id": "hermes",
+                "infer": False,
+            },
+            "query": None,
+        }
+
+    def test_local_rest_prefetch_and_sync_turn_use_rest(self, monkeypatch, tmp_path):
+        provider, calls = self._make_provider(monkeypatch, tmp_path)
+
+        provider.queue_prefetch("hello")
+        provider._prefetch_thread.join(timeout=2)
+        assert "local result" in provider.prefetch("hello")
+
+        provider.sync_turn("user said this", "assistant replied", session_id="s1")
+        provider._sync_thread.join(timeout=2)
+
+        assert calls[0] == {
+            "method": "POST",
+            "path": "/search",
+            "body": {"query": "hello", "filters": {"user_id": "u123"}, "top_k": 5},
+            "query": None,
+        }
+        assert calls[1] == {
+            "method": "POST",
+            "path": "/memories",
+            "body": {
+                "messages": [
+                    {"role": "user", "content": "user said this"},
+                    {"role": "assistant", "content": "assistant replied"},
+                ],
+                "user_id": "u123",
+                "agent_id": "hermes",
+            },
+            "query": None,
+        }
+
+    def test_local_headers_use_x_api_key(self):
+        provider = Mem0MemoryProvider()
+        provider._api_key = "local-key"
+
+        assert provider._local_headers() == {
+            "Content-Type": "application/json",
+            "X-API-Key": "local-key",
+        }
 
 
 class TestMem0Defaults:


### PR DESCRIPTION
## Summary

Adds an optional `local_rest` backend to the Mem0 memory provider so Hermes can use a self-hosted Mem0 server through its REST API while preserving the existing Mem0 Platform SDK behavior as the default.

## Changes

- Keep `platform` as the default Mem0 backend.
- Add `MEM0_BACKEND=local_rest` and `MEM0_BASE_URL` configuration support.
- Map Hermes memory operations to self-hosted Mem0 REST endpoints:
  - `mem0_profile` -> `GET /memories?user_id=...`
  - `mem0_search` and prefetch -> `POST /search`
  - `mem0_conclude` -> `POST /memories` with `infer=false`
  - turn sync -> `POST /memories`
- Authenticate local REST requests with `X-API-Key`.
- Document local REST setup and endpoint mapping.
- Add unit tests for local REST behavior and default platform compatibility.

## Tests

- `python -m py_compile plugins/memory/mem0/__init__.py`
- `python -m pytest tests/plugins/memory/test_mem0_v2.py -q -o 'addopts='`
- `python -m pytest tests/plugins/memory -q -o 'addopts='`
