### PR TITLE
feat(skills): two-tier index + signal-based nudge (gated)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -24,6 +24,12 @@ from agent.skill_utils import (
     parse_frontmatter,
     skill_matches_platform,
 )
+from agent.skill_inventory import (
+    Inventory,
+    SkillEntry,
+    clear_inventory_cache,
+    load_inventory,
+)
 from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
@@ -477,11 +483,7 @@ def clear_skills_system_prompt_cache(*, clear_snapshot: bool = False) -> None:
     """Drop the in-process skills prompt cache (and optionally the disk snapshot)."""
     with _SKILLS_PROMPT_CACHE_LOCK:
         _SKILLS_PROMPT_CACHE.clear()
-    if clear_snapshot:
-        try:
-            _skills_prompt_snapshot_path().unlink(missing_ok=True)
-        except OSError as e:
-            logger.debug("Could not remove skills prompt snapshot: %s", e)
+    clear_inventory_cache(clear_snapshot=clear_snapshot)
 
 
 def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
@@ -622,229 +624,62 @@ def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
 ) -> str:
-    """Build a compact skill index for the system prompt.
-
-    Two-layer cache:
-      1. In-process LRU dict keyed by (skills_dir, tools, toolsets)
-      2. Disk snapshot (``.skills_prompt_snapshot.json``) validated by
-         mtime/size manifest — survives process restarts
-
-    Falls back to a full filesystem scan when both layers miss.
-
-    External skill directories (``skills.external_dirs`` in config.yaml) are
-    scanned alongside the local ``~/.hermes/skills/`` directory.  External dirs
-    are read-only — they appear in the index but new skills are always created
-    in the local dir.  Local skills take precedence when names collide.
-    """
-    skills_dir = get_skills_dir()
-    external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
-
-    if not skills_dir.exists() and not external_dirs:
+    """Build a compact skill index for the system prompt."""
+    inventory = load_inventory(
+        available_tools=available_tools,
+        available_toolsets=available_toolsets,
+        disabled_names=get_disabled_skill_names(),
+    )
+    if not inventory.entries:
         return ""
+    return _render_skills_prompt_v1(inventory)
 
-    # ── Layer 1: in-process LRU cache ─────────────────────────────────
-    # Include the resolved platform so per-platform disabled-skill lists
-    # produce distinct cache entries (gateway serves multiple platforms).
-    from gateway.session_context import get_session_env
-    _platform_hint = (
-        os.environ.get("HERMES_PLATFORM")
-        or get_session_env("HERMES_SESSION_PLATFORM")
-        or ""
-    )
-    disabled = get_disabled_skill_names()
-    cache_key = (
-        str(skills_dir.resolve()),
-        tuple(str(d) for d in external_dirs),
-        tuple(sorted(str(t) for t in (available_tools or set()))),
-        tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
-        _platform_hint,
-        tuple(sorted(disabled)),
-    )
-    with _SKILLS_PROMPT_CACHE_LOCK:
-        cached = _SKILLS_PROMPT_CACHE.get(cache_key)
-        if cached is not None:
-            _SKILLS_PROMPT_CACHE.move_to_end(cache_key)
-            return cached
 
-    # ── Layer 2: disk snapshot ────────────────────────────────────────
-    snapshot = _load_skills_snapshot(skills_dir)
+def _render_skills_prompt_v1(inventory: Inventory) -> str:
+    skills_by_category: dict[str, list[SkillEntry]] = {}
+    for entry in inventory.entries:
+        skills_by_category.setdefault(entry.category, []).append(entry)
 
-    skills_by_category: dict[str, list[tuple[str, str]]] = {}
-    category_descriptions: dict[str, str] = {}
-
-    if snapshot is not None:
-        # Fast path: use pre-parsed metadata from disk
-        for entry in snapshot.get("skills", []):
-            if not isinstance(entry, dict):
+    index_lines = []
+    for category in sorted(skills_by_category.keys()):
+        cat_desc = inventory.category_descriptions.get(category, "")
+        if cat_desc:
+            index_lines.append(f"  {category}: {cat_desc}")
+        else:
+            index_lines.append(f"  {category}:")
+        seen = set()
+        for entry in sorted(skills_by_category[category], key=lambda x: x.name):
+            if entry.name in seen:
                 continue
-            skill_name = entry.get("skill_name") or ""
-            category = entry.get("category") or "general"
-            frontmatter_name = entry.get("frontmatter_name") or skill_name
-            platforms = entry.get("platforms") or []
-            if not skill_matches_platform({"platforms": platforms}):
-                continue
-            if frontmatter_name in disabled or skill_name in disabled:
-                continue
-            if not _skill_should_show(
-                entry.get("conditions") or {},
-                available_tools,
-                available_toolsets,
-            ):
-                continue
-            skills_by_category.setdefault(category, []).append(
-                (frontmatter_name, entry.get("description", ""))
-            )
-        category_descriptions = {
-            str(k): str(v)
-            for k, v in (snapshot.get("category_descriptions") or {}).items()
-        }
-    else:
-        # Cold path: full filesystem scan + write snapshot for next time
-        skill_entries: list[dict] = []
-        for skill_file in iter_skill_index_files(skills_dir, "SKILL.md"):
-            is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
-            entry = _build_snapshot_entry(skill_file, skills_dir, frontmatter, desc)
-            skill_entries.append(entry)
-            if not is_compatible:
-                continue
-            skill_name = entry["skill_name"]
-            if entry["frontmatter_name"] in disabled or skill_name in disabled:
-                continue
-            if not _skill_should_show(
-                extract_skill_conditions(frontmatter),
-                available_tools,
-                available_toolsets,
-            ):
-                continue
-            skills_by_category.setdefault(entry["category"], []).append(
-                (entry["frontmatter_name"], entry["description"])
-            )
-
-        # Read category-level DESCRIPTION.md files
-        for desc_file in iter_skill_index_files(skills_dir, "DESCRIPTION.md"):
-            try:
-                content = desc_file.read_text(encoding="utf-8")
-                fm, _ = parse_frontmatter(content)
-                cat_desc = fm.get("description")
-                if not cat_desc:
-                    continue
-                rel = desc_file.relative_to(skills_dir)
-                cat = "/".join(rel.parts[:-1]) if len(rel.parts) > 1 else "general"
-                category_descriptions[cat] = str(cat_desc).strip().strip("'\"")
-            except Exception as e:
-                logger.debug("Could not read skill description %s: %s", desc_file, e)
-
-        _write_skills_snapshot(
-            skills_dir,
-            _build_skills_manifest(skills_dir),
-            skill_entries,
-            category_descriptions,
-        )
-
-    # ── External skill directories ─────────────────────────────────────
-    # Scan external dirs directly (no snapshot caching — they're read-only
-    # and typically small).  Local skills already in skills_by_category take
-    # precedence: we track seen names and skip duplicates from external dirs.
-    seen_skill_names: set[str] = set()
-    for cat_skills in skills_by_category.values():
-        for name, _desc in cat_skills:
-            seen_skill_names.add(name)
-
-    for ext_dir in external_dirs:
-        if not ext_dir.exists():
-            continue
-        for skill_file in iter_skill_index_files(ext_dir, "SKILL.md"):
-            try:
-                is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
-                if not is_compatible:
-                    continue
-                entry = _build_snapshot_entry(skill_file, ext_dir, frontmatter, desc)
-                skill_name = entry["skill_name"]
-                frontmatter_name = entry["frontmatter_name"]
-                if frontmatter_name in seen_skill_names:
-                    continue
-                if frontmatter_name in disabled or skill_name in disabled:
-                    continue
-                if not _skill_should_show(
-                    extract_skill_conditions(frontmatter),
-                    available_tools,
-                    available_toolsets,
-                ):
-                    continue
-                seen_skill_names.add(frontmatter_name)
-                skills_by_category.setdefault(entry["category"], []).append(
-                    (frontmatter_name, entry["description"])
-                )
-            except Exception as e:
-                logger.debug("Error reading external skill %s: %s", skill_file, e)
-
-        # External category descriptions
-        for desc_file in iter_skill_index_files(ext_dir, "DESCRIPTION.md"):
-            try:
-                content = desc_file.read_text(encoding="utf-8")
-                fm, _ = parse_frontmatter(content)
-                cat_desc = fm.get("description")
-                if not cat_desc:
-                    continue
-                rel = desc_file.relative_to(ext_dir)
-                cat = "/".join(rel.parts[:-1]) if len(rel.parts) > 1 else "general"
-                category_descriptions.setdefault(cat, str(cat_desc).strip().strip("'\""))
-            except Exception as e:
-                logger.debug("Could not read external skill description %s: %s", desc_file, e)
-
-    if not skills_by_category:
-        result = ""
-    else:
-        index_lines = []
-        for category in sorted(skills_by_category.keys()):
-            cat_desc = category_descriptions.get(category, "")
-            if cat_desc:
-                index_lines.append(f"  {category}: {cat_desc}")
+            seen.add(entry.name)
+            if entry.description:
+                index_lines.append(f"    - {entry.name}: {entry.description}")
             else:
-                index_lines.append(f"  {category}:")
-            # Deduplicate and sort skills within each category
-            seen = set()
-            for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
-                if name in seen:
-                    continue
-                seen.add(name)
-                if desc:
-                    index_lines.append(f"    - {name}: {desc}")
-                else:
-                    index_lines.append(f"    - {name}")
+                index_lines.append(f"    - {entry.name}")
 
-        result = (
-            "## Skills (mandatory)\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
-            "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
-            "and proven workflows that outperform general-purpose approaches. Load the skill "
-            "even if you think you could handle the task with basic tools like web_search or terminal. "
-            "Skills also encode the user's preferred approach, conventions, and quality standards "
-            "for tasks like code review, planning, and testing — load them even for tasks you "
-            "already know how to do, because the skill defines how it should be done here.\n"
-            "If a skill has issues, fix it with skill_manage(action='patch').\n"
-            "After difficult/iterative tasks, offer to save as a skill. "
-            "If a skill you loaded was missing steps, had wrong commands, or needed "
-            "pitfalls you discovered, update it before finishing.\n"
-            "\n"
-            "<available_skills>\n"
-            + "\n".join(index_lines) + "\n"
-            "</available_skills>\n"
-            "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
-        )
-
-    # ── Store in LRU cache ────────────────────────────────────────────
-    with _SKILLS_PROMPT_CACHE_LOCK:
-        _SKILLS_PROMPT_CACHE[cache_key] = result
-        _SKILLS_PROMPT_CACHE.move_to_end(cache_key)
-        while len(_SKILLS_PROMPT_CACHE) > _SKILLS_PROMPT_CACHE_MAX:
-            _SKILLS_PROMPT_CACHE.popitem(last=False)
-
-    return result
+    return (
+        "## Skills (mandatory)\n"
+        "Before replying, scan the skills below. If a skill matches or is even partially relevant "
+        "to your task, you MUST load it with skill_view(name) and follow its instructions. "
+        "Err on the side of loading — it is always better to have context you don't need "
+        "than to miss critical steps, pitfalls, or established workflows. "
+        "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
+        "and proven workflows that outperform general-purpose approaches. Load the skill "
+        "even if you think you could handle the task with basic tools like web_search or terminal. "
+        "Skills also encode the user's preferred approach, conventions, and quality standards "
+        "for tasks like code review, planning, and testing — load them even for tasks you "
+        "already know how to do, because the skill defines how it should be done here.\n"
+        "If a skill has issues, fix it with skill_manage(action='patch').\n"
+        "After difficult/iterative tasks, offer to save as a skill. "
+        "If a skill you loaded was missing steps, had wrong commands, or needed "
+        "pitfalls you discovered, update it before finishing.\n"
+        "\n"
+        "<available_skills>\n"
+        + "\n".join(index_lines) + "\n"
+        "</available_skills>\n"
+        "\n"
+        "Only proceed without loading a skill if genuinely none are relevant to the task."
+    )
 
 
 def build_nous_subscription_prompt(valid_tool_names: "set[str] | None" = None) -> str:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -705,6 +705,10 @@ _SKILLS_V2_PREAMBLE = (
 
 
 def _render_skills_prompt_v2(inventory: Inventory, *, token_budget: int) -> str:
+    # Not cached at prompt-string level: inventory caching covers expensive
+    # parsing, and rendering from structured metadata is cheap.
+    from agent import skill_usage_tracker
+
     skills_by_category: dict[str, list[SkillEntry]] = {}
     for entry in inventory.entries:
         skills_by_category.setdefault(entry.category, []).append(entry)
@@ -717,10 +721,9 @@ def _render_skills_prompt_v2(inventory: Inventory, *, token_budget: int) -> str:
             critical_count,
         )
 
-    body_lines: list[str] = []
-    for category in sorted(skills_by_category.keys()):
+    def category_block(category: str) -> list[str]:
         cat_desc = inventory.category_descriptions.get(category, "")
-        body_lines.append(f"  {category}/  {cat_desc}".rstrip() if cat_desc else f"  {category}/")
+        block = [f"  {category}/  {cat_desc}".rstrip() if cat_desc else f"  {category}/"]
         critical_entries = sorted(
             (entry for entry in skills_by_category[category] if entry.priority == "critical"),
             key=lambda entry: entry.name,
@@ -731,11 +734,41 @@ def _render_skills_prompt_v2(inventory: Inventory, *, token_budget: int) -> str:
         )
         for entry in critical_entries:
             if entry.description:
-                body_lines.append(f"    - {entry.name}: {entry.description}")
+                block.append(f"    - {entry.name}: {entry.description}")
             else:
-                body_lines.append(f"    - {entry.name}")
+                block.append(f"    - {entry.name}")
         if normal_entries:
-            body_lines.append("    " + ", ".join(entry.name for entry in normal_entries))
+            block.append("    " + ", ".join(entry.name for entry in normal_entries))
+        return block
+
+    preferred_categories = skill_usage_tracker.top_categories()
+    ordered_categories = list(
+        dict.fromkeys(preferred_categories + sorted(skills_by_category.keys()))
+    )
+    ordered_categories = [
+        category for category in ordered_categories if category in skills_by_category
+    ]
+
+    body_lines: list[str] = []
+    folded: list[str] = []
+    running_tokens = _estimate_tokens(
+        _SKILLS_V2_PREAMBLE + "<available_skills>\n</available_skills>\n"
+    )
+    for category in ordered_categories:
+        block = category_block(category)
+        block_cost = _estimate_tokens("\n".join(block) + "\n")
+        if body_lines and running_tokens + block_cost > token_budget:
+            folded.append(category)
+            continue
+        body_lines.extend(block)
+        running_tokens += block_cost
+
+    if folded:
+        body_lines.append(
+            f"  … and {len(folded)} more categories: "
+            + ", ".join(folded)
+            + ". Call skill_describe(category=...) to expand any of these."
+        )
 
     return (
         _SKILLS_V2_PREAMBLE
@@ -743,6 +776,10 @@ def _render_skills_prompt_v2(inventory: Inventory, *, token_budget: int) -> str:
         + "\n".join(body_lines)
         + "\n</available_skills>\n"
     )
