### PR TITLE
fix: invalidate stale update cache after manual pulls

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -175,6 +175,22 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     return None
 
 
+def _current_local_revision(repo_dir: Path) -> Optional[str]:
+    """Return the current local HEAD revision for cache validation."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+            cwd=str(repo_dir),
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    value = (result.stdout or "").strip()
+    return value or None
+
+
 def check_for_updates() -> Optional[int]:
     """Check whether a Hermes update is available.
 
@@ -189,6 +205,7 @@ def check_for_updates() -> Optional[int]:
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
+    repo_dir = None if embedded_rev else _resolve_repo_dir()
 
     # Read cache — invalidate if the embedded rev has changed since last check
     now = time.time()
@@ -199,22 +216,27 @@ def check_for_updates() -> Optional[int]:
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
                 and cached.get("rev") == embedded_rev
             ):
-                return cached.get("behind")
+                if embedded_rev or repo_dir is None:
+                    return cached.get("behind")
+                current_local_rev = _current_local_revision(repo_dir)
+                cached_local_rev = cached.get("local_rev")
+                if current_local_rev and cached_local_rev == current_local_rev:
+                    return cached.get("behind")
     except Exception:
         pass
 
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
     else:
-        repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
-            repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
+        if repo_dir is None:
             return None
         behind = _check_via_local_git(repo_dir)
 
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": embedded_rev}))
+        payload = {"ts": now, "behind": behind, "rev": embedded_rev}
+        if repo_dir is not None:
+            payload["local_rev"] = _current_local_revision(repo_dir)
+        cache_file.write_text(json.dumps(payload))
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -17,7 +17,7 @@ def test_version_string_no_v_prefix():
 
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
-    """When cache is fresh, check_for_updates should return cached value without calling git."""
+    """Fresh cache is reused when the local HEAD still matches the cached revision."""
     from hermes_cli.banner import check_for_updates
 
     # Create a fake git repo and fresh cache
@@ -26,14 +26,61 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3}))
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 3,
+        "local_rev": "abc123",
+    }))
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+    mock_result = MagicMock(returncode=0, stdout="abc123\n")
+    with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
         result = check_for_updates()
 
     assert result == 3
-    mock_run.assert_not_called()
+    mock_run.assert_called_once_with(
+        ["git", "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        cwd=str(repo_dir),
+    )
+
+
+def test_check_for_updates_invalidates_stale_cache_when_local_revision_changed(tmp_path, monkeypatch):
+    """A fresh cache should be ignored after a manual git pull changes HEAD."""
+    from hermes_cli.banner import check_for_updates
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 10,
+        "local_rev": "oldrev",
+    }))
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout="newrev\n")
+        if cmd == ["git", "fetch", "origin", "--quiet"]:
+            return MagicMock(returncode=0, stdout="")
+        if cmd == ["git", "rev-list", "--count", "HEAD..origin/main"]:
+            return MagicMock(returncode=0, stdout="0\n")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run) as mock_run:
+        result = check_for_updates()
+
+    assert result == 0
+    assert mock_run.call_count == 4  # rev-parse check, fetch, rev-list, cache rewrite rev-parse
+    cached = json.loads(cache_file.read_text())
+    assert cached["behind"] == 0
+    assert cached["local_rev"] == "newrev"
 
 
 def test_check_for_updates_expired_cache(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -102,7 +102,7 @@ def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
         result = check_for_updates()
 
     assert result == 5
-    assert mock_run.call_count == 2  # git fetch + git rev-list
+    assert mock_run.call_count == 3  # git fetch + git rev-list + cache rewrite rev-parse
 
 
 def test_check_for_updates_no_git_dir(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- invalidate cached update-check results when the local git HEAD changes after a manual pull
- store the local HEAD revision alongside the cached behind-count
- add regression tests covering both cache reuse and stale-cache invalidation

## Problem
`hermes --version` could keep showing a stale "commits behind" banner for up to 6 hours after a user manually updated a git checkout with `git pull` + `pip install`, because `.update_check` only keyed freshness on timestamp and embedded revision.

## Test Plan
- `./venv/bin/python -m pytest tests/hermes_cli/test_update_check.py -q -o addopts=''`
- manual repro/verification on Termux by seeding a stale `.update_check` file and confirming `check_for_updates()` rewrites it to `behind=0` when local HEAD changed
