### PR TITLE
Add skill: digital-product-advisor

### DIFF
--- a/skills/digital-product-advisor/SKILL.md
+++ b/skills/digital-product-advisor/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: digital-product-advisor
+description: "Use when helping a user choose consumer electronics products through source-aware market research, comparison, and recommendation. MVP focuses on Bluetooth earbuds."
+version: 0.1.0
+author: Jack + Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [product-research, buying-guide, consumer-electronics, bluetooth-earbuds, shopping]
+    related_skills: []
+---
+
+# Digital Product Advisor
+
+## Overview
+
+This skill helps an agent produce practical, source-aware buying recommendations for consumer electronics. The MVP focuses on Bluetooth earbuds / true wireless earbuds.
+
+The core workflow is documentation-first: clarify the buying context, collect current market options, compare candidates using user-specific weights, and produce a clear recommendation report. Optional scripts can normalize inputs, validate candidate JSON, and calculate weighted scores, but the skill must remain useful without scripts.
+
+## When to Use
+
+Use this skill when the user asks for help choosing, comparing, shortlisting, or buying Bluetooth earbuds, especially when they mention:
+
+- budget, currency, or price range
+- country, region, marketplaces, or purchase channels
+- specific brands to include or exclude
+- use cases such as commuting, calls, music, gym, gaming, studying, or travel
+- features such as ANC, transparency mode, mic quality, multipoint, low latency, codecs, or water resistance
+
+Do not use this skill for:
+
+- automatic checkout or purchasing
+- medical/hearing-health claims
+- investment-style price prediction
+- non-earbud product categories unless clearly marked as out-of-MVP / lower-confidence
+
+## MVP Scope
+
+Supported category:
+
+- Bluetooth earbuds / true wireless earbuds
+
+Supported recommendation modes:
+
+- open-market search
+- brand-only comparison, e.g. "only Sony"
+- brand-vs-brand comparison, e.g. "Bose vs Sony"
+- budget-limited shortlist
+- region/currency-specific recommendation
+
+## Required Mindset
+
+Do not produce a stale generic list. Product availability, discounts, and value change by region and date.
+
+Always adapt recommendations to:
+
+- user location / region
+- currency
+- budget
+- brand scope
+- phone ecosystem
+- use case
+- purchase channel
+- must-have features
+- deal breakers
+
+## Clarification Workflow
+
+Infer obvious parameters from the user's message. Ask at most 3 high-impact clarification questions if needed.
+
+High-impact missing fields:
+
+1. Budget and currency
+2. Region / market / where they can buy
+3. Main use case
+4. Phone ecosystem
+5. Brand scope if they imply brand preference
+
+Examples of inference:
+
+- "1000 RMB" implies currency CNY and likely China market.
+- "JD" or "Tmall" implies China market and CNY.
+- "Only Sony" means brand_scope.mode = include_only, include = ["Sony"].
+- "Avoid Apple" means brand_scope.mode = exclude, exclude = ["Apple"].
+- "iPhone" means Apple ecosystem; AirPods compatibility may matter.
+
+If budget, region, and use case are all present, proceed without more questions.
+
+## Parameter Model
+
+See `references/parameters.md` for the canonical schema.
+
+Minimum normalized request:
+
+```json
+{
+  "product_category": "bluetooth_earbuds",
+  "region": "China",
+  "currency": "CNY",
+  "budget": {"min": null, "max": 1000, "currency": "CNY"},
+  "brand_scope": {"mode": "open_market", "include": [], "exclude": []},
+  "marketplaces": ["JD", "Tmall", "official_store"],
+  "use_case": ["commuting", "calls"],
+  "phone_ecosystem": "Android",
+  "must_have": ["ANC", "good_microphone"],
+  "nice_to_have": [],
+  "deal_breakers": [],
+  "purchase_timeline": "this_week"
+}
+```
+
+## Research Workflow
+
+1. Normalize the user request.
+2. Choose recommendation mode: open-market, include-only brand, exclude-brand, or brand-vs-brand.
+3. Gather current candidates from the user's region and marketplace context.
+4. For each candidate, collect price, availability, key specs, review signals, known issues, and product links.
+5. Use at least three source categories when possible:
+   - official/spec source
+   - review/testing source
+   - price/availability source
+6. Remove candidates that violate hard constraints.
+7. Score remaining candidates using user-specific weights.
+8. Produce a scenario-based report with tradeoffs and confidence level.
+
+## Bluetooth Earbuds Domain Guidance
+
+Use `references/bluetooth-earbuds.md` for category-specific criteria.
+
+Important dimensions:
+
+- sound quality
+- ANC / transparency
+- call microphone quality
+- comfort and fit
+- battery life
+- codec support
+- latency
+- multipoint
+- app quality / EQ
+- water resistance
+- ecosystem fit
+- reliability / known defects
+- price-to-performance
+- local warranty and availability
+
+## Scoring
+
+Use `references/scoring-framework.md`.
+
+Scoring should be weighted by user intent. Do not present the weighted score as objective truth; it is a decision aid.
+
+For commuting + calls, emphasize:
+
+- ANC
+- mic quality
+- comfort
+- battery
+- value
+
+For music-first, emphasize:
+
+- sound quality
+- comfort
+- codec/EQ support
+- reliability
+- value
+
+For gym use, emphasize:
+
+- fit stability
+- water resistance
+- comfort
+- battery
+- replacement cost
+
+## Report Format
+
+Use `templates/report-template.md`.
+
+Every final report should include:
+
+1. one-line recommendation
+2. user requirement summary
+3. shortlist table
+4. top picks by scenario
+5. detailed tradeoffs
+6. avoid / caution section if relevant
+7. final recommendation
+8. product links / where to buy
+9. sources checked
+10. confidence level
+
+Product links should be included when available:
+
+- Add marketplace product links in the shortlist table when the product can be bought online.
+- Prefer official store, flagship store, or trusted marketplace listings over affiliate, ad, or random reseller links.
+- If exact product-page links are blocked by anti-bot pages or unavailable, include a marketplace search link and label it clearly as a search link rather than a verified product page.
+- Do not invent URLs. If no reliable link is available, write `Link unavailable` and explain why in sources or confidence notes.
+
+## Markdown Export
+
+The canonical export format is Markdown. When the user asks to export/save a report, save it as a `.md` file under one grouped folder for the category:
+
+```text
+reports/earbuds/
+```
+
+Use `references/export-policy.md` for title, metadata, filename, and path rules.
+
+Default behavior:
+
+1. Generate the report normally.
+2. Create a meaningful H1 title using product category, region, budget/brand scope, and primary use case.
+3. Save the file under `reports/earbuds/` unless the user gives another folder.
+4. Use a readable lowercase hyphenated filename such as `YYYY-MM-DD-earbuds-china-under-1000-cny-commuting-calls.md`.
+5. If the target file already exists, append `-v2`, `-v3`, etc. Do not overwrite unless requested.
+6. Tell the user the exact saved path.
+
+Example title:
+
+```markdown
+# Bluetooth Earbuds Buying Report: China, Under 1000 CNY, Commuting + Calls
+```
+
+Example path:
+
+```text
+reports/earbuds/2026-05-08-earbuds-china-under-1000-cny-commuting-calls.md
+```
+
+## Optional Scripts
+
+Scripts live in `scripts/` and are optional.
+
+Use scripts when available for:
+
+- request normalization
+- candidate data validation
+- deterministic weighted scoring
+- Markdown report path generation
+
+Do not fail the task if scripts are unavailable. Continue manually using the Markdown workflow.
+
+## Common Pitfalls
+
+1. Treating global MSRP as local value. Always check region and currency.
+2. Recommending products unavailable in the user's market.
+3. Overweighting codec specs. Codec support matters only if the user's device supports it too.
+4. Ignoring fit. Earbuds can be technically excellent and still bad for a user with fit constraints.
+5. Trusting a single review source. Use multiple source categories.
+6. Pretending scores are objective. Explain assumptions and tradeoffs.
+7. Hardcoding stale rankings into the skill.
+8. Comparing across brands when the user asked for a brand-only shortlist.
+
+## Verification Checklist
+
+Before final answer, verify:
+
+- [ ] Budget, region, currency, and use case are known or explicitly assumed.
+- [ ] Brand scope is respected.
+- [ ] Candidate list matches availability region.
+- [ ] Prices use the requested currency or clearly note conversion.
+- [ ] Product links are included where available, or missing links are explicitly labeled.
+- [ ] At least three source categories were considered when possible.
+- [ ] Recommendation includes tradeoffs, not just a winner.
+- [ ] Final report includes confidence level.
+- [ ] Claims about subjective sound/fit are framed cautiously.

