### PR TITLE
fix(tui): align bundle filename check with esbuild output

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -971,7 +971,7 @@ def _tui_build_needed(tui_dir: Path) -> bool:
 
 def _hermes_ink_bundle_stale(tui_dir: Path) -> bool:
     ink_root = tui_dir / "packages" / "hermes-ink"
-    bundle = ink_root / "dist" / "ink-bundle.js"
+    bundle = ink_root / "dist" / "entry-exports.js"
     if not bundle.exists():
         return True
     bm = bundle.stat().st_mtime

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -26,7 +26,7 @@ def _touch_tui_entry(root: Path) -> None:
 
 
 def _touch_ink_bundle(root: Path) -> None:
-    bundle = root / "packages" / "hermes-ink" / "dist" / "ink-bundle.js"
+    bundle = root / "packages" / "hermes-ink" / "dist" / "entry-exports.js"
     bundle.parent.mkdir(parents=True, exist_ok=True)
     bundle.write_text("export {}")
 


### PR DESCRIPTION
## Summary

The TUI build script (`packages/hermes-ink/package.json`) outputs `entry-exports.js`, but `_hermes_ink_bundle_stale()` was checking for `ink-bundle.js`. This mismatch caused the dashboard to unnecessarily rebuild the TUI on every launch, and in some cases the build would time out before the PTY bridge could start.

## Changes

- `hermes_cli/main.py:974` — check `entry-exports.js` instead of `ink-bundle.js`
- `tests/hermes_cli/test_tui_npm_install.py:29` — update test fixture to match

## Test plan

- [x] `pytest tests/hermes_cli/test_tui_npm_install.py` passes
- [x] `_hermes_ink_bundle_stale()` correctly detects stale/missing bundle after rename

🤖 Generated with [Claude Code](https://claude.com/code)