### PR TITLE
fix(tui): support readline composer keybindings

### DIFF
--- a/ui-tui/src/__tests__/platform.test.ts
+++ b/ui-tui/src/__tests__/platform.test.ts
@@ -29,6 +29,59 @@ describe('platform action modifier', () => {
     expect(isActionMod({ ctrl: true, meta: false, super: false })).toBe(true)
     expect(isActionMod({ ctrl: false, meta: false, super: true })).toBe(false)
   })
+
+  it('uses only explicit Cmd/Super for destructive macOS action shortcuts', async () => {
+    const { isExplicitAction, isExplicitActionMod, shouldSwallowActionChordText } = await importPlatform('darwin')
+
+    expect(isExplicitActionMod({ ctrl: false, meta: false, super: true })).toBe(true)
+    expect(isExplicitActionMod({ ctrl: false, meta: true, super: false })).toBe(false)
+    expect(isExplicitActionMod({ ctrl: true, meta: false, super: false })).toBe(false)
+    expect(isExplicitAction({ ctrl: false, meta: true, super: false }, 'd', 'd')).toBe(false)
+    expect(isExplicitAction({ ctrl: false, meta: true, super: false }, 'l', 'l')).toBe(false)
+    expect(isExplicitAction({ ctrl: true, meta: false, super: false }, 'd', 'd')).toBe(false)
+    expect(isExplicitAction({ ctrl: false, meta: false, super: true }, 'd', 'd')).toBe(true)
+    expect(isExplicitAction({ ctrl: false, meta: false, super: true }, 'l', 'l')).toBe(true)
+    expect(shouldSwallowActionChordText({ ctrl: false, meta: true, super: false }, 'd')).toBe(true)
+    expect(shouldSwallowActionChordText({ ctrl: false, meta: true, super: false }, 'l')).toBe(true)
+    expect(shouldSwallowActionChordText({ ctrl: false, meta: true, super: false }, 'c')).toBe(false)
+    // Bare Ctrl+D belongs to the readline delete-char path, never the swallow.
+    expect(shouldSwallowActionChordText({ ctrl: true, meta: false, super: false }, 'd')).toBe(false)
+    // Bare Ctrl+L is the readline redraw chord — consumed, handled globally.
+    expect(shouldSwallowActionChordText({ ctrl: true, meta: false, super: false }, 'l')).toBe(true)
+  })
+
+  it('uses Ctrl as the explicit action modifier on non-macOS', async () => {
+    const { isExplicitActionMod } = await importPlatform('linux')
+
+    expect(isExplicitActionMod({ ctrl: true, meta: false, super: false })).toBe(true)
+  })
+
+  it('classifies bare-Ctrl chords consistently for readline arbitration', async () => {
+    const { isBareCtrl } = await importPlatform('linux')
+
+    expect(isBareCtrl({ ctrl: true, meta: false })).toBe(true)
+    expect(isBareCtrl({ ctrl: true, meta: false, shift: true })).toBe(false)
+    expect(isBareCtrl({ ctrl: true, meta: false, alt: true })).toBe(false)
+    expect(isBareCtrl({ ctrl: true, meta: true })).toBe(false)
+    expect(isBareCtrl({ ctrl: true, meta: false, super: true })).toBe(false)
+    expect(isBareCtrl({ ctrl: false, meta: false })).toBe(false)
+  })
+
+  it('swallows unowned Ctrl+D/L shapes in the composer on non-macOS', async () => {
+    const { shouldSwallowActionChordText } = await importPlatform('linux')
+
+    // Ctrl+L: the global handler owns redraw; the composer must not insert 'l'.
+    expect(shouldSwallowActionChordText({ ctrl: true, meta: false }, 'l')).toBe(true)
+    // Non-bare Ctrl+D (CSI-u Ctrl+Shift+D / Ctrl+Alt+D): neither exit nor
+    // readline delete-char — consume instead of inserting a literal 'd'.
+    expect(shouldSwallowActionChordText({ ctrl: true, meta: false, shift: true }, 'd')).toBe(true)
+    expect(shouldSwallowActionChordText({ ctrl: true, meta: false, alt: true }, 'd')).toBe(true)
+    // Bare Ctrl+D stays with the readline delete-char path.
+    expect(shouldSwallowActionChordText({ ctrl: true, meta: false }, 'd')).toBe(false)
+    // Ordinary typing and other chords fall through untouched.
+    expect(shouldSwallowActionChordText({ ctrl: false, meta: false }, 'd')).toBe(false)
+    expect(shouldSwallowActionChordText({ ctrl: true, meta: false }, 'f')).toBe(false)
+  })
 })
 
 describe('isCopyShortcut', () => {
@@ -56,6 +109,12 @@ describe('isCopyShortcut', () => {
     const { isCopyShortcut } = await importPlatform('darwin')
 
     expect(isCopyShortcut({ ctrl: true, meta: false, super: true }, 'c', {})).toBe(true)
+  })
+
+  it('keeps the legacy macOS key.meta Cmd+C copy fallback', async () => {
+    const { isCopyShortcut } = await importPlatform('darwin')
+
+    expect(isCopyShortcut({ ctrl: false, meta: true, super: false }, 'c', {})).toBe(true)
   })
 })
 