--- a/skills/digital-product-advisor/references/bluetooth-earbuds.md
+++ b/skills/digital-product-advisor/references/bluetooth-earbuds.md
@@ -1,0 +1,66 @@
+# Bluetooth Earbuds Buying Logic
+
+## What Matters Most
+
+Bluetooth earbuds are highly context-dependent. The best product for commuting calls may not be the best for music, gym, or gaming.
+
+Core dimensions:
+
+- Sound quality: tuning, detail, bass control, EQ flexibility.
+- ANC: strength, pressure feeling, wind handling, adaptive behavior.
+- Transparency: naturalness and voice clarity.
+- Microphone quality: quiet room, street noise, wind, office calls.
+- Comfort and fit: shell size, nozzle shape, tips, pressure, long-session fatigue.
+- Battery: earbuds runtime, case capacity, fast charging.
+- Codec support: AAC, SBC, LDAC, LHDC, aptX variants, LC3 where relevant.
+- Latency: video, gaming, device-specific game modes.
+- Multipoint: laptop + phone switching.
+- App quality: EQ, firmware updates, control customization.
+- Water resistance: IPX4 minimum for sweat, higher for gym/rain.
+- Ecosystem fit: AirPods/iPhone, Galaxy Buds/Samsung, Huawei FreeBuds/Huawei, etc.
+- Reliability: battery aging, case issues, connection issues, warranty reputation.
+- Value: local price, discounts, warranty, replacement cost.
+
+## Misleading Specs
+
+- Codec support does not guarantee better sound. Source device must support it, and tuning still matters.
+- Driver size alone says little about sound quality.
+- ANC dB claims are marketing unless independently tested.
+- Battery claims are often without ANC and at moderate volume.
+- Low latency claims may only apply in brand-specific game modes.
+
+## China-Market Notes
+
+When region is China, consider:
+
+- JD, Tmall, official store, Pinduoduo, Douyin store, and offline official channels.
+- Domestic options: Huawei, Xiaomi/Redmi, OPPO, Vivo/iQOO, Edifier, FIIL, Soundcore, 1More, Baseus.
+- Imported brands may have different warranty or inflated prices.
+- Model names may differ from global names.
+- Festival pricing can change value rankings substantially.
+
+## Use-Case Presets
+
+### Commuting + Calls
+
+Prioritize ANC, mic quality, comfort, battery, and reliability.
+
+### Music First
+
+Prioritize sound quality, EQ, codec compatibility, comfort, and reliability.
+
+### Gym / Running
+
+Prioritize fit stability, water resistance, comfort, controls, and replacement cost.
+
+### Office / Study
+
+Prioritize multipoint, comfort, ANC, transparency, mic quality, and battery.
+
+### Gaming / Video
+
+Prioritize latency, device-specific game mode, comfort, and connection stability.
+
+## Fit Warning
+
+Always mention that fit is personal. If a user has small ears, discomfort with in-ear tips, or history of earbuds falling out, comfort and return policy should be weighted heavily.

