### PR TITLE
fix(tui): pass --expose-gc as node argv instead of NODE_OPTIONS

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1067,7 +1067,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             p = Path(ext_dir)
             if (p / "dist" / "entry.js").exists() and not _tui_need_npm_install(p):
                 node = _node_bin("node")
-                return [node, str(p / "dist" / "entry.js")], p
+                return [node, "--expose-gc", str(p / "dist" / "entry.js")], p
 
     npm = _node_bin("npm")
     if _tui_need_npm_install(tui_dir):
@@ -1134,7 +1134,7 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
         sys.exit(1)
 
     node = _node_bin("node")
-    return [node, str(root / "dist" / "entry.js")], root
+    return [node, "--expose-gc", str(root / "dist" / "entry.js")], root
 
 
 def _normalize_tui_toolsets(toolsets: object) -> list[str]:
@@ -1256,16 +1256,16 @@ def _launch_tui(
         env["HERMES_TUI_TOOL_PROGRESS"] = "off"
     if accept_hooks:
         env["HERMES_ACCEPT_HOOKS"] = "1"
-    # Guarantee an 8GB V8 heap + exposed GC for the TUI. Default node cap is
-    # ~1.5–4GB depending on version and can fatal-OOM on long sessions with
-    # large transcripts / reasoning blobs. Token-level merge: respect any
-    # user-supplied --max-old-space-size (they may have set it higher) and
-    # avoid duplicating --expose-gc.
+    # Guarantee an 8GB V8 heap for the TUI. Default node cap is ~1.5–4GB
+    # depending on version and can fatal-OOM on long sessions with large
+    # transcripts / reasoning blobs. Token-level merge: respect any
+    # user-supplied --max-old-space-size (they may have set it higher).
+    # --expose-gc is *not* added here: Node rejects it in NODE_OPTIONS
+    # ("--expose-gc is not allowed in NODE_OPTIONS") and refuses to start.
+    # It is passed as a direct argv flag in _make_tui_argv() instead.
     _tokens = env.get("NODE_OPTIONS", "").split()
     if not any(t.startswith("--max-old-space-size=") for t in _tokens):
         _tokens.append("--max-old-space-size=8192")
-    if "--expose-gc" not in _tokens:
-        _tokens.append("--expose-gc")
     env["NODE_OPTIONS"] = " ".join(_tokens)
     if resume_session_id:
         env["HERMES_TUI_RESUME"] = resume_session_id


### PR DESCRIPTION
## Summary

`hermes --tui` fails to start on every modern Node release with:

```
node: --expose-gc is not allowed in NODE_OPTIONS
```

`_launch_tui()` was appending `--expose-gc` to `NODE_OPTIONS` before spawning the TUI. Node restricts `NODE_OPTIONS` to a small allowlist (so anything able to set env vars on a node child can't unilaterally enable arbitrary capabilities) — `--expose-gc` is not on that list and never has been. It must be passed as a direct argv flag.

The intent (manual GC for long sessions to avoid fatal-OOM on large transcripts / reasoning blobs) is preserved by inserting `--expose-gc` directly into the `node` argv inside `_make_tui_argv()` — same effect, but actually allowed.

`--max-old-space-size=8192` stays in `NODE_OPTIONS` because it *is* allowlisted, and keeping it there means downstream `node` spawns inherit the same heap cap without re-threading the flag through every spawn site.

The dev paths (`tsx src/entry.tsx` and `npm start` fallback) are intentionally left alone — they don't accept `node` flags directly, and the production dist path is the one users actually hit via `hermes --tui`. The shebang in `ui-tui/src/entry.tsx` already documents the intended flags for direct execution.

## Repro (before fix)

```
$ hermes --tui
/usr/bin/node: --expose-gc is not allowed in NODE_OPTIONS
```

## Test plan

- [x] `hermes --tui` starts without the `--expose-gc is not allowed` error on Node v18.20.8 (Linux/WSL2)
- [x] `import hermes_cli.main` succeeds (no syntax regressions)
- [ ] Manual smoke: long-running TUI session still has 8GB heap and a callable `global.gc()`