### PR TITLE
fix(dashboard): tolerate PID probe failures in status endpoint

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2575,7 +2575,11 @@ async def get_status(profile: Optional[str] = None):
         # Try local PID check first (same-host).  If that fails and a remote
         # GATEWAY_HEALTH_URL is configured, probe the gateway over HTTP so the
         # dashboard works when the gateway runs in a separate container.
-        gateway_pid = get_running_pid_cached()
+        try:
+            gateway_pid = get_running_pid_cached()
+        except Exception:
+            _log.warning("Failed to probe local gateway PID", exc_info=True)
+            gateway_pid = None
         gateway_running = gateway_pid is not None
         remote_health_body: dict | None = None
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -5388,6 +5388,40 @@ class TestStatusRemoteGateway:
         assert data["gateway_pid"] is None
         assert data["gateway_state"] == "running"
 
+    def test_status_falls_back_to_remote_probe_when_cached_pid_probe_raises(
+        self, monkeypatch
+    ):
+        """Cached local PID probe errors must not block remote health fallback."""
+        import hermes_cli.web_server as ws
+
+        def raise_probe_error():
+            raise SystemError("OSError returned a result with an exception set")
+
+        monkeypatch.setattr(ws, "get_running_pid_cached", raise_probe_error)
+        monkeypatch.setattr(ws, "read_runtime_status", lambda: None)
+        monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", "http://gw:8642")
+        monkeypatch.setattr(
+            ws,
+            "_probe_gateway_health",
+            lambda: (
+                True,
+                {
+                    "status": "ok",
+                    "gateway_state": "running",
+                    "platforms": {"discord": {"state": "connected"}},
+                    "pid": 999,
+                },
+            ),
+        )
+
+        resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["gateway_running"] is True
+        assert data["gateway_pid"] == 999
+        assert data["gateway_state"] == "running"
+        assert data["gateway_health_url"] == "http://gw:8642"
 
 class TestGatewayBusyReadout:
     """Tests for the NAS busy/drainable readout on /api/status.


### PR DESCRIPTION
## What does this PR do?

Narrowed on current `main`: the core Windows PID liveness work has already landed upstream through the psutil-backed `gateway.status._pid_exists()` helper and related process-helper changes.

This PR now keeps the dashboard `/api/status` endpoint best-effort when the local gateway PID probe raises unexpectedly:

- catches unexpected `get_running_pid()` probe failures in `hermes_cli.web_server.get_status()`
- logs a warning with traceback for diagnosis
- treats the local PID as unavailable (`gateway_running=false`, `gateway_pid=null`) instead of returning HTTP 500
- preserves the existing remote health fallback path for container/remote gateway setups

## Why keep this slice?

`/api/status` is a dashboard/status endpoint and should remain diagnostic/best-effort. Even if the same-host PID probe hits a platform-specific edge case such as a wrapped `SystemError`, the dashboard can still return a useful status payload and continue to any configured remote health fallback.

This is intentionally no longer a broad Windows PID-liveness PR; it only covers the remaining dashboard status guard not present on `main`.

## Validation

- `uv run --with pytest --with fastapi --with httpx python -m pytest -o addopts= -q tests/hermes_cli/test_web_server.py::TestStatusRemoteGateway::test_status_treats_pid_probe_error_as_not_running tests/hermes_cli/test_web_server.py::TestStatusRemoteGateway::test_status_falls_back_to_remote_probe tests/hermes_cli/test_web_server.py::TestStatusRemoteGateway::test_status_remote_probe_not_attempted_when_local_pid_found tests/hermes_cli/test_web_server.py::TestStatusRemoteGateway::test_status_remote_probe_not_attempted_when_no_url` -> 4 passed
- `uv run --with pytest --with fastapi --with httpx python -m pytest -o addopts= -q tests/hermes_cli/test_web_server.py::TestStatusRemoteGateway` -> 5 passed
- `uv run --with ruff ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py` -> All checks passed
