### PR TITLE
fix(feishu): skip stale messages on gateway restart to prevent infinite replay loop

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1388,6 +1388,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._pending_inbound_lock = threading.Lock()
         self._pending_drain_scheduled = False
         self._pending_inbound_max_depth = 1000  # cap queue; drop oldest beyond
+        self._adapter_start_time: float = 0.0  # set on connect(); used to skip stale inbound events
         self._chat_locks: Dict[str, asyncio.Lock] = {}  # chat_id → lock (per-chat serial processing)
         self._sent_message_ids_to_chat: Dict[str, str] = {}  # message_id → chat_id (for reaction routing)
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
@@ -1604,6 +1605,7 @@ class FeishuAdapter(BasePlatformAdapter):
             self._loop = asyncio.get_running_loop()
             await self._connect_with_retry()
             self._mark_connected()
+            self._adapter_start_time = time.time()
             logger.info("[Feishu] Connected in %s mode (%s)", self._connection_mode, self._domain_name)
             return True
         except Exception as exc:
@@ -2255,6 +2257,27 @@ class FeishuAdapter(BasePlatformAdapter):
         if not message or not sender or not getattr(sender, "sender_id", None):
             logger.debug("[Feishu] Dropping malformed inbound event: missing message/sender")
             return
+
+        # Skip stale messages that predate this adapter instance (e.g. events
+        # queued on the Feishu server while the gateway was down and delivered
+        # on reconnect).  Without this guard a "restart" message sent while
+        # the gateway was offline would be replayed on startup, potentially
+        # creating an infinite restart loop.
+        if self._adapter_start_time > 0:
+            create_time_raw = getattr(message, "create_time", None)
+            if create_time_raw is not None:
+                try:
+                    # Feishu SDK exposes create_time as a millisecond string
+                    create_time = float(create_time_raw) / 1000.0
+                    if create_time < self._adapter_start_time - 5.0:
+                        logger.info(
+                            "[Feishu] Skipping stale message %s (created %.1fs before adapter start)",
+                            getattr(message, "message_id", "?"),
+                            self._adapter_start_time - create_time,
+                        )
+                        return
+                except (ValueError, TypeError):
+                    pass  # unparseable — let the message through
 
         message_id = getattr(message, "message_id", None)
         if not message_id or self._is_duplicate(message_id):


### PR DESCRIPTION
## Problem

After a gateway restart (container reset/upgrade/crash), the Feishu platform replays all queued inbound events without checking timestamps. Old messages from hours ago are treated as new, causing the agent to process outdated commands.

In the worst case this creates an **infinite restart loop**: user sends "restart" while gateway was down → gateway comes up → replays "restart" → restarts again.

**Reproduction:**
1. Run Hermes v0.13.0 with Feishu connected
2. Send a message like "reboot" or "restart"
3. Restart the gateway (kill process or restart container)
4. Gateway replays the "restart" message → restart loop

## Fix

Records the adapter's start time (`_adapter_start_time`) in `connect()` and checks each inbound message's `create_time` against it in `_handle_message_event_data()`. Messages created more than 5 seconds before the adapter started are silently dropped with an info-level log.

The 5-second grace period accounts for clock skew between Feishu servers and the local machine.

**Changes** (1 file, +23 lines):
- `gateway/platforms/feishu.py`:
  - `__init__`: add `self._adapter_start_time: float = 0.0`
  - `connect()`: set `self._adapter_start_time = time.time()` after `_mark_connected()`
  - `_handle_message_event_data()`: check `message.create_time` vs `_adapter_start_time`, skip stale messages

## Before vs After

| Scenario | Before | After |
|---|---|---|
| Gateway restart with queued messages | All messages replayed, potential restart loop | Stale messages (>5s old) silently skipped |
| Normal message during operation | Processed normally | Processed normally (create_time > start_time) |
| Message with unparseable create_time | N/A | Falls through to normal processing (safe) |

## Tests

The fix is defensive and backward-compatible:
- `_adapter_start_time = 0.0` by default → stale check is skipped until `connect()` sets it
- `getattr()` used for SDK attributes → no crash if `create_time` is missing
- `try/except (ValueError, TypeError)` → unparseable timestamps let the message through
- 5s grace period → handles minor clock skew

Fixes NousResearch/hermes-agent#21651