### PR TITLE
fix(gateway): handle sessions command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5688,6 +5688,9 @@ class GatewayRunner:
         if canonical == "resume":
             return await self._handle_resume_command(event)
 
+        if canonical == "sessions":
+            return await self._handle_sessions_command(event)
+
         if canonical == "branch":
             return await self._handle_branch_command(event)
 
@@ -10555,6 +10558,51 @@ class GatewayRunner:
         msg_part = f" ({msg_count} message{'s' if msg_count != 1 else ''})" if msg_count else ""
 
         return f"↻ Resumed session **{title}**{msg_part}. Conversation restored."
+
+    async def _handle_sessions_command(self, event: MessageEvent) -> str:
+        """Handle /sessions command — list recent sessions for this gateway platform."""
+        if not self._session_db:
+            return "Session database not available."
+
+        source = event.source
+        user_source = source.platform.value if source.platform else None
+        try:
+            sessions = self._session_db.list_sessions_rich(
+                source=user_source,
+                limit=10,
+                order_by_last_active=True,
+            )
+        except Exception as e:
+            logger.debug("Failed to list sessions: %s", e)
+            return f"Could not list sessions: {e}"
+
+        if not sessions:
+            return "No recent sessions found. Send a message to start one."
+
+        current_id = ""
+        try:
+            current_id = self.session_store.get_or_create_session(source).session_id
+        except Exception:
+            pass
+
+        lines = ["📋 **Recent Sessions**\n"]
+        for session in sessions[:10]:
+            session_id = str(session.get("id") or "")
+            title = session.get("title") or "Untitled session"
+            preview = (session.get("preview") or "").strip()
+            msg_count = int(session.get("message_count") or 0)
+            marker = "→" if session_id == current_id else "•"
+            ended = "ended" if session.get("ended_at") else "active"
+            line = (
+                f"{marker} **{title}** `{session_id[:12]}` "
+                f"({msg_count} message{'s' if msg_count != 1 else ''}, {ended})"
+            )
+            if preview:
+                line = f"{line}\n  _{preview}_"
+            lines.append(line)
+
+        lines.append("\nUse `/title <name>` to name this chat, then `/resume <name>` to return later.")
+        return "\n".join(lines)
 
     async def _handle_branch_command(self, event: MessageEvent) -> str:
         """Handle /branch [name] — fork the current session into a new independent copy.

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -257,3 +257,60 @@ class TestHandleResumeCommand:
 
         assert real_key not in runner._agent_cache
         db.close()
+
+
+class TestHandleSessionsCommand:
+    """Tests for GatewayRunner._handle_sessions_command."""
+
+    @pytest.mark.asyncio
+    async def test_no_session_db(self):
+        runner = _make_runner(session_db=None)
+        event = _make_event(text="/sessions")
+
+        result = await runner._handle_sessions_command(event)
+
+        assert "not available" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_lists_recent_sessions_for_platform(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess_current", "telegram")
+        db.set_session_title("sess_current", "Current Work")
+        db.append_message("sess_current", "user", "current preview")
+        db.create_session("sess_other", "telegram")
+        db.set_session_title("sess_other", "Other Work")
+        db.append_message("sess_other", "user", "other preview")
+        db.create_session("sess_slack", "slack")
+        db.set_session_title("sess_slack", "Slack Work")
+
+        event = _make_event(text="/sessions")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="sess_current",
+            event=event,
+        )
+
+        result = await runner._handle_sessions_command(event)
+
+        assert "Recent Sessions" in result
+        assert "Current Work" in result
+        assert "Other Work" in result
+        assert "Slack Work" not in result
+        assert "current preview" in result
+        assert "`sess_current`" in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_no_sessions_message(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        event = _make_event(text="/sessions")
+        runner = _make_runner(session_db=db, event=event)
+
+        result = await runner._handle_sessions_command(event)
+
+        assert "No recent sessions" in result
+        db.close()


### PR DESCRIPTION
## Problem
Gateway users can send `/sessions`, and the command is registered as gateway-visible, but the gateway dispatcher has no handler for it. On messaging platforms it can fall through to the unknown-command path or be treated like plain text instead of listing sessions.

Closes #21734

## Root cause
`COMMAND_REGISTRY` includes `sessions`, so it is recognized as a gateway command, but `GatewayRunner._handle_message()` only dispatches adjacent session commands like `/resume`, `/title`, and `/branch`. There was no `canonical == "sessions"` branch.

## Fix
Wire `/sessions` into gateway command dispatch and add a small handler that lists recent sessions for the current platform using the existing `SessionDB.list_sessions_rich()` data. The response marks the current session, includes titles/previews when available, and points users to `/title` plus `/resume` for returning later.

## Testing
- `uv run --with ruff --with pytest --with pytest-xdist --python 3.11 ruff check gateway/run.py tests/gateway/test_resume_command.py`: clean
- `uv run --with pytest --with pytest-xdist --with pytest-asyncio --python 3.11 pytest tests/gateway/test_resume_command.py -q`: 13 passed
