### PR TITLE
fix(install): require uv >= 0.9.17 with actionable upgrade hint

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -166,6 +166,50 @@ log_error() {
     echo -e "${RED}✗${NC} $1"
 }
 
+# ---------------------------------------------------------------------------
+# uv version requirement
+# ---------------------------------------------------------------------------
+# pyproject.toml uses [tool.uv] exclude-newer with a relative-duration value
+# (e.g. "7 days"), which uv only learned to parse in 0.9.17 (Dec 2025). Older
+# uv — commonly a stale Homebrew formula — fails `uv venv` with a misleading
+# "input contains invalid characters" TOML error, leaving the install half
+# done. Fail fast with an actionable upgrade hint instead.
+MIN_UV_VERSION="0.9.17"
+
+uv_version_at_least() {
+    # 0 if $1 >= $2, else 1.  Uses sort -V (macOS >= 11, modern Linux, Termux).
+    [ "$(printf '%s\n%s\n' "$2" "$1" | sort -V | head -n1)" = "$2" ]
+}
+
+parse_uv_version() {
+    # Extract X.Y.Z from `uv --version` output, e.g.
+    #   "uv 0.2.25 (Homebrew 2024-07-15)" -> "0.2.25"
+    printf '%s\n' "$1" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1
+}
+
+ensure_uv_version_supported() {
+    local raw="$1"
+    local current
+    current="$(parse_uv_version "$raw")"
+    if [ -z "$current" ]; then
+        log_warn "Could not parse uv version from: $raw — skipping version check"
+        return 0
+    fi
+    if uv_version_at_least "$current" "$MIN_UV_VERSION"; then
+        return 0
+    fi
+    log_error "uv $current is too old — Hermes requires uv >= $MIN_UV_VERSION."
+    log_info "(pyproject.toml uses [tool.uv] exclude-newer with a relative"
+    log_info " duration, which was added in uv 0.9.17 — December 2025.)"
+    echo
+    log_info "Upgrade uv with one of:"
+    log_info "  • Homebrew:   brew upgrade uv"
+    log_info "  • Official:   curl -LsSf https://astral.sh/uv/install.sh | sh"
+    log_info "  • pipx:       pipx upgrade uv"
+    log_info "Then re-run the Hermes installer."
+    exit 1
+}
+
 prompt_yes_no() {
     local question="$1"
     local default="${2:-yes}"
@@ -345,6 +389,7 @@ install_uv() {
         UV_CMD="uv"
         UV_VERSION=$($UV_CMD --version 2>/dev/null)
         log_success "uv found ($UV_VERSION)"
+        ensure_uv_version_supported "$UV_VERSION"
         return 0
     fi
 
@@ -353,6 +398,7 @@ install_uv() {
         UV_CMD="$HOME/.local/bin/uv"
         UV_VERSION=$($UV_CMD --version 2>/dev/null)
         log_success "uv found at ~/.local/bin ($UV_VERSION)"
+        ensure_uv_version_supported "$UV_VERSION"
         return 0
     fi
 
@@ -361,6 +407,7 @@ install_uv() {
         UV_CMD="$HOME/.cargo/bin/uv"
         UV_VERSION=$($UV_CMD --version 2>/dev/null)
         log_success "uv found at ~/.cargo/bin ($UV_VERSION)"
+        ensure_uv_version_supported "$UV_VERSION"
         return 0
     fi
 

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -35,6 +35,36 @@ export UV_NO_CONFIG=1
 
 PYTHON_VERSION="3.11"
 
+# pyproject.toml uses [tool.uv] exclude-newer with a relative duration ("7 days"),
+# which uv only learned to parse in 0.9.17 (Dec 2025).  Older uv (commonly stale
+# Homebrew) fails `uv venv` with a misleading "input contains invalid characters"
+# TOML error.  Fail fast with an actionable upgrade hint instead.
+MIN_UV_VERSION="0.9.17"
+
+ensure_uv_version_supported() {
+    local raw="$1"
+    local current
+    current="$(printf '%s\n' "$raw" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
+    if [ -z "$current" ]; then
+        echo -e "${YELLOW}⚠${NC} Could not parse uv version from: $raw — skipping check"
+        return 0
+    fi
+    # 0 if current >= MIN_UV_VERSION
+    if [ "$(printf '%s\n%s\n' "$MIN_UV_VERSION" "$current" | sort -V | head -n1)" = "$MIN_UV_VERSION" ]; then
+        return 0
+    fi
+    echo -e "${RED}✗${NC} uv $current is too old — Hermes requires uv >= $MIN_UV_VERSION."
+    echo -e "${CYAN}→${NC} (pyproject.toml uses [tool.uv] exclude-newer with a relative"
+    echo -e "${CYAN}→${NC}  duration, which was added in uv 0.9.17 — December 2025.)"
+    echo
+    echo -e "${CYAN}→${NC} Upgrade uv with one of:"
+    echo -e "${CYAN}→${NC}   • Homebrew:   brew upgrade uv"
+    echo -e "${CYAN}→${NC}   • Official:   curl -LsSf https://astral.sh/uv/install.sh | sh"
+    echo -e "${CYAN}→${NC}   • pipx:       pipx upgrade uv"
+    echo -e "${CYAN}→${NC} Then re-run ./setup-hermes.sh"
+    exit 1
+}
+
 is_termux() {
     [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
 }
@@ -80,6 +110,7 @@ else
     if [ -n "$UV_CMD" ]; then
         UV_VERSION=$($UV_CMD --version 2>/dev/null)
         echo -e "${GREEN}✓${NC} uv found ($UV_VERSION)"
+        ensure_uv_version_supported "$UV_VERSION"
     else
         echo -e "${CYAN}→${NC} Installing uv..."
         if curl -LsSf https://astral.sh/uv/install.sh | sh 2>/dev/null; then


### PR DESCRIPTION
## Summary
- The installer currently accepts any `uv` it finds on the host. With a stale `uv` (e.g. Homebrew lag — `0.2.25` is still floating around), `uv venv` fails parsing `pyproject.toml` with a misleading `input contains invalid characters` TOML error and leaves the install half done.
- Root cause: `pyproject.toml` line 188 uses `[tool.uv] exclude-newer = "7 days"` — relative-duration values for `exclude-newer` only landed in **uv 0.9.17 (Dec 2025)** ([astral-sh/uv#14992](https://github.com/astral-sh/uv/issues/14992), [docs](https://docs.astral.sh/uv/reference/settings/#exclude-newer)). v0.13.0's release commit `498bfc7` re-introduced the `[tool.uv]` block that `d8d57fb` had previously removed, so the bug is currently active on `main`.
- This PR adds a **min-version gate** in `scripts/install.sh` and `setup-hermes.sh`. When a pre-0.9.17 `uv` is detected, the installer prints exactly which version was found, why it is too old, and concrete upgrade commands (Homebrew, the official Astral installer, pipx) — then exits before `uv venv` runs.

The fix uses `sort -V` for version comparison (cross-platform: macOS bash 3.2, modern Linux, Termux). The check is only applied to *pre-existing* `uv` discoveries — the curl-install path always pulls latest, so it is exempt.

## Why fail-fast vs. removing `exclude-newer`
A separate, smaller PR could just delete the `[tool.uv]` block from `pyproject.toml` (effectively re-applying d8d57fb). I went with fail-fast instead because:
1. `exclude-newer` is a deliberate supply-chain hardening lever — the maintainers presumably want to keep it.
2. The fail-fast guard also protects against any future uv-version-sensitive feature added later, not just this specific syntax.
3. The release-engineering process clearly has a way to re-introduce the `[tool.uv]` block (it happened in #21406). A diagnostic in the installer is more durable than re-deleting a config block.

If maintainers prefer the simpler approach, happy to swap this for a one-line `pyproject.toml` revert.

## Test plan
- [x] `bash -n scripts/install.sh setup-hermes.sh` — both clean
- [x] Helper smoke-tested on 8 cases, including the tricky `0.10.0 > 0.9.17` ordering that defeats naive string comparison: stale 0.2.25 → exits 1; 0.11.11 → passes; exactly 0.9.17 → passes; 0.9.16 → exits 1; 1.5.0 → passes; 0.10.0 → passes; 0.9.10 → exits 1; garbled output → warns and continues
- [ ] `curl -fsSL .../install.sh | bash` on a Mac with stale Homebrew `uv` shows the new error instead of the TOML one
- [ ] Same on Linux/Termux to confirm `sort -V` is present (it is in coreutils, but worth a smoke test)

## Reproducer
On a fresh macOS with `uv 0.2.25` installed via Homebrew, the current `main` install fails with:
```
error: Failed to parse: `pyproject.toml`
  Caused by: TOML parse error at line 187, column 1
    |
187 | [tool.uv]
    | ^^^^^^^^^
input contains invalid characters
```
After this PR, the same setup fails *cleanly* before `uv venv` runs:
```
✗ uv 0.2.25 is too old — Hermes requires uv >= 0.9.17.
→ (pyproject.toml uses [tool.uv] exclude-newer with a relative
→  duration, which was added in uv 0.9.17 — December 2025.)

→ Upgrade uv with one of:
→   • Homebrew:   brew upgrade uv
→   • Official:   curl -LsSf https://astral.sh/uv/install.sh | sh
→   • pipx:       pipx upgrade uv
→ Then re-run the Hermes installer.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
