### PR TITLE
fix(feishu): support progress message cleanup

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1846,6 +1846,27 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.error("[Feishu] Failed to edit message %s: %s", message_id, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a previously sent Feishu/Lark message."""
+        if not self._client:
+            return False
+
+        try:
+            request = self._build_delete_message_request(message_id)
+            response = await asyncio.to_thread(self._client.im.v1.message.delete, request)
+            if self._response_succeeded(response):
+                return True
+            logger.debug(
+                "[Feishu] Failed to delete message %s: %s %s",
+                message_id,
+                getattr(response, "code", "unknown"),
+                getattr(response, "msg", "delete failed"),
+            )
+            return False
+        except Exception as exc:
+            logger.debug("[Feishu] Failed to delete message %s: %s", message_id, exc, exc_info=True)
+            return False
+
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
@@ -4564,6 +4585,14 @@ class FeishuAdapter(BasePlatformAdapter):
         if "GetMessageRequest" in globals():
             return GetMessageRequest.builder().message_id(message_id).build()
         return SimpleNamespace(message_id=message_id)
+
+    @staticmethod
+    def _build_delete_message_request(message_id: str) -> Any:
+        try:
+            from lark_oapi.api.im.v1 import DeleteMessageRequest
+            return DeleteMessageRequest.builder().message_id(message_id).build()
+        except Exception:
+            return SimpleNamespace(message_id=message_id)
 
     @staticmethod
     def _build_message_resource_request(*, message_id: str, file_key: str, resource_type: str) -> Any:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -415,6 +415,41 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_delete_message_deletes_existing_feishu_message(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def delete(self, request):
+                captured["request"] = request
+                return SimpleNamespace(success=lambda: True)
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.delete_message(
+                    chat_id="oc_chat",
+                    message_id="om_progress",
+                )
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(captured["request"].message_id, "om_progress")
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_get_chat_info_uses_real_feishu_chat_api(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## Problem

Feishu progress bubbles can remain visible after the final reply even when `display.platforms.feishu.cleanup_progress: true` is configured. Users then see stale edited progress messages, including duplicated `(Edited)` labels.

Fixes #21746

## Root cause

The gateway only enables progress cleanup for adapters that override `BasePlatformAdapter.delete_message`. Feishu already supports progress updates through `edit_message()`, but the adapter never implemented `delete_message()`, so cleanup was disabled before it could delete temporary progress bubbles.

## Fix

Implement `FeishuAdapter.delete_message()` using the Lark/Feishu message delete API path (`client.im.v1.message.delete`). A small request-builder helper mirrors the existing get/update/create request helpers and keeps tests working when `lark-oapi` is unavailable.

## Testing

- `uv run --with pytest --with pytest-asyncio --with pytest-xdist --python 3.11 pytest tests/gateway/test_feishu.py -q -k 'edit_message or delete_message'`
- `uv run --with ruff --python 3.11 ruff check gateway/platforms/feishu.py tests/gateway/test_feishu.py`

Made with [Cursor](https://cursor.com)