### PR TITLE
fix: harden Google Workspace OAuth setup

### DIFF
--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -7,8 +7,8 @@ The agent mediates between this script and the user (works on CLI, Telegram, Dis
 Commands:
   setup.py --check                          # Is auth valid? Exit 0 = yes, 1 = no
   setup.py --client-secret /path/to.json    # Store OAuth client credentials
-  setup.py --auth-url                       # Print the OAuth URL for user to visit
-  setup.py --auth-code CODE                 # Exchange auth code for token
+  setup.py --auth-url [--services calendar] [--format json]
+  setup.py --auth-code CODE [--format json] # Exchange auth code for token
   setup.py --revoke                         # Revoke and delete stored token
   setup.py --install-deps                   # Install Python dependencies only
 
@@ -43,17 +43,38 @@ HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"
 CLIENT_SECRET_PATH = HERMES_HOME / "google_client_secret.json"
 PENDING_AUTH_PATH = HERMES_HOME / "google_oauth_pending.json"
+LAST_AUTH_URL_PATH = HERMES_HOME / "google_oauth_last_url.txt"
 
-SCOPES = [
+GMAIL_SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.send",
     "https://www.googleapis.com/auth/gmail.modify",
-    "https://www.googleapis.com/auth/calendar",
-    "https://www.googleapis.com/auth/drive",
-    "https://www.googleapis.com/auth/contacts.readonly",
-    "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/documents",
 ]
+CALENDAR_SCOPES = ["https://www.googleapis.com/auth/calendar"]
+DRIVE_SCOPES = ["https://www.googleapis.com/auth/drive"]
+CONTACTS_SCOPES = ["https://www.googleapis.com/auth/contacts.readonly"]
+SHEETS_SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
+DOCS_SCOPES = ["https://www.googleapis.com/auth/documents"]
+
+SCOPES = [
+    *GMAIL_SCOPES,
+    *CALENDAR_SCOPES,
+    *DRIVE_SCOPES,
+    *CONTACTS_SCOPES,
+    *SHEETS_SCOPES,
+    *DOCS_SCOPES,
+]
+
+SERVICE_SCOPE_MAP = {
+    "email": GMAIL_SCOPES,
+    "gmail": GMAIL_SCOPES,
+    "calendar": CALENDAR_SCOPES,
+    "drive": DRIVE_SCOPES,
+    "contacts": CONTACTS_SCOPES,
+    "sheets": SHEETS_SCOPES,
+    "docs": DOCS_SCOPES,
+    "all": SCOPES,
+}
 
 # Exact pins: keep in sync with pyproject.toml [project.optional-dependencies].google
 # and tools/lazy_deps.py LAZY_DEPS['skill.google_workspace'].
@@ -90,12 +111,59 @@ def _load_token_payload(path: Path = TOKEN_PATH) -> dict:
         return {}
 
 
-def _missing_scopes_from_payload(payload: dict) -> list[str]:
-    raw = payload.get("scopes") or payload.get("scope")
+def _coerce_scope_list(raw) -> list[str]:
     if not raw:
         return []
-    granted = {s.strip() for s in (raw.split() if isinstance(raw, str) else raw) if s.strip()}
-    return sorted(scope for scope in SCOPES if scope not in granted)
+    if isinstance(raw, str):
+        return [s.strip() for s in raw.split() if s.strip()]
+    return [str(s).strip() for s in raw if str(s).strip()]
+
+
+def _parse_services(raw: str | None) -> list[str]:
+    services = [part.strip().lower() for part in (raw or "all").split(",") if part.strip()]
+    if not services:
+        services = ["all"]
+    unknown = [service for service in services if service not in SERVICE_SCOPE_MAP]
+    if unknown:
+        choices = ", ".join(sorted(SERVICE_SCOPE_MAP))
+        raise ValueError(f"Unknown Google service(s): {', '.join(unknown)}. Valid choices: {choices}")
+    if "all" in services and len(services) > 1:
+        raise ValueError("Use either 'all' or a comma-separated subset, not both.")
+    return services
+
+
+def _scopes_for_services(services: list[str]) -> list[str]:
+    scopes: list[str] = []
+    seen: set[str] = set()
+    for service in services:
+        for scope in SERVICE_SCOPE_MAP[service]:
+            if scope not in seen:
+                seen.add(scope)
+                scopes.append(scope)
+    return scopes
+
+
+def _expected_scopes_from_payload(payload: dict) -> list[str]:
+    requested_scopes = _coerce_scope_list(payload.get("requested_scopes"))
+    if requested_scopes:
+        return requested_scopes
+    services = payload.get("services")
+    if services:
+        try:
+            return _scopes_for_services(_parse_services(",".join(services) if isinstance(services, list) else str(services)))
+        except ValueError:
+            pass
+    return list(SCOPES)
+
+
+def _missing_scopes_from_payload(payload: dict) -> list[str]:
+    raw = payload["scopes"] if "scopes" in payload else payload.get("scope")
+    if raw is None:
+        # Older tokens may not record scopes at all. Do not invent a warning.
+        return []
+    granted = set(_coerce_scope_list(raw))
+    expected = _expected_scopes_from_payload(payload)
+    return sorted(scope for scope in expected if scope not in granted)
 
 
 def _format_missing_scopes(missing_scopes: list[str]) -> str:
@@ -248,13 +316,13 @@ def check_auth(quiet: bool = False):
 
     if creds.expired and creds.refresh_token:
         try:
+            existing_payload = _load_token_payload(TOKEN_PATH)
             creds.refresh(Request())
-            TOKEN_PATH.write_text(
-                json.dumps(
-                    _normalize_authorized_user_payload(json.loads(creds.to_json())),
-                    indent=2,
-                ), encoding="utf-8"
-            )
+            refreshed_payload = _normalize_authorized_user_payload(json.loads(creds.to_json()))
+            for key in ("services", "requested_scopes"):
+                if existing_payload.get(key) and key not in refreshed_payload:
+                    refreshed_payload[key] = existing_payload[key]
+            TOKEN_PATH.write_text(json.dumps(refreshed_payload, indent=2), encoding="utf-8")
             missing_scopes = _missing_scopes_from_payload(_load_token_payload(TOKEN_PATH))
             if missing_scopes:
                 print(f"AUTHENTICATED (partial): Token refreshed but missing {len(missing_scopes)} scopes:")
@@ -307,7 +375,13 @@ def store_client_secret(path: str):
     print(f"OK: Client secret saved to {CLIENT_SECRET_PATH}")
 
 
-def _save_pending_auth(*, state: str, code_verifier: str):
+def _save_pending_auth(
+    *,
+    state: str,
+    code_verifier: str,
+    services: list[str] | None = None,
+    requested_scopes: list[str] | None = None,
+):
     """Persist the OAuth session bits needed for a later token exchange."""
     PENDING_AUTH_PATH.write_text(
         json.dumps(
@@ -315,6 +389,8 @@ def _save_pending_auth(*, state: str, code_verifier: str):
                 "state": state,
                 "code_verifier": code_verifier,
                 "redirect_uri": REDIRECT_URI,
+                "services": services or ["all"],
+                "requested_scopes": requested_scopes or list(SCOPES),
             },
             indent=2,
         ), encoding="utf-8"
@@ -359,18 +435,16 @@ def _extract_code_and_state(code_or_url: str) -> tuple[str, str | None]:
     return params["code"][0], state
 
 
-def get_auth_url():
-    """Print the OAuth authorization URL. User visits this in a browser."""
-    if not CLIENT_SECRET_PATH.exists():
-        print("ERROR: No client secret stored. Run --client-secret first.")
-        sys.exit(1)
+def _start_auth_session(services: str | None = "all") -> dict:
+    service_names = _parse_services(services)
+    requested_scopes = _scopes_for_services(service_names)
 
     _ensure_deps()
     from google_auth_oauthlib.flow import Flow
 
     flow = Flow.from_client_secrets_file(
         str(CLIENT_SECRET_PATH),
-        scopes=SCOPES,
+        scopes=requested_scopes,
         redirect_uri=REDIRECT_URI,
         autogenerate_code_verifier=True,
     )
@@ -378,22 +452,67 @@ def get_auth_url():
         access_type="offline",
         prompt="consent",
     )
