### PR TITLE
fix(gateway): clear opaque provider history on model switch

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7921,6 +7921,74 @@ class GatewayRunner:
             getattr(getattr(event, "source", None), "platform", None),
         )
 
+    def _clear_provider_opaque_history_for_model_switch(self, session_key: Optional[str]) -> int:
+        """Strip provider-specific opaque reasoning state after /model switches.
+
+        Responses-API providers can persist encrypted reasoning blobs in the
+        transcript.  Those blobs are only decryptable by the provider/model that
+        produced them.  If the user switches a live gateway session from one
+        provider to another (for example OpenAI Codex -> xAI Grok), replaying
+        the old blobs causes hard HTTP 400 failures before the new model can
+        answer.  Keep the visible conversation and tool history, but remove the
+        opaque provider-private continuation fields.
+        """
+        if not session_key:
+            return 0
+
+        session_store = getattr(self, "session_store", None)
+        if session_store is None:
+            return 0
+
+        try:
+            entry = getattr(session_store, "_entries", {}).get(session_key)
+            session_id = getattr(entry, "session_id", None)
+            if not session_id:
+                return 0
+
+            history = session_store.load_transcript(session_id)
+            if not history:
+                return 0
+
+            changed = 0
+            cleaned = []
+            opaque_keys = (
+                "codex_reasoning_items",
+                "codex_message_items",
+                "reasoning_details",
+                "reasoning_content",
+            )
+            for msg in history:
+                if not isinstance(msg, dict):
+                    cleaned.append(msg)
+                    continue
+                if msg.get("role") != "assistant":
+                    cleaned.append(msg)
+                    continue
+                new_msg = dict(msg)
+                removed = False
+                for key in opaque_keys:
+                    if key in new_msg:
+                        new_msg.pop(key, None)
+                        removed = True
+                if removed:
+                    changed += 1
+                cleaned.append(new_msg)
+
+            if changed:
+                session_store.rewrite_transcript(session_id, cleaned)
+                logger.info(
+                    "Cleared provider-opaque transcript state for model switch: session=%s messages=%d",
+                    session_key,
+                    changed,
+                )
+            return changed
+        except Exception as exc:
+            logger.debug(
+                "Failed to clear provider-opaque transcript state for model switch: %s",
+                exc,
+            )
+            return 0
+
     async def _handle_model_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /model command — switch model for this session.
 
@@ -8063,6 +8131,9 @@ class GatewayRunner:
                             "base_url": result.base_url,
                             "api_mode": result.api_mode,
                         }
+                        stripped_opaque_messages = _self._clear_provider_opaque_history_for_model_switch(
+                            _session_key
+                        )
 
                         # Evict cached agent so the next turn creates a fresh
                         # agent from the override rather than relying on the
@@ -8103,6 +8174,10 @@ class GatewayRunner:
                                 lines.append(f"Cost: {mi.format_cost()}")
                             lines.append(f"Capabilities: {mi.format_capabilities()}")
                         lines.append("_(session only — use `/model <name> --global` to persist)_")
+                        if stripped_opaque_messages:
+                            lines.append(
+                                f"Cleared provider-private reasoning state from {stripped_opaque_messages} prior message(s)."
+                            )
                         return "\n".join(lines)
 
                     metadata = {"thread_id": source.thread_id} if source.thread_id else None
@@ -8203,6 +8278,9 @@ class GatewayRunner:
             "base_url": result.base_url,
             "api_mode": result.api_mode,
         }
+        stripped_opaque_messages = self._clear_provider_opaque_history_for_model_switch(
+            session_key
+        )
 
         # Evict cached agent so the next turn creates a fresh agent from the
         # override rather than relying on cache signature mismatch detection.
@@ -8278,6 +8356,11 @@ class GatewayRunner:
             lines.append("Saved to config.yaml (`--global`)")
         else:
             lines.append("_(session only -- add `--global` to persist)_")
+
+        if stripped_opaque_messages:
+            lines.append(
+                f"Cleared provider-private reasoning state from {stripped_opaque_messages} prior message(s)."
+            )
 
         return "\n".join(lines)
 

