### PR TITLE
fix: include terminal backend in quick setup wizard

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3240,22 +3240,23 @@ def _offer_launch_chat():
 
 
 def _run_first_time_quick_setup(config: dict, hermes_home, is_existing: bool):
-    """Streamlined first-time setup: provider + model only.
+    """Streamlined first-time setup: provider, model, terminal & messaging.
 
-    Applies sensible defaults for TTS (Edge), terminal (local), agent
-    settings, and tools — the user can customize later via
-    ``hermes setup <section>``.
+    Applies sensible defaults for TTS (Edge), agent settings, and tools —
+    the user can customize later via ``hermes setup <section>``.
     """
     # Step 1: Model & Provider (essential — skips rotation/vision/TTS)
     setup_model_provider(config, quick=True)
 
-    # Step 2: Apply defaults for everything else
+    # Step 2: Terminal Backend — where commands run is a core decision
+    setup_terminal_backend(config)
+
+    # Step 3: Apply defaults for everything else
     _apply_default_agent_settings(config)
-    config.setdefault("terminal", {}).setdefault("backend", "local")
 
     save_config(config)
 
-    # Step 3: Offer messaging gateway setup
+    # Step 4: Offer messaging gateway setup
     print()
     gateway_choice = prompt_choice(
         "Connect a messaging platform? (Telegram, Discord, etc.)",


### PR DESCRIPTION
## Problem

The quick setup flow (recommended for first-time users) silently defaulted `terminal.backend` to `local` without presenting the choice. New users who wanted Docker, SSH, Modal, Daytona, or any other backend had to discover `hermes setup terminal` on their own.

## Fix

Add `setup_terminal_backend(config)` to `_run_first_time_quick_setup()` between provider selection and messaging setup.

**Quick setup flow is now:**
1. Provider selection (35+ options)
2. API key prompt
3. Terminal backend (Local / Docker / Modal / SSH / Daytona / Vercel Sandbox / Singularity)
4. Messaging platform
5. Done

## Why terminal backend belongs in quick setup

- It's a foundational decision — **where ALL shell commands execute**
- Users setting up Hermes inside a container or remote environment need this immediately
- The full setup already had it; quick setup was the only path that skipped it
- The `hermes setup` completion screen even mentions `hermes setup terminal` as a separate command, hinting that users were expected to run it manually — that's a UX gap

## Testing

- Ran `tests/hermes_cli/test_setup_reconfigure.py` and `tests/hermes_cli/test_setup.py` — all pass
- Verified interactively in a fresh Docker container that the terminal backend prompt now appears in quick setup