### PR TITLE
feat: add ShengSuanYun (胜算云) model provider

### DIFF
--- a/plugins/model-providers/shengsuanyun/__init__.py
+++ b/plugins/model-providers/shengsuanyun/__init__.py
@@ -1,0 +1,27 @@
+from providers import register_provider
+from providers.base import ProviderProfile
+
+shengsuanyun = ProviderProfile(
+    name="shengsuanyun",
+    aliases=("ssy", "sheng-suan-yun"),
+    display_name="ShengSuanYun",
+    description="胜算云 — 多模型云端 API",
+    signup_url="https://shengsuanyun.com/",
+    env_vars=("SHENGSUANYUN_API_KEY", "SHENGSUANYUN_BASE_URL"),
+    base_url="https://router.shengsuanyun.com/api/v1",
+    models_url="https://router.shengsuanyun.com/api/v1/models",
+    auth_type="api_key",
+    fallback_models=(
+        "anthropic/claude-opus-4.7",
+        "anthropic/claude-opus-4.5",
+        "anthropic/claude-opus-4.6",
+        "openai/gpt-5.1",
+        "openai/gpt-5.4",
+        "openai/gpt-5.3-chat",
+        "google/gemini-3-flash",
+        "google/gemini-2.5-flash"
+    ),
+    default_aux_model="google/gemini-2.5-pro",
+)
+
+register_provider(shengsuanyun)

--- a/plugins/model-providers/shengsuanyun/plugin.yaml
+++ b/plugins/model-providers/shengsuanyun/plugin.yaml
@@ -1,0 +1,5 @@
+name: shengsuanyun-provider
+kind: model-provider
+version: 1.0.0
+description: ShengSuanYun (胜算云)
+author: Hermes Contributors


### PR DESCRIPTION
## Summary

Add **ShengSuanYun (胜算云)** as a new OpenAI-compatible model provider plugin.

## Changes

- ✅ Added plugin at `plugins/model-providers/shengsuanyun/`
- ✅ Configured base URL: `https://router.shengsuanyun.com/api/v1`
- ✅ Dynamic model list from `/models` endpoint (150+ models)
- ✅ Environment variables: `SHENGSUANYUN_API_KEY`, `SHENGSUANYUN_BASE_URL`
- ✅ Aliases: `ssy`, `sheng-suan-yun`

## Supported Models

ShengSuanYun provides access to 150+ models including:
- OpenAI GPT-5.x series (gpt-5-nano, gpt-5.1, gpt-5.2-codex, etc.)
- Anthropic Claude Opus 4.x series
- DeepSeek V4 Pro
- Alibaba Qwen3 Max
- MiniMax M2.1
- Google Gemini 3.x

## Implementation

Follows the **fast path** for simple API-key providers as documented in [developer-guide/adding-providers.md](https://github.com/NousResearch/hermes-agent/blob/main/website/docs/developer-guide/adding-providers.md#fast-path-simple-api-key-providers):

- No changes to core files (`auth.py`, `runtime_provider.py`, `main.py`)
- Plugin auto-loads and auto-registers via the provider plugin system
- Uses standard `ProviderProfile` with `auth_type="api_key"`

## Testing

✅ Provider plugin registration verified  
✅ Auth registry integration confirmed  
✅ Runtime resolution working  
✅ Dynamic model list fetch successful (152 models)  
✅ CLI test passed with actual API call  

## Usage

```bash
# Set API key
export SHENGSUANYUN_API_KEY="your-api-key"

# Use with CLI
hermes chat --provider shengsuanyun --model "openai/gpt-5-nano"

# Or use alias
hermes chat --provider ssy --model "deepseek/deepseek-v4-pro"

# Select in model menu
hermes model
```

## Notes

ShengSuanYun (胜算云) is a Chinese AI model routing service that provides unified access to multiple leading AI models through an OpenAI-compatible API.