### PR TITLE
feat: add API server LLM proxy mode

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -119,7 +119,7 @@ jobs:
           retention-days: 14
 
       - name: Post / update PR comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
           script: |

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -592,6 +592,9 @@ class APIServerAdapter(BasePlatformAdapter):
         self._model_name: str = self._resolve_model_name(
             extra.get("model_name", os.getenv("API_SERVER_MODEL_NAME", "")),
         )
+        self._runtime_mode: str = self._resolve_runtime_mode(
+            extra.get("runtime_mode", os.getenv("API_SERVER_RUNTIME_MODE", "server_agent")),
+        )
         self._app: Optional["web.Application"] = None
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
@@ -606,6 +609,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # Pollable run status for dashboards and external control-plane UIs.
         self._run_statuses: Dict[str, Dict[str, Any]] = {}
         self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._llm_proxy_client: Optional[Any] = None  # Lazy-init OpenAI client for llm_proxy mode
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -641,6 +645,28 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             pass
         return "hermes-agent"
+
+    @staticmethod
+    def _resolve_runtime_mode(explicit: Any) -> str:
+        """Normalize API-server runtime mode.
+
+        ``server_agent`` preserves the historical behavior: the API server
+        creates a Hermes AIAgent and executes tools on the server host.
+        ``llm_proxy`` is a pure OpenAI-compatible provider mode: requests are
+        forwarded to the configured upstream LLM and any tool_calls are returned
+        to the HTTP client for local execution.
+        """
+        mode = str(explicit or "server_agent").strip().lower().replace("-", "_")
+        aliases = {
+            "agent": "server_agent",
+            "server": "server_agent",
+            "server_agent": "server_agent",
+            "proxy": "llm_proxy",
+            "llm": "llm_proxy",
+            "llm_proxy": "llm_proxy",
+            "model_proxy": "llm_proxy",
+        }
+        return aliases.get(mode, "server_agent")
 
     def _cors_headers_for_origin(self, origin: str) -> Optional[Dict[str, str]]:
         """Return CORS headers for an allowed browser origin."""
@@ -848,6 +874,163 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         return agent
 
