### PR TITLE
refactor(gmi): declare User-Agent attribution on provider profile (salvage #20907)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2141,6 +2141,20 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         )
     elif base_url_host_matches(sync_base_url, "api.kimi.com"):
         async_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+    else:
+        # Fall back to profile.default_headers for providers that declare
+        # client-level headers on their ProviderProfile (e.g. attribution
+        # User-Agent strings). Provider is inferred from the hostname.
+        try:
+            from agent.model_metadata import _infer_provider_from_url
+            from providers import get_provider_profile as _gpf_async
+            _inferred = _infer_provider_from_url(sync_base_url)
+            if _inferred:
+                _ph_async = _gpf_async(_inferred)
+                if _ph_async and _ph_async.default_headers:
+                    async_kwargs["default_headers"] = dict(_ph_async.default_headers)
+        except Exception:
+            pass
     return AsyncOpenAI(**async_kwargs), model
 
 
@@ -2368,6 +2382,16 @@ def resolve_provider_client(
                 extra["default_headers"] = copilot_request_headers(
                     is_agent_turn=True, is_vision=is_vision
                 )
+            else:
+                # Fall back to profile.default_headers for providers that
+                # declare client-level attribution headers on their profile.
+                try:
+                    from providers import get_provider_profile as _gpf_custom
+                    _ph_custom = _gpf_custom(provider)
+                    if _ph_custom and _ph_custom.default_headers:
+                        extra["default_headers"] = dict(_ph_custom.default_headers)
+                except Exception:
+                    pass
             client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
             client = _wrap_if_needed(client, final_model, custom_base, custom_key)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
@@ -2556,6 +2580,18 @@ def resolve_provider_client(
             headers.update(copilot_request_headers(
                 is_agent_turn=True, is_vision=is_vision
             ))
+        else:
+            # Fall back to profile.default_headers for providers that declare
+            # client-level attribution headers on their profile (e.g. GMI
+            # User-Agent for traffic identification, Vercel AI Gateway
+            # Referer/Title for analytics).
+            try:
+                from providers import get_provider_profile as _gpf_main
+                _ph_main = _gpf_main(provider)
+                if _ph_main and _ph_main.default_headers:
+                    headers.update(_ph_main.default_headers)
+            except Exception:
+                pass
         client = OpenAI(api_key=api_key, base_url=base_url,
                         **({"default_headers": headers} if headers else {}))
 

--- a/plugins/model-providers/gmi/__init__.py
+++ b/plugins/model-providers/gmi/__init__.py
@@ -1,5 +1,6 @@
 """GMI Cloud provider profile."""
 
+from hermes_cli import __version__ as _HERMES_VERSION
 from providers import register_provider
 from providers.base import ProviderProfile
 
@@ -12,6 +13,10 @@ gmi = ProviderProfile(
     env_vars=("GMI_API_KEY", "GMI_BASE_URL"),
     base_url="https://api.gmi-serving.com/v1",
     auth_type="api_key",
+    # Attribution so GMI can identify traffic from Hermes Agent.
+    # The generic profile.default_headers fallback in run_agent.py and
+    # agent/auxiliary_client.py picks this up at client construction time.
+    default_headers={"User-Agent": f"HermesAgent/{_HERMES_VERSION}"},
     default_aux_model="google/gemini-3.1-flash-lite-preview",
     fallback_models=(
         "zai-org/GLM-5.1-FP8",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -696,6 +696,7 @@ AUTHOR_MAP = {
     "mike@mikewaters.net": "mikewaters",
     "65117428+WadydX@users.noreply.github.com": "WadydX",
     "216480837+isaachuangGMICLOUD@users.noreply.github.com": "isaachuangGMICLOUD",
+    "isaac.h@gmicloud.ai": "isaachuangGMICLOUD",
     "nukuom976228@gmail.com": "hsy5571616",
     "11462216+Nan93@users.noreply.github.com": "Nan93",
     "l973401489@126.com": "zhouxiaoya12",

--- a/tests/hermes_cli/test_gmi_provider.py
+++ b/tests/hermes_cli/test_gmi_provider.py
@@ -284,6 +284,22 @@ class TestGmiAuxiliary:
         assert model == "google/gemini-3.1-flash-lite-preview"
         assert mock_openai.call_args.kwargs["api_key"] == "gmi-test-key"
         assert mock_openai.call_args.kwargs["base_url"] == "https://api.gmi-serving.com/v1"
+        # GMI profile declares default_headers with a HermesAgent User-Agent
+        # for traffic attribution. The generic profile-fallback branch in
+        # resolve_provider_client should carry it through to the OpenAI client.
+        headers = mock_openai.call_args.kwargs.get("default_headers", {})
+        assert headers.get("User-Agent", "").startswith("HermesAgent/")
+
+    def test_gmi_profile_declares_hermes_user_agent(self):
+        """The GMI plugin sets a HermesAgent/<ver> User-Agent on its profile."""
+        from providers import get_provider_profile
+
+        profile = get_provider_profile("gmi")
+        assert profile is not None
+        ua = profile.default_headers.get("User-Agent", "")
+        assert ua.startswith("HermesAgent/"), (
+            f"expected GMI profile User-Agent to start with 'HermesAgent/', got {ua!r}"
+        )
 
     def test_resolve_provider_client_accepts_gmi_alias(self, monkeypatch):
         monkeypatch.setenv("GMI_API_KEY", "gmi-test-key")

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -66,6 +66,31 @@ def test_routermint_base_url_applies_user_agent_header(mock_openai):
 
 
 @patch("run_agent.OpenAI")
+def test_gmi_base_url_picks_up_profile_user_agent(mock_openai):
+    """GMI declares User-Agent on its ProviderProfile.default_headers.
+
+    The ``_apply_client_headers_for_base_url`` else-branch looks up the
+    provider profile and applies its default_headers, so no GMI-specific
+    branch is needed in run_agent.
+    """
+    mock_openai.return_value = MagicMock()
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://api.gmi-serving.com/v1",
+        model="test/model",
+        provider="gmi",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    agent._apply_client_headers_for_base_url("https://api.gmi-serving.com/v1")
+
+    headers = agent._client_kwargs["default_headers"]
+    assert headers["User-Agent"].startswith("HermesAgent/")
+
+
+@patch("run_agent.OpenAI")
 def test_unknown_base_url_clears_default_headers(mock_openai):
     mock_openai.return_value = MagicMock()
     agent = AIAgent(


### PR DESCRIPTION
## Summary

Adds a `User-Agent: HermesAgent/<version>` header on all outbound requests to `api.gmi-serving.com` so GMI can identify traffic from Hermes Agent.

Based on #20907 by @isaachuangGMICLOUD.

## Approach

Instead of sprinkling GMI-specific `elif base_url_host_matches(..., "api.gmi-serving.com"):` branches across `run_agent.py` and `agent/auxiliary_client.py`, this revision uses the existing `ProviderProfile.default_headers` field (already commented as *"Client-level quirks (set once at client construction)"*) and the generic profile-fallback plumbing that's already there for that purpose.

**GMI plugin owns the header:**
```python
# plugins/model-providers/gmi/__init__.py
gmi = ProviderProfile(
    name="gmi",
    base_url="https://api.gmi-serving.com/v1",
    default_headers={"User-Agent": f"HermesAgent/{_HERMES_VERSION}"},
    ...
)
```

Other plugins already use this pattern for the same purpose — `ai-gateway` (HTTP-Referer + X-Title) and `kimi-coding` (User-Agent).

**Two of the four client-construction sites already had a profile-fallback `else` branch** that picks up `profile.default_headers` after the URL-specific hardcodes miss. Both `run_agent.py` sites (`__init__` client construction and `_apply_client_headers_for_base_url`) already had it. This PR adds the same generic fallback block to the remaining two sites in `agent/auxiliary_client.py` (`_to_async_client` and `resolve_provider_client`'s main path), closing the asymmetry.

As a side benefit, this also fixes a pre-existing gap: `ai-gateway`'s `HTTP-Referer` / `X-Title` attribution headers now flow through `_to_async_client` too.

## Files changed

| File | Change |
|------|--------|
| `plugins/model-providers/gmi/__init__.py` | +5 — `default_headers={"User-Agent": ...}` on GMI profile |
| `agent/auxiliary_client.py` | +36 — generic `else: profile.default_headers` fallback in two sites (applies to every provider that declares `default_headers`, not just GMI) |
| `tests/hermes_cli/test_gmi_provider.py` | +16 — assert aux client carries the UA header; assert GMI profile declares it |
| `tests/run_agent/test_provider_attribution_headers.py` | +25 — `_apply_client_headers_for_base_url` picks up the profile's UA |
| `scripts/release.py` | +1 — AUTHOR_MAP entry for `isaac.h@gmicloud.ai` |

**Net diff: `+83/-0` across 5 files. No core files (`run_agent.py`, `cli.py`, `gateway/`) are modified.**

## What data GMI receives

Only `User-Agent: HermesAgent/<version>`. No `HTTP-Referer`, no `X-Title`, no `X-OpenRouter-Categories` (those are OpenRouter-specific). The OpenAI Python SDK always sends `X-Stainless-*` telemetry headers (OS, arch, runtime version) — SDK behavior, same for every provider.

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_gmi_provider.py tests/run_agent/test_provider_attribution_headers.py tests/agent/test_auxiliary_client.py tests/providers/` — **253 passed**.
- E2E integration check (real imports, all four client-construction paths):
  - profile declares UA ✓
  - `resolve_provider_client("gmi")` main path applies UA ✓
  - `_to_async_client` applies UA via hostname inference ✓
  - `AIAgent._apply_client_headers_for_base_url` applies UA via profile fallback ✓
- Ruff clean on the diff.

Closes #20907
