### PR TITLE
fix(gemini): translate video_url parts to inlineData

### DIFF
--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -76,11 +76,53 @@ def _coerce_content_to_text(content: Any) -> str:
             elif isinstance(p, dict):
                 if p.get("type") == "text" and isinstance(p.get("text"), str):
                     pieces.append(p["text"])
-                # Multimodal (image_url, etc.) — stub for now; log and skip
-                elif p.get("type") in ("image_url", "input_audio"):
-                    logger.debug("Dropping multimodal part (not yet supported): %s", p.get("type"))
         return "\n".join(pieces)
     return str(content)
+
+
+def _data_url_to_inline_data(url: str) -> Optional[Dict[str, Dict[str, str]]]:
+    """Convert a data URL into Gemini inlineData, preserving base64 payload."""
+    if not isinstance(url, str) or not url.startswith("data:"):
+        return None
+    try:
+        header, encoded = url.split(",", 1)
+        mime = header.split(":", 1)[1].split(";", 1)[0]
+    except Exception:
+        return None
+    if not mime or not encoded:
+        return None
+    return {"inlineData": {"mimeType": mime, "data": encoded}}
+
+
+def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
+    """Convert OpenAI text/image/video content parts to Gemini parts."""
+    if not isinstance(content, list):
+        text = _coerce_content_to_text(content)
+        return [{"text": text}] if text else []
+
+    parts: List[Dict[str, Any]] = []
+    for item in content:
+        if isinstance(item, str):
+            parts.append({"text": item})
+            continue
+        if not isinstance(item, dict):
+            continue
+        ptype = item.get("type")
+        if ptype == "text":
+            text = item.get("text")
+            if isinstance(text, str) and text:
+                parts.append({"text": text})
+        elif ptype in ("image_url", "video_url"):
+            media = item.get(ptype) or {}
+            url = media.get("url") if isinstance(media, dict) else ""
+            inline = _data_url_to_inline_data(url)
+            if inline:
+                parts.append(inline)
+            else:
+                logger.debug("Dropping unsupported multimodal part: %s", ptype)
+        elif ptype == "input_audio":
+            logger.debug("Dropping multimodal part (not yet supported): %s", ptype)
+    return parts
 
 
 def _translate_tool_call_to_gemini(tool_call: Dict[str, Any]) -> Dict[str, Any]:
