### PR TITLE
fix(cron): run pre-run scripts from workdir

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -652,7 +652,7 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
-def _run_job_script(script_path: str) -> tuple[bool, str]:
+def _run_job_script(script_path: str, cwd: Optional[str] = None) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
     Scripts must reside within HERMES_HOME/scripts/.  Both relative and
@@ -674,6 +674,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
         script_path: Path to the script.  Relative paths are resolved
             against HERMES_HOME/scripts/.  Absolute and ~-prefixed paths
             are also validated to ensure they stay within the scripts dir.
+        cwd: Optional working directory for the subprocess.  Defaults to
+            the script's parent directory for backward compatibility.
 
     Returns:
         (success, output) — on failure *output* contains the error message so the
@@ -706,6 +708,12 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     if not path.is_file():
         return False, f"Script path is not a file: {path}"
 
+    run_cwd = path.parent
+    if cwd:
+        run_cwd = Path(cwd).expanduser()
+        if not run_cwd.is_dir():
+            return False, f"Workdir not found: {run_cwd}"
+
     script_timeout = _get_script_timeout()
 
     # Pick an interpreter by extension.  Bash for .sh/.bash, Python for
@@ -724,7 +732,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             capture_output=True,
             text=True,
             timeout=script_timeout,
-            cwd=str(path.parent),
+            cwd=str(run_cwd),
         )
         stdout = (result.stdout or "").strip()
         stderr = (result.stderr or "").strip()