--- a/skills/digital-product-advisor/references/export-policy.md
+++ b/skills/digital-product-advisor/references/export-policy.md
@@ -1,0 +1,77 @@
+# Markdown Export Policy
+
+The canonical export format for this skill is Markdown.
+
+## Default Export Root
+
+When the user asks to export, save reports under:
+
+```text
+reports/earbuds/
+```
+
+All Bluetooth earbuds reports should be grouped in this single folder unless the user explicitly asks for another path.
+
+## Filename Convention
+
+Use this filename shape:
+
+```text
+YYYY-MM-DD-earbuds-<region>-<budget-or-brand>-<use-case>.md
+```
+
+Examples:
+
+```text
+reports/earbuds/2026-05-08-earbuds-china-under-1000-cny-commuting-calls.md
+reports/earbuds/2026-05-08-earbuds-china-sony-1000-1800-cny-anc-calls.md
+reports/earbuds/2026-05-08-earbuds-us-iphone-premium-anc.md
+```
+
+## Title Convention
+
+The first line of the Markdown file should be a meaningful H1 title:
+
+```markdown
+# Bluetooth Earbuds Buying Report: China, Under 1000 CNY, Commuting + Calls
+```
+
+For brand-scoped reports:
+
+```markdown
+# Sony Bluetooth Earbuds Buying Report: China, 1000-1800 CNY, ANC + Calls
+```
+
+## Required Metadata Block
+
+After the title, include a short metadata block:
+
+```markdown
+- Generated: YYYY-MM-DD
+- Region: China
+- Currency: CNY
+- Budget: Under 1000 CNY
+- Brand scope: Open market
+- Use case: Commuting, calls
+- Product links: Included when available
+- Confidence: Medium
+```
+
+## Export Behavior
+
+When the user requests export:
+
+1. Generate the report normally using `templates/report-template.md`.
+2. Choose a clear title using region, budget/brand, and primary use case.
+3. Save the report as a Markdown file under `reports/earbuds/`.
+4. Include direct product links or clearly labeled marketplace search links when available.
+5. Tell the user the exact saved path.
+6. If a file with the same name exists, append `-v2`, `-v3`, etc. rather than overwriting unless the user asks to overwrite.
+
+## Path Safety
+
+- Use lowercase, hyphenated filenames.
+- Remove punctuation from filename parts.
+- Keep filenames readable, not overly long.
+- Do not include private user identifiers in filenames.
+- Use the user's requested folder if explicitly provided.

