### PR TITLE
fix(tui): make automatic heap dumps opt-in to prevent disk-fill

### DIFF
--- a/ui-tui/src/__tests__/memory.test.ts
+++ b/ui-tui/src/__tests__/memory.test.ts
@@ -1,0 +1,92 @@
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { performHeapDump } from '../lib/memory.js'
+
+const ENV_KEYS = ['HERMES_AUTO_HEAPDUMP', 'HERMES_HEAPDUMP_DIR'] as const
+
+describe('performHeapDump auto opt-in', () => {
+  let saved: Record<string, string | undefined>
+  let dir: string
+
+  beforeEach(() => {
+    saved = {}
+
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k]
+      delete process.env[k]
+    }
+
+    dir = mkdtempSync(join(tmpdir(), 'hermes-heapdump-test-'))
+    process.env.HERMES_HEAPDUMP_DIR = dir
+  })
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) {
+        delete process.env[k]
+      } else {
+        process.env[k] = saved[k]
+      }
+    }
+
+    rmSync(dir, { force: true, recursive: true })
+  })
+
+  it('writes only diagnostics for auto-high without HERMES_AUTO_HEAPDUMP', async () => {
+    const result = await performHeapDump('auto-high')
+
+    expect(result.success).toBe(true)
+    expect(result.diagPath).toBeDefined()
+    expect(result.heapPath).toBeUndefined()
+
+    const files = readdirSync(dir)
+    expect(files.some(f => f.endsWith('.diagnostics.json'))).toBe(true)
+    expect(files.some(f => f.endsWith('.heapsnapshot'))).toBe(false)
+  })
+
+  it('writes only diagnostics for auto-critical without HERMES_AUTO_HEAPDUMP', async () => {
+    const result = await performHeapDump('auto-critical')
+
+    expect(result.success).toBe(true)
+    expect(result.heapPath).toBeUndefined()
+
+    const files = readdirSync(dir)
+    expect(files.some(f => f.endsWith('.heapsnapshot'))).toBe(false)
+  })
+
+  it('writes both diagnostics and heap snapshot for auto-high when HERMES_AUTO_HEAPDUMP=1', async () => {
+    process.env.HERMES_AUTO_HEAPDUMP = '1'
+
+    const result = await performHeapDump('auto-high')
+
+    expect(result.success).toBe(true)
+    expect(result.diagPath).toBeDefined()
+    expect(result.heapPath).toBeDefined()
+
+    const files = readdirSync(dir)
+    expect(files.some(f => f.endsWith('.heapsnapshot'))).toBe(true)
+  })
+
+  it('writes both for manual triggers regardless of HERMES_AUTO_HEAPDUMP', async () => {
+    const result = await performHeapDump('manual')
+
+    expect(result.success).toBe(true)
+    expect(result.heapPath).toBeDefined()
+
+    const files = readdirSync(dir)
+    expect(files.some(f => f.endsWith('.heapsnapshot'))).toBe(true)
+  })
+
+  it('treats values other than "1" as opt-out for auto triggers', async () => {
+    process.env.HERMES_AUTO_HEAPDUMP = 'true'
+
+    const result = await performHeapDump('auto-high')
+
+    expect(result.success).toBe(true)
+    expect(result.heapPath).toBeUndefined()
+  })
+})

--- a/ui-tui/src/lib/memory.ts
+++ b/ui-tui/src/lib/memory.ts
@@ -154,6 +154,20 @@ export async function performHeapDump(trigger: MemoryTrigger = 'manual'): Promis
     const diagPath = join(dir, `${base}.diagnostics.json`)
 
     await writeFile(diagPath, JSON.stringify(diagnostics, null, 2), { mode: 0o600 })
