### PR TITLE
fix(gateway): mirror background deliveries into sessions

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -388,6 +388,7 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
 # via should_send_media_as_audio() so Telegram-specific rules stay in one place.
 _VIDEO_EXTS = frozenset({'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'})
 _IMAGE_EXTS = frozenset({'.jpg', '.jpeg', '.png', '.webp', '.gif'})
+_AUDIO_EXTS = frozenset({'.mp3', '.m4a', '.ogg', '.wav', '.flac', '.aac', '.opus'})
 
 
 def _send_media_via_adapter(
@@ -398,8 +399,11 @@ def _send_media_via_adapter(
     loop,
     job: dict,
     platform=None,
-) -> None:
+) -> bool:
     """Send extracted MEDIA files as native platform attachments via a live adapter.
+
+    Returns True when every attachment send succeeded, False when any attachment
+    failed or timed out.
 
     Routes each file to the appropriate adapter method (send_voice, send_image_file,
     send_video, send_document) based on file extension — mirroring the routing logic
@@ -409,6 +413,7 @@ def _send_media_via_adapter(
 
     from gateway.platforms.base import should_send_media_as_audio
 
+    all_ok = True
     for media_path, _is_voice in media_files:
         try:
             ext = Path(media_path).suffix.lower()
@@ -427,14 +432,94 @@ def _send_media_via_adapter(
                 result = future.result(timeout=30)
             except TimeoutError:
                 future.cancel()
+                all_ok = False
                 raise
             if result and not getattr(result, "success", True):
+                all_ok = False
                 logger.warning(
                     "Job '%s': media send failed for %s: %s",
                     job.get("id", "?"), media_path, getattr(result, "error", "unknown"),
                 )
         except Exception as e:
+            all_ok = False
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
+    return all_ok
+
+
+def _build_cron_mirror_text(cleaned_delivery_content: str, media_files: list[tuple[str, bool]]) -> str:
+    """Build the text mirrored back into a gateway session after cron delivery."""
+    text = (cleaned_delivery_content or "").strip()
+    if not media_files:
+        return text
+
+    if len(media_files) == 1:
+        media_path, is_voice = media_files[0]
+        ext = Path(media_path).suffix.lower()
+        if is_voice:
+            attachment_summary = "[Cron delivery sent voice attachment]"
+        elif ext in _IMAGE_EXTS:
+            attachment_summary = "[Cron delivery sent image attachment]"
+        elif ext in _VIDEO_EXTS:
+            attachment_summary = "[Cron delivery sent video attachment]"
+        elif ext in _AUDIO_EXTS:
+            attachment_summary = "[Cron delivery sent audio attachment]"
+        else:
+            attachment_summary = "[Cron delivery sent document attachment]"
+    else:
+        attachment_summary = f"[Cron delivery sent {len(media_files)} attachments]"
+
+    return f"{text}\n\n{attachment_summary}".strip() if text else attachment_summary
+
+
+def _origin_user_id_for_target(job: dict, platform_name: str, chat_id: str, thread_id: str | None) -> Optional[str]:
+    """Return the origin user_id when the delivery target matches the source chat."""
+    origin = _resolve_origin(job) or {}
+    if not origin:
+        return None
+    if str(origin.get("platform", "")).lower() != str(platform_name).lower():
+        return None
+    if str(origin.get("chat_id", "")) != str(chat_id):
+        return None
+    if str(origin.get("thread_id") or "") != str(thread_id or ""):
+        return None
+    user_id = str(origin.get("user_id") or "").strip()
+    return user_id or None
+
+
+def _maybe_mirror_cron_delivery(
+    job: dict,
+    platform_name: str,
+    chat_id: str,
+    thread_id: str | None,
+    cleaned_delivery_content: str,
+    media_files: list[tuple[str, bool]],
+) -> None:
+    """Mirror successful cron deliveries into the matching gateway session when possible."""
+    mirror_text = _build_cron_mirror_text(cleaned_delivery_content, media_files)
+    if not mirror_text:
+        return
+    try:
+        from gateway.mirror import mirror_to_session
+
+        source_label = f"cron:{job.get('name') or job.get('id', 'job')}"
+        user_id = _origin_user_id_for_target(job, platform_name, chat_id, thread_id)
+        mirrored = mirror_to_session(
+            platform_name,
+            chat_id,
+            mirror_text,
+            source_label=source_label,
+            thread_id=thread_id,
+            user_id=user_id,
+        )
+        if mirrored:
+            logger.info(
+                "Job '%s': mirrored delivery into %s:%s session",
+                job.get("id", "?"),
+                platform_name,
+                chat_id,
+            )
+    except Exception as exc:
+        logger.debug("Job '%s': cron delivery mirror failed: %s", job.get("id", "?"), exc)
 
 
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
@@ -463,9 +548,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
     # in config.yaml for clean output.
     wrap_response = True
+    mirror_deliveries_to_session = True
     try:
         user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
+        cron_cfg = user_cfg.get("cron", {}) if isinstance(user_cfg, dict) else {}
+        wrap_response = cron_cfg.get("wrap_response", True)
+        mirror_deliveries_to_session = cron_cfg.get("mirror_deliveries_to_session", True)
     except Exception:
         pass
 
@@ -561,8 +649,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         adapter_ok = False  # fall through to standalone path
 
                 # Send extracted media files as native attachments via the live adapter
+                media_delivery_succeeded = True
                 if adapter_ok and media_files:
-                    _send_media_via_adapter(
+                    media_delivery_succeeded = _send_media_via_adapter(
                         runtime_adapter,
                         chat_id,
                         media_files,
@@ -574,6 +663,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
                 if adapter_ok:
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
+                    if mirror_deliveries_to_session:
+                        _maybe_mirror_cron_delivery(
+                            job,
+                            platform_name,
+                            chat_id,
+                            thread_id,
+                            cleaned_delivery_content,
+                            media_files if media_delivery_succeeded else [],
+                        )
                     delivered = True
             except Exception as e:
                 logger.warning(
@@ -608,6 +706,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 continue
 
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
+            if mirror_deliveries_to_session:
+                _maybe_mirror_cron_delivery(
+                    job,
+                    platform_name,
+                    chat_id,
+                    thread_id,
+                    cleaned_delivery_content,
+                    media_files,
+                )
 
     if delivery_errors:
         return "; ".join(delivery_errors)

--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -1,25 +1,35 @@
 """
