### PR TITLE
fix: generate zsh completion for compinit

### DIFF
--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -147,7 +147,7 @@ def generate_zsh(parser: argparse.ArgumentParser) -> str:
     top_cmds_lines: list[str] = []
     for cmd in sorted(tree["subcommands"]):
         help_text = _clean(tree["subcommands"][cmd].get("help", ""))
-        top_cmds_lines.append(f"                '{cmd}:{help_text}'")
+        top_cmds_lines.append(f"        '{cmd}:{help_text}'")
     top_cmds_str = "\n".join(top_cmds_lines)
 
     sub_cases: list[str] = []
@@ -199,8 +199,10 @@ def generate_zsh(parser: argparse.ArgumentParser) -> str:
 
     return f"""#compdef hermes
 # Hermes Agent zsh completion
-# Add to ~/.zshrc:
-#   eval "$(hermes completion zsh)"
+# Save as one of:
+#   ~/.zfunc/_hermes
+#   $fpath[1]/_hermes
+# Then run: autoload -Uz compinit && compinit
 
 _hermes_profiles() {{
     local -a profiles
@@ -216,9 +218,12 @@ _hermes() {{
     typeset -A opt_args
 
     _arguments -C \\
-        '(-h --help){{-h,--help}}[Show help and exit]' \\
-        '(-V --version){{-V,--version}}[Show version and exit]' \\
-        '(-p --profile){{-p,--profile}}[Profile name]:profile:_hermes_profiles' \\
+        '(-h --help)-h[Show help and exit]' \\
+        '(-h --help)--help[Show help and exit]' \\
+        '(-V --version)-V[Show version and exit]' \\
+        '(-V --version)--version[Show version and exit]' \\
+        '(-p --profile)-p[Profile name]:profile:_hermes_profiles' \\
+        '(-p --profile)--profile[Profile name]:profile:_hermes_profiles' \\
         '1:command:->commands' \\
         '*::arg:->args'
 
@@ -237,10 +242,7 @@ _hermes() {{
             ;;
     esac
 }}
-
-_hermes "$@"
 """
-
 
 # ---------------------------------------------------------------------------
 # Fish

--- a/tests/hermes_cli/test_completion.py
+++ b/tests/hermes_cli/test_completion.py
@@ -140,6 +140,24 @@ class TestGenerateZsh:
         # gateway has subcommands so a _cmds array must be generated
         assert "gateway_cmds" in out
 
+    def test_does_not_self_invoke_function(self):
+        out = generate_zsh(_make_parser())
+        assert '_hermes "$@"' not in out
+
+    def test_documents_zfunc_install_path(self):
+        out = generate_zsh(_make_parser())
+        assert "~/.zfunc/_hermes" in out
+
+    def test_includes_top_level_flags(self):
+        out = generate_zsh(_make_parser())
+        assert "--profile" in out
+        assert "--help" in out
+        assert "--version" in out
+
+    def test_top_level_commands_are_not_over_indented(self):
+        out = generate_zsh(_make_parser())
+        assert "\n        'chat:" in out
+
 
 # ---------------------------------------------------------------------------
 # 4. Fish output


### PR DESCRIPTION
## Summary

- make generated zsh completion valid for `compinit` / `~/.zfunc/_hermes` installs
- replace invalid grouped `_arguments` specs like `{ -h,--help }` with separate zsh option specs
- remove direct `_hermes "$@"` self-invocation from the generated completion file
- update zsh completion comments to document the autoload/`fpath` install path
- add regression coverage for the invalid zsh output

## Validation

- [x] `git diff --check`
- [x] `python3 -m compileall hermes_cli/completion.py tests/hermes_cli/test_completion.py`
- [x] scoped assertions: generated code no longer contains `_hermes "$@"` or `{{-h,--help}}` / `{{-V,--version}}` / `{{-p,--profile}}`
- [x] manual local validation on macOS zsh 5.9 using `~/.zfunc/_hermes` + `compinit`: `hermes <TAB>` no longer raises `_arguments:comparguments:327`

## Notes

I intentionally kept the fix narrow: only zsh completion generation and regression tests changed. No provider config, dependency lockfile, shell rc file, or runtime code path was modified.

Closes #21829
Related to #17266
