### PR TITLE
fix(cloudcode): merge consecutive tool results into a single user turn

### DIFF
--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -146,12 +146,25 @@ def _build_gemini_contents(
             system_text_parts.append(_coerce_content_to_text(msg.get("content")))
             continue
 
-        # Tool result message — emit a user-role turn with functionResponse
+        # Tool result message — merge consecutive tool results into a single
+        # user-role turn. Code Assist requires the count of functionResponse
+        # parts in one turn to match the count of functionCall parts in the
+        # preceding assistant turn (parallel tool calls).
         if role == "tool" or role == "function":
-            contents.append({
-                "role": "user",
-                "parts": [_translate_tool_result_to_gemini(msg)],
-            })
+            fr_part = _translate_tool_result_to_gemini(msg)
+            if (
+                contents
+                and contents[-1].get("role") == "user"
+                and isinstance(contents[-1].get("parts"), list)
+                and contents[-1]["parts"]
+                and all(
+                    isinstance(p, dict) and "functionResponse" in p
+                    for p in contents[-1]["parts"]
+                )
+            ):
+                contents[-1]["parts"].append(fr_part)
+            else:
+                contents.append({"role": "user", "parts": [fr_part]})
             continue
 
         gemini_role = _ROLE_MAP_OPENAI_TO_GEMINI.get(role, "user")

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -635,6 +635,94 @@ class TestBuildGeminiRequest:
         assert fr_part["functionResponse"]["name"] == "get_weather"
         assert fr_part["functionResponse"]["response"] == {"temp": 72}
 
+    def test_parallel_tool_results_merged_into_single_turn(self):
+        """Code Assist requires the number of functionResponse parts in one
+        turn to match the number of functionCall parts in the preceding
+        assistant turn. When the assistant emits parallel tool_calls in a
+        single message, the corresponding tool result messages must be merged
+        into one user-role turn with N parts — not N separate turns.
+
+        Without merging, Code Assist returns HTTP 400 INVALID_ARGUMENT:
+        'Please ensure that the number of function response parts is equal to
+        the number of function call parts of the function call turn.'
+        """
+        from agent.gemini_cloudcode_adapter import build_gemini_request
+
+        req = build_gemini_request(messages=[
+            {"role": "user", "content": "summarize both files"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "c1", "type": "function", "function": {
+                        "name": "read_file", "arguments": '{"path": "a.md"}',
+                    }},
+                    {"id": "c2", "type": "function", "function": {
+                        "name": "read_file", "arguments": '{"path": "b.md"}',
+                    }},
+                ],
+            },
+            {"role": "tool", "name": "read_file",
+             "tool_call_id": "c1", "content": "content of a"},
+            {"role": "tool", "name": "read_file",
+             "tool_call_id": "c2", "content": "content of b"},
+        ])
+
+        # Model turn carries 2 functionCall parts.
+        model_turn = req["contents"][1]
+        assert model_turn["role"] == "model"
+        fc_parts = [p for p in model_turn["parts"] if "functionCall" in p]
+        assert len(fc_parts) == 2
+
+        # The two tool results must collapse into ONE user turn with 2
+        # functionResponse parts (count must match the call count above).
+        last = req["contents"][-1]
+        assert last["role"] == "user"
+        fr_parts = [p for p in last["parts"] if "functionResponse" in p]
+        assert len(fr_parts) == 2
+        assert {p["functionResponse"]["name"] for p in fr_parts} == {"read_file"}
+        responses = [p["functionResponse"]["response"] for p in fr_parts]
+        assert {"output": "content of a"} in responses
+        assert {"output": "content of b"} in responses
+
+        # And there should be no extra user turn after the merge — count
+        # check: [user_question, model_call_turn, user_response_turn] = 3.
+        assert len(req["contents"]) == 3
+
+    def test_tool_result_not_merged_across_intervening_user_message(self):
+        """A real user-text turn between tool results breaks the merge: the
+        merge condition only applies when the immediately preceding turn is
+        already a functionResponse-only user turn.
+        """
+        from agent.gemini_cloudcode_adapter import build_gemini_request
+
+        req = build_gemini_request(messages=[
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "tool_calls": [{
+                "id": "c1", "type": "function",
+                "function": {"name": "fn1", "arguments": "{}"},
+            }]},
+            {"role": "tool", "name": "fn1",
+             "tool_call_id": "c1", "content": "r1"},
+            # Real user text — should NOT be merged into the response turn.
+            {"role": "user", "content": "and now this"},
+            {"role": "assistant", "tool_calls": [{
+                "id": "c2", "type": "function",
+                "function": {"name": "fn2", "arguments": "{}"},
+            }]},
+            {"role": "tool", "name": "fn2",
+             "tool_call_id": "c2", "content": "r2"},
+        ])
+
+        # Sequence: user_q, model_fc1, user_fr1, user_text, model_fc2, user_fr2
+        roles = [c["role"] for c in req["contents"]]
+        assert roles == ["user", "model", "user", "user", "model", "user"]
+
+        # The intervening user text turn carries text, not functionResponse.
+        text_turn = req["contents"][3]
+        assert any("text" in p for p in text_turn["parts"])
+        assert not any("functionResponse" in p for p in text_turn["parts"])
+
     def test_tools_translated_to_function_declarations(self):
         from agent.gemini_cloudcode_adapter import build_gemini_request
 