-    _save_pending_auth(state=state, code_verifier=flow.code_verifier)
-    # Print just the URL so the agent can extract it cleanly
-    print(auth_url)
+    _save_pending_auth(
+        state=state,
+        code_verifier=flow.code_verifier,
+        services=service_names,
+        requested_scopes=requested_scopes,
+    )
+    LAST_AUTH_URL_PATH.write_text(auth_url)
+    return {
+        "auth_url": auth_url,
+        "services": service_names,
+        "scopes": requested_scopes,
+        "pending_path": str(PENDING_AUTH_PATH),
+        "last_url_path": str(LAST_AUTH_URL_PATH),
+    }
 
 
-def exchange_auth_code(code: str):
+def get_auth_url(services: str | None = "all", output_format: str = "text"):
+    """Print the OAuth authorization URL. User visits this in a browser."""
+    if not CLIENT_SECRET_PATH.exists():
+        if output_format == "json":
+            print(json.dumps({"status": "error", "error": "missing_client_secret", "message": "No client secret stored. Run --client-secret first."}))
+        else:
+            print("ERROR: No client secret stored. Run --client-secret first.")
+        sys.exit(1)
+
+    try:
+        payload = _start_auth_session(services)
+    except ValueError as e:
+        if output_format == "json":
+            print(json.dumps({"status": "error", "error": "invalid_services", "message": str(e)}))
+        else:
+            print(f"ERROR: {e}")
+        sys.exit(1)
+
+    if output_format == "json":
+        print(json.dumps(payload))
+    else:
+        # Print just the URL so the agent can extract it cleanly.
+        print(payload["auth_url"])
+
+
+def exchange_auth_code(code: str, output_format: str = "text"):
     """Exchange the authorization code for a token and save it."""
     if not CLIENT_SECRET_PATH.exists():
-        print("ERROR: No client secret stored. Run --client-secret first.")
+        if output_format == "json":
+            print(json.dumps({"status": "error", "error": "missing_client_secret", "message": "No client secret stored. Run --client-secret first."}))
+        else:
+            print("ERROR: No client secret stored. Run --client-secret first.")
         sys.exit(1)
 
     pending_auth = _load_pending_auth()
+    requested_scopes = _coerce_scope_list(pending_auth.get("requested_scopes")) or list(SCOPES)
+    services = pending_auth.get("services") or ["all"]
+    services_arg = ",".join(services) if isinstance(services, list) else str(services)
     raw_callback = code
     code, returned_state = _extract_code_and_state(code)
     if returned_state and returned_state != pending_auth["state"]:
-        print("ERROR: OAuth state mismatch. Run --auth-url again to start a fresh session.")
+        if output_format == "json":
+            print(json.dumps({"status": "error", "error": "oauth_state_mismatch", "message": "OAuth state mismatch. Run --auth-url again to start a fresh session."}))
+        else:
+            print("ERROR: OAuth state mismatch. Run --auth-url again to start a fresh session.")
         sys.exit(1)
 
     _ensure_deps()
@@ -401,7 +520,7 @@ def exchange_auth_code(code: str):
     from urllib.parse import parse_qs, urlparse
 
     # Extract granted scopes from the callback URL if the user pasted the full redirect URL.
-    granted_scopes = list(SCOPES)
+    granted_scopes = list(requested_scopes)
     if isinstance(raw_callback, str) and raw_callback.startswith("http"):
         params = parse_qs(urlparse(raw_callback).query)
         scope_val = (params.get("scope") or [""])[0].strip()
@@ -421,8 +540,24 @@ def exchange_auth_code(code: str):
         os.environ["OAUTHLIB_RELAX_TOKEN_SCOPE"] = "1"
         flow.fetch_token(code=code)
     except Exception as e:
-        print(f"ERROR: Token exchange failed: {e}")
-        print("The code may have expired. Run --auth-url to get a fresh URL.")
+        if output_format == "json":
+            payload = {
+                "status": "error",
+                "error": "token_exchange_failed",
+                "message": str(e),
+                "services": services if isinstance(services, list) else [services_arg],
+            }
+            try:
+                fresh = _start_auth_session(services_arg)
+                payload["fresh_auth_url"] = fresh["auth_url"]
+                payload["services"] = fresh["services"]
+                payload["scopes"] = fresh["scopes"]
+            except Exception as fresh_error:
+                payload["fresh_auth_error"] = str(fresh_error)
+            print(json.dumps(payload))
+        else:
+            print(f"ERROR: Token exchange failed: {e}")
+            print("The code may have expired. Run --auth-url to get a fresh URL.")
         sys.exit(1)
 
     creds = flow.credentials
@@ -434,19 +569,37 @@ def exchange_auth_code(code: str):
     actually_granted = list(creds.granted_scopes or []) if hasattr(creds, "granted_scopes") and creds.granted_scopes else []
     if actually_granted:
         token_payload["scopes"] = actually_granted
-    elif granted_scopes != SCOPES:
+    elif granted_scopes != requested_scopes:
         # granted_scopes was extracted from the callback URL
         token_payload["scopes"] = granted_scopes
 
+    token_payload["services"] = services
+    token_payload["requested_scopes"] = requested_scopes
+
     missing_scopes = _missing_scopes_from_payload(token_payload)
+    warnings = []
     if missing_scopes:
-        print(f"WARNING: Token missing some Google Workspace scopes: {', '.join(missing_scopes)}")
-        print("Some services may not be available.")
+        warnings.append(f"Token missing some Google Workspace scopes: {', '.join(missing_scopes)}")
+        if output_format != "json":
+            print(warnings[-1].replace("Token", "WARNING: Token", 1))
+            print("Some services may not be available.")
 
     TOKEN_PATH.write_text(json.dumps(token_payload, indent=2), encoding="utf-8")
     PENDING_AUTH_PATH.unlink(missing_ok=True)
-    print(f"OK: Authenticated. Token saved to {TOKEN_PATH}")
-    print(f"Profile-scoped token location: {display_hermes_home()}/google_token.json")
+    profile_token_location = f"{display_hermes_home()}/google_token.json"
+    if output_format == "json":
+        print(json.dumps({
+            "status": "authenticated",
+            "token_path": str(TOKEN_PATH),
+            "profile_token_location": profile_token_location,
+            "services": services,
+            "scopes": token_payload.get("scopes") or [],
+            "missing_scopes": missing_scopes,
+            "warnings": warnings,
+        }))
+    else:
+        print(f"OK: Authenticated. Token saved to {TOKEN_PATH}")
+        print(f"Profile-scoped token location: {profile_token_location}")
 
 
 def revoke():
