### PR TITLE
fix(acp): refuse to build image data URL from invalid base64 blob

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -322,11 +322,29 @@ def _embedded_resource_to_parts(block: EmbeddedResourceContentBlock) -> list[dic
         blob = resource.blob or ""
         try:
             data = base64.b64decode(blob, validate=True)
+            decode_failed = False
         except Exception:
+            # Per the MCP spec, ``BlobResourceContents.blob`` MUST be base64.
+            # If the client sent invalid base64, keep a UTF-8 fallback so
+            # text-typed resources still surface as readable garbage rather
+            # than nothing — but flag it so image_url paths can refuse.
             data = blob.encode("utf-8", errors="replace")
+            decode_failed = True
 
         # Image blobs go through as image_url so vision models can see them.
         if _is_image_resource(mime_type):
+            if decode_failed:
+                # Don't feed vision models a data URL containing the raw
+                # bytes of an invalid-base64 string — _image_data_url would
+                # re-base64-encode those bytes, producing nonsense that
+                # silently corrupts the image instead of erroring.
+                return [{
+                    "type": "text",
+                    "text": _format_resource_text(
+                        uri=uri,
+                        body=f"[Could not decode embedded image: invalid base64, mime={mime_type or 'unknown'}]",
+                    ),
+                }]
             if len(data) > _MAX_ACP_RESOURCE_BYTES:
                 return [{
                     "type": "text",

--- a/tests/acp_adapter/test_acp_images.py
+++ b/tests/acp_adapter/test_acp_images.py
@@ -157,3 +157,49 @@ def test_acp_embedded_blob_image_is_inlined_as_image_url():
         "type": "image_url",
         "image_url": {"url": f"data:image/png;base64,{b64}"},
     }
+
+
+def test_acp_embedded_blob_invalid_base64_image_returns_error_not_corrupt_data_url():
+    """Invalid base64 in an image-typed blob must surface an error, not a
+    silently-corrupted data URL.
+
+    Regression: previously, a ``BlobResourceContents`` with ``mimeType=
+    "image/*"`` and a non-base64 ``blob`` would fall through to
+    ``blob.encode("utf-8", errors="replace")`` and then have those raw
+    bytes re-base64-encoded into a ``data:image/png;base64,...`` URL.
+    Vision models received nonsense bytes that decode as neither the
+    intended image nor any valid image at all, with no error surfaced
+    to the user. With the fix in place, the resource is replaced with a
+    text part flagging the invalid base64 so the model (and the user)
+    can see why no image arrived.
+    """
+    not_b64 = "not-valid-base64-!!!"  # contains '!' which is outside the b64 alphabet
+
+    content = _content_blocks_to_openai_user_content([
+        EmbeddedResourceContentBlock(
+            type="resource",
+            resource=BlobResourceContents(
+                uri="file:///tmp/broken.png",
+                mimeType="image/png",
+                blob=not_b64,
+            ),
+        ),
+    ])
+
+    # Single text part collapses to a string per the legacy prompt path
+    # (see test_text_only_acp_blocks_stay_string_for_legacy_prompt_path).
+    # In any case, NO data URL should be produced — that would be the
+    # silently-corrupted vision-model input.
+    if isinstance(content, list):
+        assert all(p.get("type") != "image_url" for p in content), content
+        body = "\n".join(p.get("text", "") for p in content if p.get("type") == "text")
+    else:
+        assert isinstance(content, str)
+        assert "data:image" not in content
+        body = content
+
+    assert "Could not decode embedded image" in body
+    assert "image/png" in body
+    # And critically: the malformed base64 string must not have been
+    # re-encoded into a data URL anywhere in the surfaced content.
+    assert "data:image/png;base64," not in body


### PR DESCRIPTION
## Summary

`_embedded_resource_to_parts` in `acp_adapter/server.py` base64-decodes `BlobResourceContents.blob` with `validate=True`, falling back to `blob.encode(\"utf-8\", errors=\"replace\")` on failure. For non-image MIME types this fallback is benign — the user just sees malformed text. For `image/*` MIME types, however, the raw fallback bytes are fed straight into `_image_data_url`, which re-base64-encodes them into a `data:image/png;base64,...` URL. Vision models then receive nonsense that decodes as neither the intended image nor any valid image, silently corrupting the prompt with no error surfaced.

This fix tracks whether base64 decoding succeeded. When it did not, and the MIME indicates an image, return a single text part flagging the failure (including the MIME type for debugging) instead of building the corrupt data URL. The text fallback for non-image blobs is unchanged — for those, malformed-string-as-text is a reasonable best effort.

Per the MCP spec, `BlobResourceContents.blob` MUST be base64, so an invalid blob is genuinely malformed input from the ACP client; the right behavior is to refuse to forward it as an image rather than quietly mangle it.

Affects ACP clients (Zed, etc.) that send `EmbeddedResourceContentBlock` with `mimeType=\"image/*\"` and a non-base64 blob — fresh code path from #21407 (salvage of #21400 + image support).

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `acp_adapter/server.py`: In `_embedded_resource_to_parts`, capture a `decode_failed` flag from the `b64decode` try/except. In the `_is_image_resource(mime_type)` branch, return an explanatory text part when `decode_failed`, before any `len(data)` size check or `_image_data_url` construction. Non-image fallback path is unchanged.
- `tests/acp_adapter/test_acp_images.py`: Add `test_acp_embedded_blob_invalid_base64_image_returns_error_not_corrupt_data_url`. Asserts that an `EmbeddedResourceContentBlock` carrying a `BlobResourceContents` with `mimeType=\"image/png\"` and `blob=\"not-valid-base64-!!!\"` (contains `!`, outside the base64 alphabet) (a) produces no `data:image/...;base64,...` URL, and (b) surfaces a text body mentioning \"Could not decode embedded image\" and the MIME type.

## How to Test

1. `pytest -q tests/acp_adapter/ tests/acp/`
2. Confirm the new `test_acp_embedded_blob_invalid_base64_image_returns_error_not_corrupt_data_url` passes.
3. Confirm pre-existing `test_acp_embedded_blob_image_is_inlined_as_image_url` still passes (well-formed base64 image still inlines as before).

To reproduce manually: run an ACP client (e.g. Zed) that emits an `embedded_resource` content block with `BlobResourceContents` carrying a non-base64 string (or a valid string with stray punctuation that's not in the alphabet) and `mimeType=\"image/png\"`. Before this fix, the model receives a long `data:image/png;base64,<UTF-8-of-malformed-input>` and silently treats it as a (broken) image. After this fix, the model receives a clear `[Could not decode embedded image: invalid base64, mime=image/png]` text instead.

## Validation

- `pytest -q tests/acp_adapter/ tests/acp/` -> `222 passed`
- Tested on macOS 25.4 / Python 3.14.4.