@@ -157,9 +199,8 @@ def _build_gemini_contents(
         gemini_role = _ROLE_MAP_OPENAI_TO_GEMINI.get(role, "user")
         parts: List[Dict[str, Any]] = []
 
-        text = _coerce_content_to_text(msg.get("content"))
-        if text:
-            parts.append({"text": text})
+        content_parts = _extract_multimodal_parts(msg.get("content"))
+        parts.extend(content_parts)
 
         # Assistant messages can carry tool_calls
         tool_calls = msg.get("tool_calls") or []

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -17,7 +17,6 @@ OpenAI-compat layer entirely.
 from __future__ import annotations
 
 import asyncio
-import base64
 import json
 import logging
 import time
@@ -174,6 +173,20 @@ def _coerce_content_to_text(content: Any) -> str:
     return str(content)
 
 
+def _data_url_to_inline_data(url: str) -> Optional[Dict[str, Dict[str, str]]]:
+    """Convert a data URL into Gemini inlineData, preserving base64 payload."""
+    if not isinstance(url, str) or not url.startswith("data:"):
+        return None
+    try:
+        header, encoded = url.split(",", 1)
+        mime = header.split(":", 1)[1].split(";", 1)[0]
+    except Exception:
+        return None
+    if not mime or not encoded:
+        return None
+    return {"inlineData": {"mimeType": mime, "data": encoded}}
+
+
 def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
     if not isinstance(content, list):
         text = _coerce_content_to_text(content)
@@ -191,24 +204,14 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
             text = item.get("text")
             if isinstance(text, str) and text:
                 parts.append({"text": text})
-        elif ptype == "image_url":
-            url = ((item.get("image_url") or {}).get("url") or "")
-            if not isinstance(url, str) or not url.startswith("data:"):
-                continue
-            try:
-                header, encoded = url.split(",", 1)
-                mime = header.split(":", 1)[1].split(";", 1)[0]
-                raw = base64.b64decode(encoded)
-            except Exception:
-                continue
-            parts.append(
-                {
-                    "inlineData": {
-                        "mimeType": mime,
-                        "data": base64.b64encode(raw).decode("ascii"),
-                    }
-                }
-            )
+        elif ptype in ("image_url", "video_url"):
+            media = item.get(ptype) or {}
+            url = media.get("url") if isinstance(media, dict) else ""
+            inline = _data_url_to_inline_data(url)
+            if inline:
+                parts.append(inline)
+            else:
+                logger.debug("Dropping unsupported multimodal part: %s", ptype)
     return parts
 
 

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -581,6 +581,29 @@ class TestBuildGeminiRequest:
         # System should NOT appear in contents
         assert all(c["role"] != "system" for c in req["contents"])
 
+    def test_video_url_part_translates_to_inline_data(self):
+        from agent.gemini_cloudcode_adapter import build_gemini_request
+
+        req = build_gemini_request(messages=[{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this clip"},
+                {
+                    "type": "video_url",
+                    "video_url": {"url": "data:video/mp4;base64,QUJDRA=="},
+                },
+            ],
+        }])
+
+        parts = req["contents"][0]["parts"]
+        assert parts[0] == {"text": "Describe this clip"}
+        assert parts[1] == {
+            "inlineData": {
+                "mimeType": "video/mp4",
+                "data": "QUJDRA==",
+            }
+        }
+
     def test_multiple_system_messages_joined(self):
         from agent.gemini_cloudcode_adapter import build_gemini_request
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -19,6 +19,34 @@ class DummyResponse:
         return self._payload
 
 
+def test_build_native_request_translates_video_url_to_inline_data():
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this clip"},
+                {
+                    "type": "video_url",
+                    "video_url": {"url": "data:video/webm;base64,QUJDRA=="},
+                },
+            ],
+        }],
+        tools=[],
+        tool_choice=None,
+    )
+
+    parts = request["contents"][0]["parts"]
+    assert parts[0] == {"text": "Describe this clip"}
+    assert parts[1] == {
+        "inlineData": {
+            "mimeType": "video/webm",
+            "data": "QUJDRA==",
+        }
+    }
+
+
 def test_build_native_request_preserves_thought_signature_on_tool_replay():
     from agent.gemini_native_adapter import build_gemini_request
 


### PR DESCRIPTION
## Summary
- Translate OpenAI-style `video_url` content parts into Gemini `inlineData` for the `google-gemini-cli` Cloud Code adapter.
- Add the same `video_url` handling to the native Gemini adapter.
- Keep existing text/image behavior while preserving the base64 media payload instead of dropping it.

## Why
Hermes `video_analyze` sends local/remote videos as `video_url` data URLs. The Gemini adapters previously reduced multimodal content to text only, so Gemini OAuth/native paths never received the video bytes.

## Test Plan
- `venv/bin/python -m pytest tests/agent/test_gemini_cloudcode.py::TestBuildGeminiRequest::test_video_url_part_translates_to_inline_data tests/agent/test_gemini_native_adapter.py::test_build_native_request_translates_video_url_to_inline_data -q -o 'addopts='`
- `venv/bin/python -m pytest tests/agent/test_gemini_cloudcode.py::TestBuildGeminiRequest tests/agent/test_gemini_native_adapter.py -q -o 'addopts='`
- `venv/bin/python -m py_compile agent/gemini_cloudcode_adapter.py agent/gemini_native_adapter.py tools/vision_tools.py`
- Real OAuth smoke with `GeminiCloudCodeClient`, `gemini-2.5-flash`, and a generated 0.5s red MP4 returned: `C'est rouge.`
