### PR TITLE
fix(gateway): wire HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT to PTB so large media uploads stop hitting the 20s default

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -939,6 +939,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 "connect_timeout": _env_float("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", 10.0),
                 "read_timeout": _env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
                 "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
+                # PTB applies media_write_timeout (not write_timeout) to multipart
+                # uploads — send_video, send_document, etc. The library default of
+                # 20s is too short for media of any meaningful size on real-world
+                # uplinks, so default to 5 minutes and let users tune higher.
+                "media_write_timeout": _env_float("HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT", 300.0),
             }
 
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in ("1", "true", "yes", "on"))

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -939,10 +939,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 "connect_timeout": _env_float("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", 10.0),
                 "read_timeout": _env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
                 "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
-                # PTB applies media_write_timeout (not write_timeout) to multipart
-                # uploads — send_video, send_document, etc. The library default of
-                # 20s is too short for media of any meaningful size on real-world
-                # uplinks, so default to 5 minutes and let users tune higher.
+                # PTB's separate knob for multipart uploads (send_video/document); 20s default fails on large files.
                 "media_write_timeout": _env_float("HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT", 300.0),
             }
 

--- a/tests/gateway/test_telegram_timeouts.py
+++ b/tests/gateway/test_telegram_timeouts.py
@@ -1,0 +1,159 @@
+"""
+Tests for HTTP timeout wiring in gateway/platforms/telegram.py.
+
+Verifies that the request_kwargs passed to PTB's ``HTTPXRequest`` honor
+the ``HERMES_TELEGRAM_HTTP_*`` environment variables — most importantly
+``HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT``, which controls how long the
+adapter will wait for multipart media uploads (``send_video``,
+``send_document``, etc.) before giving up.
+
+PTB 22.7's ``HTTPXRequest`` defaults ``media_write_timeout`` to 20s,
+which is too short for typical video uploads on real-world uplinks.
+The adapter overrides it to 300s by default and lets the env var bump
+it higher.
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    """Install mock telegram modules so TelegramAdapter can be imported."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+
+    telegram_mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    telegram_mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    telegram_mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+    sys.modules.setdefault("telegram.error", telegram_mod.error)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+
+
+@pytest.fixture
+def _mock_connect_dependencies(monkeypatch):
+    """Stub out network-discovery and lock acquisition so connect() proceeds
+    far enough to construct HTTPXRequest, and then bails on the application
+    builder (we don't care about anything past that)."""
+
+    async def _no_fallback_ips():
+        return []
+
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.discover_fallback_ips",
+        _no_fallback_ips,
+    )
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.base_url.return_value = builder
+    builder.base_file_url.return_value = builder
+    builder.build.side_effect = RuntimeError("stop after HTTPXRequest construction")
+
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+
+
+def _capture_httpx_calls(monkeypatch):
+    """Replace HTTPXRequest with a recorder; returns the call list."""
+    calls = []
+
+    def _recorder(**kwargs):
+        calls.append(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr("gateway.platforms.telegram.HTTPXRequest", _recorder)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_media_write_timeout_default_is_300s(
+    monkeypatch, _mock_connect_dependencies
+):
+    """Without env override, media_write_timeout should default to 300s.
+
+    PTB's library default is 20s, which fails for real-world media uploads.
+    """
+    monkeypatch.delenv("HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT", raising=False)
+    calls = _capture_httpx_calls(monkeypatch)
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    try:
+        await adapter.connect()
+    except RuntimeError:
+        pass  # builder.build raises by design — we already captured kwargs
+
+    assert calls, "HTTPXRequest was never called"
+    assert calls[0]["media_write_timeout"] == 300.0
+    # The other timeouts should still be set for parity / regression coverage
+    assert calls[0]["write_timeout"] == 20.0
+    assert calls[0]["read_timeout"] == 20.0
+    assert calls[0]["connect_timeout"] == 10.0
+    assert calls[0]["pool_timeout"] == 8.0
+
+
+@pytest.mark.asyncio
+async def test_media_write_timeout_env_override(
+    monkeypatch, _mock_connect_dependencies
+):
+    """Setting HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT must propagate."""
+    monkeypatch.setenv("HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT", "600")
+    calls = _capture_httpx_calls(monkeypatch)
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    try:
+        await adapter.connect()
+    except RuntimeError:
+        pass
+
+    assert calls, "HTTPXRequest was never called"
+    assert calls[0]["media_write_timeout"] == 600.0
+
+
+@pytest.mark.asyncio
+async def test_media_write_timeout_env_invalid_falls_back_to_default(
+    monkeypatch, _mock_connect_dependencies
+):
+    """A non-float env value must not crash; it falls back to the default."""
+    monkeypatch.setenv("HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT", "not-a-number")
+    calls = _capture_httpx_calls(monkeypatch)
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    try:
+        await adapter.connect()
+    except RuntimeError:
+        pass
+
+    assert calls, "HTTPXRequest was never called"
+    assert calls[0]["media_write_timeout"] == 300.0

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -45,12 +45,25 @@ def _make_config():
     ), telegram_cfg
 
 
