### PR TITLE
fix(tui): update _hermes_ink_bundle_stale to check for entry-exports.js

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -972,7 +972,7 @@ def _tui_build_needed(tui_dir: Path) -> bool:
 
 def _hermes_ink_bundle_stale(tui_dir: Path) -> bool:
     ink_root = tui_dir / "packages" / "hermes-ink"
-    bundle = ink_root / "dist" / "ink-bundle.js"
+    bundle = ink_root / "dist" / "entry-exports.js"
     if not bundle.exists():
         return True
     bm = bundle.stat().st_mtime

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -26,7 +26,7 @@ def _touch_tui_entry(root: Path) -> None:
 
 
 def _touch_ink_bundle(root: Path) -> None:
-    bundle = root / "packages" / "hermes-ink" / "dist" / "ink-bundle.js"
+    bundle = root / "packages" / "hermes-ink" / "dist" / "entry-exports.js"
     bundle.parent.mkdir(parents=True, exist_ok=True)
     bundle.write_text("export {}")
 


### PR DESCRIPTION
## Bug Description

The dashboard "Chat" tab is permanently broken after any server restart. `/api/pty` WebSocket connections hang and eventually return HTTP 502 via nginx (`upstream prematurely closed connection`).

## Root Cause

Commit `2d3d1d973` changed the `@hermes/ink` build script from `--outfile=dist/ink-bundle.js` to `--outdir=dist` (producing `dist/entry-exports.js`), but `_hermes_ink_bundle_stale()` was never updated to match. It continues to check for the old filename `dist/ink-bundle.js`, which never exists.

This causes `_tui_build_needed()` to always return `True`, triggering a synchronous `npm run build` (~21 seconds) on **every** `/api/pty` WebSocket connection. The `subprocess.run()` call blocks the asyncio event loop, preventing the WebSocket 101 handshake from being flushed to the client, resulting in a timeout.

## Fix

One-line change in `hermes_cli/main.py:975`:
```diff
-    bundle = ink_root / "dist" / "ink-bundle.js"
+    bundle = ink_root / "dist" / "entry-exports.js"
```

Also updates the test helper `_touch_ink_bundle` in `tests/hermes_cli/test_tui_npm_install.py` to use the correct filename.

## How to Verify

1. Ensure `ui-tui/packages/hermes-ink/dist/entry-exports.js` exists and is up-to-date
2. Open the dashboard Chat tab — the WebSocket connection should succeed immediately
3. Check `_tui_build_needed()` returns `False` once the bundle is present:
   ```python
   from hermes_cli.main import _tui_build_needed, PROJECT_ROOT
   assert _tui_build_needed(PROJECT_ROOT / "ui-tui") is False
   ```

## Test Plan

- [x] All 11 existing tests in `test_tui_npm_install.py` pass
- [x] Manual verification: `/api/pty` WebSocket connects in <1s (was timing out at 5s)

## Risk Assessment

**Low** — single-line string change matching the actual esbuild output filename. Both filenames refer to the same bundled artifact; the check logic is unchanged.