### PR TITLE
fix(compressor): restore summary_model and reset fallen_back flag on session reset

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -372,6 +372,8 @@ class ContextCompressor(ContextEngine):
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
         self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
+        self.summary_model = self._configured_summary_model  # restore in case fallback cleared it
+        self._summary_model_fallen_back = False  # allow the one-shot fallback to fire again
 
     def update_model(
         self,
@@ -464,7 +466,8 @@ class ContextCompressor(ContextEngine):
         self.last_prompt_tokens = 0
         self.last_completion_tokens = 0
 
-        self.summary_model = summary_model_override or ""
+        self._configured_summary_model: str = summary_model_override or ""
+        self.summary_model = self._configured_summary_model
 
         # Stores the previous compaction summary for iterative updates
         self._previous_summary: Optional[str] = None

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1631,3 +1631,50 @@ class TestTruncateToolCallArgsJson:
         parsed = _json.loads(shrunk)
         assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
         assert parsed["content"].endswith("...[truncated]")
+
+
+class TestOnSessionResetSummaryModel:
+    """on_session_reset() must restore summary_model to the configured value.
+
+    When the aux summary model fails mid-session, the fallback logic clears
+    self.summary_model = "" so subsequent compressions use the main model.
+    On /reset the compressor is reused (not recreated), so without an explicit
+    restore the new session silently degrades to the main model even if the
+    aux model is back online. See issue companion to #15548.
+    """
+
+    def _make_compressor(self, summary_model: str):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+            return ContextCompressor(
+                model="main/model",
+                threshold_percent=0.85,
+                quiet_mode=True,
+                summary_model_override=summary_model,
+            )
+
+    def test_configured_summary_model_restored_after_fallback(self):
+        c = self._make_compressor("gpt-4o-mini")
+        assert c.summary_model == "gpt-4o-mini"
+
+        # Simulate the fallback clearing summary_model
+        c.summary_model = ""
+        c._summary_model_fallen_back = True
+
+        c.on_session_reset()
+
+        assert c.summary_model == "gpt-4o-mini", (
+            "on_session_reset() must restore summary_model to the configured value"
+        )
+
+    def test_summary_model_fallen_back_cleared_on_reset(self):
+        c = self._make_compressor("gpt-4o-mini")
+        c._summary_model_fallen_back = True
+
+        c.on_session_reset()
+
+        assert c._summary_model_fallen_back is False
+
+    def test_empty_summary_model_stays_empty_after_reset(self):
+        c = self._make_compressor("")
+        c.on_session_reset()
+        assert c.summary_model == ""


### PR DESCRIPTION
## What does this PR do?

`_generate_summary()` clears `self.summary_model = ""` when the configured auxiliary summary model fails (404, 503, timeout, etc.) and falls back to the main model for that compression call. This mutation is permanent for the lifetime of the `ContextCompressor` instance.

`reset_session_state()` in `run_agent.py` calls `on_session_reset()` on the **same** compressor instance on every `/new` and `/reset` — the compressor is never recreated. `on_session_reset()` already resets `_summary_failure_cooldown_until` to 0 so transient errors do not block a fresh session (fix #15548 / salvage #19622). The same logic applies to `summary_model`: a per-session fallback should not permanently degrade compression quality for every subsequent session.

Without this fix: after one aux model failure in a long session, every `/reset` silently leaves `summary_model = ""`. The configured model (e.g. `aux_models.compressor.model = "gpt-4o-mini"`) is never used again — even if the aux model recovered — until the gateway is restarted.

Root cause: `on_session_reset()` did not include `summary_model` in its reset list, and `_summary_model_fallen_back` was also left as `True`, preventing the one-shot fallback from firing again in the new session.

Fix:
1. Store the originally configured value in `_configured_summary_model` at `__init__` time.
2. Restore `self.summary_model` from it in `on_session_reset()`.
3. Reset `_summary_model_fallen_back = False` so the fallback logic can fire once more if the model fails again in the new session.

Symmetric with the `_summary_failure_cooldown_until = 0.0` reset already present in the same method.

## Related Issue

Companion to #15548 (same lifecycle class — `on_session_reset()` not resetting a compressor field).

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `agent/context_compressor.py`: store `_configured_summary_model` at init (+1 line); restore in `on_session_reset()` (+2 lines)
- `tests/agent/test_context_compressor.py`: 3 new regression tests in `TestOnSessionResetSummaryModel` (+35 lines)

## How to Test

```bash
python3.11 -m pytest tests/agent/test_context_compressor.py::TestOnSessionResetSummaryModel -v --override-ini="addopts="
```

Expected: 3 passed.

Manual reproduction:
1. Configure `aux_models.compressor.model` to a model that will fail (wrong name / offline).
2. Have a long session that triggers compression — the aux model fails, falls back to main.
3. Run `/reset`.
4. Have another long session that triggers compression.
5. Before fix: main model used (aux model silently absent). After fix: aux model tried again.

## Checklist

### Code
- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] This fix only
- [x] pytest run — 72 passed, 0 failed
- [x] Tests added
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs updated — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — affects all platforms; no platform-specific code
- [x] Tool descriptions — N/A