### PR TITLE
fix(tui): avoid unsupported Cmd hotkeys in macOS help

### DIFF
--- a/ui-tui/src/__tests__/constants.test.ts
+++ b/ui-tui/src/__tests__/constants.test.ts
@@ -26,8 +26,8 @@ describe('constants', () => {
     })
   })
 
-  it('documents Ctrl/Cmd+L as non-destructive redraw', () => {
-    const hotkey = HOTKEYS.find(([k]) => k.endsWith('+L'))
+  it('documents a non-destructive redraw shortcut or command', () => {
+    const hotkey = HOTKEYS.find(([k]) => k === '/redraw' || k.endsWith('+L'))
     expect(hotkey).toBeDefined()
     expect(hotkey?.[1]).toBe('redraw / repaint')
   })

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -5,8 +5,8 @@ const paste = isMac ? 'Cmd' : 'Alt'
 
 const copyHotkeys: [string, string][] = isMac
   ? [
-      ['Cmd+C', 'copy selection'],
-      ['Ctrl+C', 'interrupt / clear draft / exit']
+      ['Ctrl+C', 'interrupt / clear draft / exit'],
+      ['mouse selection', 'copy with your terminal copy gesture']
     ]
   : isRemoteShell()
     ? [
@@ -17,9 +17,9 @@ const copyHotkeys: [string, string][] = isMac
 
 export const HOTKEYS: [string, string][] = [
   ...copyHotkeys,
-  [action + '+D', 'exit'],
-  [action + '+G / Alt+G', 'open $EDITOR (Alt+G fallback for VSCode/Cursor)'],
-  [action + '+L', 'redraw / repaint'],
+  [isMac ? '/quit' : action + '+D', 'exit'],
+  [isMac ? 'Alt+G' : action + '+G / Alt+G', 'open $EDITOR'],
+  [isMac ? '/redraw' : action + '+L', 'redraw / repaint'],
   [paste + '+V / /paste', 'paste text; /paste attaches clipboard image'],
   ['Tab', 'apply completion'],
   ['↑/↓', 'completions / queue edit / history'],


### PR DESCRIPTION
## Problem

On macOS Terminal, `/help` advertises Cmd-based TUI shortcuts such as Cmd+C, Cmd+D, and Cmd+L even though those chords are often intercepted by the terminal and only beep or do nothing. This leaves users with help text that does not match the usable controls.

Fixes #21564

## Root cause

`ui-tui/src/content/hotkeys.ts` used a platform-wide `action = isMac ? 'Cmd' : 'Ctrl'` label for the help panel. That label is fine for terminals that forward Cmd as a distinct key, but it is misleading in Apple Terminal and other environments that do not forward those chords to the TUI.

## Fix

Use reliable macOS help entries for the affected actions:

- `Ctrl+C` remains documented for interrupt/clear/exit.
- Copy points users to terminal mouse selection/copy behavior instead of promising Cmd+C.
- Exit and repaint advertise `/quit` and `/redraw`, which work regardless of terminal Cmd passthrough.
- Editor help keeps `Alt+G`, the existing fallback called out in the input handler.

## Testing

- `npm test -- src/__tests__/constants.test.ts`
- `npm run type-check`

Made with [Cursor](https://cursor.com)