@@ -244,18 +303,16 @@ describe('parseVoiceRecordKey (#18994)', () => {
     expect(parseVoiceRecordKey('super+v').mod).toBe('super')
   })
 
-  it('rejects alt+{c,d,l} on macOS — meta-as-alt collides with isAction', async () => {
+  it('only rejects alt+c on macOS because copy still keeps the meta fallback', async () => {
     const { DEFAULT_VOICE_RECORD_KEY, parseVoiceRecordKey } = await importPlatform('darwin')
 
     // hermes-ink reports Alt as ``key.meta`` on many terminals, and
-    // ``isActionMod`` on darwin accepts ``key.meta`` as the action
-    // modifier. So ``alt+c`` / ``alt+d`` / ``alt+l`` get claimed by
-    // isCopyShortcut / isAction('d') / isAction('l') before voice
-    // runs (Copilot round-12 on #19835).
+    // copy intentionally keeps the broad action-modifier fallback for
+    // legacy Cmd+C compatibility. Destructive exit/clear now use the
+    // explicit action helper, so Alt+D/L can be configured for voice.
     expect(parseVoiceRecordKey('alt+c')).toEqual(DEFAULT_VOICE_RECORD_KEY)
-    expect(parseVoiceRecordKey('alt+d')).toEqual(DEFAULT_VOICE_RECORD_KEY)
-    expect(parseVoiceRecordKey('alt+l')).toEqual(DEFAULT_VOICE_RECORD_KEY)
-    // Other alt letters stay usable on darwin.
+    expect(parseVoiceRecordKey('alt+d').mod).toBe('alt')
+    expect(parseVoiceRecordKey('alt+l').mod).toBe('alt')
     expect(parseVoiceRecordKey('alt+r').mod).toBe('alt')
     expect(parseVoiceRecordKey('alt+space').mod).toBe('alt')
   })

--- a/ui-tui/src/__tests__/textInputPassThrough.test.ts
+++ b/ui-tui/src/__tests__/textInputPassThrough.test.ts
@@ -36,6 +36,16 @@ describe('shouldPassThroughToGlobalHandler', () => {
     expect(shouldPassThroughToGlobalHandler('b', key({ ctrl: true }))).toBe(true)
   })
 
+  it('does not pass through readline Ctrl+F/Ctrl+D with the default voice key', () => {
+    expect(shouldPassThroughToGlobalHandler('f', key({ ctrl: true }), DEFAULT_VOICE_RECORD_KEY)).toBe(false)
+    expect(shouldPassThroughToGlobalHandler('d', key({ ctrl: true }), DEFAULT_VOICE_RECORD_KEY)).toBe(false)
+  })
+
+  it('passes configured Alt+D/Alt+L voice shortcuts through before composer handling', () => {
+    expect(shouldPassThroughToGlobalHandler('d', key({ meta: true }), parseVoiceRecordKey('alt+d'))).toBe(true)
+    expect(shouldPassThroughToGlobalHandler('l', key({ meta: true }), parseVoiceRecordKey('alt+l'))).toBe(true)
+  })
+
   it('does not swallow ordinary typing keys', () => {
     expect(shouldPassThroughToGlobalHandler('h', key(), parseVoiceRecordKey('ctrl+o'))).toBe(false)
     expect(shouldPassThroughToGlobalHandler('o', key(), parseVoiceRecordKey('ctrl+o'))).toBe(false)

--- a/ui-tui/src/__tests__/textInputReadline.test.ts
+++ b/ui-tui/src/__tests__/textInputReadline.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyReadlineCtrlEdit } from '../components/textInput.js'
+
+const key = (overrides: Record<string, unknown> = {}) =>
+  ({ ctrl: false, meta: false, ...overrides }) as any
+
+const ctrl = key({ ctrl: true })
+
+describe('applyReadlineCtrlEdit', () => {
+  it('moves Ctrl+F and Ctrl+B by one grapheme', () => {
+    expect(applyReadlineCtrlEdit('f', ctrl, { cursor: 1, selection: null, value: 'a🙂b' })).toEqual({
+      changed: true,
+      cursor: 3,
+      value: 'a🙂b'
+    })
+    expect(applyReadlineCtrlEdit('b', ctrl, { cursor: 3, selection: null, value: 'a🙂b' })).toEqual({
+      changed: true,
+      cursor: 1,
+      value: 'a🙂b'
+    })
+  })
+
+  it('collapses selections for Ctrl+F and Ctrl+B', () => {
+    expect(applyReadlineCtrlEdit('f', ctrl, { cursor: 1, selection: { end: 4, start: 1 }, value: 'abcd' })).toEqual({
+      changed: true,
+      cursor: 4,
+      value: 'abcd'
+    })
+    expect(applyReadlineCtrlEdit('b', ctrl, { cursor: 4, selection: { end: 4, start: 1 }, value: 'abcd' })).toEqual({
+      changed: true,
+      cursor: 1,
+      value: 'abcd'
+    })
+  })
+
+  it('deletes one grapheme forward for Ctrl+D', () => {
+    expect(applyReadlineCtrlEdit('d', ctrl, { cursor: 1, selection: null, value: 'a🙂b' })).toEqual({
+      changed: true,
+      cursor: 1,
+      value: 'ab'
+    })
+  })
+
+  it('deletes the active selection for Ctrl+D', () => {
+    expect(applyReadlineCtrlEdit('d', ctrl, { cursor: 3, selection: { end: 3, start: 1 }, value: 'abcd' })).toEqual({
+      changed: true,
+      cursor: 1,
+      value: 'ad'
+    })
+  })
+
+  it('handles Ctrl+D at end of input without inserting text', () => {
+    expect(applyReadlineCtrlEdit('d', ctrl, { cursor: 3, selection: null, value: 'abc' })).toEqual({
+      changed: false,
+      cursor: 3,
+      value: 'abc'
+    })
+  })
+
+  it('consumes boundary no-ops instead of leaking literal letters', () => {
+    expect(applyReadlineCtrlEdit('b', ctrl, { cursor: 0, selection: null, value: 'abc' })).toEqual({
+      changed: false,
+      cursor: 0,
+      value: 'abc'
+    })
+    expect(applyReadlineCtrlEdit('f', ctrl, { cursor: 3, selection: null, value: 'abc' })).toEqual({
+      changed: false,
+      cursor: 3,
+      value: 'abc'
+    })
+    expect(applyReadlineCtrlEdit('d', ctrl, { cursor: 0, selection: null, value: '' })).toEqual({
+      changed: false,
+      cursor: 0,
+      value: ''
+    })
+  })
+
+  it('matches uppercase input case-insensitively', () => {
+    expect(applyReadlineCtrlEdit('D', ctrl, { cursor: 0, selection: null, value: 'ab' })).toEqual({
+      changed: true,
+      cursor: 0,
+      value: 'b'
+    })
+  })
+
+  it('ignores modified and unrelated keys', () => {
+    expect(applyReadlineCtrlEdit('f', key({ ctrl: true, shift: true }), { cursor: 0, selection: null, value: 'abc' }))
+      .toBeNull()
+    expect(applyReadlineCtrlEdit('d', key({ ctrl: true, alt: true }), { cursor: 0, selection: null, value: 'abc' }))
+      .toBeNull()
+    expect(applyReadlineCtrlEdit('d', key({ ctrl: true, super: true }), { cursor: 0, selection: null, value: 'abc' }))
+      .toBeNull()
+    expect(applyReadlineCtrlEdit('x', ctrl, { cursor: 0, selection: null, value: 'abc' })).toBeNull()
+  })
+})

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -4,6 +4,7 @@ import { getOverlayState, patchOverlayState, resetOverlayState } from '../app/ov
 import {
   applyVoiceRecordResponse,
   dismissSensitivePrompt,
+  getExplicitExitChordAction,
   handleIdleHotkeyExit,
   shouldAllowIdleHotkeyExit,
   shouldFallThroughForScroll
@@ -78,6 +79,34 @@ describe('handleIdleHotkeyExit', () => {
     expect(actions.die).not.toHaveBeenCalled()
     expect(requestDashboardNewSession).toHaveBeenCalledTimes(1)
     expect(actions.sys).toHaveBeenCalledWith('starting a fresh dashboard chat...')
+  })
+})
+
+const key = (overrides: Record<string, unknown> = {}) =>
+  ({ ctrl: false, meta: false, super: false, ...overrides }) as any
+
+describe('getExplicitExitChordAction', () => {
+  it('lets non-macOS Ctrl+D exit only when the composer is empty', () => {
+    expect(getExplicitExitChordAction(key({ ctrl: true }), 'd', false, false)).toBe('exit')
+    expect(getExplicitExitChordAction(key({ ctrl: true }), 'd', true, false)).toBe('composer')
+  })
+
+  it('uses only explicit Cmd/Super for macOS exit', () => {
+    expect(getExplicitExitChordAction(key({ super: true }), 'd', true, true)).toBe('exit')
+    expect(getExplicitExitChordAction(key({ ctrl: true }), 'd', false, true)).toBeNull()
+    expect(getExplicitExitChordAction(key({ meta: true }), 'd', false, true)).toBeNull()
+  })
+
+  it('requires the same bare Ctrl+D shape the composer readline path owns', () => {
+    // CSI-u Ctrl+Shift+D / Ctrl+Alt+D are neither exit nor delete-char; the
+    // composer swallows them, so the global handler must not claim them either.
+    expect(getExplicitExitChordAction(key({ ctrl: true, shift: true }), 'd', false, false)).toBeNull()
+    expect(getExplicitExitChordAction(key({ ctrl: true, alt: true }), 'd', false, false)).toBeNull()
+    expect(getExplicitExitChordAction(key({ ctrl: true, meta: true }), 'd', false, false)).toBeNull()
+  })
+
+  it('ignores unrelated explicit action chords', () => {
+    expect(getExplicitExitChordAction(key({ ctrl: true }), 'l', false, false)).toBeNull()
   })
 })
 

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -11,7 +11,7 @@ import type {
   SudoRespondResponse,
   VoiceRecordResponse
 } from '../gatewayTypes.js'
-import { isAction, isCopyShortcut, isMac, isVoiceToggleKey } from '../lib/platform.js'
+import { type ChordKey, isAction, isBareCtrl, isCopyShortcut, isExplicitAction, isMac, isVoiceToggleKey } from '../lib/platform.js'
 import { computePrecisionWheelStep, initPrecisionWheel } from '../lib/precisionWheel.js'
 import { computeWheelStep, initWheelAccelForHost } from '../lib/wheelAccel.js'
 
@@ -81,6 +81,29 @@ export function shouldFallThroughForScroll(key: {
   }
 
   return false
+}
+
+export type ExplicitExitChordAction = 'composer' | 'exit'
+
+export function getExplicitExitChordAction(
+  key: ChordKey,
+  ch: string,
+  composerHasText: boolean,
+  mac = isMac
+): ExplicitExitChordAction | null {
+  // Bare Ctrl+D only on non-macOS: the same modifier shape the composer's
+  // readline delete-char keys off, so global arbitration and composer editing
+  // can never disagree about who owns a Ctrl+D-family event (Ctrl+Shift+D and
+  // Ctrl+Alt+D from CSI-u terminals are neither exit nor delete-char).
+  const explicitActionMod = mac ? key.super === true : isBareCtrl(key)
+
+  if (!explicitActionMod || ch.toLowerCase() !== 'd') {
+    return null
+  }
+
+  // On non-macOS Ctrl+D is both the platform exit chord and readline
+  // delete-char. Let the focused composer own it while it has text.
+  return !mac && composerHasText ? 'composer' : 'exit'
 }
 
 export function applyVoiceRecordResponse(
@@ -562,7 +585,21 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       })
     }
 
