### PR TITLE
fix(gateway): drop non-path MEDIA captures before sending

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -63,6 +63,22 @@ def should_send_media_as_audio(platform, ext: str, is_voice: bool = False) -> bo
     return True
 
 
+def _looks_like_absolute_path(path: str) -> bool:
+    """Return True if *path* looks like an absolute filesystem path.
+
+    Accepts POSIX-absolute paths (``/foo``) and Windows drive paths
+    (``C:\\foo`` or ``C:/foo``).  Tilde paths must already be expanded
+    via ``os.path.expanduser`` before this check.
+    """
+    if not path:
+        return False
+    if path[0] == '/':
+        return True
+    if len(path) >= 3 and path[0].isalpha() and path[1] == ':' and path[2] in '\\/':
+        return True
+    return False
+
+
 def utf16_len(s: str) -> int:
     """Count UTF-16 code units in *s*.
 
@@ -1928,12 +1944,28 @@ class BasePlatformAdapter(ABC):
             r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
         for match in media_pattern.finditer(content):
-            path = match.group("path").strip()
+            raw = match.group("path").strip()
+            path = raw
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
-            if path:
-                media.append((os.path.expanduser(path), has_voice_tag))
+            if not path:
+                continue
+            expanded = os.path.expanduser(path)
+            # The regex's trailing ``\S+`` alternative is a permissive
+            # fallback that can capture arbitrary non-whitespace tokens
+            # (e.g. ``.ogg``, regex fragments echoed in tool output, or
+            # debug placeholders).  Hand only absolute-looking paths to
+            # the platform sender — anything else gets logged and
+            # dropped so we don't pass bogus strings to ``send_voice`` /
+            # ``send_image_file``.  See #21527.
+            if not _looks_like_absolute_path(expanded):
+                logger.warning(
+                    "[extract_media] Discarding non-path MEDIA value: %r",
+                    raw,
+                )
+                continue
+            media.append((expanded, has_voice_tag))
 
         # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)
         if media:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -360,6 +360,48 @@ class TestExtractMedia:
         assert "[[audio_as_voice]]" not in cleaned
         assert "[[as_document]]" not in cleaned
 
+    def test_media_tag_with_bare_extension_is_dropped(self):
+        """Regression: ``MEDIA:.ogg`` must not be passed to the platform
+        sender — the regex's permissive ``\\S+`` fallback used to capture
+        such tokens, producing ``File not found: .ogg`` errors.  See
+        #21527."""
+        content = "MEDIA:.ogg"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert media == []
+
+    def test_media_tag_with_relative_path_is_dropped(self):
+        """A relative path is not safe to feed to ``send_voice`` /
+        ``send_image_file`` — those resolve against the gateway CWD,
+        which is not what an LLM-emitted relative path implies.  See
+        #21527."""
+        content = "MEDIA:relative/audio.ogg"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert media == []
+
+    def test_media_tag_with_regex_fragment_is_dropped(self):
+        """Regression for #21527: when the regex pattern itself appeared
+        in the content (e.g. echoed back through error logs), the
+        ``\\S+`` fallback would happily capture the pattern fragment as
+        a "path".  These must be dropped, not sent."""
+        content = "MEDIA:.(?:png|jpe?g|gif)"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert media == []
+
+    def test_media_tag_mix_of_valid_and_invalid_keeps_valid(self):
+        """A response with a malformed MEDIA tag alongside a good one
+        should still deliver the good one."""
+        content = "MEDIA:.ogg\nMEDIA:/tmp/good.ogg"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/good.ogg", False)]
+
+    def test_media_tag_windows_drive_path_is_kept(self):
+        """Windows-style drive paths look absolute and must be accepted
+        even though gateway typically runs on Linux."""
+        content = "MEDIA:'C:\\\\Users\\\\me\\\\out.png'"
+        media, _ = BasePlatformAdapter.extract_media(content)
+        assert len(media) == 1
+        assert media[0][0].startswith("C:")
+
 
 # ---------------------------------------------------------------------------
 # should_send_media_as_audio


### PR DESCRIPTION
Validate that paths captured by extract_media() look absolute before handing them to the platform's media sender, so malformed `MEDIA:` tags produced by the LLM don't reach `send_voice` / `send_image_file` as bogus filesystem paths.

## What changed and why
- The `MEDIA:` regex in `gateway/platforms/base.py` ends with a permissive `\S+` fallback that captures any non-whitespace token. When the LLM emitted a malformed tag (e.g. `MEDIA:.ogg`) or when a regex fragment leaked back through error logs, the fallback would happily produce values like `.ogg` or `.(?:png|jpe?g|...)` and pass them straight to `os.path.exists()` — producing the `[Telegram] Failed to send media (...): File not found: ...` errors in the bug report.
- Added a small `_looks_like_absolute_path()` helper that accepts POSIX-absolute paths (`/foo`) and Windows drive paths (`C:\foo` / `C:/foo`). Captures that don't pass are logged at warning level (with the original raw match for debugging) and skipped.
- Tilde paths still work: `os.path.expanduser` runs before the check, so `~/foo` becomes `/home/user/foo` and passes.
- Mix-of-valid-and-invalid behavior preserved: if any captured tag is a real path, the entire `MEDIA:` text region is still stripped from user-visible content via the existing `media_pattern.sub('', cleaned)` call.

## How to test
- `pytest tests/gateway/test_platform_base.py -q` (95 passed locally)
- New regression tests cover: bare extension (`MEDIA:.ogg`), relative path, regex fragment, mixed valid+invalid input, and Windows drive paths.
- Manual: send a Telegram message that triggers TTS and verify the gateway log no longer reports `File not found: <regex-or-extension-fragment>`.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #21527

<!-- autocontrib:worker-id=issue-new-1b8c34c8 kind=pr-open -->