@@ -455,19 +608,20 @@ def revoke():
         print("No token to revoke.")
         return
 
-    _ensure_deps()
-    from google.oauth2.credentials import Credentials
-    from google.auth.transport.requests import Request
+    token_payload = _load_token_payload(TOKEN_PATH)
+    revoke_token = token_payload.get("refresh_token") or token_payload.get("token")
 
     try:
-        creds = Credentials.from_authorized_user_file(str(TOKEN_PATH), SCOPES)
-        if creds.expired and creds.refresh_token:
-            creds.refresh(Request())
+        if not revoke_token:
+            raise ValueError("token file does not contain a token or refresh_token")
 
+        import urllib.parse
         import urllib.request
+
+        encoded_token = urllib.parse.quote(str(revoke_token), safe="")
         urllib.request.urlopen(
             urllib.request.Request(
-                f"https://oauth2.googleapis.com/revoke?token={creds.token}",
+                f"https://oauth2.googleapis.com/revoke?token={encoded_token}",
                 method="POST",
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
             ),
@@ -479,6 +633,7 @@ def revoke():
 
     TOKEN_PATH.unlink(missing_ok=True)
     PENDING_AUTH_PATH.unlink(missing_ok=True)
+    LAST_AUTH_URL_PATH.unlink(missing_ok=True)
     print(f"Deleted {TOKEN_PATH}")
 
 
@@ -492,6 +647,12 @@ def main():
     group.add_argument("--auth-code", metavar="CODE", help="Exchange auth code for token")
     group.add_argument("--revoke", action="store_true", help="Revoke and delete stored token")
     group.add_argument("--install-deps", action="store_true", help="Install Python dependencies")
+    parser.add_argument(
+        "--services",
+        default="all",
+        help="Google service set for --auth-url: all, calendar, email, drive, contacts, sheets, docs; comma-separated",
+    )
+    parser.add_argument("--format", choices=["text", "json"], default="text", help="Output format")
     args = parser.parse_args()
 
     if args.check:
@@ -501,9 +662,9 @@ def main():
     elif args.client_secret:
         store_client_secret(args.client_secret)
     elif args.auth_url:
-        get_auth_url()
+        get_auth_url(args.services, args.format)
     elif args.auth_code:
-        exchange_auth_code(args.auth_code)
+        exchange_auth_code(args.auth_code, args.format)
     elif args.revoke:
         revoke()
     elif args.install_deps:

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -193,14 +193,15 @@ def _missing_required_packages() -> list[str]:
     return missing
 
 
-def install_deps():
+def install_deps(output_format: str = "text"):
     """Install missing or stale Google API packages. Returns True on success."""
+    output = sys.stderr if output_format == "json" else sys.stdout
     missing = _missing_required_packages()
     if not missing:
-        print("Dependencies already installed.")
+        print("Dependencies already installed.", file=output)
         return True
 
-    print("Installing Google API dependencies...")
+    print("Installing Google API dependencies...", file=output)
 
     # First choice: pip in the current interpreter. Works for most installs.
     try:
@@ -210,9 +211,12 @@ def install_deps():
         )
         remaining = _missing_required_packages()
         if remaining:
-            print(f"ERROR: Dependencies remain stale after pip install: {' '.join(remaining)}")
+            print(
+                f"ERROR: Dependencies remain stale after pip install: {' '.join(remaining)}",
+                file=output,
+            )
             return False
-        print("Dependencies installed.")
+        print("Dependencies installed.", file=output)
         return True
     except subprocess.CalledProcessError as e:
         pip_error = e
@@ -232,28 +236,38 @@ def install_deps():
             )
             remaining = _missing_required_packages()
             if remaining:
-                print(f"ERROR: Dependencies remain stale after uv install: {' '.join(remaining)}")
+                print(
+                    f"ERROR: Dependencies remain stale after uv install: {' '.join(remaining)}",
+                    file=output,
+                )
                 return False
-            print("Dependencies installed.")
+            print("Dependencies installed.", file=output)
             return True
         except subprocess.CalledProcessError as e:
-            print(f"ERROR: Failed to install dependencies via uv: {e}")
-            print(f"Manually: {uv} pip install --python {sys.executable} {' '.join(REQUIRED_PACKAGES)}")
+            print(f"ERROR: Failed to install dependencies via uv: {e}", file=output)
+            print(
+                f"Manually: {uv} pip install --python {sys.executable} {' '.join(REQUIRED_PACKAGES)}",
+                file=output,
+            )
             return False
 
-    print(f"ERROR: Failed to install dependencies: {pip_error}")
+    print(f"ERROR: Failed to install dependencies: {pip_error}", file=output)
     print(
         "On environments without pip (e.g. Nix, or the Hermes Docker image's "
-        "uv-managed venv), install the optional extra instead:"
+        "uv-managed venv), install the optional extra instead:",
+        file=output,
     )
-    print("  hermes setup")
-    print(f"Or manually: {sys.executable} -m pip install {' '.join(REQUIRED_PACKAGES)}")
+    print("  hermes setup", file=output)
+    print(
+        f"Or manually: {sys.executable} -m pip install {' '.join(REQUIRED_PACKAGES)}",
+        file=output,
+    )
     return False
 
 
-def _ensure_deps():
+def _ensure_deps(output_format: str = "text"):
     """Check exact dependency versions, install if stale, exit on failure."""
-    if _missing_required_packages() and not install_deps():
+    if _missing_required_packages() and not install_deps(output_format):
         sys.exit(1)
 
 
@@ -435,11 +449,13 @@ def _extract_code_and_state(code_or_url: str) -> tuple[str, str | None]:
     return params["code"][0], state
 
 
-def _start_auth_session(services: str | None = "all") -> dict:
+def _start_auth_session(
+    services: str | None = "all", output_format: str = "text"
+) -> dict:
     service_names = _parse_services(services)
     requested_scopes = _scopes_for_services(service_names)
 
-    _ensure_deps()
+    _ensure_deps(output_format)
     from google_auth_oauthlib.flow import Flow
 
     flow = Flow.from_client_secrets_file(
@@ -478,7 +494,7 @@ def get_auth_url(services: str | None = "all", output_format: str = "text"):
         sys.exit(1)
 
     try:
-        payload = _start_auth_session(services)
+        payload = _start_auth_session(services, output_format)
     except ValueError as e:
         if output_format == "json":
             print(json.dumps({"status": "error", "error": "invalid_services", "message": str(e)}))
@@ -510,12 +526,25 @@ def exchange_auth_code(code: str, output_format: str = "text"):
     code, returned_state = _extract_code_and_state(code)
     if returned_state and returned_state != pending_auth["state"]:
         if output_format == "json":
-            print(json.dumps({"status": "error", "error": "oauth_state_mismatch", "message": "OAuth state mismatch. Run --auth-url again to start a fresh session."}))
+            payload = {
+                "status": "error",
+                "error": "oauth_state_mismatch",
+                "message": "OAuth state mismatch. Use the fresh authorization URL and retry with its redirect.",
+                "services": services if isinstance(services, list) else [services_arg],
+            }
+            try:
+                fresh = _start_auth_session(services_arg, output_format)
+                payload["fresh_auth_url"] = fresh["auth_url"]
+                payload["services"] = fresh["services"]
+                payload["scopes"] = fresh["scopes"]
+            except Exception as fresh_error:
+                payload["fresh_auth_error"] = str(fresh_error)
+            print(json.dumps(payload))
         else:
             print("ERROR: OAuth state mismatch. Run --auth-url again to start a fresh session.")
         sys.exit(1)
 
-    _ensure_deps()
+    _ensure_deps(output_format)
     from google_auth_oauthlib.flow import Flow
     from urllib.parse import parse_qs, urlparse
 
@@ -548,7 +577,7 @@ def exchange_auth_code(code: str, output_format: str = "text"):
                 "services": services if isinstance(services, list) else [services_arg],
             }
             try:
