### PR TITLE
fix(gateway): queue busy follow-ups during final delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2836,12 +2836,18 @@ class BasePlatformAdapter(ABC):
                 and interrupt_event.is_set()
                 and session_key in self._pending_messages
             ):
-                logger.info(
-                    "[%s] Suppressing stale response for interrupted session %s",
-                    self.name,
-                    session_key,
+                _runner = getattr(getattr(self, "_busy_session_handler", None), "__self__", None)
+                _finalizing = bool(
+                    _runner is not None
+                    and session_key in getattr(_runner, "_finalizing_sessions", set())
                 )
-                response = None
+                if not _finalizing:
+                    logger.info(
+                        "[%s] Suppressing stale response for interrupted session %s",
+                        self.name,
+                        session_key,
+                    )
+                    response = None
             if not response:
                 logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
             if response:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1113,6 +1113,7 @@ class GatewayRunner:
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
+        self._finalizing_sessions: set[str] = set()
         # Overflow buffer for explicit /queue commands.  The adapter-level
         # _pending_messages dict is a single slot per session (designed for
         # "next-turn" follow-ups where repeated sends collapse into one
@@ -2348,11 +2349,15 @@ class GatewayRunner:
 
         running_agent = self._running_agents.get(session_key)
 
+        if session_key in self._finalizing_sessions:
+            effective_mode = "queue"
+        else:
+            effective_mode = self._busy_input_mode
+
         # Steer mode: inject mid-run via running_agent.steer() instead of
         # queueing + interrupting.  If the agent isn't running yet
         # (sentinel) or lacks steer(), or the payload is empty, fall back
         # to queue semantics so nothing is lost.
-        effective_mode = self._busy_input_mode
         steered = False
         if effective_mode == "steer":
             steer_text = (event.text or "").strip()
@@ -5446,6 +5451,13 @@ class GatewayRunner:
                 return None
 
             running_agent = self._running_agents.get(_quick_key)
+            if _quick_key in self._finalizing_sessions:
+                logger.debug(
+                    "PRIORITY follow-up for session %s arrived during final delivery — queueing without interrupt",
+                    _quick_key,
+                )
+                self._queue_or_replace_pending_event(_quick_key, event)
+                return None
             if running_agent is _AGENT_PENDING_SENTINEL:
                 # Agent is being set up but not ready yet.
                 if event.get_command() == "stop":
@@ -6752,6 +6764,8 @@ class GatewayRunner:
                 event_message_id=event.message_id,
                 channel_prompt=event.channel_prompt,
             )
+            if session_key:
+                self._finalizing_sessions.add(session_key)
 
             # Stop persistent typing indicator now that the agent is done
             try:
@@ -7155,6 +7169,8 @@ class GatewayRunner:
                 "Try again or use /reset to start a fresh session."
             )
         finally:
+            if session_key:
+                self._finalizing_sessions.discard(session_key)
             # Restore session context variables to their pre-handler state
             self._clear_session_env(_session_env_tokens)
 
@@ -14755,7 +14771,6 @@ class GatewayRunner:
                 elif pending_event:
                     pending = pending_event.text or _build_media_placeholder(pending_event)
                     logger.debug("Processing queued message after agent completion: '%s...'", pending[:40])
-
             # Leftover /steer: if a steer arrived after the last tool batch
             # (e.g. during the final API call), the agent couldn't inject it
             # and returned it in result["pending_steer"]. Deliver it as the

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -64,6 +64,7 @@ def _make_runner():
     runner._running_agents_ts = {}
     runner._pending_messages = {}
     runner._busy_ack_ts = {}
+    runner._finalizing_sessions = set()
     runner._draining = False
     runner.adapters = {}
     runner.config = MagicMock()

--- a/tests/gateway/test_duplicate_reply_suppression.py
+++ b/tests/gateway/test_duplicate_reply_suppression.py
@@ -164,6 +164,39 @@ class TestBaseInterruptSuppression:
 
         assert any(s["content"] == "Valid response" for s in adapter.sent)
 
+    @pytest.mark.asyncio
+    async def test_finalizing_response_not_suppressed_with_pending_interrupt(self):
+        """A completed response in final delivery must not be suppressed just
+        because a late follow-up has queued the next turn."""
+        adapter = StubAdapter()
+        response = "Completed response"
+
+        async def fake_handler(event):
+            return response
+
+        adapter.set_message_handler(fake_handler)
+        event = _make_event()
+        session_key = build_session_key(event.source)
+
+        interrupt_event = asyncio.Event()
+        interrupt_event.set()
+        adapter._active_sessions[session_key] = interrupt_event
+        adapter._pending_messages[session_key] = _make_event(text="late follow-up")
+
+        class Runner:
+            def __init__(self):
+                self._finalizing_sessions = {session_key}
+
+            async def busy_handler(self, _event, _session_key):
+                return True
+
+        adapter.set_busy_session_handler(Runner().busy_handler)
+
+        await adapter._process_message_background(event, session_key)
+        await adapter.cancel_background_tasks()
+
+        assert any(s["content"] == response for s in adapter.sent)
+
 
 # Test 2: run.py — partial streamed output must not suppress final send
 # ===================================================================

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -26,6 +26,7 @@ class _FakeAdapter:
         self._pending_messages = {}
         self._active_sessions = {}
         self.interrupted_sessions = []
