### PR TITLE
feat(homeassistant): split tool and platform env config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1315,13 +1315,23 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
 
     # Home Assistant
-    hass_token = os.getenv("HASS_TOKEN")
-    if hass_token:
+    # Backward-compatible default: HASS_TOKEN/HASS_URL still configure both the
+    # HA tool surface and, unless explicitly disabled, the gateway websocket
+    # platform. Operators can split them when they need a local proxy/tool-only
+    # setup:
+    #   - HASS_TOOL_TOKEN / HASS_TOOL_URL for Home Assistant tools
+    #   - HASS_PLATFORM_TOKEN / HASS_PLATFORM_URL for the websocket platform
+    #   - HASS_PLATFORM_DISABLE=1 to suppress websocket startup entirely
+    hass_platform_token = os.getenv("HASS_PLATFORM_TOKEN") or os.getenv("HASS_TOKEN")
+    hass_platform_disable = os.getenv("HASS_PLATFORM_DISABLE", "").strip().lower() in {
+        "1", "true", "yes", "on",
+    }
+    if hass_platform_token and not hass_platform_disable:
         if Platform.HOMEASSISTANT not in config.platforms:
             config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
         config.platforms[Platform.HOMEASSISTANT].enabled = True
-        config.platforms[Platform.HOMEASSISTANT].token = hass_token
-        hass_url = os.getenv("HASS_URL")
+        config.platforms[Platform.HOMEASSISTANT].token = hass_platform_token
+        hass_url = os.getenv("HASS_PLATFORM_URL") or os.getenv("HASS_URL")
         if hass_url:
             config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
 

--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -8,8 +8,8 @@ persistent notifications.
 
 Requires:
 - aiohttp (already in messaging extras)