+    def _jsonable_proxy_response(self, response: Any) -> Dict[str, Any]:
+        """Return a JSON-serializable OpenAI SDK response payload."""
+        if hasattr(response, "model_dump"):
+            return response.model_dump(mode="json", exclude_none=True)
+        if isinstance(response, dict):
+            return response
+        if hasattr(response, "to_dict_recursive"):
+            return response.to_dict_recursive()
+        return json.loads(json.dumps(response, default=lambda obj: getattr(obj, "__dict__", str(obj))))
+
+    def _llm_proxy_model_name(self, requested_model: Any) -> str:
+        """Use the gateway-configured upstream model for proxy requests.
+
+        The API server advertises ``self._model_name`` as its public model id;
+        callers should not be able to override the upstream provider/model by
+        sending a different ``model`` string in the OpenAI request body.
+        """
+        from gateway.run import _resolve_gateway_model
+
+        return _resolve_gateway_model()
+
+    def _build_llm_proxy_kwargs(self, body: Dict[str, Any]) -> Dict[str, Any]:
+        """Build a conservative OpenAI chat-completions request for proxy mode."""
+        passthrough_keys = {
+            "messages",
+            "tools",
+            "tool_choice",
+            "parallel_tool_calls",
+            "temperature",
+            "top_p",
+            "frequency_penalty",
+            "presence_penalty",
+            "max_tokens",
+            "max_completion_tokens",
+            "stop",
+            "response_format",
+            "seed",
+            "user",
+            "metadata",
+            "stream_options",
+        }
+        kwargs = {key: body[key] for key in passthrough_keys if key in body}
+        kwargs["model"] = self._llm_proxy_model_name(body.get("model"))
+        return kwargs
+
+    def _create_llm_proxy_client(self):
+        """Create/cache an OpenAI-compatible client for llm_proxy mode."""
+        if self._llm_proxy_client is not None:
+            return self._llm_proxy_client
+
+        from openai import OpenAI
+        from gateway.run import _resolve_runtime_agent_kwargs
+
+        runtime_kwargs = _resolve_runtime_agent_kwargs()
+        client_kwargs: Dict[str, Any] = {}
+        api_key = runtime_kwargs.get("api_key")
+        base_url = runtime_kwargs.get("base_url")
+        if api_key:
+            client_kwargs["api_key"] = api_key
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self._llm_proxy_client = OpenAI(**client_kwargs)
+        return self._llm_proxy_client
+
+    async def _handle_llm_proxy_chat_completions(
+        self,
+        request: "web.Request",
+        body: Dict[str, Any],
+    ) -> "web.StreamResponse":
+        """Pure provider mode: return upstream tool_calls to the HTTP client.
+
+        This intentionally does not instantiate ``AIAgent``.  It is useful when
+        a local Hermes client points ``model.base_url`` at this API server and
+        wants workspace tools to execute on the client machine.
+        """
+        kwargs = self._build_llm_proxy_kwargs(body)
+        try:
+            client = self._create_llm_proxy_client()
+        except Exception as exc:
+            logger.warning("API server llm_proxy client setup failed: %s", exc)
+            return web.json_response(_openai_error("Upstream LLM proxy is not configured."), status=503)
+        if body.get("stream", False):
+            kwargs["stream"] = True
+            return await self._write_llm_proxy_stream(request, client, kwargs)
+
+        try:
+            response = await asyncio.to_thread(client.chat.completions.create, **kwargs)
+        except Exception as exc:
+            logger.warning("API server llm_proxy request failed: %s", exc)
+            return web.json_response(_openai_error("Upstream LLM proxy request failed."), status=502)
+        return web.json_response(self._jsonable_proxy_response(response))
+
+    async def _write_llm_proxy_stream(
+        self,
+        request: "web.Request",
+        client: Any,
+        kwargs: Dict[str, Any],
+    ) -> "web.StreamResponse":
+        """Forward an upstream OpenAI streaming response as SSE."""
+        chunks: asyncio.Queue = asyncio.Queue()
+        loop = asyncio.get_running_loop()
+
+        def _put(item: tuple[str, Optional[str]]) -> None:
+            loop.call_soon_threadsafe(chunks.put_nowait, item)
+
+        def _worker() -> None:
+            try:
+                stream = client.chat.completions.create(**kwargs)
+                for chunk in stream:
+                    if hasattr(chunk, "model_dump_json"):
+                        payload = chunk.model_dump_json(exclude_none=True)
+                    else:
+                        payload = json.dumps(self._jsonable_proxy_response(chunk), ensure_ascii=False)
+                    _put(("data", payload))
+                _put(("done", None))
+            except Exception as exc:
+                logger.warning("API server llm_proxy stream failed: %s", exc)
+                _put(("error", None))
+
+        worker = None
+        response = web.StreamResponse(
+            status=200,
+            headers={
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+        await response.prepare(request)
+        worker = loop.run_in_executor(None, _worker)
+
+        try:
+            while True:
+                kind, payload = await chunks.get()
+                if kind == "data":
+                    await response.write(f"data: {payload}\n\n".encode("utf-8"))
+                elif kind == "done":
+                    await response.write(b"data: [DONE]\n\n")
+                    break
+                else:
+                    error_payload = json.dumps(_openai_error("Upstream LLM proxy stream failed."))
+                    await response.write(f"data: {error_payload}\n\n".encode("utf-8"))
+                    await response.write(b"data: [DONE]\n\n")
+                    break
+        finally:
+            if worker is not None:
+                try:
+                    await worker
+                except Exception:
+                    pass
+            try:
+                await response.write_eof()
+            except Exception:
+                pass
+        return response
+
     # ------------------------------------------------------------------
     # HTTP Handlers
     # ------------------------------------------------------------------
@@ -909,6 +1092,30 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
+        if self._runtime_mode == "llm_proxy":
+            runtime = {
+                "mode": "llm_proxy",
+                "tool_execution": "client",
+                "split_runtime": True,
+                "description": (
+                    "The API server forwards Chat Completions requests to the configured "
+                    "upstream LLM and returns raw tool_calls to the HTTP client, so tools "
+                    "execute on the client/local Hermes runtime. Remote Hermes skills and "
+                    "memory are not injected in this provider-proxy mode."
+                ),
+            }
+        else:
+            runtime = {
+                "mode": "server_agent",
+                "tool_execution": "server",
+                "split_runtime": False,
+                "description": (
+                    "The API server creates a server-side Hermes AIAgent; "
+                    "tools execute on the API-server host unless an explicit "
+                    "proxy/split-runtime mode is enabled."
+                ),
+            }
+
         return web.json_response({
             "object": "hermes.api_server.capabilities",
             "platform": "hermes-agent",
@@ -917,16 +1124,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "type": "bearer",
                 "required": bool(self._api_key),
             },
-            "runtime": {
-                "mode": "server_agent",
-                "tool_execution": "server",
-                "split_runtime": False,
-                "description": (
-                    "The API server creates a server-side Hermes AIAgent; "
-                    "tools execute on the API-server host unless a future "
-                    "explicit split-runtime mode is enabled."
-                ),
-            },
+            "runtime": runtime,
             "features": {
                 "chat_completions": True,
                 "chat_completions_streaming": True,
@@ -974,6 +1172,9 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         stream = body.get("stream", False)
+
+        if self._runtime_mode == "llm_proxy":
+            return await self._handle_llm_proxy_chat_completions(request, body)
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -924,7 +924,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if self._llm_proxy_client is not None:
             return self._llm_proxy_client
 
-        from openai import OpenAI
+        from openai import OpenAI  # type: ignore[unresolved-import]
         from gateway.run import _resolve_runtime_agent_kwargs
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -104,6 +104,7 @@ AUTHOR_MAP = {
     "rxdxxxx@users.noreply.github.com": "rxdxxxx",
     "ma.haohao2@xydigit.com": "MaHaoHao-ch",
     "29756950+revaraver@users.noreply.github.com": "revaraver",
+    "pingchesu@users.noreply.github.com": "pingchesu",
     "nexus@eptic.me": "TheEpTic",
     "74554762+wmagev@users.noreply.github.com": "wmagev",
     "ashermorse@icloud.com": "ashermorse",

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -20,14 +20,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
-from aiohttp.test_utils import AioHTTPTestCase, TestClient, TestServer
+from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
     ResponseStore,
     _IdempotencyCache,
-    _CORS_HEADERS,
     _derive_chat_session_id,
     check_api_server_requirements,
     cors_middleware,
@@ -207,6 +206,7 @@ class TestAdapterInit:
         assert adapter._host == "127.0.0.1"
         assert adapter._port == 8642
         assert adapter._api_key == ""
+        assert adapter._runtime_mode == "server_agent"
         assert adapter.platform == Platform.API_SERVER
 
     def test_custom_config_from_extra(self):
@@ -217,24 +217,28 @@ class TestAdapterInit:
                 "port": 9999,
                 "key": "sk-test",
                 "cors_origins": ["http://localhost:3000"],
+                "runtime_mode": "llm_proxy",
             },
         )
         adapter = APIServerAdapter(config)
         assert adapter._host == "0.0.0.0"
         assert adapter._port == 9999
         assert adapter._api_key == "sk-test"
+        assert adapter._runtime_mode == "llm_proxy"
         assert adapter._cors_origins == ("http://localhost:3000",)
 
     def test_config_from_env(self, monkeypatch):
         monkeypatch.setenv("API_SERVER_HOST", "10.0.0.1")
         monkeypatch.setenv("API_SERVER_PORT", "7777")
         monkeypatch.setenv("API_SERVER_KEY", "sk-env")
+        monkeypatch.setenv("API_SERVER_RUNTIME_MODE", "proxy")
         monkeypatch.setenv("API_SERVER_CORS_ORIGINS", "http://localhost:3000, http://127.0.0.1:3000")
         config = PlatformConfig(enabled=True)
         adapter = APIServerAdapter(config)
         assert adapter._host == "10.0.0.1"
         assert adapter._port == 7777
         assert adapter._api_key == "sk-env"
+        assert adapter._runtime_mode == "llm_proxy"
         assert adapter._cors_origins == (
             "http://localhost:3000",
             "http://127.0.0.1:3000",
@@ -598,6 +602,20 @@ class TestCapabilitiesEndpoint:
             assert data["endpoints"]["run_status"]["path"] == "/v1/runs/{run_id}"
 
     @pytest.mark.asyncio
+    async def test_capabilities_advertises_llm_proxy_mode(self):
+        adapter = _make_adapter()
+        adapter._runtime_mode = "llm_proxy"
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["runtime"]["mode"] == "llm_proxy"
+            assert data["runtime"]["tool_execution"] == "client"
+            assert data["runtime"]["split_runtime"] is True
+            assert "Remote Hermes skills and memory are not injected" in data["runtime"]["description"]
+
+    @pytest.mark.asyncio
     async def test_capabilities_requires_auth_when_key_configured(self, auth_adapter):
         app = _create_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -649,6 +667,61 @@ class TestChatCompletionsEndpoint:
             assert resp.status == 400
 
     @pytest.mark.asyncio
+    async def test_llm_proxy_forwards_tools_without_creating_agent(self, adapter):
+        adapter._runtime_mode = "llm_proxy"
+        app = _create_app(adapter)
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.return_value = {
+            "id": "chatcmpl-proxy",
+            "object": "chat.completion",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": "call_pwd",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{\"command\": \"pwd\"}"},
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            }],
+        }
+
+        with (
+            patch.object(adapter, "_create_llm_proxy_client", return_value=fake_client),
+            patch.object(adapter, "_create_agent") as create_agent,
+            patch("gateway.run._resolve_gateway_model", return_value="upstream-model"),
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "where am I?"}],
+                        "tools": [{
+                            "type": "function",
+                            "function": {
+                                "name": "terminal",
+                                "parameters": {"type": "object", "properties": {}},
+                            },
+                        }],
+                        "tool_choice": "auto",
+                    },
+                )
+
+                assert resp.status == 200
+                data = await resp.json()
+
+        assert data["choices"][0]["message"]["tool_calls"][0]["function"]["name"] == "terminal"
+        create_agent.assert_not_called()
+        fake_client.chat.completions.create.assert_called_once()
+        kwargs = fake_client.chat.completions.create.call_args.kwargs
+        assert kwargs["model"] == "upstream-model"
+        assert kwargs["tools"][0]["function"]["name"] == "terminal"
+        assert kwargs["tool_choice"] == "auto"
+
+    @pytest.mark.asyncio
     async def test_stream_true_returns_sse(self, adapter):
         """stream=true returns SSE format with the full response."""
         app = _create_app(adapter)