-Session mirroring for cross-platform message delivery.
+Session mirroring for out-of-band gateway deliveries.
 
-When a message is sent to a platform (via send_message or cron delivery),
-this module appends a "delivery-mirror" record to the target session's
-transcript so the receiving-side agent has context about what was sent.
+When a background command, cron job, or cross-platform delivery sends a result
+directly through a platform adapter, this module appends a compact assistant
+"delivery mirror" record to the matching gateway transcript.  That keeps the
+next live turn aware of background work the user already saw.
 
-Standalone -- works from CLI, cron, and gateway contexts without needing
-the full SessionStore machinery.
+Standalone -- works from CLI, cron, and gateway contexts without needing the
+full SessionStore machinery.
 """
+
+from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime
-from typing import Optional
+import threading
+from datetime import datetime, timezone
+from typing import Any, Optional
 
-from hermes_cli.config import get_hermes_home
+from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
 _SESSIONS_DIR = get_hermes_home() / "sessions"
 _SESSIONS_INDEX = _SESSIONS_DIR / "sessions.json"
+_LOCK = threading.Lock()
+
+
+def _now_iso() -> str:
+    """Return a timezone-aware ISO timestamp for mirrored transcript records."""
+    return datetime.now(timezone.utc).isoformat()
 
 
 def mirror_to_session(
@@ -33,42 +43,52 @@ def mirror_to_session(
     """
     Append a delivery-mirror message to the target session's transcript.
 
-    Finds the gateway session that matches the given platform + chat_id,
-    then writes a mirror entry to both the JSONL transcript and SQLite DB.
-
-    Returns True if mirrored successfully, False if no matching session or error.
-    All errors are caught -- this is never fatal.
+    Finds the gateway session that matches the given platform + chat_id, then
+    writes a mirror entry to both the JSONL transcript and SQLite DB.  Returns
+    True if mirrored successfully, False if no matching session or error.  All
+    errors are caught -- this is never fatal for the original delivery.
     """
+    text = (message_text or "").strip()
+    if not text:
+        return False
+
     try:
-        session_id = _find_session_id(
-            platform,
-            str(chat_id),
-            thread_id=thread_id,
-            user_id=user_id,
-        )
-        if not session_id:
-            logger.debug(
-                "Mirror: no session found for %s:%s:%s:%s",
+        with _LOCK:
+            match = _find_session_entry(
                 platform,
-                chat_id,
-                thread_id,
-                user_id,
+                str(chat_id),
+                thread_id=thread_id,
+                user_id=user_id,
             )
-            return False
+            if not match:
+                logger.debug(
+                    "Mirror: no session found for %s:%s:%s:%s",
+                    platform,
+                    chat_id,
+                    thread_id,
+                    user_id,
+                )
+                return False
 
-        mirror_msg = {
-            "role": "assistant",
-            "content": message_text,
-            "timestamp": datetime.now().isoformat(),
-            "mirror": True,
-            "mirror_source": source_label,
-        }
+            _session_key, entry = match
+            session_id = str(entry.get("session_id") or "").strip()
+            if not session_id:
+                return False
 
-        _append_to_jsonl(session_id, mirror_msg)
-        _append_to_sqlite(session_id, mirror_msg)
+            timestamp = _now_iso()
+            mirror_msg = {
+                "role": "assistant",
+                "content": text,
+                "timestamp": timestamp,
+                "mirror": True,
+                "mirror_source": source_label,
+            }
 
-        logger.debug("Mirror: wrote to session %s (from %s)", session_id, source_label)
-        return True
+            _append_to_jsonl(session_id, mirror_msg)
+            _append_to_sqlite(session_id, mirror_msg)
+
+            logger.debug("Mirror: wrote to session %s (from %s)", session_id, source_label)
+            return True
 
     except Exception as e:
         logger.debug(
@@ -82,36 +102,44 @@ def mirror_to_session(
         return False
 
 
-def _find_session_id(
+def _load_sessions_index() -> dict[str, Any]:
+    if not _SESSIONS_INDEX.exists():
+        return {}
+    try:
+        with open(_SESSIONS_INDEX, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _find_session_entry(
     platform: str,
     chat_id: str,
     thread_id: Optional[str] = None,
     user_id: Optional[str] = None,
-) -> Optional[str]:
+) -> Optional[tuple[str, dict[str, Any]]]:
     """