-def _install_telegram_mock(monkeypatch, bot):
+def _install_telegram_mock(monkeypatch, bot, *, capture=None):
     parse_mode = SimpleNamespace(MARKDOWN_V2="MarkdownV2", HTML="HTML")
     constants_mod = SimpleNamespace(ParseMode=parse_mode)
-    telegram_mod = SimpleNamespace(Bot=lambda token: bot, constants=constants_mod)
+
+    # Capture HTTPXRequest construction kwargs when a list is passed in.
+    def _httpx_request(**kwargs):
+        if capture is not None:
+            capture.append(kwargs)
+        return MagicMock()
+
+    request_mod = SimpleNamespace(HTTPXRequest=_httpx_request)
+    telegram_mod = SimpleNamespace(
+        Bot=lambda token, request=None: bot,
+        constants=constants_mod,
+        request=request_mod,
+    )
     monkeypatch.setitem(sys.modules, "telegram", telegram_mod)
     monkeypatch.setitem(sys.modules, "telegram.constants", constants_mod)
+    monkeypatch.setitem(sys.modules, "telegram.request", request_mod)
 
 
 def _ensure_slack_mock(monkeypatch):
@@ -1994,3 +2007,61 @@ class TestSendSignalChunking:
         # Only the existing file made it into the RPC
         params = fake.calls[0]["payload"]["params"]
         assert len(params["attachments"]) == 1
+
+
+class TestSendTelegramTimeoutWiring:
+    """Verify that ``_send_telegram`` honors HERMES_TELEGRAM_HTTP_* env vars.
+
+    Without these, large-media sends (videos, documents) hit PTB's 20s
+    ``media_write_timeout`` default and fail. The tool path must mirror
+    the gateway adapter's behavior — same env vars, same defaults.
+    """
+
+    def _make_bot(self):
+        bot = MagicMock()
+        bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+        bot.send_photo = AsyncMock()
+        bot.send_video = AsyncMock()
+        bot.send_voice = AsyncMock()
+        bot.send_audio = AsyncMock()
+        bot.send_document = AsyncMock()
+        return bot
+
+    def test_default_media_write_timeout_is_300s(self, monkeypatch):
+        """No env override → media_write_timeout defaults to 300s, not PTB's 20s."""
+        monkeypatch.delenv("HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT", raising=False)
+        capture = []
+        _install_telegram_mock(monkeypatch, self._make_bot(), capture=capture)
+
+        result = asyncio.run(_send_telegram("token", "12345", "hi"))
+
+        assert result["success"] is True
+        assert capture, "HTTPXRequest was never constructed"
+        kwargs = capture[0]
+        assert kwargs["media_write_timeout"] == 300.0
+        assert kwargs["write_timeout"] == 20.0
+        assert kwargs["read_timeout"] == 20.0
+        assert kwargs["connect_timeout"] == 10.0
+        assert kwargs["pool_timeout"] == 8.0
+
+    def test_env_override_propagates(self, monkeypatch):
+        """HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT must be honored."""
+        monkeypatch.setenv("HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT", "600")
+        capture = []
+        _install_telegram_mock(monkeypatch, self._make_bot(), capture=capture)
+
+        result = asyncio.run(_send_telegram("token", "12345", "hi"))
+
+        assert result["success"] is True
+        assert capture[0]["media_write_timeout"] == 600.0
+
+    def test_invalid_env_value_falls_back_to_default(self, monkeypatch):
+        """Bogus env value must not crash; the default is used instead."""
+        monkeypatch.setenv("HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT", "not-a-number")
+        capture = []
+        _install_telegram_mock(monkeypatch, self._make_bot(), capture=capture)
+
+        result = asyncio.run(_send_telegram("token", "12345", "hi"))
+
+        assert result["success"] is True
+        assert capture[0]["media_write_timeout"] == 300.0

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -686,6 +686,24 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
     try:
         from telegram import Bot
         from telegram.constants import ParseMode
