### PR TITLE
feat(tui): Esc interrupts running agent turn

### DIFF
--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -420,6 +420,21 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return voiceRecordToggle()
     }
 
+    // Esc while agent is running → interrupt the turn (same as Ctrl+C in busy
+    // state, but without the clear-draft / exit fallbacks).  Guard: must not
+    // be blocked by an overlay (approval, clarify, pager, etc.) — those are
+    // handled above in the `isBlocked` branch and never reach here anyway, but
+    // the explicit check keeps the intent readable.  Also skip when completions
+    // are open so Esc can first dismiss the autocomplete list.
+    if (key.escape && live.busy && live.sid && !isBlocked && !cState.completions.length) {
+      return turnController.interruptTurn({
+        appendMessage: actions.appendMessage,
+        gw: gateway.gw,
+        sid: live.sid,
+        sys: actions.sys
+      })
+    }
+
     // Queue-edit cancel beats selection-clear for plain Esc: the queue header
     // explicitly promises "Esc cancel", so honoring it takes priority over the
     // implicit selection-dismissal convention. Without an active edit, fall through.

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -311,7 +311,7 @@ const ComposerPane = memo(function ComposerPane({
                   onChange={composer.updateInput}
                   onPaste={composer.handleTextPaste}
                   onSubmit={composer.submit}
-                  placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'Ctrl+C to interrupt…' : ''}
+                  placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'Esc / Ctrl+C to interrupt…' : ''}
                   value={composer.input}
                   voiceRecordKey={composer.voiceRecordKey}
                 />

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -17,6 +17,7 @@ const copyHotkeys: [string, string][] = isMac
 
 export const HOTKEYS: [string, string][] = [
   ...copyHotkeys,
+  ['Esc', 'interrupt (when busy) / cancel queue edit / clear selection'],
   [action + '+D', 'exit'],
   [action + '+G / Alt+G', 'open $EDITOR (Alt+G fallback for VSCode/Cursor)'],
   [action + '+L', 'redraw / repaint'],


### PR DESCRIPTION
## Problem

Pressing `Ctrl+C` in the TUI is the only way to interrupt a running agent turn.
This creates a conflict on macOS where `Ctrl+C` is also the primary copy shortcut
(#16181): users who want to copy an error mid-run accidentally interrupt the agent instead.

`Esc` is the universally expected "cancel" key in terminal UIs (vim, less, fzf, Claude Code).
Hermes TUI already uses `Esc` for overlay dismissal and queue-edit cancellation;
extending it to agent interruption is the natural next step.

Related: #16181, #11352, #11355, #4903

## Solution

When the agent is busy, `Esc` calls `turnController.interruptTurn()` — the same
path `Ctrl+C` takes — without the clear-draft or exit fallbacks.

`Ctrl+C` behavior is **unchanged**.

## Changes

**`useInputHandlers.ts`** — one guard block before the existing queue-edit handler:

```ts
if (isInterruptKey(key, ch, interruptKey) && live.busy && live.sid && !isBlocked && !cState.completions.length) {
  return turnController.interruptTurn({ ... })
}
```

Guards: `live.busy` (turn running), `live.sid` (session exists), `!isBlocked` (no overlay),
`!cState.completions.length` (autocomplete gets Esc first).

All existing non-busy Esc behavior preserved: voice-record chord, queue-edit cancel, selection clear.

**`hotkeys.ts`** — Esc added to `/hotkeys` table.

**`appLayout.tsx`** — busy placeholder updated to `Esc / Ctrl+C to interrupt…`.

## Testing

Build passes. Manual:
- Esc during stream → interrupts, shows `*[interrupted]*`
- Esc with autocomplete open → dismisses list, does not interrupt
- Esc with overlay open → overlay handles it, no interrupt
- Esc while idle → existing behavior unchanged
- Ctrl+C unchanged in all states

## Notes

**Diff scope**: this branch also contains the follow-up commit from #21720.
The changes for *this* PR are the first commit only (`7785cf6`).

Configurable keybinding (`display.interrupt_key`) is in #21720 (depends on this PR).