-                fresh = _start_auth_session(services_arg)
+                fresh = _start_auth_session(services_arg, output_format)
                 payload["fresh_auth_url"] = fresh["auth_url"]
                 payload["services"] = fresh["services"]
                 payload["scopes"] = fresh["scopes"]

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -1,0 +1,663 @@
+"""Regression tests for Google Workspace OAuth setup.
+
+These tests cover the headless/manual auth-code flow where the browser step and
+code exchange happen in separate process invocations.
+"""
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/google-workspace/scripts/setup.py"
+)
+
+
+class FakeCredentials:
+    def __init__(self, payload=None):
+        self._payload = payload or {
+            "token": "access-token",
+            "refresh_token": "refresh-token",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "scopes": [
+                "https://www.googleapis.com/auth/gmail.readonly",
+                "https://www.googleapis.com/auth/gmail.send",
+                "https://www.googleapis.com/auth/gmail.modify",
+                "https://www.googleapis.com/auth/calendar",
+                "https://www.googleapis.com/auth/drive",
+                "https://www.googleapis.com/auth/contacts.readonly",
+                "https://www.googleapis.com/auth/spreadsheets",
+                "https://www.googleapis.com/auth/documents",
+            ],
+        }
+
+    def to_json(self):
+        return json.dumps(self._payload)
+
+
+class FakeFlow:
+    created = []
+    default_state = "generated-state"
+    default_verifier = "generated-code-verifier"
+    credentials_payload = None
+    fetch_error = None
+
+    def __init__(
+        self,
+        client_secrets_file,
+        scopes,
+        *,
+        redirect_uri=None,
+        state=None,
+        code_verifier=None,
+        autogenerate_code_verifier=False,
+    ):
+        self.client_secrets_file = client_secrets_file
+        self.scopes = scopes
+        self.redirect_uri = redirect_uri
+        self.state = state
+        self.code_verifier = code_verifier
+        self.autogenerate_code_verifier = autogenerate_code_verifier
+        self.authorization_kwargs = None
+        self.fetch_token_calls = []
+        self.credentials = FakeCredentials(self.credentials_payload)
+
+        if autogenerate_code_verifier and not self.code_verifier:
+            self.code_verifier = self.default_verifier
+        if not self.state:
+            self.state = self.default_state
+
+    @classmethod
+    def reset(cls):
+        cls.created = []
+        cls.default_state = "generated-state"
+        cls.default_verifier = "generated-code-verifier"
+        cls.credentials_payload = None
+        cls.fetch_error = None
+
+    @classmethod
+    def from_client_secrets_file(cls, client_secrets_file, scopes, **kwargs):
+        inst = cls(client_secrets_file, scopes, **kwargs)
+        cls.created.append(inst)
+        return inst
+
+    def authorization_url(self, **kwargs):
+        self.authorization_kwargs = kwargs
+        return f"https://auth.example/authorize?state={self.state}", self.state
+
+    def fetch_token(self, **kwargs):
+        self.fetch_token_calls.append(kwargs)
+        if self.fetch_error:
+            raise self.fetch_error
+
+
+@pytest.fixture
+def setup_module(monkeypatch, tmp_path):
+    FakeFlow.reset()
+
+    google_auth_module = types.ModuleType("google_auth_oauthlib")
+    flow_module = types.ModuleType("google_auth_oauthlib.flow")
+    flow_module.Flow = FakeFlow
+    google_auth_module.flow = flow_module
+    monkeypatch.setitem(sys.modules, "google_auth_oauthlib", google_auth_module)
+    monkeypatch.setitem(sys.modules, "google_auth_oauthlib.flow", flow_module)
+
+    spec = importlib.util.spec_from_file_location("google_workspace_setup_test", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    monkeypatch.setattr(module, "_ensure_deps", lambda: None)
+    monkeypatch.setattr(module, "CLIENT_SECRET_PATH", tmp_path / "google_client_secret.json")
+    monkeypatch.setattr(module, "TOKEN_PATH", tmp_path / "google_token.json")
+    monkeypatch.setattr(module, "PENDING_AUTH_PATH", tmp_path / "google_oauth_pending.json", raising=False)
+    monkeypatch.setattr(module, "LAST_AUTH_URL_PATH", tmp_path / "google_oauth_last_url.txt", raising=False)
+
+    client_secret = {
+        "installed": {
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+        }
+    }
+    module.CLIENT_SECRET_PATH.write_text(json.dumps(client_secret))
+    return module
+
+
+class TestGetAuthUrl:
+    def test_persists_state_and_code_verifier_for_later_exchange(self, setup_module, capsys):
+        setup_module.get_auth_url()
+
+        out = capsys.readouterr().out.strip()
+        assert out == "https://auth.example/authorize?state=generated-state"
+
+        saved = json.loads(setup_module.PENDING_AUTH_PATH.read_text())
+        assert saved["state"] == "generated-state"
+        assert saved["code_verifier"] == "generated-code-verifier"
+
+        flow = FakeFlow.created[-1]
+        assert flow.autogenerate_code_verifier is True
+        assert flow.authorization_kwargs == {"access_type": "offline", "prompt": "consent"}
+
+    def test_json_auth_url_for_calendar_is_parseable_and_saves_last_url(self, setup_module, capsys):
+        setup_module.get_auth_url("calendar", "json")
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["auth_url"] == "https://auth.example/authorize?state=generated-state"
+        assert payload["services"] == ["calendar"]
+        assert payload["scopes"] == setup_module.CALENDAR_SCOPES
+        assert setup_module.LAST_AUTH_URL_PATH.read_text() == payload["auth_url"]
+
+        saved = json.loads(setup_module.PENDING_AUTH_PATH.read_text())
+        assert saved["services"] == ["calendar"]
+        assert saved["requested_scopes"] == setup_module.CALENDAR_SCOPES
+
+
+class TestScopeMetadata:
+    def test_empty_granted_scopes_are_reported_missing_for_requested_services(self, setup_module):
+        missing = setup_module._missing_scopes_from_payload(
+            {
+                "services": ["calendar"],
+                "requested_scopes": setup_module.CALENDAR_SCOPES,
+                "scopes": [],
+            }
+        )
+
+        assert missing == setup_module.CALENDAR_SCOPES
+
+    def test_check_auth_refresh_preserves_service_metadata(self, setup_module, monkeypatch):
+        class RefreshingCredentials:
+            valid = False
+            expired = True
+            refresh_token = "refresh-token"
+
+            @classmethod
+            def from_authorized_user_file(cls, path):
+                return cls()
+
+            def refresh(self, request):
+                self.valid = True
+
+            def to_json(self):
+                return json.dumps(
+                    {
+                        "token": "new-access-token",
+                        "refresh_token": "refresh-token",
+                        "token_uri": "https://oauth2.googleapis.com/token",
+                        "client_id": "client-id",
+                        "client_secret": "client-secret",
+                        "scopes": setup_module.CALENDAR_SCOPES,
+                    }
+                )
+
+        credentials_module = types.ModuleType("google.oauth2.credentials")
+        credentials_module.Credentials = RefreshingCredentials
+        oauth2_module = types.ModuleType("google.oauth2")
+        oauth2_module.credentials = credentials_module
+        google_module = sys.modules.get("google") or types.ModuleType("google")
+        google_module.oauth2 = oauth2_module
+        transport_requests_module = types.ModuleType("google.auth.transport.requests")
+        transport_requests_module.Request = lambda: object()
+        transport_module = types.ModuleType("google.auth.transport")
+        transport_module.requests = transport_requests_module
+        auth_module = types.ModuleType("google.auth")
+        auth_module.transport = transport_module
+
+        monkeypatch.setitem(sys.modules, "google", google_module)
+        monkeypatch.setitem(sys.modules, "google.oauth2", oauth2_module)
+        monkeypatch.setitem(sys.modules, "google.oauth2.credentials", credentials_module)
+        monkeypatch.setitem(sys.modules, "google.auth", auth_module)
+        monkeypatch.setitem(sys.modules, "google.auth.transport", transport_module)
+        monkeypatch.setitem(sys.modules, "google.auth.transport.requests", transport_requests_module)
+
+        setup_module.TOKEN_PATH.write_text(
+            json.dumps(
+                {
+                    "token": "expired-access-token",
+                    "refresh_token": "refresh-token",
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                    "client_id": "client-id",
+                    "client_secret": "client-secret",
+                    "scopes": setup_module.CALENDAR_SCOPES,
+                    "services": ["calendar"],
+                    "requested_scopes": setup_module.CALENDAR_SCOPES,
+                }
+            )
+        )
+
+        assert setup_module.check_auth() is True
+        saved = json.loads(setup_module.TOKEN_PATH.read_text())
+        assert saved["services"] == ["calendar"]
+        assert saved["requested_scopes"] == setup_module.CALENDAR_SCOPES
+
+
+class TestExchangeAuthCode:
+    def test_reuses_saved_pkce_material_for_plain_code(self, setup_module):
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})
+        )
+
+        setup_module.exchange_auth_code("4/test-auth-code")
+
+        flow = FakeFlow.created[-1]
+        assert flow.state == "saved-state"
+        assert flow.code_verifier == "saved-verifier"
+        assert flow.fetch_token_calls == [{"code": "4/test-auth-code"}]
+        saved = json.loads(setup_module.TOKEN_PATH.read_text())
+        assert saved["token"] == "access-token"
+        assert saved["type"] == "authorized_user"
+        assert not setup_module.PENDING_AUTH_PATH.exists()
+
+    def test_extracts_code_from_redirect_url_and_checks_state(self, setup_module):
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})
+        )
+
+        setup_module.exchange_auth_code(
+            "http://localhost:1/?code=4/extracted-code&state=saved-state&scope=gmail"
+        )
+
+        flow = FakeFlow.created[-1]
+        assert flow.fetch_token_calls == [{"code": "4/extracted-code"}]
+
+    def test_passes_scopes_from_redirect_url_to_flow(self, setup_module):
+        """Callback URL carries space-delimited scope list; Flow must receive it (not full SCOPES)."""
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})
+        )
+        g1 = "https://www.googleapis.com/auth/gmail.readonly"
+        g2 = "https://www.googleapis.com/auth/calendar"
+        from urllib.parse import quote
+
+        scope_q = quote(f"{g1} {g2}", safe="")
+        setup_module.exchange_auth_code(
+            f"http://localhost:1/?code=4/extracted-code&state=saved-state&scope={scope_q}"
+        )
+        flow = FakeFlow.created[-1]
+        assert flow.scopes == [g1, g2]
+
+    def test_rejects_state_mismatch(self, setup_module, capsys):
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})
+        )
+
+        with pytest.raises(SystemExit):
+            setup_module.exchange_auth_code(
+                "http://localhost:1/?code=4/extracted-code&state=wrong-state"
+            )
+
+        out = capsys.readouterr().out
+        assert "state mismatch" in out.lower()
+        assert not setup_module.TOKEN_PATH.exists()
+
+    def test_requires_pending_auth_session(self, setup_module, capsys):
+        with pytest.raises(SystemExit):
+            setup_module.exchange_auth_code("4/test-auth-code")
+
+        out = capsys.readouterr().out
+        assert "run --auth-url first" in out.lower()
+        assert not setup_module.TOKEN_PATH.exists()
+
+    def test_keeps_pending_auth_session_when_exchange_fails(self, setup_module, capsys):
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})
+        )
+        FakeFlow.fetch_error = Exception("invalid_grant: Missing code verifier")
+
+        with pytest.raises(SystemExit):
+            setup_module.exchange_auth_code("4/test-auth-code")
+
+        out = capsys.readouterr().out
+        assert "token exchange failed" in out.lower()
+        assert setup_module.PENDING_AUTH_PATH.exists()
+        assert not setup_module.TOKEN_PATH.exists()
+
+    def test_accepts_narrower_scopes_with_warning(self, setup_module, capsys):
+        """Partial scopes are accepted with a warning (gws migration: v2.0)."""
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps({"state": "saved-state", "code_verifier": "saved-verifier"})
+        )
+        setup_module.TOKEN_PATH.write_text(json.dumps({"token": "***", "scopes": setup_module.SCOPES}))
+        FakeFlow.credentials_payload = {
+            "token": "***",
+            "refresh_token": "***",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "scopes": [
+                "https://www.googleapis.com/auth/drive.readonly",
+                "https://www.googleapis.com/auth/spreadsheets",
+            ],
+        }
+
+        setup_module.exchange_auth_code("4/test-auth-code")
+
+        out = capsys.readouterr().out
+        assert "warning" in out.lower()
+        assert "missing" in out.lower()
+        # Token is saved (partial scopes accepted)
+        assert setup_module.TOKEN_PATH.exists()
+        # Pending auth is cleaned up
+        assert not setup_module.PENDING_AUTH_PATH.exists()
+
+    def test_json_output_contains_warnings_without_plain_text_prefix(self, setup_module, capsys):
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps(
+                {
+                    "state": "saved-state",
+                    "code_verifier": "saved-verifier",
+                    "services": ["all"],
+                    "requested_scopes": setup_module.SCOPES,
+                }
+            )
+        )
+        FakeFlow.credentials_payload = {
+            "token": "access-token",
+            "refresh_token": "refresh-token",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "scopes": setup_module.CALENDAR_SCOPES,
+        }
+
+        setup_module.exchange_auth_code("4/test-auth-code", "json")
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "authenticated"
+        assert payload["missing_scopes"]
+        assert payload["warnings"]
+        assert setup_module.TOKEN_PATH.exists()
+
+    def test_json_exchange_failure_returns_fresh_auth_url(self, setup_module, capsys):
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps(
+                {
+                    "state": "saved-state",
+                    "code_verifier": "saved-verifier",
+                    "services": ["calendar"],
+                    "requested_scopes": setup_module.CALENDAR_SCOPES,
+                }
+            )
+        )
+        FakeFlow.fetch_error = Exception("invalid_grant: expired code")
+
+        with pytest.raises(SystemExit) as excinfo:
+            setup_module.exchange_auth_code("4/test-auth-code", "json")
+
+        assert excinfo.value.code == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "error"
+        assert payload["error"] == "token_exchange_failed"
+        assert payload["services"] == ["calendar"]
+        assert payload["fresh_auth_url"] == "https://auth.example/authorize?state=generated-state"
+        assert setup_module.PENDING_AUTH_PATH.exists()
+
+
+class TestRevoke:
+    def test_revoke_uses_stored_refresh_token_for_narrow_scope_token(self, setup_module, monkeypatch, capsys):
+        setup_module.TOKEN_PATH.write_text(
+            json.dumps(
+                {
+                    "token": "expired-access-token",
+                    "refresh_token": "refresh-token",
+                    "token_uri": "https://oauth2.googleapis.com/token",
+                    "client_id": "client-id",
+                    "client_secret": "client-secret",
+                    "scopes": setup_module.CALENDAR_SCOPES,
+                    "services": ["calendar"],
+                    "requested_scopes": setup_module.CALENDAR_SCOPES,
+                }
+            )
+        )
+        setup_module.PENDING_AUTH_PATH.write_text("{}")
+
+        class ExpiredNarrowCredentials:
+            token = "expired-access-token"
+            expired = True
+            refresh_token = "refresh-token"
+
+            @classmethod
+            def from_authorized_user_file(cls, path, scopes=None):
+                return cls()
+
+            def refresh(self, request):
+                raise Exception("invalid_scope")
+
+        credentials_module = types.ModuleType("google.oauth2.credentials")
+        credentials_module.Credentials = ExpiredNarrowCredentials
+        oauth2_module = types.ModuleType("google.oauth2")
+        oauth2_module.credentials = credentials_module
+        google_module = sys.modules.get("google") or types.ModuleType("google")
+        google_module.oauth2 = oauth2_module
+        transport_requests_module = types.ModuleType("google.auth.transport.requests")
+        transport_requests_module.Request = lambda: object()
+        transport_module = types.ModuleType("google.auth.transport")
+        transport_module.requests = transport_requests_module
+        auth_module = types.ModuleType("google.auth")
+        auth_module.transport = transport_module
+        monkeypatch.setitem(sys.modules, "google", google_module)
+        monkeypatch.setitem(sys.modules, "google.oauth2", oauth2_module)
+        monkeypatch.setitem(sys.modules, "google.oauth2.credentials", credentials_module)
+        monkeypatch.setitem(sys.modules, "google.auth", auth_module)
+        monkeypatch.setitem(sys.modules, "google.auth.transport", transport_module)
+        monkeypatch.setitem(sys.modules, "google.auth.transport.requests", transport_requests_module)
+
+        calls = []
+
+        def fake_urlopen(request, *args, **kwargs):
+            calls.append(request.full_url)
+
+            class Response:
+                def close(self):
+                    pass
+
+            return Response()
+
+        import urllib.request
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+        setup_module.revoke()
+
+        assert calls == ["https://oauth2.googleapis.com/revoke?token=refresh-token"]
+        assert not setup_module.TOKEN_PATH.exists()
+        assert not setup_module.PENDING_AUTH_PATH.exists()
+        assert "Token revoked with Google" in capsys.readouterr().out
+
+
+class TestHermesConstantsFallback:
+    """Tests for _hermes_home.py fallback when hermes_constants is unavailable."""
+
+    HELPER_PATH = (
+        Path(__file__).resolve().parents[2]
+        / "skills/productivity/google-workspace/scripts/_hermes_home.py"
+    )
+
+    def _load_helper(self, monkeypatch):
+        """Load _hermes_home.py with hermes_constants blocked."""
+        monkeypatch.setitem(sys.modules, "hermes_constants", None)
+        spec = importlib.util.spec_from_file_location("_hermes_home_test", self.HELPER_PATH)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+
+    def test_fallback_uses_hermes_home_env_var(self, monkeypatch, tmp_path):
+        """When hermes_constants is missing, HERMES_HOME comes from env var."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "custom-hermes"))
+        module = self._load_helper(monkeypatch)
+        assert module.get_hermes_home() == tmp_path / "custom-hermes"
+
+    def test_fallback_defaults_to_dot_hermes(self, monkeypatch):
+        """When hermes_constants is missing and HERMES_HOME unset, default to ~/.hermes."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        module = self._load_helper(monkeypatch)
+        assert module.get_hermes_home() == Path.home() / ".hermes"
+
+    def test_fallback_ignores_empty_hermes_home(self, monkeypatch):
+        """Empty/whitespace HERMES_HOME is treated as unset."""
+        monkeypatch.setenv("HERMES_HOME", "  ")
+        module = self._load_helper(monkeypatch)
+        assert module.get_hermes_home() == Path.home() / ".hermes"
+
+    def test_fallback_display_hermes_home_shortens_path(self, monkeypatch):
+        """Fallback display_hermes_home() uses ~/ shorthand like the real one."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        module = self._load_helper(monkeypatch)
+        assert module.display_hermes_home() == "~/.hermes"
+
+    def test_fallback_display_hermes_home_profile_path(self, monkeypatch):
+        """Fallback display_hermes_home() handles profile paths under ~/."""
+        monkeypatch.setenv("HERMES_HOME", str(Path.home() / ".hermes/profiles/coder"))
+        module = self._load_helper(monkeypatch)
+        assert module.display_hermes_home() == "~/.hermes/profiles/coder"
+
+    def test_fallback_display_hermes_home_custom_path(self, monkeypatch):
+        """Fallback display_hermes_home() returns full path for non-home locations."""
+        monkeypatch.setenv("HERMES_HOME", "/opt/hermes-custom")
+        module = self._load_helper(monkeypatch)
+        assert module.display_hermes_home() == "/opt/hermes-custom"
+
+    def test_delegates_to_hermes_constants_when_available(self):
+        """When hermes_constants IS importable, _hermes_home delegates to it."""
+        spec = importlib.util.spec_from_file_location(
+            "_hermes_home_happy", self.HELPER_PATH
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        import hermes_constants
+        assert module.get_hermes_home is hermes_constants.get_hermes_home
+        assert module.display_hermes_home is hermes_constants.display_hermes_home
+
+
+def _load_setup_module(monkeypatch):
+    """Load setup.py without stubbing _ensure_deps (for install_deps tests)."""
+    spec = importlib.util.spec_from_file_location(
+        "google_workspace_setup_installdeps_test", SCRIPT_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _force_deps_missing(monkeypatch):
+    """Make `import googleapiclient` / `import google_auth_oauthlib` fail so
+    install_deps() proceeds past its early-return short-circuit."""
+    for name in ("googleapiclient", "google_auth_oauthlib"):
+        monkeypatch.setitem(sys.modules, name, None)
+
+
+class TestInstallDeps:
+    """Tests for install_deps() interpreter/installer selection.
+
+    Regression coverage for the Hermes Docker image, whose venv is built with
+    `uv sync` and ships without pip — `sys.executable -m pip install` fails
+    with `No module named pip`, so install_deps() must fall back to uv.
+    """
+
+    def test_returns_early_when_already_installed(self, monkeypatch):
+        """If both libs import, no installer subprocess runs at all."""
+        module = _load_setup_module(monkeypatch)
+        # Don't force-missing: real test env has the libs importable. Guard
+        # against any subprocess being spawned.
+        calls = []
+        monkeypatch.setattr(
+            module.subprocess, "check_call", lambda *a, **k: calls.append(a)
+        )
+        # google_auth_oauthlib may not be installed in the test env; only run
+        # this assertion when the early-return path is actually reachable.
+        try:
+            import googleapiclient  # noqa: F401
+            import google_auth_oauthlib  # noqa: F401
+        except ImportError:
+            pytest.skip("Google libs not installed in test env")
+        assert module.install_deps() is True
+        assert calls == []
+
+    def test_uses_pip_when_available(self, monkeypatch):
+        """When pip works, install_deps succeeds via pip and never calls uv."""
+        module = _load_setup_module(monkeypatch)
+        _force_deps_missing(monkeypatch)
+
+        recorded = []
+
+        def fake_check_call(cmd, **kwargs):
+            recorded.append(cmd)
+            # pip path is the first attempt — succeed.
+            return 0
+
+        which_calls = []
+        monkeypatch.setattr(module.subprocess, "check_call", fake_check_call)
+        monkeypatch.setattr(
+            module.shutil, "which", lambda name: which_calls.append(name)
+        )
+
+        assert module.install_deps() is True
+        assert recorded[0][:3] == [module.sys.executable, "-m", "pip"]
+        # Control: uv must NOT be consulted when pip succeeds.
+        assert which_calls == []
+
+    def test_falls_back_to_uv_when_pip_missing(self, monkeypatch):
+        """No pip → uv pip install --python <interpreter> is used."""
+        module = _load_setup_module(monkeypatch)
+        _force_deps_missing(monkeypatch)
+
+        recorded = []
+
+        def fake_check_call(cmd, **kwargs):
+            recorded.append(cmd)
+            if cmd[:3] == [module.sys.executable, "-m", "pip"]:
+                raise module.subprocess.CalledProcessError(1, cmd)
+            return 0  # uv invocation succeeds
+
+        monkeypatch.setattr(module.subprocess, "check_call", fake_check_call)
+        monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/local/bin/uv")
+
+        assert module.install_deps() is True
+        assert len(recorded) == 2
+        uv_cmd = recorded[1]
+        assert uv_cmd[0] == "/usr/local/bin/uv"
+        assert uv_cmd[1:5] == ["pip", "install", "--python", module.sys.executable]
+        for pkg in module.REQUIRED_PACKAGES:
+            assert pkg in uv_cmd
+
+    def test_returns_false_when_no_pip_and_no_uv(self, monkeypatch, capsys):
+        """No pip AND no uv → failure, with the [google] extra hint printed."""
+        module = _load_setup_module(monkeypatch)
+        _force_deps_missing(monkeypatch)
+
+        def fake_check_call(cmd, **kwargs):
+            raise module.subprocess.CalledProcessError(1, cmd)
+
+        monkeypatch.setattr(module.subprocess, "check_call", fake_check_call)
+        monkeypatch.setattr(module.shutil, "which", lambda name: None)
+
+        assert module.install_deps() is False
+        out = capsys.readouterr().out
+        assert "hermes-agent[google]" in out
+
+    def test_returns_false_when_uv_fallback_also_fails(self, monkeypatch, capsys):
+        """uv present but its install fails → failure surfaced (not swallowed)."""
+        module = _load_setup_module(monkeypatch)
+        _force_deps_missing(monkeypatch)
+
+        def fake_check_call(cmd, **kwargs):
+            raise module.subprocess.CalledProcessError(1, cmd)
+
+        monkeypatch.setattr(module.subprocess, "check_call", fake_check_call)
+        monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/local/bin/uv")
+
+        assert module.install_deps() is False
+        out = capsys.readouterr().out
+        assert "via uv" in out

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -6,7 +6,10 @@ code exchange happen in separate process invocations.
 
 import importlib.util
 import json
+import os
+import subprocess
 import sys
+import textwrap
 import types
 from pathlib import Path
 
@@ -115,7 +118,7 @@ def setup_module(monkeypatch, tmp_path):
     assert spec.loader is not None
     spec.loader.exec_module(module)
 
-    monkeypatch.setattr(module, "_ensure_deps", lambda: None)
+    monkeypatch.setattr(module, "_ensure_deps", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "CLIENT_SECRET_PATH", tmp_path / "google_client_secret.json")
     monkeypatch.setattr(module, "TOKEN_PATH", tmp_path / "google_token.json")
     monkeypatch.setattr(module, "PENDING_AUTH_PATH", tmp_path / "google_oauth_pending.json", raising=False)
@@ -297,6 +300,38 @@ class TestExchangeAuthCode:
 
         out = capsys.readouterr().out
         assert "state mismatch" in out.lower()
+        assert not setup_module.TOKEN_PATH.exists()
+
+    def test_json_state_mismatch_returns_fresh_auth_url(self, setup_module, capsys):
+        setup_module.PENDING_AUTH_PATH.write_text(
+            json.dumps(
+                {
+                    "state": "saved-state",
+                    "code_verifier": "saved-verifier",
+                    "services": ["calendar"],
+                    "requested_scopes": setup_module.CALENDAR_SCOPES,
+                }
+            )
+        )
+
+        with pytest.raises(SystemExit) as excinfo:
+            setup_module.exchange_auth_code(
+                "http://localhost:1/?code=4/extracted-code&state=wrong-state",
+                "json",
+            )
+
+        assert excinfo.value.code == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "error"
+        assert payload["error"] == "oauth_state_mismatch"
+        assert payload["fresh_auth_url"] == "https://auth.example/authorize?state=generated-state"
+        assert payload["services"] == ["calendar"]
+
+        saved = json.loads(setup_module.PENDING_AUTH_PATH.read_text())
+        assert saved["state"] == "generated-state"
+        assert saved["services"] == ["calendar"]
+        assert saved["requested_scopes"] == setup_module.CALENDAR_SCOPES
+        assert setup_module.LAST_AUTH_URL_PATH.read_text() == payload["fresh_auth_url"]
         assert not setup_module.TOKEN_PATH.exists()
 
     def test_requires_pending_auth_session(self, setup_module, capsys):
@@ -551,11 +586,13 @@ def _load_setup_module(monkeypatch):
     return module
 
 
-def _force_deps_missing(monkeypatch):
-    """Make `import googleapiclient` / `import google_auth_oauthlib` fail so
-    install_deps() proceeds past its early-return short-circuit."""
-    for name in ("googleapiclient", "google_auth_oauthlib"):
-        monkeypatch.setitem(sys.modules, name, None)
+def _force_deps_missing(monkeypatch, module):
+    """Make the exact pinned requirements appear absent or stale."""
+    monkeypatch.setattr(
+        module,
+        "_missing_required_packages",
+        lambda: list(module.REQUIRED_PACKAGES),
+    )
 
 
 class TestInstallDeps:
@@ -567,34 +604,28 @@ class TestInstallDeps:
     """
 
     def test_returns_early_when_already_installed(self, monkeypatch):