### PR DESCRIPTION
## Summary

Fixes `HTTP 400 INVALID_ARGUMENT` when the assistant emits parallel tool calls and the resulting tool-role messages are converted into Gemini function-response parts. Code Assist requires N call parts → N response parts in the same turn, but `_build_gemini_contents` emits one user-role turn per tool message, breaking the part-count invariant.

## Reproducer

Use the OAuth-backed `google-gemini-cli` provider (Code Assist Standard or paid tier). Trigger a response containing parallel tool calls — e.g. a `delegate_task` subagent asked to read two files in parallel.

```python
build_gemini_request(messages=[
    {"role": "user", "content": "summarize a.md and b.md"},
    {"role": "assistant", "tool_calls": [
        {"id": "c1", "type": "function", "function": {"name": "read_file", "arguments": '{"path": "a.md"}'}},
        {"id": "c2", "type": "function", "function": {"name": "read_file", "arguments": '{"path": "b.md"}'}},
    ]},
    {"role": "tool", "name": "read_file", "tool_call_id": "c1", "content": "..."},
    {"role": "tool", "name": "read_file", "tool_call_id": "c2", "content": "..."},
])
```

Before the fix the request fails with:

```
HTTP 400: INVALID_ARGUMENT: Please ensure that the number of function
response parts is equal to the number of function call parts of the
function call turn.
```

In production, the user-visible symptom is `delegate_task` results returning `status=failed`, `exit_reason=max_iterations`, and the parent agent recovering only on the third attempt by narrowing the subagent's toolset (forcing serial calls), at the cost of ~15–20 s of wasted retry latency per delegation.

## Root cause

`_build_gemini_contents` translates each OpenAI `tool`-role message into its own user-role turn with a single `functionResponse` part. When the assistant has issued parallel `tool_calls` in one turn (one model turn with N `functionCall` parts), the conversion produces N separate response turns — Code Assist sees a call turn with N parts followed by a response turn with 1 part, hence the count mismatch.

## Fix

When a tool-role message arrives, append its `functionResponse` part to the previous turn iff that turn is already a functionResponse-only user turn. Otherwise start a new user turn. Preserves existing behavior for serial tool calls and for tool results that follow a real user-text turn.

## Tests

Added to `tests/agent/test_gemini_cloudcode.py::TestBuildGeminiRequest`:

- `test_parallel_tool_results_merged_into_single_turn` — asserts two parallel `tool_calls` + two tool results produce one model turn (2 `functionCall` parts) + one user turn (2 `functionResponse` parts), 3 contents total.
- `test_tool_result_not_merged_across_intervening_user_message` — guards against over-eager merging when a real user-text turn separates two tool-call/result cycles.

## Test plan

- [x] `pytest tests/agent/test_gemini_cloudcode.py` — 87 passed (85 baseline + 2 new)
- [x] Live reproduction via `hermes -z "...delegate_task..."` against Code Assist OAuth: before fix, parent makes 3 `delegate_task` attempts (2× HTTP 400 + 1 success after toolset narrowing); after fix, single `delegate_task` call succeeds on first attempt.