### PR TITLE
fix: skip near-empty credential pool entries

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -113,6 +113,10 @@ class PooledCredential:
     agent_key: Optional[str] = None
     agent_key_expires_at: Optional[str] = None
     request_count: int = 0
+    # Usage tracking for proactive threshold filtering
+    usage_remaining_pct: Optional[float] = None  # 0.0-100.0, generic usage pct
+    usage_window: Optional[str] = None  # e.g. "5h", "weekly", "1h", "min"
+    usage_checked_at: Optional[float] = None  # timestamp of last usage check
     extra: Dict[str, Any] = None  # type: ignore[assignment]
 
     def __post_init__(self):
@@ -836,6 +840,48 @@ class CredentialPool:
             return False
         return False
 
+    def _load_threshold_config(self) -> Dict[str, float]:
+        """Load usage threshold config from config.yaml.
+
+        Returns dict with keys like 'default', '5h', 'weekly'.
+        If no config found, returns safe defaults.
+        """
+        cfg = _load_config_safe()
+        thresholds = {}
+        if cfg and isinstance(cfg, dict):
+            pool_cfg = cfg.get("credential_pool", {})
+            if isinstance(pool_cfg, dict):
+                th = pool_cfg.get("usage_thresholds")
+                if isinstance(th, dict):
+                    thresholds = th
+        # Safe defaults requested for Codex-style long windows.
+        # Do not apply minute/hour rate-limit buckets here: those are transient
+        # throttles, not account quota health.
+        defaults = {
+            "default": 10.0,
+            "5h": 10.0,
+            "weekly": 5.0,
+        }
+        defaults.update(thresholds)
+        return defaults
+
+    def _entry_below_usage_threshold(self, entry: PooledCredential) -> bool:
+        """Return True if entry's remaining usage is below configured threshold.
+
+        Only applies when usage_remaining_pct is set and not stale (> 5 min old).
+        """
+        if entry.usage_remaining_pct is None:
+            return False
+        # Stale check: ignore usage data older than 5 minutes
+        if entry.usage_checked_at is not None:
+            age_seconds = time.time() - entry.usage_checked_at
+            if age_seconds > 300:  # 5 minutes
+                return False
+        thresholds = self._load_threshold_config()
+        window = entry.usage_window or "default"
+        threshold = thresholds.get(window, thresholds.get("default", 10.0))
+        return entry.usage_remaining_pct < threshold
+
     def select(self) -> Optional[PooledCredential]:
         with self._lock:
             return self._select_unlocked()
@@ -905,6 +951,16 @@ class CredentialPool:
                 if refreshed is None:
                     continue
                 entry = refreshed
+            # Proactive usage threshold filtering
+            if self._entry_below_usage_threshold(entry):
+                _label = entry.label or entry.id[:8]
+                _pct = entry.usage_remaining_pct
+                _window = entry.usage_window or "unknown"
+                logger.info(
+                    "credential pool: skipping %s (usage %s %.1f%% below threshold)",
+                    _label, _window, _pct,
+                )
+                continue
             available.append(entry)
         if cleared_any:
             self._persist()
@@ -949,6 +1005,31 @@ class CredentialPool:
             return current
         available = self._available_entries()
         return available[0] if available else None
