### PR TITLE
fix(deepseek): send explicit thinking:disabled when reasoning is off

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -258,6 +258,7 @@ class ChatCompletionsTransport(ProviderTransport):
         anthropic_max_out = params.get("anthropic_max_output")
         is_nvidia_nim = params.get("is_nvidia_nim", False)
         is_kimi = params.get("is_kimi", False)
+        is_deepseek = params.get("is_deepseek", False)
         is_tokenhub = params.get("is_tokenhub", False)
         reasoning_config = params.get("reasoning_config")
 
@@ -331,6 +332,19 @@ class ChatCompletionsTransport(ProviderTransport):
                     _kimi_thinking_enabled = False
             extra_body["thinking"] = {
                 "type": "enabled" if _kimi_thinking_enabled else "disabled",
+            }
+
+        # DeepSeek extra_body.thinking (same format as Kimi)
+        if is_deepseek:
+            _ds_thinking_enabled = True
+            if reasoning_config and isinstance(reasoning_config, dict):
+                if reasoning_config.get("enabled") is False:
+                    _ds_thinking_enabled = False
+                _ds_effort = (reasoning_config.get("effort") or "").strip().lower()
+                if _ds_effort == "none":
+                    _ds_thinking_enabled = False
+            extra_body["thinking"] = {
+                "type": "enabled" if _ds_thinking_enabled else "disabled",
             }
 
         # Reasoning. LM Studio is handled above via top-level reasoning_effort,

--- a/run_agent.py
+++ b/run_agent.py
@@ -8710,6 +8710,11 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "moonshot.cn")
         )
         _is_tokenhub = base_url_host_matches(self._base_url_lower, "tokenhub.tencentmaas.com")
+        _is_deepseek = (
+            self.provider == "deepseek"
+            or "deepseek" in (self.model or "").lower()
+            or base_url_host_matches(self.base_url, "api.deepseek.com")
+        )
         _is_lmstudio = (self.provider or "").strip().lower() == "lmstudio"
 
         # Temperature: _fixed_temperature_for_model may return OMIT_TEMPERATURE
@@ -8819,6 +8824,7 @@ class AIAgent:
             is_github_models=_is_gh,
             is_nvidia_nim=_is_nvidia,
             is_kimi=_is_kimi,
+            is_deepseek=_is_deepseek,
             is_tokenhub=_is_tokenhub,
             is_lmstudio=_is_lmstudio,
             is_custom_provider=self.provider == "custom",


### PR DESCRIPTION
## Problem

When using DeepSeek direct API (`api.deepseek.com`) with `reasoning_effort: none`, Hermes fails with HTTP 400:

```
The reasoning_content in the thinking mode must be passed back to the API.
```

**Root cause**: The DeepSeek API requires an explicit `thinking: {"type": "disabled"}` parameter when thinking is off. Without it, the API defaults to thinking=enabled — generating `reasoning_content` that gets stripped by the compression pipeline, then rejected on the next turn.

This is the same pattern already handled for Kimi, but missing for DeepSeek.

## Fix

Mirrors the existing Kimi `extra_body.thinking` block:

1. **`run_agent.py`**: Detect DeepSeek provider/model/base_url (`_is_deepseek`), pass to transport
2. **`agent/transports/chat_completions.py`**: Send `{"thinking": {"type": "disabled"}}` to DeepSeek API when `reasoning_config.enabled=false` or `effort=none`

## Verification

- Tested on production install (DeepSeek v4-pro direct API, `reasoning_effort: none`)
- Multi-turn conversations with tool calls that previously hit HTTP 400 now complete successfully
- No impact on thinking=enabled path

## Related Issues

Fixes #15700 — "DeepSeek API: Missing thinking:disabled parameter causes 400"
Fixes #17212 — "DeepSeek direct API 400 reasoning_content must be passed back"
Related #15213 — "HTTP 400 reasoning_content in cron/auxiliary path"