### PR TITLE
fix(kanban): /kanban slash command emits argparse garbage instead of help

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -901,15 +901,25 @@ display:
   interim_assistant_messages: true
 
   # What Enter does when Hermes is already busy (CLI and gateway platforms).
-  #   interrupt: Interrupt the current run and redirect Hermes (default)
-  #   queue:     Queue your message for the next turn
+  #   queue:     Queue your message for the next turn (default — recommended)
   #   steer:     Inject your message mid-run via /steer, arriving at the agent
   #              after the next tool call — no interrupt, no role violation.
   #              Falls back to 'queue' if the agent isn't running yet or if
   #              images are attached (steer only carries text).
+  #   interrupt: Interrupt the current run and redirect Hermes (legacy behavior;
+  #              destructive — typically loses partial work).
   # Ctrl+C (or /stop in gateway) always interrupts regardless of this setting.
   # Toggle at runtime with /busy <interrupt|queue|steer>.
-  busy_input_mode: interrupt
+  # Per-message override: gateway platforms render [Steer][Interrupt][Stop]
+  # buttons on the running tool bubble (see display.busy_buttons below).
+  busy_input_mode: queue
+
+  # Render per-message [Steer][Interrupt][Stop] buttons on the running tool
+  # bubble (gateway platforms with inline-UI support: Telegram, Discord, Slack).
+  # Lets the user pick an outcome per message instead of changing the global
+  # busy_input_mode.  Default on; set to false to disable on a single bot.
+  # Override via env: HERMES_GATEWAY_BUSY_BUTTONS=false
+  busy_buttons: true
 
   # Background process notifications (gateway/messaging only).
   # Controls how chatty the process watcher is when you use

--- a/cli.py
+++ b/cli.py
@@ -335,7 +335,7 @@ def load_cli_config() -> Dict[str, Any]:
             "resume_display": "full",
             "show_reasoning": False,
             "streaming": True,
-            "busy_input_mode": "interrupt",
+            "busy_input_mode": "queue",  # queue (default) | steer | interrupt
             "persistent_output": True,
             "persistent_output_max_lines": 200,
 
@@ -2176,13 +2176,16 @@ class HermesCLI:
         # busy_input_mode: "interrupt" (Enter interrupts current run),
         # "queue" (Enter queues for next turn), or "steer" (Enter injects
         # mid-run via /steer, arriving after the next tool call).
-        _bim = str(CLI_CONFIG["display"].get("busy_input_mode", "interrupt")).strip().lower()
-        if _bim == "queue":
-            self.busy_input_mode = "queue"
+        # Default flipped from "interrupt" → "queue": follow-ups buffered
+        # for next turn instead of destroying partial work.  Per-message
+        # override on gateway platforms via the inline-keyboard buttons.
+        _bim = str(CLI_CONFIG["display"].get("busy_input_mode", "queue")).strip().lower()
+        if _bim == "interrupt":
+            self.busy_input_mode = "interrupt"
         elif _bim == "steer":
             self.busy_input_mode = "steer"
         else:
-            self.busy_input_mode = "interrupt"
+            self.busy_input_mode = "queue"
 
         self.verbose = verbose if verbose is not None else (self.tool_progress_mode == "verbose")
         

--- a/gateway/busy_session_buttons.py
+++ b/gateway/busy_session_buttons.py
@@ -1,0 +1,233 @@
+"""Per-message busy-session control buttons.
+
+Callback-data length: Telegram limits ``InlineKeyboardButton.callback_data``
+to 64 bytes.  ``bs:<primitive>:<session_key>`` exceeds that on
+group/forum sessions whose keys embed long chat/thread/user ids
+(e.g. ``agent:main:telegram:supergroup:-1001234567890:thread:42:user:9876543210``).
+When the literal session_key would overflow, ``build_buttons`` switches
+to a short hash handle (``bs:<primitive>:#<8-char-hash>``) and the
+caller is expected to register the mapping via the returned
+``BusySessionKeyboardSpec.handle_map`` so ``parse_callback_data`` can
+later resolve it back.
+
+
+
+Renders three platform-neutral buttons — /steer, /interrupt, /stop —
+attached to the running tool bubble (or a standalone control bubble
+fallback) while the agent is actively processing. Lets the user pick
+an outcome on a specific follow-up message instead of changing the
+global ``display.busy_input_mode``.
+
+The buttons dispatch into upstream's existing primitives:
+
+- ``steer``     → ``running_agent.steer(text)``    (mid-turn text injection)
+- ``interrupt`` → ``running_agent.interrupt(text)`` (halt + replay text as next turn)
+- ``stop``      → ``_interrupt_and_clear_session(...)`` (halt + idle, no replay)
+
+Reactions on the user's follow-up messages give visible acknowledgement
+that a tap was processed:
+
+- ``steer``     → 👍
+- ``interrupt`` → ⚡
+- ``stop``      → 🙊
+
+Telegram's reaction whitelist constrains the emoji choice; these three
+glyphs are confirmed accepted on default-permission chats.
+
+Callback data wire format::
+
+    bs:<primitive>:<session_key>
+
+Example: ``bs:steer:tg/123/456``. Each platform serializes the
+:class:`BusySessionButton` spec into its native widget — Telegram
+uses ``InlineKeyboardMarkup``, Discord uses ``discord.ui.View``,
+Slack uses Block Kit ``actions`` blocks.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+CALLBACK_PREFIX = "bs"
+
+# Telegram's hard cap on InlineKeyboardButton.callback_data (UTF-8 bytes).
+# Discord and Slack are looser, but we standardize on the strictest so
+# the same callback string round-trips on all three platforms.
+CALLBACK_MAX_BYTES = 64
+
+# Reserved prefix on hashed handles inside callback_data so the parser
+# can distinguish "literal session_key" from "registered handle".
+HANDLE_SIGIL = "#"
+HANDLE_LEN = 12  # truncated SHA-256 hex; 12 chars = 48 bits, ~10^14 keys
+
+PRIMITIVE_STEER = "steer"
+PRIMITIVE_INTERRUPT = "interrupt"
+PRIMITIVE_STOP = "stop"
+
+BUSY_SESSION_PRIMITIVES: Tuple[str, ...] = (
+    PRIMITIVE_STEER,
+    PRIMITIVE_INTERRUPT,
+    PRIMITIVE_STOP,
+)
+
+REACTION_STEER = "👍"
+REACTION_INTERRUPT = "⚡"
+REACTION_STOP = "🙊"
+
+REACTION_BY_PRIMITIVE: dict[str, str] = {
+    PRIMITIVE_STEER: REACTION_STEER,
+    PRIMITIVE_INTERRUPT: REACTION_INTERRUPT,
+    PRIMITIVE_STOP: REACTION_STOP,
+}
+
+# The label rendered on each button. Slash-prefixed so users mentally
+# associate the button with the equivalent slash-command they already
+# know. Keep these short — Telegram, Discord, and Slack all clip long
+# labels (Telegram observed truncating mid-word at ~14 chars).
+BUTTON_LABELS: dict[str, str] = {
+    PRIMITIVE_STEER: "/steer",
+    PRIMITIVE_INTERRUPT: "/interrupt",
+    PRIMITIVE_STOP: "/stop",
+}
+
+
+@dataclass(frozen=True)
+class BusySessionButton:
+    """Platform-neutral spec for one button on the busy-session row."""
+
+    primitive: str
+    label: str
+    callback_data: str
+
+
+def _session_key_handle(session_key: str) -> str:
+    """Stable short hash for a session_key, prefixed with ``HANDLE_SIGIL``."""
+    digest = hashlib.sha256(session_key.encode("utf-8")).hexdigest()[:HANDLE_LEN]
+    return f"{HANDLE_SIGIL}{digest}"
+
+
+@dataclass
+class BusySessionKeyboardSpec:
+    """Built buttons + the (possibly empty) handle→session_key map.
+
+    Callers attaching the keyboard MUST merge ``handle_map`` into their
+    runner-side resolution table so a later tap can translate the
+    hashed handle back to the real session_key.  Empty when no
+    sessions exceeded the 64-byte callback cap.
+    """
+
+    buttons: List[BusySessionButton]
+    handle_map: Dict[str, str] = field(default_factory=dict)
+
+
+def build_buttons(session_key: str) -> List[BusySessionButton]:
+    """Return the ordered list of buttons for a given session.
+
+    Order matches reading direction: steer (least disruptive),
+    interrupt (halt + redirect), stop (halt + idle).
+
+    Backwards-compatible API: returns just the button list.  When
+    callers also need the hashed-handle map (long session keys), they
+    should call :func:`build_buttons_with_handles` instead.
+    """
+    return build_buttons_with_handles(session_key).buttons
+
+
+def build_buttons_with_handles(session_key: str) -> BusySessionKeyboardSpec:
+    """Build buttons and surface the handle map for long session keys."""
+    handle_map: Dict[str, str] = {}
+    payload = session_key
+    # Worst-case fits-test: longest primitive is "interrupt" (9 bytes).
+    longest = max(BUSY_SESSION_PRIMITIVES, key=len)
+    candidate = f"{CALLBACK_PREFIX}:{longest}:{payload}"
+    if len(candidate.encode("utf-8")) > CALLBACK_MAX_BYTES:
+        payload = _session_key_handle(session_key)
+        handle_map[payload] = session_key
+    buttons = [
+        BusySessionButton(
+            primitive=p,
+            label=BUTTON_LABELS[p],
+            callback_data=f"{CALLBACK_PREFIX}:{p}:{payload}",
+        )
+        for p in BUSY_SESSION_PRIMITIVES
+    ]
+    return BusySessionKeyboardSpec(buttons=buttons, handle_map=handle_map)
+
+
+def parse_callback_data(
+    data: Optional[str],
+    *,
+    handle_resolver: Optional[Dict[str, str]] = None,
+) -> Optional[Tuple[str, str]]:
+    """Parse ``bs:<primitive>:<session_key>`` (or hashed handle).
+
+    When ``handle_resolver`` is provided and the third segment starts
+    with :data:`HANDLE_SIGIL`, the function looks the handle up in the
+    resolver and returns the original session_key.  An unresolved
+    handle (e.g. gateway restart cleared the table) returns ``None`` —
+    caller should treat the tap as stale.
+    """
+    if not data or not isinstance(data, str):
+        return None
+    parts = data.split(":", 2)
+    if len(parts) != 3 or parts[0] != CALLBACK_PREFIX:
+        return None
+    primitive, payload = parts[1], parts[2]
+    if primitive not in BUSY_SESSION_PRIMITIVES:
+        return None
+    if not payload:
+        return None
+    if payload.startswith(HANDLE_SIGIL):
+        if handle_resolver is None:
+            return None
+        resolved = handle_resolver.get(payload)
+        if not resolved:
+            return None
+        return primitive, resolved
+    return primitive, payload
+
+
+def reaction_for(primitive: str) -> Optional[str]:
+    """Return the acknowledgement reaction emoji for a primitive."""
+    return REACTION_BY_PRIMITIVE.get(primitive)
+
+
+def status_text(primitive: str, *, language_hint: Optional[str] = None) -> str:
+    """Short toast/ack text shown after a successful button tap.
+
+    ``language_hint`` is currently unused — reserved for future
+    localization based on the matched halt-phrase language.
+    """
+    if primitive == PRIMITIVE_STEER:
+        return "👍 Steered into current run."
+    if primitive == PRIMITIVE_INTERRUPT:
+        return "⚡ Interrupted — your message will start the next turn."
+    if primitive == PRIMITIVE_STOP:
+        return "🙊 Stopped."
+    return ""
+
+
+__all__ = [
+    "BUSY_SESSION_PRIMITIVES",
+    "BUTTON_LABELS",
+    "BusySessionButton",
+    "BusySessionKeyboardSpec",
+    "CALLBACK_MAX_BYTES",
+    "CALLBACK_PREFIX",
+    "HANDLE_LEN",
+    "HANDLE_SIGIL",
+    "PRIMITIVE_INTERRUPT",
+    "PRIMITIVE_STEER",
+    "PRIMITIVE_STOP",
+    "REACTION_BY_PRIMITIVE",
+    "REACTION_INTERRUPT",
+    "REACTION_STEER",
+    "REACTION_STOP",
+    "build_buttons",
+    "build_buttons_with_handles",
+    "parse_callback_data",
+    "reaction_for",
+    "status_text",
+]

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1410,6 +1410,71 @@ class BasePlatformAdapter(ABC):
     def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
         """Set an optional handler for messages arriving during active sessions."""
         self._busy_session_handler = handler
+
+    # ------------------------------------------------------------------
+    # Busy-session controls (per-message inline buttons + reactions)
+    #
+    # Default implementations are no-ops so platforms without inline-UI
+    # support (Matrix, Feishu, DingTalk, WhatsApp, iMessage…) inherit
+    # silently and the runner's busy handler can call them
+    # unconditionally.  Telegram, Discord, and Slack override.
+    # ------------------------------------------------------------------
+
+    async def set_busy_reaction(self, event: "MessageEvent", emoji: str) -> bool:
+        """Emit an acknowledgement reaction on a user follow-up message.
+
+        Called from the runner after a busy-session button tap (👍 / ⚡
+        / 🙊) and after a halt-phrase match.  Returns True on success,
+        False on failure.  Default: no-op.
+        """
+        return False
+
+    async def attach_busy_session_buttons(
+        self,
+        session_key: str,
+        message_id: str,
+    ) -> bool:
+        """Attach the [/steer][/interrupt][/stop] keyboard to ``message_id``.
+
+        ``message_id`` is the current tool-progress bubble for the session.
+        Default: no-op.
+        """
+        return False
+
+    async def clear_busy_session_buttons(
+        self,
+        session_key: str,
+        message_id: str,
+    ) -> bool:
+        """Remove the busy-session keyboard from ``message_id``.
+
+        Called on turn end and on every tool-bubble reset.  Default: no-op.
+        """
+        return False
+
+    async def send_or_update_busy_control_bubble(
+        self,
+        session_key: str,
+        source: Any,  # SessionSource — kept as Any to avoid circular import.
+        summary_text: str,
+    ) -> Optional[str]:
+        """Send a standalone control message when no tool bubble exists.
+
+        Returns the platform's message id of the control bubble so the
+        runner can edit / delete it later.  Default: no-op (returns
+        None).
+        """
+        return None
+
+    async def delete_busy_control_bubble(
+        self,
+        session_key: str,
+        message_id: str,
+    ) -> bool:
+        """Delete the standalone control bubble previously sent by
+        ``send_or_update_busy_control_bubble``.  Default: no-op.
+        """
+        return False
     
     def set_session_store(self, session_store: Any) -> None:
         """

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -532,6 +532,12 @@ class DiscordAdapter(BasePlatformAdapter):
         self._ready_event = asyncio.Event()
         self._allowed_user_ids: set = set()  # For button approval authorization
         self._allowed_role_ids: set = set()  # For DISCORD_ALLOWED_ROLES filtering
+        # Busy-session view state: session_key → message_id of the
+        # message currently carrying the [Steer][Interrupt][Stop] view.
+        # Discord's BusySessionView holds session_key on the view
+        # instance directly, so callback_data length isn't a concern here.
+        self._busy_session_view_map: Dict[str, str] = {}
+        self._busy_control_bubble_ids: Dict[str, str] = {}
         self.gateway_runner = None  # Set by gateway/run.py for cross-platform delivery
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
@@ -4995,3 +5001,360 @@ if DISCORD_AVAILABLE:
         async def on_timeout(self):
             self.resolved = True
             self.clear_items()
