### PR TITLE
fix(tui): guard automatic heap dumps against disk fill

### DIFF
--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -25,7 +25,7 @@ const gw = new GatewayClient()
 gw.start()
 
 const dumpNotice = (snap: MemorySnapshot, dump: HeapDumpResult | null) =>
-  `hermes-tui: ${snap.level} memory (${formatBytes(snap.heapUsed)}) — auto heap dump → ${dump?.heapPath ?? '(failed)'}\n`
+  `hermes-tui: ${snap.level} memory (${formatBytes(snap.heapUsed)}) — auto heap dump → ${dump?.heapPath ?? dump?.diagPath ?? '(failed)'}\n`
 
 setupGracefulExit({
   cleanups: [

--- a/ui-tui/src/lib/memory.ts
+++ b/ui-tui/src/lib/memory.ts
@@ -1,5 +1,5 @@
 import { createWriteStream } from 'node:fs'
-import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readdir, readFile, stat, unlink, writeFile } from 'node:fs/promises'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { pipeline } from 'node:stream/promises'
@@ -153,12 +153,63 @@ export async function performHeapDump(trigger: MemoryTrigger = 'manual'): Promis
     const heapPath = join(dir, `${base}.heapsnapshot`)
     const diagPath = join(dir, `${base}.diagnostics.json`)
 
+    // The diagnostics JSON is KB-sized and the most useful artifact when a
+    // full snapshot is suppressed by the auto-heapdump opt-in gate below.
     await writeFile(diagPath, JSON.stringify(diagnostics, null, 2), { mode: 0o600 })
+
+    // Auto triggers require explicit opt-in: multi-GiB snapshots written on
+    // every threshold cross can fill the user's disk (issue #21767).
+    const isAuto = trigger === 'auto-critical' || trigger === 'auto-high'
+    const autoEnabled = /^(?:1|true|yes|on)$/i.test((process.env.HERMES_AUTO_HEAPDUMP ?? '').trim())
+
+    if (isAuto && !autoEnabled) {
+      await pruneHeapdumps(dir).catch(() => undefined)
+
+      return {
+        diagPath,
+        error: 'automatic heap dumps disabled; set HERMES_AUTO_HEAPDUMP=1 to enable',
+        success: false
+      }
+    }
+
     await pipeline(getHeapSnapshot(), createWriteStream(heapPath, { mode: 0o600 }))
+    await pruneHeapdumps(dir).catch(() => undefined)
 
     return { diagPath, heapPath, success: true }
   } catch (e) {
     return { error: e instanceof Error ? e.message : String(e), success: false }
+  }
+}
+
+// Cap total bytes of files in `dir`, deleting oldest first. Covers both
+// `.heapsnapshot` and `.diagnostics.json` artifacts so orphan sidecars from
+// gated auto-triggers cannot accumulate without bound. The newest file is
+// always retained even if it alone exceeds the cap.
+async function pruneHeapdumps(dir: string): Promise<void> {
+  const raw = process.env.HERMES_HEAPDUMP_MAX_BYTES?.trim()
+  const parsed = raw ? Number(raw) : NaN
+  const cap = Number.isFinite(parsed) && parsed > 0 ? parsed : 2 * 1024 ** 3
+
+  const names = await readdir(dir)
+  const stats = await Promise.all(
+    names.map(async name => {
+      const path = join(dir, name)
+      const s = await stat(path).catch(() => null)
+
+      return s && s.isFile() ? { mtimeMs: s.mtimeMs, path, size: s.size } : null
+    })
+  )
+  const valid = stats.filter((s): s is { mtimeMs: number; path: string; size: number } => s !== null)
+
+  valid.sort((a, b) => b.mtimeMs - a.mtimeMs)
+
+  let total = valid.reduce((acc, s) => acc + s.size, 0)
+
+  while (total > cap && valid.length > 1) {
+    const oldest = valid.pop()
+    if (!oldest) break
+    await unlink(oldest.path).catch(() => undefined)
+    total -= oldest.size
   }
 }
 

