### PR TITLE
fix(kanban): honour kanban.executable config in dispatcher spawn

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3852,6 +3852,23 @@ class GatewayRunner:
             )
             failure_limit = _kb.DEFAULT_FAILURE_LIMIT
 
+        # Allow config to pin the hermes executable so the dispatcher works
+        # when PATH inside the gateway process doesn't include the hermes shim
+        # (common in systemd/venv setups). kanban.executable in config.yaml.
+        configured_executable: "Optional[str]" = kanban_cfg.get("executable") or None
+        if configured_executable:
+            logger.info("kanban dispatcher: using configured executable %s", configured_executable)
+
+        def _make_spawn_fn():
+            _exe = configured_executable
+
+            def _spawn(task, workspace, *, board=None):
+                return _kb._default_spawn(task, workspace, board=board, executable=_exe)
+
+            return _spawn if _exe else None
+
+        _spawn_fn = _make_spawn_fn()
+
         # Initial delay so the gateway finishes wiring adapters before the
         # dispatcher spawns workers (those workers may hit gateway notify
         # subscriptions etc.). Matches the notifier watcher's delay.
@@ -3885,6 +3902,7 @@ class GatewayRunner:
                     board=slug,
                     max_spawn=max_spawn,
                     failure_limit=failure_limit,
+                    spawn_fn=_spawn_fn,
                 )
             except Exception:
                 logger.exception("kanban dispatcher: tick failed on board %s", slug)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3656,6 +3656,7 @@ def _default_spawn(
     workspace: str,
     *,
     board: Optional[str] = None,
+    executable: Optional[str] = None,
 ) -> Optional[int]:
     """Fire-and-forget ``hermes -p <profile> chat -q ...`` subprocess.
 
@@ -3668,7 +3669,13 @@ def _default_spawn(
     ``HERMES_KANBAN_DB`` / ``HERMES_KANBAN_BOARD`` / workspaces_root env
     vars all resolve to the same board the dispatcher claimed the task
     from. Workers cannot accidentally see other boards.
+
+    ``executable`` overrides the ``hermes`` binary path. When omitted the
+    dispatcher falls back to ``shutil.which("hermes")`` and then to
+    ``sys.executable -m hermes_cli.main`` so venv/systemd setups work even
+    when the shim is not on the process PATH.
     """
+    import shutil
     import subprocess
     if not task.assignee:
         raise ValueError(f"task {task.id} has no assignee")