+
+    // Automatic heap dumps are opt-in: a single `.heapsnapshot` can be
+    // hundreds of megabytes to multiple gigabytes, and repeated auto-high /
+    // auto-critical triggers under a long-running native leak can fill the
+    // user's disk before they notice. The lightweight diagnostics JSON
+    // above is always written so memory alerts stay actionable; the heap
+    // snapshot itself is only written when the user explicitly opts in via
+    // HERMES_AUTO_HEAPDUMP=1. Manual dumps are unaffected.
+    const isAutomatic = trigger === 'auto-critical' || trigger === 'auto-high'
+
+    if (isAutomatic && process.env.HERMES_AUTO_HEAPDUMP !== '1') {
+      return { diagPath, success: true }
+    }
+
     await pipeline(getHeapSnapshot(), createWriteStream(heapPath, { mode: 0o600 }))
 
     return { diagPath, heapPath, success: true }


### PR DESCRIPTION
## Summary

- Gate the auto-* `.heapsnapshot` write behind `HERMES_AUTO_HEAPDUMP=1` so a long-running native leak no longer turns into a disk-fill incident.
- Always write the lightweight diagnostics JSON sidecar — memory alerts remain actionable without consent.
- Manual heap dumps (`/debug` slash, `HERMES_HEAPDUMP_ON_START`) are unaffected.

## The bug

`startMemoryMonitor()` in `ui-tui/src/lib/memoryMonitor.ts` calls `performHeapDump('auto-high' | 'auto-critical')` once per `MemoryLevel` it crosses, and re-arms when the level returns to `normal`. A single V8 heap snapshot can be hundreds of MB to multiple GB; for a long-running TUI session with a native RSS leak, the level can re-cross many times in a session and `~/.hermes/heapdumps` can accumulate tens of GiB without the user noticing.

The reporter (#21767) hit exactly this — see the issue for the disk-usage observation, the related closed leak issue #15141, and the explicit suggestion to make automatic dumps opt-in via `HERMES_AUTO_HEAPDUMP`.

## The fix

In `performHeapDump`:

1. Always run `captureMemoryDiagnostics` and write the JSON sidecar (small, always useful).
2. If `trigger` is `'auto-high'` or `'auto-critical'` and `HERMES_AUTO_HEAPDUMP !== '1'`, return early before the heavy `getHeapSnapshot()` + `pipeline()` write.
3. Manual triggers (`'manual'`) still write the snapshot unconditionally.

The strict `=== '1'` check matches the existing convention in `ui-tui/src/entry.tsx:if (process.env.HERMES_HEAPDUMP_ON_START === '1')`, the sibling control for the same subsystem.

## Test plan

New test file [`ui-tui/src/__tests__/memory.test.ts`](ui-tui/src/__tests__/memory.test.ts) exercises the gate end-to-end against a real `mkdtempSync` directory (no fs mocks) and verifies what was written to disk:

- [x] auto-high without env → only `.diagnostics.json`, no `.heapsnapshot`
- [x] auto-critical without env → only `.diagnostics.json`, no `.heapsnapshot`
- [x] auto-high with `HERMES_AUTO_HEAPDUMP=1` → both files written
- [x] manual trigger → both files written regardless of env
- [x] `HERMES_AUTO_HEAPDUMP=true` → opt-out (only strict `'1'` enables)

```
$ ./node_modules/.bin/vitest run src/__tests__/memory.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

**Regression guard:** I temporarily restored `ui-tui/src/lib/memory.ts` to `origin/main` and re-ran the new test against it — 3 of the 5 tests fail (`auto-high` and `auto-critical` cases plus the strict-`'1'` case), confirming the test would catch the bug if the production fix were reverted.

Lint and typecheck on the touched files are clean (`eslint src/lib/memory.ts src/__tests__/memory.test.ts`, `tsc --noEmit -p tsconfig.json`).

## Related

- Fixes #21767
- Adjacent (referenced from the issue): #15141 (TUI native memory leak)

> Sibling code paths that may need the same fix: `ui-tui/src/lib/memoryMonitor.ts` could additionally cool down between consecutive auto triggers (the issue lists "minimum cooldown" as a possible mitigation). Intentionally left out of this PR's scope to keep the diff small — the env-var gate alone makes the disk-fill scenario non-default. Happy to widen if preferred.