### PR TITLE
feat(web): paginate dashboard session transcripts

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -64,6 +64,24 @@ except ImportError:
 WEB_DIST = Path(os.environ["HERMES_WEB_DIST"]) if "HERMES_WEB_DIST" in os.environ else Path(__file__).parent / "web_dist"
 _log = logging.getLogger(__name__)
 
+MAX_SESSION_MESSAGES_LIMIT = 500
+DEFAULT_SESSION_SEARCH_LIMIT = 20
+MAX_SESSION_SEARCH_LIMIT = 100
+
+
+def _clamp_optional_int(value: Optional[int], *, minimum: int = 0, maximum: int) -> Optional[int]:
+    if value is None:
+        return None
+    return max(minimum, min(int(value), maximum))
+
+
+def _is_recent_active_session(session: Dict[str, Any], now: float) -> bool:
+    return (
+        session.get("ended_at") is None
+        and (now - session.get("last_active", session.get("started_at", 0))) < 300
+    )
+
+
 app = FastAPI(title="Hermes Agent", version=__version__)
 
 # ---------------------------------------------------------------------------
@@ -446,6 +464,22 @@ class EnvVarReveal(BaseModel):
     key: str
 
 
+class SessionMessagesResponse(BaseModel):
+    """Contract for GET /api/sessions/{session_id}/messages.
+
+    ``limit=None`` keeps the legacy behavior and returns the full transcript.
+    With ``tail=true``, ``offset`` is resolved server-side to the final page and
+    the response reports that resolved offset so clients can prepend older
+    pages without trusting a stale message_count snapshot.
+    """
+
+    session_id: str
+    messages: List[Dict[str, Any]]
+    total: int
+    limit: Optional[int]
+    offset: int
+
+
 class ModelAssignment(BaseModel):
     """Payload for POST /api/model/set — assign a provider/model to a slot.
 
@@ -781,7 +815,7 @@ async def get_sessions(limit: int = 20, offset: int = 0):
 
 
 @app.get("/api/sessions/search")
-async def search_sessions(q: str = "", limit: int = 20):
+async def search_sessions(q: str = "", limit: int = DEFAULT_SESSION_SEARCH_LIMIT):
     """Full-text search across session message content using FTS5."""
     if not q or not q.strip():
         return {"results": []}
@@ -800,12 +834,21 @@ async def search_sessions(q: str = "", limit: int = 20):
                 else:
                     terms.append(token + "*")
             prefix_query = " ".join(terms)
-            matches = db.search_messages(query=prefix_query, limit=limit)
-            # Group by session_id — return unique sessions with their best snippet
+            safe_limit = max(0, min(int(limit), MAX_SESSION_SEARCH_LIMIT))
+            matches = db.search_messages(query=prefix_query, limit=safe_limit)
+            ordered_session_ids = list(dict.fromkeys(m["session_id"] for m in matches))
+            sessions_by_id = db.list_sessions_rich_by_ids(ordered_session_ids)
+            # Group by session_id — return unique sessions with their best snippet.
+            # Session summaries are batch-loaded above so search result rendering
+            # does not depend on which session pages the client has already loaded.
             seen: dict = {}
+            now = time.time()
             for m in matches:
                 sid = m["session_id"]
                 if sid not in seen:
+                    session = sessions_by_id.get(sid)
+                    if session:
+                        session["is_active"] = _is_recent_active_session(session, now)
                     seen[sid] = {
                         "session_id": sid,
                         "snippet": m.get("snippet", ""),
@@ -813,6 +856,7 @@ async def search_sessions(q: str = "", limit: int = 20):
                         "source": m.get("source"),
                         "model": m.get("model"),
                         "session_started": m.get("session_started"),
+                        "session": session,
                     }
             return {"results": list(seen.values())}
         finally:
@@ -2277,16 +2321,44 @@ async def get_session_latest_descendant(session_id: str):
         "changed": bool(path and latest != path[0]),
     }
 
-@app.get("/api/sessions/{session_id}/messages")
-async def get_session_messages(session_id: str):
+
+@app.get("/api/sessions/{session_id}/messages", response_model=SessionMessagesResponse)
+async def get_session_messages(
+    session_id: str,
+    limit: Optional[int] = None,
+    offset: int = 0,
+    tail: bool = False,
+):
+    """Return a session transcript page.
+
+    Contract:
+    - omitted ``limit`` preserves legacy full-transcript responses;
+    - ``limit`` is clamped to ``MAX_SESSION_MESSAGES_LIMIT``;
+    - negative or out-of-range offsets are resolved server-side;
+    - ``tail=true`` ignores the client offset and returns the newest page.
+    """
     from hermes_state import SessionDB
     db = SessionDB()
     try:
         sid = db.resolve_session_id(session_id)
         if not sid:
             raise HTTPException(status_code=404, detail="Session not found")
-        messages = db.get_messages(sid)
-        return {"session_id": sid, "messages": messages}
+        total = db.message_count(sid)
+        safe_limit = _clamp_optional_int(limit, maximum=MAX_SESSION_MESSAGES_LIMIT)
+        if safe_limit is None:
+            safe_offset = 0
+        elif tail:
+            safe_offset = max(0, total - safe_limit)
+        else:
+            safe_offset = min(max(0, int(offset or 0)), total)
+        messages = db.get_messages(sid, limit=safe_limit, offset=safe_offset)
+        return SessionMessagesResponse(
+            session_id=sid,
+            messages=messages,
+            total=total,
+            limit=safe_limit,
+            offset=safe_offset,
+        )
     finally:
         db.close()
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1182,12 +1182,20 @@ class SessionDB:
 
         return sessions
 
-    def _get_session_rich_row(self, session_id: str) -> Optional[Dict[str, Any]]:
-        """Fetch a single session with the same enriched columns as
-        ``list_sessions_rich`` (preview + last_active). Returns None if the
-        session doesn't exist.
+    def list_sessions_rich_by_ids(self, session_ids: List[str]) -> Dict[str, Dict[str, Any]]:
+        """Fetch enriched session summaries for a set of ids in one query.
+
+        Returns a mapping keyed by session id. The rows use the same lightweight
+        preview and last_active fields as ``list_sessions_rich`` without paging
+        or compression-root projection. This is intended for search endpoints
+        that already know the matched session ids and need to avoid one
+        ``get_session`` query per hit.
         """
