### PR TITLE
feat(api_server): forward agent reasoning as response.output_item.reasoning

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -961,6 +961,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
+        reasoning_callback=None,
         gateway_session_key: Optional[str] = None,
     ) -> Any:
         """
@@ -1009,6 +1010,7 @@ class APIServerAdapter(BasePlatformAdapter):
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
+            reasoning_callback=reasoning_callback,
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
             reasoning_config=reasoning_config,
@@ -2212,6 +2214,11 @@ class APIServerAdapter(BasePlatformAdapter):
         # Output items we've emitted so far (used to build the terminal
         # response.completed payload).  Kept in the order they appeared.
         emitted_items: List[Dict[str, Any]] = []
+        # Buffer for reasoning text deltas (model thinking).  Flushed as a
+        # single ``response.output_item.added/done`` pair (item.type=reasoning)
+        # right before the assistant message item closes — see _flush_reasoning.
+        reasoning_parts: List[str] = []
+        reasoning_emitted = False
         # Monotonic counter for output_index (spec requires it).
         output_index = 0
         # Monotonic counter for call_id generation if the agent doesn't
@@ -2281,6 +2288,18 @@ class APIServerAdapter(BasePlatformAdapter):
                 return
             incomplete_text = "".join(final_text_parts) or final_response_text
             incomplete_items: List[Dict[str, Any]] = list(emitted_items)
+            # If reasoning was buffered but never flushed (client disconnect
+            # before _flush_reasoning ran), append it into the incomplete
+            # snapshot so GET /v1/responses/{id} still surfaces the thinking.
+            if reasoning_parts and not reasoning_emitted:
+                _full = "".join(reasoning_parts)
+                incomplete_items.append({
+                    "id": f"rs_{uuid.uuid4().hex[:24]}",
+                    "type": "reasoning",
+                    "status": "completed",
+                    "summary": [{"type": "summary_text", "text": _full}],
+                    "content": [{"type": "reasoning_text", "text": _full}],
+                })
             if incomplete_text:
                 incomplete_items.append({
                     "type": "message",
@@ -2454,26 +2473,68 @@ class APIServerAdapter(BasePlatformAdapter):
                     "item": output_item,
                 })
 
+            async def _flush_reasoning() -> None:
+                """Emit accumulated reasoning text as a single output_item.
+
+                Called once before the assistant message item is opened/closed
+                so the canonical order in ``output[]`` is:
+                ``function_calls → reasoning → message``.
+
+                Idempotent: subsequent calls after the first do nothing.
+                """
+                nonlocal output_index, reasoning_emitted
+                if reasoning_emitted or not reasoning_parts:
+                    return
+                reasoning_emitted = True
+                full_text = "".join(reasoning_parts)
+                reasoning_parts.clear()
+                reasoning_item = {
+                    "id": f"rs_{uuid.uuid4().hex[:24]}",
+                    "type": "reasoning",
+                    "status": "completed",
+                    "summary": [{"type": "summary_text", "text": full_text}],
+                    "content": [{"type": "reasoning_text", "text": full_text}],
+                }
+                idx = output_index
+                output_index += 1
+                emitted_items.append(reasoning_item)
+                await _write_event("response.output_item.added", {
+                    "type": "response.output_item.added",
+                    "output_index": idx,
+                    "item": reasoning_item,
+                })
+                await _write_event("response.output_item.done", {
+                    "type": "response.output_item.done",
+                    "output_index": idx,
+                    "item": reasoning_item,
+                })
+
             # Main drain loop — thread-safe queue fed by agent callbacks.
             async def _dispatch(it) -> None:
                 """Route a queue item to the correct SSE emitter.
 
                 Plain strings are text deltas — they are batched (50ms)
                 to reduce Open WebUI re-render storms.  Tagged tuples