-    if (isAction(key, ch, 'd')) {
+    // ``inputBuf`` (staged multi-line continuation) counts as composer text on
+    // purpose, mirroring the Ctrl+C ladder above: while any draft is staged,
+    // Ctrl+D must not exit and throw it away. Deleting is a no-op when the
+    // editable line is empty; clear the draft with Ctrl+C before exiting.
+    const exitChordAction = getExplicitExitChordAction(key, ch, Boolean(cState.input || cState.inputBuf.length))
+
+    if (exitChordAction) {
+      if (exitChordAction !== 'exit') {
+        // Composer owns the chord (readline delete-char while it has text).
+        return undefined
+      }
+
+      // Preserve upstream's dashboard-mode behavior: an explicit exit chord
+      // should start a new session in the embedded dashboard TUI rather than
+      // killing the process, and only call die() outside dashboard mode.
       return handleIdleHotkeyExit(actions, DASHBOARD_TUI_MODE, () => {
         gateway.gw.publishLocalEvent({
           payload: { reason: 'idle_exit_hotkey' },
@@ -572,7 +609,11 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       })
     }
 
-    if (isAction(key, ch, 'l')) {
+    // Explicit clear chord (Cmd+L on macOS, Ctrl+L elsewhere) plus readline
+    // Ctrl+L on macOS, where bare Ctrl is not the action modifier. The
+    // composer swallows every Ctrl/action+L shape (shouldSwallowActionChordText)
+    // so redraw stays non-destructive to the draft.
+    if (isExplicitAction(key, ch, 'l') || (isBareCtrl(key) && ch.toLowerCase() === 'l')) {
       clearSelection()
       forceRedraw(terminal.stdout ?? process.stdout)
 

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -6,12 +6,15 @@ import { setInputSelection } from '../app/inputSelectionStore.js'
 import { readClipboardText, writeClipboardText } from '../lib/clipboard.js'
 import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
 import {
+  type ChordKey,
   DEFAULT_VOICE_RECORD_KEY,
   isActionMod,
+  isBareCtrl,
   isMac,
   isMacActionFallback,
   isVoiceToggleKey,
-  type ParsedVoiceRecordKey
+  type ParsedVoiceRecordKey,
+  shouldSwallowActionChordText
 } from '../lib/platform.js'
 import { isTermuxTuiMode } from '../lib/termux.js'
 
@@ -469,6 +472,69 @@ export function supportsFastEchoTerminal(env: NodeJS.ProcessEnv = process.env): 
   }
 
   return true
+}
+
+interface TextSelectionRange {
+  end: number
+  start: number
+}
+
+export interface ReadlineCtrlEditState {
+  cursor: number
+  selection: null | TextSelectionRange
+  value: string
+}
+
+export interface ReadlineCtrlEditResult {
+  changed: boolean
+  cursor: number
+  value: string
+}
+
+/**
+ * Readline-style bare-Ctrl edits: Ctrl+B/F move one grapheme (collapsing an
+ * active selection to its edge), Ctrl+D deletes the selection or the grapheme
+ * under the cursor. Returns ``changed: false`` when the chord is owned but is
+ * a no-op (cursor at the boundary, empty value) so the caller consumes it
+ * instead of letting the literal letter fall through to text insertion.
+ *
+ * Ctrl+B only reaches this path when the user rebinds voice recording — the
+ * default voice key is ctrl+b and the voice pass-through runs first (that
+ * ordering is deliberate and test-pinned; see shouldPassThroughToGlobalHandler).
+ */
+export function applyReadlineCtrlEdit(
+  input: string,
+  key: ChordKey,
+  { cursor, selection, value }: ReadlineCtrlEditState
+): null | ReadlineCtrlEditResult {
+  if (!isBareCtrl(key)) {
+    return null
+  }
+
+  const ch = input.toLowerCase()
+  let nextCursor = cursor
+  let nextValue = value
+
+  if (ch === 'b') {
+    nextCursor = selection ? selection.start : prevPos(value, cursor)
+  } else if (ch === 'f') {
+    nextCursor = selection ? selection.end : nextPos(value, cursor)
+  } else if (ch === 'd') {
+    if (selection) {
+      nextValue = value.slice(0, selection.start) + value.slice(selection.end)
+      nextCursor = selection.start
+    } else if (cursor < value.length) {
+      nextValue = value.slice(0, cursor) + value.slice(nextPos(value, cursor))
+    }
+  } else {
+    return null
+  }
+
+  return {
+    changed: nextValue !== value || nextCursor !== cursor || selection !== null,
+    cursor: nextCursor,
+    value: nextValue
+  }
 }
 
 function renderWithCursor(value: string, cursor: number) {
@@ -1011,6 +1077,10 @@ export function TextInput({
         return
       }
 
+      if (shouldSwallowActionChordText(k, inp)) {
+        return
+      }
+
       if (
         eventRaw === '\x1bv' ||
         eventRaw === '\x1bV' ||
@@ -1094,6 +1164,20 @@ export function TextInput({
 
       if (!isPrintableInput) {
         flushKeyBurst()
+      }
+
+      // Readline bare-Ctrl edits (Ctrl+B/F char motion, Ctrl+D delete-char)
+      // win over the legacy word-motion mappings below. An owned no-op chord
+      // (e.g. Ctrl+D at end of input) is consumed so the literal letter never
+      // falls through to text insertion.
+      const readlineEdit = applyReadlineCtrlEdit(inp, k, { cursor: c, selection: range, value: v })
+
+      if (readlineEdit) {
+        if (!readlineEdit.changed) {
+          return
+        }
+
+        return commit(readlineEdit.value, readlineEdit.cursor)
       }
 
       if (mod && inp === 'z') {

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -15,11 +15,18 @@ const copyHotkeys: [string, string][] = isMac
       ]
     : [['Ctrl+C', 'copy selection / interrupt / clear draft / exit']]
 
+const exitHotkeys: [string, string][] = isMac
+  ? [
+      ['Cmd+D', 'exit'],
+      ['Ctrl+D', 'delete char under cursor']
+    ]
+  : [['Ctrl+D', 'delete char / exit when input is empty']]
+
 export const HOTKEYS: [string, string][] = [
   ...copyHotkeys,
-  [action + '+D', 'exit'],
+  ...exitHotkeys,
   [action + '+G / Alt+G', 'open $EDITOR (Alt+G fallback for VSCode/Cursor)'],
-  [action + '+L', 'redraw / repaint'],
+  [isMac ? 'Cmd+L / Ctrl+L' : 'Ctrl+L', 'redraw / repaint'],
   [paste + '+V / /paste', 'paste text; /paste attaches clipboard image'],
   ['Tab', 'apply completion'],
   ['↑/↓', 'completions / queue edit / history'],

--- a/ui-tui/src/lib/platform.ts
+++ b/ui-tui/src/lib/platform.ts
@@ -15,6 +15,10 @@ export const isMac = process.platform === 'darwin'
 export const isActionMod = (key: { ctrl: boolean; meta: boolean; super?: boolean }): boolean =>
   isMac ? key.meta || key.super === true : key.ctrl
 
+/** True only for unambiguous platform action-modifier events. */
+export const isExplicitActionMod = (key: { ctrl: boolean; meta: boolean; super?: boolean }): boolean =>
+  isMac ? key.super === true : key.ctrl
+
 /**
  * Accept raw Ctrl+<letter> as an action shortcut on macOS, where `isActionMod`
  * otherwise means Cmd. Two motivations:
@@ -33,6 +37,55 @@ export const isMacActionFallback = (
 /** Match action-modifier + a single character (case-insensitive). */
 export const isAction = (key: { ctrl: boolean; meta: boolean; super?: boolean }, ch: string, target: string): boolean =>
   isActionMod(key) && ch.toLowerCase() === target
+
+/** Match explicit action-modifier + a single character (case-insensitive). */
+export const isExplicitAction = (
+  key: { ctrl: boolean; meta: boolean; super?: boolean },
+  ch: string,
+  target: string
+): boolean => isExplicitActionMod(key) && ch.toLowerCase() === target
+
+export interface ChordKey {
+  alt?: boolean
+  ctrl: boolean
+  meta: boolean
+  shift?: boolean
+  super?: boolean
+}
+
+/** Ctrl with no other modifier — the shape readline chords key off. */
+export const isBareCtrl = (key: ChordKey): boolean =>
+  key.ctrl && !key.alt && !key.meta && key.super !== true && !key.shift
+
+/**
+ * Action chords the focused composer must consume so they never fall through
+ * as typed text. hermes-ink reports Ctrl+<letter> with ``input`` set to the
+ * bare letter, so unowned control chords would otherwise insert that letter
+ * (or clobber an active selection).
+ *
+ *  - macOS broad action-modifier + d/l: exit / clear-screen chords (Cmd via
+ *    ``key.super``, legacy Cmd and Option both via ``key.meta``). The global
+ *    handler only acts on the explicit ``key.super`` form; the ambiguous
+ *    ``key.meta`` forms are consumed here as no-ops.
+ *  - Ctrl+L on every platform: the global handler owns redraw/clear.
+ *  - Non-bare Ctrl+D (Ctrl+Shift+D, Ctrl+Alt+D via CSI-u terminals): not an
+ *    exit chord and not readline delete-char, but still a control chord that
+ *    must not insert a literal ``d``. Bare Ctrl+D is excluded — the readline
+ *    edit path owns it.
+ */
+export const shouldSwallowActionChordText = (key: ChordKey, ch: string): boolean => {
+  const c = ch.toLowerCase()
+
+  if (isMac && isActionMod(key) && (c === 'd' || c === 'l')) {
+    return true
+  }
+
+  if (key.ctrl && c === 'l') {
+    return true
+  }
+
+  return key.ctrl && c === 'd' && !isBareCtrl(key)
+}
 
 export const isRemoteShell = (env: NodeJS.ProcessEnv = process.env): boolean =>
   Boolean(env.SSH_CONNECTION || env.SSH_CLIENT || env.SSH_TTY)
@@ -152,8 +205,7 @@ const _NAMED_KEY_ALIASES: Record<string, VoiceRecordKeyNamed> = {
  * bindings (Copilot round-8 review on #19835). */
 const _RESERVED_CTRL_CHARS = new Set(['c', 'd', 'l'])
 
-/** On macOS the action-modifier intercepts these editor chords via
- * ``isCopyShortcut`` / ``isAction`` in ``useInputHandlers()``:
+/** On macOS the action-modifier intercepts these editor chords before voice:
  *  - super+c → copy
  *  - super+d → exit
  *  - super+l → clear screen
@@ -164,14 +216,11 @@ const _RESERVED_CTRL_CHARS = new Set(['c', 'd', 'l'])
  * non-mac users (Copilot round-8 review on #19835). */
 const _RESERVED_SUPER_CHARS = new Set(['c', 'd', 'l', 'v'])
 
-/** On macOS ``isActionMod`` accepts ``key.meta`` as the action
- * modifier — but hermes-ink reports Alt as ``key.meta`` on many
- * terminals. So on darwin a configured ``alt+c`` / ``alt+d`` / ``alt+l``
- * gets swallowed by ``isCopyShortcut`` / ``isAction`` before the voice
- * check runs. Block at parse time so /voice status doesn't advertise
- * a shortcut that actually copies / quits / clears (Copilot round-12
- * review on #19835). */
-const _RESERVED_ALT_CHARS_MAC = new Set(['c', 'd', 'l'])
+/** On macOS ``isCopyShortcut`` keeps the broad ``key.meta`` fallback
+ * because legacy terminals can report Cmd+C that way. hermes-ink also
+ * reports Alt as ``key.meta`` on many terminals, so configured ``alt+c``
+ * would be swallowed by copy before the voice check runs. */
+const _RESERVED_ALT_CHARS_MAC = new Set(['c'])
 
 interface RuntimeKeyEvent {
   alt?: boolean
@@ -288,7 +337,6 @@ export const parseVoiceRecordKey = (raw: unknown): ParsedVoiceRecordKey => {
 
   // Same for ``super+c`` / ``super+d`` / ``super+l`` / ``super+v`` on
   // macOS only — those are copy / exit / clear / paste and get claimed
-  // by ``isCopyShortcut`` / ``isAction`` / the TextInput paste layer
   // before voice has a chance to toggle. On Linux/Windows the TUI
   // globals key off Ctrl (not Super), so kitty/CSI-u ``super+<letter>``
   // bindings stay usable for non-mac users.
@@ -296,11 +344,10 @@ export const parseVoiceRecordKey = (raw: unknown): ParsedVoiceRecordKey => {
     return DEFAULT_VOICE_RECORD_KEY
   }
 
-  // On macOS hermes-ink reports Alt as ``key.meta``, which ``isActionMod``
-  // accepts as the mac action modifier. So ``alt+c`` / ``alt+d`` / ``alt+l``
-  // collide with copy / exit / clear in ``useInputHandlers()`` before the
-  // voice check. Reject at parse time on darwin only — non-mac ``alt+<letter>``
-  // bindings are still usable (Copilot round-12 review on #19835).
+  // On macOS hermes-ink reports Alt as ``key.meta``, and copy keeps
+  // the broad ``key.meta`` fallback for legacy Cmd+C compatibility.
+  // Reject ``alt+c`` at parse time on darwin only; non-mac ``alt+<letter>``
+  // bindings and macOS Alt+D/L remain usable.
   if (isMac && mod === 'alt' && last.length === 1 && _RESERVED_ALT_CHARS_MAC.has(last)) {
     return DEFAULT_VOICE_RECORD_KEY
   }


### PR DESCRIPTION
## Rationale

On macOS, Option often arrives as `key.meta`. The TUI used the broad action modifier helper for global Cmd+D and Cmd+L, so Option+D could quit and Option+L could clear the screen instead of reaching the composer. The composer also lacked readline Ctrl+F character-forward, and Ctrl+D inserted a literal `d` instead of deleting the character under the cursor.

## Root Cause

`isActionMod()` intentionally accepts `key.meta` on macOS for legacy Cmd compatibility, but that is too broad for destructive global shortcuts.

The composer had no bare Ctrl+F/Ctrl+D readline branches, so parsed Ctrl+letter events could fall through to ordinary text insertion or existing platform-action handling.

## Fix

Add an explicit action helper and use it only for global exit/clear. Keep copy, paste, editor, and TextInput shortcuts on the broad compatibility path.

Add bare Ctrl+F character-forward in TextInput, making Ctrl+F readline character-forward across platforms.

Add guarded Ctrl+D delete-char in TextInput. Ctrl+D now deletes one grapheme under the cursor and is consumed at end-of-input so it no longer inserts literal `d`. On non-macOS, the global Ctrl+D exit handler now yields to the focused composer while it has text, preserving empty-buffer exit behavior without racing delete-char.

## Verification

- `npm --prefix ui-tui run test -- src/__tests__/platform.test.ts src/__tests__/textInputPassThrough.test.ts`
- `npm --prefix ui-tui run type-check`
- `npm --prefix ui-tui run build`
- `npm exec eslint -- src/lib/platform.ts src/app/useInputHandlers.ts src/components/textInput.tsx src/__tests__/platform.test.ts src/__tests__/textInputPassThrough.test.ts` (warnings only; full TUI lint has unrelated existing errors)

## Notes

Alt+D/Alt+L no longer quit or clear. This PR does not add Meta-D kill-word or Meta-L case conversion, so some terminals may pass literal d/l into the composer. Legacy macOS terminals that only report Cmd+D/Cmd+L as `key.meta` lose those two destructive shortcuts; super-capable terminals keep them.

Ctrl+D now covers delete-char/no-literal-`d`. This PR does not add macOS empty-buffer Ctrl+D EOF/exit semantics; non-macOS empty-buffer Ctrl+D exit remains intact.

Out of scope: broad keybinding config, left/right Option, macOS Ctrl+D EOF/exit, Meta-D, and Meta-L.
