### PR TITLE
feat: add Discord ops webhook routing support

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -35,6 +35,7 @@ import base64
 import binascii
 import hashlib
 import hmac
+import ipaddress
 import json
 import logging
 import re
@@ -104,6 +105,67 @@ def _is_loopback_host(host: str) -> bool:
     if not host:
         return False
     return host.strip().lower() in _LOOPBACK_HOSTS
+
+
+def _normalize_ip_literal(value: str) -> str:
+    """Extract a bare IP literal from forwarded/peer address header values."""
+    value = value.strip().strip('"')
+    if not value:
+        return ""
+    if value.startswith("["):
+        end = value.find("]")
+        if end != -1:
+            return value[1:end]
+    if value.count(":") == 1 and value.rsplit(":", 1)[1].isdigit():
+        return value.rsplit(":", 1)[0]
+    return value
+
+
+def _is_trusted_static_token_source(value: str) -> bool:
+    """Return true for source IPs that are suitable for static-token auth."""
+    literal = _normalize_ip_literal(value)
+    if not literal:
+        return False
+    try:
+        ip = ipaddress.ip_address(literal)
+    except ValueError:
+        return False
+    return ip.is_loopback or ip.is_private or ip.is_link_local
+
+
+def _static_token_request_sources(request: Any) -> list[str]:
+    """Return client/proxy source addresses relevant to static-token auth.
+
+    Static bearer tokens are intentionally weaker than HMAC signatures. When
+    a reverse proxy forwards a public request to a loopback-bound Hermes
+    gateway, `request.remote` alone looks safe. Include common forwarding
+    headers and require every visible hop to be private/link-local/loopback so
+    a public client cannot be laundered through a local proxy.
+    """
+    sources: list[str] = []
+
+    forwarded_for = request.headers.get("X-Forwarded-For", "")
+    if forwarded_for:
+        sources.extend(part.strip() for part in forwarded_for.split(",") if part.strip())
+
+    forwarded = request.headers.get("Forwarded", "")
+    if forwarded:
+        for entry in forwarded.split(","):
+            for part in entry.split(";"):
+                key, sep, header_value = part.strip().partition("=")
+                if sep and key.lower() == "for":
+                    sources.append(header_value.strip())
+
+    if request.remote:
+        sources.append(request.remote)
+
+    return sources
+
+
+def _is_trusted_static_token_request(request: Any) -> bool:
+    """True when a static token arrived only from trusted local/LAN sources."""
+    sources = _static_token_request_sources(request)
+    return bool(sources) and all(_is_trusted_static_token_source(src) for src in sources)
 
 
 def check_webhook_requirements() -> bool:
@@ -989,10 +1051,22 @@ class WebhookAdapter(BasePlatformAdapter):
         auth = request.headers.get("Authorization", "")
         prefix = "Bearer "
         if auth.startswith(prefix):
+            if not _is_trusted_static_token_request(request):
+                logger.warning(
+                    "[webhook] Static bearer token rejected for untrusted source(s): %s",
+                    _static_token_request_sources(request),
+                )
+                return False
             return hmac.compare_digest(auth[len(prefix) :], secret)
 
         token = request.headers.get("X-Webhook-Token", "")
         if token:
+            if not _is_trusted_static_token_request(request):
+                logger.warning(
+                    "[webhook] Static X-Webhook-Token rejected for untrusted source(s): %s",
+                    _static_token_request_sources(request),
+                )
+                return False
             return hmac.compare_digest(token, secret)
 
         return self._validate_signature(request, body, secret)

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -215,6 +215,7 @@ class WebhookAdapter(BasePlatformAdapter):
         # Content-Length and would otherwise bypass the header check below.
         app = web.Application(client_max_size=self._max_body_bytes)
         app.router.add_get("/health", self._handle_health)
+        app.router.add_get("/ready", self._handle_ready)
         app.router.add_post("/webhooks/{route_name}", self._handle_webhook)
         # Multi-profile multiplexing: a /p/<profile>/webhooks/<route> prefix
         # routes the inbound event to that profile. Same handler; the profile is
@@ -373,6 +374,83 @@ class WebhookAdapter(BasePlatformAdapter):
         """GET /health — simple health check."""
         return web.json_response({"status": "ok", "platform": "webhook"})
 
+    async def _handle_ready(self, request: "web.Request") -> "web.Response":
+        """GET /ready — readiness check for direct delivery routes."""
+        self._reload_dynamic_routes()
+        payload = self._build_readiness_payload()
+        status = 200 if payload["status"] == "ready" else 503
+        return web.json_response(payload, status=status)
+
+    def _build_readiness_payload(self) -> dict:
+        """Return readiness for deliver_only routes that depend on delivery targets."""
+        routes: dict[str, dict[str, Any]] = {}
+        required_targets: dict[str, dict[str, Any]] = {}
+
+        for route_name, route in self._routes.items():
+            if not route.get("deliver_only"):
+                continue
+
+            deliver = str(route.get("deliver") or "log")
+            route_status = "ready"
+            route_reason = "ok"
+            target_ready = True
+
+            if deliver in {"", "log"}:
+                target_ready = False
+                route_reason = "deliver_only route has no delivery target"
+            elif deliver == "github_comment":
+                target_ready = True
+                route_reason = "github_comment uses gh CLI at delivery time"
+            else:
+                try:
+                    target_platform = Platform(deliver)
+                except ValueError:
+                    target_ready = False
+                    route_reason = f"unknown delivery platform: {deliver}"
+                else:
+                    target_adapter = None
+                    if self.gateway_runner:
+                        target_adapter = self.gateway_runner.adapters.get(target_platform)
+                    if target_adapter is None:
+                        target_ready = False
+                        route_reason = f"platform {deliver} not connected"
+                    elif getattr(target_adapter, "has_fatal_error", False):
+                        target_ready = False
+                        route_reason = f"platform {deliver} fatal error"
+                    elif not getattr(target_adapter, "_running", False):
+                        target_ready = False
+                        route_reason = f"platform {deliver} not running"
+                    else:
+                        route_reason = "ok"
+
+            if not target_ready:
+                route_status = "not_ready"
+
+            routes[route_name] = {
+                "status": route_status,
+                "deliver": deliver,
+                "reason": route_reason,
+            }
+
+            target = required_targets.setdefault(
+                deliver,
+                {"status": "ready", "routes": [], "reason": "ok"},
+            )
+            target["routes"].append(route_name)
+            if not target_ready:
+                target["status"] = "not_ready"
+                target["reason"] = route_reason
+
+        overall_ready = all(
+            route["status"] == "ready" for route in routes.values()
+        )
+        return {
+            "status": "ready" if overall_ready else "not_ready",
+            "platform": "webhook",
+            "routes": routes,
+            "targets": required_targets,
+        }
+
     def _reload_dynamic_routes(self) -> None:
         """Reload agent-created subscriptions from disk if the file changed."""
         from hermes_constants import get_hermes_home
@@ -517,8 +595,10 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"error": "Payload too large"}, status=413
             )
 
-        # Validate HMAC signature FIRST (skip only for the explicit local-test
-        # INSECURE_NO_AUTH mode). Missing/empty secrets must fail closed here,
+        # Validate configured auth FIRST (skip only for the explicit local-test
+        # INSECURE_NO_AUTH mode). HMAC-SHA256 is the preferred mode; a static
+        # bearer token is accepted for producers that cannot compute HMACs
+        # (see _validate_auth). Missing/empty secrets must fail closed here,
         # not only during connect(), so direct handler reuse cannot turn a
         # network webhook route into an unauthenticated agent-dispatch surface.
         secret = route_config.get("secret", self._global_secret)
@@ -532,9 +612,9 @@ class WebhookAdapter(BasePlatformAdapter):
                 status=403,
             )
         if secret != _INSECURE_NO_AUTH:
-            if not self._validate_signature(request, raw_body, secret):
+            if not self._validate_auth(request, raw_body, secret):
                 logger.warning(
-                    "[webhook] Invalid signature for route %s", route_name
+                    "[webhook] Invalid auth for route %s", route_name
                 )
                 return web.json_response(
                     {"error": "Invalid signature"}, status=401
@@ -622,11 +702,15 @@ class WebhookAdapter(BasePlatformAdapter):
                 )
             payload = transformed_payload or payload
 
-        # Format prompt from template
-        prompt_template = route_config.get("prompt", "")
-        prompt = self._render_prompt(
-            prompt_template, payload, event_type, route_name
-        )
+        # Format prompt from a deterministic formatter or template.
+        formatter = route_config.get("formatter", "")
+        if formatter == "alert_event":
+            prompt = self._format_alert_event(payload, route_name)
+        else:
+            prompt_template = route_config.get("prompt", "")
+            prompt = self._render_prompt(
+                prompt_template, payload, event_type, route_name
+            )
 
         # Inject skill content if configured.
         # We call build_skill_invocation_message() directly rather than
@@ -892,6 +976,27 @@ class WebhookAdapter(BasePlatformAdapter):
     # Signature validation
     # ------------------------------------------------------------------
 
+    def _validate_auth(
+        self, request: "web.Request", body: bytes, secret: str
+    ) -> bool:
+        """Validate webhook auth.
+
+        Preferred mode is HMAC-SHA256 signatures. Some producers, including
+        Proxmox Backup Server native webhook targets, can template static
+        headers but cannot compute HMACs; for those, accept a static bearer
+        token over trusted LAN paths.
+        """
+        auth = request.headers.get("Authorization", "")
+        prefix = "Bearer "
+        if auth.startswith(prefix):
+            return hmac.compare_digest(auth[len(prefix) :], secret)
+
+        token = request.headers.get("X-Webhook-Token", "")
+        if token:
+            return hmac.compare_digest(token, secret)
+
+        return self._validate_signature(request, body, secret)
+
     def _validate_signature(
         self, request: "web.Request", body: bytes, secret: str
     ) -> bool:
@@ -1100,6 +1205,83 @@ class WebhookAdapter(BasePlatformAdapter):
             return str(value)
 
         return re.sub(r"\{([a-zA-Z0-9_.]+)\}", _resolve, template)
+
+    def _format_alert_event(self, payload: dict, route_name: str) -> str:
+        """Format a structured operational alert event for chat delivery.
+
+        This is deterministic and zero-LLM, but more readable than raw JSON
+        template dumps.  It expects the lightweight alert schema used by
+        Hermes-owned ops routes: source/kind/severity/state/summary/details.
+        Unknown detail keys are still surfaced compactly instead of hidden.
+        """
+        source = str(payload.get("source") or route_name or "unknown")
+        kind = str(payload.get("kind") or "event")
+        severity = str(payload.get("severity") or "info").lower()
+        state = str(payload.get("state") or "event").lower()
+        summary = str(payload.get("summary") or kind.replace("_", " ").title())
+        host = payload.get("host")
+        details = payload.get("details")
+        if not isinstance(details, dict):
+            details = {}
+
+        icon = {
+            "critical": "🚨",
+            "error": "🚨",
+            "warning": "⚠️",
+            "warn": "⚠️",
+            "digest": "🟢",
+            "summary": "🟢",
+            "info": "ℹ️",
+            "ok": "✅",
+        }.get(severity, "ℹ️")
+        if state in {"recovered", "resolved", "ok"}:
+            icon = "✅"
+        elif state == "firing" and severity not in {"critical", "error"}:
+            icon = "⚠️"
+
+        def _inline(value: Any, limit: int = 300) -> str:
+            if isinstance(value, (dict, list)):
+                text = json.dumps(value, separators=(",", ":"))
+            else:
+                text = str(value)
+            return text.replace("`", "ʼ")[:limit]
+
+        meta_parts = [f"source: `{_inline(source, 120)}`"]
+        if host:
+            meta_parts.append(f"host: `{_inline(host, 120)}`")
+        if state and state != "summary":
+            meta_parts.append(f"state: `{_inline(state, 80)}`")
+        if kind:
+            meta_parts.append(f"kind: `{_inline(kind, 120)}`")
+
+        lines = [f"{icon} **{_inline(summary, 240)}**", " · ".join(meta_parts)]
+
+        preferred_keys = [
+            "target_ip",
+            "checked_at",
+            "since",
+            "recovered",
+            "downtime_since",
+            "fails",
+            "threshold",
+            "note",
+        ]
+        detail_parts: list[str] = []
+        seen: set[str] = set()
+        for key in preferred_keys:
+            if key in details and details[key] not in (None, ""):
+                detail_parts.append(f"{key}: `{_inline(details[key])}`")
+                seen.add(key)
+        for key in sorted(details):
+            if key in seen or details[key] in (None, ""):
+                continue
+            value = details[key]
+            detail_parts.append(f"{key}: `{_inline(value)}`")
+
+        if detail_parts:
+            lines.append(" · ".join(detail_parts[:8]))
+
+        return "\n".join(lines)
 
     def _render_delivery_extra(
         self, extra: dict, payload: dict

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1828,7 +1828,7 @@ def _cmd_claim(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
-        workspace = kb.resolve_workspace(task)
+        workspace = kb.resolve_workspace(task, conn=conn)
         kb.set_workspace_path(conn, task.id, str(workspace))
     print(f"Claimed {task.id}")
     print(f"Workspace: {workspace}")

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -584,6 +584,15 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_unblock.add_argument("task_ids", nargs="+")
 
+    p_approve_deploy = sub.add_parser(
+        "approve-deploy",
+        help="Record attended approval for a deploy card (REQ-048) so its worker may apply",
+    )
+    p_approve_deploy.add_argument("task_ids", nargs="+")
+    p_approve_deploy.add_argument(
+        "--approver", default=None, help="Approver name (default: your profile)"
+    )
+
     p_promote = sub.add_parser(
         "promote",
         help="Manually move one or more todo/blocked tasks to ready (recovery path)",
@@ -956,6 +965,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "block":    _cmd_block,
             "schedule": _cmd_schedule,
             "unblock":  _cmd_unblock,
+            "approve-deploy": _cmd_approve_deploy,
             "promote":  _cmd_promote,
             "archive":  _cmd_archive,
             "tail":     _cmd_tail,
@@ -2014,6 +2024,23 @@ def _cmd_unblock(args: argparse.Namespace) -> int:
                 print(f"cannot unblock {tid} (not blocked/scheduled?)", file=sys.stderr)
             else:
                 print(f"Unblocked {tid}" + (f": {reason}" if reason else ""))
+    return 0 if not failed else 1
+
+
+def _cmd_approve_deploy(args: argparse.Namespace) -> int:
+    ids = list(args.task_ids or [])
+    if not ids:
+        print("at least one task_id is required", file=sys.stderr)
+        return 1
+    approver = getattr(args, "approver", None) or _profile_author()
+    failed: list[str] = []
+    with kb.connect_closing() as conn:
+        for tid in ids:
+            if kb.approve_deploy(conn, tid, approver=approver):
+                print(f"Approved deploy {tid} (approver: {approver})")
+            else:
+                failed.append(tid)
+                print(f"cannot approve {tid} (unknown task?)", file=sys.stderr)
     return 0 if not failed else 1
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8694,25 +8694,32 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
             )
             if spec.get("dry_run"):
                 lines.append(f"    1. dry-run:  {spec['dry_run']}")
-            lines.append(
-                "    2. APPROVAL GATE: after a clean dry-run, if no "
-                "`deploy_approved` event is recorded on this card, STOP and block "
-                "needs_input ('awaiting deploy approval') — do NOT apply. The "
-                "operator runs `hermes kanban approve-deploy <id>`, which releases "
-                "you to continue."
-            )
-            if spec.get("apply"):
-                lines.append(f"    3. apply:    {spec['apply']}")
-            if spec.get("verify"):
-                lines.append(f"    4. verify:   {spec['verify']}")
-            if spec.get("rollback"):
+            if not approved:
+                # REQ-049 mechanical apply-gate: the apply / verify / rollback
+                # commands are WITHHELD from the brief until a deploy_approved
+                # event exists. The worker is not handed the apply command
+                # pre-approval — it cannot run a command it was never given.
                 lines.append(
-                    f"    5. ON VERIFY FAILURE, roll back: {spec['rollback']} "
-                    "— then block for a human. Never leave a failed deploy applied."
+                    "    2. APPROVAL GATE — NOT yet approved. After a clean "
+                    "dry-run, STOP and block needs_input ('awaiting deploy "
+                    "approval'). The apply / verify / rollback commands are "
+                    "WITHHELD until an operator runs `hermes kanban approve-deploy "
+                    f"{task.id}` — they are deliberately not shown here and you do "
+                    "NOT have them yet, so you cannot and must not deploy. On "
+                    "approval you are re-dispatched with the remaining steps."
                 )
-            lines.append(
-                f"    approval recorded: {'YES — you may apply' if approved else 'NO — stop at the gate'}"
-            )
+            else:
+                lines.append("    2. APPROVAL GATE — approved ✓, proceed:")
+                if spec.get("apply"):
+                    lines.append(f"    3. apply:    {spec['apply']}")
+                if spec.get("verify"):
+                    lines.append(f"    4. verify:   {spec['verify']}")
+                if spec.get("rollback"):
+                    lines.append(
+                        f"    5. ON VERIFY FAILURE, roll back: {spec['rollback']} "
+                        "— then block for a human. Never leave a failed deploy "
+                        "applied."
+                    )
     lines.append("")
 
     if task.body and task.body.strip():

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -965,6 +965,10 @@ class Task:
     # None when unclassified. Compared to the project's autonomy_ceiling at the
     # dispatch gate; None is treated as the repo-only floor (never a deploy).
     risk_tier: Optional[str] = None
+    # REQ-045: denormalised project autonomy_ceiling (VALID_AUTONOMY_CEILINGS) or
+    # None = repo-only default. Snapshot at create; the gate compares it to
+    # risk_tier without a projects.db lookup.
+    autonomy_ceiling: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1051,6 +1055,11 @@ class Task:
             ),
             risk_tier=(
                 row["risk_tier"] if "risk_tier" in keys and row["risk_tier"] else None
+            ),
+            autonomy_ceiling=(
+                row["autonomy_ceiling"]
+                if "autonomy_ceiling" in keys and row["autonomy_ceiling"]
+                else None
             ),
         )
 
@@ -1236,7 +1245,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- gate — never a deploy). Compared against the card's project
     -- autonomy_ceiling: a card whose tier exceeds the ceiling is never
     -- spawned-to-execute (routed to a human instead).
-    risk_tier            TEXT
+    risk_tier            TEXT,
+    -- REQ-045: denormalised snapshot of the card's project autonomy_ceiling at
+    -- create time (VALID_AUTONOMY_CEILINGS, or NULL = repo-only default). Read
+    -- together with risk_tier at the dispatch gate so the cross-profile
+    -- dispatcher never needs projects.db access.
+    autonomy_ceiling     TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2076,6 +2090,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # (never a deploy) — the same conservative default a pre-column board had.
         _add_column_if_missing(conn, "tasks", "risk_tier", "risk_tier TEXT")
 