-    Find the active session_id for a platform + chat_id pair.
+    Find the active session entry for a platform + chat_id pair.
 
-    Scans sessions.json entries and matches where origin.chat_id == chat_id
-    on the right platform.  DM session keys don't embed the chat_id
-    (e.g. "agent:main:telegram:dm"), so we check the origin dict.
+    Scans sessions.json entries and matches where origin.chat_id == chat_id on
+    the right platform.  DM session keys don't necessarily embed the chat_id
+    (e.g. "agent:main:telegram:dm"), so origin metadata is authoritative.
 
     When *user_id* is provided, prefer exact sender matches. If multiple
     same-chat candidates exist and none matches the user, return None instead
     of guessing and contaminating another participant's session.
     """
-    if not _SESSIONS_INDEX.exists():
-        return None
-
-    try:
-        with open(_SESSIONS_INDEX, encoding="utf-8") as f:
-            data = json.load(f)
-    except Exception:
+    data = _load_sessions_index()
+    if not data:
         return None
 
     platform_lower = platform.lower()
-    candidates = []
+    candidates: list[tuple[str, dict[str, Any]]] = []
 
-    for _key, entry in data.items():
+    for key, entry in data.items():
+        if not isinstance(entry, dict):
+            continue
         origin = entry.get("origin") or {}
         entry_platform = (origin.get("platform") or entry.get("platform", "")).lower()
 
@@ -123,14 +151,15 @@ def _find_session_id(
             origin_thread_id = origin.get("thread_id")
             if thread_id is not None and str(origin_thread_id or "") != str(thread_id):
                 continue
-            candidates.append(entry)
+            candidates.append((key, entry))
 
     if not candidates:
         return None
 
     if user_id:
         exact_user_matches = [
-            entry for entry in candidates
+            (key, entry)
+            for key, entry in candidates
             if str((entry.get("origin") or {}).get("user_id") or "") == str(user_id)
         ]
         if exact_user_matches:
@@ -140,31 +169,29 @@ def _find_session_id(
     elif len(candidates) > 1:
         distinct_user_ids = {
             str((entry.get("origin") or {}).get("user_id") or "").strip()
-            for entry in candidates
+            for _key, entry in candidates
             if str((entry.get("origin") or {}).get("user_id") or "").strip()
         }
         if len(distinct_user_ids) > 1:
             return None
 
-    best_entry = max(candidates, key=lambda entry: entry.get("updated_at", ""))
-    return best_entry.get("session_id")
+    return max(candidates, key=lambda item: item[1].get("updated_at", ""))
 
 
-def _append_to_jsonl(session_id: str, message: dict) -> None:
+def _append_to_jsonl(session_id: str, message: dict[str, Any]) -> None:
     """Append a message to the JSONL transcript file."""
+    _SESSIONS_DIR.mkdir(parents=True, exist_ok=True)
     transcript_path = _SESSIONS_DIR / f"{session_id}.jsonl"
-    try:
-        with open(transcript_path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(message, ensure_ascii=False) + "\n")
-    except Exception as e:
-        logger.debug("Mirror JSONL write failed: %s", e)
+    with open(transcript_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(message, ensure_ascii=False) + "\n")
 
 
-def _append_to_sqlite(session_id: str, message: dict) -> None:
+def _append_to_sqlite(session_id: str, message: dict[str, Any]) -> None:
     """Append a message to the SQLite session database."""
     db = None
     try:
         from hermes_state import SessionDB
+
         db = SessionDB()
         db.append_message(
             session_id=session_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -554,6 +554,7 @@ from gateway.session import (
     is_shared_multi_user_session,
 )
 from gateway.delivery import DeliveryRouter
+from gateway.mirror import mirror_to_session
 from gateway.platforms.base import (
     BasePlatformAdapter,
     EphemeralReply,
@@ -9283,8 +9284,9 @@ class GatewayRunner:
         """Handle /background <prompt> — run a prompt in a separate background session.
 
         Spawns a new AIAgent in a background thread with its own session.