@@ -3706,8 +3713,16 @@ def _default_spawn(
     # attributed correctly regardless of how the child loads config.
     env["HERMES_PROFILE"] = profile_arg
 
+    hermes_bin: list[str]
+    if executable:
+        hermes_bin = [executable]
+    elif shutil.which("hermes"):
+        hermes_bin = [shutil.which("hermes")]  # type: ignore[list-item]
+    else:
+        hermes_bin = [sys.executable, "-m", "hermes_cli.main"]
+
     cmd = [
-        "hermes",
+        *hermes_bin,
         "-p", profile_arg,
         # Auto-load the kanban-worker skill so every dispatched worker
         # has the pattern library (good summary/metadata shapes, retry

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3713,11 +3713,11 @@ def _default_spawn(
     # attributed correctly regardless of how the child loads config.
     env["HERMES_PROFILE"] = profile_arg
 
-    hermes_bin: list[str]
+    _which = shutil.which("hermes")
     if executable:
-        hermes_bin = [executable]
-    elif shutil.which("hermes"):
-        hermes_bin = [shutil.which("hermes")]  # type: ignore[list-item]
+        hermes_bin: list[str] = [executable]
+    elif _which:
+        hermes_bin = [_which]
     else:
         hermes_bin = [sys.executable, "-m", "hermes_cli.main"]
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -39,6 +39,7 @@ PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "amin.lalji@redhelix.ca": "redhelix",
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
     "0x.badfriend@gmail.com": "discodirector",

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -914,3 +914,115 @@ def test_latest_summaries_batch_omits_tasks_without_summary(kanban_home):
         assert out == {t1: "alpha", t3: "charlie"}
         # Empty input → empty dict, no SQL syntax error from "IN ()".
         assert kb.latest_summaries(conn, []) == {}
+
+
+# ---------------------------------------------------------------------------
+# _default_spawn: configured executable + venv fallback
+# ---------------------------------------------------------------------------
+
+class TestDefaultSpawnExecutable:
+    """_default_spawn must use the configured executable path rather than
+    a bare 'hermes' string when kanban.executable is set in config.yaml.
+    This lets the dispatcher work in systemd/venv setups where the hermes
+    shim is not on the process PATH."""
+
+    def _make_task(self):
+        return kb.Task(
+            id="t_exec_test",
+            title="exec test",
+            body=None,
+            assignee="default",
+            status="ready",
+            priority=0,
+            created_by=None,
+            created_at=0,
+            started_at=None,
+            completed_at=None,
+            workspace_kind="scratch",
+            workspace_path=None,
+            claim_lock=None,
+            claim_expires=None,
+            tenant=None,
+            current_run_id=None,
+            skills=None,
+        )
+
+    def test_explicit_executable_used_as_cmd_prefix(self, tmp_path, monkeypatch):
+        """When executable='/path/to/hermes' is passed, cmd[0] must be that path."""
+        captured = {}
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                captured["cmd"] = cmd
+                self.pid = 1
+
+        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        (tmp_path / ".hermes").mkdir()
+
+        kb._default_spawn(
+            self._make_task(),
+            str(tmp_path / "ws"),
+            executable="/custom/bin/hermes",
+        )
+
+        assert captured["cmd"][0] == "/custom/bin/hermes"
+
+    def test_no_executable_falls_back_to_which(self, tmp_path, monkeypatch):
+        """Without explicit executable, cmd[0] must be whatever shutil.which returns."""
+        captured = {}
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                captured["cmd"] = cmd
+                self.pid = 1
+
+        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+        monkeypatch.setattr("shutil.which", lambda name: f"/found/{name}" if name == "hermes" else None)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        (tmp_path / ".hermes").mkdir()
+
+        kb._default_spawn(self._make_task(), str(tmp_path / "ws"))
+
+        assert captured["cmd"][0] == "/found/hermes"
+
+    def test_fallback_to_module_invocation_when_which_returns_none(self, tmp_path, monkeypatch):
+        """When shutil.which('hermes') returns None, fall back to sys.executable -m hermes_cli.main."""
+        import sys
+        captured = {}
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                captured["cmd"] = cmd
+                self.pid = 1
+
+        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        (tmp_path / ".hermes").mkdir()
+
+        kb._default_spawn(self._make_task(), str(tmp_path / "ws"))
+
+        assert captured["cmd"][:3] == [sys.executable, "-m", "hermes_cli.main"]
+
+    def test_explicit_executable_overrides_which(self, tmp_path, monkeypatch):
+        """Explicit executable wins even when shutil.which would find a different one."""
+        captured = {}
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                captured["cmd"] = cmd
+                self.pid = 1
+
+        monkeypatch.setattr("subprocess.Popen", _FakePopen)
+        monkeypatch.setattr("shutil.which", lambda name: "/wrong/hermes")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        (tmp_path / ".hermes").mkdir()
+
+        kb._default_spawn(
+            self._make_task(),
+            str(tmp_path / "ws"),
+            executable="/correct/bin/hermes",
+        )
+
+        assert captured["cmd"][0] == "/correct/bin/hermes"


### PR DESCRIPTION
## What changed and why

- `_default_spawn` in `kanban_db.py` hardcoded `cmd = ["hermes", ...]` and never read `kanban.executable` from `config.yaml`. In systemd/venv deployments the gateway process PATH can differ from the user's interactive shell, causing `FileNotFoundError` even when the binary exists at a known absolute path.
- Added an `executable` kwarg to `_default_spawn` with a three-tier fallback: configured path → `shutil.which("hermes")` → `sys.executable -m hermes_cli.main` (matching the existing `_resolve_hermes_bin` pattern in `gateway/run.py`).
- `_run_kanban_dispatcher` in `gateway/run.py` now reads `kanban.executable` from config and passes a thin `spawn_fn` wrapper to `dispatch_once` when set.

## How to reproduce / test

```yaml
# ~/.hermes/config.yaml
kanban:
  executable: /home/user/.local/bin/hermes   # absolute path to hermes shim
```

Start gateway via systemd (`hermes-gateway.service`) and queue a kanban task. Without this fix the worker spawn fails with `` `hermes` executable not found on PATH `` even though the binary exists. With the fix the dispatcher uses the configured path directly.

```bash
pytest tests/hermes_cli/test_kanban_db.py::TestDefaultSpawnExecutable -v
```

## Platforms tested

- [x] Linux
- [ ] macOS
- [ ] Windows

## Notes

The `kanban.executable` config key was already documented/used in user configs as a workaround but the code never consumed it. This PR wires it up. The fallback chain means zero behaviour change for users who do not set the key.