### PR TITLE
fix(doctor): skip /models health check for providers that don't support it

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -271,7 +271,8 @@ def _build_apikey_providers_list() -> list:
                 (_pp.models_url or (_pp.base_url.rstrip("/") + "/models"))
                 if _pp.base_url else None
             )
-            _static.append((_label, _key_vars, _models_url, _base_var, True))
+            _hc = getattr(_pp, "supports_health_check", True)
+            _static.append((_label, _key_vars, _models_url, _base_var, _hc))
     except Exception:
         pass
     return _static

--- a/plugins/model-providers/xiaomi/__init__.py
+++ b/plugins/model-providers/xiaomi/__init__.py
@@ -8,6 +8,7 @@ xiaomi = ProviderProfile(
     aliases=("mimo", "xiaomi-mimo"),
     env_vars=("XIAOMI_API_KEY",),
     base_url="https://api.xiaomimimo.com/v1",
+    supports_health_check=False,  # /v1/models returns 401 even with valid key
 )
 
 register_provider(xiaomi)

--- a/providers/base.py
+++ b/providers/base.py
@@ -40,6 +40,7 @@ class ProviderProfile:
     base_url: str = ""
     models_url: str = ""  # explicit models endpoint; falls back to {base_url}/models
     auth_type: str = "api_key"   # api_key|oauth_device_code|oauth_external|copilot|aws_sdk
+    supports_health_check: bool = True  # False → doctor skips /models probe for this provider
 
     # ── Model catalog ─────────────────────────────────────────
     # fallback_models: curated list shown in /model picker when live fetch fails.


### PR DESCRIPTION
## Problem

Xiaomi MiMo's `/v1/models` endpoint returns **401** even with a valid API key, causing `hermes doctor` to falsely report _"invalid API key"_.

This isn't unique to Xiaomi — any provider whose `/models` endpoint doesn't support auth verification will trigger the same false positive.

## Solution

3 files, 4 lines added:

1. **`providers/base.py`** — Add `supports_health_check: bool = True` field to `ProviderProfile`. Providers that don't support `/models` for auth verification can set it to `False`.

2. **`hermes_cli/doctor.py`** — Dynamic provider discovery now reads `supports_health_check` from the profile instead of hardcoding `True`.

3. **`plugins/model-providers/xiaomi/__init__.py`** — Set `supports_health_check=False` for Xiaomi MiMo.

## Before and After

```
# Before
✗ xiaomi               (invalid API key)
Found 2 issue(s) to address

# After  
✓ xiaomi               (key configured)
Found 1 issue(s) to address
```

## Testing

- Verified `hermes doctor` no longer reports false positive for Xiaomi
- Existing providers with `supports_health_check=True` (default) are unaffected