-        """If both libs import, no installer subprocess runs at all."""
+        """If all exact pins are current, no installer subprocess runs."""
         module = _load_setup_module(monkeypatch)
-        # Don't force-missing: real test env has the libs importable. Guard
-        # against any subprocess being spawned.
+        monkeypatch.setattr(module, "_missing_required_packages", lambda: [])
         calls = []
         monkeypatch.setattr(
             module.subprocess, "check_call", lambda *a, **k: calls.append(a)
         )
-        # google_auth_oauthlib may not be installed in the test env; only run
-        # this assertion when the early-return path is actually reachable.
-        try:
-            import googleapiclient  # noqa: F401
-            import google_auth_oauthlib  # noqa: F401
-        except ImportError:
-            pytest.skip("Google libs not installed in test env")
+
         assert module.install_deps() is True
         assert calls == []
 
     def test_uses_pip_when_available(self, monkeypatch):
         """When pip works, install_deps succeeds via pip and never calls uv."""
         module = _load_setup_module(monkeypatch)
-        _force_deps_missing(monkeypatch)
+        _force_deps_missing(monkeypatch, module)
 
         recorded = []
 
         def fake_check_call(cmd, **kwargs):
             recorded.append(cmd)
-            # pip path is the first attempt — succeed.
+            # pip path is the first attempt — succeed and expose current pins.
+            monkeypatch.setattr(module, "_missing_required_packages", lambda: [])
             return 0
 
         which_calls = []
