### PR TITLE
fix(gateway): harden media and reconnect handling

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1927,13 +1927,17 @@ class BasePlatformAdapter(ABC):
         media_pattern = re.compile(
             r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
+        seen_media = set()
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
             if path:
-                media.append((os.path.expanduser(path), has_voice_tag))
+                item = (os.path.expanduser(path), has_voice_tag)
+                if item not in seen_media:
+                    seen_media.add(item)
+                    media.append(item)
 
         # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
         if media:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1074,11 +1074,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             else:
                 # ── Polling mode (default) ───────────────────────────
-                # Clear any stale webhook first so polling doesn't inherit a
-                # previous webhook registration and silently stop receiving updates.
-                delete_webhook = getattr(self._bot, "delete_webhook", None)
-                if callable(delete_webhook):
-                    await delete_webhook(drop_pending_updates=False)
+                # PTB start_polling() already clears stale webhooks during its
+                # bootstrap phase. Avoid a redundant pre-flight delete_webhook()
+                # call here so transient Telegram API hiccups only go through
+                # one retry path.
 
                 loop = asyncio.get_running_loop()
 
@@ -1099,6 +1098,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 await self._app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
                     drop_pending_updates=True,
+                    timeout=15,
+                    bootstrap_retries=3,
                     error_callback=_polling_error_callback,
                 )
             

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4131,6 +4131,10 @@ class GatewayRunner:
                         except Exception:
                             pass
                     else:
+                        # Defensive cleanup: a failed reconnect() may
+                        # have allocated resources before giving up.
+                        # See startup-path comment for rationale.
+                        await self._safe_adapter_disconnect(adapter, platform)
                         # Check if the failure is non-retryable
                         if adapter.has_fatal_error and not adapter.fatal_error_retryable:
                             self._update_platform_runtime_status(
@@ -4159,6 +4163,9 @@ class GatewayRunner:
                                 platform.value, backoff,
                             )
                 except Exception as e:
+                    # Defensive cleanup: an adapter that raised mid-reconnect
+                    # may still hold a live ClientSession or child subprocess.
+                    await self._safe_adapter_disconnect(adapter, platform)
                     self._update_platform_runtime_status(
                         platform.value,
                         platform_state="retrying",

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -329,6 +329,16 @@ class TestExtractMedia:
         assert media == [("/tmp/Jane Doe/speech.flac", False)]
         assert cleaned == ""
 
+    def test_duplicate_media_tags_are_deduplicated(self):
+        content = "MEDIA:/tmp/test.png\nMEDIA:/tmp/test.png\nMEDIA:/tmp/other.png"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [
+            ("/tmp/test.png", False),
+            ("/tmp/other.png", False),
+        ]
+        assert cleaned == ""
+
+
     def test_as_document_directive_stripped_from_cleaned_text(self):
         """[[as_document]] is a routing directive — strip it from
         user-visible text just like [[audio_as_voice]]. Callers detect the

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -26,6 +26,7 @@ class StubAdapter(BasePlatformAdapter):
         self._succeed = succeed
         self._fatal_error = fatal_error
         self._fatal_retryable = fatal_retryable
+        self.disconnect_count = 0
 
     async def connect(self):
         if self._fatal_error:
@@ -34,6 +35,7 @@ class StubAdapter(BasePlatformAdapter):
         return self._succeed
 
     async def disconnect(self):
+        self.disconnect_count += 1
         return None
 
     async def send(self, chat_id, content, reply_to=None, metadata=None):
@@ -292,6 +294,47 @@ class TestPlatformReconnectWatcher:
 
         assert Platform.TELEGRAM in runner._failed_platforms
         assert runner._failed_platforms[Platform.TELEGRAM]["attempts"] == 2
+        assert fail_adapter.disconnect_count == 1
+
+    @pytest.mark.asyncio
+    async def test_reconnect_exception_disconnects_partial_adapter(self):
+        """Reconnect exceptions should clean up partially initialized adapters."""
+        runner = _make_runner()
+
+        platform_config = PlatformConfig(enabled=True, token="test")
+        runner._failed_platforms[Platform.TELEGRAM] = {
+            "config": platform_config,
+            "attempts": 1,
+            "next_retry": time.monotonic() - 1,
+        }
+
+        class RaisingAdapter(StubAdapter):
+            async def connect(self):
+                raise RuntimeError("temporary network failure")
+
+        fail_adapter = RaisingAdapter()
+        real_sleep = asyncio.sleep
+
+        with patch.object(runner, "_create_adapter", return_value=fail_adapter):
+            async def run_one_iteration():
+                runner._running = True
+                call_count = 0
+
+                async def fake_sleep(n):
+                    nonlocal call_count
+                    call_count += 1
+                    if call_count > 1:
+                        runner._running = False
+                    await real_sleep(0)
+
+                with patch("asyncio.sleep", side_effect=fake_sleep):
+                    await runner._platform_reconnect_watcher()
+
+            await run_one_iteration()
+
+        assert Platform.TELEGRAM in runner._failed_platforms
+        assert runner._failed_platforms[Platform.TELEGRAM]["attempts"] == 2
+        assert fail_adapter.disconnect_count == 1
 
     @pytest.mark.asyncio
     async def test_reconnect_gives_up_after_max_attempts(self):

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -83,7 +83,7 @@ async def test_polling_conflict_retries_before_fatal(monkeypatch):
     captured = {}
 
     async def fake_start_polling(**kwargs):
-        captured["error_callback"] = kwargs["error_callback"]
+        captured.update(kwargs)
 
     updater = SimpleNamespace(
         start_polling=AsyncMock(side_effect=fake_start_polling),
@@ -111,7 +111,9 @@ async def test_polling_conflict_retries_before_fatal(monkeypatch):
     ok = await adapter.connect()
 
     assert ok is True
-    bot.delete_webhook.assert_awaited_once_with(drop_pending_updates=False)
+    bot.delete_webhook.assert_not_awaited()
+    assert captured["bootstrap_retries"] == 3
+    assert captured["timeout"] == 15
     assert callable(captured["error_callback"])
 
     conflict = type("Conflict", (Exception,), {})
@@ -243,7 +245,7 @@ async def test_connect_marks_retryable_fatal_error_for_startup_network_failure(m
 
 
 @pytest.mark.asyncio
-async def test_connect_clears_webhook_before_polling(monkeypatch):
+async def test_connect_lets_start_polling_bootstrap_clear_webhook(monkeypatch):
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
 
     monkeypatch.setattr(
@@ -284,7 +286,12 @@ async def test_connect_clears_webhook_before_polling(monkeypatch):
     ok = await adapter.connect()
 
     assert ok is True
-    bot.delete_webhook.assert_awaited_once_with(drop_pending_updates=False)
+    bot.delete_webhook.assert_not_awaited()
+    updater.start_polling.assert_awaited_once()
+    kwargs = updater.start_polling.await_args.kwargs
+    assert kwargs["drop_pending_updates"] is True
+    assert kwargs["bootstrap_retries"] == 3
+    assert kwargs["timeout"] == 15
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Deduplicate repeated `MEDIA:` tags before dispatch so duplicate model output does not resend the same attachment.
- Defensively disconnect partially initialized platform adapters after reconnect failures/exceptions, matching the existing startup-connect cleanup path.
- Let python-telegram-bot handle polling webhook cleanup during `start_polling()` bootstrap, and give bootstrap transient network failures a small retry window.

## Why

These are small gateway reliability fixes that were previously carried as local operator patches on a Hermes VM. Upstream already has the startup cleanup helper; this extends the same protection to the reconnect loop and removes a redundant Telegram API call on polling startup.

## Test plan

```bash
uv run --extra dev pytest \
  tests/gateway/test_platform_base.py \
  tests/gateway/test_platform_reconnect.py \
  tests/gateway/test_safe_adapter_disconnect.py \
  tests/gateway/test_telegram_conflict.py \
  tests/gateway/test_telegram_network_reconnect.py -q
```

Result: `132 passed, 2 skipped`.
