### PR TITLE
feat: add pentest ops Hermes plugin layer

### DIFF
--- a/plugins/pentest-ops/__init__.py
+++ b/plugins/pentest-ops/__init__.py
@@ -1,0 +1,165 @@
+"""Pentest Ops plugin.
+
+Hermes should stay an execution substrate.  This plugin adds the pentest
+operating layer around it: Recon Graph tools when the private backend package is
+installed, plus a bundled skill pack that tells the agent how to use those tools
+without turning the core loop into a bespoke pentest hairball.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+
+TOOLSET = "recon_graph"
+PLUGIN_NAME = "pentest-ops"
+
+_SKILL_DESCRIPTIONS = {
+    "pentest-engagement-orchestrator": "Run authorised pentests as evidence-first Recon Graph workflows.",
+    "pentest-evidence-and-graph-protocol": "Use Recon Graph evidence, hypotheses, actions, and findings without unsupported claims.",
+    "dataflow-threat-modeling": "Model actors, data objects, trust boundaries, controls, and impact paths.",
+    "web-application-surface-testing": "Inventory web application surfaces and workflows before active validation.",
+    "authn-authz-session-testing": "Test authentication, session, role, object, and context-boundary behaviour.",
+    "rest-api-testing": "Test REST resources, methods, object boundaries, and API-specific controls.",
+    "graphql-api-testing": "Test GraphQL schemas, resolvers, field authorisation, and query-cost controls.",
+    "infrastructure-exposure-testing": "Assess exposed services and edge controls through policy-gated artefacts.",
+    "finding-validation-and-reporting": "Promote only evidence-backed findings with positive/control proof and approval references.",
+}
+
+_STATUS_SCHEMA = {
+    "name": "pentest_ops_status",
+    "description": (
+        "Report whether the Hermes pentest-ops plugin has the Recon Graph "
+        "backend available and list the bundled pentest skills. Does not touch targets."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+}
+
+_dependency_error: str | None = None
+_registered_recon_tools: list[str] = []
+_registered_skills: list[str] = []
+
+
+def _json(data: dict[str, Any]) -> str:
+    return json.dumps(data, indent=2, sort_keys=True, default=str)
+
+
+def _status_handler(args: dict[str, Any] | None = None, **_: Any) -> str:
+    available = _dependency_error is None
+    payload: dict[str, Any] = {
+        "plugin": PLUGIN_NAME,
+        "available": available,
+        "toolset": TOOLSET,
+        "recon_graph_tools": sorted(_registered_recon_tools),
+        "skills": sorted(_registered_skills),
+        "operating_model": "Hermes core loop unchanged; Recon Graph supplies deterministic evidence/state tools.",
+        "target_traffic": "Not from Hermes local; policy-gated target-touching work belongs on the approved scan box.",
+    }
+    if not available:
+        payload.update(
+            {
+                "dependency_error": _dependency_error,
+                "install_hint": (
+                    "Install or editable-install recon-graph-agent, then enable this plugin "
+                    "with `hermes plugins enable pentest-ops` and enable the `recon_graph` toolset."
+                ),
+            }
+        )
+    return _json(payload)
+
+
+def _iter_recon_graph_tools() -> Iterable[Any]:
+    """Return backend tool entries from recon_graph_agent, or an empty tuple.
+
+    Importing is delayed until plugin registration so Hermes can still start and
+    expose `pentest_ops_status` when the private Recon Graph package is absent.
+    Bad backend metadata is treated like an unavailable backend, not a plugin
+    load failure.
+    """
+    global _dependency_error
+    try:
+        module = importlib.import_module("recon_graph_agent.hermes_plugin.tools")
+        tools = getattr(module, "TOOLS")
+        tool_entries = tuple(tools)
+    except Exception as exc:  # pragma: no cover - exact import errors are env-specific
+        _dependency_error = f"{type(exc).__name__}: {exc}"
+        return ()
+
+    _dependency_error = None
+    return tool_entries
+
+
+def _register_status_tool(ctx) -> None:
+    ctx.register_tool(
+        name="pentest_ops_status",
+        toolset=TOOLSET,
+        schema=_STATUS_SCHEMA,
+        handler=_status_handler,
+        emoji="🕸️",
+    )
+
+
+def _register_recon_graph_tools(ctx) -> None:
+    global _dependency_error
+
+    _registered_recon_tools.clear()
+    for item in _iter_recon_graph_tools():
+        try:
+            name, schema, handler = item
+        except Exception as exc:
+            _dependency_error = f"unexpected Recon Graph tool entry {item!r}: {type(exc).__name__}: {exc}"
+            _registered_recon_tools.clear()
+            return
+
+        if not isinstance(name, str) or not isinstance(schema, dict):
+            _dependency_error = f"unexpected Recon Graph tool entry {item!r}: expected (str, dict, handler)"
+            _registered_recon_tools.clear()
+            return
+
+        try:
+            ctx.register_tool(
+                name=name,
+                toolset=TOOLSET,
+                schema=schema,
+                handler=handler,
+                emoji="🕸️",
+            )
+        except Exception as exc:
+            _dependency_error = f"failed to register Recon Graph tool {name!r}: {type(exc).__name__}: {exc}"
+            _registered_recon_tools.clear()
+            return
+
+        try:
+            from tools.registry import registry
+
+            if registry.get_toolset_for_tool(name) != TOOLSET:
+                _dependency_error = f"Recon Graph backend tool {name!r} was not registered under {TOOLSET!r}"
+                continue
+        except Exception as exc:
+            _dependency_error = f"could not verify Recon Graph tool {name!r}: {type(exc).__name__}: {exc}"
+            continue
+
+        _registered_recon_tools.append(name)
+
+
+def _register_skills(ctx) -> None:
+    _registered_skills.clear()
+    skills_root = Path(__file__).resolve().parent / "skills"
+    for name, description in _SKILL_DESCRIPTIONS.items():
+        skill_path = skills_root / name / "SKILL.md"
+        ctx.register_skill(name, skill_path, description=description)
+        _registered_skills.append(f"{PLUGIN_NAME}:{name}")
+
+
+def register(ctx) -> None:
+    """Register status tooling, Recon Graph wrappers, and pentest skills."""
+    _register_status_tool(ctx)
+    _register_recon_graph_tools(ctx)
+    _register_skills(ctx)

--- a/plugins/pentest-ops/plugin.yaml
+++ b/plugins/pentest-ops/plugin.yaml
@@ -1,0 +1,25 @@
+name: pentest-ops
+version: 0.1.0
+description: "Hermes-native pentest operating layer: Recon Graph tools, evidence-first workflows, and audit-defensible skill pack without core-loop changes."
+author: "Hermes Agent"
+kind: standalone
+provides_tools:
+  - pentest_ops_status
+  - rga_init_engagement
+  - rga_status
+  - rga_bridge_pentest_ops
+  - rga_ingest_artifact
+  - rga_run_recipes
+  - rga_list_candidate_paths
+  - rga_show_candidate_path
+  - rga_next_action
+  - rga_policy_check
+  - rga_action_queue
+  - rga_negative_evidence
+  - rga_validator_pack
+  - rga_autonomy_checkpoint
+  - rga_report_candidate
+  - rga_report_list
+  - rga_report_promote
+  - rga_report_demote
+  - rga_report_export_map

--- a/plugins/pentest-ops/skills/authn-authz-session-testing/SKILL.md
+++ b/plugins/pentest-ops/skills/authn-authz-session-testing/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: authn-authz-session-testing
+description: Test authentication, session, role, object, tenant, and context-boundary behaviour with evidence-backed matrices.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [pentest, authentication, authorisation, session, idor]
+---
+
+# Authn/Authz/Session Testing
+
+Use for login/session controls, role boundaries, object ownership, tenant boundaries, and bridge/context switching.
+
+## Matrix first
+
+Build a role/action/resource matrix before active validation:
+
+- actor / credential / auth context
+- reachable UI path or API endpoint
+- resource or data object
+- expected control
+- observed evidence
+- negative evidence
+
+## Safe hypothesis examples
+
+- A low-privilege actor may access another user's object.
+- A workflow step may trust client-supplied role/context selectors.
+- A session may remain valid after logout/password change.
+- A bridge flow may establish a privileged context without a fresh server-side entitlement check.
+
+## Validation requirements
+
+Use approved test accounts only. Compare positive and control cases. Record request/response or UI evidence IDs. Stop at proof of impact; do not enumerate records. Promote via `finding-validation-and-reporting` only after reproduction and scope checks.

--- a/plugins/pentest-ops/skills/dataflow-threat-modeling/SKILL.md
+++ b/plugins/pentest-ops/skills/dataflow-threat-modeling/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: dataflow-threat-modeling
+description: Model actors, data objects, trust boundaries, controls, and impact paths for authorised web/API pentests.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [pentest, data-flow, threat-modeling, trust-boundaries]
+---
+
+# Data-flow Threat Modelling
+
+Use this before chasing bug classes. A data-flow model makes tests less random, which is rude but useful.
+
+## Build these nodes
+
+- actors and roles
+- credentials/auth contexts
+- applications/services/endpoints
+- data objects
+- trust boundaries
+- expected controls
+- observed controls
+- evidence refs
+
+## Questions to answer
+
+- Who can initiate the flow?
+- What object crosses which boundary?
+- What control should exist: authentication, ownership, role, tenant, workflow state, CSRF, or approval?
+- What evidence shows the control exists?
+- What evidence would disprove that assumption?
+- What is the impact if the control is missing?
+
+## Output
+
+Create compact data-flow records tied to evidence, then generate hypotheses from missing or unproven controls. Do not promote a modelled risk to a finding until validation has positive and control evidence.

--- a/plugins/pentest-ops/skills/finding-validation-and-reporting/SKILL.md
+++ b/plugins/pentest-ops/skills/finding-validation-and-reporting/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: finding-validation-and-reporting
+description: Promote only evidence-backed pentest findings with positive/control proof, approval references, reporting-system mapping, and overclaiming checks.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [pentest, findings, reporting, evidence, validation]
+---
+
+# Finding Validation and Reporting
+
+Use before any candidate becomes a client-facing finding.
+
+## Promotion rule
+
+A candidate finding may be promoted only when:
+
+1. affected assets are confirmed in scope;
+2. positive evidence proves the vulnerable behaviour;
+3. control evidence proves expected/denied behaviour or contrast;
+4. auth context, actor, and network position are recorded;
+5. impact is demonstrated or explicitly marked as inferred;
+6. limitations are stated without caveat-padding;
+7. reportable evidence is redacted and uses MinIO links where required;
+8. an operator `approval_ref` is recorded for promotion/demotion/report hand-off.
+
+Use `rga_validator_pack` for independent review. Use `rga_report_promote` only with positive and control evidence refs plus `approval_ref`. Use `rga_report_demote` when evidence weakens the claim; preserve negative evidence so the same dead branch is not resurrected later like a tedious little zombie.
+
+## Reporting
+
+Map Razorthorn to Dradis. Map freelance/BlahSec-style work to SysReptor. Do not export raw sensitive artefacts or Discord attachments. Candidate/observation maturity stays in progress; only confirmed findings are finished report items.

--- a/plugins/pentest-ops/skills/graphql-api-testing/SKILL.md
+++ b/plugins/pentest-ops/skills/graphql-api-testing/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: graphql-api-testing
+description: Test GraphQL schemas, resolvers, field-level authorisation, nested traversal, batching, and query-cost controls.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [pentest, graphql, api, resolvers]
+---
+
+# GraphQL API Testing
+
+Use for authorised GraphQL assessment. GraphQL is not REST with fancier punctuation; test the resolver model.
+
+## Map
+
+- schema or observed operations
+- queries/mutations/subscriptions
+- object types and sensitive fields
+- resolvers and backend trust boundaries
+- auth context and role assumptions
+- query complexity/depth controls
+
+## Hypotheses
+
+- A resolver may enforce parent access but leak nested fields.
+- Field-level authorisation may differ from type-level authorisation.
+- Batching or aliases may bypass workflow assumptions.
+- Introspection, debug errors, or schema exposure may reveal sensitive structure.
+- Query depth/cost controls may be absent or inconsistent.
+
+## Guardrails
+
+Avoid DoS-style query-cost testing unless explicitly authorised. Use minimal controlled queries, policy-gated actions, and evidence IDs for every claim.

--- a/plugins/pentest-ops/skills/infrastructure-exposure-testing/SKILL.md
+++ b/plugins/pentest-ops/skills/infrastructure-exposure-testing/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: infrastructure-exposure-testing
+description: Assess exposed services, TLS/HTTP posture, cloud edge controls, and admin surfaces through scan-box artefacts and policy gates.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [pentest, infrastructure, exposure, scan-box]
+---
+
+# Infrastructure Exposure Testing
+
+Use for authorised infrastructure and edge exposure review.
+
+## Inputs
+
+Prefer scan-box-collected artefacts: Nmap XML, TLS summaries, HTTP screenshots, proxy captures, DNS/passive recon, and manual notes. Ingest with `rga_ingest_artifact` and preserve provenance.
+
+## Focus
+
+- exposed services and admin interfaces
+- TLS and HTTP security posture
+- cloud edge misrouting or unintended environments
+- default pages and debug surfaces
+- scope boundaries between public, VPN, and internal network positions
+
+## Hard line
+
+Hermes local does not scan live infrastructure. If more data is needed, create a policy-gated action for the scan box. Destructive, disruptive, brute-force, persistence, stealth, and lateral movement checks are outside this skill unless the engagement explicitly says otherwise.

--- a/plugins/pentest-ops/skills/pentest-engagement-orchestrator/SKILL.md
+++ b/plugins/pentest-ops/skills/pentest-engagement-orchestrator/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: pentest-engagement-orchestrator
+description: Run authorised pentests as evidence-first Recon Graph workflows, routing between scope, data-flow, testing, reporting, and validation.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [pentest, orchestration, evidence, recon-graph, scan-box]
+---
+
+# Pentest Engagement Orchestrator
+
+Use this when managing an authorised penetration test inside Hermes.
+
+## Prime rules
+
+- Do not modify Hermes' core loop. The loop is the execution substrate; this skill is the operating process.
+- No evidence ID, no claim.
+- Scope, rules of engagement, roles, assets, reporting destination, and scan-box state must come from engagement context or `pentest-ops` state, not memory gossip.
+- Local Hermes may parse artefacts, reason, create graph state, queue actions, and draft reports.
+- Target-touching work belongs on the approved scan box after policy gates. Do not run live target tooling locally.
+
+## Operating loop
+
+1. Load or create engagement state with `rga_init_engagement` / `rga_bridge_pentest_ops`.
+2. Check scope and gates with `rga_status` before active work.
+3. Ingest supplied artefacts with `rga_ingest_artifact`.
+4. Build assets, actors, trust boundaries, data flows, controls, hypotheses, and negative evidence.
+5. Run deterministic recipes with `rga_run_recipes`; inspect paths with `rga_list_candidate_paths` and `rga_show_candidate_path`.
+6. Propose, never execute, a target-touching action with `rga_next_action`; run `rga_policy_check`.
+7. Stop on blocked, approval-required, closed-gate, out-of-scope, or scan-box readiness failures.
+8. Promote only validated findings using `finding-validation-and-reporting`.
+
+## Checkpoints
+
+Every bounded pass, summarise:
+
+- scope/gate status
+- evidence IDs added
+- hypotheses supported, weakened, or killed
+- negative evidence recorded
+- pending actions and approval requirements
+- safest high-value next step
+
+Prefer a boring audit trail over an exciting pile of unsupported guesses. Computers already make enough mess unaided.

--- a/plugins/pentest-ops/skills/pentest-evidence-and-graph-protocol/SKILL.md
+++ b/plugins/pentest-ops/skills/pentest-evidence-and-graph-protocol/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: pentest-evidence-and-graph-protocol
+description: Use Recon Graph evidence, graph facts, hypotheses, action requests, negative evidence, and findings without unsupported claims.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [pentest, evidence, graph, protocol]
+---
+
+# Pentest Evidence and Graph Protocol
+
+Use this whenever observations become pentest state.
+
+## State discipline
+
+Represent every meaningful change as one of:
+
+- evidence event
+- graph patch/fact
+- data flow
+- hypothesis
+- action request
+- policy decision
+- negative evidence
+- finding candidate
+- confirmed finding
+
+Do not keep operational truth only in chat. Put it in Recon Graph state through the `recon_graph` toolset.
+
+## Required metadata
+
+Every graph-backed claim needs:
+
+- evidence refs
+- asset/scope status
+- auth context or network position
+- actor/role where relevant
+- timestamp/source artefact
+- confidence and status
+- sensitivity/redaction status
+
+## Claim rule
+
+No evidence ID, no claim. If evidence is weak, call it a hypothesis. If a test disproves a branch, record negative evidence instead of quietly forgetting it.
+
+## Action boundary
+
+Graph and report tools are local. Target-touching execution is not. For anything that can create target traffic, create an ActionRequest and run policy checks before any scan-box action exists.

--- a/plugins/pentest-ops/skills/rest-api-testing/SKILL.md
+++ b/plugins/pentest-ops/skills/rest-api-testing/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: rest-api-testing
+description: Test REST API resources, methods, object boundaries, mass-assignment risk, and error behaviour using Recon Graph evidence.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [pentest, rest, api, authorisation]
+---
+
+# REST API Testing
+
+Use for authorised REST API assessment.
+
+## Inventory
+
+Map resources, methods, auth context, object identifiers, pagination/filtering, versioning, deprecated routes, and error behaviour. Link each observation to evidence.
+
+## Test themes
+
+- object-level authorisation
+- role/action/resource mismatches
+- mass assignment / over-posting
+- filtering, sorting, pagination exposure
+- weak error consistency or information disclosure
+- unsafe state-changing verbs
+- stale versions and hidden routes
+
+## Discipline
+
+Do not brute-force identifiers. Use approved accounts and minimal controlled variations. Generate ActionRequests for target-touching checks and run policy gates. Findings need positive and control evidence, not merely a 200 response that looked interesting in dim light.

--- a/plugins/pentest-ops/skills/web-application-surface-testing/SKILL.md
+++ b/plugins/pentest-ops/skills/web-application-surface-testing/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: web-application-surface-testing
+description: Inventory web application routes, forms, workflows, client-side surface, and artefacts before active validation.
+version: 0.1.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [pentest, web, surface, workflows]
+---
+
+# Web Application Surface Testing
+
+Use for authorised web app surface discovery and workflow mapping.
+
+## Method
+
+1. Confirm target and role are in scope.
+2. Prefer supplied artefacts first: HAR, crawl notes, screenshots, route inventories, redacted sidecars.
+3. Ingest artefacts with `rga_ingest_artifact` rather than keeping raw observations in chat.
+4. Build a semantic map: routes, forms, actions, objects, roles, state transitions, upload/download points, and trust boundaries.
+5. Keep exhaustive generated fields as artefacts; ingest curated concepts only.
+6. Generate test hypotheses from control assumptions, not from a generic vulnerability shopping list.
+
+## Avoid
+
+- local crawling/probing against live targets
+- storing raw tokens/selectors in notes
+- treating route discovery as impact
+- turning every parameter into a graph node
+
+Surface discovery is there to select good tests, not to create a decorative URL collection.

--- a/tests/plugins/test_pentest_ops_plugin.py
+++ b/tests/plugins/test_pentest_ops_plugin.py
@@ -1,0 +1,197 @@
+"""Tests for the bundled pentest-ops plugin.
+
+The plugin is deliberately a Hermes-native shim: Hermes owns the operating
+layer and skill pack, while Recon Graph Agent remains the deterministic evidence
+backend.  No target traffic, no core-loop surgery.  Shocking restraint.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+
+import yaml
+
+from hermes_cli.plugins import PluginManager
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_KEY = "pentest-ops"
+PLUGIN_MODULE = "hermes_plugins.pentest_ops"
+PLUGIN_SKILLS = {
+    "pentest-engagement-orchestrator",
+    "pentest-evidence-and-graph-protocol",
+    "dataflow-threat-modeling",
+    "web-application-surface-testing",
+    "authn-authz-session-testing",
+    "rest-api-testing",
+    "graphql-api-testing",
+    "infrastructure-exposure-testing",
+    "finding-validation-and-reporting",
+}
+
+
+def _enable_plugin(tmp_path: Path, monkeypatch) -> Path:
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": [PLUGIN_KEY]}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(REPO_ROOT / "plugins"))
+    return hermes_home
+
+
+def _clean_plugin_state():
+    sys.modules.pop(PLUGIN_MODULE, None)
+    from tools.registry import registry
+
+    for name in ["pentest_ops_status", "fake_rga_status"]:
+        registry.deregister(name)
+
+
+def _install_fake_recon_graph_tools(monkeypatch, tools_value=None):
+    def fake_handler(args, **kwargs):
+        return json.dumps({"ok": True, "args": args})
+
+    fake_schema = {
+        "name": "fake_rga_status",
+        "description": "Fake Recon Graph status tool for plugin tests.",
+        "parameters": {"type": "object", "properties": {}, "additionalProperties": False},
+    }
+
+    root = types.ModuleType("recon_graph_agent")
+    hermes_plugin = types.ModuleType("recon_graph_agent.hermes_plugin")
+    tools = types.ModuleType("recon_graph_agent.hermes_plugin.tools")
+    tools.TOOLS = tools_value if tools_value is not None else (("fake_rga_status", fake_schema, fake_handler),)
+
+    monkeypatch.setitem(sys.modules, "recon_graph_agent", root)
+    monkeypatch.setitem(sys.modules, "recon_graph_agent.hermes_plugin", hermes_plugin)
+    monkeypatch.setitem(sys.modules, "recon_graph_agent.hermes_plugin.tools", tools)
+
+
+def test_pentest_ops_plugin_registers_recon_graph_tools_and_skills(tmp_path, monkeypatch):
+    _clean_plugin_state()
+    _enable_plugin(tmp_path, monkeypatch)
+    _install_fake_recon_graph_tools(monkeypatch)
+
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    loaded = manager._plugins[PLUGIN_KEY]
+    assert loaded.enabled is True
+    assert loaded.error is None
+
+    from tools.registry import registry
+
+    assert registry.get_toolset_for_tool("fake_rga_status") == "recon_graph"
+    assert registry.get_toolset_for_tool("pentest_ops_status") == "recon_graph"
+
+    qualified = set(manager._plugin_skills)
+    for skill in PLUGIN_SKILLS:
+        assert f"pentest-ops:{skill}" in qualified
+
+
+def test_pentest_ops_plugin_fails_open_with_status_tool_when_recon_graph_missing(tmp_path, monkeypatch):
+    _clean_plugin_state()
+    _enable_plugin(tmp_path, monkeypatch)
+
+    real_import_module = importlib.import_module
+
+    def guarded_import(name, package=None):
+        if name == "recon_graph_agent.hermes_plugin.tools":
+            raise ImportError("missing recon graph agent")
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", guarded_import)
+
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    loaded = manager._plugins[PLUGIN_KEY]
+    assert loaded.enabled is True
+    assert loaded.error is None
+
+    from tools.registry import registry
+
+    assert registry.get_toolset_for_tool("pentest_ops_status") == "recon_graph"
+    assert registry.get_toolset_for_tool("fake_rga_status") is None
+
+    payload = json.loads(registry.dispatch("pentest_ops_status", {}))
+    assert payload["available"] is False
+    assert "recon-graph-agent" in payload["install_hint"]
+    assert "core_loop_modified" not in payload
+
+
+def test_pentest_ops_plugin_keeps_skills_when_backend_tools_are_malformed(tmp_path, monkeypatch):
+    _clean_plugin_state()
+    _enable_plugin(tmp_path, monkeypatch)
+    _install_fake_recon_graph_tools(monkeypatch, tools_value=object())
+
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    loaded = manager._plugins[PLUGIN_KEY]
+    assert loaded.enabled is True
+    assert loaded.error is None
+    assert manager.find_plugin_skill("pentest-ops:pentest-engagement-orchestrator") is not None
+
+    from tools.registry import registry
+
+    payload = json.loads(registry.dispatch("pentest_ops_status", {}))
+    assert payload["available"] is False
+    assert "dependency_error" in payload
+    assert payload["recon_graph_tools"] == []
+
+
+def test_pentest_ops_status_omits_backend_tool_rejected_by_registry(tmp_path, monkeypatch):
+    _clean_plugin_state()
+    _enable_plugin(tmp_path, monkeypatch)
+    _install_fake_recon_graph_tools(monkeypatch)
+
+    from tools.registry import registry
+
+    registry.register(
+        name="fake_rga_status",
+        toolset="different_toolset",
+        schema={"name": "fake_rga_status", "description": "collision", "parameters": {"type": "object"}},
+        handler=lambda args, **kwargs: json.dumps({"collision": True}),
+    )
+
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    payload = json.loads(registry.dispatch("pentest_ops_status", {}))
+    assert payload["available"] is False
+    assert payload["recon_graph_tools"] == []
+    assert "fake_rga_status" in payload["dependency_error"]
+
+    registry.deregister("fake_rga_status")
+
+
+def test_pentest_ops_skill_bodies_encode_evidence_first_operating_rules(tmp_path, monkeypatch):
+    _clean_plugin_state()
+    _enable_plugin(tmp_path, monkeypatch)
+    _install_fake_recon_graph_tools(monkeypatch)
+
+    manager = PluginManager()
+    manager.discover_and_load()
+
+    orchestrator = manager.find_plugin_skill("pentest-ops:pentest-engagement-orchestrator")
+    validation = manager.find_plugin_skill("pentest-ops:finding-validation-and-reporting")
+    assert orchestrator is not None
+    assert validation is not None
+
+    orchestrator_text = orchestrator.read_text(encoding="utf-8")
+    validation_text = validation.read_text(encoding="utf-8")
+
+    assert "No evidence ID, no claim" in orchestrator_text
+    assert "scan box" in orchestrator_text.lower()
+    assert "Do not modify Hermes' core loop" in orchestrator_text
+    assert "approval_ref" in validation_text
+    assert "positive" in validation_text.lower()
+    assert "control" in validation_text.lower()

