### PR TITLE
feat: support custom base_url for Gemini native adapter

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6314,10 +6314,13 @@ class AIAgent:
             )
             return client
         if self.provider == "gemini":
-            from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
+            from agent.gemini_native_adapter import GeminiNativeClient
 
             base_url = str(client_kwargs.get("base_url", "") or "")
-            if is_native_gemini_base_url(base_url):
+            # URLs ending in /openai are OpenAI-compatible endpoints (e.g.
+            # generativelanguage.googleapis.com/v1beta/openai) — fall through
+            # to the OpenAI client for those.
+            if not base_url.rstrip("/").lower().endswith("/openai"):
                 safe_kwargs = {
                     k: v for k, v in client_kwargs.items()
                     if k in {"api_key", "base_url", "default_headers", "timeout", "http_client"}

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -218,12 +218,12 @@ class TestGeminiAgentInit:
         assert mock_client.called
         mock_openai.assert_not_called()
 
-    def test_gemini_custom_base_url_keeps_openai_client(self, monkeypatch):
+    def test_gemini_custom_base_url_uses_native_client(self, monkeypatch):
         monkeypatch.setenv("GOOGLE_API_KEY", "AIzaSy_REAL_KEY")
         with patch("agent.gemini_native_adapter.GeminiNativeClient") as mock_client, \
              patch("run_agent.OpenAI") as mock_openai, \
              patch("run_agent.ContextCompressor") as mock_compressor:
-            mock_openai.return_value = MagicMock()
+            mock_client.return_value = MagicMock()
             mock_compressor.return_value = MagicMock(context_length=128000, threshold_tokens=64000)
             from run_agent import AIAgent
             AIAgent(
@@ -232,7 +232,21 @@ class TestGeminiAgentInit:
                 api_key="AIzaSy_REAL_KEY",
                 base_url="https://proxy.example.com/v1",
             )
-        mock_openai.assert_called_once()
+        # The primary client construction must use the custom base_url —
+        # that's the assertion that proves the patched code path took the
+        # native-Gemini branch instead of falling through to OpenAI.
+        # (Auxiliary clients may construct additional GeminiNativeClient
+        # instances with the default endpoint for title-generation etc.;
+        # we don't constrain that count here.)
+        primary_calls = [
+            c for c in mock_client.call_args_list
+            if c.kwargs.get("base_url") == "https://proxy.example.com/v1"
+        ]
+        assert len(primary_calls) == 1, (
+            f"expected exactly one GeminiNativeClient call with the custom "
+            f"base_url, got: {mock_client.call_args_list}"
+        )
+        mock_openai.assert_not_called()
 
     def test_gemini_openai_compat_base_url_keeps_openai_client(self, monkeypatch):
         monkeypatch.setenv("GOOGLE_API_KEY", "AIzaSy_REAL_KEY")


### PR DESCRIPTION
## Summary

When `provider: "gemini"` is explicitly configured, use the native Gemini REST adapter (`models/{model}:generateContent`) for any `base_url` that doesn't end in `/openai` — matching how other providers work unconditionally in `_create_openai_client()`.

Gemini was the **only** provider with a domain-based gate:

| Provider | Client creation | Gated? |
|---|---|---|
| `copilot-acp` | CopilotACPClient | No |
| `google-gemini-cli` | GeminiCloudCodeClient | No |
| `gemini` | GeminiNativeClient | **Yes** (relaxed by this PR) |
| `openai`/`custom` | OpenAI() | No |
| `anthropic` | build_anthropic_client() | No |

## Problem

Previously, `is_native_gemini_base_url()` checked for `generativelanguage.googleapis.com` in the URL before using the native adapter. With a custom `base_url` (e.g. a local proxy that speaks Gemini's native REST protocol), the check would fail and silently fall through to the OpenAI-compatible client — sending `/v1/chat/completions` format instead of `/models/{model}:generateContent`.

## Fix

Replaced the domain-based `is_native_gemini_base_url()` check with a simpler `/openai` suffix check:

```python
# Before:
if is_native_gemini_base_url(base_url):  # requires googleapis.com domain

# After:
if not base_url.rstrip('/').lower().endswith('/openai'):  # only skip for OpenAI-compat endpoints
```

- Any `base_url` (including custom proxies) → native Gemini adapter
- URLs ending in `/openai` (e.g. `generativelanguage.googleapis.com/v1beta/openai`) → OpenAI client (these speak OpenAI format)
- Empty `base_url` → native adapter (defaults to Google's endpoint internally)

## Example config (cli-config.yaml)

```yaml
model:
  default: "gemini-2.5-flash"
  provider: "gemini"
  base_url: "http://localhost:8900/gemini"
  api_key: "your-proxy-api-key"
```

## Test plan

- [x] Updated `test_gemini_custom_base_url` to assert native client is used
- [x] `test_gemini_openai_compat_base_url_keeps_openai_client` unchanged (verifies `/openai` suffix fallback)
- [ ] Verify `provider: "gemini"` with no `base_url` still defaults to Google's endpoint
- [ ] Verify `provider: "gemini"` with custom `base_url` uses native adapter
- [ ] Verify other providers are unaffected