### PR TITLE
fix(dashboard): aggregate analytics across Hermes profiles

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2800,73 +2800,220 @@ async def update_config_raw(body: RawConfigUpdate):
 # ---------------------------------------------------------------------------
 
 
+def _empty_skill_analytics() -> Dict[str, Any]:
+    return {
+        "summary": {
+            "total_skill_loads": 0,
+            "total_skill_edits": 0,
+            "total_skill_actions": 0,
+            "distinct_skills_used": 0,
+        },
+        "top_skills": [],
+    }
+
+
+def _list_analytics_db_paths() -> List[Path]:
+    from hermes_cli import profiles as profiles_mod
+
+    try:
+        profile_paths = [Path(profile.path) for profile in profiles_mod.list_profiles()]
+    except Exception:
+        _log.exception("Analytics profile listing failed; falling back to directory scan")
+        profile_paths = [Path(profile["path"]) for profile in _fallback_profile_dicts(profiles_mod)]
+
+    db_paths: List[Path] = []
+    seen: set[Path] = set()
+    for profile_path in profile_paths:
+        db_path = profile_path / "state.db"
+        if not db_path.is_file():
+            continue
+        resolved = db_path.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        db_paths.append(db_path)
+    return db_paths
+
+
+def _merge_skill_reports(skill_reports: List[Dict[str, Any]]) -> Dict[str, Any]:
+    merged: Dict[str, Dict[str, Any]] = {}
+    for report in skill_reports:
+        for skill in report.get("top_skills", []):
+            entry = merged.setdefault(skill["skill"], {
+                "skill": skill["skill"],
+                "view_count": 0,
+                "manage_count": 0,
+                "total_count": 0,
+                "percentage": 0.0,
+                "last_used_at": None,
+            })
+            entry["view_count"] += int(skill.get("view_count") or 0)
+            entry["manage_count"] += int(skill.get("manage_count") or 0)
+            entry["total_count"] += int(skill.get("total_count") or 0)
+            last_used_at = skill.get("last_used_at")
+            if last_used_at is not None and (
+                entry["last_used_at"] is None or last_used_at > entry["last_used_at"]
+            ):
+                entry["last_used_at"] = last_used_at
+
+    top_skills = list(merged.values())
+    total_skill_loads = sum(skill["view_count"] for skill in top_skills)
+    total_skill_edits = sum(skill["manage_count"] for skill in top_skills)
+    total_skill_actions = total_skill_loads + total_skill_edits
+    for skill in top_skills:
+        skill["percentage"] = (
+            skill["total_count"] / total_skill_actions * 100
+            if total_skill_actions
+            else 0.0
+        )
+    top_skills.sort(
+        key=lambda skill: (
+            skill["total_count"],
+            skill["view_count"],
+            skill["manage_count"],
+            skill["last_used_at"] or 0,
+            skill["skill"],
+        ),
+        reverse=True,
+    )
+
+    return {
+        "summary": {
+            "total_skill_loads": total_skill_loads,
+            "total_skill_edits": total_skill_edits,
+            "total_skill_actions": total_skill_actions,
+            "distinct_skills_used": len(top_skills),
+        },
+        "top_skills": top_skills,
+    }
+
+
 @app.get("/api/analytics/usage")
 async def get_usage_analytics(days: int = 30):
     from hermes_state import SessionDB
     from agent.insights import InsightsEngine
 
-    db = SessionDB()
-    try:
-        cutoff = time.time() - (days * 86400)
-        cur = db._conn.execute("""
-            SELECT date(started_at, 'unixepoch') as day,
-                   SUM(input_tokens) as input_tokens,
-                   SUM(output_tokens) as output_tokens,
-                   SUM(cache_read_tokens) as cache_read_tokens,
-                   SUM(reasoning_tokens) as reasoning_tokens,
-                   COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
-                   COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
-                   COUNT(*) as sessions,
-                   SUM(COALESCE(api_call_count, 0)) as api_calls
-            FROM sessions WHERE started_at > ?
-            GROUP BY day ORDER BY day
-        """, (cutoff,))
-        daily = [dict(r) for r in cur.fetchall()]
+    cutoff = time.time() - (days * 86400)
+    daily_by_day: Dict[str, Dict[str, Any]] = {}
+    models_by_name: Dict[str, Dict[str, Any]] = {}
+    totals = {
+        "total_input": 0,
+        "total_output": 0,
+        "total_cache_read": 0,
+        "total_reasoning": 0,
+        "total_estimated_cost": 0.0,
+        "total_actual_cost": 0.0,
+        "total_sessions": 0,
+        "total_api_calls": 0,
+    }
+    skill_reports: List[Dict[str, Any]] = []
 
