### PR TITLE
 [codex] Fix Gemini CLI provider ACP handling

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -310,7 +310,7 @@ class _ACPChatNamespace:
 
 
 class CopilotACPClient:
-    """Minimal OpenAI-client-compatible facade for Copilot ACP."""
+    """Minimal OpenAI-client-compatible facade for ACP subprocesses."""
 
     def __init__(
         self,
@@ -323,10 +323,19 @@ class CopilotACPClient:
         acp_cwd: str | None = None,
         command: str | None = None,
         args: list[str] | None = None,
+        provider_label: str | None = None,
+        default_model: str | None = None,
+        install_hint: str | None = None,
         **_: Any,
     ):
         self.api_key = api_key or "copilot-acp"
         self.base_url = base_url or ACP_MARKER_BASE_URL
+        self._provider_label = provider_label or "Copilot ACP"
+        self._default_model = default_model or "copilot-acp"
+        self._install_hint = (
+            install_hint
+            or "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+        )
         self._default_headers = dict(default_headers or {})
         self._acp_command = acp_command or command or _resolve_command()
         self._acp_args = list(acp_args or args or _resolve_args())
@@ -410,7 +419,7 @@ class CopilotACPClient:
         return SimpleNamespace(
             choices=[choice],
             usage=usage,
-            model=model or "copilot-acp",
+            model=model or self._default_model,
         )
 
     def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
@@ -425,15 +434,15 @@ class CopilotACPClient:
                 cwd=self._acp_cwd,
                 env=_build_subprocess_env(),
             )
-        except FileNotFoundError as exc:
+        except (FileNotFoundError, PermissionError, OSError) as exc:
             raise RuntimeError(
-                f"Could not start Copilot ACP command '{self._acp_command}'. "
-                "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH."
+                f"Could not start {self._provider_label} command '{self._acp_command}'. "
+                f"{self._install_hint}"
             ) from exc
 
         if proc.stdin is None or proc.stdout is None:
             proc.kill()
-            raise RuntimeError("Copilot ACP process did not expose stdin/stdout pipes.")
+            raise RuntimeError(f"{self._provider_label} process did not expose stdin/stdout pipes.")
 
         self.is_closed = False
         with self._active_process_lock:
@@ -500,14 +509,14 @@ class CopilotACPClient:
                 if "error" in msg:
                     err = msg.get("error") or {}
                     raise RuntimeError(
-                        f"Copilot ACP {method} failed: {err.get('message') or err}"
+                        f"{self._provider_label} {method} failed: {err.get('message') or err}"
                     )
                 return msg.get("result")
 
             stderr_text = "\n".join(stderr_tail).strip()
             if proc.poll() is not None and stderr_text:
-                raise RuntimeError(f"Copilot ACP process exited early: {stderr_text}")
-            raise TimeoutError(f"Timed out waiting for Copilot ACP response to {method}.")
+                raise RuntimeError(f"{self._provider_label} process exited early: {stderr_text}")
+            raise TimeoutError(f"Timed out waiting for {self._provider_label} response to {method}.")
 
         try:
             _request(
@@ -536,7 +545,7 @@ class CopilotACPClient:
             ) or {}
             session_id = str(session.get("sessionId") or "").strip()
             if not session_id:
-                raise RuntimeError("Copilot ACP did not return a sessionId.")
+                raise RuntimeError(f"{self._provider_label} did not return a sessionId.")
 
             text_parts: list[str] = []
             reasoning_parts: list[str] = []

