### PR TITLE
fix: keep explicitly incomplete goals active

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -73,9 +73,13 @@ JUDGE_SYSTEM_PROMPT = (
     "the goal is fully satisfied based on that response.\n\n"
     "A goal is DONE only when:\n"
     "- The response explicitly confirms the goal was completed, OR\n"
-    "- The response clearly shows the final deliverable was produced, OR\n"
-    "- The response explains the goal is unachievable / blocked / needs "
-    "user input (treat this as DONE with reason describing the block).\n\n"
+    "- The response clearly shows the final deliverable was produced.\n\n"
+    "A goal is NOT done when the response says the work is partial, not 100% "
+    "complete, still has open items, or needs the agent to continue concrete "
+    "work. Listing remaining tasks/blockers is a progress report, not goal "
+    "completion. Only treat a blocker as terminal if the response clearly says "
+    "no further tool/action can make progress and asks the user for a specific "
+    "decision/approval/input.\n\n"
     "Otherwise the goal is NOT done — CONTINUE.\n\n"
     "Reply ONLY with a single JSON object on one line:\n"
     '{\"done\": <true|false>, \"reason\": \"<one-sentence rationale>\"}'
@@ -214,6 +218,37 @@ def clear_goal(session_id: str) -> None:
     save_goal(session_id, state)
 
 
+_EXPLICIT_INCOMPLETE_RE = re.compile(
+    r"(not\s+(?:yet\s+)?(?:100%|fully)\s+complete|not\s+complete|"
+    r"still\s+(?:short\s+of\s+)?(?:open|incomplete|not\s+done)|"
+    r"remaining\s+(?:open\s+)?items?|open\s+items?|"
+    r"phase\s+\d+[^\n.]{0,80}not\s+100%\s+complete)",
+    re.IGNORECASE,
+)
+
+_TERMINAL_BLOCKER_RE = re.compile(
+    r"(need(?:s)?\s+(?:user|human|your|shan)\s+(?:input|approval|decision)|"
+    r"blocked\s+until\s+(?:user|human|you|shan)|"
+    r"cannot\s+(?:continue|proceed|make\s+progress)\s+without\s+(?:user|human|your|shan))",
+    re.IGNORECASE,
+)
+
+
+def _response_reports_incomplete(last_response: str) -> bool:
+    """Return True when the agent explicitly says the goal is still partial.
+
+    The LLM judge is intentionally auxiliary, not authoritative. For broad
+    autonomy goals, a final response can include a clear progress report like
+    "Phase 0/1 are not 100% complete". That must force continuation unless the
+    same response is a true human-input blocker.
+    """
+    if not last_response:
+        return False
+    return bool(_EXPLICIT_INCOMPLETE_RE.search(last_response)) and not bool(
+        _TERMINAL_BLOCKER_RE.search(last_response)
+    )
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Judge
 # ──────────────────────────────────────────────────────────────────────
@@ -347,6 +382,9 @@ def judge_goal(
         raw = ""
 
     done, reason, parse_failed = _parse_judge_response(raw)
+    if done and _response_reports_incomplete(last_response):
+        return "continue", "response explicitly reports incomplete work", False
+
     verdict = "done" if done else "continue"
     logger.info("goal judge: verdict=%s reason=%s", verdict, _truncate(reason, 120))
     return verdict, reason, parse_failed

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -175,6 +175,40 @@ class TestJudgeGoal:
         assert verdict == "continue"
         assert reason == "not yet"
 
+    def test_explicit_incomplete_response_overrides_done_judge(self):
+        """A response saying the goal is not 100% done must not be marked achieved.
+
+        This guards against broad goals where the assistant reports remaining
+        open work and the LLM judge incorrectly treats that status summary as
+        a terminal blocker/deliverable.
+        """
+        from hermes_cli import goals
+
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.return_value = MagicMock(
+            choices=[
+                MagicMock(
+                    message=MagicMock(content='{"done": true, "reason": "identified blockers"}')
+                )
+            ]
+        )
+        response = (
+            "Phase 0: not 100% complete.\n"
+            "Phase 1: not 100% complete.\n"
+            "Current remaining open items include auth client consolidation, query dedupe, "
+            "and external-call timeout cleanup."
+        )
+        with patch(
+            "agent.auxiliary_client.get_text_auxiliary_client",
+            return_value=(fake_client, "judge-model"),
+        ):
+            verdict, reason, parse_failed = goals.judge_goal(
+                "continue until Phase 0/1 are 100% complete", response
+            )
+        assert verdict == "continue"
+        assert "explicitly reports incomplete" in reason
+        assert parse_failed is False
+
 
 # ──────────────────────────────────────────────────────────────────────
 # GoalManager lifecycle + persistence


### PR DESCRIPTION
## Summary
- tighten `/goal` completion judging so explicit partial/incomplete status reports cannot be marked achieved
- add deterministic incomplete-response detection after a positive judge verdict
- add regression coverage for broad goals where the assistant reports `not 100% complete` and remaining open items

## Why
A broad persistent goal can currently be ended incorrectly when the auxiliary judge returns `done: true` even though the assistant's latest response explicitly says work remains incomplete. This is especially risky for long-running project goals where a progress report lists blockers/open items.

## Test Plan
- `python -m pytest tests/hermes_cli/test_goals.py -o 'addopts=' -q`
- `python -m compileall -q hermes_cli/goals.py`
