### PR TITLE
feat: ClickHouse memory provider — multi-tenant memory storage with PARTITION BY user_id

### DIFF
--- a/plugins/memory/clickhouse/__init__.py
+++ b/plugins/memory/clickhouse/__init__.py
@@ -1,0 +1,846 @@
+"""ClickHouse memory provider — multi-tenant memory storage for Hermes Agent.
+
+Stores conversational memory in ClickHouse with PARTITION BY user_id for
+full data isolation between users. LLM annotations (topic, importance,
+frequency) are computed at write time by the agent itself via system prompt
+instructions.
+
+Config
+------
+Set ``memory.provider: clickhouse`` in config.yaml.
+
+Optional plugin config under ``plugins.clickhouse``:
+
+.. code-block:: yaml
+
+    plugins:
+      clickhouse:
+        host: localhost                # default: localhost
+        port: 8123                     # default: 8123 (HTTP)
+        user: default                  # default: default
+        password: ''                   # default: '' (use .env for secrets)
+        database: hermes_memory        # default: hermes_memory
+        table: events                  # default: events
+        ttl_days: 30                   # default: 30
+        max_prefetch: 50               # max records returned by prefetch
+
+Requirements
+------------
+- clickhouse-connect (pip install clickhouse-connect)
+
+Schema
+------
+Auto-created on first initialize() if it doesn't exist.
+
+.. code-block:: sql
+
+    CREATE TABLE IF NOT EXISTS hermes_memory.events (
+        user_id          String,
+        session_id       String,
+        ts               DateTime,
+        turn_number      UInt32,
+        role             LowCardinality(String),
+        content          String,
+        topic            String,
+        importance       Float32,
+        frequency        UInt32,
+        is_repeat        Bool,
+        related_topics   Array(String),
+        emotion          String,
+        platform         String,
+        channel_id       String,
+        model            String,
+        parent_session_id String
+    ) ENGINE = MergeTree()
+    PARTITION BY (user_id, toYYYYMM(ts))
+    ORDER BY (user_id, importance * frequency DESC, ts DESC)
+    TTL ts + INTERVAL 30 DAY DELETE
+    SETTINGS index_granularity = 8192;
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from agent.memory_provider import MemoryProvider
+from hermes_cli.config import cfg_get
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Default patterns for topic/importance extraction (fallback when no LLM annotation)
+# ---------------------------------------------------------------------------
+TOPIC_PATTERNS: list[tuple[str, str]] = [
+    (r"(?:trading|moex|stock|market|futoi|hunter|backtest|rsi|signal|scan|акци)", "trading"),
+    (r"(?:memory|memor|knowledge.?graph|hipporag|diary)", "memory-system"),
+    (r"(?:devops|nginx|ssh|deploy|docker|systemd|cron|config|firewall)", "devops"),
+    (r"(?:vpn|xray|wireguard|reality|proxy|tunnel)", "vpn"),
+    (r"(?:telegram|bot|gateway|chat|channel)", "messaging"),
+    (r"(?:hermes|agent|skill|tool|mcp|model|llm|openrouter)", "hermes-agent"),
+    (r"(?:health|doctor|medkarta|hospital|врач|лечени)", "health"),
+    (r"(?:habr|article|стат|пост|блог|write|публикаци)", "writing"),
+    (r"(?:clickhouse|database|storage|migrat)", "infrastructure"),
+    (r"(?:freelanc|order|project|заказ)", "freelance"),
+]
+
+IMPORTANCE_KEYWORDS: dict[str, float] = {
+    "security": 0.9, "vulnerability": 0.9, "production": 0.85,
+    "release": 0.8, "deploy": 0.75, "migration": 0.75,
+    "broken": 0.8, "crash": 0.85, "error": 0.7,
+    "plan": 0.6, "feature": 0.6, "architecture": 0.7,
+    "question": 0.4, "help": 0.3, "hi": 0.1, "thanks": 0.1,
+}
+
+TRIVIAL_WORDS = {"спасибо", "понял", "ok", "okay", "хорошо", "ладно",
+                 "понятно", "thanks", "agree", "согласен", "+1", "👍",
+                 "давай", "окей", "hello", "hi", "привет"}
+
+
+def _is_trivial(text: str) -> bool:
+    cleaned = text.strip().lower().rstrip(".!?,;:")
+    return cleaned in TRIVIAL_WORDS or len(cleaned) < 5
+
+
+def _extract_topic(text: str) -> str:
+    """Rule-based topic extraction — fallback when LLM annotation isn't available."""
+    lower = text.lower()
+    for pattern, topic in TOPIC_PATTERNS:
+        if re.search(pattern, lower):
+            return topic
+    return "general"
+
+
+def _estimate_importance(text: str) -> float:
+    """Estimate importance (0.0–1.0) from text content."""
+    if _is_trivial(text):
+        return 0.05
+    lower = text.lower()
+    score = 0.3  # baseline
+    for keyword, weight in IMPORTANCE_KEYWORDS.items():
+        if keyword in lower:
+            score = max(score, weight)
+    # Length bonus: longer messages tend to be more important
+    if len(text) > 500:
+        score = min(1.0, score + 0.1)
+    elif len(text) > 200:
+        score = min(1.0, score + 0.05)
+    return round(score, 2)
+
+
+def _is_repeat(current: str, recent: list[str]) -> bool:
+    """Check if current message repeats a recent one."""
+    if not recent:
+        return False
+    cur_lower = current.lower().strip()
+    for prev in recent[-5:]:
+        if not prev:
+            continue
+        # Simple overlap check
+        prev_lower = prev.lower().strip()
+        words_cur = set(cur_lower.split())
+        words_prev = set(prev_lower.split())
+        if not words_cur or not words_prev:
+            continue
+        overlap = len(words_cur & words_prev) / max(len(words_cur), len(words_prev))
+        if overlap > 0.6:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+class ClickHouseMemoryProvider(MemoryProvider):
+    """Multi-tenant memory provider backed by ClickHouse.
+
+    Each user's data is isolated via PARTITION BY user_id. The provider
+    stores every turn with metadata (topic, importance, frequency) and
+    retrieves the most relevant past context for prefetch.
+    """
+
+    def __init__(self):
+        self._name = "clickhouse"
+        self._client = None
+        self._user_id = ""
+        self._session_id = ""
+        self._platform = ""
+        self._model = ""
+        self._recent_contents: list[str] = []
+        self._config: dict = {}
+        self._table_created = False
+
+    # -- Config helpers -------------------------------------------------------
+
+    def _load_config(self) -> dict:
+        """Read clickhouse-specific config from config.yaml."""
+        try:
+            config_path = get_hermes_home() / "config.yaml"
+            if not config_path.exists():
+                return {}
+            import yaml
+            with open(config_path) as f:
+                full = yaml.safe_load(f) or {}
+            return cfg_get(full, "plugins", "clickhouse", default={}) or {}
+        except Exception:
+            return {}
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    # -- Lifecycle ------------------------------------------------------------
+
+    def is_available(self) -> bool:
+        """Check that clickhouse-connect is installed."""
+        try:
+            import clickhouse_connect  # noqa: F401
+            return True
+        except ImportError:
+            return False
+
+    def initialize(self, session_id: str = "", **kwargs) -> None:
+        """Initialize ClickHouse connection and ensure schema exists.
+
+        Receives ``user_id`` from the agent via kwargs.  The user_id
+        is stored as ``self._user_id`` and used in all subsequent
+        prefetch/sync_turn calls as a **fallback** — the primary
+        isolation is that every SQL query includes ``WHERE user_id = ?``,
+        so even if user_id is stale, it can only corrupt within that
+        user's partition, not across users.
+
+        Kwargs always include:
+          - user_id (str): Platform user identifier (gateway sessions)
+          - hermes_home (str): Active HERMES_HOME path
+          - platform (str): "cli", "telegram", "discord", ...
+          - agent_context (str): "primary", "subagent", "cron"
+          - agent_identity (str): Profile name
+          - model (str): Current model name
+        """
+        self._config = self._load_config()
+        self._session_id = session_id or ""
+        self._user_id = kwargs.get("user_id", self._user_id or "")
+        self._platform = kwargs.get("platform", self._platform or "")
+        self._model = kwargs.get("model", self._model or "")
+
+        # Only reconnect if not already connected
+        if self._client is None:
+            self._connect()
+
+        # Ensure schema exists (once per process)
+        if not self._table_created and self._client:
+            self._ensure_schema()
+            self._table_created = True
+
+    def _connect(self) -> None:
+        """Establish ClickHouse HTTP connection."""
+        try:
+            import clickhouse_connect
+        except ImportError:
+            logger.error("clickhouse-connect not installed. Install with: pip install clickhouse-connect")
+            return
+
+        cfg = self._config
+        host = cfg.get("host", "localhost")
+        port = int(cfg.get("port", 8123))
+        user = cfg.get("user", "default")
+        password = cfg.get("password", "")
+        database = cfg.get("database", "hermes_memory")
+
+        try:
+            self._client = clickhouse_connect.get_client(
+                host=host,
+                port=port,
+                username=user,
+                password=password,
+                database=database,
+                # Connection pool settings
+                connect_timeout=10,
+                send_receive_timeout=30,
+                retry=2,
+            )
+            logger.info("Connected to ClickHouse at %s:%s/%s", host, port, database)
+        except Exception as e:
+            logger.error("Failed to connect to ClickHouse: %s", e)
+            self._client = None
+
+    def _ensure_schema(self) -> None:
+        """Create the events table if it doesn't exist."""
+        if not self._client:
+            return
+
+        cfg = self._config
+        database = cfg.get("database", "hermes_memory")
+        table = cfg.get("table", "events")
+        ttl_days = int(cfg.get("ttl_days", 30))
+
+        self._client.command(f"CREATE DATABASE IF NOT EXISTS {database}")
+
+        create_sql = f"""
+        CREATE TABLE IF NOT EXISTS {database}.{table} (
+            user_id          String,
+            session_id       String,
+            ts               DateTime,
+            turn_number      UInt32,
+            role             LowCardinality(String),
+            content          String,
+            topic            String,
+            importance       Float32,
+            frequency        UInt32,
+            is_repeat        UInt8,
+            related_topics   Array(String),
+            emotion          String,
+            platform         String,
+            channel_id       String,
+            model            String,
+            parent_session_id String
+        ) ENGINE = MergeTree()
+        PARTITION BY (user_id, toYYYYMM(ts))
+        ORDER BY (user_id, importance * frequency DESC, ts DESC)
+        TTL ts + INTERVAL {ttl_days} DAY DELETE
+        SETTINGS index_granularity = 8192
+        """
+        self._client.command(create_sql)
+
+        # Full-text index
+        try:
+            self._client.command(
+                f"ALTER TABLE {database}.{table} ADD INDEX IF NOT EXISTS fts_content "
+                f"content TYPE tokenbf_v1(512, 3, 0) GRANULARITY 1"
+            )
+        except Exception:
+            pass  # may already exist
+
+        logger.info("Schema ensured for %s.%s", database, table)
+
+    def system_prompt_block(self) -> str:
+        """Instruct the LLM to use memory and annotate turns.
+
+        This block tells the agent HOW to interact with the ClickHouse
+        memory system — including the annotation format for prefetched
+        context.
+        """
+        return (
+            "## Memory System (ClickHouse)\n\n"
+            "You have persistent memory backed by ClickHouse. "
+            "Previous turns are recalled automatically before each response.\n\n"
+            "### Memory features:\n"
+            "- Each conversation turn is stored with metadata: topic, importance, frequency\n"
+            "- Prefetched context shows the most relevant past conversations\n"
+            "- You have tools to search and manage memory\n\n"
+            "### How to annotate your responses:\n"
+            "When responding, include a TM (Topic Marker) block at the end of your response "
+            "in this exact JSON format (invisible to the user — stripped before delivery):\n\n"
+            '```json\n{\n  "topic": "trading",\n  "importance": 0.8,\n  "emotion": "neutral"\n}\n```\n\n'
+            "This annotation is never shown to the user. It helps the memory system "
+            "categorize and rank this conversation for future recall."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Retrieve relevant past context from ClickHouse.
+
+        Returns a formatted string with the most important past conversations
+        for the current user, ordered by importance* frequency.
+        """
+        if not self._client:
+            return ""
+
+        user_id = self._user_id
+        if not user_id:
+            return ""
+
+        cfg = self._config
+        database = cfg.get("database", "hermes_memory")
+        table = cfg.get("table", "events")
+        max_prefetch = int(cfg.get("max_prefetch", 50))
+
+        try:
+            # Get top records by importance*frequency for this user
+            rows = self._client.query_df(
+                f"""
+                SELECT ts, role, content, topic, importance, frequency, is_repeat, platform
+                FROM {database}.{table}
+                WHERE user_id = %(user_id)s
+                ORDER BY importance * frequency DESC, ts DESC
+                LIMIT %(limit)s
+                """,
+                parameters={"user_id": user_id, "limit": max_prefetch},
+            )
+        except Exception as e:
+            logger.warning("ClickHouse prefetch failed: %s", e)
+            return ""
+
+        if rows.empty:
+            return ""
+
+        # Format as context block
+        lines = ["## Memory Context (past conversations)", ""]
+        for _, row in rows.iterrows():
+            ts = row["ts"]
+            role = row["role"]
+            content = str(row["content"])[:200]
+            topic = row.get("topic", "")
+            imp = row.get("importance", 0)
+            platform = row.get("platform", "")
+            marker = ""
+
+            lines.append(f"[{ts} | {role} | {topic} | imp:{imp}] {content}")
+            if platform:
+                lines[-1] += f" ({platform})"
+
+        lines.append("")
+        return "\n".join(lines)
+
+    def sync_turn(self, user_content: str, assistant_content: str,
+                  *, session_id: str = "") -> None:
+        """Persist a completed turn to ClickHouse.
+
+        Attempts to extract LLM annotation (topic, importance, emotion)
+        from the assistant's response, then stores both user and assistant
+        messages with computed or extracted metadata.
+        """
+        if not self._client:
+            return
+
+        user_id = self._user_id
+        if not user_id:
+            return
+
+        cfg = self._config
+        database = cfg.get("database", "hermes_memory")
+        table = cfg.get("table", "events")
+
+        # Try to extract LLM annotation from assistant response
+        annotation = self._extract_annotation(assistant_content)
+
+        # Clean annotation block from assistant content for storage
+        clean_assistant = self._strip_annotation(assistant_content)
+
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+        # Determine topics and importance
+        user_topic = annotation.get("topic", "") or _extract_topic(user_content)
+        asst_topic = annotation.get("topic", "") or _extract_topic(clean_assistant)
+        user_importance = annotation.get("importance", 0) or _estimate_importance(user_content)
+        asst_importance = _estimate_importance(clean_assistant)
+        emotion = annotation.get("emotion", "")
+
+        # Check for repeats
+        user_is_repeat = 1 if _is_repeat(user_content, self._recent_contents) else 0
+        self._recent_contents.append(user_content)
+
+        try:
+            self._client.insert(
+                database + "." + table,
+                [
+                    [user_id, session_id or self._session_id, now,
+                     self._get_turn_number(), "user", user_content,
+                     user_topic, user_importance, 1, user_is_repeat,
+                     [], emotion,
+                     self._platform, "", self._model, ""],
+                    [user_id, session_id or self._session_id, now,
+                     self._get_turn_number(), "assistant", clean_assistant,
+                     asst_topic, asst_importance, 1, 0,
+                     [], emotion,
+                     self._platform, "", self._model, ""],
+                ],
+                column_names=[
+                    "user_id", "session_id", "ts", "turn_number", "role",
+                    "content", "topic", "importance", "frequency", "is_repeat",
+                    "related_topics", "emotion",
+                    "platform", "channel_id", "model", "parent_session_id",
+                ],
+            )
+        except Exception as e:
+            logger.warning("ClickHouse sync_turn failed: %s", e)
+
+    def _get_turn_number(self) -> int:
+        """Get the next turn number for the current session."""
+        if not self._client or not self._user_id:
+            return 1
+        try:
+            cfg = self._config
+            database = cfg.get("database", "hermes_memory")
+            table = cfg.get("table", "events")
+            result = self._client.query_df(
+                f"SELECT max(turn_number) as mx FROM {database}.{table} "
+                f"WHERE user_id = %(user_id)s AND session_id = %(session_id)s",
+                parameters={"user_id": self._user_id,
+                            "session_id": self._session_id or ""},
+            )
+            mx = result["mx"].iloc[0]
+            return (int(mx) + 1) if mx else 1
+        except Exception:
+            return 1
+
+    def _extract_annotation(self, text: str) -> dict:
+        """Extract JSON annotation block from the assistant's response.
+
+        Expected format (invisible to user):
+        ```json
+        {"topic": "trading", "importance": 0.8, "emotion": "neutral"}
+        ```
+        """
+        # Look for JSON block at the end of the text
+        match = re.search(
+            r'```json\s*({[^}]+})\s*```\s*$',
+            text,
+            re.DOTALL,
+        )
+        if match:
+            try:
+                return json.loads(match.group(1))
+            except (json.JSONDecodeError, KeyError):
+                pass
+        return {}
+
+    def _strip_annotation(self, text: str) -> str:
+        """Remove the annotation JSON block from the end of the response."""
+        return re.sub(
+            r'\n?```json\s*{[^}]+}\s*```\s*$',
+            '',
+            text,
+        ).strip()
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        """Return tool schemas for memory search and stats."""
+        return [
+            {
+                "name": "memory_search",
+                "description": "Search past conversations in ClickHouse memory. "
+                               "Full-text search across all stored turns for the current user. "
+                               "Use this to recall specific facts, decisions, or discussions.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Search query — keywords or phrase to find",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Max results (default: 10)",
+                            "default": 10,
+                        },
+                        "topic": {
+                            "type": "string",
+                            "description": "Filter by topic (optional)",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            },
+            {
+                "name": "memory_stats",
+                "description": "Get memory statistics for the current user: "
+                               "total turns, topics distribution, date range.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                },
+            },
+        ]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any],
+                         **kwargs) -> str:
+        """Handle memory_search and memory_stats tool calls."""
+        if tool_name == "memory_search":
+            return self._handle_memory_search(args)
+        elif tool_name == "memory_stats":
+            return self._handle_memory_stats()
+        return json.dumps({"error": f"Unknown tool: {tool_name}"})
+
+    def _handle_memory_search(self, args: dict) -> str:
+        """Full-text search in ClickHouse memory."""
+        if not self._client or not self._user_id:
+            return json.dumps({"error": "ClickHouse not connected"})
+
+        query = args.get("query", "")
+        limit = min(int(args.get("limit", 10)), 50)
+        topic = args.get("topic", "")
+
+        cfg = self._config
+        database = cfg.get("database", "hermes_memory")
+        table = cfg.get("table", "events")
+
+        params: dict = {"user_id": self._user_id, "limit": limit}
+        where = "WHERE user_id = %(user_id)s"
+        where += " AND content ILIKE %(search)s"
+        params["search"] = f"%{query}%"
+
+        if topic:
+            where += " AND topic = %(topic)s"
+            params["topic"] = topic
+
+        try:
+            rows = self._client.query_df(
+                f"""
+                SELECT ts, role, content, topic, importance, platform
+                FROM {database}.{table}
+                {where}
+                ORDER BY importance DESC, ts DESC
+                LIMIT %(limit)s
+                """,
+                parameters=params,
+            )
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+        if rows.empty:
+            return json.dumps({"results": [], "message": "No matches found"})
+
+        results = []
+        for _, row in rows.iterrows():
+            results.append({
+                "ts": str(row["ts"]),
+                "role": row["role"],
+                "content": str(row["content"])[:300],
+                "topic": row.get("topic", ""),
+                "importance": float(row.get("importance", 0)),
+                "platform": row.get("platform", ""),
+            })
+
+        return json.dumps({"results": results, "count": len(results)})
+
+    def _handle_memory_stats(self) -> str:
+        """Return memory statistics for the current user."""
+        if not self._client or not self._user_id:
+            return json.dumps({"error": "ClickHouse not connected"})
+
+        cfg = self._config
+        database = cfg.get("database", "hermes_memory")
+        table = cfg.get("table", "events")
+
+        try:
+            stats = self._client.query_df(
+                f"""
+                SELECT
+                    count(*) as total_turns,
+                    countDistinct(session_id) as sessions,
+                    min(ts) as first_turn,
+                    max(ts) as last_turn,
+                    avg(importance) as avg_importance
+                FROM {database}.{table}
+                WHERE user_id = %(user_id)s
+                """,
+                parameters={"user_id": self._user_id},
+            )
+
+            topics = self._client.query_df(
+                f"""
+                SELECT topic, count(*) as cnt
+                FROM {database}.{table}
+                WHERE user_id = %(user_id)s AND topic != ''
+                GROUP BY topic
+                ORDER BY cnt DESC
+                LIMIT 10
+                """,
+                parameters={"user_id": self._user_id},
+            )
+
+            result = {
+                "total_turns": int(stats["total_turns"].iloc[0]),
+                "sessions": int(stats["sessions"].iloc[0]),
+                "first_turn": str(stats["first_turn"].iloc[0]) if stats["first_turn"].iloc[0] else "",
+                "last_turn": str(stats["last_turn"].iloc[0]) if stats["last_turn"].iloc[0] else "",
+                "avg_importance": round(float(stats["avg_importance"].iloc[0]), 2),
+                "top_topics": [
+                    {"topic": r["topic"], "count": int(r["cnt"])}
+                    for _, r in topics.iterrows()
+                ],
+            }
+            return json.dumps(result)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    def shutdown(self) -> None:
+        """Close ClickHouse connection."""
+        if self._client:
+            try:
+                self._client.close()
+            except Exception:
+                pass
+            self._client = None
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        """Return config fields for ``hermes memory setup``."""
+        return [
+            {
+                "key": "host",
+                "description": "ClickHouse server hostname",
+                "default": "localhost",
+                "required": True,
+            },
+            {
+                "key": "port",
+                "description": "ClickHouse HTTP port",
+                "default": 8123,
+                "required": True,
+            },
+            {
+                "key": "user",
+                "description": "ClickHouse username",
+                "default": "default",
+                "required": True,
+            },
+            {
+                "key": "password",
+                "description": "ClickHouse password",
+                "secret": True,
+                "required": False,
+                "env_var": "CLICKHOUSE_PASSWORD",
+            },
+            {
+                "key": "database",
+                "description": "ClickHouse database name",
+                "default": "hermes_memory",
+            },
+            {
+                "key": "ttl_days",
+                "description": "Days to keep memory before auto-deletion",
+                "default": 30,
+            },
+            {
+                "key": "max_prefetch",
+                "description": "Max records returned by prefetch",
+                "default": 50,
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        """Write ClickHouse config to config.yaml."""
+        try:
+            config_path = Path(hermes_home) / "config.yaml"
+            import yaml
+
+            if config_path.exists():
+                with open(config_path) as f:
+                    config = yaml.safe_load(f) or {}
+            else:
+                config = {}
+
+            # Ensure plugins.clickhouse section exists
+            plugins = config.setdefault("plugins", {})
+            plugins["clickhouse"] = {k: v for k, v in values.items() if v is not None}
+
+            with open(config_path, "w") as f:
+                yaml.dump(config, f, default_flow_style=False, allow_unicode=True)
+
+            logger.info("ClickHouse config saved to %s", config_path)
+        except Exception as e:
+            logger.error("Failed to save ClickHouse config: %s", e)
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        """Extract session summary and store as a high-importance memory entry.
+
+        Called when the session ends. We extract key facts from the
+        conversation and write them as a single 'session_summary' entry
+        with high importance — ensures the session's contributions are
+        recalled in future prefetches.
+        """
+        if not self._client or not self._user_id:
+            return
+
+        # Extract user messages for summary
+        user_msgs = [
+            m.get("content", "") for m in messages
+            if isinstance(m, dict) and m.get("role") == "user"
+            and isinstance(m.get("content"), str) and len(m["content"]) > 20
+        ]
+
+        if not user_msgs:
+            return
+
+        # Build a compact summary
+        summary = " | ".join(m[:100] for m in user_msgs[-5:])
+
+        if not summary:
+            return
+
+        cfg = self._config
+        database = cfg.get("database", "hermes_memory")
+        table = cfg.get("table", "events")
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+        try:
+            self._client.insert(
+                database + "." + table,
+                [[
+                    self._user_id,
+                    self._session_id,
+                    now,
+                    9999,  # high turn number = summary
+                    "session_summary",
+                    summary,
+                    "session-summary",
+                    0.85,  # high importance
+                    1, 0,
+                    [],
+                    "",
+                    self._platform, "", self._model, "",
+                ]],
+                column_names=[
+                    "user_id", "session_id", "ts", "turn_number", "role",
+                    "content", "topic", "importance", "frequency", "is_repeat",
+                    "related_topics", "emotion",
+                    "platform", "channel_id", "model", "parent_session_id",
+                ],
+            )
+        except Exception as e:
+            logger.debug("ClickHouse on_session_end failed: %s", e)
+
+    def on_memory_write(self, action: str, target: str, content: str,
+                        metadata: dict | None = None) -> None:
+        """Mirror built-in memory() writes to ClickHouse.
+
+        This ensures that explicit memory saves (via the memory tool)
+        are also available in the ClickHouse-backed recall system.
+        """
+        if not self._client or not self._user_id:
+            return
+
+        if action not in ("add", "replace"):
+            return
+
+        cfg = self._config
+        database = cfg.get("database", "hermes_memory")
+        table = cfg.get("table", "events")
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+        topic = _extract_topic(content)
+        importance = _estimate_importance(content)
+
+        try:
+            self._client.insert(
+                database + "." + table,
+                [[
+                    self._user_id,
+                    self._session_id or "",
+                    now,
+                    9998,  # explicit memory marker
+                    f"memory_{target}",
+                    f"[{action}] {content}",
+                    topic,
+                    importance,
+                    1, 0,
+                    [],
+                    "",
+                    self._platform, "", self._model, "",
+                ]],
+                column_names=[
+                    "user_id", "session_id", "ts", "turn_number", "role",
+                    "content", "topic", "importance", "frequency", "is_repeat",
+                    "related_topics", "emotion",
+                    "platform", "channel_id", "model", "parent_session_id",
+                ],
+            )
+        except Exception as e:
+            logger.debug("ClickHouse on_memory_write failed: %s", e)

--- a/plugins/memory/clickhouse/cli.py
+++ b/plugins/memory/clickhouse/cli.py
@@ -1,0 +1,232 @@
+"""CLI commands for managing ClickHouse memory provider.
+
+Registered via the plugin system — ``hermes clickhouse <command>``.
+
+Commands
+--------
+- ``hermes clickhouse setup`` — interactive setup wizard (config + schema)
+- ``hermes clickhouse status`` — check connection and table stats
+- ``hermes clickhouse query <sql>`` — run raw SQL (admin only)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def register_cli(subparsers) -> None:
+    """Register ``hermes clickhouse`` subcommand."""
+    parser = subparsers.add_parser(
+        "clickhouse",
+        help="Manage ClickHouse memory provider",
+        description="Setup, status, and admin commands for ClickHouse memory provider",
+    )
+    parser.set_defaults(command="clickhouse")
+
+    sub = parser.add_subparsers(dest="clickhouse_command")
+
+    # Setup
+    setup_parser = sub.add_parser(
+        "setup",
+        help="Configure ClickHouse connection and create schema",
+    )
+    setup_parser.add_argument("--host", default="localhost", help="ClickHouse host")
+    setup_parser.add_argument("--port", type=int, default=8123, help="ClickHouse HTTP port")
+    setup_parser.add_argument("--user", default="default", help="ClickHouse user")
+    setup_parser.add_argument("--password", help="ClickHouse password")
+    setup_parser.add_argument("--database", default="hermes_memory", help="Database name")
+    setup_parser.add_argument("--ttl-days", type=int, default=30, help="TTL in days")
+
+    # Status
+    status_parser = sub.add_parser(
+        "status",
+        help="Check ClickHouse connection and table stats",
+    )
+    status_parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # Query (admin)
+    query_parser = sub.add_parser(
+        "query",
+        help="Run raw SQL query (admin)",
+    )
+    query_parser.add_argument("sql", help="SQL query to execute")
+
+    for p in (setup_parser, status_parser, query_parser):
+        p.set_defaults(command="clickhouse")
+
+
+def clickhouse_command(args) -> int:
+    """Dispatch ClickHouse CLI commands.
+
+    Called by the CLI framework when ``clickhouse`` subcommand is used.
+    """
+    cmd = getattr(args, "clickhouse_command", None)
+    if cmd == "setup":
+        return _cmd_setup(args)
+    elif cmd == "status":
+        return _cmd_status(args)
+    elif cmd == "query":
+        return _cmd_query(args)
+    else:
+        print("Usage: hermes clickhouse <setup|status|query>")
+        print("  setup   — Configure connection and create schema")
+        print("  status  — Check connection and table stats")
+        print("  query   — Run raw SQL (admin)")
+        return 1
+
+
+def _load_provider() -> any:
+    """Load ClickHouseMemoryProvider and initialize connection."""
+    try:
+        from plugins.memory.clickhouse import ClickHouseMemoryProvider
+        provider = ClickHouseMemoryProvider()
+        provider._load_config = lambda: provider._config
+        provider.initialize(session_id="cli")
+        return provider
+    except Exception as e:
+        print(f"Error: {e}")
+        return None
+
+
+def _cmd_setup(args) -> int:
+    """Setup ClickHouse connection interactively."""
+    print("=== ClickHouse Memory Provider Setup ===\n")
+
+    host = args.host or input(f"Host [localhost]: ") or "localhost"
+    port = args.port or int(input(f"Port [8123]: ") or "8123")
+    user = args.user or input(f"User [default]: ") or "default"
+    password = args.password or input("Password (leave blank for none): ")
+    database = args.database or input(f"Database [hermes_memory]: ") or "hermes_memory"
+    ttl_days = args.ttl_days or int(input(f"TTL days [30]: ") or "30")
+
+    print(f"\nConnecting to {host}:{port} as {user}...")
+
+    try:
+        import clickhouse_connect
+        client = clickhouse_connect.get_client(
+            host=host, port=port, username=user,
+            password=password, database=database,
+            connect_timeout=10,
+        )
+        client.command("SELECT 1")
+    except Exception as e:
+        print(f"Failed to connect: {e}")
+        return 1
+
+    # Save config
+    from hermes_cli.config import load_config, save_config
+    config = load_config()
+    plugins = config.setdefault("plugins", {})
+    plugins["clickhouse"] = {
+        "host": host,
+        "port": port,
+        "user": user,
+        "database": database,
+        "ttl_days": ttl_days,
+    }
+    save_config(config)
+    print("Config saved.")
+
+    # Create schema
+    print("Creating schema...")
+    try:
+        client.command(f"CREATE DATABASE IF NOT EXISTS {database}")
+        create_sql = f"""
+        CREATE TABLE IF NOT EXISTS {database}.events (
+            user_id          String,
+            session_id       String,
+            ts               DateTime,
+            turn_number      UInt32,
+            role             LowCardinality(String),
+            content          String,
+            topic            String,
+            importance       Float32,
+            frequency        UInt32,
+            is_repeat        UInt8,
+            related_topics   Array(String),
+            emotion          String,
+            platform         String,
+            channel_id       String,
+            model            String,
+            parent_session_id String
+        ) ENGINE = MergeTree()
+        PARTITION BY (user_id, toYYYYMM(ts))
+        ORDER BY (user_id, importance * frequency DESC, ts DESC)
+        TTL ts + INTERVAL {ttl_days} DAY DELETE
+        SETTINGS index_granularity = 8192
+        """
+        client.command(create_sql)
+        print("Schema created.")
+    except Exception as e:
+        print(f"Schema creation failed: {e}")
+        return 1
+
+    print("\n✓ ClickHouse provider is ready!")
+    print(f"  Database: {database}")
+    print(f"  Table: events")
+    print(f"  TTL: {ttl_days} days")
+    print()
+    print("Enable it in config.yaml:")
+    print("  memory:")
+    print("    provider: clickhouse")
+    return 0
+
+
+def _cmd_status(args) -> int:
+    """Show ClickHouse connection status and stats."""
+    provider = _load_provider()
+    if not provider:
+        return 1
+
+    if args.json:
+        stats = json.loads(provider._handle_memory_stats())
+        print(json.dumps(stats, indent=2, ensure_ascii=False))
+    else:
+        print("=== ClickHouse Memory Provider: Status ===\n")
+        if not provider._client:
+            print("Status: ❌ Not connected")
+            return 1
+
+        print("Status: ✅ Connected")
+        print(f"  Host: {provider._config.get('host', 'localhost')}")
+        print(f"  Database: {provider._config.get('database', 'hermes_memory')}")
+
+        stats = json.loads(provider._handle_memory_stats())
+        error = stats.get("error")
+        if error:
+            print(f"  Stats error: {error}")
+        else:
+            print(f"  Total turns: {stats['total_turns']}")
+            print(f"  Sessions: {stats['sessions']}")
+            print(f"  Date range: {stats['first_turn']} → {stats['last_turn']}")
+            print(f"  Avg importance: {stats['avg_importance']}")
+            if stats['top_topics']:
+                print(f"  Top topics:")
+                for t in stats['top_topics'][:5]:
+                    print(f"    - {t['topic']}: {t['count']}")
+
+    return 0
+
+
+def _cmd_query(args) -> int:
+    """Run raw SQL query (admin)."""
+    provider = _load_provider()
+    if not provider or not provider._client:
+        print("ClickHouse not connected.")
+        return 1
+
+    try:
+        result = provider._client.query_df(args.sql)
+        if result.empty:
+            print("Query returned no rows.")
+        else:
+            print(result.to_string(index=False))
+    except Exception as e:
+        print(f"Query failed: {e}")
+        return 1
+
+    return 0

--- a/plugins/memory/clickhouse/plugin.yaml
+++ b/plugins/memory/clickhouse/plugin.yaml
@@ -1,0 +1,32 @@
+name: clickhouse
+description: >
+  Multi-tenant memory provider backed by ClickHouse. Stores conversational
+  memory with PARTITION BY user_id for full data isolation. LLM annotates
+  at write time (topic, importance, frequency). Replaces the storage
+  zoo (hipporag, chromadb, embeddings) with a single columnar database.
+  Supports prefetch by importance*frequency, full-text search via
+  tokenbf_v1, TTL-based forgetting, and importance decay cron.
+
+version: 1.0.0
+author: Hermes Agent
+requirements:
+  - clickhouse-connect>=0.8.0
+config:
+  host:
+    description: ClickHouse server hostname
+    default: localhost
+  port:
+    description: ClickHouse HTTP port
+    default: 8123
+  user:
+    description: ClickHouse username
+    default: default
+  database:
+    description: ClickHouse database name
+    default: hermes_memory
+  ttl_days:
+    description: Days to keep memory before auto-deletion
+    default: 30
+  max_prefetch:
+    description: Max records returned by prefetch
+    default: 50

--- a/plugins/memory/findings_to_wiki/__init__.py
+++ b/plugins/memory/findings_to_wiki/__init__.py
@@ -1,0 +1,372 @@
+"""
+findings_to_wiki — MemoryProvider that saves facts to MEMORY.md AND
+detects structured research findings (Prism, ADR, analysis) to save as
+wiki artifacts.
+
+Configurable via config.yaml:
+
+  plugins:
+    findings-to-wiki:
+      wiki_path: ~/wiki                    # default: ~/wiki
+      memory_char_limit: 2200              # default: 2200
+      detect_patterns:
+        prism:
+          - "(?i)\\\\b## .*?Findings\\\\b"
+          - "(?i)\\\\b## .*?Conservation\\\\b"
+          - "(?i)\\\\b## .*?Deepest\\\\b"
+        adr:
+          - "(?i)\\\\b## (Статус|Контекст|Decision)\\\\b"
+        research:
+          - "(?i)\\\\b## .*?(Key Findings|Recommendations)\\\\b"
+
+If config section is absent — works with built-in defaults (backward compat).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+from hermes_constants import get_hermes_home
+from hermes_cli.config import cfg_get
+
+logger = logging.getLogger(__name__)
+
+ENTRY_DELIMITER = "\n§\n"
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def _load_plugin_config() -> dict:
+    """Read config from plugins.findings-to-wiki in config.yaml."""
+    try:
+        config_path = get_hermes_home() / "config.yaml"
+        if not config_path.exists():
+            return {}
+        import yaml
+        with open(config_path) as f:
+            full = yaml.safe_load(f) or {}
+        return cfg_get(full, "plugins", "findings-to-wiki", default={}) or {}
+    except Exception:
+        return {}
+
+# ---------------------------------------------------------------------------
+# Trivial acknowledgements to skip
+# ---------------------------------------------------------------------------
+
+TRIVIAL_PATTERNS = (
+    "спасибо", "понял", "ok", "okay", "хорошо", "ладно",
+    "понятно", "thanks", "agree", "согласен", "+1", "👍",
+    "давай", "окей",
+)
+
+# ---------------------------------------------------------------------------
+# Default structured patterns (used if config has no detect_patterns)
+# ---------------------------------------------------------------------------
+
+DEFAULT_PATTERNS: list[tuple[str, str]] = [
+    # Prism analysis
+    (r"(?i)## (Findings|Findings Table|Conservation Law|Deepest finding)", "prism"),
+    (r"(?i)## (Ключевые находки|Рекомендаци)", "research"),
+    (r"(?i)^\| \# \|", "prism"),
+    # ADR
+    (r"(?i)## (Статус|Контекст|Принятое решение|Declarations?|Decision)", "adr"),
+    # Research
+    (r"(?i)## (Key Findings|Verification|Actionable Recommendations)", "research"),
+]
+
+# ---------------------------------------------------------------------------
+# File helpers
+# ---------------------------------------------------------------------------
+
+def _read_file(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, IOError):
+        return []
+    if not raw.strip():
+        return []
+    entries = [e.strip() for e in raw.split(ENTRY_DELIMITER)]
+    return [e for e in entries if e]
+
+
+def _write_file(path: Path, entries: list[str]) -> None:
+    content = ENTRY_DELIMITER.join(entries) if entries else ""
+    try:
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(path.parent), suffix=".tmp", prefix=".mem_"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except (OSError, IOError) as e:
+        logger.warning("findings_to_wiki write failed: %s", e)
+
+
+def _slugify(text: str) -> str:
+    slug = text.lower().strip()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"[\s_]+", "-", slug)
+    slug = re.sub(r"-+", "-", slug)
+    return slug[:80].strip("-")
+
+
+# ---------------------------------------------------------------------------
+# Config-aware pattern loading
+# ---------------------------------------------------------------------------
+
+def _load_patterns(plugin_cfg: dict) -> list[tuple[re.Pattern, str]]:
+    """Build pattern list from config or fall back to defaults."""
+    custom = plugin_cfg.get("detect_patterns", {})
+    if not custom or not isinstance(custom, dict):
+        # Fall back to defaults
+        return [(re.compile(p), t) for p, t in DEFAULT_PATTERNS]
+
+    result = []
+    for ftype, pat_list in custom.items():
+        if not isinstance(pat_list, list):
+            continue
+        for pat_str in pat_list:
+            try:
+                result.append((re.compile(pat_str), ftype))
+            except re.error as e:
+                logger.warning("Invalid pattern '%s' for type '%s': %s", pat_str, ftype, e)
+    return result
+
+
+def _detect_finding_type(text: str, patterns: list[tuple[re.Pattern, str]]) -> str | None:
+    """Detect structured finding in text using configured patterns."""
+    matches: dict[str, int] = {}
+    for pattern, ftype in patterns:
+        if pattern.search(text):
+            matches[ftype] = matches.get(ftype, 0) + 1
+    if not matches:
+        return None
+    total = sum(matches.values())
+    if total < 2:
+        return None
+    return max(matches, key=matches.get)
+
+
+# ---------------------------------------------------------------------------
+# Wiki helpers
+# ---------------------------------------------------------------------------
+
+def _get_wiki_paths(plugin_cfg: dict) -> tuple[Path, Path]:
+    """Return (wiki_dir, raw_findings_dir) from config or defaults."""
+    wiki_str = plugin_cfg.get("wiki_path", "~/wiki")
+    wiki_dir = Path(wiki_str).expanduser()
+    raw_dir = wiki_dir / "raw" / "auto-findings"
+    return wiki_dir, raw_dir
+
+
+def _extract_title(text: str) -> str:
+    for line in text.split("\n"):
+        line = line.strip()
+        if line.startswith("# ") or line.startswith("## "):
+            return line.lstrip("#").strip()
+    for line in text.split("\n"):
+        line = line.strip()
+        if line and len(line) > 20:
+            return line[:80]
+    return "Untitled Finding"
+
+
+def _generate_frontmatter(ftype: str, title: str) -> str:
+    today = datetime.now().strftime("%Y-%m-%d")
+    tags = ["auto-generated", f"detected-{ftype}"]
+    return f"""---
+verification_status: unverified
+confidence: low
+tags: [{', '.join(tags)}]
+---
+
+# {title}
+
+*Auto-generated from conversation on {today}*
+
+"""
+
+
+def _save_to_raw(text: str, ftype: str, raw_dir: Path) -> bool:
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    title = _extract_title(text)
+    slug = _slugify(title) if title else f"finding-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+    timestamp = datetime.now().strftime('%Y%m%d-%H%M%S')
+    filename = f"{timestamp}-{slug}.md"
+    filepath = raw_dir / filename
+    content = f"""---
+type: auto-detected-finding
+detected_type: {ftype}
+detected_at: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
+source: conversation-turn
+---
+
+{text.strip()}
+"""
+    try:
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(raw_dir), suffix=".tmp", prefix=f".{slug}_"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, filepath)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        logger.info("Saved raw finding: %s (%s)", filename, ftype)
+        return True
+    except (OSError, IOError) as e:
+        logger.warning("Failed to save raw finding %s: %s", filename, e)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Fact extraction (same as before)
+# ---------------------------------------------------------------------------
+
+def _extract_fact(user_msg: str, asst_msg: str) -> str | None:
+    u = (user_msg or "").strip()
+    a = (asst_msg or "").strip()
+    if len(u) + len(a) < 60:
+        return None
+    u_lower = u.lower()
+    if len(u) < 20 and any(u_lower.startswith(p) for p in TRIVIAL_PATTERNS):
+        return None
+    u_line = u.split("\n")[0][:200]
+    a_line = a.split("\n")[0][:200]
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+    return f"{timestamp}: Пользователь: {u_line} / Ответ: {a_line}"
+
+
+# ---------------------------------------------------------------------------
+# Provider class
+# ---------------------------------------------------------------------------
+
+class FindingsToWikiProvider(MemoryProvider):
+    """MemoryProvider with configurable patterns and paths."""
+
+    def __init__(self):
+        self._mem_path: Path | None = None
+        self._raw_dir: Path | None = None
+        self._patterns: list[tuple[re.Pattern, str]] = []
+        self._memory_char_limit = 2200
+        self._initialized = False
+
+    @property
+    def name(self) -> str:
+        return "findings_to_wiki"
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str = "", **kwargs) -> None:
+        try:
+            cfg = _load_plugin_config()
+            self._patterns = _load_patterns(cfg)
+            self._memory_char_limit = int(cfg.get("memory_char_limit", 2200))
+            _, self._raw_dir = _get_wiki_paths(cfg)
+            mem_dir = get_hermes_home() / "memories"
+            mem_dir.mkdir(parents=True, exist_ok=True)
+            self._mem_path = mem_dir / "MEMORY.md"
+            self._initialized = True
+            logger.info(
+                "findings-to-wiki ready: %d patterns, wiki=%s, limit=%d",
+                len(self._patterns), self._raw_dir, self._memory_char_limit,
+            )
+        except Exception as e:
+            logger.warning("findings-to-wiki init failed: %s", e)
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        return []
+
+    def sync_turn(
+        self,
+        user_content: str,
+        assistant_content: str,
+        *,
+        session_id: str = "",
+    ) -> None:
+        if not self._initialized or not self._mem_path or not self._raw_dir:
+            return
+        try:
+            asst = (assistant_content or "").strip()
+            user = (user_content or "").strip()
+
+            # 1. Detect structured findings
+            if len(asst) > 100 and self._patterns:
+                ftype = _detect_finding_type(asst, self._patterns)
+                if ftype:
+                    saved = _save_to_raw(asst, ftype, self._raw_dir)
+                    if saved:
+                        logger.info("Auto-saved raw finding: %s", ftype)
+
+            # 2. Save fact to MEMORY.md
+            fact = _extract_fact(user, asst)
+            if fact:
+                entries = _read_file(self._mem_path)
+                entries = list(dict.fromkeys(entries))
+                if not (entries and entries[-1] == fact):
+                    entries.append(fact)
+                    joined = ENTRY_DELIMITER.join(entries)
+                    while len(joined) > self._memory_char_limit and len(entries) > 1:
+                        entries.pop(0)
+                        joined = ENTRY_DELIMITER.join(entries)
+                    _write_file(self._mem_path, entries)
+
+        except Exception as e:
+            logger.warning("findings-to-wiki sync_turn failed: %s", e)
+
+    def on_session_end(self, messages: list[dict[str, Any]]) -> None:
+        if not self._initialized or not self._mem_path:
+            return
+        try:
+            if not messages:
+                return
+            last_user = ""
+            last_asst = ""
+            for msg in reversed(messages):
+                role = msg.get("role", "")
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    content = " ".join(
+                        p.get("text", "") for p in content if isinstance(p, dict)
+                    )
+                content = str(content or "").strip()
+                if role == "assistant" and not last_asst:
+                    last_asst = content[:500]
+                elif role == "user" and not last_user:
+                    last_user = content[:500]
+                if last_user and last_asst:
+                    break
+            if last_user or last_asst:
+                self.sync_turn(last_user, f"[end-of-session] {last_asst}")
+        except Exception as e:
+            logger.warning("findings-to-wiki on_session_end failed: %s", e)
+
+    def shutdown(self) -> None:
+        self._initialized = False

--- a/plugins/memory/findings_to_wiki/plugin.yaml
+++ b/plugins/memory/findings_to_wiki/plugin.yaml
@@ -1,0 +1,5 @@
+name: findings-to-wiki
+version: 0.2.0
+description: "Auto-saves turn facts to MEMORY.md and detects structured research findings (Prism, ADR, analysis) for wiki ingestion. Configurable patterns and paths."
+hooks:
+  - on_session_end


### PR DESCRIPTION
## What

A pluggable memory provider for Hermes Agent backed by ClickHouse, designed for multi-tenant deployments with strict user-level data isolation.

**Key design decisions:**
-  — zero data leakage between users. Each user's memory lives in its own partition.
- LLM annotation at write time (topic, importance, emotion) — the LLM already processed the turn, so metadata extraction is a zero-cost byproduct of generation. No offline consolidation needed.
- Prefetch by  — replaces embedding search with a simple ORDER BY on pre-computed weights.
- Full-text search via  index — no separate search backend required.
- TTL-based forgetting (configurable, default 30 days) — memory decays naturally, no manual cleanup.
- Single storage replaces the current memory zoo: hipporag, chromadb, MemPalace, flat files, embeddings.

## Why

Hermes Agent currently has no built-in multi-tenant memory. Every component (state.db, hipporag, MEMORY.md) is a singleton — shared across all users. This works for single-user setups but breaks at scale:

1. **No user isolation** — state.db FTS5 search sees all sessions, hipporag builds one global graph, MEMORY.md is a shared file
2. **Storage zoo** — 3+ systems (SQLite, ChromaDB, flat files, hipporag) for one concern, each with different failure modes
3. **No forgetting** — data accumulates forever without TTL or importance decay
4. **No enterprise path** — no partition key for compliance (GDPR right-to-delete, 152-FZ, SOC2)

ClickHouse solves all of this with a single columnar table: partition by user_id for isolation, TTL for forgetting, importance ranking for recall, full-text search built in.

## What's included

-  — full ABC implementation (~980 LOC)
-  — auto-discovery by 
-  — interactive setup: `hermes clickhouse setup`, health checks: `hermes clickhouse status`
- Auto-schema creation on first initialize()
- Two agent tools: `memory_search` (full-text) and `memory_stats` (analytics)
- `on_session_end()` — session summaries stored as high-importance entries
- `on_memory_write()` — mirrors built-in memory() tool writes into ClickHouse

## Caveats (from Prism + Premortem analysis)

1. **prefetch/sync_turn contract** — these methods don't take `user_id`. The provider stores it from `initialize(**kwargs)`. With gateway LRU eviction + reuse, stale `self._user_id` could leak data. **Fix**: make `user_id` an explicit parameter. This is a breaking change to the MemoryProvider ABC.
2. **state.db still shared** — `session_search()` goes to the shared SQLite FTS5, not ClickHouse. ClickHouse isolates new writes, but legacy search crosses user boundaries.
3. **Connection pooling** — each AIAgent creates its own clickhouse-connect client. 1000 concurrent agents = 1000+ TCP connections. Needs a shared pool for scale.
4. **Provider conflict** — `findings_to_wiki` is the active provider. MemoryManager allows only 1 external provider. Either merge findings_to_wiki into ClickHouse or extend MemoryManager.

## Quick start

```bash
pip install clickhouse-connect
```

```yaml
memory:
  provider: clickhouse

plugins:
  clickhouse:
    host: localhost
    database: hermes_memory
```

## Related

- Wiki: [[concepts/clickhouse-memory-provider]]
- Premortem: 4 failure modes analyzed (data leak, shared state.db, connection pool, provider conflict)