-        When it completes, sends the result back to the same chat without
-        modifying the active session's conversation history.
+        When it completes, sends the result back to the same chat and mirrors a
+        completion record into the active gateway transcript so the next live
+        turn has continuity.
         """
         prompt = event.get_command_args().strip()
         if not prompt:
@@ -9320,6 +9322,125 @@ class GatewayRunner:
             return
 
         _thread_metadata = {"thread_id": source.thread_id} if source.thread_id else None
+        _platform_label = getattr(source.platform, "value", source.platform)
+
+        def _mirror_background_result(message_text: str) -> None:
+            if not message_text:
+                return
+            try:
+                mirrored = mirror_to_session(
+                    _platform_label,
+                    source.chat_id,
+                    message_text,
+                    source_label=f"background:{task_id}",
+                    thread_id=source.thread_id,
+                    user_id=source.user_id,
+                )
+                if not mirrored:
+                    logger.warning(
+                        "Background task %s could not mirror into session for %s:%s",
+                        task_id,
+                        _platform_label,
+                        source.chat_id,
+                    )
+            except Exception as exc:
+                logger.debug("Background task %s mirror failed: %s", task_id, exc)
+
+        def _build_background_completion_text(
+            *,
+            preview: str,
+            text_content: str,
+            image_count: int,
+            attachment_count: int,
+            expected_image_count: int,
+            expected_attachment_count: int,
+            failed: bool = False,
+        ) -> str:
+            header_status = (
+                f'❌ Background task {task_id} failed\nPrompt: "{preview}"\n\n'
+                if failed
+                else f'✅ Background task complete\nPrompt: "{preview}"\n\n'
+            )
+
+            delivered_parts = []
+            if image_count:
+                delivered_parts.append(
+                    f"{image_count} image{'s' if image_count != 1 else ''}"
+                )
+            if attachment_count:
+                delivered_parts.append(
+                    f"{attachment_count} attachment{'s' if attachment_count != 1 else ''}"
+                )
+
+            failed_parts = []
+            failed_images = max(expected_image_count - image_count, 0)
+            failed_attachments = max(expected_attachment_count - attachment_count, 0)
+            if failed_images:
+                failed_parts.append(
+                    f"{failed_images} image{'s' if failed_images != 1 else ''}"
+                )
+            if failed_attachments:
+                failed_parts.append(
+                    f"{failed_attachments} attachment{'s' if failed_attachments != 1 else ''}"
+                )
+
+            delivery_notes = []
+            if delivered_parts:
+                prefix = "Also delivered separately" if text_content.strip() else "Delivered separately"
+                delivery_notes.append(f"{prefix}: {', '.join(delivered_parts)}")
+            if failed_parts:
+                delivery_notes.append(f"Failed to send: {', '.join(failed_parts)}")
+
+            if text_content.strip():
+                text = header_status + text_content
+                if not delivery_notes:
+                    return text
+                return text + "\n\n(" + "; ".join(delivery_notes) + ")"
+
+            if delivery_notes:
+                return header_status + "(" + "; ".join(delivery_notes) + ")"
+            return header_status + "(No response generated)"
+
+        def _send_result_succeeded(result: object) -> bool:
+            if result is None:
+                return True
+            if isinstance(result, dict):
+                if "success" in result:
+                    return bool(result.get("success"))
+                return not result.get("error")
+            success = getattr(result, "success", None)
+            if success is None:
+                return result is not False
+            return bool(success)
+
+        def _send_result_error(result: object) -> str:
+            if result is None:
+                return ""
+            if isinstance(result, dict):
+                return str(result.get("error") or "").strip()
+            return str(getattr(result, "error", "") or "").strip()
+
+        async def _send_text_with_mirror(message_text: str) -> None:
+            mirror_text = message_text
+            try:
+                send_result = await adapter.send(
+                    chat_id=source.chat_id,
+                    content=message_text,
+                    metadata=_thread_metadata,
+                )
+                if not _send_result_succeeded(send_result):
+                    error_detail = _send_result_error(send_result)
+                    suffix = (
+                        f"Chat delivery to {_platform_label} failed: {error_detail}"
+                        if error_detail
+                        else f"Chat delivery to {_platform_label} failed"
+                    )
+                    mirror_text = f"{message_text}\n\n({suffix})"
+            except Exception as exc:
+                mirror_text = (
+                    f"{message_text}\n\n(Chat delivery to {_platform_label} failed: {exc})"
+                )
+            _mirror_background_result(mirror_text)
 
         try:
             user_config = _load_gateway_config()
@@ -9328,11 +9449,8 @@ class GatewayRunner:
                 user_config=user_config,
             )
             if not runtime_kwargs.get("api_key"):
-                await adapter.send(
-                    source.chat_id,
-                    f"❌ Background task {task_id} failed: no provider credentials configured.",
-                    metadata=_thread_metadata,
-                )
+                error_text = f"❌ Background task {task_id} failed: no provider credentials configured."
+                await _send_text_with_mirror(error_text)
                 return
 
             platform_key = _platform_config_key(source.platform)
@@ -9389,68 +9507,80 @@ class GatewayRunner:
             result = await self._run_in_executor_with_context(run_sync)
 
             response = result.get("final_response", "") if result else ""
+            background_failed = bool(result and result.get("failed"))
             if not response and result and result.get("error"):
+                background_failed = True
                 response = f"Error: {result['error']}"
+
+            preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
 
             # Extract media files from the response
             if response:
                 media_files, response = adapter.extract_media(response)
                 images, text_content = adapter.extract_images(response)
+                expected_image_count = len(images or [])
+                expected_attachment_count = len(media_files or [])
 
-                preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
-                header = f'✅ Background task complete\nPrompt: "{preview}"\n\n'
-
-                if text_content:
-                    await adapter.send(
-                        chat_id=source.chat_id,
-                        content=header + text_content,
-                        metadata=_thread_metadata,
-                    )
-                elif not images and not media_files:
-                    await adapter.send(
-                        chat_id=source.chat_id,
-                        content=header + "(No response generated)",
-                        metadata=_thread_metadata,
-                    )
-
-                # Send extracted images
+                delivered_images = 0
                 for image_url, alt_text in (images or []):
                     try:
-                        await adapter.send_image(
+                        send_result = await adapter.send_image(
                             chat_id=source.chat_id,
                             image_url=image_url,
                             caption=alt_text,
                             metadata=_thread_metadata,
                         )
+                        if _send_result_succeeded(send_result):
+                            delivered_images += 1
                     except Exception:
                         pass
 
-                # Send media files
+                delivered_attachments = 0
                 for media_path, _is_voice in (media_files or []):
                     try:
-                        await adapter.send_document(
+                        send_result = await adapter.send_document(
                             chat_id=source.chat_id,
                             file_path=media_path,
                             metadata=_thread_metadata,
                         )
+                        if _send_result_succeeded(send_result):
+                            delivered_attachments += 1
                     except Exception:
                         pass
-            else:
-                preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
-                await adapter.send(
-                    chat_id=source.chat_id,
-                    content=f'✅ Background task complete\nPrompt: "{preview}"\n\n(No response generated)',
-                    metadata=_thread_metadata,
+
+                completion_text = _build_background_completion_text(
+                    preview=preview,
+                    text_content=text_content,
+                    image_count=delivered_images,
+                    attachment_count=delivered_attachments,
+                    expected_image_count=expected_image_count,
+                    expected_attachment_count=expected_attachment_count,
+                    failed=background_failed,
                 )
+
+                if text_content or (delivered_images + delivered_attachments) != (
+                    expected_image_count + expected_attachment_count
+                ) or (not images and not media_files):
+                    await _send_text_with_mirror(completion_text)
+                else:
+                    _mirror_background_result(completion_text)
+            else:
+                completion_text = _build_background_completion_text(
+                    preview=preview,
+                    text_content="",
+                    image_count=0,
+                    attachment_count=0,
+                    expected_image_count=0,
+                    expected_attachment_count=0,
+                    failed=background_failed,
+                )
+                await _send_text_with_mirror(completion_text)
 
         except Exception as e:
             logger.exception("Background task %s failed", task_id)
             try:
-                await adapter.send(
-                    chat_id=source.chat_id,
-                    content=f"❌ Background task {task_id} failed: {e}",
-                    metadata=_thread_metadata,
-                )
+                error_text = f"❌ Background task {task_id} failed: {e}"
+                await _send_text_with_mirror(error_text)
             except Exception:
                 pass
 

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -16,6 +16,7 @@ DEFAULT_CODEX_MODELS: List[str] = [
     "gpt-5.4-mini",
     "gpt-5.4",
     "gpt-5.3-codex",
+    "gpt-5.3-codex-spark",
     "gpt-5.2-codex",
     "gpt-5.1-codex-max",
     "gpt-5.1-codex-mini",
@@ -26,6 +27,7 @@ _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
     ("gpt-5.4-mini", ("gpt-5.3-codex", "gpt-5.2-codex")),
     ("gpt-5.4", ("gpt-5.3-codex", "gpt-5.2-codex")),
     ("gpt-5.3-codex", ("gpt-5.2-codex",)),
+    ("gpt-5.3-codex-spark", ("gpt-5.3-codex",)),
 ]
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1247,8 +1247,11 @@ DEFAULT_CONFIG = {
 
     "cron": {
         # Wrap delivered cron responses with a header (task name) and footer
-        # ("The agent cannot see this message").  Set to false for clean output.
+        # so recipients can tell the message came from a scheduled job.
         "wrap_response": True,
+        # Mirror successful cron deliveries back into the receiving gateway
+        # session so the next live turn can see what background work already ran.
+        "mirror_deliveries_to_session": True,
         # Maximum number of due jobs to run in parallel per tick.
         # null/0 = unbounded (limited only by thread count).
         # 1 = serial (pre-v0.9 behaviour).

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -352,7 +352,7 @@ class TestResolveDeliveryTarget:
 
 
 class TestDeliverResultWrapping:
-    """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""
+    """Verify that cron deliveries are wrapped cleanly and mirrored into gateway sessions."""
 
     def test_delivery_wraps_content_with_header_and_footer(self):
         """Delivered content should include task name header and agent-invisible note."""
