### PR TITLE
fix: keep dashboard importable without Unix PTY modules

### DIFF
--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -29,22 +29,35 @@ Design constraints:
 from __future__ import annotations
 
 import errno
-import fcntl
 import os
 import select
 import signal
 import struct
 import sys
-import termios
 import time
 from typing import Optional, Sequence
 
 try:
+    import fcntl  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - native Windows
+    fcntl = None  # type: ignore[assignment]
+
+try:
+    import termios  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - native Windows
+    termios = None  # type: ignore[assignment]
+
+try:
     import ptyprocess  # type: ignore
-    _PTY_AVAILABLE = not sys.platform.startswith("win")
 except ImportError:  # pragma: no cover - dev env without ptyprocess
-    ptyprocess = None  # type: ignore
-    _PTY_AVAILABLE = False
+    ptyprocess = None  # type: ignore[assignment]
+
+_PTY_AVAILABLE = (
+    ptyprocess is not None
+    and fcntl is not None
+    and termios is not None
+    and not sys.platform.startswith("win")
+)
 
 
 __all__ = ["PtyBridge", "PtyUnavailableError"]

--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -60,6 +60,35 @@ _PTY_AVAILABLE = (
 )
 
 
+def _pty_unavailable_message() -> str:
+    """Return an actionable reason for spawn-time PTY unavailability."""
+    if sys.platform.startswith("win"):
+        return (
+            "Pseudo-terminals are unavailable on native Windows for the "
+            "dashboard chat/TUI path. Run Hermes Agent inside WSL to use "
+            "the dashboard chat tab."
+        )
+
+    missing_modules = [
+        name
+        for name, module in (
+            ("ptyprocess", ptyprocess),
+            ("fcntl", fcntl),
+            ("termios", termios),
+        )
+        if module is None
+    ]
+    if missing_modules:
+        return (
+            "Pseudo-terminals are unavailable because this Python environment "
+            f"is missing Unix PTY module(s): {', '.join(missing_modules)}. "
+            "On Windows, run Hermes Agent inside WSL for POSIX PTY support; "
+            "otherwise install the PTY extra with: pip install -e '.[pty]'."
+        )
+
+    return "Pseudo-terminals are unavailable."
+
+
 __all__ = ["PtyBridge", "PtyUnavailableError"]
 
 