-        cur2 = db._conn.execute("""
-            SELECT model,
-                   SUM(input_tokens) as input_tokens,
-                   SUM(output_tokens) as output_tokens,
-                   COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
-                   COUNT(*) as sessions,
-                   SUM(COALESCE(api_call_count, 0)) as api_calls
-            FROM sessions WHERE started_at > ? AND model IS NOT NULL
-            GROUP BY model ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
-        """, (cutoff,))
-        by_model = [dict(r) for r in cur2.fetchall()]
+    for db_path in _list_analytics_db_paths():
+        db = SessionDB(db_path=db_path)
+        try:
+            cur = db._conn.execute("""
+                SELECT date(started_at, 'unixepoch') as day,
+                       SUM(input_tokens) as input_tokens,
+                       SUM(output_tokens) as output_tokens,
+                       SUM(cache_read_tokens) as cache_read_tokens,
+                       SUM(reasoning_tokens) as reasoning_tokens,
+                       COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
+                       COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
+                       COUNT(*) as sessions,
+                       SUM(COALESCE(api_call_count, 0)) as api_calls
+                FROM sessions WHERE started_at > ?
+                GROUP BY day ORDER BY day
+            """, (cutoff,))
+            for row in cur.fetchall():
+                day = row["day"]
+                entry = daily_by_day.setdefault(day, {
+                    "day": day,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_tokens": 0,
+                    "reasoning_tokens": 0,
+                    "estimated_cost": 0.0,
+                    "actual_cost": 0.0,
+                    "sessions": 0,
+                    "api_calls": 0,
+                })
+                entry["input_tokens"] += int(row["input_tokens"] or 0)
+                entry["output_tokens"] += int(row["output_tokens"] or 0)
+                entry["cache_read_tokens"] += int(row["cache_read_tokens"] or 0)
+                entry["reasoning_tokens"] += int(row["reasoning_tokens"] or 0)
+                entry["estimated_cost"] += float(row["estimated_cost"] or 0.0)
+                entry["actual_cost"] += float(row["actual_cost"] or 0.0)
+                entry["sessions"] += int(row["sessions"] or 0)
+                entry["api_calls"] += int(row["api_calls"] or 0)
 
-        cur3 = db._conn.execute("""
-            SELECT SUM(input_tokens) as total_input,
-                   SUM(output_tokens) as total_output,
-                   SUM(cache_read_tokens) as total_cache_read,
-                   SUM(reasoning_tokens) as total_reasoning,
-                   COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
-                   COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
-                   COUNT(*) as total_sessions,
-                   SUM(COALESCE(api_call_count, 0)) as total_api_calls
-            FROM sessions WHERE started_at > ?
-        """, (cutoff,))
-        totals = dict(cur3.fetchone())
-        insights_report = InsightsEngine(db).generate(days=days)
-        skills = insights_report.get("skills", {
-            "summary": {
-                "total_skill_loads": 0,
-                "total_skill_edits": 0,
-                "total_skill_actions": 0,
-                "distinct_skills_used": 0,
-            },
-            "top_skills": [],
-        })
+            cur2 = db._conn.execute("""
+                SELECT model,
+                       SUM(input_tokens) as input_tokens,
+                       SUM(output_tokens) as output_tokens,
+                       COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
+                       COUNT(*) as sessions,
+                       SUM(COALESCE(api_call_count, 0)) as api_calls
+                FROM sessions WHERE started_at > ? AND model IS NOT NULL
+                GROUP BY model ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
+            """, (cutoff,))
+            for row in cur2.fetchall():
+                model = row["model"]
+                entry = models_by_name.setdefault(model, {
+                    "model": model,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "estimated_cost": 0.0,
+                    "sessions": 0,
+                    "api_calls": 0,
+                })
+                entry["input_tokens"] += int(row["input_tokens"] or 0)
+                entry["output_tokens"] += int(row["output_tokens"] or 0)
+                entry["estimated_cost"] += float(row["estimated_cost"] or 0.0)
+                entry["sessions"] += int(row["sessions"] or 0)
+                entry["api_calls"] += int(row["api_calls"] or 0)
 
