### PR TITLE
fix(hindsight): persist HINDSIGHT_EMBED_API_DATABASE_URL into embedded profile env

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -316,6 +316,12 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
     current_provider = config.get("llm_provider", "")
     current_model = config.get("llm_model", "")
     current_base_url = config.get("llm_base_url") or os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")
+    current_database_url = (
+        config.get("embed_database_url")
+        or config.get("database_url")
+        or config.get("HINDSIGHT_EMBED_API_DATABASE_URL")
+        or os.environ.get("HINDSIGHT_EMBED_API_DATABASE_URL", "")
+    )
 
     # The embedded daemon expects OpenAI wire format for these providers.
     daemon_provider = "openai" if current_provider in ("openai_compatible", "openrouter") else current_provider
@@ -328,6 +334,8 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
     }
     if current_base_url:
         env_values["HINDSIGHT_API_LLM_BASE_URL"] = str(current_base_url)
+    if current_database_url:
+        env_values["HINDSIGHT_EMBED_API_DATABASE_URL"] = str(current_database_url)
 
     idle_timeout = (
         config.get("idle_timeout")

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -337,6 +337,18 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
     if current_database_url:
         env_values["HINDSIGHT_EMBED_API_DATABASE_URL"] = str(current_database_url)
 
+    # Database URL for the embedded store. Canonical config key is
+    # embed_database_url; fall back to the environment variable so that
+    # operators who already set HINDSIGHT_EMBED_API_DATABASE_URL in their
+    # shell do not need to duplicate it in config.yaml.
+    embed_db_url = (
+        config.get("embed_database_url")
+        or config.get("embedDatabaseUrl")
+        or os.environ.get("HINDSIGHT_EMBED_API_DATABASE_URL", "")
+    )
+    if embed_db_url:
+        env_values["HINDSIGHT_EMBED_API_DATABASE_URL"] = str(embed_db_url)
+
     idle_timeout = (
         config.get("idle_timeout")
         if config.get("idle_timeout") is not None
@@ -753,6 +765,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "llm_base_url", "description": "Endpoint URL (e.g. http://192.168.1.10:8080/v1)", "default": "", "when": {"mode": "local_embedded", "llm_provider": "openai_compatible"}},
             {"key": "llm_api_key", "description": "LLM API key (optional for openai_compatible)", "secret": True, "env_var": "HINDSIGHT_LLM_API_KEY", "when": {"mode": "local_embedded"}},
             {"key": "llm_model", "description": "LLM model", "default": "gpt-4o-mini", "default_from": {"field": "llm_provider", "map": _PROVIDER_DEFAULT_MODELS}, "when": {"mode": "local_embedded"}},
+            {"key": "embed_database_url", "description": "Database URL for the embedded vector store (e.g. postgresql+asyncpg://user:pass@host/db). Set HINDSIGHT_EMBED_API_DATABASE_URL as env fallback.", "default": "", "when": {"mode": "local_embedded"}},
             {"key": "bank_id", "description": "Memory bank name (static fallback when bank_id_template is unset)", "default": "hermes"},
             {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}", "default": ""},
             {"key": "bank_mission", "description": "Mission/purpose description for the memory bank"},

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -273,6 +273,45 @@ class TestConfig:
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "42"
 
+    def test_embedded_profile_env_includes_database_url_from_config(self):
+        """embed_database_url config key must appear as HINDSIGHT_EMBED_API_DATABASE_URL
+        in the generated profile env (issue #21818)."""
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "embed_database_url": "postgresql+asyncpg://user:pass@localhost/hindsight",
+        })
+        assert "HINDSIGHT_EMBED_API_DATABASE_URL" in env, (
+            "embed_database_url config key must be written as "
+            "HINDSIGHT_EMBED_API_DATABASE_URL in the profile env"
+        )
+        assert env["HINDSIGHT_EMBED_API_DATABASE_URL"] == "postgresql+asyncpg://user:pass@localhost/hindsight"
+
+    def test_embedded_profile_env_includes_database_url_from_env(self, monkeypatch):
+        """HINDSIGHT_EMBED_API_DATABASE_URL env var must fall through to profile env
+        when embed_database_url is not in config."""
+        monkeypatch.setenv("HINDSIGHT_EMBED_API_DATABASE_URL", "sqlite:///./hindsight.db")
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        })
+        assert env.get("HINDSIGHT_EMBED_API_DATABASE_URL") == "sqlite:///./hindsight.db", (
+            "HINDSIGHT_EMBED_API_DATABASE_URL env var must be forwarded to the "
+            "profile env when not set in config"
+        )
+
+    def test_embedded_profile_env_omits_database_url_when_unset(self, monkeypatch):
+        """When neither config nor env provides a database URL, the key must be absent."""
+        monkeypatch.delenv("HINDSIGHT_EMBED_API_DATABASE_URL", raising=False)
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+        })
+        assert "HINDSIGHT_EMBED_API_DATABASE_URL" not in env, (
+            "HINDSIGHT_EMBED_API_DATABASE_URL must be absent when neither config "
+            "nor env provides a value"
+        )
+
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):
         captured = {}
 
@@ -1117,6 +1156,7 @@ class TestConfigSchema:
             "retain_every_n_turns", "retain_async", "retain_context",
             "recall_max_tokens", "recall_max_input_chars",
             "recall_prompt_preamble",
+            "embed_database_url",
         }
         assert expected_keys.issubset(keys), f"Missing: {expected_keys - keys}"
 


### PR DESCRIPTION
## Problem

_build_embedded_profile_env() included LLM settings but not the embedded DB URL override. Daemon reconnected to default per-profile pg0 on restart even when HINDSIGHT_EMBED_API_DATABASE_URL was set.

## Fix

Read HINDSIGHT_EMBED_API_DATABASE_URL from config or environment and write it into the profile env dict when set. The lower layer (DaemonEmbedManager) already supports the override.

Reported and diagnosed by @linglichao.

Fixes #21809