+    if "autonomy_ceiling" not in cols:
+        # REQ-045: denormalised project autonomy ceiling. NULL on legacy rows =
+        # repo-only default at the gate (no autonomous deploy without opt-in).
+        _add_column_if_missing(
+            conn, "tasks", "autonomy_ceiling", "autonomy_ceiling TEXT"
+        )
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -2498,6 +2519,7 @@ def create_task(
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     risk_tier: Optional[str] = None,
+    autonomy_ceiling: Optional[str] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2540,6 +2562,13 @@ def create_task(
         raise ValueError(
             f"risk_tier must be one of {sorted(VALID_RISK_TIERS)}, got {risk_tier!r}"
         )
+    if autonomy_ceiling is not None:
+        autonomy_ceiling = str(autonomy_ceiling).strip() or None
+    if autonomy_ceiling is not None and autonomy_ceiling not in VALID_AUTONOMY_CEILINGS:
+        raise ValueError(
+            "autonomy_ceiling must be one of "
+            f"{sorted(VALID_AUTONOMY_CEILINGS)}, got {autonomy_ceiling!r}"
+        )
     if branch_name is not None:
         branch_name = str(branch_name).strip() or None
     if branch_name and workspace_kind != "worktree":
@@ -2575,6 +2604,11 @@ def create_task(
             # Canonicalise (a slug may have been passed) and anchor the
             # worktree under the project's primary repo.
             project_id = project_obj.id
+            # REQ-045: denormalise the project's autonomy ceiling onto the card so
+            # the dispatch gate enforces it without cross-profile projects.db
+            # access. An explicit autonomy_ceiling arg (rare) wins.
+            if autonomy_ceiling is None:
+                autonomy_ceiling = getattr(project_obj, "autonomy_ceiling", None)
             if workspace_kind == "scratch" and project_obj.primary_path:
                 workspace_kind = "worktree"
             if (
@@ -2749,8 +2783,8 @@ def create_task(
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
                         skills, max_retries, goal_mode, goal_max_turns, session_id,
-                        risk_tier
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        risk_tier, autonomy_ceiling
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2774,6 +2808,7 @@ def create_task(
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
                         risk_tier,
+                        autonomy_ceiling,
                     ),
                 )
                 for pid in parents:
@@ -6110,6 +6145,15 @@ class DispatchResult:
     DB writes this tick — the lock holder is making progress on the same
     board. This is the steady-state signal that a single-writer guard is
     actively preventing two dispatchers from racing on ``kanban.db``."""
+    skipped_ceiling: list[str] = field(default_factory=list)
+    """REQ-046 (decision 0007): ready task ids NOT spawned because their
+    ``risk_tier`` exceeds their project's ``autonomy_ceiling`` — routed to
+    blocked-for-human (plan-only). This is the deployment-safety enforcement: a
+    Tier-C card (wanctl/work-ansible) or a deploy card on a repo whose ceiling
+    doesn't permit that tier lands here instead of executing."""
+    autonomy_paused: bool = False
+    """REQ-046: True when the global kill-switch halted spawning this tick.
+    Reclaim/promote housekeeping still ran; no new workers were launched."""
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -7379,6 +7423,71 @@ def dispatch_once(
         )
 
 
+def _autonomy_pause_file() -> Path:
+    """Path to the global autonomy kill-switch sentinel (REQ-046).
+
+    Lives at the shared kanban root so it halts the WHOLE board, not one
+    profile. ``touch``-ing it pauses all spawning; ``rm``-ing it resumes.
+    Overridable via ``HERMES_AUTONOMY_PAUSE_FILE`` (used by tests).
+    """
+    override = os.environ.get("HERMES_AUTONOMY_PAUSE_FILE", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return kanban_home() / "AUTONOMY_PAUSED"
+
+
+def _autonomy_is_paused() -> bool:
+    """REQ-046 global kill-switch. Paused when ``HERMES_AUTONOMY_PAUSED`` is
+    truthy OR the sentinel file exists. A FS error resolving the sentinel is
+    treated as NOT paused for that check (the env var is the reliable override),
+    so a transient hiccup can't wedge the dispatcher.
+    """
+    if os.environ.get("HERMES_AUTONOMY_PAUSED", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        return True
+    try:
+        return _autonomy_pause_file().exists()
+    except Exception:
+        return False
+
+
+def _block_over_ceiling(
+    conn: sqlite3.Connection,
+    task_id: str,
+    risk_tier: Optional[str],
+    ceiling: Optional[str],
+) -> None:
+    """REQ-046: route a ready card whose risk tier exceeds its project ceiling to
+    ``blocked`` for a human (plan-only), with an auditable event — never execute
+    it. ``block_kind='needs_input'`` keeps it out of the auto-dispatch path (it
+    needs a human decision, not a retry).
+    """
+    with write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='blocked', block_kind='needs_input', "
+            "claim_lock=NULL, claim_expires=NULL "
+            "WHERE id=? AND status='ready'",
+            (task_id,),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "skipped_autonomy_ceiling",
+            {
+                "risk_tier": risk_tier,
+                "autonomy_ceiling": ceiling or DEFAULT_AUTONOMY_CEILING,
+                "reason": (
+                    "risk tier exceeds the project autonomy ceiling; "
+                    "routed to a human (plan-only, not executed)"
+                ),
+            },
+        )
+
+
 def _dispatch_once_locked(
     conn: sqlite3.Connection,
     *,
@@ -7450,6 +7559,13 @@ def _dispatch_once_locked(
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
+    # REQ-046: global kill-switch. When autonomy is paused, still reclaim/promote
+    # above (safety housekeeping keeps running) but spawn NOTHING new this tick —
+    # the emergency brake for deployment autonomy.
+    if _autonomy_is_paused():
+        result.autonomy_paused = True
+        return result
+
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full
     # rationale; the short version is that a 60-second tick interval with a
@@ -7466,7 +7582,7 @@ def _dispatch_once_locked(
         )
 
     ready_rows = conn.execute(
-        "SELECT id, assignee FROM tasks "
+        "SELECT id, assignee, risk_tier, autonomy_ceiling FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
@@ -7524,6 +7640,20 @@ def _dispatch_once_locked(
     for row in ready_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
+        # REQ-046: autonomy-ceiling gate. A card whose deploy tier exceeds its
+        # project's ceiling is never spawned-to-execute — routed to blocked-for-
+        # human (plan-only). Applied BEFORE assignment so an over-ceiling card
+        # can't dispatch regardless of who it is routed to. inspect/repo-only
+        # work under the default ceiling passes untouched; a deploy-C card
+        # (wanctl/work-ansible) never passes any ceiling.
+        _rk = row.keys()
+        _risk = row["risk_tier"] if "risk_tier" in _rk else None
+        _ceil = row["autonomy_ceiling"] if "autonomy_ceiling" in _rk else None
+        if not tier_permitted_by_ceiling(_risk, _ceil):
+            if not dry_run:
+                _block_over_ceiling(conn, row["id"], _risk, _ceil)
+            result.skipped_ceiling.append(row["id"])
+            continue
         row_assignee = row["assignee"]
         if not row_assignee:
             # Honour kanban.default_assignee: when the dispatcher hits an

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4322,12 +4322,32 @@ def complete_task(
     else:
         verified_cards = []
 
+    # REQ-047 (decision 0007): risk-gated completion. A deploy / live-mutation
+    # card does NOT auto-close — it parks in `review` for human sign-off unless
+    # an attended-approval was recorded (a `deploy_approved` event, emitted when
+    # a human approves the apply per REQ-048). Docs/tests/repo-only/inspect cards
+    # auto-complete on gate-green exactly as before. One transition path: only
+    # the target status differs.
+    _rt_row = conn.execute(
+        "SELECT risk_tier FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    _risk_tier = _rt_row["risk_tier"] if _rt_row else None
+    _hold_for_review = False
+    if _risk_tier in ("deploy-A", "deploy-B", "deploy-C"):
+        _approved = conn.execute(
+            "SELECT 1 FROM task_events "
+            "WHERE task_id = ? AND kind = 'deploy_approved' LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        _hold_for_review = not _approved
+    _target_status = "review" if _hold_for_review else "done"
+
     with write_txn(conn):
         if expected_run_id is None:
             cur = conn.execute(
                 """
                 UPDATE tasks
-                   SET status       = 'done',
+                   SET status       = ?,
                        result       = ?,
                        completed_at = ?,
                        claim_lock   = NULL,
@@ -4338,13 +4358,13 @@ def complete_task(
                  WHERE id = ?
                    AND status IN ('running', 'ready', 'blocked')
                 """,
-                (result, now, task_id),
+                (_target_status, result, now, task_id),
             )
         else:
             cur = conn.execute(
                 """
                 UPDATE tasks
-                   SET status       = 'done',
+                   SET status       = ?,
                        result       = ?,
                        completed_at = ?,
                        claim_lock   = NULL,
@@ -4356,10 +4376,23 @@ def complete_task(
                    AND status IN ('running', 'ready', 'blocked')
                    AND current_run_id = ?
                 """,
-                (result, now, task_id, int(expected_run_id)),
+                (_target_status, result, now, task_id, int(expected_run_id)),
             )
         if cur.rowcount != 1:
             return False
+        if _hold_for_review:
+            _append_event(
+                conn,
+                task_id,
+                "completion_held_for_review",
+                {
+                    "risk_tier": _risk_tier,
+                    "reason": (
+                        "deploy/live-mutation card requires human sign-off; "
+                        "no attended approval (deploy_approved) recorded"
+                    ),
+                },
+            )
         # REQ-027 (saga decision 0004: surface-don't-merge): a completing
         # worktree task surfaces integration facts — branch, HEAD, ahead
         # count vs the default branch, dirty flag (auto-WIP-committed,
@@ -4383,8 +4416,10 @@ def complete_task(
         except Exception as exc:
             worktree_facts = {"error": f"worktree surfacing failed: {exc}"}
         run_id = _end_run(
-            conn, task_id,
-            outcome="completed", status="done",
+            conn,
+            task_id,
+            outcome="completed",
+            status=_target_status,
             summary=summary if summary is not None else result,
             metadata=metadata,
         )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2512,6 +2512,22 @@ def create_task(
                 # ``<repo>/.worktrees/<task-id>`` dir keyed on the new task id.
                 project_repo = str(project_obj.primary_path)
 
+    # REQ-026: even without a project link, isolate cards on a repo-backed board.
+    # When the board's default_workdir resolves to a git repo, a dispatched card
+    # should run in a per-task git worktree, not the live checkout. Leaving
+    # workspace_path unset lets _resolve_worktree_workspace anchor the worktree on
+    # that same board repo (<repo>/.worktrees/<task-id>) at dispatch time. Boards
+    # with no repo-backed default_workdir stay scratch (unchanged).
+    if workspace_kind == "scratch" and workspace_path is None:
+        _board_slug = board if board else get_current_board()
+        _board_default = (
+            read_board_metadata(_board_slug).get("default_workdir") or ""
+        ).strip()
+        if _board_default:
+            _anchor = Path(_board_default).expanduser()
+            if _anchor.is_absolute() and _git_toplevel(_anchor) is not None:
+                workspace_kind = "worktree"
+
     parents = tuple(p for p in parents if p)
 
     # Normalise + validate skills: strip whitespace, drop empties, dedupe

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -166,6 +166,66 @@ _CEILING_RANK = {"plan-only": 0, "repo-only": 1, "deploy-A": 2, "deploy-B": 3}
 DEFAULT_AUTONOMY_CEILING = "repo-only"
 
 
+# REQ-048: a deploy-tier card's deploy_spec is a JSON object of shell commands.
+# verify + rollback are REQUIRED for the card to execute autonomously — a deploy
+# without a validated verify step and a rollback command is not reversible, so
+# the dispatch gate routes it to plan-only instead.
+DEPLOY_SPEC_KEYS = ("dry_run", "apply", "verify", "rollback")
+DEPLOY_SPEC_REQUIRED_KEYS = ("verify", "rollback")
+_DEPLOY_TIERS = ("deploy-A", "deploy-B", "deploy-C")
+
+
+def normalize_deploy_spec(spec) -> Optional[dict]:
+    """Coerce a deploy_spec (dict or JSON string) to a validated dict, or None.
+
+    Accepts only the known DEPLOY_SPEC_KEYS with non-empty string values. Raises
+    ValueError on a malformed spec (bad JSON, non-dict, unknown/blank keys) so a
+    typo fails loudly at create time rather than silently disarming the gate.
+    """
+    if spec is None:
+        return None
+    if isinstance(spec, str):
+        spec = spec.strip()
+        if not spec:
+            return None
+        try:
+            spec = json.loads(spec)
+        except Exception as exc:
+            raise ValueError(f"deploy_spec is not valid JSON: {exc}")
+    if not isinstance(spec, dict):
+        raise ValueError("deploy_spec must be a JSON object of command strings")
+    out: dict = {}
+    for key, val in spec.items():
+        if key not in DEPLOY_SPEC_KEYS:
+            raise ValueError(
+                f"deploy_spec key {key!r} is not one of {DEPLOY_SPEC_KEYS}"
+            )
+        if val is None:
+            continue
+        val = str(val).strip()
+        if val:
+            out[key] = val
+    return out or None
+
+
+def deploy_spec_is_executable(spec: Optional[dict]) -> bool:
+    """True if a normalized deploy_spec carries every REQUIRED key (verify +
+    rollback) — the minimum for an autonomous, reversible deploy."""
+    if not spec:
+        return False
+    return all(spec.get(k) for k in DEPLOY_SPEC_REQUIRED_KEYS)
+
+
+def _safe_json_dict(raw) -> Optional[dict]:
+    """Parse a JSON-object column into a dict, fail-open to None (never crash a
+    row read on a malformed blob)."""
+    try:
+        val = json.loads(raw)
+        return val if isinstance(val, dict) else None
+    except Exception:
+        return None
+
+
 def tier_permitted_by_ceiling(risk_tier: Optional[str], ceiling: Optional[str]) -> bool:
     """True if a card of ``risk_tier`` may spawn-to-execute under ``ceiling``.
 
@@ -969,6 +1029,9 @@ class Task:
     # None = repo-only default. Snapshot at create; the gate compares it to
     # risk_tier without a projects.db lookup.
     autonomy_ceiling: Optional[str] = None
+    # REQ-048: deploy-gate contract dict {dry_run,apply,verify,rollback} or None.
+    # A deploy-tier card needs verify+rollback to be gate-executable.
+    deploy_spec: Optional[dict] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1059,6 +1122,11 @@ class Task:
             autonomy_ceiling=(
                 row["autonomy_ceiling"]
                 if "autonomy_ceiling" in keys and row["autonomy_ceiling"]
+                else None
+            ),
+            deploy_spec=(
+                _safe_json_dict(row["deploy_spec"])
+                if "deploy_spec" in keys and row["deploy_spec"]
                 else None
             ),
         )
@@ -1250,7 +1318,14 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- create time (VALID_AUTONOMY_CEILINGS, or NULL = repo-only default). Read
     -- together with risk_tier at the dispatch gate so the cross-profile
     -- dispatcher never needs projects.db access.
-    autonomy_ceiling     TEXT
+    autonomy_ceiling     TEXT,
+    -- REQ-048 (decision 0007): deploy-gate contract for a deploy-tier card, as a
+    -- JSON object {dry_run, apply, verify, rollback} of shell commands (all
+    -- optional strings). A deploy-tier card MUST carry verify + rollback to be
+    -- allowed to execute — absent, the dispatch gate routes it to plan-only
+    -- (no autonomous deploy without a validated reversibility plan). NULL for
+    -- non-deploy cards.
+    deploy_spec          TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2097,6 +2172,12 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             conn, "tasks", "autonomy_ceiling", "autonomy_ceiling TEXT"
         )
 
+    if "deploy_spec" not in cols:
+        # REQ-048: deploy-gate contract JSON {dry_run,apply,verify,rollback}.
+        # NULL on legacy/non-deploy rows; a deploy-tier card needs verify+rollback
+        # to execute (else the gate routes it to plan-only).
+        _add_column_if_missing(conn, "tasks", "deploy_spec", "deploy_spec TEXT")
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -2520,6 +2601,7 @@ def create_task(
     project_id: Optional[str] = None,
     risk_tier: Optional[str] = None,
     autonomy_ceiling: Optional[str] = None,
+    deploy_spec=None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2569,6 +2651,9 @@ def create_task(
             "autonomy_ceiling must be one of "
             f"{sorted(VALID_AUTONOMY_CEILINGS)}, got {autonomy_ceiling!r}"
         )
+    # REQ-048: normalize + validate the deploy_spec (raises on malformed input).
+    deploy_spec = normalize_deploy_spec(deploy_spec)
+    deploy_spec_json = json.dumps(deploy_spec) if deploy_spec else None
     if branch_name is not None:
         branch_name = str(branch_name).strip() or None
     if branch_name and workspace_kind != "worktree":
@@ -2783,8 +2868,8 @@ def create_task(
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
                         skills, max_retries, goal_mode, goal_max_turns, session_id,
-                        risk_tier, autonomy_ceiling
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        risk_tier, autonomy_ceiling, deploy_spec
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2809,6 +2894,7 @@ def create_task(
                         session_id,
                         risk_tier,
                         autonomy_ceiling,
+                        deploy_spec_json,
                     ),
                 )
                 for pid in parents:
@@ -6189,6 +6275,11 @@ class DispatchResult:
     autonomy_paused: bool = False
     """REQ-046: True when the global kill-switch halted spawning this tick.
     Reclaim/promote housekeeping still ran; no new workers were launched."""
+    skipped_deploy_unsafe: list[str] = field(default_factory=list)
+    """REQ-048: deploy-tier cards permitted by their ceiling but NOT spawned
+    because they lack a reversible deploy_spec (verify + rollback). Routed to
+    plan-only (draft the runbook) — no autonomous deploy without a validated
+    rollback."""
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -7523,6 +7614,61 @@ def _block_over_ceiling(
         )
 
 
+def _block_deploy_unsafe(
+    conn: sqlite3.Connection, task_id: str, risk_tier: Optional[str]
+) -> None:
+    """REQ-048: route a deploy-tier card that lacks a reversible deploy_spec
+    (verify + rollback) to ``blocked`` for a human — draft the runbook, do not
+    execute. Never runs the card."""
+    with write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status='blocked', block_kind='needs_input', "
+            "claim_lock=NULL, claim_expires=NULL "
+            "WHERE id=? AND status='ready'",
+            (task_id,),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "skipped_deploy_unsafe",
+            {
+                "risk_tier": risk_tier,
+                "reason": (
+                    "deploy-tier card has no reversible deploy_spec "
+                    "(verify + rollback required); routed to plan-only"
+                ),
+            },
+        )
+
+
+def approve_deploy(
+    conn: sqlite3.Connection, task_id: str, *, approver: Optional[str] = None
+) -> bool:
+    """REQ-048: record attended approval for a deploy card.
+
+    Emits a ``deploy_approved`` event (which the completion gate REQ-047 checks
+    before letting the card close to ``done``) and releases a card that parked
+    itself ``blocked`` awaiting approval back to ``ready`` so the worker can
+    proceed to the apply step. Returns False for an unknown task.
+    """
+    if not get_task(conn, task_id):
+        return False
+    with write_txn(conn):
+        _append_event(
+            conn,
+            task_id,
+            "deploy_approved",
+            {"approver": (approver or "operator")},
+        )
+        conn.execute(
+            "UPDATE tasks SET status='ready', block_kind=NULL, "
+            "claim_lock=NULL, claim_expires=NULL "
+            "WHERE id=? AND status='blocked'",
+            (task_id,),
+        )
+    return True
+
+
 def _dispatch_once_locked(
     conn: sqlite3.Connection,
     *,
@@ -7617,7 +7763,7 @@ def _dispatch_once_locked(
         )
 
     ready_rows = conn.execute(
-        "SELECT id, assignee, risk_tier, autonomy_ceiling FROM tasks "
+        "SELECT id, assignee, risk_tier, autonomy_ceiling, deploy_spec FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
@@ -7689,6 +7835,19 @@ def _dispatch_once_locked(
                 _block_over_ceiling(conn, row["id"], _risk, _ceil)
             result.skipped_ceiling.append(row["id"])
             continue
+        # REQ-048: deploy-readiness gate. A deploy-tier card that passed the
+        # ceiling still must carry a reversible deploy_spec (verify + rollback)
+        # before it can execute — otherwise route it to plan-only (draft the
+        # runbook, never run an irreversible deploy).
+        if _risk in _DEPLOY_TIERS:
+            _spec = (
+                _safe_json_dict(row["deploy_spec"]) if "deploy_spec" in _rk else None
+            )
+            if not deploy_spec_is_executable(_spec):
+                if not dry_run:
+                    _block_deploy_unsafe(conn, row["id"], _risk)
+                result.skipped_deploy_unsafe.append(row["id"])
+                continue
         row_assignee = row["assignee"]
         if not row_assignee:
             # Honour kanban.default_assignee: when the dispatcher hits an
@@ -8515,16 +8674,44 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
         lines.append(f"Branch:   {task.branch_name}")
     if task.risk_tier:
         lines.append(f"Risk tier: {task.risk_tier}")
-        if task.risk_tier in ("deploy-A", "deploy-B", "deploy-C"):
-            # REQ-044/048: a live-mutation card is told the deploy-gate protocol.
-            # Enforcement is mechanical (dispatch gate REQ-046, completion gate
-            # REQ-047); this brief is the worker-facing contract.
+        if task.risk_tier in _DEPLOY_TIERS:
+            # REQ-044/048: a live-mutation card is told the deploy-gate protocol
+            # AND its concrete deploy_spec commands. Enforcement is mechanical
+            # (dispatch gate REQ-046/048, completion gate REQ-047); this brief is
+            # the worker-facing contract for how to run the deploy safely.
+            spec = task.deploy_spec or {}
+            approved = (
+                conn.execute(
+                    "SELECT 1 FROM task_events "
+                    "WHERE task_id = ? AND kind = 'deploy_approved' LIMIT 1",
+                    (task.id,),
+                ).fetchone()
+                is not None
+            )
             lines.append(
-                "  ⚠ Live-mutation/deploy card. Follow the deploy-gate protocol: "
-                "dry-run first, capture a validated rollback, apply only after a "
-                "clean dry-run, then health-verify and auto-rollback on failure. "
-                "Never execute beyond your project's autonomy ceiling — if unsure, "
-                "draft the plan and block for a human."
+                "  ⚠ Live-mutation/deploy card. Run the deploy-gate protocol IN "
+                "ORDER, do not skip steps:"
+            )
+            if spec.get("dry_run"):
+                lines.append(f"    1. dry-run:  {spec['dry_run']}")
+            lines.append(
+                "    2. APPROVAL GATE: after a clean dry-run, if no "
+                "`deploy_approved` event is recorded on this card, STOP and block "
+                "needs_input ('awaiting deploy approval') — do NOT apply. The "
+                "operator runs `hermes kanban approve-deploy <id>`, which releases "
+                "you to continue."
+            )
+            if spec.get("apply"):
+                lines.append(f"    3. apply:    {spec['apply']}")
+            if spec.get("verify"):
+                lines.append(f"    4. verify:   {spec['verify']}")
+            if spec.get("rollback"):
+                lines.append(
+                    f"    5. ON VERIFY FAILURE, roll back: {spec['rollback']} "
+                    "— then block for a human. Never leave a failed deploy applied."
+                )
+            lines.append(
+                f"    approval recorded: {'YES — you may apply' if approved else 'NO — stop at the gate'}"
             )
     lines.append("")
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1566,7 +1566,24 @@ class KanbanDbCorruptError(RuntimeError):
         )
 
 
-def _backup_corrupt_db(path: Path) -> Optional[Path]:
+def _kanban_db_fingerprint(path: Path) -> Optional[str]:
+    """Return the first 16 hex chars of ``path``'s sha256, or ``None``.
+
+    Used to content-address ``.corrupt.*.bak`` names. Callers must fingerprint
+    the on-disk bytes *before* any read/write probe that could checkpoint a
+    WAL DB and mutate the file — see :func:`_guard_existing_db_is_healthy`.
+    """
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return digest.hexdigest()[:16]
+
+
+def _backup_corrupt_db(path: Path, token: Optional[str] = None) -> Optional[Path]:
     """Copy a corrupt DB (and its WAL/SHM sidecars) to a content-addressed backup.
 
     The backup filename is deterministic in the main DB's sha256, so repeated
@@ -1589,14 +1606,14 @@ def _backup_corrupt_db(path: Path) -> Optional[Path]:
     resolved = path.resolve()
     parent = resolved.parent
     base_name = resolved.name  # basename only
-    digest = hashlib.sha256()
-    try:
-        with resolved.open("rb") as handle:
-            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-                digest.update(chunk)
-    except OSError:
+    # Prefer a caller-supplied fingerprint taken from the pre-probe bytes so
+    # repeated quarantines of the same corruption reuse one backup even after
+    # an R/W integrity probe has checkpointed the WAL into the main file. Fall
+    # back to hashing the current bytes for callers that pass nothing.
+    if token is None:
+        token = _kanban_db_fingerprint(resolved)
+    if token is None:
         return None
-    token = digest.hexdigest()[:16]
     candidate = parent / f"{base_name}.corrupt.{token}.bak"
     # Defensive: candidate must still be inside parent after construction.
     if candidate.parent != parent:
@@ -1658,6 +1675,12 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
         return
     if str(resolved) in _INITIALIZED_PATHS:
         return
+    # Fingerprint the on-disk bytes BEFORE the R/W probe below. Opening a
+    # WAL-mode DB read/write checkpoints frames into the main file and changes
+    # its content hash; fingerprinting afterward gave every re-probe of the
+    # same corruption a different .corrupt.<hash>.bak and defeated the
+    # content-addressed dedup (2026-07-09 backup storm).
+    pre_probe_token = _kanban_db_fingerprint(resolved)
     reason: Optional[str] = None
     try:
         probe = _sqlite_connect(resolved)
@@ -1674,7 +1697,7 @@ def _guard_existing_db_is_healthy(path: Path) -> None:
         reason = f"sqlite refused to open file: {exc}"
     if reason is None:
         return
-    backup = _backup_corrupt_db(resolved)
+    backup = _backup_corrupt_db(resolved, token=pre_probe_token)
     raise KanbanDbCorruptError(resolved, backup, reason)
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -138,6 +138,48 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+
+# REQ-044/045/046 (decision 0007): deployment execution tiers + the enforcement
+# floor. A card's ``risk_tier`` describes what the work DOES; a project's
+# ``autonomy_ceiling`` (hermes_cli/projects_db) is the highest tier the loop may
+# EXECUTE autonomously for that repo. The dispatch gate spawns-to-execute only
+# when the card's tier is permitted by its project ceiling; anything above is
+# routed to a human (plan-only / blocked). Tier-C surfaces (live WAN, external
+# prod) have no ceiling value that permits them, so a ``deploy-C`` card can never
+# execute autonomously — it is always routed to a human.
+VALID_RISK_TIERS = {"inspect", "repo-only", "deploy-A", "deploy-B", "deploy-C"}
+# Increasing blast radius; used only for the ``<=`` comparison at the gate.
+_RISK_TIER_RANK = {
+    "inspect": 0,
+    "repo-only": 1,
+    "deploy-A": 2,
+    "deploy-B": 3,
+    "deploy-C": 4,
+}
+# A project's autonomy ceiling = the MOST that may run autonomously. ``plan-only``
+# permits only read-only ``inspect`` (rank 0) — every mutation is drafted/blocked
+# (Tier-C hard-exclude: wanctl, work-ansible). ``repo-only`` is the safe default
+# for an unset ceiling (repo/doc/test edits, no deploys). No ceiling permits
+# ``deploy-C``.
+VALID_AUTONOMY_CEILINGS = {"plan-only", "repo-only", "deploy-A", "deploy-B"}
+_CEILING_RANK = {"plan-only": 0, "repo-only": 1, "deploy-A": 2, "deploy-B": 3}
+DEFAULT_AUTONOMY_CEILING = "repo-only"
+
+
+def tier_permitted_by_ceiling(risk_tier: Optional[str], ceiling: Optional[str]) -> bool:
+    """True if a card of ``risk_tier`` may spawn-to-execute under ``ceiling``.
+
+    Fails CLOSED. An unclassified card (``risk_tier`` None/unknown) is treated as
+    the ``repo-only`` floor — never as a deploy. A None/unknown ceiling falls back
+    to ``DEFAULT_AUTONOMY_CEILING`` (``repo-only``): no autonomous deploy without an
+    explicit per-repo opt-in. ``deploy-C`` outranks every ceiling, so a Tier-C card
+    is never permitted regardless of configuration.
+    """
+    tier = risk_tier if risk_tier in _RISK_TIER_RANK else "repo-only"
+    cap = ceiling if ceiling in _CEILING_RANK else DEFAULT_AUTONOMY_CEILING
+    return _RISK_TIER_RANK[tier] <= _CEILING_RANK[cap]
+
+
 KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 _IS_WINDOWS = sys.platform == "win32"
 
@@ -919,6 +961,10 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # REQ-044: deploy risk tier of this card's work (one of VALID_RISK_TIERS) or
+    # None when unclassified. Compared to the project's autonomy_ceiling at the
+    # dispatch gate; None is treated as the repo-only floor (never a deploy).
+    risk_tier: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1002,6 +1048,9 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            risk_tier=(
+                row["risk_tier"] if "risk_tier" in keys and row["risk_tier"] else None
             ),
         )
 
@@ -1180,7 +1229,14 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- REQ-044 (decision 0007): deploy risk tier of the work this card does, one
+    -- of VALID_RISK_TIERS (inspect < repo-only < deploy-A < deploy-B < deploy-C)
+    -- or NULL when unclassified (treated as the repo-only floor at the dispatch
+    -- gate — never a deploy). Compared against the card's project
+    -- autonomy_ceiling: a card whose tier exceeds the ceiling is never
+    -- spawned-to-execute (routed to a human instead).
+    risk_tier            TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2014,6 +2070,12 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
 
+    if "risk_tier" not in cols:
+        # REQ-044: deploy risk tier (VALID_RISK_TIERS) or NULL. Existing rows get
+        # NULL = unclassified, treated as the repo-only floor at the dispatch gate
+        # (never a deploy) — the same conservative default a pre-column board had.
+        _add_column_if_missing(conn, "tasks", "risk_tier", "risk_tier TEXT")
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -2435,6 +2497,7 @@ def create_task(
     session_id: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
+    risk_tier: Optional[str] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2470,6 +2533,12 @@ def create_task(
         raise ValueError(
             f"workspace_kind must be one of {sorted(VALID_WORKSPACE_KINDS)}, "
             f"got {workspace_kind!r}"
+        )
+    if risk_tier is not None:
+        risk_tier = str(risk_tier).strip() or None
+    if risk_tier is not None and risk_tier not in VALID_RISK_TIERS:
+        raise ValueError(
+            f"risk_tier must be one of {sorted(VALID_RISK_TIERS)}, got {risk_tier!r}"
         )
     if branch_name is not None:
         branch_name = str(branch_name).strip() or None
@@ -2679,8 +2748,9 @@ def create_task(
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, goal_mode, goal_max_turns, session_id,
+                        risk_tier
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2703,6 +2773,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        risk_tier,
                     ),
                 )
                 for pid in parents:
@@ -8277,6 +8348,19 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
             lines.append(f"Terminal timeout: {effective_terminal_timeout}s")
     if task.branch_name:
         lines.append(f"Branch:   {task.branch_name}")
+    if task.risk_tier:
+        lines.append(f"Risk tier: {task.risk_tier}")
+        if task.risk_tier in ("deploy-A", "deploy-B", "deploy-C"):
+            # REQ-044/048: a live-mutation card is told the deploy-gate protocol.
+            # Enforcement is mechanical (dispatch gate REQ-046, completion gate
+            # REQ-047); this brief is the worker-facing contract.
+            lines.append(
+                "  ⚠ Live-mutation/deploy card. Follow the deploy-gate protocol: "
+                "dry-run first, capture a validated rollback, apply only after a "
+                "clean dry-run, then health-verify and auto-rollback on failure. "
+                "Never execute beyond your project's autonomy ceiling — if unsure, "
+                "draft the plan and block for a human."
+            )
     lines.append("")
 
     if task.body and task.body.strip():

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5607,8 +5607,65 @@ def _repo_root_for_worktree_target(path: Path) -> Optional[Path]:
         current = current.parent
 
 
-def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> None:
-    """Materialize ``target`` as a linked git worktree under ``repo_root``."""
+def _resolve_parent_worktree_base(
+    conn: sqlite3.Connection, task_id: str
+) -> Optional[str]:
+    """Return a parent's surfaced ``head_sha`` if one exists.
+
+    REQ-034: when a child worktree task is created, branch from the
+    parent's surfaced branch SHA so the child builds on its parent's
+    work. Returns None when there is no done parent with worktree
+    integration facts, or when the parent's head_sha is missing /
+    contains an error. Never raises — failures are swallowed so the
+    claim path is never blocked.
+    """
+    try:
+        parent_rows = conn.execute(
+            "SELECT parent_id FROM task_links WHERE child_id = ? ORDER BY parent_id",
+            (task_id,),
+        ).fetchall()
+        for row in parent_rows:
+            pid = row["parent_id"]
+            pt = get_task(conn, pid)
+            if not pt or pt.status != "done":
+                continue
+            runs = [r for r in list_runs(conn, pid) if r.outcome == "completed"]
+            runs.sort(key=lambda r: r.started_at, reverse=True)
+            if not runs:
+                continue
+            run = runs[0]
+            if not run.metadata:
+                continue
+            try:
+                meta = json.loads(run.metadata) if isinstance(run.metadata, str) else run.metadata
+            except Exception:
+                continue
+            wt = meta.get("worktree_integration")
+            if not isinstance(wt, dict):
+                continue
+            if "error" in wt:
+                continue
+            head_sha = wt.get("head_sha")
+            if head_sha and isinstance(head_sha, str) and head_sha.strip():
+                return head_sha.strip()
+    except Exception:
+        pass
+    return None
+
+
+def _ensure_git_worktree(
+    repo_root: Path,
+    target: Path,
+    branch_name: str,
+    base_ref: Optional[str] = None,
+) -> None:
+    """Materialize ``target`` as a linked git worktree under ``repo_root``.
+
+    When the branch does not yet exist, ``base_ref`` is used as the
+    starting point.  If omitted (or None), falls back to ``HEAD``.
+    REQ-034: ``base_ref`` is the parent's surfaced ``head_sha`` when
+    available, so child worktrees branch from their parent's work.
+    """
     target = target.expanduser()
     repo_common = _git_common_dir(repo_root)
     if target.exists() and repo_common is not None:
@@ -5619,9 +5676,10 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
     if _git_branch_exists(repo_root, branch_name):
         cmd = ["git", "-C", str(repo_root), "worktree", "add", str(target), branch_name]
     else:
+        start = base_ref if base_ref else "HEAD"
         cmd = [
             "git", "-C", str(repo_root), "worktree", "add", "-b", branch_name,
-            str(target), "HEAD",
+            str(target), start,
         ]
     result = subprocess.run(
         cmd,
@@ -5632,13 +5690,33 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
     )
     if result.returncode != 0:
         stderr = (result.stderr or result.stdout or "").strip()
+        # REQ-034: if base_ref was provided but is unreachable (e.g.,
+        # parent's branch was garbage-collected), fall back to HEAD.
+        if base_ref and base_ref != "HEAD":
+            fallback_cmd = [
+                "git", "-C", str(repo_root), "worktree", "add", "-b", branch_name,
+                str(target), "HEAD",
+            ]
+            result = subprocess.run(
+                fallback_cmd,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+            if result.returncode != 0:
+                stderr = (result.stderr or result.stdout or "").strip()
+                raise RuntimeError(
+                    f"git worktree add failed for {target} on branch {branch_name}: {stderr}"
+                )
+            return
         raise RuntimeError(
             f"git worktree add failed for {target} on branch {branch_name}: {stderr}"
         )
 
 
 def _resolve_worktree_workspace(
-    task: Task, *, board: Optional[str] = None
+    task: Task, *, board: Optional[str] = None, conn: Optional[sqlite3.Connection] = None
 ) -> tuple[Path, str]:
     """Resolve + materialize a linked git worktree for ``task``.
 
@@ -5649,8 +5727,17 @@ def _resolve_worktree_workspace(
     working directory (which is whatever directory the gateway happened to be
     launched from, e.g. the Hermes checkout). If no anchor is configured
     anywhere, we fail loudly rather than guess.
+
+    REQ-034: when ``conn`` is provided, the worktree is branched from the
+    parent's surfaced ``head_sha`` if one exists, so child cards build on
+    their parent's work. Falls back to ``HEAD`` when no parent facts are
+    available. Never errors the claim path.
     """
     branch_name = (task.branch_name or "").strip() or f"wt/{task.id}"
+    # REQ-034: resolve parent base ref for branching
+    base_ref = None
+    if conn is not None:
+        base_ref = _resolve_parent_worktree_base(conn, task.id)
     if not task.workspace_path:
         # Anchor on the board's configured default_workdir, not Path.cwd().
         # The dispatcher's CWD is incidental (gateway launch dir) and using it
@@ -5677,7 +5764,7 @@ def _resolve_worktree_workspace(
                 f"{board_slug!r} default_workdir {board_default!r} is not inside a git repo"
             )
         target = repo_root / ".worktrees" / task.id
-        _ensure_git_worktree(repo_root, target, branch_name)
+        _ensure_git_worktree(repo_root, target, branch_name, base_ref=base_ref)
         return target, branch_name
 
     requested = Path(task.workspace_path).expanduser()
@@ -5695,7 +5782,7 @@ def _resolve_worktree_workspace(
     repo_root = _git_toplevel(requested)
     if repo_root is not None and requested_resolved == repo_root:
         target = repo_root / ".worktrees" / task.id
-        _ensure_git_worktree(repo_root, target, branch_name)
+        _ensure_git_worktree(repo_root, target, branch_name, base_ref=base_ref)
         return target, branch_name
 
     repo_root = _repo_root_for_worktree_target(requested.parent)
@@ -5704,11 +5791,13 @@ def _resolve_worktree_workspace(
             f"task {task.id} worktree path {task.workspace_path!r} is not inside a git repo "
             "and does not point at a git repo root"
         )
-    _ensure_git_worktree(repo_root, requested, branch_name)
+    _ensure_git_worktree(repo_root, requested, branch_name, base_ref=base_ref)
     return requested, branch_name
 
 
-def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
+def resolve_workspace(
+    task: Task, *, board: Optional[str] = None, conn: Optional[sqlite3.Connection] = None
+) -> Path:
     """Resolve (and create if needed) the workspace for a task.
 
     - ``scratch``: a fresh dir under ``<board-root>/workspaces/<id>/``,
@@ -5765,7 +5854,7 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
         p.mkdir(parents=True, exist_ok=True)
         return p
     if kind == "worktree":
-        p, _branch_name = _resolve_worktree_workspace(task, board=board)
+        p, _branch_name = _resolve_worktree_workspace(task, board=board, conn=conn)
         return p
     raise ValueError(f"unknown workspace_kind: {kind}")
 
@@ -7482,9 +7571,9 @@ def _dispatch_once_locked(
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":
-                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
+                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board, conn=conn)
             else:
-                workspace = resolve_workspace(claimed, board=board)
+                workspace = resolve_workspace(claimed, board=board, conn=conn)
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
@@ -7574,9 +7663,9 @@ def _dispatch_once_locked(
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":
-                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
+                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board, conn=conn)
             else:
-                workspace = resolve_workspace(claimed, board=board)
+                workspace = resolve_workspace(claimed, board=board, conn=conn)
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -90,6 +90,11 @@ from pathlib import Path
 from typing import Any, Iterable, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing
+from hermes_cli.worktree_safety import (
+    branch_ahead_count as _wt_branch_ahead_count,
+    detect_default_branch as _wt_detect_default_branch,
+    is_worktree_dirty as _wt_is_worktree_dirty,
+)
 from toolsets import get_toolset_names
 
 _log = logging.getLogger(__name__)
@@ -4014,6 +4019,136 @@ class HallucinatedCardsError(ValueError):
         )
 
 
+def _locate_completed_worktree(
+    task_id: str, workspace_path: Optional[str]
+) -> Optional[Path]:
+    """READ-ONLY locator for a worktree task's checkout at completion time.
+
+    Mirrors the resolution order of :func:`_resolve_worktree_workspace`
+    WITHOUT materializing anything: prefer ``workspace_path`` when it names
+    an existing linked worktree; treat an existing repo-root ``workspace_path``
+    as an anchor (``<repo>/.worktrees/<task_id>``); otherwise fall back to the
+    active board's ``default_workdir`` anchor. Returns ``None`` when no
+    existing linked worktree can be found — completion NEVER creates one.
+    """
+    if workspace_path:
+        p = Path(workspace_path).expanduser()
+        if p.exists():
+            if _is_linked_worktree_checkout(p):
+                return p
+            # Anchor form: workspace_path names the repo root (create_task
+            # persists the board default_workdir verbatim for worktree cards).
+            root = _git_toplevel(p)
+            if root is not None:
+                cand = root / ".worktrees" / task_id
+                if cand.exists() and _is_linked_worktree_checkout(cand):
+                    return cand
+    board_default = (
+        read_board_metadata(get_current_board()).get("default_workdir") or ""
+    ).strip()
+    if not board_default:
+        return None
+    anchor = Path(board_default).expanduser()
+    if not anchor.is_absolute():
+        return None
+    repo_root = _git_toplevel(anchor)
+    if repo_root is None:
+        return None
+    cand = repo_root / ".worktrees" / task_id
+    if cand.exists() and _is_linked_worktree_checkout(cand):
+        return cand
+    return None
+
+
+def _worktree_repo_root(wt: Path) -> Optional[Path]:
+    """Main-repo root for a linked worktree (common dir's parent)."""
+    common = _git_common_dir(wt)
+    if common is not None and common.name == ".git":
+        return common.parent
+    return _git_toplevel(wt)
+
+
+def _run_worktree_git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def _collect_worktree_integration_facts(
+    task_id: str, workspace_path: Optional[str]
+) -> dict:
+    """Gather surface-don't-merge integration facts for a completing worktree task.
+
+    REQ-027 (saga decision 0004): completed worktree work is surfaced, never
+    auto-merged. Facts: repo_root, branch, head_sha, base_branch, ahead_count,
+    dirty, wip_commit, diffstat. Preserve-don't-stash: a dirty tree is first
+    committed on the task branch as ``wip(<task_id>): auto-preserve at
+    completion`` — never ``git stash`` (the stash stack is shared across all
+    worktrees of a repo). Never raises: any failure is reported via an
+    ``error`` field so completion is never blocked by git.
+    """
+    try:
+        wt = _locate_completed_worktree(task_id, workspace_path)
+        if wt is None:
+            return {
+                "error": (
+                    f"worktree for task {task_id} not found "
+                    f"(workspace_path={workspace_path!r})"
+                )
+            }
+        facts: dict[str, Any] = {
+            "repo_root": None,
+            "branch": None,
+            "head_sha": None,
+            "base_branch": None,
+            "ahead_count": None,
+            "dirty": None,
+            "wip_commit": None,
+            "diffstat": None,
+        }
+        repo_root = _worktree_repo_root(wt)
+        facts["repo_root"] = str(repo_root) if repo_root is not None else None
+        branch = _git_current_branch(wt)
+        facts["branch"] = branch
+        dirty = _wt_is_worktree_dirty(wt)
+        facts["dirty"] = dirty
+        if dirty:
+            # Preserve-don't-stash: WIP commit on the task branch.
+            add = _run_worktree_git(wt, "add", "-A")
+            commit = _run_worktree_git(
+                wt, "commit", "-m", f"wip({task_id}): auto-preserve at completion"
+            )
+            if add.returncode != 0 or commit.returncode != 0:
+                stderr = (
+                    (commit.stderr or commit.stdout or add.stderr or add.stdout or "")
+                ).strip()
+                facts["error"] = f"auto-preserve WIP commit failed: {stderr[:400]}"
+            else:
+                head = _run_worktree_git(wt, "rev-parse", "HEAD")
+                if head.returncode == 0:
+                    facts["wip_commit"] = (head.stdout or "").strip() or None
+        head = _run_worktree_git(wt, "rev-parse", "HEAD")
+        if head.returncode == 0:
+            facts["head_sha"] = (head.stdout or "").strip() or None
+        base = _wt_detect_default_branch(repo_root) if repo_root is not None else None
+        facts["base_branch"] = base
+        if repo_root is not None and branch and base:
+            try:
+                facts["ahead_count"] = _wt_branch_ahead_count(repo_root, branch, base)
+            except Exception as exc:
+                facts.setdefault("error", f"ahead_count failed: {exc}")
+            diff = _run_worktree_git(repo_root, "diff", "--stat", f"{base}...{branch}")
+            if diff.returncode == 0:
+                facts["diffstat"] = (diff.stdout or "").strip()[:800] or None
+        return facts
+    except Exception as exc:  # never let git block completion
+        return {"error": f"worktree integration surfacing failed: {exc}"}
+
+
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -4119,6 +4254,28 @@ def complete_task(
             )
         if cur.rowcount != 1:
             return False
+        # REQ-027 (saga decision 0004: surface-don't-merge): a completing
+        # worktree task surfaces integration facts — branch, HEAD, ahead
+        # count vs the default branch, dirty flag (auto-WIP-committed,
+        # never stashed), diffstat — into the closing run's metadata and a
+        # `worktree_surfaced` event. Handoff context propagates run
+        # metadata to children, so downstream cards and the operator see
+        # exactly what work exists and where; merging stays deliberate.
+        # Wrapped so a git failure can NEVER block the completion itself.
+        worktree_facts: Optional[dict] = None
+        try:
+            ws_row = conn.execute(
+                "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
+                (task_id,),
+            ).fetchone()
+            if ws_row and (ws_row["workspace_kind"] or "scratch") == "worktree":
+                worktree_facts = _collect_worktree_integration_facts(
+                    task_id, ws_row["workspace_path"]
+                )
+                metadata = dict(metadata) if metadata else {}
+                metadata["worktree_integration"] = worktree_facts
+        except Exception as exc:
+            worktree_facts = {"error": f"worktree surfacing failed: {exc}"}
         run_id = _end_run(
             conn, task_id,
             outcome="completed", status="done",
@@ -4135,6 +4292,16 @@ def complete_task(
                 outcome="completed",
                 summary=summary if summary is not None else result,
                 metadata=metadata,
+            )
+        # REQ-027: audit trail for the surfaced (or failed-to-surface)
+        # worktree facts. Non-worktree tasks never emit this event.
+        if worktree_facts is not None:
+            _append_event(
+                conn,
+                task_id,
+                "worktree_surfaced",
+                worktree_facts,
+                run_id=run_id,
             )
         # Carry the handoff summary in the event payload so gateway
         # notifiers and dashboard WS consumers can render it without a

--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -64,6 +64,12 @@ CREATE TABLE IF NOT EXISTS projects (
     color         TEXT,
     board_slug    TEXT,
     primary_path  TEXT,
+    -- REQ-045 (decision 0007): highest deploy tier the autonomous loop may
+    -- EXECUTE for this repo (one of VALID_AUTONOMY_CEILINGS, or NULL = the
+    -- repo-only default). Denormalised onto each card at create time so the
+    -- cross-profile dispatcher never needs projects.db at dispatch. Tier-C repos
+    -- (wanctl, work-ansible) are set to 'plan-only' = execute nothing, draft only.
+    autonomy_ceiling TEXT,
     created_at    INTEGER NOT NULL,
     archived      INTEGER NOT NULL DEFAULT 0
 );
@@ -200,7 +206,13 @@ def connect_closing(db_path: Optional[Path] = None):
 
 # TEXT columns added to `projects` after v1; re-applied idempotently on every
 # open so a legacy DB upgrades in place.
-_OPTIONAL_PROJECT_COLUMNS = ("board_slug", "primary_path", "icon", "color")
+_OPTIONAL_PROJECT_COLUMNS = (
+    "board_slug",
+    "primary_path",
+    "icon",
+    "color",
+    "autonomy_ceiling",
+)
 
 
 def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
@@ -243,6 +255,9 @@ class Project:
     color: Optional[str] = None
     board_slug: Optional[str] = None
     primary_path: Optional[str] = None
+    # REQ-045: highest deploy tier the autonomous loop may execute for this repo
+    # (VALID_AUTONOMY_CEILINGS) or None = the repo-only default.
+    autonomy_ceiling: Optional[str] = None
     archived: bool = False
     folders: List[ProjectFolder] = field(default_factory=list)
 
@@ -256,6 +271,7 @@ class Project:
             "color": self.color,
             "board_slug": self.board_slug,
             "primary_path": self.primary_path,
+            "autonomy_ceiling": self.autonomy_ceiling,
             "archived": bool(self.archived),
             "created_at": self.created_at,
             "folders": [f.to_dict() for f in self.folders],
@@ -274,6 +290,11 @@ def _project_from_row(row: sqlite3.Row) -> Project:
         color=row["color"] if "color" in keys else None,
         board_slug=row["board_slug"] if "board_slug" in keys else None,
         primary_path=row["primary_path"] if "primary_path" in keys else None,
+        autonomy_ceiling=(
+            row["autonomy_ceiling"]
+            if "autonomy_ceiling" in keys and row["autonomy_ceiling"]
+            else None
+        ),
         archived=bool(row["archived"]) if "archived" in keys else False,
     )
 
@@ -422,12 +443,15 @@ def update_project(
     icon: Optional[str] = None,
     color: Optional[str] = None,
     board_slug: Optional[str] = None,
+    autonomy_ceiling: Optional[str] = None,
 ) -> bool:
     """Patch top-level project fields. Only provided fields change.
 
-    ``icon``, ``color``, and ``board_slug`` accept an empty string to clear
-    (store NULL) — passing ``None`` leaves the field untouched, so callers that
-    want to clear must send ``""``.
+    ``icon``, ``color``, ``board_slug``, and ``autonomy_ceiling`` accept an empty
+    string to clear (store NULL) — passing ``None`` leaves the field untouched, so
+    callers that want to clear must send ``""``. ``autonomy_ceiling`` is validated
+    against ``VALID_AUTONOMY_CEILINGS`` (decision 0007); clearing it means the
+    dispatch gate falls back to the repo-only default for this repo.
     """
     sets: List[str] = []
     params: List[object] = []
@@ -449,6 +473,20 @@ def update_project(
     if board_slug is not None:
         sets.append("board_slug = ?")
         params.append(normalize_slug(board_slug) if board_slug.strip() else None)
+    if autonomy_ceiling is not None:
+        ac = str(autonomy_ceiling).strip()
+        if ac:
+            # Single source of truth for the vocabulary lives in kanban_db; lazy
+            # import avoids a module-load cycle (kanban_db imports projects_db).
+            from hermes_cli.kanban_db import VALID_AUTONOMY_CEILINGS
+
+            if ac not in VALID_AUTONOMY_CEILINGS:
+                raise ValueError(
+                    "autonomy_ceiling must be one of "
+                    f"{sorted(VALID_AUTONOMY_CEILINGS)}, got {ac!r}"
+                )
+        sets.append("autonomy_ceiling = ?")
+        params.append(ac or None)
     if not sets:
         return False
     params.append(project_id)

--- a/hermes_cli/prune_plan.py
+++ b/hermes_cli/prune_plan.py
@@ -1,0 +1,176 @@
+"""Ancestry-gated prune planning for task worktrees.
+
+REQ-028 (saga decision 0004): a task worktree may be removed only when its
+branch is fully merged into the repo default branch (merge-base ancestry,
+not name matching), its tree is clean, AND it is at least one day old.
+Unmerged or dirty worktrees are NEVER pruned — they are reported instead.
+Merged+pruned branches are deleted with ``git branch -d`` (safe delete)
+only; ``git worktree remove`` is never forced.
+
+:func:`plan_worktree_prune` is the pure decision function (no git, no I/O)
+so the gate is unit-testable in isolation; :func:`prune_task_worktrees`
+does the scanning/removal around it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+from hermes_cli.worktree_safety import (
+    detect_default_branch,
+    is_branch_unmerged,
+    is_worktree_dirty,
+)
+
+__all__ = ["plan_worktree_prune", "prune_task_worktrees"]
+
+_REQUIRED_KEYS = ("id", "merged", "dirty", "age_days")
+
+_GIT_TIMEOUT = 60
+
+
+def plan_worktree_prune(worktrees: list[dict]) -> list[str]:
+    """Return the sorted ids of worktree entries that are safe to prune.
+
+    Each entry MUST have keys ``id`` (str), ``merged`` (bool), ``dirty``
+    (bool), ``age_days`` (int|float); a missing key raises
+    :class:`ValueError` naming the entry's ``id`` when present, else its
+    index. An entry is pruned iff ``merged`` is True AND ``dirty`` is
+    False AND ``age_days >= 1`` (exactly 1 day IS pruned). Extra keys are
+    ignored; the input is not mutated and its order does not matter.
+    """
+    planned: list[str] = []
+    for index, entry in enumerate(worktrees):
+        missing = [k for k in _REQUIRED_KEYS if k not in entry]
+        if missing:
+            label = entry["id"] if "id" in entry else str(index)
+            raise ValueError(
+                f"worktree entry {label} is missing required key(s): "
+                f"{', '.join(missing)}"
+            )
+        if entry["merged"] is True and entry["dirty"] is False and entry["age_days"] >= 1:
+            planned.append(entry["id"])
+    return sorted(planned)
+
+
+def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        timeout=_GIT_TIMEOUT,
+        check=False,
+    )
+
+
+def _worktree_branch(wt: Path) -> str | None:
+    """Current branch of ``wt``, or ``None`` when detached / not a checkout."""
+    try:
+        result = _run_git(wt, "branch", "--show-current")
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    branch = (result.stdout or "").strip()
+    return branch or None
+
+
+def prune_task_worktrees(
+    repo_root: Path, *, dry_run: bool = True, now: float | None = None
+) -> dict:
+    """Scan ``<repo_root>/.worktrees/*`` and prune the ancestry-safe entries.
+
+    Per entry: ``merged`` = branch fully merged into the repo default branch
+    (detached HEAD, missing branch, or no default branch → treated as
+    unmerged, i.e. NEVER prunable), ``dirty`` = ``git status --porcelain``
+    non-empty, ``age_days`` = directory mtime age. The prune decision is
+    delegated to :func:`plan_worktree_prune`.
+
+    With ``dry_run=True`` (the default) nothing is removed. With
+    ``dry_run=False`` planned worktrees are removed via ``git worktree
+    remove`` (never ``--force``) and their branches deleted with ``git
+    branch -d`` (safe delete only). A git failure on one entry is recorded
+    under ``errors`` and never aborts the others.
+
+    Returns ``{"planned", "removed", "kept_unmerged", "kept_dirty",
+    "kept_young", "errors"}``.
+    """
+    if now is None:
+        now = time.time()
+    report: dict = {
+        "planned": [],
+        "removed": [],
+        "kept_unmerged": [],
+        "kept_dirty": [],
+        "kept_young": [],
+        "errors": {},
+    }
+    wt_root = Path(repo_root) / ".worktrees"
+    if not wt_root.is_dir():
+        return report
+
+    base = detect_default_branch(repo_root)
+    entries: list[dict] = []
+    for wt_dir in sorted(p for p in wt_root.iterdir() if p.is_dir()):
+        wt_id = wt_dir.name
+        try:
+            branch = _worktree_branch(wt_dir)
+            if branch is None or base is None:
+                # Detached HEAD / missing branch / no default branch: we
+                # cannot prove ancestry, so the entry is NEVER prunable.
+                merged = False
+            else:
+                merged = not is_branch_unmerged(repo_root, branch, base)
+            entries.append(
+                {
+                    "id": wt_id,
+                    "merged": merged,
+                    "dirty": is_worktree_dirty(wt_dir),
+                    "age_days": (now - wt_dir.stat().st_mtime) / 86400.0,
+                    "branch": branch,
+                    "path": wt_dir,
+                }
+            )
+        except Exception as exc:  # one bad entry must not abort the scan
+            report["errors"][wt_id] = str(exc)
+
+    planned = plan_worktree_prune(entries)
+    report["planned"] = planned
+    planned_set = set(planned)
+    for entry in entries:
+        if entry["id"] in planned_set:
+            continue
+        if not entry["merged"]:
+            report["kept_unmerged"].append(entry["id"])
+        elif entry["dirty"]:
+            report["kept_dirty"].append(entry["id"])
+        else:
+            report["kept_young"].append(entry["id"])
+
+    if dry_run:
+        return report
+
+    by_id = {e["id"]: e for e in entries}
+    for wt_id in planned:
+        entry = by_id[wt_id]
+        try:
+            result = _run_git(
+                Path(repo_root), "worktree", "remove", str(entry["path"])
+            )
+            if result.returncode != 0:
+                stderr = (result.stderr or result.stdout or "").strip()
+                report["errors"][wt_id] = f"git worktree remove failed: {stderr}"
+                continue
+            branch = entry["branch"]
+            if branch and branch != base:
+                result = _run_git(Path(repo_root), "branch", "-d", branch)
+                if result.returncode != 0:
+                    stderr = (result.stderr or result.stdout or "").strip()
+                    report["errors"][wt_id] = f"git branch -d {branch} failed: {stderr}"
+                    # The worktree itself was removed; still count it.
+            report["removed"].append(wt_id)
+        except Exception as exc:
+            report["errors"][wt_id] = str(exc)
+    return report

--- a/hermes_cli/worktree_safety.py
+++ b/hermes_cli/worktree_safety.py
@@ -1,0 +1,93 @@
+"""Read-only git safety helpers for task-worktree lifecycle decisions.
+
+REQ-027/REQ-028 (saga decision 0004 — surface-don't-merge, preserve-don't-
+stash, ancestry-gated prune). Every helper in this module is strictly
+read-only: nothing here mutates a repository, moves refs, or touches the
+working tree. Mutation (WIP commits, worktree removal, branch deletion)
+lives with the callers so the safety predicates stay trivially auditable.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+__all__ = [
+    "is_branch_unmerged",
+    "detect_default_branch",
+    "is_worktree_dirty",
+    "branch_ahead_count",
+]
+
+_GIT_TIMEOUT = 30
+
+
+def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        timeout=_GIT_TIMEOUT,
+        check=False,
+    )
+
+
+def _local_branch_exists(repo: Path, name: str) -> bool:
+    """True iff ``name`` resolves to a commit in ``repo`` (read-only)."""
+    result = _run_git(repo, "rev-parse", "--verify", "--quiet", f"{name}^{{commit}}")
+    return result.returncode == 0
+
+
+def is_branch_unmerged(repo: Path, branch: str, base: str = "main") -> bool:
+    """True iff ``branch`` has at least one commit not reachable from ``base``.
+
+    - ``False`` when every commit of ``branch`` is an ancestor of (or equal
+      to) ``base``; ``branch == base`` is trivially ``False``.
+    - Unknown ``branch`` or ``base`` raises :class:`ValueError` naming the
+      missing ref.
+    - Ancestry is checked via ``git merge-base --is-ancestor`` — pure
+      read-only plumbing; the repository is never mutated.
+    """
+    for ref in (branch, base):
+        if not _local_branch_exists(repo, ref):
+            raise ValueError(f"unknown ref {ref!r} in repo {repo}")
+    if branch == base:
+        return False
+    result = _run_git(repo, "merge-base", "--is-ancestor", branch, base)
+    if result.returncode == 0:
+        return False
+    if result.returncode == 1:
+        return True
+    stderr = (result.stderr or result.stdout or "").strip()
+    raise RuntimeError(
+        f"git merge-base --is-ancestor {branch} {base} failed in {repo}: {stderr}"
+    )
+
+
+def detect_default_branch(repo: Path) -> str | None:
+    """Return ``"main"`` if it exists, else ``"master"``, else ``None``."""
+    for name in ("main", "master"):
+        result = _run_git(repo, "show-ref", "--verify", "--quiet", f"refs/heads/{name}")
+        if result.returncode == 0:
+            return name
+    return None
+
+
+def is_worktree_dirty(wt: Path) -> bool:
+    """True iff ``git status --porcelain`` reports anything (incl. untracked)."""
+    result = _run_git(wt, "status", "--porcelain")
+    if result.returncode != 0:
+        stderr = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(f"git status failed in {wt}: {stderr}")
+    return bool((result.stdout or "").strip())
+
+
+def branch_ahead_count(repo: Path, branch: str, base: str) -> int:
+    """Number of commits on ``branch`` not reachable from ``base``."""
+    result = _run_git(repo, "rev-list", "--count", f"{base}..{branch}")
+    if result.returncode != 0:
+        stderr = (result.stderr or result.stdout or "").strip()
+        raise ValueError(
+            f"git rev-list --count {base}..{branch} failed in {repo}: {stderr}"
+        )
+    return int((result.stdout or "0").strip())

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -119,19 +119,24 @@ def _resolve_board(board: Optional[str]) -> Optional[str]:
 def _conn(board: Optional[str] = None):
     """Open a kanban_db connection, creating the schema on first use.
 
-    Every handler that mutates the DB goes through this so the plugin
-    self-heals on a fresh install (no user-visible "no such table"
-    error if somebody hits POST /tasks before GET /board).
-    ``init_db`` is idempotent.
+    ``kanban_db.connect()`` auto-creates the schema and runs additive
+    migrations on the first open per process (its ``needs_init`` path), so the
+    plugin still self-heals on a fresh install (no "no such table" if somebody
+    hits POST /tasks before GET /board) without a separate ``init_db`` call.
+
+    This deliberately no longer calls ``kanban_db.init_db()`` on every request.
+    ``init_db`` discards kanban_db's per-path health-probe cache
+    (``_INITIALIZED_PATHS``), which forced a full read/write ``PRAGMA
+    integrity_check`` on *every* connect. On a corrupt DB that probe
+    re-checkpoints the WAL and re-quarantines a fresh ``.corrupt.*.bak`` on
+    each call — turning one corruption event into a storm of backups and log
+    lines (2026-07-09 incident). Relying on connect()'s own first-open init
+    keeps the fast-path cache intact.
 
     ``board`` is the query-param slug (already normalised by
     :func:`_resolve_board`). When ``None`` the active board is used
     via the resolution chain (env var → ``current`` file → ``default``).
     """
-    try:
-        kanban_db.init_db(board=board)
-    except Exception as exc:
-        log.warning("kanban init_db failed: %s", exc)
     return kanban_db.connect(board=board)
 
 
@@ -2432,8 +2437,27 @@ async def stream_events(ws: WebSocket):
             finally:
                 conn.close()
 
+        corrupt_backoff = 0.0
         while True:
-            cursor, events = await asyncio.to_thread(_fetch_new, cursor)
+            try:
+                cursor, events = await asyncio.to_thread(_fetch_new, cursor)
+            except kanban_db.KanbanDbCorruptError as exc:
+                # Corrupt board DB: do NOT let this kill the stream. If the
+                # handler exits, the browser reconnects immediately and
+                # re-enters here, and every connect() re-runs a read/write
+                # PRAGMA integrity_check that re-checkpoints the WAL and
+                # re-quarantines a .corrupt.*.bak. Hold the socket open and
+                # back off (1s→30s) so a single corruption can't become a
+                # probe/backup storm (2026-07-09 incident).
+                corrupt_backoff = min((corrupt_backoff * 2) or 1.0, 30.0)
+                log.warning(
+                    "Kanban event stream: board DB corrupt, backing off %.0fs: %s",
+                    corrupt_backoff,
+                    exc,
+                )
+                await asyncio.sleep(corrupt_backoff)
+                continue
+            corrupt_backoff = 0.0
             if events:
                 await ws.send_json({"events": events, "cursor": cursor})
             await asyncio.sleep(_EVENT_POLL_SECONDS)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -49,6 +49,7 @@ AUTHOR_MAP = {
     "sonxi@nous.local": "17324393074",  # PR #53196 salvage (tools_config: known_plugin_toolsets null guard; commit under unlinked local identity)
     "lemonwan@users.noreply.github.com": "lemonwan",  # PR #59430 sibling salvage (adapter reconnect contract guard)
     "luxuguangno1@163.com": "luxuguang-leo",  # PR #52966 + #52908 salvage (QQBot reconnect + Feishu Channel signaling)
+    "kevin.blalock@gmail.com": "kevinb361",  # PR #1 (Discord ops webhook routing)
     "grace@weeb.onl": "evelynburger",  # PR #57544 salvage (gateway: webhook payload filters + route scripts; commit under unlinked identity)
     "contato@siteup.com.br": "SiteupAgencia",  # PR #57435 salvage (tui_gateway: back off notification poller when session is busy; #55578)
     "164521089+rainbowgits@users.noreply.github.com": "rainbowgore",  # PR #59405 salvage (mcp: bound stdio initialize handshake to stop subprocess/FD leak; #59349)

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -40,6 +40,7 @@ def _make_adapter(routes, **extra_kw) -> WebhookAdapter:
 def _create_app(adapter: WebhookAdapter) -> web.Application:
     app = web.Application()
     app.router.add_get("/health", adapter._handle_health)
+    app.router.add_get("/ready", adapter._handle_ready)
     app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
     return app
 
@@ -47,6 +48,8 @@ def _create_app(adapter: WebhookAdapter) -> web.Application:
 def _wire_mock_target(adapter: WebhookAdapter, platform_name: str = "telegram"):
     """Attach a gateway_runner with a mocked target adapter."""
     mock_target = AsyncMock()
+    mock_target._running = True
+    mock_target.has_fatal_error = False
     mock_target.send = AsyncMock(return_value=SendResult(success=True))
 
     mock_runner = MagicMock()
@@ -174,6 +177,89 @@ class TestDeliverOnlyBypassesAgent:
         assert mock_target.send.await_args.kwargs["metadata"] == {
             "thread_id": "topic-42"
         }
+    @pytest.mark.asyncio
+    async def test_alert_event_formatter_renders_compact_digest(self):
+        """Structured alert-event formatter avoids raw JSON dumps."""
+        routes = {
+            "ops-digest": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "chat-1"},
+                "formatter": "alert_event",
+                "prompt": "ignored when formatter is set",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/ops-digest",
+                json={
+                    "source": "rack-util/librenms-heartbeat",
+                    "kind": "heartbeat_alive",
+                    "severity": "digest",
+                    "state": "summary",
+                    "summary": "LibreNMS heartbeat watcher alive on rack-util",
+                    "host": "rack-util",
+                    "details": {
+                        "target_ip": "10.10.99.60",
+                        "checked_at": "2026-05-07T22:44:04+00:00",
+                    },
+                },
+                headers={"X-GitHub-Delivery": "d-alert-format-1"},
+            )
+            assert resp.status == 200
+
+        content_arg = mock_target.send.await_args.args[1]
+        assert content_arg == (
+            "🟢 **LibreNMS heartbeat watcher alive on rack-util**\n"
+            "source: `rack-util/librenms-heartbeat` · host: `rack-util` · "
+            "kind: `heartbeat_alive`\n"
+            "target_ip: `10.10.99.60` · "
+            "checked_at: `2026-05-07T22:44:04+00:00`"
+        )
+        assert "{\n" not in content_arg
+
+    @pytest.mark.asyncio
+    async def test_alert_event_formatter_renders_firing_alert(self):
+        routes = {
+            "ops-alerts": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "chat-1"},
+                "formatter": "alert_event",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/ops-alerts",
+                json={
+                    "source": "rack-util/librenms-heartbeat",
+                    "kind": "monitor_target_down",
+                    "severity": "critical",
+                    "state": "firing",
+                    "summary": "LibreNMS heartbeat failed 3 consecutive checks on rack-util",
+                    "details": {"fails": 3, "threshold": 3, "target_ip": "10.10.99.60"},
+                },
+                headers={"X-GitHub-Delivery": "d-alert-format-2"},
+            )
+            assert resp.status == 200
+
+        content_arg = mock_target.send.await_args.args[1]
+        assert content_arg.startswith(
+            "🚨 **LibreNMS heartbeat failed 3 consecutive checks on rack-util**"
+        )
+        assert "state: `firing`" in content_arg
+        assert "target_ip: `10.10.99.60`" in content_arg
+        assert "fails: `3`" in content_arg
 
 
 # ===================================================================
@@ -431,6 +517,85 @@ class TestDeliverOnlySecurityInvariants:
                 headers={"X-GitHub-Delivery": "rl-3"},
             )
             assert r3.status == 429
+
+
+# ===================================================================
+# Readiness endpoint
+# ===================================================================
+class TestWebhookReadiness:
+
+    @pytest.mark.asyncio
+    async def test_ready_returns_200_when_direct_delivery_target_running(self):
+        routes = {
+            "ops-digest": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "chat-1"},
+                "formatter": "alert_event",
+            }
+        }
+        adapter = _make_adapter(routes)
+        _wire_mock_target(adapter, "telegram")
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/ready")
+            assert resp.status == 200
+            data = await resp.json()
+
+        assert data["status"] == "ready"
+        assert data["routes"]["ops-digest"] == {
+            "status": "ready",
+            "deliver": "telegram",
+            "reason": "ok",
+        }
+        assert data["targets"]["telegram"]["routes"] == ["ops-digest"]
+
+    @pytest.mark.asyncio
+    async def test_ready_returns_503_when_direct_delivery_target_missing(self):
+        routes = {
+            "ops-alerts": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "discord",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "alerts"},
+            }
+        }
+        adapter = _make_adapter(routes)
+        _wire_mock_target(adapter, "telegram")  # discord intentionally absent
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/ready")
+            assert resp.status == 503
+            data = await resp.json()
+
+        assert data["status"] == "not_ready"
+        assert data["routes"]["ops-alerts"]["status"] == "not_ready"
+        assert data["routes"]["ops-alerts"]["reason"] == "platform discord not connected"
+
+    @pytest.mark.asyncio
+    async def test_ready_returns_503_when_target_adapter_not_running(self):
+        routes = {
+            "ops-alerts": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "alerts"},
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter, "telegram")
+        mock_target._running = False
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/ready")
+            assert resp.status == 503
+            data = await resp.json()
+
+        assert data["routes"]["ops-alerts"]["reason"] == "platform telegram not running"
 
 
 # ===================================================================

--- a/tests/gateway/test_webhook_signature_rate_limit.py
+++ b/tests/gateway/test_webhook_signature_rate_limit.py
@@ -287,3 +287,103 @@ class TestSignatureBeforeRateLimit:
             assert resp.status == 429
 
         assert len(captured_events) == 3
+
+
+class TestBearerTokenAuth:
+    """Static bearer-token auth for producers that cannot compute HMAC."""
+
+    @pytest.mark.asyncio
+    async def test_bearer_token_auth_accepts_valid_token(self):
+        secret = "test-bearer-token"
+        route_name = "pbs-alerts"
+        routes = {
+            route_name: {
+                "secret": secret,
+                "prompt": "Event: {event}",
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+        captured_events = []
+
+        async def _capture(event):
+            captured_events.append(event)
+
+        adapter.handle_message = _capture
+        app = _create_app(adapter)
+        body = json.dumps(SIMPLE_PAYLOAD).encode()
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/webhooks/{route_name}",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {secret}",
+                    "X-Request-ID": "bearer-good-001",
+                },
+            )
+            assert resp.status == 202
+
+        assert len(captured_events) == 1
+
+    @pytest.mark.asyncio
+    async def test_query_token_auth_is_rejected(self):
+        secret = "test-query-token"
+        route_name = "pbs-alerts"
+        routes = {
+            route_name: {
+                "secret": secret,
+                "prompt": "Event: {event}",
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+        captured_events = []
+
+        async def _capture(event):
+            captured_events.append(event)
+
+        adapter.handle_message = _capture
+        app = _create_app(adapter)
+        body = json.dumps(SIMPLE_PAYLOAD).encode()
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/webhooks/{route_name}?token={secret}",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Request-ID": "query-token-rejected-001",
+                },
+            )
+            assert resp.status == 401
+
+        assert captured_events == []
+
+    @pytest.mark.asyncio
+    async def test_bearer_token_auth_rejects_wrong_token(self):
+        secret = "test-bearer-token"
+        route_name = "pbs-alerts"
+        routes = {
+            route_name: {
+                "secret": secret,
+                "prompt": "Event: {event}",
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+        app = _create_app(adapter)
+        body = json.dumps(SIMPLE_PAYLOAD).encode()
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/webhooks/{route_name}",
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": "Bearer wrong-token",
+                    "X-Request-ID": "bearer-bad-001",
+                },
+            )
+            assert resp.status == 401

--- a/tests/gateway/test_webhook_signature_rate_limit.py
+++ b/tests/gateway/test_webhook_signature_rate_limit.py
@@ -292,13 +292,105 @@ class TestSignatureBeforeRateLimit:
 class TestBearerTokenAuth:
     """Static bearer-token auth for producers that cannot compute HMAC."""
 
+    @pytest.mark.parametrize(
+        "auth_headers",
+        [
+            pytest.param({"Authorization": "Bearer TOKEN"}, id="authorization-bearer"),
+            pytest.param({"X-Webhook-Token": "TOKEN"}, id="x-webhook-token"),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_bearer_token_auth_accepts_valid_token(self):
+    async def test_static_token_auth_accepts_valid_token_from_trusted_source(
+        self, auth_headers
+    ):
         secret = "test-bearer-token"
         route_name = "pbs-alerts"
         routes = {
             route_name: {
                 "secret": secret,
+                "prompt": "Event: {event}",
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+        captured_events = []
+
+        async def _capture(event):
+            captured_events.append(event)
+
+        adapter.handle_message = _capture
+        app = _create_app(adapter)
+        body = json.dumps(SIMPLE_PAYLOAD).encode()
+        headers = {
+            "Content-Type": "application/json",
+            "X-Request-ID": "static-token-good-001",
+        }
+        headers.update({k: v.replace("TOKEN", secret) for k, v in auth_headers.items()})
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/webhooks/{route_name}",
+                data=body,
+                headers=headers,
+            )
+            assert resp.status == 202
+
+        assert len(captured_events) == 1
+
+    @pytest.mark.parametrize(
+        "auth_headers",
+        [
+            pytest.param({"Authorization": "Bearer TOKEN"}, id="authorization-bearer"),
+            pytest.param({"X-Webhook-Token": "TOKEN"}, id="x-webhook-token"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_static_token_auth_rejects_public_forwarded_source(
+        self, auth_headers
+    ):
+        secret = "test-bearer-token"
+        route_name = "pbs-alerts"
+        routes = {
+            route_name: {
+                "secret": secret,
+                "prompt": "Event: {event}",
+                "deliver": "log",
+            }
+        }
+        adapter = _make_adapter(routes)
+        captured_events = []
+
+        async def _capture(event):
+            captured_events.append(event)
+
+        adapter.handle_message = _capture
+        app = _create_app(adapter)
+        body = json.dumps(SIMPLE_PAYLOAD).encode()
+        headers = {
+            "Content-Type": "application/json",
+            "X-Forwarded-For": "8.8.8.8",
+            "X-Request-ID": "static-token-public-001",
+        }
+        headers.update({k: v.replace("TOKEN", secret) for k, v in auth_headers.items()})
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                f"/webhooks/{route_name}",
+                data=body,
+                headers=headers,
+            )
+            assert resp.status == 401
+
+        assert captured_events == []
+
+    @pytest.mark.asyncio
+    async def test_hmac_signature_accepts_public_forwarded_source(self):
+        secret = "test-hmac-secret"
+        route_name = "github-alerts"
+        routes = {
+            route_name: {
+                "secret": secret,
+                "events": ["push"],
                 "prompt": "Event: {event}",
                 "deliver": "log",
             }
@@ -319,8 +411,10 @@ class TestBearerTokenAuth:
                 data=body,
                 headers={
                     "Content-Type": "application/json",
-                    "Authorization": f"Bearer {secret}",
-                    "X-Request-ID": "bearer-good-001",
+                    "X-GitHub-Event": "push",
+                    "X-Hub-Signature-256": _github_signature(body, secret),
+                    "X-Forwarded-For": "8.8.8.8",
+                    "X-GitHub-Delivery": "hmac-public-001",
                 },
             )
             assert resp.status == 202

--- a/tests/hermes_cli/test_kanban_autonomy_gate.py
+++ b/tests/hermes_cli/test_kanban_autonomy_gate.py
@@ -100,17 +100,25 @@ def test_deploy_card_over_ceiling_is_blocked(isolated_kanban_home):
 
 def test_deploy_card_within_ceiling_passes_gate(isolated_kanban_home):
     kb, _ = isolated_kanban_home
+    # A reversible deploy_spec so it clears the REQ-048 readiness gate too — this
+    # test isolates the ceiling gate (deploy-A tier under a deploy-B ceiling).
+    spec = {"apply": "./go", "verify": "./v", "rollback": "./rb"}
     with kb.connect_closing() as conn:
         kb.create_board(slug="default", name="Test")
         tid = _mk_ready(
-            kb, conn, title="deploy bot",
-            risk_tier="deploy-A", autonomy_ceiling="deploy-B",
+            kb,
+            conn,
+            title="deploy bot",
+            risk_tier="deploy-A",
+            autonomy_ceiling="deploy-B",
+            deploy_spec=spec,
         )
     with kb.connect_closing() as conn:
         res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
-    # The gate let it through — it is NOT ceiling-blocked (whether it then
-    # spawned depends on profile resolution, which is not what we assert here).
+    # The gate let it through — NOT ceiling-blocked and NOT deploy-unsafe (whether
+    # it then spawned depends on profile resolution, not asserted here).
     assert tid not in res.skipped_ceiling
+    assert tid not in res.skipped_deploy_unsafe
     with kb.connect_closing() as conn:
         row = conn.execute(
             "SELECT status FROM tasks WHERE id = ?", (tid,)
@@ -296,3 +304,127 @@ def test_repo_card_auto_completes(isolated_kanban_home):
     with kb.connect_closing() as conn:
         row = conn.execute("SELECT status FROM tasks WHERE id = ?", (tid,)).fetchone()
     assert row["status"] == "done"
+
+
+# --------------------------------------------------------------------------
+# Deploy-gate contract (REQ-048)
+# --------------------------------------------------------------------------
+
+_SPEC = {
+    "dry_run": "./deploy.sh --check",
+    "apply": "./deploy.sh",
+    "verify": "curl -f localhost/ready",
+    "rollback": "./deploy.sh --rollback",
+}
+
+
+def test_deploy_spec_normalization_and_validation(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    assert kb.deploy_spec_is_executable(kb.normalize_deploy_spec(_SPEC)) is True
+    assert kb.deploy_spec_is_executable({"verify": "v"}) is False  # no rollback
+    with pytest.raises(ValueError):
+        kb.normalize_deploy_spec({"bogus": "x"})
+    with pytest.raises(ValueError):
+        kb.normalize_deploy_spec("{not json")
+
+
+def test_deploy_card_without_spec_is_plan_only(isolated_kanban_home):
+    """A deploy card that passes the ceiling but has no reversible spec is routed
+    to plan-only — no autonomous deploy without a validated rollback."""
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        tid = _mk_ready(
+            kb, conn, title="deploy", risk_tier="deploy-A", autonomy_ceiling="deploy-A"
+        )  # ceiling OK, no spec
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+    assert tid in res.skipped_deploy_unsafe
+    assert tid not in res.skipped_ceiling
+    with kb.connect_closing() as conn:
+        row = conn.execute("SELECT status FROM tasks WHERE id=?", (tid,)).fetchone()
+    assert row["status"] == "blocked"
+
+
+def test_deploy_card_missing_rollback_is_plan_only(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        tid = _mk_ready(
+            kb,
+            conn,
+            title="deploy",
+            risk_tier="deploy-A",
+            autonomy_ceiling="deploy-A",
+            deploy_spec={"apply": "./go", "verify": "./v"},
+        )
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+    assert tid in res.skipped_deploy_unsafe
+
+
+def test_deploy_card_with_reversible_spec_passes_gates(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        tid = _mk_ready(
+            kb,
+            conn,
+            title="deploy bot",
+            risk_tier="deploy-A",
+            autonomy_ceiling="deploy-A",
+            deploy_spec=_SPEC,
+        )
+        assert kb.get_task(conn, tid).deploy_spec["rollback"] == _SPEC["rollback"]
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+    assert tid not in res.skipped_deploy_unsafe
+    assert tid not in res.skipped_ceiling
+
+
+def test_approve_deploy_emits_event_and_unblocks(isolated_kanban_home):
+    """approve_deploy records the token AND releases a card parked blocked at the
+    approval gate → the completion gate then lets it close to done."""
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        tid = kb.create_task(
+            conn,
+            title="deploy",
+            assignee="default",
+            risk_tier="deploy-A",
+            deploy_spec=_SPEC,
+        )
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='blocked', "
+                "block_kind='needs_input' WHERE id=?",
+                (tid,),
+            )
+        assert kb.approve_deploy(conn, tid, approver="kevin") is True
+        row = conn.execute("SELECT status FROM tasks WHERE id=?", (tid,)).fetchone()
+        assert row["status"] == "ready"  # released from the approval gate
+        assert kb.complete_task(conn, tid, result="deployed") is True
+        row = conn.execute("SELECT status FROM tasks WHERE id=?", (tid,)).fetchone()
+    assert row["status"] == "done"
+
+
+def test_deploy_worker_context_surfaces_protocol(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        tid = kb.create_task(
+            conn,
+            title="deploy",
+            assignee="default",
+            risk_tier="deploy-A",
+            deploy_spec=_SPEC,
+        )
+        ctx = kb.build_worker_context(conn, tid)
+    assert "deploy-gate protocol" in ctx
+    assert _SPEC["rollback"] in ctx and _SPEC["verify"] in ctx
+    assert "approval recorded: NO" in ctx  # not yet approved
+    with kb.connect_closing() as conn:
+        kb.approve_deploy(conn, tid, approver="kevin")
+        ctx2 = kb.build_worker_context(conn, tid)
+    assert "approval recorded: YES" in ctx2

--- a/tests/hermes_cli/test_kanban_autonomy_gate.py
+++ b/tests/hermes_cli/test_kanban_autonomy_gate.py
@@ -1,0 +1,240 @@
+"""REQ-050 (decision 0007) — forced-failure safety-path tests for the deployment
+autonomy enforcement floor. These GATE the first real deploy: the dispatch gate
+must refuse to spawn work above a repo's autonomy ceiling, the kill-switch must
+halt all spawning, and a Tier-C card must never execute regardless of config.
+
+Covers REQ-044 (risk_tier plumbing), REQ-045 (autonomy_ceiling denormalisation),
+and REQ-046 (dispatch gate + kill-switch).
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+
+import pytest
+
+
+@pytest.fixture()
+def isolated_kanban_home(monkeypatch):
+    """Fresh HERMES_HOME with a clean kanban DB (mirrors the default-assignee
+    test fixture so the reimport picks up the isolated home)."""
+    test_home = tempfile.mkdtemp(prefix="kanban_autonomy_gate_test_")
+    monkeypatch.setenv("HERMES_HOME", test_home)
+    # Ensure the kill-switch is off by default for every test.
+    monkeypatch.delenv("HERMES_AUTONOMY_PAUSED", raising=False)
+    monkeypatch.delenv("HERMES_AUTONOMY_PAUSE_FILE", raising=False)
+    for mod in list(sys.modules.keys()):
+        if (
+            mod.startswith("hermes_cli")
+            or mod.startswith("hermes_state")
+            or mod == "hermes_constants"
+        ):
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+    yield kanban_db, test_home
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+def _mk_ready(kb, conn, **kw):
+    """Create a ready, assigned card (defaults to a spawnable assignee)."""
+    kw.setdefault("assignee", "default")
+    return kb.create_task(conn, **kw)
+
+
+# --------------------------------------------------------------------------
+# Pure tier/ceiling logic (REQ-044)
+# --------------------------------------------------------------------------
+
+def test_tier_permitted_matrix(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    f = kb.tier_permitted_by_ceiling
+    assert f("deploy-A", "deploy-A") is True
+    assert f("deploy-A", "deploy-B") is True
+    assert f("deploy-B", "deploy-A") is False
+    # Tier-C never permitted, even under the highest ceiling.
+    assert f("deploy-C", "deploy-B") is False
+    # Unclassified card => repo-only floor (never a deploy).
+    assert f(None, "deploy-B") is True
+    assert f("deploy-A", None) is False          # no ceiling => repo-only default
+    assert f("repo-only", None) is True
+    # plan-only permits only read-only inspect.
+    assert f("inspect", "plan-only") is True
+    assert f("repo-only", "plan-only") is False
+    # Garbage fails closed (treated as max-risk / default ceiling).
+    assert f("bogus", "deploy-B") is True        # unknown tier => repo-only floor
+    assert f("deploy-B", "bogus") is False       # unknown ceiling => repo-only
+
+
+# --------------------------------------------------------------------------
+# Dispatch gate (REQ-046)
+# --------------------------------------------------------------------------
+
+def test_deploy_card_over_ceiling_is_blocked(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        tid = _mk_ready(
+            kb, conn, title="deploy fleet",
+            risk_tier="deploy-B", autonomy_ceiling="deploy-A",
+        )
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+    assert tid in res.skipped_ceiling
+    assert tid not in [s[0] for s in res.spawned]
+    with kb.connect_closing() as conn:
+        row = conn.execute(
+            "SELECT status, block_kind FROM tasks WHERE id = ?", (tid,)
+        ).fetchone()
+        ev = conn.execute(
+            "SELECT COUNT(*) c FROM task_events "
+            "WHERE task_id = ? AND kind = 'skipped_autonomy_ceiling'",
+            (tid,),
+        ).fetchone()
+    assert row["status"] == "blocked"
+    assert row["block_kind"] == "needs_input"
+    assert ev["c"] == 1
+
+
+def test_deploy_card_within_ceiling_passes_gate(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        tid = _mk_ready(
+            kb, conn, title="deploy bot",
+            risk_tier="deploy-A", autonomy_ceiling="deploy-B",
+        )
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+    # The gate let it through — it is NOT ceiling-blocked (whether it then
+    # spawned depends on profile resolution, which is not what we assert here).
+    assert tid not in res.skipped_ceiling
+    with kb.connect_closing() as conn:
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (tid,)
+        ).fetchone()
+    assert row["status"] != "blocked"
+
+
+def test_tier_c_card_never_executes(isolated_kanban_home):
+    """Hard-exclude proof: a deploy-C card (wanctl/work-ansible surface) is
+    blocked even under the most permissive ceiling."""
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        tid = _mk_ready(
+            kb, conn, title="touch live router",
+            risk_tier="deploy-C", autonomy_ceiling="deploy-B",
+        )
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+    assert tid in res.skipped_ceiling
+
+
+def test_unclassified_deploy_defaults_safe(isolated_kanban_home):
+    """No ceiling (no project) => repo-only default: a deploy card is blocked,
+    a repo-only card passes. No autonomous deploy without an explicit opt-in."""
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        deploy = _mk_ready(kb, conn, title="deploy", risk_tier="deploy-A")
+        repo = _mk_ready(kb, conn, title="edit docs", risk_tier="repo-only")
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+    assert deploy in res.skipped_ceiling
+    assert repo not in res.skipped_ceiling
+
+
+def test_dry_run_does_not_block(isolated_kanban_home):
+    """A dry-run tick reports the ceiling skip but must NOT mutate the row."""
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        tid = _mk_ready(
+            kb, conn, title="deploy fleet",
+            risk_tier="deploy-B", autonomy_ceiling="deploy-A",
+        )
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    assert tid in res.skipped_ceiling
+    with kb.connect_closing() as conn:
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (tid,)
+        ).fetchone()
+    assert row["status"] == "ready"  # untouched by dry-run
+
+
+# --------------------------------------------------------------------------
+# Kill-switch (REQ-046)
+# --------------------------------------------------------------------------
+
+def test_kill_switch_env_halts_spawning(isolated_kanban_home, monkeypatch):
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        tid = _mk_ready(kb, conn, title="safe repo card", risk_tier="repo-only")
+    monkeypatch.setenv("HERMES_AUTONOMY_PAUSED", "1")
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+    assert res.autonomy_paused is True
+    assert not res.spawned
+    with kb.connect_closing() as conn:
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (tid,)
+        ).fetchone()
+    # Paused => not spawned, but NOT blocked either (it just waits).
+    assert row["status"] == "ready"
+    # Resume: same card now dispatches (gate lets a repo-only card through).
+    monkeypatch.delenv("HERMES_AUTONOMY_PAUSED", raising=False)
+    with kb.connect_closing() as conn:
+        res2 = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+    assert res2.autonomy_paused is False
+    assert tid not in res2.skipped_ceiling
+
+
+def test_kill_switch_sentinel_file(isolated_kanban_home, monkeypatch):
+    kb, _ = isolated_kanban_home
+    pause_file = tempfile.mktemp(prefix="autonomy_pause_")
+    monkeypatch.setenv("HERMES_AUTONOMY_PAUSE_FILE", pause_file)
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        _mk_ready(kb, conn, title="card", risk_tier="repo-only")
+    # No file yet => not paused.
+    assert kb._autonomy_is_paused() is False
+    import pathlib
+    pathlib.Path(pause_file).write_text("paused by operator\n")
+    assert kb._autonomy_is_paused() is True
+    with kb.connect_closing() as conn:
+        res = kb.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=False)
+    assert res.autonomy_paused is True
+
+
+# --------------------------------------------------------------------------
+# Ceiling denormalisation from the project (REQ-045)
+# --------------------------------------------------------------------------
+
+def test_ceiling_denormalised_from_project(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    from hermes_cli import projects_db as pdb
+    repo = tempfile.mkdtemp(prefix="proj_repo_")
+    with pdb.connect_closing() as pconn:
+        pid = pdb.create_project(pconn, name="wanctl", primary_path=repo)
+        assert pdb.update_project(pconn, pid, autonomy_ceiling="plan-only")
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        tid = kb.create_task(conn, title="wanctl work", assignee="default",
+                             project_id=pid)
+        t = kb.get_task(conn, tid)
+    assert t.autonomy_ceiling == "plan-only"
+
+
+def test_invalid_ceiling_rejected(isolated_kanban_home):
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        with pytest.raises(ValueError):
+            kb.create_task(conn, title="x", autonomy_ceiling="bogus")
+        with pytest.raises(ValueError):
+            kb.create_task(conn, title="x", risk_tier="bogus")

--- a/tests/hermes_cli/test_kanban_autonomy_gate.py
+++ b/tests/hermes_cli/test_kanban_autonomy_gate.py
@@ -411,6 +411,14 @@ def test_approve_deploy_emits_event_and_unblocks(isolated_kanban_home):
 
 def test_deploy_worker_context_surfaces_protocol(isolated_kanban_home):
     kb, _ = isolated_kanban_home
+    # Distinct, non-overlapping command strings so a substring of one step can't
+    # masquerade as another (real specs may share prefixes, e.g. deploy.sh).
+    spec = {
+        "dry_run": "DRYRUN_CMD",
+        "apply": "APPLY_CMD",
+        "verify": "VERIFY_CMD",
+        "rollback": "ROLLBACK_CMD",
+    }
     with kb.connect_closing() as conn:
         kb.create_board(slug="default", name="Test")
         tid = kb.create_task(
@@ -418,13 +426,22 @@ def test_deploy_worker_context_surfaces_protocol(isolated_kanban_home):
             title="deploy",
             assignee="default",
             risk_tier="deploy-A",
-            deploy_spec=_SPEC,
+            deploy_spec=spec,
         )
         ctx = kb.build_worker_context(conn, tid)
+    # REQ-049 mechanical apply-gate: pre-approval the brief shows the dry-run and
+    # the gate, but WITHHOLDS the apply / verify / rollback commands entirely.
     assert "deploy-gate protocol" in ctx
-    assert _SPEC["rollback"] in ctx and _SPEC["verify"] in ctx
-    assert "approval recorded: NO" in ctx  # not yet approved
+    assert "DRYRUN_CMD" in ctx
+    assert "WITHHELD" in ctx and "NOT yet approved" in ctx
+    assert "APPLY_CMD" not in ctx
+    assert "ROLLBACK_CMD" not in ctx
+    assert "VERIFY_CMD" not in ctx
+    # After approval, re-dispatch surfaces the withheld steps.
     with kb.connect_closing() as conn:
         kb.approve_deploy(conn, tid, approver="kevin")
         ctx2 = kb.build_worker_context(conn, tid)
-    assert "approval recorded: YES" in ctx2
+    assert "approved" in ctx2
+    assert "APPLY_CMD" in ctx2
+    assert "ROLLBACK_CMD" in ctx2
+    assert "VERIFY_CMD" in ctx2

--- a/tests/hermes_cli/test_kanban_autonomy_gate.py
+++ b/tests/hermes_cli/test_kanban_autonomy_gate.py
@@ -238,3 +238,61 @@ def test_invalid_ceiling_rejected(isolated_kanban_home):
             kb.create_task(conn, title="x", autonomy_ceiling="bogus")
         with pytest.raises(ValueError):
             kb.create_task(conn, title="x", risk_tier="bogus")
+
+
+# --------------------------------------------------------------------------
+# Risk-gated completion (REQ-047)
+# --------------------------------------------------------------------------
+
+
+def test_deploy_card_completion_held_for_review(isolated_kanban_home):
+    """A deploy card with no attended approval parks in `review`, not `done`."""
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        tid = kb.create_task(
+            conn, title="deploy", assignee="default", risk_tier="deploy-A"
+        )
+        ok = kb.complete_task(conn, tid, result="deployed")
+    assert ok is True
+    with kb.connect_closing() as conn:
+        row = conn.execute("SELECT status FROM tasks WHERE id = ?", (tid,)).fetchone()
+        ev = conn.execute(
+            "SELECT COUNT(*) c FROM task_events "
+            "WHERE task_id = ? AND kind = 'completion_held_for_review'",
+            (tid,),
+        ).fetchone()
+    assert row["status"] == "review"
+    assert ev["c"] == 1
+
+
+def test_deploy_card_completes_with_approval(isolated_kanban_home):
+    """A recorded `deploy_approved` event lets a deploy card auto-close."""
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        tid = kb.create_task(
+            conn, title="deploy", assignee="default", risk_tier="deploy-A"
+        )
+        with kb.write_txn(conn):
+            kb._append_event(conn, tid, "deploy_approved", {"by": "operator"})
+        ok = kb.complete_task(conn, tid, result="deployed")
+    assert ok is True
+    with kb.connect_closing() as conn:
+        row = conn.execute("SELECT status FROM tasks WHERE id = ?", (tid,)).fetchone()
+    assert row["status"] == "done"
+
+
+def test_repo_card_auto_completes(isolated_kanban_home):
+    """Non-deploy cards (repo-only/docs/tests/inspect) auto-close as before."""
+    kb, _ = isolated_kanban_home
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Test")
+        tid = kb.create_task(
+            conn, title="edit docs", assignee="default", risk_tier="repo-only"
+        )
+        ok = kb.complete_task(conn, tid, result="done")
+    assert ok is True
+    with kb.connect_closing() as conn:
+        row = conn.execute("SELECT status FROM tasks WHERE id = ?", (tid,)).fetchone()
+    assert row["status"] == "done"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2205,6 +2205,39 @@ def test_worktree_no_path_no_board_default_raises(kanban_home, tmp_path, monkeyp
             kb.resolve_workspace(task)
 
 
+def test_repo_backed_board_defaults_scratch_card_to_worktree(kanban_home, tmp_path):
+    """REQ-026: a card created on a repo-backed board with no explicit project
+    and no explicit workspace_kind auto-upgrades scratch -> worktree, so a
+    dispatched card is isolated in a per-task worktree instead of running in
+    the board's live checkout."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    kb.create_board("req026-repo-board", default_workdir=str(repo))
+    with kb.connect(board="req026-repo-board") as conn:
+        # NOTE: no workspace_kind arg (defaults to "scratch") and no project.
+        t = kb.create_task(conn, title="edit the repo", board="req026-repo-board")
+        task = kb.get_task(conn, t)
+        assert task is not None
+        assert task.workspace_kind == "worktree"
+        # ...and it provisions under the board repo, not the live checkout.
+        ws = kb.resolve_workspace(task, board="req026-repo-board")
+        assert ws == repo / ".worktrees" / t
+        assert ws != repo
+
+
+def test_non_git_board_default_leaves_card_scratch(kanban_home, tmp_path):
+    """REQ-026 control: a board whose default_workdir is NOT a git repo must not
+    upgrade — the card stays scratch (no spurious worktrees for non-repo work)."""
+    plain = tmp_path / "plain"
+    plain.mkdir()  # a directory, deliberately not a git repo
+    kb.create_board("req026-plain-board", default_workdir=str(plain))
+    with kb.connect(board="req026-plain-board") as conn:
+        t = kb.create_task(conn, title="just a note", board="req026-plain-board")
+        task = kb.get_task(conn, t)
+        assert task is not None
+        assert task.workspace_kind == "scratch"
+
+
 def test_worktree_workspace_explicit_target_materializes_linked_worktree(kanban_home, tmp_path):
     repo = tmp_path / "repo"
     _init_git_repo(repo)

--- a/tests/hermes_cli/test_kanban_worktree_surfacing.py
+++ b/tests/hermes_cli/test_kanban_worktree_surfacing.py
@@ -1,0 +1,197 @@
+"""REQ-027 integration tests — complete_task surfaces worktree integration facts.
+
+saga decision 0004 (surface-don't-merge, preserve-don't-stash): completing a
+``workspace_kind='worktree'`` task must record integration facts into the
+closing run's metadata (``worktree_integration``) and a ``worktree_surfaced``
+task event — and a dirty tree is auto-preserved as a WIP commit on the task
+branch, never stashed. Non-worktree tasks are completely unaffected.
+
+Follows the fixture patterns of tests/hermes_cli/test_kanban_db.py (REQ-026
+worktree board tests).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _init_git_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "kanban@example.com"], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Kanban Test"], check=True, capture_output=True, text=True)
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True, capture_output=True, text=True)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
+def _wt_commit(ws: Path, name: str, msg: str) -> str:
+    (ws / name).write_text(f"{name}\n", encoding="utf-8")
+    _git(ws, "add", "-A")
+    _git(ws, "commit", "-m", msg)
+    return _git(ws, "rev-parse", "HEAD")
+
+
+def _last_run_metadata(conn, task_id: str) -> dict | None:
+    row = conn.execute(
+        "SELECT metadata FROM task_runs WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if row is None or row["metadata"] is None:
+        return None
+    return json.loads(row["metadata"])
+
+
+def _events(conn, task_id: str, kind: str) -> list[dict]:
+    rows = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? AND kind = ? ORDER BY id",
+        (task_id, kind),
+    ).fetchall()
+    return [json.loads(r["payload"]) if r["payload"] else {} for r in rows]
+
+
+def _make_worktree_task(conn, board: str, repo: Path, title: str = "ship") -> tuple[str, Path]:
+    """create_task → materialize worktree → claim: the pre-completion flow."""
+    t = kb.create_task(conn, title=title, workspace_kind="worktree", board=board)
+    task = kb.get_task(conn, t)
+    assert task is not None
+    assert task.workspace_kind == "worktree"
+    ws = kb.resolve_workspace(task, board=board)
+    assert ws == repo / ".worktrees" / t
+    claimed = kb.claim_task(conn, t)
+    assert claimed is not None
+    return t, ws
+
+
+def test_complete_clean_worktree_surfaces_integration_facts(kanban_home, tmp_path):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    kb.create_board("req027-clean", default_workdir=str(repo))
+    with kb.connect(board="req027-clean") as conn:
+        t, ws = _make_worktree_task(conn, "req027-clean", repo)
+        _wt_commit(ws, "one.txt", "first")
+        head = _wt_commit(ws, "two.txt", "second")
+
+        assert kb.complete_task(conn, t, result="ok", summary="done")
+
+        md = _last_run_metadata(conn, t)
+        assert md is not None
+        facts = md["worktree_integration"]
+        assert "error" not in facts
+        assert facts["branch"] == f"wt/{t}"
+        assert facts["head_sha"] == head
+        assert facts["base_branch"] == "main"
+        assert facts["ahead_count"] == 2
+        assert facts["dirty"] is False
+        assert facts["wip_commit"] is None
+        assert facts["repo_root"] == str(repo.resolve())
+        assert facts["diffstat"]
+        assert "one.txt" in facts["diffstat"]
+        assert "two.txt" in facts["diffstat"]
+
+        events = _events(conn, t, "worktree_surfaced")
+        assert len(events) == 1
+        assert events[0]["head_sha"] == head
+        assert events[0]["ahead_count"] == 2
+
+
+def test_complete_dirty_worktree_auto_preserves_wip_commit(kanban_home, tmp_path):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    kb.create_board("req027-dirty", default_workdir=str(repo))
+    with kb.connect(board="req027-dirty") as conn:
+        t, ws = _make_worktree_task(conn, "req027-dirty", repo)
+        _wt_commit(ws, "one.txt", "first")
+        # Leave uncommitted work: one modified tracked file + one untracked.
+        (ws / "one.txt").write_text("changed\n", encoding="utf-8")
+        (ws / "loose.txt").write_text("wip\n", encoding="utf-8")
+
+        assert kb.complete_task(conn, t, result="ok")
+
+        md = _last_run_metadata(conn, t)
+        facts = md["worktree_integration"]
+        assert "error" not in facts
+        assert facts["dirty"] is True
+        wip = facts["wip_commit"]
+        assert wip
+        assert facts["head_sha"] == wip
+        # The dirtiness was preserved INTO the branch (never stashed): the
+        # worktree is clean afterwards and the WIP commit carries both files.
+        assert _git(ws, "status", "--porcelain") == ""
+        msg = _git(repo, "log", "-1", "--format=%s", wip)
+        assert msg == f"wip({t}): auto-preserve at completion"
+        changed = _git(repo, "show", "--stat", "--format=", wip)
+        assert "one.txt" in changed
+        assert "loose.txt" in changed
+        # No stash entries were created.
+        assert _git(repo, "stash", "list") == ""
+        # WIP commit counts toward the surfaced ahead-count (first + wip).
+        assert facts["ahead_count"] == 2
+
+        events = _events(conn, t, "worktree_surfaced")
+        assert len(events) == 1
+        assert events[0]["wip_commit"] == wip
+
+
+def test_complete_non_worktree_task_untouched(kanban_home, tmp_path):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="plain scratch card")
+        task = kb.get_task(conn, t)
+        assert task is not None
+        assert task.workspace_kind == "scratch"
+        kb.claim_task(conn, t)
+
+        assert kb.complete_task(
+            conn, t, result="ok", metadata={"tests_run": ["a"]}
+        )
+
+        md = _last_run_metadata(conn, t)
+        assert md == {"tests_run": ["a"]}  # metadata untouched
+        assert _events(conn, t, "worktree_surfaced") == []
+
+
+def test_complete_worktree_task_missing_worktree_records_error_and_completes(
+    kanban_home, tmp_path
+):
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    kb.create_board("req027-missing", default_workdir=str(repo))
+    with kb.connect(board="req027-missing") as conn:
+        t, ws = _make_worktree_task(conn, "req027-missing", repo)
+        # Simulate a lost checkout: remove the worktree before completion.
+        subprocess.run(
+            ["git", "-C", str(repo), "worktree", "remove", "--force", str(ws)],
+            check=True, capture_output=True, text=True,
+        )
+
+        assert kb.complete_task(conn, t, result="ok")  # never blocked
+
+        task = kb.get_task(conn, t)
+        assert task is not None and task.status == "done"
+        events = _events(conn, t, "worktree_surfaced")
+        assert len(events) == 1
+        assert "error" in events[0]

--- a/tests/hermes_cli/test_prune_plan.py
+++ b/tests/hermes_cli/test_prune_plan.py
@@ -1,0 +1,73 @@
+"""Gate tests for hermes_cli/prune_plan.py — plan_worktree_prune().
+
+Spec (must match exactly):
+  plan_worktree_prune(worktrees: list[dict]) -> list[str]
+  - Each entry MUST have keys: "id" (str), "merged" (bool), "dirty" (bool),
+    "age_days" (int|float). A missing required key raises
+    ValueError mentioning the entry's "id" when it is present, else the
+    entry's index.
+  - An entry is pruned iff: merged is True AND dirty is False AND
+    age_days >= 1 (boundary: exactly 1 day IS pruned).
+  - Unmerged worktrees are NEVER pruned, regardless of age or cleanliness.
+  - Dirty worktrees are NEVER pruned, even when merged and old.
+  - Extra/unknown keys are ignored.
+  - Returns the pruned ids sorted lexicographically; input order must not
+    matter and the input list must not be mutated.
+"""
+import pytest
+
+from hermes_cli.prune_plan import plan_worktree_prune
+
+
+def wt(id, merged, dirty, age_days, **extra):
+    d = {"id": id, "merged": merged, "dirty": dirty, "age_days": age_days}
+    d.update(extra)
+    return d
+
+
+def test_basic_prune_and_keep():
+    plan = plan_worktree_prune([
+        wt("b", True, False, 3),
+        wt("a", True, False, 2.5),
+        wt("keep-young", True, False, 0.5),
+        wt("keep-dirty", True, True, 30),
+        wt("keep-unmerged", False, False, 400),
+    ])
+    assert plan == ["a", "b"]
+
+
+def test_boundary_exactly_one_day():
+    assert plan_worktree_prune([wt("x", True, False, 1)]) == ["x"]
+    assert plan_worktree_prune([wt("x", True, False, 0.999)]) == []
+
+
+def test_unmerged_never_pruned_even_dirty_old():
+    assert plan_worktree_prune([
+        wt("u1", False, True, 999),
+        wt("u2", False, False, 999),
+    ]) == []
+
+
+def test_empty_input():
+    assert plan_worktree_prune([]) == []
+
+
+def test_extra_keys_ignored():
+    assert plan_worktree_prune([wt("x", True, False, 2, branch="b", note=1)]) == ["x"]
+
+
+def test_missing_key_names_id():
+    with pytest.raises(ValueError, match="wt-7"):
+        plan_worktree_prune([{"id": "wt-7", "merged": True, "dirty": False}])
+
+
+def test_missing_key_names_index_when_no_id():
+    with pytest.raises(ValueError, match="0"):
+        plan_worktree_prune([{"merged": True, "dirty": False, "age_days": 2}])
+
+
+def test_input_not_mutated_and_order_independent():
+    items = [wt("z", True, False, 2), wt("a", True, False, 2)]
+    snapshot = [dict(i) for i in items]
+    assert plan_worktree_prune(items) == ["a", "z"]
+    assert items == snapshot

--- a/tests/hermes_cli/test_worktree_lifecycle.py
+++ b/tests/hermes_cli/test_worktree_lifecycle.py
@@ -1,0 +1,273 @@
+"""Tests for the REQ-027/REQ-028 worktree lifecycle helpers.
+
+Covers the read-only helpers in hermes_cli/worktree_safety.py beyond the
+gate-spec suite (detect_default_branch / is_worktree_dirty /
+branch_ahead_count) and the scan+remove orchestration in
+hermes_cli/prune_plan.py (prune_task_worktrees) against real tmp git repos.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.prune_plan import prune_task_worktrees
+from hermes_cli.worktree_safety import (
+    branch_ahead_count,
+    detect_default_branch,
+    is_worktree_dirty,
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
+def _make_repo(path: Path, *, initial_branch: str = "main") -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-b", initial_branch)
+    _git(path, "config", "user.email", "t@t")
+    _git(path, "config", "user.name", "t")
+    (path / "a.txt").write_text("a\n")
+    _git(path, "add", "-A")
+    _git(path, "commit", "-m", "A")
+    return path
+
+
+def _add_commit(repo: Path, name: str, msg: str) -> str:
+    (repo / name).write_text(f"{name}\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", msg)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _add_worktree(repo: Path, wt_id: str, branch: str) -> Path:
+    target = repo / ".worktrees" / wt_id
+    _git(repo, "worktree", "add", "-b", branch, str(target), "HEAD")
+    return target
+
+
+def _age_dir(path: Path, days: float) -> None:
+    """Backdate a directory's mtime by ``days``."""
+    import os
+    import time
+
+    old = time.time() - days * 86400
+    os.utime(path, (old, old))
+
+
+# ---------------------------------------------------------------------------
+# worktree_safety extra helpers
+# ---------------------------------------------------------------------------
+
+def test_detect_default_branch_main(tmp_path):
+    repo = _make_repo(tmp_path / "r", initial_branch="main")
+    assert detect_default_branch(repo) == "main"
+
+
+def test_detect_default_branch_master(tmp_path):
+    repo = _make_repo(tmp_path / "r", initial_branch="master")
+    assert detect_default_branch(repo) == "master"
+
+
+def test_detect_default_branch_prefers_main_over_master(tmp_path):
+    repo = _make_repo(tmp_path / "r", initial_branch="master")
+    _git(repo, "branch", "main")
+    assert detect_default_branch(repo) == "main"
+
+
+def test_detect_default_branch_neither(tmp_path):
+    repo = _make_repo(tmp_path / "r", initial_branch="trunk")
+    assert detect_default_branch(repo) is None
+
+
+def test_is_worktree_dirty_clean(tmp_path):
+    repo = _make_repo(tmp_path / "r")
+    assert is_worktree_dirty(repo) is False
+
+
+def test_is_worktree_dirty_untracked(tmp_path):
+    repo = _make_repo(tmp_path / "r")
+    (repo / "new.txt").write_text("x\n")
+    assert is_worktree_dirty(repo) is True
+
+
+def test_is_worktree_dirty_modified_tracked(tmp_path):
+    repo = _make_repo(tmp_path / "r")
+    (repo / "a.txt").write_text("changed\n")
+    assert is_worktree_dirty(repo) is True
+
+
+def test_is_worktree_dirty_nonrepo_raises(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    with pytest.raises(RuntimeError):
+        is_worktree_dirty(plain)
+
+
+def test_branch_ahead_count_zero_and_two(tmp_path):
+    repo = _make_repo(tmp_path / "r")
+    _git(repo, "checkout", "-b", "feat")
+    assert branch_ahead_count(repo, "feat", "main") == 0
+    _add_commit(repo, "b.txt", "B")
+    _add_commit(repo, "c.txt", "C")
+    _git(repo, "checkout", "main")
+    assert branch_ahead_count(repo, "feat", "main") == 2
+    # base moving ahead does not change feat's ahead count semantics
+    _add_commit(repo, "d.txt", "D")
+    assert branch_ahead_count(repo, "feat", "main") == 2
+
+
+def test_branch_ahead_count_unknown_ref_raises(tmp_path):
+    repo = _make_repo(tmp_path / "r")
+    with pytest.raises(ValueError, match="nope"):
+        branch_ahead_count(repo, "nope", "main")
+
+
+# ---------------------------------------------------------------------------
+# prune_task_worktrees
+# ---------------------------------------------------------------------------
+
+def test_prune_merged_old_worktree_removed_and_branch_deleted(tmp_path):
+    repo = _make_repo(tmp_path / "r")
+    wt = _add_worktree(repo, "t_merged", "wt/t_merged")
+    _add_commit(wt, "b.txt", "B")
+    _git(repo, "merge", "--no-ff", "wt/t_merged", "-m", "merge")
+    _age_dir(wt, days=3)
+
+    report = prune_task_worktrees(repo, dry_run=False)
+
+    assert report["planned"] == ["t_merged"]
+    assert report["removed"] == ["t_merged"]
+    assert report["errors"] == {}
+    assert not wt.exists()
+    listed = _git(repo, "worktree", "list", "--porcelain")
+    assert "t_merged" not in listed
+    branches = _git(repo, "branch", "--list", "wt/t_merged")
+    assert branches == ""  # branch safe-deleted
+
+
+def test_prune_unmerged_never_pruned_even_when_ancient(tmp_path):
+    repo = _make_repo(tmp_path / "r")
+    wt = _add_worktree(repo, "t_unmerged", "wt/t_unmerged")
+    _add_commit(wt, "b.txt", "B")  # not merged into main
+    _age_dir(wt, days=400)
+
+    report = prune_task_worktrees(repo, dry_run=False)
+
+    assert report["planned"] == []
+    assert report["removed"] == []
+    assert report["kept_unmerged"] == ["t_unmerged"]
+    assert wt.exists()
+    assert _git(repo, "branch", "--list", "wt/t_unmerged") != ""
+
+
+def test_prune_dirty_worktree_kept(tmp_path):
+    repo = _make_repo(tmp_path / "r")
+    wt = _add_worktree(repo, "t_dirty", "wt/t_dirty")
+    _add_commit(wt, "b.txt", "B")
+    _git(repo, "merge", "--no-ff", "wt/t_dirty", "-m", "merge")
+    (wt / "uncommitted.txt").write_text("wip\n")
+    _age_dir(wt, days=10)
+
+    report = prune_task_worktrees(repo, dry_run=False)
+
+    assert report["planned"] == []
+    assert report["kept_dirty"] == ["t_dirty"]
+    assert wt.exists()
+
+
+def test_prune_young_merged_worktree_kept(tmp_path):
+    repo = _make_repo(tmp_path / "r")
+    wt = _add_worktree(repo, "t_young", "wt/t_young")
+    _add_commit(wt, "b.txt", "B")
+    _git(repo, "merge", "--no-ff", "wt/t_young", "-m", "merge")
+    # mtime is "now" → age < 1 day
+
+    report = prune_task_worktrees(repo, dry_run=False)
+
+    assert report["planned"] == []
+    assert report["kept_young"] == ["t_young"]
+    assert wt.exists()
+
+
+def test_prune_dry_run_removes_nothing(tmp_path):
+    repo = _make_repo(tmp_path / "r")
+    wt = _add_worktree(repo, "t_merged", "wt/t_merged")
+    _add_commit(wt, "b.txt", "B")
+    _git(repo, "merge", "--no-ff", "wt/t_merged", "-m", "merge")
+    _age_dir(wt, days=3)
+
+    report = prune_task_worktrees(repo)  # dry_run defaults True
+
+    assert report["planned"] == ["t_merged"]
+    assert report["removed"] == []
+    assert wt.exists()
+    assert _git(repo, "branch", "--list", "wt/t_merged") != ""
+
+
+def test_prune_now_override_controls_age(tmp_path):
+    repo = _make_repo(tmp_path / "r")
+    wt = _add_worktree(repo, "t_x", "wt/t_x")
+    _add_commit(wt, "b.txt", "B")
+    _git(repo, "merge", "--no-ff", "wt/t_x", "-m", "merge")
+    mtime = wt.stat().st_mtime
+
+    young = prune_task_worktrees(repo, now=mtime + 3600)  # 1h old
+    old = prune_task_worktrees(repo, now=mtime + 2 * 86400)  # 2d old
+    assert young["planned"] == []
+    assert young["kept_young"] == ["t_x"]
+    assert old["planned"] == ["t_x"]
+
+
+def test_prune_detached_head_treated_as_unmerged(tmp_path):
+    repo = _make_repo(tmp_path / "r")
+    wt = _add_worktree(repo, "t_detached", "wt/t_detached")
+    _git(wt, "checkout", "--detach", "HEAD")
+    _age_dir(wt, days=5)
+
+    report = prune_task_worktrees(repo, dry_run=False)
+
+    assert report["planned"] == []
+    assert report["kept_unmerged"] == ["t_detached"]
+    assert wt.exists()
+
+
+def test_prune_no_worktrees_dir(tmp_path):
+    repo = _make_repo(tmp_path / "r")
+    report = prune_task_worktrees(repo, dry_run=False)
+    assert report == {
+        "planned": [],
+        "removed": [],
+        "kept_unmerged": [],
+        "kept_dirty": [],
+        "kept_young": [],
+        "errors": {},
+    }
+
+
+def test_prune_error_on_one_entry_does_not_abort_others(tmp_path):
+    repo = _make_repo(tmp_path / "r")
+    # A plain directory inside .worktrees that is NOT a git checkout: the
+    # dirty probe raises for it, but the sibling must still be processed.
+    bogus = repo / ".worktrees" / "a_bogus"
+    bogus.mkdir(parents=True)
+    # git treats a plain subdir of the repo as part of the main checkout, so
+    # simulate a scan failure via an unreadable state instead: use a name
+    # that git worktree knows nothing about but whose branch probe works.
+    wt = _add_worktree(repo, "t_ok", "wt/t_ok")
+    _add_commit(wt, "b.txt", "B")
+    _git(repo, "merge", "--no-ff", "wt/t_ok", "-m", "merge")
+    _age_dir(wt, days=3)
+    _age_dir(bogus, days=3)
+
+    report = prune_task_worktrees(repo, dry_run=False)
+
+    # t_ok is pruned regardless of what happened with the bogus entry.
+    assert "t_ok" in report["removed"]
+    assert not wt.exists()

--- a/tests/hermes_cli/test_worktree_parent_base.py
+++ b/tests/hermes_cli/test_worktree_parent_base.py
@@ -1,0 +1,317 @@
+"""REQ-034 integration tests — child worktree branches from parent's surfaced head_sha.
+
+When a kanban card has a parent whose completed run metadata contains
+``worktree_integration`` facts, the child's worktree is created FROM the
+parent's ``head_sha`` instead of ``HEAD``.  Falls back to current behavior
+(HEAD) when no parent facts exist or the ref is missing — never errors the
+claim path.
+
+Follows the fixture patterns of tests/hermes_cli/test_kanban_worktree_surfacing.py.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _init_git_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "kanban@example.com"], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Kanban Test"], check=True, capture_output=True, text=True)
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True, capture_output=True, text=True)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
+def _wt_commit(ws: Path, name: str, msg: str) -> str:
+    (ws / name).write_text(f"{name}\n", encoding="utf-8")
+    _git(ws, "add", "-A")
+    _git(ws, "commit", "-m", msg)
+    return _git(ws, "rev-parse", "HEAD")
+
+
+def _last_run_metadata(conn, task_id: str) -> dict | None:
+    row = conn.execute(
+        "SELECT metadata FROM task_runs WHERE task_id = ? ORDER BY id DESC LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if row is None or row["metadata"] is None:
+        return None
+    return json.loads(row["metadata"])
+
+
+def _make_worktree_task(conn, board: str, repo: Path, title: str = "parent") -> tuple[str, Path]:
+    """create_task -> materialize worktree -> claim: the pre-completion flow."""
+    t = kb.create_task(conn, title=title, workspace_kind="worktree", board=board)
+    task = kb.get_task(conn, t)
+    assert task is not None
+    assert task.workspace_kind == "worktree"
+    ws = kb.resolve_workspace(task, board=board)
+    assert ws == repo / ".worktrees" / t
+    claimed = kb.claim_task(conn, t)
+    assert claimed is not None
+    return t, ws
+
+
+# ---------------------------------------------------------------------------
+# Test 1: parent with surfaced branch -> child worktree HEAD == parent head_sha
+# ---------------------------------------------------------------------------
+
+def test_child_worktree_branches_from_parent_head_sha(kanban_home, tmp_path):
+    """When a parent worktree task completes with surfaced integration facts,
+    a child worktree task's worktree is branched from the parent's head_sha."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    kb.create_board("req034-parent", default_workdir=str(repo))
+
+    with kb.connect(board="req034-parent") as conn:
+        # Create and complete parent with work on its branch
+        parent_id, parent_ws = _make_worktree_task(conn, "req034-parent", repo, "parent task")
+        parent_head = _wt_commit(parent_ws, "parent_file.txt", "parent work")
+
+        assert kb.complete_task(conn, parent_id, result="ok", summary="parent done")
+
+        # Verify parent has worktree_integration facts
+        parent_md = _last_run_metadata(conn, parent_id)
+        assert parent_md is not None
+        wt_facts = parent_md["worktree_integration"]
+        assert wt_facts["head_sha"] == parent_head
+
+        # Create child task linked to parent
+        child_id = kb.create_task(
+            conn, title="child task", workspace_kind="worktree",
+            board="req034-parent", parents=[parent_id],
+        )
+        child_task = kb.get_task(conn, child_id)
+        assert child_task is not None
+
+        # Claim and resolve workspace — this is where the branching happens
+        kb.claim_task(conn, child_id)
+        child_task = kb.get_task(conn, child_id)
+        child_ws = kb.resolve_workspace(child_task, board="req034-parent", conn=conn)
+
+        # Verify child worktree HEAD == parent head_sha
+        child_head = _git(child_ws, "rev-parse", "HEAD")
+        assert child_head == parent_head, (
+            f"child worktree HEAD {child_head} should equal parent head_sha {parent_head}"
+        )
+
+        # Verify child is on its own branch
+        child_branch = _git(child_ws, "rev-parse", "--abbrev-ref", "HEAD")
+        assert child_branch == f"wt/{child_id}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: no parent facts -> falls back to HEAD
+# ---------------------------------------------------------------------------
+
+def test_child_worktree_falls_back_to_head_when_no_parent_facts(kanban_home, tmp_path):
+    """When a parent exists but has no worktree_integration metadata,
+    child falls back to HEAD (current behavior)."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    kb.create_board("req034-nofacts", default_workdir=str(repo))
+
+    # Record the main HEAD before any worktree work
+    main_head_before = _git(repo, "rev-parse", "HEAD")
+
+    with kb.connect(board="req034-nofacts") as conn:
+        # Create a non-worktree parent (scratch) — no worktree_integration facts
+        parent_id = kb.create_task(conn, title="scratch parent")
+        parent_task = kb.get_task(conn, parent_id)
+        assert parent_task is not None
+        kb.claim_task(conn, parent_id)
+        kb.complete_task(conn, parent_id, result="ok")
+
+        # Create child worktree task linked to the scratch parent
+        child_id = kb.create_task(
+            conn, title="child worktree", workspace_kind="worktree",
+            board="req034-nofacts", parents=[parent_id],
+        )
+        child_task = kb.get_task(conn, child_id)
+        assert child_task is not None
+
+        kb.claim_task(conn, child_id)
+        child_task = kb.get_task(conn, child_id)
+        child_ws = kb.resolve_workspace(child_task, board="req034-nofacts", conn=conn)
+
+        # Child should branch from HEAD (which is main_head_before since no
+        # worktree commits touched main)
+        child_head = _git(child_ws, "rev-parse", "HEAD")
+        assert child_head == main_head_before, (
+            f"child should fall back to HEAD ({main_head_before}), got {child_head}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: missing/deleted parent branch -> falls back cleanly
+# ---------------------------------------------------------------------------
+
+def test_child_worktree_falls_back_when_parent_branch_deleted(kanban_home, tmp_path):
+    """When parent had worktree_integration facts but the branch is gone,
+    child falls back to HEAD without error."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    kb.create_board("req034-deleted", default_workdir=str(repo))
+
+    with kb.connect(board="req034-deleted") as conn:
+        # Create and complete parent
+        parent_id, parent_ws = _make_worktree_task(conn, "req034-deleted", repo)
+        parent_head = _wt_commit(parent_ws, "parent.txt", "parent work")
+
+        assert kb.complete_task(conn, parent_id, result="ok", summary="done")
+
+        # Verify parent metadata has the head_sha
+        parent_md = _last_run_metadata(conn, parent_id)
+        assert parent_md["worktree_integration"]["head_sha"] == parent_head
+
+        # Now remove the worktree and delete the parent branch from the repo
+        parent_branch = f"wt/{parent_id}"
+        subprocess.run(
+            ["git", "-C", str(repo), "worktree", "remove", "--force", str(parent_ws)],
+            capture_output=True, text=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "branch", "-D", parent_branch],
+            capture_output=True, text=True,
+        )
+        assert not _git(repo, "branch", "--list", parent_branch)
+
+        # Force GC so the parent's SHA is truly unreachable
+        subprocess.run(
+            ["git", "-C", str(repo), "reflog", "expire", "--expire-unreachable=0", "--all"],
+            capture_output=True, text=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo), "gc", "--prune=now"],
+            capture_output=True, text=True,
+        )
+
+        # Verify the parent SHA is now gone (use check=False since cat-file -e returns 1 when missing)
+        result = subprocess.run(
+            ["git", "-C", str(repo), "cat-file", "-e", parent_head],
+            capture_output=True, text=True, check=False,
+        )
+        assert result.returncode != 0, (
+            "parent head_sha should be unreachable after GC"
+        )
+
+        # Record current HEAD (main, unchanged)
+        main_head = _git(repo, "rev-parse", "HEAD")
+
+        # Create child — should fall back to HEAD since parent branch is gone
+        child_id = kb.create_task(
+            conn, title="child after parent branch deleted",
+            workspace_kind="worktree",
+            board="req034-deleted", parents=[parent_id],
+        )
+        child_task = kb.get_task(conn, child_id)
+        assert child_task is not None
+
+        kb.claim_task(conn, child_id)
+        child_task = kb.get_task(conn, child_id)
+
+        # Should NOT raise — falls back to HEAD
+        child_ws = kb.resolve_workspace(child_task, board="req034-deleted", conn=conn)
+
+        # Child should have branched from HEAD (main) since parent SHA is
+        # unreachable
+        child_head = _git(child_ws, "rev-parse", "HEAD")
+        assert child_head == main_head, (
+            f"child should fall back to HEAD ({main_head}), got {child_head}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: no parents at all -> falls back to HEAD (baseline)
+# ---------------------------------------------------------------------------
+
+def test_worktree_with_no_parents_uses_head(kanban_home, tmp_path):
+    """A worktree task with no parents at all branches from HEAD."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    kb.create_board("req034-noparent", default_workdir=str(repo))
+
+    main_head = _git(repo, "rev-parse", "HEAD")
+
+    with kb.connect(board="req034-noparent") as conn:
+        child_id = kb.create_task(
+            conn, title="orphan worktree", workspace_kind="worktree",
+            board="req034-noparent",
+        )
+        child_task = kb.get_task(conn, child_id)
+        assert child_task is not None
+
+        kb.claim_task(conn, child_id)
+        child_task = kb.get_task(conn, child_id)
+        child_ws = kb.resolve_workspace(child_task, board="req034-noparent", conn=conn)
+
+        child_head = _git(child_ws, "rev-parse", "HEAD")
+        assert child_head == main_head
+
+
+# ---------------------------------------------------------------------------
+# Test 5: parent with worktree_integration error -> falls back to HEAD
+# ---------------------------------------------------------------------------
+
+def test_child_falls_back_when_parent_worktree_integration_has_error(kanban_home, tmp_path):
+    """When parent's worktree_integration contains an 'error' key,
+    child falls back to HEAD instead of trying the bad ref."""
+    repo = tmp_path / "repo"
+    _init_git_repo(repo)
+    kb.create_board("req034-errparent", default_workdir=str(repo))
+
+    main_head = _git(repo, "rev-parse", "HEAD")
+
+    with kb.connect(board="req034-errparent") as conn:
+        # Create a scratch parent with manually injected bad metadata
+        parent_id = kb.create_task(conn, title="broken parent")
+        parent_task = kb.get_task(conn, parent_id)
+        assert parent_task is not None
+        kb.claim_task(conn, parent_id)
+        kb.complete_task(
+            conn, parent_id, result="ok",
+            metadata={"worktree_integration": {"error": "worktree not found"}},
+        )
+
+        # Create child
+        child_id = kb.create_task(
+            conn, title="child of broken parent", workspace_kind="worktree",
+            board="req034-errparent", parents=[parent_id],
+        )
+        child_task = kb.get_task(conn, child_id)
+        assert child_task is not None
+
+        kb.claim_task(conn, child_id)
+        child_task = kb.get_task(conn, child_id)
+        child_ws = kb.resolve_workspace(child_task, board="req034-errparent", conn=conn)
+
+        child_head = _git(child_ws, "rev-parse", "HEAD")
+        assert child_head == main_head, (
+            f"child should fall back to HEAD when parent has error, got {child_head}"
+        )

--- a/tests/hermes_cli/test_worktree_safety.py
+++ b/tests/hermes_cli/test_worktree_safety.py
@@ -1,0 +1,89 @@
+"""Gate tests for hermes_cli/worktree_safety.py — is_branch_unmerged().
+
+Spec (must match exactly):
+  is_branch_unmerged(repo: Path, branch: str, base: str = "main") -> bool
+  - True  iff `branch` has at least one commit NOT reachable from `base`.
+  - False if every commit of `branch` is an ancestor of (or equal to) `base`.
+  - branch == base -> False.
+  - Unknown branch OR unknown base -> raise ValueError naming the missing ref.
+  - Must not mutate the repository (read-only git commands only).
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.worktree_safety import is_branch_unmerged
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "r"
+    r.mkdir()
+    _git(r, "init", "-b", "main")
+    _git(r, "config", "user.email", "t@t")
+    _git(r, "config", "user.name", "t")
+    (r / "a.txt").write_text("a\n")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-m", "A")
+    return r
+
+
+def test_unmerged_branch_true(repo: Path):
+    _git(repo, "checkout", "-b", "feat")
+    (repo / "b.txt").write_text("b\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "B")
+    _git(repo, "checkout", "main")
+    assert is_branch_unmerged(repo, "feat") is True
+
+
+def test_merged_branch_false(repo: Path):
+    _git(repo, "checkout", "-b", "feat")
+    (repo / "b.txt").write_text("b\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "B")
+    _git(repo, "checkout", "main")
+    _git(repo, "merge", "--no-ff", "feat", "-m", "merge")
+    assert is_branch_unmerged(repo, "feat") is False
+
+
+def test_branch_equals_base(repo: Path):
+    assert is_branch_unmerged(repo, "main") is False
+
+
+def test_branch_at_older_ancestor_false(repo: Path):
+    _git(repo, "branch", "old")  # points at A
+    (repo / "c.txt").write_text("c\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "C")  # main moves ahead
+    assert is_branch_unmerged(repo, "old") is False
+
+
+def test_unknown_branch_raises(repo: Path):
+    with pytest.raises(ValueError, match="nope"):
+        is_branch_unmerged(repo, "nope")
+
+
+def test_unknown_base_raises(repo: Path):
+    with pytest.raises(ValueError, match="devel"):
+        is_branch_unmerged(repo, "main", base="devel")
+
+
+def test_readonly(repo: Path):
+    _git(repo, "checkout", "-b", "feat")
+    (repo / "b.txt").write_text("b\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "B")
+    _git(repo, "checkout", "main")
+    before = _git(repo, "rev-parse", "main") + _git(repo, "rev-parse", "feat")
+    is_branch_unmerged(repo, "feat")
+    after = _git(repo, "rev-parse", "main") + _git(repo, "rev-parse", "feat")
+    assert before == after

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -325,6 +325,160 @@ class TestChannelInfo:
 
 
 # ---------------------------------------------------------------------------
+# Action: create_channel
+# ---------------------------------------------------------------------------
+
+class TestCreateChannel:
+    @patch("tools.discord_tool._discord_request")
+    def test_create_text_channel_request_and_response(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": ""}},
+        )
+        mock_req.return_value = {
+            "id": "900",
+            "name": "ops_alerts",
+            "type": 0,
+            "guild_id": "111",
+            "parent_id": "10",
+            "topic": "Operational alerts",
+        }
+
+        result = json.loads(discord_admin_handler(
+            action="create_channel",
+            guild_id="111",
+            name="Ops_Alerts",
+            channel_type="text",
+            topic="Operational alerts",
+            parent_id="10",
+        ))
+
+        assert result == {
+            "success": True,
+            "channel_id": "900",
+            "name": "ops_alerts",
+            "type": "text",
+            "guild_id": "111",
+            "parent_id": "10",
+            "topic": "Operational alerts",
+        }
+        mock_req.assert_called_once_with(
+            "POST", "/guilds/111/channels", "test-token",
+            body={
+                "name": "ops_alerts",
+                "type": 0,
+                "topic": "Operational alerts",
+                "parent_id": "10",
+            },
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_voice_channel_ignores_topic(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": ""}},
+        )
+        mock_req.return_value = {
+            "id": "901", "name": "standup", "type": 2, "guild_id": "111",
+            "parent_id": "10",
+        }
+
+        result = json.loads(discord_admin_handler(
+            action="create_channel",
+            guild_id="111",
+            name="standup",
+            channel_type="voice",
+            topic="voice channels cannot have a topic",
+            parent_id="10",
+        ))
+
+        assert result["success"] is True
+        assert result["type"] == "voice"
+        mock_req.assert_called_once_with(
+            "POST", "/guilds/111/channels", "test-token",
+            body={"name": "standup", "type": 2, "parent_id": "10"},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_channel_requires_guild_id_and_name(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": ""}},
+        )
+
+        missing_guild = json.loads(discord_admin_handler(
+            action="create_channel", name="ops-alerts",
+        ))
+        missing_name = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111",
+        ))
+
+        assert "guild_id" in missing_guild["error"]
+        assert "name" in missing_name["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_channel_rejects_unsupported_channel_type_without_api_call(
+        self, mock_req, monkeypatch,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": ""}},
+        )
+
+        result = json.loads(discord_admin_handler(
+            action="create_channel",
+            guild_id="111",
+            name="ops-alerts",
+            channel_type="thread",
+        ))
+
+        assert "Unsupported channel_type" in result["error"]
+        assert "text" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_channel_rejects_invalid_name_without_api_call(
+        self, mock_req, monkeypatch,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": ""}},
+        )
+
+        result = json.loads(discord_admin_handler(
+            action="create_channel",
+            guild_id="111",
+            name="bad channel name!",
+        ))
+
+        assert "Invalid channel name" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_create_channel_403_is_enriched(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": ""}},
+        )
+        mock_req.side_effect = DiscordAPIError(403, '{"message":"Missing Permissions"}')
+
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="ops-alerts",
+        ))
+
+        assert "error" in result
+        assert "MANAGE_CHANNELS" in result["error"]
+        assert "Missing Permissions" in result["error"]
+
+
+# ---------------------------------------------------------------------------
 # Action: list_roles
 # ---------------------------------------------------------------------------
 
@@ -616,6 +770,19 @@ class TestRegistration:
         assert props["limit"]["maximum"] == 100
         assert props["auto_archive_duration"]["enum"] == [60, 1440, 4320, 10080]
 
+    def test_admin_schema_create_channel_parameters(self):
+        from tools.registry import registry
+        entry = registry._tools["discord_admin"]
+        props = entry.schema["parameters"]["properties"]
+        actions = entry.schema["parameters"]["properties"]["action"]["enum"]
+        assert "create_channel" in actions
+        assert props["channel_type"]["enum"] == [
+            "text", "voice", "category", "announcement", "forum", "media",
+        ]
+        assert props["topic"]["description"] == "Channel topic for create_channel."
+        assert props["parent_id"]["description"] == "Category parent ID for create_channel."
+        assert "create_channel" in props["name"]["description"]
+
     def test_core_schema_description(self):
         """Core schema description should mention core actions."""
         from tools.registry import registry
@@ -634,6 +801,7 @@ class TestRegistration:
         entry = registry._tools["discord_admin"]
         desc = entry.schema["description"]
         assert "list_guilds()" in desc
+        assert "create_channel(guild_id, name)" in desc
         assert "add_role(guild_id, user_id, role_id)" in desc
         assert "delete_message(channel_id, message_id)" in desc
         # Core actions should NOT be in admin description
@@ -1191,6 +1359,22 @@ class TestRuntimeAllowlistEnforcement:
         result = json.loads(discord_admin_handler(action="list_guilds"))
         assert "guilds" in result
 
+    @patch("tools.discord_tool._discord_request")
+    def test_create_channel_is_governed_by_runtime_allowlist(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "tok")
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"server_actions": "list_guilds"}},
+        )
+
+        result = json.loads(discord_admin_handler(
+            action="create_channel", guild_id="111", name="ops-alerts",
+        ))
+
+        assert "disabled by config" in result["error"]
+        assert "list_guilds" in result["error"]
+        mock_req.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # 403 enrichment
@@ -1206,6 +1390,11 @@ class Test403Enrichment:
         msg = _enrich_403("some_new_action", '{"message":"weird"}')
         assert "some_new_action" in msg
         assert "weird" in msg
+
+    def test_create_channel_enrichment_mentions_manage_channels(self):
+        msg = _enrich_403("create_channel", '{"message":"Missing Permissions"}')
+        assert "MANAGE_CHANNELS" in msg
+        assert "Missing Permissions" in msg
 
     @patch("tools.discord_tool._discord_request")
     def test_403_in_runtime_is_enriched(self, mock_req, monkeypatch):

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -28,6 +28,7 @@ actionable guidance the model can relay to the user.
 import json
 import logging
 import os
+import re
 import threading
 import urllib.error
 import urllib.parse
@@ -451,6 +452,69 @@ def _channel_info(token: str, channel_id: str, **_kwargs: Any) -> str:
     })
 
 
+def _create_channel(
+    token: str,
+    guild_id: str,
+    name: str,
+    channel_type: str = "text",
+    topic: Optional[str] = None,
+    parent_id: Optional[str] = None,
+    **_kwargs: Any,
+) -> str:
+    """Create a channel in a guild."""
+    type_map = {
+        "text": 0,
+        "voice": 2,
+        "category": 4,
+        "announcement": 5,
+        "forum": 15,
+        "media": 16,
+    }
+    normalized_type = (channel_type or "text").strip().lower()
+    if normalized_type not in type_map:
+        return json.dumps(
+            {
+                "error": (
+                    f"Unsupported channel_type: {channel_type!r}. "
+                    f"Allowed: {', '.join(type_map.keys())}"
+                ),
+            }
+        )
+
+    normalized_name = (name or "").strip().lower()
+    if not re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,98}", normalized_name):
+        return json.dumps(
+            {
+                "error": (
+                    "Invalid channel name. Use 1-99 lowercase letters, numbers, "
+                    "hyphens, or underscores, starting with a letter or number."
+                ),
+            }
+        )
+
+    body: Dict[str, Any] = {
+        "name": normalized_name,
+        "type": type_map[normalized_type],
+    }
+    if topic and normalized_type in {"text", "announcement", "forum", "media"}:
+        body["topic"] = topic
+    if parent_id and normalized_type != "category":
+        body["parent_id"] = parent_id
+
+    channel = _discord_request("POST", f"/guilds/{guild_id}/channels", token, body=body)
+    return json.dumps(
+        {
+            "success": True,
+            "channel_id": channel["id"],
+            "name": channel.get("name"),
+            "type": _channel_type_name(channel.get("type", body["type"])),
+            "guild_id": channel.get("guild_id"),
+            "parent_id": channel.get("parent_id"),
+            "topic": channel.get("topic"),
+        }
+    )
+
+
 def _list_roles(token: str, guild_id: str, **_kwargs: Any) -> str:
     """List all roles in a guild."""
     roles = _discord_request("GET", f"/guilds/{guild_id}/roles", token)
@@ -635,6 +699,7 @@ _ACTIONS = {
     "server_info": _server_info,
     "list_channels": _list_channels,
     "channel_info": _channel_info,
+    "create_channel": _create_channel,
     "list_roles": _list_roles,
     "member_info": _member_info,
     "search_members": _search_members,
@@ -662,6 +727,11 @@ _ACTION_MANIFEST: List[Tuple[str, str, str]] = [
     ("server_info", "(guild_id)", "server details + member counts"),
     ("list_channels", "(guild_id)", "all channels grouped by category"),
     ("channel_info", "(channel_id)", "single channel details"),
+    (
+        "create_channel",
+        "(guild_id, name)",
+        "create a channel; optional channel_type, topic, parent_id",
+    ),
     ("list_roles", "(guild_id)", "roles sorted by position"),
     ("member_info", "(guild_id, user_id)", "lookup a specific member"),
     ("search_members", "(guild_id, query)", "find members by name prefix"),
@@ -682,6 +752,7 @@ _INTENT_GATED_MEMBERS = frozenset({"member_info", "search_members"})
 _REQUIRED_PARAMS: Dict[str, List[str]] = {
     "server_info": ["guild_id"],
     "list_channels": ["guild_id"],
+    "create_channel": ["guild_id", "name"],
     "list_roles": ["guild_id"],
     "member_info": ["guild_id", "user_id"],
     "search_members": ["guild_id", "query"],
@@ -851,7 +922,20 @@ def _build_schema(
         },
         "name": {
             "type": "string",
-            "description": "New thread name (create_thread).",
+            "description": "New thread name (create_thread) or channel name (create_channel).",
+        },
+        "channel_type": {
+            "type": "string",
+            "enum": ["text", "voice", "category", "announcement", "forum", "media"],
+            "description": "Channel type for create_channel (default text).",
+        },
+        "topic": {
+            "type": "string",
+            "description": "Channel topic for create_channel.",
+        },
+        "parent_id": {
+            "type": "string",
+            "description": "Category parent ID for create_channel.",
         },
         "limit": {
             "type": "integer",
@@ -933,6 +1017,10 @@ _ACTION_403_HINT = {
     "create_thread": (
         "Bot lacks CREATE_PUBLIC_THREADS in this channel, or cannot view it."
     ),
+    "create_channel": (
+        "Bot lacks MANAGE_CHANNELS in this server, or the bot role does not have "
+        "access to create channels in the target category."
+    ),
     "add_role": (
         "Either the bot lacks MANAGE_ROLES, or the target role sits higher "
         "than the bot's highest role. Roles can only be assigned below the "
@@ -995,6 +1083,9 @@ def _run_discord_action(
     message_id: str = "",
     query: str = "",
     name: str = "",
+    channel_type: str = "text",
+    topic: str = "",
+    parent_id: str = "",
     limit: int = 50,
     before: str = "",
     after: str = "",
@@ -1032,6 +1123,9 @@ def _run_discord_action(
         "message_id": message_id,
         "query": query,
         "name": name,
+        "channel_type": channel_type,
+        "topic": topic,
+        "parent_id": parent_id,
     }
 
     missing = [p for p in _REQUIRED_PARAMS.get(action, []) if not local_vars.get(p)]
@@ -1050,6 +1144,9 @@ def _run_discord_action(
             message_id=message_id,
             query=query,
             name=name,
+            channel_type=channel_type,
+            topic=topic or None,
+            parent_id=parent_id or None,
             limit=limit,
             before=before,
             after=after,
@@ -1080,9 +1177,21 @@ def discord_admin_handler(action: str, **kwargs) -> str:
 # ---------------------------------------------------------------------------
 
 _HANDLER_DEFAULTS = {
-    "action": "", "guild_id": "", "channel_id": "", "user_id": "",
-    "role_id": "", "message_id": "", "query": "", "name": "",
-    "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
+    "action": "",
+    "guild_id": "",
+    "channel_id": "",
+    "user_id": "",
+    "role_id": "",
+    "message_id": "",
+    "query": "",
+    "name": "",
+    "channel_type": "text",
+    "topic": "",
+    "parent_id": "",
+    "limit": 50,
+    "before": "",
+    "after": "",
+    "auto_archive_duration": 1440,
 }
 
 

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -6,7 +6,7 @@ description: "Receive events from GitHub, GitLab, and other services to trigger 
 
 # Webhooks
 
-Receive events from external services (GitHub, GitLab, JIRA, Stripe, etc.) and trigger Hermes agent runs automatically. The webhook adapter runs an HTTP server that accepts POST requests, validates HMAC signatures, transforms payloads into agent prompts, and routes responses back to the source or to another configured platform.
+Receive events from external services (GitHub, GitLab, JIRA, Stripe, etc.) and trigger Hermes agent runs automatically. The webhook adapter runs an HTTP server that accepts POST requests, validates route authentication, transforms payloads into agent prompts, and routes responses back to the source or to another configured platform.
 
 The agent processes the event and can respond by posting comments on PRs, sending messages to Telegram/Discord, or logging the result.
 
@@ -68,6 +68,37 @@ Expected response:
 {"status": "ok", "platform": "webhook"}
 ```
 
+For direct-delivery routes, also check target readiness:
+
+```bash
+curl http://localhost:8644/ready
+```
+
+`GET /ready` returns `200 OK` when every `deliver_only` route has a usable delivery target and `503 Service Unavailable` when any direct-delivery route is not ready. The JSON body includes per-route and per-target status, for example:
+
+```json
+{
+  "status": "not_ready",
+  "platform": "webhook",
+  "routes": {
+    "ops-alerts": {
+      "status": "not_ready",
+      "deliver": "discord",
+      "reason": "platform discord not connected"
+    }
+  },
+  "targets": {
+    "discord": {
+      "status": "not_ready",
+      "routes": ["ops-alerts"],
+      "reason": "platform discord not connected"
+    }
+  }
+}
+```
+
+Only `deliver_only` routes are included because agent-mode routes can accept the event before the final delivery target is used. `github_comment` routes are considered ready here because the `gh` CLI is checked at delivery time.
+
 ---
 
 ## Configuring Routes {#configuring-routes}
@@ -79,8 +110,9 @@ Routes define how different webhook sources are handled. Each route is a named e
 | Property | Required | Description |
 |----------|----------|-------------|
 | `events` | No | List of event types to accept (e.g. `["pull_request"]`). If empty, all events are accepted. Event type is read from `X-GitHub-Event`, `X-GitLab-Event`, or `event_type` in the payload. |
-| `secret` | **Yes** | HMAC secret for signature validation. Falls back to the global `secret` if not set on the route. Set to `"INSECURE_NO_AUTH"` for testing only (skips validation). |
+| `secret` | **Yes** | Shared route secret. Preferred use is HMAC signature validation. Static bearer-token headers can use the same secret only for producers that cannot compute HMACs and only inside the enforced trusted-network boundary; see [Static bearer-token auth](#static-bearer-token-auth). Falls back to the global `secret` if not set on the route. Set to `"INSECURE_NO_AUTH"` for local testing only (skips validation). |
 | `prompt` | No | Template string with dot-notation payload access (e.g. `{pull_request.title}`). If omitted, the full JSON payload is dumped into the prompt. Payload fields are untrusted — see [Authenticated does not mean trusted](#authenticated-does-not-mean-trusted). |
+| `formatter` | No | Deterministic formatter for the rendered message. Set `formatter: alert_event` for compact operational alert/digest messages instead of a free-form `prompt` template. See [Alert event formatter](#alert-event-formatter). |
 | `filters` | No | Declarative payload filters evaluated after auth/body/event filtering and before agent or direct delivery work. Non-matches return `{"status":"ignored","reason":"filter"}` with HTTP 200. |
 | `script` | No | Filter/transform script under `~/.hermes/scripts/`. The webhook payload is passed as JSON on stdin. JSON object stdout replaces the payload before templating; text stdout is exposed as `script_output`; empty stdout, `[SILENT]`, or a nonzero exit code ignores the webhook. |
 | `skills` | No | List of skill names to load for the agent run. |
@@ -206,6 +238,65 @@ prompt: "PR #{pull_request.number} by {pull_request.user.login}: {__raw__}"
 If no `prompt` template is configured for a route, the entire payload is dumped as indented JSON (truncated at 4000 characters).
 
 The same dot-notation templates work in `deliver_extra` values.
+
+### Alert event formatter {#alert-event-formatter}
+
+Set `formatter: alert_event` when a route receives structured operational alerts and should produce a compact, deterministic chat message without invoking the agent or dumping raw JSON. This is most useful with `deliver_only: true` routes that forward monitoring alerts or digest events to Discord, Telegram, Slack, or another chat platform.
+
+When `formatter: alert_event` is set, the formatter ignores `prompt` and renders the payload using this schema:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `source` | No | Producer or watcher name, such as `rack-util/librenms-heartbeat`. Defaults to the route name. |
+| `kind` | No | Machine-readable event kind, such as `monitor_target_down`, `heartbeat_alive`, or `backup_failed`. Defaults to `event`. |
+| `severity` | No | Display severity. Known values include `critical`, `error`, `warning`, `warn`, `digest`, `summary`, `info`, and `ok`. Controls the leading icon. Defaults to `info`. |
+| `state` | No | Event state, such as `firing`, `recovered`, `resolved`, `ok`, or `summary`. Recovered/OK states force a success icon; `summary` is omitted from the metadata line. |
+| `summary` | No | Human-readable one-line summary. Defaults to a title-cased version of `kind`. |
+| `host` | No | Host or device involved in the alert. Included in the metadata line when present. |
+| `details` | No | Object of additional scalar details. Preferred keys (`target_ip`, `checked_at`, `since`, `recovered`, `downtime_since`, `fails`, `threshold`, `note`) are shown first; other keys are sorted and included compactly. |
+
+Example route:
+
+```yaml
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      routes:
+        ops-alerts:
+          secret: "ops-alert-secret"
+          deliver: "discord"
+          deliver_only: true
+          formatter: "alert_event"
+          deliver_extra:
+            chat_id: "123456789012345678"
+```
+
+Example payload:
+
+```json
+{
+  "source": "rack-util/librenms-heartbeat",
+  "kind": "monitor_target_down",
+  "severity": "critical",
+  "state": "firing",
+  "summary": "LibreNMS heartbeat failed 3 consecutive checks on rack-util",
+  "host": "rack-util",
+  "details": {
+    "target_ip": "10.10.99.60",
+    "fails": 3,
+    "threshold": 3
+  }
+}
+```
+
+Rendered message:
+
+```text
+🚨 **LibreNMS heartbeat failed 3 consecutive checks on rack-util**
+source: `rack-util/librenms-heartbeat` · host: `rack-util` · state: `firing` · kind: `monitor_target_down`
+target_ip: `10.10.99.60` · fails: `3` · threshold: `3`
+```
 
 ### Forum Topic Delivery
 
@@ -338,8 +429,9 @@ Benefits:
 
 - **Zero LLM tokens** — the agent is never invoked
 - **Sub-second delivery** — a single adapter call, no reasoning loop
-- **Same security as agent mode** — HMAC auth, rate limits, idempotency, and body-size limits all still apply
+- **Same security as agent mode** — route auth, rate limits, idempotency, and body-size limits all still apply
 - **Synchronous response** — the POST returns `200 OK` once delivery succeeds, or `502` if the target rejects it, so your upstream service can retry intelligently
+- **Readiness probe** — `GET /ready` reports whether direct-delivery routes can reach their target platform before producers start sending alerts
 
 ### Example: Telegram push from Supabase
 
@@ -379,19 +471,21 @@ hermes webhook subscribe antenna-matches \
 |--------|---------|
 | `200 OK` | Delivered successfully. Body: `{"status": "delivered", "route": "...", "target": "...", "delivery_id": "..."}` |
 | `200 OK` (status=duplicate) | Duplicate `X-GitHub-Delivery` ID within the idempotency TTL (1 hour). Not re-delivered. |
-| `401 Unauthorized` | HMAC signature invalid or missing. |
+| `401 Unauthorized` | Route auth invalid or missing: HMAC signature failed, static token mismatched, or static token was sent from outside the trusted-network boundary. |
 | `400 Bad Request` | Malformed JSON body. |
 | `404 Not Found` | Unknown route name. |
 | `413 Payload Too Large` | Body exceeded `max_body_bytes`. |
 | `429 Too Many Requests` | Route rate limit exceeded. |
 | `502 Bad Gateway` | Target adapter rejected the message or raised. The error is logged server-side; the response body is a generic `Delivery failed` to avoid leaking adapter internals. |
+| `503 Service Unavailable` | `GET /ready` found at least one `deliver_only` route whose target platform is not connected/running or whose target is unknown. |
 
 ### Configuration gotchas
 
 - `deliver_only: true` requires `deliver` to be a real target. `deliver: log` (or omitting `deliver`) is rejected at startup — the adapter refuses to start if it finds a misconfigured route.
 - The `skills` field is ignored in direct delivery mode (no agent runs, so there's nothing to inject skills into).
-- Template rendering uses the same `{dot.notation}` syntax as agent mode, including the `{__raw__}` token.
+- Template rendering uses the same `{dot.notation}` syntax as agent mode, including the `{__raw__}` token, unless `formatter: alert_event` is set.
 - Idempotency uses the same `X-GitHub-Delivery` / `X-Request-ID` header — retries with the same ID return `status=duplicate` and do NOT re-deliver.
+- Use `GET /ready` in monitoring/producer startup checks when delivery loss matters. A healthy `/health` response only proves the webhook HTTP server is alive; it does not prove Discord/Telegram/etc. is connected.
 
 ---
 
@@ -449,16 +543,43 @@ The agent can create subscriptions via the terminal tool when guided by the `web
 
 The webhook adapter includes multiple layers of security:
 
-### HMAC signature validation
+### Route authentication
 
-The adapter validates incoming webhook signatures using the appropriate method for each source:
+The adapter validates every authenticated route with one of the supported mechanisms below. **HMAC is preferred** because it proves both possession of the secret and integrity of the exact request body.
 
 - **GitHub**: `X-Hub-Signature-256` header — HMAC-SHA256 hex digest prefixed with `sha256=`
 - **GitLab**: `X-Gitlab-Token` header — plain secret string match
 - **Generic (V2, recommended)**: `X-Webhook-Signature-V2` + `X-Webhook-Timestamp` headers — HMAC-SHA256 hex digest of `<timestamp>.<body>`. The timestamp (Unix seconds) must be within ±300 seconds of the server clock, which prevents captured requests from being replayed later.
 - **Generic (V1, legacy)**: `X-Webhook-Signature` header — raw HMAC-SHA256 hex digest of the body only. Still accepted for backward compatibility, but it has no replay protection (a captured request replays indefinitely); the gateway logs a deprecation warning once per route. Switch senders to V2.
+- **Static bearer token (restricted fallback)**: the `Authorization` header with the `Bearer` scheme, or `X-Webhook-Token`, where the supplied value exactly matches the route secret. Use only for producers that cannot compute HMACs.
 
-If a secret is configured but no recognized signature header is present, the request is rejected.
+If a secret is configured but no recognized auth header is present, the request is rejected.
+
+### Static bearer-token auth {#static-bearer-token-auth}
+
+Static bearer-token auth exists for webhook producers that can set a fixed HTTP header but cannot compute an HMAC over the request body. HMAC remains the safer default and should be used whenever the producer supports it.
+
+Supported static-token headers:
+
+```http
+Authorization: Bearer <route-secret>
+X-Webhook-Token: <route-secret>
+```
+
+The static token is the same value as the route's `secret` (or the global fallback `secret`). Do not use both static-token headers and HMAC headers on the same producer; choose one mode and monitor failures clearly.
+
+:::warning
+Static bearer tokens are replayable. Anyone who captures the header can resend it until the route secret is rotated, and the token does not prove that the request body was not modified. Use static-token auth only when all of these are true:
+
+- The producer cannot compute HMAC signatures.
+- The webhook request travels over HTTPS or a private, trusted network path.
+- The gateway's enforced boundary accepts the request as trusted only when every visible source address is local/private/link-local. Hermes checks the actual peer address observed by the webhook server plus any `X-Forwarded-For` entries and `Forwarded` `for=` values; all of them must parse as loopback, private/non-public, or link-local addresses. A public address in any visible hop is rejected for static-token auth.
+- Forwarding headers do not make a request trusted by themselves; they are treated as additional evidence that can only narrow acceptance. If you terminate TLS at a proxy, run the webhook listener on loopback/private networking behind that proxy and do not expose the listener directly to the internet.
+
+HMAC signatures do not have this trusted-network restriction and remain the correct choice for internet-facing webhooks.
+:::
+
+This boundary is intentionally narrow: it preserves static headers for LAN-only appliances while preventing a replayable bearer secret from becoming a public webhook credential on the default `0.0.0.0` bind.
 
 ### Secret is required
 
@@ -497,7 +618,7 @@ platforms:
 ### Authenticated does not mean trusted
 
 :::warning
-**HMAC validation authenticates the _sender_, not the _content_.** A valid signature only proves the request came from a party holding the route's secret (e.g. GitHub). It says nothing about who wrote the _business fields_ inside the payload — PR titles, commit messages, issue descriptions, and any other upstream text are authored by arbitrary third parties and must be treated as untrusted.
+**Webhook authentication authenticates the _sender_, not the _content_.** A valid HMAC signature or accepted static token only proves the request came from a party holding the route's secret (e.g. GitHub or a trusted LAN appliance). It says nothing about who wrote the _business fields_ inside the payload — PR titles, commit messages, issue descriptions, alert summaries, and any other upstream text are authored by arbitrary third parties and must be treated as untrusted.
 
 This is the same trust model that applies to everything the agent reads: web pages, files, and tool output are all untrusted input. Hermes does not — and cannot reliably — sanitize untrusted text with a blocklist; phrasing, encoding, and translation make that trivially bypassable. **The trust boundary is the agent's capability surface, not the input channel.** Harden there:
 
@@ -517,13 +638,24 @@ This is the same trust model that applies to everything the agent reads: web pag
 - Check firewall rules — port `8644` (or your configured port) must be open
 - Verify the URL path matches: `http://your-server:8644/webhooks/<route-name>`
 - Use the `/health` endpoint to confirm the server is running
+- For `deliver_only` routes, use `/ready` to confirm the target platform is connected/running before sending production alerts
 
-### Signature validation failing
+### Auth validation failing
 
 - Ensure the secret in your route config exactly matches the secret configured in the webhook source
 - For GitHub, the secret is HMAC-based — check `X-Hub-Signature-256`
 - For GitLab, the secret is a plain token match — check `X-Gitlab-Token`
-- Check gateway logs for `Invalid signature` warnings
+- For generic producers, prefer `X-Webhook-Signature-V2` + `X-Webhook-Timestamp`
+- For static-token producers, verify the header is either `Authorization` using the `Bearer` scheme or `X-Webhook-Token`, and verify the request reaches the webhook server from an allowed loopback/private/link-local peer address. Public-source static-token requests are rejected even when the token is correct.
+- Check gateway logs for `Invalid auth` or `Invalid signature` warnings
+
+### `/ready` returns `not_ready`
+
+- Inspect the `routes` object in the response; each `deliver_only` route includes the target and reason.
+- `platform <name> not connected` means the target gateway adapter is not connected. Enable/configure that platform and restart the gateway if needed.
+- `platform <name> not running` or `platform <name> fatal error` means the target adapter exists but is not usable; check gateway logs for the platform-specific failure.
+- `unknown delivery platform` means the route's `deliver` value is not a known gateway platform or plugin platform.
+- `github_comment` routes are intentionally considered ready by `/ready`; install/authenticate `gh` separately because it is checked at delivery time.
 
 ### Event being ignored
 


### PR DESCRIPTION

    markdown
    What does this PR do?

    Adds small, deterministic primitives for using Hermes as an operational webhook/router surface.

    This solves a practical gap for webhook producers: /health only proves the webhook HTTP adapter is alive, not that the downstream delivery path is ready. Alert producers need to know whether configured deliver-only targets, like Discord, are connected before sending events.

    This PR adds:

    - webhook /ready endpoint for deliver-only route readiness
    - deterministic alert_event formatting for compact Discord-friendly operational alerts
    - static bearer/header webhook auth for producers that cannot compute HMAC signatures
    - Discord admin create_channel support with conservative validation
    - tests covering readiness, formatting, and token auth behavior

    The approach keeps critical alert delivery deterministic. No LLM reasoning is in the hot path.

    Related Issue

    No linked issue.

    Type of Change

    - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
    - [x] ✨ New feature (non-breaking change that adds functionality)
    - [ ] 🔒 Security fix
    - [ ] 📝 Documentation update
    - [x] ✅ Tests (adding or improving test coverage)
    - [ ] ♻️  Refactor (no behavior change)
    - [ ] 🎯 New skill (bundled or hub)

    Changes Made

    - gateway/platforms/webhook.py
      - Added GET /ready endpoint.
      - Readiness checks configured deliver_only routes and their target platform adapters.
      - Returns 200 when delivery targets are ready and 503 with route/target reasons when not ready.
      - Added formatter: alert_event support for deterministic Discord-friendly alert formatting.
      - Added bearer/header static token auth alongside existing HMAC validation.
      - Explicitly avoids query-string token auth.

    - tools/discord_tool.py
      - Added create_channel Discord admin action.
      - Added conservative validation for channel type and channel name before API calls.
      - Updated tool schema/manifest behavior for the new action.

    - tests/gateway/test_webhook_deliver_only.py
      - Added tests for alert_event formatting.
      - Added tests for /ready success and not-ready behavior.

    - tests/gateway/test_webhook_signature_rate_limit.py
      - Added tests for bearer/header token auth.
      - Added test confirming query-string token auth is rejected.

    How to Test

    1. Run focused webhook tests:

       bash
       venv/bin/python -m pytest -q tests/gateway/test_webhook_signature_rate_limit.py tests/gateway/test_webhook_deliver_only.py


    2. Compile changed modules:

       bash
       python -m py_compile gateway/platforms/webhook.py tools/discord_tool.py


    3. Optional live smoke test with gateway running and a deliver-only Discord route configured:
       - GET /ready should return 200 when Discord is connected.
       - If the Discord platform adapter is disconnected/missing, /ready should return 503.
       - Posting an alert_event payload to a route configured with formatter: alert_event should produce compact readable Discord text instead of raw JSON.

    Checklist

    Code

    - [x] I've read the Contributing Guide
    - [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
    - [x] I searched for existing PRs to make sure this isn't a duplicate
    - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
    - [ ] I've run pytest tests/ -q and all tests pass
    - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
    - [x] I've tested on my platform: Ubuntu Linux

    Documentation & Housekeeping

    - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
    - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
    - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
    - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
    - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

    Screenshots / Logs

    Focused tests passed:

    text
    $ venv/bin/python -m pytest -q tests/gateway/test_webhook_signature_rate_limit.py tests/gateway/test_webhook_deliver_only.py
    .........................                                                [100%]
    25 passed in 2.41s


    Compile checks passed:

    bash
    python -m py_compile gateway/platforms/webhook.py tools/discord_tool.py



    One note: leave the full-suite checkbox unchecked unless you actually run:

    bash
    pytest tests/ -q


    We only ran the focused tests for the changed area.
