### PR TITLE
fix(dashboard): chat tab fails outside nix containers (HERMES_PYTHON_SRC_ROOT + Node 20 detection)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1046,6 +1046,54 @@ def _ensure_tui_node() -> None:
     os.environ["PATH"] = os.pathsep.join(parts)
 
 
+_TUI_MIN_NODE_MAJOR = 20
+
+# Common version-manager install layouts. Used to find a Node >=
+# ``_TUI_MIN_NODE_MAJOR`` install when PATH only has an older one — e.g.
+# the macOS default `node` is still 16 for many users while nvm has 22+.
+_NODE_VM_LAYOUTS = [
+    # (root_dir, glob_under_root_for_version_dirs, bin_path_relative_to_version_dir)
+    (Path.home() / ".nvm" / "versions" / "node", "v*", Path("bin") / "node"),
+    (Path.home() / ".fnm" / "node-versions", "v*", Path("installation") / "bin" / "node"),
+    (Path.home() / ".volta" / "tools" / "image" / "node", "*", Path("bin") / "node"),
+    (Path.home() / ".asdf" / "installs" / "nodejs", "*", Path("bin") / "node"),
+]
+
+
+def _node_major(node_bin: str) -> Optional[int]:
+    """Return the major version for ``node_bin``, or None if it can't be probed."""
+    try:
+        out = subprocess.run(
+            [node_bin, "--version"],
+            capture_output=True, text=True, timeout=5, check=True,
+        ).stdout.strip()
+        if out.startswith("v"):
+            return int(out[1:].split(".", 1)[0])
+    except (subprocess.SubprocessError, ValueError, OSError):
+        pass
+    return None
+
+
+def _find_modern_node() -> Optional[str]:
+    """Find the highest installed Node >= ``_TUI_MIN_NODE_MAJOR`` from common
+    version-manager directories. Returns the absolute path or None."""
+    candidates: list[tuple[int, str]] = []
+    for vm_root, glob_pat, bin_relpath in _NODE_VM_LAYOUTS:
+        if not vm_root.is_dir():
+            continue
+        for entry in vm_root.glob(glob_pat):
+            bin_path = entry / bin_relpath
+            if not (bin_path.is_file() and os.access(bin_path, os.X_OK)):
+                continue
+            major = _node_major(str(bin_path))
+            if major and major >= _TUI_MIN_NODE_MAJOR:
+                candidates.append((major, str(bin_path)))
+    if not candidates:
+        return None
+    candidates.sort(reverse=True)
+    return candidates[0][1]
+
+
 def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
     """TUI: --dev → tsx src; else node dist (HERMES_TUI_DIR or ui-tui, build when stale)."""
     _ensure_tui_node()
@@ -1055,6 +1103,31 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
             env_node = os.environ.get("HERMES_NODE")
             if env_node and os.path.isfile(env_node) and os.access(env_node, os.X_OK):
                 return env_node
