### PR TITLE
feat(gateway): limit tool progress lines

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -877,6 +877,12 @@ display:
   # Toggle at runtime with /verbose in the CLI
   tool_progress: all
 
+  # Gateway-only cap for rendered tool-progress bubble length.
+  #   0: Unlimited accumulated progress lines (default)
+  #   N: Keep only the last N rendered physical lines in each edited bubble
+  # Per-platform override: display.platforms.telegram.tool_progress_max_lines
+  tool_progress_max_lines: 0
+
   # Auto-cleanup of temporary progress bubbles after the final response lands.
   # On platforms that support message deletion (currently Telegram), this
   # removes the tool-progress bubble, "⏳ Still working..." notices, and

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -34,6 +34,7 @@ _GLOBAL_DEFAULTS: dict[str, Any] = {
     "tool_progress": "all",
     "show_reasoning": False,
     "tool_preview_length": 0,
+    "tool_progress_max_lines": 0,  # 0 = unlimited accumulated progress lines
     "streaming": None,  # None = follow top-level streaming config
     # When true, delete tool-progress / "Still working..." / status bubbles
     # after the final response lands on platforms that support message
@@ -55,6 +56,7 @@ _TIER_HIGH = {
     "tool_progress": "all",
     "show_reasoning": False,
     "tool_preview_length": 40,
+    "tool_progress_max_lines": 0,
     "streaming": None,  # follow global
 }
 
@@ -62,6 +64,7 @@ _TIER_MEDIUM = {
     "tool_progress": "new",
     "show_reasoning": False,
     "tool_preview_length": 40,
+    "tool_progress_max_lines": 0,
     "streaming": None,
 }
 
@@ -69,6 +72,7 @@ _TIER_LOW = {
     "tool_progress": "off",
     "show_reasoning": False,
     "tool_preview_length": 40,
+    "tool_progress_max_lines": 0,
     "streaming": False,
 }
 
@@ -76,6 +80,7 @@ _TIER_MINIMAL = {
     "tool_progress": "off",
     "show_reasoning": False,
     "tool_preview_length": 0,
+    "tool_progress_max_lines": 0,
     "streaming": False,
 }
 
@@ -137,10 +142,17 @@ def resolve_display_setting(
     -------
     The resolved value, or *fallback* if nothing is configured.
     """
+    if not isinstance(user_config, dict):
+        user_config = {}
+
     display_cfg = user_config.get("display") or {}
+    if not isinstance(display_cfg, dict):
+        display_cfg = {}
 
     # 1. Explicit per-platform override (display.platforms.<platform>.<key>)
     platforms = display_cfg.get("platforms") or {}
+    if not isinstance(platforms, dict):
+        platforms = {}
     plat_overrides = platforms.get(platform_key)
     if isinstance(plat_overrides, dict):
         val = plat_overrides.get(setting)
@@ -198,9 +210,12 @@ def _normalise(setting: str, value: Any) -> Any:
         if isinstance(value, str):
             return value.lower() in ("true", "1", "yes", "on")
         return bool(value)
-    if setting == "tool_preview_length":
+    if setting in ("tool_preview_length", "tool_progress_max_lines"):
+        if isinstance(value, bool):
+            return 0
         try:
-            return int(value)
+            value_int = int(value)
         except (TypeError, ValueError):
             return 0
+        return value_int if value_int > 0 else 0
     return value

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13181,6 +13181,8 @@ class GatewayRunner:
         _env_tp = os.getenv("HERMES_TOOL_PROGRESS_MODE")
         _display_cfg = display_config if isinstance(display_config, dict) else {}
         _platforms_cfg = _display_cfg.get("platforms") or {}
+        if not isinstance(_platforms_cfg, dict):
+            _platforms_cfg = {}
         _platform_cfg = _platforms_cfg.get(platform_key) or {}
         _legacy_tp_overrides = _display_cfg.get("tool_progress_overrides") or {}
         _tool_progress_configured = (
@@ -13216,6 +13218,14 @@ class GatewayRunner:
         
         # Queue for progress messages (thread-safe)
         progress_queue = queue.Queue() if tool_progress_enabled else None
+        try:
+            tool_progress_max_lines = int(
+                resolve_display_setting(user_config, platform_key, "tool_progress_max_lines", 0) or 0
+            )
+        except (TypeError, ValueError):
+            tool_progress_max_lines = 0
+        if tool_progress_max_lines < 0:
+            tool_progress_max_lines = 0
         last_tool = [None]  # Mutable container for tracking in closure
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
@@ -13398,6 +13408,15 @@ class GatewayRunner:
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
             _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
 
+            def _render_progress_text() -> str:
+                full_text = "\n".join(progress_lines)
+                if tool_progress_max_lines <= 0:
+                    return full_text
+                # Verbose entries and raw previews can contain embedded
+                # newlines, so trim the rendered physical lines rather than
+                # merely counting progress events.
+                return "\n".join(full_text.splitlines()[-tool_progress_max_lines:])
+
             while True:
                 try:
                     if not _run_still_current():
@@ -13468,7 +13487,7 @@ class GatewayRunner:
 
                     if can_edit and progress_msg_id is not None:
                         # Try to edit the existing progress message
-                        full_text = "\n".join(progress_lines)
+                        full_text = _render_progress_text()
                         result = await adapter.edit_message(
                             chat_id=source.chat_id,
                             message_id=progress_msg_id,
@@ -13500,7 +13519,7 @@ class GatewayRunner:
                     else:
                         if can_edit:
                             # First tool: send all accumulated text as new message
-                            full_text = "\n".join(progress_lines)
+                            full_text = _render_progress_text()
                             result = await adapter.send(
                                 chat_id=source.chat_id,
                                 content=full_text,
@@ -13543,7 +13562,7 @@ class GatewayRunner:
                                 # the current progress bubble and start a fresh
                                 # one for any tool lines that arrived after.
                                 if can_edit and progress_lines and progress_msg_id:
-                                    _pending_text = "\n".join(progress_lines)
+                                    _pending_text = _render_progress_text()
                                     try:
                                         await adapter.edit_message(
                                             chat_id=source.chat_id,
@@ -13562,7 +13581,7 @@ class GatewayRunner:
                             break
                     # Final edit with all remaining tools (only if editing works)
                     if can_edit and progress_lines and progress_msg_id:
-                        full_text = "\n".join(progress_lines)
+                        full_text = _render_progress_text()
                         try:
                             await adapter.edit_message(
                                 chat_id=source.chat_id,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -855,6 +855,7 @@ DEFAULT_CONFIG = {
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         "tool_progress_overrides": {},  # DEPRECATED — use display.platforms instead
         "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)
+        "tool_progress_max_lines": 0,  # Gateway: max rendered tool-progress lines per edited bubble (0 = unlimited)
         # Auto-delete system-notice replies (e.g. "✨ New session started!",
         # "♻ Restarting gateway…", "⚡ Stopped…") after N seconds on platforms
         # that support message deletion (currently Telegram; other platforms

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -163,6 +163,28 @@ class TestYAMLNormalisation:
         config = {"display": {"platforms": {"slack": {"tool_preview_length": "80"}}}}
         assert resolve_display_setting(config, "slack", "tool_preview_length") == 80
 
+    def test_tool_progress_max_lines_string(self):
+        """String numbers are normalised to int for tool-progress line trimming."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"platforms": {"telegram": {"tool_progress_max_lines": "3"}}}}
+        assert resolve_display_setting(config, "telegram", "tool_progress_max_lines") == 3
+
+    def test_tool_progress_max_lines_invalid_values_are_unlimited(self):
+        """Invalid/non-integer line limits resolve to 0 (unlimited)."""
+        from gateway.display_config import resolve_display_setting
+
+        for value in ("many", None, {}, [], True, False):
+            config = {"display": {"tool_progress_max_lines": value}}
+            assert resolve_display_setting(config, "telegram", "tool_progress_max_lines") == 0
+
+    def test_malformed_display_config_falls_back_to_defaults(self):
+        """Malformed display blocks should not crash gateway startup."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({"display": "bad"}, "telegram", "tool_progress_max_lines") == 0
+        assert resolve_display_setting({"display": {"platforms": "bad"}}, "telegram", "tool_progress_max_lines") == 0
+
     def test_platform_override_false_tool_progress(self):
         """Per-platform bare off → normalised."""
         from gateway.display_config import resolve_display_setting
@@ -333,6 +355,44 @@ class TestStreamingPerPlatform:
             }
         }
         assert resolve_display_setting(config, "email", "streaming") is True
+
+
+# ---------------------------------------------------------------------------
+# tool_progress_max_lines — trim displayed progress to the last N lines
+# ---------------------------------------------------------------------------
+
+class TestToolProgressMaxLines:
+    """``tool_progress_max_lines`` defaults to unlimited and supports overrides."""
+
+    def test_default_unlimited_for_all_platforms(self):
+        """No config set → tool_progress_max_lines resolves to 0 everywhere."""
+        from gateway.display_config import resolve_display_setting
+
+        for plat in ("telegram", "discord", "slack", "email", "unknown"):
+            assert resolve_display_setting({}, plat, "tool_progress_max_lines") == 0
+
+    def test_global_applies_to_all_platforms(self):
+        """display.tool_progress_max_lines applies globally."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"tool_progress_max_lines": 5}}
+        assert resolve_display_setting(config, "telegram", "tool_progress_max_lines") == 5
+        assert resolve_display_setting(config, "discord", "tool_progress_max_lines") == 5
+
+    def test_per_platform_override_wins(self):
+        """display.platforms.<plat>.tool_progress_max_lines beats global value."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "tool_progress_max_lines": 5,
+                "platforms": {
+                    "telegram": {"tool_progress_max_lines": 2},
+                },
+            }
+        }
+        assert resolve_display_setting(config, "telegram", "tool_progress_max_lines") == 2
+        assert resolve_display_setting(config, "discord", "tool_progress_max_lines") == 5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -123,6 +123,46 @@ class DelayedProgressAgent:
         }
 
 
+class ManyProgressLinesAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        for tool_name, preview in (
+            ("terminal", "first command"),
+            ("web_search", "second query"),
+            ("browser_navigate", "third url"),
+            ("python", "fourth script"),
+        ):
+            self.tool_progress_callback("tool.started", tool_name, preview, {})
+            time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class VerboseMultiLineProgressAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        for tool_name, args in (
+            ("terminal", {"cmd": "first command"}),
+            ("web_search", {"query": "second query"}),
+        ):
+            self.tool_progress_callback("tool.started", tool_name, None, args)
+            time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class DelayedInterimAgent:
     def __init__(self, **kwargs):
         self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
@@ -209,6 +249,106 @@ async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_pa
     ]
     assert adapter.edits
     assert all(call["metadata"] == {"thread_id": "17585"} for call in adapter.typing)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_trims_display_to_configured_last_lines(monkeypatch, tmp_path):
+    """tool_progress_max_lines trims accumulated progress before send/edit."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    import yaml
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({"display": {"tool_progress": "all", "tool_progress_max_lines": 2}}),
+        encoding="utf-8",
+    )
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ManyProgressLinesAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter(platform=Platform.TELEGRAM)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-trim",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.edits
+    final_progress = adapter.edits[-1]["content"]
+    assert final_progress.splitlines() == [
+        '🌐 browser_navigate: "third url"',
+        '⚙️ python: "fourth script"',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_max_lines_trims_rendered_verbose_lines(monkeypatch, tmp_path):
+    """Verbose progress emits multi-line entries; max_lines must cap rendered lines."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    import yaml
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({"display": {"tool_progress": "verbose", "tool_progress_max_lines": 2}}),
+        encoding="utf-8",
+    )
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = VerboseMultiLineProgressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter(platform=Platform.TELEGRAM)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-trim-verbose",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.edits
+    final_progress = adapter.edits[-1]["content"]
+    assert final_progress.splitlines() == [
+        "🔍 web_search(['query'])",
+        '{"query": "second query"}',
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Adds a gateway display config knob, `display.tool_progress_max_lines`, that limits edited tool-progress bubbles to the last N rendered physical lines. This keeps long-running tool progress readable on messaging platforms without changing the default behavior: `0` remains unlimited.

The limit is applied at render time so verbose entries or previews containing embedded newlines are trimmed by actual displayed lines, not just by progress event count.

## Related Issue

No issue filed. This is a small gateway UX/config improvement.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/display_config.py`: adds `tool_progress_max_lines` defaults and integer normalization, with malformed display config handling.
- `gateway/run.py`: trims rendered editable tool-progress bubble text to the configured last N physical lines.
- `hermes_cli/config.py`: adds the default config key.
- `cli-config.yaml.example`: documents the new config key and per-platform override path.
- `tests/gateway/test_display_config.py`: covers default/global/per-platform/invalid config behavior.
- `tests/gateway/test_run_progress_topics.py`: covers line trimming for editable progress bubbles, including embedded multiline entries.

## How to Test

1. Set `display.tool_progress_max_lines: 3` or `display.platforms.telegram.tool_progress_max_lines: 3`.
2. Run a gateway turn that emits more than three rendered tool-progress lines.
3. Verify the edited progress bubble shows only the last three rendered lines, while the final response behavior is unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused validation run:

```text
git diff --check
python -m pytest -q \
  tests/gateway/test_run_progress_topics.py \
  tests/gateway/test_run_progress_interrupt.py \
  tests/gateway/test_run_cleanup_progress.py \
  tests/gateway/test_stream_consumer.py \
  tests/gateway/test_stream_consumer_fresh_final.py \
  tests/gateway/test_display_config.py
# 168 passed in 13.77s

python -m ruff check gateway/display_config.py gateway/run.py hermes_cli/config.py tests/gateway/test_display_config.py tests/gateway/test_run_progress_topics.py
# All checks passed!

python -m py_compile gateway/display_config.py gateway/run.py hermes_cli/config.py
# passed

python - <<'PY'
from pathlib import Path
import yaml
yaml.safe_load(Path('cli-config.yaml.example').read_text())
print('yaml ok')
PY
# yaml ok
```