+
+    def update_usage(
+        self,
+        credential_id: str,
+        remaining_pct: float,
+        window: str = "default",
+    ) -> bool:
+        """Update usage metadata for a specific pool entry.
+
+        Called after API responses when rate-limit headers are available.
+        Returns True if the entry was found and updated.
+        """
+        with self._lock:
+            for entry in self._entries:
+                if entry.id == credential_id:
+                    updated = replace(
+                        entry,
+                        usage_remaining_pct=remaining_pct,
+                        usage_window=window,
+                        usage_checked_at=time.time(),
+                    )
+                    self._replace_entry(entry, updated)
+                    self._persist()
+                    return True
+            return False
 
     def mark_exhausted_and_rotate(
         self,

--- a/run_agent.py
+++ b/run_agent.py
@@ -4810,6 +4810,9 @@ class AIAgent:
 
         Called after each streaming API call.  The httpx Response object is
         available on the OpenAI SDK Stream via ``stream.response``.
+
+        Also updates the current credential pool entry with usage metadata
+        for proactive threshold filtering.
         """
         if http_response is None:
             return
@@ -4821,8 +4824,61 @@ class AIAgent:
             state = parse_rate_limit_headers(headers, provider=self.provider)
             if state is not None:
                 self._rate_limit_state = state
+            # Update current pool entry from long-window quota headers when
+            # providers expose them.  Short RPM/TPM windows are deliberately not
+            # used for pool selection because a temporary minute/hour dip should
+            # not suppress an account for long-running tasks.
+            self._update_pool_entry_usage_from_headers(headers)
         except Exception:
             pass  # Never let header parsing break the agent loop
+
+    def _update_pool_entry_usage_from_headers(self, headers: Any) -> None:
+        """Update current pool entry using long-window quota headers.
+
+        Codex/ChatGPT-style accounts can have 5-hour and weekly quota windows.
+        When a provider exposes long-window remaining/limit headers, persist the
+        remaining percentage on the active pool entry so selection can skip
+        near-empty accounts before they trigger fallback.
+        """
+        pool = getattr(self, "credential_pool", None)
+        if pool is None:
+            return
+        current = pool.current()
+        if current is None:
+            return
+
+        lowered = {str(k).lower(): v for k, v in getattr(headers, "items", lambda: [])()}
+
+        def _float(key: str):
+            value = lowered.get(key)
+            if value in (None, ""):
+                return None
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                return None
+
+        def _window_pct(window: str, aliases: list[str]):
+            for alias in aliases:
+                pct = _float(f"x-ratelimit-remaining-pct-{alias}")
+                if pct is not None:
+                    return window, max(0.0, min(100.0, pct))
+                for resource in ("tokens", "requests"):
+                    limit = _float(f"x-ratelimit-limit-{resource}-{alias}")
+                    remaining = _float(f"x-ratelimit-remaining-{resource}-{alias}")
+                    if limit and remaining is not None and limit > 0:
+                        return window, max(0.0, min(100.0, (remaining / limit) * 100.0))
+            return None
+
+        candidates = [
+            _window_pct("weekly", ["weekly", "week", "1w", "7d"]),
+            _window_pct("5h", ["5h", "5hour", "5-hour", "five-hour"]),
+        ]
+        valid = [c for c in candidates if c is not None]
+        if not valid:
+            return
+        window, pct = min(valid, key=lambda item: item[1])
+        pool.update_usage(current.id, remaining_pct=pct, window=window)
 
     def get_rate_limit_state(self):
         """Return the last captured RateLimitState, or None."""

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -136,6 +136,174 @@ def test_round_robin_strategy_rotates_priorities(tmp_path, monkeypatch):
     assert second.id == "cred-2"
 
 
+def test_round_robin_skips_low_5h_usage_entry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-low",
+                        "label": "low-5h",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "tok-low",
+                        "usage_remaining_pct": 9.0,
+                        "usage_window": "5h",
+                        "usage_checked_at": time.time(),
+                    },
+                    {
+                        "id": "cred-ok",
+                        "label": "healthy",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "tok-ok",
+                        "usage_remaining_pct": 20.0,
+                        "usage_window": "5h",
+                        "usage_checked_at": time.time(),
+                    },
+                ]
+            },
+        },
+    )
+    config_path = tmp_path / "hermes" / "config.yaml"
+    config_path.write_text("credential_pool_strategies:\n  openai-codex: round_robin\n")
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    selected = pool.select()
+
+    assert selected is not None
+    assert selected.id == "cred-ok"
+
+
+def test_round_robin_skips_low_weekly_usage_entry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-low-weekly",
+                        "label": "low-weekly",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "tok-low",
+                        "usage_remaining_pct": 4.9,
+                        "usage_window": "weekly",
+                        "usage_checked_at": time.time(),
+                    },
+                    {
+                        "id": "cred-ok",
+                        "label": "healthy",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "tok-ok",
+                        "usage_remaining_pct": 5.0,
+                        "usage_window": "weekly",
+                        "usage_checked_at": time.time(),
+                    },
+                ]
+            },
+        },
+    )
+    config_path = tmp_path / "hermes" / "config.yaml"
+    config_path.write_text("credential_pool_strategies:\n  openai-codex: round_robin\n")
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    selected = pool.select()
+
+    assert selected is not None
+    assert selected.id == "cred-ok"
+
+
+def test_stale_usage_metadata_does_not_suppress_entry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-stale",
+                        "label": "stale-low",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "tok-stale",
+                        "usage_remaining_pct": 1.0,
+                        "usage_window": "5h",
+                        "usage_checked_at": time.time() - 600,
+                    },
+                    {
+                        "id": "cred-next",
+                        "label": "next",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "tok-next",
+                    },
+                ]
+            },
+        },
+    )
+    config_path = tmp_path / "hermes" / "config.yaml"
+    config_path.write_text("credential_pool_strategies:\n  openai-codex: round_robin\n")
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    selected = pool.select()
+
+    assert selected is not None
+    assert selected.id == "cred-stale"
+
+
+def test_update_usage_persists_usage_metadata(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "tok-1",
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    assert pool.update_usage("cred-1", remaining_pct=8.0, window="5h") is True
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted = auth_payload["credential_pool"]["openai-codex"][0]
+    assert persisted["usage_remaining_pct"] == 8.0
+    assert persisted["usage_window"] == "5h"
+    assert persisted["usage_checked_at"] > 0
+
+
 def test_random_strategy_uses_random_choice(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)

--- a/tests/agent/test_rate_limit_tracker.py
+++ b/tests/agent/test_rate_limit_tracker.py
@@ -210,3 +210,30 @@ class TestAgentIntegration:
         # None should not crash
         result = parse_rate_limit_headers({})
         assert result is None
+
+    def test_long_window_headers_update_pool_usage(self):
+        """Codex-style 5h/weekly headers update current credential metadata."""
+        from types import SimpleNamespace
+        from run_agent import AIAgent
+
+        calls = []
+
+        class Pool:
+            def current(self):
+                return SimpleNamespace(id="cred-1")
+
+            def update_usage(self, credential_id, *, remaining_pct, window):
+                calls.append((credential_id, remaining_pct, window))
+                return True
+
+        agent = SimpleNamespace(credential_pool=Pool())
+        headers = {
+            "x-ratelimit-limit-requests-5h": "100",
+            "x-ratelimit-remaining-requests-5h": "9",
+            "x-ratelimit-limit-requests-weekly": "1000",
+            "x-ratelimit-remaining-requests-weekly": "40",
+        }
+
+        AIAgent._update_pool_entry_usage_from_headers(agent, headers)
+
+        assert calls == [("cred-1", 4.0, "weekly")]


### PR DESCRIPTION
## Summary

Fix credential-pool round_robin allocating near-empty Codex accounts and causing avoidable fallback to Kimi.

## Behavior

- Persists per-entry quota metadata: `usage_remaining_pct`, `usage_window`, `usage_checked_at`
- Captures long-window quota headers when providers expose them:
  - 5h aliases: `5h`, `5hour`, `5-hour`, `five-hour`
  - weekly aliases: `weekly`, `week`, `1w`, `7d`
- Skips entries below default thresholds:
  - 5h remaining < 10%
  - weekly remaining < 5%
- Ignores stale usage metadata after 5 minutes
- Thresholds configurable via:

```yaml
credential_pool:
  usage_thresholds:
    5h: 10
    weekly: 5
```

## Validation

- `venv/bin/python -m py_compile agent/credential_pool.py run_agent.py`
- `venv/bin/python -m pytest tests/agent/test_credential_pool.py tests/agent/test_rate_limit_tracker.py -q`
- Result: 72 passed

## Notes

PMO tracking issue: wangrenzhu-ola/infra-hermes-core-skills#223.