### PR TITLE
fix(cron): instruct agent that response is delivered verbatim, no preamble

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -413,8 +413,16 @@ PLATFORM_HINTS = {
         "You are running as a scheduled cron job. There is no user present — you "
         "cannot ask questions, request clarification, or wait for follow-up. Execute "
         "the task fully and autonomously, making reasonable decisions where needed. "
-        "Your final response is automatically delivered to the job's configured "
-        "destination — put the primary content directly in your response."
+        "Your final response is automatically delivered VERBATIM to the job's "
+        "configured destination — there is no separate summarization step between "
+        "your response and the chat. "
+        "Output ONLY the deliverable content (the report, alert, digest, etc.). "
+        "Do not add preamble (e.g. \"Here's the report\", \"I'm analyzing\", "
+        "\"Now let me\", \"Based on the output\"), do not narrate your process or "
+        "write meta-commentary about what you're about to do, and do not add "
+        "postamble (e.g. \"Status:\", \"All done\", trailing checkmarks). "
+        "Your response IS the message the user receives — if a line wouldn't read "
+        "well in the chat verbatim, don't write it."
     ),
     "cli": (
         "You are a CLI AI Agent. Try not to use markdown but simple text "


### PR DESCRIPTION
## Summary

The cron platform prompt in `agent/prompt_builder.py` currently says only:

> Your final response is automatically delivered to the job's configured destination — put the primary content directly in your response.

This leaves room for the model to add chatty preamble that lands in the user's chat verbatim, because cron delivery does not run a separate summarization pass — the assistant's final message *is* the chat message.

In practice (Haiku-driven crons especially) this surfaces as messages like:

- `"Now let me generate the final output:"` followed by the actual output
- `"I'm analyzing the script output to format ..."` followed by the formatted result
- `"Good. Now let me format the output:"` followed by the bullets

Each affected cron's per-job prompt can be hardened individually, but the better fix is at the platform layer so all crons inherit the rule.

This PR tightens the platform prompt to explicitly state:

- the response is delivered **verbatim** (no summarization step downstream)
- output ONLY the deliverable content
- no preamble, no process narration, no postamble
- the response IS the chat message

## A/B test (no messages sent)

Tested locally against `claude-haiku-4-5` with identical model, tools, and per-job prompt — varying only the `PLATFORM_HINTS["cron"]` block. Scenario: a multi-document summarization task where the agent makes a sequence of `read_file` tool calls and then writes a final bullet-list digest. This is the flow under which preamble most commonly leaks.

```
========== OLD cron prompt — 5 runs ==========
  run 1 [LEAKED]: ## Summary
  run 2 [LEAKED]: ## Summary
  run 3 [LEAKED]: ## Summary
  run 4 [LEAKED]: ## Summary of documents
  run 5 [LEAKED]: ## Summary
  → 5/5 leaks

========== NEW cron prompt — 5 runs ==========
  run 1 [clean ]: • **Doc 1** — <bullet content>
  run 2 [clean ]: • **Doc 1** — <bullet content>
  run 3 [clean ]: • **Doc 1** — <bullet content>
  run 4 [clean ]: • **Doc 1** — <bullet content>
  run 5 [clean ]: • **Doc 1** — <bullet content>
  → 0/5 leaks
```

The leak shape in the harness (a `## Summary` title header) is one variant of the same class of behavior seen in production (`Now let me generate the final output:`, `I'm analyzing the script output:`, etc.) — the model treating its response as *about to deliver* something rather than as the deliverable itself. The new wording reframes that.

## Why platform-level

The previous wording lets each per-job prompt invent its own anti-preamble rules (some do, with varying success). Centralizing the rule once means:

- new cron jobs don't have to relearn this
- existing jobs that don't restate output rules still get protection
- it matches the architectural reality that cron output goes straight to the user

## Test plan

- [x] A/B test against live model, same tool history — 5/5 leaks → 0/5 leaks
- [ ] Run an existing cron job and confirm it still produces its expected output (no regression on jobs that already do the right thing)
- [ ] `[SILENT]` suppression still works (the per-job hint in `cron/scheduler.py:741` is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