@@ -664,7 +737,7 @@ class TestChatCompletionsEndpoint:
                     {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
                 )
 
-            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent) as mock_run:
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
                 resp = await cli.post(
                     "/v1/chat/completions",
                     json={
@@ -2594,8 +2667,7 @@ class TestConversationParameter:
                     "conversation": "test-conv",
                 })
                 assert resp1.status == 200
-                data1 = await resp1.json()
-                resp1_id = data1["id"]
+                await resp1.json()
 
                 # Second request — should chain
                 mock_run.return_value = (

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -16,12 +16,14 @@ Memory providers are one of two **provider plugin** types. The other is [Context
 
 Each memory provider lives in `plugins/memory/<name>/`:
 
-```
+<!-- ascii-guard-ignore -->
+```text
 plugins/memory/my-provider/
 ├── __init__.py      # MemoryProvider implementation + register() entry point
 ├── plugin.yaml      # Metadata (name, description, hooks)
 └── README.md        # Setup instructions, config reference, tools
 ```
+<!-- ascii-guard-ignore-end -->
 
 ## The MemoryProvider ABC
 

--- a/website/docs/guides/cron-script-only.md
+++ b/website/docs/guides/cron-script-only.md
@@ -10,6 +10,7 @@ Sometimes you already know exactly what message you want to send. You don't need
 
 Hermes calls this **no-agent mode**. It's the cron system minus the LLM.
 
+<!-- ascii-guard-ignore -->
 ```
    ┌──────────────────┐          ┌──────────────────┐
    │ scheduler tick   │  every   │ run script       │
@@ -23,6 +24,7 @@ Hermes calls this **no-agent mode**. It's the cron system minus the LLM.
                                  │ (telegram/disc…) │
                                  └──────────────────┘
 ```
+<!-- ascii-guard-ignore-end -->
 
 - **No LLM call.** Zero tokens, zero agent loop, zero model spend.
 - **Script is the job.** The script decides whether to alert. Emit output → message gets sent. Emit nothing → silent tick.

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -464,6 +464,7 @@ Visually the target is the familiar Linear / Fusion layout: dark theme, column h
 
 The GUI is strictly a **read-through-the-DB + write-through-kanban_db** layer with no domain logic of its own:
 
+<!-- ascii-guard-ignore -->
 ```
 ┌────────────────────────┐      WebSocket (tails task_events)
 │   React SPA (plugin)   │ ◀──────────────────────────────────┐
@@ -483,6 +484,7 @@ The GUI is strictly a **read-through-the-DB + write-through-kanban_db** layer wi
 │  (WAL, shared)         │
 └────────────────────────┘
 ```
+<!-- ascii-guard-ignore-end -->
 
 ### REST surface
 

--- a/website/docs/user-guide/messaging/open-webui.md
+++ b/website/docs/user-guide/messaging/open-webui.md
@@ -235,6 +235,16 @@ With streaming enabled (the default), you'll see brief inline indicators as tool
 | `API_SERVER_PORT` | `8642` | HTTP server port |
 | `API_SERVER_HOST` | `127.0.0.1` | Bind address |
 | `API_SERVER_KEY` | _(required)_ | Bearer token for auth. Match `OPENAI_API_KEY`. |
+| `API_SERVER_RUNTIME_MODE` | `server_agent` | `server_agent` runs a full server-side Hermes agent; `llm_proxy` forwards Chat Completions to the configured upstream LLM and returns raw `tool_calls` to the client for local execution. |
+
+### Runtime modes
+
+| Mode | Tool execution | Remote skills/memory | Use case |
+|------|----------------|----------------------|----------|
+| `server_agent` | API-server host | Yes | Open WebUI as a frontend for that Hermes runtime. |
+| `llm_proxy` | HTTP client / local Hermes | No | Use the remote machine as a pure model/provider proxy while keeping local workspace tools local. |
+
+`llm_proxy` is a compatibility step toward split-runtime workflows: it solves the immediate locality surprise for clients that already execute tools themselves, such as a local Hermes instance using the remote API server as `model.base_url`. It does **not** inject the remote Hermes skills or memory; full "remote brain, local hands" remains tracked in [#18715](https://github.com/NousResearch/hermes-agent/issues/18715).
 
 ### Open WebUI
 


### PR DESCRIPTION
## Summary

Follow-up for #18715.

- Adds `API_SERVER_RUNTIME_MODE=llm_proxy` for the OpenAI-compatible API server
- In `llm_proxy` mode, `/v1/chat/completions` forwards requests to the configured upstream OpenAI-compatible LLM and returns raw `tool_calls` to the HTTP client
- Keeps the existing default `server_agent` behavior backward compatible
- Advertises runtime locality through `/v1/capabilities`
- Documents the trade-off: `llm_proxy` keeps tools local to the client, but does not inject remote Hermes skills/memory yet

## Why

The current API server is a server-side Hermes runtime: when a local Hermes instance points `model.base_url` at a remote Hermes API server, tool calls execute on the remote host. `llm_proxy` provides an explicit provider-proxy mode for the common “local hands” case while the fuller split-runtime design is developed.

## Test Plan

- `python -m ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py -q`
- `python -m pytest tests/gateway/test_api_server.py -q -o 'addopts='`
- Claude Code review: no blocking issues found

Closes #18715
