### PR TITLE
feat(image-gen): add opt-in image_edit tool

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -142,6 +142,44 @@ class ImageGenProvider(abc.ABC):
         should ignore unknown keys.
         """
 
+    def supports_edit(self) -> bool:
+        """Return True when this backend supports prompt-guided image editing."""
+        return False
+
+    def edit(
+        self,
+        prompt: str,
+        images: List[str] | None = None,
+        *,
+        image: str | None = None,
+        mask: str | None = None,
+        aspect_ratio: str | None = DEFAULT_ASPECT_RATIO,
+        size: str | None = None,
+        model: str | None = None,
+        quality_tier: str | None = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """Edit one or more existing images.
+
+        Providers that support image-to-image should override this and return
+        the same uniform response shape as :meth:`generate`. ``images`` is the
+        canonical ordered list of reference inputs; ``image`` is a legacy
+        single-reference alias kept for call-site compatibility. Providers that
+        support both should merge ``image`` ahead of/into ``images`` according to
+        their API's ordering semantics. The default is a structured unsupported
+        response so existing generate-only providers do not need to implement an
+        edit method and unknown future keyword arguments are safely ignored.
+        """
+        aspect = resolve_aspect_ratio(aspect_ratio)
+        return error_response(
+            error=f"Image provider '{self.name}' does not support image editing",
+            error_type="unsupported",
+            provider=self.name,
+            model=model or "",
+            prompt=str(prompt or ""),
+            aspect_ratio=aspect,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/agent/image_reference.py
+++ b/agent/image_reference.py
@@ -1,0 +1,215 @@
+"""Safe validation helpers for image reference inputs.
+
+Providers can accept local files, data URLs, or remote URLs in different ways.
+This module performs provider-independent validation before any provider upload
+so callers do not accidentally read arbitrary local files or accept malformed
+image data.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+
+_ALLOWED_DATA_MIMES = {
+    "image/png": "png",
+    "image/jpeg": "jpeg",
+    "image/webp": "webp",
+    "image/gif": "gif",
+}
+
+_DATA_URL_RE = re.compile(
+    r"^data:\s*(image/(?:png|jpeg|webp|gif))\s*;\s*base64\s*,(.*)$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+DEFAULT_MAX_IMAGE_REFERENCE_BYTES = 20 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ImageReference:
+    """A validated image reference ready for provider-specific handling."""
+
+    kind: str
+    value: str
+    mime_type: Optional[str] = None
+    path: Optional[Path] = None
+    bytes_size: Optional[int] = None
+
+
+class ImageReferenceError(ValueError):
+    """Typed validation error for image references."""
+
+    def __init__(self, message: str, *, error_type: str = "invalid_argument") -> None:
+        super().__init__(message)
+        self.error_type = error_type
+
+
+def validate_image_reference(
+    reference: str,
+    *,
+    max_bytes: int = DEFAULT_MAX_IMAGE_REFERENCE_BYTES,
+) -> ImageReference:
+    """Validate and normalize a single image reference.
+
+    Accepted references:
+    - ``http://`` or ``https://`` URLs (not fetched here)
+    - ``data:image/(png|jpeg|webp|gif);base64,...`` with valid image bytes
+    - local files below ``$HERMES_HOME/cache/images`` or
+      ``$HERMES_HOME/image_cache`` after symlink resolution
+
+    Invalid references raise :class:`ImageReferenceError` with ``error_type`` of
+    ``not_found`` or ``invalid_argument``.
+    """
+
+    if not isinstance(reference, str) or not reference.strip():
+        raise ImageReferenceError("Image reference must be a non-empty string")
+
+    ref = reference.strip()
+    parsed = urlparse(ref)
+    scheme = parsed.scheme.lower()
+
+    if scheme in {"http", "https"}:
+        if not parsed.netloc:
+            raise ImageReferenceError("Image URL must include a host")
+        return ImageReference(kind="url", value=ref)
+
+    if scheme == "data" or ref.lower().startswith("data:"):
+        return _validate_data_url(ref, max_bytes=max_bytes)
+
+    if scheme:
+        raise ImageReferenceError(f"Unsupported image reference scheme: {scheme}")
+
+    return _validate_local_path(ref, max_bytes=max_bytes)
+
+
+def _validate_data_url(ref: str, *, max_bytes: int) -> ImageReference:
+    match = _DATA_URL_RE.match(ref)
+    if not match:
+        raise ImageReferenceError(
+            "Data URL must be data:image/(png|jpeg|webp|gif);base64,..."
+        )
+
+    mime_type = match.group(1).lower()
+    b64_compact = re.sub(r"\s+", "", match.group(2))
+    if not b64_compact:
+        raise ImageReferenceError("Data URL does not contain image bytes")
+
+    max_encoded_chars = 4 * math.ceil(max_bytes / 3)
+    if len(b64_compact) > max_encoded_chars:
+        raise ImageReferenceError(
+            f"Image reference is too large (encoded length {len(b64_compact)} exceeds {max_encoded_chars} chars)"
+        )
+
+    try:
+        raw = base64.b64decode(b64_compact, validate=True)
+    except binascii.Error as exc:
+        raise ImageReferenceError("Data URL contains invalid base64") from exc
+
+    _ensure_size(raw, max_bytes=max_bytes)
+    detected = _detect_mime(raw)
+    if detected is None:
+        raise ImageReferenceError("Data URL does not contain a supported image")
+    if detected != mime_type:
+        raise ImageReferenceError(
+            f"Data URL MIME type {mime_type} does not match image bytes ({detected})"
+        )
+
+    return ImageReference(
+        kind="data",
+        value=f"data:{mime_type};base64,{b64_compact}",
+        mime_type=mime_type,
+        bytes_size=len(raw),
+    )
+
+
+def _validate_local_path(ref: str, *, max_bytes: int) -> ImageReference:
+    path = Path(ref).expanduser()
+    try:
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise ImageReferenceError("Image file was not found", error_type="not_found") from exc
+    except OSError as exc:
+        raise ImageReferenceError(f"Could not resolve image file: {exc}") from exc
+
+    allowed_roots = _allowed_local_roots()
+    if not any(_is_relative_to(resolved, root) for root in allowed_roots):
+        raise ImageReferenceError(
+            "Local image references must be under $HERMES_HOME/cache/images or $HERMES_HOME/image_cache"
+        )
+
+    if not resolved.is_file():
+        raise ImageReferenceError("Image reference is not a file")
+
+    with resolved.open("rb") as fh:
+        size = fh.seek(0, 2)
+        if size > max_bytes:
+            raise ImageReferenceError(
+                f"Image reference is too large ({size} bytes > {max_bytes} bytes)"
+            )
+        fh.seek(0)
+        sample = fh.read(16)
+    mime_type = _detect_mime(sample)
+    if mime_type is None:
+        raise ImageReferenceError("Local file is not a supported image")
+
+    return ImageReference(
+        kind="file",
+        value=str(resolved),
+        mime_type=mime_type,
+        path=resolved,
+        bytes_size=size,
+    )
+
+
+def _allowed_local_roots() -> list[Path]:
+    try:
+        from hermes_constants import get_hermes_home
+
+        home = get_hermes_home()
+    except Exception:
+        import os
+
+        home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+
+    roots: list[Path] = []
+    for child in ("cache/images", "image_cache"):
+        root = home / child
+        try:
+            roots.append(root.resolve(strict=False))
+        except OSError:
+            roots.append(root.absolute())
+    return roots
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _ensure_size(raw: bytes, *, max_bytes: int) -> None:
+    if len(raw) > max_bytes:
+        raise ImageReferenceError(
+            f"Image reference is too large ({len(raw)} bytes > {max_bytes} bytes)"
+        )
+
+
+def _detect_mime(raw: bytes) -> Optional[str]:
+    if raw.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if raw.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if raw.startswith(b"GIF87a") or raw.startswith(b"GIF89a"):
+        return "image/gif"
+    if len(raw) >= 12 and raw[0:4] == b"RIFF" and raw[8:12] == b"WEBP":
+        return "image/webp"
+    return None

--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 
 import logging
 import os
+from contextlib import ExitStack
+from io import BytesIO
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.image_gen_provider import (
@@ -36,6 +38,7 @@ from agent.image_gen_provider import (
     save_url_image,
     success_response,
 )
+from agent.image_reference import ImageReference, ImageReferenceError, validate_image_reference
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +81,63 @@ _SIZES = {
     "square": "1024x1024",
     "portrait": "1024x1536",
 }
+
+
+def _normalize_edit_sources(images: List[str] | None, image: str | None) -> List[str]:
+    """Merge the legacy single-image argument with the canonical list."""
+    refs: List[str] = []
+    if image:
+        refs.append(image)
+    if images:
+        refs.extend(img for img in images if img)
+    return refs
+
+
+def _resolve_edit_model(
+    model: str | None,
+    quality_tier: str | None,
+) -> Tuple[str, Dict[str, Any]]:
+    """Resolve a public tier id plus OpenAI quality metadata for edits."""
+    if model and model in _MODELS:
+        tier_id = model
+        meta = dict(_MODELS[model])
+    else:
+        tier_id, resolved_meta = _resolve_model()
+        meta = dict(resolved_meta)
+
+    if quality_tier in {"low", "medium", "high"}:
+        meta["quality"] = quality_tier
+        tier_id = next(
+            candidate
+            for candidate, candidate_meta in _MODELS.items()
+            if candidate_meta["quality"] == quality_tier
+        )
+
+    return tier_id, meta
+
+
+def _image_reference_to_file(ref: ImageReference):
+    """Convert a validated local/data image reference to OpenAI SDK file input."""
+    if ref.kind == "file" and ref.path is not None:
+        return open(ref.path, "rb")
+
+    if ref.kind == "data":
+        import base64
+
+        _, encoded = ref.value.split(",", 1)
+        suffix = {
+            "image/png": "png",
+            "image/jpeg": "jpg",
+            "image/webp": "webp",
+            "image/gif": "gif",
+        }.get(ref.mime_type or "", "img")
+        stream = BytesIO(base64.b64decode(encoded))
+        stream.name = f"image-reference.{suffix}"
+        return stream
+
+    raise ImageReferenceError(
+        "OpenAI image edits currently require local files or data URLs; HTTP(S) image URLs are not supported"
+    )
 
 
 def _load_openai_config() -> Dict[str, Any]:
@@ -157,6 +217,9 @@ class OpenAIImageGenProvider(ImageGenProvider):
     def default_model(self) -> Optional[str]:
         return DEFAULT_MODEL
 
+    def supports_edit(self) -> bool:
+        return True
+
     def get_setup_schema(self) -> Dict[str, Any]:
         return {
             "name": "OpenAI",
@@ -170,6 +233,182 @@ class OpenAIImageGenProvider(ImageGenProvider):
                 },
             ],
         }
