### PR TITLE
feat(audio): add OpenRouter as a transcription + speech provider

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -777,8 +777,10 @@ platform_toolsets:
 # Voice Transcription (Speech-to-Text)
 # =============================================================================
 # Automatically transcribe voice messages on messaging platforms.
-# Providers: local (free, faster-whisper) | groq (free tier) | openai (Whisper API) | mistral (Voxtral Transcribe)
-# Set the corresponding API key in .env: GROQ_API_KEY, OPENAI_API_KEY, or MISTRAL_API_KEY.
+# Providers: local (free, faster-whisper) | groq (free tier) | openrouter (unified)
+#          | openai (Whisper API) | mistral (Voxtral Transcribe) | xai (Grok STT)
+# Set the corresponding API key in .env:
+#   GROQ_API_KEY, OPENROUTER_API_KEY, OPENAI_API_KEY, MISTRAL_API_KEY, XAI_API_KEY
 stt:
   enabled: true
   # provider: "local"          # auto-detected if omitted
@@ -787,6 +789,11 @@ stt:
     # language: ""             # auto-detect; set to "en", "es", "fr", etc. to force
   openai:
     model: "whisper-1"         # whisper-1 | gpt-4o-mini-transcribe | gpt-4o-transcribe
+  # openrouter:
+  #   model: "openai/whisper-large-v3"   # any STT slug OpenRouter routes; query
+  #                                      # the Models API with output_modalities=
+  #                                      # transcription to discover the full set.
+  #   # base_url: "https://openrouter.ai/api/v1"  # override for self-hosted/proxy
   # mistral:
   #   model: "voxtral-mini-latest"  # voxtral-mini-latest | voxtral-mini-2602
 

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -1346,3 +1346,303 @@ class TestTranscribeAudioXAIDispatch:
             transcribe_audio(sample_ogg, model="custom-stt")
 
         assert mock_xai.call_args[0][1] == "custom-stt"
