### PR TITLE
docs(usage): document reasoning tokens and cost status

### DIFF
--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -80,7 +80,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | Command | Description |
 |---------|-------------|
 | `/help` | Show this help message |
-| `/usage` | Show token usage, cost breakdown, session duration, and — when available from the active provider — an **Account limits** section with remaining quota / credits / plan usage pulled live from the provider's API. |
+| `/usage` | Show token usage, cache read/write tokens, reasoning tokens when reported by the provider, cost status/source, session duration, context-window state, and — when available from the active provider — an **Account limits** section with remaining quota / credits / plan usage pulled live from the provider's API. |
 | `/insights` | Show usage insights and analytics (last 30 days) |
 | `/platforms` (alias: `/gateway`) | Show gateway/messaging platform status |
 | `/paste` | Attach a clipboard image |
@@ -186,7 +186,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/topic [off\|help\|session-id]` | **Telegram DM only.** Manage user-managed multi-session topic mode. `/topic` enables it or shows status; `/topic off` disables it and clears bindings; `/topic help` shows usage; `/topic <session-id>` inside a topic restores a previous session. See [Multi-session DM mode](/docs/user-guide/messaging/telegram#multi-session-dm-mode-topic). |
 | `/title [name]` | Set or show the session title. |
 | `/resume [name]` | Resume a previously named session. |
-| `/usage` | Show token usage, estimated cost breakdown (input/output), context window state, session duration, and — when available from the active provider — an **Account limits** section with remaining quota / credits pulled live from the provider's API. |
+| `/usage` | Show token usage, cache read/write tokens, reasoning tokens when reported by the provider, cost status/source, context-window state, session duration, and — when available from the active provider — an **Account limits** section with remaining quota / credits pulled live from the provider's API. |
 | `/insights [days]` | Show usage analytics. |
 | `/reasoning [level\|show\|hide]` | Change reasoning effort or toggle reasoning display. |
 | `/voice [on\|off\|tts\|join\|channel\|leave\|status]` | Control spoken replies in chat. `join`/`channel`/`leave` manage Discord voice-channel mode. |

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -81,7 +81,16 @@ The bar adapts to terminal width — full layout at ≥ 76 columns, compact at 5
 | Orange | 80–95% | Approaching limit |
 | Red | ≥ 95% | Near overflow — consider `/compress` |
 
-Use `/usage` for a detailed breakdown including per-category costs (input vs output tokens).
+Use `/usage` for a detailed breakdown of the current session: input tokens, cache read/write tokens, output tokens, API calls, context-window state, cost status/source, and account limits when the active provider exposes them. When a provider reports reasoning tokens, Hermes shows them as a subset under output so you can see how much of the completion budget went to hidden reasoning.
+
+Cost status tells you how to read the dollar amount:
+
+| Status | Meaning |
+|--------|---------|
+| `actual` | The provider returned billed cost for the request. |
+| `estimated` | Hermes estimated cost from known model pricing and reported token counts. |
+| `included` | The active auth route is treated as subscription or plan-included usage. |
+| `unknown` | Hermes has token counts, but no reliable pricing entry for this route/model. |
 
 ### Session Resume Display
 

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -90,7 +90,7 @@ All slash commands work unchanged. A few are TUI-owned — they produce richer o
 | `/model` | Modal model picker grouped by provider, with cost hints |
 | `/skin` | Live preview — theme change applies as you browse |
 | `/details` | Toggle verbose tool-call details (global or per-section) |
-| `/usage` | Rich token / cost / context panel |
+| `/usage` | Rich token / cost / context panel, including cache read/write tokens, reasoning tokens when the provider reports them, and cost status/source |
 | `/agents` (alias `/tasks`) | Observability overlay — live subagent tree with kill/pause controls, per-branch cost / token / file rollups, turn-by-turn history |
 | `/reload` | Re-reads `~/.hermes/.env` into the running TUI process so newly added API keys take effect without a restart |
 | `/mouse` | Toggle mouse tracking on/off at runtime (also persists to `display.mouse_tracking` in `config.yaml`) |


### PR DESCRIPTION
## What does this PR do?

Documents the user-facing `/usage` output added by the analytics/token accounting work: reasoning-token reporting, cache token categories, and cost status/source semantics in the classic CLI, TUI guide, and slash-command reference.

## Related Issue

Follow-up to docs drift from `d87c7b99e` / #21455.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `website/docs/user-guide/cli.md` to describe `/usage` token categories, reasoning-token display, and `actual` / `estimated` / `included` / `unknown` cost statuses.
- Updated `website/docs/user-guide/tui.md` to reflect the richer TUI `/usage` panel.
- Updated `website/docs/reference/slash-commands.md` so CLI and gateway `/usage` references match current behavior.

## How to Test

1. Review the changed docs pages for accuracy against `cli.py` and `tui_gateway/server.py`.
2. Confirm `git diff --check` passes.
3. Docs-only change; no runtime tests run.

## Checklist

### Code

- [ ] I’ve read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn’t a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I’ve run `pytest tests/ -q` and all tests pass
- [ ] I’ve added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I’ve tested on my platform: N/A docs-only

### Documentation & Housekeeping

- [x] I’ve updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I’ve updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I’ve updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I’ve considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I’ve updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren’t already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I’ve tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

`git diff --check` passed.