@@ -112,18 +141,7 @@ class PtyBridge:
         ordinary exec failures (missing binary, bad cwd, etc.).
         """
         if not _PTY_AVAILABLE:
-            if sys.platform.startswith("win"):
-                raise PtyUnavailableError(
-                    "Pseudo-terminals are unavailable on this platform. "
-                    "Hermes Agent supports Windows only via WSL."
-                )
-            if ptyprocess is None:
-                raise PtyUnavailableError(
-                    "The `ptyprocess` package is missing. "
-                    "Install with: pip install ptyprocess "
-                    "(or pip install -e '.[pty]')."
-                )
-            raise PtyUnavailableError("Pseudo-terminals are unavailable.")
+            raise PtyUnavailableError(_pty_unavailable_message())
         # PTY-hosted programs expect TERM to describe the terminal type.
         # CI often runs without TERM in the parent process, which makes
         # simple terminal probes like `tput cols` fail before winsize reads.

--- a/tests/hermes_cli/test_pty_bridge.py
+++ b/tests/hermes_cli/test_pty_bridge.py
@@ -177,3 +177,36 @@ class TestPtyBridgeUnavailable:
     def test_error_carries_user_message(self):
         err = PtyUnavailableError("platform not supported")
         assert "platform" in str(err)
+
+    def test_spawn_error_names_missing_unix_pty_modules(self, monkeypatch):
+        import hermes_cli.pty_bridge as pty_bridge
+
+        monkeypatch.setattr(pty_bridge, "_PTY_AVAILABLE", False)
+        monkeypatch.setattr(pty_bridge, "ptyprocess", object())
+        monkeypatch.setattr(pty_bridge, "fcntl", None)
+        monkeypatch.setattr(pty_bridge, "termios", None)
+        monkeypatch.setattr(pty_bridge.sys, "platform", "linux")
+
+        with pytest.raises(PtyUnavailableError) as exc_info:
+            PtyBridge.spawn(["/bin/sh"])
+
+        message = str(exc_info.value)
+        assert "fcntl" in message
+        assert "termios" in message
+        assert "Unix PTY module" in message
+        assert "Windows" in message
+        assert "WSL" in message
+
+    def test_spawn_error_names_native_windows_wsl_path(self, monkeypatch):
+        import hermes_cli.pty_bridge as pty_bridge
+
+        monkeypatch.setattr(pty_bridge, "_PTY_AVAILABLE", False)
+        monkeypatch.setattr(pty_bridge.sys, "platform", "win32")
+
+        with pytest.raises(PtyUnavailableError) as exc_info:
+            PtyBridge.spawn(["cmd.exe"])
+
+        message = str(exc_info.value)
+        assert "native Windows" in message
+        assert "WSL" in message
+        assert "dashboard" in message

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1940,6 +1940,43 @@ class TestDashboardPluginManifestExtensions:
         ]
 
 
+
+class TestNativeWindowsPtyImportFallback:
+    def test_web_server_imports_when_unix_pty_modules_are_missing(self, monkeypatch):
+        """Dashboard import should not fail just because PTY support is unavailable.
+
+        Native Windows lacks Unix-only modules such as fcntl/termios. The dashboard
+        should still import and expose non-PTY routes, while the PTY bridge reports
+        itself unavailable.
+        """
+        import builtins
+        import importlib
+        import sys
+
+        real_import = builtins.__import__
+
+        def reject_unix_pty_modules(name, globals=None, locals=None, fromlist=(), level=0):
+            importing_module = (globals or {}).get("__name__")
+            if importing_module == "hermes_cli.pty_bridge" and name in {"fcntl", "termios"}:
+                raise ModuleNotFoundError(f"No module named '{name}'")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", reject_unix_pty_modules)
+        sys.modules.pop("hermes_cli.web_server", None)
+        sys.modules.pop("hermes_cli.pty_bridge", None)
+
+        try:
+            ws = importlib.import_module("hermes_cli.web_server")
+
+            assert ws.app is not None
+            assert ws.PtyBridge.is_available() is False
+            with pytest.raises(ws.PtyUnavailableError):
+                ws.PtyBridge.spawn(["hermes"])
+        finally:
+            sys.modules.pop("hermes_cli.web_server", None)
+            sys.modules.pop("hermes_cli.pty_bridge", None)
+
+
 # ---------------------------------------------------------------------------
 # /api/pty WebSocket — terminal bridge for the dashboard "Chat" tab.
 #
@@ -2104,6 +2141,8 @@ class TestPtyWebSocket:
             assert b"99" in buf and b"41" in buf
 
     def test_unavailable_platform_closes_with_message(self, monkeypatch):
+        from starlette.websockets import WebSocketDisconnect
+
         from hermes_cli.pty_bridge import PtyUnavailableError
 
         def _raise(argv, **kwargs):
@@ -2117,12 +2156,21 @@ class TestPtyWebSocket:
         # Patch PtyBridge.spawn at the web_server module's binding.
         import hermes_cli.web_server as ws_mod
 
-        monkeypatch.setattr(ws_mod.PtyBridge, "spawn", classmethod(lambda cls, *a, **k: _raise(*a, **k)))
+        monkeypatch.setattr(
+            ws_mod.PtyBridge,
+            "spawn",
+            classmethod(lambda cls, *a, **k: _raise(*a, **k)),
+        )
 
         with self.client.websocket_connect(self._url()) as conn:
-            # Expect a final text frame with the error message, then close.
+            # Expect a final text frame with the error message, then a clean
+            # endpoint-level close. The dashboard server must stay alive even
+            # when the embedded chat PTY cannot start.
             msg = conn.receive_text()
             assert "pty missing" in msg or "unavailable" in msg.lower() or "pty" in msg.lower()
+            with pytest.raises(WebSocketDisconnect) as exc:
+                conn.receive_text()
+            assert exc.value.code == 1011
 
     def test_resume_parameter_is_forwarded_to_argv(self, monkeypatch):
         captured: dict = {}


### PR DESCRIPTION
## Summary

Native Windows is documented as an early-beta runtime, but the dashboard /chat embedded terminal path is still the main native-Windows gap because it depends on POSIX PTY primitives. This PR keeps the rest of the dashboard usable and makes the /chat failure mode friendlier while testing there:

- Guard Unix-only `fcntl` and `termios` imports in `hermes_cli.pty_bridge`
- Keep `hermes_cli.web_server` importable when PTY support is unavailable
- Preserve existing Linux/macOS behavior: `PtyBridge.is_available()` remains true only when `ptyprocess`, `fcntl`, and `termios` are all available and the platform is not native Windows
- Add a regression test that simulates missing Unix PTY modules and verifies non-PTY dashboard routes can still import while PTY spawn reports unavailable
- Strengthen the embedded-chat WebSocket test so PTY unavailability sends a clear message and closes the socket instead of crashing the dashboard server

Related to #5246 and complements #5247. That PR covers `tools/memory_tool.py` plus guarded `SIGKILL` lookups; this PR covers the dashboard chat PTY bridge import path, which is a separate `fcntl`/`termios` import site.

## Testing

- `python -m pytest tests/hermes_cli/test_web_server.py::TestNativeWindowsPtyImportFallback::test_web_server_imports_when_unix_pty_modules_are_missing tests/hermes_cli/test_web_server.py::TestPtyWebSocket -q -o addopts=`
  - `12 passed`
- `python -m pytest tests/hermes_cli/test_web_server.py -q -o addopts=`
  - `138 passed`
- `ruff check hermes_cli/pty_bridge.py tests/hermes_cli/test_web_server.py`
  - `All checks passed!`
- Native Windows Python smoke via the Hermes Windows venv:
  - `platform= win32`
  - `fcntl= None`
  - `termios= None`
  - `pty_available= False`
  - `web_server_app= True`

Note: I could not run the pytest target inside the Windows Hermes venv because that venv does not have pytest installed. The Linux/WSL venv ran the regression suite above, and the native Windows Python smoke directly verified this import path with missing fcntl/termios.