+        from telegram.request import HTTPXRequest
+
+        # Honor the same HTTP timeout env vars the gateway adapter uses so
+        # large-media sends (videos, documents) don't hit PTB's 20s
+        # media_write_timeout default. See gateway/platforms/telegram.py.
+        def _env_float(name: str, default: float) -> float:
+            try:
+                return float(os.environ.get(name, default))
+            except (ValueError, TypeError):
+                return default
+
+        _request = HTTPXRequest(
+            connect_timeout=_env_float("HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT", 10.0),
+            read_timeout=_env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
+            write_timeout=_env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
+            pool_timeout=_env_float("HERMES_TELEGRAM_HTTP_POOL_TIMEOUT", 8.0),
+            media_write_timeout=_env_float("HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT", 300.0),
+        )
 
         # Auto-detect HTML tags — if present, skip MarkdownV2 and send as HTML.
         # Inspired by github.com/ashaney — PR #1568.
@@ -705,7 +723,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 formatted = message
             send_parse_mode = ParseMode.MARKDOWN_V2
 
-        bot = Bot(token=token)
+        bot = Bot(token=token, request=_request)
         int_chat_id = int(chat_id)
         media_files = media_files or []
         thread_kwargs = {}

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -417,6 +417,7 @@ Advanced per-platform knobs for throttling the outbound message batcher. Most us
 | `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS` | Grace window before flushing queued Telegram media (default: `0.6`). |
 | `HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS` | Delay before sending a follow-up after the agent finishes, to avoid racing the last stream chunk. |
 | `HERMES_TELEGRAM_HTTP_CONNECT_TIMEOUT` / `_READ_TIMEOUT` / `_WRITE_TIMEOUT` / `_POOL_TIMEOUT` | Override the underlying `python-telegram-bot` HTTP timeouts (seconds). |
+| `HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT` | Upload timeout for Telegram media (`send_video`, `send_document`, etc.) in seconds (default: `300`). PTB defaults this to 20s, which fails on real-world uplinks; bump higher for very large files on slow connections. |
 | `HERMES_TELEGRAM_HTTP_POOL_SIZE` | Max concurrent HTTP connections to the Telegram API. |
 | `HERMES_TELEGRAM_DISABLE_FALLBACK_IPS` | Disable the hard-coded Cloudflare fallback IPs used when DNS fails (`true`/`false`). |
 | `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS` | Grace window before flushing a queued Discord text chunk (default: `0.6`). |


### PR DESCRIPTION
## What does this PR do?