-                with ``__tool_started__`` / ``__tool_completed__``
-                prefixes are tool lifecycle events and flush the buffer
-                before emitting.
+                with ``__tool_started__`` / ``__tool_completed__`` /
+                ``__reasoning__`` prefixes are control events and flush
+                the text buffer before emitting.
                 """
                 nonlocal _batch_timer
                 if isinstance(it, tuple) and len(it) == 2 and isinstance(it[0], str):
                     tag, payload = it
-                    # Flush batched text before tool events
+                    # Flush batched text before tool / reasoning events
                     if _batch_buf:
                         await _flush_batch()
                     if tag == "__tool_started__":
                         await _emit_tool_started(payload)
                     elif tag == "__tool_completed__":
                         await _emit_tool_completed(payload)
+                    elif tag == "__reasoning__":
+                        # Buffer reasoning text — emit as a single output_item
+                        # at end-of-run via _flush_reasoning so consumers see
+                        # the full thinking block in one piece.
+                        if isinstance(payload, str) and payload:
+                            reasoning_parts.append(payload)
                 elif isinstance(it, str):
                     # Batch text deltas — append to buffer, flush on timer
                     _batch_buf.append(it)
@@ -2563,6 +2624,10 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception as e:  # noqa: BLE001
                 logger.error("Error running agent for streaming responses: %s", e, exc_info=True)
                 agent_error = str(e)
+
+            # Flush any accumulated reasoning before the message item closes
+            # so the persisted output[] order is function_calls → reasoning → message
+            await _flush_reasoning()
 
             # Close the message item if it was opened
             final_response_text = "".join(final_text_parts) or final_response_text
@@ -2888,6 +2953,16 @@ class APIServerAdapter(BasePlatformAdapter):
                     "result": function_result,
                 }))
 
+            def _on_reasoning(text):
+                """Queue reasoning text (model thinking) for live emission as a
+                reasoning output_item.  Fires from AIAgent._fire_reasoning_delta
+                during streaming and from the post-response capture in
+                non-streaming mode.  The SSE writer batches deltas and emits
+                a single reasoning output_item.added/done pair before the
+                assistant message item closes."""
+                if text:
+                    _stream_q.put(("__reasoning__", str(text)))
+
             agent_ref = [None]
             agent_task = asyncio.ensure_future(self._run_agent(
                 user_message=user_message,
@@ -2898,6 +2973,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_progress_callback=_on_tool_progress,
                 tool_start_callback=_on_tool_start,
                 tool_complete_callback=_on_tool_complete,
+                reasoning_callback=_on_reasoning,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
             ))
@@ -3433,6 +3509,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
+        reasoning_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
     ) -> tuple:
@@ -3457,6 +3534,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_progress_callback=tool_progress_callback,
                 tool_start_callback=tool_start_callback,
                 tool_complete_callback=tool_complete_callback,
+                reasoning_callback=reasoning_callback,
                 gateway_session_key=gateway_session_key,
             )
             if agent_ref is not None:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2214,11 +2214,16 @@ class APIServerAdapter(BasePlatformAdapter):
         # Output items we've emitted so far (used to build the terminal
         # response.completed payload).  Kept in the order they appeared.
         emitted_items: List[Dict[str, Any]] = []
-        # Buffer for reasoning text deltas (model thinking).  Flushed as a
-        # single ``response.output_item.added/done`` pair (item.type=reasoning)
-        # right before the assistant message item closes — see _flush_reasoning.
-        reasoning_parts: List[str] = []
-        reasoning_emitted = False
+        # Streaming reasoning text (model thinking).  Each chunk is emitted
+        # immediately as ``response.reasoning_text.delta`` after a single
+        # opening ``response.output_item.added`` (status=in_progress).  The
+        # matching ``response.reasoning_text.done`` + ``response.output_item.done``
+        # pair is sent at end-of-run — see _emit_reasoning_delta / _close_reasoning.
+        reasoning_text_parts: List[str] = []
+        reasoning_item_id: Optional[str] = None
+        reasoning_output_index: Optional[int] = None
+        reasoning_opened = False
+        reasoning_closed = False
         # Monotonic counter for output_index (spec requires it).
         output_index = 0
         # Monotonic counter for call_id generation if the agent doesn't
@@ -2288,15 +2293,16 @@ class APIServerAdapter(BasePlatformAdapter):
                 return
             incomplete_text = "".join(final_text_parts) or final_response_text
             incomplete_items: List[Dict[str, Any]] = list(emitted_items)
-            # If reasoning was buffered but never flushed (client disconnect
-            # before _flush_reasoning ran), append it into the incomplete
-            # snapshot so GET /v1/responses/{id} still surfaces the thinking.
-            if reasoning_parts and not reasoning_emitted:
-                _full = "".join(reasoning_parts)
+            # If reasoning item was opened (deltas streamed) but never closed
+            # (client disconnect before _close_reasoning ran), snapshot it into
+            # the incomplete payload so GET /v1/responses/{id} still surfaces
+            # the partial thinking.
+            if reasoning_opened and not reasoning_closed:
+                _full = "".join(reasoning_text_parts)
                 incomplete_items.append({
-                    "id": f"rs_{uuid.uuid4().hex[:24]}",
+                    "id": reasoning_item_id or f"rs_{uuid.uuid4().hex[:24]}",
                     "type": "reasoning",
-                    "status": "completed",
+                    "status": "incomplete",
                     "summary": [{"type": "summary_text", "text": _full}],
                     "content": [{"type": "reasoning_text", "text": _full}],
                 })
@@ -2473,40 +2479,81 @@ class APIServerAdapter(BasePlatformAdapter):
                     "item": output_item,
                 })
 
-            async def _flush_reasoning() -> None:
-                """Emit accumulated reasoning text as a single output_item.
+            async def _emit_reasoning_delta(delta_text: str) -> None:
+                """Stream a single reasoning chunk in real time.
 
-                Called once before the assistant message item is opened/closed
-                so the canonical order in ``output[]`` is:
-                ``function_calls → reasoning → message``.
+                First chunk opens a ``response.output_item.added`` (item.type=
+                reasoning, status=in_progress) so clients can render a "thinking"
+                block immediately.  Every chunk (including the first) emits
+                ``response.reasoning_text.delta`` mirroring how regular text
+                deltas stream — the model's chain-of-thought is no longer
+                buffered until end-of-run.
 
-                Idempotent: subsequent calls after the first do nothing.
+                The matching close pair is sent by ``_close_reasoning``.
                 """
