### PR TITLE
fix(auth): read api_key from config.yaml for built-in providers — fixes #21725

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -552,13 +552,31 @@ def _resolve_api_key_provider_secret(
         return "", ""
 
     from hermes_cli.config import get_env_value
+
+    # Priority 1: config.yaml providers.<id>.api_key — lets users store keys
+    # in their config file without requiring an environment variable.  This
+    # mirrors the behaviour of user-defined ("providers:") entries and fixes
+    # built-in providers like DeepSeek that previously ignored this field.
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+        providers_cfg = cfg.get("providers", {}) if isinstance(cfg, dict) else {}
+        if isinstance(providers_cfg, dict):
+            entry_cfg = providers_cfg.get(provider_id, {})
+            if isinstance(entry_cfg, dict):
+                cfg_api_key = str(entry_cfg.get("api_key", "") or "").strip()
+                if has_usable_secret(cfg_api_key):
+                    return cfg_api_key, f"config.yaml:providers.{provider_id}.api_key"
+    except Exception:
+        pass
+
+    # Priority 2: environment variables (os.environ + ~/.hermes/.env)
     for env_var in pconfig.api_key_env_vars:
-        # Check both os.environ and ~/.hermes/.env file
         val = (get_env_value(env_var) or "").strip()
         if has_usable_secret(val):
             return val, env_var
 
-    # Fallback: try credential pool (e.g. zai key stored via auth.json)
+    # Priority 3: credential pool (e.g. zai key stored via auth.json)
     try:
         from agent.credential_pool import load_pool
         pool = load_pool(provider_id)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -281,6 +281,7 @@ AUTHOR_MAP = {
     "barnacleboy.jezzahehn@agentmail.to": "JezzaHehn",
     "254021826+dodo-reach@users.noreply.github.com": "dodo-reach",
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
+    "bartok9@users.noreply.github.com": "Bartok9",
     "270082434+crayfish-ai@users.noreply.github.com": "crayfish-ai",
     "241404605+MestreY0d4-Uninter@users.noreply.github.com": "MestreY0d4-Uninter",
     "268667990+Roy-oss1@users.noreply.github.com": "Roy-oss1",


### PR DESCRIPTION
## Problem

Built-in providers (DeepSeek, and any other `PROVIDER_REGISTRY` entry) completely ignore the `api_key` field in `config.yaml`. Users who configure:

```yaml
providers:
  deepseek:
    api_key: sk-...
```

get a 401 auth failure because `_resolve_api_key_provider_secret()` only checks environment variables and the credential pool — it never reads `config.yaml`.

This is inconsistent with user-defined (`providers:`) custom entries, which already read `api_key` from config via `_resolve_named_custom_runtime()`.

## Root Cause

`_resolve_api_key_provider_secret()` (the function used for all PROVIDER_REGISTRY providers) does:
1. Check env vars (`DEEPSEEK_API_KEY`, etc.)
2. Check credential pool

It never checks `config.yaml` at all.

## Fix

Add config.yaml as the highest-priority source, before env var lookup:

```
Priority 1: config.yaml providers.<id>.api_key  ← NEW
Priority 2: env vars (DEEPSEEK_API_KEY, etc.)   ← unchanged
Priority 3: credential pool                      ← unchanged
```

Config takes priority because it is an explicit user decision — if you wrote a key in your config file, you almost certainly want that key to win over a stale env var.

## No Breaking Changes

- If `config.yaml` has no `providers.deepseek` section (the common case), behaviour is identical.
- Existing env-var setups are unaffected — the new check only runs when a non-empty `api_key` is present in config.
- All other PROVIDER_REGISTRY providers gain the same fix automatically.

Fixes #21725