### PR TITLE
fix(state): apply SQLite database pragmas from config

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -198,10 +198,36 @@ class SessionDB:
             isolation_level=None,
         )
         self._conn.row_factory = sqlite3.Row
+        self._apply_connection_pragmas()
+
+        self._init_schema()
+
+    def _apply_connection_pragmas(self) -> None:
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA foreign_keys=ON")
 
-        self._init_schema()
+        try:
+            from hermes_cli.config import load_config
+
+            database_cfg = load_config().get("database") or {}
+        except Exception as exc:
+            logger.debug("SessionDB: failed to load database config: %s", exc)
+            return
+
+        for pragma_name in ("journal_size_limit", "wal_autocheckpoint"):
+            raw_value = database_cfg.get(pragma_name)
+            if raw_value is None:
+                continue
+            try:
+                value = int(raw_value)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "SessionDB: ignoring non-integer database.%s=%r",
+                    pragma_name,
+                    raw_value,
+                )
+                continue
+            self._conn.execute(f"PRAGMA {pragma_name}={value}")
 
     # ── Core write helper ──
 
@@ -2671,4 +2697,3 @@ class SessionDB:
             result["error"] = str(exc)
 
         return result
-

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,5 +1,6 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
+import os
 import time
 import pytest
 from pathlib import Path
@@ -1401,6 +1402,22 @@ class TestSchemaInit:
     def test_foreign_keys_enabled(self, db):
         cursor = db._conn.execute("PRAGMA foreign_keys")
         assert cursor.fetchone()[0] == 1
+
+    def test_database_config_applies_sqlite_pragmas(self, tmp_path):
+        hermes_home = Path(os.environ["HERMES_HOME"])
+        (hermes_home / "config.yaml").write_text(
+            "database:\n"
+            "  wal_autocheckpoint: 200\n"
+            "  journal_size_limit: 10485760\n",
+            encoding="utf-8",
+        )
+
+        db = SessionDB(db_path=tmp_path / "configured_state.db")
+        try:
+            assert db._conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0] == 200
+            assert db._conn.execute("PRAGMA journal_size_limit").fetchone()[0] == 10485760
+        finally:
+            db.close()
 
     def test_tables_exist(self, db):
         cursor = db._conn.execute(
@@ -2909,4 +2926,3 @@ class TestFTS5ToolCallMigration:
             assert version == 11
         finally:
             session_db.close()
-


### PR DESCRIPTION
## Summary

This fixes Hermes issue #21807 by applying `database.journal_size_limit` and `database.wal_autocheckpoint` from `config.yaml` when `SessionDB` opens its SQLite connection.

## Root Cause

`SessionDB.__init__()` always enabled `journal_mode=WAL` and `foreign_keys=ON`, but never read the `database` config block. That meant users could set WAL sizing and checkpoint knobs in `config.yaml` and Hermes would silently ignore them.

## What Changed

- added connection-time pragma application for `journal_size_limit` and `wal_autocheckpoint`
- normalized pragma values to integers before applying them
- added a regression test proving a temp `config.yaml` changes the live SQLite pragma values on a new `SessionDB`

## Validation

- `uv run --frozen python -m py_compile hermes_state.py tests/test_hermes_state.py`
- `uv run --frozen --extra all python -m pytest tests/test_hermes_state.py -q -k 'TestSchemaInit'`
- `git diff --check`
- `uv sync --frozen --extra all`
- `uv run --frozen --extra all ruff check .`
- local `lint-diff` attribution against `origin/main` for `ruff + ty`
- `HERMES_GATE_HOME="$(mktemp -d /tmp/hermes-gate-home.XXXXXX)" env -i PATH="$PATH" TMPDIR="${TMPDIR:-/tmp}" LANG="${LANG:-C.UTF-8}" HOME="$HERMES_GATE_HOME" XDG_CONFIG_HOME="$HERMES_GATE_HOME/.config" XDG_CACHE_HOME="$HERMES_GATE_HOME/.cache" XDG_DATA_HOME="$HERMES_GATE_HOME/.local/share" uv run --frozen --extra all python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto`

## Quality Firewall Proof

- `local_proof_sha`: `a1e9b2e3d2533df6a383ec0f0188e322f2508431`
- `github_pr_head_sha`: `a1e9b2e3d2533df6a383ec0f0188e322f2508431`
- `worktree_path`: `/private/tmp/hermes-pr-45662ee1-02db712a`
- `branch`: `mainline/HER-71-45662ee1-02db712a`
- `base_origin_main_sha`: `80775d758562821c4bd5ad6e2f26afa3d5223d5d`
- `latest_fetch_at`: `2026-05-08T11:46:44Z`
- `commands`: see local proof JSON and attribution summary in `.paperclip_artifacts/quality-gate/`
- `exit_codes`: all candidate-local gate steps required for push were `0`; the full CI-equivalent suite stayed red due shared baseline debt documented below
- `started_at`: `2026-05-08T11:27:42Z`
- `completed_at`: `2026-05-08T11:46:44Z`
- `log_artifacts_or_inline_summary`: `.paperclip_artifacts/quality-gate/her71-20260508T114644Z-attribution-summary-a1e9b2e3.md`, `.lint-reports-her71/summary.md`
- `gatekeeper_audit_id`: `her71-20260508T114644Z-self-proof-a1e9b2e3`
- `baseline_attribution`: `preexisting_unrelated`
- `baseline_compare_summary`: representative failing nodes reproduced on detached latest `origin/main` using the same Python 3.11 runner
- `baseline_worktree_path`: `/private/tmp/her71-baseline-45662ee1-02db712a` (already removed after evidence capture)
- `repair_mode`: `false`