--- a/skills/digital-product-advisor/references/parameters.md
+++ b/skills/digital-product-advisor/references/parameters.md
@@ -1,0 +1,72 @@
+# Parameter Model
+
+The advisor should treat currency, location, and brand scope as first-class parameters.
+
+## Canonical Request Schema
+
+```json
+{
+  "product_category": "bluetooth_earbuds",
+  "region": null,
+  "city": null,
+  "currency": null,
+  "display_currency": null,
+  "budget": {
+    "min": null,
+    "max": null,
+    "currency": null
+  },
+  "brand_scope": {
+    "mode": "open_market",
+    "include": [],
+    "exclude": []
+  },
+  "marketplaces": [],
+  "purchase_channel": ["online"],
+  "use_case": [],
+  "phone_ecosystem": null,
+  "must_have": [],
+  "nice_to_have": [],
+  "deal_breakers": [],
+  "purchase_timeline": null,
+  "link_policy": {
+    "include_product_links": true,
+    "preferred_link_types": ["official", "trusted_marketplace"],
+    "allow_search_links_when_direct_unavailable": true
+  }
+}
+```
+
+## Product Link Rules
+
+- Include product links in reports by default when the user is making a buying decision.
+- Prefer official product pages and trusted marketplace links from the user's region.
+- For China requests, useful link types include official brand pages, JD/Tmall flagship-store product pages, or clearly labeled JD/Tmall search links.
+- Never fabricate exact product URLs. If a direct listing cannot be verified, use a search link and label it as `search link`.
+- Avoid affiliate links unless the user explicitly asks for them and disclose that they are affiliate links.
+
+## Brand Scope Modes
+
+- `open_market`: compare all relevant brands.
+- `include_only`: only compare listed brands.
+- `exclude`: compare broadly but exclude listed brands.
+- `brand_first`: user wants one brand; compare models within that brand.
+- `brand_vs_brand`: user asks to compare a small set of brands.
+
+## Currency Rules
+
+- If region is China and currency is missing, infer CNY.
+- If user says RMB or 元, infer CNY.
+- If user says USD, EUR, GBP, JPY, etc., use that display currency.
+- If source prices use different currencies, label them clearly.
+- Avoid live exchange conversion unless needed; if converting, mention the rate date/source.
+
+## Location Rules
+
+- Region/country is enough for MVP.
+- City is optional and mainly affects offline stores, shipping, and service availability.
+- Marketplace hints can imply region: JD/Tmall/Pinduoduo imply China; Best Buy implies US/Canada; Amazon depends on domain.
+
+## Clarification Limit
+
+Ask no more than 3 questions before proceeding. Prefer assumptions when obvious, but state them.

