### PR TITLE
feat(webui): add HERA-198 control-plane canary cockpit

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import secrets
+import shutil
 import subprocess
 import sys
 import threading
@@ -505,6 +506,310 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
         except Exception:
             continue
     return False, None
+
+
+_CONTROL_PLANE_CLI_LOCK = threading.Lock()
+
+_CONTROL_PLANE_DISABLED_REASONS = {
+    "supabase_cli_missing": "Supabase CLI not found on server PATH",
+    "control_plane_query_failed": "Control-plane read query failed",
+    "control_plane_invalid_json": "Control-plane query returned invalid JSON",
+    "control_plane_unexpected_shape": "Control-plane query returned an unexpected shape",
+}
+
+
+def _redact_control_plane_error(text: str) -> str:
+    """Return a generic client-safe CLI error without credential details."""
+    if not text:
+        return _CONTROL_PLANE_DISABLED_REASONS["control_plane_query_failed"]
+    return "Control-plane read query failed; check server logs or Supabase CLI link state."
+
+
+def _control_plane_workdir() -> Path:
+    configured = os.environ.get("HERMES_CONTROL_PLANE_WORKDIR")
+    if configured:
+        return Path(configured).expanduser()
+    return get_hermes_home() / "webui-workspace"
+
+
+def _run_supabase_control_plane_read(sql: str) -> Tuple[Optional[List[Dict[str, Any]]], Optional[Dict[str, Any]]]:
+    """Run a read-only Supabase CLI query against the linked control-plane project.
+
+    The browser never receives Supabase credentials. The server shells out to
+    the already-authenticated CLI and returns a disabled state instead of
+    raising if the CLI/link/workdir is unavailable.
+    """
+    supabase = shutil.which("supabase")
+    if not supabase:
+        return None, {
+            "enabled": False,
+            "reason": "supabase_cli_missing",
+            "message": _CONTROL_PLANE_DISABLED_REASONS["supabase_cli_missing"],
+        }
+
+    cmd = [supabase, "db", "query", "--linked", "-o", "json", sql]
+    try:
+        with _CONTROL_PLANE_CLI_LOCK:
+            proc = subprocess.run(
+                cmd,
+                cwd=str(_control_plane_workdir()),
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+    except Exception:  # pragma: no cover - defensive around local CLI failures
+        return None, {
+            "enabled": False,
+            "reason": "control_plane_query_failed",
+            "message": _redact_control_plane_error(""),
+        }
+
+    if proc.returncode != 0:
+        return None, {
+            "enabled": False,
+            "reason": "control_plane_query_failed",
+            "message": _redact_control_plane_error(proc.stderr or proc.stdout),
+        }
+
+    stdout = (proc.stdout or "").strip()
+    if stdout.startswith("Initialising login role..."):
+        stdout = stdout.split("\n", 1)[1].strip() if "\n" in stdout else ""
+    try:
+        parsed = json.loads(stdout or "[]")
+    except json.JSONDecodeError:
+        return None, {
+            "enabled": False,
+            "reason": "control_plane_invalid_json",
+            "message": _CONTROL_PLANE_DISABLED_REASONS["control_plane_invalid_json"],
+        }
+    if not isinstance(parsed, list):
+        return None, {
+            "enabled": False,
+            "reason": "control_plane_unexpected_shape",
+            "message": _CONTROL_PLANE_DISABLED_REASONS["control_plane_unexpected_shape"],
+        }
+    return parsed, None
+
+
+def _control_plane_payload_query() -> str:
+    return """
+with latest as (
+  select
+    id::text,
+    report_type,
+    run_ref,
+    status,
+    report_date::text,
+    title,
+    summary_kr,
+    obsidian_ref,
+    paperclip_parent_ref,
+    created_at::text,
+    updated_at::text
+  from hermes_reports.report_runs
+  where report_type = 'morning_brief'
+  order by created_at desc
+  limit 1
+), latest_id as (
+  select id::uuid as id from latest
+), counts as (
+  select jsonb_build_object(
+    'report_runs', (select count(*) from hermes_reports.report_runs),
+    'report_sections', (select count(*) from hermes_reports.report_sections),
+    'source_anchors', (select count(*) from hermes_sources.source_anchors),
+    'delivery_events', (select count(*) from hermes_notify.delivery_events),
+    'audit_events', (select count(*) from hermes_audit.audit_events)
+  ) as payload
+)
+select jsonb_build_object(
+  'enabled', true,
+  'status', 'ok',
+  'mode', 'read_only',
+  'project', 'hermes-control-plane',
+  'updated_at', now()::text,
+  'run', (select to_jsonb(latest) from latest),
+  'sections', coalesce((
+    select jsonb_agg(to_jsonb(s) order by s.section_order)
+    from (
+      select section_key, section_order, title, body_md, judgment_label, created_at::text
+      from hermes_reports.report_sections
+      where report_run_id in (select id from latest_id)
+      order by section_order
+    ) s
+  ), '[]'::jsonb),
+  'sources', coalesce((
+    select jsonb_agg(to_jsonb(src) order by src.created_at)
+    from (
+      select source_ref, source_title, publisher, published_at::text, observed_at::text,
+             timing_label, quality_label, claim_ref, created_at::text
+      from hermes_sources.source_anchors
+      where report_run_id in (select id from latest_id)
+      order by created_at
+    ) src
+  ), '[]'::jsonb),
+  'delivery_events', coalesce((
+    select jsonb_agg(to_jsonb(d) order by d.created_at)
+    from (
+      select
+             channel,
+             case
+               when channel = 'dry_run'
+                    and delivery_status = 'dry_run'
+                    and target_ref like 'telegram://dry-run/%'
+                 then target_ref
+               else '[redacted]'
+             end as target_ref,
+             case
+               when channel = 'dry_run' and delivery_status = 'dry_run'
+                 then payload_summary
+               else null
+             end as payload_summary,
+             delivery_status,
+             delivered_at::text,
+             null::text as error_summary,
+             created_at::text
+      from hermes_notify.delivery_events
+      where report_run_id in (select id from latest_id)
+        and channel = 'dry_run'
+        and delivery_status = 'dry_run'
+      order by created_at
+    ) d
+  ), '[]'::jsonb),
+  'audit_events', coalesce((
+    select jsonb_agg(to_jsonb(a) order by a.created_at)
+    from (
+      select event_type, subject_ref, actor_ref, source_refs, artifact_refs,
+             summary, verification_status, created_at::text
+      from hermes_audit.audit_events
+      where event_type = 'canary_insert'
+      order by created_at desc
+      limit 5
+    ) a
+  ), '[]'::jsonb),
+  'counts', (select payload from counts),
+  'boundaries', jsonb_build_object(
+    'writes_enabled', false,
+    'telegram_send_enabled', false,
+    'obsidian_authority_edit_enabled', false,
+    'cron_change_enabled', false
+  )
+) as payload;
+"""
+
+
+def _get_control_plane_morning_brief_payload() -> Dict[str, Any]:
+    rows, disabled = _run_supabase_control_plane_read(_control_plane_payload_query())
+    if disabled is not None:
+        return disabled
+    if not rows:
+        return {
+            "enabled": False,
+            "reason": "control_plane_empty_response",
+            "message": "Control-plane read query returned no rows",
+        }
+    payload = rows[0].get("payload") if isinstance(rows[0], dict) else None
+    if not isinstance(payload, dict):
+        return {
+            "enabled": False,
+            "reason": "control_plane_unexpected_shape",
+            "message": _CONTROL_PLANE_DISABLED_REASONS["control_plane_unexpected_shape"],
+        }
+    return payload
+
+
+def _first_dry_run_target_ref(delivery_events: Any) -> str:
+    if not isinstance(delivery_events, list):
+        return "telegram://dry-run/hera-198"
+    for event in delivery_events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("channel") == "dry_run" and event.get("delivery_status") == "dry_run":
+            target_ref = event.get("target_ref")
+            if (
+                isinstance(target_ref, str)
+                and target_ref.strip().startswith("telegram://dry-run/")
+            ):
+                return target_ref.strip()
+    return "telegram://dry-run/hera-198"
+
+
+def _build_morning_brief_telegram_preview(canary: Dict[str, Any]) -> Dict[str, Any]:
+    run = canary.get("run") if isinstance(canary.get("run"), dict) else {}
+    counts = canary.get("counts") if isinstance(canary.get("counts"), dict) else {}
+    boundaries = canary.get("boundaries") if isinstance(canary.get("boundaries"), dict) else {}
+    delivery_events = canary.get("delivery_events")
+
+    title = str(run.get("title") or "Morning Brief Canary")
+    status = str(run.get("status") or canary.get("status") or "unknown")
+    project = str(canary.get("project") or "hermes-control-plane")
+    target_ref = _first_dry_run_target_ref(delivery_events)
+    report_sections = counts.get("report_sections", len(canary.get("sections") or []))
+    source_anchors = counts.get("source_anchors", len(canary.get("sources") or []))
+    delivery_status = "dry_run"
+    if isinstance(delivery_events, list) and delivery_events:
+        first = delivery_events[0] if isinstance(delivery_events[0], dict) else {}
+        delivery_status = str(first.get("delivery_status") or "dry_run")
+
+    message_text = "\n".join([
+        f"[HERA-198] {title} 준비됨",
+        "",
+        f"상태: {status}",
+        f"대상: {project} read-only canary",
+        f"섹션: {report_sections}",
+        f"소스: {source_anchors}",
+        f"전달상태: {delivery_status}",
+        "",
+        "처리 이유: Supabase control-plane → WebUI cockpit readback 통과 후 Telegram 알림 계약을 실제 발송 전 dry-run으로 검증.",
+    ])
+
+    max_length = 600
+    return {
+        "enabled": True,
+        "status": "ok",
+        "mode": "dry_run_preview",
+        "project": project,
+        "target_ref": target_ref,
+        "channel": "telegram",
+        "send_enabled": False,
+        "write_enabled": False,
+        "message_text": message_text,
+        "message_length": len(message_text),
+        "validation": {
+            "length_ok": len(message_text) <= max_length,
+            "max_length": max_length,
+            "requires_approval_before_send": True,
+            "no_telegram_send_performed": True,
+            "no_supabase_write_performed": True,
+            "no_cron_change_performed": True,
+            "no_obsidian_authority_edit_performed": True,
+        },
+        "source": {
+            "run_ref": run.get("run_ref"),
+            "report_status": status,
+            "control_plane_mode": canary.get("mode"),
+        },
+        "boundaries": {
+            "writes_enabled": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "cron_change_enabled": False,
+            **boundaries,
+        },
+    }
+
+
+@app.get("/api/control-plane/morning-brief-canary")
+def get_control_plane_morning_brief_canary():
+    return _get_control_plane_morning_brief_payload()
+
+
+@app.get("/api/control-plane/morning-brief-canary/telegram-preview")
+def get_control_plane_morning_brief_telegram_preview():
+    canary = _get_control_plane_morning_brief_payload()
+    if not canary.get("enabled"):
+        return canary
+    return _build_morning_brief_telegram_preview(canary)
 
 
 @app.get("/api/status")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12,6 +12,7 @@ Usage:
 import asyncio
 import hmac
 import importlib.util
+import inspect
 import json
 import logging
 import os
@@ -53,7 +54,7 @@ from gateway.status import get_running_pid, read_runtime_status
 try:
     from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
     from fastapi.middleware.cors import CORSMiddleware
-    from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
+    from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response
     from fastapi.staticfiles import StaticFiles
     from pydantic import BaseModel
 except ImportError:
@@ -471,9 +472,22 @@ except (ValueError, TypeError):
     )
     _GATEWAY_HEALTH_TIMEOUT = 3.0
 
+# DEPRECATED (scheduled for removal): GATEWAY_HEALTH_URL / GATEWAY_HEALTH_TIMEOUT.
+# Cross-container / cross-host gateway liveness detection will be folded into a
+# first-class dashboard config key so it's no longer Docker-adjacent lore buried
+# in env vars.  The env vars still work for now so existing Compose deployments
+# don't break.  Do not add new callers — wire new uses through the planned
+# config surface.
+
 
 def _probe_gateway_health() -> tuple[bool, dict | None]:
     """Probe the gateway via its HTTP health endpoint (cross-container).
+
+    .. deprecated::
+        Driven by the deprecated ``GATEWAY_HEALTH_URL`` /
+        ``GATEWAY_HEALTH_TIMEOUT`` env vars.  Scheduled for removal alongside
+        a move to a first-class dashboard config key.  See
+        :data:`_GATEWAY_HEALTH_URL` for context.
 
     Uses ``/health/detailed`` first (returns full state), falling back to
     the simpler ``/health`` endpoint.  Returns ``(is_alive, body_dict)``.
@@ -621,6 +635,13 @@ with latest as (
     'delivery_events', (select count(*) from hermes_notify.delivery_events),
     'audit_events', (select count(*) from hermes_audit.audit_events)
   ) as payload
+), latest_run_counts as (
+  select jsonb_build_object(
+    'report_sections', (select count(*) from hermes_reports.report_sections where report_run_id in (select id from latest_id)),
+    'source_anchors', (select count(*) from hermes_sources.source_anchors where report_run_id in (select id from latest_id)),
+    'delivery_events', (select count(*) from hermes_notify.delivery_events where report_run_id in (select id from latest_id)),
+    'audit_events', (select count(*) from hermes_audit.audit_events where subject_ref in (select run_ref from latest))
+  ) as payload
 )
 select jsonb_build_object(
   'enabled', true,
@@ -654,14 +675,14 @@ select jsonb_build_object(
       select
              channel,
              case
-               when channel = 'dry_run'
-                    and delivery_status = 'dry_run'
-                    and target_ref like 'telegram://dry-run/%'
+              when channel in ('telegram', 'dry_run')
+                   and delivery_status = 'dry_run'
+                   and target_ref like 'telegram://dry-run/%'
                  then target_ref
                else '[redacted]'
              end as target_ref,
              case
-               when channel = 'dry_run' and delivery_status = 'dry_run'
+               when channel in ('telegram', 'dry_run') and delivery_status = 'dry_run'
                  then payload_summary
                else null
              end as payload_summary,
@@ -671,8 +692,9 @@ select jsonb_build_object(
              created_at::text
       from hermes_notify.delivery_events
       where report_run_id in (select id from latest_id)
-        and channel = 'dry_run'
         and delivery_status = 'dry_run'
+        and target_ref like 'telegram://dry-run/%'
+        and channel in ('telegram', 'dry_run')
       order by created_at
     ) d
   ), '[]'::jsonb),
@@ -688,6 +710,7 @@ select jsonb_build_object(
     ) a
   ), '[]'::jsonb),
   'counts', (select payload from counts),
+  'latest_run_counts', (select payload from latest_run_counts),
   'boundaries', jsonb_build_object(
     'writes_enabled', false,
     'telegram_send_enabled', false,
@@ -696,6 +719,63 @@ select jsonb_build_object(
   )
 ) as payload;
 """