-        return {
-            "daily": daily,
-            "by_model": by_model,
-            "totals": totals,
-            "period_days": days,
-            "skills": skills,
-        }
-    finally:
-        db.close()
+            cur3 = db._conn.execute("""
+                SELECT SUM(input_tokens) as total_input,
+                       SUM(output_tokens) as total_output,
+                       SUM(cache_read_tokens) as total_cache_read,
+                       SUM(reasoning_tokens) as total_reasoning,
+                       COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
+                       COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
+                       COUNT(*) as total_sessions,
+                       SUM(COALESCE(api_call_count, 0)) as total_api_calls
+                FROM sessions WHERE started_at > ?
+            """, (cutoff,))
+            row = dict(cur3.fetchone())
+            totals["total_input"] += int(row["total_input"] or 0)
+            totals["total_output"] += int(row["total_output"] or 0)
+            totals["total_cache_read"] += int(row["total_cache_read"] or 0)
+            totals["total_reasoning"] += int(row["total_reasoning"] or 0)
+            totals["total_estimated_cost"] += float(row["total_estimated_cost"] or 0.0)
+            totals["total_actual_cost"] += float(row["total_actual_cost"] or 0.0)
+            totals["total_sessions"] += int(row["total_sessions"] or 0)
+            totals["total_api_calls"] += int(row["total_api_calls"] or 0)
+
+            skill_reports.append(
+                InsightsEngine(db).generate(days=days).get("skills", _empty_skill_analytics())
+            )
+        finally:
+            db.close()
+
+    daily = [daily_by_day[day] for day in sorted(daily_by_day)]
+    by_model = sorted(
+        models_by_name.values(),
+        key=lambda row: (row["input_tokens"] + row["output_tokens"], row["model"]),
+        reverse=True,
+    )
+    skills = _merge_skill_reports(skill_reports) if skill_reports else _empty_skill_analytics()
+
+    return {
+        "daily": daily,
+        "by_model": by_model,
+        "totals": totals,
+        "period_days": days,
+        "skills": skills,
+    }
 
 
 @app.get("/api/analytics/models")
