### PR TITLE
fix(profiles): preserve skill symlinks when cloning

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -531,10 +531,17 @@ def create_profile(
             # Clone installed skills from the source profile. The dashboard's
             # "clone from default" flow is expected to preserve both bundled
             # and user-installed skills so the new profile immediately has the
-            # same agent capabilities as the source profile.
+            # same agent capabilities as the source profile. Preserve symlinks
+            # instead of dereferencing them so shared skill payloads stay
+            # shared when the source profile already deduped them.
             source_skills = source_dir / "skills"
             if source_skills.is_dir():
-                shutil.copytree(source_skills, profile_dir / "skills", dirs_exist_ok=True)
+                shutil.copytree(
+                    source_skills,
+                    profile_dir / "skills",
+                    dirs_exist_ok=True,
+                    symlinks=True,
+                )
 
             # Clone memory and other subdirectory files
             for relpath in _CLONE_SUBDIR_FILES:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -197,6 +197,26 @@ class TestCreateProfile:
             / "SKILL.md"
         ).read_text() == "---\nname: installed-skill\n---\n"
 
+    def test_clone_config_preserves_skill_symlinks(self, profile_env):
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        shared_skill = tmp_path / "shared-gstack"
+        shared_skill.mkdir()
+        (shared_skill / "SKILL.md").write_text("---\nname: gstack\n---\n")
+        (shared_skill / "payload.bin").write_bytes(b"x" * 32)
+
+        source_skills = default_home / "skills"
+        source_skills.mkdir(parents=True, exist_ok=True)
+        source_link = source_skills / "gstack"
+        source_link.symlink_to(shared_skill, target_is_directory=True)
+
+        profile_dir = create_profile("coder", clone_config=True, no_alias=True)
+
+        cloned_link = profile_dir / "skills" / "gstack"
+        assert cloned_link.is_symlink()
+        assert cloned_link.resolve() == shared_skill.resolve()
+        assert (cloned_link / "SKILL.md").read_text() == "---\nname: gstack\n---\n"
+
     def test_clone_all_copies_entire_tree(self, profile_env):
         tmp_path = profile_env
         default_home = tmp_path / ".hermes"


### PR DESCRIPTION
## What does this PR do?

Preserves skill symlinks when `hermes profile create --clone` copies the source profile's `skills/` tree.

Today the `clone_config` path uses `shutil.copytree(..., dirs_exist_ok=True)` without `symlinks=True`, so a shared skill symlink gets dereferenced into a full physical copy inside the new profile. This is especially painful for heavy installed skills such as GStack.

This patch keeps the existing clone behavior for normal directories, but preserves symlinks as symlinks when the source profile already deduped a skill payload.

This reduces unnecessary copies when the source skill is already shared via symlink.
It does not solve the broader design problem of physically duplicated payload directories across profiles when the source skill itself is a real directory.

## Related Issue

Refs #21485

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/profiles.py`
  - pass `symlinks=True` when cloning `source_dir/skills` in the `clone_config` path
  - document why this path should preserve existing shared skill symlinks instead of dereferencing them
- `tests/hermes_cli/test_profiles.py`
  - add a regression test covering a symlinked `skills/gstack` source during `create_profile(..., clone_config=True)`

## How to Test

1. Create a source profile where `skills/gstack` is a symlink to a shared directory.
2. Run `hermes profile create <name> --clone` or the dashboard's "clone from default" flow.
3. Verify the cloned profile keeps `skills/gstack` as a symlink instead of materializing a full copy.
4. Run:
   - `python -m pytest -o addopts='' tests/hermes_cli/test_profiles.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A: no user-facing docs changed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A: no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A: no workflow docs changed)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A: no tool schemas changed)

## Screenshots / Logs

Focused validation run:

- `python -m pytest -o addopts='' tests/hermes_cli/test_profiles.py -q -k 'clone_config_preserves_skill_symlinks or clone_config_copies_source_skills'`
  - `2 passed, 104 deselected`
- `python -m pytest -o addopts='' tests/hermes_cli/test_profiles.py -q`
  - `106 passed`
