### PR TITLE
fix: always send tenant headers in OpenViking _headers() when account/user are set

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -100,18 +100,19 @@ class _VikingClient:
             raise ImportError("httpx is required for OpenViking: pip install httpx")
 
     def _headers(self) -> dict:
-        # Only send tenant headers when the user actually configured them.
-        # Legacy installs had account/user defaulted to the literal string
-        # "default" — treat that as unset so authenticated remote servers
-        # that derive tenancy from the Bearer key aren't overridden by a
-        # bogus tenant value.
+        # Always send tenant headers when account/user are configured.
+        # OpenViking 0.3.x requires X-OpenViking-Account and X-OpenViking-User
+        # for ROOT API key requests to tenant-scoped APIs — omitting them
+        # causes INVALID_ARGUMENT errors even when account="default".
+        # User-level keys can omit them (server derives tenancy from the key),
+        # but ROOT keys must always include them explicitly.
         h = {
             "Content-Type": "application/json",
             "X-OpenViking-Agent": self._agent,
         }
-        if self._account and self._account != "default":
+        if self._account:
             h["X-OpenViking-Account"] = self._account
-        if self._user and self._user != "default":
+        if self._user:
             h["X-OpenViking-User"] = self._user
         if self._api_key:
             h["X-API-Key"] = self._api_key


### PR DESCRIPTION
## Problem

The `_headers()` method in `plugins/memory/openviking/__init__.py` skips `X-OpenViking-Account` and `X-OpenViking-User` headers when their values equal `"default"`:

```python
if self._account and self._account != "default":
    h["X-OpenViking-Account"] = self._account
if self._user and self._user != "default":
    h["X-OpenViking-User"] = self._user
```

This causes `INVALID_ARGUMENT` errors from OpenViking 0.3.x servers when using the ROOT API key, because ROOT-key requests to tenant-scoped APIs **require** these headers explicitly — even when the account is the literal string `"default"`.

Error message:
```
ROOT requests to tenant-scoped APIs must include X-OpenViking-Account and X-OpenViking-User headers. Use a user key for regular data access.
```

## Fix

Remove the `!= "default"` guard so headers are always sent when `account`/`user` are non-empty:

```python
if self._account:
    h["X-OpenViking-Account"] = self._account
if self._user:
    h["X-OpenViking-User"] = self._user
```

User-level keys derive tenancy from the key itself and can omit these headers, but ROOT keys cannot.

## Testing

- Verified on OpenViking 0.3.14 with ROOT API key + account=`"default"` + user=`"hermes"`
- Session commit, search, and all tenant-scoped APIs work correctly after the fix
- No regressions with user-level keys (tested both with and without explicit headers)