@@ -779,6 +787,18 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
+def _resolve_job_workdir(job_id: str, job: dict) -> Optional[str]:
+    """Return a configured cron workdir if it still exists."""
+    job_workdir = (job.get("workdir") or "").strip() or None
+    if job_workdir and not Path(job_workdir).is_dir():
+        logger.warning(
+            "Job '%s': configured workdir %r no longer exists — running without it",
+            job_id, job_workdir,
+        )
+        return None
+    return job_workdir
+
+
 def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
     """Build the effective prompt for a cron job, optionally loading one or more skills first.
 
@@ -799,7 +819,10 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
         if prerun_script is not None:
             success, script_output = prerun_script
         else:
-            success, script_output = _run_job_script(script_path)
+            success, script_output = _run_job_script(
+                script_path,
+                cwd=_resolve_job_workdir(str(job.get("id") or "?"), job),
+            )
         if success:
             if script_output:
                 prompt = (
@@ -961,6 +984,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     job_id = job["id"]
     job_name = job["name"]
+    _job_workdir = _resolve_job_workdir(job_id, job)
 
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
@@ -987,26 +1011,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             logger.error("Job '%s': %s", job_id, err)
             return False, "", "", err
 
-        # Apply workdir if configured — lets scripts use predictable relative
-        # paths. For no_agent jobs this is just the subprocess cwd (not an
-        # agent TERMINAL_CWD bridge).
-        _job_workdir = (job.get("workdir") or "").strip() or None
-        _prior_cwd = None
-        if _job_workdir and Path(_job_workdir).is_dir():
-            _prior_cwd = os.getcwd()
-            try:
-                os.chdir(_job_workdir)
-            except OSError:
-                _prior_cwd = None
-
-        try:
-            ok, output = _run_job_script(script_path)
-        finally:
-            if _prior_cwd is not None:
-                try:
-                    os.chdir(_prior_cwd)
-                except OSError:
-                    pass
+        ok, output = _run_job_script(script_path, cwd=_job_workdir)
 
         now_iso = _hermes_now().strftime("%Y-%m-%d %H:%M:%S")
 
@@ -1089,7 +1094,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script(script_path)
+        prerun_script = _run_job_script(script_path, cwd=_job_workdir)
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info(
@@ -1172,15 +1177,6 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     # os.environ["TERMINAL_CWD"] here is safe for those jobs.  For workdir-less
     # jobs we leave TERMINAL_CWD untouched — preserves the original behaviour
     # (skip_context_files=True, tools use whatever cwd the scheduler has).
-    _job_workdir = (job.get("workdir") or "").strip() or None
-    if _job_workdir and not Path(_job_workdir).is_dir():
-        # Directory was removed between create-time validation and now.  Log
-        # and drop back to old behaviour rather than crashing the job.
-        logger.warning(
-            "Job '%s': configured workdir %r no longer exists — running without it",
-            job_id, _job_workdir,
-        )
-        _job_workdir = None
     _prior_terminal_cwd = os.environ.get("TERMINAL_CWD", "_UNSET_")
     if _job_workdir:
         os.environ["TERMINAL_CWD"] = _job_workdir

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -602,6 +602,7 @@ AUTHOR_MAP = {
     "danieldliu@tencent.com": "danieldliu",
     "loongzhao@tencent.com": "loongzhao",
     "Bartok9@users.noreply.github.com": "Bartok9",
+    "bartok9@users.noreply.github.com": "Bartok9",
     "LeonSGP43@users.noreply.github.com": "LeonSGP43",
     "kshitijk4poor@users.noreply.github.com": "kshitijk4poor",
     "mbelleau@Michels-MacBook-Pro.local": "malaiwah",

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -111,6 +111,19 @@ class TestRunJobScript:
         assert success is True
         assert output == "relative works"
 
+    def test_script_uses_explicit_workdir(self, cron_env, tmp_path):
+        from cron.scheduler import _run_job_script
+
+        workdir = tmp_path / "project"
+        workdir.mkdir()
+        script = cron_env / "scripts" / "cwd.py"
+        script.write_text("import os\nprint(os.getcwd())\n")
+
+        success, output = _run_job_script(str(script), cwd=str(workdir))
+
+        assert success is True
+        assert output == str(workdir)
+
     def test_script_not_found(self, cron_env):
         from cron.scheduler import _run_job_script
 
@@ -192,6 +205,44 @@ class TestBuildJobPromptWithScript:
         assert "## Script Output" in prompt
         assert "new PR: #123 fix typo" in prompt
         assert "Report any notable changes." in prompt
+
+    def test_script_output_uses_job_workdir(self, cron_env, tmp_path):
+        from cron.scheduler import _build_job_prompt
+
+        workdir = tmp_path / "project"
+        workdir.mkdir()
+        script = cron_env / "scripts" / "cwd.py"
+        script.write_text("import os\nprint(os.getcwd())\n")
+
+        prompt = _build_job_prompt({
+            "id": "job-workdir",
+            "prompt": "Report cwd.",
+            "script": str(script),
+            "workdir": str(workdir),
+        })
+
+        assert str(workdir) in prompt
+        assert "Report cwd." in prompt
+
+    def test_no_agent_script_uses_job_workdir(self, cron_env, tmp_path):
+        from cron.scheduler import run_job
+
+        workdir = tmp_path / "project"
+        workdir.mkdir()
+        script = cron_env / "scripts" / "cwd.py"
+        script.write_text("import os\nprint(os.getcwd())\n")
+
+        ok, _doc, output, error = run_job({
+            "id": "job-workdir",
+            "name": "Workdir script",
+            "script": str(script),
+            "workdir": str(workdir),
+            "no_agent": True,
+        })
+
+        assert ok is True
+        assert output == str(workdir)
+        assert error is None
 
     def test_script_error_injected(self, cron_env):
         from cron.scheduler import _build_job_prompt


### PR DESCRIPTION
## Problem
Cron jobs that set both `workdir` and `script` still run the pre-run script from `~/.hermes/scripts`, so scripts cannot rely on project-relative paths, local env files, or project virtualenv layout.

Closes #21721

## Root cause
`_run_job_script()` always passed `cwd=str(path.parent)` to `subprocess.run()`. `run_job()` extracted the job workdir only after the default-path pre-run script had already executed, and the no-agent path's temporary `os.chdir()` was overridden by `_run_job_script()`'s explicit cwd.

## Fix
Let `_run_job_script()` accept an optional subprocess cwd, resolve the job workdir once at the start of `run_job()`, and pass it to both no-agent scripts and default-path pre-run scripts. The existing `TERMINAL_CWD` handling remains for the agent/tool phase.

## Testing
- `uv run --with ruff --with pytest --with pytest-xdist --python 3.11 ruff check cron/scheduler.py tests/cron/test_cron_script.py`: clean
- `uv run --with pytest --with pytest-xdist --python 3.11 pytest tests/cron/test_cron_script.py -q -k 'explicit_workdir or output_uses_job_workdir or no_agent_script_uses_job_workdir'`: 3 passed
- `uv run --with pytest --with pytest-xdist --python 3.11 pytest tests/cron/test_cron_script.py -q`: 39 passed, 1 pre-existing failure in `test_script_empty_output_noted` (current main returns `None` for empty script output)