--- a/skills/digital-product-advisor/references/scoring-framework.md
+++ b/skills/digital-product-advisor/references/scoring-framework.md
@@ -1,0 +1,108 @@
+# Scoring Framework
+
+Scores are decision aids, not objective truth. Always explain tradeoffs.
+
+## Candidate Score Fields
+
+Each candidate may be rated 0-10 on:
+
+- sound
+- anc
+- transparency
+- mic
+- comfort
+- battery
+- codec
+- latency
+- multipoint
+- app
+- water_resistance
+- ecosystem
+- reliability
+- value
+
+Unknown fields should be null, not guessed.
+
+## Default Weights
+
+### Balanced
+
+```json
+{
+  "sound": 0.15,
+  "anc": 0.15,
+  "mic": 0.12,
+  "comfort": 0.15,
+  "battery": 0.10,
+  "codec": 0.05,
+  "latency": 0.03,
+  "multipoint": 0.05,
+  "app": 0.05,
+  "water_resistance": 0.03,
+  "ecosystem": 0.05,
+  "reliability": 0.07,
+  "value": 0.10
+}
+```
+
+### Commuting + Calls
+
+```json
+{
+  "anc": 0.25,
+  "mic": 0.22,
+  "comfort": 0.15,
+  "battery": 0.10,
+  "sound": 0.08,
+  "multipoint": 0.05,
+  "reliability": 0.07,
+  "value": 0.08
+}
+```
+
+### Music First
+
+```json
+{
+  "sound": 0.35,
+  "comfort": 0.15,
+  "codec": 0.10,
+  "app": 0.10,
+  "anc": 0.08,
+  "battery": 0.07,
+  "reliability": 0.07,
+  "value": 0.08
+}
+```
+
+### Gym
+
+```json
+{
+  "comfort": 0.22,
+  "water_resistance": 0.20,
+  "battery": 0.12,
+  "reliability": 0.12,
+  "sound": 0.10,
+  "mic": 0.08,
+  "value": 0.16
+}
+```
+
+## Hard Constraints
+
+Remove candidates before scoring if they violate hard constraints:
+
+- above maximum budget unless user allows stretch picks
+- unavailable in target region
+- excluded brand
+- missing must-have feature
+- known deal breaker
+
+## Handling Unknowns
+
+If a score field is unknown:
+
+- Do not invent it.
+- Exclude that weight from the denominator for the numeric score.
+- Mention lower confidence in the report.