@@ -611,7 +642,7 @@ class TestInstallDeps:
     def test_falls_back_to_uv_when_pip_missing(self, monkeypatch):
         """No pip → uv pip install --python <interpreter> is used."""
         module = _load_setup_module(monkeypatch)
-        _force_deps_missing(monkeypatch)
+        _force_deps_missing(monkeypatch, module)
 
         recorded = []
 
@@ -619,7 +650,8 @@ class TestInstallDeps:
             recorded.append(cmd)
             if cmd[:3] == [module.sys.executable, "-m", "pip"]:
                 raise module.subprocess.CalledProcessError(1, cmd)
-            return 0  # uv invocation succeeds
+            monkeypatch.setattr(module, "_missing_required_packages", lambda: [])
+            return 0  # uv invocation succeeds and exposes current pins
 
         monkeypatch.setattr(module.subprocess, "check_call", fake_check_call)
         monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/local/bin/uv")
@@ -633,9 +665,9 @@ class TestInstallDeps:
             assert pkg in uv_cmd
 
     def test_returns_false_when_no_pip_and_no_uv(self, monkeypatch, capsys):
-        """No pip AND no uv → failure, with the [google] extra hint printed."""
+        """No pip AND no uv → failure, with the supported setup hint printed."""
         module = _load_setup_module(monkeypatch)
