### PR TITLE
feat(memory): add hard rules guardrails to MEMORY_SCHEMA description

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -535,7 +535,17 @@ MEMORY_SCHEMA = {
         "- 'memory': your notes -- environment facts, project conventions, tool quirks, lessons learned\n\n"
         "ACTIONS: add (new entry), replace (update existing -- old_text identifies it), "
         "remove (delete -- old_text identifies it).\n\n"
-        "SKIP: trivial/obvious info, things easily re-discovered, raw data dumps, and temporary task state."
+        "HARD RULES — never violate:\n"
+        "- Do NOT save task progress, session outcomes, completed-work logs, or temporary TODO state.\n"
+        "- Do NOT save investigative findings, system mechanism explanations, or 'how X works' notes.\n"
+        "  Memory is for verified stable facts, not exploration artifacts that may go stale.\n"
+        "- Do NOT save skill content, methodology rules, or self-referential meta-instructions.\n"
+        "  Procedures belong in skills, never in memory.\n"
+        "- Do NOT save raw data dumps, trivial/obvious info, or things easily re-discovered.\n"
+        "- If you discovered a new way to do something or solved a tricky problem, save it as a skill\n"
+        "  (skill_manage), not as a memory entry.\n\n"
+        "Before writing, ask: 'Will this still be true and useful 10 sessions from now?'\n"
+        "If no, don't write it."
     ),
     "parameters": {
         "type": "object",


### PR DESCRIPTION
## What

Replace the soft `SKIP` hint in the memory tool schema description with explicit `HARD RULES` block. The LLM sees this description on every memory tool call.

## Why

The previous `SKIP: trivial/obvious info, things easily re-discovered...` was a single vague sentence buried at the end of a lengthy description. Non-compliant memory writes (task progress, investigative findings, meta-instructions) were common because there were no explicit negative rules.

The tool schema description is the natural enforcement point — it is always in context when the model invokes the memory tool.

## Rules added

- No task progress / session outcomes / completed-work logs / temporary TODO
- No investigative findings, system mechanism explanations, or "how X works" notes
- No skill content, methodology rules, or self-referential meta-instructions
- No raw data dumps or trivially re-discoverable info
- New problem-solving approaches → save as skill, not memory
- Self-check question before every write: "Will this still be true 10 sessions from now?"

## Testing

- Verified `MEMORY_SCHEMA` imports correctly
- Verified new description content present in schema
- No behavioral changes to memory tool logic — description-only change