### PR TITLE
docs(mcp): document image content results

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/references/native-mcp.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/native-mcp.md
@@ -119,6 +119,12 @@ Examples:
 
 After discovery, MCP tools are automatically injected into all `hermes-*` platform toolsets (CLI, Discord, Telegram, etc.). This means MCP tools are available in every conversation without any additional configuration.
 
+### Image Results
+
+MCP tools can return `ImageContent` blocks, for example screenshots from browser automation servers or rendered panels from visualization tools. Hermes caches valid image blocks in the shared image cache and surfaces them in the tool result as `MEDIA:<path>` tags, so the agent can inspect the image or include it in a final response on platforms that support native media delivery.
+
+Malformed base64, non-image MIME types, and payloads that fail image validation are logged and dropped without failing the whole tool call. Text and structured content from the same result still come through.
+
 ### Connection Lifecycle
 
 - Each server runs as a long-lived asyncio Task in a background daemon thread
@@ -338,7 +344,7 @@ Disable sampling for untrusted servers with `sampling: { enabled: false }`.
 ## Notes
 
 - MCP tools are called synchronously from the agent's perspective but run asynchronously on a dedicated background event loop
-- Tool results are returned as JSON with either `{"result": "..."}` or `{"error": "..."}`
+- Tool results are returned as JSON with either `{"result": "..."}` or `{"error": "..."}`; image content blocks are exposed inside successful results as `MEDIA:<path>` tags
 - The native MCP client is independent of `mcporter` -- you can use both simultaneously
 - Server connections are persistent and shared across all conversations in the same agent process
 - Adding or removing servers requires restarting the agent (no hot-reload currently)

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -362,6 +362,14 @@ Examples:
 
 In practice, you usually do not need to call the prefixed name manually — Hermes sees the tool and chooses it during normal reasoning.
 
+## Tool results with images
+
+MCP tool calls can return image content blocks as well as text. This is common with browser, Playwright, Puppeteer, Blockbench, Grafana, and other visual MCP servers that return screenshots or rendered panels.
+
+When an MCP tool returns a valid image block, Hermes decodes the image, validates that the bytes look like an image, caches it in the shared Hermes image cache, and adds a `MEDIA:<path>` tag to the tool result. That gives the agent a local file handle it can inspect with vision tools or include in the final response on platforms that support native media delivery.
+
+Malformed base64, non-image MIME types, or payloads that claim to be images but fail validation are logged and dropped from the result instead of failing the entire MCP tool call. Any text or structured content from the same tool result still comes through.
+
 ## MCP utility tools
 
 When supported, Hermes also registers utility tools around MCP resources and prompts:


### PR DESCRIPTION
## What does this PR do?

Documents current MCP image-result behavior from `c8e3e3918` / #21328. MCP tools can now surface valid `ImageContent` blocks as cached `MEDIA:<path>` tags instead of losing image-only results.

## Related Issue

Follow-up to docs drift from `c8e3e3918` / #21328.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added an MCP guide section explaining image content blocks, cached `MEDIA:<path>` results, validation, and graceful drop behavior for invalid payloads.
- Updated the bundled native-MCP skill source with the same image-result behavior.
- Updated the generated bundled-skill docs page so the website matches the source skill.

## How to Test

1. Review the changed docs against `tools/mcp_tool.py` image-content handling.
2. Confirm `git diff --check` passes.
3. Docs-only change; no runtime tests run.

## Checklist

### Code

- [ ] I’ve read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn’t a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I’ve run `pytest tests/ -q` and all tests pass
- [ ] I’ve added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I’ve tested on my platform: N/A docs-only

### Documentation & Housekeeping

- [x] I’ve updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I’ve updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I’ve updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I’ve considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I’ve updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren’t already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I’ve tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

`git diff --check` passed.