### PR TITLE
fix(cli): resolve update-check repo from running code + exclude infra artifacts from --clone-all

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -206,9 +206,12 @@ def check_for_updates() -> Optional[int]:
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
     else:
-        repo_dir = hermes_home / "hermes-agent"
+        # Prefer the running code's location over the profile-scoped path.
+        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
+        # Path(__file__) always resolves to the actual installed checkout.
+        repo_dir = Path(__file__).parent.parent.resolve()
         if not (repo_dir / ".git").exists():
-            repo_dir = Path(__file__).parent.parent.resolve()
+            repo_dir = hermes_home / "hermes-agent"
         if not (repo_dir / ".git").exists():
             return None
         behind = _check_via_local_git(repo_dir)
@@ -222,11 +225,16 @@ def check_for_updates() -> Optional[int]:
 
 
 def _resolve_repo_dir() -> Optional[Path]:
-    """Return the active Hermes git checkout, or None if this isn't a git install."""
-    hermes_home = get_hermes_home()
-    repo_dir = hermes_home / "hermes-agent"
+    """Return the active Hermes git checkout, or None if this isn't a git install.
+
+    Prefers the running code's location over the profile-scoped path
+    because ``$HERMES_HOME/hermes-agent/`` may be a stale copy carried
+    over by ``--clone-all``.
+    """
+    repo_dir = Path(__file__).parent.parent.resolve()
     if not (repo_dir / ".git").exists():
-        repo_dir = Path(__file__).parent.parent.resolve()
+        hermes_home = get_hermes_home()
+        repo_dir = hermes_home / "hermes-agent"
     return repo_dir if (repo_dir / ".git").exists() else None
 
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -64,8 +64,27 @@ _CLONE_SUBDIR_FILES = [
     "memories/USER.md",
 ]
 
-# Runtime files stripped after --clone-all (shouldn't carry over)
-_CLONE_ALL_STRIP = [
+# Infrastructure artifacts excluded from --clone-all at the profile root.
+# These are never read at runtime — Python imports resolve from the shared
+# checkout (Path(__file__)), not the profile copy.  See also the shared
+# export exclusion set _DEFAULT_EXPORT_EXCLUDE_ROOT for the canonical list
+# of artifact vs. data items in the default profile.
+#
+# Rationale per item:
+#   hermes-agent  — git repo checkout (84 MB source + .git); venv inside is ~3 GB
+#   .worktrees    — git worktrees
+#   node_modules  — npm packages (hundreds of MB)
+_CLONE_ALL_EXCLUDE_ROOT: frozenset[str] = frozenset({
+    "hermes-agent",
+    ".worktrees",
+    "profiles",        # sibling profiles — recursive copy is never intended
+    "node_modules",
+})
+
+# Runtime state files stripped after --clone-all (shouldn't carry over).
+# Kept as a post-copy step rather than in the ignore filter because they
+# are created dynamically during normal use and may be absent at copy time.
+_CLONE_ALL_STRIP: list[str] = [
     "gateway.pid",
     "gateway_state.json",
     "processes.json",
@@ -89,23 +108,35 @@ def has_bundled_skills_opt_out(profile_dir: Path) -> bool:
 
 
 def _clone_all_copytree_ignore(source_dir: Path):
-    """Ignore ``profiles/`` at the root of *source_dir* only.
+    """Exclude infrastructure artifacts when cloning a profile via --clone-all.
 
-    ``~/.hermes`` contains ``profiles/<name>/`` for sibling named profiles.
-    ``shutil.copytree`` would otherwise duplicate that entire tree inside the
-    new profile (recursive ``.../profiles/.../profiles/...``). Export already
-    excludes ``profiles`` via ``_DEFAULT_EXPORT_EXCLUDE_ROOT`` — match that
-    behavior for ``--clone-all``.
+    Two categories:
+      1. Root-level entries in ``_CLONE_ALL_EXCLUDE_ROOT`` — known Hermes
+         infrastructure directories that are never read at runtime.
+      2. Universal exclusions at any depth — Python bytecode caches that
+         are stale or regenerated (``__pycache__``, ``*.pyc``, ``*.pyo``).
+
+    Export (``_default_export_ignore``) uses the same two-tier pattern for
+    the same reason, but with a different exclusion set (``_DEFAULT_EXPORT_EXCLUDE_ROOT``
+    is broader because export goes to an archive, not a local clone).
     """
     source_resolved = source_dir.resolve()
 
     def _ignore(directory: str, names: List[str]) -> List[str]:
-        try:
-            if Path(directory).resolve() == source_resolved:
-                return [n for n in names if n == "profiles"]
-        except (OSError, ValueError):
-            pass
-        return []
+        ignored: list[str] = []
+        for entry in names:
+            # Universal exclusions at any depth
+            if entry == "__pycache__" or entry.endswith((".pyc", ".pyo")):
+                ignored.append(entry)
+                continue
+            # Root-level exclusions only
+            try:
+                if Path(directory).resolve() == source_resolved:
+                    if entry in _CLONE_ALL_EXCLUDE_ROOT:
+                        ignored.append(entry)
+            except (OSError, ValueError):
+                pass  # resolve() can fail on unusual FS layouts
+        return ignored
 
     return _ignore
 


### PR DESCRIPTION
## Summary

Two fixes in the profile/git interaction area:

### 1. Update check resolves from wrong repo directory (banner.py)

`check_for_updates()` and `_resolve_repo_dir()` preferred `$HERMES_HOME/hermes-agent/` when resolving the git checkout for the "N commits behind" banner. When a profile was created with `--clone-all`, the copy of the repo inside the profile directory had its own `.git` with a frozen HEAD. The update check queried this stale copy instead of the real shared checkout, causing persistent "272 commits behind" banners that never resolved.

**Fix:** Reverse the resolution order — prefer `Path(__file__).parent.parent.resolve()` (the running code's directory, always the real checkout) first. Fall back to `$HERMES_HOME/hermes-agent/`.

### 2. --clone-all copies infrastructure artifacts (profiles.py)

`shutil.copytree` in the `--clone-all` branch copied the entire source directory including infrastructure artifacts never read at runtime: the full git repo checkout with `.git` and 3 GB venv, git worktrees, and npm packages.

**Fix:** Add `_CLONE_ALL_EXCLUDE_ROOT` excluding `hermes-agent`, `.worktrees`, `profiles`, and `node_modules` at the profile root, plus `__pycache__` and `*.pyc`/`*.pyo` at all depths. The export system already used the same two-tier pattern.

## Files changed

- `hermes_cli/banner.py` — `check_for_updates()` (line 209) and `_resolve_repo_dir()` (line 224)
- `hermes_cli/profiles.py` — `_CLONE_ALL_EXCLUDE_ROOT`, `_clone_all_copytree_ignore()`, `_CLONE_ALL_STRIP`

## Testing

- All 8 `tests/hermes_cli/test_update_check.py` tests pass
- All 105 `tests/hermes_cli/test_profiles.py` tests pass

## Related

The export system (`_DEFAULT_EXPORT_EXCLUDE_ROOT`) already had the correct exclusion philosophy. These fixes align `--clone-all` and the update check with that same design intent.