@@ -2878,88 +3025,139 @@ async def get_models_analytics(days: int = 30):
     """
     from hermes_state import SessionDB
 
-    db = SessionDB()
-    try:
-        cutoff = time.time() - (days * 86400)
+    cutoff = time.time() - (days * 86400)
+    rows_by_key: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    distinct_models: set[str] = set()
+    totals = {
+        "distinct_models": 0,
+        "total_input": 0,
+        "total_output": 0,
+        "total_cache_read": 0,
+        "total_reasoning": 0,
+        "total_estimated_cost": 0.0,
+        "total_actual_cost": 0.0,
+        "total_sessions": 0,
+        "total_api_calls": 0,
+    }
 
-        cur = db._conn.execute("""
-            SELECT model,
-                   billing_provider,
-                   SUM(input_tokens) as input_tokens,
-                   SUM(output_tokens) as output_tokens,
-                   SUM(cache_read_tokens) as cache_read_tokens,
-                   SUM(reasoning_tokens) as reasoning_tokens,
-                   COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
-                   COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
-                   COUNT(*) as sessions,
-                   SUM(COALESCE(api_call_count, 0)) as api_calls,
-                   SUM(tool_call_count) as tool_calls,
-                   MAX(started_at) as last_used_at,
-                   AVG(input_tokens + output_tokens) as avg_tokens_per_session
-            FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
-            GROUP BY model, billing_provider
-            ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
-        """, (cutoff,))
-        rows = [dict(r) for r in cur.fetchall()]
+    for db_path in _list_analytics_db_paths():
+        db = SessionDB(db_path=db_path)
+        try:
+            cur = db._conn.execute("""
+                SELECT model,
+                       billing_provider,
+                       SUM(input_tokens) as input_tokens,
+                       SUM(output_tokens) as output_tokens,
+                       SUM(cache_read_tokens) as cache_read_tokens,
+                       SUM(reasoning_tokens) as reasoning_tokens,
+                       COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
+                       COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
+                       COUNT(*) as sessions,
+                       SUM(COALESCE(api_call_count, 0)) as api_calls,
+                       SUM(tool_call_count) as tool_calls,
+                       MAX(started_at) as last_used_at,
+                       AVG(input_tokens + output_tokens) as avg_tokens_per_session
+                FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
+                GROUP BY model, billing_provider
+                ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
+            """, (cutoff,))
+            for row in cur.fetchall():
+                model = row["model"]
+                provider = row["billing_provider"] or ""
+                distinct_models.add(model)
+                key = (model, provider)
+                entry = rows_by_key.setdefault(key, {
+                    "model": model,
+                    "provider": provider,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_tokens": 0,
+                    "reasoning_tokens": 0,
+                    "estimated_cost": 0.0,
+                    "actual_cost": 0.0,
+                    "sessions": 0,
+                    "api_calls": 0,
+                    "tool_calls": 0,
+                    "last_used_at": None,
+                    "avg_tokens_per_session": 0.0,
+                    "capabilities": {},
+                })
+                entry["input_tokens"] += int(row["input_tokens"] or 0)
+                entry["output_tokens"] += int(row["output_tokens"] or 0)
+                entry["cache_read_tokens"] += int(row["cache_read_tokens"] or 0)
+                entry["reasoning_tokens"] += int(row["reasoning_tokens"] or 0)
+                entry["estimated_cost"] += float(row["estimated_cost"] or 0.0)
+                entry["actual_cost"] += float(row["actual_cost"] or 0.0)
+                entry["sessions"] += int(row["sessions"] or 0)
+                entry["api_calls"] += int(row["api_calls"] or 0)
+                entry["tool_calls"] += int(row["tool_calls"] or 0)
+                last_used_at = row["last_used_at"]
+                if last_used_at is not None and (
+                    entry["last_used_at"] is None or last_used_at > entry["last_used_at"]
+                ):
+                    entry["last_used_at"] = last_used_at
 
-        models = []
-        for row in rows:
-            provider = row.get("billing_provider") or ""
-            model_name = row["model"]
-            caps = {}
-            try:
-                from agent.models_dev import get_model_capabilities
-                mc = get_model_capabilities(provider=provider, model=model_name)
-                if mc is not None:
-                    caps = {
-                        "supports_tools": mc.supports_tools,
-                        "supports_vision": mc.supports_vision,
-                        "supports_reasoning": mc.supports_reasoning,
-                        "context_window": mc.context_window,
-                        "max_output_tokens": mc.max_output_tokens,
-                        "model_family": mc.model_family,
-                    }
-            except Exception:
-                pass
+            totals_cur = db._conn.execute("""
+                SELECT COUNT(DISTINCT model) as distinct_models,
+                       SUM(input_tokens) as total_input,
+                       SUM(output_tokens) as total_output,
+                       SUM(cache_read_tokens) as total_cache_read,
+                       SUM(reasoning_tokens) as total_reasoning,
+                       COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
+                       COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
+                       COUNT(*) as total_sessions,
+                       SUM(COALESCE(api_call_count, 0)) as total_api_calls
+                FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
+            """, (cutoff,))
+            row = dict(totals_cur.fetchone())
+            totals["total_input"] += int(row["total_input"] or 0)
+            totals["total_output"] += int(row["total_output"] or 0)
+            totals["total_cache_read"] += int(row["total_cache_read"] or 0)
+            totals["total_reasoning"] += int(row["total_reasoning"] or 0)
+            totals["total_estimated_cost"] += float(row["total_estimated_cost"] or 0.0)
+            totals["total_actual_cost"] += float(row["total_actual_cost"] or 0.0)
+            totals["total_sessions"] += int(row["total_sessions"] or 0)
+            totals["total_api_calls"] += int(row["total_api_calls"] or 0)
+        finally:
+            db.close()
 
-            models.append({
-                "model": model_name,
-                "provider": provider,
-                "input_tokens": row["input_tokens"],
-                "output_tokens": row["output_tokens"],
-                "cache_read_tokens": row["cache_read_tokens"],
-                "reasoning_tokens": row["reasoning_tokens"],
-                "estimated_cost": row["estimated_cost"],
-                "actual_cost": row["actual_cost"],
-                "sessions": row["sessions"],
-                "api_calls": row["api_calls"],
-                "tool_calls": row["tool_calls"],
-                "last_used_at": row["last_used_at"],
-                "avg_tokens_per_session": row["avg_tokens_per_session"],
-                "capabilities": caps,
-            })
+    models = []
+    for row in rows_by_key.values():
+        provider = row["provider"]
+        model_name = row["model"]
+        total_tokens = row["input_tokens"] + row["output_tokens"]
+        row["avg_tokens_per_session"] = (
+            total_tokens / row["sessions"] if row["sessions"] else 0.0
+        )
+        caps = {}
+        try:
+            from agent.models_dev import get_model_capabilities
+            mc = get_model_capabilities(provider=provider, model=model_name)
+            if mc is not None:
+                caps = {
+                    "supports_tools": mc.supports_tools,
+                    "supports_vision": mc.supports_vision,
+                    "supports_reasoning": mc.supports_reasoning,
+                    "context_window": mc.context_window,
+                    "max_output_tokens": mc.max_output_tokens,
+                    "model_family": mc.model_family,
+                }
+        except Exception:
+            pass
+        row["capabilities"] = caps
+        models.append(row)
 
-        totals_cur = db._conn.execute("""
-            SELECT COUNT(DISTINCT model) as distinct_models,
-                   SUM(input_tokens) as total_input,
-                   SUM(output_tokens) as total_output,
-                   SUM(cache_read_tokens) as total_cache_read,
-                   SUM(reasoning_tokens) as total_reasoning,
-                   COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
-                   COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
-                   COUNT(*) as total_sessions,
-                   SUM(COALESCE(api_call_count, 0)) as total_api_calls
-            FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
-        """, (cutoff,))
-        totals = dict(totals_cur.fetchone())
+    models.sort(
+        key=lambda row: (row["input_tokens"] + row["output_tokens"], row["model"], row["provider"]),
+        reverse=True,
+    )
+    totals["distinct_models"] = len(distinct_models)
 
-        return {
-            "models": models,
-            "totals": totals,
-            "period_days": days,
-        }
-    finally:
-        db.close()
+    return {
+        "models": models,
+        "totals": totals,
+        "period_days": days,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -570,6 +570,54 @@ class TestNewEndpoints:
         self.client = TestClient(app)
         self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
 
+    def _write_analytics_session(
+        self,
+        db_path: Path,
+        session_id: str,
+        *,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        billing_provider: str | None = None,
+        api_call_count: int = 0,
+        skill_name: str | None = None,
+        tool_name: str | None = None,
+    ) -> None:
+        from hermes_state import SessionDB
+
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session(session_id=session_id, source="cli", model=model, user_id="tester")
+            db.update_token_counts(
+                session_id,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                billing_provider=billing_provider,
+                api_call_count=api_call_count,
+            )
+            if skill_name:
+                db.append_message(
+                    session_id,
+                    role="assistant",
+                    content=f"Load {skill_name}",
+                    tool_calls=[{
+                        "function": {
+                            "name": "skill_view",
+                            "arguments": json.dumps({"name": skill_name}),
+                        },
+                    }],
+                )
+            if tool_name:
+                db.append_message(
+                    session_id,
+                    role="assistant",
+                    content=f"Call {tool_name}",
+                    tool_calls=[{"function": {"name": tool_name}}],
+                )
+        finally:
+            db.close()
+
     def test_get_logs_default(self):
         resp = self.client.get("/api/logs")
         assert resp.status_code == 200
@@ -632,6 +680,101 @@ class TestNewEndpoints:
         assert profiles["default"]["provider"] == "openrouter"
         assert profiles["multi-agent"]["has_env"] is True
         assert profiles["multi-agent"]["skill_count"] == 1
+
+    def test_usage_analytics_aggregates_across_profiles(self):
+        from hermes_constants import get_hermes_home
+
+        hermes_home = get_hermes_home()
+        hermes_home.mkdir(parents=True, exist_ok=True)
+
+        self._write_analytics_session(
+            hermes_home / "state.db",
+            "default-usage",
+            model="gpt-4o",
+            input_tokens=100,
+            output_tokens=50,
+            api_call_count=1,
+            skill_name="github-pr-workflow",
+        )
+        self._write_analytics_session(
+            hermes_home / "profiles" / "coder" / "state.db",
+            "coder-usage",
+            model="gpt-4o",
+            input_tokens=200,
+            output_tokens=100,
+            api_call_count=2,
+            skill_name="github-pr-workflow",
+        )
+
+        resp = self.client.get("/api/analytics/usage?days=30")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["totals"]["total_input"] == 300
+        assert data["totals"]["total_output"] == 150
+        assert data["totals"]["total_sessions"] == 2
+        assert data["totals"]["total_api_calls"] == 3
+        assert len(data["daily"]) == 1
+        assert data["daily"][0]["sessions"] == 2
+        assert data["by_model"] == [{
+            "model": "gpt-4o",
+            "input_tokens": 300,
+            "output_tokens": 150,
+            "estimated_cost": 0.0,
+            "sessions": 2,
+            "api_calls": 3,
+        }]
+        assert data["skills"]["summary"]["total_skill_loads"] == 2
+        assert data["skills"]["summary"]["distinct_skills_used"] == 1
+        assert data["skills"]["top_skills"][0]["skill"] == "github-pr-workflow"
+        assert data["skills"]["top_skills"][0]["total_count"] == 2
+
+    def test_models_analytics_aggregates_across_profiles(self):
+        from hermes_constants import get_hermes_home
+
+        hermes_home = get_hermes_home()
+        hermes_home.mkdir(parents=True, exist_ok=True)
+
+        self._write_analytics_session(
+            hermes_home / "state.db",
+            "default-models",
+            model="gpt-4o",
+            input_tokens=100,
+            output_tokens=50,
+            billing_provider="openai",
+            api_call_count=1,
+            tool_name="terminal",
+        )
+        self._write_analytics_session(
+            hermes_home / "profiles" / "coder" / "state.db",
+            "coder-models",
+            model="gpt-4o",
+            input_tokens=200,
+            output_tokens=100,
+            billing_provider="openai",
+            api_call_count=2,
+            tool_name="terminal",
+        )
+
+        resp = self.client.get("/api/analytics/models?days=30")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["totals"]["distinct_models"] == 1
+        assert data["totals"]["total_input"] == 300
+        assert data["totals"]["total_output"] == 150
+        assert data["totals"]["total_sessions"] == 2
+        assert data["totals"]["total_api_calls"] == 3
+        assert len(data["models"]) == 1
+        model = data["models"][0]
+        assert model["model"] == "gpt-4o"
+        assert model["provider"] == "openai"
+        assert model["input_tokens"] == 300
+        assert model["output_tokens"] == 150
+        assert model["sessions"] == 2
+        assert model["api_calls"] == 3
+        assert model["tool_calls"] == 2
+        assert model["avg_tokens_per_session"] == 225.0
 
     def test_profiles_create_rename_delete_round_trip(self, monkeypatch):
         # Stub gateway service teardown so the test doesn't shell out to


### PR DESCRIPTION

## Summary

Closes #21705.

The analytics dashboard was reading only the active profile's `state.db`, which
undercounted token usage, sessions, costs, and API calls for multi-profile
users. This change aggregates analytics across the default profile and named
profile databases for the usage and models endpoints.

## What Changed

- discover all profile `state.db` files once for dashboard analytics
- merge per-profile usage totals into the `/api/analytics/usage` response
- merge per-profile model totals into the `/api/analytics/models` response
- add regression coverage proving multi-profile aggregation for both endpoints

## Scope Boundary

- no UI selector or profile filter was added
- no broader dashboard refactor was included
- no unrelated CLI, gateway, or tool behavior was changed

## Verification

- targeted analytics regressions passed
- `uv run --frozen python -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `git diff --check`
- `uv sync --frozen --extra all`
- `uv run --frozen ruff check .`
- lint-diff proof showed no net-new diagnostics in touched files
- clean-env CI-equivalent pytest rerun remained red only in unrelated suite areas; preserved same-base attribution evidence marks the residual failures as `preexisting_unrelated`

## Quality Firewall Proof

- `local_proof_sha`: `ca2574cef1d1077e3596b4e8cf87d466b0f05b1e`
- `github_pr_head_sha`: `TBD after push`
- `worktree_path`: `/private/tmp/hermes-pr-HER-64-0ec0c564-6e80b26b`
- `branch`: `fix/HER-64-issue-21705`
- `base_origin_main_sha`: `faa13e49f81480771ceeb55991bb0c27edf1a5fb`
- `latest_fetch_at`: `2026-05-08T08:09:34Z`
- `commands`: see `proof-input-ca2574cef1d1077e3596b4e8cf87d466b0f05b1e.json`
- `exit_codes`: see `proof-input-ca2574cef1d1077e3596b4e8cf87d466b0f05b1e.json`
- `started_at`: `2026-05-08T08:07:33Z`
- `completed_at`: `2026-05-08T08:16:52Z`
- `log_artifacts_or_inline_summary`: see `proof-input-ca2574cef1d1077e3596b4e8cf87d466b0f05b1e.json`
- `gatekeeper_audit_id`: `her61-20260508T080207Z-attribution-summary-11db70159`
- `baseline_attribution`: `preexisting_unrelated`
- `repair_mode`: `false`

## Submission Note

Do not open or push this PR draft until Gatekeeper either:

1. rebinds the preserved green proof from `11db7015986440698b6609e79fd08f9e41e49c2c` to the current identical tree at `ca2574cef1d1077e3596b4e8cf87d466b0f05b1e`, or
2. instructs submission from the preserved proof-bearing branch/worktree instead.
