### PR TITLE
docs(qqbot): document chunked media upload

### DIFF
--- a/website/docs/user-guide/messaging/qqbot.md
+++ b/website/docs/user-guide/messaging/qqbot.md
@@ -8,6 +8,7 @@ The QQ Bot adapter uses the [Official QQ Bot API](https://bot.q.qq.com/wiki/deve
 
 - Receive messages via a persistent **WebSocket** connection to the QQ Gateway
 - Send text and markdown replies via the **REST API**
+- Send native images, voice, video, and file attachments in C2C and group chats
 - Download and process images, voice messages, and file attachments
 - Transcribe voice messages using Tencent's built-in ASR or a configurable STT provider
 
@@ -93,6 +94,24 @@ Voice transcription works in two stages:
    - **Zhipu/GLM (zai)**: Default provider, uses `glm-asr` model
    - **OpenAI Whisper**: Set `QQ_STT_BASE_URL` and `QQ_STT_MODEL`
    - Any OpenAI-compatible STT endpoint
+
+## Outbound media and files
+
+QQ Bot supports native image, voice, video, and file sends for C2C and group chats. Guild channels do not use this native upload path.
+
+Hermes chooses the upload strategy from the media source:
+
+| Source | Upload path | Notes |
+|---|---|---|
+| HTTP(S) URL | Single `POST /v2/{users|groups}/{id}/files` request | QQ fetches the URL directly. This is the fastest path when the media is already hosted. |
+| Local file path | Chunked upload: `upload_prepare`, COS part `PUT`s, `upload_part_finish`, then `/files` with `upload_id` | Used for local files above the inline upload size. Handles files up to the QQ platform per-file limit, approximately 100 MB. |
+
+Two upload failures are surfaced as non-retryable send errors so Hermes can reply clearly instead of looping:
+
+| QQ condition | Hermes behavior |
+|---|---|
+| Daily cumulative upload quota exceeded (`biz_code=40093002`) | Returns an error like `QQ daily upload limit exceeded for 'file' (...)`. Retry the next day. |
+| File exceeds the QQ per-file upload limit | Returns an error naming the file size and platform limit. Send a smaller file or host it somewhere and send a link. |
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What does this PR do?

Documents QQBot's outbound native media/file support after the adapter gained chunked local-file upload and structured non-retryable upload errors.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `website/docs/user-guide/messaging/qqbot.md` to list outbound native image, voice, video, and file sends for C2C and group chats.
- Added an outbound media section describing URL uploads versus local-file chunked uploads.
- Documented the non-retryable daily-upload-limit and file-too-large error surfaces.

## How to Test

1. Review the QQ Bot docs page and confirm the new outbound media section matches the current adapter behavior.
2. Run `git diff --check`.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: N/A, docs-only change

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

`git diff --check` passed.