-- HASS_TOKEN env var (Long-Lived Access Token)
-- HASS_URL env var (default: http://homeassistant.local:8123)
+- HASS_PLATFORM_TOKEN env var (preferred websocket token, falls back to HASS_TOKEN)
+- HASS_PLATFORM_URL env var (preferred websocket URL, falls back to HASS_URL)
 """
 
 import asyncio
@@ -43,7 +43,7 @@ def check_ha_requirements() -> bool:
     """Check if Home Assistant dependencies are available and configured."""
     if not AIOHTTP_AVAILABLE:
         return False
-    if not os.getenv("HASS_TOKEN"):
+    if not (os.getenv("HASS_PLATFORM_TOKEN") or os.getenv("HASS_TOKEN")):
         return False
     return True
 
@@ -74,8 +74,16 @@ class HomeAssistantAdapter(BasePlatformAdapter):
 
         # Configuration from extra
         extra = config.extra or {}
-        token = config.token or os.getenv("HASS_TOKEN", "")
-        url = extra.get("url") or os.getenv("HASS_URL", "http://homeassistant.local:8123")
+        token = (
+            config.token
+            or os.getenv("HASS_PLATFORM_TOKEN")
+            or os.getenv("HASS_TOKEN", "")
+        )
+        url = (
+            extra.get("url")
+            or os.getenv("HASS_PLATFORM_URL")
+            or os.getenv("HASS_URL", "http://homeassistant.local:8123")
+        )
         self._hass_url: str = url.rstrip("/")
         self._hass_token: str = token
 
@@ -145,44 +153,49 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         self._session = aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30)
         )
-        self._ws = await self._session.ws_connect(ws_url, heartbeat=30, timeout=30)
+        try:
+            self._ws = await self._session.ws_connect(ws_url, heartbeat=30, timeout=30)
 
-        # Step 1: Receive auth_required
-        msg = await self._ws.receive_json()
-        if msg.get("type") != "auth_required":
-            logger.error("Expected auth_required, got: %s", msg.get("type"))
+            # Step 1: Receive auth_required
+            msg = await self._ws.receive_json()
+            if msg.get("type") != "auth_required":
+                logger.error("Expected auth_required, got: %s", msg.get("type"))
+                await self._cleanup_ws()
+                return False
+
+            # Step 2: Send auth
+            await self._ws.send_json({
+                "type": "auth",
+                "access_token": self._hass_token,
+            })
+
+            # Step 3: Wait for auth_ok
+            msg = await self._ws.receive_json()
+            if msg.get("type") != "auth_ok":
+                logger.error("Auth failed: %s", msg)
+                await self._cleanup_ws()
+                return False
+
+            # Step 4: Subscribe to state_changed events
+            sub_id = self._next_id()
+            await self._ws.send_json({
+                "id": sub_id,
+                "type": "subscribe_events",
+                "event_type": "state_changed",
+            })
+
+            # Verify subscription acknowledgement
+            msg = await self._ws.receive_json()
+            if not msg.get("success"):
+                logger.error("Failed to subscribe to events: %s", msg)
+                await self._cleanup_ws()
+                return False
+
+            return True
+
+        except Exception:
             await self._cleanup_ws()
-            return False
-
-        # Step 2: Send auth
-        await self._ws.send_json({
-            "type": "auth",
-            "access_token": self._hass_token,
-        })
-
-        # Step 3: Wait for auth_ok
-        msg = await self._ws.receive_json()
-        if msg.get("type") != "auth_ok":
-            logger.error("Auth failed: %s", msg)
-            await self._cleanup_ws()
-            return False
-
-        # Step 4: Subscribe to state_changed events
-        sub_id = self._next_id()
-        await self._ws.send_json({
-            "id": sub_id,
-            "type": "subscribe_events",
-            "event_type": "state_changed",
-        })
-
-        # Verify subscription acknowledgement
-        msg = await self._ws.receive_json()
-        if not msg.get("success"):
-            logger.error("Failed to subscribe to events: %s", msg)
-            await self._cleanup_ws()
-            return False
-
-        return True
+            raise
 
     async def _cleanup_ws(self) -> None:
         """Close WebSocket and session."""

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -34,6 +34,11 @@ class TestCheckRequirements:
         monkeypatch.setenv("HASS_TOKEN", "test-token")
         assert check_ha_requirements() is True
 
+    def test_returns_true_with_platform_token(self, monkeypatch):
+        monkeypatch.delenv("HASS_TOKEN", raising=False)
+        monkeypatch.setenv("HASS_PLATFORM_TOKEN", "platform-token")
+        assert check_ha_requirements() is True
+
     @patch("gateway.platforms.homeassistant.AIOHTTP_AVAILABLE", False)
     def test_returns_false_without_aiohttp(self, monkeypatch):
         monkeypatch.setenv("HASS_TOKEN", "test-token")
@@ -438,13 +443,35 @@ class TestConfigIntegration:
         assert ha.extra["url"] == "http://10.0.0.5:8123"
 
     def test_no_env_no_platform(self, monkeypatch):
-        for v in ["HASS_TOKEN", "HASS_URL", "TELEGRAM_BOT_TOKEN",
+        for v in ["HASS_TOKEN", "HASS_URL", "HASS_PLATFORM_TOKEN", "HASS_PLATFORM_URL", "HASS_PLATFORM_DISABLE", "TELEGRAM_BOT_TOKEN",
                    "DISCORD_BOT_TOKEN", "SLACK_BOT_TOKEN"]:
             monkeypatch.delenv(v, raising=False)
 
         from gateway.config import load_gateway_config
         config = load_gateway_config()
         assert Platform.HOMEASSISTANT not in config.platforms
+
+    def test_platform_disable_skips_ha_platform(self, monkeypatch):
+        monkeypatch.setenv("HASS_TOKEN", "env-token")
+        monkeypatch.setenv("HASS_URL", "http://10.0.0.5:8123")
+        monkeypatch.setenv("HASS_PLATFORM_DISABLE", "1")
+
+        from gateway.config import load_gateway_config
+        config = load_gateway_config()
+        assert Platform.HOMEASSISTANT not in config.platforms
+
+    def test_platform_specific_env_overrides_shared_values(self, monkeypatch):
+        monkeypatch.setenv("HASS_TOKEN", "shared-token")
+        monkeypatch.setenv("HASS_URL", "http://127.0.0.1:18123")
+        monkeypatch.setenv("HASS_PLATFORM_TOKEN", "platform-token")
+        monkeypatch.setenv("HASS_PLATFORM_URL", "http://10.0.0.5:8123")
+
+        from gateway.config import load_gateway_config
+        config = load_gateway_config()
+
+        ha = config.platforms[Platform.HOMEASSISTANT]
+        assert ha.token == "platform-token"
+        assert ha.extra["url"] == "http://10.0.0.5:8123"
 
     def test_config_roundtrip_preserves_extra(self):
         config = GatewayConfig(

--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -11,6 +11,7 @@ import pytest
 
 from tools.homeassistant_tool import (
     _check_ha_available,
+    _get_config,
     _filter_and_summarize,
     _build_service_payload,
     _parse_service_response,
@@ -447,6 +448,33 @@ class TestServiceNameValidation:
 
 
 # ---------------------------------------------------------------------------
+# Environment config
+# ---------------------------------------------------------------------------
+
+
+class TestGetConfig:
+    def test_prefers_tool_specific_env(self, monkeypatch):
+        monkeypatch.setenv("HASS_URL", "http://legacy.example:8123")
+        monkeypatch.setenv("HASS_TOKEN", "legacy-token")
+        monkeypatch.setenv("HASS_TOOL_URL", "http://tool.example:8123")
+        monkeypatch.setenv("HASS_TOOL_TOKEN", "tool-token")
+
+        url, token = _get_config()
+        assert url == "http://tool.example:8123"
+        assert token == "tool-token"
+
+    def test_falls_back_to_legacy_env(self, monkeypatch):
+        monkeypatch.delenv("HASS_TOOL_URL", raising=False)
+        monkeypatch.delenv("HASS_TOOL_TOKEN", raising=False)
+        monkeypatch.setenv("HASS_URL", "http://legacy.example:8123")
+        monkeypatch.setenv("HASS_TOKEN", "legacy-token")
+
+        url, token = _get_config()
+        assert url == "http://legacy.example:8123"
+        assert token == "legacy-token"
+
+
+# ---------------------------------------------------------------------------
 # Availability check
 # ---------------------------------------------------------------------------
 
@@ -458,6 +486,11 @@ class TestCheckAvailable:
 
     def test_available_with_token(self, monkeypatch):
         monkeypatch.setenv("HASS_TOKEN", "eyJ0eXAiOiJKV1Q")
+        assert _check_ha_available() is True
+
+    def test_available_with_tool_specific_token(self, monkeypatch):
+        monkeypatch.delenv("HASS_TOKEN", raising=False)
+        monkeypatch.setenv("HASS_TOOL_TOKEN", "tool-token")
         assert _check_ha_available() is True
 
     def test_empty_token_is_unavailable(self, monkeypatch):

--- a/tests/tools/test_send_message_missing_platforms.py
+++ b/tests/tools/test_send_message_missing_platforms.py
@@ -251,6 +251,18 @@ class TestSendHomeAssistant:
         url = session.post.call_args[0][0]
         assert "hass.env.com" in url
 
+    def test_tool_env_var_fallback(self):
+        resp = _make_aiohttp_resp(200)
+        session_ctx, session = _make_aiohttp_session(resp)
+
+        with patch("aiohttp.ClientSession", return_value=session_ctx),              patch.dict(os.environ, {"HASS_URL": "", "HASS_TOKEN": "", "HASS_TOOL_URL": "https://hass.tool.com", "HASS_TOOL_TOKEN": "tool-tok"}, clear=False):
+            result = asyncio.run(_send_homeassistant("", {}, "notify_target", "hi"))
+
+        assert result["success"] is True
+        call_kwargs = session.post.call_args
+        assert call_kwargs[0][0] == "https://hass.tool.com/api/services/notify/notify"
+        assert call_kwargs[1]["headers"]["Authorization"] == "Bearer tool-tok"
+
 
 # ---------------------------------------------------------------------------
 # _send_dingtalk

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -6,8 +6,8 @@ Registers four LLM-callable tools:
 - ``ha_list_services`` -- list available services (actions) per domain
 - ``ha_call_service`` -- call a HA service (turn_on, turn_off, set_temperature, etc.)
 
-Authentication uses a Long-Lived Access Token via ``HASS_TOKEN`` env var.
-The HA instance URL is read from ``HASS_URL`` (default: http://homeassistant.local:8123).
+Authentication prefers ``HASS_TOOL_TOKEN`` / ``HASS_TOOL_URL`` and falls back
+to ``HASS_TOKEN`` / ``HASS_URL`` for backwards compatibility.
 """
 
 import asyncio
@@ -31,8 +31,14 @@ _HASS_TOKEN: str = ""
 def _get_config():
     """Return (hass_url, hass_token) from env vars at call time."""
     return (
-        (_HASS_URL or os.getenv("HASS_URL", "http://homeassistant.local:8123")).rstrip("/"),
-        _HASS_TOKEN or os.getenv("HASS_TOKEN", ""),
+        (
+            _HASS_URL
+            or os.getenv("HASS_TOOL_URL")
+            or os.getenv("HASS_URL", "http://homeassistant.local:8123")
+        ).rstrip("/"),
+        _HASS_TOKEN
+        or os.getenv("HASS_TOOL_TOKEN")
+        or os.getenv("HASS_TOKEN", ""),
     )
 
 # Regex for valid HA entity_id format (e.g. "light.living_room", "sensor.temperature_1")
@@ -342,8 +348,8 @@ def _handle_list_services(args: dict, **kw) -> str:
 # ---------------------------------------------------------------------------
 
 def _check_ha_available() -> bool:
-    """Tool is only available when HASS_TOKEN is set."""
-    return bool(os.getenv("HASS_TOKEN"))
+    """Tool is only available when a Home Assistant tool token is configured."""
+    return bool(_HASS_TOKEN or os.getenv("HASS_TOOL_TOKEN") or os.getenv("HASS_TOKEN"))
 
 
 # ---------------------------------------------------------------------------

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1482,10 +1482,10 @@ async def _send_homeassistant(token, extra, chat_id, message):
     except ImportError:
         return {"error": "aiohttp not installed. Run: pip install aiohttp"}
     try:
-        hass_url = (extra.get("url") or os.getenv("HASS_URL", "")).rstrip("/")
-        token = token or os.getenv("HASS_TOKEN", "")
+        hass_url = (extra.get("url") or os.getenv("HASS_TOOL_URL") or os.getenv("HASS_URL", "")).rstrip("/")
+        token = token or os.getenv("HASS_TOOL_TOKEN") or os.getenv("HASS_TOKEN", "")
         if not hass_url or not token:
-            return {"error": "Home Assistant not configured (HASS_URL, HASS_TOKEN required)"}
+            return {"error": "Home Assistant not configured (HASS_TOOL_URL/HASS_TOOL_TOKEN or HASS_URL/HASS_TOKEN required)"}
         url = f"{hass_url}/api/services/notify/notify"
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:


### PR DESCRIPTION
## Summary

- Add `HASS_TOOL_URL` / `HASS_TOOL_TOKEN` for the Home Assistant tool surface.
- Add `HASS_PLATFORM_URL` / `HASS_PLATFORM_TOKEN` for the Home Assistant websocket platform.
- Add `HASS_PLATFORM_DISABLE=1` to allow tool-only Home Assistant setups.
- Preserve legacy `HASS_URL` / `HASS_TOKEN` as the shared fallback for both surfaces.
- Clean up partially opened Home Assistant websocket resources when connect fails midway.

## Why

Some deployments want Hermes tools to talk to a local Home Assistant proxy while not enabling the gateway websocket platform, or want the platform and tools to use different credentials/URLs. Today both surfaces are forced through the same `HASS_URL` / `HASS_TOKEN` values.

This keeps existing behavior by default while allowing safer tool-only/proxy deployments.

## Test plan

```bash
uv run --extra dev pytest \
  tests/gateway/test_homeassistant.py \
  tests/tools/test_homeassistant_tool.py \
  tests/tools/test_send_message_missing_platforms.py -q
```

Result: `139 passed, 1 existing RuntimeWarning about _async_call_service`.