@@ -637,8 +637,8 @@ class TestDeliverResultWrapping:
         assert "MEDIA:" not in text_sent
         assert "Report" in text_sent
 
-    def test_no_mirror_to_session_call(self):
-        """Cron deliveries should NOT mirror into the gateway session."""
+    def test_mirror_to_session_called_after_successful_delivery(self):
+        """Successful cron deliveries should mirror back into the target gateway session."""
         from gateway.config import Platform
 
         pconfig = MagicMock()
@@ -648,7 +648,8 @@ class TestDeliverResultWrapping:
 
         with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
              patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
-             patch("gateway.mirror.mirror_to_session") as mirror_mock:
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False, "mirror_deliveries_to_session": True}}):
             job = {
                 "id": "test-job",
                 "deliver": "origin",
@@ -656,7 +657,80 @@ class TestDeliverResultWrapping:
             }
             _deliver_result(job, "Hello!")
 
-        mirror_mock.assert_not_called()
+        mirror_mock.assert_called_once_with(
+            "telegram",
+            "123",
+            "Hello!",
+            source_label="cron:test-job",
+            thread_id=None,
+            user_id=None,
+        )
+
+    def test_mirror_includes_attachment_summary_when_text_and_media_are_sent(self):
+        """Mirrored cron text should retain attachment context, not just the plain text body."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False, "mirror_deliveries_to_session": True}}):
+            job = {
+                "id": "img-job",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "Report\nMEDIA:/tmp/chart.png")
+
+        mirror_text = mirror_mock.call_args.args[2]
+        assert "Report" in mirror_text
+        assert "image attachment" in mirror_text
+
+    def test_live_adapter_media_failures_do_not_claim_attachment_mirror_success(self):
+        """If a live adapter fails to send media, the mirrored text should not claim the attachment landed."""
+        from gateway.config import Platform
+
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.DISCORD: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            from concurrent.futures import Future
+            future = Future()
+            future.set_result(MagicMock(success=True))
+            coro.close()
+            return future
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock, \
+             patch("cron.scheduler._send_media_via_adapter", return_value=False), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False, "mirror_deliveries_to_session": True}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            job = {
+                "id": "img-live-job",
+                "deliver": "origin",
+                "origin": {"platform": "discord", "chat_id": "1234"},
+            }
+            _deliver_result(
+                job,
+                "Report\nMEDIA:/tmp/chart.png",
+                adapters={Platform.DISCORD: adapter},
+                loop=loop,
+            )
+
+        mirror_text = mirror_mock.call_args.args[2]
+        assert mirror_text == "Report"
 
     def test_origin_delivery_preserves_thread_id(self):
         """Origin delivery should forward thread_id to the send helper."""

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -5,13 +5,15 @@ background session) across gateway messenger platforms.
 """
 
 import asyncio
