### PR TITLE
fix(status): always redact API keys in status output

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -89,7 +89,8 @@ from hermes_constants import is_termux as _is_termux
 
 def show_status(args):
     """Show status of all Hermes Agent components."""
-    show_all = getattr(args, 'all', False)
+    # API keys stay redacted even when args.all is set; --all only expands
+    # non-secret diagnostics.
     deep = getattr(args, 'deep', False)
 
     print()
@@ -165,12 +166,12 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -14,6 +14,50 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     assert "tvly...cdef" in output
 
 
+def test_show_status_all_redacts_api_keys(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+    import hermes_cli.gateway as gateway_mod
+
+    openrouter_key = "sk-or-super-secret-value"
+    xai_key = "xai-super-secret-value"
+    anthropic_key = "sk-ant-super-secret-value"
+
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openrouter", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openrouter", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenRouter", raising=False)
+    monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_qwen_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_minimax_oauth_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_anthropic_key", lambda: anthropic_key, raising=False)
+
+    def fake_get_env_value(name):
+        return {
+            "OPENROUTER_API_KEY": openrouter_key,
+            "XAI_API_KEY": xai_key,
+        }.get(name, "")
+
+    monkeypatch.setattr(status_mod, "get_env_value", fake_get_env_value, raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert "OpenRouter" in output
+    assert "xAI / Grok" in output
+    assert "Anthropic" in output
+    assert openrouter_key not in output
+    assert xai_key not in output
+    assert anthropic_key not in output
+    assert "sk-o...alue" in output
+    assert "xai-...alue" in output
+    assert "sk-a...alue" in output
+
+
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
     import hermes_cli.auth as auth_mod


### PR DESCRIPTION
## What does this PR do?

Prevents `hermes status --all` from printing raw provider API keys. Full status output still shows whether keys are configured, but secret values are always redacted.

This fixes a secret-exposure footgun where diagnostic output could accidentally leak API keys into chats, logs, screenshots, or support transcripts.

## Related Issue

No issue filed.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/status.py`
  - Always redacts provider API key values in status output, including `--all`.
  - Always redacts Anthropic key output as well.
- `tests/hermes_cli/test_status.py`
  - Adds regression coverage proving raw OpenRouter, xAI, and Anthropic key values do not appear in `--all` output.

## How to Test

Manual verification:

1. Use an isolated `HERMES_HOME` and configure dummy provider key environment variables.
2. Run `hermes status --all`.
3. Verify provider rows still show configured status but never print full raw key values.

Automated tests run locally with the canonical CI-parity wrapper from `AGENTS.md` / `CONTRIBUTING.md`:

```bash
scripts/run_tests.sh tests/hermes_cli/test_status.py -q
```

Result:

```text
5 passed in 1.15s
```

Additional manual smoke check:

```text
PASS: hermes status --all did not print dummy provider key values
```

Platform tested: macOS 26.4.1 arm64 / Apple Silicon, Python 3.11.15.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted CI-parity wrapper test above passes; full suite not run locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1 arm64 / Apple Silicon, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted wrapper test output:

```text
▶ running pytest with 4 workers, hermetic env, in /Users/m3nt8l/.hermes/hermes-agent
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)
.....                                                                    [100%]
5 passed in 1.15s
```
