### PR TITLE
fix(cli): handle OSError EINVAL from kqueue when registering stdin on macOS

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12215,7 +12215,11 @@ class HermesCLI:
             # and I/O errors from broken stdout during interrupt (#13710).
             if isinstance(_stdin_err, OSError) and getattr(_stdin_err, "errno", None) == errno.EIO:
                 pass  # suppress broken-stdout I/O errors on interrupt (#13710)
-            elif "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err):
+            elif (
+                "is not registered" in str(_stdin_err)
+                or "Bad file descriptor" in str(_stdin_err)
+                or (isinstance(_stdin_err, OSError) and getattr(_stdin_err, "errno", None) == errno.EINVAL)
+            ):
                 print(
                     f"\nError: stdin is not usable ({_stdin_err}).\n"
                     "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"


### PR DESCRIPTION
## Problem

On macOS with uv-managed cPython (e.g. installed via `uv python install`), Hermes crashes on startup with an unhandled traceback instead of a friendly error message:

```
Traceback (most recent call last):
  ...
  File ".../selectors.py", line 523, in register
    self._selector.control([kev], 0, 0)
OSError: [Errno 22] Invalid argument
```

**Root cause:** When `prompt_toolkit` calls `loop.add_reader(fd=0, ...)`, asyncio's `KqueueSelector` (the default on macOS) fails to register stdin with `OSError: [Errno 22] Invalid argument` (`errno.EINVAL`). This is the same broken-stdin scenario already described in #6393, but the error surfaces with a different errno.

## Error chain

1. `KqueueSelector.get_key(fd=0)` → `KeyError: '0 is not registered'` (caught internally by asyncio)
2. asyncio fallback calls `kqueue.control()` to register fd=0 → `OSError: [Errno 22] Invalid argument`
3. The existing `except (KeyError, OSError)` block in `cli.py` checks for `errno.EIO`, `"is not registered"`, or `"Bad file descriptor"` — none of which match `errno.EINVAL=22`, so it re-raises and crashes

## Fix

Extend the existing `elif` condition to also catch `errno.EINVAL`, so users see the actionable error message already written for this case:

```
Error: stdin is not usable ([Errno 22] Invalid argument).
This can happen with certain Python installations (e.g. uv-managed cPython on macOS).
Try reinstalling Python via pyenv or Homebrew, then re-run: hermes setup
```

The change is a one-liner addition to the existing broken-stdin handler in `cli.py`.