+
+    def edit(
+        self,
+        prompt: str,
+        images: List[str] | None = None,
+        *,
+        image: str | None = None,
+        mask: str | None = None,
+        aspect_ratio: str | None = DEFAULT_ASPECT_RATIO,
+        size: str | None = None,
+        model: str | None = None,
+        quality_tier: str | None = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider="openai",
+                aspect_ratio=aspect,
+            )
+
+        source_refs = _normalize_edit_sources(images, image)
+        if not source_refs:
+            return error_response(
+                error="At least one source image is required for OpenAI image edits",
+                error_type="invalid_argument",
+                provider="openai",
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        if not os.environ.get("OPENAI_API_KEY"):
+            return error_response(
+                error=(
+                    "OPENAI_API_KEY not set. Run `hermes tools` → Image "
+                    "Generation → OpenAI to configure, or `hermes setup` "
+                    "to add the key."
+                ),
+                error_type="auth_required",
+                provider="openai",
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            import openai
+        except ImportError:
+            return error_response(
+                error="openai Python package not installed (pip install openai)",
+                error_type="missing_dependency",
+                provider="openai",
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            validated_sources = [validate_image_reference(ref) for ref in source_refs]
+            validated_mask = validate_image_reference(mask) if mask else None
+        except ImageReferenceError as exc:
+            return error_response(
+                error=str(exc),
+                error_type=getattr(exc, "error_type", "invalid_argument"),
+                provider="openai",
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        tier_id, meta = _resolve_edit_model(model, quality_tier)
+        request_size = size or _SIZES.get(aspect, _SIZES["square"])
+
+        try:
+            with ExitStack() as stack:
+                source_files = [
+                    stack.enter_context(_image_reference_to_file(ref))
+                    for ref in validated_sources
+                ]
+                payload: Dict[str, Any] = {
+                    "model": API_MODEL,
+                    "prompt": prompt,
+                    "image": source_files[0] if len(source_files) == 1 else source_files,
+                    "size": request_size,
+                    "n": 1,
+                    "quality": meta["quality"],
+                }
+                if validated_mask is not None:
+                    payload["mask"] = stack.enter_context(_image_reference_to_file(validated_mask))
+
+                client = openai.OpenAI()
+                response = client.images.edit(**payload)
+        except ImageReferenceError as exc:
+            return error_response(
+                error=str(exc),
+                error_type=getattr(exc, "error_type", "invalid_argument"),
+                provider="openai",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except Exception as exc:
+            logger.debug("OpenAI image edit failed", exc_info=True)
+            return error_response(
+                error=f"OpenAI image edit failed: {exc}",
+                error_type="api_error",
+                provider="openai",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        data = getattr(response, "data", None) or []
+        if not data:
+            return error_response(
+                error="OpenAI returned no image data",
+                error_type="empty_response",
+                provider="openai",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        first = data[0]
+        b64 = getattr(first, "b64_json", None)
+        url = getattr(first, "url", None)
+        revised_prompt = getattr(first, "revised_prompt", None)
+
+        if b64:
+            try:
+                saved_path = save_b64_image(b64, prefix=f"openai_edit_{tier_id}")
+            except Exception as exc:
+                return error_response(
+                    error=f"Could not save image to cache: {exc}",
+                    error_type="io_error",
+                    provider="openai",
+                    model=tier_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+            image_ref = str(saved_path)
+        elif url:
+            try:
+                saved_path = save_url_image(url, prefix=f"openai_edit_{tier_id}")
+            except Exception as exc:
+                logger.warning(
+                    "OpenAI image edit URL %s could not be cached (%s); falling back to bare URL.",
+                    url,
+                    exc,
+                )
+                image_ref = url
+            else:
+                image_ref = str(saved_path)
+        else:
+            return error_response(
+                error="OpenAI response contained neither b64_json nor URL",
+                error_type="empty_response",
+                provider="openai",
+                model=tier_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        extra: Dict[str, Any] = {"size": request_size, "quality": meta["quality"]}
+        if revised_prompt:
+            extra["revised_prompt"] = revised_prompt
+
+        return success_response(
+            image=image_ref,
+            model=tier_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider="openai",
+            extra=extra,
+        )
 
     def generate(
         self,

--- a/tests/agent/test_image_gen_provider_edit_contract.py
+++ b/tests/agent/test_image_gen_provider_edit_contract.py
@@ -1,0 +1,90 @@
+"""Tests for the base image generation provider edit contract."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from agent.image_gen_provider import ImageGenProvider
+
+
+class GenerateOnlyProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "generate_only"
+
+    def generate(self, prompt: str, aspect_ratio: str = "landscape", **kwargs: Any) -> Dict[str, Any]:
+        return {"success": True, "prompt": prompt, "aspect_ratio": aspect_ratio}
+
+
+def test_generate_only_provider_can_instantiate_without_edit_override():
+    provider = GenerateOnlyProvider()
+
+    assert provider.name == "generate_only"
+    assert provider.supports_edit() is False
+
+
+def test_default_edit_returns_structured_unsupported_response():
+    provider = GenerateOnlyProvider()
+
+    result = provider.edit(
+        "make it brighter",
+        images=["https://example.test/source.png"],
+        image="https://example.test/alias.png",
+        mask="https://example.test/mask.png",
+        aspect_ratio="square",
+        model="future-model",
+        quality_tier="high",
+        ignored_future_kwarg=True,
+    )
+
+    assert result["success"] is False
+    assert result["image"] is None
+    assert result["error_type"] == "unsupported"
+    assert "does not support image editing" in result["error"]
+    assert result["provider"] == "generate_only"
+    assert result["prompt"] == "make it brighter"
+    assert result["aspect_ratio"] == "square"
+    assert result["model"] == "future-model"
+
+
+def test_default_edit_clamps_invalid_aspect_ratio():
+    result = GenerateOnlyProvider().edit("prompt", image="source", aspect_ratio="wide")
+
+    assert result["aspect_ratio"] == "landscape"
+
+
+def test_default_edit_accepts_no_reference_images():
+    result = GenerateOnlyProvider().edit("prompt")
+
+    assert result["success"] is False
+    assert result["error_type"] == "unsupported"
+    assert result["model"] == ""
+
+
+def test_default_edit_accepts_none_and_empty_edge_values():
+    result = GenerateOnlyProvider().edit(
+        "prompt",
+        images=None,
+        image=None,
+        mask=None,
+        aspect_ratio="",
+        model=None,
+        quality_tier=None,
+        ignored_future_kwarg=None,
+    )
+
+    assert result["success"] is False
+    assert result["aspect_ratio"] == "landscape"
+    assert result["model"] == ""
+
+
+def test_default_edit_accepts_empty_images_and_extra_kwargs():
+    result = GenerateOnlyProvider().edit(
+        "prompt",
+        images=[],
+        aspect_ratio=None,
+        nested_future_kwarg={"x": object()},
+    )
+
+    assert result["success"] is False
+    assert result["aspect_ratio"] == "landscape"

--- a/tests/agent/test_image_reference.py
+++ b/tests/agent/test_image_reference.py
@@ -1,0 +1,197 @@
+"""Tests for safe image reference validation."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agent.image_reference import ImageReferenceError, validate_image_reference
+
+PNG_BYTES = bytes.fromhex(
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000d49444154789c6300010000000500010d0a2db40000000049454e44"
+    "ae426082"
+)
+JPEG_BYTES = b"\xff\xd8\xff\xe0" + b"jpeg"
+WEBP_BYTES = b"RIFF" + (4).to_bytes(4, "little") + b"WEBP" + b"data"
+GIF_BYTES = b"GIF89a" + b"gif"
+
+
+@pytest.fixture(autouse=True)
+def hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _data_url(raw: bytes, mime: str = "image/png") -> str:
+    return f"data:{mime};base64,{base64.b64encode(raw).decode()}"
+
+
+@pytest.mark.parametrize(
+    "url",
+    ["https://example.test/image.png", "http://example.test/image.png"],
+)
+def test_allows_http_urls(url):
+    ref = validate_image_reference(url)
+
+    assert ref.kind == "url"
+    assert ref.value == url
+    assert ref.mime_type is None
+    assert ref.path is None
+    assert ref.bytes_size is None
+
+
+@pytest.mark.parametrize(
+    "raw,mime",
+    [
+        (PNG_BYTES, "image/png"),
+        (JPEG_BYTES, "image/jpeg"),
+        (WEBP_BYTES, "image/webp"),
+        (GIF_BYTES, "image/gif"),
+    ],
+)
+def test_allows_supported_data_urls(raw, mime):
+    ref = validate_image_reference(_data_url(raw, mime))
+
+    assert ref.kind == "data"
+    assert ref.mime_type == mime
+    assert ref.bytes_size == len(raw)
+    assert ref.value == _data_url(raw, mime)
+
+
+def test_normalizes_whitespace_bearing_data_url():
+    compact = base64.b64encode(PNG_BYTES).decode()
+    spaced = " \n ".join([compact[:12], compact[12:]])
+
+    ref = validate_image_reference(f"data: image/png ; base64 , {spaced}")
+
+    assert ref.value == f"data:image/png;base64,{compact}"
+
+
+def test_rejects_fake_data_url_even_with_supported_mime():
+    with pytest.raises(ImageReferenceError) as excinfo:
+        validate_image_reference(_data_url(b"not an image", "image/png"))
+
+    assert excinfo.value.error_type == "invalid_argument"
+
+
+def test_rejects_data_url_mime_mismatch():
+    with pytest.raises(ImageReferenceError):
+        validate_image_reference(_data_url(PNG_BYTES, "image/jpeg"))
+
+
+def test_rejects_oversized_data_url():
+    with pytest.raises(ImageReferenceError) as excinfo:
+        validate_image_reference(_data_url(PNG_BYTES), max_bytes=len(PNG_BYTES) - 1)
+
+    assert excinfo.value.error_type == "invalid_argument"
+    assert "too large" in str(excinfo.value)
+
+
+def test_rejects_oversized_data_url_before_decoding():
+    oversized = "data:image/png;base64," + ("A" * 1024)
+
+    with patch("agent.image_reference.base64.b64decode", side_effect=AssertionError("decoded")):
+        with pytest.raises(ImageReferenceError) as excinfo:
+            validate_image_reference(oversized, max_bytes=8)
+
+    assert excinfo.value.error_type == "invalid_argument"
+    assert "too large" in str(excinfo.value)
+
+
+def test_invalid_base64_after_size_precheck_still_reports_invalid():
+    with pytest.raises(ImageReferenceError) as excinfo:
+        validate_image_reference("data:image/png;base64,!!!!", max_bytes=128)
+
+    assert excinfo.value.error_type == "invalid_argument"
+    assert "invalid base64" in str(excinfo.value)
+
+
+def test_allows_local_file_under_cache_images(hermes_home):
+    path = hermes_home / "cache" / "images" / "source.png"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(PNG_BYTES)
+
+    ref = validate_image_reference(str(path))
+
+    assert ref.kind == "file"
+    assert ref.value == str(path.resolve())
+    assert ref.path == path.resolve()
+    assert ref.mime_type == "image/png"
+    assert ref.bytes_size == len(PNG_BYTES)
+
+
+def test_local_file_validation_reads_only_header_not_entire_file(hermes_home, monkeypatch):
+    path = hermes_home / "cache" / "images" / "source.png"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(PNG_BYTES + (b"x" * 1024))
+    monkeypatch.setattr(Path, "read_bytes", lambda self: (_ for _ in ()).throw(AssertionError("read whole file")))
+
+    ref = validate_image_reference(str(path), max_bytes=2048)
+
+    assert ref.kind == "file"
+    assert ref.mime_type == "image/png"
+    assert ref.bytes_size == len(PNG_BYTES) + 1024
+
+
+def test_allows_local_file_under_legacy_image_cache(hermes_home):
+    path = hermes_home / "image_cache" / "source.gif"
+    path.parent.mkdir(parents=True)
+    path.write_bytes(GIF_BYTES)
+
+    ref = validate_image_reference(str(path))
+
+    assert ref.kind == "file"
+    assert ref.mime_type == "image/gif"
+
+
+def test_symlink_must_resolve_inside_allowed_cache(hermes_home, tmp_path):
+    outside = tmp_path / "outside.png"
+    outside.write_bytes(PNG_BYTES)
+    link = hermes_home / "cache" / "images" / "link.png"
+    link.parent.mkdir(parents=True)
+    link.symlink_to(outside)
+
+    with pytest.raises(ImageReferenceError) as excinfo:
+        validate_image_reference(str(link))
+
+    assert excinfo.value.error_type == "invalid_argument"
+
+
+def test_rejects_arbitrary_local_path(tmp_path):
+    path = tmp_path / "source.png"
+    path.write_bytes(PNG_BYTES)
+
+    with pytest.raises(ImageReferenceError) as excinfo:
+        validate_image_reference(str(path))
+
+    assert excinfo.value.error_type == "invalid_argument"
+
+
+@pytest.mark.parametrize("ref", ["file:///tmp/source.png", "ftp://example.test/source.png", "s3://bucket/key"])
+def test_rejects_unsupported_schemes(ref):
+    with pytest.raises(ImageReferenceError) as excinfo:
+        validate_image_reference(ref)
+
+    assert excinfo.value.error_type == "invalid_argument"
+
+
+def test_missing_file_raises_not_found(hermes_home):
+    with pytest.raises(ImageReferenceError) as excinfo:
+        validate_image_reference(str(hermes_home / "cache" / "images" / "missing.png"))
+
+    assert excinfo.value.error_type == "not_found"
+
+
+def test_rejects_local_non_image_file(hermes_home):
+    path = hermes_home / "cache" / "images" / "source.txt"
+    path.parent.mkdir(parents=True)
+    path.write_text("not an image")
+
+    with pytest.raises(ImageReferenceError) as excinfo:
+        validate_image_reference(str(path))
+
+    assert excinfo.value.error_type == "invalid_argument"

--- a/tests/plugins/image_gen/test_openai_provider.py
+++ b/tests/plugins/image_gen/test_openai_provider.py
@@ -67,6 +67,9 @@ class TestMetadata:
             assert entry["speed"]
             assert entry["strengths"]
 
+    def test_supports_edit(self, provider):
+        assert provider.supports_edit() is True
+
 
 # ── Availability ────────────────────────────────────────────────────────────
 
@@ -269,3 +272,167 @@ class TestGenerate:
 
         assert result["success"] is True
         assert result["image"] == "https://example.com/img.png"
+
+
+# ── Edit ────────────────────────────────────────────────────────────────────
+
+
+class TestEdit:
+    def _cached_png(self, tmp_path: Path, name: str = "source.png") -> Path:
+        path = tmp_path / "cache" / "images" / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(bytes.fromhex(_PNG_HEX))
+        return path
+
+    def test_empty_prompt_rejected(self, provider, tmp_path):
+        source = self._cached_png(tmp_path)
+
+        result = provider.edit("", image=str(source))
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+
+    def test_requires_at_least_one_image(self, provider):
+        result = provider.edit("make it brighter")
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert "source image" in result["error"]
+
+    def test_missing_api_key(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        source = self._cached_png(tmp_path)
+
+        result = openai_plugin.OpenAIImageGenProvider().edit("edit", image=str(source))
+
+        assert result["success"] is False
+        assert result["error_type"] == "auth_required"
+
+    def test_missing_openai_dependency(self, provider, tmp_path):
+        source = self._cached_png(tmp_path)
+
+        with patch.dict("sys.modules", {"openai": None}):
+            result = provider.edit("edit", image=str(source))
+
+        assert result["success"] is False
+        assert result["error_type"] == "missing_dependency"
+
+    def test_local_image_edit_calls_openai_and_saves_b64(self, provider, tmp_path):
+        source = self._cached_png(tmp_path)
+        fake_client = MagicMock()
+        fake_client.images.edit.return_value = _fake_response(b64=_b64_png(), revised_prompt="Edited")
+
+        with _patched_openai(fake_client):
+            result = provider.edit("add a hat", image=str(source), aspect_ratio="portrait")
+
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2-medium"
+        assert result["provider"] == "openai"
+        assert result["size"] == "1024x1536"
+        assert result["quality"] == "medium"
+        assert result["revised_prompt"] == "Edited"
+        assert Path(result["image"]).read_bytes() == bytes.fromhex(_PNG_HEX)
+
+        call_kwargs = fake_client.images.edit.call_args.kwargs
+        assert call_kwargs["model"] == "gpt-image-2"
+        assert call_kwargs["prompt"] == "add a hat"
+        assert call_kwargs["size"] == "1024x1536"
+        assert call_kwargs["quality"] == "medium"
+        assert call_kwargs["image"].name == str(source.resolve())
+        assert "response_format" not in call_kwargs
+
+    def test_data_url_image_edit(self, provider):
+        import base64
+
+        fake_client = MagicMock()
+        fake_client.images.edit.return_value = _fake_response(url="https://example.test/edited.png")
+        data_url = f"data:image/png;base64,{base64.b64encode(bytes.fromhex(_PNG_HEX)).decode()}"
+
+        with _patched_openai(fake_client), patch(
+            "plugins.image_gen.openai.save_url_image",
+            return_value=Path("/tmp/openai_edit_gpt-image-2-high_20260524_000000_deadbeef.png"),
+        ) as mock_save_url:
+            result = provider.edit("edit", image=data_url, size="1024x1024", quality_tier="high")
+
+        assert result["success"] is True
+        assert result["image"].startswith("/tmp/openai_edit_gpt-image-2-high")
+        mock_save_url.assert_called_once_with(
+            "https://example.test/edited.png",
+            prefix="openai_edit_gpt-image-2-high",
+        )
+        assert result["model"] == "gpt-image-2-high"
+        assert result["quality"] == "high"
+        call_kwargs = fake_client.images.edit.call_args.kwargs
+        assert call_kwargs["size"] == "1024x1024"
+        assert call_kwargs["quality"] == "high"
+        assert call_kwargs["image"].name == "image-reference.png"
+
+    def test_multiple_images_use_sdk_list_shape(self, provider, tmp_path):
+        source1 = self._cached_png(tmp_path, "source1.png")
+        source2 = self._cached_png(tmp_path, "source2.png")
+        fake_client = MagicMock()
+        fake_client.images.edit.return_value = _fake_response(url="https://example.test/edited.png")
+
+        with _patched_openai(fake_client):
+            result = provider.edit("combine", images=[str(source1), str(source2)])
+
+        assert result["success"] is True
+        call_kwargs = fake_client.images.edit.call_args.kwargs
+        assert isinstance(call_kwargs["image"], list)
+        assert [item.name for item in call_kwargs["image"]] == [str(source1.resolve()), str(source2.resolve())]
+
+    def test_mask_is_validated_and_passed(self, provider, tmp_path):
+        source = self._cached_png(tmp_path, "source.png")
+        mask = self._cached_png(tmp_path, "mask.png")
+        fake_client = MagicMock()
+        fake_client.images.edit.return_value = _fake_response(url="https://example.test/edited.png")
+
+        with _patched_openai(fake_client):
+            result = provider.edit("edit", image=str(source), mask=str(mask))
+
+        assert result["success"] is True
+        assert fake_client.images.edit.call_args.kwargs["mask"].name == str(mask.resolve())
+
+    def test_invalid_reference_does_not_call_api(self, provider):
+        fake_client = MagicMock()
+
+        with _patched_openai(fake_client):
+            result = provider.edit("edit", image="/etc/passwd")
+
+        assert result["success"] is False
+        assert result["error_type"] in {"invalid_argument", "not_found"}
+        fake_client.images.edit.assert_not_called()
+
+    def test_http_reference_rejected_before_api_call(self, provider):
+        fake_client = MagicMock()
+
+        with _patched_openai(fake_client):
+            result = provider.edit("edit", image="https://example.test/source.png")
+
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+        assert "HTTP(S)" in result["error"]
+        fake_client.images.edit.assert_not_called()
+
+    def test_api_error_returns_error_response(self, provider, tmp_path):
+        source = self._cached_png(tmp_path)
+        fake_client = MagicMock()
+        fake_client.images.edit.side_effect = RuntimeError("boom")
+
+        with _patched_openai(fake_client):
+            result = provider.edit("edit", image=str(source))
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "boom" in result["error"]
+
+    def test_empty_response_data(self, provider, tmp_path):
+        source = self._cached_png(tmp_path)
+        fake_client = MagicMock()
+        fake_client.images.edit.return_value = SimpleNamespace(data=[])
+
+        with _patched_openai(fake_client):
+            result = provider.edit("edit", image=str(source))
+
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"

--- a/tests/tools/test_image_edit_tool.py
+++ b/tests/tools/test_image_edit_tool.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent.image_gen_provider import ImageGenProvider
+
+
+class _EditProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "edit-capable"
+
+    def is_available(self) -> bool:
+        return True
+
+    def supports_edit(self) -> bool:
+        return True
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):  # pragma: no cover - not used
+        raise AssertionError("generate should not be called")
+
+    def edit(self, prompt, images=None, *, image=None, aspect_ratio=None, **kwargs):
+        return {
+            "success": True,
+            "image": "/tmp/edited.png",
+            "model": kwargs.get("model", "test-model"),
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "provider": self.name,
+            "source_image": image,
+        }
+
+
+class _GenerateOnlyProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "generate-only"
+
+    def is_available(self) -> bool:
+        return True
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):  # pragma: no cover - not used
+        return {}
+
+
+def _png_bytes() -> bytes:
+    return b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    from agent import image_gen_registry
+
+    image_gen_registry._reset_for_tests()
+    yield
+    image_gen_registry._reset_for_tests()
+
+
+def test_image_edit_is_in_image_gen_toolset_but_not_default_core():
+    import toolsets
+    import tools.image_edit_tool  # noqa: F401 - ensure registry side effect
+    from tools.registry import registry
+
+    assert "image_edit" in toolsets.resolve_toolset("image_gen")
+    assert "image_edit" not in toolsets.resolve_toolset("hermes")
+    assert registry.get_entry("image_edit") is not None
+
+
+def test_image_edit_dispatches_to_configured_edit_provider(monkeypatch, tmp_path):
+    from agent import image_gen_registry as registry_module
+    from hermes_cli import plugins as plugins_module
+    from tools import image_edit_tool
+
+    home = tmp_path / "hermes-home"
+    image_dir = home / "cache" / "images"
+    image_dir.mkdir(parents=True)
+    source = image_dir / "source.png"
+    source.write_bytes(_png_bytes())
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_provider", lambda: "edit-capable")
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_model", lambda: "configured-model")
+    monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+    monkeypatch.setattr(registry_module, "get_provider", lambda name: _EditProvider() if name == "edit-capable" else None)
+
+    payload = json.loads(image_edit_tool._handle_image_edit({
+        "prompt": "make the background blue",
+        "image": str(source),
+        "aspect_ratio": "square",
+    }))
+
+    assert payload["success"] is True
+    assert payload["provider"] == "edit-capable"
+    assert payload["model"] == "configured-model"
+    assert payload["source_image"] == str(source.resolve())
+    assert payload["aspect_ratio"] == "square"
+
+
+def test_image_edit_rejects_unsupported_provider(monkeypatch):
+    from agent import image_gen_registry as registry_module
+    from hermes_cli import plugins as plugins_module
+    from tools import image_edit_tool
+
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_provider", lambda: "generate-only")
+    monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+    monkeypatch.setattr(registry_module, "get_provider", lambda name: _GenerateOnlyProvider())
+
+    payload = json.loads(image_edit_tool._handle_image_edit({
+        "prompt": "edit it",
+        "image": "https://example.com/source.png",
+    }))
+
+    assert payload["success"] is False
+    assert payload["error_type"] == "unsupported"
+
+
+def test_image_edit_validates_reference_before_provider(monkeypatch):
+    from agent import image_gen_registry as registry_module
+    from hermes_cli import plugins as plugins_module
+    from tools import image_edit_tool
+
+    monkeypatch.setattr(image_edit_tool, "_read_configured_image_provider", lambda: "edit-capable")
+    monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+    monkeypatch.setattr(registry_module, "get_provider", lambda name: _EditProvider())
+
+    payload = json.loads(image_edit_tool._handle_image_edit({
+        "prompt": "edit it",
+        "image": "file:///etc/passwd",
+    }))
+
+    assert payload["success"] is False
+    assert payload["error_type"] == "invalid_argument"
+    assert "Unsupported image reference scheme" in payload["error"]

--- a/tools/image_edit_tool.py
+++ b/tools/image_edit_tool.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Opt-in image editing tool.
+
+Dispatches prompt-guided image edits to the configured ``image_gen`` provider
+when that provider explicitly advertises edit support.  The tool is registered
+under the existing ``image_gen`` toolset so it is not exposed unless users opt
+into image generation tools.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+from agent.image_gen_provider import DEFAULT_ASPECT_RATIO, VALID_ASPECT_RATIOS
+from agent.image_reference import ImageReferenceError, validate_image_reference
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+IMAGE_EDIT_SCHEMA = {
+    "name": "image_edit",
+    "description": (
+        "Edit an existing image using a text instruction and a reference image. "
+        "Use only when image generation tools are enabled and the configured "
+        "image backend supports editing. Returns either a URL or an absolute "
+        "file path in the `image` field; display it with markdown "
+        "![description](url-or-path)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "Instruction describing the edit to apply while preserving "
+                    "unchanged parts of the source image."
+                ),
+            },
+            "image": {
+                "type": "string",
+                "description": (
+                    "Reference image as an HTTP(S) URL, data:image URL, or local "
+                    "file path under Hermes' image cache."
+                ),
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": list(VALID_ASPECT_RATIOS),
+                "description": "Desired output aspect ratio.",
+                "default": DEFAULT_ASPECT_RATIO,
+            },
+            "size": {
+                "type": "string",
+                "description": "Optional provider-specific exact output size, for example WIDTHxHEIGHT.",
+            },
+            "model": {
+                "type": "string",
+                "description": "Optional provider-specific model override.",
+            },
+            "quality_tier": {
+                "type": "string",
+                "description": "Optional provider-specific quality tier override.",
+            },
+        },
+        "required": ["prompt", "image"],
+    },
+}
+
+
+def _read_configured_image_provider():
+    """Reuse image_generate's provider selection logic."""
+    try:
+        from tools.image_generation_tool import _read_configured_image_provider as _reader
+
+        return _reader()
+    except Exception as exc:
+        logger.debug("Could not read configured image provider for image_edit: %s", exc)
+        return None
+
+
+def _read_configured_image_model():
+    """Reuse image_generate's selected model as an optional provider hint."""
+    try:
+        from tools.image_generation_tool import _read_configured_image_model as _reader
+
+        return _reader()
+    except Exception as exc:
+        logger.debug("Could not read configured image model for image_edit: %s", exc)
+        return None
+
+
+def _get_active_edit_provider():
+    configured = _read_configured_image_provider()
+    if not configured or configured == "fal":
+        return None, configured
+
+    try:
+        from agent.image_gen_registry import get_provider
+        from hermes_cli.plugins import _ensure_plugins_discovered
+
+        _ensure_plugins_discovered()
+        provider = get_provider(configured)
+        if provider is None:
+            _ensure_plugins_discovered(force=True)
+            provider = get_provider(configured)
+        return provider, configured
+    except Exception as exc:
+        logger.debug("image_edit provider discovery failed: %s", exc)
+        return None, configured
+
+
+def _provider_error(message: str, error_type: str) -> str:
+    return json.dumps({"success": False, "image": None, "error": message, "error_type": error_type})
+
+
+def _dispatch_to_plugin_provider(
+    prompt: str,
+    image: str,
+    aspect_ratio: str,
+    *,
+    size: str | None = None,
+    model: str | None = None,
+    quality_tier: str | None = None,
+) -> str:
+    provider, configured = _get_active_edit_provider()
+    if configured is None or configured == "fal":
+        return _provider_error(
+            "image_edit requires image_gen.provider to be set to an edit-capable backend.",
+            "provider_not_configured",
+        )
+
+    if provider is None:
+        return _provider_error(
+            f"image_gen.provider='{configured}' is set but no plugin registered that name.",
+            "provider_not_registered",
+        )
+
+    if not getattr(provider, "supports_edit", lambda: False)():
+        return _provider_error(
+            f"Image provider '{getattr(provider, 'name', configured)}' does not support image_edit",
+            "unsupported",
+        )
+
+    try:
+        validated = validate_image_reference(image)
+    except ImageReferenceError as exc:
+        return _provider_error(str(exc), exc.error_type)
+
+    try:
+        edit_kwargs: Dict[str, Any] = {}
+        if size:
+            edit_kwargs["size"] = size
+        if quality_tier:
+            edit_kwargs["quality_tier"] = quality_tier
+        configured_model = _read_configured_image_model()
+        if model:
+            edit_kwargs["model"] = model
+        elif configured_model:
+            edit_kwargs["model"] = configured_model
+
+        result = provider.edit(
+            prompt=prompt,
+            image=validated.value,
+            aspect_ratio=aspect_ratio,
+            **edit_kwargs,
+        )
+    except Exception as exc:
+        logger.warning("Image edit provider '%s' raised: %s", getattr(provider, "name", "?"), exc)
+        return _provider_error(
+            f"Provider '{getattr(provider, 'name', '?')}' error: {exc}",
+            "provider_exception",
+        )
+
+    if not isinstance(result, dict):
+        return _provider_error("Provider returned a non-dict result", "provider_contract")
+    return json.dumps(result)
+
+
+def check_image_edit_requirements() -> bool:
+    provider, configured = _get_active_edit_provider()
+    if not configured or provider is None:
+        return False
+    try:
+        return bool(provider.is_available() and provider.supports_edit())
+    except Exception:
+        return False
+
+
+def _handle_image_edit(args: Dict[str, Any], **kw):
+    prompt = (args.get("prompt") or "").strip()
+    if not prompt:
+        return tool_error("prompt is required for image editing")
+
+    image = args.get("image") or args.get("image_path") or args.get("image_url")
+    if not isinstance(image, str) or not image.strip():
+        return tool_error("image is required for image editing and must be a path or URL")
+
+    return _dispatch_to_plugin_provider(
+        prompt,
+        image.strip(),
+        args.get("aspect_ratio", DEFAULT_ASPECT_RATIO),
+        size=args.get("size"),
+        model=args.get("model"),
+        quality_tier=args.get("quality_tier"),
+    )
+
+
+registry.register(
+    name="image_edit",
+    toolset="image_gen",
+    schema=IMAGE_EDIT_SCHEMA,
+    handler=_handle_image_edit,
+    check_fn=check_image_edit_requirements,
+    requires_env=[],
+    is_async=False,
+    emoji="🖼️",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -124,7 +124,7 @@ TOOLSETS = {
     
     "image_gen": {
         "description": "Creative generation tools (images)",
-        "tools": ["image_generate"],
+        "tools": ["image_generate", "image_edit"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary
- add an opt-in `image_edit` tool under the existing `image_gen` toolset
- reuse the configured image-generation provider and dispatch only when that provider advertises edit support
- keep `image_edit` out of the default Hermes core toolset; users must explicitly enable/request the `image_gen` toolset

## Relationship to the image-edit stack
This PR is intentionally stacked after the clean image-edit foundation PRs:

Recommended merge order: #26967 → #26968 → #26969 → #21765. Please merge this PR last in the stack; after #26967, #26968, and #26969 land, I will rebase/refresh this branch onto `main` so the diff only shows the opt-in tool delta.

1. #26967: provider-level edit capability contract
2. #26968: reusable image reference validation helper
3. #26969: OpenAI provider implementation for image editing
4. this PR: model-facing opt-in `image_edit` tool

Until the earlier PRs merge, GitHub will show their commits in this PR too. The tool-only delta in this PR is limited to:

- `tools/image_edit_tool.py`
- `toolsets.py`
- `tests/tools/test_image_edit_tool.py`

## Implementation
- registers `image_edit` in the `image_gen` toolset
- validates source images before provider dispatch
- returns a structured `unsupported` response when the configured provider has no edit support
- preserves conservative defaults by not adding `image_edit` to `_HERMES_CORE_TOOLS`
- reuses the same provider configuration path as `image_generate`

## Testing
- `python3 -m pytest tests/tools/test_image_edit_tool.py tests/tools/test_image_generation_plugin_dispatch.py tests/plugins/image_gen/test_openai_provider.py tests/agent/test_image_gen_provider_edit_contract.py tests/agent/test_image_reference.py -q -o 'addopts='`
- `python3 -m py_compile tools/image_edit_tool.py tests/tools/test_image_edit_tool.py toolsets.py plugins/image_gen/openai/__init__.py agent/image_reference.py agent/image_gen_provider.py`
- `git diff --check origin/main...HEAD`

No live image generation or external API calls used; provider behavior is covered with mocks.
