### PR TITLE
feat(slack): make reaction emojis configurable via env vars

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1267,6 +1267,20 @@ class SlackAdapter(BasePlatformAdapter):
         """Check if message reactions are enabled via config/env."""
         return os.getenv("SLACK_REACTIONS", "true").lower() not in ("false", "0", "no")
 
+    @staticmethod
+    def _resolve_reaction_emoji(env_suffix: str, default: str) -> str:
+        """Resolve a reaction emoji name from `SLACK_REACTION_<SUFFIX>`.
+
+        Default `eyes` for processing reads as a verdict ("I see what you said")
+        rather than a neutral progress signal. Operators can override per
+        reaction without code change. Pass the name without colons
+        (`writing_hand`, not `:writing_hand:`); leading/trailing colons are
+        stripped defensively. Empty values fall back to the default.
+        """
+        raw = os.getenv(f"SLACK_REACTION_{env_suffix.upper()}", default)
+        cleaned = raw.strip().strip(":").strip()
+        return cleaned or default
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction when message processing begins."""
         if not self._reactions_enabled():
@@ -1276,7 +1290,9 @@ class SlackAdapter(BasePlatformAdapter):
             return
         channel_id = getattr(event.source, "chat_id", None)
         if channel_id:
-            await self._add_reaction(channel_id, ts, "eyes")
+            await self._add_reaction(
+                channel_id, ts, self._resolve_reaction_emoji("processing", "eyes")
+            )
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Swap the in-progress reaction for a final success/failure reaction."""
@@ -1289,11 +1305,17 @@ class SlackAdapter(BasePlatformAdapter):
         channel_id = getattr(event.source, "chat_id", None)
         if not channel_id:
             return
-        await self._remove_reaction(channel_id, ts, "eyes")
+        await self._remove_reaction(
+            channel_id, ts, self._resolve_reaction_emoji("processing", "eyes")
+        )
         if outcome == ProcessingOutcome.SUCCESS:
-            await self._add_reaction(channel_id, ts, "white_check_mark")
+            await self._add_reaction(
+                channel_id, ts, self._resolve_reaction_emoji("success", "white_check_mark")
+            )
         elif outcome == ProcessingOutcome.FAILURE:
-            await self._add_reaction(channel_id, ts, "x")
+            await self._add_reaction(
+                channel_id, ts, self._resolve_reaction_emoji("failure", "x")
+            )
 
     # ----- User identity resolution -----
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1883,6 +1883,65 @@ class TestReactions:
         """SLACK_REACTIONS defaults to true (matches existing behavior)."""
         assert adapter._reactions_enabled() is True
 
+    def test_resolve_reaction_emoji_default(self, adapter, monkeypatch):
+        """Without env override, the default name is returned."""
+        monkeypatch.delenv("SLACK_REACTION_PROCESSING", raising=False)
+        assert adapter._resolve_reaction_emoji("processing", "eyes") == "eyes"
+
+    def test_resolve_reaction_emoji_env_override(self, adapter, monkeypatch):
+        """SLACK_REACTION_<NAME> overrides the default."""
+        monkeypatch.setenv("SLACK_REACTION_PROCESSING", "writing_hand")
+        monkeypatch.setenv("SLACK_REACTION_SUCCESS", "tada")
+        monkeypatch.setenv("SLACK_REACTION_FAILURE", "boom")
+        assert adapter._resolve_reaction_emoji("processing", "eyes") == "writing_hand"
+        assert adapter._resolve_reaction_emoji("success", "white_check_mark") == "tada"
+        assert adapter._resolve_reaction_emoji("failure", "x") == "boom"
+
+    def test_resolve_reaction_emoji_strips_colons(self, adapter, monkeypatch):
+        """Colons in the env value are stripped (operator-friendly input)."""
+        monkeypatch.setenv("SLACK_REACTION_PROCESSING", ":writing_hand:")
+        assert adapter._resolve_reaction_emoji("processing", "eyes") == "writing_hand"
+
+    def test_resolve_reaction_emoji_empty_falls_back(self, adapter, monkeypatch):
+        """Empty or whitespace env value falls back to the default."""
+        monkeypatch.setenv("SLACK_REACTION_PROCESSING", "   ")
+        assert adapter._resolve_reaction_emoji("processing", "eyes") == "eyes"
+
+    @pytest.mark.asyncio
+    async def test_reactions_use_env_overrides_in_message_flow(self, adapter, monkeypatch):
+        """Configured emojis flow through processing_start and processing_complete."""
+        monkeypatch.setenv("SLACK_REACTION_PROCESSING", "hourglass")
+        monkeypatch.setenv("SLACK_REACTION_SUCCESS", "tada")
+        monkeypatch.setenv("SLACK_REACTION_FAILURE", "boom")
+
+        adapter._app.client.reactions_add = AsyncMock()
+        adapter._app.client.reactions_remove = AsyncMock()
+
+        from gateway.platforms.base import MessageEvent, MessageType, SessionSource, ProcessingOutcome
+        from gateway.config import Platform
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="dm",
+            user_id="U_USER",
+        )
+        adapter._reacting_message_ids.add("1234567890.000999")
+        msg_event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="1234567890.000999",
+        )
+        await adapter.on_processing_start(msg_event)
+        await adapter.on_processing_complete(msg_event, ProcessingOutcome.SUCCESS)
+
+        add_calls = adapter._app.client.reactions_add.call_args_list
+        remove_calls = adapter._app.client.reactions_remove.call_args_list
+        # processing add → custom hourglass; success add → custom tada
+        assert [c.kwargs["name"] for c in add_calls] == ["hourglass", "tada"]
+        # remove must use the SAME custom processing emoji that was added
+        assert [c.kwargs["name"] for c in remove_calls] == ["hourglass"]
+
 
 # ---------------------------------------------------------------------------
 # TestThreadReplyHandling


### PR DESCRIPTION
## What

Add three env vars (read lazily; no behavior change unless set):

- `SLACK_REACTION_PROCESSING` — default `eyes`
- `SLACK_REACTION_SUCCESS` — default `white_check_mark`
- `SLACK_REACTION_FAILURE` — default `x`

Pass the emoji name without colons (`writing_hand`, not `:writing_hand:`). Leading/trailing colons are stripped defensively. Empty/whitespace-only values fall back to the default.

`on_processing_complete` resolves the processing emoji again before calling `reactions_remove`, so add/remove stay paired even if configuration changes between start and complete.

## Why

The default `eyes` for the in-progress reaction can read like a verdict ("I see what you said") rather than a neutral progress signal. Operators running the gateway under a persona or brand where this lands wrong currently have no way to override without forking.

The new env vars mirror the existing `SLACK_REACTIONS` pattern in `gateway/platforms/slack.py` (read via `os.getenv` at call time), so the surface stays familiar.

## How to test

```
SLACK_REACTION_PROCESSING=writing_hand \
SLACK_REACTION_SUCCESS=tada \
SLACK_REACTION_FAILURE=boom \
hermes gateway run
```

Send a message via Slack DM. The in-progress reaction should be `:writing_hand:`, then on completion be replaced by `:tada:` (or `:boom:` on failure).

## Platforms tested

macOS (Sequoia, ARM) with Slack Socket Mode.

## Tests

- 5 new tests in `tests/gateway/test_slack.py::TestReactions` cover default behaviour, env override, colon-stripping, empty fallback, and an end-to-end integration flow asserting the configured emojis flow through `on_processing_start` and `on_processing_complete`.
- Existing 8 reaction tests still pass.
- Full `tests/gateway/test_slack.py`: 185 passed.

## Scope

One logical change. No mixed refactor or unrelated cleanup.