### PR TITLE
fix(dashboard): trust fresh gateway runtime state

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -525,8 +525,15 @@ def _runtime_status_recently_running(
     runtime: dict | None,
     *,
     max_age_seconds: float = 180.0,
+    future_skew_seconds: float = 5.0,
 ) -> bool:
-    """Return True when gateway_state.json is a fresh running heartbeat."""
+    """Return True when gateway_state.json is a fresh running heartbeat.
+
+    Stale, malformed, or future-dated runtime files (clock skew or corruption)
+    fall back to ``False`` so callers preserve the existing stopped behavior.
+    A small ``future_skew_seconds`` tolerance accommodates benign clock drift
+    between containers without trusting timestamps from the far future.
+    """
     if not isinstance(runtime, dict) or runtime.get("gateway_state") != "running":
         return False
 
@@ -541,7 +548,19 @@ def _runtime_status_recently_running(
 
     if stamp.tzinfo is None:
         stamp = stamp.replace(tzinfo=timezone.utc)
-    age = time.time() - stamp.timestamp()
+
+    try:
+        stamp_seconds = stamp.timestamp()
+    except (OverflowError, OSError, ValueError):
+        # Extreme-but-parseable dates (e.g. year 9999) can blow up timestamp
+        # conversion on some platforms; treat them as not-fresh rather than
+        # bubbling up a 500 from /api/status.
+        return False
+
+    age = time.time() - stamp_seconds
+    if age < -future_skew_seconds:
+        # Timestamp is meaningfully in the future -> corrupted or skewed clock.
+        return False
     return age <= max_age_seconds
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -22,6 +22,7 @@ import threading
 import time
 import urllib.parse
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -520,6 +521,30 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
     return False, None
 
 
+def _runtime_status_recently_running(
+    runtime: dict | None,
+    *,
+    max_age_seconds: float = 180.0,
+) -> bool:
+    """Return True when gateway_state.json is a fresh running heartbeat."""
+    if not isinstance(runtime, dict) or runtime.get("gateway_state") != "running":
+        return False
+
+    updated_at = runtime.get("updated_at")
+    if not isinstance(updated_at, str) or not updated_at.strip():
+        return False
+
+    try:
+        stamp = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+
+    if stamp.tzinfo is None:
+        stamp = stamp.replace(tzinfo=timezone.utc)
+    age = time.time() - stamp.timestamp()
+    return age <= max_age_seconds
+
+
 @app.get("/api/status")
 async def get_status():
     current_ver, latest_ver = check_config_version()
@@ -561,8 +586,16 @@ async def get_status():
     # Prefer the detailed health endpoint response (has full state) when the
     # local runtime status file is absent or stale (cross-container).
     runtime = read_runtime_status()
-    if runtime is None and remote_health_body and remote_health_body.get("gateway_state"):
+    if (
+        runtime is None
+        and remote_health_body
+        and remote_health_body.get("gateway_state")
+    ):
         runtime = remote_health_body
+    if not gateway_running and _runtime_status_recently_running(runtime):
+        gateway_running = True
+        if isinstance(runtime, dict):
+            gateway_pid = runtime.get("pid")
 
     if runtime:
         gateway_state = runtime.get("gateway_state")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1528,6 +1528,82 @@ class TestStatusRemoteGateway:
         assert data["gateway_state"] == "running"
         assert data["gateway_platforms"] == {"weixin": {"state": "connected"}}
 
+    def test_status_future_runtime_updated_at_not_trusted(self, monkeypatch):
+        """Future-dated gateway_state.json must NOT be treated as fresh.
+
+        Without clamping, a negative ``age`` would still satisfy
+        ``age <= max_age_seconds`` and report the gateway as running
+        indefinitely on clock-skewed/corrupted runtime files.
+        """
+        import gateway.config as gateway_config
+        import hermes_cli.web_server as ws
+
+        # updated_at is one hour ahead of "now" -> clearly future-dated
+        future = "2026-05-08T13:00:00+00:00"
+        monkeypatch.setattr(ws, "get_running_pid", lambda: None)
+        monkeypatch.setattr(
+            ws,
+            "read_runtime_status",
+            lambda: {
+                "gateway_state": "running",
+                "updated_at": future,
+                "pid": 7,
+            },
+        )
+        monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", None)
+        # time.time() corresponds to 2026-05-08T12:00:00+00:00
+        monkeypatch.setattr(ws.time, "time", lambda: 1778241600.0)
+        monkeypatch.setattr(
+            gateway_config,
+            "load_gateway_config",
+            lambda: (_ for _ in ()).throw(RuntimeError("no gateway config")),
+        )
+
+        resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["gateway_running"] is False
+
+    def test_status_malformed_runtime_updated_at_falls_back(self, monkeypatch):
+        """Malformed/extreme ``updated_at`` must fall back to stopped, not 500.
+
+        Year-9999 timestamps parse via ``datetime.fromisoformat`` but can raise
+        ``OverflowError``/``OSError`` from ``stamp.timestamp()`` on some
+        platforms. The freshness check should catch that and return False so
+        ``/api/status`` keeps reporting a stopped gateway instead of erroring.
+        """
+        import gateway.config as gateway_config
+        import hermes_cli.web_server as ws
+
+        # Parseable by datetime.fromisoformat but unrepresentable as a POSIX
+        # timestamp on many platforms.
+        malformed = "9999-12-31T23:59:59+00:00"
+        monkeypatch.setattr(ws, "get_running_pid", lambda: None)
+        monkeypatch.setattr(
+            ws,
+            "read_runtime_status",
+            lambda: {
+                "gateway_state": "running",
+                "updated_at": malformed,
+                "pid": 7,
+            },
+        )
+        monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", None)
+        monkeypatch.setattr(ws.time, "time", lambda: 1778241600.0)
+        monkeypatch.setattr(
+            gateway_config,
+            "load_gateway_config",
+            lambda: (_ for _ in ()).throw(RuntimeError("no gateway config")),
+        )
+
+        resp = self.client.get("/api/status")
+
+        # Must not 500, must fall back to gateway_running == False.
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["gateway_running"] is False
+
     def test_status_remote_running_null_pid(self, monkeypatch):
         """Remote gateway running but PID not in response — pid should be None."""
         import hermes_cli.web_server as ws

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1494,6 +1494,40 @@ class TestStatusRemoteGateway:
         assert data["gateway_running"] is False
         assert data["gateway_health_url"] is None
 
+    def test_status_fresh_runtime_running_without_lock(self, monkeypatch):
+        """Fresh gateway_state.json can prove liveness when lock is not shared."""
+        import gateway.config as gateway_config
+        import hermes_cli.web_server as ws
+
+        now = "2026-05-08T12:00:00+00:00"
+        monkeypatch.setattr(ws, "get_running_pid", lambda: None)
+        monkeypatch.setattr(
+            ws,
+            "read_runtime_status",
+            lambda: {
+                "gateway_state": "running",
+                "updated_at": now,
+                "pid": 7,
+                "platforms": {"weixin": {"state": "connected"}},
+            },
+        )
+        monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", None)
+        monkeypatch.setattr(ws.time, "time", lambda: 1778241600.0)
+        monkeypatch.setattr(
+            gateway_config,
+            "load_gateway_config",
+            lambda: (_ for _ in ()).throw(RuntimeError("no gateway config")),
+        )
+
+        resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["gateway_running"] is True
+        assert data["gateway_pid"] == 7
+        assert data["gateway_state"] == "running"
+        assert data["gateway_platforms"] == {"weixin": {"state": "connected"}}
+
     def test_status_remote_running_null_pid(self, monkeypatch):
         """Remote gateway running but PID not in response — pid should be None."""
         import hermes_cli.web_server as ws


### PR DESCRIPTION
## What does this PR do?

In multi-container Docker deployments the WebUI can show the gateway as **stopped** even when it's actively running and `gateway_state.json` is visible. This happens when the dashboard container cannot see the gateway container's lock file.

`/api/status` previously treated the lock-file PID check as the only local liveness signal. When `get_running_pid()` returned `None`, a runtime status file with `gateway_state: running` was still downgraded to **stopped**, so shared-volume Docker setups reported a false negative.

This PR adds a narrow freshness check for `gateway_state.json`: if it says `running` and has a recent `updated_at` heartbeat, the dashboard treats the gateway as running and preserves runtime platform details. Stale, malformed, or future-dated runtime files still fall back to the existing **stopped** behavior — they don't lock the dashboard into a permanent false-positive.

## Related Issue

Fixes #21706

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`
  - Add `_runtime_status_recently_running(runtime, *, max_age_seconds=180.0, future_skew_seconds=5.0)`. Returns `True` only when `gateway_state.json` says `running` with a parseable, non-future, non-stale `updated_at`.
  - Use the freshness check in `/api/status`: when `get_running_pid()` is `None` but a fresh runtime file exists, mark `gateway_running = True` and carry over `pid` / platforms.
  - Defensive against future-dated `updated_at` (tolerates a small `future_skew_seconds` for benign clock drift between containers; meaningfully future timestamps are rejected).
  - Wrap `stamp.timestamp()` in `try/except OverflowError, OSError, ValueError` so extreme-but-parseable dates (e.g. year 9999) don't 500 `/api/status`.
- `tests/hermes_cli/test_web_server.py`
  - `test_status_fresh_runtime_running_without_lock` — happy path: fresh `running` runtime file + no shared lock → gateway reported running with carried-over pid/platforms.
  - `test_status_future_runtime_updated_at_not_trusted` — `updated_at` one hour in the future → `gateway_running == False`.
  - `test_status_malformed_runtime_updated_at_falls_back` — year-9999 `updated_at` → no 500, falls back to `gateway_running == False`.

## How to Test

1. Run the targeted tests:
   ```bash
   uv run --no-project --python 3.11 \
     --with pytest --with pytest-xdist --with pytest-asyncio \
     --with fastapi --with starlette --with pyyaml --with httpx \
     python -m pytest tests/hermes_cli/test_web_server.py -q \
     -k 'fresh_runtime_running_without_lock or future_runtime_updated_at or malformed_runtime_updated_at or remote_probe'
   ```
   Expected: **6 passed**.
2. Lint the changed files:
   ```bash
   uv run --no-project --with ruff --python 3.11 \
     ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py
   ```
   Expected: **All checks passed**.
3. Manual sanity: run a multi-container Docker deployment where the dashboard cannot see the gateway lock file but can read `gateway_state.json`. Confirm the dashboard now reports the gateway as running while `gateway_state.json` heartbeats stay fresh, and reverts to stopped within `max_age_seconds` (180s) of heartbeats halting.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(dashboard): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the targeted tests above (`tests/hermes_cli/test_web_server.py -k …`) and all pass
- [x] I've added tests for my changes (happy-path + future-dated + malformed regression tests)
- [x] I've tested on my platform: macOS 26.2 (Darwin 25.2.0), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — **N/A**, the new helper has a docstring explaining the freshness/skew/fallback contract
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — **N/A**, no config keys touched
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — **N/A**
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the `OverflowError`/`OSError` guard around `stamp.timestamp()` is specifically for platforms where extreme dates can't be represented as POSIX timestamps (32-bit `time_t`, Windows)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — **N/A**, no tool schemas changed

## Screenshots / Logs

Targeted test run:

```
......                                                                   [100%]
6 passed in 1.78s
```

Lint:

```
All checks passed!
```
