### PR TITLE
fix(hindsight): sanitize base64 data URLs before retain

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -72,6 +72,181 @@ _PROVIDER_DEFAULT_MODELS = {
 }
 
 
+_DATA_URL_CONTINUATION_MIN_CHARS = 64
+_DATA_URL_WRAP_MAX_CHARS = 128
+_DATA_URL_LARGE_CONTINUATION_CHARS = 512
+_DATA_URL_WRAPPED_LINE_MIN_COUNT = 4
+_DATA_URL_BASE64_CHARS = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=_-")
+_DATA_URL_SCHEME = "data:"
+_DATA_URL_HEADER_MAX_CHARS = 512
+
+
+def _data_url_has_boundary(text: str, pos: int) -> bool:
+    """Return whether ``data:`` at ``pos`` is not embedded in another token."""
+    return pos == 0 or not (text[pos - 1].isalnum() or text[pos - 1] in "+-.")
+
+
+def _parse_data_url_prefix(text: str, pos: int) -> tuple[int, str] | None:
+    """Parse a base64 data URL prefix at ``pos`` using a bounded linear scan."""
+    if not _data_url_has_boundary(text, pos):
+        return None
+
+    header_start = pos + len(_DATA_URL_SCHEME)
+    header_limit = min(len(text), header_start + _DATA_URL_HEADER_MAX_CHARS)
+    header_end = header_start
+    while header_end < header_limit and text[header_end] not in ",\r\n\t ":
+        header_end += 1
+    if header_end >= len(text) or text[header_end] != ",":
+        return None
+
+    header = text[header_start:header_end]
+    if not any(part.lower() == "base64" for part in header.split(";")[1:]):
+        return None
+    return header_end + 1, header
+
+
+def _find_data_url_scheme(text: str, start: int) -> int:
+    """Find the next ASCII-case-insensitive ``data:`` using original offsets."""
+    max_start = len(text) - len(_DATA_URL_SCHEME)
+    for pos in range(start, max_start + 1):
+        if (
+            text[pos] in "dD"
+            and text[pos + 1] in "aA"
+            and text[pos + 2] in "tT"
+            and text[pos + 3] in "aA"
+            and text[pos + 4] == ":"
+        ):
+            return pos
+    return -1
+
+
+def _data_url_mime(header: str) -> str:
+    """Return a normalized MIME type from a data URL header."""
+    return (header.split(";", 1)[0] or "unknown").lower()
+
+
+def _base64_chunk_end(text: str, pos: int) -> tuple[int, int]:
+    """Return ``(end, length)`` for a base64-ish chunk starting at ``pos``."""
+    start = pos
+    while pos < len(text) and text[pos] in _DATA_URL_BASE64_CHARS:
+        pos += 1
+    return pos, pos - start
+
+
+def _data_url_line_break_end(text: str, pos: int) -> tuple[int, str] | None:
+    """Return ``(end, kind)`` for a real or escaped line break at ``pos``."""
+    if text.startswith("\r\n", pos):
+        return pos + 2, "actual"
+    if pos < len(text) and text[pos] in "\r\n":
+        return pos + 1, "actual"
+    if text.startswith("\\r\\n", pos):
+        return pos + 4, "escaped"
+    if text.startswith("\\n", pos) or text.startswith("\\r", pos):
+        return pos + 2, "escaped"
+    return None
+
+
+def _data_url_continuations(text: str, pos: int) -> List[tuple[str, int, int]]:
+    """Collect plausible wrapped base64 continuation chunks after ``pos``.
+
+    Each returned tuple is ``(break_kind, chunk_len, chunk_end)``. The line
+    break before each chunk is included when a caller advances to ``chunk_end``.
+    """
+    continuations: List[tuple[str, int, int]] = []
+    scan = pos
+    while True:
+        line_break = _data_url_line_break_end(text, scan)
+        if line_break is None:
+            break
+        chunk_start, break_kind = line_break
+        while chunk_start < len(text) and text[chunk_start] in " \t":
+            chunk_start += 1
+        chunk_end, chunk_len = _base64_chunk_end(text, chunk_start)
+        if chunk_len < _DATA_URL_CONTINUATION_MIN_CHARS:
+            break
+        continuations.append((break_kind, chunk_len, chunk_end))
+        scan = chunk_end
+    return continuations
+
+
+def _wrapish_base64_line(length: int) -> bool:
+    return _DATA_URL_CONTINUATION_MIN_CHARS <= length <= _DATA_URL_WRAP_MAX_CHARS and length % 4 == 0
+
+
+def _should_consume_data_url_continuations(
+    _initial_len: int,
+    continuations: List[tuple[str, int, int]],
+) -> bool:
+    """Return whether continuation-like lines are likely part of the data URL.
+
+    Crossing real newlines is intentionally conservative: it prevents huge
+    wrapped payloads while avoiding deletion of ordinary follow-up text that
+    merely happens to use base64-alphabet characters.
+    """
+    if not continuations:
+        return False
+
+    chunk_lengths = [chunk_len for _, chunk_len, _ in continuations]
+    if any(break_kind == "escaped" for break_kind, _, _ in continuations):
+        return True
+    if any(chunk_len >= _DATA_URL_LARGE_CONTINUATION_CHARS for chunk_len in chunk_lengths):
+        return True
+    return (
+        len(continuations) >= _DATA_URL_WRAPPED_LINE_MIN_COUNT
+        and all(_wrapish_base64_line(chunk_len) for chunk_len in chunk_lengths)
+    )
+
+
+def _sanitize_retain_text(value: Any) -> str:
+    """Return retain-safe text with inline base64 data URLs redacted.
+
+    Multimodal gateway payloads can include ``data:image/...;base64,...``
+    URLs. Those are useful to the live model call, but disastrous for long-term
+    memory extraction: one image can serialize into millions of meaningless
+    characters and trigger many expensive Hindsight extraction calls. Preserve
+    surrounding semantic text and replace the binary payload with compact
+    metadata before it reaches Hindsight retain.
+    """
+    if isinstance(value, str):
+        text = value
+    else:
+        try:
+            text = json.dumps(value, ensure_ascii=False, default=str)
+        except Exception:
+            text = str(value)
+
+    parts: List[str] = []
+    cursor = 0
+    search_pos = 0
+    while True:
+        match_start = _find_data_url_scheme(text, search_pos)
+        if match_start == -1:
+            parts.append(text[cursor:])
+            break
+
+        parsed_prefix = _parse_data_url_prefix(text, match_start)
+        if parsed_prefix is None:
+            search_pos = match_start + len(_DATA_URL_SCHEME)
+            continue
+
+        payload_start, header = parsed_prefix
+        payload_end, initial_len = _base64_chunk_end(text, payload_start)
+        continuations = _data_url_continuations(text, payload_end)
+        if _should_consume_data_url_continuations(initial_len, continuations):
+            payload_end = continuations[-1][2]
+
+        mime_type = _data_url_mime(header)
+        parts.append(text[cursor:match_start])
+        parts.append(
+            f"[omitted base64 {mime_type} data URL from Hindsight retain, "
+            f"data_url_chars={payload_end - match_start}]"
+        )
+        cursor = payload_end
+        search_pos = payload_end
+
+    return "".join(parts)
+
+
 def _parse_int_setting(value: Any, default: int) -> int:
     """Parse an integer config/env value, falling back on invalid input."""
     if value is None or value == "":
