### PR TITLE
feat(dashboard): add /api/local-token and /health endpoints

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -106,6 +106,7 @@ _PUBLIC_API_PATHS: frozenset = frozenset({
     "/api/dashboard/themes",
     "/api/dashboard/plugins",
     "/api/dashboard/plugins/rescan",
+    "/api/local-token",
 })
 
 
@@ -479,6 +480,21 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
         except Exception:
             continue
     return False, None
+
+
+@app.get("/api/local-token")
+async def get_local_token(request: Request):
+    """Return session token for localhost clients only — no auth required."""
+    client_ip = (request.client.host if request.client else "") or ""
+    if client_ip not in ("127.0.0.1", "::1", "localhost", ""):
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return {"token": _SESSION_TOKEN}
+
+
+@app.get("/health")
+async def health_check():
+    """Health check for hermes-web-ui compatibility."""
+    return {"status": "ok"}
 
 
 @app.get("/api/status")


### PR DESCRIPTION
## Summary

- **`GET /api/local-token`** — returns the ephemeral session token for localhost clients only (`127.0.0.1` / `::1`). No auth required. This lets companion web UIs (e.g. [hermes-web-ui](https://github.com/NousResearch/hermes-web-ui)) auto-fetch the token on startup and skip the manual login step that was required after every server restart.
- **`GET /health`** — returns `{"status": "ok"}` for health-check compatibility with hermes-web-ui and any other client that probes this standard path.
- `/api/local-token` is added to `_PUBLIC_API_PATHS` so the auth middleware does not intercept it before the route handler runs.

## Motivation

The dashboard generates a new random `_SESSION_TOKEN` on every startup. Users of hermes-web-ui had to manually copy-paste the token from the console log into the login form after every reboot. The `/api/local-token` endpoint enables the companion UI to recover the current token automatically without exposing it to non-localhost clients.

## Security

- `/api/local-token` checks `request.client.host` and returns `403 Forbidden` for any non-localhost origin. Since the dashboard's CORS policy already restricts to localhost origins, this is an additional defence-in-depth check.
- `/health` carries no sensitive information.

## Test plan

- [ ] `curl http://127.0.0.1:9119/api/local-token` returns `{"token": "<current token>"}` from localhost
- [ ] `curl http://127.0.0.1:9119/health` returns `{"status": "ok"}`
- [ ] Accessing `/api/local-token` from a non-localhost IP returns `403`
- [ ] Existing auth middleware still protects all other `/api/` routes