+        self._send_with_retry = AsyncMock()
 
     async def send(self, chat_id, text, **kwargs):
         pass
@@ -47,6 +48,8 @@ def _make_runner():
     runner._running_agents_ts = {}
     runner._session_run_generation = {}
     runner._pending_messages = {}
+    runner._finalizing_sessions = set()
+    runner._busy_ack_ts = {}
     runner._pending_approvals = {}
     runner._voice_mode = {}
     runner._background_tasks = set()
@@ -475,6 +478,49 @@ async def test_stop_clears_pending_messages():
     # Pending messages must be cleared
     assert session_key not in runner._pending_messages
     adapter.get_pending_message.assert_called_once_with(session_key)
+
+
+# ------------------------------------------------------------------
+# Test 6d: Finalizing sessions queue follow-ups instead of interrupting
+# ------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_followup_during_finalizing_is_queued_without_interrupt():
+    """Once the agent has finished and the gateway is only finalizing delivery,
+    a late follow-up must queue behind that completed turn instead of
+    interrupting it and suppressing the reply (#21611)."""
+    runner = _make_runner()
+    event = _make_event(text="is the file ready yet?")
+    session_key = build_session_key(event.source)
+
+    fake_agent = MagicMock()
+    runner._running_agents[session_key] = fake_agent
+    runner._finalizing_sessions.add(session_key)
+
+    result = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert result is True
+    assert runner.adapters[Platform.TELEGRAM]._pending_messages[session_key] is event
+    fake_agent.interrupt.assert_not_called()
+
+
+# ------------------------------------------------------------------
+# Test 6e: Normal active sessions still interrupt when not finalizing
+# ------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_followup_interrupts_when_session_not_finalizing():
+    """The finalizing-session exception must not change normal interrupt mode."""
+    runner = _make_runner()
+    event = _make_event(text="please switch tasks")
+    session_key = build_session_key(event.source)
+
+    fake_agent = MagicMock()
+    runner._running_agents[session_key] = fake_agent
+
+    result = await runner._handle_active_session_busy_message(event, session_key)
+
+    assert result is True
+    assert runner.adapters[Platform.TELEGRAM]._pending_messages[session_key] is event
+    fake_agent.interrupt.assert_called_once_with("please switch tasks")
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway race where a completed turn can lose its final reply if a user sends a follow-up during the narrow "final delivery" window.

Issue #21611 reports a pattern where Hermes finishes the real work, but the final "Done" message does not get delivered until the user sends another message such as `/status`. That behavior matches a late follow-up interrupting a turn that has already finished agent execution and is only waiting for the gateway to drain and deliver the response.

This PR adds a small runner-level `finalizing` guard in the gateway delivery path. Once `_run_agent()` has returned a completed result to `_handle_message_with_agent()`, the session is marked as finalizing until that outer handler finishes persistence and response handoff. If another message arrives during that window, the active-session busy handler queues it for the next turn instead of interrupting the already-completed reply.

It also keeps the adapter-level stale-response suppression from treating a finalizing response as stale. That preserves the normal interrupted-response suppression behavior, while allowing a completed response to be delivered when a late follow-up has merely queued the next turn.


## Related Issue

Fixes #21611

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `self._finalizing_sessions` to `GatewayRunner` in `gateway/run.py`
- Marked sessions as finalizing in `_handle_message_with_agent()` after `_run_agent()` completes and before final response persistence / handoff
- Cleared the finalizing marker in `_handle_message_with_agent()` cleanup
- Updated `_handle_active_session_busy_message()` so follow-ups arriving during final delivery use queue semantics instead of interrupting the completed turn
- Updated `gateway/platforms/base.py` so stale-response suppression does not drop a response while the runner reports the session as finalizing
- Added regression tests for:
  - finalizing sessions queueing follow-ups through the real busy-session handler
  - normal active sessions still interrupting when not finalizing
  - adapter-level stale-response suppression preserving finalizing responses

## How to Test

1. Reproduce the original issue pattern:
   run a gateway task that finishes tool work but has not yet delivered the final response, then send a late follow-up during that delivery window.
2. Verify the completed turn's final response is still delivered instead of being suppressed.
3. Verify the follow-up is queued and processed as the next turn, not merged into an interrupt of the completed one.
4. Run:
   `python -m py_compile gateway/run.py gateway/platforms/base.py tests/gateway/test_session_race_guard.py tests/gateway/test_duplicate_reply_suppression.py`
5. Run:
   `python -m pytest tests/gateway/test_session_race_guard.py tests/gateway/test_duplicate_reply_suppression.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (WSL Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Test output:

```text
python -m pytest tests/gateway/test_session_race_guard.py -q
python -m pytest tests/gateway/test_session_race_guard.py tests/gateway/test_duplicate_reply_suppression.py -q
42 passed in 76.24s
```