@@ -1331,17 +1506,19 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="hindsight-prefetch")
         self._prefetch_thread.start()
 
-    def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:
+    def _build_turn_messages(self, user_content: Any, assistant_content: Any) -> List[Dict[str, str]]:
         now = datetime.now(timezone.utc).isoformat()
+        safe_user_content = _sanitize_retain_text(user_content)
+        safe_assistant_content = _sanitize_retain_text(assistant_content)
         return [
             {
                 "role": "user",
-                "content": f"{self._retain_user_prefix}: {user_content}",
+                "content": f"{self._retain_user_prefix}: {safe_user_content}",
                 "timestamp": now,
             },
             {
                 "role": "assistant",
-                "content": f"{self._retain_assistant_prefix}: {assistant_content}",
+                "content": f"{self._retain_assistant_prefix}: {safe_assistant_content}",
                 "timestamp": now,
             },
         ]
@@ -1384,13 +1561,14 @@ class HindsightMemoryProvider(MemoryProvider):
         tags: List[str] | None = None,
         retain_async: bool | None = None,
     ) -> Dict[str, Any]:
+        safe_content = _sanitize_retain_text(content)
         kwargs: Dict[str, Any] = {
             "bank_id": self._bank_id,
-            "content": content,
+            "content": safe_content,
             "metadata": metadata or self._build_metadata(message_count=1, turn_index=self._turn_index),
         }
         if context is not None:
