### PR TITLE
feat(tui): show active profile in status bar

### DIFF
--- a/tests/tui_gateway/test_session_info.py
+++ b/tests/tui_gateway/test_session_info.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def test_session_info_includes_active_profile_name():
+    from tui_gateway.server import _session_info
+
+    agent = SimpleNamespace(
+        model="gpt-test",
+        reasoning_config={"enabled": True, "effort": "high"},
+        service_tier=None,
+        tools=[],
+        total_tokens=0,
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+    )
+
+    with (
+        patch("hermes_cli.profiles.get_active_profile_name", return_value="guilddali"),
+        patch("hermes_cli.banner.get_update_result", return_value=None),
+        patch("hermes_cli.config.recommended_update_command", return_value=""),
+    ):
+        info = _session_info(agent)
+
+    assert info["profile"] == "guilddali"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1371,8 +1371,15 @@ def _session_info(agent) -> dict:
     ):
         reasoning_effort = str(reasoning_config.get("effort", "") or "")
     service_tier = getattr(agent, "service_tier", None) or ""
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        profile = get_active_profile_name()
+    except Exception:
+        profile = ""
     info: dict = {
         "model": getattr(agent, "model", ""),
+        "profile": profile,
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",

--- a/ui-tui/src/__tests__/statusBarTicker.test.ts
+++ b/ui-tui/src/__tests__/statusBarTicker.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { padVerb, VERB_PAD_LEN } from '../components/appChrome.js'
+import { padVerb, profileLabel, VERB_PAD_LEN } from '../components/appChrome.js'
 import { VERBS } from '../content/verbs.js'
 
 describe('FaceTicker verb padding', () => {
@@ -14,5 +14,16 @@ describe('FaceTicker verb padding', () => {
     for (const verb of VERBS) {
       expect(padVerb(verb).startsWith(`${verb}…`)).toBe(true)
     }
+  })
+})
+
+describe('StatusRule profile label', () => {
+  it('formats a visible profile segment', () => {
+    expect(profileLabel('guilddali')).toBe('profile: guilddali')
+  })
+
+  it('hides empty profile names', () => {
+    expect(profileLabel('  ')).toBe('')
+    expect(profileLabel()).toBe('')
   })
 })

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -245,6 +245,12 @@ const shortModelLabel = (model: string) =>
 const modelLabel = (model: string, effort?: string, fast?: boolean) =>
   [shortModelLabel(model), effortLabel(effort), fast ? 'fast' : ''].filter(Boolean).join(' ')
 
+export const profileLabel = (profile?: string) => {
+  const value = String(profile ?? '').trim()
+
+  return value ? `profile: ${value}` : ''
+}
+
 export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
   const [active, setActive] = useState(false)
   const [color, setColor] = useState(t.color.accent)
@@ -279,6 +285,7 @@ export function StatusRule({
   model,
   modelFast,
   modelReasoningEffort,
+  profile,
   usage,
   bgCount,
   sessionStartedAt,
@@ -296,6 +303,7 @@ export function StatusRule({
       ? `${fmtK(usage.total)} tok`
       : ''
 
+  const activeProfile = profileLabel(profile)
   const bar = usage.context_max ? ctxBar(pct) : ''
   const leftWidth = Math.max(12, cols - cwdLabel.length - 3)
 
@@ -310,6 +318,7 @@ export function StatusRule({
             <Text color={statusColor}>{status}</Text>
           )}
           <Text color={t.color.muted}> │ {modelLabel(model, modelReasoningEffort, modelFast)}</Text>
+          {activeProfile ? <Text color={t.color.muted}> │ {activeProfile}</Text> : null}
           {ctxLabel ? <Text color={t.color.muted}> │ {ctxLabel}</Text> : null}
           {bar ? (
             <Text color={t.color.muted}>
@@ -461,6 +470,7 @@ interface StatusRuleProps {
   model: string
   modelFast?: boolean
   modelReasoningEffort?: string
+  profile?: string
   sessionStartedAt?: null | number
   showCost: boolean
   status: string

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -358,6 +358,7 @@ const StatusRulePane = memo(function StatusRulePane({
         model={ui.info?.model ?? ''}
         modelFast={ui.info?.fast || ui.info?.service_tier === 'priority'}
         modelReasoningEffort={ui.info?.reasoning_effort}
+        profile={ui.info?.profile}
         sessionStartedAt={status.sessionStartedAt}
         showCost={ui.showCost}
         status={ui.status}

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -146,6 +146,7 @@ export interface SessionInfo {
   lazy?: boolean
   mcp_servers?: McpServerStatus[]
   model: string
+  profile?: string
   reasoning_effort?: string
   release_date?: string
   service_tier?: string


### PR DESCRIPTION
## Summary
- include the active Hermes profile name in TUI session info
- render the profile segment in the TUI status rule alongside the model
- add focused Python and TUI tests for profile propagation/formatting

Fixes #20650.

## Testing
- `/Users/lee/Documents/Claude/Projects/10 Work OS/projects/hermes/venv/bin/python -m pytest -q tests/tui_gateway/test_session_info.py`
- `PATH="/opt/homebrew/bin:$PATH" npm test -- --run src/__tests__/statusBarTicker.test.ts` from `ui-tui/`
- `PATH="/opt/homebrew/bin:$PATH" npm run type-check` from `ui-tui/`
