### PR TITLE
fix(agent): repair mcp_ prefix drop in _repair_tool_call

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5629,6 +5629,22 @@ class AIAgent:
         if normalized in self.valid_tool_names:
             return normalized
 
+        # MCP prefix-strip: models sometimes drop the ``mcp_`` prefix that
+        # Hermes prepends when registering MCP server tools, e.g. calling
+        # ``APE_search`` instead of ``mcp_APE_search``.  A direct prepend
+        # check is unambiguous — only resolves when there's an exact match.
+        # (difflib scores ~0.60 for this pattern, just under the 0.7 cutoff.)
+        for prefix_candidate in (f"mcp_{tool_name}", f"mcp_{lowered}", f"mcp_{normalized}"):
+            if prefix_candidate in self.valid_tool_names:
+                return prefix_candidate
+        # Also try mcp_ + each valid name stripped of its prefix, case-folded.
+        # Handles APE_SEARCH -> mcp_APE_search when the registered name has
+        # mixed case after the server component.
+        lowered_with_prefix = f"mcp_{lowered}"
+        for vname in self.valid_tool_names:
+            if vname.lower() == lowered_with_prefix:
+                return vname
+
         # Build the full candidate set for class-like emissions.
         cands: set[str] = {tool_name, lowered, normalized, _camel_snake(tool_name)}
         # Strip trailing tool-suffix up to twice — TodoTool_tool needs it.

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -115,3 +115,68 @@ class TestEdgeCases:
     def test_very_long_name_does_not_match_by_accident(self, repair):
         # Fuzzy match should not claim a tool for something obviously unrelated.
         assert repair("ThisIsNotRemotelyARealToolName_tool") is None
+
+
+MCP_VALID = {
+    "mcp_APE_meta",
+    "mcp_APE_search",
+    "mcp_APE_add",
+    "mcp_APE_contextualize",
+    "mcp_APE_graph_nearby",
+    "mcp_APE_graph_connect",
+    "mcp_discord_send",
+    "terminal",
+    "read_file",
+}
+
+
+@pytest.fixture
+def mcp_repair():
+    """Repair fixture with MCP-prefixed tool names registered."""
+    from run_agent import AIAgent
+    stub = SimpleNamespace(valid_tool_names=MCP_VALID)
+    return AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+
+class TestMcpPrefixDrop:
+    """Regression guard: models drop the ``mcp_`` prefix Hermes adds when
+    registering MCP server tools (e.g. ``APE_search`` instead of
+    ``mcp_APE_search``).  difflib scores ~0.60 for this pattern — just
+    below the 0.7 cutoff — so the fuzzy path misses it.  The explicit
+    prefix-prepend check introduced alongside these tests catches it."""
+
+    def test_ape_meta_without_prefix(self, mcp_repair):
+        assert mcp_repair("APE_meta") == "mcp_APE_meta"
+
+    def test_ape_search_without_prefix(self, mcp_repair):
+        assert mcp_repair("APE_search") == "mcp_APE_search"
+
+    def test_ape_add_without_prefix(self, mcp_repair):
+        assert mcp_repair("APE_add") == "mcp_APE_add"
+
+    def test_ape_contextualize_without_prefix(self, mcp_repair):
+        assert mcp_repair("APE_contextualize") == "mcp_APE_contextualize"
+
+    def test_ape_graph_nearby_without_prefix(self, mcp_repair):
+        assert mcp_repair("APE_graph_nearby") == "mcp_APE_graph_nearby"
+
+    def test_other_mcp_server_without_prefix(self, mcp_repair):
+        # Not APE-specific — any mcp_<server>_<tool> pattern should resolve.
+        assert mcp_repair("discord_send") == "mcp_discord_send"
+
+    def test_already_correct_name_unchanged(self, mcp_repair):
+        # Already has prefix — fast-path returns it directly, no double-prefix.
+        assert mcp_repair("mcp_APE_meta") == "mcp_APE_meta"
+
+    def test_uppercase_without_prefix(self, mcp_repair):
+        # Case-insensitive: APE_SEARCH -> mcp_APE_search via lowered candidate.
+        assert mcp_repair("APE_SEARCH") == "mcp_APE_search"
+
+    def test_non_mcp_tool_unaffected(self, mcp_repair):
+        # Non-MCP tools in the valid set must still resolve normally.
+        assert mcp_repair("TERMINAL") == "terminal"
+
+    def test_prefix_drop_does_not_invent_tools(self, mcp_repair):
+        # Prepending mcp_ to a non-existent name must not return a wrong match.
+        assert mcp_repair("APE_nonexistent") is None
+


### PR DESCRIPTION
## What

Models sometimes call MCP server tools without the `mcp_` prefix that Hermes adds at registration time — e.g. `APE_search` instead of `mcp_APE_search`, or `discord_send` instead of `mcp_discord_send`. The call fails with `Tool does not exist` and the agent burns retries before giving up.

## Why it happens

Hermes registers MCP tools as `mcp_{server}_{tool}` (line ~995 in `mcp_tool.py`). The existing `_repair_tool_call` fuzzy matcher uses difflib with cutoff=0.7, but `APE_search` scores ~0.60 against `mcp_APE_search` — just below the threshold. The fuzzy path misses it every time.

## Fix

Add an explicit `mcp_` prepend check before the candidate-set / fuzzy-match path. Four candidates tried in order:
1. `mcp_<original>`
2. `mcp_<lowered>`
3. `mcp_<normalized>`
4. Case-folded linear scan (handles `APE_SEARCH` → `mcp_APE_search` where server name has mixed case)

The check is unambiguous — only resolves on an exact match in `valid_tool_names`, cannot mis-route non-MCP tools.

## How to reproduce

1. Configure any MCP server (e.g. named `APE`)
2. Use a model that tends to drop the `mcp_` prefix (observed with several models including Gemma and Claude variants)
3. Model calls `APE_search` → `Tool 'APE_search' does not exist`

## Tests

Added `TestMcpPrefixDrop` (10 tests) to the existing `test_repair_tool_call_name.py`:
- All APE tool variants without prefix
- Other MCP server names
- Already-correct names (no double-prefix)
- Uppercase input
- Non-MCP tools in valid set unaffected
- No-invent guard (unknown tools still return None)

All 28 tests pass. The 2 pre-existing failures in `test_concurrent_interrupt.py` are present on `main` before this change and unrelated.

## Platform

Tested on macOS 14 / Python 3.11.