### PR TITLE
docs(mcp): document OAuth metadata state files

### DIFF
--- a/website/docs/getting-started/nix-setup.md
+++ b/website/docs/getting-started/nix-setup.md
@@ -466,7 +466,7 @@ Set `auth = "oauth"` for servers using OAuth 2.1. Hermes implements the full PKC
 }
 ```
 
-Tokens are stored in `$HERMES_HOME/mcp-tokens/<server-name>.json` and persist across restarts and rebuilds.
+OAuth state is stored under `$HERMES_HOME/mcp-tokens/` and persists across restarts and rebuilds. Each OAuth server can have up to three files: `<server-name>.json` for tokens, `<server-name>.client.json` for client registration, and `<server-name>.meta.json` for discovered OAuth server metadata.
 
 <details>
 <summary><strong>Initial OAuth authorization on headless servers</strong></summary>
@@ -491,7 +491,7 @@ The container uses `--network=host`, so the OAuth callback listener on `127.0.0.
 
 ```bash
 hermes mcp add my-oauth-server --url https://mcp.example.com/mcp --auth oauth
-scp ~/.hermes/mcp-tokens/my-oauth-server{,.client}.json \
+scp ~/.hermes/mcp-tokens/my-oauth-server{,.client,.meta}.json \
     server:/var/lib/hermes/.hermes/mcp-tokens/
 # Ensure: chown hermes:hermes, chmod 0600
 ```

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -242,6 +242,8 @@ mcp_servers:
 Behavior:
 - Hermes uses the MCP SDK's OAuth 2.1 PKCE flow (metadata discovery, dynamic client registration, token exchange, and refresh)
 - On first connect, a browser window opens for authorization
-- Tokens are persisted to `~/.hermes/mcp-tokens/<server>.json` and reused across sessions
+- OAuth state is persisted under `~/.hermes/mcp-tokens/` and reused across sessions: `<server>.json` for tokens, `<server>.client.json` for client registration, and `<server>.meta.json` for discovered OAuth server metadata such as the token endpoint
 - Token refresh is automatic; re-authorization only happens when refresh fails
 - Only applies to HTTP/StreamableHTTP transport (`url`-based servers)
+
+If you pre-seed OAuth state on another machine, copy all three files for that server. Missing metadata is recoverable, but keeping `<server>.meta.json` avoids a cold-start discovery/refresh path that can otherwise fall back to the wrong token endpoint on some providers.


### PR DESCRIPTION
## What does this PR do?

Updates MCP OAuth docs for the current persisted state layout after `c4a799231` / #21226. OAuth state now includes token, client registration, and discovered server metadata files under `~/.hermes/mcp-tokens/`.

## Related Issue

Follow-up to docs drift from `c4a799231` / #21226.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `website/docs/reference/mcp-config-reference.md` to document `<server>.json`, `<server>.client.json`, and `<server>.meta.json`.
- Added guidance to copy all three OAuth state files when pre-seeding another machine.
- Updated the Nix/headless setup example to copy `<server>.meta.json` alongside the token and client files.

## How to Test

1. Review the docs against `tools/mcp_oauth.py` and `tools/mcp_oauth_manager.py`.
2. Confirm `git diff --check` passes.
3. Docs-only change; no runtime tests run.

## Checklist

### Code

- [ ] I’ve read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn’t a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I’ve run `pytest tests/ -q` and all tests pass
- [ ] I’ve added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I’ve tested on my platform: N/A docs-only

### Documentation & Housekeeping

- [x] I’ve updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I’ve updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I’ve updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I’ve considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I’ve updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren’t already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I’ve tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

`git diff --check` passed.