### PR TITLE
fix(skills): skill_manage create respects skills.external_dirs

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -268,11 +268,26 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
     return None
 
 
+def _default_creation_root() -> Path:
+    """Return the preferred root dir for new skills.
+
+    If the user has configured ``skills.external_dirs``, the first entry is
+    used so that newly created skills land in the user-managed directory
+    rather than the bundled ``~/.hermes/skills/``.  Falls back to
+    ``SKILLS_DIR`` when no external dirs are configured.
+    """
+    from agent.skill_utils import get_external_skills_dirs
+
+    ext = get_external_skills_dirs()
+    return ext[0] if ext else SKILLS_DIR
+
+
 def _resolve_skill_dir(name: str, category: str = None) -> Path:
     """Build the directory path for a new skill, optionally under a category."""
+    root = _default_creation_root()
     if category:
-        return SKILLS_DIR / category / name
-    return SKILLS_DIR / name
+        return root / category / name
+    return root / name
 
 
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:


### PR DESCRIPTION
## Summary

`skill_manage(action='create')` previously always wrote new skills to
`~/.hermes/skills/` (hardcoded `SKILLS_DIR`), ignoring any
`skills.external_dirs` configured in `config.yaml`.

This means users who maintain skills in a separate git repository via
`external_dirs` had no way to use the tool to create skills there —
they had to use `write_file` directly.

## Change

Added `_default_creation_root()` that returns the first configured
external dir when `skills.external_dirs` is set, falling back to
`SKILLS_DIR` when it is not. `_resolve_skill_dir()` now uses this
instead of the hardcoded constant.

**No regression:** users without `external_dirs` get identical behavior.

## Closes

Fixes #21810