### PR TITLE
fix(config): parse flat provider/model strings

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -107,6 +107,24 @@ def _auto_detect_local_model(base_url: str) -> str:
     return ""
 
 
+def split_provider_model_string(raw: str) -> tuple[str | None, str]:
+    """Split config shorthand ``provider/model`` when the provider is known.
+
+    Unknown slash-containing model IDs are preserved so aggregator model names
+    such as ``vendor/model`` keep working unless ``vendor`` is a Hermes
+    provider or a ``custom:...`` alias.
+    """
+    value = (raw or "").strip()
+    if "/" not in value:
+        return None, value
+    provider, model = value.split("/", 1)
+    provider = provider.strip().lower()
+    model = model.strip()
+    if model and (provider in PROVIDER_REGISTRY or provider.startswith("custom:")):
+        return provider, model
+    return None, value
+
+
 def _get_model_config() -> Dict[str, Any]:
     config = load_config()
     model_cfg = config.get("model")
@@ -125,7 +143,11 @@ def _get_model_config() -> Dict[str, Any]:
                 cfg["default"] = detected
         return cfg
     if isinstance(model_cfg, str) and model_cfg.strip():
-        return {"default": model_cfg.strip()}
+        raw = model_cfg.strip()
+        provider, model = split_provider_model_string(raw)
+        if provider:
+            return {"provider": provider, "default": model}
+        return {"default": raw}
     return {}
 
 


### PR DESCRIPTION
## Summary
- Parse flat `model: provider/model` strings into a strong provider binding.
- Preserve aggregator-style model IDs such as `vendor/model` unless the prefix is a known Hermes provider or `custom:*` provider.
- Prevent `model: deepseek/deepseek-v4-flash` or `model: custom:tokenfree/gpt-5.5` from falling through to `provider=auto` and being paired with the wrong endpoint.

## Test Plan
- `./venv/bin/python3 -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q`