+
+    # ── Busy-session view + adapter overrides ─────────────────────────
+
+    class BusySessionView(discord.ui.View):
+        """Three-button view for per-message busy-session control.
+
+        Lets the user pick steer / interrupt / stop on a specific
+        follow-up message instead of changing the global
+        ``display.busy_input_mode``.  Auth mirrors the other component
+        views via :func:`_component_check_auth`.
+        """
+
+        def __init__(
+            self,
+            session_key: str,
+            adapter_self: "DiscordAdapter",
+            allowed_user_ids: set,
+            allowed_role_ids: Optional[set] = None,
+        ):
+            # No timeout: a busy-session lives as long as the agent is
+            # busy, which is bounded by the agent's own iteration cap.
+            super().__init__(timeout=None)
+            self.session_key = session_key
+            self._adapter = adapter_self
+            self.allowed_user_ids = allowed_user_ids
+            self.allowed_role_ids = allowed_role_ids or set()
+
+        def _check_auth(self, interaction: discord.Interaction) -> bool:
+            return _component_check_auth(
+                interaction, self.allowed_user_ids, self.allowed_role_ids,
+            )
+
+        async def _dispatch(
+            self,
+            interaction: discord.Interaction,
+            primitive: str,
+        ) -> None:
+            if not self._check_auth(interaction):
+                await interaction.response.send_message(
+                    "You're not authorized to control this run~", ephemeral=True,
+                )
+                return
+            await interaction.response.defer(ephemeral=True)
+            applied = False
+            try:
+                toast = await self._adapter._handle_busy_session_view_tap(
+                    self.session_key, primitive, interaction,
+                )
+                # The runner returns toast strings starting with "⛔" or
+                # "Couldn't" / "Unknown" / "Busy-session" when it
+                # rejected/failed.  Treat anything else as a successful
+                # apply so we only freeze the row when the action
+                # actually fired.
+                applied = bool(toast) and not (
+                    toast.startswith("⛔")
+                    or toast.lower().startswith(("couldn't", "unknown", "busy-session"))
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error(
+                    "[%s] BusySessionView dispatch failed: %s",
+                    self._adapter.name, exc, exc_info=True,
+                )
+                toast = "Couldn't apply that — see logs."
+            try:
+                await interaction.followup.send(toast or "Done.", ephemeral=True)
+            except Exception:
+                pass
+            # Only disable the shared button row after a SUCCESSFUL apply.
+            # An ownership-rejection from a non-owner clicker must not
+            # take the controls away from the legitimate session owner.
+            if applied:
+                for child in self.children:
+                    child.disabled = True
+                try:
+                    await interaction.message.edit(view=self)
+                except Exception:
+                    pass
+
+        @discord.ui.button(label="Steer", style=discord.ButtonStyle.green)
+        async def steer(
+            self, interaction: discord.Interaction, button: discord.ui.Button
+        ):
+            from gateway.busy_session_buttons import PRIMITIVE_STEER
+            await self._dispatch(interaction, PRIMITIVE_STEER)
+
+        @discord.ui.button(label="Interrupt", style=discord.ButtonStyle.blurple)
+        async def interrupt(
+            self, interaction: discord.Interaction, button: discord.ui.Button
+        ):
+            from gateway.busy_session_buttons import PRIMITIVE_INTERRUPT
+            await self._dispatch(interaction, PRIMITIVE_INTERRUPT)
+
+        @discord.ui.button(label="Stop", style=discord.ButtonStyle.red)
+        async def stop(
+            self, interaction: discord.Interaction, button: discord.ui.Button
+        ):
+            from gateway.busy_session_buttons import PRIMITIVE_STOP
+            await self._dispatch(interaction, PRIMITIVE_STOP)
+
+    # ── Adapter-level busy-session methods ───────────────────────────
+    #
+    # These functions are defined inside the ``if DISCORD_AVAILABLE:``
+    # block (so the BusySessionView reference resolves), then bound onto
+    # ``DiscordAdapter`` at the bottom of the block.  Without this
+    # binding step Discord instances would inherit the no-op base
+    # implementations and the buttons would never render.
+
+    @staticmethod
+    def _ds_busy_buttons_enabled() -> bool:
+        raw = os.getenv("HERMES_GATEWAY_BUSY_BUTTONS")
+        if raw is None:
+            return True
+        return raw.strip().lower() not in ("0", "false", "no", "off")
+
+    def _ds_chat_id_for_session(self, session_key: str) -> Optional[str]:
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        if runner is None:
+            return None
+        followups = getattr(runner, "_pending_followups", {}) or {}
+        for ev in reversed(followups.get(session_key) or []):
+            chat_id = getattr(getattr(ev, "source", None), "chat_id", None)
+            if chat_id:
+                return str(chat_id)
+        return None
+
+    async def _ds_attach_busy_session_buttons(
+        self,
+        session_key: str,
+        message_id: str,
+    ) -> bool:
+        if not self._busy_buttons_enabled() or not self._client:
+            return False
+        chat_id = self._chat_id_for_session(session_key)
+        if not chat_id:
+            return False
+        try:
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            msg = await channel.fetch_message(int(message_id))
+            view = BusySessionView(
+                session_key=session_key,
+                adapter_self=self,
+                allowed_user_ids=self._allowed_user_ids,
+                allowed_role_ids=self._allowed_role_ids,
+            )
+            await msg.edit(view=view)
+            self._busy_session_view_map[session_key] = str(message_id)
+            return True
+        except Exception as exc:
+            logger.debug(
+                "[%s] attach_busy_session_buttons failed for %s on %s: %s",
+                self.name, session_key, message_id, exc,
+            )
+            return False
+
+    async def _ds_clear_busy_session_buttons(
+        self,
+        session_key: str,
+        message_id: str,
+    ) -> bool:
+        # Only forget the tracked anchor if the caller is clearing the
+        # one currently mapped — otherwise multiple anchors can't be
+        # cleared independently.
+        if self._busy_session_view_map.get(session_key) == str(message_id):
+            self._busy_session_view_map.pop(session_key, None)
+        if not self._client:
+            return False
+        chat_id = self._chat_id_for_session(session_key)
+        if not chat_id:
+            return False
+        try:
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            msg = await channel.fetch_message(int(message_id))
+            await msg.edit(view=None)
+            return True
+        except Exception as exc:
+            logger.debug(
+                "[%s] clear_busy_session_buttons failed for %s on %s: %s",
+                self.name, session_key, message_id, exc,
+            )
+            return False
+
+    async def _ds_send_or_update_busy_control_bubble(
+        self,
+        session_key: str,
+        source: Any,
+        summary_text: str,
+    ) -> Optional[str]:
+        if not self._busy_buttons_enabled() or not self._client:
+            return None
+        chat_id_raw = getattr(source, "chat_id", None) if source else None
+        if not chat_id_raw:
+            return None
+        try:
+            channel = self._client.get_channel(int(chat_id_raw))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id_raw))
+        except Exception as exc:
+            logger.debug(
+                "[%s] control-bubble channel resolve failed for %s: %s",
+                self.name, session_key, exc,
+            )
+            return None
+        view = BusySessionView(
+            session_key=session_key,
+            adapter_self=self,
+            allowed_user_ids=self._allowed_user_ids,
+            allowed_role_ids=self._allowed_role_ids,
+        )
+        existing = self._busy_control_bubble_ids.get(session_key)
+        if existing:
+            try:
+                msg = await channel.fetch_message(int(existing))
+                await msg.edit(content=summary_text, view=view)
+                self._busy_session_view_map[session_key] = existing
+                return existing
+            except Exception:
+                self._busy_control_bubble_ids.pop(session_key, None)
+        try:
+            sent = await channel.send(content=summary_text, view=view)
+        except Exception as exc:
+            logger.debug(
+                "[%s] control-bubble send failed for %s: %s",
+                self.name, session_key, exc,
+            )
+            return None
+        msg_id = str(getattr(sent, "id", "")) or None
+        if msg_id:
+            self._busy_control_bubble_ids[session_key] = msg_id
+            self._busy_session_view_map[session_key] = msg_id
+        return msg_id
+
+    async def _ds_delete_busy_control_bubble(
+        self,
+        session_key: str,
+        message_id: str,
+    ) -> bool:
+        self._busy_control_bubble_ids.pop(session_key, None)
+        if not self._client:
+            return False
+        chat_id = self._chat_id_for_session(session_key)
+        if not chat_id:
+            return False
+        try:
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            msg = await channel.fetch_message(int(message_id))
+            await msg.delete()
+            return True
+        except Exception as exc:
+            logger.debug(
+                "[%s] delete_busy_control_bubble failed for %s on %s: %s",
+                self.name, session_key, message_id, exc,
+            )
+            return False
+
+    async def _ds_set_busy_reaction(self, event: MessageEvent, emoji: str) -> bool:
+        msg = getattr(event, "raw_message", None)
+        if msg is None or not hasattr(msg, "add_reaction"):
+            return False
+        try:
+            await self._add_reaction(msg, emoji)
+            return True
+        except Exception:
+            return False
+
+    async def _ds_handle_busy_session_view_tap(
+        self,
+        session_key: str,
+        primitive: str,
+        interaction: Any,
+    ) -> str:
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        handler = getattr(runner, "_handle_busy_session_button_tap", None)
+        if not callable(handler):
+            return "Busy-session controls unavailable."
+        try:
+            from gateway.session import SessionSource
+            user = getattr(interaction, "user", None)
+            channel = getattr(interaction, "channel", None)
+            user_id = str(getattr(user, "id", "")) if user else ""
+            user_name = getattr(user, "display_name", None) if user else None
+            # Match how inbound messages build the source so the runner's
+            # ownership check (build_session_key) computes the same key.
+            # Discord thread runs use chat_id == thread_id and chat_type
+            # "thread"; channel runs use chat_id == channel.id and
+            # chat_type "group"; DMs use "dm".
+            ch_type = getattr(channel, "type", None)
+            is_thread = isinstance(channel, discord.Thread) if channel is not None else False
+            if ch_type == discord.ChannelType.private:
+                chat_type = "dm"
+                chat_id = str(getattr(channel, "id", "")) if channel else ""
+                thread_id = None
+            elif is_thread:
+                chat_type = "thread"
+                chat_id = str(getattr(channel, "id", "")) if channel else ""
+                thread_id = chat_id  # thread channels report their own id as the thread id
+            else:
+                chat_type = "group"
+                chat_id = str(getattr(channel, "id", "")) if channel else ""
+                thread_id = None
+            source = SessionSource(
+                platform=Platform.DISCORD,
+                chat_id=chat_id,
+                chat_type=chat_type,
+                user_id=user_id,
+                user_name=user_name,
+                thread_id=thread_id,
+            )
+        except Exception as exc:
+            logger.debug("[%s] could not build SessionSource for view tap: %s", self.name, exc)
+            return "Couldn't apply that — try again."
+        # Run the runner-side authorization check too — the BusySessionView
+        # already gates on _component_check_auth, but that allowlist is
+        # empty in deployments that authorize via GATEWAY_ALLOWED_USERS or
+        # pairing.  Without this second gate, any user who can see the
+        # buttons in a shared channel could steer/interrupt/stop another
+        # user's active session.  Mirrors the Slack handler's belt-and-
+        # suspenders gating.
+        auth_fn = getattr(runner, "_is_user_authorized", None)
+        if callable(auth_fn):
+            try:
+                if not auth_fn(source):
+                    logger.warning(
+                        "[%s] Unauthorized busy-session view tap by %s (%s) — ignoring",
+                        self.name, user_name or "?", user_id,
+                    )
+                    return "⛔ You are not authorized to control this run."
+            except Exception:
+                logger.debug(
+                    "[%s] auth check raised — denying busy-action", self.name, exc_info=True,
+                )
+                return "Couldn't apply that — try again."
+        try:
+            return await handler(session_key, primitive, source)
+        except Exception as exc:
+            logger.error(
+                "[%s] busy-session view dispatch failed: %s",
+                self.name, exc, exc_info=True,
+            )
+            return "Couldn't apply that — see logs."
+
+    # Bind the busy-session helpers onto DiscordAdapter so they OVERRIDE
+    # the base class no-ops.  Without this step they remain free
+    # functions and Discord falls back to BasePlatformAdapter.
+    DiscordAdapter._busy_buttons_enabled = staticmethod(_ds_busy_buttons_enabled)
+    DiscordAdapter._chat_id_for_session = _ds_chat_id_for_session
+    DiscordAdapter.attach_busy_session_buttons = _ds_attach_busy_session_buttons
+    DiscordAdapter.clear_busy_session_buttons = _ds_clear_busy_session_buttons
+    DiscordAdapter.send_or_update_busy_control_bubble = _ds_send_or_update_busy_control_bubble
+    DiscordAdapter.delete_busy_control_bubble = _ds_delete_busy_control_bubble
+    DiscordAdapter.set_busy_reaction = _ds_set_busy_reaction
+    DiscordAdapter._handle_busy_session_view_tap = _ds_handle_busy_session_view_tap

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -327,6 +327,11 @@ class SlackAdapter(BasePlatformAdapter):
         # (channel_id, user_id) to avoid cross-user collisions.
         # Each value: {"response_url": str, "ts": float}
         self._slash_command_contexts: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        # Busy-session button state.  ``_busy_session_button_map`` keyed
+        # by session_key holds (channel_id, ts) of the message currently
+        # carrying the [Steer][Interrupt][Stop] block.
+        self._busy_session_button_map: Dict[str, Tuple[str, str]] = {}
+        self._busy_control_bubble_ids: Dict[str, Tuple[str, str]] = {}
 
     def _describe_slack_api_error(self, response: Any, *, file_obj: Optional[Dict[str, Any]] = None) -> Optional[str]:
         """Convert Slack API auth/permission failures into actionable user-facing text."""
@@ -660,6 +665,14 @@ class SlackAdapter(BasePlatformAdapter):
             ):
                 self._app.action(_action_id)(self._handle_slash_confirm_action)
 
+            # Register Block Kit action handlers for busy-session buttons.
+            for _action_id in (
+                "hermes_busy_steer",
+                "hermes_busy_interrupt",
+                "hermes_busy_stop",
+            ):
+                self._app.action(_action_id)(self._handle_busy_session_action)
+
             # Start Socket Mode handler in background
             self._handler = AsyncSocketModeHandler(self._app, app_token, proxy=proxy_url)
             _apply_slack_proxy(self._handler.client, proxy_url)
@@ -820,16 +833,40 @@ class SlackAdapter(BasePlatformAdapter):
         *,
         finalize: bool = False,
     ) -> SendResult:
-        """Edit a previously sent Slack message."""
+        """Edit a previously sent Slack message.
+
+        If ``message_id`` is currently anchoring a busy-session keyboard,
+        we re-render the message with both the new text AND the actions
+        block so the buttons survive the edit — Slack's chat_update
+        otherwise drops blocks if only ``text`` is supplied.
+        """
         if not self._app:
             return SendResult(success=False, error="Not connected")
         try:
             formatted = self.format_message(content)
-            await self._get_client(chat_id).chat_update(
-                channel=chat_id,
-                ts=message_id,
-                text=formatted,
-            )
+            update_kwargs: Dict[str, Any] = {
+                "channel": chat_id,
+                "ts": message_id,
+                "text": formatted,
+            }
+            # Re-attach busy-session action block if this message is the
+            # current anchor (value-side lookup against the small map).
+            try:
+                anchored_session = next(
+                    (
+                        sk
+                        for sk, coords in self._busy_session_button_map.items()
+                        if coords == (chat_id, message_id)
+                    ),
+                    None,
+                )
+                if anchored_session:
+                    update_kwargs["blocks"] = self._busy_session_blocks(
+                        anchored_session, formatted or " "
+                    )
+            except Exception:
+                pass
+            await self._get_client(chat_id).chat_update(**update_kwargs)
             if finalize:
                 await self.stop_typing(chat_id)
             return SendResult(success=True, message_id=message_id)
@@ -2946,3 +2983,444 @@ class SlackAdapter(BasePlatformAdapter):
         if isinstance(raw, str) and raw.strip():
             return {part.strip() for part in raw.split(",") if part.strip()}
         return set()