+import json
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import gateway.mirror as mirror_mod
 from gateway.config import Platform
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, SendResult
 from gateway.session import SessionSource
 
 
@@ -177,7 +179,7 @@ class TestRunBackgroundTask:
 
     @pytest.mark.asyncio
     async def test_no_credentials_sends_error(self):
-        """When provider credentials are missing, an error is sent."""
+        """When provider credentials are missing, an error is sent and mirrored."""
         runner = _make_runner()
         mock_adapter = AsyncMock()
         mock_adapter.send = AsyncMock()
@@ -190,17 +192,27 @@ class TestRunBackgroundTask:
             user_name="testuser",
         )
 
-        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": None}):
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": None}), \
+             patch("gateway.run.mirror_to_session", return_value=True) as mock_mirror:
             await runner._run_background_task("test prompt", source, "bg_test")
 
         # Should have sent an error message
         mock_adapter.send.assert_called_once()
         call_args = mock_adapter.send.call_args
-        assert "failed" in call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "").lower()
+        content = call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "")
+        assert "failed" in content.lower()
+        mock_mirror.assert_called_once_with(
+            "telegram",
+            "67890",
+            content,
+            source_label="background:bg_test",
+            thread_id=None,
+            user_id="12345",
+        )
 
     @pytest.mark.asyncio
     async def test_successful_task_sends_result(self):
-        """When the agent completes successfully, the result is sent."""
+        """When the agent completes successfully, the result is sent and mirrored."""
         runner = _make_runner()
         mock_adapter = AsyncMock()
         mock_adapter.send = AsyncMock()
@@ -218,7 +230,8 @@ class TestRunBackgroundTask:
         mock_result = {"final_response": "Hello from background!", "messages": []}
 
         with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
-             patch("run_agent.AIAgent") as MockAgent:
+             patch("run_agent.AIAgent") as MockAgent, \
+             patch("gateway.run.mirror_to_session", return_value=True) as mock_mirror:
             mock_agent_instance = MagicMock()
             mock_agent_instance.shutdown_memory_provider = MagicMock()
             mock_agent_instance.close = MagicMock()
@@ -233,6 +246,337 @@ class TestRunBackgroundTask:
         content = call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "")
         assert "Background task complete" in content
         assert "Hello from background!" in content
