### PR TITLE
fix: trigger auth fallback on 401 errors in auxiliary_client.py

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3837,7 +3837,8 @@ def call_llm(
         # back to an alternative provider instead of exhausting retries
         # against the same rate-limited endpoint.
         should_fallback = (
-            _is_payment_error(first_err)
+            _is_auth_error(first_err)
+            or _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
         )
@@ -3846,7 +3847,9 @@ def call_llm(
         # auto (the default) = best-effort fallback chain.  (#7559)
         is_auto = resolved_provider in ("auto", "", None)
         if should_fallback and is_auto:
-            if _is_payment_error(first_err):
+            if _is_auth_error(first_err):
+                reason = "auth error"
+            elif _is_payment_error(first_err):
                 reason = "payment error"
             elif _is_rate_limit_error(first_err):
                 reason = "rate limit"
@@ -4135,13 +4138,16 @@ async def async_call_llm(
 
         # ── Payment / connection / rate-limit fallback (mirrors sync call_llm) ──
         should_fallback = (
-            _is_payment_error(first_err)
+            _is_auth_error(first_err)
+            or _is_payment_error(first_err)
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
         )
         is_auto = resolved_provider in ("auto", "", None)
         if should_fallback and is_auto:
-            if _is_payment_error(first_err):
+            if _is_auth_error(first_err):
+                reason = "auth error"
+            elif _is_payment_error(first_err):
                 reason = "payment error"
             elif _is_rate_limit_error(first_err):
                 reason = "rate limit"


### PR DESCRIPTION
## What

Add `_is_auth_error(first_err)` to the `should_fallback` condition in both `call_llm()` (sync) and `async_call_llm()`, so that 401 authentication errors trigger the fallback provider chain when the primary provider returns an invalid/expired API key.

## Why

Previously, only payment errors (402/429 credits), connection errors, and rate-limit errors triggered the fallback. Auth errors were handled by the refresh path, but when refresh also fails (e.g. genuinely invalid API key), the fallback was never attempted — compression and session-search silently failed with "Compression summary failed: 401".

## Changes

**Sync version** (`call_llm`, ~L3840):
- Added `_is_auth_error(first_err)` to `should_fallback`
- Added `"auth error"` reason branch in the if/elif/else

**Async version** (`async_call_llm`, ~L4141):
- Identical patch

## Verification

```bash
grep -c "_is_auth_error(first_err)" agent/auxiliary_client.py
# Expected: >= 4 (2 in should_fallback + 2 in reason blocks)
```

## Related

Fixes #21165