-        query = """
+        unique_ids = list(dict.fromkeys(session_ids))
+        if not unique_ids:
+            return {}
+        placeholders = ",".join("?" for _ in unique_ids)
+        query = f"""
             SELECT s.*,
                 COALESCE(
                     (SELECT SUBSTR(REPLACE(REPLACE(m.content, X'0A', ' '), X'0D', ' '), 1, 63)
@@ -1201,13 +1209,14 @@ class SessionDB:
                     s.started_at
                 ) AS last_active
             FROM sessions s
-            WHERE s.id = ?
+            WHERE s.id IN ({placeholders})
         """
         with self._lock:
-            cursor = self._conn.execute(query, (session_id,))
-            row = cursor.fetchone()
-        if not row:
-            return None
+            rows = self._conn.execute(query, unique_ids).fetchall()
+        return {s["id"]: s for s in (self._format_session_rich_row(row) for row in rows)}
+
+    @staticmethod
+    def _format_session_rich_row(row) -> Dict[str, Any]:
         s = dict(row)
         raw = s.pop("_preview_raw", "").strip()
         if raw:
@@ -1216,6 +1225,14 @@ class SessionDB:
         else:
             s["preview"] = ""
         return s
+
+    def _get_session_rich_row(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Fetch a single session with the same enriched columns as
+        ``list_sessions_rich`` (preview + last_active). Returns None if the
+        session doesn't exist.
+        """
+        rows = self.list_sessions_rich_by_ids([session_id])
+        return rows.get(session_id)
 
     # =========================================================================
     # Message storage
@@ -1429,13 +1446,24 @@ class SessionDB:
 
         self._execute_write(_do)
 
-    def get_messages(self, session_id: str) -> List[Dict[str, Any]]:
-        """Load all messages for a session, ordered by timestamp."""
+    def get_messages(
+        self,
+        session_id: str,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """Load messages for a session, ordered by timestamp."""
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT * FROM messages WHERE session_id = ? ORDER BY timestamp, id",
-                (session_id,),
-            )
+            if limit is None:
+                cursor = self._conn.execute(
+                    "SELECT * FROM messages WHERE session_id = ? ORDER BY timestamp, id",
+                    (session_id,),
+                )
+            else:
+                cursor = self._conn.execute(
+                    "SELECT * FROM messages WHERE session_id = ? ORDER BY timestamp, id LIMIT ? OFFSET ?",
+                    (session_id, max(0, int(limit)), max(0, int(offset))),
+                )
             rows = cursor.fetchall()
         result = []
         for row in rows:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -125,6 +125,99 @@ class TestWebServerEndpoints:
         assert "hermes_home" in data
         assert "active_sessions" in data
 
+    def test_get_session_messages_supports_pagination_and_tail(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="paged-session", source="cli")
+            for i in range(5):
+                db.append_message("paged-session", role="user", content=f"m{i}")
+        finally:
+            db.close()
+
+        page = self.client.get("/api/sessions/paged-session/messages?limit=2&offset=1")
+        assert page.status_code == 200
+        body = page.json()
+        assert body["total"] == 5
+        assert body["limit"] == 2
+        assert body["offset"] == 1
+        assert [m["content"] for m in body["messages"]] == ["m1", "m2"]
+
+        tail = self.client.get("/api/sessions/paged-session/messages?limit=2&tail=true")
+        assert tail.status_code == 200
+        body = tail.json()
+        assert body["offset"] == 3
+        assert [m["content"] for m in body["messages"]] == ["m3", "m4"]
+
+    def test_get_session_messages_clamps_offset_and_limit(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="clamped-session", source="cli")
+            db.append_message("clamped-session", role="user", content="only")
+        finally:
+            db.close()
+
+        resp = self.client.get(
+            "/api/sessions/clamped-session/messages?limit=999&offset=999"
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["limit"] == 500
+        assert body["offset"] == 1
+        assert body["messages"] == []
+
+    def test_search_sessions_includes_session_summary(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="search-session",
+                source="cli",
+                model="test-model",
+            )
+            db.set_session_title("search-session", "Needle Session")
+            db.append_message("search-session", role="user", content="needle-in-history")
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/search?q=needle-in-history")
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert results[0]["session_id"] == "search-session"
+        assert results[0]["session"]["id"] == "search-session"
+        assert results[0]["session"]["title"] == "Needle Session"
+        assert results[0]["session"]["preview"] == "needle-in-history"
+        assert "last_active" in results[0]["session"]
+
+    def test_search_sessions_clamps_limit(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+        from hermes_state import SessionDB
+
+        seen = {}
+        original_search_messages = SessionDB.search_messages
+
+        def tracking_search_messages(self, query, limit=20):
+            seen["limit"] = limit
+            return original_search_messages(self, query=query, limit=limit)
+
+        monkeypatch.setattr(SessionDB, "search_messages", tracking_search_messages)
+
+        db = SessionDB()
+        try:
+            db.create_session(session_id="search-limit-session", source="cli")
+            db.append_message("search-limit-session", role="user", content="clampneedle")
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/search?q=clampneedle&limit=9999")
+        assert resp.status_code == 200
+        assert seen["limit"] == web_server.MAX_SESSION_SEARCH_LIMIT
+        assert resp.json()["results"][0]["session_id"] == "search-limit-session"
+
     def test_get_status_filters_unconfigured_gateway_platforms(self, monkeypatch):
         import gateway.config as gateway_config
         import hermes_cli.web_server as web_server

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -153,6 +153,40 @@ class TestMessageStorage:
         assert messages[0]["content"] == "Hello"
         assert messages[1]["role"] == "assistant"
 
+    def test_get_messages_paginates_in_timestamp_order(self, db):
+        db.create_session(session_id="s1", source="cli")
+        for i in range(5):
+            db.append_message("s1", role="user", content=f"m{i}")
+
+        page = db.get_messages("s1", limit=2, offset=1)
+
+        assert [m["content"] for m in page] == ["m1", "m2"]
+
+    def test_get_messages_normalizes_pagination_bounds(self, db):
+        db.create_session(session_id="s1", source="cli")
+        for i in range(3):
+            db.append_message("s1", role="user", content=f"m{i}")
+
+        assert [m["content"] for m in db.get_messages("s1", limit=2, offset=-10)] == [
+            "m0",
+            "m1",
+        ]
+        assert db.get_messages("s1", limit=0, offset=0) == []
+
+    def test_list_sessions_rich_by_ids_batches_enriched_rows(self, db):
+        db.create_session(session_id="s1", source="cli", model="m1")
+        db.create_session(session_id="s2", source="telegram", model="m2")
+        db.append_message("s1", role="user", content="first session preview text")
+        db.append_message("s2", role="user", content="second session preview text")
+        db.set_session_title("s2", "Second")
+
+        rows = db.list_sessions_rich_by_ids(["s2", "missing", "s1", "s2"])
+
+        assert set(rows) == {"s1", "s2"}
+        assert rows["s1"]["preview"].startswith("first session")
+        assert rows["s2"]["title"] == "Second"
+        assert rows["s2"]["last_active"] >= rows["s2"]["started_at"]
+
     def test_message_increments_session_count(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="user", content="Hello")

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -132,6 +132,7 @@ export const en: Translations = {
     noMatch: "No sessions match your search",
     startConversation: "Start a conversation to see it here",
     noMessages: "No messages",
+    loadOlderMessages: "Scroll up to load older messages",
     untitledSession: "Untitled session",
     deleteSession: "Delete session",
     confirmDeleteTitle: "Delete session?",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -134,6 +134,7 @@ export interface Translations {
     noMatch: string;
     startConversation: string;
     noMessages: string;
+    loadOlderMessages: string;
     untitledSession: string;
     deleteSession: string;
     confirmDeleteTitle: string;

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -131,6 +131,7 @@ export const zh: Translations = {
     noMatch: "没有匹配的会话",
     startConversation: "开始对话后将显示在此处",
     noMessages: "暂无消息",
+    loadOlderMessages: "向上滚动以加载更早的消息",
     untitledSession: "无标题会话",
     deleteSession: "删除会话",
     confirmDeleteTitle: "删除会话？",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -61,12 +61,29 @@ async function getSessionToken(): Promise<string> {
   throw new Error("Session token not available — page must be served by the Hermes dashboard server");
 }
 
+export interface SessionMessagesParams {
+  /** Maximum messages to return. Omit to preserve legacy full-transcript behavior. */
+  limit?: number;
+  /** Zero-based resolved offset. Ignored when tail=true. */
+  offset?: number;
+  /** Return the newest page and let the server resolve the offset. */
+  tail?: boolean;
+}
+
 export const api = {
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
   getSessions: (limit = 20, offset = 0) =>
     fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
-  getSessionMessages: (id: string) =>
-    fetchJSON<SessionMessagesResponse>(`/api/sessions/${encodeURIComponent(id)}/messages`),
+  getSessionMessages: (id: string, params?: SessionMessagesParams) => {
+    const qs = new URLSearchParams();
+    if (params?.limit !== undefined) qs.set("limit", String(params.limit));
+    if (params?.offset !== undefined) qs.set("offset", String(params.offset));
+    if (params?.tail !== undefined) qs.set("tail", String(params.tail));
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return fetchJSON<SessionMessagesResponse>(
+      `/api/sessions/${encodeURIComponent(id)}/messages${suffix}`,
+    );
+  },
   getSessionLatestDescendant: (id: string) =>
     fetchJSON<SessionLatestDescendantResponse>(
       `/api/sessions/${encodeURIComponent(id)}/latest-descendant`,
@@ -424,6 +441,7 @@ export interface EnvVarInfo {
 }
 
 export interface SessionMessage {
+  id?: number;
   role: "user" | "assistant" | "system" | "tool";
   content: string | null;
   tool_calls?: Array<{
@@ -438,6 +456,9 @@ export interface SessionMessage {
 export interface SessionMessagesResponse {
   session_id: string;
   messages: SessionMessage[];
+  total?: number;
+  limit?: number | null;
+  offset?: number;
 }
 
 export interface LogsResponse {
@@ -588,6 +609,7 @@ export interface SessionSearchResult {
   source: string | null;
   model: string | null;
   session_started: number | null;
+  session?: SessionInfo | null;
 }
 
 export interface SessionSearchResponse {

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -10,7 +10,6 @@ import {
   AlertTriangle,
   CheckCircle2,
   ChevronDown,
-  ChevronLeft,
   ChevronRight,
   Database,
   MessageSquare,
@@ -59,6 +58,15 @@ const SOURCE_CONFIG: Record<string, { icon: typeof Terminal; color: string }> =
     whatsapp: { icon: Globe, color: "text-success" },
     cron: { icon: Clock, color: "text-warning" },
   };
+
+const MESSAGE_PAGE_SIZE = 50;
+const SESSION_LIST_PREFETCH_MARGIN = "300px 0px";
+const SEARCH_DEBOUNCE_MS = 300;
+
+const tailMessagePageParams = () => ({
+  limit: MESSAGE_PAGE_SIZE,
+  tail: true,
+});
 
 /** Render an FTS5 snippet with highlighted matches.
  *  The backend wraps matches in >>> and <<< delimiters. */
@@ -224,11 +232,48 @@ function MessageBubble({
 function MessageList({
   messages,
   highlight,
+  hasMoreBefore = false,
+  loadingOlder = false,
+  loadOlderLabel,
+  onLoadOlder,
 }: {
   messages: SessionMessage[];
   highlight?: string;
+  hasMoreBefore?: boolean;
+  loadingOlder?: boolean;
+  loadOlderLabel: string;
+  onLoadOlder?: () => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const initialScrollDoneRef = useRef(false);
+  const restoreAfterPrependRef = useRef<number | null>(null);
+
+  const requestOlder = useCallback(() => {
+    const el = containerRef.current;
+    if (!el || !hasMoreBefore || loadingOlder) return;
+    restoreAfterPrependRef.current = el.scrollHeight;
+    onLoadOlder?.();
+  }, [hasMoreBefore, loadingOlder, onLoadOlder]);
+
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    const previousHeight = restoreAfterPrependRef.current;
+    if (!el || previousHeight === null) return;
+    restoreAfterPrependRef.current = null;
+    el.scrollTop += Math.max(0, el.scrollHeight - previousHeight);
+  }, [messages.length]);
+
+  useEffect(() => {
+    if (highlight || !containerRef.current || initialScrollDoneRef.current) return;
+    const timer = setTimeout(() => {
+      const el = containerRef.current;
+      if (el) {
+        el.scrollTop = el.scrollHeight;
+        initialScrollDoneRef.current = true;
+      }
+    }, 50);
+    return () => clearTimeout(timer);
+  }, [messages.length, highlight]);
 
   useEffect(() => {
     if (!highlight || !containerRef.current) return;
@@ -246,9 +291,17 @@ function MessageList({
     <div
       ref={containerRef}
       className="flex flex-col gap-3 max-h-[600px] overflow-y-auto pr-2"
+      onScroll={(e) => {
+        if (e.currentTarget.scrollTop <= 80) requestOlder();
+      }}
     >
+      {hasMoreBefore && (
+        <div className="flex items-center justify-center py-2 text-xs text-muted-foreground">
+          {loadingOlder ? <Spinner className="text-primary" /> : loadOlderLabel}
+        </div>
+      )}
       {messages.map((msg, i) => (
-        <MessageBubble key={i} msg={msg} highlight={highlight} />
+        <MessageBubble key={msg.id ?? i} msg={msg} highlight={highlight} />
       ))}
     </div>
   );
@@ -272,21 +325,95 @@ function SessionRow({
   resumeInChatEnabled: boolean;
 }) {
   const [messages, setMessages] = useState<SessionMessage[] | null>(null);
+  const [loadedStart, setLoadedStart] = useState(0);
+  const [hasMoreBefore, setHasMoreBefore] = useState(false);
+  const [allMessagesLoaded, setAllMessagesLoaded] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const loadingOlderRef = useRef(false);
   const [error, setError] = useState<string | null>(null);
   const { t } = useI18n();
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (isExpanded && messages === null && !loading) {
+    if (!isExpanded || messages !== null || loading) return;
+    const timer = window.setTimeout(() => {
+      const loadAllForSearch = Boolean(searchQuery?.trim());
+      // Search highlights can target old messages, so search-mode expansion keeps
+      // the legacy full-transcript call. Normal expansion asks the backend for
+      // the newest page and uses the returned offset as the pagination cursor.
       setLoading(true);
+      setError(null);
       api
-        .getSessionMessages(session.id)
-        .then((resp) => setMessages(resp.messages))
+        .getSessionMessages(
+          session.id,
+          loadAllForSearch ? undefined : tailMessagePageParams(),
+        )
+        .then((resp) => {
+          const offset = resp.offset ?? 0;
+          setMessages(resp.messages);
+          setLoadedStart(offset);
+          setHasMoreBefore(!loadAllForSearch && offset > 0);
+          setAllMessagesLoaded(loadAllForSearch || offset === 0);
+        })
         .catch((err) => setError(String(err)))
         .finally(() => setLoading(false));
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [isExpanded, session.id, searchQuery, messages, loading]);
+
+  useEffect(() => {
+    if (!isExpanded || !searchQuery?.trim() || allMessagesLoaded || loading) return;
+    const timer = window.setTimeout(() => {
+      setLoading(true);
+      setError(null);
+      api
+        .getSessionMessages(session.id)
+        .then((resp) => {
+          setMessages(resp.messages);
+          setLoadedStart(0);
+          setHasMoreBefore(false);
+          setAllMessagesLoaded(true);
+        })
+        .catch((err) => setError(String(err)))
+        .finally(() => setLoading(false));
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [allMessagesLoaded, isExpanded, loading, searchQuery, session.id]);
+
+  const loadOlderMessages = useCallback(() => {
+    if (
+      !hasMoreBefore ||
+      loadingOlderRef.current ||
+      loading ||
+      messages === null
+    ) {
+      return;
     }
-  }, [isExpanded, session.id, messages, loading]);
+    const nextOffset = Math.max(0, loadedStart - MESSAGE_PAGE_SIZE);
+    const nextLimit = loadedStart - nextOffset;
+    if (nextLimit <= 0) return;
+    loadingOlderRef.current = true;
+    setLoadingOlder(true);
+    setError(null);
+    api
+      .getSessionMessages(session.id, {
+        limit: nextLimit,
+        offset: nextOffset,
+      })
+      .then((resp) => {
+        const offset = resp.offset ?? nextOffset;
+        setMessages((prev) => [...resp.messages, ...(prev ?? [])]);
+        setLoadedStart(offset);
+        setHasMoreBefore(offset > 0);
+        setAllMessagesLoaded(offset === 0);
+      })
+      .catch((err) => setError(String(err)))
+      .finally(() => {
+        loadingOlderRef.current = false;
+        setLoadingOlder(false);
+      });
+  }, [hasMoreBefore, loadedStart, loading, messages, session.id]);
 
   const sourceInfo = (session.source
     ? SOURCE_CONFIG[session.source]
@@ -401,7 +528,14 @@ function SessionRow({
             </p>
           )}
           {messages && messages.length > 0 && (
-            <MessageList messages={messages} highlight={searchQuery} />
+            <MessageList
+              messages={messages}
+              highlight={searchQuery}
+              hasMoreBefore={hasMoreBefore}
+              loadingOlder={loadingOlder}
+              loadOlderLabel={t.sessions.loadOlderMessages}
+              onLoadOlder={loadOlderMessages}
+            />
           )}
         </div>
       )}
@@ -415,6 +549,7 @@ export default function SessionsPage() {
   const [page, setPage] = useState(0);
   const PAGE_SIZE = 20;
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [search, setSearch] = useState("");
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [searchResults, setSearchResults] = useState<
@@ -422,6 +557,9 @@ export default function SessionsPage() {
   >(null);
   const [searching, setSearching] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const historyEndRef = useRef<HTMLDivElement | null>(null);
+  const loadingSessionsRef = useRef(false);
+  const searchRequestRef = useRef(0);
   const logScrollRef = useRef<HTMLPreElement | null>(null);
   const [status, setStatus] = useState<StatusResponse | null>(null);
   const [overviewSessions, setOverviewSessions] = useState<SessionInfo[]>([]);
@@ -484,19 +622,42 @@ export default function SessionsPage() {
   ]);
 
   const loadSessions = useCallback((p: number) => {
-    setLoading(true);
+    loadingSessionsRef.current = true;
+    if (p === 0) {
+      setLoading(true);
+    } else {
+      setLoadingMore(true);
+    }
     api
       .getSessions(PAGE_SIZE, p * PAGE_SIZE)
       .then((resp) => {
-        setSessions(resp.sessions);
+        setSessions((prev) => {
+          if (p === 0) return resp.sessions;
+          const seen = new Set(prev.map((s) => s.id));
+          return [...prev, ...resp.sessions.filter((s) => !seen.has(s.id))];
+        });
         setTotal(resp.total);
       })
       .catch(() => {})
-      .finally(() => setLoading(false));
+      .finally(() => {
+        loadingSessionsRef.current = false;
+        setLoading(false);
+        setLoadingMore(false);
+      });
   }, []);
 
+  const requestNextPage = useCallback(() => {
+    // IntersectionObserver and the fallback button can both fire before React
+    // commits loadingMore. The ref closes that synchronous race.
+    if (loadingSessionsRef.current || loadingMore) return;
+    loadingSessionsRef.current = true;
+    setLoadingMore(true);
+    setPage((p) => p + 1);
+  }, [loadingMore]);
+
   useEffect(() => {
-    loadSessions(page);
+    const timer = window.setTimeout(() => loadSessions(page), 0);
+    return () => window.clearTimeout(timer);
   }, [loadSessions, page]);
 
   useEffect(() => {
@@ -525,19 +686,37 @@ export default function SessionsPage() {
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
     if (!search.trim()) {
-      setSearchResults(null);
-      setSearching(false);
-      return;
+      searchRequestRef.current += 1;
+      const timer = window.setTimeout(() => {
+        setSearchResults(null);
+        setSearching(false);
+      }, 0);
+      return () => window.clearTimeout(timer);
     }
 
-    setSearching(true);
+    const query = search.trim();
+    const requestId = searchRequestRef.current + 1;
+    searchRequestRef.current = requestId;
     debounceRef.current = setTimeout(() => {
+      setSearching(true);
       api
-        .searchSessions(search.trim())
-        .then((resp) => setSearchResults(resp.results))
-        .catch(() => setSearchResults(null))
-        .finally(() => setSearching(false));
-    }, 300);
+        .searchSessions(query)
+        .then((resp) => {
+          if (searchRequestRef.current === requestId) {
+            setSearchResults(resp.results);
+          }
+        })
+        .catch(() => {
+          if (searchRequestRef.current === requestId) {
+            setSearchResults(null);
+          }
+        })
+        .finally(() => {
+          if (searchRequestRef.current === requestId) {
+            setSearching(false);
+          }
+        });
+    }, SEARCH_DEBOUNCE_MS);
 
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -579,11 +758,30 @@ export default function SessionsPage() {
     }
   }
 
-  // When searching, filter sessions to those with FTS matches;
-  // when not searching, show all sessions
+  // When searching, render the sessions returned by the search endpoint so
+  // matches outside the currently loaded infinite-scroll window still appear.
+  const loadedSessionMap = new Map(sessions.map((s) => [s.id, s]));
   const filtered = searchResults
-    ? sessions.filter((s) => snippetMap.has(s.id))
+    ? searchResults
+        .map((r) => r.session ?? loadedSessionMap.get(r.session_id) ?? null)
+        .filter((s): s is SessionInfo => s !== null)
     : sessions;
+  const hasMoreSessions = !searchResults && sessions.length < total;
+
+  useEffect(() => {
+    const target = historyEndRef.current;
+    if (!target || !hasMoreSessions || loading || loadingMore) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          requestNextPage();
+        }
+      },
+      { rootMargin: SESSION_LIST_PREFETCH_MARGIN },
+    );
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [hasMoreSessions, loading, loadingMore, requestNextPage, sessions.length]);
 
   const platformEntries = status
     ? Object.entries(status.gateway_platforms ?? {})
@@ -812,22 +1010,22 @@ export default function SessionsPage() {
             ))}
           </div>
 
+          {!searchResults && (
+            <div ref={historyEndRef} aria-hidden="true" className="h-px" />
+          )}
+
+          {loadingMore && (
+            <div className="flex items-center justify-center py-2">
+              <Spinner className="text-sm text-primary" />
+            </div>
+          )}
+
           {!searchResults && total > PAGE_SIZE && (
             <div className="flex items-center justify-between pt-2">
               <span className="text-xs text-muted-foreground">
-                {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, total)}{" "}
-                {t.common.of} {total}
+                1–{Math.min(sessions.length, total)} {t.common.of} {total}
               </span>
               <div className="flex items-center gap-1">
-                <Button
-                  outlined
-                  size="icon"
-                  disabled={page === 0}
-                  onClick={() => setPage((p) => p - 1)}
-                  aria-label={t.sessions.previousPage}
-                >
-                  <ChevronLeft />
-                </Button>
                 <span className="text-xs text-muted-foreground px-2">
                   {t.common.page} {page + 1} {t.common.of}{" "}
                   {Math.ceil(total / PAGE_SIZE)}
@@ -835,8 +1033,8 @@ export default function SessionsPage() {
                 <Button
                   outlined
                   size="icon"
-                  disabled={(page + 1) * PAGE_SIZE >= total}
-                  onClick={() => setPage((p) => p + 1)}
+                  disabled={!hasMoreSessions || loadingMore}
+                  onClick={requestNextPage}
                   aria-label={t.sessions.nextPage}
                 >
                   <ChevronRight />


### PR DESCRIPTION
## Summary
- add a paginated `/api/sessions/{session_id}/messages` endpoint with legacy full-transcript behavior when `limit` is omitted
- add batched enriched session lookup for search results so matches render without depending on already-loaded session pages
- update the dashboard Sessions page to load the newest message page first and prepend older messages while preserving scroll position

## Test Plan
- `python -m pytest tests/hermes_cli/test_web_server.py tests/test_hermes_state.py -q -o 'addopts='`
- `python -m py_compile hermes_cli/web_server.py hermes_state.py`
- `cd web && ./node_modules/.bin/tsc -b` (using the existing local web dependencies)