--- a/tests/gateway/test_model_switch_persistence.py
+++ b/tests/gateway/test_model_switch_persistence.py
@@ -243,3 +243,52 @@ class TestIsIntentionalModelSwitch:
         }
 
         assert runner._is_intentional_model_switch(sk, "gpt-5.4") is False
+
+
+class TestClearProviderOpaqueHistoryForModelSwitch:
+    """Provider-private Responses state must not survive /model switches."""
+
+    def test_removes_encrypted_reasoning_state_but_keeps_visible_history(self):
+        runner = _make_runner()
+        sk = build_session_key(_make_source())
+        runner.session_store.load_transcript.return_value = [
+            {"role": "user", "content": "hi", "timestamp": 1.0},
+            {
+                "role": "assistant",
+                "content": "hello",
+                "timestamp": 2.0,
+                "codex_reasoning_items": [{"type": "reasoning", "encrypted_content": "secret"}],
+                "codex_message_items": [{"type": "message", "id": "msg_1"}],
+                "reasoning_details": [{"provider": "old"}],
+                "reasoning_content": "private chain",
+                "reasoning": "visible summary is safe",
+            },
+            {
+                "role": "tool",
+                "content": "tool result",
+                "tool_call_id": "call_1",
+            },
+        ]
+
+        changed = runner._clear_provider_opaque_history_for_model_switch(sk)
+
+        assert changed == 1
+        runner.session_store.rewrite_transcript.assert_called_once()
+        session_id, rewritten = runner.session_store.rewrite_transcript.call_args.args
+        assert session_id == "sess-1"
+        assert rewritten[0]["content"] == "hi"
+        assistant = rewritten[1]
+        assert assistant["content"] == "hello"
+        assert assistant["reasoning"] == "visible summary is safe"
+        assert "codex_reasoning_items" not in assistant
+        assert "codex_message_items" not in assistant
+        assert "reasoning_details" not in assistant
+        assert "reasoning_content" not in assistant
+        assert rewritten[2]["tool_call_id"] == "call_1"
+
+    def test_noops_when_session_missing(self):
+        runner = _make_runner()
+        changed = runner._clear_provider_opaque_history_for_model_switch("missing")
+        assert changed == 0
+        runner.session_store.load_transcript.assert_not_called()
+        runner.session_store.rewrite_transcript.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Clears provider-private opaque reasoning/continuation fields from gateway session transcripts after a session-level `/model` switch.

Some providers persist encrypted or provider-specific Responses/Codex state in assistant messages. If a live gateway session switches to another provider/model, replaying those stale opaque fields can cause the next request to fail before the new model can answer. This keeps visible conversation and tool history intact while removing only provider-private continuation state.

## Related Issue

No issue filed.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - Adds transcript cleanup for provider-private opaque fields after `/model` switches.
  - Removes only assistant-message fields such as `codex_reasoning_items`, `codex_message_items`, `reasoning_details`, and `reasoning_content`.
  - Preserves visible assistant content, user messages, tool messages, and visible reasoning summaries.
  - Reports when prior provider-private state was cleared.
- `tests/gateway/test_model_switch_persistence.py`
  - Adds regression coverage proving cleanup removes opaque provider fields while retaining visible history.
  - Adds no-op coverage for missing sessions.

## How to Test

Manual verification:

1. Start a gateway session with a provider that stores opaque Responses/Codex reasoning state.
2. Switch models/providers with `/model <new-model>`.
3. Send another message.
4. Verify the new provider does not receive stale provider-private continuation state from the old provider.

Automated tests run locally with the canonical CI-parity wrapper from `AGENTS.md` / `CONTRIBUTING.md`:

```bash
scripts/run_tests.sh tests/gateway/test_model_switch_persistence.py -q
```

Result:

```text
11 passed in 1.05s
```

Platform tested: macOS 26.4.1 arm64 / Apple Silicon, Python 3.11.15.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted CI-parity wrapper test above passes; full suite not run locally
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1 arm64 / Apple Silicon, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted wrapper test output:

```text
▶ running pytest with 4 workers, hermetic env, in /Users/m3nt8l/.hermes/hermes-agent
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)
...........                                                              [100%]
11 passed in 1.05s
```