+
+            # ui-tui transitively depends on string-width, which uses the /v
+            # regex flag (ECMAScript 2024, Node >= 20 only). Older Node
+            # crashes the PTY child with `SyntaxError: Invalid regular
+            # expression flags` immediately on import. Validate the PATH
+            # node's version, and if it's too old, sniff version-manager
+            # directories for a usable install before erroring out.
+            path = shutil.which("node")
+            if path:
+                major = _node_major(path)
+                if major and major >= _TUI_MIN_NODE_MAJOR:
+                    return path
+                modern = _find_modern_node()
+                if modern:
+                    return modern
+                sys.exit(
+                    f"node {major or '?'} found on PATH but ui-tui requires "
+                    f"Node >= {_TUI_MIN_NODE_MAJOR} (string-width uses the /v "
+                    f"regex flag, ECMAScript 2024).\n"
+                    f"Fix: install Node {_TUI_MIN_NODE_MAJOR}+ via "
+                    f"nvm/fnm/volta/asdf, or set "
+                    f"HERMES_NODE=/path/to/node{_TUI_MIN_NODE_MAJOR}+/bin/node."
+                )
+            # No node on PATH at all — fall through to original "not found" error.
+
         path = shutil.which(bin)
         if not path:
             print(f"{bin} not found — install Node.js to use the TUI.")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3039,6 +3039,17 @@ def _resolve_chat_argv(
     argv, cwd = _make_tui_argv(PROJECT_ROOT / "ui-tui", tui_dev=False)
     env = os.environ.copy()
     env.setdefault("NODE_ENV", "production")
+    # GatewayClient resolves the Python source root from this env var (see
+    # ui-tui/src/gatewayClient.ts). When unset, it falls back to
+    # ``import.meta.dirname`` which is unreliable across the various ways
+    # ``entry.js`` ends up loaded under PTY (it can be ``undefined`` even on
+    # Node 22, depending on loader path), causing
+    # ``path.resolve(undefined, '../../')`` to throw ``ERR_INVALID_ARG_TYPE``.
+    # The CLI launch path (``_launch_tui``) already sets this; the dashboard
+    # PTY path missed it and was relying on inheritance from the user's
+    # shell. Set it explicitly with ``setdefault`` so an operator-provided
+    # value still wins.
+    env.setdefault("HERMES_PYTHON_SRC_ROOT", str(PROJECT_ROOT))
     # Browser-embedded chat should prefer stable wheel-based scrollback over
     # native terminal mouse tracking. When mouse tracking is enabled, wheel
     # events are consumed by the TUI and forwarded as terminal input, which


### PR DESCRIPTION
## Summary
- inject `HERMES_PYTHON_SRC_ROOT` in `_resolve_chat_argv` so the dashboard PTY child can resolve the python source root, matching what `_launch_tui` already does for the CLI path
- have `_node_bin("node")` reject Node < 20 with a clear error and prefer a discovered Node ≥ 20 from common version-manager paths (nvm, fnm, volta) before failing — fixes `string-width`'s `/v` flag crash on machines whose default `node` is < 20

## Why

Two crashes hit the dashboard chat tab on a non-nix mac after applying #20615:

**1. `path argument must be of type string. Received undefined`**

The PTY child runs `ui-tui/dist/entry.js`, which constructs a Python source root with:

```js
// gatewayClient.js
const root = process.env.HERMES_PYTHON_SRC_ROOT ?? resolve(import.meta.dirname, '../../');
```

`import.meta.dirname` is unreliable across the various ways `entry.js` ends up loaded under PTY (it can be `undefined` even on Node 22, depending on loader path), and `path.resolve(undefined, …)` then throws `ERR_INVALID_ARG_TYPE`.

The CLI launch path (`hermes_cli/main.py:_launch_tui`) already sets `env["HERMES_PYTHON_SRC_ROOT"]`, but the dashboard PTY launch path (`hermes_cli/web_server.py:_resolve_chat_argv`) does not — so the chat tab inherits whatever `HERMES_PYTHON_SRC_ROOT` happens to be in the user's shell, which on a fresh login is nothing.

**2. `SyntaxError: Invalid regular expression flags`**

When the PTY child's first `PATH` lookup of `node` returns Node 18 or older (common on macOS where the system / older nvm install ships first), `string-width` ESM crashes immediately because it uses the `/v` regex flag (ECMAScript 2024, Node 20+ only).

PR #12159 fixed this for nix containers via `HERMES_NODE`, but non-nix users (mac/Linux without HERMES_NODE set) still hit it. The current `_node_bin` falls through to whatever `shutil.which("node")` returns with no version check, so the failure surfaces only after the PTY is up and `entry.js` imports `string-width`.

This change has `_node_bin("node")` (a) keep honoring `HERMES_NODE` first, (b) sniff common version-manager directories for a Node ≥ 20 binary if `PATH` only has an old one, and (c) emit a clear `Node ≥ 20 required (found vX on PATH)` error instead of crashing inside the TUI.

## Test plan
- [x] `python -m pytest tests/hermes_cli/test_tui_npm_install.py -q`
- [x] manual: macOS 14, default `node` v16.18 on PATH, nvm v22.22 also installed → without this PR chat tab dies on `/v` regex flag; with this PR `_node_bin` finds the v22 nvm install and chat connects
- [x] manual: macOS, `HERMES_NODE` unset, no `HERMES_PYTHON_SRC_ROOT` in dashboard env → without this PR `path.resolve(undefined, '../../')` throws; with this PR `_resolve_chat_argv` injects `HERMES_PYTHON_SRC_ROOT=str(PROJECT_ROOT)`

## Notes
- Stacked on / complementary to #20615 (the WS-behind-cloudflared fix). Both are needed for a working dashboard chat tab outside nix containers.
- Does not change behavior for users who already export `HERMES_NODE` or `HERMES_PYTHON_SRC_ROOT` (both calls use `setdefault` / explicit env precedence).
