### PR TITLE
feat: add config option to disable eager rate-limit fallback

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -466,6 +466,12 @@ DEFAULT_CONFIG = {
         # on flaky primaries; raise it if you prefer to tolerate longer
         # provider hiccups on a single provider.
         "api_max_retries": 3,
+        # When True (default), rate-limit/billing errors (429/402) trigger
+        # an immediate fallback to a backup provider instead of retrying the
+        # primary model.  Set to False to let the normal retry loop with
+        # exponential backoff handle these errors as well — the primary is
+        # retried api_max_retries times before falling back.
+        "eager_rate_limit_fallback": True,
         "service_tier": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.

--- a/run_agent.py
+++ b/run_agent.py
@@ -2098,6 +2098,15 @@ class AIAgent:
             _api_retries = 3
         self._api_max_retries = _api_retries
 
+        # Whether to eagerly fallback on rate-limit/billing errors (429/402)
+        # instead of retrying the primary model.  Default True preserves
+        # existing behavior.  Configurable via agent.eager_rate_limit_fallback.
+        try:
+            _eager_rl = str(_agent_section.get("eager_rate_limit_fallback", True)).lower()
+            self._eager_rate_limit_fallback = _eager_rl in ("true", "1", "yes")
+        except Exception:
+            self._eager_rate_limit_fallback = True
+
         # Initialize context compressor for automatic context management
         # Compresses conversation when approaching model's context limit
         # Configuration via config.yaml (compression section)
@@ -13837,7 +13846,7 @@ class AIAgent:
                         FailoverReason.rate_limit,
                         FailoverReason.billing,
                     }
-                    if is_rate_limited and self._fallback_index < len(self._fallback_chain):
+                    if is_rate_limited and self._eager_rate_limit_fallback and self._fallback_index < len(self._fallback_chain):
                         # Don't eagerly fallback if credential pool rotation may
                         # still recover.  See _pool_may_recover_from_rate_limit
                         # for the single-credential-pool and CloudCode-quota


### PR DESCRIPTION
## Summary

Add `agent.eager_rate_limit_fallback` config option (default: `true`) to control whether rate-limit/billing errors (429/402) trigger an immediate fallback to a backup provider.

When set to `false`, rate limit errors go through the normal retry loop with exponential backoff — the primary model is retried `api_max_retries` times before falling back.

## Motivation

Users hitting transient/burst rate limits (e.g. DashScope quota bursting) would often prefer to retry the primary model a few times rather than immediately switching to a potentially slower/less capable fallback model. The current hardcoded eager fallback burns no retries before switching.

## Changes

- **`hermes_cli/config.py`** — added `eager_rate_limit_fallback: true` to `DEFAULT_CONFIG`
- **`run_agent.py`** — `AIAgent.__init__` reads config into `self._eager_rate_limit_fallback`
- **`run_agent.py`** — eager fallback block gated on `self._eager_rate_limit_fallback`

Default is `true` — fully backward compatible, no behavior change for existing users.

## Usage

```bash
# Disable eager fallback — let 429 errors retry before falling back
hermes config set agent.eager_rate_limit_fallback false
hermes config set agent.api_max_retries 6
```

## Related

- #11616 — original `api_max_retries` config