### PR TITLE
fix: recognize current Hermes Ink bundle artifact

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -972,9 +972,15 @@ def _tui_build_needed(tui_dir: Path) -> bool:
 
 def _hermes_ink_bundle_stale(tui_dir: Path) -> bool:
     ink_root = tui_dir / "packages" / "hermes-ink"
-    bundle = ink_root / "dist" / "ink-bundle.js"
+    # Current @hermes/ink build outputs entry-exports.js. Older builds used
+    # ink-bundle.js; accept either so dashboard /api/pty doesn't rebuild on
+    # every WebSocket connection and time out before the TUI starts.
+    bundle = ink_root / "dist" / "entry-exports.js"
     if not bundle.exists():
-        return True
+        legacy_bundle = ink_root / "dist" / "ink-bundle.js"
+        if not legacy_bundle.exists():
+            return True
+        bundle = legacy_bundle
     bm = bundle.stat().st_mtime
     skip = frozenset({"node_modules", "dist"})
     for dirpath, dirnames, filenames in os.walk(ink_root, topdown=True):

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -25,7 +25,13 @@ def _touch_tui_entry(root: Path) -> None:
     entry.write_text("console.log('tui')")
 
 
-def _touch_ink_bundle(root: Path) -> None:
+def _touch_ink_entry_exports(root: Path) -> None:
+    bundle = root / "packages" / "hermes-ink" / "dist" / "entry-exports.js"
+    bundle.parent.mkdir(parents=True, exist_ok=True)
+    bundle.write_text("export {}")
+
+
+def _touch_legacy_ink_bundle(root: Path) -> None:
     bundle = root / "packages" / "hermes-ink" / "dist" / "ink-bundle.js"
     bundle.parent.mkdir(parents=True, exist_ok=True)
     bundle.write_text("export {}")
@@ -130,9 +136,17 @@ def test_build_needed_when_local_ink_bundle_missing(tmp_path: Path, main_mod) ->
     assert main_mod._tui_build_needed(tmp_path) is True
 
 
-def test_build_not_needed_when_entry_and_ink_bundle_present(tmp_path: Path, main_mod) -> None:
+def test_build_not_needed_when_entry_and_current_ink_bundle_present(tmp_path: Path, main_mod) -> None:
     _touch_tui_entry(tmp_path)
     _touch_ink(tmp_path)
-    _touch_ink_bundle(tmp_path)
+    _touch_ink_entry_exports(tmp_path)
+
+    assert main_mod._tui_build_needed(tmp_path) is False
+
+
+def test_build_not_needed_when_entry_and_legacy_ink_bundle_present(tmp_path: Path, main_mod) -> None:
+    _touch_tui_entry(tmp_path)
+    _touch_ink(tmp_path)
+    _touch_legacy_ink_bundle(tmp_path)
 
     assert main_mod._tui_build_needed(tmp_path) is False


### PR DESCRIPTION
## Summary
- Recognize the current `@hermes/ink` build artifact, `dist/entry-exports.js`, when deciding whether the TUI bundle is stale
- Keep the legacy `dist/ink-bundle.js` fallback for older builds
- Add regression coverage for both current and legacy bundle artifact names

## Why
The dashboard Chat tab opens `/api/pty` and calls the TUI build/staleness check before spawning the PTY child. The current Ink build outputs `entry-exports.js`, but the stale check only looked for `ink-bundle.js`, so Hermes considered the bundle missing and attempted to rebuild on every WebSocket open. On slower machines this can block the WebSocket handshake long enough for the browser to report that the session ended / WebSocket connection failed.

## Test Plan
- `python -m pytest tests/hermes_cli/test_tui_npm_install.py -q`
