### PR TITLE
fix(skills): replace symlink install destinations

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -26,6 +26,7 @@ from tools.skills_hub import (
     append_audit_log,
     _skill_meta_to_dict,
     quarantine_bundle,
+    install_from_quarantine,
 )
 
 
@@ -1491,6 +1492,53 @@ class TestQuarantineBundleBinaryAssets:
                 quarantine_bundle(bundle)
 
         assert not absolute_target.exists()
+
+
+class TestInstallFromQuarantine:
+    def test_replaces_existing_symlink_install_destination(self, tmp_path):
+        import tools.skills_hub as hub
+        from tools.skills_guard import ScanResult
+
+        hub_dir = tmp_path / "skills" / ".hub"
+        target_dir = tmp_path / "linked-skill"
+        target_dir.mkdir()
+        with patch.object(hub, "SKILLS_DIR", tmp_path / "skills"), \
+             patch.object(hub, "HUB_DIR", hub_dir), \
+             patch.object(hub, "LOCK_FILE", hub_dir / "lock.json"), \
+             patch.object(hub, "QUARANTINE_DIR", hub_dir / "quarantine"), \
+             patch.object(hub, "AUDIT_LOG", hub_dir / "audit.log"), \
+             patch.object(hub, "TAPS_FILE", hub_dir / "taps.json"), \
+             patch.object(hub, "INDEX_CACHE_DIR", hub_dir / "index-cache"):
+            bundle = SkillBundle(
+                name="demo",
+                files={"SKILL.md": "---\nname: demo\n---\n"},
+                source="github",
+                identifier="owner/repo/demo",
+                trust_level="community",
+            )
+            q_path = quarantine_bundle(bundle)
+            install_link = tmp_path / "skills" / "demo"
+            install_link.symlink_to(target_dir, target_is_directory=True)
+
+            install_dir = install_from_quarantine(
+                q_path,
+                "demo",
+                "",
+                bundle,
+                ScanResult(
+                    skill_name="demo",
+                    source="github",
+                    trust_level="community",
+                    verdict="safe",
+                ),
+            )
+
+        assert install_dir == tmp_path / "skills" / "demo"
+        assert install_dir.is_dir()
+        assert not install_dir.is_symlink()
+        assert (install_dir / "SKILL.md").exists()
+        assert target_dir.exists()
+        assert not any(target_dir.iterdir())
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2715,6 +2715,14 @@ def quarantine_bundle(bundle: SkillBundle) -> Path:
     return dest
 
 
+def _remove_existing_skill_install_path(path: Path) -> None:
+    """Remove a prior skill install without following directory symlinks."""
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.exists():
+        shutil.rmtree(path)
+
+
 def install_from_quarantine(
     quarantine_path: Path,
     skill_name: str,
@@ -2735,8 +2743,7 @@ def install_from_quarantine(
     else:
         install_dir = SKILLS_DIR / safe_skill_name
 
-    if install_dir.exists():
-        shutil.rmtree(install_dir)
+    _remove_existing_skill_install_path(install_dir)
 
     # Warn (but don't block) if SKILL.md is very large
     skill_md = quarantine_path / "SKILL.md"


### PR DESCRIPTION
## Problem
`hermes skills install --force` crashes when the existing install destination is a symbolic link because the installer tries to pass that path to `shutil.rmtree()`, which refuses to operate on symlinks.

Closes #21735

## Root cause
`install_from_quarantine()` only checked `install_dir.exists()` before cleanup, then always called `shutil.rmtree(install_dir)`. For directory symlinks, that raises `OSError` instead of replacing the previous install path.

## Fix
Add a small cleanup helper that unlinks symlinks and files, while preserving the existing recursive removal behavior for real directories. The regression test installs over a symlinked skill path and verifies the symlink target is left intact.

## Testing
- `uv run --with ruff --with pytest --with pytest-xdist --python 3.11 ruff check tools/skills_hub.py tests/tools/test_skills_hub.py`: clean
- `uv run --with pytest --with pytest-xdist --python 3.11 pytest tests/tools/test_skills_hub.py -q`: 107 passed

Made with [Cursor](https://cursor.com)