-            kwargs["context"] = context
+            kwargs["context"] = _sanitize_retain_text(context)
         if document_id:
             kwargs["document_id"] = document_id
         if retain_async is not None:
@@ -1403,7 +1581,7 @@ class HindsightMemoryProvider(MemoryProvider):
             kwargs["tags"] = merged_tags
         return kwargs
 
-    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+    def sync_turn(self, user_content: Any, assistant_content: Any, *, session_id: str = "") -> None:
         """Enqueue a retain for the current turn. Non-blocking.
 
         The actual aretain_batch runs on a single long-lived writer thread
@@ -1487,9 +1665,10 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if tool_name == "hindsight_retain":
-            content = args.get("content", "")
-            if not content:
+            raw_content = args.get("content", "")
+            if not isinstance(raw_content, str) or not raw_content:
                 return tool_error("Missing required parameter: content")
+            content = _sanitize_retain_text(raw_content)
             context = args.get("context")
             try:
                 retain_kwargs = self._build_retain_kwargs(
@@ -1497,8 +1676,10 @@ class HindsightMemoryProvider(MemoryProvider):
                     context=context,
                     tags=args.get("tags"),
                 )
-                logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
-                             self._bank_id, len(content), context)
+                safe_context = retain_kwargs.get("context")
+                safe_context_len = len(safe_context) if isinstance(safe_context, str) else 0
+                logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context_len=%d",
+                             self._bank_id, len(content), safe_context_len)
                 self._run_hindsight_operation(lambda client: client.aretain(**retain_kwargs))
                 logger.debug("Tool hindsight_retain: success")
                 return json.dumps({"result": "Memory stored successfully."})

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -23,6 +23,7 @@ from plugins.memory.hindsight import (
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
+    _sanitize_retain_text,
 )
 
 
@@ -149,6 +150,217 @@ def test_normalize_retain_tags_accepts_csv_and_dedupes():
 def test_normalize_retain_tags_accepts_json_array_string():
     value = json.dumps(["agent:fakeassistantname", "source_system:hermes-agent"])
     assert _normalize_retain_tags(value) == ["agent:fakeassistantname", "source_system:hermes-agent"]
+
+
+def test_sanitize_retain_text_redacts_base64_data_urls():
+    payload = "look " + "data:image/png;base64," + ("A" * 1200) + " done"
+
+    sanitized = _sanitize_retain_text(payload)
+
+    assert "data:image/png;base64" not in sanitized
+    assert "A" * 1200 not in sanitized
+    assert "omitted base64 image/png data URL" in sanitized
+    assert "data_url_chars=" in sanitized
+    assert sanitized.startswith("look ")
+    assert sanitized.endswith(" done")
+
+
+def test_sanitize_retain_text_handles_data_url_variants():
+    parameterized = "data:image/png;charset=utf-8;base64," + ("B" * 1200)
+    unknown_mime = "data:;base64," + ("C" * 1200)
+    mixed_case = "DATA:IMAGE/JPEG;BASE64," + ("D" * 1200)
+
+    sanitized = _sanitize_retain_text(f"variants {parameterized} {unknown_mime} {mixed_case}")
+
+    assert parameterized not in sanitized
+    assert unknown_mime not in sanitized
+    assert mixed_case not in sanitized
+    assert "B" * 1000 not in sanitized
+    assert "C" * 1000 not in sanitized
+    assert "D" * 1000 not in sanitized
+    assert "omitted base64 image/png data URL" in sanitized
+    assert "omitted base64 unknown data URL" in sanitized
+    assert "omitted base64 image/jpeg data URL" in sanitized
+
+
+def test_sanitize_retain_text_preserves_data_scheme_inside_larger_tokens():
+    semantic = "metadata:image/png;base64," + ("A" * 1200)
+
+    sanitized = _sanitize_retain_text(f"keep {semantic}")
+
+    assert semantic in sanitized
+    assert "omitted base64" not in sanitized
+
+
+def test_sanitize_retain_text_handles_many_invalid_data_markers():
+    text = ("data:not-base64 " * 1000) + "data:image/png;base64," + ("A" * 1200)
+
+    sanitized = _sanitize_retain_text(text)
+
+    assert "data:not-base64" in sanitized
+    assert "A" * 1000 not in sanitized
+    assert "omitted base64 image/png data URL" in sanitized
+
+
+def test_sanitize_retain_text_handles_unicode_before_data_url():
+    payload = "İ before data:image/png;base64," + ("A" * 1200)
+
+    sanitized = _sanitize_retain_text(payload)
+
+    assert "İ before" in sanitized
+    assert "A" * 1000 not in sanitized
+    assert "omitted base64 image/png data URL" in sanitized
+
+
+def test_sanitize_retain_text_preserves_text_after_data_url_line():
+    data_url = "data:image/png;base64," + ("E" * 1000)
+
+    sanitized = _sanitize_retain_text(f"before {data_url}\nKeep this follow-up text")
+
+    assert data_url not in sanitized
+    assert "E" * 1000 not in sanitized
+    assert "before" in sanitized
+    assert "Keep this follow-up text" in sanitized
+
+
+def test_sanitize_retain_text_redacts_wrapped_data_urls():
+    wrapped_payload = "data:image/png;base64," + "\n".join(
+        ["H" * 80, "I" * 80, "Q" * 80, "S" * 80, "T" * 80]
+    )
+    escaped_wrapped_payload = "data:image/jpeg;base64," + "\\n".join(["J" * 80, "K" * 80, "R" * 80])
+
+    sanitized = _sanitize_retain_text(
+        f"before {wrapped_payload}\nafter actual newline {escaped_wrapped_payload} after escaped newline"
+    )
+
+    assert "H" * 80 not in sanitized
+    assert "I" * 80 not in sanitized
+    assert "Q" * 80 not in sanitized
+    assert "S" * 80 not in sanitized
+    assert "T" * 80 not in sanitized
+    assert "J" * 80 not in sanitized
+    assert "K" * 80 not in sanitized
+    assert "R" * 80 not in sanitized
+    assert "after actual newline" in sanitized
+    assert "after escaped newline" in sanitized
+    assert "omitted base64 image/png data URL" in sanitized
+    assert "omitted base64 image/jpeg data URL" in sanitized
+
+
+def test_sanitize_retain_text_redacts_large_two_line_wrapped_data_url():
+    payload = "data:image/png;base64," + ("H" * 80) + "\n" + ("I" * 600)
+
+    sanitized = _sanitize_retain_text(f"before {payload} after")
+
+    assert "H" * 80 not in sanitized
+    assert "I" * 512 not in sanitized
+    assert "before" in sanitized
+    assert "after" in sanitized
+    assert "omitted base64 image/png data URL" in sanitized
+
+
+def test_sanitize_retain_text_redacts_nonstandard_wrapped_data_url_with_large_tail():
+    payload = "data:image/png;base64," + ("W" * 200) + "\n" + ("X" * 600)
+
+    sanitized = _sanitize_retain_text(f"before {payload} after")
+
+    assert "W" * 200 not in sanitized
+    assert "X" * 512 not in sanitized
+    assert "before" in sanitized
+    assert "after" in sanitized
+    assert "omitted base64 image/png data URL" in sanitized
+
+
+def test_sanitize_retain_text_redacts_payload_starting_after_header_line():
+    payload = "data:image/png;base64,\n" + ("P" * 600)
+
+    sanitized = _sanitize_retain_text(f"before {payload} after")
+
+    assert "P" * 512 not in sanitized
+    assert "before" in sanitized
+    assert "after" in sanitized
+    assert "omitted base64 image/png data URL" in sanitized
+
+
+def test_sanitize_retain_text_redacts_many_wrapped_lines_after_short_first_line():
+    payload = "data:image/png;base64," + ("Y" * 52) + "\n" + "\n".join(
+        ["Z" * 80, "U" * 80, "O" * 80, "R" * 80]
+    )
+
+    sanitized = _sanitize_retain_text(f"before {payload} after")
+
+    assert "Y" * 52 not in sanitized
+    assert "Z" * 80 not in sanitized
+    assert "U" * 80 not in sanitized
+    assert "O" * 80 not in sanitized
+    assert "R" * 80 not in sanitized
+    assert "before" in sanitized
+    assert "after" in sanitized
+    assert "omitted base64 image/png data URL" in sanitized
+
+
+def test_sanitize_retain_text_preserves_header_line_followed_by_single_semantic_line():
+    semantic_line = "SemanticBase64AlphabetIdentifierShouldRemainVisible1234567890" + ("c" * 80)
+
+    sanitized = _sanitize_retain_text(f"before data:image/png;base64,\n{semantic_line} after")
+
+    assert semantic_line in sanitized
+    assert "omitted base64 image/png data URL" in sanitized
+
+
+def test_sanitize_retain_text_preserves_long_text_after_data_url():
+    data_url = "data:image/png;base64," + ("M" * 1000)
+    long_followup = "thisLongFollowupIdentifierShouldRemainVisible1234567890"
+
+    sanitized = _sanitize_retain_text(f"before {data_url} {long_followup}")
+
+    assert data_url not in sanitized
+    assert "M" * 1000 not in sanitized
+    assert long_followup in sanitized
+
+
+def test_sanitize_retain_text_preserves_long_newline_text_after_data_url():
+    data_url = "data:image/png;base64," + ("N" * 1000)
+    followup_1 = "thisLongFollowupIdentifierShouldRemainVisible1234567890" * 2
+    followup_2 = "anotherLongFollowupIdentifierShouldRemainVisible1234567890" * 2
+
+    sanitized = _sanitize_retain_text(f"before {data_url}\n{followup_1}\n{followup_2}")
+
+    assert data_url not in sanitized
+    assert "N" * 1000 not in sanitized
+    assert followup_1 in sanitized
+    assert followup_2 in sanitized
+
+
+def test_sanitize_retain_text_preserves_short_data_url_followed_by_semantic_base64ish_lines():
+    data_url = "data:image/png;base64," + ("V" * 80)
+    followup_1 = "SemanticBase64AlphabetIdentifierShouldRemainVisible1234567890" + ("a" * 80)
+    followup_2 = "AnotherSemanticBase64AlphabetIdentifierShouldRemainVisible1234567890" + ("b" * 80)
+
+    sanitized = _sanitize_retain_text(f"before {data_url}\n{followup_1}\n{followup_2}")
+
+    assert "V" * 80 not in sanitized
+    assert followup_1 in sanitized
+    assert followup_2 in sanitized
+
+
+def test_sanitize_retain_text_handles_multimodal_payloads():
+    payload = [
+        {"type": "text", "text": "describe this"},
+        {
+            "type": "image_url",
+            "image_url": {
+                "url": "data:image/png;base64," + ("F" * 2048),
+            },
+        },
+    ]
+
+    sanitized = _sanitize_retain_text(payload)
+
+    assert "describe this" in sanitized
+    assert "data:image/png;base64" not in sanitized
+    assert "F" * 1000 not in sanitized
+    assert "omitted base64 image/png data URL" in sanitized
 
 
 # ---------------------------------------------------------------------------
@@ -449,6 +661,59 @@ class TestToolHandlers:
         assert call_kwargs["bank_id"] == "test-bank"
         assert call_kwargs["content"] == "user likes dark mode"
 
+    def test_retain_redacts_inline_base64_data_url(self, provider):
+        data_url = "data:image/png;base64," + ("A" * 4096)
+
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_retain", {"content": f"keep text {data_url}"}
+        ))
+
+        assert result["result"] == "Memory stored successfully."
+        call_kwargs = provider._client.aretain.call_args.kwargs
+        assert "keep text" in call_kwargs["content"]
+        assert "data:image/png;base64" not in call_kwargs["content"]
+        assert "A" * 1000 not in call_kwargs["content"]
+        assert "omitted base64 image/png data URL" in call_kwargs["content"]
+
+    def test_retain_redacts_inline_base64_data_url_context(self, provider):
+        data_url = "data:image/png;base64," + ("G" * 4096)
+
+        result = json.loads(provider.handle_tool_call(
+            "hindsight_retain",
+            {"content": "keep text", "context": f"screenshot context {data_url}"},
+        ))
+
+        assert result["result"] == "Memory stored successfully."
+        call_kwargs = provider._client.aretain.call_args.kwargs
+        assert "screenshot context" in call_kwargs["context"]
+        assert "data:image/png;base64" not in call_kwargs["context"]
+        assert "G" * 1000 not in call_kwargs["context"]
+        assert "omitted base64 image/png data URL" in call_kwargs["context"]
+
+    def test_retain_does_not_log_raw_base64_context(self, provider, caplog):
+        import logging
+
+        data_url = "data:image/png;base64," + ("L" * 4096)
+
+        with caplog.at_level(logging.DEBUG, logger="plugins.memory.hindsight"):
+            result = json.loads(provider.handle_tool_call(
+                "hindsight_retain",
+                {"content": "keep text", "context": f"screenshot context {data_url}"},
+            ))
+
+        assert result["result"] == "Memory stored successfully."
+        assert "data:image/png;base64" not in caplog.text
+        assert "L" * 1000 not in caplog.text
+        assert "context_len=" in caplog.text
+
+    def test_retain_rejects_non_string_content(self, provider):
+        for content in (None, [], {}, 0, False):
+            result = json.loads(provider.handle_tool_call(
+                "hindsight_retain", {"content": content}
+            ))
+            assert "error" in result
+        provider._client.aretain.assert_not_called()
+
     def test_retain_with_tags(self, provider_with_config):
         p = provider_with_config(retain_tags=["pref", "ui"])
         p.handle_tool_call("hindsight_retain", {"content": "likes dark mode"})
@@ -715,6 +980,44 @@ class TestSyncTurn:
         assert "conv" in item["tags"]
         assert "session1" in item["tags"]
         assert "session:test-session" in item["tags"]
+
+    def test_sync_turn_redacts_inline_image_data_urls(self, provider):
+        data_url = "data:image/png;base64," + ("B" * 200_000)
+        user_content = [
+            {"type": "text", "text": "please inspect this image"},
+            {
+                "type": "image_url",
+                "image_url": {
+                    "url": data_url,
+                },
+            },
+        ]
+
+        provider.sync_turn(user_content, "done")
+        provider._retain_queue.join()
+
+        item = provider._client.aretain_batch.call_args.kwargs["items"][0]
+        content = item["content"]
+        assert "please inspect this image" in content
+        assert data_url not in content
+        assert "data:image/png;base64" not in content
+        assert "B" * 1000 not in content
+        assert "omitted base64 image/png data URL" in content
+        assert len(content) < 3_000
+
+    def test_sync_turn_redacts_assistant_data_urls(self, provider):
+        data_url = "data:image/jpeg;base64," + ("C" * 200_000)
+
+        provider.sync_turn("hello", f"assistant payload {data_url}")
+        provider._retain_queue.join()
+
+        item = provider._client.aretain_batch.call_args.kwargs["items"][0]
+        content = item["content"]
+        assert "assistant payload" in content
+        assert data_url not in content
+        assert "C" * 1000 not in content
+        assert "omitted base64 image/jpeg data URL" in content
+        assert len(content) < 3_000
 
     def test_sync_turn_uses_aretain_batch(self, provider):
         """sync_turn should use aretain_batch with retain_async."""


### PR DESCRIPTION
## Summary

Fixes #21751.

This PR prevents raw inline base64 data URLs from being retained into Hindsight memory. Instead of sending payloads like `data:image/png;base64,<millions of chars>` to Hindsight extraction, Hermes now replaces the binary payload with compact metadata while preserving surrounding semantic text.

## Root cause

Multimodal gateway/tool payloads can include image data as inline `data:*;base64,...` URLs. Hindsight retain treated those payloads as normal text, so a single image could become a multi-megabyte memory extraction input.

In one local incident, a retained payload was approximately 5.67 MB and produced repeated extraction attempts, OpenAI 429/quota failures, and more than $100 of API spend before the queue was stopped.

## Fix

- Add a retain sanitizer for `data:*;base64,...` payloads.
- Replace matched payloads with placeholders like:

  ```text
  [omitted base64 image/png data URL from Hindsight retain, data_url_chars=5000022]
  ```

- Apply sanitizer to:
  - auto-retained user/assistant turn content
  - direct `_retain_memory` content
  - direct `_retain_memory` context
  - `hindsight_retain` tool content/context
- Preserve existing `hindsight_retain` validation for missing/non-string `content`.
- Avoid logging raw retain context; debug logs now include context length instead.
- Use a bounded scanner rather than a broad data URL regex to avoid expensive/overbroad matching.

## Tests

- `python -m py_compile plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py`
- `python -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='` → `118 passed`
- `ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py` → passed; only existing pyproject deprecation warning
- Added-line security scans for hardcoded secrets, shell injection, eval/exec, pickle.loads, and SQL string-format issues → no findings
- Independent diff review → passed

## Notes

This is a Hermes-side boundary fix. Hindsight itself should probably also enforce server/client-side retain limits and reject or strip base64 data URLs defensively, but this PR stops the immediate Hermes retain path from sending image-sized payloads into extraction.

## Related prior work

Related: #18093 was opened earlier and addresses the same root cause. This PR overlaps with that work, but adds extra hardening for explicit `hindsight_retain` content/context sanitization, raw-context logging avoidance, bounded scanning, and broader regression tests. Maintainers can close this in favor of #18093 or cherry-pick/adapt useful deltas.