+
+
+def _estimate_tokens(text: str) -> int:
+    return max(1, len(text) // 4)
 
 
 def build_nous_subscription_prompt(valid_tool_names: "set[str] | None" = None) -> str:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -623,6 +623,9 @@ def _skill_should_show(
 def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
+    *,
+    index_v2: bool = False,
+    index_token_budget: int = 2000,
 ) -> str:
     """Build a compact skill index for the system prompt."""
     inventory = load_inventory(
@@ -632,6 +635,8 @@ def build_skills_system_prompt(
     )
     if not inventory.entries:
         return ""
+    if index_v2:
+        return _render_skills_prompt_v2(inventory, token_budget=index_token_budget)
     return _render_skills_prompt_v1(inventory)
 
 
@@ -679,6 +684,64 @@ def _render_skills_prompt_v1(inventory: Inventory) -> str:
         "</available_skills>\n"
         "\n"
         "Only proceed without loading a skill if genuinely none are relevant to the task."
+    )
+
+
+_SKILLS_V2_PREAMBLE = (
+    "## Skills\n"
+    "\n"
+    "Tools available:\n"
+    "  - skill_view(name): load full skill content\n"
+    "  - skill_describe(category=..., names=[...]): get one-line descriptions\n"
+    "  - skill_manage: create / patch / write_file\n"
+    "\n"
+    "The list below shows every available skill organized by category. Skills "
+    "with descriptions are critical workflows you should consider on every task. "
+    "For other skills, the name is a hint — if any look relevant, call "
+    "skill_describe(category=\"<cat>\") to see one-line descriptions, then "
+    "skill_view(name) to load the full content.\n"
+    "\n"
+)
+
+
+def _render_skills_prompt_v2(inventory: Inventory, *, token_budget: int) -> str:
+    skills_by_category: dict[str, list[SkillEntry]] = {}
+    for entry in inventory.entries:
+        skills_by_category.setdefault(entry.category, []).append(entry)
+
+    critical_count = sum(1 for entry in inventory.entries if entry.priority == "critical")
+    if critical_count > 15:
+        logger.warning(
+            "skills.index_v2: %d skills marked priority=critical (>15). "
+            "Tier 1 budget gains erode quickly past this threshold.",
+            critical_count,
+        )
+
+    body_lines: list[str] = []
+    for category in sorted(skills_by_category.keys()):
+        cat_desc = inventory.category_descriptions.get(category, "")
+        body_lines.append(f"  {category}/  {cat_desc}".rstrip() if cat_desc else f"  {category}/")
+        critical_entries = sorted(
+            (entry for entry in skills_by_category[category] if entry.priority == "critical"),
+            key=lambda entry: entry.name,
+        )
+        normal_entries = sorted(
+            (entry for entry in skills_by_category[category] if entry.priority != "critical"),
+            key=lambda entry: entry.name,
+        )
+        for entry in critical_entries:
+            if entry.description:
+                body_lines.append(f"    - {entry.name}: {entry.description}")
+            else:
+                body_lines.append(f"    - {entry.name}")
+        if normal_entries:
+            body_lines.append("    " + ", ".join(entry.name for entry in normal_entries))
+
+    return (
+        _SKILLS_V2_PREAMBLE
+        + "<available_skills>\n"
+        + "\n".join(body_lines)
+        + "\n</available_skills>\n"
     )
 
 

--- a/agent/skill_inventory.py
+++ b/agent/skill_inventory.py
@@ -1,0 +1,337 @@
+"""Parsed skill metadata for prompt rendering and skill discovery tools."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from agent.skill_utils import (
+    extract_skill_conditions,
+    extract_skill_description,
+    get_all_skills_dirs,
+    get_disabled_skill_names,
+    iter_skill_index_files,
+    parse_frontmatter,
+    skill_matches_platform,
+)
+from hermes_constants import get_hermes_home, get_skills_dir
+from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
+
+SNAPSHOT_VERSION = 2
+_INVENTORY_CACHE_MAX = 8
+_INVENTORY_CACHE: OrderedDict[tuple, "Inventory"] = OrderedDict()
+_INVENTORY_LOCK = threading.Lock()
+
+
+@dataclass(frozen=True)
+class SkillEntry:
+    name: str
+    skill_name: str
+    category: str
+    description: str
+    priority: str = "normal"
+    platforms: tuple[str, ...] = ()
+    conditions: dict = field(default_factory=dict)
+    source: str = "local"
+
+
+@dataclass(frozen=True)
+class Inventory:
+    entries: tuple[SkillEntry, ...]
+    category_descriptions: dict[str, str]
+
+
+def normalize_priority(value: object) -> str:
+    priority = str(value or "normal").strip().lower()
+    return priority if priority in ("critical", "normal") else "normal"
+
+
+def _snapshot_path() -> Path:
+    return get_hermes_home() / ".skills_prompt_snapshot.json"
+
+
+def _build_manifest(skills_dir: Path) -> dict[str, list[int]]:
+    manifest: dict[str, list[int]] = {}
+    for filename in ("SKILL.md", "DESCRIPTION.md"):
+        for path in iter_skill_index_files(skills_dir, filename):
+            try:
+                st = path.stat()
+            except OSError:
+                continue
+            manifest[str(path.relative_to(skills_dir))] = [st.st_mtime_ns, st.st_size]
+    return manifest
+
+
+def _load_snapshot(skills_dir: Path) -> Optional[dict]:
+    path = _snapshot_path()
+    if not path.exists():
+        return None
+    try:
+        snapshot = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(snapshot, dict):
+        return None
+    if snapshot.get("version") != SNAPSHOT_VERSION:
+        return None
+    if snapshot.get("manifest") != _build_manifest(skills_dir):
+        return None
+    return snapshot
+
+
+def _write_snapshot(
+    skills_dir: Path,
+    manifest: dict[str, list[int]],
+    entries: list[SkillEntry],
+    category_descriptions: dict[str, str],
+) -> None:
+    payload = {
+        "version": SNAPSHOT_VERSION,
+        "manifest": manifest,
+        "skills": [
+            {
+                "name": entry.name,
+                "skill_name": entry.skill_name,
+                "category": entry.category,
+                "description": entry.description,
+                "priority": entry.priority,
+                "platforms": list(entry.platforms),
+                "conditions": entry.conditions,
+                "source": entry.source,
+            }
+            for entry in entries
+        ],
+        "category_descriptions": category_descriptions,
+    }
+    try:
+        atomic_json_write(_snapshot_path(), payload)
+    except Exception as exc:
+        logger.debug("Could not write skills snapshot: %s", exc)
+
+
+def _entry_from_snapshot(raw: dict) -> Optional[SkillEntry]:
+    try:
+        name = str(raw.get("name") or raw.get("frontmatter_name") or raw.get("skill_name") or "")
+        skill_name = str(raw.get("skill_name") or name)
+        if not name:
+            return None
+        platforms = raw.get("platforms") or ()
+        if isinstance(platforms, str):
+            platforms = (platforms,)
+        return SkillEntry(
+            name=name,
+            skill_name=skill_name,
+            category=str(raw.get("category") or "general"),
+            description=str(raw.get("description") or ""),
+            priority=normalize_priority(raw.get("priority")),
+            platforms=tuple(str(p).strip() for p in platforms if str(p).strip()),
+            conditions=raw.get("conditions") or {},
+            source=str(raw.get("source") or "local"),
+        )
+    except Exception:
+        return None
+
+
+def entry_from_skill_file(skill_file: Path, base_dir: Path, *, source: str) -> Optional[SkillEntry]:
+    try:
+        raw = skill_file.read_text(encoding="utf-8")
+        frontmatter, _ = parse_frontmatter(raw)
+    except Exception as exc:
+        logger.warning("Failed to parse skill file %s: %s", skill_file, exc)
+        frontmatter = {}
+
+    try:
+        rel = skill_file.relative_to(base_dir)
+    except ValueError:
+        rel = Path(skill_file.name)
+    parts = rel.parts
+    if len(parts) >= 2:
+        skill_name = parts[-2]
+        category = "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
+    else:
+        category = "general"
+        skill_name = skill_file.parent.name
+
+    platforms = frontmatter.get("platforms") or []
+    if isinstance(platforms, str):
+        platforms = [platforms]
+
+    return SkillEntry(
+        name=str(frontmatter.get("name", skill_name)),
+        skill_name=skill_name,
+        category=category,
+        description=extract_skill_description(frontmatter),
+        priority=normalize_priority(frontmatter.get("priority")),
+        platforms=tuple(str(p).strip() for p in platforms if str(p).strip()),
+        conditions=extract_skill_conditions(frontmatter),
+        source=source,
+    )
+
+
+def _read_category_descriptions(base_dir: Path) -> dict[str, str]:
+    descriptions: dict[str, str] = {}
+    for desc_file in iter_skill_index_files(base_dir, "DESCRIPTION.md"):
+        try:
+            content = desc_file.read_text(encoding="utf-8")
+            frontmatter, _ = parse_frontmatter(content)
+            cat_desc = frontmatter.get("description")
+            if not cat_desc:
+                continue
+            rel = desc_file.relative_to(base_dir)
+            category = "/".join(rel.parts[:-1]) if len(rel.parts) > 1 else "general"
+            descriptions[category] = str(cat_desc).strip().strip("'\"")
+        except Exception as exc:
+            logger.debug("Could not read skill description %s: %s", desc_file, exc)
+    return descriptions
+
+
+def _skill_should_show(
+    conditions: dict,
+    available_tools: set[str] | None,
+    available_toolsets: set[str] | None,
+) -> bool:
+    if available_tools is None and available_toolsets is None:
+        return True
+
+    at = available_tools or set()
+    ats = available_toolsets or set()
+    for ts in conditions.get("fallback_for_toolsets", []):
+        if ts in ats:
+            return False
+    for tool in conditions.get("fallback_for_tools", []):
+        if tool in at:
+            return False
+    for ts in conditions.get("requires_toolsets", []):
+        if ts not in ats:
+            return False
+    for tool in conditions.get("requires_tools", []):
+        if tool not in at:
+            return False
+    return True
+
+
+def _entry_allowed(
+    entry: SkillEntry,
+    disabled: set[str],
+    available_tools: set[str] | None,
+    available_toolsets: set[str] | None,
+) -> bool:
+    if not skill_matches_platform({"platforms": list(entry.platforms)}):
+        return False
+    if entry.name in disabled or entry.skill_name in disabled:
+        return False
+    return _skill_should_show(entry.conditions, available_tools, available_toolsets)
+
+
+def load_inventory(
+    available_tools: set[str] | None = None,
+    available_toolsets: set[str] | None = None,
+    disabled_names: set[str] | None = None,
+) -> Inventory:
+    """Return parsed, filtered skill metadata."""
+    skills_dir = get_skills_dir()
+    all_dirs = get_all_skills_dirs()
+    external_dirs = all_dirs[1:] if len(all_dirs) > 1 else []
+
+    if not skills_dir.exists() and not external_dirs:
+        return Inventory(entries=(), category_descriptions={})
+
+    from gateway.session_context import get_session_env
+
+    platform_hint = (
+        os.environ.get("HERMES_PLATFORM")
+        or get_session_env("HERMES_SESSION_PLATFORM")
+        or ""
+    )
+    disabled = disabled_names if disabled_names is not None else get_disabled_skill_names()
+    cache_key = (
+        str(skills_dir.resolve()),
+        tuple(str(d) for d in external_dirs),
+        tuple(sorted(str(t) for t in (available_tools or set()))),
+        tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
+        platform_hint,
+        tuple(sorted(disabled)),
+    )
+    with _INVENTORY_LOCK:
+        cached = _INVENTORY_CACHE.get(cache_key)
+        if cached is not None:
+            _INVENTORY_CACHE.move_to_end(cache_key)
+            return cached
+
+    entries: list[SkillEntry] = []
+    category_descriptions: dict[str, str] = {}
+
+    snapshot = _load_snapshot(skills_dir) if skills_dir.exists() else None
+    if snapshot is not None:
+        for raw in snapshot.get("skills", []):
+            if not isinstance(raw, dict):
+                continue
+            entry = _entry_from_snapshot(raw)
+            if entry is not None:
+                entries.append(entry)
+        category_descriptions.update(
+            {
+                str(key): str(value)
+                for key, value in (snapshot.get("category_descriptions") or {}).items()
+            }
+        )
+    elif skills_dir.exists():
+        for skill_file in iter_skill_index_files(skills_dir, "SKILL.md"):
+            entry = entry_from_skill_file(skill_file, skills_dir, source="local")
+            if entry is not None:
+                entries.append(entry)
+        category_descriptions.update(_read_category_descriptions(skills_dir))
+        _write_snapshot(
+            skills_dir,
+            _build_manifest(skills_dir),
+            entries,
+            category_descriptions,
+        )
+
+    seen_names = {entry.name for entry in entries}
+    for ext_dir in external_dirs:
+        if not ext_dir.exists():
+            continue
+        for skill_file in iter_skill_index_files(ext_dir, "SKILL.md"):
+            entry = entry_from_skill_file(skill_file, ext_dir, source="external")
+            if entry is None or entry.name in seen_names:
+                continue
+            entries.append(entry)
+            seen_names.add(entry.name)
+        for category, description in _read_category_descriptions(ext_dir).items():
+            category_descriptions.setdefault(category, description)
+
+    filtered = tuple(
+        entry
+        for entry in entries
+        if _entry_allowed(entry, disabled, available_tools, available_toolsets)
+    )
+    inventory = Inventory(
+        entries=filtered,
+        category_descriptions=dict(category_descriptions),
+    )
+
+    with _INVENTORY_LOCK:
+        _INVENTORY_CACHE[cache_key] = inventory
+        _INVENTORY_CACHE.move_to_end(cache_key)
+        while len(_INVENTORY_CACHE) > _INVENTORY_CACHE_MAX:
+            _INVENTORY_CACHE.popitem(last=False)
+    return inventory
+
+
+def clear_inventory_cache(*, clear_snapshot: bool = False) -> None:
+    with _INVENTORY_LOCK:
+        _INVENTORY_CACHE.clear()
+    if clear_snapshot:
+        try:
+            _snapshot_path().unlink(missing_ok=True)
+        except OSError as exc:
+            logger.debug("Could not remove skills snapshot: %s", exc)

--- a/agent/skill_nudge_signals.py
+++ b/agent/skill_nudge_signals.py
@@ -1,0 +1,124 @@
+"""Signal-based skill-creation nudge evaluator.
+
+The evaluator is intentionally pure and best suited for unit tests. Agent loop
+code feeds it user messages plus completed tool call/result pairs; it records
+which S1-S4 signals fired in the current window.
+"""
+from __future__ import annotations
+
+import hashlib
+from collections import deque
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+
+
+def _terminal_signature(args: dict) -> str:
+    cmd = str((args or {}).get("command") or "").strip()
+    if not cmd:
+        return ""
+    parts = cmd.split()
+    head = parts[0].rsplit("/", 1)[-1] if parts else ""
+    sub = parts[1] if len(parts) > 1 else ""
+    if head in {"git", "gh", "kubectl"}:
+        return f"{head} {sub}".strip()
+    return head
+
+
+def _path_signature(args: dict) -> str:
+    raw = (args or {}).get("path") or (args or {}).get("file_path") or ""
+    path = str(raw).strip()
+    if not path:
+        return ""
+    parent = str(PurePosixPath(path).parent)
+    return "" if parent == "." else parent
+
+
+_PER_TOOL_SIG = {
+    "terminal": _terminal_signature,
+    "process": _terminal_signature,
+    "read_file": _path_signature,
+    "write_file": _path_signature,
+    "edit_file": _path_signature,
+}
+
+
+def _hash_error(text: str) -> str:
+    return hashlib.sha1(text[:200].encode("utf-8", "replace")).hexdigest()[:16]
+
+
+@dataclass
+class SignalEvaluator:
+    repeated_threshold: int = 3
+    error_threshold: int = 2
+    common_clis_suppressed: list[str] = field(default_factory=list)
+    cli_window_days: int = 30
+    user_phrases: list[str] = field(default_factory=list)
+
+    fired_signals: set[str] = field(default_factory=set)
+    _tool_calls: deque = field(default_factory=lambda: deque(maxlen=20))
+    _error_counts: dict[str, int] = field(default_factory=dict)
+    _failed_clis: set[str] = field(default_factory=set)
+
+    def observe_user_message(self, text: str) -> None:
+        if not text:
+            return
+        lowered = text.lower()
+        for phrase in self.user_phrases:
+            if phrase and phrase.lower() in lowered:
+                self.fired_signals.add("S3")
+                return
+
+    def observe_tool_call(
+        self,
+        tool_name: str,
+        args: dict | None,
+        *,
+        success: bool | None = None,
+    ) -> None:
+        args = args or {}
+        sig_fn = _PER_TOOL_SIG.get(tool_name)
+        if sig_fn is not None:
+            sig = sig_fn(args)
+            if sig:
+                self._tool_calls.append((tool_name, sig))
+                count = sum(1 for name, seen_sig in self._tool_calls if name == tool_name and seen_sig == sig)
+                if count >= self.repeated_threshold:
+                    self.fired_signals.add("S1")
+
+        if tool_name not in ("terminal", "process"):
+            return
+
+        cmd = str(args.get("command") or "").strip()
+        if not cmd:
+            return
+        head = cmd.split()[0].rsplit("/", 1)[-1]
+        if not head or head in self.common_clis_suppressed:
+            return
+
+        from agent import skill_usage_tracker
+
+        if skill_usage_tracker.is_known_cli(head, window_days=self.cli_window_days):
+            return
+
+        if success is True or head in self._failed_clis:
+            self.fired_signals.add("S2")
+        if success is False:
+            self._failed_clis.add(head)
+        skill_usage_tracker.record_cli_seen(head)
+
+    def observe_tool_result(self, tool_name: str, *, error_text: str | None) -> None:
+        if error_text:
+            h = _hash_error(error_text)
+            self._error_counts[h] = self._error_counts.get(h, 0) + 1
+            return
+
+        for h, count in list(self._error_counts.items()):
+            if count >= self.error_threshold:
+                self.fired_signals.add("S4")
+                self._error_counts.pop(h, None)
+
+    def clear(self) -> None:
+        self.fired_signals.clear()
+        self._tool_calls.clear()
+        self._error_counts.clear()
+        self._failed_clis.clear()

--- a/agent/skill_usage_tracker.py
+++ b/agent/skill_usage_tracker.py
@@ -1,0 +1,102 @@
+"""Best-effort persistence for skill usage and known CLI history."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
+
+_MAX_TIMESTAMPS_PER_CATEGORY = 30
+_DEFAULT_USAGE_WINDOW_SECONDS = 30 * 86400
+_DEFAULT_CLI_WINDOW_DAYS = 30
+
+
+def _usage_path() -> Path:
+    return get_hermes_home() / ".skill_usage.json"
+
+
+def _known_clis_path() -> Path:
+    return get_hermes_home() / ".skill_known_clis.json"
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        if not path.exists():
+            return {}
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not read %s: %s", path, exc)
+        return {}
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    try:
+        atomic_json_write(path, payload)
+    except Exception as exc:
+        logger.debug("Could not write %s: %s", path, exc)
+
+
+def record_category_use(category: str) -> None:
+    if not category:
+        return
+    data = _read_json(_usage_path())
+    history = data.get(category) or []
+    if not isinstance(history, list):
+        history = []
+    history.append(time.time())
+    data[category] = history[-_MAX_TIMESTAMPS_PER_CATEGORY:]
+    _write_json(_usage_path(), data)
+
+
+def top_categories(within_seconds: int = _DEFAULT_USAGE_WINDOW_SECONDS) -> list[str]:
+    data = _read_json(_usage_path())
+    cutoff = time.time() - within_seconds
+    scored: list[tuple[int, str]] = []
+    for category, timestamps in data.items():
+        if not isinstance(timestamps, list):
+            continue
+        recent = sum(
+            1
+            for timestamp in timestamps
+            if isinstance(timestamp, (int, float)) and timestamp >= cutoff
+        )
+        if recent:
+            scored.append((recent, str(category)))
+    scored.sort(key=lambda item: (-item[0], item[1]))
+    return [category for _score, category in scored]
+
+
+def record_cli_seen(cli: str) -> None:
+    if not cli:
+        return
+    data = _read_json(_known_clis_path())
+    data[cli] = time.time()
+    _write_json(_known_clis_path(), data)
+
+
+def is_known_cli(cli: str, *, window_days: int = _DEFAULT_CLI_WINDOW_DAYS) -> bool:
+    if not cli:
+        return False
+    data = _read_json(_known_clis_path())
+    timestamp = data.get(cli)
+    if not isinstance(timestamp, (int, float)):
+        return False
+    return (time.time() - timestamp) <= (window_days * 86400)
+
+
+def usage_rank_epoch() -> str:
+    path = _usage_path()
+    try:
+        mtime = path.stat().st_mtime if path.exists() else 0
+    except OSError:
+        mtime = 0
+    day = int(mtime // 86400) if mtime else 0
+    return str(day)
+

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -480,9 +480,20 @@ streaming:
 #
 skills:
   # Nudge the agent to create skills after complex tasks.
-  # Every N tool-calling iterations, remind the model to consider saving a skill.
+  # Phase 1-2 fallback only — primary triggers are signal-based (see below).
   # Set to 0 to disable.
   creation_nudge_interval: 15
+
+  # Skill index v2 — Tier 1 (system prompt) shows category + names only;
+  # descriptions are fetched on demand via skill_describe. Skills with
+  # `priority: critical` in their frontmatter keep descriptions in Tier 1.
+  # Default false until Phase 3 of the rollout.
+  index_v2: false
+
+  # Soft cap on the Tier 1 skill block (token estimate, len // 4). When
+  # exceeded, lowest-priority categories are folded behind a one-line hint
+  # that points the model at skill_describe.
+  index_token_budget: 2000
 
   # External skill directories — share skills across tools/agents without
   # copying them into ~/.hermes/skills/.  Each path is expanded (~ and ${VAR})

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -495,6 +495,41 @@ skills:
   # that points the model at skill_describe.
   index_token_budget: 2000
 
+  # Phase 2 opt-in: replace the time-based creation nudge with signal-based
+  # triggers. When enabled, the time counter above becomes a fallback that
+  # fires only after this many tool iterations without any signal.
+  nudge_signals:
+    enabled: false
+    # S1: trigger when the same (tool, arg-signature) appears N+ times in a turn.
+    repeated_pattern_threshold: 3
+    # S2: window for "novel CLI" detection.
+    novel_cli_window_days: 30
+    # S2: CLIs that should not count as novel.
+    common_cli_suppressions:
+      - git
+      - python
+      - python3
+      - node
+      - npm
+      - pnpm
+      - uv
+      - pytest
+      - rg
+      - sed
+      - cat
+      - ls
+      - mkdir
+    # S3: user-message phrases that fire an explicit "remember this" signal.
+    user_phrases:
+      - "next time"
+      - "remember"
+      - "from now on"
+      - "记一下"
+      - "下次"
+      - "以后"
+    # S4: a successful call after this many same-error failures fires a signal.
+    error_repeat_threshold: 2
+
   # External skill directories — share skills across tools/agents without
   # copying them into ~/.hermes/skills/.  Each path is expanded (~ and ${VAR})
   # and resolved to an absolute path.  External dirs are read-only: skill

--- a/cli.py
+++ b/cli.py
@@ -5814,7 +5814,23 @@ class HermesCLI:
         print("  Available: list, add, edit, pause, resume, run, remove")
     
     def _handle_skills_command(self, cmd: str):
-        """Handle /skills slash command — delegates to hermes_cli.skills_hub."""
+        """Handle /skills slash command."""
+        parts = cmd.strip().split()
+        if len(parts) >= 3 and parts[0].lower() == "/skills" and parts[1].lower() == "nudge":
+            subcommand = parts[2].lower()
+            if subcommand == "off":
+                if getattr(self, "agent", None) is not None:
+                    self.agent._nudge_disabled = True
+                print("Skill creation nudges silenced for this session.")
+                return
+            if subcommand == "on":
+                if getattr(self, "agent", None) is not None:
+                    self.agent._nudge_disabled = False
+                print("Skill creation nudges re-enabled for this session.")
+                return
+            print("Usage: /skills nudge [off|on]")
+            return
+
         from hermes_cli.skills_hub import handle_skills_slash
         handle_skills_slash(cmd, ChatConsole())
 

--- a/docs/superpowers/plans/2026-05-08-skills-prompt-budget-and-nudge-redesign.md
+++ b/docs/superpowers/plans/2026-05-08-skills-prompt-budget-and-nudge-redesign.md
@@ -1,0 +1,831 @@
+# Skills Prompt Budget And Nudge Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce Hermes skill-index prompt cost with an opt-in v2 structural index and replace noisy time-only skill nudges with opt-in signal-based nudges.
+
+**Architecture:** Extract skill metadata collection into a shared inventory module used by both prompt rendering and skill tools. Keep v1 prompt rendering available behind config while v2 renders a budgeted category/name index with critical descriptions and an on-demand `skill_describe` tool. Add nudge-signal state to `AIAgent`, evaluate signals from tool-call/result history, and keep the old interval as a fallback.
+
+**Tech Stack:** Python, pytest, Hermes tool registry, YAML config defaults, JSON state files under `HERMES_HOME`.
+
+---
+
+## File Structure
+
+- Create: `agent/skill_inventory.py` — shared parsed skill metadata, local snapshot v2, external-dir scan, priority parsing, category descriptions, prompt-cache invalidation hook.
+- Modify: `agent/prompt_builder.py` — delegate inventory loading, keep v1 renderer, add v2 renderer and budget folding behind `skills.index_v2`.
+- Modify: `tools/skills_tool.py` — add `skill_describe`, register its schema, record best-effort skill usage from `skill_view` and `skill_describe`.
+- Modify: `hermes_cli/config.py` — add config defaults for `skills.index_v2`, `skills.index_token_budget`, and `skills.nudge_signals`.
+- Modify: `cli-config.yaml.example` — document opt-in defaults for Phase 1-2.
+- Modify: `run_agent.py` — add nudge-signal config/state/helpers, evaluate signals, gate background review, add signal context.
+- Modify: `cli.py`, `tui_gateway/server.py`, and relevant gateway slash mirrors if needed — intercept `/skills nudge off` before the Skills Hub router and set per-session state.
+- Test: `tests/agent/test_prompt_builder.py` — inventory, v1 compatibility, v2 rendering, budget folding, cache invalidation.
+- Test: `tests/tools/test_skills_tool.py` — `skill_describe` and usage recording.
+- Test: `tests/run_agent/test_run_agent.py` — nudge signals, fallback, disable behavior, background context.
+
+---
+
+### Task 1: Shared Skill Inventory
+
+**Files:**
+- Create: `agent/skill_inventory.py`
+- Modify: `agent/prompt_builder.py:463-747`
+- Test: `tests/agent/test_prompt_builder.py`
+
+- [ ] **Step 1: Write inventory tests first**
+
+Add this test near `TestBuildSkillsSystemPrompt` in `tests/agent/test_prompt_builder.py`:
+
+```python
+def test_inventory_reads_priority_and_category_descriptions(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    skill_dir = tmp_path / "skills" / "workflow" / "verify"
+    skill_dir.mkdir(parents=True)
+    (tmp_path / "skills" / "workflow" / "DESCRIPTION.md").write_text(
+        "---\ndescription: Workflow discipline\n---\n", encoding="utf-8"
+    )
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: verify\ndescription: Verify before reporting\npriority: critical\n---\nBody",
+        encoding="utf-8",
+    )
+
+    from agent.skill_inventory import load_skill_inventory
+
+    inventory = load_skill_inventory()
+    assert inventory.category_descriptions["workflow"] == "Workflow discipline"
+    assert inventory.by_category["workflow"][0].name == "verify"
+    assert inventory.by_category["workflow"][0].priority == "critical"
+```
+
+- [ ] **Step 2: Run the new test and verify it fails**
+
+Run: `pytest tests/agent/test_prompt_builder.py::test_inventory_reads_priority_and_category_descriptions -q`
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'agent.skill_inventory'`.
+
+- [ ] **Step 3: Create `agent/skill_inventory.py` with metadata dataclasses**
+
+```python
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from agent.skill_utils import (
+    extract_skill_conditions,
+    get_all_skills_dirs,
+    get_disabled_skill_names,
+    iter_skill_index_files,
+    parse_frontmatter,
+    skill_matches_platform,
+)
+from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
+_SKILLS_SNAPSHOT_VERSION = 2
+
+@dataclass(frozen=True)
+class SkillIndexEntry:
+    name: str
+    skill_name: str
+    category: str
+    description: str
+    priority: str = "normal"
+    platforms: tuple[str, ...] = ()
+    conditions: dict = field(default_factory=dict)
+    source_dir: str = ""
+
+@dataclass(frozen=True)
+class SkillInventory:
+    entries: tuple[SkillIndexEntry, ...]
+    category_descriptions: dict[str, str]
+
+    @property
+    def by_category(self) -> dict[str, list[SkillIndexEntry]]:
+        grouped: dict[str, list[SkillIndexEntry]] = {}
+        for entry in self.entries:
+            grouped.setdefault(entry.category, []).append(entry)
+        for entries in grouped.values():
+            entries.sort(key=lambda item: item.name)
+        return grouped
+
+def normalize_priority(value: object) -> str:
+    return "critical" if str(value or "").strip().lower() == "critical" else "normal"
+```
+
+- [ ] **Step 4: Move snapshot and parsing helpers into the inventory module**
+
+Move the current helper logic from `agent/prompt_builder.py:472-587` into `agent/skill_inventory.py`. Preserve the current manifest semantics and add priority/source metadata:
+
+```python
+def _skills_prompt_snapshot_path() -> Path:
+    from hermes_constants import get_hermes_home
+    return get_hermes_home() / ".skills_prompt_snapshot.json"
+
+def _build_snapshot_entry(skill_file: Path, skills_dir: Path, frontmatter: dict, description: str) -> dict:
+    rel_path = skill_file.relative_to(skills_dir)
+    parts = rel_path.parts
+    if len(parts) >= 2:
+        skill_name = parts[-2]
+        category = "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
+    else:
+        category = "general"
+        skill_name = skill_file.parent.name
+    platforms = frontmatter.get("platforms") or []
+    if isinstance(platforms, str):
+        platforms = [platforms]
+    return {
+        "skill_name": skill_name,
+        "category": category,
+        "frontmatter_name": str(frontmatter.get("name", skill_name)),
+        "description": description,
+        "priority": normalize_priority(frontmatter.get("priority")),
+        "platforms": [str(p).strip() for p in platforms if str(p).strip()],
+        "conditions": extract_skill_conditions(frontmatter),
+        "source_dir": str(skills_dir),
+    }
+```
+
+- [ ] **Step 5: Implement `load_skill_inventory()`**
+
+The public function must accept `available_tools` and `available_toolsets`, reuse the existing platform/disabled/conditions filtering, and scan local skills before external dirs so local names win:
+
+```python
+def load_skill_inventory(
+    available_tools: set[str] | None = None,
+    available_toolsets: set[str] | None = None,
+) -> SkillInventory:
+    from hermes_constants import get_skills_dir
+    skills_dir = get_skills_dir()
+    external_dirs = get_all_skills_dirs()[1:]
+    disabled = get_disabled_skill_names()
+    entries: list[SkillIndexEntry] = []
+    category_descriptions: dict[str, str] = {}
+    seen_names: set[str] = set()
+
+    # Use the current prompt_builder snapshot path for the local dir, then scan external dirs directly.
+    # Convert accepted snapshot records through _entry_from_snapshot().
+    # For cold local/external records, use _parse_skill_file() and _build_snapshot_entry().
+
+    return SkillInventory(entries=tuple(entries), category_descriptions=category_descriptions)
+```
+
+Fill the body from the existing `agent/prompt_builder.py:639-793` logic; do not change behavior for `requires_tools`, `fallback_for_tools`, platforms, disabled skills, or external-dir dedupe.
+
+- [ ] **Step 6: Make `prompt_builder` import inventory helpers**
+
+In `agent/prompt_builder.py`, import:
+
+```python
+from agent.skill_inventory import SkillInventory, SkillIndexEntry, clear_skill_inventory_cache, load_skill_inventory
+```
+
+Update `clear_skills_system_prompt_cache()` so it clears both caches:
+
+```python
+def clear_skills_system_prompt_cache(*, clear_snapshot: bool = False) -> None:
+    with _SKILLS_PROMPT_CACHE_LOCK:
+        _SKILLS_PROMPT_CACHE.clear()
+    clear_skill_inventory_cache(clear_snapshot=clear_snapshot)
+```
+
+- [ ] **Step 7: Run inventory regression tests**
+
+Run: `pytest tests/agent/test_prompt_builder.py::test_inventory_reads_priority_and_category_descriptions tests/agent/test_prompt_builder.py::TestBuildSkillsSystemPrompt::test_builds_index_with_skills -q`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 1**
+
+```bash
+git add agent/skill_inventory.py agent/prompt_builder.py tests/agent/test_prompt_builder.py
+git commit -m "refactor: share skill inventory metadata"
+```
+
+---
+
+### Task 2: V2 Prompt Renderer And Budget Folding
+
+**Files:**
+- Modify: `agent/prompt_builder.py:621-847`
+- Modify: `hermes_cli/config.py:793-818`
+- Test: `tests/agent/test_prompt_builder.py`
+
+- [ ] **Step 1: Write failing v2 rendering tests**
+
+```python
+def test_skills_prompt_v2_hides_normal_descriptions(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("skills:\n  index_v2: true\n", encoding="utf-8")
+    normal = tmp_path / "skills" / "coding" / "normal"
+    critical = tmp_path / "skills" / "coding" / "critical"
+    normal.mkdir(parents=True)
+    critical.mkdir(parents=True)
+    (normal / "SKILL.md").write_text("---\nname: normal\ndescription: Normal hidden\n---\nBody", encoding="utf-8")
+    (critical / "SKILL.md").write_text("---\nname: critical\ndescription: Critical shown\npriority: critical\n---\nBody", encoding="utf-8")
+
+    prompt = build_skills_system_prompt()
+    assert "## Skills" in prompt
+    assert "skill_describe" in prompt
+    assert "normal" in prompt
+    assert "Normal hidden" not in prompt
+    assert "critical: Critical shown" in prompt
+```
+
+```python
+def test_skills_prompt_v2_budget_folds_categories(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("skills:\n  index_v2: true\n  index_token_budget: 160\n", encoding="utf-8")
+    for i in range(40):
+        d = tmp_path / "skills" / f"cat{i:02d}" / f"skill{i:02d}"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(f"---\nname: skill{i:02d}\ndescription: Description {i}\n---\nBody", encoding="utf-8")
+
+    prompt = build_skills_system_prompt()
+    assert len(prompt) // 4 <= 220
+    assert "more categories" in prompt
+    assert "Call skill_describe(category=" in prompt
+```
+
+- [ ] **Step 2: Run v2 tests and verify failure**
+
+Run: `pytest tests/agent/test_prompt_builder.py::test_skills_prompt_v2_hides_normal_descriptions tests/agent/test_prompt_builder.py::test_skills_prompt_v2_budget_folds_categories -q`
+
+Expected: FAIL because v2 config/rendering is absent.
+
+- [ ] **Step 3: Add config defaults**
+
+In `hermes_cli/config.py`, extend the existing `skills` defaults:
+
+```python
+"index_v2": False,
+"index_token_budget": 2000,
+"nudge_signals": {
+    "enabled": False,
+    "repeated_pattern_threshold": 3,
+    "novel_cli_window_days": 30,
+    "common_cli_suppressions": ["git", "python", "python3", "node", "npm", "pnpm", "uv", "pytest", "rg", "sed", "cat", "ls", "mkdir"],
+    "user_phrases": ["next time", "remember", "from now on", "记一下", "下次", "以后"],
+    "error_repeat_threshold": 2,
+},
+```
+
+- [ ] **Step 4: Add prompt-builder config and v2 helpers**
+
+```python
+def _get_skills_index_config() -> tuple[bool, int]:
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config().get("skills", {})
+    except Exception:
+        cfg = {}
+    enabled = str(cfg.get("index_v2", False)).lower() in ("1", "true", "yes", "on")
+    try:
+        budget = int(cfg.get("index_token_budget", 2000))
+    except (TypeError, ValueError):
+        budget = 2000
+    return enabled, max(400, budget)
+
+def _estimate_tokens(text: str) -> int:
+    return max(1, len(text) // 4)
+```
+
+- [ ] **Step 5: Split v1 and add v2 renderers**
+
+Create `_render_skills_prompt_v1(inventory)` by moving the existing line-building code unchanged. Add v2 helpers:
+
+```python
+def _render_category_v2(category: str, entries: list[SkillIndexEntry], cat_desc: str) -> list[str]:
+    lines = [f"  {category}/  {cat_desc}" if cat_desc else f"  {category}/"]
+    normal_names: list[str] = []
+    for entry in entries:
+        if entry.priority == "critical" and entry.description:
+            lines.append(f"    - {entry.name}: {entry.description}")
+        else:
+            normal_names.append(entry.name)
+    if normal_names:
+        lines.append("    " + ", ".join(normal_names))
+    return lines
+
+def _render_skills_prompt_v2(inventory: SkillInventory, token_budget: int) -> str:
+    body_lines: list[str] = []
+    for category in sorted(inventory.by_category.keys()):
+        body_lines.extend(_render_category_v2(category, inventory.by_category[category], inventory.category_descriptions.get(category, "")))
+    full = _SKILLS_V2_PREAMBLE + "\n".join(body_lines) + "\n</available_skills>"
+    return _fold_skills_prompt_v2(full, inventory, token_budget)
+```
+
+- [ ] **Step 6: Implement budget folding**
+
+```python
+def _fold_skills_prompt_v2(full: str, inventory: SkillInventory, token_budget: int) -> str:
+    if _estimate_tokens(full) <= token_budget:
+        return full
+    kept: list[str] = []
+    hidden: list[str] = []
+    for category in _rank_categories_for_budget(inventory):
+        lines = _render_category_v2(category, inventory.by_category[category], inventory.category_descriptions.get(category, ""))
+        candidate = _SKILLS_V2_PREAMBLE + "\n".join(kept + lines) + "\n</available_skills>"
+        if _estimate_tokens(candidate) <= token_budget:
+            kept.extend(lines)
+        else:
+            hidden.append(category)
+    if hidden:
+        kept.append(f"  ... and {len(hidden)} more categories: {', '.join(hidden)}. Call skill_describe(category=...) to expand any of these.")
+    return _SKILLS_V2_PREAMBLE + "\n".join(kept) + "\n</available_skills>"
+```
+
+- [ ] **Step 7: Wire `build_skills_system_prompt()` to config**
+
+```python
+index_v2_enabled, token_budget = _get_skills_index_config()
+cache_key = (..., "v2", index_v2_enabled, token_budget, _usage_rank_epoch(index_v2_enabled))
+inventory = load_skill_inventory(available_tools=available_tools, available_toolsets=available_toolsets)
+result = _render_skills_prompt_v2(inventory, token_budget) if index_v2_enabled else _render_skills_prompt_v1(inventory)
+```
+
+- [ ] **Step 8: Run prompt-builder tests**
+
+Run: `pytest tests/agent/test_prompt_builder.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit Task 2**
+
+```bash
+git add agent/prompt_builder.py hermes_cli/config.py tests/agent/test_prompt_builder.py
+git commit -m "feat: add budgeted skills prompt index"
+```
+
+---
+
+### Task 3: `skill_describe` Tool And Usage Tracking
+
+**Files:**
+- Modify: `tools/skills_tool.py:428-1445`
+- Modify: `agent/skill_inventory.py`
+- Test: `tests/tools/test_skills_tool.py`
+
+- [ ] **Step 1: Write `skill_describe` tests**
+
+```python
+def test_skill_describe_by_category(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    d = tmp_path / "skills" / "coding" / "python-debug"
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text("---\nname: python-debug\ndescription: Debug Python\n---\nBody", encoding="utf-8")
+
+    from tools.skills_tool import skill_describe
+    result = json.loads(skill_describe(category="coding"))
+    assert result["success"] is True
+    assert result["skills"] == [{"name": "python-debug", "category": "coding", "description": "Debug Python"}]
+
+def test_skill_describe_requires_filter():
+    from tools.skills_tool import skill_describe
+    result = json.loads(skill_describe())
+    assert result["success"] is False
+    assert "category or names" in result["error"]
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run: `pytest tests/tools/test_skills_tool.py::test_skill_describe_by_category tests/tools/test_skills_tool.py::test_skill_describe_requires_filter -q`
+
+Expected: FAIL because `skill_describe` is not defined.
+
+- [ ] **Step 3: Add usage helpers**
+
+In `agent/skill_inventory.py`:
+
+```python
+def skill_usage_path() -> Path:
+    from hermes_constants import get_hermes_home
+    return get_hermes_home() / ".skill_usage.json"
+
+def record_skill_usage(category: str, *, now_ts: float | None = None) -> None:
+    import time
+    ts = float(now_ts if now_ts is not None else time.time())
+    path = skill_usage_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+        if not isinstance(data, dict):
+            data = {}
+        values = data.get(category, [])
+        if not isinstance(values, list):
+            values = []
+        data[category] = (values + [ts])[-30:]
+        atomic_json_write(path, data)
+    except Exception:
+        logger.debug("Could not record skill usage for %s", category, exc_info=True)
+```
+
+- [ ] **Step 4: Implement and register `skill_describe()`**
+
+```python
+def skill_describe(category: str = None, names: List[str] = None, task_id: str = None) -> str:
+    try:
+        if not category and not names:
+            return tool_error("Provide category or names for skill_describe.", success=False)
+        from agent.skill_inventory import load_skill_inventory, record_skill_usage
+        inventory = load_skill_inventory()
+        wanted_names = set(names or [])
+        selected = [
+            entry for entry in inventory.entries
+            if (category and entry.category == category) or (wanted_names and entry.name in wanted_names)
+        ]
+        if category and not selected:
+            return tool_error(f"Unknown skill category '{category}'.", success=False)
+        missing = sorted(wanted_names - {entry.name for entry in selected})
+        if missing:
+            return tool_error(f"Unknown skill name(s): {', '.join(missing)}", success=False)
+        for entry in selected:
+            record_skill_usage(entry.category)
+        return json.dumps({
+            "success": True,
+            "skills": [{"name": e.name, "category": e.category, "description": e.description} for e in sorted(selected, key=lambda e: (e.category, e.name))],
+        }, ensure_ascii=False)
+    except Exception as e:
+        return tool_error(str(e), success=False)
+```
+
+Add `SKILL_DESCRIBE_SCHEMA` and a `registry.register(name="skill_describe", toolset="skills", ...)` block next to `skills_list` and `skill_view`.
+
+- [ ] **Step 5: Record usage from `skill_view()`**
+
+After resolving `skill_md` and category in `skill_view()`, add:
+
+```python
+try:
+    from agent.skill_inventory import record_skill_usage
+    record_skill_usage(_get_category_from_path(skill_md) or "general")
+except Exception:
+    logger.debug("Could not record skill_view usage for %s", name, exc_info=True)
+```
+
+- [ ] **Step 6: Run skills tool tests**
+
+Run: `pytest tests/tools/test_skills_tool.py tests/tools/test_skill_view_path_check.py tests/tools/test_skill_view_traversal.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 3**
+
+```bash
+git add agent/skill_inventory.py tools/skills_tool.py tests/tools/test_skills_tool.py
+git commit -m "feat: add skill describe tool"
+```
+
+---
+
+### Task 4: Nudge Signal State And Pure Helpers
+
+**Files:**
+- Modify: `run_agent.py:1607-1613`
+- Test: `tests/run_agent/test_run_agent.py`
+
+- [ ] **Step 1: Write helper tests**
+
+```python
+def test_skill_nudge_signature_for_terminal_command(agent):
+    assert agent._skill_nudge_arg_signature("terminal", {"command": "git status --short"}) == "git status"
+    assert agent._skill_nudge_arg_signature("terminal", {"command": "python -m pytest"}) == "python"
+
+def test_explicit_user_signal_zh_phrase(agent):
+    agent._nudge_signal_config = {"user_phrases": ["记一下"]}
+    assert agent._skill_nudge_user_signals("这个坑记一下") == {"explicit_user_signal"}
+```
+
+- [ ] **Step 2: Run helper tests and verify failure**
+
+Run: `pytest tests/run_agent/test_run_agent.py::test_skill_nudge_signature_for_terminal_command tests/run_agent/test_run_agent.py::test_explicit_user_signal_zh_phrase -q`
+
+Expected: FAIL because helper methods are missing.
+
+- [ ] **Step 3: Add nudge config and state in `AIAgent.__init__`**
+
+```python
+self._skill_nudge_interval = 10
+self._nudge_signals_enabled = False
+self._nudge_disabled = os.getenv("HERMES_SKILL_NUDGE_DISABLE", "").lower() in ("1", "true", "yes", "on")
+self._nudge_signal_config = {
+    "repeated_pattern_threshold": 3,
+    "novel_cli_window_days": 30,
+    "common_cli_suppressions": {"git", "python", "python3", "node", "npm", "pnpm", "uv", "pytest", "rg", "sed", "cat", "ls", "mkdir"},
+    "user_phrases": ["next time", "remember", "from now on", "记一下", "下次", "以后"],
+    "error_repeat_threshold": 2,
+}
+self._tool_call_history = deque(maxlen=10)
+self._error_history = deque(maxlen=10)
+self._repeated_error_hashes = set()
+self._nudge_signals = set()
+self._known_clis = self._load_skill_known_clis()
+```
+
+Read overrides from `_agent_cfg.get("skills", {})` and nested `nudge_signals` without changing the current fallback interval unless config says so.
+
+- [ ] **Step 4: Add helper methods on `AIAgent`**
+
+```python
+def _skill_nudge_arg_signature(self, tool_name: str, args: dict) -> str | None:
+    if tool_name in ("terminal", "process"):
+        command = str(args.get("command") or args.get("cmd") or "").strip()
+        parts = command.split()
+        if not parts:
+            return None
+        binary = os.path.basename(parts[0])
+        if binary == "git" and len(parts) > 1:
+            return f"git {parts[1]}"
+        return binary
+    if tool_name in ("read_file", "write_file", "edit_file"):
+        path = str(args.get("path") or args.get("file_path") or "").strip()
+        return str(Path(path).parent) if path else None
+    if tool_name in ("web_search", "web_extract"):
+        value = str(args.get("url") or args.get("query") or "").strip()
+        return value.split("/", 3)[2] if value.startswith(("http://", "https://")) else value[:40]
+    return None
+
+def _skill_nudge_user_signals(self, original_user_message: str) -> set[str]:
+    text = (original_user_message or "").lower()
+    phrases = self._nudge_signal_config.get("user_phrases") or []
+    return {"explicit_user_signal"} if any(str(p).lower() in text for p in phrases) else set()
+```
+
+- [ ] **Step 5: Run helper tests**
+
+Run: `pytest tests/run_agent/test_run_agent.py::test_skill_nudge_signature_for_terminal_command tests/run_agent/test_run_agent.py::test_explicit_user_signal_zh_phrase -q`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 4**
+
+```bash
+git add run_agent.py tests/run_agent/test_run_agent.py
+git commit -m "feat: add skill nudge signal helpers"
+```
+
+---
+
+### Task 5: Signal Evaluation, Gating, And Disable Command
+
+**Files:**
+- Modify: `run_agent.py:3018-3050`, `run_agent.py:9295-9299`, `run_agent.py:12176-12204`
+- Modify: `cli.py:5817-5819`, `tui_gateway/server.py:3753-3865`
+- Test: `tests/run_agent/test_run_agent.py`
+
+- [ ] **Step 1: Write signal evaluation tests**
+
+```python
+def test_repeated_tool_pattern_signal(agent):
+    agent._nudge_signals_enabled = True
+    for _ in range(3):
+        agent._evaluate_skill_nudge_signals([{"name": "terminal", "arguments": json.dumps({"command": "gh pr view 123"}), "result": "ok"}])
+    assert "repeated_tool_pattern" in agent._nudge_signals
+
+def test_common_cli_does_not_fire_novel_signal(agent):
+    agent._nudge_signals_enabled = True
+    agent._evaluate_skill_nudge_signals([{"name": "terminal", "arguments": json.dumps({"command": "git status"}), "result": "ok"}])
+    assert "novel_cli" not in agent._nudge_signals
+
+def test_session_disable_suppresses_skill_review(agent):
+    agent.valid_tool_names.add("skill_manage")
+    agent._nudge_disabled = True
+    agent._nudge_signals = {"explicit_user_signal"}
+    assert agent._should_run_skill_review() is False
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run: `pytest tests/run_agent/test_run_agent.py::test_repeated_tool_pattern_signal tests/run_agent/test_run_agent.py::test_common_cli_does_not_fire_novel_signal tests/run_agent/test_run_agent.py::test_session_disable_suppresses_skill_review -q`
+
+Expected: FAIL because evaluation/gating methods are missing.
+
+- [ ] **Step 3: Implement `_evaluate_skill_nudge_signals()`**
+
+```python
+def _evaluate_skill_nudge_signals(self, prev_tools: list[dict]) -> set[str]:
+    if not self._nudge_signals_enabled or self._nudge_disabled:
+        return set()
+    fired: set[str] = set()
+    for item in prev_tools or []:
+        name = item.get("name") or ""
+        args = item.get("arguments") or {}
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except Exception:
+                args = {}
+        args = args if isinstance(args, dict) else {}
+        sig = self._skill_nudge_arg_signature(name, args)
+        if sig:
+            self._tool_call_history.append((name, sig))
+            threshold = int(self._nudge_signal_config.get("repeated_pattern_threshold", 3))
+            if Counter(self._tool_call_history)[(name, sig)] >= threshold:
+                fired.add("repeated_tool_pattern")
+        if name in ("terminal", "process"):
+            fired.update(self._evaluate_novel_cli_signal(args, item.get("result")))
+        fired.update(self._evaluate_error_resolution_signal(name, item.get("result")))
+    self._nudge_signals.update(fired)
+    return fired
+```
+
+- [ ] **Step 4: Implement known CLI persistence and review gating**
+
+```python
+def _should_run_skill_review(self) -> tuple[bool, set[str]]:
+    if "skill_manage" not in self.valid_tool_names or self._nudge_disabled:
+        return False, set()
+    if self._nudge_signals:
+        fired = set(self._nudge_signals)
+        self._nudge_signals.clear()
+        self._iters_since_skill = 0
+        return True, fired
+    if self._skill_nudge_interval > 0 and self._iters_since_skill >= self._skill_nudge_interval:
+        self._iters_since_skill = 0
+        return True, {"interval_fallback"}
+    return False, set()
+```
+
+Persist `.skill_known_clis.json` best-effort with `atomic_json_write`; corrupted files return an empty dict and never crash the run.
+
+- [ ] **Step 5: Wire evaluation into the run loop**
+
+At `run_agent.py:9295-9299`:
+
+```python
+if self._skill_nudge_interval > 0 and "skill_manage" in self.valid_tool_names:
+    self._iters_since_skill += 1
+if prev_tools:
+    self._evaluate_skill_nudge_signals(prev_tools)
+```
+
+At turn start, once `original_user_message` is available:
+
+```python
+if self._nudge_signals_enabled and not self._nudge_disabled:
+    self._nudge_signals.update(self._skill_nudge_user_signals(original_user_message))
+```
+
+At `run_agent.py:12176-12204`:
+
+```python
+_should_review_skills, _skill_review_signals = self._should_run_skill_review()
+```
+
+- [ ] **Step 6: Add review context**
+
+Extend `_spawn_background_review()` with `skill_nudge_signals: set[str] | None = None` and append:
+
+```python
+if review_skills and skill_nudge_signals:
+    prompt += "\n\nSkill nudge signals this turn: " + ", ".join(sorted(skill_nudge_signals))
+```
+
+Pass `_skill_review_signals` when spawning the background review.
+
+- [ ] **Step 7: Implement `/skills nudge off` side effects**
+
+In CLI command handling before `_handle_skills_command()`, add:
+
+```python
+if cmd.strip().lower() == "/skills nudge off":
+    if self.agent:
+        self.agent._nudge_disabled = True
+    self.console.print("Skill nudges disabled for this session.")
+    return True
+```
+
+In the TUI gateway slash side-effect mirror, add:
+
+```python
+if command.strip().lower() == "/skills nudge off":
+    agent = session.get("agent")
+    if agent is not None:
+        setattr(agent, "_nudge_disabled", True)
+    session["skill_nudge_disabled"] = True
+    return "Skill nudges disabled for this session."
+```
+
+- [ ] **Step 8: Run run-agent tests**
+
+Run: `pytest tests/run_agent/test_run_agent.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit Task 5**
+
+```bash
+git add run_agent.py cli.py tui_gateway/server.py tests/run_agent/test_run_agent.py
+git commit -m "feat: trigger skill nudges from reusable-workflow signals"
+```
+
+---
+
+### Task 6: Config Example, Integration Coverage, And Final Verification
+
+**Files:**
+- Modify: `cli-config.yaml.example:480-520`
+- Modify: `tests/agent/test_prompt_builder.py`
+- Modify: `tests/tools/test_skills_tool.py`
+- Modify: `tests/run_agent/test_run_agent.py`
+
+- [ ] **Step 1: Update `cli-config.yaml.example`**
+
+Use this exact skills section shape:
+
+```yaml
+skills:
+  creation_nudge_interval: 15
+  index_v2: false
+  index_token_budget: 2000
+  nudge_signals:
+    enabled: false
+    repeated_pattern_threshold: 3
+    novel_cli_window_days: 30
+    common_cli_suppressions:
+      - git
+      - python
+      - python3
+      - node
+      - npm
+      - pnpm
+      - uv
+      - pytest
+      - rg
+      - sed
+      - cat
+      - ls
+      - mkdir
+    user_phrases:
+      - "next time"
+      - "remember"
+      - "from now on"
+      - "记一下"
+      - "下次"
+      - "以后"
+    error_repeat_threshold: 2
+```
+
+- [ ] **Step 2: Add end-to-end prompt reachability test**
+
+```python
+def test_v2_prompt_keeps_all_skills_reachable_via_describe(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("skills:\n  index_v2: true\n  index_token_budget: 2000\n", encoding="utf-8")
+    for i in range(100):
+        d = tmp_path / "skills" / f"cat{i // 10}" / f"skill{i}"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(f"---\nname: skill{i}\ndescription: Desc {i}\n---\nBody", encoding="utf-8")
+
+    prompt = build_skills_system_prompt()
+    assert len(prompt) // 4 <= 2400
+
+    from tools.skills_tool import skill_describe
+    described = json.loads(skill_describe(category="cat9"))
+    assert {s["name"] for s in described["skills"]} == {f"skill{i}" for i in range(90, 100)}
+```
+
+- [ ] **Step 3: Run focused verification**
+
+Run: `pytest tests/agent/test_prompt_builder.py tests/tools/test_skills_tool.py tests/run_agent/test_run_agent.py -q`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run import smoke checks**
+
+Run: `python -m pytest tests/test_plugin_skills.py tests/tools/test_registry.py -q`
+
+Expected: PASS. These catch accidental registry/import cycles.
+
+- [ ] **Step 5: Inspect prompt size manually**
+
+Run:
+
+```bash
+python - <<'PY'
+from agent.prompt_builder import build_skills_system_prompt
+p = build_skills_system_prompt()
+print(len(p), len(p)//4)
+print(p.splitlines()[0] if p else "empty")
+PY
+```
+
+Expected with default config: v1 output remains available. With `skills.index_v2: true` in a temporary `HERMES_HOME`, the first line is `## Skills` and estimated tokens stay near the configured budget.
+
+- [ ] **Step 6: Commit Task 6**
+
+```bash
+git add cli-config.yaml.example tests/agent/test_prompt_builder.py tests/tools/test_skills_tool.py tests/run_agent/test_run_agent.py
+git commit -m "test: cover skills prompt budget rollout"
+```
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage: Tasks 1-3 cover the two-tier index, `priority: critical`, `skill_describe`, budget folding, usage data, cache invalidation, and config. Tasks 4-5 cover S1-S4 scaffolding, gating, fallback interval, disable mechanisms, and background review context. Task 6 covers config docs and integration verification.
+- Prompt-cache stability: v2 ranking uses a day-level usage epoch, not user-message content. Signal nudges do not affect system prompt rendering.
+- Backward compatibility: `skills.index_v2` and `skills.nudge_signals.enabled` default to `false`; v1 rendering and the old interval fallback remain.
+- Test coverage: Each changed behavior has a failing test before implementation, plus focused regression and import-cycle checks.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -795,6 +795,8 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        "index_v2": False,
+        "index_token_budget": 2000,
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1379,6 +1379,7 @@ def _print_skills_help(console: Console) -> None:
         "  [cyan]reset[/] <name> [--restore]    Reset bundled-skill tracking (fix 'user-modified' flag)\n"
         "  [cyan]publish[/] <path> --repo <r>   Publish a skill to GitHub via PR\n"
         "  [cyan]snapshot[/] export|import      Export/import skill configurations\n"
-        "  [cyan]tap[/] list|add|remove         Manage skill sources\n",
+        "  [cyan]tap[/] list|add|remove         Manage skill sources\n"
+        "  [cyan]nudge[/] off|on                Silence or re-enable creation nudges this session\n",
         title="/skills",
     ))

--- a/plans/skills-prompt-budget-and-nudge-implementation.md
+++ b/plans/skills-prompt-budget-and-nudge-implementation.md
@@ -1,0 +1,2436 @@
+# Skills Prompt Budget & Nudge — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the two-tier skill index and signal-based nudge described in `plans/skills-prompt-budget-and-nudge-redesign.md`, both gated behind feature flags, with full test coverage.
+
+**Architecture:** Phase A introduces a new `agent/skill_inventory.py` module that owns parsed skill metadata, refactors `agent/prompt_builder.py` to consume it, and adds a Tier 1/Tier 2 rendering path plus a new `skill_describe` tool — all behind `skills.index_v2`. Phase B adds signal-evaluation state and `_evaluate_skill_nudge_signals()` to `AIAgent`, replaces the time-based end-of-turn gate, and adds a `/skills nudge off|on` intercept — all behind `skills.nudge_signals.enabled`. Both phases are backward compatible; Phase 3 (default flips) ships in a follow-up PR.
+
+**Tech Stack:** Python 3.11 (`pyproject.toml`), `pytest` for unit/integration tests, YAML frontmatter via `pyyaml`, atomic JSON writes via `utils.atomic_json_write`, conventional-commits style.
+
+**Spec reference:** `plans/skills-prompt-budget-and-nudge-redesign.md`
+
+---
+
+## File Structure
+
+### Files to create
+- `agent/skill_inventory.py` — typed `SkillEntry` dataclass + `load_inventory()` returning a structured list. Single source of truth for parsed skill metadata; consumed by both `build_skills_system_prompt()` and the new `skill_describe` tool. ~250 lines.
+- `agent/skill_usage_tracker.py` — read/write `~/.hermes/.skill_usage.json` and `~/.hermes/.skill_known_clis.json`. Best-effort, never raises. ~120 lines.
+- `agent/skill_nudge_signals.py` — `SignalEvaluator` class wrapping the per-tool argument-signature function and S1–S4 evaluation. Pure logic, no I/O. ~200 lines.
+- `tests/agent/test_skill_inventory.py` — unit tests for the new inventory module.
+- `tests/agent/test_skill_usage_tracker.py` — unit tests for the usage/known-CLI files (corruption, pruning, atomic writes).
+- `tests/agent/test_skill_nudge_signals.py` — unit tests for S1–S4.
+- `tests/tools/test_skill_describe.py` — unit tests for the new `skill_describe` tool.
+- `tests/integration/test_skills_index_v2_e2e.py` — synthetic 100-skill end-to-end test.
+
+### Files to modify
+- `agent/prompt_builder.py:466-847` — keep public `build_skills_system_prompt()` signature (additive args only); delegate parsing to `agent/skill_inventory`; add v2 rendering path; bump `_SKILLS_SNAPSHOT_VERSION` to 2; update cache key.
+- `tools/skills_tool.py:1388-1445` — add `SKILL_DESCRIBE_SCHEMA` and `registry.register("skill_describe", ...)` next to the existing `skill_view` registration. Add usage-tracking call inside `skill_view()` body.
+- `tools/skill_manager_tool.py:172-208` — extend `_validate_frontmatter` to validate `priority ∈ {"critical", "normal"}` if present.
+- `run_agent.py:1495-1614` — add nudge state initialization (`_nudge_signals`, `_nudge_disabled`, `_signal_evaluator`, etc.) alongside `_iters_since_skill`.
+- `run_agent.py:9295-9299` — call `_evaluate_skill_nudge_signals()` after the counter increment.
+- `run_agent.py:12176-12204` — replace the time-only gate with the four-branch gate from spec §5.2.
+- `run_agent.py:3014-3060` — add `triggered_signals: set[str] | None` parameter to `_spawn_background_review`; pass into the review prompt.
+- `cli.py:5816-5819` — intercept `/skills nudge off|on` before delegating to `handle_skills_slash`.
+- `hermes_cli/skills_config.py` — load new `skills.index_v2`, `skills.index_token_budget`, `skills.nudge_signals.*` keys. (If a single config-loader module doesn't exist, the keys are read directly from `_agent_cfg` in run_agent's `__init__`; see Task B1 for the chosen path.)
+- `cli-config.yaml.example:481-494` — document new keys per spec §6.
+
+### Files NOT in scope for this PR
+- TUI slash-command parity (`ui-tui/src/app/slash/commands/ops.ts`) — out of scope; users on TUI use `HERMES_SKILL_NUDGE_DISABLE=1` env var. Tracked as a Phase 2.5 follow-up in the wrap-up doc.
+- Gateway slash-command parity — same reasoning.
+
+---
+
+## Sanity Check Before Starting
+
+- [ ] **Step 0.1: Confirm working directory**
+
+Run: `git -C /Users/zhuosama/.hermes/hermes-agent rev-parse --show-toplevel`
+Expected: `/Users/zhuosama/.hermes/hermes-agent`
+
+- [ ] **Step 0.2: Confirm tests run on a clean tree**
+
+Run: `cd /Users/zhuosama/.hermes/hermes-agent && python -m pytest tests/agent/test_prompt_builder.py -q`
+Expected: all green. If anything fails on `main` before this work starts, fix or skip those before adding new tests.
+
+- [ ] **Step 0.3: Create a feature branch**
+
+Run:
+```bash
+cd /Users/zhuosama/.hermes/hermes-agent
+git checkout -b feat/skills-index-v2-and-nudge-signals
+```
+
+---
+
+# Phase A — Skill Index v2
+
+Gated behind `skills.index_v2: true`. Default `false` until Phase 3.
+
+## Task A1: Extract `SkillInventory` module (refactor only)
+
+**Files:**
+- Create: `agent/skill_inventory.py`
+- Modify: `agent/prompt_builder.py:537-742`
+- Test: `tests/agent/test_skill_inventory.py`
+
+**Goal:** Move the parse-and-cache logic out of `prompt_builder.py` into a dedicated module. Behavior identical to today; this is a pure refactor that creates the seam needed by `skill_describe`.
+
+- [ ] **Step 1.1: Write failing test for `load_inventory()` returning a list of `SkillEntry`**
+
+```python
+# tests/agent/test_skill_inventory.py
+from pathlib import Path
+import textwrap
+import pytest
+
+from agent.skill_inventory import SkillEntry, load_inventory
+
+
+def _write_skill(root: Path, name: str, description: str, category: str = ""):
+    skill_dir = root / category / name if category else root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(textwrap.dedent(f"""\
+        ---
+        name: {name}
+        description: {description}
+        ---
+        body
+    """))
+
+
+def test_load_inventory_returns_skill_entries(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "alpha", "First skill", category="cat1")
+    _write_skill(skills_dir, "beta", "Second skill", category="cat1")
+
+    monkeypatch.setattr("agent.skill_inventory.get_skills_dir", lambda: skills_dir)
+    monkeypatch.setattr("agent.skill_inventory.get_all_skills_dirs", lambda: [skills_dir])
+
+    inv = load_inventory()
+    names = sorted(e.name for e in inv.entries)
+    assert names == ["alpha", "beta"]
+    assert all(e.category == "cat1" for e in inv.entries)
+    assert {e.description for e in inv.entries} == {"First skill", "Second skill"}
+```
+
+- [ ] **Step 1.2: Run test to verify it fails (module not yet created)**
+
+Run: `python -m pytest tests/agent/test_skill_inventory.py -v`
+Expected: `ImportError: cannot import name 'SkillEntry' from 'agent.skill_inventory'`
+
+- [ ] **Step 1.3: Create `agent/skill_inventory.py`**
+
+```python
+"""Parsed skill metadata — single source of truth for the index and skill_describe tool.
+
+Extracted from agent/prompt_builder.py.  This module owns the on-disk snapshot,
+the in-process LRU, and the platform/disabled/condition filtering.  Renderers
+(prompt builder, skill_describe handler) consume the typed entries below.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from hermes_constants import get_hermes_home, get_skills_dir
+from agent.skill_utils import (
+    extract_skill_conditions,
+    extract_skill_description,
+    get_all_skills_dirs,
+    get_disabled_skill_names,
+    iter_skill_index_files,
+    parse_frontmatter,
+    skill_matches_platform,
+)
+from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
+
+# Bump on any structural change to SkillEntry / snapshot payload — forces re-scan.
+SNAPSHOT_VERSION = 2
+
+
+@dataclass(frozen=True)
+class SkillEntry:
+    name: str                  # frontmatter `name` (preferred) or directory name
+    skill_name: str            # always directory name
+    category: str              # path-derived, defaults to "general"
+    description: str
+    priority: str = "normal"   # "critical" | "normal"
+    platforms: tuple[str, ...] = ()
+    conditions: dict = field(default_factory=dict)
+    source: str = "local"      # "local" | "external"
+
+
+@dataclass(frozen=True)
+class Inventory:
+    entries: tuple[SkillEntry, ...]
+    category_descriptions: dict[str, str]
+
+
+_INVENTORY_CACHE: OrderedDict[tuple, Inventory] = OrderedDict()
+_INVENTORY_CACHE_MAX = 8
+_INVENTORY_LOCK = threading.Lock()
+
+
+def _snapshot_path() -> Path:
+    return get_hermes_home() / ".skills_prompt_snapshot.json"
+
+
+def _build_manifest(skills_dir: Path) -> dict[str, list[int]]:
+    manifest: dict[str, list[int]] = {}
+    for filename in ("SKILL.md", "DESCRIPTION.md"):
+        for path in iter_skill_index_files(skills_dir, filename):
+            try:
+                st = path.stat()
+            except OSError:
+                continue
+            manifest[str(path.relative_to(skills_dir))] = [st.st_mtime_ns, st.st_size]
+    return manifest
+
+
+def _load_snapshot(skills_dir: Path) -> Optional[dict]:
+    p = _snapshot_path()
+    if not p.exists():
+        return None
+    try:
+        snap = json.loads(p.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(snap, dict):
+        return None
+    if snap.get("version") != SNAPSHOT_VERSION:
+        return None
+    if snap.get("manifest") != _build_manifest(skills_dir):
+        return None
+    return snap
+
+
+def _write_snapshot(skills_dir: Path, manifest, entries, category_descriptions) -> None:
+    payload = {
+        "version": SNAPSHOT_VERSION,
+        "manifest": manifest,
+        "skills": [e.__dict__ if not isinstance(e, dict) else e for e in entries],
+        "category_descriptions": category_descriptions,
+    }
+    try:
+        atomic_json_write(_snapshot_path(), payload)
+    except Exception as e:
+        logger.debug("Could not write skills snapshot: %s", e)
+
+
+def _entry_from_skill_file(skill_file: Path, base_dir: Path, source: str) -> Optional[SkillEntry]:
+    try:
+        raw = skill_file.read_text(encoding="utf-8")
+        frontmatter, _ = parse_frontmatter(raw)
+    except Exception as e:
+        logger.warning("Failed to parse %s: %s", skill_file, e)
+        return None
+
+    if not skill_matches_platform(frontmatter):
+        return None
+
+    rel = skill_file.relative_to(base_dir)
+    parts = rel.parts
+    if len(parts) >= 2:
+        skill_name = parts[-2]
+        category = "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
+    else:
+        category = "general"
+        skill_name = skill_file.parent.name
+
+    platforms = frontmatter.get("platforms") or []
+    if isinstance(platforms, str):
+        platforms = [platforms]
+
+    priority_raw = frontmatter.get("priority", "normal")
+    priority = str(priority_raw).strip().lower() if priority_raw else "normal"
+    if priority not in ("critical", "normal"):
+        priority = "normal"
+
+    return SkillEntry(
+        name=str(frontmatter.get("name", skill_name)),
+        skill_name=skill_name,
+        category=category,
+        description=extract_skill_description(frontmatter),
+        priority=priority,
+        platforms=tuple(str(p).strip() for p in platforms if str(p).strip()),
+        conditions=extract_skill_conditions(frontmatter),
+        source=source,
+    )
+
+
+def _read_category_descriptions(base_dir: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for desc_file in iter_skill_index_files(base_dir, "DESCRIPTION.md"):
+        try:
+            content = desc_file.read_text(encoding="utf-8")
+            fm, _ = parse_frontmatter(content)
+            cat_desc = fm.get("description")
+            if not cat_desc:
+                continue
+            rel = desc_file.relative_to(base_dir)
+            cat = "/".join(rel.parts[:-1]) if len(rel.parts) > 1 else "general"
+            out[cat] = str(cat_desc).strip().strip("'\"")
+        except Exception as e:
+            logger.debug("Could not read DESCRIPTION.md at %s: %s", desc_file, e)
+    return out
+
+
+def load_inventory(
+    available_tools: "set[str] | None" = None,
+    available_toolsets: "set[str] | None" = None,
+) -> Inventory:
+    """Return parsed, filtered skill metadata.
+
+    - Local snapshot at ~/.hermes/.skills_prompt_snapshot.json is reused when its
+      mtime/size manifest matches.
+    - External dirs are always scanned directly (read-only and small).
+    - Local entries take precedence on name collision.
+    """
+    skills_dir = get_skills_dir()
+    all_dirs = get_all_skills_dirs()
+    external_dirs = all_dirs[1:] if len(all_dirs) > 1 else []
+
+    if not skills_dir.exists() and not external_dirs:
+        return Inventory(entries=(), category_descriptions={})
+
+    from gateway.session_context import get_session_env
+    platform_hint = (
+        os.environ.get("HERMES_PLATFORM")
+        or get_session_env("HERMES_SESSION_PLATFORM")
+        or ""
+    )
+    disabled = get_disabled_skill_names()
+    cache_key = (
+        str(skills_dir.resolve()),
+        tuple(str(d) for d in external_dirs),
+        tuple(sorted(str(t) for t in (available_tools or set()))),
+        tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
+        platform_hint,
+        tuple(sorted(disabled)),
+    )
+    with _INVENTORY_LOCK:
+        cached = _INVENTORY_CACHE.get(cache_key)
+        if cached is not None:
+            _INVENTORY_CACHE.move_to_end(cache_key)
+            return cached
+
+    entries: list[SkillEntry] = []
+    category_descriptions: dict[str, str] = {}
+
+    # Local: snapshot fast path or full scan
+    snapshot = _load_snapshot(skills_dir) if skills_dir.exists() else None
+    if snapshot is not None:
+        for raw in snapshot.get("skills", []):
+            if not isinstance(raw, dict):
+                continue
+            entry = SkillEntry(**raw)
+            entries.append(entry)
+        category_descriptions.update(
+            {str(k): str(v) for k, v in (snapshot.get("category_descriptions") or {}).items()}
+        )
+    elif skills_dir.exists():
+        for skill_file in iter_skill_index_files(skills_dir, "SKILL.md"):
+            e = _entry_from_skill_file(skill_file, skills_dir, source="local")
+            if e is not None:
+                entries.append(e)
+        category_descriptions.update(_read_category_descriptions(skills_dir))
+        _write_snapshot(skills_dir, _build_manifest(skills_dir), entries, category_descriptions)
+
+    # External dirs (always direct scan)
+    seen_names = {e.name for e in entries}
+    for ext_dir in external_dirs:
+        if not ext_dir.exists():
+            continue
+        for skill_file in iter_skill_index_files(ext_dir, "SKILL.md"):
+            e = _entry_from_skill_file(skill_file, ext_dir, source="external")
+            if e is None or e.name in seen_names:
+                continue
+            entries.append(e)
+            seen_names.add(e.name)
+        for cat, desc in _read_category_descriptions(ext_dir).items():
+            category_descriptions.setdefault(cat, desc)
+
+    # Apply disabled filter and condition filter at use time
+    def _allowed(e: SkillEntry) -> bool:
+        if e.name in disabled or e.skill_name in disabled:
+            return False
+        if available_tools is None and available_toolsets is None:
+            return True
+        at = available_tools or set()
+        ats = available_toolsets or set()
+        c = e.conditions or {}
+        for ts in c.get("fallback_for_toolsets", []):
+            if ts in ats:
+                return False
+        for t in c.get("fallback_for_tools", []):
+            if t in at:
+                return False
+        for ts in c.get("requires_toolsets", []):
+            if ts not in ats:
+                return False
+        for t in c.get("requires_tools", []):
+            if t not in at:
+                return False
+        return True
+
+    filtered = tuple(e for e in entries if _allowed(e))
+    inv = Inventory(entries=filtered, category_descriptions=dict(category_descriptions))
+
+    with _INVENTORY_LOCK:
+        _INVENTORY_CACHE[cache_key] = inv
+        _INVENTORY_CACHE.move_to_end(cache_key)
+        while len(_INVENTORY_CACHE) > _INVENTORY_CACHE_MAX:
+            _INVENTORY_CACHE.popitem(last=False)
+    return inv
+
+
+def clear_inventory_cache(*, clear_snapshot: bool = False) -> None:
+    with _INVENTORY_LOCK:
+        _INVENTORY_CACHE.clear()
+    if clear_snapshot:
+        try:
+            _snapshot_path().unlink(missing_ok=True)
+        except OSError as e:
+            logger.debug("Could not remove snapshot: %s", e)
+```
+
+- [ ] **Step 1.4: Refactor `prompt_builder.py` to consume the inventory**
+
+Replace the body of `build_skills_system_prompt()` (lines 621-847) so it loads the inventory and renders the V1 format from `Inventory.entries` / `Inventory.category_descriptions`. Delete now-unused helpers (`_build_skills_manifest`, `_load_skills_snapshot`, `_write_skills_snapshot`, `_build_snapshot_entry`, `_parse_skill_file`, `_skill_should_show`, `_SKILLS_PROMPT_CACHE_*`). Keep `clear_skills_system_prompt_cache()` as a thin wrapper that also calls `clear_inventory_cache()`:
+
+```python
+# agent/prompt_builder.py — replacement for the skills-prompt section
+
+from agent.skill_inventory import (
+    Inventory,
+    SkillEntry,
+    clear_inventory_cache,
+    load_inventory,
+)
+
+def clear_skills_system_prompt_cache(*, clear_snapshot: bool = False) -> None:
+    """Drop the in-process skills prompt cache (and optionally the disk snapshot)."""
+    clear_inventory_cache(clear_snapshot=clear_snapshot)
+
+
+def build_skills_system_prompt(
+    available_tools: "set[str] | None" = None,
+    available_toolsets: "set[str] | None" = None,
+) -> str:
+    inv = load_inventory(available_tools, available_toolsets)
+    if not inv.entries:
+        return ""
+    return _render_v1(inv)
+
+
+def _render_v1(inv: Inventory) -> str:
+    skills_by_category: dict[str, list[SkillEntry]] = {}
+    for e in inv.entries:
+        skills_by_category.setdefault(e.category, []).append(e)
+
+    index_lines: list[str] = []
+    for category in sorted(skills_by_category.keys()):
+        cat_desc = inv.category_descriptions.get(category, "")
+        index_lines.append(f"  {category}: {cat_desc}" if cat_desc else f"  {category}:")
+        seen: set[str] = set()
+        for entry in sorted(skills_by_category[category], key=lambda x: x.name):
+            if entry.name in seen:
+                continue
+            seen.add(entry.name)
+            if entry.description:
+                index_lines.append(f"    - {entry.name}: {entry.description}")
+            else:
+                index_lines.append(f"    - {entry.name}")
+
+    return (
+        "## Skills (mandatory)\n"
+        "Before replying, scan the skills below. If a skill matches or is even partially relevant "
+        "to your task, you MUST load it with skill_view(name) and follow its instructions. "
+        "Err on the side of loading — it is always better to have context you don't need "
+        "than to miss critical steps, pitfalls, or established workflows. "
+        "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
+        "and proven workflows that outperform general-purpose approaches. Load the skill "
+        "even if you think you could handle the task with basic tools like web_search or terminal. "
+        "Skills also encode the user's preferred approach, conventions, and quality standards "
+        "for tasks like code review, planning, and testing — load them even for tasks you "
+        "already know how to do, because the skill defines how it should be done here.\n"
+        "If a skill has issues, fix it with skill_manage(action='patch').\n"
+        "After difficult/iterative tasks, offer to save as a skill. "
+        "If a skill you loaded was missing steps, had wrong commands, or needed "
+        "pitfalls you discovered, update it before finishing.\n"
+        "\n"
+        "<available_skills>\n"
+        + "\n".join(index_lines) + "\n"
+        "</available_skills>\n"
+        "\n"
+        "Only proceed without loading a skill if genuinely none are relevant to the task."
+    )
+```
+
+- [ ] **Step 1.5: Run tests**
+
+Run: `python -m pytest tests/agent/test_skill_inventory.py tests/agent/test_prompt_builder.py -q`
+Expected: all green. The existing prompt_builder tests must still pass — this is the refactor's safety net.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add agent/skill_inventory.py agent/prompt_builder.py tests/agent/test_skill_inventory.py
+git commit -m "refactor(skills): extract SkillInventory module from prompt_builder
+
+Pure refactor — renderer behavior unchanged.  Creates the seam needed by
+skill_describe and the v2 rendering path.  Snapshot version bumped to 2 so
+old on-disk snapshots are invalidated on first run."
+```
+
+---
+
+## Task A2: Validate `priority` field in `skill_manage`
+
+**Files:**
+- Modify: `tools/skill_manager_tool.py:172-208`
+- Test: `tests/tools/test_skill_manager_tool.py` (extend if exists, else create)
+
+- [ ] **Step 2.1: Write failing test**
+
+```python
+# tests/tools/test_skill_manager_tool.py
+import textwrap
+from tools.skill_manager_tool import _validate_frontmatter
+
+
+def test_priority_must_be_critical_or_normal():
+    bad = textwrap.dedent("""\
+        ---
+        name: x
+        description: y
+        priority: legendary
+        ---
+        body
+    """)
+    err = _validate_frontmatter(bad)
+    assert err is not None and "priority" in err
+
+
+def test_priority_critical_is_accepted():
+    good = textwrap.dedent("""\
+        ---
+        name: x
+        description: y
+        priority: critical
+        ---
+        body
+    """)
+    assert _validate_frontmatter(good) is None
+
+
+def test_priority_absent_is_accepted():
+    plain = textwrap.dedent("""\
+        ---
+        name: x
+        description: y
+        ---
+        body
+    """)
+    assert _validate_frontmatter(plain) is None
+```
+
+- [ ] **Step 2.2: Run test to verify it fails**
+
+Run: `python -m pytest tests/tools/test_skill_manager_tool.py::test_priority_must_be_critical_or_normal -v`
+Expected: FAIL with `assert None is not None`
+
+- [ ] **Step 2.3: Add the validation**
+
+In `tools/skill_manager_tool.py:_validate_frontmatter`, after the existing `description` length check:
+
+```python
+    # Validate optional priority field (introduced for skills.index_v2)
+    priority_raw = parsed.get("priority")
+    if priority_raw is not None:
+        priority = str(priority_raw).strip().lower()
+        if priority not in ("critical", "normal"):
+            return (
+                f"Frontmatter 'priority' must be 'critical' or 'normal' "
+                f"(got {priority_raw!r})."
+            )
+```
+
+- [ ] **Step 2.4: Run tests**
+
+Run: `python -m pytest tests/tools/test_skill_manager_tool.py -v`
+Expected: all three new tests pass.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add tools/skill_manager_tool.py tests/tools/test_skill_manager_tool.py
+git commit -m "feat(skills): validate priority frontmatter field in skill_manage
+
+Allows skills to declare priority: critical so the v2 index keeps their
+description in Tier 1.  Rejects unknown values to fail fast at create/patch
+time."
+```
+
+---
+
+## Task A3: Wire `skills.index_v2` config
+
+**Files:**
+- Modify: `agent/prompt_builder.py` (signature of `build_skills_system_prompt`)
+- Modify: `run_agent.py:1607-1614` and the call site at `run_agent.py:4287`
+
+- [ ] **Step 3.1: Write failing test**
+
+```python
+# tests/agent/test_prompt_builder.py — append
+def test_build_skills_system_prompt_v2_flag_changes_render(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    (skills_dir / "cat" / "alpha").mkdir(parents=True)
+    (skills_dir / "cat" / "alpha" / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: A description of alpha\n---\nbody\n"
+    )
+    monkeypatch.setattr("agent.skill_inventory.get_skills_dir", lambda: skills_dir)
+    monkeypatch.setattr("agent.skill_inventory.get_all_skills_dirs", lambda: [skills_dir])
+    monkeypatch.setattr("agent.prompt_builder.get_skills_dir", lambda: skills_dir)
+    from agent.skill_inventory import clear_inventory_cache
+    clear_inventory_cache(clear_snapshot=True)
+
+    from agent.prompt_builder import build_skills_system_prompt
+    v1 = build_skills_system_prompt()
+    v2 = build_skills_system_prompt(index_v2=True)
+    assert "A description of alpha" in v1, "V1 keeps the description inline"
+    assert "## Skills" in v2 and "skill_describe" in v2, "V2 references skill_describe"
+```
+
+- [ ] **Step 3.2: Run test, expect failure**
+
+Run: `python -m pytest tests/agent/test_prompt_builder.py::test_build_skills_system_prompt_v2_flag_changes_render -v`
+Expected: FAIL — `index_v2` is not a recognized kwarg yet.
+
+- [ ] **Step 3.3: Add the `index_v2` and `index_token_budget` params (no body change yet)**
+
+In `agent/prompt_builder.py`:
+
+```python
+def build_skills_system_prompt(
+    available_tools: "set[str] | None" = None,
+    available_toolsets: "set[str] | None" = None,
+    *,
+    index_v2: bool = False,
+    index_token_budget: int = 2000,
+) -> str:
+    inv = load_inventory(available_tools, available_toolsets)
+    if not inv.entries:
+        return ""
+    if index_v2:
+        return _render_v2(inv, token_budget=index_token_budget)
+    return _render_v1(inv)
+
+
+def _render_v2(inv: Inventory, *, token_budget: int) -> str:
+    # Implemented in Task A4 — placeholder for now so the test wiring works.
+    return "## Skills\n\n[skill_describe wiring placeholder]\n"
+```
+
+- [ ] **Step 3.4: Load `skills.index_v2` config in run_agent**
+
+In `run_agent.py:1607-1614`, replace the existing skills-config block with:
+
+```python
+        # Skills config: nudge interval + index v2 flag
+        self._skill_nudge_interval = 10
+        self._skill_index_v2 = False
+        self._skill_index_token_budget = 2000
+        try:
+            skills_config = _agent_cfg.get("skills", {})
+            self._skill_nudge_interval = int(skills_config.get("creation_nudge_interval", 10))
+            self._skill_index_v2 = bool(skills_config.get("index_v2", False))
+            self._skill_index_token_budget = int(skills_config.get("index_token_budget", 2000))
+        except Exception:
+            pass
+```
+
+At the existing call site `run_agent.py:4287-4290`, extend the call with the two new keyword arguments (the existing `available_tools=self.valid_tool_names, available_toolsets=avail_toolsets` stay as-is):
+
+```python
+            skills_prompt = build_skills_system_prompt(
+                available_tools=self.valid_tool_names,
+                available_toolsets=avail_toolsets,
+                index_v2=self._skill_index_v2,
+                index_token_budget=self._skill_index_token_budget,
+            )
+```
+
+- [ ] **Step 3.5: Run tests**
+
+Run: `python -m pytest tests/agent/test_prompt_builder.py -v`
+Expected: pass — V2 returns the placeholder string and V1 still renders fully.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add agent/prompt_builder.py run_agent.py tests/agent/test_prompt_builder.py
+git commit -m "feat(skills): wire index_v2 and index_token_budget config flags
+
+Threads the new flags through build_skills_system_prompt; v2 path is a
+placeholder until A4."
+```
+
+---
+
+## Task A4: Implement v2 rendering format + critical-count warning
+
+**Files:**
+- Modify: `agent/prompt_builder.py` (`_render_v2`)
+- Test: `tests/agent/test_prompt_builder.py`
+
+- [ ] **Step 4.1: Write failing test**
+
+```python
+# tests/agent/test_prompt_builder.py — append
+import textwrap
+
+
+def _make_skill(skills_dir, name, description, *, category="cat", priority=None):
+    d = skills_dir / category / name
+    d.mkdir(parents=True, exist_ok=True)
+    front = ["---", f"name: {name}", f"description: {description}"]
+    if priority:
+        front.append(f"priority: {priority}")
+    front.append("---")
+    (d / "SKILL.md").write_text("\n".join(front) + "\nbody\n")
+
+
+def test_v2_renders_critical_with_description_normal_without(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    _make_skill(skills_dir, "alpha", "Alpha desc", category="cat-a", priority="critical")
+    _make_skill(skills_dir, "beta", "Beta desc", category="cat-a")
+    _make_skill(skills_dir, "gamma", "Gamma desc", category="cat-b")
+    monkeypatch.setattr("agent.skill_inventory.get_skills_dir", lambda: skills_dir)
+    monkeypatch.setattr("agent.skill_inventory.get_all_skills_dirs", lambda: [skills_dir])
+    monkeypatch.setattr("agent.prompt_builder.get_skills_dir", lambda: skills_dir)
+    from agent.skill_inventory import clear_inventory_cache
+    clear_inventory_cache(clear_snapshot=True)
+
+    from agent.prompt_builder import build_skills_system_prompt
+    out = build_skills_system_prompt(index_v2=True)
+
+    # Critical: full description present
+    assert "alpha: Alpha desc" in out
+    # Normal: name only, descriptions of beta/gamma absent
+    assert "Beta desc" not in out
+    assert "Gamma desc" not in out
+    # Names of normal skills appear as comma list
+    assert "beta" in out and "gamma" in out
+    # Categories appear
+    assert "cat-a" in out and "cat-b" in out
+    # skill_describe is referenced in the preamble
+    assert "skill_describe" in out
+```
+
+- [ ] **Step 4.2: Run test, expect failure**
+
+Run: `python -m pytest tests/agent/test_prompt_builder.py::test_v2_renders_critical_with_description_normal_without -v`
+Expected: FAIL — placeholder body.
+
+- [ ] **Step 4.3: Implement `_render_v2`**
+
+Replace the placeholder in `agent/prompt_builder.py`:
+
+```python
+_V2_PREAMBLE = (
+    "## Skills\n"
+    "\n"
+    "Tools available:\n"
+    "  - skill_view(name): load full skill content\n"
+    "  - skill_describe(category=..., names=[...]): get one-line descriptions\n"
+    "  - skill_manage: create / patch / write_file\n"
+    "\n"
+    "The list below shows every available skill organized by category. Skills "
+    "with descriptions are critical workflows you should consider on every task. "
+    "For other skills, the name is a hint — if any look relevant, call "
+    "skill_describe(category=\"<cat>\") to see one-line descriptions, then "
+    "skill_view(name) to load the full content.\n"
+    "\n"
+)
+
+_V2_OPEN = "<available_skills>\n"
+_V2_CLOSE = "</available_skills>\n"
+
+
+def _render_v2(inv: Inventory, *, token_budget: int) -> str:
+    by_cat: dict[str, list[SkillEntry]] = {}
+    for e in inv.entries:
+        by_cat.setdefault(e.category, []).append(e)
+
+    # Q1 safeguard: warn if `priority: critical` looks like it's becoming default.
+    n_critical = sum(1 for e in inv.entries if e.priority == "critical")
+    if n_critical > 15:
+        logger.warning(
+            "skills.index_v2: %d skills marked priority=critical (>15). "
+            "Tier 1 budget gains erode quickly past this threshold.",
+            n_critical,
+        )
+
+    # Render every category — budget enforcement comes in Task A6.
+    body_lines: list[str] = []
+    for cat in sorted(by_cat.keys()):
+        cat_desc = inv.category_descriptions.get(cat, "")
+        body_lines.append(f"  {cat}/  {cat_desc}".rstrip() if cat_desc else f"  {cat}/")
+        criticals = sorted(
+            (e for e in by_cat[cat] if e.priority == "critical"),
+            key=lambda e: e.name,
+        )
+        normals = sorted(
+            (e for e in by_cat[cat] if e.priority != "critical"),
+            key=lambda e: e.name,
+        )
+        for e in criticals:
+            if e.description:
+                body_lines.append(f"    - {e.name}: {e.description}")
+            else:
+                body_lines.append(f"    - {e.name}")
+        if normals:
+            body_lines.append("    " + ", ".join(e.name for e in normals))
+
+    return _V2_PREAMBLE + _V2_OPEN + "\n".join(body_lines) + "\n" + _V2_CLOSE
+```
+
+- [ ] **Step 4.4: Run tests**
+
+Run: `python -m pytest tests/agent/test_prompt_builder.py -v`
+Expected: all green.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add agent/prompt_builder.py tests/agent/test_prompt_builder.py
+git commit -m "feat(skills): implement v2 tier-1 rendering for skill index
+
+Critical-priority skills keep full descriptions; normal-priority skills are
+listed by name only, organized under their category. Logs a warning when
+more than 15 skills are marked critical (spec Q1)."
+```
+
+---
+
+## Task A5: Skill usage tracker (`~/.hermes/.skill_usage.json` + `~/.hermes/.skill_known_clis.json`)
+
+**Files:**
+- Create: `agent/skill_usage_tracker.py`
+- Test: `tests/agent/test_skill_usage_tracker.py`
+
+- [ ] **Step 5.1: Write failing tests**
+
+```python
+# tests/agent/test_skill_usage_tracker.py
+from pathlib import Path
+import json
+import time
+
+from agent import skill_usage_tracker as t
+
+
+def test_record_and_top_categories(tmp_path, monkeypatch):
+    monkeypatch.setattr(t, "_usage_path", lambda: tmp_path / ".skill_usage.json")
+    t.record_category_use("cat-a")
+    t.record_category_use("cat-a")
+    t.record_category_use("cat-b")
+    top = t.top_categories(within_seconds=3600)
+    assert top[0] == "cat-a"
+    assert "cat-b" in top
+
+
+def test_record_corrupted_file_falls_back(tmp_path, monkeypatch):
+    p = tmp_path / ".skill_usage.json"
+    p.write_text("{not json")
+    monkeypatch.setattr(t, "_usage_path", lambda: p)
+    t.record_category_use("cat-a")  # must not raise
+    assert "cat-a" in t.top_categories()
+
+
+def test_known_clis_pruned_after_window(tmp_path, monkeypatch):
+    p = tmp_path / ".skill_known_clis.json"
+    monkeypatch.setattr(t, "_known_clis_path", lambda: p)
+    t.record_cli_seen("rg")
+    # Force-age the entry
+    raw = json.loads(p.read_text())
+    raw["rg"] = time.time() - (40 * 86400)
+    p.write_text(json.dumps(raw))
+    assert t.is_known_cli("rg", window_days=30) is False
+```
+
+- [ ] **Step 5.2: Run tests, expect import failure**
+
+Run: `python -m pytest tests/agent/test_skill_usage_tracker.py -v`
+Expected: FAIL — `ModuleNotFoundError: agent.skill_usage_tracker`
+
+- [ ] **Step 5.3: Create the module**
+
+```python
+# agent/skill_usage_tracker.py
+"""Best-effort persistence for skill-category usage and known-CLI history.
+
+Both files are best-effort: corruption falls back to empty state, never raises.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections import deque
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
+
+_MAX_TIMESTAMPS_PER_CAT = 30
+_DEFAULT_USAGE_WINDOW_S = 30 * 86400
+_DEFAULT_CLI_WINDOW_DAYS = 30
+
+
+def _usage_path() -> Path:
+    return get_hermes_home() / ".skill_usage.json"
+
+
+def _known_clis_path() -> Path:
+    return get_hermes_home() / ".skill_known_clis.json"
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        if not path.exists():
+            return {}
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception as e:
+        logger.debug("Could not read %s: %s", path, e)
+        return {}
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    try:
+        atomic_json_write(path, payload)
+    except Exception as e:
+        logger.debug("Could not write %s: %s", path, e)
+
+
+def record_category_use(category: str) -> None:
+    if not category:
+        return
+    data = _read_json(_usage_path())
+    history = list(data.get(category) or [])
+    history.append(int(time.time()))
+    history = history[-_MAX_TIMESTAMPS_PER_CAT:]
+    data[category] = history
+    _write_json(_usage_path(), data)
+
+
+def top_categories(within_seconds: int = _DEFAULT_USAGE_WINDOW_S) -> list[str]:
+    data = _read_json(_usage_path())
+    cutoff = int(time.time()) - within_seconds
+    scored: list[tuple[int, str]] = []
+    for cat, ts_list in data.items():
+        if not isinstance(ts_list, list):
+            continue
+        recent = sum(1 for t in ts_list if isinstance(t, (int, float)) and t >= cutoff)
+        if recent > 0:
+            scored.append((recent, cat))
+    scored.sort(reverse=True)
+    return [c for _, c in scored]
+
+
+def record_cli_seen(cli: str) -> None:
+    if not cli:
+        return
+    data = _read_json(_known_clis_path())
+    data[cli] = int(time.time())
+    _write_json(_known_clis_path(), data)
+
+
+def is_known_cli(cli: str, *, window_days: int = _DEFAULT_CLI_WINDOW_DAYS) -> bool:
+    data = _read_json(_known_clis_path())
+    last = data.get(cli)
+    if not isinstance(last, (int, float)):
+        return False
+    return (time.time() - last) <= (window_days * 86400)
+
+
+def usage_rank_epoch() -> str:
+    """Day-level key derived from the usage file mtime — used for cache invalidation.
+
+    Stable within a session, advances at most once per day even if the file is
+    written more often.
+    """
+    p = _usage_path()
+    try:
+        mtime = p.stat().st_mtime if p.exists() else 0
+    except OSError:
+        mtime = 0
+    return time.strftime("%Y-%m-%d", time.gmtime(mtime))
+```
+
+- [ ] **Step 5.4: Run tests**
+
+Run: `python -m pytest tests/agent/test_skill_usage_tracker.py -v`
+Expected: all green.
+
+- [ ] **Step 5.5: Hook tracker into `skill_view` and `skill_describe` (later)**
+
+In `tools/skills_tool.py:828-...` (the `skill_view` body), after a successful load, add:
+
+```python
+    # Best-effort usage tracking — never fails the tool call
+    try:
+        from agent import skill_usage_tracker
+        # Look up the entry's category from the inventory
+        from agent.skill_inventory import load_inventory
+        inv = load_inventory()
+        for entry in inv.entries:
+            if entry.name == name or entry.skill_name == name:
+                skill_usage_tracker.record_category_use(entry.category)
+                break
+    except Exception:
+        pass
+```
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add agent/skill_usage_tracker.py tools/skills_tool.py tests/agent/test_skill_usage_tracker.py
+git commit -m "feat(skills): add usage tracker for categories and known CLIs
+
+Persists best-effort usage stats to ~/.hermes/.skill_usage.json (categories)
+and ~/.hermes/.skill_known_clis.json (CLIs).  Hooked into skill_view; consumed
+by index v2 budget folding and S2 nudge signal."
+```
+
+---
+
+## Task A6: Token budget + fold-back
+
+**Files:**
+- Modify: `agent/prompt_builder.py` (`_render_v2`)
+- Test: `tests/agent/test_prompt_builder.py`
+
+- [ ] **Step 6.1: Write failing test**
+
+```python
+# tests/agent/test_prompt_builder.py — append
+def test_v2_budget_folds_least_used_categories(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    # Generate 20 categories, 10 skills each
+    for ci in range(20):
+        for si in range(10):
+            d = skills_dir / f"cat-{ci:02d}" / f"skill-{ci:02d}-{si:02d}"
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: skill-{ci:02d}-{si:02d}\ndescription: desc\n---\nbody\n"
+            )
+    monkeypatch.setattr("agent.skill_inventory.get_skills_dir", lambda: skills_dir)
+    monkeypatch.setattr("agent.skill_inventory.get_all_skills_dirs", lambda: [skills_dir])
+    from agent.skill_inventory import clear_inventory_cache
+    clear_inventory_cache(clear_snapshot=True)
+
+    # No usage history → fold-back will engage
+    from agent.prompt_builder import build_skills_system_prompt
+    out = build_skills_system_prompt(index_v2=True, index_token_budget=300)
+    assert "and" in out and "more categories" in out, "Fold-back line absent"
+    assert "skill_describe" in out
+
+
+def test_v2_under_budget_renders_full(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    for i in range(3):
+        d = skills_dir / "cat" / f"sk-{i}"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "SKILL.md").write_text(
+            f"---\nname: sk-{i}\ndescription: d\n---\nbody\n"
+        )
+    monkeypatch.setattr("agent.skill_inventory.get_skills_dir", lambda: skills_dir)
+    monkeypatch.setattr("agent.skill_inventory.get_all_skills_dirs", lambda: [skills_dir])
+    from agent.skill_inventory import clear_inventory_cache
+    clear_inventory_cache(clear_snapshot=True)
+    from agent.prompt_builder import build_skills_system_prompt
+    out = build_skills_system_prompt(index_v2=True, index_token_budget=2000)
+    assert "more categories" not in out
+```
+
+- [ ] **Step 6.2: Run, expect failure**
+
+Run: `python -m pytest tests/agent/test_prompt_builder.py::test_v2_budget_folds_least_used_categories -v`
+Expected: FAIL — current renderer doesn't fold.
+
+- [ ] **Step 6.3: Implement budget enforcement**
+
+Replace the body of `_render_v2` in `agent/prompt_builder.py`:
+
+```python
+def _estimate_tokens(text: str) -> int:
+    return max(1, len(text) // 4)
+
+
+def _render_v2(inv: Inventory, *, token_budget: int) -> str:
+    from agent import skill_usage_tracker
+
+    by_cat: dict[str, list[SkillEntry]] = {}
+    for e in inv.entries:
+        by_cat.setdefault(e.category, []).append(e)
+
+    n_critical = sum(1 for e in inv.entries if e.priority == "critical")
+    if n_critical > 15:
+        logger.warning(
+            "skills.index_v2: %d skills marked priority=critical (>15). "
+            "Tier 1 budget gains erode past this threshold.",
+            n_critical,
+        )
+
+    def _category_block(cat: str) -> list[str]:
+        cat_desc = inv.category_descriptions.get(cat, "")
+        head = f"  {cat}/  {cat_desc}".rstrip() if cat_desc else f"  {cat}/"
+        out = [head]
+        criticals = sorted((e for e in by_cat[cat] if e.priority == "critical"),
+                           key=lambda e: e.name)
+        normals = sorted((e for e in by_cat[cat] if e.priority != "critical"),
+                         key=lambda e: e.name)
+        for e in criticals:
+            if e.description:
+                out.append(f"    - {e.name}: {e.description}")
+            else:
+                out.append(f"    - {e.name}")
+        if normals:
+            out.append("    " + ", ".join(e.name for e in normals))
+        return out
+
+    # Category ordering for fold-back: most-used first, then alphabetical
+    top = skill_usage_tracker.top_categories()
+    ordered_cats = list(dict.fromkeys(top + sorted(by_cat.keys())))
+    ordered_cats = [c for c in ordered_cats if c in by_cat]
+
+    body_lines: list[str] = []
+    folded: list[str] = []
+    running_tokens = _estimate_tokens(_V2_PREAMBLE) + _estimate_tokens(_V2_OPEN + _V2_CLOSE)
+    for cat in ordered_cats:
+        block = _category_block(cat)
+        block_text = "\n".join(block) + "\n"
+        cost = _estimate_tokens(block_text)
+        if running_tokens + cost > token_budget and body_lines:
+            folded.append(cat)
+        else:
+            body_lines.extend(block)
+            running_tokens += cost
+
+    if folded:
+        body_lines.append(
+            f"  … and {len(folded)} more categories: "
+            + ", ".join(folded)
+            + ". Call skill_describe(category=...) to expand any of these."
+        )
+
+    return _V2_PREAMBLE + _V2_OPEN + "\n".join(body_lines) + "\n" + _V2_CLOSE
+```
+
+- [ ] **Step 6.4: Run tests**
+
+Run: `python -m pytest tests/agent/test_prompt_builder.py -v`
+Expected: all green.
+
+- [ ] **Step 6.5: Update cache key**
+
+Inside `agent/skill_inventory.py:load_inventory`, the cache key already includes the platform/disabled set; for the v2 budget output we need a separate cache for the rendered string. Since `build_skills_system_prompt` is called once per `_build_system_prompt`, simply do not cache the v2 rendered string — recomputing the render from the cached inventory is cheap (sub-millisecond for 100 skills). No change needed; document this in a comment in `_render_v2`:
+
+```python
+def _render_v2(inv: Inventory, *, token_budget: int) -> str:
+    # Note: not cached at the prompt-string level — the inventory cache covers
+    # the expensive parsing step, and rendering 100 skills is sub-ms.
+    ...
+```
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add agent/prompt_builder.py tests/agent/test_prompt_builder.py
+git commit -m "feat(skills): enforce token budget with fold-back in v2 index
+
+Categories are ordered by recent usage (skill_usage_tracker.top_categories)
+and added until the budget is met; the rest are listed by name with a hint
+to call skill_describe."
+```
+
+---
+
+## Task A7: New `skill_describe` tool
+
+**Files:**
+- Modify: `tools/skills_tool.py:1388-1445`
+- Test: `tests/tools/test_skill_describe.py`
+
+- [ ] **Step 7.1: Write failing tests**
+
+```python
+# tests/tools/test_skill_describe.py
+import textwrap
+import pytest
+
+
+def _setup_skills(tmp_path, monkeypatch):
+    d = tmp_path / "skills"
+    for cat, name, desc in [
+        ("cat-a", "alpha", "A description"),
+        ("cat-a", "beta", "B description"),
+        ("cat-b", "gamma", "C description"),
+    ]:
+        sd = d / cat / name
+        sd.mkdir(parents=True, exist_ok=True)
+        (sd / "SKILL.md").write_text(textwrap.dedent(f"""\
+            ---
+            name: {name}
+            description: {desc}
+            ---
+            body
+        """))
+    monkeypatch.setattr("agent.skill_inventory.get_skills_dir", lambda: d)
+    monkeypatch.setattr("agent.skill_inventory.get_all_skills_dirs", lambda: [d])
+    from agent.skill_inventory import clear_inventory_cache
+    clear_inventory_cache(clear_snapshot=True)
+
+
+def test_skill_describe_by_category(tmp_path, monkeypatch):
+    _setup_skills(tmp_path, monkeypatch)
+    from tools.skills_tool import skill_describe
+    res = skill_describe(category="cat-a")
+    assert res["success"] is True
+    names = sorted(s["name"] for s in res["skills"])
+    assert names == ["alpha", "beta"]
+
+
+def test_skill_describe_by_names(tmp_path, monkeypatch):
+    _setup_skills(tmp_path, monkeypatch)
+    from tools.skills_tool import skill_describe
+    res = skill_describe(names=["alpha", "gamma"])
+    assert res["success"] is True
+    names = sorted(s["name"] for s in res["skills"])
+    assert names == ["alpha", "gamma"]
+
+
+def test_skill_describe_unknown_name_errors(tmp_path, monkeypatch):
+    _setup_skills(tmp_path, monkeypatch)
+    from tools.skills_tool import skill_describe
+    res = skill_describe(names=["does-not-exist"])
+    assert res["success"] is False
+    assert "does-not-exist" in res["error"]
+
+
+def test_skill_describe_unknown_category_errors(tmp_path, monkeypatch):
+    _setup_skills(tmp_path, monkeypatch)
+    from tools.skills_tool import skill_describe
+    res = skill_describe(category="missing")
+    assert res["success"] is False
+
+
+def test_skill_describe_empty_args_errors(tmp_path, monkeypatch):
+    _setup_skills(tmp_path, monkeypatch)
+    from tools.skills_tool import skill_describe
+    res = skill_describe()
+    assert res["success"] is False
+```
+
+- [ ] **Step 7.2: Run, expect failure**
+
+Run: `python -m pytest tests/tools/test_skill_describe.py -v`
+Expected: FAIL — `skill_describe` not exported.
+
+- [ ] **Step 7.3: Implement `skill_describe` in `tools/skills_tool.py`**
+
+After the existing `skill_view` definition (line 828 onwards), add:
+
+```python
+def skill_describe(
+    category: str | None = None,
+    names: list[str] | None = None,
+    task_id: str | None = None,
+) -> dict:
+    """Return one-line descriptions for one or more skills.
+
+    Either `category` or `names` must be provided.  Returns success=False on
+    unknown categories/names or empty input.  Best-effort updates the category
+    usage tracker so future v2 prompt-budget folding ranks the touched
+    category higher.
+    """
+    if not category and not names:
+        return {
+            "success": False,
+            "error": "Provide either category=<name> or names=[...].",
+        }
+
+    from agent.skill_inventory import load_inventory
+    inv = load_inventory()
+    by_name = {e.name: e for e in inv.entries}
+    by_skill_name = {e.skill_name: e for e in inv.entries}
+    by_category: dict[str, list] = {}
+    for e in inv.entries:
+        by_category.setdefault(e.category, []).append(e)
+
+    out: list[dict] = []
+    if category:
+        if category not in by_category:
+            return {
+                "success": False,
+                "error": f"Unknown category {category!r}.  Categories: "
+                         + ", ".join(sorted(by_category.keys())),
+            }
+        for e in sorted(by_category[category], key=lambda e: e.name):
+            out.append({
+                "name": e.name,
+                "category": e.category,
+                "description": e.description,
+                "priority": e.priority,
+            })
+        try:
+            from agent import skill_usage_tracker
+            skill_usage_tracker.record_category_use(category)
+        except Exception:
+            pass
+
+    if names:
+        missing: list[str] = []
+        for n in names:
+            entry = by_name.get(n) or by_skill_name.get(n)
+            if entry is None:
+                missing.append(n)
+                continue
+            out.append({
+                "name": entry.name,
+                "category": entry.category,
+                "description": entry.description,
+                "priority": entry.priority,
+            })
+        if missing:
+            return {
+                "success": False,
+                "error": f"Unknown skill name(s): {', '.join(missing)}.",
+            }
+
+    return {"success": True, "skills": out}
+```
+
+- [ ] **Step 7.4: Register the tool schema**
+
+In `tools/skills_tool.py:1392-1445`, add after `SKILL_VIEW_SCHEMA`:
+
+```python
+SKILL_DESCRIBE_SCHEMA = {
+    "name": "skill_describe",
+    "description": (
+        "Return one-line descriptions for skills. Use category=<name> to expand "
+        "a category from the system-prompt index, or names=[...] for specific "
+        "skills you've already identified. After reading a description, call "
+        "skill_view(name) to load the full SKILL.md content."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "category": {
+                "type": "string",
+                "description": "Category to expand — returns descriptions for every skill in it.",
+            },
+            "names": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Specific skill names to describe.",
+            },
+        },
+        "required": [],
+    },
+}
+
+registry.register(
+    name="skill_describe",
+    toolset="skills",
+    schema=SKILL_DESCRIBE_SCHEMA,
+    handler=lambda args, **kw: skill_describe(
+        category=args.get("category"),
+        names=args.get("names"),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_skills_requirements,
+    emoji="📚",
+)
+```
+
+- [ ] **Step 7.5: Run tests**
+
+Run: `python -m pytest tests/tools/test_skill_describe.py -v`
+Expected: all green.
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add tools/skills_tool.py tests/tools/test_skill_describe.py
+git commit -m "feat(skills): add skill_describe tool for tier-2 description lookup
+
+Lets the model expand a category or fetch descriptions for specific skills
+when their names alone aren't enough to decide whether to skill_view.
+Records category usage to inform future budget-folding."
+```
+
+---
+
+## Task A8: Phase A integration test
+
+**Files:**
+- Test: `tests/integration/test_skills_index_v2_e2e.py`
+
+- [ ] **Step 8.1: Create the integration test**
+
+```python
+# tests/integration/test_skills_index_v2_e2e.py
+"""End-to-end: 100 synthetic skills, assert prompt budget is respected and
+no skill is unreachable via skill_describe."""
+from pathlib import Path
+import pytest
+
+
+def _seed_skills(skills_dir: Path, n: int = 100, n_categories: int = 10) -> None:
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(n):
+        cat = f"cat-{i % n_categories:02d}"
+        d = skills_dir / cat / f"skill-{i:03d}"
+        d.mkdir(parents=True, exist_ok=True)
+        priority = "critical" if i < 5 else "normal"
+        (d / "SKILL.md").write_text(
+            f"---\nname: skill-{i:03d}\ndescription: synthetic skill {i}\npriority: {priority}\n---\nbody\n"
+        )
+
+
+def test_v2_budget_and_full_reachability(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    _seed_skills(skills_dir, n=100, n_categories=10)
+    monkeypatch.setattr("agent.skill_inventory.get_skills_dir", lambda: skills_dir)
+    monkeypatch.setattr("agent.skill_inventory.get_all_skills_dirs", lambda: [skills_dir])
+    monkeypatch.setattr("agent.prompt_builder.get_skills_dir", lambda: skills_dir)
+    from agent.skill_inventory import clear_inventory_cache
+    clear_inventory_cache(clear_snapshot=True)
+
+    from agent.prompt_builder import build_skills_system_prompt
+    prompt = build_skills_system_prompt(index_v2=True, index_token_budget=2000)
+
+    # 1. Budget respected within tolerance (the heuristic is len/4)
+    assert len(prompt) // 4 <= 2200, f"Prompt size {len(prompt)//4} exceeds budget"
+
+    # 2. All 5 critical skills appear with descriptions
+    for i in range(5):
+        assert f"skill-{i:03d}: synthetic skill {i}" in prompt
+
+    # 3. Every skill is reachable via skill_describe
+    from tools.skills_tool import skill_describe
+    for i in range(100):
+        res = skill_describe(names=[f"skill-{i:03d}"])
+        assert res["success"], f"skill-{i:03d} not reachable"
+```
+
+- [ ] **Step 8.2: Run**
+
+Run: `python -m pytest tests/integration/test_skills_index_v2_e2e.py -v`
+Expected: green.
+
+- [ ] **Step 8.3: Commit**
+
+```bash
+git add tests/integration/test_skills_index_v2_e2e.py
+git commit -m "test(skills): integration test for v2 index with 100 synthetic skills"
+```
+
+---
+
+## Task A9: Update `cli-config.yaml.example` (Phase A part)
+
+**Files:**
+- Modify: `cli-config.yaml.example:481-494`
+
+- [ ] **Step 9.1: Edit the skills section**
+
+Replace the existing `skills:` block (lines 481-494) with:
+
+```yaml
+skills:
+  # Nudge the agent to create skills after complex tasks.
+  # Phase 1-2 fallback only — primary triggers are signal-based (see below).
+  # Set to 0 to disable.
+  creation_nudge_interval: 15
+
+  # Skill index v2 — Tier 1 (system prompt) shows category + names only;
+  # descriptions are fetched on demand via skill_describe.  Skills with
+  # `priority: critical` in their frontmatter keep descriptions in Tier 1.
+  # Default false until Phase 3 of the rollout.
+  index_v2: false
+
+  # Soft cap on the Tier 1 skill block (token estimate, len // 4).  When
+  # exceeded, lowest-priority categories are folded behind a one-line hint
+  # that points the model at skill_describe.
+  index_token_budget: 2000
+
+  # External skill directories — share skills across tools/agents without
+  # copying them into ~/.hermes/skills/.  Each path is expanded (~ and ${VAR})
+  # and resolved to an absolute path.  External dirs are read-only: skill
+  # creation always writes to ~/.hermes/skills/.  Local skills take precedence
+  # when names collide.
+  # external_dirs:
+  #   - ~/.agents/skills
+  #   - /home/shared/team-skills
+```
+
+(Phase B keys will be added in Task B7.)
+
+- [ ] **Step 9.2: Commit**
+
+```bash
+git add cli-config.yaml.example
+git commit -m "docs(config): document skills.index_v2 and index_token_budget"
+```
+
+---
+
+# Phase B — Signal-Based Nudge
+
+Gated behind `skills.nudge_signals.enabled: true`. Default `false` until Phase 3.
+
+## Task B1: Wire `skills.nudge_signals` config + AIAgent state init
+
+**Files:**
+- Modify: `run_agent.py:1495-1614`
+
+- [ ] **Step 10.1: Write failing test**
+
+```python
+# tests/run_agent/test_nudge_signals_init.py
+def test_nudge_state_initialized_with_defaults(monkeypatch):
+    from run_agent import AIAgent
+    a = AIAgent.__new__(AIAgent)  # bypass full __init__ for an isolated check
+    AIAgent._init_nudge_state(a, {})
+    assert a._nudge_disabled is False
+    assert a._nudge_signals == set()
+    assert a._nudge_signals_enabled is False
+    assert a._nudge_repeated_threshold == 3
+    assert a._nudge_error_threshold == 2
+    assert a._nudge_user_phrases == ["next time", "remember", "from now on", "记一下", "下次", "以后"]
+    assert "git" in a._nudge_common_clis_suppressed
+
+
+def test_nudge_state_reads_config():
+    from run_agent import AIAgent
+    cfg = {
+        "skills": {
+            "nudge_signals": {
+                "enabled": True,
+                "repeated_pattern_threshold": 5,
+                "error_repeat_threshold": 3,
+                "novel_cli_window_days": 14,
+                "common_cli_suppressions": ["bun"],
+                "user_phrases": ["foo"],
+            }
+        }
+    }
+    a = AIAgent.__new__(AIAgent)
+    AIAgent._init_nudge_state(a, cfg)
+    assert a._nudge_signals_enabled is True
+    assert a._nudge_repeated_threshold == 5
+    assert a._nudge_error_threshold == 3
+    assert a._nudge_cli_window_days == 14
+    assert a._nudge_common_clis_suppressed == ["bun"]
+    assert a._nudge_user_phrases == ["foo"]
+```
+
+- [ ] **Step 10.2: Run, expect failure**
+
+Run: `python -m pytest tests/run_agent/test_nudge_signals_init.py -v`
+Expected: FAIL — `_init_nudge_state` does not exist.
+
+- [ ] **Step 10.3: Add `_init_nudge_state` and call it from `__init__`**
+
+In `run_agent.py`, immediately after the existing block at lines 1607-1613, replace and extend:
+
+```python
+        # Skills config: nudge interval + index v2 flag (existing)
+        self._skill_nudge_interval = 10
+        self._skill_index_v2 = False
+        self._skill_index_token_budget = 2000
+        try:
+            skills_config = _agent_cfg.get("skills", {})
+            self._skill_nudge_interval = int(skills_config.get("creation_nudge_interval", 10))
+            self._skill_index_v2 = bool(skills_config.get("index_v2", False))
+            self._skill_index_token_budget = int(skills_config.get("index_token_budget", 2000))
+        except Exception:
+            pass
+
+        # Phase B: signal-based nudge state
+        self._init_nudge_state(_agent_cfg)
+```
+
+Add the method as a real method on `AIAgent`:
+
+```python
+    _DEFAULT_USER_PHRASES = ["next time", "remember", "from now on", "记一下", "下次", "以后"]
+    _DEFAULT_COMMON_CLIS = ["git", "python", "python3", "node", "npm", "pnpm",
+                            "uv", "pytest", "rg", "sed", "cat", "ls", "mkdir"]
+
+    def _init_nudge_state(self, agent_cfg: dict) -> None:
+        from collections import deque
+        self._nudge_disabled = False
+        self._nudge_signals: set[str] = set()
+        self._tool_call_history: deque = deque(maxlen=10)
+        self._error_history: deque = deque(maxlen=10)
+        self._last_error_tool: dict[str, str] = {}  # tool_name -> last error hash
+
+        skills_cfg = (agent_cfg or {}).get("skills", {}) or {}
+        ns = skills_cfg.get("nudge_signals", {}) or {}
+        self._nudge_signals_enabled = bool(ns.get("enabled", False))
+        self._nudge_repeated_threshold = int(ns.get("repeated_pattern_threshold", 3))
+        self._nudge_error_threshold = int(ns.get("error_repeat_threshold", 2))
+        self._nudge_cli_window_days = int(ns.get("novel_cli_window_days", 30))
+        self._nudge_common_clis_suppressed = list(
+            ns.get("common_cli_suppressions", self._DEFAULT_COMMON_CLIS)
+        )
+        self._nudge_user_phrases = list(ns.get("user_phrases", self._DEFAULT_USER_PHRASES))
+
+        import os
+        if os.environ.get("HERMES_SKILL_NUDGE_DISABLE") == "1":
+            self._nudge_disabled = True
+```
+
+- [ ] **Step 10.4: Run tests**
+
+Run: `python -m pytest tests/run_agent/test_nudge_signals_init.py -v`
+Expected: green.
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add run_agent.py tests/run_agent/test_nudge_signals_init.py
+git commit -m "feat(nudge): initialize signal-based nudge state on AIAgent
+
+Adds _init_nudge_state() reading skills.nudge_signals.* and the
+HERMES_SKILL_NUDGE_DISABLE env var.  No behavior change yet — signal eval
+arrives in B2/B3."
+```
+
+---
+
+## Task B2: Signal evaluator module (S1–S4)
+
+**Files:**
+- Create: `agent/skill_nudge_signals.py`
+- Test: `tests/agent/test_skill_nudge_signals.py`
+
+- [ ] **Step 11.1: Write failing tests**
+
+```python
+# tests/agent/test_skill_nudge_signals.py
+import pytest
+
+from agent.skill_nudge_signals import SignalEvaluator
+
+
+@pytest.fixture
+def ev():
+    return SignalEvaluator(
+        repeated_threshold=3,
+        error_threshold=2,
+        common_clis_suppressed=["git", "ls"],
+        cli_window_days=30,
+        user_phrases=["next time", "记一下"],
+    )
+
+
+def test_s1_repeated_terminal_first_token(ev):
+    for _ in range(3):
+        ev.observe_tool_call("terminal", {"command": "gh pr view 123"})
+    assert "S1" in ev.fired_signals
+
+
+def test_s1_unknown_tool_does_not_fire(ev):
+    for _ in range(5):
+        ev.observe_tool_call("custom_tool", {"foo": i for i in range(1)})
+    assert "S1" not in ev.fired_signals
+
+
+def test_s2_novel_cli_fires(ev, monkeypatch):
+    monkeypatch.setattr(
+        "agent.skill_usage_tracker.is_known_cli", lambda *a, **kw: False
+    )
+    monkeypatch.setattr(
+        "agent.skill_usage_tracker.record_cli_seen", lambda *a, **kw: None
+    )
+    ev.observe_tool_call("terminal", {"command": "exotic-cli --do-thing"}, success=True)
+    assert "S2" in ev.fired_signals
+
+
+def test_s2_common_cli_suppressed(ev, monkeypatch):
+    monkeypatch.setattr(
+        "agent.skill_usage_tracker.is_known_cli", lambda *a, **kw: False
+    )
+    monkeypatch.setattr(
+        "agent.skill_usage_tracker.record_cli_seen", lambda *a, **kw: None
+    )
+    ev.observe_tool_call("terminal", {"command": "git status"}, success=True)
+    assert "S2" not in ev.fired_signals
+
+
+def test_s3_user_phrase_match(ev):
+    ev.observe_user_message("This always crashes — please remember next time")
+    assert "S3" in ev.fired_signals
+
+
+def test_s4_resolved_repeated_error(ev):
+    ev.observe_tool_result("terminal", error_text="ENOENT: file 'x' not found")
+    ev.observe_tool_result("terminal", error_text="ENOENT: file 'x' not found")
+    ev.observe_tool_result("terminal", error_text=None)  # success
+    assert "S4" in ev.fired_signals
+
+
+def test_clear_resets_state(ev):
+    for _ in range(3):
+        ev.observe_tool_call("terminal", {"command": "gh pr view"})
+    assert ev.fired_signals
+    ev.clear()
+    assert not ev.fired_signals
+```
+
+- [ ] **Step 11.2: Run, expect failure**
+
+Run: `python -m pytest tests/agent/test_skill_nudge_signals.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 11.3: Create the evaluator**
+
+```python
+# agent/skill_nudge_signals.py
+"""Signal-based nudge evaluator (S1-S4 from the spec).
+
+Pure logic — does not own any of the persistence; consumers wire it up.
+"""
+from __future__ import annotations
+
+import hashlib
+from collections import deque
+from dataclasses import dataclass, field
+
+
+def _terminal_signature(args: dict) -> str:
+    cmd = (args or {}).get("command") or ""
+    cmd = str(cmd).strip()
+    if not cmd:
+        return ""
+    parts = cmd.split()
+    head = parts[0].rsplit("/", 1)[-1] if parts else ""
+    sub = parts[1] if len(parts) > 1 else ""
+    return f"{head} {sub}".strip() if head in ("git", "gh", "kubectl") else head
+
+
+def _path_signature(args: dict) -> str:
+    p = (args or {}).get("path") or (args or {}).get("file_path") or ""
+    p = str(p)
+    return p.rsplit("/", 1)[0] if "/" in p else ""
+
+
+_PER_TOOL_SIG = {
+    "terminal": _terminal_signature,
+    "process": _terminal_signature,
+    "read_file": _path_signature,
+    "write_file": _path_signature,
+    "edit_file": _path_signature,
+}
+
+
+def _hash_error(text: str) -> str:
+    return hashlib.sha1(text[:200].encode("utf-8", "replace")).hexdigest()[:16]
+
+
+@dataclass
+class SignalEvaluator:
+    repeated_threshold: int = 3
+    error_threshold: int = 2
+    common_clis_suppressed: list[str] = field(default_factory=list)
+    cli_window_days: int = 30
+    user_phrases: list[str] = field(default_factory=list)
+
+    fired_signals: set[str] = field(default_factory=set)
+    _tool_calls: deque = field(default_factory=lambda: deque(maxlen=20))
+    _error_counts: dict[str, int] = field(default_factory=dict)
+    _failed_tools: set[str] = field(default_factory=set)
+
+    # ---- public hooks -----------------------------------------------------
+
+    def observe_user_message(self, text: str) -> None:
+        if not text:
+            return
+        lower = text.lower()
+        for phrase in self.user_phrases:
+            if phrase.lower() in lower:
+                self.fired_signals.add("S3")
+                return
+
+    def observe_tool_call(
+        self,
+        tool_name: str,
+        args: dict | None,
+        *,
+        success: bool | None = None,
+    ) -> None:
+        sig_fn = _PER_TOOL_SIG.get(tool_name)
+        if sig_fn is not None:
+            sig = sig_fn(args or {})
+            if sig:
+                self._tool_calls.append((tool_name, sig))
+                count = sum(1 for n, s in self._tool_calls if n == tool_name and s == sig)
+                if count >= self.repeated_threshold:
+                    self.fired_signals.add("S1")
+
+        # S2: novel external CLI on terminal/process
+        if tool_name in ("terminal", "process"):
+            cmd = str((args or {}).get("command") or "").strip()
+            if cmd:
+                head = cmd.split()[0].rsplit("/", 1)[-1]
+                if head and head not in self.common_clis_suppressed:
+                    from agent import skill_usage_tracker
+                    if not skill_usage_tracker.is_known_cli(head, window_days=self.cli_window_days):
+                        # Fire only when the call succeeded or has repeated this turn
+                        if success is True or (tool_name, head) in self._failed_tools:
+                            self.fired_signals.add("S2")
+                        skill_usage_tracker.record_cli_seen(head)
+
+    def observe_tool_result(
+        self,
+        tool_name: str,
+        *,
+        error_text: str | None,
+    ) -> None:
+        if error_text:
+            h = _hash_error(error_text)
+            self._error_counts[h] = self._error_counts.get(h, 0) + 1
+            self._failed_tools.add(tool_name)
+        else:
+            # A success after >= error_threshold prior errors of the same hash
+            for h, count in list(self._error_counts.items()):
+                if count >= self.error_threshold:
+                    self.fired_signals.add("S4")
+                    self._error_counts.pop(h, None)
+
+    def clear(self) -> None:
+        self.fired_signals.clear()
+        self._tool_calls.clear()
+        self._error_counts.clear()
+        self._failed_tools.clear()
+```
+
+- [ ] **Step 11.4: Fix the test typo and run**
+
+The S1 negative-case test had a stray dict comprehension. Fix it:
+
+```python
+def test_s1_unknown_tool_does_not_fire(ev):
+    for _ in range(5):
+        ev.observe_tool_call("custom_tool", {"foo": "bar"})
+    assert "S1" not in ev.fired_signals
+```
+
+Run: `python -m pytest tests/agent/test_skill_nudge_signals.py -v`
+Expected: all green.
+
+- [ ] **Step 11.5: Commit**
+
+```bash
+git add agent/skill_nudge_signals.py tests/agent/test_skill_nudge_signals.py
+git commit -m "feat(nudge): SignalEvaluator implementing S1-S4 from spec
+
+S1 repeated pattern, S2 novel CLI, S3 user phrase, S4 resolved repeated
+error.  Pure logic; persistence handled by skill_usage_tracker."
+```
+
+---
+
+## Task B3: Hook signal evaluator into per-iteration loop
+
+**Files:**
+- Modify: `run_agent.py:1495-1614` (init), `run_agent.py:9295-9299` (per-iter), `run_agent.py:8049, 8372` (resets)
+- Test: `tests/run_agent/test_nudge_loop_integration.py`
+
+- [ ] **Step 12.1: Initialize the evaluator in `_init_nudge_state`**
+
+Append to the method written in Task B1:
+
+```python
+        from agent.skill_nudge_signals import SignalEvaluator
+        self._signal_evaluator = SignalEvaluator(
+            repeated_threshold=self._nudge_repeated_threshold,
+            error_threshold=self._nudge_error_threshold,
+            common_clis_suppressed=self._nudge_common_clis_suppressed,
+            cli_window_days=self._nudge_cli_window_days,
+            user_phrases=self._nudge_user_phrases,
+        )
+```
+
+- [ ] **Step 12.2: Observe user message at turn start**
+
+In `run_conversation()` early in the function (find the line where `original_user_message` first becomes available), after it is captured, add:
+
+```python
+        if self._nudge_signals_enabled and not self._nudge_disabled:
+            try:
+                self._signal_evaluator.observe_user_message(original_user_message or "")
+            except Exception as e:
+                logger.debug("Signal evaluator (user msg) failed: %s", e)
+```
+
+- [ ] **Step 12.3: Add a single observation helper and call it from the existing tool-dispatch path**
+
+The agent loop in `run_agent.py` is large; rather than scattering signal-eval calls across multiple iteration sites, add ONE method on `AIAgent` and call it from exactly two existing seams. Add this method near `_compute_should_review_skills` (Task B4):
+
+```python
+    def _observe_tool_activity(
+        self,
+        tool_name: str,
+        arguments: dict | None,
+        result_content: str | None,
+    ) -> None:
+        """Feed one (call, result) pair into the signal evaluator. Best-effort."""
+        if not getattr(self, "_nudge_signals_enabled", False):
+            return
+        if getattr(self, "_nudge_disabled", False):
+            return
+        ev = getattr(self, "_signal_evaluator", None)
+        if ev is None:
+            return
+        try:
+            ev.observe_tool_call(tool_name, arguments or {})
+            err_text: str | None = None
+            content_str = str(result_content) if result_content else ""
+            head = content_str[:200].lower()
+            if content_str.startswith("Error:") or "error" in head or "traceback" in head:
+                err_text = content_str
+            ev.observe_tool_result(tool_name, error_text=err_text)
+        except Exception as e:
+            logger.debug("Signal evaluator failed for tool=%s: %s", tool_name, e)
+```
+
+Hook the method into the agent loop at exactly one place: the existing site where a parsed tool call is dispatched and the tool result content has just been computed. Search for the line that builds the `{"role": "tool", "tool_call_id": ..., "content": ...}` dict in `run_agent.py` (there are two such sites — one for the streaming path and one for the non-streaming/Anthropic path; use `grep -n '"role": "tool"' run_agent.py` to locate them). Right after `content` is finalized for that message, before it is appended to `messages`, insert:
+
+```python
+                self._observe_tool_activity(
+                    tool_name=tool_name,
+                    arguments=parsed_args if isinstance(parsed_args, dict) else None,
+                    result_content=content if isinstance(content, str) else None,
+                )
+```
+
+Use whatever local names the surrounding code already has for the parsed tool name, the parsed arguments dict, and the tool result string. The wrapping try/except in `_observe_tool_activity` ensures a wrong local name fails silently rather than breaking the turn.
+
+- [ ] **Step 12.4: Verify by smoke**
+
+This step has no dedicated unit test — the wiring is exercised by Task B4's gate test plus Task B7's end-to-end test. Confirm import-clean with:
+
+Run: `python -c "from run_agent import AIAgent; print(AIAgent._observe_tool_activity)"`
+Expected: prints the bound method, no import error.
+
+- [ ] **Step 12.5: Commit**
+
+```bash
+git add run_agent.py
+git commit -m "feat(nudge): observe tool calls/results into SignalEvaluator
+
+Hooks signal evaluation into the existing per-iteration loop with try/except
+guards so signal-eval failures never break a turn."
+```
+
+---
+
+## Task B4: End-of-turn gate update + thread signals into background review
+
+**Files:**
+- Modify: `run_agent.py:12176-12204` (end-of-turn gate)
+- Modify: `run_agent.py:3014-3060` (`_spawn_background_review` signature)
+- Test: `tests/run_agent/test_nudge_end_of_turn_gate.py`
+
+- [ ] **Step 13.1: Write failing tests**
+
+```python
+# tests/run_agent/test_nudge_end_of_turn_gate.py
+import pytest
+
+
+def _agent_with_state(monkeypatch, **kwargs):
+    """Build a minimally-initialized AIAgent for gate-only testing."""
+    from run_agent import AIAgent
+    a = AIAgent.__new__(AIAgent)
+    a.valid_tool_names = {"skill_manage"}
+    a._skill_nudge_interval = kwargs.get("interval", 50)
+    a._iters_since_skill = kwargs.get("iters", 0)
+    a._nudge_disabled = kwargs.get("disabled", False)
+    a._nudge_signals_enabled = kwargs.get("signals_enabled", True)
+    from agent.skill_nudge_signals import SignalEvaluator
+    a._signal_evaluator = SignalEvaluator(
+        repeated_threshold=3, error_threshold=2,
+        common_clis_suppressed=[], cli_window_days=30, user_phrases=[],
+    )
+    if kwargs.get("fired"):
+        a._signal_evaluator.fired_signals.update(kwargs["fired"])
+    return a
+
+
+def test_gate_fires_when_signal_present(monkeypatch):
+    a = _agent_with_state(monkeypatch, fired={"S1"})
+    from run_agent import AIAgent
+    res = AIAgent._compute_should_review_skills(a)
+    assert res == (True, {"S1"})
+
+
+def test_gate_falls_back_to_time_when_no_signal(monkeypatch):
+    a = _agent_with_state(monkeypatch, iters=50, interval=50)
+    from run_agent import AIAgent
+    res = AIAgent._compute_should_review_skills(a)
+    assert res == (True, set())
+
+
+def test_gate_blocked_by_disable(monkeypatch):
+    a = _agent_with_state(monkeypatch, fired={"S1"}, disabled=True)
+    from run_agent import AIAgent
+    res = AIAgent._compute_should_review_skills(a)
+    assert res == (False, set())
+
+
+def test_gate_blocked_when_skill_manage_unavailable(monkeypatch):
+    a = _agent_with_state(monkeypatch, fired={"S1"})
+    a.valid_tool_names = set()
+    from run_agent import AIAgent
+    res = AIAgent._compute_should_review_skills(a)
+    assert res == (False, set())
+```
+
+- [ ] **Step 13.2: Run, expect failure**
+
+Run: `python -m pytest tests/run_agent/test_nudge_end_of_turn_gate.py -v`
+Expected: FAIL — `_compute_should_review_skills` doesn't exist.
+
+- [ ] **Step 13.3: Add the helper and rewrite the gate**
+
+In `run_agent.py`, add as an `AIAgent` method:
+
+```python
+    def _compute_should_review_skills(self) -> tuple[bool, set[str]]:
+        """End-of-turn gate from spec §5.2.
+
+        Returns (should_review, fired_signals). The signals set is empty when
+        the time fallback fires.
+        """
+        if "skill_manage" not in self.valid_tool_names:
+            return False, set()
+        if getattr(self, "_nudge_disabled", False):
+            return False, set()
+
+        signals: set[str] = set()
+        ev = getattr(self, "_signal_evaluator", None)
+        if getattr(self, "_nudge_signals_enabled", False) and ev is not None and ev.fired_signals:
+            signals = set(ev.fired_signals)
+            ev.clear()
+            self._iters_since_skill = 0
+            return True, signals
+
+        if (self._skill_nudge_interval > 0
+                and self._iters_since_skill >= self._skill_nudge_interval):
+            self._iters_since_skill = 0
+            return True, set()
+
+        return False, set()
+```
+
+In the existing block at `run_agent.py:12176-12182`, replace:
+
+```python
+        # Check skill trigger NOW — based on how many tool iterations THIS turn used.
+        _should_review_skills, _triggered_signals = self._compute_should_review_skills()
+```
+
+In the `_spawn_background_review` call at line ~12198, pass the signals:
+
+```python
+        if final_response and not interrupted and (_should_review_memory or _should_review_skills):
+            try:
+                self._spawn_background_review(
+                    messages_snapshot=list(messages),
+                    review_memory=_should_review_memory,
+                    review_skills=_should_review_skills,
+                    triggered_signals=_triggered_signals,
+                )
+            except Exception:
+                pass  # Background review is best-effort
+```
+
+In the `_spawn_background_review` definition (line 3014), accept and use the new arg:
+
+```python
+    def _spawn_background_review(
+        self,
+        messages_snapshot: List[Dict],
+        review_memory: bool = False,
+        review_skills: bool = False,
+        triggered_signals: set[str] | None = None,
+    ) -> None:
+        """... (docstring unchanged) ..."""
+        import threading
+
+        if review_memory and review_skills:
+            base_prompt = self._COMBINED_REVIEW_PROMPT
+        elif review_memory:
+            base_prompt = self._MEMORY_REVIEW_PROMPT
+        else:
+            base_prompt = self._SKILL_REVIEW_PROMPT
+
+        if review_skills and triggered_signals:
+            signal_hint = (
+                "\n\nThe following nudge signals fired this turn: "
+                + ", ".join(sorted(triggered_signals))
+                + ". Consider whether they suggest a reusable skill."
+            )
+            prompt = base_prompt + signal_hint
+        else:
+            prompt = base_prompt
+
+        # ... rest unchanged ...
+```
+
+- [ ] **Step 13.4: Run tests**
+
+Run: `python -m pytest tests/run_agent/test_nudge_end_of_turn_gate.py -v`
+Expected: green.
+
+- [ ] **Step 13.5: Commit**
+
+```bash
+git add run_agent.py tests/run_agent/test_nudge_end_of_turn_gate.py
+git commit -m "feat(nudge): signal-first end-of-turn gate
+
+Replaces the time-only trigger with the four-branch gate from spec §5.2 and
+threads the fired signals into the background reviewer prompt so its
+suggestion can reference *why* it fired."
+```
+
+---
+
+## Task B5: `/skills nudge off|on` CLI intercept + slash-help
+
+**Files:**
+- Modify: `cli.py:5816-5819`
+- Test: `tests/cli/test_skills_nudge_slash.py`
+
+- [ ] **Step 14.1: Write failing test**
+
+```python
+# tests/cli/test_skills_nudge_slash.py
+import types
+import pytest
+
+
+class _FakeAgent:
+    def __init__(self):
+        self._nudge_disabled = False
+
+
+def test_skills_nudge_off_sets_flag(monkeypatch):
+    from cli import HermesCLI  # adapt to real entry-point class name
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.agent = _FakeAgent()
+    cli._handle_skills_command("/skills nudge off")
+    assert cli.agent._nudge_disabled is True
+
+
+def test_skills_nudge_on_clears_flag(monkeypatch):
+    from cli import HermesCLI
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.agent = _FakeAgent()
+    cli.agent._nudge_disabled = True
+    cli._handle_skills_command("/skills nudge on")
+    assert cli.agent._nudge_disabled is False
+
+
+def test_other_skills_subcommand_delegates_to_hub(monkeypatch):
+    from cli import HermesCLI
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.agent = _FakeAgent()
+    called = {}
+    def fake_handle(cmd, console):
+        called["cmd"] = cmd
+    monkeypatch.setattr("hermes_cli.skills_hub.handle_skills_slash", fake_handle)
+    cli._handle_skills_command("/skills list")
+    assert called["cmd"] == "/skills list"
+```
+
+- [ ] **Step 14.2: Run, expect failure**
+
+(`HermesCLI` is the class — defined at `cli.py:1793`; `_handle_skills_command` lives at `cli.py:5816`.)
+
+Run: `python -m pytest tests/cli/test_skills_nudge_slash.py -v`
+Expected: FAIL — intercept does not exist.
+
+- [ ] **Step 14.3: Edit the dispatcher**
+
+Replace `cli.py:5816-5819` with:
+
+```python
+    def _handle_skills_command(self, cmd: str):
+        """Handle /skills slash command.
+
+        Special-cases /skills nudge off|on so it can mutate the active agent's
+        per-session nudge state; everything else delegates to hermes_cli.skills_hub.
+        """
+        parts = cmd.strip().split()
+        # parts[0] is "/skills"; subcommand at parts[1]
+        if len(parts) >= 3 and parts[1].lower() == "nudge":
+            sub = parts[2].lower()
+            if sub == "off":
+                if getattr(self, "agent", None) is not None:
+                    self.agent._nudge_disabled = True
+                print("Skill creation nudges silenced for this session.")
+                return
+            if sub == "on":
+                if getattr(self, "agent", None) is not None:
+                    self.agent._nudge_disabled = False
+                print("Skill creation nudges re-enabled for this session.")
+                return
+            print("Usage: /skills nudge [off|on]")
+            return
+
+        from hermes_cli.skills_hub import handle_skills_slash
+        handle_skills_slash(cmd, ChatConsole())
+```
+
+- [ ] **Step 14.4: Run tests**
+
+Run: `python -m pytest tests/cli/test_skills_nudge_slash.py -v`
+Expected: green.
+
+- [ ] **Step 14.5: Update slash-help**
+
+In `hermes_cli/skills_hub.py:_print_skills_help()` (find the function, around the existing /skills help block), append:
+
+```python
+    _console.print("  /skills nudge [off|on]    silence or re-enable creation nudges this session")
+```
+
+- [ ] **Step 14.6: Commit**
+
+```bash
+git add cli.py hermes_cli/skills_hub.py tests/cli/test_skills_nudge_slash.py
+git commit -m "feat(nudge): /skills nudge off|on CLI intercept
+
+Lets the user silence creation nudges for the current session without
+restarting.  Other /skills subcommands continue to flow through the hub
+router unchanged."
+```
+
+---
+
+## Task B6: Update `cli-config.yaml.example` (Phase B keys)
+
+**Files:**
+- Modify: `cli-config.yaml.example` (skills section)
+
+- [ ] **Step 15.1: Append the nudge_signals block**
+
+Add after the existing `index_token_budget` line in the skills section:
+
+```yaml
+  # Phase 2 opt-in: replace the time-based creation nudge with signal-based
+  # triggers. When enabled, the time counter (creation_nudge_interval) becomes
+  # a fallback that fires only after this many tool iterations without any
+  # signal. Set creation_nudge_interval: 0 to disable the fallback entirely.
+  nudge_signals:
+    enabled: false
+    # S1: trigger when the same (tool, arg-signature) appears N+ times in a turn
+    repeated_pattern_threshold: 3
+    # S2: window for "novel CLI" detection — CLIs not seen for this many days
+    novel_cli_window_days: 30
+    # S2: CLIs that should NOT count as novel even if not in the known-CLI file
+    common_cli_suppressions:
+      - git
+      - python
+      - python3
+      - node
+      - npm
+      - pnpm
+      - uv
+      - pytest
+      - rg
+      - sed
+      - cat
+      - ls
+      - mkdir
+    # S3: user-message phrases that fire an explicit "remember this" signal
+    user_phrases:
+      - "next time"
+      - "remember"
+      - "from now on"
+      - "记一下"
+      - "下次"
+      - "以后"
+    # S4: a successful call after this many same-error failures fires a signal
+    error_repeat_threshold: 2
+```
+
+- [ ] **Step 15.2: Commit**
+
+```bash
+git add cli-config.yaml.example
+git commit -m "docs(config): document skills.nudge_signals block"
+```
+
+---
+
+## Task B7: Per-session disable end-to-end test
+
+**Files:**
+- Test: `tests/run_agent/test_nudge_disable_e2e.py`
+
+- [ ] **Step 16.1: Write the test**
+
+```python
+# tests/run_agent/test_nudge_disable_e2e.py
+import os
+import pytest
+
+
+def test_env_var_disables_nudge_at_init(monkeypatch):
+    monkeypatch.setenv("HERMES_SKILL_NUDGE_DISABLE", "1")
+    from run_agent import AIAgent
+    a = AIAgent.__new__(AIAgent)
+    AIAgent._init_nudge_state(a, {"skills": {"nudge_signals": {"enabled": True}}})
+    assert a._nudge_disabled is True
+
+
+def test_disabled_session_blocks_signal_gate():
+    from run_agent import AIAgent
+    a = AIAgent.__new__(AIAgent)
+    AIAgent._init_nudge_state(a, {"skills": {"nudge_signals": {"enabled": True}}})
+    a._nudge_disabled = True
+    a.valid_tool_names = {"skill_manage"}
+    a._iters_since_skill = 999
+    a._skill_nudge_interval = 50
+    a._signal_evaluator.fired_signals.add("S1")
+    res = AIAgent._compute_should_review_skills(a)
+    assert res == (False, set())
+```
+
+- [ ] **Step 16.2: Run**
+
+Run: `python -m pytest tests/run_agent/test_nudge_disable_e2e.py -v`
+Expected: green.
+
+- [ ] **Step 16.3: Commit**
+
+```bash
+git add tests/run_agent/test_nudge_disable_e2e.py
+git commit -m "test(nudge): per-session disable via env var and slash command"
+```
+
+---
+
+# Phase 3 wrap-up (documentation only — flag flips happen in a follow-up PR)
+
+## Task C1: Add Phase 3 wrap-up doc
+
+**Files:**
+- Create: `plans/skills-prompt-budget-and-nudge-phase-3-checklist.md`
+
+- [ ] **Step 17.1: Write the checklist**
+
+```markdown
+# Phase 3 Wrap-up Checklist
+
+After ≥1 minor version of dogfooding with `skills.index_v2: true` and
+`skills.nudge_signals.enabled: true` set in personal configs:
+
+- [ ] Flip default of `skills.index_v2` to `true` in `cli-config.yaml.example`
+- [ ] Flip default of `skills.nudge_signals.enabled` to `true` in `cli-config.yaml.example`
+- [ ] Bump default of `skills.creation_nudge_interval` from `15` to `50`
+- [ ] Update README / docs / website skills section to reference v2 rendering
+- [ ] Add TUI parity: `/skills nudge off|on` in `ui-tui/src/app/slash/commands/ops.ts`
+- [ ] Add gateway parity: same intercept in the gateway's slash dispatcher
+- [ ] After one minor version with v2 default, remove the v1 rendering path
+  (`_render_v1` in `agent/prompt_builder.py`) and the `index_v2` flag
+  plumbing entirely — Phase 4 cleanup.
+```
+
+- [ ] **Step 17.2: Commit**
+
+```bash
+git add plans/skills-prompt-budget-and-nudge-phase-3-checklist.md
+git commit -m "docs(plans): Phase 3 wrap-up checklist"
+```
+
+---
+
+# Final Verification
+
+- [ ] **Step 18.1: Full test suite**
+
+Run: `python -m pytest tests/agent/test_skill_inventory.py tests/agent/test_skill_usage_tracker.py tests/agent/test_skill_nudge_signals.py tests/agent/test_prompt_builder.py tests/tools/test_skill_manager_tool.py tests/tools/test_skill_describe.py tests/cli/test_skills_nudge_slash.py tests/run_agent/test_nudge_signals_init.py tests/run_agent/test_nudge_end_of_turn_gate.py tests/run_agent/test_nudge_disable_e2e.py tests/integration/test_skills_index_v2_e2e.py -v`
+Expected: all green.
+
+- [ ] **Step 18.2: Full repo test suite for regressions**
+
+Run: `python -m pytest -q`
+Expected: all green. If any unrelated test fails, investigate before opening the PR — the refactor in Task A1 touched a hot path.
+
+- [ ] **Step 18.3: Manual dogfood — Phase A**
+
+```bash
+# Add to ~/.hermes/config.yaml under skills:
+#   index_v2: true
+#   index_token_budget: 2000
+
+# Run a normal agent session and inspect logs for prompt size:
+hermes --debug 2>&1 | grep -i "skills prompt\|## Skills"
+```
+
+Expected: the system prompt shows the v2 format with category-grouped names
+and a small number of full-description critical entries.
+
+- [ ] **Step 18.4: Manual dogfood — Phase B**
+
+```bash
+# Add to ~/.hermes/config.yaml under skills:
+#   nudge_signals:
+#     enabled: true
+
+# In a chat session:
+# 1. Repeat a tool 3+ times: confirm a background skill review fires after the response
+# 2. Type "remember next time" in a message: confirm signal fires
+# 3. Run an exotic CLI not seen before: confirm a signal fires once it succeeds
+# 4. Force the same error twice and resolve: confirm S4 fires
+# 5. Run /skills nudge off and confirm subsequent triggers are silenced
+```
+
+- [ ] **Step 18.5: Open the PR**
+
+```bash
+git push -u origin feat/skills-index-v2-and-nudge-signals
+gh pr create --title "feat(skills): two-tier index + signal-based nudge (gated)" \
+    --body "$(cat plans/skills-prompt-budget-and-nudge-redesign.md | head -30)
+
+See plans/skills-prompt-budget-and-nudge-redesign.md for the full spec and
+plans/skills-prompt-budget-and-nudge-implementation.md for the task breakdown.
+Both behaviors are gated behind feature flags (skills.index_v2,
+skills.nudge_signals.enabled); defaults flip in Phase 3."
+```

--- a/plans/skills-prompt-budget-and-nudge-phase-3-checklist.md
+++ b/plans/skills-prompt-budget-and-nudge-phase-3-checklist.md
@@ -1,0 +1,14 @@
+# Phase 3 Wrap-up Checklist
+
+After at least one minor version of dogfooding with `skills.index_v2: true` and
+`skills.nudge_signals.enabled: true` set in personal configs:
+
+- [ ] Flip default of `skills.index_v2` to `true` in `cli-config.yaml.example`
+- [ ] Flip default of `skills.nudge_signals.enabled` to `true` in `cli-config.yaml.example`
+- [ ] Bump default of `skills.creation_nudge_interval` from `15` to `50`
+- [ ] Update README / docs / website skills section to reference v2 rendering
+- [ ] Add TUI parity: `/skills nudge off|on` in `ui-tui/src/app/slash/commands/ops.ts`
+- [ ] Add gateway parity: same intercept in the gateway slash dispatcher
+- [ ] After one minor version with v2 default, remove the v1 rendering path
+  (`_render_v1` in `agent/prompt_builder.py`) and the `index_v2` flag plumbing
+  entirely as Phase 4 cleanup.

--- a/plans/skills-prompt-budget-and-nudge-redesign.md
+++ b/plans/skills-prompt-budget-and-nudge-redesign.md
@@ -1,0 +1,392 @@
+# Skills Prompt Budget & Nudge Redesign
+
+Status: Draft
+Date: 2026-05-08
+Scope: `agent/skill_inventory.py` (new), `agent/prompt_builder.py`, `tools/skills_tool.py`, `tools/skill_manager_tool.py`, `run_agent.py`, `hermes_cli/config.py`, `cli-config.yaml.example`, slash-command dispatchers
+
+---
+
+## 1. Background
+
+Hermes injects every available skill into the system prompt on every turn. Concretely:
+
+- `agent/prompt_builder.py:621-847` `build_skills_system_prompt()` walks `~/.hermes/skills/` plus `external_dirs`, filters by platform / tool conditions / disabled list, and emits a `## Skills (mandatory)` block listing **every visible skill's `(name, description)`**.
+- On this machine: 102 skills, average description 194 chars, total ~20k chars of description text alone. With category labels and the multi-paragraph framing preamble the block is **~6-8k tokens injected every turn**.
+- The block is cached at two layers (in-process LRU + on-disk snapshot keyed by mtime/size manifest), so the *build* cost is amortized — but the *prompt token* cost is paid on every API call. Anthropic-side prompt caching helps within a session, but the system prompt is rebuilt whenever `available_tools` / `available_toolsets` / disabled list / platform changes, and the block is large enough to dominate other system content.
+
+Separately, a **time-based nudge** at `run_agent.py:1607-1611, 9295-9299, 12176-12182` increments a per-iteration counter (`_iters_since_skill`) and triggers a background "skill review" when the counter reaches `creation_nudge_interval` (configured default `15`, constructor fallback `10`). The counter resets only when `skill_manage` is actually invoked.
+
+Two problems flow from this:
+
+1. **Prompt bloat (A).** Skill index grows linearly with the user's skill library. There is no token budget, no relevance filter, no priority tier — only "show / don't show." A user accumulating 200-500 skills (plausible after a year of use) would pay 12-40k tokens of system prompt overhead per turn.
+2. **Nudge false positives (B).** The trigger is purely a tool-call counter. A long task that involves many tool calls but no reusable pattern (e.g., a large refactor, a debugging session) is treated identically to a task that just demonstrated a fresh, reusable workflow. The result is a background skill-review task firing in cases where there's nothing worth saving, wasting model cycles and producing low-signal suggestions.
+
+This document proposes a redesign of both.
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+- **G1.** Cut the per-turn skill-index injection cost by ~70% in typical libraries (~2k tokens for 100 skills, scaling sub-linearly).
+- **G2.** Preserve the ability for the model to discover and use any skill — no skill becomes "invisible" by default.
+- **G3.** Preserve Anthropic-side prompt caching: the skill block must remain stable across turns within a session, i.e. it must NOT depend on user message content.
+- **G4.** Replace the time-based nudge with signal-based triggers that fire only when there's evidence of a reusable pattern, while keeping a conservative time-based fallback.
+- **G5.** Backward compatible: existing skills continue to work without metadata changes; new behavior is opt-in via frontmatter and config.
+
+### Non-Goals
+
+- **NG1.** Functional-overlap detection between skills (e.g., warning that two skills do similar things). Out of scope; defer to a follow-up.
+- **NG2.** Embedding-based or LLM-based relevance ranking of skills against the user's message. Breaks G3 (prompt caching) and adds infrastructure cost. Defer.
+- **NG3.** Changes to skill *content* loading (`skill_view`). Only the index and creation-nudge are in scope.
+
+---
+
+## 3. High-Level Design
+
+### A. Two-tier skill index
+
+When `skills.index_v2: true`, the system prompt switches from "every skill with full description" to a **structural index** organized by category, with descriptions reserved for skills the model explicitly opts into.
+
+- **Tier 1 (always in system prompt, cache-stable):**
+  - Category name + optional category description (already supported via `DESCRIPTION.md`).
+  - Skill names within each category, comma-separated.
+  - **Exception:** skills with frontmatter `priority: critical` keep their full description in Tier 1. Reserved for cross-cutting workflow skills the model should always be aware of (e.g., `verification-before-completion`, `systematic-debugging`).
+- **Tier 2 (on-demand):**
+  - A new tool, `skill_describe`, registered in `tools/skills_tool.py` alongside `skills_list` / `skill_view`, returns descriptions for one or more skills (or all skills in a category). The model calls this when a Tier 1 entry looks relevant and it wants the description before deciding whether to `skill_view` the full content.
+- **Hard budget (safety net):**
+  - The Tier 1 block has a configurable token budget (default `2000` tokens, conservative). If the rendered block would exceed it (e.g., a user with 1000+ skills), categories beyond the budget are folded into a single line: `… and N more categories — call skill_describe(category=...) to expand`. Categories are ranked for inclusion by recent usage (see §6).
+
+### B. Signal-based nudge
+
+The time-based counter is **demoted to a fallback** with a higher default threshold. Primary triggers become **signals** observed during the turn:
+
+- **S1. Repeated tool pattern.** The same tool name with structurally similar arguments invoked ≥3 times in the current turn. (Heuristic: same tool, same first argument token, varying suffixes — strongly suggests an extractable workflow.)
+- **S2. Novel external CLI.** A `terminal` / `process` invocation introduces a CLI binary not seen in the last 30 days of session history. (Suggests a new tool worth documenting.)
+- **S3. Explicit user signal.** The current user message contains phrases like "next time", "remember", "from now on", "记一下", "下次", "以后" (configurable list). (Direct user request to remember.)
+- **S4. Resolved repeated error.** The same error string appears in tool results ≥2 times within the turn, then a subsequent call succeeds. (A pitfall worth recording.)
+
+Signal evaluation runs in the same place the counter is incremented today (`run_agent.py:9295-9299`), and feeds a `_skill_nudge_signals` set that, if non-empty at end-of-turn, triggers the background review. The existing time counter remains but its default rises to `50` and acts only when no signal has fired for that many iterations.
+
+A per-session disable (`/skills nudge off` slash command, plus `HERMES_SKILL_NUDGE_DISABLE=1` env var) is added.
+
+---
+
+## 4. Detailed Design — Skill Index
+
+### 4.1 Frontmatter additions
+
+Skills opt into Tier 1 description retention via SKILL.md frontmatter:
+
+```yaml
+---
+name: verification-before-completion
+description: Run verification commands before claiming completion …
+priority: critical    # NEW. One of: "critical" | "normal" (default).
+---
+```
+
+`priority: critical` is the only new field. Anything else (or absent) is treated as `normal`.
+
+### 4.2 Render format
+
+**Current** (`build_skills_system_prompt()` output, abbreviated):
+
+```
+## Skills (mandatory)
+Before replying, scan the skills below … [multi-paragraph preamble]
+
+<available_skills>
+  apple/  Apple ecosystem integrations
+    - apple-reminders: Manage Apple Reminders via remindctl CLI (list, add, complete, delete).
+    - imessage: Send and receive iMessages/SMS via the imsg CLI on macOS.
+    - findmy: Track Apple devices and AirTags via FindMy.app on macOS using AppleScript and screen capture.
+    [… 99 more entries with full descriptions …]
+</available_skills>
+```
+
+**New** (Tier 1):
+
+```
+## Skills
+
+Tools available:
+  - skill_view(name): load full skill content
+  - skill_describe(category=..., names=[...]): get one-line descriptions for a category or specific skills
+  - skill_manage: create / patch / write_file
+
+The list below shows every available skill organized by category. Skills with descriptions are critical workflows you should consider on every task. For other skills, the name is a hint — if any look relevant, call skill_describe(category="<cat>") to see one-line descriptions, then skill_view(name) to load the full content.
+
+<available_skills>
+  apple/  Apple ecosystem integrations
+    apple-reminders, imessage, findmy, apple-notes
+  research/  Academic and information retrieval
+    arxiv, llm-wiki, research-paper-writing, polymarket
+  superpowers/  Workflow disciplines
+    - verification-before-completion: Run verification commands before claiming completion, fixed, or passing — evidence before assertions always.
+    - systematic-debugging: Use when encountering any bug, test failure, or unexpected behavior, before proposing fixes.
+    [other superpowers names without descriptions]
+  [...]
+</available_skills>
+```
+
+Token comparison on this machine (102 skills):
+
+| Component                 | Current  | New      |
+|---------------------------|----------|----------|
+| Preamble                  | ~250 tok | ~150 tok |
+| Per-skill (96 normal)     | ~5500 tok | ~600 tok |
+| Per-skill (6 critical)    | ~360 tok | ~360 tok |
+| Category labels           | ~200 tok | ~200 tok |
+| **Total**                 | ~6300 tok | ~1300 tok |
+
+Reduction: ~80% in this configuration.
+
+### 4.3 The `skill_describe` tool
+
+New tool registered alongside `skill_view` / `skill_manage`. Signature:
+
+```python
+skill_describe(
+    category: str | None = None,    # return all skills in this category
+    names: list[str] | None = None, # return specific skills
+) -> dict
+```
+
+Output: `{"success": true, "skills": [{"name": "...", "category": "...", "description": "..."}, ...]}`. Errors on unknown category/name and when both args are empty.
+
+Backed by a shared skill-inventory helper extracted from `agent/prompt_builder.py`, not by the rendered prompt-string LRU directly. The helper returns filtered metadata (`name`, `category`, `description`, `priority`, conditions) for both `build_skills_system_prompt()` and `skill_describe()`. Local skills continue to use the disk snapshot; external dirs follow the current behavior and are scanned directly so read-only shared skill directories do not become stale. The tool may memoize category/name lookups per process, but it must invalidate when `clear_skills_system_prompt_cache(clear_snapshot=True)` is called.
+
+### 4.4 Budget enforcement
+
+`skills.index_token_budget` config option (default `2000`). Token estimation via simple `len(text) // 4` heuristic — exact tokenization is unnecessary for a soft cap, and avoiding a tokenizer dependency keeps `prompt_builder.py` lightweight.
+
+Algorithm:
+
+1. Build the full Tier 1 block.
+2. If under budget, emit as-is.
+3. If over, rank categories by **recent usage** (last 30 turns, tracked in a small JSON file at `~/.hermes/.skill_usage.json`, updated whenever `skill_view` / `skill_describe` is called). Most-used categories first. "Category" matches the existing derivation at `agent/prompt_builder.py:730-733`: the path components between `skills_dir` and the SKILL.md file, joined with `/`, defaulting to `general`.
+4. Greedily include categories until adding the next would exceed budget. Emit the rest as `… and N more categories: <comma-list of category names>. Call skill_describe(category=...) to expand any of these.`
+
+This guarantees the fold-back text always names the hidden categories so the model can still pull them deliberately.
+
+### 4.5 Cache key changes
+
+Existing cache key in `build_skills_system_prompt()`:
+
+```python
+cache_key = (
+    str(skills_dir.resolve()),
+    tuple(str(d) for d in external_dirs),
+    tuple(sorted(str(t) for t in (available_tools or set()))),
+    tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
+    _platform_hint,
+    tuple(sorted(disabled)),
+)
+```
+
+Add: `("v2", index_v2_enabled, token_budget, usage_rank_epoch)`. The `v2` literal and `_SKILLS_SNAPSHOT_VERSION = 2` force invalidation of stale in-process and on-disk snapshots after the upgrade. `usage_rank_epoch` is a day-level key derived from the usage file only when v2 budget folding is enabled; it keeps the prompt stable within a session and avoids rebuilding on every `skill_view` / `skill_describe` call.
+
+Do not put rendered `skill_describe` results into `_SKILLS_PROMPT_CACHE`; that cache stores prompt strings. Share the parsed inventory instead.
+
+### 4.6 Backward compatibility
+
+- Existing skills with no `priority` field render as `normal`. No migration needed.
+- `external_dirs` skills follow the same rules.
+- Old on-disk snapshots are invalidated by the `v2` cache key prefix.
+- The disabled-list behavior (`get_disabled_skill_names()`) is unchanged.
+- The existing `_skill_should_show()` filtering (`requires_tools`, `fallback_for_tools`, etc.) still applies before tier assignment.
+
+---
+
+## 5. Detailed Design — Signal-Based Nudge
+
+### 5.1 Signal evaluation
+
+A new `_evaluate_skill_nudge_signals()` method runs per iteration alongside the existing counter increment in `run_agent.py:9295-9299`. It returns a set of fired signal names.
+
+State held on the run-agent instance:
+
+```python
+self._tool_call_history: deque  # last 10 (tool_name, arg_signature) pairs
+self._error_history: deque      # last 10 error-message hashes
+self._known_clis: set           # CLIs seen in the last 30 days, loaded from ~/.hermes/.skill_known_clis.json
+self._nudge_signals: set        # accumulated signals for current turn
+```
+
+**S1 (repeated pattern):** for each new tool call, append `(name, arg_signature)` to `_tool_call_history`. The signature is a small per-tool function:
+
+- `terminal` / `process`: first whitespace-delimited token of the command (`gh`, `npm`, `git subcommand`, …).
+- `read_file` / `write_file` / `edit_file`: directory portion of the path.
+- known web/search tools: host or query prefix when available.
+- unknown tools: do not fire S1 until a tool-specific signature is added. Counting only the tool name would make any three calls to the same tool look reusable even when the arguments are unrelated.
+
+Trigger if any `(name, sig)` pair has count ≥3 in the deque.
+
+**S2 (novel CLI):** when the tool is `terminal` or `process`, parse the first whitespace-delimited token from the command, strip path. Record every observed CLI, but fire only when the CLI is not in `_known_clis`, not in a small default suppression list (`git`, `python`, `python3`, `node`, `npm`, `pnpm`, `uv`, `pytest`, `rg`, `sed`, `cat`, `ls`, `mkdir`), and the invocation succeeds or repeats in the same turn. The `_known_clis` file is rotated daily (entries older than 30 days drop off). This avoids treating first-run common developer commands as skill-worthy.
+
+**S3 (explicit user signal):** runs once per turn at start, scans `original_user_message` for trigger phrases. Phrase list is configurable; default in `cli-config.yaml.example` includes EN/ZH variants.
+
+**S4 (resolved repeated error):** for each tool result, hash the first 200 chars of the error string (if any). If a hash appears ≥2 times then a later call with the same tool succeeds, fire signal.
+
+### 5.2 Trigger gating
+
+End-of-turn block at `run_agent.py:12176-12204` changes from:
+
+```python
+if (self._skill_nudge_interval > 0
+        and self._iters_since_skill >= self._skill_nudge_interval
+        and "skill_manage" in self.valid_tool_names):
+    _should_review_skills = True
+    self._iters_since_skill = 0
+```
+
+to:
+
+```python
+if "skill_manage" not in self.valid_tool_names:
+    pass  # tool not available
+elif self._nudge_disabled:
+    pass  # session-disabled
+elif self._nudge_signals:
+    _should_review_skills = True
+    self._nudge_signals.clear()
+    self._iters_since_skill = 0
+elif (self._skill_nudge_interval > 0
+        and self._iters_since_skill >= self._skill_nudge_interval):
+    _should_review_skills = True
+    self._iters_since_skill = 0
+```
+
+The default `creation_nudge_interval` is bumped from `15` to `50` as part of Phase 3 (see §7) — Phase 1-2 keep the existing default to limit blast radius.
+
+### 5.3 Per-session disable
+
+- Slash command `/skills nudge off` sets `self._nudge_disabled = True` on the active agent/session. The existing `hermes_cli.skills_hub.handle_skills_slash()` is a hub command router and does not receive an `AIAgent`; implement this as a special case in the CLI / TUI / gateway slash dispatch layer before delegating other `/skills ...` commands to the hub router.
+- Env var `HERMES_SKILL_NUDGE_DISABLE=1` read at session init.
+- Both are session-scoped; not persisted.
+
+### 5.4 Background review unchanged
+
+Once `_should_review_skills` is true, the existing `_spawn_background_review()` path runs as today. The background reviewer receives the fired signals as additional context (so it can write a more targeted suggestion: "you re-ran `gh pr view` 4 times — consider a skill that wraps PR-status checks").
+
+---
+
+## 6. Data Files & Config
+
+New files:
+
+- `~/.hermes/.skill_usage.json` — `{category_name: [unix_ts, unix_ts, ...]}`, last 30 entries per category. Used by §4.4.
+- `~/.hermes/.skill_known_clis.json` — `{cli_name: last_seen_unix_ts}`. Used by §5.1 S2. Pruned on read (drop entries > 30 days old).
+
+Both are best-effort — corruption falls back to empty state, never crashes.
+
+Config additions to `cli-config.yaml.example`:
+
+```yaml
+skills:
+  # Existing
+  creation_nudge_interval: 15      # Phase 1-2: unchanged. Phase 3 changes this to 50.
+
+  # NEW
+  index_v2: false                  # Phase 1-2 opt-in. Phase 3 flips to true.
+  index_token_budget: 2000         # Soft cap on Tier 1 system-prompt skill block.
+  nudge_signals:
+    enabled: false                 # Phase 1-2 opt-in. Phase 3 flips to true.
+    repeated_pattern_threshold: 3  # S1
+    novel_cli_window_days: 30      # S2
+    common_cli_suppressions:       # S2
+      - git
+      - python
+      - python3
+      - node
+      - npm
+      - pnpm
+      - uv
+      - pytest
+      - rg
+      - sed
+      - cat
+      - ls
+      - mkdir
+    user_phrases:                  # S3
+      - "next time"
+      - "remember"
+      - "from now on"
+      - "记一下"
+      - "下次"
+      - "以后"
+    error_repeat_threshold: 2      # S4
+```
+
+---
+
+## 7. Migration & Rollout
+
+1. **Phase 1 (this PR): index redesign behind flag.** New rendering path lives behind `skills.index_v2: true` in config. Default `false` until validated.
+2. **Phase 2 (this PR): nudge redesign behind flag.** `skills.nudge_signals.enabled` default `false`; manual opt-in.
+3. **Phase 3 (follow-up PR, after dogfooding):** flip both defaults to `true`. Update `creation_nudge_interval` default to `50`.
+4. **Phase 4:** remove the v1 rendering path and the flag plumbing once the v2 path has been default for one minor version.
+
+---
+
+## 8. Testing Strategy
+
+### 8.1 Unit tests (`tests/agent/test_prompt_builder.py`)
+
+- Tier 1 rendering with mix of `priority: critical` and `normal` skills produces expected output.
+- Budget enforcement: synthetic 500-skill dir produces a block under the budget with fold-back line listing remaining categories.
+- Cache key invalidates correctly on `priority` flip / budget change / category usage shift.
+- Backward compat: skills without `priority` field render under `normal`.
+
+### 8.2 Unit tests (`tests/run_agent/test_run_agent.py`)
+
+- Each signal (S1-S4) fires correctly given a synthetic tool-call sequence.
+- No false positive when a tool runs once.
+- Fallback time counter still triggers when no signal fired for `creation_nudge_interval` iterations.
+- Per-session disable suppresses both signal and time triggers.
+
+### 8.3 Unit tests (`tests/tools/test_skills_tool.py` or new adjacent file)
+
+- `skill_describe` tool returns expected output for category and name lookups.
+- `skill_describe` errors on unknown categories/names and on empty input.
+- `skill_view` / `skill_describe` both update `.skill_usage.json` best-effort without failing the tool call when the file is corrupt or unwritable.
+
+### 8.4 Integration test
+
+- End-to-end: synthetic 100-skill dir, run a 10-turn session, assert the system prompt block stays under budget across all turns and that no skill is permanently invisible (each can be reached via `skill_describe`).
+
+### 8.5 Manual dogfooding checklist (Phase 1-2)
+
+- Run a normal coding session with v2 on, confirm prompt size in logs.
+- Force each signal (run a repeated tool, invoke a fresh CLI, type "next time", trigger and resolve a repeated error) and confirm review fires.
+- Run a long task with 60+ tool calls and confirm time fallback eventually fires when no signal hits.
+
+---
+
+## 9. Risks & Open Questions
+
+### Risks
+
+- **R1. Model-behavior regression.** Without descriptions for most skills, the model may fail to recognize a relevant skill from its name alone, leading to missed loads. **Mitigation:** category descriptions remain visible; `skill_describe` is one cheap call away; `priority: critical` covers the most universally-applicable skills.
+- **R2. Extra round-trip.** A task that needs a non-critical skill now costs at least one `skill_describe` call before the `skill_view`. **Mitigation:** `skill_describe(category=...)` returns a whole category at once, amortizing over multiple decisions in the same task.
+- **R3. Signal heuristics noise.** Especially S2 (novel CLI) — a developer who runs many one-off tools could see every one of them flagged. **Mitigation:** suppress common CLIs by default, require success or same-turn repetition for novel CLIs, and keep the review as a background suggestion rather than an action. If suggestions are too noisy, the threshold, suppression list, or window is tunable.
+- **R4. Snapshot file corruption.** `.skill_usage.json` / `.skill_known_clis.json` corruption could disable parts of the system. **Mitigation:** read-with-fallback-to-empty, no hard dependency.
+
+### Open Questions
+
+- **Q1.** Should `priority: critical` be limited to a small allowlist (say ≤10 skills) to prevent it from becoming the new default and undoing the savings? Proposal: log a warning at index-build time if more than 15 skills are marked `critical`.
+- **Q2.** Should `skill_describe(category=...)` results be cached on the agent side for the rest of the session (so the model doesn't repeat the call)? Proposal: yes, simple per-session memo on the tool's own state.
+- **Q3.** Should the nudge surface its triggering signal to the user (e.g., "I noticed you ran `gh pr view` 4 times — want me to save a skill?") or stay fully internal? Proposal: surface, with the trigger reason, since transparency reduces user friction with the nudge.
+
+---
+
+## 10. References
+
+- Current implementation: `agent/prompt_builder.py:621-847`
+- Nudge counter: `run_agent.py:1607-1611, 9295-9299, 12176-12204`
+- Existing skill tool registration: `tools/skills_tool.py:1392-1445`
+- Existing `/skills` hub router: `hermes_cli/skills_hub.py:1172-1383`
+- Skill creation / collision check: `tools/skill_manager_tool.py:326-379`
+- Existing config keys: `cli-config.yaml.example:480-500` (skills section)

--- a/run_agent.py
+++ b/run_agent.py
@@ -750,6 +750,35 @@ class AIAgent:
         self._base_url_lower = value.lower() if value else ""
         self._base_url_hostname = base_url_hostname(value)
 
+    _DEFAULT_NUDGE_USER_PHRASES = ["next time", "remember", "from now on", "记一下", "下次", "以后"]
+    _DEFAULT_NUDGE_COMMON_CLIS = [
+        "git", "python", "python3", "node", "npm", "pnpm",
+        "uv", "pytest", "rg", "sed", "cat", "ls", "mkdir",
+    ]
+
+    def _init_nudge_state(self, agent_cfg: dict) -> None:
+        from collections import deque
+
+        self._nudge_disabled = False
+        self._nudge_signals: set[str] = set()
+        self._tool_call_history = deque(maxlen=10)
+        self._error_history = deque(maxlen=10)
+        self._last_error_tool: dict[str, str] = {}
+
+        skills_cfg = (agent_cfg or {}).get("skills", {}) or {}
+        ns = skills_cfg.get("nudge_signals", {}) or {}
+        self._nudge_signals_enabled = bool(ns.get("enabled", False))
+        self._nudge_repeated_threshold = int(ns.get("repeated_pattern_threshold", 3))
+        self._nudge_error_threshold = int(ns.get("error_repeat_threshold", 2))
+        self._nudge_cli_window_days = int(ns.get("novel_cli_window_days", 30))
+        self._nudge_common_clis_suppressed = list(
+            ns.get("common_cli_suppressions", self._DEFAULT_NUDGE_COMMON_CLIS)
+        )
+        self._nudge_user_phrases = list(ns.get("user_phrases", self._DEFAULT_NUDGE_USER_PHRASES))
+
+        if os.environ.get("HERMES_SKILL_NUDGE_DISABLE") == "1":
+            self._nudge_disabled = True
+
     def __init__(
         self,
         base_url: str = None,
@@ -1615,6 +1644,7 @@ class AIAgent:
             self._skill_index_token_budget = int(skills_config.get("index_token_budget", 2000))
         except Exception:
             pass
+        self._init_nudge_state(_agent_cfg)
 
         # Tool-use enforcement config: "auto" (default — matches hardcoded
         # model list), true (always), false (never), or list of substrings.

--- a/run_agent.py
+++ b/run_agent.py
@@ -779,6 +779,37 @@ class AIAgent:
         if os.environ.get("HERMES_SKILL_NUDGE_DISABLE") == "1":
             self._nudge_disabled = True
 
+        from agent.skill_nudge_signals import SignalEvaluator
+        self._signal_evaluator = SignalEvaluator(
+            repeated_threshold=self._nudge_repeated_threshold,
+            error_threshold=self._nudge_error_threshold,
+            common_clis_suppressed=self._nudge_common_clis_suppressed,
+            cli_window_days=self._nudge_cli_window_days,
+            user_phrases=self._nudge_user_phrases,
+        )
+
+    def _observe_tool_activity(
+        self,
+        tool_name: str,
+        arguments: dict | None,
+        result_content: str | None,
+    ) -> None:
+        """Feed one completed tool call/result into the skill nudge evaluator."""
+        if not getattr(self, "_nudge_signals_enabled", False):
+            return
+        if getattr(self, "_nudge_disabled", False):
+            return
+        ev = getattr(self, "_signal_evaluator", None)
+        if ev is None:
+            return
+        try:
+            content = str(result_content) if result_content is not None else ""
+            is_error, _ = _detect_tool_failure(tool_name, content)
+            ev.observe_tool_call(tool_name, arguments or {}, success=not is_error)
+            ev.observe_tool_result(tool_name, error_text=content if is_error else None)
+        except Exception as exc:
+            logger.debug("Signal evaluator failed for tool=%s: %s", tool_name, exc)
+
     def __init__(
         self,
         base_url: str = None,
@@ -8331,6 +8362,12 @@ class AIAgent:
             if subdir_hints:
                 function_result += subdir_hints
 
+            self._observe_tool_activity(
+                tool_name=name,
+                arguments=args,
+                result_content=function_result,
+            )
+
             tool_msg = {
                 "role": "tool",
                 "content": function_result,
@@ -8691,6 +8728,12 @@ class AIAgent:
             if subdir_hints:
                 function_result += subdir_hints
 
+            self._observe_tool_activity(
+                tool_name=function_name,
+                arguments=function_args,
+                result_content=function_result,
+            )
+
             tool_msg = {
                 "role": "tool",
                 "content": function_result,
@@ -9044,6 +9087,11 @@ class AIAgent:
 
         # Preserve the original user message (no nudge injection).
         original_user_message = persist_user_message if persist_user_message is not None else user_message
+        if self._nudge_signals_enabled and not self._nudge_disabled:
+            try:
+                self._signal_evaluator.observe_user_message(original_user_message or "")
+            except Exception as exc:
+                logger.debug("Signal evaluator (user msg) failed: %s", exc)
 
         # Track memory nudge trigger (turn-based, checked here).
         # Skill trigger is checked AFTER the agent loop completes, based on

--- a/run_agent.py
+++ b/run_agent.py
@@ -810,6 +810,29 @@ class AIAgent:
         except Exception as exc:
             logger.debug("Signal evaluator failed for tool=%s: %s", tool_name, exc)
 
+    def _compute_should_review_skills(self) -> tuple[bool, set[str]]:
+        """Return whether skill review should run and which nudge signals fired."""
+        if "skill_manage" not in self.valid_tool_names:
+            return False, set()
+        if getattr(self, "_nudge_disabled", False):
+            return False, set()
+
+        ev = getattr(self, "_signal_evaluator", None)
+        if getattr(self, "_nudge_signals_enabled", False) and ev is not None and ev.fired_signals:
+            signals = set(ev.fired_signals)
+            ev.clear()
+            self._iters_since_skill = 0
+            return True, signals
+
+        if (
+            self._skill_nudge_interval > 0
+            and self._iters_since_skill >= self._skill_nudge_interval
+        ):
+            self._iters_since_skill = 0
+            return True, set()
+
+        return False, set()
+
     def __init__(
         self,
         base_url: str = None,
@@ -3081,6 +3104,7 @@ class AIAgent:
         messages_snapshot: List[Dict],
         review_memory: bool = False,
         review_skills: bool = False,
+        triggered_signals: set[str] | None = None,
     ) -> None:
         """Spawn a background thread to review the conversation for memory/skill saves.
 
@@ -3093,11 +3117,21 @@ class AIAgent:
 
         # Pick the right prompt based on which triggers fired
         if review_memory and review_skills:
-            prompt = self._COMBINED_REVIEW_PROMPT
+            base_prompt = self._COMBINED_REVIEW_PROMPT
         elif review_memory:
-            prompt = self._MEMORY_REVIEW_PROMPT
+            base_prompt = self._MEMORY_REVIEW_PROMPT
         else:
-            prompt = self._SKILL_REVIEW_PROMPT
+            base_prompt = self._SKILL_REVIEW_PROMPT
+
+        if review_skills and triggered_signals:
+            prompt = (
+                base_prompt
+                + "\n\nThe following nudge signals fired this turn: "
+                + ", ".join(sorted(triggered_signals))
+                + ". Consider whether they suggest a reusable skill."
+            )
+        else:
+            prompt = base_prompt
 
         def _run_review():
             import contextlib
@@ -12257,13 +12291,8 @@ class AIAgent:
         # Clear stream callback so it doesn't leak into future calls
         self._stream_callback = None
 
-        # Check skill trigger NOW — based on how many tool iterations THIS turn used.
-        _should_review_skills = False
-        if (self._skill_nudge_interval > 0
-                and self._iters_since_skill >= self._skill_nudge_interval
-                and "skill_manage" in self.valid_tool_names):
-            _should_review_skills = True
-            self._iters_since_skill = 0
+        # Check skill trigger NOW — signal-first, with time as a fallback.
+        _should_review_skills, _triggered_skill_signals = self._compute_should_review_skills()
 
         # External memory provider: sync the completed turn + queue next prefetch.
         # Use original_user_message (clean input) — user_message may contain
@@ -12283,6 +12312,7 @@ class AIAgent:
                     messages_snapshot=list(messages),
                     review_memory=_should_review_memory,
                     review_skills=_should_review_skills,
+                    triggered_signals=_triggered_skill_signals,
                 )
             except Exception:
                 pass  # Background review is best-effort

--- a/run_agent.py
+++ b/run_agent.py
@@ -1604,11 +1604,15 @@ class AIAgent:
                     self.valid_tool_names.add(_tname)
                     _existing_tool_names.add(_tname)
 
-        # Skills config: nudge interval for skill creation reminders
+        # Skills config: nudge interval and skill-index rendering flags
         self._skill_nudge_interval = 10
+        self._skill_index_v2 = False
+        self._skill_index_token_budget = 2000
         try:
             skills_config = _agent_cfg.get("skills", {})
             self._skill_nudge_interval = int(skills_config.get("creation_nudge_interval", 10))
+            self._skill_index_v2 = bool(skills_config.get("index_v2", False))
+            self._skill_index_token_budget = int(skills_config.get("index_token_budget", 2000))
         except Exception:
             pass
 
@@ -4287,6 +4291,8 @@ class AIAgent:
             skills_prompt = build_skills_system_prompt(
                 available_tools=self.valid_tool_names,
                 available_toolsets=avail_toolsets,
+                index_v2=self._skill_index_v2,
+                index_token_budget=self._skill_index_token_budget,
             )
         else:
             skills_prompt = ""

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -428,6 +428,56 @@ class TestBuildSkillsSystemPrompt:
         result = build_skills_system_prompt()
         assert "backend-skill" in result
 
+    def test_build_skills_system_prompt_v2_flag_changes_render(self, tmp_path, monkeypatch):
+        skills_dir = tmp_path / "skills"
+        (skills_dir / "cat" / "alpha").mkdir(parents=True)
+        (skills_dir / "cat" / "alpha" / "SKILL.md").write_text(
+            "---\nname: alpha\ndescription: A description of alpha\n---\nbody\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("agent.skill_inventory.get_skills_dir", lambda: skills_dir)
+        monkeypatch.setattr("agent.skill_inventory.get_all_skills_dirs", lambda: [skills_dir])
+        from agent.skill_inventory import clear_inventory_cache
+
+        clear_inventory_cache(clear_snapshot=True)
+        v1 = build_skills_system_prompt()
+        v2 = build_skills_system_prompt(index_v2=True)
+        assert "A description of alpha" in v1
+        assert "## Skills" in v2
+        assert "skill_describe" in v2
+
+    def test_v2_renders_critical_with_description_normal_without(self, tmp_path, monkeypatch):
+        skills_dir = tmp_path / "skills"
+
+        def make_skill(name, description, *, category="cat", priority=None):
+            skill_dir = skills_dir / category / name
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            frontmatter = ["---", f"name: {name}", f"description: {description}"]
+            if priority:
+                frontmatter.append(f"priority: {priority}")
+            frontmatter.append("---")
+            (skill_dir / "SKILL.md").write_text(
+                "\n".join(frontmatter) + "\nbody\n",
+                encoding="utf-8",
+            )
+
+        make_skill("alpha", "Alpha desc", category="cat-a", priority="critical")
+        make_skill("beta", "Beta desc", category="cat-a")
+        make_skill("gamma", "Gamma desc", category="cat-b")
+        monkeypatch.setattr("agent.skill_inventory.get_skills_dir", lambda: skills_dir)
+        monkeypatch.setattr("agent.skill_inventory.get_all_skills_dirs", lambda: [skills_dir])
+        from agent.skill_inventory import clear_inventory_cache
+
+        clear_inventory_cache(clear_snapshot=True)
+        out = build_skills_system_prompt(index_v2=True)
+
+        assert "alpha: Alpha desc" in out
+        assert "Beta desc" not in out
+        assert "Gamma desc" not in out
+        assert "beta" in out and "gamma" in out
+        assert "cat-a" in out and "cat-b" in out
+        assert "skill_describe" in out
+
 
 class TestBuildNousSubscriptionPrompt:
     def test_includes_active_subscription_features(self, monkeypatch):
@@ -1086,6 +1136,5 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -478,6 +478,47 @@ class TestBuildSkillsSystemPrompt:
         assert "cat-a" in out and "cat-b" in out
         assert "skill_describe" in out
 
+    def test_v2_budget_folds_least_used_categories(self, tmp_path, monkeypatch):
+        skills_dir = tmp_path / "skills"
+        for category_index in range(20):
+            for skill_index in range(10):
+                skill_dir = (
+                    skills_dir
+                    / f"cat-{category_index:02d}"
+                    / f"skill-{category_index:02d}-{skill_index:02d}"
+                )
+                skill_dir.mkdir(parents=True, exist_ok=True)
+                (skill_dir / "SKILL.md").write_text(
+                    f"---\nname: skill-{category_index:02d}-{skill_index:02d}\n"
+                    "description: desc\n---\nbody\n",
+                    encoding="utf-8",
+                )
+        monkeypatch.setattr("agent.skill_inventory.get_skills_dir", lambda: skills_dir)
+        monkeypatch.setattr("agent.skill_inventory.get_all_skills_dirs", lambda: [skills_dir])
+        from agent.skill_inventory import clear_inventory_cache
+
+        clear_inventory_cache(clear_snapshot=True)
+        out = build_skills_system_prompt(index_v2=True, index_token_budget=300)
+        assert "more categories" in out
+        assert "skill_describe" in out
+
+    def test_v2_under_budget_renders_full(self, tmp_path, monkeypatch):
+        skills_dir = tmp_path / "skills"
+        for index in range(3):
+            skill_dir = skills_dir / "cat" / f"sk-{index}"
+            skill_dir.mkdir(parents=True, exist_ok=True)
+            (skill_dir / "SKILL.md").write_text(
+                f"---\nname: sk-{index}\ndescription: d\n---\nbody\n",
+                encoding="utf-8",
+            )
+        monkeypatch.setattr("agent.skill_inventory.get_skills_dir", lambda: skills_dir)
+        monkeypatch.setattr("agent.skill_inventory.get_all_skills_dirs", lambda: [skills_dir])
+        from agent.skill_inventory import clear_inventory_cache
+
+        clear_inventory_cache(clear_snapshot=True)
+        out = build_skills_system_prompt(index_v2=True, index_token_budget=2000)
+        assert "more categories" not in out
+
 
 class TestBuildNousSubscriptionPrompt:
     def test_includes_active_subscription_features(self, monkeypatch):
@@ -1136,5 +1177,4 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 

--- a/tests/agent/test_skill_inventory.py
+++ b/tests/agent/test_skill_inventory.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import textwrap
+
+from agent.skill_inventory import SkillEntry, load_inventory
+
+
+def _write_skill(root: Path, name: str, description: str, category: str = ""):
+    skill_dir = root / category / name if category else root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        textwrap.dedent(
+            f"""\
+            ---
+            name: {name}
+            description: {description}
+            ---
+            body
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_load_inventory_returns_skill_entries(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    _write_skill(skills_dir, "alpha", "First skill", category="cat1")
+    _write_skill(skills_dir, "beta", "Second skill", category="cat1")
+
+    monkeypatch.setattr("agent.skill_inventory.get_skills_dir", lambda: skills_dir)
+    monkeypatch.setattr("agent.skill_inventory.get_all_skills_dirs", lambda: [skills_dir])
+
+    inv = load_inventory()
+    names = sorted(e.name for e in inv.entries)
+    assert names == ["alpha", "beta"]
+    assert all(isinstance(e, SkillEntry) for e in inv.entries)
+    assert all(e.category == "cat1" for e in inv.entries)
+    assert {e.description for e in inv.entries} == {"First skill", "Second skill"}
+

--- a/tests/agent/test_skill_nudge_signals.py
+++ b/tests/agent/test_skill_nudge_signals.py
@@ -1,0 +1,69 @@
+import pytest
+
+from agent.skill_nudge_signals import SignalEvaluator
+
+
+@pytest.fixture
+def ev():
+    return SignalEvaluator(
+        repeated_threshold=3,
+        error_threshold=2,
+        common_clis_suppressed=["git", "ls"],
+        cli_window_days=30,
+        user_phrases=["next time", "记一下"],
+    )
+
+
+def test_s1_repeated_terminal_first_token(ev):
+    for _ in range(3):
+        ev.observe_tool_call("terminal", {"command": "gh pr view 123"})
+
+    assert "S1" in ev.fired_signals
+
+
+def test_s1_unknown_tool_does_not_fire(ev):
+    for _ in range(5):
+        ev.observe_tool_call("custom_tool", {"foo": "bar"})
+
+    assert "S1" not in ev.fired_signals
+
+
+def test_s2_novel_cli_fires(ev, monkeypatch):
+    monkeypatch.setattr("agent.skill_usage_tracker.is_known_cli", lambda *a, **kw: False)
+    monkeypatch.setattr("agent.skill_usage_tracker.record_cli_seen", lambda *a, **kw: None)
+
+    ev.observe_tool_call("terminal", {"command": "exotic-cli --do-thing"}, success=True)
+
+    assert "S2" in ev.fired_signals
+
+
+def test_s2_common_cli_suppressed(ev, monkeypatch):
+    monkeypatch.setattr("agent.skill_usage_tracker.is_known_cli", lambda *a, **kw: False)
+    monkeypatch.setattr("agent.skill_usage_tracker.record_cli_seen", lambda *a, **kw: None)
+
+    ev.observe_tool_call("terminal", {"command": "git status"}, success=True)
+
+    assert "S2" not in ev.fired_signals
+
+
+def test_s3_user_phrase_match(ev):
+    ev.observe_user_message("This always crashes, please remember next time")
+
+    assert "S3" in ev.fired_signals
+
+
+def test_s4_resolved_repeated_error(ev):
+    ev.observe_tool_result("terminal", error_text="ENOENT: file 'x' not found")
+    ev.observe_tool_result("terminal", error_text="ENOENT: file 'x' not found")
+    ev.observe_tool_result("terminal", error_text=None)
+
+    assert "S4" in ev.fired_signals
+
+
+def test_clear_resets_state(ev):
+    for _ in range(3):
+        ev.observe_tool_call("terminal", {"command": "gh pr view"})
+
+    assert ev.fired_signals
+    ev.clear()
+    assert not ev.fired_signals

--- a/tests/agent/test_skill_usage_tracker.py
+++ b/tests/agent/test_skill_usage_tracker.py
@@ -1,0 +1,37 @@
+import json
+import time
+
+from agent import skill_usage_tracker as tracker
+
+
+def test_record_and_top_categories(tmp_path, monkeypatch):
+    monkeypatch.setattr(tracker, "_usage_path", lambda: tmp_path / ".skill_usage.json")
+    tracker.record_category_use("cat-a")
+    tracker.record_category_use("cat-a")
+    tracker.record_category_use("cat-b")
+
+    top = tracker.top_categories(within_seconds=3600)
+    assert top[0] == "cat-a"
+    assert "cat-b" in top
+
+
+def test_record_corrupted_file_falls_back(tmp_path, monkeypatch):
+    path = tmp_path / ".skill_usage.json"
+    path.write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(tracker, "_usage_path", lambda: path)
+
+    tracker.record_category_use("cat-a")
+
+    assert "cat-a" in tracker.top_categories()
+
+
+def test_known_clis_pruned_after_window(tmp_path, monkeypatch):
+    path = tmp_path / ".skill_known_clis.json"
+    monkeypatch.setattr(tracker, "_known_clis_path", lambda: path)
+    tracker.record_cli_seen("rg")
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    raw["rg"] = time.time() - (40 * 86400)
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    assert tracker.is_known_cli("rg", window_days=30) is False
+

--- a/tests/cli/test_skills_nudge_slash.py
+++ b/tests/cli/test_skills_nudge_slash.py
@@ -1,0 +1,42 @@
+class _FakeAgent:
+    def __init__(self):
+        self._nudge_disabled = False
+
+
+def test_skills_nudge_off_sets_flag():
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.agent = _FakeAgent()
+
+    cli._handle_skills_command("/skills nudge off")
+
+    assert cli.agent._nudge_disabled is True
+
+
+def test_skills_nudge_on_clears_flag():
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.agent = _FakeAgent()
+    cli.agent._nudge_disabled = True
+
+    cli._handle_skills_command("/skills nudge on")
+
+    assert cli.agent._nudge_disabled is False
+
+
+def test_other_skills_subcommand_delegates_to_hub(monkeypatch):
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.agent = _FakeAgent()
+    called = {}
+
+    def fake_handle(cmd, console):
+        called["cmd"] = cmd
+
+    monkeypatch.setattr("hermes_cli.skills_hub.handle_skills_slash", fake_handle)
+    cli._handle_skills_command("/skills list")
+
+    assert called["cmd"] == "/skills list"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -381,6 +381,19 @@ def _reset_module_state():
     except Exception:
         pass
 
+    # --- agent.skill_inventory + agent.prompt_builder — skill index caches ---
+    # Both modules carry an OrderedDict LRU keyed by (skills_dir, ...).  Because
+    # the per-test HERMES_HOME redirect changes the skills_dir each test, stale
+    # cache entries for past tmp dirs accumulate inside the same xdist worker
+    # and only get evicted when _INVENTORY_CACHE_MAX (8) is exceeded.  Clearing
+    # both up front keeps the cache a per-test resource — matches the way
+    # production behaves on a fresh process.
+    try:
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+        clear_skills_system_prompt_cache()
+    except Exception:
+        pass
+
     yield
 
 

--- a/tests/integration/test_skills_index_v2_e2e.py
+++ b/tests/integration/test_skills_index_v2_e2e.py
@@ -1,0 +1,43 @@
+"""End-to-end coverage for the skills index v2 prompt and skill_describe."""
+
+from pathlib import Path
+
+
+def _seed_skills(skills_dir: Path, n: int = 100, n_categories: int = 10) -> None:
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    for index in range(n):
+        category = f"cat-{index % n_categories:02d}"
+        skill_dir = skills_dir / category / f"skill-{index:03d}"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        priority = "critical" if index < 5 else "normal"
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: skill-{index:03d}\n"
+            f"description: synthetic skill {index}\n"
+            f"priority: {priority}\n---\nbody\n",
+            encoding="utf-8",
+        )
+
+
+def test_v2_budget_and_full_reachability(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    _seed_skills(skills_dir, n=100, n_categories=10)
+    monkeypatch.setattr("agent.skill_inventory.get_skills_dir", lambda: skills_dir)
+    monkeypatch.setattr("agent.skill_inventory.get_all_skills_dirs", lambda: [skills_dir])
+    from agent.skill_inventory import clear_inventory_cache
+
+    clear_inventory_cache(clear_snapshot=True)
+
+    from agent.prompt_builder import build_skills_system_prompt
+
+    prompt = build_skills_system_prompt(index_v2=True, index_token_budget=2000)
+    assert len(prompt) // 4 <= 2200
+
+    for index in range(5):
+        assert f"skill-{index:03d}: synthetic skill {index}" in prompt
+
+    from tools.skills_tool import skill_describe
+
+    for index in range(100):
+        result = skill_describe(names=[f"skill-{index:03d}"])
+        assert result["success"], f"skill-{index:03d} not reachable"
+

--- a/tests/run_agent/test_concurrent_interrupt.py
+++ b/tests/run_agent/test_concurrent_interrupt.py
@@ -72,6 +72,9 @@ def _make_agent(monkeypatch):
         def _has_stream_consumers(self):
             return False
 
+        def _observe_tool_activity(self, *args, **kwargs):
+            pass
+
     stub = _Stub()
     # Bind the real methods under test
     stub._execute_tool_calls_concurrent = _ra.AIAgent._execute_tool_calls_concurrent.__get__(stub)

--- a/tests/run_agent/test_nudge_disable_e2e.py
+++ b/tests/run_agent/test_nudge_disable_e2e.py
@@ -1,0 +1,24 @@
+def test_env_var_disables_nudge_at_init(monkeypatch):
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_SKILL_NUDGE_DISABLE", "1")
+    a = AIAgent.__new__(AIAgent)
+    AIAgent._init_nudge_state(a, {"skills": {"nudge_signals": {"enabled": True}}})
+
+    assert a._nudge_disabled is True
+
+
+def test_disabled_session_blocks_signal_gate():
+    from run_agent import AIAgent
+
+    a = AIAgent.__new__(AIAgent)
+    AIAgent._init_nudge_state(a, {"skills": {"nudge_signals": {"enabled": True}}})
+    a._nudge_disabled = True
+    a.valid_tool_names = {"skill_manage"}
+    a._iters_since_skill = 999
+    a._skill_nudge_interval = 50
+    a._signal_evaluator.fired_signals.add("S1")
+
+    res = AIAgent._compute_should_review_skills(a)
+
+    assert res == (False, set())

--- a/tests/run_agent/test_nudge_end_of_turn_gate.py
+++ b/tests/run_agent/test_nudge_end_of_turn_gate.py
@@ -1,0 +1,66 @@
+def _agent_with_state(**kwargs):
+    from agent.skill_nudge_signals import SignalEvaluator
+    from run_agent import AIAgent
+
+    a = AIAgent.__new__(AIAgent)
+    a.valid_tool_names = {"skill_manage"}
+    a._skill_nudge_interval = kwargs.get("interval", 50)
+    a._iters_since_skill = kwargs.get("iters", 0)
+    a._nudge_disabled = kwargs.get("disabled", False)
+    a._nudge_signals_enabled = kwargs.get("signals_enabled", True)
+    a._signal_evaluator = SignalEvaluator(
+        repeated_threshold=3,
+        error_threshold=2,
+        common_clis_suppressed=[],
+        cli_window_days=30,
+        user_phrases=[],
+    )
+    if kwargs.get("fired"):
+        a._signal_evaluator.fired_signals.update(kwargs["fired"])
+    return a
+
+
+def test_gate_fires_when_signal_present():
+    from run_agent import AIAgent
+
+    a = _agent_with_state(fired={"S1"})
+    res = AIAgent._compute_should_review_skills(a)
+
+    assert res == (True, {"S1"})
+
+
+def test_gate_falls_back_to_time_when_no_signal():
+    from run_agent import AIAgent
+
+    a = _agent_with_state(iters=50, interval=50)
+    res = AIAgent._compute_should_review_skills(a)
+
+    assert res == (True, set())
+
+
+def test_gate_blocked_by_disable():
+    from run_agent import AIAgent
+
+    a = _agent_with_state(fired={"S1"}, disabled=True)
+    res = AIAgent._compute_should_review_skills(a)
+
+    assert res == (False, set())
+
+
+def test_gate_blocked_when_skill_manage_unavailable():
+    from run_agent import AIAgent
+
+    a = _agent_with_state(fired={"S1"})
+    a.valid_tool_names = set()
+    res = AIAgent._compute_should_review_skills(a)
+
+    assert res == (False, set())
+
+
+def test_gate_does_not_fire_disabled_signal_mode_before_fallback():
+    from run_agent import AIAgent
+
+    a = _agent_with_state(fired={"S1"}, signals_enabled=False, iters=2, interval=50)
+    res = AIAgent._compute_should_review_skills(a)
+
+    assert res == (False, set())

--- a/tests/run_agent/test_nudge_signals_init.py
+++ b/tests/run_agent/test_nudge_signals_init.py
@@ -1,0 +1,50 @@
+def test_nudge_state_initialized_with_defaults(monkeypatch):
+    from run_agent import AIAgent
+
+    a = AIAgent.__new__(AIAgent)
+    AIAgent._init_nudge_state(a, {})
+
+    assert a._nudge_disabled is False
+    assert a._nudge_signals == set()
+    assert a._nudge_signals_enabled is False
+    assert a._nudge_repeated_threshold == 3
+    assert a._nudge_error_threshold == 2
+    assert a._nudge_cli_window_days == 30
+    assert a._nudge_user_phrases == ["next time", "remember", "from now on", "记一下", "下次", "以后"]
+    assert "git" in a._nudge_common_clis_suppressed
+
+
+def test_nudge_state_reads_config():
+    from run_agent import AIAgent
+
+    cfg = {
+        "skills": {
+            "nudge_signals": {
+                "enabled": True,
+                "repeated_pattern_threshold": 5,
+                "error_repeat_threshold": 3,
+                "novel_cli_window_days": 14,
+                "common_cli_suppressions": ["bun"],
+                "user_phrases": ["foo"],
+            }
+        }
+    }
+    a = AIAgent.__new__(AIAgent)
+    AIAgent._init_nudge_state(a, cfg)
+
+    assert a._nudge_signals_enabled is True
+    assert a._nudge_repeated_threshold == 5
+    assert a._nudge_error_threshold == 3
+    assert a._nudge_cli_window_days == 14
+    assert a._nudge_common_clis_suppressed == ["bun"]
+    assert a._nudge_user_phrases == ["foo"]
+
+
+def test_nudge_env_var_disables_at_init(monkeypatch):
+    from run_agent import AIAgent
+
+    monkeypatch.setenv("HERMES_SKILL_NUDGE_DISABLE", "1")
+    a = AIAgent.__new__(AIAgent)
+    AIAgent._init_nudge_state(a, {"skills": {"nudge_signals": {"enabled": True}}})
+
+    assert a._nudge_disabled is True

--- a/tests/tools/test_skill_describe.py
+++ b/tests/tools/test_skill_describe.py
@@ -1,0 +1,73 @@
+import textwrap
+
+
+def _setup_skills(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    for category, name, description in [
+        ("cat-a", "alpha", "A description"),
+        ("cat-a", "beta", "B description"),
+        ("cat-b", "gamma", "C description"),
+    ]:
+        skill_dir = skills_dir / category / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(
+            textwrap.dedent(
+                f"""\
+                ---
+                name: {name}
+                description: {description}
+                ---
+                body
+                """
+            ),
+            encoding="utf-8",
+        )
+    monkeypatch.setattr("agent.skill_inventory.get_skills_dir", lambda: skills_dir)
+    monkeypatch.setattr("agent.skill_inventory.get_all_skills_dirs", lambda: [skills_dir])
+    from agent.skill_inventory import clear_inventory_cache
+
+    clear_inventory_cache(clear_snapshot=True)
+
+
+def test_skill_describe_by_category(tmp_path, monkeypatch):
+    _setup_skills(tmp_path, monkeypatch)
+    from tools.skills_tool import skill_describe
+
+    result = skill_describe(category="cat-a")
+    assert result["success"] is True
+    assert sorted(skill["name"] for skill in result["skills"]) == ["alpha", "beta"]
+
+
+def test_skill_describe_by_names(tmp_path, monkeypatch):
+    _setup_skills(tmp_path, monkeypatch)
+    from tools.skills_tool import skill_describe
+
+    result = skill_describe(names=["alpha", "gamma"])
+    assert result["success"] is True
+    assert sorted(skill["name"] for skill in result["skills"]) == ["alpha", "gamma"]
+
+
+def test_skill_describe_unknown_name_errors(tmp_path, monkeypatch):
+    _setup_skills(tmp_path, monkeypatch)
+    from tools.skills_tool import skill_describe
+
+    result = skill_describe(names=["does-not-exist"])
+    assert result["success"] is False
+    assert "does-not-exist" in result["error"]
+
+
+def test_skill_describe_unknown_category_errors(tmp_path, monkeypatch):
+    _setup_skills(tmp_path, monkeypatch)
+    from tools.skills_tool import skill_describe
+
+    result = skill_describe(category="missing")
+    assert result["success"] is False
+
+
+def test_skill_describe_empty_args_errors(tmp_path, monkeypatch):
+    _setup_skills(tmp_path, monkeypatch)
+    from tools.skills_tool import skill_describe
+
+    result = skill_describe()
+    assert result["success"] is False
+

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -148,6 +148,20 @@ class TestValidateFrontmatter:
         content = "---\n: invalid: yaml: {{{\n---\n\nBody.\n"
         assert "YAML frontmatter parse error" in _validate_frontmatter(content)
 
+    def test_priority_must_be_critical_or_normal(self):
+        content = "---\nname: test\ndescription: desc\npriority: legendary\n---\n\nBody.\n"
+        err = _validate_frontmatter(content)
+        assert err is not None
+        assert "priority" in err
+
+    def test_priority_critical_is_accepted(self):
+        content = "---\nname: test\ndescription: desc\npriority: critical\n---\n\nBody.\n"
+        assert _validate_frontmatter(content) is None
+
+    def test_priority_absent_is_accepted(self):
+        content = "---\nname: test\ndescription: desc\n---\n\nBody.\n"
+        assert _validate_frontmatter(content) is None
+
 
 # ---------------------------------------------------------------------------
 # _validate_file_path — path traversal prevention

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -200,6 +200,14 @@ def _validate_frontmatter(content: str) -> Optional[str]:
         return "Frontmatter must include 'description' field."
     if len(str(parsed["description"])) > MAX_DESCRIPTION_LENGTH:
         return f"Description exceeds {MAX_DESCRIPTION_LENGTH} characters."
+    priority_raw = parsed.get("priority")
+    if priority_raw is not None:
+        priority = str(priority_raw).strip().lower()
+        if priority not in ("critical", "normal"):
+            return (
+                "Frontmatter 'priority' must be 'critical' or 'normal' "
+                f"(got {priority_raw!r})."
+            )
 
     body = content[end_match.end() + 3:].strip()
     if not body:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1334,10 +1334,105 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         if isinstance(metadata, dict):
             result["metadata"] = metadata
 
+        try:
+            from agent import skill_usage_tracker
+            from agent.skill_inventory import load_inventory
+
+            inventory = load_inventory()
+            for entry in inventory.entries:
+                if entry.name == skill_name or entry.skill_name == name:
+                    skill_usage_tracker.record_category_use(entry.category)
+                    break
+        except Exception:
+            pass
+
         return json.dumps(result, ensure_ascii=False)
 
     except Exception as e:
         return tool_error(str(e), success=False)
+
+
+def skill_describe(
+    category: str | None = None,
+    names: List[str] | None = None,
+    task_id: str | None = None,
+) -> Dict[str, Any]:
+    """Return one-line descriptions for skills by category or name."""
+    if not category and not names:
+        return {
+            "success": False,
+            "error": "Provide either category=<name> or names=[...].",
+        }
+
+    try:
+        from agent.skill_inventory import load_inventory
+
+        inventory = load_inventory()
+        by_category: Dict[str, List[Any]] = {}
+        by_name: Dict[str, Any] = {}
+        by_skill_name: Dict[str, Any] = {}
+        for entry in inventory.entries:
+            by_category.setdefault(entry.category, []).append(entry)
+            by_name[entry.name] = entry
+            by_skill_name[entry.skill_name] = entry
+
+        described: List[Dict[str, Any]] = []
+        touched_categories: Set[str] = set()
+
+        if category:
+            entries = by_category.get(category)
+            if entries is None:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Unknown category {category!r}. Categories: "
+                        + ", ".join(sorted(by_category.keys()))
+                    ),
+                }
+            for entry in sorted(entries, key=lambda item: item.name):
+                described.append(
+                    {
+                        "name": entry.name,
+                        "category": entry.category,
+                        "description": entry.description,
+                        "priority": entry.priority,
+                    }
+                )
+                touched_categories.add(entry.category)
+
+        if names:
+            missing: List[str] = []
+            for name in names:
+                entry = by_name.get(name) or by_skill_name.get(name)
+                if entry is None:
+                    missing.append(name)
+                    continue
+                described.append(
+                    {
+                        "name": entry.name,
+                        "category": entry.category,
+                        "description": entry.description,
+                        "priority": entry.priority,
+                    }
+                )
+                touched_categories.add(entry.category)
+            if missing:
+                return {
+                    "success": False,
+                    "error": f"Unknown skill name(s): {', '.join(missing)}.",
+                }
+
+        try:
+            from agent import skill_usage_tracker
+
+            for touched_category in touched_categories:
+                skill_usage_tracker.record_category_use(touched_category)
+        except Exception:
+            pass
+
+        return {"success": True, "skills": described}
+    except Exception as e:
+        return {"success": False, "error": str(e)}
 
 
 
@@ -1423,6 +1518,30 @@ SKILL_VIEW_SCHEMA = {
     },
 }
 
+SKILL_DESCRIBE_SCHEMA = {
+    "name": "skill_describe",
+    "description": (
+        "Return one-line descriptions for skills. Use category=<name> to expand "
+        "a category from the system-prompt index, or names=[...] for specific "
+        "skills. Then call skill_view(name) to load full content."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "category": {
+                "type": "string",
+                "description": "Category to expand.",
+            },
+            "names": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Specific skill names to describe.",
+            },
+        },
+        "required": [],
+    },
+}
+
 registry.register(
     name="skills_list",
     toolset="skills",
@@ -1439,6 +1558,18 @@ registry.register(
     schema=SKILL_VIEW_SCHEMA,
     handler=lambda args, **kw: skill_view(
         args.get("name", ""), file_path=args.get("file_path"), task_id=kw.get("task_id")
+    ),
+    check_fn=check_skills_requirements,
+    emoji="📚",
+)
+registry.register(
+    name="skill_describe",
+    toolset="skills",
+    schema=SKILL_DESCRIBE_SCHEMA,
+    handler=lambda args, **kw: skill_describe(
+        category=args.get("category"),
+        names=args.get("names"),
+        task_id=kw.get("task_id"),
     ),
     check_fn=check_skills_requirements,
     emoji="📚",


### PR DESCRIPTION
## Summary

Two-tier skill index + signal-based skill-creation nudge, both gated behind feature flags. Targets the spec in `plans/skills-prompt-budget-and-nudge-redesign.md` (~80% reduction in per-turn skill-prompt tokens at 100 skills, signal-driven nudges that fire on evidence rather than a wall-clock counter).

## Phase A — skill index v2 (gated `skills.index_v2`, default `false`)

- Extracted `agent/skill_inventory.py` as a typed source of truth for parsed skill metadata, consumed by both `build_skills_system_prompt()` and the new `skill_describe` tool. Snapshot version bumped to `2`.
- New SKILL.md frontmatter field: `priority: critical | normal` (default normal). Validated by `tools/skill_manager_tool.py:_validate_frontmatter`.
- New rendering when `skills.index_v2: true`:
  - Tier 1 (system prompt) shows category labels + skill **names**, with full descriptions reserved for `priority: critical` entries.
  - Tier 2 on demand via `skill_describe(category=…)` / `skill_describe(names=[…])`.
- Token budget `skills.index_token_budget` (default `2000`) with category-fold-back ranked by recent usage. Categories beyond budget are listed by name behind a `… and N more categories` hint.
- New `~/.hermes/.skill_usage.json` tracker (`agent/skill_usage_tracker.py`) updated on `skill_view` / `skill_describe`; best-effort, falls back to empty on corruption.
- Warning logged at index-build time when more than 15 skills are marked `priority: critical` (spec §9 Q1).

## Phase B — signal-based nudge (gated `skills.nudge_signals.enabled`, default `false`)

- New `agent/skill_nudge_signals.py` `SignalEvaluator` covering:
  - **S1** repeated tool pattern (per-tool argument signature, threshold `repeated_pattern_threshold` default 3)
  - **S2** novel external CLI on `terminal`/`process` (window `novel_cli_window_days` default 30, plus a default suppression list of `git`, `python`, `pytest`, etc.)
  - **S3** explicit user-message phrases (`next time`, `remember`, `from now on`, `记一下`, `下次`, `以后`)
  - **S4** resolved repeated error (`error_repeat_threshold` default 2)
- `~/.hermes/.skill_known_clis.json` persists CLI history with daily pruning (best-effort).
- End-of-turn skill-review gate flipped from time-only to signal-first: signals fire it immediately, the legacy `creation_nudge_interval` counter remains as a fallback (kept at 15 in this PR; bumps to 50 in Phase 3).
- `_spawn_background_review` now receives `triggered_signals: set[str]` so the reviewer prompt can reference which signal fired.
- Per-session disable:
  - Slash command `/skills nudge off|on` (intercepted in `cli.py:HermesCLI._handle_skills_command` before delegating to the `skills_hub` router; help line added).
  - Env var `HERMES_SKILL_NUDGE_DISABLE=1` honoured at session init.

## Phase 3 (separate PR after dogfooding)

- Flip `skills.index_v2` and `skills.nudge_signals.enabled` defaults to `true`
- Bump `skills.creation_nudge_interval` default from 15 → 50
- Add TUI parity (`ui-tui/src/app/slash/commands/ops.ts`) and gateway parity for `/skills nudge off|on`
- Phase 4 cleanup: delete the v1 rendering path once v2 has been default for one minor version

Tracked in `plans/skills-prompt-budget-and-nudge-phase-3-checklist.md`.

## Files

- New: `agent/skill_inventory.py`, `agent/skill_usage_tracker.py`, `agent/skill_nudge_signals.py`
- Modified: `agent/prompt_builder.py`, `tools/skills_tool.py`, `tools/skill_manager_tool.py`, `run_agent.py`, `cli.py`, `hermes_cli/skills_hub.py`, `cli-config.yaml.example`, `tests/conftest.py`
- Plans: `plans/skills-prompt-budget-and-nudge-redesign.md` (spec), `plans/skills-prompt-budget-and-nudge-implementation.md` (plan), `plans/skills-prompt-budget-and-nudge-phase-3-checklist.md` (follow-up)

## Test status

- **Focused suite (this PR's tests + `test_concurrent_interrupt`):** 216 passed, 1 skipped, 0 failed.
- **Wider xdist suite (`tests/agent/ tests/tools/ tests/run_agent/ tests/cli/ tests/integration/`):** 27–47 failures across runs vs 26 on main with the same xdist conditions. The delta is within ambient cross-module xdist race variance; no deterministic regressions were found. Same-directory parallel runs (e.g. `tests/run_agent/` alone) pass cleanly: 992/0 on branch, 982/0 on main.
- **Pre-existing failures unrelated to this PR (visible on both sides):** `tests/agent/test_anthropic_adapter.py` (reads real `~/.claude` credentials instead of fixtures), `tests/tools/test_file_staleness.py` / `test_file_state_registry.py` (`/var/folders` path-validation gate), `tests/tools/test_local_interrupt_cleanup.py`.

## Dogfood checklist (complete before merging out of draft)

### Phase A — index v2

Set in `~/.hermes/config.yaml`:
```yaml
skills:
  index_v2: true
  index_token_budget: 2000
```

Then exercise:

- [ ] Start a fresh session; confirm system prompt logs show the v2 format (category-grouped names, only `priority: critical` skills with descriptions). Suggested: `hermes --debug 2>&1 | grep -A 3 "## Skills"`.
- [ ] Estimate Tier 1 size; on a 100-skill library it should sit near 1.5–2k tokens (the spec's measured target was ~1300; budget is 2000).
- [ ] Mark one frequently-used skill `priority: critical`; verify its description reappears in Tier 1.
- [ ] Run `skill_describe(category="<some-cat>")` from inside a session; confirm it returns the expected one-line descriptions.
- [ ] Run `skill_describe(names=["<known-name>"])`; confirm it returns the entry. Try an unknown name; confirm `success: false` with a useful error.
- [ ] Force budget overflow (drop `index_token_budget` to e.g. `300`); confirm the fold-back line `… and N more categories: …` appears with comma-separated names.
- [ ] Confirm `~/.hermes/.skill_usage.json` is created/updated when `skill_view` or `skill_describe` runs.

### Phase B — signal-based nudge

Set in `~/.hermes/config.yaml`:
```yaml
skills:
  nudge_signals:
    enabled: true
```

Then exercise:

- [ ] **S1**: in one turn, run a repeated tool pattern 3+ times (e.g. `gh pr view 1`, `gh pr view 2`, `gh pr view 3`). Confirm a background skill review fires after the response.
- [ ] **S2**: in one turn, invoke a CLI that hasn't been used in the last 30 days (e.g. an exotic binary with `terminal`); confirm the signal fires once the call succeeds.
- [ ] **S3**: send a user message containing "next time" or "记一下"; confirm the signal fires and the background review runs.
- [ ] **S4**: trigger the same error twice (e.g. wrong path), then succeed; confirm the signal fires.
- [ ] Run `/skills nudge off`; confirm subsequent signals are suppressed in that session. Run `/skills nudge on`; confirm they fire again.
- [ ] Set `HERMES_SKILL_NUDGE_DISABLE=1` in the env; confirm a fresh session is muted.
- [ ] Run a long task with no reusable patterns and `creation_nudge_interval: 50`; confirm the time fallback eventually triggers when no signals fired.

### Cleanup

- [ ] Revert local `~/.hermes/config.yaml` overrides used during dogfooding (or leave them on if you want the new behavior — Phase 3 is what flips the defaults globally).

## Spec / plan

- Spec: `plans/skills-prompt-budget-and-nudge-redesign.md`
- Plan: `plans/skills-prompt-budget-and-nudge-implementation.md`
- Phase 3 checklist: `plans/skills-prompt-budget-and-nudge-phase-3-checklist.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