+    # ----- Busy-session controls -----
+
+    @staticmethod
+    def _busy_buttons_enabled() -> bool:
+        raw = os.getenv("HERMES_GATEWAY_BUSY_BUTTONS")
+        if raw is None:
+            return True
+        return raw.strip().lower() not in ("0", "false", "no", "off")
+
+    # Slack's section-text mrkdwn field has a hard 3000-char cap.  Long
+    # tool-progress bubbles can exceed it; rendering them inside a section
+    # block triggers `invalid_blocks` from chat_update.  We truncate here
+    # so the buttons can attach without breaking the underlying message.
+    # The fallback `text` field on chat_update preserves the full body for
+    # legacy clients.
+    _BUSY_SECTION_TEXT_CAP = 2900  # leave headroom under Slack's 3000 limit
+
+    @classmethod
+    def _truncate_for_block(cls, text: str) -> str:
+        if not text:
+            return ""
+        if len(text) <= cls._BUSY_SECTION_TEXT_CAP:
+            return text
+        return text[: cls._BUSY_SECTION_TEXT_CAP - 1] + "…"
+
+    def _busy_session_blocks(
+        self,
+        session_key: str,
+        summary_text: str,
+    ) -> List[Dict[str, Any]]:
+        """Build the Block Kit blocks carrying [Steer][Interrupt][Stop]."""
+        section_text = self._truncate_for_block(summary_text) or "_Working…_"
+        return [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": section_text},
+            },
+            {
+                "type": "actions",
+                "block_id": f"hermes_busy::{session_key}",
+                "elements": [
+                    {
+                        "type": "button",
+                        "action_id": "hermes_busy_steer",
+                        "text": {"type": "plain_text", "text": "Steer", "emoji": True},
+                        "value": session_key,
+                        "style": "primary",
+                    },
+                    {
+                        "type": "button",
+                        "action_id": "hermes_busy_interrupt",
+                        "text": {"type": "plain_text", "text": "Interrupt", "emoji": True},
+                        "value": session_key,
+                    },
+                    {
+                        "type": "button",
+                        "action_id": "hermes_busy_stop",
+                        "text": {"type": "plain_text", "text": "Stop", "emoji": True},
+                        "value": session_key,
+                        "style": "danger",
+                    },
+                ],
+            },
+        ]
+
+    def _channel_ts_for_session(
+        self, session_key: str
+    ) -> Optional[Tuple[str, str]]:
+        """Return (channel_id, ts) where the keyboard is currently anchored."""
+        return self._busy_session_button_map.get(session_key)
+
+    def _resolve_busy_channel_id(self, session_key: str) -> Optional[str]:
+        """Resolve a Slack channel id for ``session_key`` from runner state."""
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        if runner is None:
+            return None
+        followups = getattr(runner, "_pending_followups", {}) or {}
+        for ev in reversed(followups.get(session_key) or []):
+            chat_id = getattr(getattr(ev, "source", None), "chat_id", None)
+            if chat_id:
+                return str(chat_id)
+        return None
+
+    async def _fetch_slack_message_text(
+        self,
+        channel_id: str,
+        message_id: str,
+        thread_ts: Optional[str] = None,
+    ) -> str:
+        """Best-effort fetch of an existing Slack message's text.
+
+        ``conversations_history`` only returns top-level channel messages
+        — thread replies are NOT addressable by ts.  When the message is
+        a thread reply, fall back to ``conversations_replies`` and locate
+        the target ts in the reply list.  Returns "" if the message
+        can't be found, so callers fall back gracefully.
+        """
+        if not self._app:
+            return ""
+        client = self._get_client(channel_id)
+        # Top-level: history works.
+        try:
+            hist = await client.conversations_history(
+                channel=channel_id, latest=message_id,
+                inclusive=True, limit=1,
+            )
+            msgs = hist.get("messages") if hasattr(hist, "get") else None
+            if msgs:
+                got = msgs[0]
+                if got.get("ts") == message_id:
+                    return got.get("text") or ""
+        except Exception:
+            pass
+        # Thread reply: look it up via replies.  We don't always know the
+        # parent thread_ts; try the explicit one first, then probe with
+        # the message ts as the parent (single-reply threads).
+        candidates: List[str] = []
+        if thread_ts:
+            candidates.append(thread_ts)
+        candidates.append(message_id)
+        for parent_ts in candidates:
+            try:
+                replies = await client.conversations_replies(
+                    channel=channel_id, ts=parent_ts, limit=200,
+                )
+                for m in replies.get("messages", []) if hasattr(replies, "get") else []:
+                    if m.get("ts") == message_id:
+                        return m.get("text") or ""
+            except Exception:
+                continue
+        return ""
+
+    async def attach_busy_session_buttons(
+        self,
+        session_key: str,
+        message_id: str,
+    ) -> bool:
+        """Attach the busy-session block to ``message_id`` (Slack ts).
+
+        Re-renders the target message via ``chat_update`` so the actions
+        block (Steer / Interrupt / Stop) appears underneath the existing
+        body.  ``message_id`` IS the Slack message ts.  The runner pairs
+        it with a channel id resolved from the most-recent follow-up's
+        source.
+        """
+        if not self._busy_buttons_enabled() or not self._app:
+            return False
+        channel_id = self._resolve_busy_channel_id(session_key)
+        if not channel_id:
+            return False
+        existing = self._busy_session_button_map.get(session_key)
+        if existing == (channel_id, message_id):
+            return True
+        try:
+            client = self._get_client(channel_id)
+            # Resolve thread_ts from runner state for the most recent
+            # follow-up so the threaded-message text lookup uses the
+            # correct API.
+            thread_ts = self._resolve_busy_thread_ts(session_key)
+            current_text = await self._fetch_slack_message_text(
+                channel_id, message_id, thread_ts=thread_ts,
+            )
+            # If we still couldn't fetch the body, abort the chat_update
+            # rather than blanking the message with "Working…".  The
+            # buttons attach on the next progress edit instead.
+            if not current_text:
+                logger.debug(
+                    "[%s] busy-button attach skipped for %s on %s: body fetch returned empty",
+                    self.name, session_key, message_id,
+                )
+                return False
+            blocks = self._busy_session_blocks(session_key, current_text)
+            await client.chat_update(
+                channel=channel_id,
+                ts=message_id,
+                text=current_text,
+                blocks=blocks,
+            )
+            self._busy_session_button_map[session_key] = (channel_id, message_id)
+            return True
+        except Exception as exc:
+            logger.debug(
+                "[%s] attach_busy_session_buttons failed for %s on %s: %s",
+                self.name, session_key, message_id, exc,
+            )
+            return False
+
+    def _resolve_busy_thread_ts(self, session_key: str) -> Optional[str]:
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        if runner is None:
+            return None
+        followups = getattr(runner, "_pending_followups", {}) or {}
+        for ev in reversed(followups.get(session_key) or []):
+            thread_id = getattr(getattr(ev, "source", None), "thread_id", None)
+            if thread_id:
+                return str(thread_id)
+        return None
+
+    async def clear_busy_session_buttons(
+        self,
+        session_key: str,
+        message_id: str,
+    ) -> bool:
+        """Drop the busy-session actions block from ``message_id``.
+
+        Operates on the SPECIFIC ``message_id`` requested (not just the
+        stored mapping) so that clearing the latest anchor doesn't
+        leave older anchors with live keyboards.  Re-renders the
+        message with its existing body but no actions block — the chat
+        history stays intact, only the buttons go away.
+        """
+        if not self._app:
+            return False
+        channel_id = self._resolve_busy_channel_id(session_key)
+        if not channel_id:
+            # Fallback to the stored mapping if we still have it.
+            coords = self._busy_session_button_map.get(session_key)
+            channel_id = coords[0] if coords else None
+        if not channel_id or not message_id:
+            self._busy_session_button_map.pop(session_key, None)
+            return False
+        # Pop the mapping ONLY when clearing the currently-tracked anchor,
+        # so callers iterating multiple anchors don't break each other.
+        tracked = self._busy_session_button_map.get(session_key)
+        if tracked == (channel_id, message_id):
+            self._busy_session_button_map.pop(session_key, None)
+        try:
+            client = self._get_client(channel_id)
+            thread_ts = self._resolve_busy_thread_ts(session_key)
+            current_text = await self._fetch_slack_message_text(
+                channel_id, message_id, thread_ts=thread_ts,
+            )
+            # If we couldn't recover the body, skip the destructive
+            # chat_update — leaving the keyboard attached is much less
+            # bad than overwriting an unrelated message.  The keyboard
+            # will eventually clear when the cached message ages out.
+            if not current_text:
+                logger.debug(
+                    "[%s] busy-button clear skipped for %s on %s: body fetch returned empty",
+                    self.name, session_key, message_id,
+                )
+                return False
+            section_text = self._truncate_for_block(current_text)
+            await client.chat_update(
+                channel=channel_id,
+                ts=message_id,
+                # Preserve the body text; keyboard goes away by sending
+                # an empty blocks list (top-level text remains).
+                text=current_text,
+                blocks=[
+                    {"type": "section", "text": {"type": "mrkdwn", "text": section_text or " "}}
+                ],
+            )
+            return True
+        except Exception as exc:
+            logger.debug(
+                "[%s] clear_busy_session_buttons failed for %s on %s: %s",
+                self.name, session_key, message_id, exc,
+            )
+            return False
+
+    async def send_or_update_busy_control_bubble(
+        self,
+        session_key: str,
+        source: Any,
+        summary_text: str,
+    ) -> Optional[str]:
+        if not self._busy_buttons_enabled() or not self._app:
+            return None
+        channel_id = getattr(source, "chat_id", None) if source else None
+        if not channel_id:
+            return None
+        thread_ts = getattr(source, "thread_id", None) if source else None
+        blocks = self._busy_session_blocks(session_key, summary_text)
+        existing = self._busy_control_bubble_ids.get(session_key)
+        try:
+            client = self._get_client(channel_id)
+            if existing:
+                _, ts = existing
+                await client.chat_update(
+                    channel=channel_id,
+                    ts=ts,
+                    text=summary_text,
+                    blocks=blocks,
+                )
+                self._busy_session_button_map[session_key] = (channel_id, ts)
+                return ts
+            kwargs: Dict[str, Any] = {
+                "channel": channel_id,
+                "text": summary_text,
+                "blocks": blocks,
+            }
+            if thread_ts:
+                kwargs["thread_ts"] = thread_ts
+            result = await client.chat_postMessage(**kwargs)
+            ts = result.get("ts") if isinstance(result, dict) else getattr(result, "data", {}).get("ts")
+            if not ts:
+                return None
+            self._busy_control_bubble_ids[session_key] = (channel_id, str(ts))
+            self._busy_session_button_map[session_key] = (channel_id, str(ts))
+            return str(ts)
+        except Exception as exc:
+            logger.debug(
+                "[%s] busy control-bubble send/update failed for %s: %s",
+                self.name, session_key, exc,
+            )
+            return None
+
+    async def delete_busy_control_bubble(
+        self,
+        session_key: str,
+        message_id: str,
+    ) -> bool:
+        coords = self._busy_control_bubble_ids.pop(session_key, None)
+        if not coords or not self._app:
+            return False
+        channel_id, ts = coords
+        try:
+            await self._get_client(channel_id).chat_delete(
+                channel=channel_id, ts=ts,
+            )
+            return True
+        except Exception as exc:
+            logger.debug(
+                "[%s] delete_busy_control_bubble failed for %s: %s",
+                self.name, session_key, exc,
+            )
+            return False
+
+    async def set_busy_reaction(self, event: MessageEvent, emoji: str) -> bool:
+        chat_id = getattr(event.source, "chat_id", None) if event and event.source else None
+        ts = getattr(event, "message_id", None) if event else None
+        if not chat_id or not ts:
+            return False
+        # Slack reaction names are textual (e.g. "thumbsup"), not glyphs.
+        slack_name = self._slack_reaction_name(emoji)
+        if not slack_name:
+            return False
+        return await self._add_reaction(chat_id, str(ts), slack_name)
+
+    @staticmethod
+    def _slack_reaction_name(emoji: str) -> Optional[str]:
+        """Translate a glyph to a Slack reaction shortcode."""
+        return {
+            "👍": "thumbsup",
+            "⚡": "zap",
+            "🙊": "speak_no_evil",
+            "🙈": "see_no_evil",
+            "👀": "eyes",
+            "✅": "white_check_mark",
+            "❌": "x",
+        }.get(emoji)
+
+    async def _handle_busy_session_action(self, ack, body, action) -> None:
+        """Handle a busy-session button click from Block Kit."""
+        await ack()
+        action_id = action.get("action_id", "")
+        session_key = action.get("value", "")
+        user_id = body.get("user", {}).get("id", "")
+        user_name = body.get("user", {}).get("name", "unknown")
+        channel_id = body.get("channel", {}).get("id", "")
+
+        primitive_map = {
+            "hermes_busy_steer": "steer",
+            "hermes_busy_interrupt": "interrupt",
+            "hermes_busy_stop": "stop",
+        }
+        primitive = primitive_map.get(action_id)
+        if not primitive or not session_key:
+            return
+
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        handler = getattr(runner, "_handle_busy_session_button_tap", None)
+        if not callable(handler):
+            return
+
+        try:
+            from gateway.session import SessionSource
+            # Match how inbound messages build the source.  Slack DMs
+            # come from channels prefixed with "D" (im/mpim).  The
+            # action body's `message` carries `thread_ts` for thread
+            # context; top-level messages set thread_ts == ts == the
+            # message's own ts in tests, so we read it directly from
+            # the action payload.
+            ch_type_hint = body.get("channel", {}).get("channel_type", "") or ""
+            is_dm = ch_type_hint in ("im", "mpim") or channel_id.startswith("D")
+            msg_meta = body.get("message", {}) or {}
+            thread_ts = msg_meta.get("thread_ts") or msg_meta.get("ts") or None
+            source = SessionSource(
+                platform=Platform.SLACK,
+                chat_id=channel_id,
+                chat_type="dm" if is_dm else "group",
+                user_id=user_id,
+                user_name=user_name,
+                thread_id=str(thread_ts) if thread_ts else None,
+            )
+        except Exception as exc:
+            logger.debug("[Slack] could not build SessionSource for busy action: %s", exc)
+            return
+
+        # Route through the runner's full authorization stack so
+        # GATEWAY_ALLOWED_USERS / pairing / org-level rules apply,
+        # not just SLACK_ALLOWED_USERS.  Block Kit actions skip the
+        # normal message handler so without this check any workspace
+        # user could steer/interrupt/stop another user's session.
+        auth_fn = getattr(runner, "_is_user_authorized", None)
+        if callable(auth_fn):
+            try:
+                if not auth_fn(source):
+                    logger.warning(
+                        "[Slack] Unauthorized busy-session click by %s (%s) — ignoring",
+                        user_name, user_id,
+                    )
+                    return
+            except Exception:
+                logger.debug("[Slack] auth check raised — denying busy-action", exc_info=True)
+                return
+        else:
+            # No runner auth available — fall back to SLACK_ALLOWED_USERS
+            # only if it's set; if it's empty in this fallback path we
+            # FAIL CLOSED rather than allow-all.
+            allowed_csv = os.getenv("SLACK_ALLOWED_USERS", "").strip()
+            if not allowed_csv:
+                logger.warning(
+                    "[Slack] No runner auth + empty SLACK_ALLOWED_USERS — denying busy-action"
+                )
+                return
+            allowed_ids = {uid.strip() for uid in allowed_csv.split(",") if uid.strip()}
+            if "*" not in allowed_ids and user_id not in allowed_ids:
+                logger.warning(
+                    "[Slack] Unauthorized busy-session click by %s (%s) — ignoring",
+                    user_name, user_id,
+                )
+                return
+
+        try:
+            await handler(session_key, primitive, source)
+        except Exception as exc:
+            logger.error(
+                "[Slack] busy-session action dispatch failed: %s", exc, exc_info=True,
+            )

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -305,6 +305,21 @@ class TelegramAdapter(BasePlatformAdapter):
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
+        # Busy-session button state: session_key → message_id of the bubble
+        # currently carrying the [/steer][/interrupt][/stop] keyboard.  Used
+        # by edit_message() to re-attach the keyboard on every progress
+        # edit (a plain edit_message_text would otherwise strip it).
+        self._busy_session_button_map: Dict[str, str] = {}
+        # Long-session-key callback handle table (#hash → session_key).
+        # Telegram callback_data is capped at 64 bytes; long group/forum
+        # session keys overflow, so we substitute a hashed handle and
+        # resolve it back here on tap.  Populated from
+        # build_buttons_with_handles().handle_map at attach time.
+        self._busy_session_handles: Dict[str, str] = {}
+        # Standalone busy-session control-bubble state: session_key → msg_id.
+        # Tracked separately from the tool-progress bubble so the runner can
+        # delete the control bubble at turn end without touching the tool log.
+        self._busy_control_bubble_ids: Dict[str, str] = {}
 
     def _is_callback_user_authorized(
         self,
@@ -329,8 +344,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
                 if normalized_chat_type == "private":
                     normalized_chat_type = "dm"
-                elif normalized_chat_type == "supergroup":
-                    normalized_chat_type = "forum" if thread_id is not None else "group"
+                elif normalized_chat_type in ("supergroup", "group"):
+                    # Telegram inbound messages key both group and supergroup
+                    # (incl. forum topics) as chat_type="group" plus thread_id.
+                    # Match that here so the runner's session_key reconstruction
+                    # produces the SAME key as the original inbound message.
+                    normalized_chat_type = "group"
 
                 source = SessionSource(
                     platform=Platform.TELEGRAM,
@@ -1368,28 +1387,58 @@ class TelegramAdapter(BasePlatformAdapter):
         *,
         finalize: bool = False,
     ) -> SendResult:
-        """Edit a previously sent Telegram message."""
+        """Edit a previously sent Telegram message.
+
+        If ``message_id`` is currently anchoring a busy-session keyboard,
+        we re-attach that keyboard on the edit — Telegram's
+        ``edit_message_text`` strips ``reply_markup`` unless explicitly
+        included, which would otherwise wipe the [/steer][/interrupt]
+        [/stop] row on every tool-progress update.
+        """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+        # Re-attach the busy-session keyboard if this message is currently
+        # the keyboard's anchor.  Done via a value-side lookup against the
+        # map (small dict; max ~few active sessions).
+        busy_keyboard = None
+        try:
+            anchored_session = next(
+                (
+                    sk
+                    for sk, mid in self._busy_session_button_map.items()
+                    if str(mid) == str(message_id)
+                ),
+                None,
+            )
+            if anchored_session:
+                busy_keyboard = self._build_busy_session_keyboard(anchored_session)
+        except Exception:
+            busy_keyboard = None
         try:
             formatted = self.format_message(content)
             try:
-                await self._bot.edit_message_text(
+                edit_kwargs: Dict[str, Any] = dict(
                     chat_id=int(chat_id),
                     message_id=int(message_id),
                     text=formatted,
                     parse_mode=ParseMode.MARKDOWN_V2,
                 )
+                if busy_keyboard is not None:
+                    edit_kwargs["reply_markup"] = busy_keyboard
+                await self._bot.edit_message_text(**edit_kwargs)
             except Exception as fmt_err:
                 # "Message is not modified" is a no-op, not an error
                 if "not modified" in str(fmt_err).lower():
                     return SendResult(success=True, message_id=message_id)
                 # Fallback: retry without markdown formatting
-                await self._bot.edit_message_text(
+                fallback_kwargs: Dict[str, Any] = dict(
                     chat_id=int(chat_id),
                     message_id=int(message_id),
                     text=content,
                 )
+                if busy_keyboard is not None:
+                    fallback_kwargs["reply_markup"] = busy_keyboard
+                await self._bot.edit_message_text(**fallback_kwargs)
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
             err_str = str(e).lower()
@@ -2060,6 +2109,18 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._bot.send_message(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Busy-session button callbacks (bs:primitive:session_key) ---
+        if data.startswith("bs:"):
+            await self._handle_busy_session_callback(
+                query,
+                data,
+                chat_id=query_chat_id,
+                chat_type=query_chat_type,
+                thread_id=query_thread_id,
+                user_name=query_user_name,
+            )
             return
 
         # --- Update prompt callbacks ---
@@ -3742,3 +3803,374 @@ class TelegramAdapter(BasePlatformAdapter):
                 message_id,
                 "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
             )
+
+    # ── Busy-session buttons + reactions ─────────────────────────────────
+
+    @staticmethod
+    def _busy_buttons_enabled() -> bool:
+        """Whether to render the [/steer][/interrupt][/stop] keyboard.
+
+        Toggle via env (HERMES_GATEWAY_BUSY_BUTTONS) or
+        ``display.busy_buttons`` in the gateway config.  Default on.
+        """
+        raw = os.getenv("HERMES_GATEWAY_BUSY_BUTTONS")
+        if raw is None:
+            return True
+        return raw.strip().lower() not in ("0", "false", "no", "off")
+
+    def _build_busy_session_keyboard(self, session_key: str) -> Optional[Any]:
+        """Build the InlineKeyboardMarkup for the busy-session control row.
+
+        Registers any hashed handle in ``self._busy_session_handles`` so
+        the callback handler can resolve it back to ``session_key`` even
+        when the literal key would have overflowed Telegram's 64-byte
+        callback_data cap.
+        """
+        if InlineKeyboardMarkup is None or InlineKeyboardButton is None:
+            return None
+        if InlineKeyboardMarkup is Any:  # python-telegram-bot not installed
+            return None
+        from gateway.busy_session_buttons import build_buttons_with_handles
+        spec = build_buttons_with_handles(session_key)
+        if spec.handle_map:
+            self._busy_session_handles.update(spec.handle_map)
+        row = [
+            InlineKeyboardButton(text=b.label, callback_data=b.callback_data)
+            for b in spec.buttons
+        ]
+        return InlineKeyboardMarkup([row])
+
+    async def attach_busy_session_buttons(
+        self,
+        session_key: str,
+        message_id: str,
+    ) -> bool:
+        """Attach (or replace) the busy-session keyboard on ``message_id``."""
+        if not self._busy_buttons_enabled():
+            return False
+        if not self._bot or not message_id:
+            return False
+        # Resolve chat_id from runner state (runner stores last-known chat
+        # via SessionSource on the most recent follow-up).  We piggyback on
+        # the runner's _pending_followups (deduplication set) to find it.
+        chat_id = self._chat_id_for_session(session_key)
+        if not chat_id:
+            return False
+        keyboard = self._build_busy_session_keyboard(session_key)
+        if keyboard is None:
+            return False
+        try:
+            await self._bot.edit_message_reply_markup(
+                chat_id=int(chat_id),
+                message_id=int(message_id),
+                reply_markup=keyboard,
+            )
+        except Exception as exc:
+            # "message is not modified" is benign (same keyboard already
+            # attached after a prior progress edit re-applied it).
+            err = str(exc).lower()
+            if "not modified" in err:
+                self._busy_session_button_map[session_key] = str(message_id)
+                return True
+            logger.debug(
+                "[%s] attach_busy_session_buttons failed for session %s on %s: %s",
+                self.name,
+                session_key,
+                message_id,
+                exc,
+            )
+            return False
+        self._busy_session_button_map[session_key] = str(message_id)
+        return True
+
+    async def clear_busy_session_buttons(
+        self,
+        session_key: str,
+        message_id: str,
+    ) -> bool:
+        """Detach the busy-session keyboard from ``message_id``."""
+        recorded = self._busy_session_button_map.pop(session_key, None)
+        if not self._bot or not message_id:
+            return False
+        chat_id = self._chat_id_for_session(session_key)
+        if not chat_id:
+            return False
+        try:
+            await self._bot.edit_message_reply_markup(
+                chat_id=int(chat_id),
+                message_id=int(message_id),
+                reply_markup=None,
+            )
+        except Exception as exc:
+            err = str(exc).lower()
+            # Common, harmless: the bubble was already deleted, or the
+            # keyboard already removed by a prior edit.
+            if "not modified" in err or "message to edit not found" in err:
+                return True
+            logger.debug(
+                "[%s] clear_busy_session_buttons failed for session %s on %s: %s",
+                self.name,
+                session_key,
+                message_id,
+                exc,
+            )
+            return False
+        return True
+
+    async def send_or_update_busy_control_bubble(
+        self,
+        session_key: str,
+        source: Any,
+        summary_text: str,
+    ) -> Optional[str]:
+        """Send/update a standalone control bubble when no tool bubble exists."""
+        if not self._busy_buttons_enabled():
+            return None
+        if not self._bot:
+            return None
+        chat_id_raw = getattr(source, "chat_id", None) if source else None
+        if not chat_id_raw:
+            return None
+        keyboard = self._build_busy_session_keyboard(session_key)
+        if keyboard is None:
+            return None
+        thread_id = getattr(source, "thread_id", None) if source else None
+
+        existing = self._busy_control_bubble_ids.get(session_key)
+        if existing:
+            try:
+                await self._bot.edit_message_text(
+                    chat_id=int(chat_id_raw),
+                    message_id=int(existing),
+                    text=summary_text,
+                    reply_markup=keyboard,
+                )
+                return existing
+            except Exception as exc:
+                err = str(exc).lower()
+                if "not modified" not in err:
+                    logger.debug(
+                        "[%s] control-bubble edit failed for %s, falling back to send: %s",
+                        self.name,
+                        session_key,
+                        exc,
+                    )
+                    self._busy_control_bubble_ids.pop(session_key, None)
+                else:
+                    return existing
+
+        try:
+            send_kwargs = {
+                "chat_id": int(chat_id_raw),
+                "text": summary_text,
+                "reply_markup": keyboard,
+            }
+            if thread_id:
+                try:
+                    send_kwargs["message_thread_id"] = int(thread_id)
+                except (TypeError, ValueError):
+                    pass
+            sent = await self._bot.send_message(**send_kwargs)
+        except Exception as exc:
+            logger.debug(
+                "[%s] control-bubble send failed for %s: %s",
+                self.name,
+                session_key,
+                exc,
+            )
+            return None
+        msg_id = getattr(sent, "message_id", None)
+        if msg_id is not None:
+            self._busy_control_bubble_ids[session_key] = str(msg_id)
+            self._busy_session_button_map[session_key] = str(msg_id)
+            return str(msg_id)
+        return None
+
+    async def delete_busy_control_bubble(
+        self,
+        session_key: str,
+        message_id: str,
+    ) -> bool:
+        """Delete the standalone control bubble for ``session_key``."""
+        self._busy_control_bubble_ids.pop(session_key, None)
+        if not self._bot or not message_id:
+            return False
+        chat_id = self._chat_id_for_session(session_key)
+        if not chat_id:
+            return False
+        try:
+            await self._bot.delete_message(
+                chat_id=int(chat_id),
+                message_id=int(message_id),
+            )
+        except Exception as exc:
+            err = str(exc).lower()
+            if "message to delete not found" in err or "message can't be deleted" in err:
+                return True
+            logger.debug(
+                "[%s] delete_busy_control_bubble failed for %s on %s: %s",
+                self.name,
+                session_key,
+                message_id,
+                exc,
+            )
+            return False
+        return True
+
+    async def set_busy_reaction(self, event: MessageEvent, emoji: str) -> bool:
+        """Emit a busy-session acknowledgement reaction on ``event``.
+
+        Uses ``ReactionTypeEmoji`` explicitly to avoid python-telegram-bot's
+        variation-selector serialization bug — bare emoji strings with VS-16
+        (e.g. ⚡️) are otherwise mis-routed as ``custom_emoji_id`` and rejected.
+        """
+        if not self._bot or not emoji:
+            return False
+        chat_id = getattr(event.source, "chat_id", None) if event and event.source else None
+        message_id = getattr(event, "message_id", None) if event else None
+        if not chat_id or not message_id:
+            return False
+        try:
+            from telegram import ReactionTypeEmoji  # type: ignore
+            reaction = [ReactionTypeEmoji(emoji=emoji)]
+        except Exception:
+            reaction = emoji  # fallback — older telegram lib
+        try:
+            await self._bot.set_message_reaction(
+                chat_id=int(chat_id),
+                message_id=int(message_id),
+                reaction=reaction,
+            )
+            return True
+        except Exception as exc:
+            logger.debug(
+                "[%s] set_busy_reaction(%s) failed: %s",
+                self.name,
+                emoji,
+                exc,
+            )
+            return False
+
+    def _chat_id_for_session(self, session_key: str) -> Optional[str]:
+        """Resolve a Telegram chat_id for a session_key.
+
+        The busy-session APIs receive only ``session_key + message_id`` from
+        the runner; Telegram's edit/delete APIs need the chat_id too.  Pull
+        it from the runner's pending follow-up event (the most recent inbound
+        message in this busy turn) which has it on its ``source``.
+        """
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        if runner is None:
+            return None
+        followups = getattr(runner, "_pending_followups", {}) or {}
+        events = followups.get(session_key) or []
+        for event in reversed(events):
+            chat_id = getattr(getattr(event, "source", None), "chat_id", None)
+            if chat_id:
+                return str(chat_id)
+        # Fallback: look up from active running-agents source if exposed.
+        running = getattr(runner, "_running_agents", {}) or {}
+        agent = running.get(session_key)
+        source = getattr(agent, "_session_source", None)
+        if source is not None:
+            chat_id = getattr(source, "chat_id", None)
+            if chat_id:
+                return str(chat_id)
+        return None
+
+    async def _handle_busy_session_callback(
+        self,
+        query: Any,
+        data: str,
+        *,
+        chat_id: Optional[Any],
+        chat_type: Optional[Any],
+        thread_id: Optional[Any],
+        user_name: Optional[Any],
+    ) -> None:
+        """Dispatch a ``bs:<primitive>:<session_key>`` button tap."""
+        from gateway.busy_session_buttons import parse_callback_data
+
+        parsed = parse_callback_data(
+            data, handle_resolver=self._busy_session_handles
+        )
+        if parsed is None:
+            try:
+                await query.answer(text="Invalid button data.")
+            except Exception:
+                pass
+            return
+        primitive, session_key = parsed
+
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=chat_id,
+            chat_type=str(chat_type) if chat_type is not None else None,
+            thread_id=str(thread_id) if thread_id is not None else None,
+            user_name=user_name,
+        ):
+            try:
+                await query.answer(text="⛔ You are not authorized to control this run.")
+            except Exception:
+                pass
+            return
+
+        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        handler = getattr(runner, "_handle_busy_session_button_tap", None)
+        if not callable(handler):
+            try:
+                await query.answer(text="Busy-session controls unavailable.")
+            except Exception:
+                pass
+            return
+
+        # Reconstruct a SessionSource for the dispatch.
+        try:
+            from gateway.session import SessionSource
+
+            normalized_chat_type = str(chat_type or "dm").strip().lower() or "dm"
+            if normalized_chat_type == "private":
+                normalized_chat_type = "dm"
+            elif normalized_chat_type in ("supergroup", "group"):
+                # Inbound messages key both group and supergroup (incl.
+                # forum topics) as chat_type="group" + thread_id.
+                # Match that here so the runner's session_key
+                # reconstruction produces the SAME key as the
+                # original inbound message.
+                normalized_chat_type = "group"
+            source = SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id=str(chat_id) if chat_id is not None else "",
+                chat_type=normalized_chat_type,
+                user_id=caller_id,
+                user_name=user_name,
+                thread_id=str(thread_id) if thread_id is not None else None,
+            )
+        except Exception as exc:
+            logger.debug("[%s] could not build SessionSource for bs callback: %s", self.name, exc)
+            try:
+                await query.answer(text="Couldn't apply that — try again.")
+            except Exception:
+                pass
+            return
+
+        try:
+            toast = await handler(session_key, primitive, source)
+        except Exception as exc:
+            logger.error(
+                "[%s] busy-session button dispatch failed: %s",
+                self.name,
+                exc,
+                exc_info=True,
+            )
+            try:
+                await query.answer(text="Couldn't apply that — see logs.")
+            except Exception:
+                pass
+            return
+
+        try:
+            await query.answer(text=toast or "Done.")
+        except Exception:
+            pass

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4073,6 +4073,78 @@ class GatewayRunner:
                     break
                 await asyncio.sleep(1)
 
+    @staticmethod
+    def _kanban_profile_default_board(kanban_cfg: dict) -> str:
+        """Return the default kanban board for this gateway profile.
+
+        Explicit config wins.  Otherwise infer the obvious profile→board
+        mapping so a profile gateway does not inherit the shared
+        ``kanban/current`` file as ambient global state.
+        """
+        explicit = str(
+            kanban_cfg.get("default_board")
+            or os.environ.get("HERMES_KANBAN_DEFAULT_BOARD")
+            or ""
+        ).strip()
+        if explicit:
+            return explicit
+        try:
+            from hermes_cli.profiles import get_active_profile_name
+            profile = (get_active_profile_name() or "default").strip().lower()
+        except Exception:
+            profile = os.environ.get("HERMES_PROFILE", "default").strip().lower()
+        aliases = {
+            "default": "hermes",
+            "nagatha": "hermes",
+            "hermes": "hermes",
+            "klasificados": "klasificados",
+            "nagaklas": "klasificados",
+            "nagovernor": "governor",
+            "governor": "governor",
+            "skippy": "skippy",
+        }
+        return aliases.get(profile, profile or "default")
+
+    @classmethod
+    def _kanban_scoped_board_slugs(cls, kanban_cfg: dict, key: str, kb_module: Any) -> list[str]:
+        """Resolve dispatcher/notifier board scope from config.
+
+        ``kanban.dispatch_boards`` / ``kanban.notify_boards`` may be a
+        list or comma-separated string.  ``["*"]`` preserves the old
+        all-boards behavior deliberately.  When unset, use the profile's
+        default board only.
+        """
+        env_key = f"HERMES_KANBAN_{key.upper()}"
+        raw = os.environ.get(env_key)
+        if raw is None:
+            raw = kanban_cfg.get(key)
+        if raw is None:
+            raw = [cls._kanban_profile_default_board(kanban_cfg)]
+        if isinstance(raw, str):
+            parts = [p.strip() for p in raw.split(",") if p.strip()]
+        elif isinstance(raw, (list, tuple, set)):
+            parts = [str(p).strip() for p in raw if str(p).strip()]
+        else:
+            parts = []
+        if not parts:
+            parts = [cls._kanban_profile_default_board(kanban_cfg)]
+        if "*" in parts:
+            try:
+                boards = kb_module.list_boards(include_archived=False)
+            except Exception:
+                boards = [kb_module.read_board_metadata(kb_module.DEFAULT_BOARD)]
+            return [b.get("slug") or kb_module.DEFAULT_BOARD for b in boards]
+        out: list[str] = []
+        for slug in parts:
+            try:
+                normed = kb_module._normalize_board_slug(slug) or kb_module.DEFAULT_BOARD
+            except Exception:
+                logger.warning("kanban: ignoring invalid board slug %r in %s", slug, key)
+                continue
+            if normed not in out:
+                out.append(normed)
+        return out or [kb_module.DEFAULT_BOARD]
+
     async def _kanban_notifier_watcher(self, interval: float = 5.0) -> None:
         """Poll ``kanban_notify_subs`` and deliver terminal events to users.
 
@@ -4098,6 +4170,14 @@ class GatewayRunner:
         except Exception:
             logger.warning("kanban notifier: kanban_db not importable; notifier disabled")
             return
+        try:
+            from hermes_cli.config import load_config as _load_config
+            cfg = _load_config()
+        except Exception:
+            cfg = {}
+        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        notify_boards = self._kanban_scoped_board_slugs(kanban_cfg, "notify_boards", _kb)
+        logger.info("kanban notifier: scoped to boards=%s", ",".join(notify_boards))
 
         TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out")
         # Terminal event kinds trigger automatic unsubscription — the task
@@ -4124,15 +4204,10 @@ class GatewayRunner:
             try:
                 def _collect():
                     deliveries: list[dict] = []
-                    # Enumerate every board on disk. Cheap: a few
-                    # directory stat calls per tick. Missing/empty
-                    # boards are silently skipped.
-                    try:
-                        boards = _kb.list_boards(include_archived=False)
-                    except Exception:
-                        boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
-                    for board_meta in boards:
-                        slug = board_meta.get("slug") or _kb.DEFAULT_BOARD
+                    # Poll only the boards this gateway profile owns (or
+                    # the explicit kanban.notify_boards list).  Use
+                    # notify_boards: ["*"] to preserve old all-board fan-out.
+                    for slug in notify_boards:
                         try:
                             conn = _kb.connect(board=slug)
                         except Exception:
@@ -4410,6 +4485,8 @@ class GatewayRunner:
             )
             failure_limit = _kb.DEFAULT_FAILURE_LIMIT
 
+        dispatch_boards = self._kanban_scoped_board_slugs(kanban_cfg, "dispatch_boards", _kb)
+
         # Initial delay so the gateway finishes wiring adapters before the
         # dispatcher spawns workers (those workers may hit gateway notify
         # subscriptions etc.). Matches the notifier watcher's delay.
@@ -4455,19 +4532,9 @@ class GatewayRunner:
                         pass
 
         def _tick_once() -> "list[tuple[str, Optional[object]]]":
-            """Run one dispatch_once per board. Returns (slug, result) pairs.
-
-            Enumerating boards on every tick keeps the dispatcher honest
-            when users create a new board mid-run: no restart required,
-            the next tick picks it up automatically.
-            """
-            try:
-                boards = _kb.list_boards(include_archived=False)
-            except Exception:
-                boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+            """Run one dispatch_once per configured/owned board."""
             out: list[tuple[str, "Optional[object]"]] = []
-            for b in boards:
-                slug = b.get("slug") or _kb.DEFAULT_BOARD
+            for slug in dispatch_boards:
                 out.append((slug, _tick_once_for_board(slug)))
             return out
 
@@ -4483,12 +4550,7 @@ class GatewayRunner:
             here keeps the stuck-warn fire only on real failures (broken
             PATH, missing venv, credential loss for a real Hermes profile).
             """
-            try:
-                boards = _kb.list_boards(include_archived=False)
-            except Exception:
-                boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
-            for b in boards:
-                slug = b.get("slug") or _kb.DEFAULT_BOARD
+            for slug in dispatch_boards:
                 conn = None
                 try:
                     conn = _kb.connect(board=slug)
@@ -4505,7 +4567,9 @@ class GatewayRunner:
             return False
 
         logger.info(
-            "kanban dispatcher: embedded in gateway (interval=%.1fs)", interval
+            "kanban dispatcher: embedded in gateway (interval=%.1fs, boards=%s)",
+            interval,
+            ",".join(dispatch_boards),
         )
         while self._running:
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4119,7 +4119,10 @@ class GatewayRunner:
         if raw is None:
             raw = kanban_cfg.get(key)
         if raw is None:
-            raw = [cls._kanban_profile_default_board(kanban_cfg)]
+            try:
+                raw = [kb_module.get_profile_default_board()]
+            except Exception:
+                raw = [cls._kanban_profile_default_board(kanban_cfg)]
         if isinstance(raw, str):
             parts = [p.strip() for p in raw.split(",") if p.strip()]
         elif isinstance(raw, (list, tuple, set)):
@@ -4127,7 +4130,10 @@ class GatewayRunner:
         else:
             parts = []
         if not parts:
-            parts = [cls._kanban_profile_default_board(kanban_cfg)]
+            try:
+                parts = [kb_module.get_profile_default_board()]
+            except Exception:
+                parts = [cls._kanban_profile_default_board(kanban_cfg)]
         if "*" in parts:
             try:
                 boards = kb_module.list_boards(include_archived=False)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -468,6 +468,8 @@ if _config_path.exists():
                 os.environ["HERMES_GATEWAY_BUSY_INPUT_MODE"] = str(_display_cfg["busy_input_mode"])
             if "busy_ack_enabled" in _display_cfg:
                 os.environ["HERMES_GATEWAY_BUSY_ACK_ENABLED"] = str(_display_cfg["busy_ack_enabled"])
+            if "busy_buttons" in _display_cfg:
+                os.environ["HERMES_GATEWAY_BUSY_BUTTONS"] = str(_display_cfg["busy_buttons"])
         # Timezone: bridge config.yaml → HERMES_TIMEZONE env var.
         _tz_cfg = _cfg.get("timezone", "")
         if _tz_cfg and isinstance(_tz_cfg, str):
@@ -561,6 +563,17 @@ from gateway.platforms.base import (
     MessageType,
     merge_pending_message_event,
 )
+from gateway.busy_session_buttons import (
+    PRIMITIVE_INTERRUPT,
+    PRIMITIVE_STEER,
+    PRIMITIVE_STOP,
+    REACTION_INTERRUPT,
+    REACTION_STEER,
+    REACTION_STOP,
+    reaction_for as _busy_button_reaction_for,
+    status_text as _busy_button_status_text,
+)
+from gateway.stop_phrases import matches_stop_phrase
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
@@ -1056,7 +1069,7 @@ class GatewayRunner:
     # Class-level defaults so partial construction in tests doesn't
     # blow up on attribute access.
     _running_agents_ts: Dict[str, float] = {}
-    _busy_input_mode: str = "interrupt"
+    _busy_input_mode: str = "queue"
     _restart_drain_timeout: float = DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
     _exit_code: Optional[int] = None
     _draining: bool = False
@@ -1133,6 +1146,26 @@ class GatewayRunner:
         # cannot grow unbounded over a long-running gateway lifetime.
         self._session_sources: "OrderedDict[str, SessionSource]" = OrderedDict()
         self._session_sources_max = 512
+
+        # Per-session tool-progress bubble msg_id (single growing message
+        # edited as tools fire). Written by send_progress_messages() and
+        # read by the busy-session button-attach path so it knows which
+        # message to anchor the [/steer][/interrupt][/stop] keyboard to.
+        self._tool_bubble_msg_ids: Dict[str, str] = {}
+
+        # Per-session list of ack-message ids that currently hold a
+        # busy-session keyboard.  A long-running turn with multiple
+        # follow-ups across the 30s ack-cooldown can produce more than
+        # one ack message — every ack still has its own keyboard, so
+        # cleanup must clear all of them, not just the most recent.
+        self._busy_control_bubble_ids: Dict[str, List[str]] = {}
+
+        # Per-session FIFO of follow-up MessageEvents that arrived while
+        # the agent was busy.  A button tap acts on ALL of them — texts
+        # are joined, the chosen primitive fires once, and a reaction is
+        # emitted on each event's message_id so every follow-up gets an
+        # acknowledgement.
+        self._pending_followups: Dict[str, List[MessageEvent]] = {}
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -2188,11 +2221,11 @@ class GatewayRunner:
                     mode = str(cfg_get(cfg, "display", "busy_input_mode", default="") or "").strip().lower()
             except Exception:
                 pass
-        if mode == "queue":
-            return "queue"
+        if mode == "interrupt":
+            return "interrupt"
         if mode == "steer":
             return "steer"
-        return "interrupt"
+        return "queue"
 
     @staticmethod
     def _load_restart_drain_timeout() -> float:
@@ -2320,6 +2353,19 @@ class GatewayRunner:
             )
             return True  # handled (silently dropped); do not fall through
 
