### PR TITLE
fix(webhook): filter route actions before agent dispatch

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -406,6 +406,29 @@ class WebhookAdapter(BasePlatformAdapter):
                 {"status": "ignored", "event": event_type}
             )
 
+        # Check payload action filter (GitHub/GitLab-style payloads).
+        # Event headers only identify the broad event type (for example,
+        # ``pull_request``); providers put the concrete action (``opened``,
+        # ``synchronize``, ``closed``) in the JSON payload. Filtering here
+        # prevents non-actionable deliveries from spawning an agent run or
+        # sending no-op messages to downstream platforms.
+        allowed_actions = route_config.get("actions", [])
+        payload_action = payload.get("action")
+        if allowed_actions and payload_action not in allowed_actions:
+            logger.debug(
+                "[webhook] Ignoring action %s for route %s (allowed: %s)",
+                payload_action,
+                route_name,
+                allowed_actions,
+            )
+            return web.json_response(
+                {
+                    "status": "ignored",
+                    "event": event_type,
+                    "action": payload_action,
+                }
+            )
+
         # Format prompt from template
         prompt_template = route_config.get("prompt", "")
         prompt = self._render_prompt(

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -304,6 +304,58 @@ class TestEventFilter:
             )
             assert resp.status == 202
 
+    @pytest.mark.asyncio
+    async def test_action_filter_rejects_non_matching(self):
+        """Non-matching payload action is ignored before agent dispatch."""
+        routes = {
+            "gh": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["pull_request"],
+                "actions": ["opened"],
+                "prompt": "PR: {action}",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/gh",
+                json={"action": "synchronize"},
+                headers={"X-GitHub-Event": "pull_request"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "ignored"
+            assert data["event"] == "pull_request"
+            assert data["action"] == "synchronize"
+            adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_action_filter_accepts_matching(self):
+        """Matching payload action passes through."""
+        routes = {
+            "gh": {
+                "secret": _INSECURE_NO_AUTH,
+                "events": ["pull_request"],
+                "actions": ["opened"],
+                "prompt": "PR: {action}",
+            }
+        }
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/gh",
+                json={"action": "opened"},
+                headers={"X-GitHub-Event": "pull_request"},
+            )
+            assert resp.status == 202
+            adapter.handle_message.assert_called_once()
+
 
 # ===================================================================
 # HTTP handling
@@ -834,4 +886,3 @@ class TestInsecureNoAuthSafetyRail:
             assert result is True
         finally:
             await adapter.disconnect()
-

--- a/website/docs/guides/webhook-github-pr-review.md
+++ b/website/docs/guides/webhook-github-pr-review.md
@@ -51,6 +51,9 @@ platforms:
           secret: "your-webhook-secret-here"   # must match the GitHub webhook secret exactly
           events:
             - pull_request
+          actions:
+            - opened
+            - synchronize
 
           # The agent is instructed to fetch the actual diff before reviewing.
           # {number} and {repository.full_name} are resolved from the GitHub payload.
@@ -82,6 +85,7 @@ platforms:
 |---|---|
 | `secret` (route-level) | HMAC secret for this route. Falls back to `extra.secret` global if omitted. |
 | `events` | List of `X-GitHub-Event` header values to accept. Empty list = accept all. |
+| `actions` | Optional list of payload `action` values to accept, such as `opened` or `synchronize`. Empty or omitted = accept all actions for the accepted events. |
 | `prompt` | Template; `{field}` and `{nested.field}` resolve from the GitHub payload. |
 | `deliver` | `github_comment` posts via `gh pr comment`. `log` just writes to the gateway log. |
 | `deliver_extra.repo` | Resolves to e.g. `org/repo` from the payload. |
@@ -182,13 +186,22 @@ tail -f "${HERMES_HOME:-$HOME/.hermes}/logs/gateway.log"
 
 ## Filtering to specific actions
 
-GitHub sends `pull_request` events for many actions: `opened`, `synchronize`, `reopened`, `closed`, `labeled`, etc. The `events` list filters only by the `X-GitHub-Event` header value — it cannot filter by action sub-type at the routing level.
+GitHub sends `pull_request` events for many actions: `opened`, `synchronize`, `reopened`, `closed`, `labeled`, etc. The `events` list filters by the `X-GitHub-Event` header value, and `actions` filters by the JSON payload's `action` field before the agent runs.
 
-The prompt in Step 1 already handles this by instructing the agent to stop early for `closed` and `labeled` events.
+For example, review only newly opened PRs:
 
-:::warning The agent still runs and consumes tokens
-The "stop here" instruction prevents a meaningful review, but the agent still runs to completion for every `pull_request` event regardless of action. GitHub webhooks can only filter by event type (`pull_request`, `push`, `issues`, etc.) — not by action sub-type (`opened`, `closed`, `labeled`). There is no routing-level filter for sub-actions. For high-volume repos, accept this cost or filter upstream with a GitHub Actions workflow that calls your webhook URL conditionally.
-:::
+```yaml
+events: [pull_request]
+actions: [opened]
+```
+
+When an accepted event has a non-matching action, Hermes returns an ignored response and skips agent dispatch:
+
+```json
+{"status":"ignored","event":"pull_request","action":"synchronize"}
+```
+
+Use prompt instructions for any remaining business logic within the accepted actions.
 
 > There is no Jinja2 or conditional template syntax. `{field}` and `{nested.field}` are the only substitutions supported. Anything else is passed verbatim to the agent.
 


### PR DESCRIPTION
## What does this PR do?

Adds route-level `actions` filtering for webhook routes so providers such as GitHub can be filtered by payload action before the agent runs.

This fixes cases where a route accepts a broad event type such as `pull_request`, then still dispatches agents for non-actionable sub-actions like `synchronize`, `closed`, or `labeled`. With this change, routes can opt into action filtering:

```yaml
events: [pull_request]
actions: [opened]
```

A non-matching action now returns an ignored response and skips agent dispatch:

```json
{"status":"ignored","event":"pull_request","action":"synchronize"}
```

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/webhook.py`
  - Adds optional route config key `actions`.
  - Checks `payload["action"]` after event filtering and before prompt rendering / agent dispatch.
  - Returns `status=ignored` with the event and action when the action does not match.
- `tests/gateway/test_webhook_adapter.py`
  - Adds coverage for rejected non-matching actions.
  - Adds coverage for accepted matching actions.
- `website/docs/guides/webhook-github-pr-review.md`
  - Documents the new `actions` route field.
  - Updates the action-filtering section to explain ignore-before-agent behavior.

## How to Test

1. Configure a webhook route with:
   ```yaml
   events: [pull_request]
   actions: [opened]
   ```
2. Send a `pull_request` payload with `action: synchronize`.
3. Verify Hermes returns:
   ```json
   {"status":"ignored","event":"pull_request","action":"synchronize"}
   ```
4. Send a `pull_request` payload with `action: opened`.
5. Verify Hermes accepts the delivery and dispatches the agent.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test run:

```text
$ /Users/william/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_webhook_adapter.py -q
bringing up nodes...
bringing up nodes...

........................................................                 [100%]
56 passed in 1.93s
```

Manual verification from a local Hermes gateway:

```http
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8

{"status":"ignored","event":"pull_request","action":"synchronize"}
```

A real GitHub `pull_request/synchronize` delivery returned `200` after this change, where the same route previously returned `202` and dispatched the agent.