--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -146,12 +146,22 @@ def _build_gemini_contents(
             system_text_parts.append(_coerce_content_to_text(msg.get("content")))
             continue
 
-        # Tool result message — emit a user-role turn with functionResponse
+        # Tool result message — Gemini requires all tool responses for a single
+        # assistant turn to be grouped into one 'user' role turn.
         if role == "tool" or role == "function":
-            contents.append({
-                "role": "user",
-                "parts": [_translate_tool_result_to_gemini(msg)],
-            })
+            part = _translate_tool_result_to_gemini(msg)
+            last_turn_is_tool_response = (
+                contents
+                and contents[-1]["role"] == "user"
+                and any("functionResponse" in p for p in contents[-1]["parts"])
+            )
+            if last_turn_is_tool_response:
+                contents[-1]["parts"].append(part)
+            else:
+                contents.append({
+                    "role": "user",
+                    "parts": [part],
+                })
             continue
 
         gemini_role = _ROLE_MAP_OPENAI_TO_GEMINI.get(role, "user")
@@ -450,9 +460,11 @@ def _make_stream_chunk(
     finish_reason: Optional[str] = None,
     reasoning: str = "",
 ) -> _GeminiStreamChunk:
-    delta_kwargs: Dict[str, Any] = {"role": "assistant"}
-    if content:
-        delta_kwargs["content"] = content
+    delta_kwargs: Dict[str, Any] = {
+        "role": "assistant",
+        "content": content or None,
+        "tool_calls": None,
+    }
     if tool_call_delta is not None:
         delta_kwargs["tool_calls"] = [SimpleNamespace(
             index=tool_call_delta.get("index", 0),

--- a/run_agent.py
+++ b/run_agent.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 import os
 import random
 import re
+import shutil
 import ssl
 import sys
 import tempfile
@@ -5543,6 +5544,16 @@ class AIAgent:
         return False
 
     @staticmethod
+    def _is_acp_client(client: Any) -> bool:
+        """Return True for local ACP subprocess clients.
+
+        ACP clients expose an OpenAI-compatible chat surface, but they return
+        concrete response objects rather than SSE iterators.
+        """
+        base_url = str(getattr(client, "base_url", "") or "").lower()
+        return base_url.startswith("acp://") or base_url.startswith("acp+tcp://")
+
+    @staticmethod
     def _build_keepalive_http_client(base_url: str = "") -> Any:
         try:
             import httpx as _httpx
@@ -5592,6 +5603,48 @@ class AIAgent:
             )
             return client
         if self.provider == "google-gemini-cli" or str(client_kwargs.get("base_url", "")).startswith("cloudcode-pa://"):
+            _use_gemini_acp = str(os.getenv("HERMES_GEMINI_CLI_ACP", "0")).strip().lower()
+            _default_gemini_cmd = os.path.expanduser("~/.bun/bin/gemini")
+            _default_gemini_cmd = (
+                _default_gemini_cmd
+                if os.path.isfile(_default_gemini_cmd) and os.access(_default_gemini_cmd, os.X_OK)
+                else ""
+            )
+            _gemini_cmd = (
+                os.getenv("HERMES_GEMINI_CLI_COMMAND", "").strip()
+                or _default_gemini_cmd
+                or shutil.which("gemini")
+                or ""
+            )
+            if _use_gemini_acp in {"1", "true", "yes", "on"} and _gemini_cmd:
+                from agent.copilot_acp_client import CopilotACPClient
+
+                _gemini_args = ["--acp"]
+                _gemini_model = str(self.model or "").strip()
+                if _gemini_model:
+                    _gemini_args.extend(["-m", _gemini_model])
+                client = CopilotACPClient(
+                    api_key=client_kwargs.get("api_key") or "gemini-cli-acp",
+                    base_url="acp://gemini-cli",
+                    command=_gemini_cmd,
+                    args=_gemini_args,
+                    acp_cwd=os.getenv("TERMINAL_CWD") or os.getcwd(),
+                    default_headers=client_kwargs.get("default_headers"),
+                    provider_label="Gemini CLI ACP",
+                    default_model="gemini-cli-acp",
+                    install_hint=(
+                        "Install Gemini CLI or set HERMES_GEMINI_CLI_COMMAND to an executable path."
+                    ),
+                )
+                logger.info(
+                    "Gemini CLI ACP client created (%s, shared=%s, command=%s) %s",
+                    reason,
+                    shared,
+                    _gemini_cmd,
+                    self._client_log_context(),
+                )
+                return client
+
             from agent.gemini_cloudcode_adapter import GeminiCloudCodeClient
 
             # Strip OpenAI-specific kwargs the Gemini client doesn't accept
@@ -11376,14 +11429,13 @@ class AIAgent:
                     # session instead of re-failing every retry.
                     if getattr(self, "_disable_streaming", False):
                         _use_streaming = False
-                    # CopilotACPClient communicates via subprocess stdio and
-                    # returns a plain SimpleNamespace — not an iterable
-                    # stream.  Mirror the ACP exclusion used for Responses
-                    # API upgrade (lines ~1083-1085).
+                    # ACP clients communicate via subprocess stdio and return
+                    # a plain SimpleNamespace — not an iterable stream.
                     elif (
                         self.provider == "copilot-acp"
                         or str(self.base_url or "").lower().startswith("acp://copilot")
                         or str(self.base_url or "").lower().startswith("acp+tcp://")
+                        or self._is_acp_client(getattr(self, "client", None))
                     ):
                         _use_streaming = False
                     elif not self._has_stream_consumers():

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -205,3 +205,25 @@ def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
 
     assert "env" in captured["kwargs"]
     assert captured["kwargs"]["env"]["HOME"]
+
+
+def test_acp_client_allows_provider_specific_label_and_default_model(tmp_path):
+    client = CopilotACPClient(
+        api_key="gemini-cli-acp",
+        base_url="acp://gemini-cli",
+        command="gemini",
+        args=["--acp"],
+        acp_cwd=str(tmp_path),
+        provider_label="Gemini CLI ACP",
+        default_model="gemini-cli-acp",
+        install_hint="Install Gemini CLI.",
+    )
+
+    with _patch.object(client, "_run_prompt", return_value=("hello", "")):
+        response = client.chat.completions.create(messages=[{"role": "user", "content": "hi"}])
+
+    assert response.model == "gemini-cli-acp"
+
+    with _patch("agent.copilot_acp_client.subprocess.Popen", side_effect=FileNotFoundError("missing")):
+        with pytest.raises(RuntimeError, match="Could not start Gemini CLI ACP command"):
+            client._run_prompt("hello", timeout_seconds=1)

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -875,6 +875,7 @@ class TestTranslateStreamEvent:
         indices = [c.choices[0].delta.tool_calls[0].index for c in chunks]
         assert indices == [0, 1, 2]
         assert counter[0] == 3
+        assert chunks[0].choices[0].delta.content is None
 
     def test_counter_persists_across_events(self):
         """Index assignment must continue across SSE events in the same stream."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4124,6 +4124,164 @@ def test_aiagent_uses_copilot_acp_client():
     assert mock_acp_client.call_args.kwargs["args"] == ["--acp", "--stdio"]
 
 
+def test_google_gemini_cli_prefers_local_gemini_acp(monkeypatch):
+    monkeypatch.setenv("HERMES_GEMINI_CLI_ACP", "1")
+    monkeypatch.setenv("TERMINAL_CWD", "/tmp")
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI") as mock_openai,
+        patch("run_agent.os.path.isfile", return_value=False),
+        patch("run_agent.os.access", return_value=False),
+        patch("run_agent.shutil.which", return_value="/usr/local/bin/gemini"),
+        patch("agent.copilot_acp_client.CopilotACPClient") as mock_acp_client,
+        patch("agent.gemini_cloudcode_adapter.GeminiCloudCodeClient") as mock_cloudcode,
+    ):
+        acp_client = MagicMock()
+        mock_acp_client.return_value = acp_client
+
+        agent = AIAgent(
+            api_key="google-oauth",
+            base_url="cloudcode-pa://google",
+            provider="google-gemini-cli",
+            model="gemini-3-flash-preview",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.client is acp_client
+    mock_openai.assert_not_called()
+    mock_cloudcode.assert_not_called()
+    mock_acp_client.assert_called_once()
+    assert mock_acp_client.call_args.kwargs["base_url"] == "acp://gemini-cli"
+    assert mock_acp_client.call_args.kwargs["command"] == "/usr/local/bin/gemini"
+    assert mock_acp_client.call_args.kwargs["args"] == [
+        "--acp",
+        "-m",
+        "gemini-3-flash-preview",
+    ]
+    assert mock_acp_client.call_args.kwargs["acp_cwd"] == "/tmp"
+    assert mock_acp_client.call_args.kwargs["provider_label"] == "Gemini CLI ACP"
+    assert mock_acp_client.call_args.kwargs["default_model"] == "gemini-cli-acp"
+
+
+def test_google_gemini_cli_uses_cloudcode_by_default(monkeypatch):
+    monkeypatch.delenv("HERMES_GEMINI_CLI_ACP", raising=False)
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI") as mock_openai,
+        patch("run_agent.os.path.isfile", return_value=False),
+        patch("run_agent.os.access", return_value=False),
+        patch("run_agent.shutil.which", return_value="/usr/local/bin/gemini"),
+        patch("agent.copilot_acp_client.CopilotACPClient") as mock_acp_client,
+        patch("agent.gemini_cloudcode_adapter.GeminiCloudCodeClient") as mock_cloudcode,
+    ):
+        cloud_client = MagicMock()
+        mock_cloudcode.return_value = cloud_client
+
+        agent = AIAgent(
+            api_key="google-oauth",
+            base_url="cloudcode-pa://google",
+            provider="google-gemini-cli",
+            model="gemini-3-flash-preview",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.client is cloud_client
+    mock_openai.assert_not_called()
+    mock_acp_client.assert_not_called()
+    mock_cloudcode.assert_called_once()
+
+
+def test_google_gemini_cli_can_disable_local_acp(monkeypatch):
+    monkeypatch.setenv("HERMES_GEMINI_CLI_ACP", "0")
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI") as mock_openai,
+        patch("run_agent.os.path.isfile", return_value=False),
+        patch("run_agent.os.access", return_value=False),
+        patch("run_agent.shutil.which", return_value="/usr/local/bin/gemini"),
+        patch("agent.copilot_acp_client.CopilotACPClient") as mock_acp_client,
+        patch("agent.gemini_cloudcode_adapter.GeminiCloudCodeClient") as mock_cloudcode,
+    ):
+        cloud_client = MagicMock()
+        mock_cloudcode.return_value = cloud_client
+
+        agent = AIAgent(
+            api_key="google-oauth",
+            base_url="cloudcode-pa://google",
+            provider="google-gemini-cli",
+            model="gemini-3-flash-preview",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.client is cloud_client
+    mock_openai.assert_not_called()
+    mock_acp_client.assert_not_called()
+    mock_cloudcode.assert_called_once()
+
+
+def test_google_gemini_cli_prefers_bun_gemini_path(monkeypatch):
+    monkeypatch.setenv("HERMES_GEMINI_CLI_ACP", "1")
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent.os.path.isfile", return_value=True),
+        patch("run_agent.os.access", return_value=True),
+        patch("run_agent.shutil.which", return_value="/usr/local/bin/gemini"),
+        patch("agent.copilot_acp_client.CopilotACPClient") as mock_acp_client,
+    ):
+        AIAgent(
+            api_key="google-oauth",
+            base_url="cloudcode-pa://google",
+            provider="google-gemini-cli",
+            model="gemini-3-flash-preview",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert mock_acp_client.call_args.kwargs["command"].endswith("/.bun/bin/gemini")
+
+
+def test_google_gemini_cli_falls_back_to_path_for_npm_install(monkeypatch):
+    monkeypatch.setenv("HERMES_GEMINI_CLI_ACP", "1")
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent.os.path.isfile", return_value=True),
+        patch("run_agent.os.access", return_value=False),
+        patch("run_agent.shutil.which", return_value="/usr/local/bin/gemini"),
+        patch("agent.copilot_acp_client.CopilotACPClient") as mock_acp_client,
+    ):
+        AIAgent(
+            api_key="google-oauth",
+            base_url="cloudcode-pa://google",
+            provider="google-gemini-cli",
+            model="gemini-3-flash-preview",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert mock_acp_client.call_args.kwargs["command"] == "/usr/local/bin/gemini"
+
+
+def test_acp_client_detection_covers_gemini_cli():
+    assert AIAgent._is_acp_client(SimpleNamespace(base_url="acp://gemini-cli")) is True
+    assert AIAgent._is_acp_client(SimpleNamespace(base_url="acp+tcp://127.0.0.1:1234")) is True
+    assert AIAgent._is_acp_client(SimpleNamespace(base_url="cloudcode-pa://google")) is False
+
+
 def test_quiet_spinner_allowed_with_explicit_print_fn(agent):
     agent._print_fn = lambda *_a, **_kw: None
     with patch.object(run_agent.sys.stdout, "isatty", return_value=False):

--- a/website/docs/guides/google-gemini.md
+++ b/website/docs/guides/google-gemini.md
@@ -111,6 +111,21 @@ hermes model
 
 This uses browser PKCE login and the Cloud Code Assist backend. It can be useful for users who want Gemini CLI-style OAuth, but Hermes shows an explicit warning because Google may treat use of the Gemini CLI OAuth client from third-party software as a policy violation. For production or lowest-risk usage, prefer the API-key provider above.
 
+By default, `google-gemini-cli` talks to Cloud Code Assist directly. If you want Hermes to spawn a local Gemini CLI ACP subprocess instead, install Gemini CLI and opt in explicitly. The official Gemini CLI install path is npm:
+
+```bash
+npm install -g @google/gemini-cli
+```
+
+```bash
+HERMES_GEMINI_CLI_ACP=1 hermes chat \
+  --provider google-gemini-cli \
+  --model gemini-3.1-pro-preview \
+  -q "Hello from Gemini ACP"
+```
+
+Hermes resolves Gemini CLI in this order: `HERMES_GEMINI_CLI_COMMAND`, executable `~/.bun/bin/gemini` for Bun installs, then `gemini` on `PATH` for npm and other installs.
+
 ## Available Models
 
 The `hermes model` picker shows Gemini models maintained in Hermes' provider registry. Common choices include:

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -61,6 +61,8 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `HERMES_GEMINI_CLIENT_ID` | OAuth client ID for `google-gemini-cli` PKCE login (optional; defaults to Google's public gemini-cli client) |
 | `HERMES_GEMINI_CLIENT_SECRET` | OAuth client secret for `google-gemini-cli` (optional) |
 | `HERMES_GEMINI_PROJECT_ID` | GCP project ID for paid Gemini tiers (free tier auto-provisions) |
+| `HERMES_GEMINI_CLI_ACP` | Set to `1`, `true`, `yes`, or `on` to make `google-gemini-cli` spawn local Gemini CLI in ACP mode instead of using Cloud Code Assist directly |
+| `HERMES_GEMINI_CLI_COMMAND` | Executable path for Gemini CLI ACP mode; if unset, Hermes tries executable `~/.bun/bin/gemini` for Bun installs, then `gemini` on `PATH` for npm and other installs |
 | `ANTHROPIC_API_KEY` | Anthropic Console API key ([console.anthropic.com](https://console.anthropic.com/)) |
 | `ANTHROPIC_TOKEN` | Manual or legacy Anthropic OAuth/setup-token override |
 | `DASHSCOPE_API_KEY` | Alibaba Cloud DashScope API key for Qwen models ([modelstudio.console.alibabacloud.com](https://modelstudio.console.alibabacloud.com/)) |


### PR DESCRIPTION
 ## What does this PR do?

  Fixes `google-gemini-cli` provider handling around Gemini CLI ACP and streaming.

  The default `google-gemini-cli` path remains Cloud Code Assist, so users are not silently routed through a local Gemini CLI subprocess just because
  `gemini` is installed. Local Gemini CLI ACP is now explicit via `HERMES_GEMINI_CLI_ACP=1`.

  This also fixes a live-chat crash where Gemini streaming deltas could omit `content`, while Hermes expected OpenAI-like delta objects with stable
  `content` / `tool_calls` attributes.

  ## Related Issue

  No issue filed.

  Fixes #

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [x] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - `run_agent.py`
    - keep `google-gemini-cli` on Cloud Code Assist by default
    - add opt-in Gemini CLI ACP mode via `HERMES_GEMINI_CLI_ACP=1`
    - resolve Gemini CLI from `HERMES_GEMINI_CLI_COMMAND`, executable `~/.bun/bin/gemini`, then `gemini` on `PATH`
    - disable streaming for ACP subprocess clients

  - `agent/gemini_cloudcode_adapter.py`
    - group consecutive Gemini function responses into one user turn
    - make stream deltas expose stable `content` and `tool_calls` attributes

  - `agent/copilot_acp_client.py`
    - generalize ACP labels/default model names so Gemini ACP errors do not say Copilot

  - `tests/run_agent/test_run_agent.py`
    - add coverage for Gemini ACP opt-in/default behavior and CLI resolution

  - `tests/agent/test_gemini_cloudcode.py`
    - add stream delta shape regression coverage

  - `tests/agent/test_copilot_acp_client.py`
    - add provider-specific ACP label/default model coverage

  - `website/docs/guides/google-gemini.md`
    - document official npm install, Bun path support, and Gemini ACP opt-in

  - `website/docs/reference/environment-variables.md`
    - document `HERMES_GEMINI_CLI_ACP` and `HERMES_GEMINI_CLI_COMMAND`

  ## How to Test

  1. Run focused Gemini provider and stream tests:

     ```bash
     pytest tests/agent/test_gemini_cloudcode.py -k "stream or provider_registry or runtime_provider or determine_api_mode or auth_status"

  2. Run focused run-agent Gemini/ACP tests:

     pytest tests/run_agent/test_run_agent.py -k "gemini_cli or acp_client_detection or aiagent_uses_copilot_acp"

  3. Run ACP client tests:

     pytest tests/agent/test_copilot_acp_client.py

  4. Optional live smoke test, with Gemini OAuth already configured:

     hermes chat --provider google-gemini-cli --model gemini-3.1-pro-preview --ignore-rules -Q -q 'Reply with exactly: gemini live ok'

     Expected output:

     gemini live ok

  ## Checklist

  ### Code

  - [ ] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [ ] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
  - [ ] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
  - [ ] I've run pytest tests/ -q and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Ubuntu/Linux

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
  - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
  - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
    (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A