+        # --- Multilingual halt-phrase pre-flight ---
+        # A short message that matches a literal stop intent (English "stop",
+        # Spanish "alto", Japanese "止まれ", lone "/", empty msg, etc.) halts
+        # the running agent immediately, no matter what busy_input_mode is
+        # configured.  This is the language-neutral equivalent of /stop —
+        # users on phones rarely remember the slash command.
+        msg_type = getattr(event, "message_type", None)
+        if msg_type is None or msg_type == MessageType.TEXT or event.text:
+            halt_lang = matches_stop_phrase(event.text)
+            if halt_lang is not None:
+                if await self._handle_halt_phrase_match(event, session_key, halt_lang):
+                    return True
+
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:
             adapter = self.adapters.get(event.source.platform)
@@ -2390,6 +2436,20 @@ class GatewayRunner:
                 running_agent.interrupt(event.text)
             except Exception:
                 pass  # don't let interrupt failure block the ack
+
+        # Track this follow-up for the button-tap path (a tap acts on every
+        # follow-up that arrived during the current busy turn) and ensure
+        # the [/steer][/interrupt][/stop] keyboard is attached to the
+        # active tool bubble — or a standalone control bubble if no tool
+        # has fired yet.  Best-effort: failures are logged and don't block
+        # the busy ack.
+        try:
+            _pf = getattr(self, "_pending_followups", None)
+            if _pf is not None:
+                _pf.setdefault(session_key, []).append(event)
+            await self._ensure_busy_session_controls(session_key, event)
+        except Exception as _bs_err:
+            logger.debug("Busy-session control attach failed for %s: %s", session_key, _bs_err)
 
         # Check if busy ack is disabled — skip sending but still process the input.
         # Placed before debounce so we don't stamp a "last ack" timestamp that was
@@ -2475,7 +2535,7 @@ class GatewayRunner:
 
         thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
         try:
-            await adapter._send_with_retry(
+            ack_result = await adapter._send_with_retry(
                 chat_id=event.source.chat_id,
                 content=message,
                 reply_to=event.message_id,
@@ -2483,8 +2543,453 @@ class GatewayRunner:
             )
         except Exception as e:
             logger.debug("Failed to send busy-ack: %s", e)
+            ack_result = None
+
+        # Attach the busy-session keyboard to the ack message (or use
+        # the tool bubble as the anchor if one exists).  This makes the
+        # ack message itself the per-message control surface, so we
+        # never produce a duplicate "/queue'd: ..." + standalone-control
+        # message pair.
+        if ack_result is not None and getattr(ack_result, "success", False):
+            ack_msg_id = getattr(ack_result, "message_id", None)
+            if ack_msg_id:
+                try:
+                    await self._anchor_busy_session_buttons_to_ack(
+                        session_key, event, str(ack_msg_id)
+                    )
+                except Exception as _bs_err:
+                    logger.debug(
+                        "Anchoring busy-session keyboard to ack failed for %s: %s",
+                        session_key,
+                        _bs_err,
+                    )
 
         return True
+
+    # ------------------------------------------------------------------
+    # Busy-session controls — halt-phrase + per-message buttons
+    # ------------------------------------------------------------------
+
+    async def _handle_halt_phrase_match(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        lang: str,
+    ) -> bool:
+        """Halt the running agent in response to a literal stop intent.
+
+        Triggered from the busy handler when ``matches_stop_phrase()``
+        returns non-None.  Bypasses the configured ``busy_input_mode`` —
+        a stop intent is unconditional.
+        """
+        running_agent = self._running_agents.get(session_key)
+        adapter = self.adapters.get(event.source.platform) if event.source else None
+
+        # Acknowledge with the stop reaction directly on the user's
+        # message before tearing things down — emoji on the user's
+        # original message is the only feedback they get if the rest
+        # of the cleanup races their next action.
+        if adapter is not None and hasattr(adapter, "set_busy_reaction"):
+            try:
+                await adapter.set_busy_reaction(event, REACTION_STOP)
+            except Exception as exc:
+                logger.debug("Halt-phrase reaction failed for %s: %s", session_key, exc)
+
+        # Make sure the halt event is visible to platform-side
+        # ``_chat_id_for_session`` lookups during cleanup — without
+        # this, a halt phrase that fires before any other follow-up
+        # has been registered leaves no chat_id source for
+        # ``clear_busy_session_buttons`` to use.
+        if hasattr(self, "_pending_followups"):
+            self._pending_followups.setdefault(session_key, []).append(event)
+
+        # Run the FULL stop path so the chat unlocks even when the
+        # agent is wedged inside a tool or still represented by the
+        # pending sentinel: invalidates the run generation, calls
+        # interrupt_session_activity, drops queued events, and frees
+        # the running-state slot.  Mirrors `/stop` and the [Stop]
+        # button so all three paths converge behaviorally.
+        try:
+            await self._interrupt_and_clear_session(
+                session_key,
+                event.source,
+                interrupt_reason=_INTERRUPT_REASON_STOP,
+                invalidation_reason=f"halt-phrase: {lang}",
+            )
+        except Exception as exc:
+            logger.debug("Halt-phrase clear-session failed for %s: %s", session_key, exc)
+            # Best-effort fallback so the agent at least stops.
+            try:
+                if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+                    running_agent.interrupt(None)
+            except Exception:
+                pass
+
+        logger.info(
+            "Busy-session halt-phrase matched (lang=%s) for session %s",
+            lang,
+            session_key,
+        )
+        return True
+
+    async def _ensure_busy_session_controls(
+        self,
+        session_key: str,
+        event: MessageEvent,
+    ) -> None:
+        """Attach the [/steer][/interrupt][/stop] keyboard for the session.
+
+        Anchors the keyboard to the current tool-progress bubble when one
+        exists.  When no tool bubble is live yet (pre-first-tool / mid-
+        streaming-response), the upstream busy-ack message itself becomes
+        the anchor — see ``_anchor_busy_session_buttons_to_ack`` invoked
+        from ``_handle_active_session_busy_message`` after the ack send.
+        Two anchors (ack + tool bubble) are fine: both refer to the same
+        session and either tap acts on every queued follow-up.
+        """
+        adapter = self.adapters.get(event.source.platform) if event.source else None
+        if adapter is None:
+            return
+
+        _tbm = getattr(self, "_tool_bubble_msg_ids", None)
+        bubble_id = _tbm.get(session_key) if _tbm else None
+        if bubble_id and hasattr(adapter, "attach_busy_session_buttons"):
+            try:
+                await adapter.attach_busy_session_buttons(session_key, bubble_id)
+            except Exception as exc:
+                logger.debug(
+                    "attach_busy_session_buttons failed for %s on %s: %s",
+                    session_key,
+                    bubble_id,
+                    exc,
+                )
+
+    async def _anchor_busy_session_buttons_to_ack(
+        self,
+        session_key: str,
+        event: MessageEvent,
+        ack_msg_id: str,
+    ) -> None:
+        """Treat the upstream busy-ack message as the keyboard anchor.
+
+        Avoids the duplicate "queue'd / control-bubble" pair by reusing
+        the message that's already going to be sent.  The previous
+        anchor (if any) keeps its keyboard intact — both are valid tap
+        targets and the user only sees the most recent one anyway.  The
+        new id replaces the tracked control-bubble so end-of-turn
+        cleanup detaches the right keyboard.
+        """
+        adapter = self.adapters.get(event.source.platform) if event.source else None
+        if adapter is None:
+            return
+        if not hasattr(adapter, "attach_busy_session_buttons"):
+            return
+        try:
+            await adapter.attach_busy_session_buttons(session_key, ack_msg_id)
+        except Exception as exc:
+            logger.debug(
+                "ack-anchor attach failed for %s on %s: %s",
+                session_key,
+                ack_msg_id,
+                exc,
+            )
+            return
+        _bcb = getattr(self, "_busy_control_bubble_ids", None)
+        if _bcb is not None:
+            existing = _bcb.setdefault(session_key, [])
+            if ack_msg_id not in existing:
+                existing.append(ack_msg_id)
+
+    async def _handle_busy_session_button_tap(
+        self,
+        session_key: str,
+        primitive: str,
+        source: SessionSource,
+    ) -> str:
+        """Apply a busy-session button tap to a session.
+
+        Drains every follow-up that arrived during the current busy
+        turn, joins their texts, and dispatches the selected primitive
+        once.  Emits an acknowledgement reaction on each follow-up.
+        Returns a short status string suitable for a callback toast.
+        """
+        if primitive not in (PRIMITIVE_STEER, PRIMITIVE_INTERRUPT, PRIMITIVE_STOP):
+            return "Unknown action."
+
+        # Ownership gate: in shared channels with per-user session keys,
+        # user A's busy-session buttons are visible to user B.  An
+        # otherwise-authorized user B could otherwise tap them and
+        # control A's run.  Resolve the session_key for the tapping user
+        # the SAME way inbound messages do (via the runner-configured
+        # resolver that honors `group_sessions_per_user` / `thread_sessions_per_user`
+        # from the session store) and compare against the target key.
+        try:
+            tapper_key = self._session_key_for_source(source) if source else None
+        except Exception:
+            tapper_key = None
+        if tapper_key and tapper_key != session_key:
+            logger.warning(
+                "Busy-session button cross-user tap rejected: "
+                "tapper=%s wants to control session=%s (their own session=%s)",
+                getattr(source, "user_id", "?"),
+                session_key,
+                tapper_key,
+            )
+            return "⛔ This isn't your session."
+
+        adapter = self.adapters.get(source.platform) if source else None
+        _pf = getattr(self, "_pending_followups", None)
+        # Take a copy of the follow-ups but DO NOT pop yet — platform
+        # ``_chat_id_for_session`` resolves the chat_id from this list
+        # during ``_clear_busy_session_controls``.  Popping early would
+        # leave stale keyboards in chat.  ``_clear_busy_session_controls``
+        # itself pops at the end of cleanup.
+        followups = list(_pf.get(session_key, []) or []) if _pf else []
+        joined_text = "\n\n".join(
+            (e.text or "").strip() for e in followups if (e.text or "").strip()
+        )
+
+        # Capture the ack anchors BEFORE applying the primitive — the stop
+        # path runs ``_interrupt_and_clear_session`` which itself calls
+        # ``_clear_busy_session_controls`` and pops the control-bubble
+        # list, so by the time the finally block runs we'd otherwise have
+        # lost the msg_ids needed to rewrite ack text.
+        _bcb = getattr(self, "_busy_control_bubble_ids", None)
+        ack_msg_ids_for_rewrite: List[str] = (
+            list(_bcb.get(session_key) or []) if _bcb else []
+        )
+
+        running_agent = self._running_agents.get(session_key)
+        ok = True
+        try:
+            if primitive == PRIMITIVE_STEER:
+                steered = False
+                if (
+                    running_agent
+                    and running_agent is not _AGENT_PENDING_SENTINEL
+                    and hasattr(running_agent, "steer")
+                    and joined_text
+                ):
+                    try:
+                        steered = bool(running_agent.steer(joined_text))
+                    except Exception as exc:
+                        logger.debug("Button-tap steer failed for %s: %s", session_key, exc)
+                if steered:
+                    # The text landed inside the run.  Normally we then
+                    # pop the queued copy so it isn't ALSO replayed as
+                    # the next-turn prompt.  Exception: if the queued
+                    # event carries media (steer is text-only and can't
+                    # ferry an image/document), KEEP the event queued so
+                    # the next turn still gets the attachment — only
+                    # null the text portion that already landed via steer.
+                    if adapter is not None and hasattr(adapter, "_pending_messages"):
+                        pending = adapter._pending_messages.get(session_key)
+                        has_media = bool(getattr(pending, "media_urls", None))
+                        if has_media:
+                            try:
+                                pending.text = ""  # text already steered in
+                            except Exception:
+                                pass
+                        else:
+                            adapter._pending_messages.pop(session_key, None)
+                else:
+                    ok = False
+
+            elif primitive == PRIMITIVE_INTERRUPT:
+                if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+                    try:
+                        running_agent.interrupt(joined_text or None)
+                    except Exception as exc:
+                        logger.debug(
+                            "Button-tap interrupt failed for %s: %s", session_key, exc
+                        )
+                        ok = False
+                # Replace the adapter's queued event (single-slot, holds
+                # only the latest follow-up because merge_pending_message_event
+                # defaults to text-replace) with the JOINED text so the
+                # post-run drain promotes the full set, not just the last
+                # message.  Without this, "first follow-up\n\nsecond"
+                # gets truncated to just "second" on next-turn replay.
+                if (
+                    adapter is not None
+                    and joined_text
+                    and hasattr(adapter, "_pending_messages")
+                ):
+                    pending = adapter._pending_messages.get(session_key)
+                    if pending is not None and hasattr(pending, "text"):
+                        try:
+                            pending.text = joined_text
+                        except Exception:
+                            pass
+
+            elif primitive == PRIMITIVE_STOP:
+                # /stop semantics: halt without replay; clear queued slot.
+                try:
+                    await self._interrupt_and_clear_session(
+                        session_key,
+                        source,
+                        interrupt_reason=_INTERRUPT_REASON_STOP,
+                        invalidation_reason="busy-session button: stop",
+                    )
+                except Exception as exc:
+                    logger.debug(
+                        "Button-tap stop failed for %s: %s", session_key, exc
+                    )
+                    ok = False
+        finally:
+            # Emit acknowledgement reactions on every follow-up, even on
+            # failure — the user pressed a button and deserves feedback.
+            if adapter is not None and hasattr(adapter, "set_busy_reaction"):
+                emoji = _busy_button_reaction_for(primitive)
+                if emoji:
+                    for fu in followups:
+                        try:
+                            await adapter.set_busy_reaction(fu, emoji)
+                        except Exception as exc:
+                            logger.debug(
+                                "Busy-session reaction failed for %s: %s",
+                                session_key,
+                                exc,
+                            )
+            # Update the ack message body so the user can see what actually
+            # happened — without this the message keeps saying "Queued for
+            # the next turn..." even after a steer / interrupt / stop tap.
+            for _ack_id in ack_msg_ids_for_rewrite:
+                await self._update_busy_session_ack_text(
+                    session_key,
+                    source,
+                    primitive,
+                    ok,
+                    ack_msg_id=_ack_id,
+                )
+            await self._clear_busy_session_controls(session_key, source)
+
+        if not ok:
+            return "Couldn't apply that — the run may have already finished."
+        return _busy_button_status_text(primitive)
+
+    async def _update_busy_session_ack_text(
+        self,
+        session_key: str,
+        source: Optional[SessionSource],
+        primitive: str,
+        ok: bool,
+        *,
+        ack_msg_id: Optional[str] = None,
+    ) -> None:
+        """Edit the ack message body to reflect the chosen primitive.
+
+        The upstream ack starts as "⏳ Queued for the next turn..." which
+        is correct for the default queue path but misleading after a
+        Steer / Interrupt / Stop tap.  Rewriting it makes the chat
+        history readable: "⏩ Steered..." / "⚡ Interrupted..." / "🛑 Stopped."
+        """
+        if source is None:
+            return
+        adapter = self.adapters.get(source.platform)
+        if adapter is None or not hasattr(adapter, "edit_message"):
+            return
+        if ack_msg_id is None:
+            _bcb = getattr(self, "_busy_control_bubble_ids", None)
+            ids = _bcb.get(session_key) if _bcb else None
+            ack_msg_id = (ids[-1] if ids else None) if ids else None
+        if not ack_msg_id:
+            return
+        chat_id = getattr(source, "chat_id", None)
+        if not chat_id:
+            return
+        new_text = self._busy_session_ack_text(primitive, ok)
+        if not new_text:
+            return
+        # Detach the keyboard FIRST.  Telegram's edit_message override
+        # re-attaches the keyboard from _busy_session_button_map; without
+        # the pre-clear, the keyboard would survive the body edit.
+        if hasattr(adapter, "clear_busy_session_buttons"):
+            try:
+                await adapter.clear_busy_session_buttons(session_key, ack_msg_id)
+            except Exception:
+                pass
+        try:
+            await adapter.edit_message(
+                chat_id=chat_id,
+                message_id=ack_msg_id,
+                content=new_text,
+            )
+        except Exception as exc:
+            logger.debug(
+                "Updating busy-ack text failed for %s on %s: %s",
+                session_key,
+                ack_msg_id,
+                exc,
+            )
+
+    @staticmethod
+    def _busy_session_ack_text(primitive: str, ok: bool) -> str:
+        if not ok:
+            return "⚠️ Couldn't apply that — the run may have already finished."
+        if primitive == PRIMITIVE_STEER:
+            return "⏩ Steered into the current run."
+        if primitive == PRIMITIVE_INTERRUPT:
+            return "⚡ Interrupted — your message starts the next turn."
+        if primitive == PRIMITIVE_STOP:
+            return "🛑 Stopped."
+        return ""
+
+    async def _clear_busy_session_controls(
+        self,
+        session_key: str,
+        source: Optional[SessionSource],
+    ) -> None:
+        """Tear down keyboard + control bubble + follow-up state for a session.
+
+        Called from the button-tap path, the halt-phrase path, and the
+        end-of-turn cleanup in ``_release_running_agent_state``.  Best-effort.
+        """
+        # Test fixtures that bypass __init__ (e.g. object.__new__(GatewayRunner))
+        # may not have these attributes; guard reads via getattr(...).
+        tool_bubbles = getattr(self, "_tool_bubble_msg_ids", None)
+        control_bubbles = getattr(self, "_busy_control_bubble_ids", None)
+        followups = getattr(self, "_pending_followups", None)
+
+        adapter = None
+        if source is not None:
+            adapter = self.adapters.get(source.platform) if hasattr(self, "adapters") else None
+
+        # Detach the keyboard from EVERY potential anchor: the tool-progress
+        # bubble (set by send_progress_messages) and every upstream busy-ack
+        # message (set by _anchor_busy_session_buttons_to_ack — a long
+        # turn that crosses the 30s ack-cooldown can produce more than
+        # one).  Each is a real chat message we DO NOT own — only the
+        # keyboard goes away, the message body stays so the conversation
+        # history is preserved.
+        anchor_ids: list[str] = []
+        if tool_bubbles is not None:
+            tb = tool_bubbles.pop(session_key, None)
+            if tb:
+                anchor_ids.append(tb)
+        if control_bubbles is not None:
+            cbs = control_bubbles.pop(session_key, None) or []
+            # ``cbs`` may be a list (current shape) or a bare str from a
+            # legacy gateway snapshot; normalize.
+            if isinstance(cbs, str):
+                cbs = [cbs]
+            for cb in cbs:
+                if cb and cb not in anchor_ids:
+                    anchor_ids.append(cb)
+        if adapter is not None and hasattr(adapter, "clear_busy_session_buttons"):
+            for anchor_id in anchor_ids:
+                try:
+                    await adapter.clear_busy_session_buttons(session_key, anchor_id)
+                except Exception as exc:
+                    logger.debug(
+                        "clear_busy_session_buttons failed for %s on %s: %s",
+                        session_key,
+                        anchor_id,
+                        exc,
+                    )
+
+        if followups is not None:
+            followups.pop(session_key, None)
 
     async def _drain_active_agents(self, timeout: float) -> tuple[Dict[str, Any], bool]:
         snapshot = self._snapshot_running_agents()
@@ -12514,6 +13019,21 @@ class GatewayRunner:
         self._running_agents_ts.pop(session_key, None)
         if hasattr(self, "_busy_ack_ts"):
             self._busy_ack_ts.pop(session_key, None)
+        # Clear busy-session UI bookkeeping in-memory.  Adapter-side
+        # teardown (deleting the control bubble, removing the keyboard)
+        # is handled by the async ``_clear_busy_session_controls`` from
+        # ``_run_agent``'s finally block and from
+        # ``_interrupt_and_clear_session``; this sync path runs from
+        # contexts that have no event loop access.  ``hasattr`` guards
+        # mirror the ``_busy_ack_ts`` pattern so test fixtures that
+        # bypass ``__init__`` (object.__new__(GatewayRunner)) don't
+        # AttributeError on cleanup paths.
+        if hasattr(self, "_tool_bubble_msg_ids"):
+            self._tool_bubble_msg_ids.pop(session_key, None)
+        if hasattr(self, "_busy_control_bubble_ids"):
+            self._busy_control_bubble_ids.pop(session_key, None)
+        if hasattr(self, "_pending_followups"):
+            self._pending_followups.pop(session_key, None)
         return True
 
     def _clear_session_boundary_security_state(self, session_key: str) -> None:
@@ -12624,6 +13144,8 @@ class GatewayRunner:
         if adapter and hasattr(adapter, "get_pending_message"):
             adapter.get_pending_message(session_key)  # consume and discard
         self._pending_messages.pop(session_key, None)
+        # Tear down busy-session UI now that the run is being aborted.
+        await self._clear_busy_session_controls(session_key, source)
         if release_running_state:
             self._release_running_agent_state(session_key)
 
@@ -13441,6 +13963,21 @@ class GatewayRunner:
                         # order. Mirrors GatewayStreamConsumer.on_segment_break
                         # on the content side. (Issue: tool + content
                         # linearization regression after PR #7885.)
+                        # Detach any busy-session keyboard from the prior
+                        # bubble — the next tool will create a new bubble
+                        # and the keyboard will re-anchor there.
+                        if session_key and progress_msg_id and adapter is not None:
+                            if hasattr(adapter, "clear_busy_session_buttons"):
+                                try:
+                                    await adapter.clear_busy_session_buttons(
+                                        session_key, progress_msg_id
+                                    )
+                                except Exception:
+                                    pass
+                        if session_key:
+                            _tbm = getattr(self, "_tool_bubble_msg_ids", None)
+                            if _tbm is not None:
+                                _tbm.pop(session_key, None)
                         progress_msg_id = None
                         progress_lines = []
                         last_progress_msg[0] = None
@@ -13519,6 +14056,18 @@ class GatewayRunner:
                             progress_msg_id = result.message_id
                             if _cleanup_progress:
                                 _cleanup_msg_ids.append(str(result.message_id))
+                            # Publish the bubble id so the busy-session
+                            # button-attach path can anchor [/steer]
+                            # [/interrupt][/stop] to this message instead
+                            # of falling back to a standalone control
+                            # bubble.  Cleared on turn end.  ``getattr``
+                            # guard mirrors the rest of the busy-session
+                            # state — test fixtures that bypass __init__
+                            # don't carry these dicts.
+                            if session_key:
+                                _tbm = getattr(self, "_tool_bubble_msg_ids", None)
+                                if _tbm is not None:
+                                    _tbm[session_key] = progress_msg_id
 
                     _last_edit_ts = time.monotonic()
 
@@ -14927,6 +15476,17 @@ class GatewayRunner:
                     except Exception:
                         pass
 
+                # The previous turn is fully drained; clear the busy-session
+                # tracking now so a button tap during the queued follow-up
+                # turn doesn't pick up the prior turn's already-consumed
+                # follow-ups (they would otherwise be re-injected into a
+                # steer/interrupt prompt).  The outer ``finally`` will run
+                # again after the queued turn returns.
+                try:
+                    await self._clear_busy_session_controls(session_key, source)
+                except Exception:
+                    pass
+
                 return await self._run_agent(
                     message=next_message,
                     context_prompt=context_prompt,
@@ -14960,6 +15520,17 @@ class GatewayRunner:
             # Clean up tracking
             tracking_task.cancel()
             if session_key:
+                # Tear down any busy-session UI (keyboard / control bubble)
+                # before releasing the running-state slot so the cleanup
+                # has access to bubble ids that release would clear.
+                try:
+                    await self._clear_busy_session_controls(session_key, source)
+                except Exception as _bs_err:
+                    logger.debug(
+                        "Busy-session control teardown failed for %s: %s",
+                        session_key,
+                        _bs_err,
+                    )
                 # Only release the slot if this run's generation still owns
                 # it.  A /stop or /new that bumped the generation while we
                 # were unwinding has already installed its own state; this

--- a/gateway/stop_phrases.py
+++ b/gateway/stop_phrases.py
@@ -1,0 +1,161 @@
+"""Multilingual conservative stop-phrase matcher for busy-session routing.
+
+Goal: detect literal halt intent in mid-stream user messages with near-zero
+false-positive rate. Used by gateway busy-session router to decide whether
+a follow-up message means "stop the running agent" vs "incorporate this
+into the running stream as a steer."
+
+Match conditions (ALL must hold):
+- Normalized text length <= MAX_STOP_LEN (longer messages always steer)
+- Word-boundary exact match against language tables below (case-insensitive)
+- Optional trailing "!", ".", "。" tolerated
+
+Universal triggers (matched regardless of language):
+- empty message, whitespace-only
+- lone "/"
+- "/stop", "/cancel", "/halt", "/abort"
+
+This is intentionally narrow. "we should stop including Bob" does NOT match
+because length > MAX_STOP_LEN. "stopover" does NOT match because of word-
+boundary semantics in our normalize() routine.
+"""
+
+from typing import Optional
+
+# Per-language frozensets of literal halt phrases. All <= 30 chars normalized.
+#
+# Selection bias is conservative: we deliberately exclude common function
+# words that double as halts ("para" in Spanish/Portuguese is also the
+# preposition "for"; "basta" in Italian is also the filler "enough"; etc.)
+# Native-speaker review encouraged via the issue tracker — the table is
+# meant to be extended/corrected over time. False-positives here are more
+# damaging than missed-positives: a missed stop just steers (the agent
+# can still respond), but a false-positive interrupts unrelated work.
+STOP_PHRASES: dict[str, frozenset[str]] = {
+    "en": frozenset({
+        "stop", "wait", "halt", "cancel", "abort", "pause",
+        "please stop", "please wait",
+    }),
+    # Spanish: dropped "para" (also the preposition "for") in favor of more
+    # imperative forms. "alto" is universally recognized as the stop-sign word.
+    "es": frozenset({
+        "alto", "espera", "detén", "deten", "cancela", "pausa",
+        "por favor para",  # safe in this multi-word form
+    }),
+    "fr": frozenset({
+        "stop", "arrête", "arrete", "attends", "pause", "annule",
+    }),
+    "de": frozenset({
+        "stopp", "halt", "warte", "pause", "abbrechen",
+    }),
+    # Portuguese: prefer "pare" (verb imperative) over "para" (also "for").
+    "pt": frozenset({
+        "pare", "espera", "pausa", "cancela",
+    }),
+    # Italian: dropped "basta" (also a filler "enough") in favor of imperatives.
+    "it": frozenset({
+        "ferma", "aspetta", "pausa", "annulla",
+    }),
+    "nl": frozenset({
+        "stop", "wacht", "pauze", "annuleer",
+    }),
+    "ja": frozenset({
+        "止まれ", "止まって", "待って", "ストップ", "中断",
+    }),
+    "zh-Hans": frozenset({
+        "停", "停下", "等等", "暂停", "取消",
+    }),
+    "zh-Hant": frozenset({
+        "停", "停下", "等等", "暫停", "取消",
+    }),
+    # Korean: dropped "잠깐" (often a filler "just a moment") in favor of
+    # explicit halt verbs.
+    "ko": frozenset({
+        "멈춰", "정지", "일시정지", "중단",
+    }),
+    "ru": frozenset({
+        "стой", "погоди", "стоп", "пауза", "отмена",
+    }),
+    "ar": frozenset({
+        "قف", "انتظر", "توقف", "إلغاء",
+    }),
+    "hi": frozenset({
+        "रुको", "ठहरो", "बंद करो",
+    }),
+    "tr": frozenset({
+        "dur", "bekle", "iptal",
+    }),
+    "pl": frozenset({
+        "stop", "czekaj", "pauza", "anuluj",
+    }),
+}
+
+# Slash-command and panic-button shortcuts (universal, language-independent).
+SLASH_STOP_COMMANDS: frozenset[str] = frozenset({
+    "/", "/stop", "/cancel", "/halt", "/abort",
+})
+
+# Flattened union for O(1) lookup.
+_ALL_STOP_PHRASES: frozenset[str] = frozenset().union(*STOP_PHRASES.values())
+
+# Conservative length cap. Longer messages always steer (never match as stop).
+MAX_STOP_LEN: int = 30
+
+# Trailing punctuation we tolerate before stripping.
+_TRAILING_PUNCT = ("!", ".", "。", "！", "．")
+
+
+def normalize(text: Optional[str]) -> str:
+    """Lowercase, strip whitespace, drop trailing punctuation.
+
+    Used for word-boundary exact matching against the phrase tables.
+    """
+    if not text:
+        return ""
+    n = text.strip().lower()
+    # Strip trailing punctuation iteratively (e.g. "stop!." -> "stop")
+    changed = True
+    while changed:
+        changed = False
+        for p in _TRAILING_PUNCT:
+            if n.endswith(p):
+                n = n[: -len(p)].rstrip()
+                changed = True
+    return n
+
+
+def matches_stop_phrase(text: Optional[str]) -> Optional[str]:
+    """Return the matched language code if `text` is a stop signal, else None.
+
+    Return values:
+    - "universal" — empty / whitespace-only message
+    - "slash"     — slash-command shortcut ("/", "/stop", etc.)
+    - "<lang>"    — matched a phrase in language <lang> (e.g. "en", "es", "ja")
+    - None        — does not match (proceed with default routing)
+    """
+    if text is None:
+        return "universal"
+    raw = text.strip()
+    if not raw:
+        return "universal"
+    if raw in SLASH_STOP_COMMANDS:
+        return "slash"
+    n = normalize(text)
+    if not n or len(n) > MAX_STOP_LEN:
+        return None
+    if n not in _ALL_STOP_PHRASES:
+        return None
+    # Found in flattened set — identify which language.
+    for lang, phrases in STOP_PHRASES.items():
+        if n in phrases:
+            return lang
+    return None
+
+
+__all__ = [
+    "MAX_STOP_LEN",
+    "SLASH_STOP_COMMANDS",
+    "STOP_PHRASES",
+    "matches_stop_phrase",
+    "normalize",
+]

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -821,7 +821,12 @@ DEFAULT_CONFIG = {
         "compact": False,
         "personality": "kawaii",
         "resume_display": "full",
-        "busy_input_mode": "interrupt",  # interrupt | queue | steer
+        "busy_input_mode": "queue",  # queue (default) | steer | interrupt
+        # When true, gateway platforms with inline-UI support (Telegram,
+        # Discord, Slack) render [Steer][Interrupt][Stop] buttons on the
+        # running tool bubble so the user can override busy_input_mode
+        # per message.  See gateway/busy_session_buttons.py.
+        "busy_buttons": True,
         # When true, `hermes --tui` auto-resumes the most recent human-
         # facing session on launch instead of forging a fresh one.
         # Mirrors `hermes -c` muscle memory.  Default off so existing

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1274,6 +1274,18 @@ DEFAULT_CONFIG = {
         # only if you run the dispatcher as a separate systemd unit or
         # don't want the gateway to spawn workers.
         "dispatch_in_gateway": True,
+        # This profile's home Kanban board. CLI/gateway default here unless
+        # an explicit HERMES_KANBAN_BOARD or `hermes kanban --board ...` is
+        # supplied. Keeping this profile-scoped prevents one bot's ambient
+        # board selection from spilling into another bot's work queue.
+        "default_board": "default",
+        # Optional allowlist of boards this profile's gateway dispatcher owns.
+        # When empty, the embedded dispatcher scans only `default_board`.
+        # Set to ["*"] to deliberately restore old all-board scanning.
+        "dispatch_boards": [],
+        # Optional allowlist for gateway kanban notifications. Defaults to
+        # `default_board`; set to ["*"] for old all-board notification fan-out.
+        "notify_boards": [],
         # Seconds between dispatcher ticks (idle or not). Lower = snappier
         # pickup of newly-ready tasks; higher = less SQL pressure.
         "dispatch_interval_seconds": 60,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1278,7 +1278,7 @@ DEFAULT_CONFIG = {
         # an explicit HERMES_KANBAN_BOARD or `hermes kanban --board ...` is
         # supplied. Keeping this profile-scoped prevents one bot's ambient
         # board selection from spilling into another bot's work queue.
-        "default_board": "default",
+        "default_board": None,
         # Optional allowlist of boards this profile's gateway dispatcher owns.
         # When empty, the embedded dispatcher scans only `default_board`.
         # Set to ["*"] to deliberately restore old all-board scanning.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2136,6 +2136,29 @@ def _cmd_gc(args: argparse.Namespace) -> int:
 # Slash-command entry point (used by /kanban from CLI and gateway)
 # ---------------------------------------------------------------------------
 
+_SLASH_KANBAN_HELP = """\
+**/kanban** — manage the shared task board.
+
+Common subcommands:
+  `list` (alias `ls`)   List tasks on the current board
+  `show <id>`           Task details + comments + events
+  `stats`               Per-status / per-assignee counts
+  `create <title>…`     Create a task (auto-subscribes you to events)
+  `comment <id> <msg>`  Append a comment
+  `complete <id>…`      Mark task(s) done
+  `block <id> [reason]` Mark blocked; `unblock <id>` to revive
+  `assign <id> <profile>`  Reassign
+  `boards list`         Show all boards
+  `assignees`           Known profiles + counts
+  `context <id>`        Full worker-context dump
+  `runs <id>`           Attempt history
+  `log <id>`            Worker log
+
+Run `/kanban <subcommand> -h` for arguments. \
+Read-only commands are safe while an agent is running.\
+"""
+
+
 def run_slash(rest: str) -> str:
     """Execute a ``/kanban …`` string and return captured stdout/stderr.
 
@@ -2148,26 +2171,47 @@ def run_slash(rest: str) -> str:
 
     tokens = shlex.split(rest) if rest and rest.strip() else []
 
-    parser = argparse.ArgumentParser(prog="/kanban", add_help=False)
-    parser.exit_on_error = False  # type: ignore[attr-defined]
-    sub = parser.add_subparsers(dest="kanban_action")
-    # Reuse the argparse builder -- call it with a throwaway parent
-    # subparsers via a wrapping top-level parser.
-    wrap = argparse.ArgumentParser(prog="/", add_help=False)
-    wrap.exit_on_error = False  # type: ignore[attr-defined]
-    wrap_sub = wrap.add_subparsers(dest="_top")
-    build_parser(wrap_sub)
+    # Bare ``/kanban`` or ``/kanban help`` / ``--help`` / ``-h`` / ``?``:
+    # show the curated short-help block instead of dumping argparse's full
+    # usage tree (which is enormous and reads as garbage in a chat
+    # bubble).  Per-subcommand help still works via ``/kanban foo -h``.
+    if not tokens or tokens[0] in {"help", "--help", "-h", "?"}:
+        return _SLASH_KANBAN_HELP
+
+    # Single argparse tree rooted at "/kanban".  build_parser() expects a
+    # subparsers action to attach to, so build a throwaway one and pull
+    # the kanban_parser back out — then drive it directly so usage/error
+    # text reads as ``/kanban`` (not ``/kanban-wrap kanban``).
+    _wrap = argparse.ArgumentParser(prog="/kanban-wrap", add_help=False)
+    _wrap.exit_on_error = False  # type: ignore[attr-defined]
+    _top_sub = _wrap.add_subparsers(dest="_top")
+    kanban_parser = build_parser(_top_sub)
+    kanban_parser.prog = "/kanban"
+    kanban_parser.exit_on_error = False  # type: ignore[attr-defined]
+    for _action in kanban_parser._actions:
+        if isinstance(_action, argparse._SubParsersAction):
+            for _name, _choice in _action.choices.items():
+                _choice.prog = f"/kanban {_name}"
+                _choice.exit_on_error = False  # type: ignore[attr-defined]
 
     buf_out = io.StringIO()
     buf_err = io.StringIO()
+    # ``-h`` / ``--help`` makes argparse print to stdout and SystemExit(0).
+    # Capture both streams so neither the help text nor the error text
+    # bypasses our buffer.
     try:
-        # Prepend the "kanban" token so our top-level subparser routes here.
-        argv = ["kanban", *tokens] if tokens else ["kanban"]
-        args = wrap.parse_args(argv)
+        with contextlib.redirect_stdout(buf_out), contextlib.redirect_stderr(buf_err):
+            args = kanban_parser.parse_args(tokens)
     except SystemExit as exc:
-        return f"(usage error: {exc})"
+        out = buf_out.getvalue().rstrip()
+        err = buf_err.getvalue().rstrip()
+        # Help dump (exit 0) → return the captured help text directly.
+        if exc.code in (0, None) and out:
+            return out
+        body = err or out
+        return f"⚠ /kanban usage error\n{body}" if body else "⚠ /kanban usage error"
     except argparse.ArgumentError as exc:
-        return f"(usage error: {exc})"
+        return f"⚠ /kanban usage error: {exc}"
 
     with contextlib.redirect_stdout(buf_out), contextlib.redirect_stderr(buf_err):
         try:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -624,37 +624,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 # ---------------------------------------------------------------------------
 
 def _profile_default_board() -> str:
-    """Resolve this profile's default kanban board.
-
-    Profile config wins.  Otherwise infer common profile→board mappings
-    and fall back to the profile name.  The root/default profile maps to
-    ``hermes`` rather than the shared ``kanban/current`` ambient state.
-    """
-    try:
-        from hermes_cli.config import load_config
-        cfg = load_config()
-        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
-        explicit = str(kanban_cfg.get("default_board") or "").strip()
-        if explicit:
-            return explicit
-    except Exception:
-        pass
-    try:
-        from hermes_cli.profiles import get_active_profile_name
-        profile = (get_active_profile_name() or "default").strip().lower()
-    except Exception:
-        profile = os.environ.get("HERMES_PROFILE", "default").strip().lower()
-    aliases = {
-        "default": "hermes",
-        "nagatha": "hermes",
-        "hermes": "hermes",
-        "klasificados": "klasificados",
-        "nagaklas": "klasificados",
-        "nagovernor": "governor",
-        "governor": "governor",
-        "skippy": "skippy",
-    }
-    return aliases.get(profile, profile or kb.DEFAULT_BOARD)
+    """Resolve this profile's default kanban board."""
+    return kb.get_profile_default_board()
 
 
 def kanban_command(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -623,6 +623,40 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 # Command dispatch
 # ---------------------------------------------------------------------------
 
+def _profile_default_board() -> str:
+    """Resolve this profile's default kanban board.
+
+    Profile config wins.  Otherwise infer common profile→board mappings
+    and fall back to the profile name.  The root/default profile maps to
+    ``hermes`` rather than the shared ``kanban/current`` ambient state.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        explicit = str(kanban_cfg.get("default_board") or "").strip()
+        if explicit:
+            return explicit
+    except Exception:
+        pass
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        profile = (get_active_profile_name() or "default").strip().lower()
+    except Exception:
+        profile = os.environ.get("HERMES_PROFILE", "default").strip().lower()
+    aliases = {
+        "default": "hermes",
+        "nagatha": "hermes",
+        "hermes": "hermes",
+        "klasificados": "klasificados",
+        "nagaklas": "klasificados",
+        "nagovernor": "governor",
+        "governor": "governor",
+        "skippy": "skippy",
+    }
+    return aliases.get(profile, profile or kb.DEFAULT_BOARD)
+
+
 def kanban_command(args: argparse.Namespace) -> int:
     """Entry point from ``hermes kanban …`` argparse dispatch.
 
@@ -666,7 +700,29 @@ def kanban_command(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
+        default_board = _profile_default_board()
+        mutating = action in {
+            "create", "assign", "reclaim", "reassign", "link", "unlink",
+            "claim", "comment", "complete", "edit", "block", "unblock",
+            "archive", "dispatch", "specify", "gc", "heartbeat",
+            "notify-subscribe", "notify-unsubscribe",
+        }
+        # Keep mutating verbs noisy about their board. Explicit cross-board
+        # writes are still allowed; the warning above makes the blast radius
+        # visible instead of relying on ambient state.
+        if mutating and normed != default_board:
+            print(
+                f"kanban: cross-board write: profile default is {default_board!r}, "
+                f"explicit --board is {normed!r}",
+                file=sys.stderr,
+            )
         os.environ["HERMES_KANBAN_BOARD"] = normed
+    elif action != "boards" and not os.environ.get("HERMES_KANBAN_BOARD"):
+        # Profile-local default beats shared kanban/current ambient state.
+        # `boards list/switch` remains global human convenience; normal
+        # task operations use the active profile's board unless --board is
+        # explicit.
+        os.environ["HERMES_KANBAN_BOARD"] = _profile_default_board()
 
     # Boards management doesn't touch the DB at all — dispatch early so
     # fresh installs that haven't initialized any DB can still use
@@ -727,6 +783,8 @@ def kanban_command(args: argparse.Namespace) -> int:
     if not handler:
         print(f"kanban: unknown action {action!r}", file=sys.stderr)
         return 2
+    if action in _MUTATING_ACTIONS:
+        _emit_board_scope_notice(args, explicit_board=bool(board_override))
     try:
         return int(handler(args) or 0)
     except (ValueError, RuntimeError) as exc:
@@ -750,6 +808,37 @@ def _profile_author() -> str:
     except Exception:
         return "user"
 
+
+_MUTATING_ACTIONS = {
+    "init", "create", "assign", "reclaim", "reassign", "link", "unlink",
+    "claim", "comment", "complete", "edit", "block", "unblock", "archive",
+    "dispatch", "daemon", "gc", "heartbeat", "notify-subscribe",
+    "notify-unsubscribe", "specify",
+}
+
+
+def _is_json_mode(args: argparse.Namespace) -> bool:
+    return bool(getattr(args, "json", False))
+
+
+def _emit_board_scope_notice(args: argparse.Namespace, *, explicit_board: bool) -> None:
+    """Show the target board for mutating CLI commands.
+
+    Human output only. JSON callers need parseable stdout/stderr, so they get
+    board identity via command payloads where supported, not this banner.
+    """
+    if _is_json_mode(args):
+        return
+    target = kb.get_current_board()
+    print(f"Target board: {target}")
+    default = kb.get_profile_default_board()
+    if target != default and not explicit_board:
+        print(
+            f"warning: target board {target!r} differs from this profile's "
+            f"default board {default!r}; use `--board {target}` to make "
+            "cross-board mutation explicit.",
+            file=sys.stderr,
+        )
 
 # ---------------------------------------------------------------------------
 # Boards management (hermes kanban boards …)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -192,14 +192,42 @@ def legacy_current_board_path() -> Path:
 
 
 def get_profile_default_board() -> str:
-    """Return this profile's configured default board.
+    """Return this profile's configured/inferred default board.
 
-    Reads ``kanban.default_board`` from the active profile's config. Missing,
-    malformed, or stale values fall back to ``default``. This is deliberately
-    separate from the mutable ``boards switch`` pointer: default board is the
-    profile's home lane; switching is an explicit operator choice.
+    Reads ``kanban.default_board`` from the active profile's config. When it
+    is unset, infer a profile-local board from the active profile name. Root
+    installs still use ``default``; profile homes under ``profiles/<name>``
+    use ``<name>``. This is deliberately separate from the mutable
+    ``boards switch`` pointer: default board is the profile's home lane;
+    switching is an explicit operator choice.
     """
-    return _get_configured_profile_default_board() or DEFAULT_BOARD
+    return _get_configured_profile_default_board() or _infer_profile_default_board()
+
+
+def _infer_profile_default_board() -> str:
+    """Infer a default board from the active profile, or ``default``."""
+    profile = ""
+    try:
+        from hermes_constants import get_hermes_home
+        home = get_hermes_home()
+        if home.parent.name == "profiles":
+            profile = home.name
+    except Exception:
+        pass
+    profile = str(profile).strip().lower()
+    aliases = {
+        "nagatha": "hermes",
+        "hermes": "hermes",
+        "klasificados": "klasificados",
+        "nagaklas": "klasificados",
+        "nagovernor": "governor",
+        "governor": "governor",
+        "skippy": "skippy",
+    }
+    try:
+        return _normalize_board_slug(aliases.get(profile, profile)) or DEFAULT_BOARD
+    except ValueError:
+        return DEFAULT_BOARD
 
 
 def _get_configured_profile_default_board() -> Optional[str]:
@@ -209,7 +237,7 @@ def _get_configured_profile_default_board() -> Optional[str]:
         cfg = load_config()
         raw = (cfg.get("kanban", {}) if isinstance(cfg, dict) else {}).get("default_board")
         normed = _normalize_board_slug(raw)
-        if normed and (normed == DEFAULT_BOARD or board_exists(normed)):
+        if normed:
             return normed
     except Exception:
         pass

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -174,13 +174,46 @@ def boards_root() -> Path:
 
 
 def current_board_path() -> Path:
-    """Return the path to ``<root>/kanban/current``.
+    """Return the path to this profile's ``kanban/current`` pointer.
 
     One-line text file written by ``hermes kanban boards switch <slug>``
-    to persist the user's board selection across CLI invocations. Absent
-    by default (meaning: active board is ``default``).
+    to persist the user's board selection across CLI invocations for the
+    active profile only. Older Hermes releases wrote a global pointer under
+    ``<root>/kanban/current``; see :func:`legacy_current_board_path` for the
+    read-only compatibility path.
     """
+    from hermes_constants import get_hermes_home
+    return get_hermes_home() / "kanban" / "current"
+
+
+def legacy_current_board_path() -> Path:
+    """Return the pre-profile-scoping global current-board pointer path."""
     return kanban_home() / "kanban" / "current"
+
+
+def get_profile_default_board() -> str:
+    """Return this profile's configured default board.
+
+    Reads ``kanban.default_board`` from the active profile's config. Missing,
+    malformed, or stale values fall back to ``default``. This is deliberately
+    separate from the mutable ``boards switch`` pointer: default board is the
+    profile's home lane; switching is an explicit operator choice.
+    """
+    return _get_configured_profile_default_board() or DEFAULT_BOARD
+
+
+def _get_configured_profile_default_board() -> Optional[str]:
+    """Return a valid configured profile default board, or ``None``."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        raw = (cfg.get("kanban", {}) if isinstance(cfg, dict) else {}).get("default_board")
+        normed = _normalize_board_slug(raw)
+        if normed and (normed == DEFAULT_BOARD or board_exists(normed)):
+            return normed
+    except Exception:
+        pass
+    return None
 
 
 def get_current_board() -> str:
@@ -209,6 +242,22 @@ def get_current_board() -> str:
     try:
         f = current_board_path()
         if f.exists():
+            val = f.read_text(encoding="utf-8").strip()
+            if val:
+                try:
+                    normed = _normalize_board_slug(val)
+                    if normed and board_exists(normed):
+                        return normed
+                except ValueError:
+                    pass
+    except OSError:
+        pass
+    configured = _get_configured_profile_default_board()
+    if configured:
+        return configured
+    try:
+        f = legacy_current_board_path()
+        if f.exists() and f != current_board_path():
             val = f.read_text(encoding="utf-8").strip()
             if val:
                 try:

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -103,17 +103,20 @@ class TestVerboseAndToolProgress:
 
 
 class TestBusyInputMode:
-    def test_default_busy_input_mode_is_interrupt(self):
+    def test_default_busy_input_mode_is_queue(self):
+        # Default flipped: queue buffers follow-ups for the next turn instead
+        # of interrupt-by-default destroying partial work.  Per-message
+        # overrides on gateway platforms via the inline-keyboard buttons.
         cli = _make_cli()
-        assert cli.busy_input_mode == "interrupt"
-
-    def test_busy_input_mode_queue_is_honored(self):
-        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "queue"}})
         assert cli.busy_input_mode == "queue"
 
-    def test_unknown_busy_input_mode_falls_back_to_interrupt(self):
-        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "bogus"}})
+    def test_busy_input_mode_interrupt_is_honored(self):
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "interrupt"}})
         assert cli.busy_input_mode == "interrupt"
+
+    def test_unknown_busy_input_mode_falls_back_to_queue(self):
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "bogus"}})
+        assert cli.busy_input_mode == "queue"
 
     def test_queue_command_works_while_busy(self):
         """When agent is running, /queue should still put the prompt in _pending_input."""
@@ -150,8 +153,8 @@ class TestBusyInputMode:
         assert cli._interrupt_queue.empty()
 
     def test_interrupt_mode_routes_busy_enter_to_interrupt(self):
-        """In interrupt mode (default), Enter while busy goes to _interrupt_queue."""
-        cli = _make_cli()
+        """In interrupt mode (opt-in), Enter while busy goes to _interrupt_queue."""
+        cli = _make_cli(config_overrides={"display": {"busy_input_mode": "interrupt"}})
         cli._agent_running = True
         text = "redirect"
         if cli.busy_input_mode == "queue":

--- a/tests/gateway/test_busy_session_buttons.py
+++ b/tests/gateway/test_busy_session_buttons.py
@@ -1,0 +1,198 @@
+"""Tests for the platform-neutral busy-session button module.
+
+Runner integration is exercised separately (mocked adapter); these
+tests cover the standalone wire format, primitive set, and reaction
+map so the contract stays stable across platforms.
+"""
+
+import pytest
+
+from gateway.busy_session_buttons import (
+    BUSY_SESSION_PRIMITIVES,
+    BUTTON_LABELS,
+    BusySessionButton,
+    CALLBACK_PREFIX,
+    PRIMITIVE_INTERRUPT,
+    PRIMITIVE_STEER,
+    PRIMITIVE_STOP,
+    REACTION_BY_PRIMITIVE,
+    REACTION_INTERRUPT,
+    REACTION_STEER,
+    REACTION_STOP,
+    build_buttons,
+    parse_callback_data,
+    reaction_for,
+    status_text,
+)
+
+
+# --- build_buttons ----------------------------------------------------------
+
+
+def test_build_buttons_returns_three_in_canonical_order():
+    buttons = build_buttons("tg/123/456")
+    assert len(buttons) == 3
+    assert [b.primitive for b in buttons] == [
+        PRIMITIVE_STEER,
+        PRIMITIVE_INTERRUPT,
+        PRIMITIVE_STOP,
+    ]
+
+
+def test_build_buttons_labels_match_primitive_table():
+    buttons = build_buttons("session-x")
+    for b in buttons:
+        assert b.label == BUTTON_LABELS[b.primitive]
+
+
+def test_build_buttons_callback_data_uses_bs_prefix():
+    buttons = build_buttons("session-x")
+    for b in buttons:
+        assert b.callback_data.startswith(f"{CALLBACK_PREFIX}:")
+        assert b.callback_data.endswith(":session-x")
+
+
+def test_build_buttons_returned_objects_are_immutable():
+    buttons = build_buttons("session-x")
+    with pytest.raises((AttributeError, Exception)):
+        buttons[0].primitive = "tampered"  # type: ignore[misc]
+
+
+# --- parse_callback_data ----------------------------------------------------
+
+
+def test_parse_callback_data_round_trips_through_build_buttons():
+    buttons = build_buttons("tg/789/threadX")
+    for b in buttons:
+        parsed = parse_callback_data(b.callback_data)
+        assert parsed == (b.primitive, "tg/789/threadX")
+
+
+def test_parse_callback_data_returns_none_for_other_prefixes():
+    # Other Telegram callback prefixes used elsewhere (ea:, sc:, mp:, etc.)
+    # must not be mistaken for busy-session callbacks.
+    for foreign in ["ea:approve:42", "sc:once:7", "mp:select:gpt-5", "random"]:
+        assert parse_callback_data(foreign) is None
+
+
+def test_parse_callback_data_returns_none_for_unknown_primitive():
+    assert parse_callback_data("bs:steamroll:session-x") is None
+    assert parse_callback_data("bs::session-x") is None
+
+
+def test_parse_callback_data_returns_none_for_empty_session_key():
+    assert parse_callback_data("bs:steer:") is None
+
+
+def test_parse_callback_data_returns_none_for_empty_or_none():
+    assert parse_callback_data(None) is None
+    assert parse_callback_data("") is None
+
+
+def test_parse_callback_data_handles_session_keys_with_colons():
+    # Session keys can contain colons (e.g. tg:123:thread:42). The split
+    # is bounded so the third segment captures the entire remaining key.
+    parsed = parse_callback_data("bs:interrupt:tg:123:thread:42")
+    assert parsed == (PRIMITIVE_INTERRUPT, "tg:123:thread:42")
+
+
+# --- reaction_for / REACTION_BY_PRIMITIVE -----------------------------------
+
+
+def test_reaction_for_each_primitive_distinct():
+    reactions = {reaction_for(p) for p in BUSY_SESSION_PRIMITIVES}
+    assert len(reactions) == 3
+    assert reaction_for(PRIMITIVE_STEER) == REACTION_STEER
+    assert reaction_for(PRIMITIVE_INTERRUPT) == REACTION_INTERRUPT
+    assert reaction_for(PRIMITIVE_STOP) == REACTION_STOP
+
+
+def test_reaction_for_unknown_primitive_returns_none():
+    assert reaction_for("badverb") is None
+    assert reaction_for("") is None
+
+
+def test_reaction_table_keys_match_primitives():
+    assert set(REACTION_BY_PRIMITIVE.keys()) == set(BUSY_SESSION_PRIMITIVES)
+
+
+# --- status_text ------------------------------------------------------------
+
+
+def test_status_text_includes_primitive_emoji():
+    assert REACTION_STEER in status_text(PRIMITIVE_STEER)
+    assert REACTION_INTERRUPT in status_text(PRIMITIVE_INTERRUPT)
+    assert REACTION_STOP in status_text(PRIMITIVE_STOP)
+
+
+def test_status_text_unknown_primitive_returns_empty():
+    assert status_text("badverb") == ""
+
+
+# --- Constants invariants ---------------------------------------------------
+
+
+def test_primitives_match_button_labels_keys():
+    assert set(BUTTON_LABELS.keys()) == set(BUSY_SESSION_PRIMITIVES)
+
+
+def test_button_labels_short_enough_for_telegram():
+    # Telegram clips inline-keyboard labels around 14 chars in practice.
+    for primitive, label in BUTTON_LABELS.items():
+        assert len(label) <= 14, f"{primitive} label {label!r} too long"
+
+
+def test_callback_data_under_telegram_64_byte_cap():
+    # Telegram's callback_data limit is 64 bytes. A long session key plus
+    # primitive plus prefix must fit comfortably.
+    long_session = "tg/9999999999/" + ("x" * 30)
+    buttons = build_buttons(long_session)
+    for b in buttons:
+        assert len(b.callback_data.encode("utf-8")) <= 64, b.callback_data
+
+
+def test_long_session_key_uses_hashed_handle_under_64_bytes():
+    """Real group/forum session keys overflow Telegram's 64-byte cap.
+
+    ``build_buttons_with_handles`` switches to a stable short hash and
+    surfaces the handle map so the platform can resolve it on tap.
+    """
+    from gateway.busy_session_buttons import (
+        CALLBACK_MAX_BYTES,
+        HANDLE_SIGIL,
+        build_buttons_with_handles,
+        parse_callback_data,
+    )
+
+    very_long = "agent:main:telegram:supergroup:-1001234567890:thread:42:user:9876543210"
+    spec = build_buttons_with_handles(very_long)
+
+    # Every callback_data fits Telegram's hard cap.
+    for b in spec.buttons:
+        assert len(b.callback_data.encode("utf-8")) <= CALLBACK_MAX_BYTES, b.callback_data
+    # Handle map is populated so the runner can resolve back.
+    assert spec.handle_map, "Long key should use hashed handle"
+    handle = next(iter(spec.handle_map.keys()))
+    assert handle.startswith(HANDLE_SIGIL)
+    assert spec.handle_map[handle] == very_long
+    # parse_callback_data with the resolver returns the original key.
+    parsed = parse_callback_data(spec.buttons[0].callback_data, handle_resolver=spec.handle_map)
+    assert parsed == (spec.buttons[0].primitive, very_long)
+
+
+def test_short_session_key_does_not_use_handle():
+    from gateway.busy_session_buttons import build_buttons_with_handles
+
+    short = "agent:main:telegram:dm:42:42"
+    spec = build_buttons_with_handles(short)
+    assert spec.handle_map == {}
+    for b in spec.buttons:
+        assert short in b.callback_data
+
+
+def test_parse_callback_data_unresolvable_handle_returns_none():
+    from gateway.busy_session_buttons import parse_callback_data
+    # Hash-prefixed payload but no resolver supplied.
+    assert parse_callback_data("bs:steer:#deadbeefcafe") is None
+    # Hash-prefixed payload with empty resolver.
+    assert parse_callback_data("bs:steer:#deadbeefcafe", handle_resolver={}) is None

--- a/tests/gateway/test_busy_session_runner.py
+++ b/tests/gateway/test_busy_session_runner.py
@@ -1,0 +1,555 @@
+"""Runner integration tests for busy-session controls.
+
+Covers:
+- Halt-phrase pre-flight (multilingual stop intent triggers immediate
+  interrupt + 🙊 reaction without falling through to mode dispatch).
+- Button-tap dispatch (steer / interrupt / stop) and the contract that
+  one tap acts on ALL pending follow-ups.
+- Multi follow-up text concatenation in the order received.
+- Reaction lifecycle (👍 / ⚡ / 🙊 emitted on each follow-up).
+- Control-bubble fallback when no tool bubble exists.
+
+Adapter is mocked; we exercise GatewayRunner methods directly to keep
+the surface tight.  These complement the platform-neutral wire-format
+tests in ``tests/gateway/test_busy_session_buttons.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Stub telegram so gateway.run imports cleanly on a bare CI runner.
+_tg = types.ModuleType("telegram")
+_tg.constants = types.ModuleType("telegram.constants")
+_ct = MagicMock()
+_ct.SUPERGROUP = "supergroup"
+_ct.GROUP = "group"
+_ct.PRIVATE = "private"
+_tg.constants.ChatType = _ct
+sys.modules.setdefault("telegram", _tg)
+sys.modules.setdefault("telegram.constants", _tg.constants)
+sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
+
+from gateway.busy_session_buttons import (
+    PRIMITIVE_INTERRUPT,
+    PRIMITIVE_STEER,
+    PRIMITIVE_STOP,
+    REACTION_INTERRUPT,
+    REACTION_STEER,
+    REACTION_STOP,
+)
+from gateway.platforms.base import (
+    MessageEvent,
+    MessageType,
+    SessionSource,
+    build_session_key,
+)
+
+
+def _make_event(text="hello", chat_id="123", platform_val="telegram", message_id="msg1"):
+    source = SessionSource(
+        platform=MagicMock(value=platform_val),
+        chat_id=chat_id,
+        chat_type="private",
+        user_id="user1",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id=message_id,
+    )
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
+
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._busy_ack_ts = {}
+    runner._draining = False
+    runner.adapters = {}
+    runner.config = MagicMock()
+    runner.session_store = None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = True
+    runner._is_user_authorized = lambda _source: True
+    runner._busy_input_mode = "queue"
+
+    # New-state fields exercised by busy-session-buttons.
+    runner._tool_bubble_msg_ids = {}
+    runner._busy_control_bubble_ids = {}
+    runner._pending_followups = {}
+    runner._session_run_generation = {}
+
+    # _interrupt_and_clear_session needs these.
+    runner._invalidate_session_run_generation = MagicMock()
+    runner._release_running_agent_state = MagicMock(return_value=True)
+    runner._is_session_run_current = MagicMock(return_value=True)
+
+    return runner, _AGENT_PENDING_SENTINEL
+
+
+def _make_adapter():
+    adapter = MagicMock()
+    adapter._pending_messages = {}
+    adapter._send_with_retry = AsyncMock()
+    adapter.set_busy_reaction = AsyncMock(return_value=True)
+    adapter.attach_busy_session_buttons = AsyncMock(return_value=True)
+    adapter.clear_busy_session_buttons = AsyncMock(return_value=True)
+    adapter.send_or_update_busy_control_bubble = AsyncMock(return_value="ctrl_msg_id")
+    adapter.delete_busy_control_bubble = AsyncMock(return_value=True)
+    # get_pending_message has consume-and-discard semantics on real adapters.
+    adapter.get_pending_message = MagicMock(
+        side_effect=lambda sk: adapter._pending_messages.pop(sk, None)
+    )
+    adapter.interrupt_session_activity = AsyncMock()
+    adapter.edit_message = AsyncMock(return_value=MagicMock(success=True))
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Halt-phrase pre-flight
+# ---------------------------------------------------------------------------
+
+
+class TestHaltPhrasePreflight:
+    @pytest.mark.asyncio
+    async def test_english_stop_word_triggers_immediate_halt(self):
+        from gateway.run import GatewayRunner
+
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event(text="stop")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        adapter._pending_messages[sk] = "leftover"
+
+        result = await GatewayRunner._handle_active_session_busy_message(runner, event, sk)
+
+        assert result is True
+        # Halt phrase routes through the full _interrupt_and_clear_session
+        # path so the chat unlocks even when the agent is wedged inside a
+        # tool — same behavior as /stop and the [Stop] button.
+        agent.interrupt.assert_called_once_with("Stop requested")
+        adapter.set_busy_reaction.assert_awaited_with(event, REACTION_STOP)
+        # Pending slot cleared — halt does NOT replay text as next turn.
+        assert sk not in adapter._pending_messages
+
+    @pytest.mark.asyncio
+    async def test_japanese_halt_phrase_matches(self):
+        from gateway.run import GatewayRunner
+
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event(text="止まれ")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+        runner._running_agents[sk] = MagicMock()
+
+        result = await GatewayRunner._handle_active_session_busy_message(runner, event, sk)
+
+        assert result is True
+        adapter.set_busy_reaction.assert_awaited_with(event, REACTION_STOP)
+
+    @pytest.mark.asyncio
+    async def test_long_message_with_stop_word_does_not_halt(self):
+        """The conservative length cap is the main false-positive defense."""
+        from gateway.run import GatewayRunner
+
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        long_text = "we should stop including Bob in the email today"
+        event = _make_event(text=long_text)
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+
+        await GatewayRunner._handle_active_session_busy_message(runner, event, sk)
+
+        # Mode is "queue" — agent is NOT interrupted.
+        agent.interrupt.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Button-tap dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestButtonTap:
+    @pytest.mark.asyncio
+    async def test_steer_tap_routes_to_running_agent_steer(self):
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event(text="also include vector DBs")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+        runner._pending_followups[sk] = [event]
+        adapter._pending_messages[sk] = event  # would normally be replayed
+
+        toast = await runner._handle_busy_session_button_tap(
+            sk, PRIMITIVE_STEER, event.source
+        )
+
+        agent.steer.assert_called_once_with("also include vector DBs")
+        # Steer landed inside the run, so the queued copy must be cleared
+        # to avoid double-processing it as next turn.
+        assert sk not in adapter._pending_messages
+        adapter.set_busy_reaction.assert_awaited_with(event, REACTION_STEER)
+        assert "Steered" in toast or REACTION_STEER in toast
+
+    @pytest.mark.asyncio
+    async def test_interrupt_tap_calls_running_agent_interrupt_with_text(self):
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event(text="completely different task: refactor module X")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner._pending_followups[sk] = [event]
+
+        await runner._handle_busy_session_button_tap(
+            sk, PRIMITIVE_INTERRUPT, event.source
+        )
+
+        agent.interrupt.assert_called_once_with(
+            "completely different task: refactor module X"
+        )
+        adapter.set_busy_reaction.assert_awaited_with(event, REACTION_INTERRUPT)
+
+    @pytest.mark.asyncio
+    async def test_interrupt_tap_replaces_pending_slot_with_joined_text(self):
+        """The post-run drain promotes ``adapter._pending_messages[sk]`` as
+        the next-turn prompt.  Because that slot is single-slot text-
+        replacing, an interrupt tap with multiple follow-ups must
+        rewrite its text to the joined version, otherwise the next turn
+        only sees the last follow-up."""
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        e1 = _make_event(text="first", message_id="m1")
+        e2 = _make_event(text="second", message_id="m2")
+        sk = build_session_key(e1.source)
+        runner.adapters[e1.source.platform] = adapter
+
+        # Simulate the upstream busy-handler outcome: only the latest
+        # follow-up is in adapter._pending_messages, but both are tracked
+        # in runner._pending_followups for the button-tap path.
+        adapter._pending_messages[sk] = e2
+        runner._running_agents[sk] = MagicMock()
+        runner._pending_followups[sk] = [e1, e2]
+
+        await runner._handle_busy_session_button_tap(
+            sk, PRIMITIVE_INTERRUPT, e1.source
+        )
+
+        # The pending event's text now carries BOTH messages so the next
+        # turn replay sees the full conversation, not just "second".
+        assert "first" in adapter._pending_messages[sk].text
+        assert "second" in adapter._pending_messages[sk].text
+
+    @pytest.mark.asyncio
+    async def test_stop_tap_runs_full_clear_session_path(self):
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event(text="please halt")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+        runner._pending_followups[sk] = [event]
+        adapter._pending_messages[sk] = "should be cleared"
+
+        await runner._handle_busy_session_button_tap(
+            sk, PRIMITIVE_STOP, event.source
+        )
+
+        agent.interrupt.assert_called_once()
+        # _interrupt_and_clear_session pops the pending slot.
+        assert sk not in adapter._pending_messages
+        adapter.set_busy_reaction.assert_awaited_with(event, REACTION_STOP)
+
+    @pytest.mark.asyncio
+    async def test_unknown_primitive_returns_unknown_action(self):
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event()
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        toast = await runner._handle_busy_session_button_tap(
+            sk, "fortify", event.source
+        )
+
+        assert "Unknown" in toast
+
+    @pytest.mark.asyncio
+    async def test_cross_user_tap_in_shared_chat_is_rejected(self):
+        """Per-user session keys: another authorized user in the chat
+        must not be able to control someone else's run via a visible
+        button.  Reject if the tapping user's session_key doesn't match
+        the target session_key."""
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event(text="x")
+        sk_owner = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+        runner._running_agents[sk_owner] = MagicMock()
+        runner._pending_followups[sk_owner] = [event]
+
+        # A different authorized user clicks the button.  Their source
+        # has a different user_id and therefore a different session_key.
+        from gateway.platforms.base import SessionSource as _SS
+        other = _SS(
+            platform=event.source.platform,
+            chat_id="123",
+            chat_type="private",
+            user_id="user2",  # different from event.source.user_id == "user1"
+        )
+
+        toast = await runner._handle_busy_session_button_tap(
+            sk_owner, PRIMITIVE_INTERRUPT, other
+        )
+
+        assert "isn't your session" in toast.lower() or "not your session" in toast.lower()
+        # And the agent was not interrupted on behalf of the wrong user.
+        runner._running_agents[sk_owner].interrupt.assert_not_called()
+
+
+class TestMultipleFollowUps:
+    @pytest.mark.asyncio
+    async def test_two_followups_get_concatenated_and_each_reacted(self):
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        e1 = _make_event(text="first follow up", message_id="m1")
+        e2 = _make_event(text="second follow up", message_id="m2")
+        sk = build_session_key(e1.source)
+        runner.adapters[e1.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+        runner._pending_followups[sk] = [e1, e2]
+
+        await runner._handle_busy_session_button_tap(
+            sk, PRIMITIVE_STEER, e1.source
+        )
+
+        agent.steer.assert_called_once()
+        passed = agent.steer.call_args.args[0]
+        assert "first follow up" in passed
+        assert "second follow up" in passed
+        # First in list, first in joined text — preserves arrival order.
+        assert passed.index("first follow up") < passed.index("second follow up")
+
+        # Each follow-up gets its own reaction.
+        reaction_targets = [
+            call.args[0] for call in adapter.set_busy_reaction.await_args_list
+        ]
+        assert e1 in reaction_targets
+        assert e2 in reaction_targets
+
+    @pytest.mark.asyncio
+    async def test_pending_followups_cleared_after_tap(self):
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        e1 = _make_event(text="x")
+        sk = build_session_key(e1.source)
+        runner.adapters[e1.source.platform] = adapter
+        runner._pending_followups[sk] = [e1]
+        runner._running_agents[sk] = MagicMock()
+
+        await runner._handle_busy_session_button_tap(
+            sk, PRIMITIVE_INTERRUPT, e1.source
+        )
+        assert sk not in runner._pending_followups
+
+
+class TestAckAnchorAndToolBubbleAnchor:
+    @pytest.mark.asyncio
+    async def test_no_tool_bubble_does_not_send_standalone_message(self):
+        """No tool bubble → _ensure_busy_session_controls is a no-op.
+
+        The upstream busy-ack message becomes the keyboard anchor via
+        ``_anchor_busy_session_buttons_to_ack`` (called separately from
+        the busy handler after the ack send).  This avoids the duplicate
+        "/queue'd ..." + standalone-control message pair that the
+        previous design produced.
+        """
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event(text="hello before any tool")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._ensure_busy_session_controls(sk, event)
+
+        adapter.attach_busy_session_buttons.assert_not_called()
+        adapter.send_or_update_busy_control_bubble.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_tool_bubble_present_attaches_keyboard_directly(self):
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event(text="mid-tool follow up")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+        runner._tool_bubble_msg_ids[sk] = "bubble_42"
+
+        await runner._ensure_busy_session_controls(sk, event)
+
+        adapter.attach_busy_session_buttons.assert_awaited_once_with(sk, "bubble_42")
+        adapter.send_or_update_busy_control_bubble.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_anchor_to_ack_attaches_keyboard_to_ack_message(self):
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event()
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._anchor_busy_session_buttons_to_ack(sk, event, "ack_msg_77")
+
+        adapter.attach_busy_session_buttons.assert_awaited_once_with(sk, "ack_msg_77")
+        assert runner._busy_control_bubble_ids[sk] == ["ack_msg_77"]
+
+    @pytest.mark.asyncio
+    async def test_anchor_to_ack_appends_each_subsequent_anchor(self):
+        """Long turns crossing the 30s ack-cooldown produce multiple acks.
+
+        Each ack carries its own keyboard, so the runner must remember
+        every anchor — cleanup at turn end has to detach every one of
+        them, not just the latest.
+        """
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event()
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._anchor_busy_session_buttons_to_ack(sk, event, "ack_1")
+        await runner._anchor_busy_session_buttons_to_ack(sk, event, "ack_2")
+        await runner._anchor_busy_session_buttons_to_ack(sk, event, "ack_3")
+
+        assert runner._busy_control_bubble_ids[sk] == ["ack_1", "ack_2", "ack_3"]
+
+
+class TestAckTextUpdateAfterTap:
+    """A button tap must rewrite the ack body so it doesn't keep saying
+    'Queued for the next turn...' after the user picked Steer / Interrupt
+    / Stop."""
+
+    @pytest.mark.asyncio
+    async def test_steer_tap_rewrites_ack_text(self):
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event(text="hello")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+        agent = MagicMock()
+        agent.steer = MagicMock(return_value=True)
+        runner._running_agents[sk] = agent
+        runner._pending_followups[sk] = [event]
+        runner._busy_control_bubble_ids[sk] = ["ack_77"]
+
+        await runner._handle_busy_session_button_tap(
+            sk, PRIMITIVE_STEER, event.source
+        )
+
+        edit_calls = [
+            c.kwargs for c in adapter.edit_message.await_args_list
+        ]
+        assert any("Steered" in (kw.get("content") or "") for kw in edit_calls)
+        # Keyboard cleared before edit so the keyboard re-attach in
+        # edit_message() doesn't immediately re-add it.
+        adapter.clear_busy_session_buttons.assert_any_await(sk, "ack_77")
+
+    @pytest.mark.asyncio
+    async def test_interrupt_tap_rewrites_ack_text(self):
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event(text="redirect")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+        runner._running_agents[sk] = MagicMock()
+        runner._pending_followups[sk] = [event]
+        runner._busy_control_bubble_ids[sk] = ["ack_91"]
+
+        await runner._handle_busy_session_button_tap(
+            sk, PRIMITIVE_INTERRUPT, event.source
+        )
+
+        edit_calls = [
+            c.kwargs for c in adapter.edit_message.await_args_list
+        ]
+        assert any("Interrupted" in (kw.get("content") or "") for kw in edit_calls)
+
+    @pytest.mark.asyncio
+    async def test_stop_tap_rewrites_ack_text(self):
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event(text="halt")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+        runner._running_agents[sk] = MagicMock()
+        runner._pending_followups[sk] = [event]
+        runner._busy_control_bubble_ids[sk] = ["ack_55"]
+
+        await runner._handle_busy_session_button_tap(
+            sk, PRIMITIVE_STOP, event.source
+        )
+
+        edit_calls = [
+            c.kwargs for c in adapter.edit_message.await_args_list
+        ]
+        assert any("Stopped" in (kw.get("content") or "") for kw in edit_calls)
+
+
+class TestCleanup:
+    @pytest.mark.asyncio
+    async def test_clear_busy_session_controls_tears_everything_down(self):
+        """Cleanup detaches the keyboard from BOTH anchors and forgets state.
+
+        The control-bubble entry is the ack message (real chat history we
+        don't own), so cleanup detaches the keyboard but does NOT delete
+        the message itself.
+        """
+        runner, _ = _make_runner()
+        adapter = _make_adapter()
+        event = _make_event()
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+        runner._tool_bubble_msg_ids[sk] = "bubble_1"
+        runner._busy_control_bubble_ids[sk] = ["ack_1"]
+        runner._pending_followups[sk] = [event]
+
+        await runner._clear_busy_session_controls(sk, event.source)
+
+        clear_calls = [c.args for c in adapter.clear_busy_session_buttons.await_args_list]
+        assert (sk, "bubble_1") in clear_calls
+        assert (sk, "ack_1") in clear_calls
+        # Cleanup must NOT delete the ack message — it's part of chat history.
+        adapter.delete_busy_control_bubble.assert_not_called()
+        assert sk not in runner._tool_bubble_msg_ids
+        assert sk not in runner._busy_control_bubble_ids
+        assert sk not in runner._pending_followups

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -83,12 +83,15 @@ def test_load_busy_input_mode_prefers_env_then_config_then_default(tmp_path, mon
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.delenv("HERMES_GATEWAY_BUSY_INPUT_MODE", raising=False)
 
-    assert gateway_run.GatewayRunner._load_busy_input_mode() == "interrupt"
+    # Default is now "queue" — interrupt-by-default has been retired in
+    # favor of buffering follow-ups (with explicit per-message override
+    # via the inline-keyboard buttons on the tool bubble).
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "queue"
 
     (tmp_path / "config.yaml").write_text(
-        "display:\n  busy_input_mode: queue\n", encoding="utf-8"
+        "display:\n  busy_input_mode: interrupt\n", encoding="utf-8"
     )
-    assert gateway_run.GatewayRunner._load_busy_input_mode() == "queue"
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "interrupt"
 
     (tmp_path / "config.yaml").write_text(
         "display:\n  busy_input_mode: steer\n", encoding="utf-8"
@@ -101,9 +104,9 @@ def test_load_busy_input_mode_prefers_env_then_config_then_default(tmp_path, mon
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "steer")
     assert gateway_run.GatewayRunner._load_busy_input_mode() == "steer"
 
-    # Unknown values fall through to the safe default
+    # Unknown values fall through to the safe default ("queue").
     monkeypatch.setenv("HERMES_GATEWAY_BUSY_INPUT_MODE", "bogus")
-    assert gateway_run.GatewayRunner._load_busy_input_mode() == "interrupt"
+    assert gateway_run.GatewayRunner._load_busy_input_mode() == "queue"
 
 
 def test_load_restart_drain_timeout_prefers_env_then_config_then_default(

--- a/tests/gateway/test_stop_phrase_matcher.py
+++ b/tests/gateway/test_stop_phrase_matcher.py
@@ -1,0 +1,229 @@
+"""Tests for the multilingual stop-phrase matcher.
+
+These guard against accidental drift in the conservative phrase set —
+false-positives in any language would erode trust ("why did the bot
+interrupt itself?") so the bar is high.
+"""
+
+from gateway.stop_phrases import (
+    MAX_STOP_LEN,
+    SLASH_STOP_COMMANDS,
+    STOP_PHRASES,
+    matches_stop_phrase,
+    normalize,
+)
+
+
+# --- Empty / whitespace / slash universals ----------------------------------
+
+
+def test_empty_string_matches_universal():
+    assert matches_stop_phrase("") == "universal"
+
+
+def test_none_matches_universal():
+    assert matches_stop_phrase(None) == "universal"
+
+
+def test_whitespace_only_matches_universal():
+    assert matches_stop_phrase("   \t\n  ") == "universal"
+
+
+def test_lone_slash_matches_slash():
+    assert matches_stop_phrase("/") == "slash"
+
+
+def test_slash_stop_commands_match_slash():
+    for cmd in ["/stop", "/cancel", "/halt", "/abort"]:
+        assert matches_stop_phrase(cmd) == "slash", cmd
+
+
+# --- English exact matches --------------------------------------------------
+
+
+def test_english_basic_words_match():
+    for w in ["stop", "wait", "halt", "cancel", "abort", "pause"]:
+        assert matches_stop_phrase(w) == "en", w
+
+
+def test_english_case_insensitive():
+    for w in ["STOP", "Stop", "sToP", "WAIT", "Halt"]:
+        assert matches_stop_phrase(w) == "en", w
+
+
+def test_english_trailing_punctuation_tolerated():
+    for w in ["stop!", "wait.", "halt!.", "cancel!", "abort."]:
+        assert matches_stop_phrase(w) == "en", w
+
+
+def test_english_please_phrases():
+    assert matches_stop_phrase("please stop") == "en"
+    assert matches_stop_phrase("please wait") == "en"
+
+
+# --- Other languages --------------------------------------------------------
+
+
+def test_spanish_phrases_match():
+    """Spanish 'para' deliberately excluded (also means preposition 'for')."""
+    for w in ["alto", "espera", "cancela", "pausa"]:
+        assert matches_stop_phrase(w) == "es", w
+
+
+def test_spanish_para_alone_does_not_match():
+    """Confirms 'para' (the preposition 'for') doesn't trigger a stop."""
+    assert matches_stop_phrase("para") is None
+
+
+def test_french_phrases_match():
+    """Words unique to French resolve to 'fr'.
+
+    Phrases shared with other languages (e.g. 'pause' in fr/de, 'stop' in
+    en/fr/nl/pl) resolve to whichever language is checked first in dict
+    iteration order. Either way the action is 'stop' — what matters.
+    """
+    for w in ["arrête", "arrete", "attends", "annule"]:
+        result = matches_stop_phrase(w)
+        assert result == "fr", f"{w} got {result}"
+
+
+def test_german_phrases_match():
+    for w in ["stopp", "warte", "abbrechen"]:
+        assert matches_stop_phrase(w) == "de", w
+
+
+def test_japanese_phrases_match():
+    for w in ["止まれ", "止まって", "待って", "ストップ"]:
+        assert matches_stop_phrase(w) == "ja", w
+
+
+def test_japanese_full_stop_punctuation():
+    assert matches_stop_phrase("止まって。") == "ja"
+
+
+def test_mandarin_simplified_phrases_match():
+    # 停 and 等等 are shared with traditional. Lookup hits Hans first by dict order.
+    result = matches_stop_phrase("暂停")
+    assert result == "zh-Hans"
+
+
+def test_mandarin_traditional_specific():
+    result = matches_stop_phrase("暫停")
+    assert result == "zh-Hant"
+
+
+def test_korean_phrases_match():
+    """'잠깐' deliberately excluded (often a filler 'just a moment')."""
+    for w in ["멈춰", "정지", "일시정지", "중단"]:
+        assert matches_stop_phrase(w) == "ko", w
+
+
+def test_russian_phrases_match():
+    for w in ["стой", "стоп", "пауза", "отмена"]:
+        assert matches_stop_phrase(w) == "ru", w
+
+
+def test_arabic_phrases_match():
+    for w in ["قف", "انتظر", "توقف"]:
+        assert matches_stop_phrase(w) == "ar", w
+
+
+def test_hindi_phrases_match():
+    for w in ["रुको", "ठहरो", "बंद करो"]:
+        assert matches_stop_phrase(w) == "hi", w
+
+
+# --- Negative cases (the bar for these is HIGH) -----------------------------
+
+
+def test_long_message_with_stop_buried_does_not_match():
+    """The conservative length cap is the main false-positive defense."""
+    msg = "we should stop including Bob in the email today"
+    assert len(msg) > MAX_STOP_LEN
+    assert matches_stop_phrase(msg) is None
+
+
+def test_word_with_stop_prefix_does_not_match():
+    """'stopover' is a word, 'stop' is the phrase. Exact-word match required."""
+    assert matches_stop_phrase("stopover") is None
+    assert matches_stop_phrase("stopgap") is None
+    assert matches_stop_phrase("stoppage") is None
+
+
+def test_normal_conversation_does_not_match():
+    benign = [
+        "hello there",
+        "thanks for the help",
+        "ok cool",
+        "what about X?",
+        "by the way also include the docs",
+        "actually let me think about this",
+        "could you also check Y",
+        "instead of Z try W",  # contains "instead" but is a long sentence
+        "different task perhaps",
+    ]
+    for msg in benign:
+        result = matches_stop_phrase(msg)
+        assert result is None, f"false-positive on: {msg!r} → {result}"
+
+
+def test_unknown_short_word_does_not_match():
+    for w in ["hi", "hey", "ok", "yes", "no", "sure", "ah"]:
+        assert matches_stop_phrase(w) is None, w
+
+
+def test_emoji_only_does_not_match():
+    assert matches_stop_phrase("👍") is None
+    assert matches_stop_phrase("🤔") is None
+
+
+# --- normalize() helper -----------------------------------------------------
+
+
+def test_normalize_lowercases():
+    assert normalize("STOP") == "stop"
+    assert normalize("Stop") == "stop"
+
+
+def test_normalize_strips_whitespace():
+    assert normalize("  stop  ") == "stop"
+
+
+def test_normalize_strips_trailing_punct():
+    assert normalize("stop!") == "stop"
+    assert normalize("stop.") == "stop"
+    assert normalize("stop!.") == "stop"
+    assert normalize("止まって。") == "止まって"
+
+
+def test_normalize_handles_none_and_empty():
+    assert normalize(None) == ""
+    assert normalize("") == ""
+
+
+# --- Coverage sanity --------------------------------------------------------
+
+
+def test_all_phrases_under_length_cap():
+    """Every entry in STOP_PHRASES must be <= MAX_STOP_LEN normalized."""
+    for lang, phrases in STOP_PHRASES.items():
+        for p in phrases:
+            n = normalize(p)
+            assert len(n) <= MAX_STOP_LEN, f"{lang}: {p!r} normalized to {n!r} exceeds {MAX_STOP_LEN}"
+
+
+def test_slash_commands_set_is_finite():
+    assert isinstance(SLASH_STOP_COMMANDS, frozenset)
+    assert "/" in SLASH_STOP_COMMANDS
+    assert "/stop" in SLASH_STOP_COMMANDS
+
+
+def test_lang_codes_are_canonical():
+    """Language codes follow ISO 639 / IETF BCP-47 conventions."""
+    valid = {
+        "en", "es", "fr", "de", "pt", "it", "nl",
+        "ja", "ko", "ru", "ar", "hi", "tr", "pl",
+        "zh-Hans", "zh-Hant",
+    }
+    for lang in STOP_PHRASES.keys():
+        assert lang in valid, f"unexpected language code: {lang}"

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -411,6 +411,13 @@ def _cli(args: list[str], env_extra: dict | None = None) -> subprocess.Completed
     """Run ``hermes kanban …`` with PYTHONPATH pinned to the worktree."""
     env = dict(os.environ)
     env["PYTHONPATH"] = str(_WORKTREE)
+    for var in (
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_HOME",
+        "HERMES_KANBAN_BOARD",
+    ):
+        env.pop(var, None)
     if env_extra:
         env.update(env_extra)
     return subprocess.run(
@@ -490,3 +497,77 @@ class TestCLI:
         res = _cli(["boards", "list", "--json"], env_extra=env)
         slugs = [b["slug"] for b in json.loads(res.stdout)]
         assert "rmme" not in slugs
+
+
+# ---------------------------------------------------------------------------
+# Profile-scoped defaults / contamination prevention
+# ---------------------------------------------------------------------------
+
+def _write_profile_config(profile_home: Path, default_board: str) -> None:
+    profile_home.mkdir(parents=True, exist_ok=True)
+    (profile_home / "config.yaml").write_text(
+        f"kanban:\n  default_board: {default_board}\n  dispatch_boards: []\n  notify_boards: []\n",
+        encoding="utf-8",
+    )
+
+
+class TestProfileScopedDefaults:
+    def test_configured_default_board_is_profile_scoped(self, tmp_path, monkeypatch):
+        root = tmp_path / ".hermes"
+        alpha_home = root / "profiles" / "alpha"
+        beta_home = root / "profiles" / "beta"
+        monkeypatch.setenv("HERMES_KANBAN_HOME", str(root))
+        monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+        monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+        monkeypatch.delenv("HERMES_KANBAN_WORKSPACES_ROOT", raising=False)
+        kb._INITIALIZED_PATHS.clear()
+
+        monkeypatch.setenv("HERMES_HOME", str(alpha_home))
+        kb.create_board("alpha-board")
+        kb.create_board("beta-board")
+        _write_profile_config(alpha_home, "alpha-board")
+        _write_profile_config(beta_home, "beta-board")
+
+        assert kb.get_current_board() == "alpha-board"
+        with kb.connect() as conn:
+            kb.create_task(conn, title="alpha-only")
+
+        monkeypatch.setenv("HERMES_HOME", str(beta_home))
+        assert kb.get_current_board() == "beta-board"
+        with kb.connect() as conn:
+            kb.create_task(conn, title="beta-only")
+
+        with kb.connect(board="alpha-board") as conn:
+            assert [t.title for t in kb.list_tasks(conn)] == ["alpha-only"]
+        with kb.connect(board="beta-board") as conn:
+            assert [t.title for t in kb.list_tasks(conn)] == ["beta-only"]
+
+    def test_boards_switch_writes_profile_local_pointer(self, tmp_path, monkeypatch):
+        root = tmp_path / ".hermes"
+        alpha_home = root / "profiles" / "alpha"
+        beta_home = root / "profiles" / "beta"
+        monkeypatch.setenv("HERMES_KANBAN_HOME", str(root))
+        monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+        monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(alpha_home))
+        kb._INITIALIZED_PATHS.clear()
+        kb.create_board("shared-board")
+        kb.set_current_board("shared-board")
+        assert (alpha_home / "kanban" / "current").read_text(encoding="utf-8").strip() == "shared-board"
+        assert not (root / "kanban" / "current").exists()
+
+        monkeypatch.setenv("HERMES_HOME", str(beta_home))
+        assert kb.get_current_board() == "default"
+
+    def test_cli_mutation_names_target_board_and_json_stays_parseable(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        assert _cli(["boards", "create", "ops"], env_extra=env).returncode == 0
+
+        human = _cli(["--board", "ops", "create", "Human Task"], env_extra=env)
+        assert human.returncode == 0, human.stderr
+        assert "Target board: ops" in human.stdout
+
+        machine = _cli(["--board", "ops", "create", "JSON Task", "--json"], env_extra=env)
+        assert machine.returncode == 0, machine.stderr
+        data = json.loads(machine.stdout)
+        assert data["title"] == "JSON Task"

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -331,13 +331,64 @@ def test_run_slash_specify_end_to_end(kanban_home, monkeypatch):
 
 
 def test_run_slash_specify_help_is_reachable(kanban_home):
-    """`--help` on a subcommand is handled by argparse itself — it prints
-    to the process stdout and raises SystemExit before run_slash's output
-    redirection is installed, so the returned string is the usage-error
-    sentinel. All we're asserting here is that the subcommand is
-    registered (no "unknown action" error) — the shape of the help text
-    is covered by the direct argparse tests in test_kanban_specify.py."""
+    """`-h`/`--help` on a subcommand returns the actual help text — see
+    issue #21794. argparse writes help to stdout and exits 0; run_slash
+    must capture both streams and treat exit 0 as success, not error."""
     out = kc.run_slash("specify --help")
-    # Either the usage-error sentinel (stdout swallowed by argparse) or
-    # a real help rendering — both mean the subcommand exists.
-    assert "usage error" in out.lower() or "specify" in out.lower()
+    assert "specify" in out.lower()
+    # Help dump should NOT come back wrapped as a usage error.
+    assert not out.startswith("⚠")
+
+
+# ---------------------------------------------------------------------------
+# /kanban help / no-args / unknown-action UX (issue #21794)
+# ---------------------------------------------------------------------------
+
+def test_run_slash_bare_returns_curated_help(kanban_home):
+    """Bare `/kanban` returns the curated short-help block — not a 5KB
+    argparse usage dump."""
+    out = kc.run_slash("")
+    assert "/kanban" in out
+    assert "list" in out
+    assert "show" in out
+    # Sanity: should be a chat-friendly size, not the raw usage tree.
+    assert len(out) < 2000
+    # Shouldn't surface argparse's usage-error sentinel.
+    assert "usage error" not in out.lower()
+
+
+@pytest.mark.parametrize("alias", ["help", "--help", "-h", "?"])
+def test_run_slash_help_aliases_match_bare(kanban_home, alias):
+    """Every documented help alias produces the same curated output."""
+    bare = kc.run_slash("")
+    out = kc.run_slash(alias)
+    assert out == bare
+
+
+def test_run_slash_subcommand_help_returns_help_text(kanban_home):
+    """`/kanban show -h` returns the actual subcommand help, not a
+    fake `(usage error: 0)` sentinel."""
+    out = kc.run_slash("show -h")
+    assert "task_id" in out
+    assert "/kanban show" in out
+    assert not out.startswith("⚠")
+
+
+def test_run_slash_unknown_action_friendly_error(kanban_home):
+    """Unknown subcommand surfaces a single-line usage error prefixed
+    with our marker — no `(usage error: 2)` wrapping, no doubled
+    `kanban kanban` prog string."""
+    out = kc.run_slash("frobnicate")
+    assert "/kanban" in out
+    assert "frobnicate" in out
+    assert "/kanban-wrap" not in out
+    assert "/kanban kanban" not in out
+    assert "(usage error: " not in out
+
+
+def test_run_slash_missing_required_arg_friendly_error(kanban_home):
+    """Missing positional argument shows the subcommand-scoped usage
+    line, not the top-level kanban tree."""
+    out = kc.run_slash("show")
+    assert "/kanban show" in out
+    assert "task_id" in out

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3293,6 +3293,36 @@ def test_gateway_dispatcher_watcher_env_truthy_uses_config(monkeypatch):
     )
 
 
+
+
+def test_gateway_kanban_scoped_board_slugs_default_and_explicit(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes" / "profiles" / "nagaklas"))
+    monkeypatch.delenv("HERMES_KANBAN_DISPATCH_BOARDS", raising=False)
+    kb._INITIALIZED_PATHS.clear()
+
+    assert GatewayRunner._kanban_scoped_board_slugs(
+        {"default_board": "klasificados"}, "dispatch_boards", kb
+    ) == ["klasificados"]
+    assert GatewayRunner._kanban_scoped_board_slugs(
+        {"dispatch_boards": "alpha,beta"}, "dispatch_boards", kb
+    ) == ["alpha", "beta"]
+
+
+def test_gateway_kanban_scoped_board_slugs_star_lists_all(tmp_path, monkeypatch):
+    from gateway.run import GatewayRunner
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    kb._INITIALIZED_PATHS.clear()
+    kb.create_board("alpha")
+    kb.create_board("beta")
+
+    assert GatewayRunner._kanban_scoped_board_slugs(
+        {"dispatch_boards": ["*"]}, "dispatch_boards", kb
+    ) == ["default", "alpha", "beta"]
+
 # ---------------------------------------------------------------------------
 # Hallucination gate (created_cards verify + prose scan)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #21794.

## Before / after

**Before:**
- `/kanban` → 3KB argparse dump (visual garbage in chat bubbles)
- `/kanban help` → `(usage error: 2)` + dump
- `/kanban --help` → `(usage error: 0)` (help silently swallowed)
- `/kanban show -h` → `(usage error: 0)` (help silently swallowed)
- Unknown action → `(usage error: 2)` + dump
- Usage cosmetic: `usage: / kanban …` and `usage: /kanban kanban …`

**After:**
- `/kanban`, `/kanban help`, `--help`, `-h`, `?` → curated short-help block
- `/kanban <sub> -h` → that subcommand's actual argparse help
- Unknown action → single-line `⚠ /kanban usage error: …`
- Usage strings consistently read `/kanban` and `/kanban <sub>`

## Root cause

`hermes_cli.kanban.run_slash` had three compounding bugs:

1. argparse writes help to **stdout** but `run_slash` only captured stderr at parse time, so `-h` text was lost and replaced with a fake `(usage error: 0)` sentinel.
2. The wrapping parser used `prog="/"` and routed via a synthetic `_top → kanban` subparser, producing `usage: / kanban …` (stray space) and `usage: /kanban kanban …` (doubled token) in error text.
3. Bare `/kanban` and `/kanban help` dumped argparse's full ~3KB usage tree.

## Fix

- Drive `kanban_parser` directly (no double-wrap).
- Rewrite `prog` strings on every leaf subparser so usage reads `/kanban <sub>`.
- Capture both stdout and stderr around `parse_args`.
- Distinguish `SystemExit(0)` (help — return captured stdout) from `SystemExit(2)` (error — return ⚠-prefixed message).
- Add an explicit, chat-friendly short-help block returned for bare invocation and every help alias.

## Tests

5 new regression tests in `tests/hermes_cli/test_kanban_cli.py`:

- `test_run_slash_bare_returns_curated_help` — bare invocation
- `test_run_slash_help_aliases_match_bare` (parametrized over `help`, `--help`, `-h`, `?`)
- `test_run_slash_subcommand_help_returns_help_text` — `show -h`
- `test_run_slash_unknown_action_friendly_error` — `frobnicate`
- `test_run_slash_missing_required_arg_friendly_error` — `show` without id

Plus updated `test_run_slash_specify_help_is_reachable` (previously documented the bug as expected behavior).

All 36 tests in `tests/hermes_cli/test_kanban_cli.py` pass.

## Affected surfaces

- `gateway/run.py::_handle_kanban_command` — every chat platform that supports `/kanban`
- `cli.py::_handle_kanban_command` — interactive CLI

No behavior change for valid invocations (`/kanban list`, `/kanban show t_…`, `/kanban create …`, etc.).