Telegram media uploads (`send_video`, `send_document`, large `send_photo`) hit `WriteTimeout` after exactly 20 seconds because both Telegram send paths construct PTB's `HTTPXRequest` without passing `media_write_timeout`. The existing env var infrastructure suggests this is meant to be tunable — the gateway adapter already plumbs `connect_timeout`, `read_timeout`, `write_timeout`, `pool_timeout` through `HERMES_TELEGRAM_HTTP_*` — but `media_write_timeout` was simply never wired up.

Result: setting `HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT=600` in `.env` does nothing. Bumping `HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT` doesn't help either, because PTB applies a *separate* `media_write_timeout` to multipart uploads — `write_timeout` only governs JSON message sends.

This PR plugs the gap in both Telegram send paths and defaults to **300s** (matching the request-level generosity already present elsewhere). Users who need more for very large files on slow uplinks can override via env.

## Related Issue

Fixes #21757

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`gateway/platforms/telegram.py:936-948`** — add `media_write_timeout` to `request_kwargs` so both the polling client and the dedicated `get_updates` client receive it. Default 300s, override via `HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT`.
- **`tools/send_message_tool.py:_send_telegram`** — replace the bare `Bot(token=token)` with an `HTTPXRequest`-configured client that mirrors the gateway adapter's env vars. Cron-delivered media and direct `send_message` tool calls also need the longer timeout, otherwise they hit the same 20s ceiling.
- **`tests/gateway/test_telegram_timeouts.py`** (new) — three tests covering default, env override, and graceful fallback for malformed env values.
- **`tests/tools/test_send_message_tool.py`** — updated `_install_telegram_mock` helper (now also mocks `telegram.request` and accepts the new `request=` kwarg on `Bot`); added `TestSendTelegramTimeoutWiring` mirroring the gateway tests.
- **`website/docs/reference/environment-variables.md:419`** — document the new `HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT` knob alongside the existing Telegram HTTP timeouts.

## How to Test

Repro on `main` (`faa13e49f`):

1. Configure a Telegram bot, install the gateway, and have the agent reply with a video file ≥ ~10 MB on a real uplink (≤ 5 Mbps upstream is enough to trigger).
2. Tail `journalctl --user -u hermes-gateway -f` and observe `httpx.WriteTimeout` after ~20s.
3. Add `HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT=600` to `~/.hermes/.env`, restart the gateway → **same failure**, because the env var was never read.

After this PR:

1. Same setup; large media uploads now succeed (default 300s budget).
2. With `HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT=600` set, `HTTPXRequest` is constructed with `media_write_timeout=600.0` (verified by the new tests).

### Test runs

```
$ python -m pytest tests/gateway/test_telegram_timeouts.py tests/tools/test_send_message_tool.py::TestSendTelegramTimeoutWiring -v -o addopts=
======================== 6 passed in 23.39s ========================

$ python -m pytest tests/tools/test_send_message_tool.py tests/gateway/test_telegram_conflict.py tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_timeouts.py -q -o addopts=
======================== 148 passed, 2 warnings in 112.33s ========================
```

Pinned via `scripts/run_tests.sh` for parity, but I ran in single-process mode here because `xdist` was thrashing on this machine (unrelated load).

## Why a Telegram-specific env var (rather than a generic gateway one)

The repo already has a generic gateway HTTP knob — `HERMES_GATEWAY_HTTPX_*` in `gateway/platforms/_http_client_limits.py` — but it controls `httpx.Limits` (keepalive, max-connections), not request-level timeouts. `media_write_timeout` is unique to PTB's `HTTPXRequest` wrapper; raw httpx and the other platforms' SDKs (discord.py, slack_bolt, baileys) don't have an equivalent concept. Keeping this Telegram-specific avoids a leaky abstraction.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest` and the targeted tests pass; full Telegram suite (148 tests) is green
- [x] I've added tests for my changes (3 gateway + 3 tool path)
- [x] I've tested on my platform: Ubuntu 22.04, Python 3.11.15, python-telegram-bot 22.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `website/docs/reference/environment-variables.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (env var only, no YAML key)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (env-var read only, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (timeout change is invisible to the agent)