### PR TITLE
fix(dashboard): prefix WebSocket URLs with HERMES_BASE_PATH

### DIFF
--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -30,6 +30,7 @@ import { Card } from "@/components/ui/card";
 import { ModelPickerDialog } from "@/components/ModelPickerDialog";
 import { ToolCall, type ToolEntry } from "@/components/ToolCall";
 import { GatewayClient, type ConnectionState } from "@/lib/gatewayClient";
+import { HERMES_BASE_PATH } from "@/lib/api";
 
 import { cn } from "@/lib/utils";
 import { AlertCircle, ChevronDown, RefreshCw } from "lucide-react";
@@ -160,7 +161,7 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
     const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
     const qs = new URLSearchParams({ token, channel });
     const ws = new WebSocket(
-      `${proto}//${window.location.host}/api/events?${qs.toString()}`,
+      `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/events?${qs.toString()}`,
     );
 
     // `unmounting` suppresses the banner during cleanup — `ws.close()`

--- a/web/src/lib/gatewayClient.ts
+++ b/web/src/lib/gatewayClient.ts
@@ -13,6 +13,8 @@
  *   await gw.request("prompt.submit", { session_id, text: "hi" })
  */
 
+import { HERMES_BASE_PATH } from "./api";
+
 export type GatewayEventName =
   | "gateway.ready"
   | "session.info"
