### PR TITLE
docs(gateway): document progress cleanup setting

### DIFF
--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1167,6 +1167,7 @@ This controls both the `text_to_speech` tool and spoken replies in voice mode (`
 display:
   tool_progress: all      # off | new | all | verbose
   tool_progress_command: false  # Enable /verbose slash command in messaging gateway
+  cleanup_progress: false # Gateway: delete temporary progress/status bubbles after successful final delivery
   platforms: {}           # Per-platform display overrides (see below)
   tool_progress_overrides: {}  # DEPRECATED — use display.platforms instead
   interim_assistant_messages: true  # Gateway: send natural mid-turn assistant updates as separate messages
@@ -1205,6 +1206,22 @@ display:
 
 In the CLI, cycle through these modes with `/verbose`. To use `/verbose` in messaging platforms (Telegram, Discord, Slack, etc.), set `tool_progress_command: true` in the `display` section above. The command will then cycle the mode and save to config.
 
+### Progress cleanup (gateway only)
+
+When `display.cleanup_progress: true`, Hermes keeps live progress visible during long gateway turns, then deletes temporary progress/status bubbles after the final response is delivered successfully. This covers tool-progress bubbles, long-running "Still working..." notices, and context-pressure status messages.
+
+Cleanup is best-effort and only works on adapters that support message deletion. Today that mainly means Telegram. Failed runs skip cleanup so the progress bubbles remain as breadcrumbs for debugging.
+
+You can set this globally or per platform:
+
+```yaml
+display:
+  cleanup_progress: false
+  platforms:
+    telegram:
+      cleanup_progress: true
+```
+
 ### Runtime-metadata footer (gateway only)
 
 When `display.runtime_metadata_footer: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn — same info the CLI shows in its status bar (model, session duration, tokens, cost). Off by default; opt in per-gateway if your team wants every reply to include the provenance.
@@ -1234,6 +1251,7 @@ display:
       tool_progress: 'off'    # silence progress on Signal
     telegram:
       tool_progress: verbose  # detailed progress on Telegram
+      cleanup_progress: true  # delete temporary progress/status bubbles after success
     slack:
       tool_progress: 'off'    # quiet in shared Slack workspace
 ```


### PR DESCRIPTION
## What does this PR do?

Documents the gateway `display.cleanup_progress` setting added by `bf843adf0` / #21186. The setting keeps live progress visible during a turn and then deletes temporary progress/status bubbles after successful final delivery on platforms that support deletion.

## Related Issue

Follow-up to docs drift from `bf843adf0` / #21186.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `display.cleanup_progress` to the display settings example.
- Documented global and per-platform cleanup configuration.
- Explained current behavior: best-effort deletion on adapters that support it, primarily Telegram, and failed runs leave progress breadcrumbs in place.

## How to Test

1. Review the docs against `gateway/display_config.py` and the cleanup path in `gateway/run.py`.
2. Confirm `git diff --check` passes.
3. Docs-only change; no runtime tests run.

## Checklist

### Code

- [ ] I’ve read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn’t a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I’ve run `pytest tests/ -q` and all tests pass
- [ ] I’ve added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I’ve tested on my platform: N/A docs-only

### Documentation & Housekeeping

- [x] I’ve updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I’ve updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I’ve updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I’ve considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I’ve updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren’t already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I’ve tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

`git diff --check` passed.