### PR TITLE
fix(cli): resolve direct model aliases before agent init

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3874,6 +3874,31 @@ class HermesCLI:
                 "credential_pool": getattr(self, "_credential_pool", None),
             }
             effective_model = model_override or self.model
+            if effective_model:
+                try:
+                    from hermes_cli.model_switch import DIRECT_ALIASES, _ensure_direct_aliases, resolve_alias
+                    from hermes_cli.providers import determine_api_mode
+
+                    alias_result = resolve_alias(effective_model, runtime.get("provider") or self.provider or "")
+                    if alias_result is not None:
+                        resolved_provider, resolved_model, resolved_alias = alias_result
+                        effective_model = resolved_model
+                        runtime = dict(runtime)
+                        runtime["provider"] = resolved_provider or runtime.get("provider")
+                        _ensure_direct_aliases()
+                        direct_alias = DIRECT_ALIASES.get(resolved_alias)
+                        if direct_alias is not None and getattr(direct_alias, "base_url", ""):
+                            runtime["base_url"] = direct_alias.base_url
+                            if not runtime.get("api_key"):
+                                runtime["api_key"] = "no-key-required"
+                        runtime["api_mode"] = determine_api_mode(runtime.get("provider") or "", runtime.get("base_url") or "")
+                        if model_override is None and runtime_override is None:
+                            self.model = effective_model
+                            self.provider = runtime.get("provider")
+                            self.base_url = runtime.get("base_url")
+                            self.api_mode = runtime.get("api_mode")
+                except Exception:
+                    pass
             self.agent = AIAgent(
                 model=effective_model,
                 api_key=runtime.get("api_key"),

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -172,6 +172,45 @@ def test_runtime_resolution_failure_is_not_sticky(monkeypatch):
     assert shell.agent is not None
 
 
+def test_init_agent_resolves_direct_model_alias_before_agent_construction(monkeypatch):
+    cli = _import_cli()
+
+    from hermes_cli.model_switch import DIRECT_ALIASES, DirectAlias
+
+    DIRECT_ALIASES.clear()
+    DIRECT_ALIASES["stack-local"] = DirectAlias(
+        model="assistant-local",
+        provider="custom",
+        base_url="http://127.0.0.1:14000/v1",
+    )
+
+    captured = {}
+
+    class _DummyAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(cli, "AIAgent", _DummyAgent)
+
+    shell = cli.HermesCLI(
+        model="stack-local",
+        provider="custom",
+        base_url="http://wrong.example/v1",
+        api_key="",
+        compact=True,
+        max_turns=1,
+    )
+    shell._ensure_runtime_credentials = lambda: True
+
+    assert shell._init_agent() is True
+    assert captured["model"] == "assistant-local"
+    assert captured["provider"] == "custom"
+    assert captured["base_url"] == "http://127.0.0.1:14000/v1"
+    assert captured["api_key"] == "no-key-required"
+    assert shell.model == "assistant-local"
+    assert shell.base_url == "http://127.0.0.1:14000/v1"
+
+
 def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     cli = _import_cli()
 


### PR DESCRIPTION
## Summary

- Resolve direct model aliases immediately before constructing `AIAgent`.
- Carry the alias provider/base URL/api mode into the runtime used by the agent.
- Preserve the resolved model/runtime on the CLI session when the primary session route is being initialized.

## Why

Hermes already supports `model_aliases` / direct aliases in model switching, but the CLI agent construction path could still pass the alias string itself as `model`. For local OpenAI-compatible gateways this can send values like `stack-local` to the gateway instead of the configured real model such as `assistant-local`, causing model-access or routing failures.

## Test plan

```bash
uv run --extra dev pytest tests/cli/test_cli_provider_resolution.py -q
```

Result: `20 passed`.