--- a/skills/digital-product-advisor/references/source-quality.md
+++ b/skills/digital-product-advisor/references/source-quality.md
@@ -1,0 +1,59 @@
+# Source Quality
+
+Use multiple source categories. Do not rely on one reviewer, retailer, or brand page.
+
+## Source Categories
+
+1. Official/spec source
+   - manufacturer page
+   - official store listing
+   - product manual/spec sheet
+
+2. Review/testing source
+   - measurement-focused reviews where available
+   - reputable long-form reviewers
+   - comparative tests
+
+3. Price/availability source
+   - marketplace listings
+   - official store prices
+   - local retailers
+
+4. Community sentiment
+   - Reddit, Head-Fi, Zhihu, Bilibili, 酷安, 小红书
+   - use cautiously; watch for astroturfing and selection bias
+
+5. Product links / where to buy
+   - official product pages
+   - official/flagship marketplace listings
+   - clearly labeled marketplace search links when direct product pages are blocked or unstable
+
+## Confidence Levels
+
+High confidence:
+
+- Current price checked in target region
+- Multiple candidates compared
+- At least one independent review/testing source
+- Known tradeoffs identified
+
+Medium confidence:
+
+- Price and specs checked, but review evidence limited
+- Some source disagreement
+- Candidate availability uncertain
+
+Low confidence:
+
+- Few sources
+- Unclear region/market
+- No independent reviews
+- Mostly inferred from specs
+
+## Pitfalls
+
+- Retailer reviews may be biased toward recent purchase satisfaction.
+- YouTube sponsorships can affect emphasis.
+- Official ANC/battery claims are often idealized.
+- Community complaints may overrepresent defective units.
+- Marketplace product URLs can be unstable or blocked by anti-bot pages; label fallback search links clearly.