@@ -117,7 +119,7 @@ export class GatewayClient {
 
     const scheme = location.protocol === "https:" ? "wss:" : "ws:";
     const ws = new WebSocket(
-      `${scheme}//${location.host}/api/ws?token=${encodeURIComponent(resolved)}`,
+      `${scheme}//${location.host}${HERMES_BASE_PATH}/api/ws?token=${encodeURIComponent(resolved)}`,
     );
     this.ws = ws;
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -33,7 +33,7 @@ import { useSearchParams } from "react-router-dom";
 import { ChatSidebar } from "@/components/ChatSidebar";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
-import { api } from "@/lib/api";
+import { api, HERMES_BASE_PATH } from "@/lib/api";
 import { PluginSlot } from "@/plugins";
 
 function buildWsUrl(
@@ -44,7 +44,7 @@ function buildWsUrl(
   const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
   const qs = new URLSearchParams({ token, channel });
   if (resume) qs.set("resume", resume);
-  return `${proto}//${window.location.host}/api/pty?${qs.toString()}`;
+  return `${proto}//${window.location.host}${HERMES_BASE_PATH}/api/pty?${qs.toString()}`;
 }
 
 // Channel id ties this chat tab's PTY child (publisher) to its sidebar


### PR DESCRIPTION
## What does this PR do?

Follow-up to #19450 ("feat(dashboard): support serving under URL prefix via X-Forwarded-Prefix"). That commit made HTTP fetches and asset URLs prefix-aware via `HERMES_BASE_PATH`, but missed the three WebSocket URL builders. They still hardcode `/api/...` instead of `${HERMES_BASE_PATH}/api/...`, so when the dashboard is served under a subpath (e.g. `/hermes/`), the Chat tab cannot connect.

User-visible symptom: every other tab (Sessions, Analytics, Models, Kanban, etc.) works fine, but the Chat tab shows a "RECONNECT" button and the model badge stays at `—`. The browser tries to open `wss://your-host/api/pty?...` (no `/hermes/` prefix), which the reverse proxy has no route for → handshake fails.

## Related Issue

No exact match. Adjacent: #18415 ("Dashboard chat websocket endpoints reject same-host reverse proxy deployments with `client_host_not_loopback`") — a different reverse-proxy bug in the same area, already closed.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Prepend `HERMES_BASE_PATH` (already exported from `web/src/lib/api.ts`) to each of the three WebSocket URL builders. At root the constant is `""` so root deployments see no behavior change; under a prefix, the WebSocket handshake hits the same `${prefix}/api/...` path the reverse proxy is already routing for HTTP requests.

- `web/src/pages/ChatPage.tsx` — `buildWsUrl()` for `/api/pty` (the PTY bridge that drives the xterm.js terminal). Expands existing `import { api } from "@/lib/api"` to also pull in `HERMES_BASE_PATH`.
- `web/src/components/ChatSidebar.tsx` — `/api/events` subscriber (sidebar tool-call feed). Adds new `import { HERMES_BASE_PATH } from "@/lib/api"`.
- `web/src/lib/gatewayClient.ts` — `/api/ws` JSON-RPC sidecar (model picker / slash commands). Adds new `import { HERMES_BASE_PATH } from "./api"`.

The diff hunks are all the same shape:

```diff
-`${proto}//${window.location.host}/api/pty?${qs}`
+`${proto}//${window.location.host}${HERMES_BASE_PATH}/api/pty?${qs}`
```

No backend changes. The FastAPI WebSocket handlers already accept the prefixed path because the reverse proxy strips the prefix before forwarding (e.g. `handle_path /hermes*` in Caddy), and `X-Forwarded-Prefix` is for the SPA's awareness, not the routing.

## How to Test

1. Build the SPA: `cd web && npm run build`
2. Run the dashboard bound to loopback: `hermes dashboard --port 9119 --host 127.0.0.1 --no-open --tui`
3. Reverse-proxy under a subpath, e.g. with Caddy:
   ```caddyfile
   handle_path /hermes* {
       reverse_proxy 127.0.0.1:9119 {
           header_up Host {upstream_hostport}
           header_up X-Forwarded-Prefix /hermes
       }
   }
   ```
   (`Host` rewrite is required to satisfy the dashboard's DNS-rebinding guard; not new.)
4. Open `https://your-host/hermes/chat`. Before this PR: "RECONNECT" button, model badge stays at `—`. After this PR: terminal connects, model badge populates, events sidebar streams tool calls.
5. Regression check: open the same dashboard bound to root (no prefix) — Chat tab still works exactly as before.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(dashboard): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (checked queries for "websocket prefix" and "HERMES_BASE_PATH")
- [x] My PR contains **only** changes related to this fix (3 frontend files, no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/ -q` (the area covering this change) — 3902 passed, 7 skipped, plus 10 pre-existing failures in unrelated suites (`test_cmd_update`, `test_kanban_boards`, `test_list_picker_providers`, `test_model_provider_persistence`, `test_model_switch_custom_providers`, `test_model_validation`, `test_update_yes_flag`) that don't touch web / dashboard / WebSockets. The dashboard test file `test_web_server.py` passes (137 tests).
- [ ] I've added tests for my changes — N/A: this is a frontend-only TS change to URL string construction, and `web/` doesn't currently have a JS unit-test harness. The behavior is verified end-to-end manually (see "How to Test"). Happy to add a Python integration test that builds a fake `index.html`+SPA bundle and asserts the WS URLs include the prefix, if maintainers prefer.
- [x] I've tested on my platform: Arch Linux x86_64, Caddy 2 reverse proxy, Tailscale serve fronting it, dashboard accessed from desktop Firefox + iOS Safari.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no user-facing docs change. The original prefix-support PR #19450 already documented the pattern.
- [x] I've updated `cli-config.yaml.example` — N/A, no config keys added or changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A, no architecture or workflow change.
- [x] I've considered cross-platform impact — N/A, all changes are in browser-side TypeScript that runs identically across platforms.
- [x] I've updated tool descriptions/schemas — N/A, no tool changes.

## Screenshots / Logs

Before — Chat tab on `/hermes/chat`:

> "RECONNECT" button visible, model badge `—` (disabled).
> Browser network tab shows: `wss://host/api/pty?token=…` → 502 (no proxy route).

After — same URL with this PR:

> No RECONNECT, model badge shows e.g. `claude-opus-4-7`, terminal accepts input, events sidebar streams `tool.start` / `tool.complete` frames.
> Browser network tab shows: `wss://host/hermes/api/pty?token=…` → 101 Switching Protocols.