--- a/ui-tui/src/lib/memoryMonitor.ts
+++ b/ui-tui/src/lib/memoryMonitor.ts
@@ -62,6 +62,14 @@ export function startMemoryMonitor({
   const dumped = new Set<Exclude<MemoryLevel, 'normal'>>()
   const inFlight = new Set<Exclude<MemoryLevel, 'normal'>>()
 
+  // Cooldown prevents repeated auto dumps when heap oscillates around the
+  // threshold (issue #21767). `dumped` alone is not enough — it clears on
+  // every transition back to `normal`.
+  const cooldownRaw = process.env.HERMES_AUTO_HEAPDUMP_COOLDOWN_MS?.trim()
+  const cooldownParsed = cooldownRaw ? Number(cooldownRaw) : NaN
+  const cooldownMs = Number.isFinite(cooldownParsed) && cooldownParsed >= 0 ? cooldownParsed : 600_000
+  let lastAutoDumpAt = 0
+
   const tick = async () => {
     const { heapUsed, rss } = process.memoryUsage()
     const level: MemoryLevel = heapUsed >= criticalBytes ? 'critical' : heapUsed >= highBytes ? 'high' : 'normal'
@@ -75,7 +83,12 @@ export function startMemoryMonitor({
       return
     }
 
+    if (Date.now() - lastAutoDumpAt < cooldownMs) {
+      return
+    }
+
     inFlight.add(level)
+    lastAutoDumpAt = Date.now()
 
     // Prune Ink content caches before dump/exit — half on 'high' (recoverable),
     // full on 'critical' (post-dump RSS reduction, keeps user running).


### PR DESCRIPTION
## Problem

  `hermes --tui` can repeatedly write multi-GiB V8 heap snapshots to
  `~/.hermes/heapdumps` whenever the TUI memory monitor crosses the
  `auto-high` (1.5 GiB) or `auto-critical` (2.5 GiB) thresholds. In real
  local installs this directory has grown to tens of GiB.

  Concretely, four invariants are missing in `ui-tui/src/lib/`:

  1. **No opt-in gate.** `memoryMonitor.tick()` calls `performHeapDump('auto-*')`
     unconditionally on every threshold cross.
  2. **No retention.** `~/.hermes/heapdumps` is never pruned — every dump
     accumulates forever.
  3. **No cooldown.** The `dumped` Set clears on every transition back to
     `normal`, so a heap oscillating around the threshold re-dumps each cycle.
  4. **Snapshot vs diagnostics coupled.** The lightweight `.diagnostics.json`
     sidecar (the actually-actionable artifact) is only written alongside the
     full snapshot, so users couldn't get diagnostics without paying the
     multi-GiB write cost.

  Closes #21767.

  ## Solution

  Four layered safeguards, all in `ui-tui/src/lib/memory.ts`,
  `ui-tui/src/lib/memoryMonitor.ts`, and `ui-tui/src/entry.tsx`:

  1. **Opt-in gate for auto triggers.** `performHeapDump` writes the full
     `.heapsnapshot` for `auto-high` / `auto-critical` only when
     `HERMES_AUTO_HEAPDUMP=1` (also accepts `true|yes|on`, case-insensitive).
     Manual dumps are unchanged.
  2. **Always-on lightweight diagnostics.** The KB-sized `.diagnostics.json`
     sidecar is written on every trigger, including gated auto triggers, so
     users still get an actionable artifact when the snapshot is suppressed.
  3. **Retention guard.** New `pruneHeapdumps(dir)` caps total bytes of all
     files in the dump directory (default 2 GiB, override via
     `HERMES_HEAPDUMP_MAX_BYTES`), evicting oldest first and always retaining
     the newest. Covers both `.heapsnapshot` and orphan `.diagnostics.json`
     files so neither can grow without bound.
  4. **Cooldown in `memoryMonitor`.** A per-process cooldown
     (default 10 min, override via `HERMES_AUTO_HEAPDUMP_COOLDOWN_MS`) prevents
     back-to-back auto dumps when the heap oscillates around the threshold.

  Plus one UX touch-up: `entry.tsx`'s `dumpNotice` now falls back to
  `diagPath` before `'(failed)'`, so users in gated mode see a pointer to the
  diag JSON instead of a misleading "failed" message.

  ## Test plan

  - [x] Manual `performHeapDump('manual')` writes both `.heapsnapshot` and
        `.diagnostics.json` (unchanged behavior).
  - [x] `auto-high` / `auto-critical` without `HERMES_AUTO_HEAPDUMP` write
        diag only, return `success: false` with `diagPath` and an error
        string mentioning the env var.
  - [x] `auto-high` with `HERMES_AUTO_HEAPDUMP=1` writes the full snapshot.
  - [x] Opt-in env var accepts `1 | true | yes | on` (case-insensitive) and
        rejects `0 | false | no | "" | maybe`.
  - [x] Prune respects `HERMES_HEAPDUMP_MAX_BYTES`, deletes oldest first.
  - [x] Prune always retains the newest file even when it alone exceeds the cap.
  - [x] Prune evicts orphan `.diagnostics.json` files (gated-mode accumulation).
  - [x] `memoryMonitor` cooldown prevents back-to-back auto dumps under
        sustained pressure.
  - [x] Cooldown holds across `normal → high → normal → high` oscillation
        (where the `dumped` Set alone would not).
  - [x] `tsc --noEmit` clean against the project's tsconfig.

  ## Compatibility

  - All new behavior is gated by env vars and defaults to safe values; no
    changes to `HeapDumpResult` shape, function signatures, or call sites.
  - Manual dumps (`performHeapDump('manual')`) are byte-for-byte unchanged.