### PR TITLE
fix(anthropic): defend normalize_response against content=None

### DIFF
--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -106,7 +106,11 @@ class AnthropicTransport(ProviderTransport):
         # tests/agent/test_anthropic_thinking_block_order.py.
         ordered_blocks = []
 
-        for block in response.content:
+        # Some Anthropic-compatible endpoints return non-spec ``content=None``.
+        # Direct callers such as AnthropicAuxiliaryClient normalize before any
+        # validation, so keep normalization total; validate_response() still
+        # classifies the original response as invalid for guarded call paths.
+        for block in (response.content or []):
             block_dict = _to_plain_data(block)
             clean_block = None
             if isinstance(block_dict, dict):

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1195,6 +1195,19 @@ class TestNormalizeResponse:
 
 
 
+    def test_null_content_does_not_raise(self):
+        """Direct normalizer callers handle a non-spec null content value."""
+        resp = self._make_response(None)
+        transport = get_transport("anthropic_messages")
+
+        assert transport.validate_response(resp) is False
+
+        nr = transport.normalize_response(resp)
+        assert nr.content is None
+        assert nr.tool_calls is None
+        assert nr.reasoning is None
+        assert nr.finish_reason == "stop"
+
 
 # ---------------------------------------------------------------------------
 # Role alternation

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1149,6 +1149,19 @@ class TestNormalizeResponse:
 
 
 
+    def test_null_content_does_not_raise(self):
+        """Direct normalizer callers handle a non-spec null content value."""
+        resp = self._make_response(None)
+        transport = get_transport("anthropic_messages")
+
+        assert transport.validate_response(resp) is False
+
+        nr = transport.normalize_response(resp)
+        assert nr.content is None
+        assert nr.tool_calls is None
+        assert nr.reasoning is None
+        assert nr.finish_reason == "stop"
+
 
 # ---------------------------------------------------------------------------
 # Role alternation


### PR DESCRIPTION
## Summary

Some Anthropic-compatible endpoints return HTTP 200 with `content: null` instead of a list of content blocks. Kimi For Coding (`api.kimi.com/coding/v1/messages`) has been observed returning this non-spec shape for some prompt patterns.

`AnthropicTransport.normalize_response` directly iterated `response.content`, which raises `TypeError: 'NoneType' object is not iterable`. The ordinary conversation path validates before normalization, but direct callers such as `AnthropicAuxiliaryClient` normalize immediately and therefore crash before validation can guard the response.

## Fix

Iterate `(response.content or [])` so normalization remains safe for direct callers. The validation contract does not change: `validate_response(response)` still returns `False` for the original null-content response.

```diff
-        for block in response.content:
+        for block in (response.content or []):
```

## Scope

This PR has been rebuilt on current `main` as one focused commit. The unrelated macOS Keychain test-isolation commit previously present on the branch has been removed.

## Test plan

- [x] Regression test reproduces the `TypeError` on current `main`
- [x] Regression test explicitly asserts `validate_response(resp) is False`
- [x] `TestNormalizeResponse`: 8 passed
- [x] Anthropic thinking, auxiliary client, pool fallback, custom-provider, and Kimi compatibility tests: 327 passed
- [x] Ruff passed
- [x] `git diff --check` passed
