### PR TITLE
fix(gateway): handle sessions slash command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5685,6 +5685,9 @@ class GatewayRunner:
         if canonical == "title":
             return await self._handle_title_command(event)
 
+        if canonical == "sessions":
+            return await self._handle_resume_command(event)
+
         if canonical == "resume":
             return await self._handle_resume_command(event)
 

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -293,6 +293,7 @@ class TestAllResolvableCommandsBypassGuard:
             ("/voice on", "voice"),
             ("/insights 7", "insights"),
             ("/title my session", "title"),
+            ("/sessions", "sessions"),
             ("/resume yesterday", "resume"),
             ("/retry", "retry"),
             ("/undo", "undo"),

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -91,6 +91,24 @@ class TestHandleResumeCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_sessions_lists_named_sessions_when_no_arg(self, tmp_path):
+        """/sessions should reuse the gateway session browser semantics."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess_001", "telegram")
+        db.create_session("sess_002", "telegram")
+        db.set_session_title("sess_001", "Research")
+        db.set_session_title("sess_002", "Coding")
+
+        event = _make_event(text="/sessions")
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+        assert "Research" in result
+        assert "Coding" in result
+        assert "Named Sessions" in result
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_list_shows_usage_when_no_titled(self, tmp_path):
         """With no arg and no titled sessions, shows instructions."""
         from hermes_state import SessionDB
@@ -122,6 +140,29 @@ class TestHandleResumeCommand:
         assert "My Project" in result
         # Verify switch_session was called with the old session ID
         runner.session_store.switch_session.assert_called_once()
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "old_session_abc"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_sessions_resumes_by_name(self, tmp_path):
+        """/sessions <name> should resume the named session on gateway platforms."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("old_session_abc", "telegram")
+        db.set_session_title("old_session_abc", "My Project")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/sessions My Project")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        assert "My Project" in result
         call_args = runner.session_store.switch_session.call_args
         assert call_args[0][1] == "old_session_abc"
         db.close()


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway slash-command dispatch gap where `/sessions` is recognized by the shared command registry but has no gateway handler. On gateway platforms this made `/sessions` fall through as unknown command or plain text instead of listing resumable sessions.

This PR fixes that by routing gateway `/sessions` through the existing `/resume` session-browser/resume flow, which is already the closest matching gateway behavior for "browse and resume previous sessions".

## Related Issue

Fixes #21734

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a gateway dispatch branch in `gateway/run.py` so canonical `sessions` commands are handled instead of falling through.
- Reused the existing `_handle_resume_command()` flow for gateway `/sessions`, so:
  - `/sessions` lists recent named sessions
  - `/sessions <name>` resumes the named session
- Added regression coverage in `tests/gateway/test_resume_command.py` for both `/sessions` listing and `/sessions <name>` resume behavior.
- Added `/sessions` to the active-session bypass regression matrix in `tests/gateway/test_command_bypass_active_session.py` so it keeps bypassing the Level-1 busy-session guard like other recognized slash commands.

## How to Test

1. Run `python -m pytest tests/gateway/test_resume_command.py -q`
2. Run `python -m pytest tests/gateway/test_command_bypass_active_session.py -q`
3. On a gateway platform, send `/sessions` and verify it lists named sessions instead of falling through as unknown/plain text. Then send `/sessions <name>` and verify the session resumes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (WSL2 / Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Test runs:

- `python -m pytest tests/gateway/test_resume_command.py -q` → `12 passed`
- `python -m pytest tests/gateway/test_command_bypass_active_session.py -q` → `41 passed`