+
+
+# ============================================================================
+# _transcribe_openrouter — JSON+base64 protocol via requests.post
+# ============================================================================
+
+class TestTranscribeOpenRouter:
+    def test_no_key(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        from tools.transcription_tools import _transcribe_openrouter
+        result = _transcribe_openrouter("/tmp/test.mp3", "openai/whisper-large-v3")
+        assert result["success"] is False
+        assert "OPENROUTER_API_KEY" in result["error"]
+
+    def test_successful_transcription(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "text": "hello world",
+            "usage": {"seconds": 1.0, "cost": 0.0001},
+        }
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_openrouter
+            result = _transcribe_openrouter(sample_wav, "openai/whisper-large-v3")
+
+        assert result["success"] is True
+        assert result["transcript"] == "hello world"
+        assert result["provider"] == "openrouter"
+
+    def test_whitespace_stripped(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "  hello  \n"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_openrouter
+            result = _transcribe_openrouter(sample_wav, "openai/whisper-large-v3")
+
+        assert result["transcript"] == "hello"
+
+    def test_api_error_returns_failure(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.json.return_value = {"error": {"message": "No auth credentials found"}}
+        mock_response.text = '{"error":{"message":"No auth credentials found"}}'
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_openrouter
+            result = _transcribe_openrouter(sample_wav, "openai/whisper-large-v3")
+
+        assert result["success"] is False
+        assert "HTTP 401" in result["error"]
+        assert "No auth credentials found" in result["error"]
+
+    def test_empty_transcript_returns_failure(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "   "}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response):
+            from tools.transcription_tools import _transcribe_openrouter
+            result = _transcribe_openrouter(sample_wav, "openai/whisper-large-v3")
+
+        assert result["success"] is False
+        assert "empty transcript" in result["error"]
+
+    def test_permission_error(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("builtins.open", side_effect=PermissionError("denied")):
+            from tools.transcription_tools import _transcribe_openrouter
+            result = _transcribe_openrouter(sample_wav, "openai/whisper-large-v3")
+
+        assert result["success"] is False
+        assert "Permission denied" in result["error"]
+
+    def test_unsupported_format_rejected(self, monkeypatch, tmp_path):
+        """OR's STT only accepts a fixed set of formats — reject others early."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+        bogus = tmp_path / "test.exotic"
+        bogus.write_bytes(b"\x00\x01\x02")
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}):
+            from tools.transcription_tools import _transcribe_openrouter
+            result = _transcribe_openrouter(str(bogus), "openai/whisper-large-v3")
+
+        assert result["success"] is False
+        assert "format" in result["error"].lower()
+
+    def test_format_aliases_normalized(self, monkeypatch, tmp_path):
+        """`.oga`/`.opus` map to `ogg`; `.mpeg` maps to `mp3`."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+        for ext in ("oga", "opus", "mpeg"):
+            f = tmp_path / f"test.{ext}"
+            f.write_bytes(b"\x00\x01\x02")
+
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"text": "ok"}
+
+            with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+                 patch("requests.post", return_value=mock_response) as mock_post:
+                from tools.transcription_tools import _transcribe_openrouter
+                _transcribe_openrouter(str(f), "openai/whisper-large-v3")
+
+            body = mock_post.call_args.kwargs.get("json", {})
+            audio_format = body.get("input_audio", {}).get("format")
+            expected = "ogg" if ext in ("oga", "opus") else "mp3"
+            assert audio_format == expected, f"expected {expected} for .{ext}, got {audio_format}"
+
+    def test_sends_json_with_base64_audio(self, monkeypatch, sample_wav):
+        """Sends JSON (not multipart) with base64-encoded `input_audio.data`."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "ok"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_openrouter
+            _transcribe_openrouter(sample_wav, "openai/whisper-large-v3")
+
+        kwargs = mock_post.call_args.kwargs
+        # JSON body, not multipart
+        assert "json" in kwargs and "files" not in kwargs and "data" not in kwargs
+        body = kwargs["json"]
+        assert body["model"] == "openai/whisper-large-v3"
+        assert body["input_audio"]["format"] == "wav"
+        encoded = body["input_audio"]["data"]
+        assert isinstance(encoded, str) and len(encoded) > 0
+        # base64 alphabet only — round-trip must succeed
+        import base64
+        base64.b64decode(encoded, validate=True)
+
+    def test_uses_openrouter_base_url(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "ok"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_openrouter
+            _transcribe_openrouter(sample_wav, "openai/whisper-large-v3")
+
+        url = mock_post.call_args[0][0] if mock_post.call_args[0] else mock_post.call_args.kwargs.get("url", "")
+        assert "openrouter.ai/api/v1/audio/transcriptions" in url
+
+    def test_custom_base_url_via_config(self, monkeypatch, sample_wav):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "ok"}
+
+        with patch("tools.transcription_tools._load_stt_config",
+                   return_value={"openrouter": {"base_url": "https://or.example.com/v1"}}), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_openrouter
+            _transcribe_openrouter(sample_wav, "openai/whisper-large-v3")
+
+        url = mock_post.call_args[0][0] if mock_post.call_args[0] else mock_post.call_args.kwargs.get("url", "")
+        assert "or.example.com" in url
+
+    def test_sends_correct_headers(self, monkeypatch, sample_wav):
+        """Authorization bearer + Content-Type JSON."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"text": "ok"}
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", return_value=mock_response) as mock_post:
+            from tools.transcription_tools import _transcribe_openrouter
+            _transcribe_openrouter(sample_wav, "openai/whisper-large-v3")
+
+        headers = mock_post.call_args.kwargs.get("headers", {})
+        assert headers.get("Authorization") == "Bearer or-test-key"
+        assert headers.get("Content-Type") == "application/json"
+
+    def test_connection_error(self, monkeypatch, sample_wav):
+        """Network failures surface as a clean failure result, not a traceback."""
+        import requests as _requests
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("requests.post", side_effect=_requests.exceptions.ConnectionError("dns failure")):
+            from tools.transcription_tools import _transcribe_openrouter
+            result = _transcribe_openrouter(sample_wav, "openai/whisper-large-v3")
+
+        assert result["success"] is False
+        assert "error" in result
+        assert result["error"]  # non-empty
+
+
+# ============================================================================
+# _get_provider — openrouter routing
+# ============================================================================
+
+class TestGetProviderOpenRouter:
+    def test_explicit_openrouter_with_key(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "openrouter"}) == "openrouter"
+
+    def test_explicit_openrouter_no_key(self, monkeypatch):
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "openrouter"}) == "none"
+
+    def test_auto_detect_openrouter(self, monkeypatch):
+        """Auto-detect picks openrouter when local + groq are unavailable but OR key set."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+        monkeypatch.delenv("GROQ_API_KEY", raising=False)
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "openrouter"
+
+    def test_auto_detect_groq_preferred_over_openrouter(self, monkeypatch):
+        """Free Groq tier wins over OR in auto-detect (cost preference)."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+        monkeypatch.setenv("GROQ_API_KEY", "groq-test-key")
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._HAS_OPENAI", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "groq"
+
+
+# ============================================================================
+# transcribe_audio — openrouter dispatch
+# ============================================================================
+
+class TestTranscribeAudioOpenRouterDispatch:
+    def test_dispatches_to_openrouter(self, sample_wav):
+        with patch("tools.transcription_tools._load_stt_config",
+                   return_value={"provider": "openrouter"}), \
+             patch("tools.transcription_tools._get_provider", return_value="openrouter"), \
+             patch("tools.transcription_tools._transcribe_openrouter",
+                   return_value={"success": True, "transcript": "hi", "provider": "openrouter"}) as mock_or:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_wav)
+
+        assert result["success"] is True
+        assert result["provider"] == "openrouter"
+        mock_or.assert_called_once()
+
+    def test_model_default_from_constant(self, sample_wav):
+        from tools.transcription_tools import DEFAULT_OPENROUTER_STT_MODEL
+        with patch("tools.transcription_tools._load_stt_config",
+                   return_value={"provider": "openrouter"}), \
+             patch("tools.transcription_tools._get_provider", return_value="openrouter"), \
+             patch("tools.transcription_tools._transcribe_openrouter",
+                   return_value={"success": True, "transcript": "hi"}) as mock_or:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_wav, model=None)
+
+        assert mock_or.call_args[0][1] == DEFAULT_OPENROUTER_STT_MODEL
+
+    def test_model_from_config_overrides_default(self, sample_wav):
+        with patch("tools.transcription_tools._load_stt_config",
+                   return_value={"provider": "openrouter",
+                                 "openrouter": {"model": "groq/whisper-large-v3-turbo"}}), \
+             patch("tools.transcription_tools._get_provider", return_value="openrouter"), \
+             patch("tools.transcription_tools._transcribe_openrouter",
+                   return_value={"success": True, "transcript": "hi"}) as mock_or:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_wav, model=None)
+
+        assert mock_or.call_args[0][1] == "groq/whisper-large-v3-turbo"
+
+    def test_explicit_model_argument_wins(self, sample_wav):
+        with patch("tools.transcription_tools._load_stt_config",
+                   return_value={"provider": "openrouter",
+                                 "openrouter": {"model": "openai/whisper-1"}}), \
+             patch("tools.transcription_tools._get_provider", return_value="openrouter"), \
+             patch("tools.transcription_tools._transcribe_openrouter",
+                   return_value={"success": True, "transcript": "hi"}) as mock_or:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_wav, model="openai/whisper-large-v3")
+
+        assert mock_or.call_args[0][1] == "openai/whisper-large-v3"