+        mock_mirror.assert_called_once_with(
+            "telegram",
+            "67890",
+            content,
+            source_label="background:bg_test",
+            thread_id=None,
+            user_id="12345",
+        )
+        mock_agent_instance.shutdown_memory_provider.assert_called_once()
+        mock_agent_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_successful_task_real_mirror_writes_transcript(self, tmp_path):
+        """The real mirror path writes the background completion into the session transcript."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        index_file = sessions_dir / "sessions.json"
+        index_file.write_text(json.dumps({
+            "agent:main:telegram:dm": {
+                "session_id": "sess_abc",
+                "origin": {"platform": "telegram", "chat_id": "67890", "user_id": "12345"},
+                "updated_at": "2026-01-01T00:00:00",
+            }
+        }))
+
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "Hello from background!"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "Hello from background!"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        mock_result = {"final_response": "Hello from background!", "messages": []}
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch("gateway.mirror._append_to_sqlite"), \
+             patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("say hello", source, "bg_test")
+
+        transcript = sessions_dir / "sess_abc.jsonl"
+        assert transcript.exists()
+        lines = transcript.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        message = json.loads(lines[0])
+        assert message["mirror"] is True
+        assert message["mirror_source"] == "background:bg_test"
+        assert "Hello from background!" in message["content"]
+
+    @pytest.mark.asyncio
+    async def test_mixed_text_and_media_task_mirrors_both(self):
+        """Mixed text+media completions mention the separately delivered media."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.send_image = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "Hello from background!"))
+        mock_adapter.extract_images = MagicMock(return_value=([("https://example.com/cat.png", "cat")], "Hello from background!"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        mock_result = {"final_response": "text and image", "messages": []}
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent, \
+             patch("gateway.run.mirror_to_session", return_value=True) as mock_mirror:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("send both", source, "bg_test")
+
+        mock_adapter.send.assert_called_once()
+        sent_text = mock_adapter.send.call_args[1]["content"]
+        assert "Hello from background!" in sent_text
+        assert "Also delivered separately: 1 image" in sent_text
+        mock_adapter.send_image.assert_called_once()
+        mirror_text = mock_mirror.call_args[0][2]
+        assert "Also delivered separately: 1 image" in mirror_text
+        mock_agent_instance.shutdown_memory_provider.assert_called_once()
+        mock_agent_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_media_only_task_mirrors_delivery_summary(self):
+        """Media-only completions are mirrored as a delivery summary."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.send_image = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], ""))
+        mock_adapter.extract_images = MagicMock(return_value=([("https://example.com/cat.png", "cat")], ""))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        mock_result = {"final_response": "image only", "messages": []}
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent, \
+             patch("gateway.run.mirror_to_session", return_value=True) as mock_mirror:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("send image", source, "bg_test")
+
+        mock_adapter.send.assert_not_called()
+        mock_adapter.send_image.assert_called_once()
+        mirror_text = mock_mirror.call_args[0][2]
+        assert "Delivered separately: 1 image" in mirror_text
+        mock_agent_instance.shutdown_memory_provider.assert_called_once()
+        mock_agent_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_mixed_text_and_media_failure_mentions_failed_delivery(self):
+        """Mixed text+media completions mention failed attachment delivery accurately."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.send_image = AsyncMock(return_value=SendResult(success=False, error="upload failed"))
+        mock_adapter.extract_media = MagicMock(return_value=([], "Hello from background!"))
+        mock_adapter.extract_images = MagicMock(return_value=([("https://example.com/cat.png", "cat")], "Hello from background!"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        mock_result = {"final_response": "text and image", "messages": []}
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent, \
+             patch("gateway.run.mirror_to_session", return_value=True) as mock_mirror:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("send both", source, "bg_test")
+
+        sent_text = mock_adapter.send.call_args[1]["content"]
+        assert "Failed to send: 1 image" in sent_text
+        mirror_text = mock_mirror.call_args[0][2]
+        assert "Failed to send: 1 image" in mirror_text
+        mock_agent_instance.shutdown_memory_provider.assert_called_once()
+        mock_agent_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_media_only_failed_delivery_sends_failure_summary(self):
+        """Media-only delivery failures send and mirror an explicit failure summary."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.send_image = AsyncMock(return_value=SendResult(success=False, error="upload failed"))
+        mock_adapter.extract_media = MagicMock(return_value=([], ""))
+        mock_adapter.extract_images = MagicMock(return_value=([("https://example.com/cat.png", "cat")], ""))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        mock_result = {"final_response": "image only", "messages": []}
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent, \
+             patch("gateway.run.mirror_to_session", return_value=True) as mock_mirror:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("send image", source, "bg_test")
+
+        mock_adapter.send.assert_called_once()
+        sent_text = mock_adapter.send.call_args[1]["content"]
+        assert "Failed to send: 1 image" in sent_text
+        mirror_text = mock_mirror.call_args[0][2]
+        assert "Failed to send: 1 image" in mirror_text
+        mock_agent_instance.shutdown_memory_provider.assert_called_once()
+        mock_agent_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_attachment_delivery_failure_sends_failure_summary(self):
+        """Document delivery failures are reported and mirrored accurately."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.send_document = AsyncMock(return_value=SendResult(success=False, error="upload failed"))
+        mock_adapter.extract_media = MagicMock(return_value=([("/tmp/report.pdf", False)], ""))
+        mock_adapter.extract_images = MagicMock(return_value=([], ""))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        mock_result = {"final_response": "document only", "messages": []}
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent, \
+             patch("gateway.run.mirror_to_session", return_value=True) as mock_mirror:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("send document", source, "bg_test")
+
+        mock_adapter.send.assert_called_once()
+        sent_text = mock_adapter.send.call_args[1]["content"]
+        assert "Failed to send: 1 attachment" in sent_text
+        mock_adapter.send_document.assert_called_once()
+        mirror_text = mock_mirror.call_args[0][2]
+        assert "Failed to send: 1 attachment" in mirror_text
+        mock_agent_instance.shutdown_memory_provider.assert_called_once()
+        mock_agent_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_text_delivery_failure_still_mirrors_outcome(self):
+        """Even if chat delivery fails, the background outcome is mirrored."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=False, error="chat blocked"))
+        mock_adapter.extract_media = MagicMock(return_value=([], "Hello from background!"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "Hello from background!"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        mock_result = {"final_response": "Hello from background!", "messages": []}
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent, \
+             patch("gateway.run.mirror_to_session", return_value=True) as mock_mirror:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("say hello", source, "bg_test")
+
+        mock_adapter.send.assert_called_once()
+        mirror_text = mock_mirror.call_args[0][2]
+        assert "Hello from background!" in mirror_text
+        assert "Chat delivery to telegram failed: chat blocked" in mirror_text
+        mock_agent_instance.shutdown_memory_provider.assert_called_once()
+        mock_agent_instance.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_returned_error_payload_is_reported_as_failure(self):
+        """Structured failed results render a failure header instead of success."""
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "Error: boom"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "Error: boom"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            user_name="testuser",
+        )
+
+        mock_result = {"failed": True, "error": "boom", "messages": []}
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("run_agent.AIAgent") as MockAgent, \
+             patch("gateway.run.mirror_to_session", return_value=True) as mock_mirror:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.shutdown_memory_provider = MagicMock()
+            mock_agent_instance.close = MagicMock()
+            mock_agent_instance.run_conversation.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_background_task("cause error", source, "bg_test")
+
+        sent_text = mock_adapter.send.call_args[1]["content"]
+        assert "❌ Background task bg_test failed" in sent_text
+        assert "Error: boom" in sent_text
+        mirror_text = mock_mirror.call_args[0][2]
+        assert "❌ Background task bg_test failed" in mirror_text
         mock_agent_instance.shutdown_memory_provider.assert_called_once()
         mock_agent_instance.close.assert_called_once()
 
@@ -267,7 +611,7 @@ class TestRunBackgroundTask:
 
     @pytest.mark.asyncio
     async def test_exception_sends_error_message(self):
-        """When the agent raises an exception, an error message is sent."""
+        """When the agent raises an exception, an error message is sent and mirrored."""
         runner = _make_runner()
         mock_adapter = AsyncMock()
         mock_adapter.send = AsyncMock()
@@ -280,13 +624,22 @@ class TestRunBackgroundTask:
             user_name="testuser",
         )
 
-        with patch("gateway.run._resolve_runtime_agent_kwargs", side_effect=RuntimeError("boom")):
+        with patch("gateway.run._resolve_runtime_agent_kwargs", side_effect=RuntimeError("boom")), \
+             patch("gateway.run.mirror_to_session", return_value=True) as mock_mirror:
             await runner._run_background_task("test prompt", source, "bg_test")
 
         mock_adapter.send.assert_called_once()
         call_args = mock_adapter.send.call_args
         content = call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "")
         assert "failed" in content.lower()
+        mock_mirror.assert_called_once_with(
+            "telegram",
+            "67890",
+            content,
+            source_label="background:bg_test",
+            thread_id=None,
+            user_id="12345",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/__init__.py
+++ b/tests/hermes_cli/__init__.py
@@ -1,0 +1,9 @@
+"""Test package helper.
+
+Avoid shadowing the real `hermes_cli` package so imports like
+`from hermes_cli import __version__, __release_date__` still succeed when
+pytest puts `tests/` early on `sys.path`.
+"""
+
+__version__ = "0.12.0"
+__release_date__ = "2026.4.30"

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -54,7 +54,7 @@ def test_get_codex_model_ids_falls_back_to_curated_defaults(tmp_path, monkeypatc
 
     assert models[: len(DEFAULT_CODEX_MODELS)] == DEFAULT_CODEX_MODELS
     assert "gpt-5.4" in models
-    assert "gpt-5.3-codex-spark" not in models
+    assert "gpt-5.3-codex-spark" in models
 
 
 def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypatch):
@@ -65,7 +65,7 @@ def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypat
 
     models = get_codex_model_ids(access_token="codex-access-token")
 
-    assert models == ["gpt-5.2-codex", "gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex"]
+    assert models == ["gpt-5.2-codex", "gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex", "gpt-5.3-codex-spark"]
 
 
 def test_model_command_uses_runtime_access_token_for_codex_list(monkeypatch):


### PR DESCRIPTION
## Summary
- mirror /background completions into the active gateway transcript
- mirror successful cron deliveries back into the matching gateway session, gated by cron.mirror_deliveries_to_session
- preserve accurate summaries for media-only and failed media delivery paths
- add gpt-5.3-codex-spark to Codex model discovery defaults

## Verification
- python -m py_compile gateway/mirror.py cron/scheduler.py gateway/run.py hermes_cli/config.py hermes_cli/codex_models.py
- python -m pytest tests/gateway/test_background_command.py tests/cron/test_scheduler.py tests/hermes_cli/test_codex_models.py -q -o 'addopts='
- git diff --check
- codex read-only re-review: PASS

Note: a broader local run of tests/cron surfaced 3 failures in unrelated pre-existing paths (cron script empty output and MCP init auth ordering), outside this diff.