### PR TITLE
[codex] Avoid importing Feishu SDK during startup checks

### DIFF
--- a/tests/tools/test_feishu_tools.py
+++ b/tests/tools/test_feishu_tools.py
@@ -2,12 +2,13 @@
 
 import importlib
 import unittest
+from unittest.mock import patch
 
 from tools.registry import registry
 
 # Trigger tool discovery so feishu tools get registered
-importlib.import_module("tools.feishu_doc_tool")
-importlib.import_module("tools.feishu_drive_tool")
+feishu_doc_tool = importlib.import_module("tools.feishu_doc_tool")
+feishu_drive_tool = importlib.import_module("tools.feishu_drive_tool")
 
 
 class TestFeishuToolRegistration(unittest.TestCase):
@@ -56,6 +57,18 @@ class TestFeishuToolRegistration(unittest.TestCase):
             props = entry.schema["parameters"].get("properties", {})
             self.assertIn("file_token", props, f"{tool_name} missing file_token param")
             self.assertIn("file_type", props, f"{tool_name} missing file_type param")
+
+    def test_availability_checks_probe_without_importing_lark_sdk(self):
+        def fail_on_lark_import(name, *args, **kwargs):
+            if name == "lark_oapi" or name.startswith("lark_oapi."):
+                raise AssertionError("availability check must not import lark_oapi")
+            return real_import(name, *args, **kwargs)
+
+        real_import = __import__
+        with patch("importlib.util.find_spec", return_value=object()):
+            with patch("builtins.__import__", side_effect=fail_on_lark_import):
+                self.assertTrue(feishu_doc_tool._check_feishu())
+                self.assertTrue(feishu_drive_tool._check_feishu())
 
 
 if __name__ == "__main__":

--- a/tools/feishu_doc_tool.py
+++ b/tools/feishu_doc_tool.py
@@ -5,6 +5,7 @@ Uses the same lazy-import + BaseRequest pattern as feishu_comment.py.
 """
 
 import json
+import importlib.util
 import logging
 import threading
 
@@ -52,11 +53,7 @@ FEISHU_DOC_READ_SCHEMA = {
 
 
 def _check_feishu():
-    try:
-        import lark_oapi  # noqa: F401
-        return True
-    except ImportError:
-        return False
+    return importlib.util.find_spec("lark_oapi") is not None
 
 
 def _handle_feishu_doc_read(args: dict, **kwargs) -> str:

--- a/tools/feishu_drive_tool.py
+++ b/tools/feishu_drive_tool.py
@@ -6,6 +6,7 @@ The lark client is injected per-thread by the comment event handler.
 """
 
 import json
+import importlib.util
 import logging
 import threading
 
@@ -28,11 +29,7 @@ def get_client():
 
 
 def _check_feishu():
-    try:
-        import lark_oapi  # noqa: F401
-        return True
-    except ImportError:
-        return False
+    return importlib.util.find_spec("lark_oapi") is not None
 
 
 def _do_request(client, method, uri, paths=None, queries=None, body=None):


### PR DESCRIPTION
## Summary

- avoid importing the full `lark_oapi` SDK during Feishu doc/drive tool availability checks
- use `importlib.util.find_spec("lark_oapi")` for the startup-time dependency probe
- add a regression test proving the availability checks do not execute the SDK import

## Why

Plain `hermes` startup renders the welcome banner, which calls `check_tool_availability()`. With Feishu extras installed, the previous `_check_feishu()` implementation imported `lark_oapi` just to decide whether the toolset was available. That SDK import fans out through a large module tree and can make startup appear to hang before the prompt is shown.

The actual Feishu handlers still import the SDK when the tool is used, so runtime behavior remains unchanged; this only makes the banner availability probe cheap.

## Verification

- `/home/sacred/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/tools/test_feishu_tools.py -q`
- `timeout 20 bash -lc "printf 'exit\\n' | hermes"`
