### PR TITLE
fix(acp): include clarify toolset in default ACP session to prevent safety refusals

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -596,7 +596,12 @@ class SessionManager:
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
+                # clarify is added alongside hermes-acp so mini-class models
+                # can ask for intent instead of triggering a safety refusal on
+                # ambiguous greetings. clarify_tool returns a graceful error
+                # when no interactive callback is registered (ACP path), so
+                # the model falls back to answering directly. See #21666.
+                ["hermes-acp", "clarify"],
                 mcp_server_names=configured_mcp_servers,
             ),
             "quiet_mode": True,

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -246,3 +246,25 @@ class TestPluginToolsets:
         all_toolsets = get_all_toolsets()
         assert "plugin_bundle" in all_toolsets
         assert all_toolsets["plugin_bundle"]["tools"] == ["plugin_tool"]
+
+
+class TestAcpSessionToolsets:
+    def test_acp_session_default_toolsets_include_clarify(self):
+        """ACP sessions must include clarify alongside hermes-acp.
+
+        Without clarify, mini-class OpenRouter models trigger a canonical safety
+        refusal on plain greetings. clarify_tool gracefully handles the
+        no-callback ACP context (returns an error the model uses to answer
+        directly). See issue #21666.
+        """
+        from acp_adapter.session import _expand_acp_enabled_toolsets
+
+        toolsets = _expand_acp_enabled_toolsets(["hermes-acp", "clarify"])
+        assert "hermes-acp" in toolsets
+        assert "clarify" in toolsets
+
+    def test_acp_session_clarify_toolset_expands_to_clarify_tool(self):
+        """clarify standalone toolset resolves to the clarify tool name."""
+        ts = get_toolset("clarify")
+        assert ts is not None
+        assert "clarify" in ts["tools"]


### PR DESCRIPTION
## What does this PR do?

`_start_agent_session()` in `acp_adapter/session.py` constructs `AIAgent` with `enabled_toolsets=["hermes-acp"]`. The `hermes-acp` toolset deliberately excludes the `clarify` tool because it is an editor-integration toolset (VS Code, Zed, JetBrains) without an interactive UI. Without `clarify` available in the schema, mini-class OpenRouter models (e.g. `openai/gpt-5.4-mini`) have no tool for expressing user-intent uncertainty — they fall back to the OpenAI canonical safety refusal `"I'm sorry, but I cannot assist with that request."` even on plain greetings like `"hello"` or `"你好"`. The same model and prompt respond normally via `hermes -z` or `hermes chat`, both of which use `hermes-cli` (which includes `clarify`).

Root cause confirmed by a Cartesian-product experiment on `acp_adapter/session.py:598-601` (same machine, same model, same provider, same prompt, zero MCP servers):

| `enabled_toolsets` | Result |
|---|---|
| `["hermes-acp"]` | ❌ safety refusal |
| `["hermes-cli"]` | ✅ normal response |
| `["hermes-acp", "clarify"]` | ✅ normal response |

Fix: prepend `"clarify"` to the default toolset list. `clarify_tool` gracefully handles the no-callback ACP context by returning `{"error": "Clarify tool is not available in this execution context."}` — the model reads this error and falls back to answering directly, which is the expected behavior. No behavior change for models that do not call `clarify`.

## Related Issue

Fixes #21666

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `acp_adapter/session.py`: add `"clarify"` to the default toolset list in `_expand_acp_enabled_toolsets(...)` call (+6 lines including comment)
- `tests/test_toolsets.py`: two new tests — verify `_expand_acp_enabled_toolsets` returns `clarify` when requested, and that the `clarify` standalone toolset resolves to the `clarify` tool (+20 lines)

## How to Test

Run with a mini-class OpenRouter model:

```bash
hermes acp
# In another terminal, send via JSON-RPC:
# session/new + session/set_model openai/gpt-5.4-mini + session/prompt "hello"
# Before fix: "I'm sorry, but I cannot assist with that request."
# After fix:  "Hello! How can I help you?"
```

Unit tests:

```bash
python3.11 -m pytest tests/test_toolsets.py::TestAcpSessionToolsets -v --override-ini="addopts="
```

Expected: `2 passed`.

## Checklist

### Code
- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] This fix only
- [x] pytest run
- [x] Tests added
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs updated — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — all platforms using `hermes acp` are affected
- [x] Tool descriptions — N/A