### PR TITLE
fix: forward configured timeout to Codex Responses API requests

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -675,7 +675,7 @@ def _preflight_codex_api_kwargs(
         "model", "instructions", "input", "tools", "store",
         "reasoning", "include", "max_output_tokens", "temperature",
         "tool_choice", "parallel_tool_calls", "prompt_cache_key", "service_tier",
-        "extra_headers",
+        "extra_headers", "timeout",
     }
     normalized: Dict[str, Any] = {
         "model": model,
@@ -724,6 +724,10 @@ def _preflight_codex_api_kwargs(
             normalized_headers[key.strip()] = str(value)
         if normalized_headers:
             normalized["extra_headers"] = normalized_headers
+
+    timeout = api_kwargs.get("timeout")
+    if isinstance(timeout, (int, float)) and timeout > 0:
+        normalized["timeout"] = float(timeout)
 
     if allow_stream:
         stream = api_kwargs.get("stream")

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -142,6 +142,10 @@ class ResponsesApiTransport(ProviderTransport):
         if max_tokens is not None and not is_codex_backend:
             kwargs["max_output_tokens"] = max_tokens
 
+        timeout = params.get("timeout")
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+
         if is_xai_responses and session_id:
             existing_extra_headers = kwargs.get("extra_headers")
             merged_extra_headers: Dict[str, str] = {}

--- a/run_agent.py
+++ b/run_agent.py
@@ -8690,6 +8690,7 @@ class AIAgent:
                 is_codex_backend=is_codex_backend,
                 is_xai_responses=is_xai_responses,
                 github_reasoning_extra=self._github_models_reasoning_extra_body() if is_github_responses else None,
+                timeout=self._resolved_api_call_timeout(),
             )
 
         # ── chat_completions (default) ─────────────────────────────────────

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -308,7 +308,9 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert kwargs["parallel_tool_calls"] is True
     assert isinstance(kwargs["prompt_cache_key"], str)
     assert len(kwargs["prompt_cache_key"]) > 0
-    assert "timeout" not in kwargs
+    assert "timeout" in kwargs
+    assert isinstance(kwargs["timeout"], (int, float))
+    assert kwargs["timeout"] > 0
     assert "max_tokens" not in kwargs
     assert "extra_body" not in kwargs
 


### PR DESCRIPTION
## Summary

The main agent `codex_responses` path computes a request timeout via `AIAgent._resolved_api_call_timeout()`, but the timeout is never forwarded to `ResponsesApiTransport.build_kwargs()`. The transport's `build_kwargs()` and the preflight validator `_preflight_codex_api_kwargs()` also lack timeout handling, so the configured timeout is silently dropped before the request reaches `responses.stream()`.

This causes long Codex sessions to hang indefinitely when the provider is slow or unresponsive. By contrast, the `chat_completions` path and the auxiliary Codex adapter both forward timeout correctly.

## Changes

- **`agent/transports/codex.py`**: Accept `timeout` via `params` in `build_kwargs()` and include it in the returned kwargs dict.
- **`agent/codex_responses_adapter.py`**: Add `"timeout"` to `_preflight_codex_api_kwargs()` allowed keys and pass through valid numeric values in the normalized dict.
- **`run_agent.py`**: Pass `timeout=self._resolved_api_call_timeout()` in the `codex_responses` branch of `_build_api_kwargs()`.

## Testing

- All 85 tests in `test_run_agent_codex_responses.py` + `test_codex_transport.py` pass.
- Updated `test_build_api_kwargs_codex` to verify timeout is now present and valid.
- Manual verification: `_preflight_codex_api_kwargs()` correctly passes through `timeout=300.0`.
- `ruff check` and `py_compile` pass on all modified files.

Closes #21644