-        _force_deps_missing(monkeypatch)
+        _force_deps_missing(monkeypatch, module)
 
         def fake_check_call(cmd, **kwargs):
             raise module.subprocess.CalledProcessError(1, cmd)
@@ -645,12 +677,12 @@ class TestInstallDeps:
 
         assert module.install_deps() is False
         out = capsys.readouterr().out
-        assert "hermes-agent[google]" in out
+        assert "hermes setup" in out
 
     def test_returns_false_when_uv_fallback_also_fails(self, monkeypatch, capsys):
         """uv present but its install fails → failure surfaced (not swallowed)."""
         module = _load_setup_module(monkeypatch)
-        _force_deps_missing(monkeypatch)
+        _force_deps_missing(monkeypatch, module)
 
         def fake_check_call(cmd, **kwargs):
             raise module.subprocess.CalledProcessError(1, cmd)
@@ -661,3 +693,83 @@ class TestInstallDeps:
         assert module.install_deps() is False
         out = capsys.readouterr().out
         assert "via uv" in out
+
+    def test_json_auth_url_auto_install_keeps_stdout_machine_readable(self, tmp_path):
+        """Dependency installation diagnostics stay off stdout in JSON mode."""
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        (hermes_home / "google_client_secret.json").write_text(
+            json.dumps(
+                {
+                    "installed": {
+                        "client_id": "client-id",
+                        "client_secret": "client-secret",
+                        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                        "token_uri": "https://oauth2.googleapis.com/token",
+                    }
+                }
+            )
+        )
+
+        child = textwrap.dedent(
+            """
+            import importlib.metadata
+            import runpy
+            import subprocess
+            import sys
+            import types
+
+            script = sys.argv[1]
+            installed = False
+
+            class InstalledVersion:
+                def __eq__(self, other):
+                    return installed
+
+                def __ne__(self, other):
+                    return not installed
+
+            importlib.metadata.version = lambda name: InstalledVersion()
+
+            class Flow:
+                code_verifier = "generated-code-verifier"
+
+                @classmethod
+                def from_client_secrets_file(cls, *args, **kwargs):
+                    return cls()
+
+                def authorization_url(self, **kwargs):
+                    return "https://auth.example/authorize?state=generated-state", "generated-state"
+
+            google_auth_oauthlib = types.ModuleType("google_auth_oauthlib")
+            flow_module = types.ModuleType("google_auth_oauthlib.flow")
+            flow_module.Flow = Flow
+            google_auth_oauthlib.flow = flow_module
+            sys.modules["googleapiclient"] = None
+            sys.modules["google_auth_oauthlib"] = google_auth_oauthlib
+            sys.modules["google_auth_oauthlib.flow"] = flow_module
+
+            def fake_check_call(*args, **kwargs):
+                global installed
+                installed = True
+                return 0
+
+            subprocess.check_call = fake_check_call
+            sys.argv = [script, "--auth-url", "--services", "calendar", "--format", "json"]
+            runpy.run_path(script, run_name="__main__")
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", child, str(SCRIPT_PATH)],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "HERMES_HOME": str(hermes_home)},
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["auth_url"] == "https://auth.example/authorize?state=generated-state"
+        assert payload["services"] == ["calendar"]
+        assert result.stdout.strip() == json.dumps(payload)
+        assert "Installing Google API dependencies" in result.stderr


### PR DESCRIPTION
## Summary
- adds service-scoped Google Workspace OAuth setup via `--services`
- adds parseable `--format json` responses for auth URL and auth code flows
- preserves requested scope metadata across token refreshes and hardens revoke for narrow-scope tokens
- keeps the per-service scope structure while aligning Drive/Docs with current full-scope upstream behavior
- adds regression tests for JSON output, scope metadata, fresh auth URL, missing scopes, and revoke behavior

## Latest main refresh
- Base: `355af2c20` (`origin/main`)
- Head: `a2bf3b0496844d732be2a9bf7ad12b81181eb1e6`
- Rebuilt as one clean commit on latest main.
- Cherry-pick was clean; no conflict-resolution edits were needed.

## Test Plan
- `git diff --check`
- `/home/ubuntu/.hermes/hermes-agent/.venv/bin/python -m pytest -o addopts='' tests/skills/test_google_oauth_setup.py -q`

Focused result: `21 passed in 0.23s`.
