### PR TITLE
fix(cron): expose in-progress run state

### DIFF
--- a/cron/__init__.py
+++ b/cron/__init__.py
@@ -24,6 +24,7 @@ from cron.jobs import (
     pause_job,
     resume_job,
     trigger_job,
+    mark_job_started,
     JOBS_FILE,
 )
 from cron.scheduler import tick
@@ -37,6 +38,7 @@ __all__ = [
     "pause_job",
     "resume_job",
     "trigger_job",
+    "mark_job_started",
     "tick",
     "JOBS_FILE",
 ]

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -557,6 +557,8 @@ def create_job(
         "paused_reason": None,
         "created_at": now,
         "next_run_at": compute_next_run(parsed_schedule),
+        "last_started_at": None,
+        "current_run_started_at": None,
         "last_run_at": None,
         "last_status": None,
         "last_error": None,
@@ -700,6 +702,30 @@ def remove_job(job_id: str) -> bool:
     return False
 
 
+def mark_job_started(job_id: str) -> bool:
+    """Mark a job as actively executing without claiming completion.
+
+    Recurring cron jobs pre-advance ``next_run_at`` before execution to avoid
+    duplicate fires after a crash.  Without a separate started marker,
+    observers see ``next_run_at`` move while ``last_run_at`` remains stale and
+    cannot distinguish a healthy in-progress run from integrity drift.
+    """
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        for job in jobs:
+            if job["id"] == job_id:
+                now = _hermes_now().isoformat()
+                job["last_started_at"] = now
+                job["current_run_started_at"] = now
+                if job.get("state") != "paused":
+                    job["state"] = "running"
+                save_jobs(jobs)
+                return True
+
+        logger.warning("mark_job_started: job_id %s not found, skipping save", job_id)
+        return False
+
+
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                  delivery_error: Optional[str] = None):
     """
@@ -716,6 +742,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
         for i, job in enumerate(jobs):
             if job["id"] == job_id:
                 now = _hermes_now().isoformat()
+                job["current_run_started_at"] = None
                 job["last_run_at"] = now
                 job["last_status"] = "ok" if success else "error"
                 job["last_error"] = error if not success else None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -120,7 +120,7 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
+from cron.jobs import get_due_jobs, mark_job_run, mark_job_started, save_job_output, advance_next_run
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -1620,6 +1620,7 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
         # Advance next_run_at for all recurring jobs FIRST, under the file lock,
         # before any execution begins.  This preserves at-most-once semantics.
         for job in due_jobs:
+            mark_job_started(job["id"])
             advance_next_run(job["id"])
 
         # Resolve max parallel workers: env var > config.yaml > unbounded.

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -75,6 +75,8 @@ def cron_list(show_all: bool = False):
         skills = job.get("skills") or ([job["skill"]] if job.get("skill") else [])
         if state == "paused":
             status = color("[paused]", Colors.YELLOW)
+        elif state == "running":
+            status = color("[running]", Colors.YELLOW)
         elif state == "completed":
             status = color("[completed]", Colors.BLUE)
         elif job.get("enabled", True):
@@ -100,6 +102,10 @@ def cron_list(show_all: bool = False):
             print(f"    Workdir:   {workdir}")
 
         # Execution history
+        current_started = job.get("current_run_started_at")
+        if current_started:
+            print(f"    Running:   since {current_started}")
+
         last_status = job.get("last_status")
         if last_status:
             last_run = job.get("last_run_at", "?")

--- a/tests/cron/test_cron_running_state.py
+++ b/tests/cron/test_cron_running_state.py
@@ -1,0 +1,99 @@
+"""Cron run-integrity state tests."""
+
+from __future__ import annotations
+
+import importlib
+import threading
+from datetime import datetime
+
+import pytest
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "cron").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import cron.jobs
+    importlib.reload(cron.jobs)
+    import cron.scheduler
+    importlib.reload(cron.scheduler)
+
+    return home
+
+
+def test_mark_job_started_records_in_progress_state_without_claiming_completion(hermes_env):
+    from cron.jobs import create_job, get_job, mark_job_started
+
+    job = create_job(prompt="report", schedule="every 5m", deliver="local")
+
+    assert mark_job_started(job["id"]) is True
+    reloaded = get_job(job["id"])
+
+    assert reloaded["state"] == "running"
+    assert reloaded["last_started_at"]
+    assert reloaded["current_run_started_at"] == reloaded["last_started_at"]
+    assert reloaded["last_run_at"] is None
+    assert reloaded["last_status"] is None
+
+
+def test_mark_job_run_clears_in_progress_state_after_completion(hermes_env):
+    from cron.jobs import create_job, get_job, mark_job_run, mark_job_started
+
+    job = create_job(prompt="report", schedule="every 5m", deliver="local")
+    mark_job_started(job["id"])
+
+    mark_job_run(job["id"], True)
+    reloaded = get_job(job["id"])
+
+    assert reloaded["state"] == "scheduled"
+    assert reloaded["last_started_at"]
+    assert reloaded["current_run_started_at"] is None
+    assert reloaded["last_run_at"]
+    assert reloaded["last_status"] == "ok"
+
+
+def test_tick_exposes_running_state_while_job_is_executing(hermes_env, monkeypatch):
+    import cron.jobs as jobs
+    from cron.jobs import create_job, get_job
+    import cron.scheduler as scheduler
+
+    job = create_job(prompt="report", schedule="every 5m", deliver="local")
+    frozen_now = datetime.fromisoformat(job["next_run_at"])
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: frozen_now)
+    monkeypatch.setattr(scheduler, "_hermes_now", lambda: frozen_now)
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def fake_run_job(due_job):
+        started.set()
+        release.wait(timeout=5)
+        return True, "# output", "done", None
+
+    monkeypatch.setattr(scheduler, "run_job", fake_run_job)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda job_id, output: hermes_env / "out.md")
+    monkeypatch.setattr(scheduler, "_deliver_result", lambda *args, **kwargs: None)
+
+    thread = threading.Thread(target=scheduler.tick, kwargs={"verbose": False})
+    thread.start()
+    assert started.wait(timeout=5)
+
+    in_progress = get_job(job["id"])
+    assert in_progress["state"] == "running"
+    assert in_progress["current_run_started_at"]
+    assert in_progress["last_run_at"] is None
+
+    release.set()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+
+    completed = get_job(job["id"])
+    assert completed["state"] == "scheduled"
+    assert completed["current_run_started_at"] is None
+    assert completed["last_run_at"]
+    assert completed["last_status"] == "ok"

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -235,6 +235,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "repeat": _repeat_display(job),
         "deliver": job.get("deliver", "local"),
         "next_run_at": job.get("next_run_at"),
+        "last_started_at": job.get("last_started_at"),
+        "current_run_started_at": job.get("current_run_started_at"),
         "last_run_at": job.get("last_run_at"),
         "last_status": job.get("last_status"),
         "last_delivery_error": job.get("last_delivery_error"),


### PR DESCRIPTION
## Summary
- record `last_started_at` / `current_run_started_at` before cron execution so pre-advanced recurring jobs have an observable in-progress state
- clear `current_run_started_at` when `mark_job_run()` records success/failure
- surface `[running]` in `hermes cron list` and expose start timestamps through the cronjob tool

## Repro / root cause
Kai PM heartbeat jobs created `session_cron_*` files and pre-advanced `next_run_at` before output/report/`last_run_at` existed. That is expected at-most-once behavior in `cron/scheduler.py:1620` + `cron/jobs.py:776`, but the persisted job record had no “run has started” field, so watchdogs could only see `next_run_at` moved while `last_run_at` stayed stale and had to treat a healthy long run as integrity drift.

## Test Plan
- `scripts/run_tests.sh tests/cron/test_cron_running_state.py -q`
- `scripts/run_tests.sh tests/cron/test_cron_running_state.py tests/tools/test_cronjob_tools.py tests/hermes_cli/test_cron.py -q`

Note: a broader `scripts/run_tests.sh tests/cron tests/tools/test_cronjob_tools.py tests/hermes_cli/test_cron.py -q` currently hits unrelated existing failures in `tests/cron/test_cron_script.py::TestBuildJobPromptWithScript::test_script_empty_output_noted` and two MCP-init auth fixture tests; the targeted changed paths pass.