--- a/skills/digital-product-advisor/scripts/normalize_request.py
+++ b/skills/digital-product-advisor/scripts/normalize_request.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Lightweight heuristic request normalizer for MVP demos.
+
+This is intentionally simple and should not replace agent judgment.
+"""
+
+import argparse
+import json
+import re
+
+BRANDS = ["Sony", "Bose", "Apple", "Samsung", "Huawei", "Xiaomi", "Redmi", "OPPO", "Vivo", "Edifier", "Soundcore", "Jabra", "Sennheiser", "Beats"]
+
+
+def detect_currency(query):
+    q = query.lower()
+    if "rmb" in q or "cny" in q or "元" in query:
+        return "CNY"
+    if "usd" in q or "$" in query:
+        return "USD"
+    if "eur" in q or "€" in query:
+        return "EUR"
+    if "jpy" in q or "円" in query:
+        return "JPY"
+    return None
+
+
+def detect_region(query, currency):
+    q = query.lower()
+    if any(x in q for x in ["china", "jd", "tmall", "pinduoduo", "taobao"]) or currency == "CNY":
+        return "China"
+    if any(x in q for x in ["us", "usa", "best buy", "amazon us"]):
+        return "US"
+    return None
+
+
+def detect_budget(query):
+    match = re.search(r"(?:under|below|around|about|预算|以内|低于)?\s*([0-9]{2,6})\s*(?:rmb|cny|元|usd|eur|jpy|dollars?)?", query, re.I)
+    return int(match.group(1)) if match else None
+
+
+def detect_brands(query):
+    found = [brand for brand in BRANDS if re.search(rf"\b{re.escape(brand)}\b", query, re.I)]
+    q = query.lower()
+    if found and any(x in q for x in ["only", "just", "brand", "compare", "vs"]):
+        mode = "brand_vs_brand" if len(found) > 1 and (" vs " in q or "compare" in q) else "include_only"
+    elif found:
+        mode = "brand_first"
+    else:
+        mode = "open_market"
+    return {"mode": mode, "include": found, "exclude": []}
+
+
+def detect_use_case(query):
+    q = query.lower()
+    cases = []
+    mapping = {
+        "commuting": ["commute", "commuting", "subway", "metro", "train"],
+        "calls": ["call", "calls", "meeting", "mic", "microphone"],
+        "music": ["music", "sound", "audio"],
+        "gym": ["gym", "running", "workout", "sport"],
+        "gaming": ["gaming", "game", "latency"],
+        "office": ["office", "study", "work"]
+    }
+    for name, needles in mapping.items():
+        if any(n in q for n in needles):
+            cases.append(name)
+    return cases
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--query", required=True)
+    args = parser.parse_args()
+    currency = detect_currency(args.query)
+    region = detect_region(args.query, currency)
+    budget_max = detect_budget(args.query)
+    normalized = {
+        "product_category": "bluetooth_earbuds",
+        "region": region,
+        "currency": currency,
+        "budget": {"min": None, "max": budget_max, "currency": currency},
+        "brand_scope": detect_brands(args.query),
+        "marketplaces": ["JD", "Tmall", "official_store"] if region == "China" else [],
+        "use_case": detect_use_case(args.query),
+        "phone_ecosystem": "iPhone" if re.search(r"\biphone\b", args.query, re.I) else ("Android" if re.search(r"\bandroid\b", args.query, re.I) else None),
+        "must_have": [],
+        "nice_to_have": [],
+        "deal_breakers": [],
+        "purchase_timeline": None,
+        "notes": ["Heuristic MVP normalization; agent should verify assumptions."]
+    }
+    print(json.dumps(normalized, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/digital-product-advisor/scripts/report_path.py
+++ b/skills/digital-product-advisor/scripts/report_path.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Generate a safe Markdown report path for Bluetooth earbuds reports.
+
+This helper is optional. The skill can also follow references/export-policy.md manually.
+"""
+
+import argparse
+import re
+from datetime import date
+from pathlib import Path
+
+
+def slugify(value):
+    value = value.lower().strip()
+    value = re.sub(r"[^a-z0-9\u4e00-\u9fff]+", "-", value)
+    value = re.sub(r"-+", "-", value).strip("-")
+    return value or "report"
+
+
+def unique_path(path):
+    if not path.exists():
+        return path
+    stem = path.stem
+    suffix = path.suffix
+    parent = path.parent
+    version = 2
+    while True:
+        candidate = parent / f"{stem}-v{version}{suffix}"
+        if not candidate.exists():
+            return candidate
+        version += 1
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default="reports/earbuds", help="Export folder")
+    parser.add_argument("--region", default="unknown-region")
+    parser.add_argument("--budget", default=None, help="Example: under-1000-cny or 1000-1800-cny")
+    parser.add_argument("--brand", default=None, help="Example: sony or open-market")
+    parser.add_argument("--use-case", default="general", help="Example: commuting-calls")
+    parser.add_argument("--date", default=date.today().isoformat())
+    args = parser.parse_args()
+
+    parts = [args.date, "earbuds", slugify(args.region)]
+    if args.brand:
+        parts.append(slugify(args.brand))
+    if args.budget:
+        parts.append(slugify(args.budget))
+    if args.use_case:
+        parts.append(slugify(args.use_case))
+
+    filename = "-".join(parts) + ".md"
+    folder = Path(args.root)
+    folder.mkdir(parents=True, exist_ok=True)
+    print(unique_path(folder / filename))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/digital-product-advisor/scripts/score_candidates.py
+++ b/skills/digital-product-advisor/scripts/score_candidates.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Score product candidates with weighted 0-10 dimensions.
+
+Input JSON shape:
+{
+  "weights": {"anc": 0.25, "mic": 0.22},
+  "candidates": [
+    {"model": "...", "scores": {"anc": 8, "mic": 7}}
+  ]
+}
+
+Unknown score fields are ignored and the denominator is renormalized.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+
+def weighted_score(candidate, weights):
+    scores = candidate.get("scores", {})
+    total = 0.0
+    denom = 0.0
+    missing = []
+    for key, weight in weights.items():
+        value = scores.get(key)
+        if value is None:
+            missing.append(key)
+            continue
+        total += float(value) * float(weight)
+        denom += float(weight)
+    if denom == 0:
+        return None, missing
+    return round(total / denom, 2), missing
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, help="Path to candidate JSON")
+    args = parser.parse_args()
+
+    data = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    weights = data.get("weights", {})
+    candidates = data.get("candidates", [])
+
+    ranked = []
+    for candidate in candidates:
+        score, missing = weighted_score(candidate, weights)
+        item = dict(candidate)
+        item["weighted_score"] = score
+        item["missing_score_fields"] = missing
+        ranked.append(item)
+
+    ranked.sort(key=lambda item: (-1 if item["weighted_score"] is None else -item["weighted_score"], item.get("price", 0)))
+    print(json.dumps({"ranked_candidates": ranked}, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/digital-product-advisor/scripts/validate_candidates.py
+++ b/skills/digital-product-advisor/scripts/validate_candidates.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Validate MVP candidate JSON for the digital product advisor skill."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+REQUIRED_CANDIDATE_FIELDS = ["model", "brand", "price", "currency", "scores"]
+
+
+def validate(data):
+    errors = []
+    if not isinstance(data.get("weights"), dict) or not data["weights"]:
+        errors.append("weights must be a non-empty object")
+    if not isinstance(data.get("candidates"), list) or not data["candidates"]:
+        errors.append("candidates must be a non-empty list")
+        return errors
+    for index, candidate in enumerate(data["candidates"]):
+        for field in REQUIRED_CANDIDATE_FIELDS:
+            if field not in candidate:
+                errors.append(f"candidates[{index}] missing required field: {field}")
+        scores = candidate.get("scores", {})
+        if not isinstance(scores, dict):
+            errors.append(f"candidates[{index}].scores must be an object")
+            continue
+        for key, value in scores.items():
+            if value is not None and not (0 <= float(value) <= 10):
+                errors.append(f"candidates[{index}].scores.{key} must be between 0 and 10 or null")
+        links = candidate.get("links", {})
+        if links is not None and not isinstance(links, dict):
+            errors.append(f"candidates[{index}].links must be an object when present")
+        elif isinstance(links, dict):
+            for key, value in links.items():
+                if value is None:
+                    continue
+                if not isinstance(value, str):
+                    errors.append(f"candidates[{index}].links.{key} must be a URL string or null")
+                    continue
+                parsed = urlparse(value)
+                if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+                    errors.append(f"candidates[{index}].links.{key} must be an http(s) URL")
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, help="Path to candidate JSON")
+    args = parser.parse_args()
+    data = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    errors = validate(data)
+    if errors:
+        print(json.dumps({"valid": False, "errors": errors}, ensure_ascii=False, indent=2))
+        sys.exit(1)
+    print(json.dumps({"valid": True, "errors": []}, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/digital-product-advisor/templates/report-template.md
+++ b/skills/digital-product-advisor/templates/report-template.md
@@ -1,0 +1,74 @@
+# Bluetooth Earbuds Recommendation Report Template
+
+## One-line Recommendation
+
+[Direct answer: best pick for this user and why.]
+
+## User Requirements Summary
+
+- Region:
+- Currency:
+- Budget:
+- Brand scope:
+- Main use cases:
+- Phone ecosystem:
+- Must-have features:
+- Deal breakers:
+- Assumptions:
+
+## Shortlist
+
+| Rank | Model | Approx Price | Product Link | Best For | Strengths | Weaknesses | Verdict |
+|---:|---|---:|---|---|---|---|---|
+| 1 |  |  |  |  |  |  |  |
+
+## Top Picks by Scenario
+
+- Best overall:
+- Best value:
+- Best for calls:
+- Best ANC:
+- Best sound:
+- Best ecosystem fit:
+- Stretch pick:
+- Avoid / not recommended:
+
+## Detailed Tradeoffs
+
+### [Model A]
+
+- Why it fits:
+- Tradeoffs:
+- Who should buy it:
+- Who should skip it:
+
+### [Model B]
+
+- Why it fits:
+- Tradeoffs:
+- Who should buy it:
+- Who should skip it:
+
+## Final Recommendation
+
+[Clear final answer. Mention if the user should wait for a sale, buy from official store, or prioritize return policy because of fit risk.]
+
+## Product Links / Where to Buy
+
+- [Model A]: [Official/spec page](); [Marketplace product/search link](); notes:
+- [Model B]: [Official/spec page](); [Marketplace product/search link](); notes:
+
+Use direct product pages when reliable. If marketplaces block direct lookup or links are unstable, provide clearly labeled search links instead of pretending they are verified product pages.
+
+## Sources Checked
+
+- Official/spec:
+- Review/testing:
+- Price/availability:
+- Community sentiment:
+
+## Confidence Level
+
+Confidence: High / Medium / Low
+
+Reason:


### PR DESCRIPTION
Submitting the `digital-product-advisor` skill via Hermes Skills Hub.

This skill was scanned by the Hermes Skills Guard before submission.