-                nonlocal output_index, reasoning_emitted
-                if reasoning_emitted or not reasoning_parts:
+                nonlocal output_index, reasoning_item_id, reasoning_output_index, reasoning_opened
+                if not isinstance(delta_text, str) or not delta_text:
                     return
-                reasoning_emitted = True
-                full_text = "".join(reasoning_parts)
-                reasoning_parts.clear()
-                reasoning_item = {
-                    "id": f"rs_{uuid.uuid4().hex[:24]}",
+
+                if not reasoning_opened:
+                    reasoning_item_id = f"rs_{uuid.uuid4().hex[:24]}"
+                    reasoning_output_index = output_index
+                    output_index += 1
+                    reasoning_opened = True
+                    initial_item = {
+                        "id": reasoning_item_id,
+                        "type": "reasoning",
+                        "status": "in_progress",
+                        "summary": [],
+                        "content": [{"type": "reasoning_text", "text": ""}],
+                    }
+                    await _write_event("response.output_item.added", {
+                        "type": "response.output_item.added",
+                        "output_index": reasoning_output_index,
+                        "item": initial_item,
+                    })
+
+                reasoning_text_parts.append(delta_text)
+                await _write_event("response.reasoning_text.delta", {
+                    "type": "response.reasoning_text.delta",
+                    "item_id": reasoning_item_id,
+                    "output_index": reasoning_output_index,
+                    "content_index": 0,
+                    "delta": delta_text,
+                })
+
+            async def _close_reasoning() -> None:
+                """Close the streaming reasoning item at end-of-run.
+
+                Emits ``response.reasoning_text.done`` then
+                ``response.output_item.done`` (status=completed) with the
+                full accumulated text.  Idempotent and a no-op when no
+                reasoning was ever streamed.
+                """
+                nonlocal reasoning_closed
+                if reasoning_closed or not reasoning_opened:
+                    return
+                reasoning_closed = True
+                full_text = "".join(reasoning_text_parts)
+                await _write_event("response.reasoning_text.done", {
+                    "type": "response.reasoning_text.done",
+                    "item_id": reasoning_item_id,
+                    "output_index": reasoning_output_index,
+                    "content_index": 0,
+                    "text": full_text,
+                })
+                final_item = {
+                    "id": reasoning_item_id,
                     "type": "reasoning",
                     "status": "completed",
                     "summary": [{"type": "summary_text", "text": full_text}],
                     "content": [{"type": "reasoning_text", "text": full_text}],
                 }
-                idx = output_index
-                output_index += 1
-                emitted_items.append(reasoning_item)
-                await _write_event("response.output_item.added", {
-                    "type": "response.output_item.added",
-                    "output_index": idx,
-                    "item": reasoning_item,
-                })
+                emitted_items.append(final_item)
                 await _write_event("response.output_item.done", {
                     "type": "response.output_item.done",
-                    "output_index": idx,
-                    "item": reasoning_item,
+                    "output_index": reasoning_output_index,
+                    "item": final_item,
                 })
 
             # Main drain loop — thread-safe queue fed by agent callbacks.
@@ -2530,11 +2577,10 @@ class APIServerAdapter(BasePlatformAdapter):
                     elif tag == "__tool_completed__":
                         await _emit_tool_completed(payload)
                     elif tag == "__reasoning__":
-                        # Buffer reasoning text — emit as a single output_item
-                        # at end-of-run via _flush_reasoning so consumers see
-                        # the full thinking block in one piece.
-                        if isinstance(payload, str) and payload:
-                            reasoning_parts.append(payload)
+                        # Stream reasoning chunk in real time via SSE delta —
+                        # consumers see the thinking unfold like normal text,
+                        # not a single end-of-run dump.
+                        await _emit_reasoning_delta(payload)
                 elif isinstance(it, str):
                     # Batch text deltas — append to buffer, flush on timer
                     _batch_buf.append(it)
@@ -2625,9 +2671,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.error("Error running agent for streaming responses: %s", e, exc_info=True)
                 agent_error = str(e)
 
-            # Flush any accumulated reasoning before the message item closes
+            # Close the streaming reasoning item before the message item closes
             # so the persisted output[] order is function_calls → reasoning → message
-            await _flush_reasoning()
+            await _close_reasoning()
 
             # Close the message item if it was opened
             final_response_text = "".join(final_text_parts) or final_response_text

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2161,18 +2161,26 @@ class TestResponsesStreaming:
                 assert resp.status == 200
                 body = await resp.text()
 
-                # SSE events: reasoning item.added/done present, with full text
+                # SSE events: reasoning streams per-chunk (delta) with explicit
+                # in_progress open + final completed close
                 assert '"type": "reasoning"' in body
                 assert "Step 1: parse the question." in body
                 assert "Step 2: pick the answer." in body
                 assert '"type": "summary_text"' in body
                 assert '"type": "reasoning_text"' in body
+                assert '"type": "response.reasoning_text.delta"' in body
+                assert '"type": "response.reasoning_text.done"' in body
 
-                # Walk the SSE stream to validate ordering and final envelope
+                # Walk the SSE stream to validate ordering + delta sequence
                 completed_envelope = None
+                reasoning_added_seen = False
                 reasoning_done_seen = False
                 message_done_seen = False
                 reasoning_before_message = False
+                delta_count = 0
+                delta_done_seen = False
+                added_before_delta = True
+                delta_before_done = True
                 for line in body.splitlines():
                     if not line.startswith("data: "):
                         continue
@@ -2180,19 +2188,37 @@ class TestResponsesStreaming:
                         payload = json.loads(line[len("data: "):])
                     except json.JSONDecodeError:
                         continue
-                    if payload.get("type") == "response.output_item.done":
+                    p_type = payload.get("type")
+                    if p_type == "response.output_item.added" and payload.get("item", {}).get("type") == "reasoning":
+                        reasoning_added_seen = True
+                        assert payload["item"]["status"] == "in_progress"
+                    elif p_type == "response.reasoning_text.delta":
+                        if not reasoning_added_seen:
+                            added_before_delta = False
+                        delta_count += 1
+                        if delta_done_seen:
+                            delta_before_done = False
+                    elif p_type == "response.reasoning_text.done":
+                        delta_done_seen = True
+                    elif p_type == "response.output_item.done":
                         item_type = payload.get("item", {}).get("type")
                         if item_type == "reasoning":
                             reasoning_done_seen = True
+                            assert payload["item"]["status"] == "completed"
                             if not message_done_seen:
                                 reasoning_before_message = True
                         elif item_type == "message":
                             message_done_seen = True
-                    elif payload.get("type") == "response.completed":
+                    elif p_type == "response.completed":
                         completed_envelope = payload["response"]
 
+                assert reasoning_added_seen, "reasoning output_item.added event missing"
                 assert reasoning_done_seen, "reasoning output_item.done event missing"
                 assert reasoning_before_message, "reasoning must precede message in stream order"
+                assert added_before_delta, "delta must come after the opening added event"
+                assert delta_count >= 2, f"expected ≥2 reasoning deltas, got {delta_count}"
+                assert delta_done_seen, "response.reasoning_text.done event missing"
+                assert delta_before_done, "no delta should arrive after the done event"
 
                 # Final envelope keeps reasoning in output[] for GET /v1/responses/{id}
                 assert completed_envelope is not None

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2129,6 +2129,108 @@ class TestResponsesStreaming:
                 assert '"output": [{"type": "input_text", "text": "{\\"content\\":\\"hello\\"}"}]' in body
 
     @pytest.mark.asyncio
+    async def test_stream_emits_reasoning_output_item(self, adapter):
+        """Reasoning callback fired by the agent must surface as a single
+        ``output_item.added/done`` pair with ``item.type == 'reasoning'``,
+        positioned BEFORE the assistant message item in the persisted
+        ``output[]`` array.  Validates the wiring added to expose model
+        thinking via /v1/responses (previously only available via /v1/runs).
+        """
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                reasoning_cb = kwargs.get("reasoning_callback")
+                text_cb = kwargs.get("stream_delta_callback")
+                # Reasoning typically arrives as multiple deltas before
+                # the assistant text starts streaming.
+                if reasoning_cb:
+                    reasoning_cb("Step 1: parse the question.\n")
+                    reasoning_cb("Step 2: pick the answer.")
+                if text_cb:
+                    text_cb("42")
+                return (
+                    {"final_response": "42", "messages": [], "api_calls": 1},
+                    {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "what is the answer?", "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+                # SSE events: reasoning item.added/done present, with full text
+                assert '"type": "reasoning"' in body
+                assert "Step 1: parse the question." in body
+                assert "Step 2: pick the answer." in body
+                assert '"type": "summary_text"' in body
+                assert '"type": "reasoning_text"' in body
+
+                # Walk the SSE stream to validate ordering and final envelope
+                completed_envelope = None
+                reasoning_done_seen = False
+                message_done_seen = False
+                reasoning_before_message = False
+                for line in body.splitlines():
+                    if not line.startswith("data: "):
+                        continue
+                    try:
+                        payload = json.loads(line[len("data: "):])
+                    except json.JSONDecodeError:
+                        continue
+                    if payload.get("type") == "response.output_item.done":
+                        item_type = payload.get("item", {}).get("type")
+                        if item_type == "reasoning":
+                            reasoning_done_seen = True
+                            if not message_done_seen:
+                                reasoning_before_message = True
+                        elif item_type == "message":
+                            message_done_seen = True
+                    elif payload.get("type") == "response.completed":
+                        completed_envelope = payload["response"]
+
+                assert reasoning_done_seen, "reasoning output_item.done event missing"
+                assert reasoning_before_message, "reasoning must precede message in stream order"
+
+                # Final envelope keeps reasoning in output[] for GET /v1/responses/{id}
+                assert completed_envelope is not None
+                output_types = [it.get("type") for it in completed_envelope["output"]]
+                assert "reasoning" in output_types
+                assert output_types.index("reasoning") < output_types.index("message")
+
+                # Reasoning item shape: summary[] + content[] both carry the joined text
+                reasoning_item = next(it for it in completed_envelope["output"] if it["type"] == "reasoning")
+                joined = "Step 1: parse the question.\nStep 2: pick the answer."
+                assert reasoning_item["summary"][0]["text"] == joined
+                assert reasoning_item["content"][0]["text"] == joined
+
+    @pytest.mark.asyncio
+    async def test_stream_no_reasoning_emits_no_reasoning_item(self, adapter):
+        """When the model produces no reasoning (callback never fires), the
+        SSE stream and final envelope must NOT contain a reasoning item —
+        prevents an empty reasoning block from appearing in output[]."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                text_cb = kwargs.get("stream_delta_callback")
+                if text_cb:
+                    text_cb("ok")
+                return (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "hi", "stream": True},
+                )
+                body = await resp.text()
+                assert '"type": "reasoning"' not in body
+
+    @pytest.mark.asyncio
     async def test_streamed_response_is_stored_for_get(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:


### PR DESCRIPTION
Closes #21655.

## Summary

`/v1/responses` streaming + batch endpoints emit `function_call`, `function_call_output`, and `message` items but never expose the agent's reasoning — `Telegram`/`Slack` get a CLI-style preview, but Responses-API consumers (e.g. an external job runner persisting `output[]`) lose the chain-of-thought entirely even though `run_agent.py` already fires `reasoning_callback` during streaming.

This patch wires `reasoning_callback` through `APIServerAdapter` and streams reasoning text deltas in real time alongside regular text — matching the OpenAI Responses event order.

## What changed

**Wiring**
- `_create_agent` / `_run_agent` grow a `reasoning_callback` kwarg passed straight to `AIAgent`
- `_handle_responses` installs `_on_reasoning` that pushes `("__reasoning__", text)` onto the SSE queue
- `_dispatch` routes `__reasoning__` tag straight to `_emit_reasoning_delta`

**Per-chunk streaming (the key change)**

| Event | When | Effect |
|---|---|---|
| `response.output_item.added` (reasoning, `in_progress`) | first reasoning chunk | client knows a thinking block has started |
| `response.reasoning_text.delta` | every chunk | live-streamed thinking, no buffering |
| `response.reasoning_text.done` | agent done | marks end of thinking |
| `response.output_item.done` (reasoning, `completed`) | agent done | closes the reasoning item |

**SSE event order comparison**

- Before: `text deltas → [wait for agent end] → reasoning.added + done (one dump) → message.done`
- After: `text deltas → reasoning.added → reasoning.delta → reasoning.delta → … → reasoning.done → message.done`

`function_calls → reasoning → message` ordering in the persisted `output[]` is preserved (reasoning item closes before the assistant message item closes).

**Incomplete-snapshot path** also keeps any opened-but-unclosed reasoning into the incomplete payload as `status="incomplete"` so `GET /v1/responses/{id}` surfaces partial thinking on early disconnect.

## Test plan

- [x] `python -m pytest tests/gateway/test_api_server.py` — **140 passed** (+2 vs main, with strengthened reasoning assertions)
  - `test_stream_emits_reasoning_output_item` — covers wiring, per-chunk delta ordering (added → delta… → done), item shape (`in_progress` open → `completed` close)
  - `test_stream_no_reasoning_emits_no_reasoning_item` — baseline that confirms no reasoning item / delta when callback never fires
- [x] Validated end-to-end against an external Rails worker that consumes `/v1/responses` SSE: reasoning items now show up in persisted `output[]` AND stream live — thinking content arrives chunk-by-chunk in the UI, no end-of-run flash.

## Notes

- Item id uses `rs_<24 hex>` to match the OpenAI Responses spec id prefix.
- `_emit_reasoning_delta` is idempotent on the "open" step (`reasoning_opened` guard); repeated chunks just emit deltas.
- `_close_reasoning` is idempotent (`reasoning_closed` guard) so repeated calls are safe.
- No public API change — `reasoning_callback` is a new optional kwarg with default `None`; preserves all existing call sites.