+
+
+def _morning_brief_v0_status_path() -> Path:
+    return (
+        _control_plane_workdir()
+        / "hera-198-data-architecture-reset"
+        / "gate-b-v0.2-execution-readback.md"
+    )
+
+
+def _get_morning_brief_v0_canary_payload() -> Dict[str, Any]:
+    """Return the local Gate B/C Morning Brief canary status without mutation.
+
+    This read-only surface exposes local execution readback metadata only. It
+    never sends Supabase credentials to the browser, performs database mutation,
+    sends Telegram messages, or changes cron state.
+    """
+    status_path = _morning_brief_v0_status_path()
+    try:
+        status_text = status_path.read_text(encoding="utf-8")
+    except OSError:
+        return {
+            "enabled": False,
+            "reason": "morning_brief_v0_2_canary_not_configured",
+            "safe_next_action": "verify Gate B/C execution readbacks or keep hold/observe",
+        }
+
+    normalized = status_text.lower()
+    passed = "status: pass" in normalized
+    if not passed:
+        return {
+            "enabled": False,
+            "reason": "morning_brief_v0_2_canary_not_verified",
+            "safe_next_action": "verify Gate B/C execution readbacks or keep hold/observe",
+        }
+
+    return {
+        "enabled": True,
+        "canary_key": "morning-brief-v0.2-preview-canary",
+        "report_kind": "morning_brief",
+        "verification_status": "verified",
+        "rollback_status": "ready_not_needed",
+        "gateb_verification_result": "pass",
+        "hermes_direct_db_verification": True,
+        "verification_source": "hermes_supabase_cli_readback",
+        "report_snapshot_ref": "supabase://hermes_projection/morning_brief_cockpit_v1",
+        "preview_payload_present": True,
+        "source_quality_present": True,
+        "safe_next_action": "Gate D WebUI local read-only observation; Telegram send/cron still require separate approval",
+        "boundaries": {
+            "writes_enabled": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "cron_change_enabled": False,
+            "webui_mutation_enabled": False,
+        },
+    }
 
 
 def _get_control_plane_morning_brief_payload() -> Dict[str, Any]:
@@ -718,13 +798,332 @@ def _get_control_plane_morning_brief_payload() -> Dict[str, Any]:
     return payload
 
 