--- a/tests/tools/test_tts_openrouter.py
+++ b/tests/tools/test_tts_openrouter.py
@@ -1,0 +1,202 @@
+"""Tests for the OpenRouter TTS provider in tools/tts_tool.py."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in (
+        "OPENROUTER_API_KEY",
+        "TTS_OPENROUTER_BASE_URL",
+        "HERMES_SESSION_PLATFORM",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture
+def mock_openai_client():
+    """Patch _import_openai_client to return a fake OpenAI class.
+
+    The fake stream_to_file just touches the output_path so the dispatcher's
+    "file produced" check succeeds.
+    """
+
+    def _stream_to_file(path):
+        with open(path, "wb") as fh:
+            fh.write(b"fake-audio-mp3-bytes")
+
+    response = MagicMock()
+    response.stream_to_file.side_effect = _stream_to_file
+
+    client = MagicMock()
+    client.audio.speech.create.return_value = response
+
+    fake_class = MagicMock(return_value=client)
+    with patch("tools.tts_tool._import_openai_client", return_value=fake_class):
+        yield client, fake_class
+
+
+class TestGenerateOpenRouterTts:
+    def test_missing_api_key_raises(self, tmp_path, mock_openai_client):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        out = str(tmp_path / "out.mp3")
+        with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
+            _generate_openrouter_tts("hi", out, {})
+
+    def test_successful_generation(self, tmp_path, mock_openai_client, monkeypatch):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+        client, _ = mock_openai_client
+
+        out = str(tmp_path / "out.mp3")
+        result = _generate_openrouter_tts("Hello world", out, {})
+
+        assert result == out
+        assert (tmp_path / "out.mp3").exists()
+        client.audio.speech.create.assert_called_once()
+        kwargs = client.audio.speech.create.call_args.kwargs
+        assert kwargs["input"] == "Hello world"
+        # OR only accepts mp3 / pcm — provider always requests mp3 and lets
+        # downstream ffmpeg convert to .ogg when the platform needs Opus.
+        assert kwargs["response_format"] == "mp3"
+
+    def test_default_model_and_voice(self, tmp_path, mock_openai_client, monkeypatch):
+        from tools.tts_tool import (
+            DEFAULT_OPENROUTER_TTS_MODEL,
+            DEFAULT_OPENROUTER_TTS_VOICE,
+            _generate_openrouter_tts,
+        )
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+        client, _ = mock_openai_client
+
+        _generate_openrouter_tts("hi", str(tmp_path / "out.mp3"), {})
+
+        kwargs = client.audio.speech.create.call_args.kwargs
+        assert kwargs["model"] == DEFAULT_OPENROUTER_TTS_MODEL
+        assert kwargs["voice"] == DEFAULT_OPENROUTER_TTS_VOICE
+
+    def test_custom_model_and_voice(self, tmp_path, mock_openai_client, monkeypatch):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+        client, _ = mock_openai_client
+
+        cfg = {"openrouter": {"model": "google/gemini-flash-tts", "voice": "Kore"}}
+        _generate_openrouter_tts("hi", str(tmp_path / "out.mp3"), cfg)
+
+        kwargs = client.audio.speech.create.call_args.kwargs
+        assert kwargs["model"] == "google/gemini-flash-tts"
+        assert kwargs["voice"] == "Kore"
+
+    def test_default_base_url(self, tmp_path, mock_openai_client, monkeypatch):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+        _, fake_class = mock_openai_client
+
+        _generate_openrouter_tts("hi", str(tmp_path / "out.mp3"), {})
+
+        # The OpenAI client was constructed with OR's base_url
+        ctor_kwargs = fake_class.call_args.kwargs
+        assert ctor_kwargs["api_key"] == "or-test-key"
+        assert "openrouter.ai/api/v1" in ctor_kwargs["base_url"]
+
+    def test_base_url_override_via_config(self, tmp_path, mock_openai_client, monkeypatch):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+        _, fake_class = mock_openai_client
+
+        cfg = {"openrouter": {"base_url": "https://or.example.com/v1"}}
+        _generate_openrouter_tts("hi", str(tmp_path / "out.mp3"), cfg)
+
+        assert fake_class.call_args.kwargs["base_url"] == "https://or.example.com/v1"
+
+    def test_base_url_override_via_env(self, tmp_path, mock_openai_client, monkeypatch):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+        monkeypatch.setenv("TTS_OPENROUTER_BASE_URL", "https://env.example.com/v1")
+        _, fake_class = mock_openai_client
+
+        _generate_openrouter_tts("hi", str(tmp_path / "out.mp3"), {})
+
+        assert fake_class.call_args.kwargs["base_url"] == "https://env.example.com/v1"
+
+    def test_response_format_always_mp3_even_for_ogg_path(
+        self, tmp_path, mock_openai_client, monkeypatch
+    ):
+        """OR's API does not accept opus — provider must request mp3 regardless of
+        the output path extension. The downstream ffmpeg pass converts to Opus."""
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+        client, _ = mock_openai_client
+
+        _generate_openrouter_tts("hi", str(tmp_path / "out.ogg"), {})
+
+        kwargs = client.audio.speech.create.call_args.kwargs
+        assert kwargs["response_format"] == "mp3"
+
+    def test_speed_clamped(self, tmp_path, mock_openai_client, monkeypatch):
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+        client, _ = mock_openai_client
+
+        _generate_openrouter_tts(
+            "hi", str(tmp_path / "out.mp3"), {"openrouter": {"speed": 99.0}}
+        )
+
+        kwargs = client.audio.speech.create.call_args.kwargs
+        assert kwargs["speed"] == 4.0  # upper-clamp
+
+    def test_speed_default_omitted(self, tmp_path, mock_openai_client, monkeypatch):
+        """speed=1.0 should not be sent (matches OpenAI provider behavior)."""
+        from tools.tts_tool import _generate_openrouter_tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+        client, _ = mock_openai_client
+
+        _generate_openrouter_tts("hi", str(tmp_path / "out.mp3"), {})
+
+        kwargs = client.audio.speech.create.call_args.kwargs
+        assert "speed" not in kwargs
+
+
+class TestTtsDispatcherOpenRouter:
+    def test_dispatcher_routes_to_openrouter(
+        self, tmp_path, mock_openai_client, monkeypatch
+    ):
+        """text_to_speech_tool with provider=openrouter routes through the new
+        _generate_openrouter_tts function."""
+        import json
+
+        import tools.tts_tool as tts
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+        cfg = {"provider": "openrouter", "openrouter": {"voice": "alloy"}}
+
+        with patch.object(tts, "_load_tts_config", return_value=cfg):
+            result_json = tts.text_to_speech_tool("hello dispatcher")
+
+        result = json.loads(result_json)
+        assert result["success"] is True
+        assert result["provider"] == "openrouter"
+
+    def test_openrouter_in_builtin_provider_set(self):
+        """openrouter must be in BUILTIN_TTS_PROVIDERS so user-declared
+        ``tts.providers.openrouter`` command blocks can never shadow it."""
+        from tools.tts_tool import BUILTIN_TTS_PROVIDERS
+
+        assert "openrouter" in BUILTIN_TTS_PROVIDERS
+
+    def test_openrouter_has_max_text_length(self):
+        from tools.tts_tool import PROVIDER_MAX_TEXT_LENGTH
+
+        assert PROVIDER_MAX_TEXT_LENGTH["openrouter"] == 4096

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,12 +2,16 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with six providers:
+Provides speech-to-text transcription with seven providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
+  - **openrouter** — OpenRouter unified STT API, requires ``OPENROUTER_API_KEY``.
+    Routes Whisper requests to a healthy provider (Groq, OpenAI, etc.) via
+    OR's ``/v1/audio/transcriptions`` endpoint; pricing is per-second-of-audio
+    using the caller's OpenRouter key.
   - **mistral** — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
   - **xai** — xAI Grok STT API, requires ``XAI_API_KEY``. High accuracy,
     Inverse Text Normalization, diarization, 21 languages.
@@ -84,6 +88,7 @@ DEFAULT_LOCAL_STT_LANGUAGE = "en"
 DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
+DEFAULT_OPENROUTER_STT_MODEL = os.getenv("STT_OPENROUTER_MODEL", "openai/whisper-large-v3")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
@@ -91,6 +96,20 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
+OPENROUTER_BASE_URL = os.getenv("STT_OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
+
+# Audio format extensions OpenRouter accepts in the `input_audio.format` field.
+# OR's STT endpoint expects a hint matching the encoded bytes; we derive from
+# the file extension and only pass through accepted values. Narrower than the
+# `SUPPORTED_FORMATS` validator set (line below): e.g. Hermes accepts `.mp4`
+# but OR doesn't, so a `.mp4` voice note routed via openrouter is rejected
+# with a clear error before the API call.
+OPENROUTER_STT_FORMATS = {"wav", "mp3", "flac", "m4a", "ogg", "webm", "aac"}
+
+# Hard cap on bytes we'll base64-encode into a JSON body. Matches the OpenAI/
+# Groq Whisper 25 MB ceiling so users get a consistent failure mode across
+# providers, and so we don't blow up memory base64-encoding a 100 MB file.
+MAX_OPENROUTER_AUDIO_BYTES = 25 * 1024 * 1024
 
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
@@ -268,9 +287,17 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "openrouter":
+            if get_env_value("OPENROUTER_API_KEY"):
+                return "openrouter"
+            logger.warning(
+                "STT provider 'openrouter' configured but OPENROUTER_API_KEY not set"
+            )
+            return "none"
+
         return provider  # Unknown — let it fail downstream
 
-    # --- Auto-detect (no explicit provider): local > groq > openai > mistral > xai -
+    # --- Auto-detect (no explicit provider): local > groq > openrouter > openai > mistral > xai -
 
     if _HAS_FASTER_WHISPER:
         return "local"
@@ -279,6 +306,9 @@ def _get_provider(stt_config: dict) -> str:
     if _HAS_OPENAI and get_env_value("GROQ_API_KEY"):
         logger.info("No local STT available, using Groq Whisper API")
         return "groq"
+    if get_env_value("OPENROUTER_API_KEY"):
+        logger.info("No local STT available, using OpenRouter STT API")
+        return "openrouter"
     if _HAS_OPENAI and _has_openai_audio_backend():
         logger.info("No local STT available, using OpenAI Whisper API")
         return "openai"
@@ -782,6 +812,161 @@ def _transcribe_xai(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: openrouter (unified STT — routes to Groq/OpenAI/etc. via OR)
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_openrouter(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe via OpenRouter's unified STT API.
+
+    Routes Whisper requests to a healthy underlying provider (Groq, OpenAI,
+    etc.) via a single endpoint, billed against the caller's OpenRouter key.
+
+    OR's ``POST /v1/audio/transcriptions`` is **not** OpenAI-multipart
+    compatible despite the matching path — it expects a JSON body with
+    base64-encoded audio:
+
+        {"model": "...", "input_audio": {"data": "<base64>", "format": "wav"}}
+
+    Response shape: ``{"text": "...", "usage": {"seconds", "cost", ...}}``
+
+    Requires ``OPENROUTER_API_KEY``. The ``base_url`` and ``model`` can be
+    overridden via ``stt.openrouter.base_url`` / ``stt.openrouter.model`` in
+    config, or ``STT_OPENROUTER_BASE_URL`` / ``STT_OPENROUTER_MODEL`` env vars.
+    """
+    api_key = get_env_value("OPENROUTER_API_KEY")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "OPENROUTER_API_KEY not set"}
+
+    stt_config = _load_stt_config()
+    or_config = stt_config.get("openrouter", {})
+    base_url = str(
+        or_config.get("base_url")
+        or get_env_value("STT_OPENROUTER_BASE_URL")
+        or OPENROUTER_BASE_URL
+    ).strip().rstrip("/")
+
+    audio_format = Path(file_path).suffix.lstrip(".").lower()
+    if not audio_format:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": (
+                f"OpenRouter STT: cannot infer audio format from filename "
+                f"'{Path(file_path).name}' (no extension)"
+            ),
+        }
+    # Normalize a couple of common aliases the file extension might carry.
+    if audio_format in ("oga", "opus"):
+        audio_format = "ogg"
+    if audio_format == "mpeg":
+        audio_format = "mp3"
+    if audio_format not in OPENROUTER_STT_FORMATS:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": (
+                f"OpenRouter STT does not support format '.{audio_format}'. "
+                f"Accepted: {sorted(OPENROUTER_STT_FORMATS)}"
+            ),
+        }
+
+    # Size guard before reading into memory + base64-encoding (1.33× expansion).
+    try:
+        size = os.path.getsize(file_path)
+    except OSError as exc:
+        return {"success": False, "transcript": "", "error": f"Cannot stat audio file: {exc}"}
+    if size > MAX_OPENROUTER_AUDIO_BYTES:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": (
+                f"OpenRouter STT: audio file exceeds "
+                f"{MAX_OPENROUTER_AUDIO_BYTES // (1024 * 1024)} MB ({size} bytes). "
+                "Split the file into smaller segments."
+            ),
+        }
+
+    try:
+        import base64
+        import requests
+
+        with open(file_path, "rb") as audio_file:
+            encoded = base64.b64encode(audio_file.read()).decode("ascii")
+
+        body = {
+            "model": model_name,
+            "input_audio": {"data": encoded, "format": audio_format},
+        }
+
+        response = requests.post(
+            f"{base_url}/audio/transcriptions",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+            timeout=60,
+        )
+
+        if response.status_code != 200:
+            detail = ""
+            try:
+                err_body = response.json()
+                detail = err_body.get("error", {}).get("message", "") or response.text[:300]
+            except Exception:
+                detail = response.text[:300]
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"OpenRouter STT API error (HTTP {response.status_code}): {detail}",
+            }
+
+        result = response.json()
+        transcript_text = str(result.get("text", "")).strip()
+
+        if not transcript_text:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "OpenRouter STT returned empty transcript",
+            }
+
+        usage = result.get("usage") or {}
+        seconds_raw = usage.get("seconds")
+        try:
+            seconds = float(seconds_raw) if seconds_raw is not None else 0.0
+        except (TypeError, ValueError):
+            seconds = 0.0
+        cost = usage.get("cost")
+        cost_str = str(cost) if cost is not None else "n/a"
+        logger.info(
+            "Transcribed %s via OpenRouter STT (%s, %.1fs audio, %d chars, cost=%s)",
+            Path(file_path).name,
+            model_name,
+            seconds,
+            len(transcript_text),
+            cost_str,
+        )
+
+        return {"success": True, "transcript": transcript_text, "provider": "openrouter"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        # `requests` exceptions (Timeout, ConnectionError, etc.) flow through
+        # here. We could branch on type for better error strings but the
+        # message from `e` already includes the exception class for callers.
+        # Mistral and xAI siblings take the same approach.
+        if e.__class__.__name__ == "Timeout":
+            return {"success": False, "transcript": "", "error": f"Request timeout: {e}"}
+        if e.__class__.__name__ == "ConnectionError":
+            return {"success": False, "transcript": "", "error": f"Connection error: {e}"}
+        logger.error("OpenRouter STT transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"OpenRouter STT transcription failed: {e}"}
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -854,6 +1039,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or "grok-stt"
         return _transcribe_xai(file_path, model_name)
 
+    if provider == "openrouter":
+        or_cfg = stt_config.get("openrouter", {})
+        model_name = model or or_cfg.get("model", DEFAULT_OPENROUTER_STT_MODEL)
+        return _transcribe_openrouter(file_path, model_name)
+
     # No provider available
     return {
         "success": False,
@@ -861,9 +1051,10 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         "error": (
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
-            "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
-            "Voxtral Transcribe, set XAI_API_KEY for xAI Grok STT, or set VOICE_TOOLS_OPENAI_KEY "
-            "or OPENAI_API_KEY for the OpenAI Whisper API."
+            "set GROQ_API_KEY for free Groq Whisper, set OPENROUTER_API_KEY for OpenRouter's "
+            "unified STT, set MISTRAL_API_KEY for Mistral Voxtral Transcribe, set XAI_API_KEY "
+            "for xAI Grok STT, or set VOICE_TOOLS_OPENAI_KEY or OPENAI_API_KEY for the OpenAI "
+            "Whisper API."
         ),
     }
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -6,6 +6,8 @@ Built-in TTS providers:
 - Edge TTS (default, free, no API key): Microsoft Edge neural voices
 - ElevenLabs (premium): High-quality voices, needs ELEVENLABS_API_KEY
 - OpenAI TTS: Good quality, needs OPENAI_API_KEY
+- OpenRouter TTS: OpenAI-compatible aggregator (OpenAI / Google / Mistral /
+  ... routed under one key), needs OPENROUTER_API_KEY
 - MiniMax TTS: High-quality with voice cloning, needs MINIMAX_API_KEY
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
 - Google Gemini TTS: Controllable, 30 prebuilt voices, needs GEMINI_API_KEY
@@ -136,6 +138,13 @@ DEFAULT_KITTENTTS_VOICE = "Jasper"
 DEFAULT_PIPER_VOICE = "en_US-lessac-medium"  # balanced size/quality
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
+# OpenRouter exposes OpenAI-compatible /v1/audio/speech, but routes the request
+# to the underlying provider implied by the model slug ("openai/...",
+# "google/...", "mistral/..."). The default below tracks the model OpenRouter
+# recommends for the OpenAI route as of the May 2026 audio API launch.
+DEFAULT_OPENROUTER_TTS_MODEL = "openai/gpt-4o-mini-tts-2025-12-15"
+DEFAULT_OPENROUTER_TTS_VOICE = "alloy"
+DEFAULT_OPENROUTER_TTS_BASE_URL = "https://openrouter.ai/api/v1"
 DEFAULT_MINIMAX_MODEL = "speech-01"
 DEFAULT_MINIMAX_VOICE_ID = "female-shaonv"
 DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.chat/v1/text_to_speech"
@@ -170,6 +179,7 @@ DEFAULT_OUTPUT_DIR = _get_default_output_dir()
 PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "edge": 5000,         # edge-tts practical sync limit
     "openai": 4096,       # https://platform.openai.com/docs/guides/text-to-speech
+    "openrouter": 4096,   # follows the underlying OpenAI cap; OR routes ride on it
     "xai": 15000,         # https://docs.x.ai/developers/model-capabilities/audio/text-to-speech
     "minimax": 10000,     # https://platform.minimax.io/docs/api-reference/speech-t2a-http (sync)
     "mistral": 4000,      # conservative; no published per-request cap
@@ -317,6 +327,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "edge",
     "elevenlabs",
     "openai",
+    "openrouter",
     "minimax",
     "xai",
     "mistral",
@@ -847,6 +858,59 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
             create_kwargs["speed"] = max(0.25, min(4.0, speed))
         response = client.audio.speech.create(**create_kwargs)
 
+        response.stream_to_file(output_path)
+        return output_path
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+
+
+# ===========================================================================
+# Provider: OpenRouter TTS
+# ===========================================================================
+def _generate_openrouter_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using OpenRouter's /v1/audio/speech endpoint.
+
+    OpenRouter exposes the same JSON request shape as OpenAI's audio.speech
+    API, so we reuse the OpenAI client with a swapped base_url + key. The
+    underlying provider (OpenAI, Google, Mistral, ...) is selected by the
+    ``tts.openrouter.model`` slug.
+    """
+    api_key = (get_env_value("OPENROUTER_API_KEY") or "").strip()
+    if not api_key:
+        raise ValueError(
+            "OPENROUTER_API_KEY not set. Get one at https://openrouter.ai/keys"
+        )
+
+    or_config = tts_config.get("openrouter", {})
+    model = str(or_config.get("model") or DEFAULT_OPENROUTER_TTS_MODEL).strip() \
+        or DEFAULT_OPENROUTER_TTS_MODEL
+    voice = str(or_config.get("voice") or DEFAULT_OPENROUTER_TTS_VOICE).strip() \
+        or DEFAULT_OPENROUTER_TTS_VOICE
+    base_url = str(
+        or_config.get("base_url")
+        or get_env_value("TTS_OPENROUTER_BASE_URL")
+        or DEFAULT_OPENROUTER_TTS_BASE_URL
+    ).strip() or DEFAULT_OPENROUTER_TTS_BASE_URL
+    speed = float(or_config.get("speed", tts_config.get("speed", 1.0)))
+
+    # OpenRouter's /v1/audio/speech accepts only `mp3` or `pcm` (per the
+    # May 2026 audio API launch). Telegram-bound `.ogg` outputs are converted
+    # downstream via ffmpeg, same path Edge TTS takes.
+    OpenAIClient = _import_openai_client()
+    client = OpenAIClient(api_key=api_key, base_url=base_url)
+    try:
+        create_kwargs = dict(
+            model=model,
+            voice=voice,
+            input=text,
+            response_format="mp3",
+            extra_headers={"x-idempotency-key": str(uuid.uuid4())},
+        )
+        if speed != 1.0:
+            create_kwargs["speed"] = max(0.25, min(4.0, speed))
+        response = client.audio.speech.create(**create_kwargs)
         response.stream_to_file(output_path)
         return output_path
     finally:
@@ -1641,6 +1705,17 @@ def text_to_speech_tool(
             logger.info("Generating speech with OpenAI TTS...")
             _generate_openai_tts(text, file_str, tts_config)
 
+        elif provider == "openrouter":
+            try:
+                _import_openai_client()
+            except ImportError:
+                return json.dumps({
+                    "success": False,
+                    "error": "OpenRouter provider selected but 'openai' package not installed (OpenRouter reuses the OpenAI client with a swapped base_url)."
+                }, ensure_ascii=False)
+            logger.info("Generating speech with OpenRouter TTS...")
+            _generate_openrouter_tts(text, file_str, tts_config)
+
         elif provider == "minimax":
             logger.info("Generating speech with MiniMax TTS...")
             _generate_minimax_tts(text, file_str, tts_config)
@@ -1750,7 +1825,7 @@ def text_to_speech_tool(
                     if opus_path:
                         file_str = opus_path
                 voice_compatible = file_str.endswith(".ogg")
-        elif provider in ("edge", "neutts", "minimax", "xai", "kittentts", "piper") and not file_str.endswith(".ogg"):
+        elif provider in ("edge", "openrouter", "neutts", "minimax", "xai", "kittentts", "piper") and not file_str.endswith(".ogg"):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -961,12 +961,19 @@ def check_voice_requirements() -> Dict[str, Any]:
         details_parts.append("STT provider: OK (local faster-whisper)")
     elif stt_provider == "groq":
         details_parts.append("STT provider: OK (Groq)")
+    elif stt_provider == "openrouter":
+        details_parts.append("STT provider: OK (OpenRouter)")
     elif stt_provider == "openai":
         details_parts.append("STT provider: OK (OpenAI)")
+    elif stt_provider == "mistral":
+        details_parts.append("STT provider: OK (Mistral Voxtral)")
+    elif stt_provider == "xai":
+        details_parts.append("STT provider: OK (xAI Grok)")
     else:
         details_parts.append(
-            "STT provider: MISSING (pip install faster-whisper, "
-            "or set GROQ_API_KEY / VOICE_TOOLS_OPENAI_KEY)"
+            "STT provider: MISSING (pip install faster-whisper, or set "
+            "GROQ_API_KEY / OPENROUTER_API_KEY / VOICE_TOOLS_OPENAI_KEY / "
+            "MISTRAL_API_KEY / XAI_API_KEY)"
         )
 
     for warning in env_check["warnings"]:

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -14,13 +14,14 @@ If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, 
 
 ## Text-to-Speech
 
-Convert text to speech with ten providers:
+Convert text to speech with eleven providers:
 
 | Provider | Quality | Cost | API Key |
 |----------|---------|------|---------|
 | **Edge TTS** (default) | Good | Free | None needed |
 | **ElevenLabs** | Excellent | Paid | `ELEVENLABS_API_KEY` |
 | **OpenAI TTS** | Good | Paid | `VOICE_TOOLS_OPENAI_KEY` |
+| **OpenRouter TTS** | Good | Paid | `OPENROUTER_API_KEY` |
 | **MiniMax TTS** | Excellent | Paid | `MINIMAX_API_KEY` |
 | **Mistral (Voxtral TTS)** | Excellent | Paid | `MISTRAL_API_KEY` |
 | **Google Gemini TTS** | Excellent | Free tier | `GEMINI_API_KEY` |
@@ -43,7 +44,7 @@ Convert text to speech with ten providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "openrouter" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -56,6 +57,14 @@ tts:
     voice: "alloy"              # alloy, echo, fable, onyx, nova, shimmer
     base_url: "https://api.openai.com/v1"  # Override for OpenAI-compatible TTS endpoints
     speed: 1.0                  # 0.25 - 4.0
+  openrouter:
+    # OpenAI-compatible aggregator: same JSON shape, OPENROUTER_API_KEY auth.
+    # The model slug picks the underlying provider (openai/google/mistral/...).
+    # Discoverable via Models API with output_modalities=audio.
+    model: "openai/gpt-4o-mini-tts-2025-12-15"
+    voice: "alloy"
+    speed: 1.0                  # 0.25 - 4.0
+    # base_url: "https://openrouter.ai/api/v1"  # override for self-hosted/proxy
   minimax:
     model: "speech-2.8-hd"     # speech-2.8-hd (default), speech-2.8-turbo
     voice_id: "English_Graceful_Lady"  # See https://platform.minimax.io/faq/system-voice-id
@@ -106,6 +115,7 @@ Each provider has a documented per-request input-character cap. Hermes truncates
 |----------|---------------------|
 | Edge TTS | 5000 |
 | OpenAI | 4096 |
+| OpenRouter | 4096 |
 | xAI | 15000 |
 | MiniMax | 10000 |
 | Mistral | 4000 |


### PR DESCRIPTION
## Summary

Adds `openrouter` as a unified provider for both transcription (STT) and speech synthesis (TTS), alongside the existing local/groq/openai/mistral/xai (STT) and edge/elevenlabs/openai/minimax/mistral/gemini/xai/neutts/kittentts/piper (TTS) sets.

OpenRouter [announced their audio APIs on May 1, 2026](https://openrouter.ai/announcements/announcing-audio-apis), exposing both `/v1/audio/transcriptions` and `/v1/audio/speech` that route across providers (OpenAI Whisper, GPT-4o-transcribe, Google Chirp 3, Groq Whisper for STT; OpenAI TTS, Google Gemini Flash TTS, Mistral Voxtral Mini TTS for speech) under one API key.

> "Text-to-speech and transcription are now live on OpenRouter. Two new endpoints give you access to speech synthesis and audio transcription across multiple providers, under one API."

### Why this is useful

- One key (`OPENROUTER_API_KEY`) covers chat + STT + TTS for users already on OpenRouter for LLMs.
- OpenRouter handles fallback across providers automatically.
- Lets users try premium audio models (`openai/gpt-4o-mini-tts`, `google/chirp-3`, etc.) without separate accounts.

## STT — `tools/transcription_tools.py`

OR's transcription endpoint takes JSON body with base64-encoded audio (not OpenAI-style multipart), so it can't reuse the existing `openai` client path.

- New `_transcribe_openrouter()` — JSON body with `input_audio.data` (base64) + `format` string.
- Format whitelist (`wav`/`mp3`/`flac`/`m4a`/`ogg`/`webm`/`aac`); rejects unsupported extensions early. Aliases: `.oga`/`.opus` → `ogg`, `.mpeg` → `mp3`.
- 25 MiB size cap matching the documented limit.
- Typed exception branches for `Timeout` / `ConnectionError` so transient failures surface cleanly.
- `_get_provider()` — explicit `openrouter` routing + auto-detect entry that ranks below `local`/`groq` and above `openai`.
- `tools/voice_mode.py` — `voice_doctor` now reports the openrouter / mistral / xai branches.

## TTS — `tools/tts_tool.py`

OR's speech endpoint *is* OpenAI-shape JSON, so this provider reuses the OpenAI client with a swapped base_url + key.

- New `_generate_openrouter_tts()` — uses the OpenAI SDK against OR's base URL, default model `openai/gpt-4o-mini-tts-2025-12-15`.
- `response_format` is hard-coded to `mp3` — OR only accepts `mp3` / `pcm`. Telegram-bound `.ogg` outputs go through the existing ffmpeg-to-Opus path (same as Edge TTS).
- `BUILTIN_TTS_PROVIDERS` includes `openrouter` so a user's `tts.providers.openrouter` command block can never shadow it.
- `PROVIDER_MAX_TEXT_LENGTH["openrouter"] = 4096` (follows the underlying OpenAI cap).
- Configurable `base_url` via `tts.openrouter.base_url` or `TTS_OPENROUTER_BASE_URL`.

## Tests

- 19 STT tests + 13 TTS tests = 32 new tests total. All pass.
- Full suite (`pytest tests/tools/test_transcription_tools.py tests/tools/test_tts_*.py`): **265 passed, 7 skipped**.

## Live verification

- Direct `curl` to OR's `/v1/audio/transcriptions` with a real `.wav` → correct transcript + usage metadata.
- Direct `curl` to OR's `/v1/audio/speech` with model `openai/gpt-4o-mini-tts-2025-12-15` → valid audio/mpeg.
- `_transcribe_openrouter()` end-to-end → `{"success": true, "transcript": "...", "provider": "openrouter"}`.
- `_generate_openrouter_tts()` end-to-end → 75 KiB MP3.
- Full TTS dispatcher with `HERMES_SESSION_PLATFORM=telegram` → valid Opus OGG (24 kHz mono) via ffmpeg conversion, marked `voice_compatible: true`.

(A bug was caught during live verification: my first TTS impl asked for `response_format: opus` when the output path was `.ogg`, which OR rejects with `ZodError`. Fixed by always requesting `mp3` and routing through the existing ffmpeg conversion path.)

## Test plan

- [x] Unit tests pass (`pytest tests/tools/test_transcription_tools.py tests/tools/test_tts_openrouter.py`)
- [x] STT: manually verified against the live `/v1/audio/transcriptions` endpoint
- [x] TTS: manually verified against the live `/v1/audio/speech` endpoint, including the Telegram Opus path
- [ ] Reviewer can verify config: set `stt.provider: openrouter` + `tts.provider: openrouter` + `OPENROUTER_API_KEY` and exchange a voice note