--- a/website/docs/guides/pentest-ops-layer.md
+++ b/website/docs/guides/pentest-ops-layer.md
@@ -1,0 +1,97 @@
+---
+sidebar_position: 19
+title: "Pentest Ops Layer"
+description: "Use Hermes as an evidence-first authorised pentest operator without modifying the core agent loop."
+---
+
+# Pentest Ops Layer
+
+Hermes can run an authorised pentest workflow without becoming a bespoke pentest bot in the core loop. The bundled `pentest-ops` plugin keeps the split clean:
+
+- **Hermes core loop**: unchanged execution substrate.
+- **Recon Graph backend**: deterministic evidence, graph, policy, action, and reporting state.
+- **Plugin tools**: Hermes-facing wrappers under the `recon_graph` toolset.
+- **Plugin skills**: workflow guidance for orchestration, data-flow modelling, auth testing, API testing, infrastructure exposure, and finding validation.
+
+No evidence ID, no claim. Dull motto, excellent bug repellent.
+
+## Enable the plugin
+
+```bash
+hermes plugins enable pentest-ops
+hermes tools enable recon_graph
+```
+
+Restart Hermes, or start a fresh session, after enabling tools/plugins.
+
+If the private Recon Graph backend package is not installed, Hermes still loads the plugin and exposes `pentest_ops_status`. The status tool returns the dependency error and install hint rather than breaking agent startup.
+
+## What the plugin adds
+
+### Tools
+
+The plugin always registers:
+
+- `pentest_ops_status` — confirms backend availability, registered Recon Graph tools, and bundled skill names.
+
+When `recon-graph-agent` is installed, it also registers the backend tools under `recon_graph`, including:
+
+- `rga_init_engagement`
+- `rga_status`
+- `rga_bridge_pentest_ops`
+- `rga_ingest_artifact`
+- `rga_run_recipes`
+- `rga_list_candidate_paths`
+- `rga_show_candidate_path`
+- `rga_next_action`
+- `rga_policy_check`
+- `rga_action_queue`
+- `rga_negative_evidence`
+- `rga_validator_pack`
+- `rga_autonomy_checkpoint`
+- `rga_report_candidate`
+- `rga_report_promote`
+- `rga_report_demote`
+- `rga_report_export_map`
+
+These tools parse local artefacts, maintain graph state, evaluate recipes, queue policy-gated actions, and manage finding maturity. They do **not** make Hermes local run live target tooling.
+
+### Skills
+
+Plugin skills are explicit loads, namespaced under `pentest-ops:`:
+
+```text
+pentest-ops:pentest-engagement-orchestrator
+pentest-ops:pentest-evidence-and-graph-protocol
+pentest-ops:dataflow-threat-modeling
+pentest-ops:web-application-surface-testing
+pentest-ops:authn-authz-session-testing
+pentest-ops:rest-api-testing
+pentest-ops:graphql-api-testing
+pentest-ops:infrastructure-exposure-testing
+pentest-ops:finding-validation-and-reporting
+```
+
+Load them with `/skill pentest-ops:pentest-engagement-orchestrator` or the `skill_view` tool.
+
+## Operating model
+
+1. Put per-engagement truth in project context or `pentest-ops` state: scope, roles, assets, rules of engagement, rate limits, reporting destination, scan-box readiness, and evidence-store rules.
+2. Bridge or initialise Recon Graph state with `rga_bridge_pentest_ops` / `rga_init_engagement`.
+3. Ingest supplied artefacts. Local Hermes parses and reasons; it does not probe live targets.
+4. Generate hypotheses from data flows and control assumptions.
+5. Create ActionRequests for target-touching checks and run `rga_policy_check`.
+6. Execute approved target-touching work only through the approved scan box workflow.
+7. Promote findings only with positive evidence, control evidence, and an operator `approval_ref`.
+
+## Safety boundary
+
+The plugin is designed to fail closed around active testing:
+
+- no local target tooling;
+- no destructive or disruptive checks by default;
+- no brute force, stealth, persistence, or unauthorised lateral movement;
+- no report promotion without evidence refs and approval references;
+- no raw sensitive artefacts in report exports.
+
+Hermes remains adaptable; the evidence and policy layer remains deterministic. That is the point.

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -56,6 +56,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | Plugin | Kind | Purpose |
 |---|---|---|
 | `disk-cleanup` | hooks + slash command | Auto-track ephemeral files and clean them on session end |