+_CONTROL_PLANE_SAFETY_PREVIEW_FORBIDDEN_KEYS = frozenset({
+    "target_ref",
+    "provider_message_ref",
+    "error_summary",
+    "provider_error_body",
+    "raw_source_packet",
+    "raw_source_dump",
+    "raw_payload",
+    "private_target_payload",
+})
+
+
+def _control_plane_safety_preview_query() -> str:
+    return """
+select
+  run_ref,
+  title,
+  status,
+  lifecycle_state,
+  report_date::text,
+  source_count,
+  quarantined_source_count,
+  source_safety_state,
+  source_safety_summary_kr,
+  source_safety_refs,
+  latest_channel,
+  latest_delivery_mode,
+  latest_send_result,
+  latest_approval_state,
+  delivery_browser_safe,
+  latest_redaction_class,
+  latest_provider_error_class,
+  notification_action_state,
+  authority_boundary_state,
+  obsidian_ref,
+  paperclip_parent_ref,
+  rollback_available,
+  publish_blocked,
+  publish_block_reason_kr
+from hermes_projection.morning_brief_cockpit_v2
+order by report_date desc, run_ref desc
+limit 1;
+"""
+
+
+def _strip_control_plane_forbidden_fields(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): _strip_control_plane_forbidden_fields(item)
+            for key, item in value.items()
+            if str(key) not in _CONTROL_PLANE_SAFETY_PREVIEW_FORBIDDEN_KEYS
+        }
+    if isinstance(value, list):
+        return [_strip_control_plane_forbidden_fields(item) for item in value]
+    return value
+
+
+def _control_plane_safety_severity(row: Dict[str, Any]) -> Tuple[str, str]:
+    if row.get("delivery_browser_safe") is False:
+        return "BLOCKED", "delivery_not_browser_safe"
+    if row.get("latest_send_result") in {"failed", "error"}:
+        return "BLOCKED", "delivery_error_present"
+    if row.get("publish_blocked") or row.get("source_safety_state") == "has_quarantine" or (row.get("quarantined_source_count") or 0) > 0:
+        return "HOLD", "publish_blocked_or_quarantined_source"
+    if row.get("latest_approval_state") in {"pending", "required"}:
+        return "ACTION_REQUIRED", "approval_required"
+    if row.get("notification_action_state") in {"preview_only", "observe"}:
+        return "WATCH", "preview_or_observe_only"
+    return "OK", "read_only_checks_passed"
+
+
+def _get_control_plane_safety_preview_payload() -> Dict[str, Any]:
+    rows, disabled = _run_supabase_control_plane_read(_control_plane_safety_preview_query())
+    if disabled is not None:
+        return disabled
+    if not rows:
+        return {
+            "enabled": False,
+            "reason": "control_plane_empty_response",
+            "message": "Control-plane safety-preview query returned no rows",
+        }
+    row = rows[0] if isinstance(rows[0], dict) else None
+    if not isinstance(row, dict):
+        return {
+            "enabled": False,
+            "reason": "control_plane_unexpected_shape",
+            "message": _CONTROL_PLANE_DISABLED_REASONS["control_plane_unexpected_shape"],
+        }
+
+    source_refs = _strip_control_plane_forbidden_fields(row.get("source_safety_refs") or [])
+    severity, severity_reason = _control_plane_safety_severity(row)
+    return {
+        "enabled": True,
+        "status": "ok",
+        "severity": severity,
+        "severity_reason": severity_reason,
+        "mode": "read_only_safety_preview",
+        "run": {
+            "run_ref": row.get("run_ref"),
+            "title": row.get("title"),
+            "status": row.get("status"),
+            "lifecycle_state": row.get("lifecycle_state"),
+            "report_date": row.get("report_date"),
+            "paperclip_parent_ref": row.get("paperclip_parent_ref"),
+        },
+        "source_safety": {
+            "state": row.get("source_safety_state"),
+            "source_count": row.get("source_count"),
+            "quarantined_source_count": row.get("quarantined_source_count"),
+            "summary_kr": row.get("source_safety_summary_kr"),
+            "refs": source_refs,
+        },
+        "notification_readiness": {
+            "action_state": row.get("notification_action_state"),
+            "latest_channel": row.get("latest_channel"),
+            "latest_delivery_mode": row.get("latest_delivery_mode"),
+            "latest_send_result": row.get("latest_send_result"),
+            "latest_approval_state": row.get("latest_approval_state"),
+            "delivery_browser_safe": row.get("delivery_browser_safe"),
+            "latest_redaction_class": row.get("latest_redaction_class"),
+            "latest_provider_error_class": row.get("latest_provider_error_class"),
+        },
+        "authority_boundary": {
+            "state": row.get("authority_boundary_state"),
+            "obsidian_ref_present": bool(row.get("obsidian_ref")),
+            "supabase_is_authority": False,
+            "requires_obsidian_merge_review_before_authority": True,
+        },
+        "rollback_readiness": {
+            "available": row.get("rollback_available"),
+            "publish_blocked": row.get("publish_blocked"),
+            "publish_block_reason_kr": row.get("publish_block_reason_kr"),
+        },
+        "boundaries": {
+            "writes_enabled": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "cron_change_enabled": False,
+            "webui_mutation_enabled": False,
+        },
+    }
+
+
+_CONTROL_PLANE_COCKPIT_ARTIFACTS = {
+    "gate_d": "gated_latest_run_status.md",
+    "github_watcher_no_agent": "github_watcher_v0_latest_poll_status.md",
+    "supabase_role_boundary": "supabase_obsidian_role_boundary_decision_record.md",
+    "obsidian_merge_review": "obsidian_merge_review_note_creation_result.md",
+}
+
+_CONTROL_PLANE_COCKPIT_SOURCE_REFS = {
+    "gate_d": "artifact://gated_latest_run_status",
+    "github_watcher_no_agent": "artifact://github_watcher_v0_latest_poll_status",
+    "supabase_role_boundary": "artifact://supabase_obsidian_role_boundary_decision_record",
+    "obsidian_merge_review": "artifact://obsidian_merge_review_note_creation_result",
+}
+
+
+def _control_plane_artifacts_dir() -> Path:
+    workdir = _control_plane_workdir()
+    direct = workdir / "artifacts"
+    if direct.exists():
+        return direct
+    nested = workdir / "hermes-control-plane" / "artifacts"
+    if nested.exists():
+        return nested
+    return direct
+
+
+def _safe_read_control_plane_artifact(name: str) -> str:
+    path = _control_plane_artifacts_dir() / name
+    try:
+        if path.stat().st_size > 128_000:
+            return ""
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def _cockpit_boundaries() -> Dict[str, bool]:
+    return {
+        "read_only": True,
+        "action_controls": False,
+        "mutation_controls": False,
+        "telegram_send_enabled": False,
+        "obsidian_authority_edit_enabled": False,
+        "supabase_schema_change_enabled": False,
+        "cron_change_enabled": False,
+    }
+
+
+def _cockpit_disabled() -> Dict[str, Any]:
+    return {
+        "enabled": False,
+        "reason": "control_plane_not_configured",
+        "safe_next_action": "verify control-plane artifact availability or keep observe",
+    }
+
+
+def _cockpit_panel_severity(status: str) -> str:
+    value = (status or "").lower()
+    if value in {"pass", "recorded", "complete", "ok"}:
+        return "OK"
+    if value in {"blocked", "missing", "failed", "error"}:
+        return "BLOCKED"
+    if value in {"hold"}:
+        return "HOLD"
+    if value in {"action_required", "approval_required"}:
+        return "ACTION_REQUIRED"
+    return "WATCH"
+
+
+def _max_control_plane_severity(values: List[str]) -> str:
+    order = {"OK": 0, "WATCH": 1, "HOLD": 2, "ACTION_REQUIRED": 3, "BLOCKED": 4}
+    return max(values or ["OK"], key=lambda item: order.get(item, 1))
+
+
+def _classify_cockpit_artifacts() -> Tuple[Dict[str, Dict[str, Any]], List[str]]:
+    texts = {
+        key: _safe_read_control_plane_artifact(filename)
+        for key, filename in _CONTROL_PLANE_COCKPIT_ARTIFACTS.items()
+    }
+    if not any(texts.values()):
+        return {}, list(_CONTROL_PLANE_COCKPIT_ARTIFACTS)
+
+    status_values = {
+        "gate_d": "pass" if "run_status: pass" in texts["gate_d"].lower() else "unknown",
+        "github_watcher_no_agent": "pass" if "status: pass" in texts["github_watcher_no_agent"].lower() else "unknown",
+        "supabase_role_boundary": "recorded" if texts["supabase_role_boundary"] else "missing",
+        "obsidian_merge_review": "complete" if "status: complete" in texts["obsidian_merge_review"].lower() else ("recorded" if texts["obsidian_merge_review"] else "missing"),
+    }
+    summaries = {
+        "gate_d": "Gate D Morning Brief runner artifact is present and read-only.",
+        "github_watcher_no_agent": "GitHub Watcher no-agent artifact is present and read-only.",
+        "supabase_role_boundary": "Supabase/Obsidian role-boundary decision record is present.",
+        "obsidian_merge_review": "Obsidian Merge Review note creation result is present.",
+    }
+    statuses = {
+        key: {
+            "status": value,
+            "severity": _cockpit_panel_severity(value),
+            "safe_summary": summaries[key],
+            "artifact_refs": [f"artifact://{Path(_CONTROL_PLANE_COCKPIT_ARTIFACTS[key]).stem}"],
+        }
+        for key, value in status_values.items()
+    }
+    missing = [key for key, text in texts.items() if not text]
+    return statuses, missing
+
+
+def _get_control_plane_cockpit_summary() -> Dict[str, Any]:
+    statuses, missing = _classify_cockpit_artifacts()
+    if not statuses:
+        return _cockpit_disabled()
+
+    ready = all(
+        panel.get("status") in {"pass", "recorded", "complete"}
+        for panel in statuses.values()
+    )
+    return {
+        "enabled": True,
+        "severity": _max_control_plane_severity([panel.get("severity", "WATCH") for panel in statuses.values()]),
+        "counts": {
+            "panels": len(_CONTROL_PLANE_COCKPIT_ARTIFACTS),
+            "missing": len(missing),
+        },
+        "status": statuses,
+        "handoff_summary": "Gate D, GitHub Watcher no-agent, Supabase role boundary, and Obsidian Merge Review are exposed as server-side read-only status only.",
+        "safe_next_action": "frontend_api_client_contract_gate" if ready else "observe",
+        "source_refs": list(_CONTROL_PLANE_COCKPIT_SOURCE_REFS.values()),
+        "artifact_refs": [
+            f"artifact://{Path(name).stem}"
+            for name in _CONTROL_PLANE_COCKPIT_ARTIFACTS.values()
+        ],
+        "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+
+def _get_control_plane_cockpit_blockers() -> Dict[str, Any]:
+    statuses, missing = _classify_cockpit_artifacts()
+    if not statuses:
+        return _cockpit_disabled()
+
+    blockers = [
+        {
+            "id": f"{key}:artifact_missing",
+            "status": "blocked",
+            "severity": "BLOCKED",
+            "title": key,
+            "detail": "artifact_missing",
+            "safe_next_action": "observe",
+            "artifact_refs": [f"artifact://{Path(_CONTROL_PLANE_COCKPIT_ARTIFACTS[key]).stem}"],
+        }
+        for key in missing
+    ]
+    blockers.extend(
+        {
+            "id": f"{key}:status_{panel.get('status', 'unknown')}",
+            "status": "observe",
+            "severity": _cockpit_panel_severity(panel.get("status", "unknown")),
+            "title": key,
+            "detail": f"status_{panel.get('status', 'unknown')}",
+            "safe_next_action": "observe",
+            "artifact_refs": panel.get("artifact_refs", []),
+        }
+        for key, panel in statuses.items()
+        if panel.get("status") not in {"pass", "recorded", "complete"}
+        and key not in missing
+    )
+    return {
+        "enabled": True,
+        "severity": _max_control_plane_severity([blocker.get("severity", "WATCH") for blocker in blockers]),
+        "blockers": blockers,
+        "boundaries": _cockpit_boundaries(),
+        "safe_next_action": "frontend_api_client_contract_gate" if not blockers else "observe",
+        "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+
 def _first_dry_run_target_ref(delivery_events: Any) -> str:
     if not isinstance(delivery_events, list):
         return "telegram://dry-run/hera-198"
     for event in delivery_events:
         if not isinstance(event, dict):
             continue
-        if event.get("channel") == "dry_run" and event.get("delivery_status") == "dry_run":
+        if event.get("channel") in {"telegram", "dry_run"} and event.get("delivery_status") == "dry_run":
             target_ref = event.get("target_ref")
             if (
                 isinstance(target_ref, str)
@@ -737,6 +1136,8 @@ def _first_dry_run_target_ref(delivery_events: Any) -> str:
 def _build_morning_brief_telegram_preview(canary: Dict[str, Any]) -> Dict[str, Any]:
     run = canary.get("run") if isinstance(canary.get("run"), dict) else {}
     counts = canary.get("counts") if isinstance(canary.get("counts"), dict) else {}
+    latest_run_counts = canary.get("latest_run_counts") if isinstance(canary.get("latest_run_counts"), dict) else {}
+    reader_counts = latest_run_counts or counts
     boundaries = canary.get("boundaries") if isinstance(canary.get("boundaries"), dict) else {}
     delivery_events = canary.get("delivery_events")
 
@@ -744,8 +1145,8 @@ def _build_morning_brief_telegram_preview(canary: Dict[str, Any]) -> Dict[str, A
     status = str(run.get("status") or canary.get("status") or "unknown")
     project = str(canary.get("project") or "hermes-control-plane")
     target_ref = _first_dry_run_target_ref(delivery_events)
-    report_sections = counts.get("report_sections", len(canary.get("sections") or []))
-    source_anchors = counts.get("source_anchors", len(canary.get("sources") or []))
+    report_sections = reader_counts.get("report_sections", len(canary.get("sections") or []))
+    source_anchors = reader_counts.get("source_anchors", len(canary.get("sources") or []))
     delivery_status = "dry_run"
     if isinstance(delivery_events, list) and delivery_events:
         first = delivery_events[0] if isinstance(delivery_events[0], dict) else {}
@@ -799,6 +1200,11 @@ def _build_morning_brief_telegram_preview(canary: Dict[str, Any]) -> Dict[str, A
     }
 
 
+@app.get("/api/control-plane/morning-brief-v0/canary")
+def get_control_plane_morning_brief_v0_canary():
+    return _get_morning_brief_v0_canary_payload()
+
+
 @app.get("/api/control-plane/morning-brief-canary")
 def get_control_plane_morning_brief_canary():
     return _get_control_plane_morning_brief_payload()
@@ -810,6 +1216,21 @@ def get_control_plane_morning_brief_telegram_preview():
     if not canary.get("enabled"):
         return canary
     return _build_morning_brief_telegram_preview(canary)
+
+
+@app.get("/api/control-plane/morning-brief-canary/safety-preview")
+def get_control_plane_morning_brief_safety_preview():
+    return _get_control_plane_safety_preview_payload()
+
+
+@app.get("/api/control-plane/cockpit/summary")
+def get_control_plane_cockpit_summary():
+    return _get_control_plane_cockpit_summary()
+
+
+@app.get("/api/control-plane/cockpit/blockers")
+def get_control_plane_cockpit_blockers():
+    return _get_control_plane_cockpit_blockers()
 
 
 @app.get("/api/status")
@@ -2169,8 +2590,8 @@ async def _start_device_code_flow(provider_id: str) -> Dict[str, Any]:
             name=f"oauth-codex-{sid[:6]}",
         ).start()
         # Block briefly until the worker has populated the user_code, OR error.
-        deadline = time.time() + 10
-        while time.time() < deadline:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
             with _oauth_sessions_lock:
                 s = _oauth_sessions.get(sid)
             if s and (s.get("user_code") or s["status"] != "pending"):
@@ -2304,10 +2725,10 @@ def _codex_full_login_worker(session_id: str) -> None:
             sess["expires_at"] = time.time() + sess["expires_in"]
 
         # Step 2: poll until authorized
-        deadline = time.time() + sess["expires_in"]
+        deadline = time.monotonic() + sess["expires_in"]
         code_resp = None
         with httpx.Client(timeout=httpx.Timeout(15.0)) as client:
-            while time.time() < deadline:
+            while time.monotonic() < deadline:
                 time.sleep(poll_interval)
                 poll = client.post(
                     f"{issuer}/api/accounts/deviceauth/token",
@@ -2465,6 +2886,83 @@ async def cancel_oauth_session(session_id: str, request: Request):
 # ---------------------------------------------------------------------------
 
 
+
+def _session_latest_descendant(session_id: str):
+    """Resolve a session id to the newest child leaf session.
+
+    /model may create child sessions. Dashboard refresh should continue the
+    newest child instead of reopening the old parent.
+    """
+    from hermes_state import SessionDB
+
+    def row_get(row, key, index):
+        if isinstance(row, dict):
+            return row.get(key)
+        try:
+            return row[key]
+        except Exception:
+            try:
+                return row[index]
+            except Exception:
+                return None
+
+    db = SessionDB()
+    try:
+        sid = db.resolve_session_id(session_id)
+        if not sid or not db.get_session(sid):
+            return None, []
+
+        conn = (
+            getattr(db, "conn", None)
+            or getattr(db, "_conn", None)
+            or getattr(db, "connection", None)
+            or getattr(db, "_connection", None)
+        )
+
+        rows = []
+        if conn is not None:
+            raw_rows = conn.execute(
+                "SELECT id, parent_session_id, started_at FROM sessions"
+            ).fetchall()
+            for row in raw_rows:
+                rows.append({
+                    "id": row_get(row, "id", 0),
+                    "parent_session_id": row_get(row, "parent_session_id", 1),
+                    "started_at": row_get(row, "started_at", 2),
+                })
+        else:
+            rows = db.list_sessions_rich(limit=10000, offset=0)
+
+        children = {}
+        for row in rows:
+            rid = row.get("id")
+            parent = row.get("parent_session_id")
+            if rid and parent:
+                children.setdefault(parent, []).append(row)
+
+        def started(row):
+            try:
+                return float(row.get("started_at") or 0)
+            except Exception:
+                return 0.0
+
+        current = sid
+        path = [sid]
+        seen = {sid}
+
+        while children.get(current):
+            candidates = [r for r in children[current] if r.get("id") not in seen]
+            if not candidates:
+                break
+            candidates.sort(key=started, reverse=True)
+            current = candidates[0]["id"]
+            path.append(current)
+            seen.add(current)
+
+        return current, path
+    finally:
+        db.close()
+
 @app.get("/api/sessions/{session_id}")
 async def get_session_detail(session_id: str):
     from hermes_state import SessionDB
@@ -2478,6 +2976,19 @@ async def get_session_detail(session_id: str):
     finally:
         db.close()
 
+
+
+@app.get("/api/sessions/{session_id}/latest-descendant")
+async def get_session_latest_descendant(session_id: str):
+    latest, path = _session_latest_descendant(session_id)
+    if not latest:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return {
+        "requested_session_id": path[0] if path else session_id,
+        "session_id": latest,
+        "path": path,
+        "changed": bool(path and latest != path[0]),
+    }
 
 @app.get("/api/sessions/{session_id}/messages")
 async def get_session_messages(session_id: str):
@@ -2658,6 +3169,7 @@ async def delete_cron_job(job_id: str):
 class ProfileCreate(BaseModel):
     name: str
     clone_from_default: bool = False
+    no_skills: bool = False
 
 
 class ProfileRename(BaseModel):
@@ -2759,15 +3271,19 @@ async def list_profiles_endpoint():
 async def create_profile_endpoint(body: ProfileCreate):
     from hermes_cli import profiles as profiles_mod
     try:
-        path = profiles_mod.create_profile(
-            name=body.name,
-            clone_from="default" if body.clone_from_default else None,
-            clone_config=body.clone_from_default,
-        )
+        create_profile_kwargs = {
+            "name": body.name,
+            "clone_from": "default" if body.clone_from_default else None,
+            "clone_config": body.clone_from_default,
+        }
+        if "no_skills" in inspect.signature(profiles_mod.create_profile).parameters:
+            create_profile_kwargs["no_skills"] = body.no_skills
+        path = profiles_mod.create_profile(**create_profile_kwargs)
         # Match the CLI's profile-create flow: fresh named profiles get the
         # bundled skills installed. When cloning from default, create_profile()
         # has already copied the source profile's skills, including any
-        # user-installed skills.
+        # user-installed skills. When no_skills=True, create_profile() wrote
+        # the opt-out marker and seed_profile_skills() will no-op.
         if not body.clone_from_default:
             profiles_mod.seed_profile_skills(path, quiet=True)
 
@@ -3238,8 +3754,18 @@ def _resolve_chat_argv(
     argv, cwd = _make_tui_argv(PROJECT_ROOT / "ui-tui", tui_dev=False)
     env = os.environ.copy()
     env.setdefault("NODE_ENV", "production")
+    # Browser-embedded chat should prefer stable wheel-based scrollback over
+    # native terminal mouse tracking. When mouse tracking is enabled, wheel
+    # events are consumed by the TUI and forwarded as terminal input, which
+    # makes browser-side transcript scrolling feel broken. Keep the terminal
+    # build unchanged for native CLI usage; only disable mouse tracking for
+    # the dashboard PTY path.
+    env.setdefault("HERMES_TUI_DISABLE_MOUSE", "1")
 
     if resume:
+        latest_resume, _latest_path = _session_latest_descendant(resume)
+        if latest_resume:
+            resume = latest_resume
         env["HERMES_TUI_RESUME"] = resume
 
     if sidecar_url:
@@ -3497,12 +4023,42 @@ async def events_ws(ws: WebSocket) -> None:
                     _event_channels.pop(channel, None)
 
 
+def _normalise_prefix(raw: Optional[str]) -> str:
+    """Normalise an X-Forwarded-Prefix header value.
+
+    Returns a string like ``"/hermes"`` (no trailing slash) or ``""`` when
+    no prefix is set / the header is malformed. We deliberately reject
+    anything containing ``..`` or non-printable bytes so a hostile proxy
+    can't inject HTML via the prefix.
+    """
+    if not raw:
+        return ""
+    p = raw.strip()
+    if not p:
+        return ""
+    if not p.startswith("/"):
+        p = "/" + p
+    p = p.rstrip("/")
+    if "//" in p or ".." in p or any(c in p for c in ('"', "'", "<", ">", " ", "\n", "\r", "\t")):
+        return ""
+    if len(p) > 64:
+        return ""
+    return p
+
+
 def mount_spa(application: FastAPI):
     """Mount the built SPA. Falls back to index.html for client-side routing.
 
     The session token is injected into index.html via a ``<script>`` tag so
     the SPA can authenticate against protected API endpoints without a
     separate (unauthenticated) token-dispensing endpoint.
+
+    When served behind a path-prefix reverse proxy (e.g.
+    ``mission-control.tilos.com/hermes/*`` -> local Caddy -> :9119), the
+    proxy injects ``X-Forwarded-Prefix: /hermes`` on every request. We
+    rewrite the served ``index.html`` so absolute asset URLs (``/assets/...``)
+    and the SPA's runtime ``__HERMES_BASE_PATH__`` honour that prefix
+    without rebuilding the bundle.
     """
     if not WEB_DIST.exists():
         @application.get("/{full_path:path}")
@@ -3515,24 +4071,62 @@ def mount_spa(application: FastAPI):
 
     _index_path = WEB_DIST / "index.html"
 
-    def _serve_index():
-        """Return index.html with the session token injected."""
+    def _serve_index(prefix: str = ""):
+        """Return index.html with the session token + base-path injected.
+
+        ``prefix`` is the normalised ``X-Forwarded-Prefix`` (e.g. ``/hermes``)
+        or empty string when served at root.
+        """
         html = _index_path.read_text()
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
         token_script = (
             f'<script>window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
-            f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};</script>"
+            f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"
+            f'window.__HERMES_BASE_PATH__="{prefix}";</script>'
         )
+        if prefix:
+            # Rewrite absolute asset URLs baked into the Vite build so the
+            # browser fetches them through the same proxy prefix.
+            html = html.replace('href="/assets/', f'href="{prefix}/assets/')
+            html = html.replace('src="/assets/', f'src="{prefix}/assets/')
+            html = html.replace('href="/favicon.ico"', f'href="{prefix}/favicon.ico"')
+            html = html.replace('href="/fonts/', f'href="{prefix}/fonts/')
+            html = html.replace('href="/ds-assets/', f'href="{prefix}/ds-assets/')
+            html = html.replace('src="/ds-assets/', f'src="{prefix}/ds-assets/')
         html = html.replace("</head>", f"{token_script}</head>", 1)
         return HTMLResponse(
             html,
             headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
         )
 
+    # When served behind a path-prefix proxy, the built CSS contains
+    # absolute ``url(/fonts/...)`` and ``url(/ds-assets/...)`` references.
+    # Browsers resolve those against the document origin, which means
+    # under ``/hermes`` they'd hit ``mission-control.tilos.com/fonts/...``
+    # (the MC Pages app), not the Hermes backend. Intercept CSS asset
+    # requests BEFORE the StaticFiles mount and rewrite the absolute paths
+    # when a prefix is in play.
+    @application.get("/assets/{filename}.css")
+    async def serve_css(filename: str, request: Request):
+        css_path = WEB_DIST / "assets" / f"{filename}.css"
+        if not css_path.is_file() or not css_path.resolve().is_relative_to(
+            WEB_DIST.resolve()
+        ):
+            return JSONResponse({"error": "not found"}, status_code=404)
+        prefix = _normalise_prefix(request.headers.get("x-forwarded-prefix"))
+        css = css_path.read_text()
+        if prefix:
+            for asset_dir in ("/fonts/", "/fonts-terminal/", "/ds-assets/", "/assets/"):
+                css = css.replace(f"url({asset_dir}", f"url({prefix}{asset_dir}")
+                css = css.replace(f"url(\"{asset_dir}", f"url(\"{prefix}{asset_dir}")
+                css = css.replace(f"url('{asset_dir}", f"url('{prefix}{asset_dir}")
+        return Response(content=css, media_type="text/css")
+
     application.mount("/assets", StaticFiles(directory=WEB_DIST / "assets"), name="assets")
 
     @application.get("/{full_path:path}")
-    async def serve_spa(full_path: str):
+    async def serve_spa(full_path: str, request: Request):
+        prefix = _normalise_prefix(request.headers.get("x-forwarded-prefix"))
         file_path = WEB_DIST / full_path
         # Prevent path traversal via url-encoded sequences (%2e%2e/)
         if (
@@ -3542,7 +4136,7 @@ def mount_spa(application: FastAPI):
             and file_path.is_file()
         ):
             return FileResponse(file_path)
-        return _serve_index()
+        return _serve_index(prefix)
 
 
 # ---------------------------------------------------------------------------
@@ -3552,8 +4146,9 @@ def mount_spa(application: FastAPI):
 # Built-in dashboard themes — label + description only.  The actual color
 # definitions live in the frontend (web/src/themes/presets.ts).
 _BUILTIN_DASHBOARD_THEMES = [
-    {"name": "default",   "label": "Hermes Teal",  "description": "Classic dark teal — the canonical Hermes look"},
-    {"name": "midnight",  "label": "Midnight",      "description": "Deep blue-violet with cool accents"},
+    {"name": "default",       "label": "Hermes Teal",         "description": "Classic dark teal — the canonical Hermes look"},
+    {"name": "default-large", "label": "Hermes Teal (Large)", "description": "Hermes Teal with bigger fonts and roomier spacing"},
+    {"name": "midnight",      "label": "Midnight",            "description": "Deep blue-violet with cool accents"},
     {"name": "ember",     "label": "Ember",          "description": "Warm crimson and bronze — forge vibes"},
     {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
     {"name": "cyberpunk", "label": "Cyberpunk",      "description": "Neon green on black — matrix terminal"},

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -191,6 +191,303 @@ class TestWebServerEndpoints:
         assert resp.json()["gateway_state"] == "startup_failed"
         assert resp.json()["gateway_platforms"] == {}
 
+
+    def test_control_plane_canary_requires_session_token(self):
+        import hermes_cli.web_server as web_server
+
+        resp = self.client.get(
+            "/api/control-plane/morning-brief-canary",
+            headers={web_server._SESSION_HEADER_NAME: "invalid-token"},
+        )
+
+        assert resp.status_code == 401
+
+    def test_control_plane_canary_disabled_when_supabase_missing(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: None)
+        resp = self.client.get("/api/control-plane/morning-brief-canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["reason"] == "supabase_cli_missing"
+
+
+    def test_control_plane_error_message_does_not_leak_cli_secrets(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        class Completed:
+            returncode = 1
+            stdout = ""
+            stderr = "failed postgresql://user:secret@db.example.com:5432/postgres service_role eyJabc"
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(
+            web_server.subprocess,
+            "run",
+            lambda *args, **kwargs: Completed(),
+        )
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["reason"] == "control_plane_query_failed"
+        message = data["message"].lower()
+        assert "secret" not in message
+        assert "postgresql://" not in message
+        assert "service_role" not in message
+        assert "eyj" not in message
+
+    def test_control_plane_exception_message_does_not_leak_cli_command(self, monkeypatch, tmp_path):
+        import subprocess
+        import hermes_cli.web_server as web_server
+
+        def fake_run(*args, **kwargs):
+            raise subprocess.TimeoutExpired(
+                cmd=[
+                    "/usr/bin/supabase",
+                    "db",
+                    "query",
+                    "--linked",
+                    "select * from hermes_notify.delivery_events where target_ref = 'telegram:999000111'",
+                ],
+                timeout=30,
+            )
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["reason"] == "control_plane_query_failed"
+        message = data["message"].lower()
+        assert "supabase" not in message
+        assert "hermes_notify" not in message
+        assert "999000111" not in message
+        assert "delivery_events" not in message
+
+    def test_control_plane_cli_query_uses_serialization_lock(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        class Completed:
+            returncode = 0
+            stderr = ""
+            stdout = json.dumps([{"payload": {"enabled": True, "mode": "read_only"}}])
+
+        class FakeLock:
+            entered = False
+            exited = False
+
+            def __enter__(self):
+                self.entered = True
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.exited = True
+                return False
+
+        fake_lock = FakeLock()
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(web_server, "_CONTROL_PLANE_CLI_LOCK", fake_lock)
+        monkeypatch.setattr(web_server.subprocess, "run", lambda *args, **kwargs: Completed())
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary")
+
+        assert resp.status_code == 200
+        assert resp.json()["enabled"] is True
+        assert fake_lock.entered is True
+        assert fake_lock.exited is True
+
+    def test_control_plane_canary_returns_read_only_payload(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        class Completed:
+            returncode = 0
+            stderr = ""
+            stdout = json.dumps([
+                {
+                    "payload": {
+                        "enabled": True,
+                        "status": "ok",
+                        "mode": "read_only",
+                        "project": "hermes-control-plane",
+                        "run": {
+                            "title": "HERA-198 Morning Brief Canary",
+                            "run_ref": "hermes://canary/HERA-198/morning-brief/phase1",
+                            "status": "generated",
+                        },
+                        "sections": [{"section_key": "summary", "section_order": 1}],
+                        "sources": [{"source_ref": "hermes://design/HERA-198/schema-domain-map"}],
+                        "delivery_events": [{"channel": "dry_run", "delivery_status": "dry_run"}],
+                        "audit_events": [{"event_type": "canary_insert"}],
+                        "counts": {"report_runs": 1},
+                        "boundaries": {
+                            "writes_enabled": False,
+                            "telegram_send_enabled": False,
+                            "obsidian_authority_edit_enabled": False,
+                            "cron_change_enabled": False,
+                        },
+                    }
+                }
+            ])
+
+        calls = []
+
+        def fake_run(cmd, cwd, check, capture_output, text, timeout):
+            calls.append({"cmd": cmd, "cwd": cwd, "check": check, "timeout": timeout})
+            return Completed()
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["mode"] == "read_only"
+        assert data["run"]["title"] == "HERA-198 Morning Brief Canary"
+        assert data["boundaries"]["writes_enabled"] is False
+        assert calls
+        assert calls[0]["cmd"][:5] == ["/usr/bin/supabase", "db", "query", "--linked", "-o"]
+        sql = calls[0]["cmd"][-1].lower()
+        assert "insert into" not in sql
+        assert "update " not in sql
+        assert "delete from" not in sql
+        assert "target_ref like 'telegram://dry-run/%'" in sql
+        assert "and channel = 'dry_run'" in sql
+        assert "null::text as error_summary" in sql
+
+    def test_control_plane_telegram_preview_requires_session_token(self):
+        import hermes_cli.web_server as web_server
+
+        resp = self.client.get(
+            "/api/control-plane/morning-brief-canary/telegram-preview",
+            headers={web_server._SESSION_HEADER_NAME: "invalid-token"},
+        )
+
+        assert resp.status_code == 401
+
+    def test_control_plane_telegram_preview_is_dry_run_and_read_only(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        class Completed:
+            returncode = 0
+            stderr = ""
+            stdout = json.dumps([
+                {
+                    "payload": {
+                        "enabled": True,
+                        "status": "ok",
+                        "mode": "read_only",
+                        "project": "hermes-control-plane",
+                        "run": {
+                            "title": "HERA-198 Morning Brief Canary",
+                            "run_ref": "hermes://canary/HERA-198/morning-brief/phase1",
+                            "status": "generated",
+                            "summary_kr": "Supabase control-plane readback 통과.",
+                        },
+                        "sections": [{"section_key": "summary", "section_order": 1}],
+                        "sources": [{"source_ref": "hermes://design/HERA-198/schema-domain-map"}],
+                        "delivery_events": [
+                            {
+                                "channel": "dry_run",
+                                "delivery_status": "dry_run",
+                                "target_ref": "telegram://dry-run/hera-198",
+                            }
+                        ],
+                        "audit_events": [{"event_type": "canary_insert"}],
+                        "counts": {
+                            "report_runs": 1,
+                            "report_sections": 1,
+                            "source_anchors": 1,
+                            "delivery_events": 1,
+                            "audit_events": 1,
+                        },
+                        "boundaries": {
+                            "writes_enabled": False,
+                            "telegram_send_enabled": False,
+                            "obsidian_authority_edit_enabled": False,
+                            "cron_change_enabled": False,
+                        },
+                    }
+                }
+            ])
+
+        calls = []
+
+        def fake_run(cmd, cwd, check, capture_output, text, timeout):
+            calls.append({"cmd": cmd, "cwd": cwd, "check": check, "timeout": timeout})
+            return Completed()
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary/telegram-preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["mode"] == "dry_run_preview"
+        assert data["send_enabled"] is False
+        assert data["write_enabled"] is False
+        assert data["target_ref"] == "telegram://dry-run/hera-198"
+        assert data["validation"]["length_ok"] is True
+        assert data["validation"]["requires_approval_before_send"] is True
+        assert "처리 이유:" in data["message_text"]
+        assert "HERA-198 Morning Brief Canary" in data["message_text"]
+        assert "dry_run" in data["message_text"]
+        assert calls
+        sql = calls[0]["cmd"][-1].lower()
+        assert "insert into" not in sql
+        assert "update " not in sql
+        assert "delete from" not in sql
+
+    def test_control_plane_telegram_preview_propagates_disabled_state(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: None)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary/telegram-preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["reason"] == "supabase_cli_missing"
+
+    def test_control_plane_telegram_preview_rejects_non_dry_run_target_refs(self):
+        import hermes_cli.web_server as web_server
+
+        preview = web_server._build_morning_brief_telegram_preview({
+            "enabled": True,
+            "project": "hermes-control-plane",
+            "run": {"title": "Canary", "status": "generated"},
+            "delivery_events": [
+                {
+                    "channel": "telegram",
+                    "delivery_status": "sent",
+                    "target_ref": "telegram:999000111",
+                }
+            ],
+            "counts": {},
+            "boundaries": {},
+        })
+
+        assert preview["target_ref"] == "telegram://dry-run/hera-198"
+        assert "999000111" not in preview["message_text"]
+
     def test_get_config_schema(self):
         resp = self.client.get("/api/config/schema")
         assert resp.status_code == 200

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -253,7 +253,7 @@ class TestWebServerEndpoints:
                     "db",
                     "query",
                     "--linked",
-                    "select * from hermes_notify.delivery_events where target_ref = 'telegram:999000111'",
+                    "select * from hermes_notify.delivery_events where target_ref = 'telegram:test-recipient'",
                 ],
                 timeout=30,
             )
@@ -271,7 +271,7 @@ class TestWebServerEndpoints:
         message = data["message"].lower()
         assert "supabase" not in message
         assert "hermes_notify" not in message
-        assert "999000111" not in message
+        assert "test-recipient" not in message
         assert "delivery_events" not in message
 
     def test_control_plane_cli_query_uses_serialization_lock(self, monkeypatch, tmp_path):
@@ -330,7 +330,13 @@ class TestWebServerEndpoints:
                         "sources": [{"source_ref": "hermes://design/HERA-198/schema-domain-map"}],
                         "delivery_events": [{"channel": "dry_run", "delivery_status": "dry_run"}],
                         "audit_events": [{"event_type": "canary_insert"}],
-                        "counts": {"report_runs": 1},
+                        "counts": {"report_runs": 6, "report_sections": 15},
+                        "latest_run_counts": {
+                            "report_sections": 1,
+                            "source_anchors": 1,
+                            "delivery_events": 1,
+                            "audit_events": 1,
+                        },
                         "boundaries": {
                             "writes_enabled": False,
                             "telegram_send_enabled": False,
@@ -359,15 +365,194 @@ class TestWebServerEndpoints:
         assert data["mode"] == "read_only"
         assert data["run"]["title"] == "HERA-198 Morning Brief Canary"
         assert data["boundaries"]["writes_enabled"] is False
+        assert data["latest_run_counts"] == {
+            "report_sections": 1,
+            "source_anchors": 1,
+            "delivery_events": 1,
+            "audit_events": 1,
+        }
         assert calls
         assert calls[0]["cmd"][:5] == ["/usr/bin/supabase", "db", "query", "--linked", "-o"]
         sql = calls[0]["cmd"][-1].lower()
         assert "insert into" not in sql
         assert "update " not in sql
         assert "delete from" not in sql
+        assert "'latest_run_counts'" in sql
         assert "target_ref like 'telegram://dry-run/%'" in sql
-        assert "and channel = 'dry_run'" in sql
+        assert "channel in ('telegram', 'dry_run')" in sql
+        assert "delivery_status = 'dry_run'" in sql
         assert "null::text as error_summary" in sql
+
+    def test_control_plane_morning_brief_v0_canary_requires_session_token(self):
+        import hermes_cli.web_server as web_server
+
+        resp = self.client.get(
+            "/api/control-plane/morning-brief-v0/canary",
+            headers={web_server._SESSION_HEADER_NAME: "invalid-token"},
+        )
+
+        assert resp.status_code == 401
+
+    def test_control_plane_morning_brief_v0_canary_returns_safe_disabled_state(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+
+        resp = self.client.get("/api/control-plane/morning-brief-v0/canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {
+            "enabled": False,
+            "reason": "morning_brief_v0_2_canary_not_configured",
+            "safe_next_action": "verify Gate B/C execution readbacks or keep hold/observe",
+        }
+
+    def test_control_plane_morning_brief_v0_canary_returns_read_only_user_reported_pass(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        artifacts = tmp_path / "hera-198-data-architecture-reset"
+        artifacts.mkdir(parents=True)
+        (artifacts / "gate-b-v0.2-execution-readback.md").write_text(
+            "Status: PASS\n"
+            "projection_exists: 1\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+
+        resp = self.client.get("/api/control-plane/morning-brief-v0/canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["canary_key"] == "morning-brief-v0.2-preview-canary"
+        assert data["report_kind"] == "morning_brief"
+        assert data["verification_status"] == "verified"
+        assert data["rollback_status"] == "ready_not_needed"
+        assert data["gateb_verification_result"] == "pass"
+        assert data["hermes_direct_db_verification"] is True
+        assert data["verification_source"] == "hermes_supabase_cli_readback"
+        assert data["preview_payload_present"] is True
+        assert data["source_quality_present"] is True
+        assert data["boundaries"] == {
+            "writes_enabled": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "cron_change_enabled": False,
+            "webui_mutation_enabled": False,
+        }
+        dumped = json.dumps(data).lower()
+        assert "service_role" not in dumped
+        assert "postgresql://" not in dumped
+        assert "eyj" not in dumped
+
+    def test_control_plane_cockpit_routes_require_session_token_and_are_not_public(self):
+        import hermes_cli.web_server as web_server
+
+        assert "/api/control-plane/cockpit/summary" not in web_server._PUBLIC_API_PATHS
+        assert "/api/control-plane/cockpit/blockers" not in web_server._PUBLIC_API_PATHS
+
+        for path in [
+            "/api/control-plane/cockpit/summary",
+            "/api/control-plane/cockpit/blockers",
+        ]:
+            resp = self.client.get(
+                path,
+                headers={web_server._SESSION_HEADER_NAME: "invalid-token"},
+            )
+            assert resp.status_code == 401
+
+    def test_control_plane_cockpit_returns_safe_disabled_state_when_artifacts_missing(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+
+        for path in [
+            "/api/control-plane/cockpit/summary",
+            "/api/control-plane/cockpit/blockers",
+        ]:
+            resp = self.client.get(path)
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["enabled"] is False
+            assert data["reason"] == "control_plane_not_configured"
+
+    def test_control_plane_cockpit_summary_returns_browser_safe_status(self, monkeypatch, tmp_path):
+        import json
+
+        artifacts = tmp_path / "artifacts"
+        artifacts.mkdir()
+        (artifacts / "gated_latest_run_status.md").write_text(
+            "run_status: pass\nroutine_id: morning_brief_v0_daily_candidate\ngatec3_verification_result: pass\n",
+            encoding="utf-8",
+        )
+        (artifacts / "github_watcher_v0_latest_poll_status.md").write_text(
+            "status: pass\nerrors: 0\nGitHub mutation: not performed\nraw payload archive: not stored\n",
+            encoding="utf-8",
+        )
+        (artifacts / "supabase_obsidian_role_boundary_decision_record.md").write_text(
+            "Supabase is a supporting control-plane DB; Obsidian remains canonical authority\n",
+            encoding="utf-8",
+        )
+        (artifacts / "obsidian_merge_review_note_creation_result.md").write_text(
+            "Status: complete\nObsidian authority edit: not performed\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+
+        resp = self.client.get("/api/control-plane/cockpit/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["status"]["gate_d"]["status"] == "pass"
+        assert data["status"]["github_watcher_no_agent"]["status"] == "pass"
+        assert data["status"]["supabase_role_boundary"]["status"] == "recorded"
+        assert data["status"]["obsidian_merge_review"]["status"] == "complete"
+        assert data["severity"] == "OK"
+        assert data["status"]["gate_d"]["severity"] == "OK"
+        assert data["status"]["github_watcher_no_agent"]["severity"] == "OK"
+        assert data["status"]["supabase_role_boundary"]["severity"] == "OK"
+        assert data["status"]["obsidian_merge_review"]["severity"] == "OK"
+        assert data["safe_next_action"] in {"observe", "frontend_api_client_contract_gate"}
+        assert set(data["source_refs"]) == {
+            "artifact://gated_latest_run_status",
+            "artifact://github_watcher_v0_latest_poll_status",
+            "artifact://supabase_obsidian_role_boundary_decision_record",
+            "artifact://obsidian_merge_review_note_creation_result",
+        }
+        dumped = json.dumps(data).lower()
+        for forbidden in [
+            "postgresql" + "://",
+            "service" + "_role",
+            "ey" + "j",
+            "target" + "_ref",
+            "provider" + "_message" + "_ref",
+            "raw payload archive: not stored",
+        ]:
+            assert forbidden not in dumped
+
+    def test_control_plane_cockpit_blockers_returns_no_action_controls(self, monkeypatch, tmp_path):
+        artifacts = tmp_path / "artifacts"
+        artifacts.mkdir()
+        (artifacts / "gated_latest_run_status.md").write_text("run_status: pass\n", encoding="utf-8")
+        (artifacts / "github_watcher_v0_latest_poll_status.md").write_text("status: pass\nerrors: 0\n", encoding="utf-8")
+        (artifacts / "supabase_obsidian_role_boundary_decision_record.md").write_text("supporting control-plane DB\n", encoding="utf-8")
+        (artifacts / "obsidian_merge_review_note_creation_result.md").write_text("Status: complete\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+
+        resp = self.client.get("/api/control-plane/cockpit/blockers")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["blockers"] == []
+        assert data["severity"] == "OK"
+        assert data["boundaries"] == {
+            "read_only": True,
+            "action_controls": False,
+            "mutation_controls": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "supabase_schema_change_enabled": False,
+            "cron_change_enabled": False,
+        }
 
     def test_control_plane_telegram_preview_requires_session_token(self):
         import hermes_cli.web_server as web_server
@@ -409,7 +594,13 @@ class TestWebServerEndpoints:
                         ],
                         "audit_events": [{"event_type": "canary_insert"}],
                         "counts": {
-                            "report_runs": 1,
+                            "report_runs": 6,
+                            "report_sections": 15,
+                            "source_anchors": 17,
+                            "delivery_events": 8,
+                            "audit_events": 15,
+                        },
+                        "latest_run_counts": {
                             "report_sections": 1,
                             "source_anchors": 1,
                             "delivery_events": 1,
@@ -448,6 +639,10 @@ class TestWebServerEndpoints:
         assert data["validation"]["requires_approval_before_send"] is True
         assert "처리 이유:" in data["message_text"]
         assert "HERA-198 Morning Brief Canary" in data["message_text"]
+        assert "섹션: 1" in data["message_text"]
+        assert "소스: 1" in data["message_text"]
+        assert "섹션: 15" not in data["message_text"]
+        assert "소스: 17" not in data["message_text"]
         assert "dry_run" in data["message_text"]
         assert calls
         sql = calls[0]["cmd"][-1].lower()
@@ -478,7 +673,7 @@ class TestWebServerEndpoints:
                 {
                     "channel": "telegram",
                     "delivery_status": "sent",
-                    "target_ref": "telegram:999000111",
+                    "target_ref": "telegram:test-recipient",
                 }
             ],
             "counts": {},
@@ -486,7 +681,140 @@ class TestWebServerEndpoints:
         })
 
         assert preview["target_ref"] == "telegram://dry-run/hera-198"
-        assert "999000111" not in preview["message_text"]
+        assert "test-recipient" not in preview["message_text"]
+
+    def test_control_plane_safety_preview_requires_session_token(self):
+        import hermes_cli.web_server as web_server
+
+        resp = self.client.get(
+            "/api/control-plane/morning-brief-canary/safety-preview",
+            headers={web_server._SESSION_HEADER_NAME: "invalid-token"},
+        )
+
+        assert resp.status_code == 401
+
+    def test_control_plane_safety_preview_is_private_api_path(self):
+        import hermes_cli.web_server as web_server
+
+        assert "/api/control-plane/morning-brief-canary/safety-preview" not in web_server._PUBLIC_API_PATHS
+
+    def test_control_plane_safety_preview_returns_browser_safe_v2_payload(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        class Completed:
+            returncode = 0
+            stderr = ""
+            stdout = json.dumps([
+                {
+                    "run_ref": "hermes://canary/HERA-198/morning-brief/gate-g-real-source-packet-dry-run",
+                    "title": "HERA-198 Gate G Morning Brief dry-run canary",
+                    "status": "generated",
+                    "lifecycle_state": "reviewed",
+                    "report_date": "2026-05-08",
+                    "source_count": 3,
+                    "quarantined_source_count": 1,
+                    "source_safety_state": "has_quarantine",
+                    "source_safety_summary_kr": "격리 출처 1건 포함 — 발행/전송 전 Hermes source review 필요",
+                    "source_safety_refs": [
+                        {
+                            "claim_key": "kospi-close-7490",
+                            "section_key": "korea_economy",
+                            "source_title": "browser-safe source title",
+                            "publisher": "KRX required",
+                            "source_tier": "quarantined",
+                            "quality_label": "hold",
+                            "timing_label": "NEW_24H",
+                            "is_quarantined": True,
+                            "quarantine_reason": "Same-run Tier-1 KRX confirmation not attached",
+                            "target_ref": "telegram://private-target/must-not-leak",
+                        }
+                    ],
+                    "latest_channel": "dry_run",
+                    "latest_delivery_mode": "dry_run",
+                    "latest_send_result": "not_attempted",
+                    "latest_approval_state": "pending",
+                    "delivery_browser_safe": True,
+                    "latest_redaction_class": "internal_safe",
+                    "latest_provider_error_class": None,
+                    "notification_action_state": "preview_only",
+                    "authority_boundary_state": "no_obsidian_ref",
+                    "obsidian_ref": None,
+                    "paperclip_parent_ref": "paperclip://HERA-207",
+                    "rollback_available": True,
+                    "publish_blocked": True,
+                    "publish_block_reason_kr": "격리 출처 포함 — Hermes source review 전 발행/전송 불가",
+                }
+            ])
+
+        calls = []
+
+        def fake_run(cmd, cwd, check, capture_output, text, timeout):
+            calls.append({"cmd": cmd, "cwd": cwd, "check": check, "timeout": timeout})
+            return Completed()
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary/safety-preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["mode"] == "read_only_safety_preview"
+        assert data["run"]["status"] == "generated"
+        assert data["source_safety"]["state"] == "has_quarantine"
+        assert data["severity"] == "HOLD"
+        assert data["severity_reason"] == "publish_blocked_or_quarantined_source"
+        assert data["source_safety"]["quarantined_source_count"] == 1
+        assert data["notification_readiness"]["action_state"] == "preview_only"
+        assert data["authority_boundary"]["supabase_is_authority"] is False
+        assert data["authority_boundary"]["requires_obsidian_merge_review_before_authority"] is True
+        assert data["rollback_readiness"]["publish_blocked"] is True
+        assert data["boundaries"] == {
+            "writes_enabled": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "cron_change_enabled": False,
+            "webui_mutation_enabled": False,
+        }
+        dumped = json.dumps(data).lower()
+        assert "private-target" not in dumped
+        assert "target_ref" not in dumped
+        assert "provider_message_ref" not in dumped
+        assert "error_summary" not in dumped
+        assert "provider_error_body" not in dumped
+        assert calls
+        sql = calls[0]["cmd"][-1].lower()
+        assert "from hermes_projection.morning_brief_cockpit_v2" in sql
+        assert "gate-g-real-source-packet-dry-run" not in sql
+        assert "where run_ref =" not in sql
+        assert "order by report_date desc, run_ref desc" in sql
+        assert "insert into" not in sql
+        assert "update " not in sql
+        assert "delete from" not in sql
+        assert "drop " not in sql
+        assert "alter " not in sql
+        assert "target_ref" not in sql
+        assert "provider_message_ref" not in sql
+        assert "error_summary" not in sql
+        assert "provider_error_body" not in sql
+
+    def test_control_plane_safety_preview_propagates_disabled_state_without_raw_error(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: None)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary/safety-preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["reason"] == "supabase_cli_missing"
+        dumped = json.dumps(data).lower()
+        assert "postgresql://" not in dumped
+        assert "service_role" not in dumped
+        assert "eyj" not in dumped
 
     def test_get_config_schema(self):
         resp = self.client.get("/api/config/schema")

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -63,6 +63,7 @@ import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import ModelsPage from "@/pages/ModelsPage";
 import CronPage from "@/pages/CronPage";
+import ControlPlanePage from "@/pages/ControlPlanePage";
 import ProfilesPage from "@/pages/ProfilesPage";
 import SkillsPage from "@/pages/SkillsPage";
 import PluginsPage from "@/pages/PluginsPage";
@@ -102,6 +103,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
   "/logs": LogsPage,
+  "/control-plane": ControlPlanePage,
   "/cron": CronPage,
   "/skills": SkillsPage,
   "/plugins": PluginsPage,
@@ -139,6 +141,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
     icon: Cpu,
   },
   { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
+  { path: "/control-plane", label: "Control Plane", icon: Database },
   { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
   { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -45,6 +45,12 @@ async function getSessionToken(): Promise<string> {
 
 export const api = {
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
+  getMorningBriefCanary: () =>
+    fetchJSON<MorningBriefCanaryResponse>("/api/control-plane/morning-brief-canary"),
+  getMorningBriefTelegramPreview: () =>
+    fetchJSON<MorningBriefTelegramPreviewResponse>(
+      "/api/control-plane/morning-brief-canary/telegram-preview",
+    ),
   getSessions: (limit = 20, offset = 0) =>
     fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
   getSessionMessages: (id: string) =>
@@ -562,6 +568,115 @@ export interface SessionSearchResult {
 
 export interface SessionSearchResponse {
   results: SessionSearchResult[];
+}
+
+
+export interface MorningBriefRun {
+  id?: string;
+  report_type?: string;
+  run_ref?: string;
+  status?: string;
+  report_date?: string;
+  title?: string;
+  summary_kr?: string | null;
+  obsidian_ref?: string | null;
+  paperclip_parent_ref?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface MorningBriefSection {
+  section_key?: string;
+  section_order?: number;
+  title?: string;
+  body_md?: string;
+  judgment_label?: string | null;
+  created_at?: string;
+}
+
+export interface MorningBriefSourceAnchor {
+  source_ref?: string;
+  source_title?: string | null;
+  publisher?: string | null;
+  published_at?: string | null;
+  observed_at?: string | null;
+  timing_label?: string | null;
+  quality_label?: string | null;
+  claim_ref?: string | null;
+  created_at?: string;
+}
+
+export interface MorningBriefDeliveryEvent {
+  channel?: string;
+  target_ref?: string | null;
+  payload_summary?: string;
+  delivery_status?: string;
+  delivered_at?: string | null;
+  error_summary?: string | null;
+  created_at?: string;
+}
+
+export interface MorningBriefAuditEvent {
+  event_type?: string;
+  subject_ref?: string | null;
+  actor_ref?: string;
+  source_refs?: unknown[];
+  artifact_refs?: unknown[];
+  summary?: string;
+  verification_status?: string | null;
+  created_at?: string;
+}
+
+export interface MorningBriefCanaryResponse {
+  enabled: boolean;
+  reason?: string;
+  message?: string;
+  status?: string;
+  mode?: "read_only" | string;
+  project?: string;
+  updated_at?: string;
+  run?: MorningBriefRun | null;
+  sections?: MorningBriefSection[];
+  sources?: MorningBriefSourceAnchor[];
+  delivery_events?: MorningBriefDeliveryEvent[];
+  audit_events?: MorningBriefAuditEvent[];
+  counts?: Record<string, number>;
+  boundaries?: {
+    writes_enabled?: boolean;
+    telegram_send_enabled?: boolean;
+    obsidian_authority_edit_enabled?: boolean;
+    cron_change_enabled?: boolean;
+  };
+}
+
+export interface MorningBriefTelegramPreviewResponse {
+  enabled: boolean;
+  reason?: string;
+  message?: string;
+  status?: string;
+  mode?: "dry_run_preview" | string;
+  project?: string;
+  target_ref?: string;
+  channel?: "telegram" | string;
+  send_enabled?: boolean;
+  write_enabled?: boolean;
+  message_text?: string;
+  message_length?: number;
+  validation?: {
+    length_ok?: boolean;
+    max_length?: number;
+    requires_approval_before_send?: boolean;
+    no_telegram_send_performed?: boolean;
+    no_supabase_write_performed?: boolean;
+    no_cron_change_performed?: boolean;
+    no_obsidian_authority_edit_performed?: boolean;
+  };
+  source?: {
+    run_ref?: string | null;
+    report_status?: string;
+    control_plane_mode?: string;
+  };
+  boundaries?: MorningBriefCanaryResponse["boundaries"];
 }
 
 // ── Model info types ──────────────────────────────────────────────────

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,21 @@
-const BASE = "";
+// The dashboard can be served either at the root of its host (e.g.
+// https://kanban.tilos.com/) or under a URL prefix when reverse-proxied
+// (e.g. https://mission-control.tilos.com/hermes/). The Python backend
+// injects ``window.__HERMES_BASE_PATH__`` into index.html based on the
+// incoming ``X-Forwarded-Prefix`` header so the SPA can address its own
+// ``/api/...`` and ``/dashboard-plugins/...`` URLs correctly without a
+// rebuild. Empty string means "served at root".
+function readBasePath(): string {
+  if (typeof window === "undefined") return "";
+  const raw = window.__HERMES_BASE_PATH__ ?? "";
+  if (!raw) return "";
+  // Normalise: ensure leading slash, strip trailing slash.
+  const withLead = raw.startsWith("/") ? raw : `/${raw}`;
+  return withLead.replace(/\/+$/, "");
+}
+
+export const HERMES_BASE_PATH = readBasePath();
+const BASE = HERMES_BASE_PATH;
 
 import type { DashboardTheme } from "@/themes/types";
 
@@ -7,6 +24,7 @@ import type { DashboardTheme } from "@/themes/types";
 declare global {
   interface Window {
     __HERMES_SESSION_TOKEN__?: string;
+    __HERMES_BASE_PATH__?: string;
   }
 }
 let _sessionToken: string | null = null;
@@ -47,14 +65,28 @@ export const api = {
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
   getMorningBriefCanary: () =>
     fetchJSON<MorningBriefCanaryResponse>("/api/control-plane/morning-brief-canary"),
+  getMorningBriefV0Canary: () =>
+    fetchJSON<MorningBriefV0CanaryResponse>("/api/control-plane/morning-brief-v0/canary"),
   getMorningBriefTelegramPreview: () =>
     fetchJSON<MorningBriefTelegramPreviewResponse>(
       "/api/control-plane/morning-brief-canary/telegram-preview",
     ),
+  getMorningBriefSafetyPreview: () =>
+    fetchJSON<MorningBriefSafetyPreviewResponse>(
+      "/api/control-plane/morning-brief-canary/safety-preview",
+    ),
+  getControlPlaneCockpitSummary: () =>
+    fetchJSON<ControlPlaneCockpitSummaryResponse>("/api/control-plane/cockpit/summary"),
+  getControlPlaneCockpitBlockers: () =>
+    fetchJSON<ControlPlaneCockpitBlockersResponse>("/api/control-plane/cockpit/blockers"),
   getSessions: (limit = 20, offset = 0) =>
     fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
   getSessionMessages: (id: string) =>
     fetchJSON<SessionMessagesResponse>(`/api/sessions/${encodeURIComponent(id)}/messages`),
+  getSessionLatestDescendant: (id: string) =>
+    fetchJSON<SessionLatestDescendantResponse>(
+      `/api/sessions/${encodeURIComponent(id)}/latest-descendant`,
+    ),
   deleteSession: (id: string) =>
     fetchJSON<{ ok: boolean }>(`/api/sessions/${encodeURIComponent(id)}`, {
       method: "DELETE",
@@ -379,6 +411,14 @@ export interface SessionInfo {
   input_tokens: number;
   output_tokens: number;
   preview: string | null;
+  parent_session_id?: string | null;
+}
+
+export interface SessionLatestDescendantResponse {
+  requested_session_id: string;
+  session_id: string;
+  path: string[];
+  changed: boolean;
 }
 
 export interface PaginatedSessions {
@@ -641,11 +681,31 @@ export interface MorningBriefCanaryResponse {
   delivery_events?: MorningBriefDeliveryEvent[];
   audit_events?: MorningBriefAuditEvent[];
   counts?: Record<string, number>;
+  latest_run_counts?: Record<string, number>;
   boundaries?: {
     writes_enabled?: boolean;
     telegram_send_enabled?: boolean;
     obsidian_authority_edit_enabled?: boolean;
     cron_change_enabled?: boolean;
+  };
+}
+
+export interface MorningBriefV0CanaryResponse {
+  enabled: boolean;
+  reason?: string;
+  safe_next_action?: string;
+  canary_key?: "morning-brief-v0.2-preview-canary" | string;
+  report_kind?: "morning_brief" | string;
+  verification_status?: "verified" | string;
+  rollback_status?: "ready_not_needed" | string;
+  gateb_verification_result?: "pass" | string;
+  hermes_direct_db_verification?: boolean;
+  verification_source?: "hermes_supabase_cli_readback" | string;
+  report_snapshot_ref?: string;
+  preview_payload_present?: boolean;
+  source_quality_present?: boolean;
+  boundaries?: MorningBriefCanaryResponse["boundaries"] & {
+    webui_mutation_enabled?: boolean;
   };
 }
 
@@ -677,6 +737,140 @@ export interface MorningBriefTelegramPreviewResponse {
     control_plane_mode?: string;
   };
   boundaries?: MorningBriefCanaryResponse["boundaries"];
+}
+
+export interface MorningBriefSafetyRun {
+  run_ref?: string;
+  title?: string;
+  status?: string;
+  lifecycle_state?: string;
+  report_date?: string;
+  paperclip_parent_ref?: string | null;
+}
+
+export interface MorningBriefSourceSafetyRef {
+  claim_key?: string;
+  section_key?: string;
+  source_title?: string | null;
+  publisher?: string | null;
+  source_tier?: string | null;
+  quality_label?: string | null;
+  timing_label?: string | null;
+  is_quarantined?: boolean;
+  quarantine_reason?: string | null;
+}
+
+export interface MorningBriefSourceSafetySummary {
+  state?: "clean" | "has_quarantine" | string;
+  source_count?: number;
+  quarantined_source_count?: number;
+  summary_kr?: string | null;
+  refs?: MorningBriefSourceSafetyRef[];
+}
+
+export interface MorningBriefNotificationReadiness {
+  action_state?: "preview_only" | "blocked" | string;
+  latest_channel?: string | null;
+  latest_delivery_mode?: string | null;
+  latest_send_result?: string | null;
+  latest_approval_state?: string | null;
+  delivery_browser_safe?: boolean | null;
+  latest_redaction_class?: string | null;
+  latest_provider_error_class?: string | null;
+}
+
+export interface MorningBriefAuthorityBoundary {
+  state?: "no_obsidian_ref" | string;
+  obsidian_ref_present?: boolean;
+  supabase_is_authority?: false;
+  requires_obsidian_merge_review_before_authority?: boolean;
+}
+
+export interface MorningBriefRollbackReadiness {
+  available?: boolean;
+  publish_blocked?: boolean;
+  publish_block_reason_kr?: string | null;
+}
+
+export interface MorningBriefSafetyPreviewResponse {
+  enabled: boolean;
+  reason?: string;
+  message?: string;
+  status?: string;
+  severity?: "OK" | "WATCH" | "HOLD" | "BLOCKED" | "ACTION_REQUIRED" | string;
+  severity_reason?: string;
+  mode?: "read_only_safety_preview" | string;
+  run?: MorningBriefSafetyRun;
+  source_safety?: MorningBriefSourceSafetySummary;
+  notification_readiness?: MorningBriefNotificationReadiness;
+  authority_boundary?: MorningBriefAuthorityBoundary;
+  rollback_readiness?: MorningBriefRollbackReadiness;
+  boundaries?: MorningBriefCanaryResponse["boundaries"] & {
+    webui_mutation_enabled?: boolean;
+  };
+}
+
+export interface ControlPlaneCockpitDisabledState {
+  enabled: false;
+  reason: "control_plane_not_configured" | string;
+  message?: string;
+}
+
+export interface ControlPlaneCockpitStatusPanel {
+  status?: string;
+  severity?: "OK" | "WATCH" | "HOLD" | "BLOCKED" | "ACTION_REQUIRED" | string;
+  state?: string;
+  enabled?: boolean;
+  last_status?: string | null;
+  last_run_at?: string | null;
+  next_run_at?: string | null;
+  safe_summary?: string | null;
+  artifact_refs?: string[];
+}
+
+export interface ControlPlaneCockpitSummaryResponse {
+  enabled?: boolean;
+  reason?: string;
+  severity?: "OK" | "WATCH" | "HOLD" | "BLOCKED" | "ACTION_REQUIRED" | string;
+  counts?: Record<string, number>;
+  status?: Record<
+    "gate_d" | "github_watcher_no_agent" | "supabase_role_boundary" | "obsidian_merge_review" | string,
+    ControlPlaneCockpitStatusPanel
+  >;
+  handoff_summary?: string;
+  safe_next_action?: string;
+  source_refs?: string[];
+  artifact_refs?: string[];
+  updated_at?: string;
+}
+
+export interface ControlPlaneCockpitBoundaryFlags {
+  read_only?: boolean;
+  server_side_only?: boolean;
+  session_token_protected?: boolean;
+  public_api_path?: false;
+  browser_side_supabase_secret?: false;
+  direct_browser_to_supabase?: false;
+  action_controls?: false;
+  mutation_controls?: false;
+}
+
+export interface ControlPlaneCockpitBlocker {
+  id: string;
+  status: "blocked" | "hold" | "observe" | "pass" | string;
+  title?: string;
+  detail?: string;
+  safe_next_action?: string;
+  artifact_refs?: string[];
+}
+
+export interface ControlPlaneCockpitBlockersResponse {
+  enabled?: boolean;
+  reason?: string;
+  blockers?: ControlPlaneCockpitBlocker[];
+  boundaries?: ControlPlaneCockpitBoundaryFlags;
+  safe_next_action?: string;
+  updated_at?: string;
 }
 
 // ── Model info types ──────────────────────────────────────────────────

--- a/web/src/pages/ControlPlanePage.tsx
+++ b/web/src/pages/ControlPlanePage.tsx
@@ -1,0 +1,259 @@
+import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { Database, MessageSquareText, RefreshCw, ShieldCheck } from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  api,
+  type MorningBriefCanaryResponse,
+  type MorningBriefTelegramPreviewResponse,
+} from "@/lib/api";
+import { usePageHeader } from "@/contexts/usePageHeader";
+
+function JsonList({ value }: { value: unknown[] | undefined }) {
+  if (!value || value.length === 0) {
+    return <p className="text-sm text-muted-foreground">No rows.</p>;
+  }
+  return (
+    <div className="space-y-2">
+      {value.map((item, index) => (
+        <pre
+          key={index}
+          className="overflow-auto rounded-md border border-current/15 bg-black/20 p-3 font-mono-ui text-[11px] leading-4 text-muted-foreground normal-case"
+        >
+          {JSON.stringify(item, null, 2)}
+        </pre>
+      ))}
+    </div>
+  );
+}
+
+function BoundaryBadge({ label, value }: { label: string; value?: boolean }) {
+  return (
+    <Badge tone={value ? "destructive" : "success"} className="text-[10px]">
+      {label}: {value ? "enabled" : "off"}
+    </Badge>
+  );
+}
+
+export default function ControlPlanePage() {
+  const [data, setData] = useState<MorningBriefCanaryResponse | null>(null);
+  const [telegramPreview, setTelegramPreview] =
+    useState<MorningBriefTelegramPreviewResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { setAfterTitle, setEnd } = usePageHeader();
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setTelegramPreview(null);
+
+    try {
+      const canary = await api.getMorningBriefCanary();
+      setData(canary);
+    } catch {
+      setData(null);
+      setError("Control-plane read failed; check server logs or Supabase CLI link state.");
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const preview = await api.getMorningBriefTelegramPreview();
+      setTelegramPreview(preview);
+    } catch {
+      setTelegramPreview({
+        enabled: false,
+        reason: "telegram_preview_unavailable",
+        message: "Telegram preview unavailable; control-plane readback can still be shown.",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useLayoutEffect(() => {
+    setAfterTitle(
+      <span className="flex items-center gap-2">
+        {loading && <Spinner className="shrink-0 text-base text-primary" />}
+        <Badge tone={loading && !data ? "secondary" : data?.enabled ? "success" : "secondary"} className="text-[10px]">
+          {loading && !data ? "loading canary" : data?.enabled ? "read-only canary" : "not configured"}
+        </Badge>
+      </span>,
+    );
+    setEnd(
+      <Button
+        type="button"
+        size="sm"
+        outlined
+        onClick={refresh}
+        disabled={loading}
+        prefix={loading ? <Spinner /> : <RefreshCw />}
+      >
+        Refresh
+      </Button>,
+    );
+    return () => {
+      setAfterTitle(null);
+      setEnd(null);
+    };
+  }, [data?.enabled, loading, refresh, setAfterTitle, setEnd]);
+
+  const run = data?.run;
+  const boundaries = data?.boundaries ?? {};
+
+  return (
+    <div className="flex flex-col gap-4 normal-case">
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <CardTitle className="flex items-center gap-2 text-sm uppercase">
+            <Database className="h-4 w-4" />
+            HERA-198 Control Plane Canary
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 p-4">
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          {data && !data.enabled && (
+            <div className="rounded-md border border-warning/30 bg-warning/10 p-3">
+              <p className="text-sm font-semibold uppercase text-warning">Disabled</p>
+              <p className="text-sm text-muted-foreground">{data.reason}: {data.message}</p>
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2 uppercase">
+            <Badge tone="secondary" className="text-[10px]">project: {loading && !data ? "loading" : data?.project ?? "unknown"}</Badge>
+            <Badge tone="secondary" className="text-[10px]">mode: {data?.mode ?? "read-only"}</Badge>
+            <Badge tone="secondary" className="text-[10px]">updated: {data?.updated_at ?? "-"}</Badge>
+          </div>
+          <div className="flex flex-wrap gap-2 uppercase">
+            <BoundaryBadge label="writes" value={boundaries.writes_enabled} />
+            <BoundaryBadge label="telegram" value={boundaries.telegram_send_enabled} />
+            <BoundaryBadge label="obsidian authority" value={boundaries.obsidian_authority_edit_enabled} />
+            <BoundaryBadge label="cron" value={boundaries.cron_change_enabled} />
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <Card>
+          <CardHeader className="py-3 px-4">
+            <CardTitle className="text-sm uppercase">Latest Morning Brief Run</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 p-4 text-sm">
+            {run ? (
+              <>
+                <p className="font-semibold text-foreground">{run.title}</p>
+                <p className="text-muted-foreground">{run.summary_kr}</p>
+                <dl className="grid gap-2 md:grid-cols-2">
+                  <div><dt className="text-xs uppercase text-muted-foreground">Status</dt><dd>{run.status}</dd></div>
+                  <div><dt className="text-xs uppercase text-muted-foreground">Date</dt><dd>{run.report_date}</dd></div>
+                  <div className="md:col-span-2"><dt className="text-xs uppercase text-muted-foreground">Run ref</dt><dd className="break-all font-mono-ui text-xs">{run.run_ref}</dd></div>
+                  <div className="md:col-span-2"><dt className="text-xs uppercase text-muted-foreground">Obsidian ref</dt><dd className="break-all font-mono-ui text-xs">{run.obsidian_ref}</dd></div>
+                  <div className="md:col-span-2"><dt className="text-xs uppercase text-muted-foreground">Paperclip ref</dt><dd className="break-all font-mono-ui text-xs">{run.paperclip_parent_ref}</dd></div>
+                </dl>
+              </>
+            ) : loading ? (
+              <p className="text-muted-foreground">Loading Morning Brief run…</p>
+            ) : (
+              <p className="text-muted-foreground">No Morning Brief run found.</p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="py-3 px-4">
+            <CardTitle className="flex items-center gap-2 text-sm uppercase">
+              <ShieldCheck className="h-4 w-4" />
+              Counts / Verification
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-4">
+            <div className="grid gap-2 md:grid-cols-2">
+              {Object.entries(data?.counts ?? {}).map(([key, value]) => (
+                <div key={key} className="rounded-md border border-current/15 p-3">
+                  <p className="text-xs uppercase text-muted-foreground">{key}</p>
+                  <p className="text-lg font-semibold text-foreground">{value}</p>
+                </div>
+              ))}
+              {loading && !data && (
+                <p className="text-sm text-muted-foreground">Loading verification counts…</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <CardTitle className="flex items-center gap-2 text-sm uppercase">
+            <MessageSquareText className="h-4 w-4" />
+            Telegram Dry-run Payload Preview
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 p-4">
+          {telegramPreview && !telegramPreview.enabled && (
+            <div className="rounded-md border border-warning/30 bg-warning/10 p-3">
+              <p className="text-sm font-semibold uppercase text-warning">Preview disabled</p>
+              <p className="text-sm text-muted-foreground">
+                {telegramPreview.reason}: {telegramPreview.message}
+              </p>
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2 uppercase">
+            <Badge tone="secondary" className="text-[10px]">
+              channel: {telegramPreview?.channel ?? "telegram"}
+            </Badge>
+            <Badge tone="secondary" className="text-[10px]">
+              mode: {telegramPreview?.mode ?? "dry-run preview"}
+            </Badge>
+            <Badge tone={telegramPreview?.send_enabled ? "destructive" : "success"} className="text-[10px]">
+              send: {telegramPreview?.send_enabled ? "enabled" : "off"}
+            </Badge>
+            <Badge tone={telegramPreview?.write_enabled ? "destructive" : "success"} className="text-[10px]">
+              supabase write: {telegramPreview?.write_enabled ? "enabled" : "off"}
+            </Badge>
+            <Badge tone={telegramPreview?.validation?.length_ok ? "success" : "secondary"} className="text-[10px]">
+              length: {telegramPreview?.message_length ?? 0}/{telegramPreview?.validation?.max_length ?? 600}
+            </Badge>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-muted-foreground">Target ref</p>
+            <p className="break-all font-mono-ui text-xs text-foreground">
+              {telegramPreview?.target_ref ?? "telegram://dry-run/hera-198"}
+            </p>
+          </div>
+          <pre className="whitespace-pre-wrap rounded-md border border-current/15 bg-black/20 p-3 text-sm leading-6 text-foreground normal-case">
+            {telegramPreview?.message_text ?? "No preview generated."}
+          </pre>
+          <p className="text-xs text-muted-foreground normal-case">
+            Dry-run only: no Telegram send, no Supabase write, no cron change, no Obsidian authority edit.
+          </p>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <Card>
+          <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Sections</CardTitle></CardHeader>
+          <CardContent className="p-4"><JsonList value={data?.sections} /></CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Source Anchors</CardTitle></CardHeader>
+          <CardContent className="p-4"><JsonList value={data?.sources} /></CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Delivery Events</CardTitle></CardHeader>
+          <CardContent className="p-4"><JsonList value={data?.delivery_events} /></CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Audit Events</CardTitle></CardHeader>
+          <CardContent className="p-4"><JsonList value={data?.audit_events} /></CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/ControlPlanePage.tsx
+++ b/web/src/pages/ControlPlanePage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useState } from "react";
-import { Database, MessageSquareText, RefreshCw, ShieldCheck } from "lucide-react";
+import { Database, Gauge, MessageSquareText, RefreshCw, ShieldCheck } from "lucide-react";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
@@ -7,7 +7,15 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   api,
   type MorningBriefCanaryResponse,
+  type MorningBriefV0CanaryResponse,
   type MorningBriefTelegramPreviewResponse,
+  type MorningBriefSafetyPreviewResponse,
+  type MorningBriefSection,
+  type MorningBriefSourceAnchor,
+  type MorningBriefDeliveryEvent,
+  type ControlPlaneCockpitBlockersResponse,
+  type ControlPlaneCockpitStatusPanel,
+  type ControlPlaneCockpitSummaryResponse,
 } from "@/lib/api";
 import { usePageHeader } from "@/contexts/usePageHeader";
 
@@ -37,10 +45,163 @@ function BoundaryBadge({ label, value }: { label: string; value?: boolean }) {
   );
 }
 
+type ControlPlaneSeverity = "OK" | "WATCH" | "HOLD" | "BLOCKED" | "ACTION_REQUIRED" | string;
+
+function severityTone(severity?: ControlPlaneSeverity): "success" | "warning" | "secondary" | "destructive" {
+  switch ((severity ?? "").toUpperCase()) {
+    case "OK":
+      return "success";
+    case "WATCH":
+    case "HOLD":
+    case "ACTION_REQUIRED":
+      return "warning";
+    case "BLOCKED":
+      return "destructive";
+    default:
+      return "secondary";
+  }
+}
+
+function statusToSeverity(panel?: ControlPlaneCockpitStatusPanel): ControlPlaneSeverity {
+  if (panel?.severity) return panel.severity;
+  const value = `${panel?.status ?? ""} ${panel?.state ?? ""} ${panel?.last_status ?? ""}`.toLowerCase();
+  if (value.includes("fail") || value.includes("error") || value.includes("blocked")) return "BLOCKED";
+  if (value.includes("hold")) return "HOLD";
+  if (value.includes("observe")) return "WATCH";
+  if (value.includes("pass") || value.includes("ok") || value.includes("recorded") || value.includes("complete") || panel?.enabled) return "OK";
+  return "WATCH";
+}
+
+function panelTone(panel?: ControlPlaneCockpitStatusPanel): "success" | "warning" | "secondary" | "destructive" {
+  return severityTone(statusToSeverity(panel));
+}
+
+function CockpitPanelSummary({
+  label,
+  panel,
+}: {
+  label: string;
+  panel?: ControlPlaneCockpitStatusPanel;
+}) {
+  return (
+    <div className="rounded-md border border-current/15 p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <p className="text-xs uppercase text-muted-foreground">{label}</p>
+        <Badge tone={panelTone(panel)} className="text-[10px]">
+          {statusToSeverity(panel)}
+        </Badge>
+      </div>
+      <p className="normal-case text-sm text-muted-foreground">
+        {panel?.safe_summary ?? "No cockpit summary loaded yet."}
+      </p>
+      <dl className="mt-2 grid gap-1 text-xs text-muted-foreground">
+        <div><dt className="inline uppercase">last</dt>: <dd className="inline">{panel?.last_run_at ?? "-"}</dd></div>
+        <div><dt className="inline uppercase">next</dt>: <dd className="inline">{panel?.next_run_at ?? "-"}</dd></div>
+      </dl>
+    </div>
+  );
+}
+
+function CountCards({ title, counts }: { title: string; counts?: Record<string, number> }) {
+  const entries = Object.entries(counts ?? {});
+  return (
+    <div className="space-y-2">
+      <p className="text-xs uppercase text-muted-foreground">{title}</p>
+      <div className="grid gap-2 md:grid-cols-2">
+        {entries.length > 0 ? entries.map(([key, value]) => (
+          <div key={key} className="rounded-md border border-current/15 p-3">
+            <p className="text-xs uppercase text-muted-foreground">{key}</p>
+            <p className="text-lg font-semibold text-foreground">{value}</p>
+          </div>
+        )) : <p className="text-sm text-muted-foreground">No counts loaded.</p>}
+      </div>
+    </div>
+  );
+}
+
+function SectionCards({ sections }: { sections?: MorningBriefSection[] }) {
+  if (!sections || sections.length === 0) {
+    return <p className="text-sm text-muted-foreground">No sections for latest run.</p>;
+  }
+  return (
+    <div className="space-y-3">
+      {sections.map((section, index) => (
+        <article key={`${section.section_key ?? "section"}-${index}`} className="rounded-md border border-current/15 p-3">
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <Badge tone="secondary" className="text-[10px]">#{section.section_order ?? index + 1}</Badge>
+            {section.judgment_label && <Badge tone="warning" className="text-[10px]">{section.judgment_label}</Badge>}
+          </div>
+          <h3 className="text-sm font-semibold text-foreground">{section.title ?? section.section_key ?? "Untitled section"}</h3>
+          <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-muted-foreground normal-case">
+            {section.body_md ?? "No section body."}
+          </p>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function SourceAnchorCards({ sources }: { sources?: MorningBriefSourceAnchor[] }) {
+  if (!sources || sources.length === 0) {
+    return <p className="text-sm text-muted-foreground">No source anchors for latest run.</p>;
+  }
+  return (
+    <div className="space-y-3">
+      {sources.map((source, index) => (
+        <article key={`${source.source_ref ?? "source"}-${index}`} className="rounded-md border border-current/15 p-3">
+          <div className="mb-2 flex flex-wrap items-center gap-2 uppercase">
+            <Badge tone={source.quality_label === "hold" ? "warning" : "secondary"} className="text-[10px]">
+              quality: {source.quality_label ?? "unknown"}
+            </Badge>
+            <Badge tone="secondary" className="text-[10px]">timing: {source.timing_label ?? "unknown"}</Badge>
+          </div>
+          <h3 className="text-sm font-semibold text-foreground">{source.source_title ?? source.source_ref ?? "Untitled source"}</h3>
+          <dl className="mt-2 grid gap-1 text-xs text-muted-foreground">
+            <div><dt className="inline uppercase">publisher</dt>: <dd className="inline">{source.publisher ?? "-"}</dd></div>
+            <div><dt className="inline uppercase">claim</dt>: <dd className="inline break-all font-mono-ui">{source.claim_ref ?? "-"}</dd></div>
+            <div><dt className="inline uppercase">source ref</dt>: <dd className="inline break-all font-mono-ui">{source.source_ref ?? "-"}</dd></div>
+          </dl>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function DeliveryEventCards({ events }: { events?: MorningBriefDeliveryEvent[] }) {
+  if (!events || events.length === 0) {
+    return <p className="text-sm text-muted-foreground">No dry-run delivery event for latest run.</p>;
+  }
+  return (
+    <div className="space-y-3">
+      {events.map((event, index) => (
+        <article key={`${event.channel ?? "delivery"}-${event.created_at ?? index}`} className="rounded-md border border-current/15 p-3">
+          <div className="mb-2 flex flex-wrap items-center gap-2 uppercase">
+            <Badge tone="secondary" className="text-[10px]">channel: {event.channel ?? "-"}</Badge>
+            <Badge tone={event.delivery_status === "dry_run" ? "success" : "warning"} className="text-[10px]">
+              status: {event.delivery_status ?? "unknown"}
+            </Badge>
+          </div>
+          <dl className="grid gap-1 text-xs text-muted-foreground">
+            <div><dt className="inline uppercase">target</dt>: <dd className="inline break-all font-mono-ui">{event.target_ref ?? "[redacted]"}</dd></div>
+            <div><dt className="inline uppercase">payload</dt>: <dd className="inline normal-case">{event.payload_summary ?? "No browser-safe payload summary."}</dd></div>
+          </dl>
+        </article>
+      ))}
+    </div>
+  );
+}
+
 export default function ControlPlanePage() {
   const [data, setData] = useState<MorningBriefCanaryResponse | null>(null);
+  const [v0Canary, setV0Canary] = useState<MorningBriefV0CanaryResponse | null>(null);
   const [telegramPreview, setTelegramPreview] =
     useState<MorningBriefTelegramPreviewResponse | null>(null);
+  const [safetyPreview, setSafetyPreview] =
+    useState<MorningBriefSafetyPreviewResponse | null>(null);
+  const [cockpitSummary, setCockpitSummary] =
+    useState<ControlPlaneCockpitSummaryResponse | null>(null);
+  const [cockpitBlockers, setCockpitBlockers] =
+    useState<ControlPlaneCockpitBlockersResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { setAfterTitle, setEnd } = usePageHeader();
@@ -49,6 +210,10 @@ export default function ControlPlanePage() {
     setLoading(true);
     setError(null);
     setTelegramPreview(null);
+    setSafetyPreview(null);
+    setCockpitSummary(null);
+    setCockpitBlockers(null);
+    setV0Canary(null);
 
     try {
       const canary = await api.getMorningBriefCanary();
@@ -61,6 +226,17 @@ export default function ControlPlanePage() {
     }
 
     try {
+      const v0 = await api.getMorningBriefV0Canary();
+      setV0Canary(v0);
+    } catch {
+      setV0Canary({
+        enabled: false,
+        reason: "morning_brief_v0_canary_unavailable",
+        safe_next_action: "verify Gate B artifact status or keep hold/observe",
+      });
+    }
+
+    try {
       const preview = await api.getMorningBriefTelegramPreview();
       setTelegramPreview(preview);
     } catch {
@@ -69,13 +245,49 @@ export default function ControlPlanePage() {
         reason: "telegram_preview_unavailable",
         message: "Telegram preview unavailable; control-plane readback can still be shown.",
       });
+    }
+
+    try {
+      const safety = await api.getMorningBriefSafetyPreview();
+      setSafetyPreview(safety);
+    } catch {
+      setSafetyPreview({
+        enabled: false,
+        reason: "safety_preview_unavailable",
+        message: "Safety preview unavailable; keep publish/send blocked until verified.",
+      });
+    }
+
+    try {
+      const [summary, blockers] = await Promise.all([
+        api.getControlPlaneCockpitSummary(),
+        api.getControlPlaneCockpitBlockers(),
+      ]);
+      setCockpitSummary(summary);
+      setCockpitBlockers(blockers);
+    } catch {
+      setCockpitSummary({
+        enabled: false,
+        reason: "control_plane_cockpit_unavailable",
+        handoff_summary: "Control Plane Cockpit read failed; keep current observe posture.",
+        safe_next_action: "verify backend route status before relying on cockpit summary",
+      });
+      setCockpitBlockers({
+        enabled: false,
+        reason: "control_plane_cockpit_unavailable",
+        blockers: [],
+        safe_next_action: "verify backend route status before relying on cockpit blockers",
+      });
     } finally {
       setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    void refresh();
+    const timer = window.setTimeout(() => {
+      void refresh();
+    }, 0);
+    return () => window.clearTimeout(timer);
   }, [refresh]);
 
   useLayoutEffect(() => {
@@ -107,6 +319,9 @@ export default function ControlPlanePage() {
 
   const run = data?.run;
   const boundaries = data?.boundaries ?? {};
+  const cockpitStatus = cockpitSummary?.status ?? {};
+  const cockpitBlockerCount = cockpitBlockers?.blockers?.length ?? 0;
+  const cockpitBoundaryFlags = cockpitBlockers?.boundaries ?? {};
 
   return (
     <div className="flex flex-col gap-4 normal-case">
@@ -139,12 +354,119 @@ export default function ControlPlanePage() {
         </CardContent>
       </Card>
 
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <CardTitle className="flex items-center gap-2 text-sm uppercase">
+            <Gauge className="h-4 w-4" />
+            Control Plane Cockpit
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 p-4 text-sm">
+          <div className="flex flex-wrap gap-2 uppercase">
+            <Badge tone="secondary" className="text-[10px]">Operator Mode</Badge>
+            <Badge tone="success" className="text-[10px]">read-only cockpit</Badge>
+          </div>
+          {cockpitSummary && !cockpitSummary.enabled && (
+            <div className="rounded-md border border-warning/30 bg-warning/10 p-3">
+              <p className="text-sm font-semibold uppercase text-warning">Cockpit disabled</p>
+              <p className="text-sm text-muted-foreground">
+                {cockpitSummary.reason ?? "control_plane_not_configured"}
+              </p>
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2 uppercase">
+            <Badge tone={severityTone(cockpitSummary?.severity)} className="text-[10px]">
+              severity: {cockpitSummary?.severity ?? "loading"}
+            </Badge>
+            <Badge tone={cockpitSummary?.enabled === false ? "secondary" : "success"} className="text-[10px]">
+              {cockpitSummary?.enabled === false ? "safe disabled" : "read-only"}
+            </Badge>
+            <Badge tone={cockpitBlockerCount > 0 ? "warning" : "success"} className="text-[10px]">
+              blockers: {cockpitBlockerCount}
+            </Badge>
+            <Badge tone={cockpitBoundaryFlags.action_controls ? "destructive" : "success"} className="text-[10px]">
+              actions: {cockpitBoundaryFlags.action_controls ? "enabled" : "off"}
+            </Badge>
+            <Badge tone={cockpitBoundaryFlags.mutation_controls ? "destructive" : "success"} className="text-[10px]">
+              mutations: {cockpitBoundaryFlags.mutation_controls ? "enabled" : "off"}
+            </Badge>
+          </div>
+          <div className="grid gap-3 xl:grid-cols-4">
+            <CockpitPanelSummary label="Gate D" panel={cockpitStatus.gate_d} />
+            <CockpitPanelSummary label="GitHub Watcher" panel={cockpitStatus.github_watcher_no_agent} />
+            <CockpitPanelSummary label="Supabase Boundary" panel={cockpitStatus.supabase_role_boundary} />
+            <CockpitPanelSummary label="Obsidian Merge Review" panel={cockpitStatus.obsidian_merge_review} />
+          </div>
+          <dl className="grid gap-2 md:grid-cols-2">
+            <div>
+              <dt className="text-xs uppercase text-muted-foreground">handoff summary</dt>
+              <dd className="normal-case text-muted-foreground">
+                {cockpitSummary?.handoff_summary ?? "No cockpit summary loaded yet."}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-muted-foreground">safe next step</dt>
+              <dd className="normal-case text-muted-foreground">
+                {cockpitSummary?.safe_next_action ?? cockpitBlockers?.safe_next_action ?? "Keep observe until verified."}
+              </dd>
+            </div>
+          </dl>
+          <p className="text-xs text-muted-foreground normal-case">
+            Visible read-only cockpit: backend/API readback only; no action controls, no browser-side Supabase access, no public endpoint.
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <CardTitle className="flex items-center gap-2 text-sm uppercase">
+            <ShieldCheck className="h-4 w-4" />
+            Morning Brief v0.2 Gate B/C Verification
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 p-4 text-sm">
+          <div className="flex flex-wrap gap-2 uppercase">
+            <Badge tone={v0Canary?.enabled ? "success" : "secondary"} className="text-[10px]">
+              {v0Canary?.enabled ? "local readback pass" : "safe disabled"}
+            </Badge>
+            <Badge tone="secondary" className="text-[10px]">
+              Hermes DB readback: {v0Canary?.hermes_direct_db_verification ? "yes" : "no"}
+            </Badge>
+            <Badge tone={v0Canary?.boundaries?.webui_mutation_enabled ? "destructive" : "success"} className="text-[10px]">
+              webui mutation: {v0Canary?.boundaries?.webui_mutation_enabled ? "enabled" : "off"}
+            </Badge>
+          </div>
+          {v0Canary?.enabled ? (
+            <dl className="grid gap-2 md:grid-cols-2">
+              <div><dt className="text-xs uppercase text-muted-foreground">Canary key</dt><dd className="break-all font-mono-ui text-xs">{v0Canary.canary_key}</dd></div>
+              <div><dt className="text-xs uppercase text-muted-foreground">Result</dt><dd>{v0Canary.gateb_verification_result}</dd></div>
+              <div><dt className="text-xs uppercase text-muted-foreground">Verification</dt><dd>{v0Canary.verification_status}</dd></div>
+              <div><dt className="text-xs uppercase text-muted-foreground">Rollback</dt><dd>{v0Canary.rollback_status}</dd></div>
+              <div className="md:col-span-2"><dt className="text-xs uppercase text-muted-foreground">Evidence source</dt><dd>{v0Canary.verification_source}</dd></div>
+              <div className="md:col-span-2"><dt className="text-xs uppercase text-muted-foreground">Snapshot ref</dt><dd className="break-all font-mono-ui text-xs">{v0Canary.report_snapshot_ref}</dd></div>
+            </dl>
+          ) : (
+            <div className="rounded-md border border-warning/30 bg-warning/10 p-3">
+              <p className="text-sm font-semibold uppercase text-warning">Safe disabled</p>
+              <p className="text-sm text-muted-foreground">{v0Canary?.reason ?? "morning_brief_v0_canary_not_configured"}</p>
+            </div>
+          )}
+          <p className="text-xs text-muted-foreground normal-case">
+            Read-only only: no browser-side Supabase secret, no DB mutation, no Telegram send, no cron/routine integration.
+          </p>
+        </CardContent>
+      </Card>
+
       <div className="grid gap-4 xl:grid-cols-2">
         <Card>
           <CardHeader className="py-3 px-4">
             <CardTitle className="text-sm uppercase">Latest Morning Brief Run</CardTitle>
           </CardHeader>
           <CardContent className="space-y-2 p-4 text-sm">
+            <div className="flex flex-wrap gap-2 uppercase">
+              <Badge tone="success" className="text-[10px]">Reader Mode</Badge>
+              <Badge tone="secondary" className="text-[10px]">latest-run scoped</Badge>
+            </div>
             {run ? (
               <>
                 <p className="font-semibold text-foreground">{run.title}</p>
@@ -172,21 +494,77 @@ export default function ControlPlanePage() {
               Counts / Verification
             </CardTitle>
           </CardHeader>
-          <CardContent className="p-4">
-            <div className="grid gap-2 md:grid-cols-2">
-              {Object.entries(data?.counts ?? {}).map(([key, value]) => (
-                <div key={key} className="rounded-md border border-current/15 p-3">
-                  <p className="text-xs uppercase text-muted-foreground">{key}</p>
-                  <p className="text-lg font-semibold text-foreground">{value}</p>
-                </div>
-              ))}
-              {loading && !data && (
-                <p className="text-sm text-muted-foreground">Loading verification counts…</p>
-              )}
-            </div>
+          <CardContent className="space-y-4 p-4">
+            <CountCards title="Latest run counts" counts={data?.latest_run_counts} />
+            <CountCards title="Control-plane totals" counts={data?.counts} />
+            {loading && !data && (
+              <p className="text-sm text-muted-foreground">Loading verification counts…</p>
+            )}
           </CardContent>
         </Card>
       </div>
+
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <CardTitle className="flex items-center gap-2 text-sm uppercase">
+            <ShieldCheck className="h-4 w-4" />
+            Source Safety Preview
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 p-4 text-sm">
+          {safetyPreview && !safetyPreview.enabled && (
+            <div className="rounded-md border border-warning/30 bg-warning/10 p-3">
+              <p className="text-sm font-semibold uppercase text-warning">Safety preview disabled</p>
+              <p className="text-sm text-muted-foreground">
+                {safetyPreview.reason}: {safetyPreview.message}
+              </p>
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2 uppercase">
+            <Badge tone={severityTone(safetyPreview?.severity)} className="text-[10px]">
+              severity: {safetyPreview?.severity ?? "loading"}
+            </Badge>
+            <Badge tone={safetyPreview?.source_safety?.state === "has_quarantine" ? "warning" : "success"} className="text-[10px]">
+              source safety: {safetyPreview?.source_safety?.state ?? "loading"}
+            </Badge>
+            <Badge tone={safetyPreview?.rollback_readiness?.publish_blocked ? "warning" : "success"} className="text-[10px]">
+              publish_blocked: {safetyPreview?.rollback_readiness?.publish_blocked ? "yes" : "no"}
+            </Badge>
+            <Badge tone={safetyPreview?.boundaries?.webui_mutation_enabled ? "destructive" : "success"} className="text-[10px]">
+              webui mutation: {safetyPreview?.boundaries?.webui_mutation_enabled ? "enabled" : "off"}
+            </Badge>
+          </div>
+          <dl className="grid gap-2 md:grid-cols-2">
+            <div>
+              <dt className="text-xs uppercase text-muted-foreground">quarantined_source_count</dt>
+              <dd className="text-lg font-semibold text-foreground">
+                {safetyPreview?.source_safety?.quarantined_source_count ?? 0}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-muted-foreground">notification action</dt>
+              <dd>{safetyPreview?.notification_readiness?.action_state ?? "preview_only"}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-muted-foreground">authority state</dt>
+              <dd>{safetyPreview?.authority_boundary?.state ?? "no_obsidian_ref"}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-muted-foreground">rollback available</dt>
+              <dd>{safetyPreview?.rollback_readiness?.available ? "yes" : "no"}</dd>
+            </div>
+            <div className="md:col-span-2">
+              <dt className="text-xs uppercase text-muted-foreground">publish block reason</dt>
+              <dd className="normal-case text-muted-foreground">
+                {safetyPreview?.rollback_readiness?.publish_block_reason_kr ?? "No safety preview loaded yet."}
+              </dd>
+            </div>
+          </dl>
+          <p className="text-xs text-muted-foreground normal-case">
+            Read-only safety preview: no send controls, no browser-side Supabase access, no cron change, no Obsidian authority edit.
+          </p>
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader className="py-3 px-4">
@@ -239,15 +617,15 @@ export default function ControlPlanePage() {
       <div className="grid gap-4 xl:grid-cols-2">
         <Card>
           <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Sections</CardTitle></CardHeader>
-          <CardContent className="p-4"><JsonList value={data?.sections} /></CardContent>
+          <CardContent className="p-4"><SectionCards sections={data?.sections} /></CardContent>
         </Card>
         <Card>
           <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Source Anchors</CardTitle></CardHeader>
-          <CardContent className="p-4"><JsonList value={data?.sources} /></CardContent>
+          <CardContent className="p-4"><SourceAnchorCards sources={data?.sources} /></CardContent>
         </Card>
         <Card>
           <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Delivery Events</CardTitle></CardHeader>
-          <CardContent className="p-4"><JsonList value={data?.delivery_events} /></CardContent>
+          <CardContent className="p-4"><DeliveryEventCards events={data?.delivery_events} /></CardContent>
         </Card>
         <Card>
           <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Audit Events</CardTitle></CardHeader>


### PR DESCRIPTION
## Summary
- Add a HERA-198 Morning Brief control-plane canary payload endpoint for WebUI cockpit readback.
- Add a Telegram-safe preview endpoint that redacts restricted delivery fields.
- Add a Control Plane page surface in WebUI with Morning Brief canary status, delivery summary, handoff queue, verification checks, and rollout gates.
- Add tests for the control-plane endpoints and Telegram-safe redaction behavior.

## Safety / Boundaries
- Preview-only canary data; no production schema migration.
- No Obsidian authority-file changes.
- No cron/routine changes.
- No Telegram sends.
- No WebUI production route replacement.
- No historical report bulk migration.

## Verification
- `python -m pytest tests/hermes_cli/test_web_server.py -q`
- Local diff public-exposure scan: PASS, with only reviewed false-positive route-decorator hits.
- Remote fork branch diff public-exposure scan: PASS, with only reviewed false-positive route-decorator hits.

## Notes
- Draft PR for design and implementation review before any durable control-plane rollout.
