### PR TITLE
fix(google-workspace): detect disabled_client in --check and add --check-live (salvage of #19643)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,7 @@ AUTHOR_MAP = {
     "qiyin.zuo@pcitc.com": "qiyin-code",
     "oleksii.lisikh@gmail.com": "olisikh",
     "leone.parise@gmail.com": "leoneparise",
+    "buraysandro9@gmail.com": "ygd58",
     "teknium@nousresearch.com": "teknium1",
     "piyushvp1@gmail.com": "thelumiereguy",
     "harish.kukreja@gmail.com": "counterposition",

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -132,9 +132,10 @@ def _ensure_deps():
 
 def check_auth_live():
     """Check auth with a real API call to detect disabled_client/account issues."""
-    if not check_auth():
+    # quiet=True suppresses the "AUTHENTICATED" print from check_auth so the
+    # final status line reflects the live-call outcome (OK or FAILED).
+    if not check_auth(quiet=True):
         return False
-    _ensure_deps()
     try:
         from googleapiclient.discovery import build
         from google.oauth2.credentials import Credentials
@@ -155,7 +156,7 @@ def check_auth_live():
         return False
 
 
-def check_auth():
+def check_auth(quiet: bool = False):
     """Check if stored credentials are valid. Prints status, exits 0 or 1."""
     if not TOKEN_PATH.exists():
         print(f"NOT_AUTHENTICATED: No token at {TOKEN_PATH}")
@@ -182,7 +183,8 @@ def check_auth():
             print(f"AUTHENTICATED (partial): Token valid but missing {len(missing_scopes)} scopes:")
             for s in missing_scopes:
                 print(f"  - {s}")
-        print(f"AUTHENTICATED: Token valid at {TOKEN_PATH}")
+        if not quiet:
+            print(f"AUTHENTICATED: Token valid at {TOKEN_PATH}")
         return True
 
     if creds.expired and creds.refresh_token:
@@ -199,7 +201,8 @@ def check_auth():
                 print(f"AUTHENTICATED (partial): Token refreshed but missing {len(missing_scopes)} scopes:")
                 for s in missing_scopes:
                     print(f"  - {s}")
-            print(f"AUTHENTICATED: Token refreshed at {TOKEN_PATH}")
+            if not quiet:
+                print(f"AUTHENTICATED: Token refreshed at {TOKEN_PATH}")
             return True
         except Exception as e:
             err_str = str(e).lower()

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -130,6 +130,31 @@ def _ensure_deps():
             sys.exit(1)
 
 
+def check_auth_live():
+    """Check auth with a real API call to detect disabled_client/account issues.""""
+    if not check_auth():
+        return False
+    _ensure_deps()
+    try:
+        from googleapiclient.discovery import build
+        from google.oauth2.credentials import Credentials
+        creds = Credentials.from_authorized_user_file(str(TOKEN_PATH))
+        service = build("calendar", "v3", credentials=creds)
+        service.calendarList().list(maxResults=1).execute()
+        print("LIVE_CHECK_OK: Real API call succeeded.")
+        return True
+    except Exception as e:
+        err_str = str(e).lower()
+        if "disabled_client" in err_str or "invalid_client" in err_str:
+            print(f"LIVE_CHECK_FAILED: OAuth client or account disabled: {e}")
+            print("  1. Check Google Cloud Console for disabled OAuth client")
+            print("  2. Check myaccount.google.com for account status")
+            print("  3. Do NOT retry with a disabled account")
+        else:
+            print(f"LIVE_CHECK_FAILED: {e}")
+        return False
+
+
 def check_auth():
     """Check if stored credentials are valid. Prints status, exits 0 or 1."""
     if not TOKEN_PATH.exists():
@@ -177,7 +202,21 @@ def check_auth():
             print(f"AUTHENTICATED: Token refreshed at {TOKEN_PATH}")
             return True
         except Exception as e:
-            print(f"REFRESH_FAILED: {e}")
+            err_str = str(e).lower()
+            if "disabled_client" in err_str or "invalid_client" in err_str:
+                print(f"OAUTH_CLIENT_DISABLED: {e}")
+                print("  The OAuth client or Google account has been disabled.")
+                print("  Steps to resolve:")
+                print("    1. Check your Google Cloud Console — verify the OAuth client is not disabled")
+                print("    2. Check if your Google account itself has been disabled at myaccount.google.com")
+                print("    3. If the account is disabled, you can appeal at accounts.google.com/signin/recovery")
+                print("    4. Do NOT retry API calls with a disabled account — this may worsen the situation")
+                print("    5. If the OAuth client is disabled, create a new one in Google Cloud Console")
+            elif "token_revoked" in err_str or "invalid_grant" in err_str:
+                print(f"TOKEN_REVOKED: {e}")
+                print("  Re-run setup to re-authenticate.")
+            else:
+                print(f"REFRESH_FAILED: {e}")
             return False
 
     print("TOKEN_INVALID: Re-run setup.")
@@ -384,6 +423,7 @@ def main():
     parser = argparse.ArgumentParser(description="Google Workspace OAuth setup for Hermes")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--check", action="store_true", help="Check if auth is valid (exit 0=yes, 1=no)")
+    group.add_argument("--check-live", action="store_true", help="Check auth with a real API call (detects disabled_client)")
     group.add_argument("--client-secret", metavar="PATH", help="Store OAuth client_secret.json")
     group.add_argument("--auth-url", action="store_true", help="Print OAuth URL for user to visit")
     group.add_argument("--auth-code", metavar="CODE", help="Exchange auth code for token")
@@ -393,6 +433,8 @@ def main():
 
     if args.check:
         sys.exit(0 if check_auth() else 1)
+    if getattr(args, "check_live", False):
+        sys.exit(0 if check_auth_live() else 1)
     elif args.client_secret:
         store_client_secret(args.client_secret)
     elif args.auth_url:

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -131,7 +131,7 @@ def _ensure_deps():
 
 
 def check_auth_live():
-    """Check auth with a real API call to detect disabled_client/account issues.""""
+    """Check auth with a real API call to detect disabled_client/account issues."""
     if not check_auth():
         return False
     _ensure_deps()


### PR DESCRIPTION
Salvages @ygd58's #19643 onto current main, plus small cleanups.

## What it does
`setup.py --check` now detects `disabled_client`/`invalid_client` during token refresh with actionable guidance. Adds `--check-live` which performs a real Calendar API call to catch accounts Google disabled after token issuance (the exact case from #19570 where `--check` reported `AUTHENTICATED` while real API calls failed).

## Commits (attribution preserved)
- `3363aa1fc` @ygd58 — original fix + `--check-live` implementation
- `63bb9c474` @ygd58 — docstring syntax fix
- `de5ad235b` — cleanup: `check_auth()` takes `quiet` kwarg so `check_auth_live()` doesn't print `AUTHENTICATED` before its own status line; drop redundant `_ensure_deps()`; add AUTHOR_MAP entry.

## Validation
- `py_compile` clean
- `--check` on missing token → `NOT_AUTHENTICATED`, exit 1
- `--check-live` on missing token → `NOT_AUTHENTICATED`, exit 1
- `--check-live` with valid token + successful live call → prints only `LIVE_CHECK_OK` (no spurious `AUTHENTICATED` line)
- `--help` lists `--check-live` in mutex group

Fixes #19570. Closes #19643.