+| `pentest-ops` | standalone tools + skills | Evidence-first authorised pentest operating layer backed by Recon Graph |
 | `observability/langfuse` | hooks | Trace turns / LLM calls / tools to [Langfuse](https://langfuse.com) |
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
@@ -66,7 +67,22 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `example-dashboard` | dashboard example | Reference dashboard plugin for [Extending the Dashboard](./extending-the-dashboard.md) |
 | `strike-freedom-cockpit` | dashboard skin | Sample custom dashboard skin |
 
-Memory providers (`plugins/memory/*`) and context engines (`plugins/context_engine/*`) are listed separately on [Memory Providers](./memory-providers.md) — they're managed through `hermes memory` and `hermes plugins` respectively. The full per-plugin detail for the two long-running hooks-based plugins follows.
+Memory providers (`plugins/memory/*`) and context engines (`plugins/context_engine/*`) are listed separately on [Memory Providers](./memory-providers.md) — they're managed through `hermes memory` and `hermes plugins` respectively. The full per-plugin detail for selected bundled plugins follows.
+
+### pentest-ops
+
+Adds a Hermes-native authorised pentest operating layer without changing the core agent loop. The plugin registers a `recon_graph` toolset, a `pentest_ops_status` diagnostic tool, and a namespaced skill pack (`pentest-ops:*`) for engagement orchestration, evidence discipline, data-flow modelling, web/API testing, infrastructure exposure, and finding validation.
+
+When the Recon Graph backend package is installed, the plugin also exposes the backend tools (`rga_status`, `rga_ingest_artifact`, `rga_policy_check`, `rga_report_promote`, and friends) through Hermes. If the backend is missing, the plugin still loads and the status tool reports the dependency problem instead of breaking startup.
+
+**Enabling:**
+
+```bash
+hermes plugins enable pentest-ops
+hermes tools enable recon_graph
+```
+
+**Usage:** load `pentest-ops:pentest-engagement-orchestrator` for the operating loop. See [Pentest Ops Layer](/docs/guides/pentest-ops-layer) for the full workflow.
 
 ### disk-cleanup
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -170,6 +170,7 @@ const sidebars: SidebarsConfig = {
         'guides/use-soul-with-hermes',
         'guides/use-voice-mode-with-hermes',
         'guides/build-a-hermes-plugin',
+        'guides/pentest-ops-layer',
         'guides/automate-with-cron',
         'guides/cron-script-only',
         'guides/automation-templates',


### PR DESCRIPTION
## Summary
- Adds a bundled opt-in `pentest-ops` plugin that keeps Hermes' core loop unchanged while exposing a pentest operating layer.
- Registers `pentest_ops_status` and, when `recon_graph_agent.hermes_plugin.tools` is importable, forwards Recon Graph backend tools into the `recon_graph` toolset.
- Adds nine namespaced plugin skills for evidence-first pentest orchestration, data-flow modelling, web/API/auth/infrastructure testing, and finding validation.
- Documents setup and usage in the guides and built-in plugin docs.

## Safety / design notes
- No local target execution is introduced.
- Missing or malformed Recon Graph backend metadata fails open to a diagnostic status tool rather than breaking plugin startup.
- Findings guidance enforces evidence refs, positive/control proof, and `approval_ref` for promotion/demotion.

## Test plan
- `uv run --extra dev python -m compileall plugins/pentest-ops tests/plugins/test_pentest_ops_plugin.py -q`
- `uv run --extra dev pytest tests/plugins/test_pentest_ops_plugin.py tests/hermes_cli/test_plugins.py::TestPluginContext::test_register_tool_adds_to_registry tests/test_plugin_skills.py tests/test_toolsets.py tests/test_packaging_metadata.py -q`
- `uv run --extra dev ruff check plugins/pentest-ops tests/plugins/test_pentest_ops_plugin.py`
- `git diff --check -- plugins/pentest-ops tests/plugins/test_pentest_ops_plugin.py website/docs/guides/pentest-ops-layer.md website/docs/user-guide/features/built-in-plugins.md website/sidebars.ts`
- Smoke: plugin enabled with local `recon-graph-agent` on `PYTHONPATH` registers 19 `recon_graph` tools and 9 plugin skills.

## Known unrelated validation notes
A broader `tests/plugins ...` run surfaced existing/unrelated issues:
- `tests/plugins/test_kanban_dashboard_plugin.py` requires missing `fastapi`.
- `tests/plugins/test_achievements_plugin.py::test_evaluate_all_stale_cache_serves_stale_and_refreshes_in_background` failed once in stale-cache timing/state.
